### PR TITLE
Test 6.3 pre-filter behaviors for update_option()

### DIFF
--- a/tests/phpunit/tests/option/networkOption.php
+++ b/tests/phpunit/tests/option/networkOption.php
@@ -330,7 +330,7 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 		 * If the option is the same as the pre-filtered value, the option should not
 		 * be updated. Otherwise, the option should be updated regardless of the pre-filter.
 		 */
-		if ( $option === true ) {
+		if ( true === $option ) {
 			$this->assertFalse( update_network_option( null, 'foo', $option ) );
 		} else {
 			$this->assertTrue( update_network_option( null, 'foo', $option ) );

--- a/tests/phpunit/tests/option/networkOption.php
+++ b/tests/phpunit/tests/option/networkOption.php
@@ -228,4 +228,112 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 		// Check that no new database queries were performed.
 		$this->assertSame( $num_queries_pre_update, get_num_queries() );
 	}
+
+	/**
+	 * Test cases for testing whether update_network_option() will add a non-existent option.
+	 */
+	public function data_option_values() {
+		return array(
+			array( '1' ),
+			array( 1 ),
+			array( 1.0 ),
+			array( true ),
+			array( 'true' ),
+			array( '0' ),
+			array( 0 ),
+			array( 0.0 ),
+			array( false ),
+			array( '' ),
+			array( null ),
+			array( array() ),
+		);
+	}
+
+	/**
+	 * Tests that a non-existent option is added only when the pre-filter matches the default 'false'.
+	 *
+	 * @ticket 59360
+	 * @dataProvider data_option_values
+	 *
+	 * @covers ::update_network_option
+	 */
+	public function test_update_option_with_false_pre_filter_adds_missing_option( $option ) {
+		// Filter the old option value to `false`.
+		add_filter( 'pre_option_foo', '__return_false' );
+		add_filter( 'pre_site_option_foo', '__return_false' );
+
+		/*
+		 * When the network option is equal to the filtered version, update option will bail early.
+		 * Otherwise, The pre-filter will make the old option `false`, which is equal to the
+		 * default value. This causes an add_network_option() to be triggered.
+		 */
+		if ( false === $option ) {
+			$this->assertFalse( update_network_option( null, 'foo', $option ) );
+		} else {
+			$this->assertTrue( update_network_option( null, 'foo', $option ) );
+		}
+	}
+
+	/**
+	 * Tests that a non-existent option is never added when the pre-filter is not 'false'.
+	 *
+	 * @ticket 59360
+	 * @dataProvider data_option_values
+	 *
+	 * @covers ::update_network_option
+	 */
+	public function test_update_option_with_truthy_pre_filter_does_not_add_missing_option( $option ) {
+		// Filter the old option value to `true`.
+		add_filter( 'pre_option_foo', '__return_true' );
+		add_filter( 'pre_site_option_foo', '__return_true' );
+
+		$this->assertFalse( update_network_option( null, 'foo', $option ) );
+	}
+
+	/**
+	 * Tests that an existing option is updated even when its pre filter returns the same value.
+	 *
+	 * @ticket 59360
+	 * @dataProvider data_option_values
+	 *
+	 * @covers ::update_network_option
+	 */
+	public function test_update_option_with_false_pre_filter_updates_option( $option ) {
+		// Add the option with a value that is different than any updated.
+		add_network_option( null, 'foo', 'bar' );
+
+		// Force a return value of false.
+		add_filter( 'pre_option_foo', '__return_false' );
+		add_filter( 'pre_site_option_foo', '__return_false' );
+
+		// This should succeed, since the pre-filtered option will be treated as the default.
+		$this->assertTrue( update_network_option( null, 'foo', $option ) );
+	}
+
+	/**
+	 * Tests that an existing option is updated even when its pre filter returns the same value.
+	 *
+	 * @ticket 59360
+	 * @dataProvider data_option_values
+	 *
+	 * @covers ::update_network_option
+	 */
+	public function test_update_option_with_true_pre_filter_updates_option( $option ) {
+		// Add the option with a value that is different than any updated.
+		update_network_option( null, 'foo', 'bar' );
+
+		// Force a return value of true.
+		add_filter( 'pre_option_foo', '__return_true' );
+		add_filter( 'pre_site_option_foo', '__return_true' );
+
+		/*
+		 * If the option is the same as the pre-filtered value, the option should not
+		 * be updated. Otherwise, the option should be updated regardless of the pre-filter.
+		 */
+		if ( $option === true ) {
+			$this->assertFalse( update_network_option( null, 'foo', $option ) );
+		} else {
+			$this->assertTrue( update_network_option( null, 'foo', $option ) );
+		}
+	}
 }

