### PR TITLE
Block supports: Avoid warning for non string class attributes

### DIFF
--- a/src/wp-includes/block-supports/background.php
+++ b/src/wp-includes/block-supports/background.php
@@ -87,16 +87,13 @@ function wp_render_background_support( $block_content, $block ) {
 
 		if ( $tags->next_tag() ) {
 			$existing_style = $tags->get_attribute( 'style' );
-			$updated_style  = '';
-
-			if ( ! empty( $existing_style ) ) {
-				$updated_style = $existing_style;
-				if ( ! str_ends_with( $existing_style, ';' ) ) {
-					$updated_style .= ';';
-				}
+			if ( is_string( $existing_style ) && '' !== $existing_style ) {
+				$separator     = str_ends_with( $existing_style, ';' ) ? '' : ';';
+				$updated_style = "{$existing_style}{$separator}{$styles['css']}";
+			} else {
+				$updated_style = $styles['css'];
 			}
 
-			$updated_style .= $styles['css'];
 			$tags->set_attribute( 'style', $updated_style );
 			$tags->add_class( 'has-background' );
 		}

--- a/tests/phpunit/tests/block-supports/layout.php
+++ b/tests/phpunit/tests/block-supports/layout.php
@@ -184,7 +184,7 @@ class Tests_Block_Supports_Layout extends WP_UnitTestCase {
 	public function test_layout_support_flag_renders_classnames_on_wrapper( $args, $expected_output ) {
 		switch_theme( 'default' );
 		$actual_output = wp_render_layout_support_flag( $args['block_content'], $args['block'] );
-		$this->assertSame( $expected_output, $actual_output );
+		$this->assertEqualHTML( $expected_output, $actual_output );
 	}
 
 	/**

--- a/tests/phpunit/tests/block-supports/wpRenderBackgroundSupport.php
+++ b/tests/phpunit/tests/block-supports/wpRenderBackgroundSupport.php
@@ -186,6 +186,21 @@ class Tests_Block_Supports_WpRenderBackgroundSupport extends WP_UnitTestCase {
 				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;font-size: 15px;background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
 				'wrapper'             => '<div class="wp-block-test" style="color: red;font-size: 15px;">Content</div>',
 			),
+			'background image style is appended if a boolean style attribute already exists' => array(
+				'theme_name'          => 'block-theme-child-with-fluid-typography',
+				'block_name'          => 'test/background-rules-are-output',
+				'background_settings' => array(
+					'backgroundImage' => true,
+				),
+				'background_style'    => array(
+					'backgroundImage' => array(
+						'url'    => 'https://example.com/image.jpg',
+						'source' => 'file',
+					),
+				),
+				'expected_wrapper'    => '<div class="has-background" classname="wp-block-test" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
+				'wrapper'             => '<div classname="wp-block-test" style>Content</div>',
+			),
 			'background image style is not applied if the block does not support background image' => array(
 				'theme_name'          => 'block-theme-child-with-fluid-typography',
 				'block_name'          => 'test/background-rules-are-not-output',


### PR DESCRIPTION
Trac ticket: Core-59622
Gutenberg backport: WordPress/gutenberg#71594

Block Supports: Avoid throwing warning when checking for class attribute as string.

When encountering HTML tags with boolean or missing tags, the `get_attribute()`
method in the HTML API returns `true` and `null`, respectively. If these returned
values are sent directly into string comparison functions then as of PHP 8.0 they
will throw `E_DEPRECATED` errors.

In this patch, block supports is enhanced to check that the `class` value is a
string before it performs string operations on it.

---

There is a small likelihood of any real damage in production here, as these are only deprecation notices and the logic in these cases isn't affected by the change. That is,
the intention of the code is maintained even when the attribute values aren't strings.

For background support there's a tiny but benign defect when the `style` attribute is
boolean. It will erroneously inject a `;` at the beginning of the wrapper's new `style`
value. As this doesn't impact the rendering of the wrapper, it's not a true defect.

Further review belongs to block rendering code, but this will occur in the Gutenberg
repo since that PHP comes back into Core through the generated packages.

## Testing

There should be no functional or visual changes in this patch. Please consult blocks with layout and background support to verify that this hasn't adversely affected existing rendering. Verify that the test suite continues to pass.