### PR TITLE
HTML API: Scan to end of tag when getting updated HTML output.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2323,6 +2323,9 @@ class WP_HTML_Tag_Processor {
 		while ( $this->parse_next_attribute() ) {
 			continue;
 		}
+		$tag_ends_at                = strpos( $this->html, '>', $this->bytes_already_parsed );
+		$this->tag_ends_at          = $tag_ends_at;
+		$this->bytes_already_parsed = $tag_ends_at;
 
 		return $this->html;
 	}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/59643

Fixes a bug introduced in #5475.

When applying updates to HTML, one step was left out in #5475 which updated the position of the end of the current tag. This made it possible to create bookmarks with null or earlier end positions than their start position. This in turn broke the Directive Processor in Gutenberg during the backport of changes from Core into Gutenberg.

In this patch, after applying updates, the HTML document is now scanned fully to the end of the current tag, updating the internal pointer to its end, so that nothing else will be broken or misaligned.

cc: @ramonjd @andrewserong