### PR TITLE
Adds new WP_DEBUG_LEVEL constant to load.php

### DIFF
--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -283,6 +283,11 @@ class WP_Debug_Data {
 					'value' => WP_DEBUG ? __( 'Enabled' ) : __( 'Disabled' ),
 					'debug' => WP_DEBUG,
 				),
+				'WP_DEBUG_LEVEL'      => array(
+					'label' => 'WP_DEBUG_LEVEL',
+					'value' => WP_DEBUG_LEVEL ? __( 'Enabled' ) : __( 'Disabled' ),
+					'debug' => WP_DEBUG_LEVEL,
+				),
 				'WP_DEBUG_DISPLAY'    => array(
 					'label' => 'WP_DEBUG_DISPLAY',
 					'value' => WP_DEBUG_DISPLAY ? __( 'Enabled' ) : __( 'Disabled' ),

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -96,6 +96,14 @@ function wp_initial_constants() {
 	}
 
 	/*
+	 * Add define( 'WP_DEBUG_LEVEL', null ); to wp-config.php to use the globally configured setting
+	 * for 'error_reporting'.
+	 */
+	if ( ! defined( 'WP_DEBUG_LEVEL' ) ) {
+		define( 'WP_DEBUG_LEVEL', '' );
+	}
+
+	/*
 	 * Add define( 'WP_DEBUG_DISPLAY', null ); to wp-config.php to use the globally configured setting
 	 * for 'display_errors' and not force errors to be displayed. Use false to force 'display_errors' off.
 	 */

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -574,7 +574,11 @@ function wp_debug_mode() {
 	}
 
 	if ( WP_DEBUG ) {
-		error_reporting( E_ALL );
+		if ( WP_DEBUG_LEVEL ) {
+			error_reporting( WP_DEBUG_LEVEL );
+		} else {
+			error_reporting( E_ALL );
+		}
 
 		if ( WP_DEBUG_DISPLAY ) {
 			ini_set( 'display_errors', 1 );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
My proposal is to add a new constant used in wp-includes/load.php changing the setting of error_reporting.

This would introduce the constant WP_DEBUG_LEVEL which developers can use to set their own level of error reporting in wp-config.php while defaulting back to the same value it has always been in WordPress.

- It would not cause issues with any existing WordPress install.

- It would allow developers that want to upgrade to PHP 8 while still being able to use WP_DEBUG in their development environment.
- It would overall support the use of a single constant for a WordPress install to use for determining the desired error reporting level. This means that plugin developers can also use this constant to set their desired log level in their code. An example of a valid case of such can be found in the WP Sentry plugin where there's a constant called WP_SENTRY_ERROR_TYPES used. This could default to using WP_DEBUG_LEVEL if that is set.

Trac ticket: https://core.trac.wordpress.org/ticket/31839

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