--- a/tests/phpunit/tests/option/option.php
+++ b/tests/phpunit/tests/option/option.php
@@ -280,6 +280,113 @@ class Tests_Option_Option extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test cases for testing whether update_option() will add a non-existent option.
+	 */
+	public function data_option_values() {
+		return array(
+			array( '1' ),
+			array( 1 ),
+			array( 1.0 ),
+			array( true ),
+			array( 'true' ),
+			array( '0' ),
+			array( 0 ),
+			array( 0.0 ),
+			array( false ),
+			array( '' ),
+			array( null ),
+			array( array() ),
+		);
+	}
+
+	/**
+	 * Tests that a non-existent option is added only when the pre-filter matches the default 'false'.
+	 *
+	 * @ticket 22192
+	 * @dataProvider data_option_values
+	 *
+	 * @covers ::update_option
+	 */
+	public function test_update_option_with_false_pre_filter_adds_missing_option( $option ) {
+		// Filter the old option value to `false`.
+		add_filter( 'pre_option_foo', '__return_false' );
+
+		/*
+		 * When the option is equal to the filtered version, update option will bail early.
+		 * Otherwise, The pre-filter will make the old option `false`, which is equal to the
+		 *  default value. This causes an add_option() to be triggered.
+		 */
+		if ( false === $option ) {
+			$this->assertFalse( update_option( 'foo', $option ) );
+		} else {
+			$this->assertTrue( update_option( 'foo', $option ) );
+		}
+	}
+
+	/**
+	 * Tests that a non-existent option is never added when the pre-filter is not 'false'.
+	 *
+	 * @ticket 22192
+	 * @dataProvider data_option_values
+	 *
+	 * @covers ::update_option
+	 */
+	public function test_update_option_with_truthy_pre_filter_does_not_add_missing_option( $option ) {
+		// Filter the old option value to `true`.
+		add_filter( 'pre_option_foo', '__return_true' );
+
+		$this->assertFalse( update_option( 'foo', $option ) );
+	}
+
+	/**
+	 * Tests that an existing option is updated even when its pre filter returns the same value.
+	 *
+	 * @ticket 22192
+	 * @dataProvider data_option_values
+	 *
+	 * @covers ::update_option
+	 */
+	public function test_update_option_with_false_pre_filter_updates_option( $option ) {
+		// Add the option with a value that is different than any updated.
+		add_option( 'foo', 'bar' );
+
+		// Force a return value of false.
+		add_filter( 'pre_option_foo', '__return_false' );
+
+		/*
+		 * This should succeed, since the 'foo' option has a value of 0 in the database.
+		 * Therefore it differs from true and should be updated.
+		 */
+		$this->assertTrue( update_option( 'foo', $option ) );
+	}
+
+	/**
+	 * Tests that an existing option is updated even when its pre filter returns the same value.
+	 *
+	 * @ticket 22192
+	 * @dataProvider data_option_values
+	 *
+	 * @covers ::update_option
+	 */
+	public function test_update_option_with_true_pre_filter_updates_option( $option ) {
+		// Add the option with a value that is different than any updated.
+		add_option( 'foo', 'bar' );
+
+		// Force a return value of true.
+		add_filter( 'pre_option_foo', '__return_true' );
+
+		/*
+		 * Option `true` is the same as the filtered old value, so it will fail.
+		 * All other options should update.
+		 */
+		if ( true === $option ) {
+			$this->assertFalse( update_option( 'foo', $option ) );
+		} else {
+			$this->assertTrue( update_option( 'foo', $option ) );
+		}
+	}
+
+	/**
 	 * Options should be autoloaded unless they were added with "no" or `false`.
 	 *
 	 * @ticket 31119

--- a/tests/phpunit/tests/option/option.php
+++ b/tests/phpunit/tests/option/option.php
@@ -353,10 +353,7 @@ class Tests_Option_Option extends WP_UnitTestCase {
 		// Force a return value of false.
 		add_filter( 'pre_option_foo', '__return_false' );
 
-		/*
-		 * This should succeed, since the 'foo' option has a value of 0 in the database.
-		 * Therefore it differs from true and should be updated.
-		 */
+		// This should succeed, since the pre-filtered option will be treated as the default.
 		$this->assertTrue( update_option( 'foo', $option ) );
 	}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
**For demonstration only – not intended for merge**
This set of unit tests are created from the 6.3 branch in order to confirm the previous behavior of `update_option()` when the old option value has been pre-filtered. These same behaviors should be protected as part of the updates in 6.4.

Trac ticket: https://core.trac.wordpress.org/ticket/22192

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
