### PR TITLE
Patterns: update pattern category capabilities to prevent authors adding new categories

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-categories-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-categories-controller.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * REST API: WP_REST_Pattern_Categories_Controller class
+ *
+ * @package WordPress
+ * @subpackage REST_API
+ * @since 6.4.0
+ */
+
+/**
+ * Core class used to managed permissions check for wp_pattern_category terms.
+ *
+ * @since 6.4.0
+ *
+ * @see WP_REST_Controller
+ */
+class WP_REST_Pattern_Categories_Controller extends WP_REST_Terms_Controller {
+	/**
+	 * Make pattern categories behave more like a hierarchical taxonomy in terms of permissions.
+	 * Check the edit_terms cap to see whether term creation is possible.
+	 *
+	 * @since 6.4.0
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function create_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		if ( ! $this->check_is_taxonomy_allowed( $this->taxonomy ) ) {
+			return false;
+		}
+
+		$taxonomy_obj = get_taxonomy( $this->taxonomy );
+
+		// Patterns categories are a flat hierarchy (like tags), but work more like post categories in terms of permissions.
+		if ( ! current_user_can( $taxonomy_obj->cap->edit_terms ) ) {
+			return new WP_Error(
+				'rest_cannot_create',
+				__( 'Sorry, you are not allowed to create terms in this taxonomy.' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+}

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -227,20 +227,21 @@ function create_initial_taxonomies() {
 		'wp_pattern_category',
 		array( 'wp_block' ),
 		array(
-			'public'             => true,
-			'publicly_queryable' => false,
-			'hierarchical'       => false,
-			'labels'             => array(
+			'public'                => true,
+			'publicly_queryable'    => false,
+			'hierarchical'          => false,
+			'labels'                => array(
 				'name'          => _x( 'Pattern Categories', 'taxonomy general name' ),
 				'singular_name' => _x( 'Pattern Category', 'taxonomy singular name' ),
 			),
-			'query_var'          => false,
-			'rewrite'            => false,
-			'show_ui'            => true,
-			'_builtin'           => true,
-			'show_in_nav_menus'  => false,
-			'show_in_rest'       => true,
-			'show_admin_column'  => true,
+			'query_var'             => false,
+			'rewrite'               => false,
+			'show_ui'               => true,
+			'_builtin'              => true,
+			'show_in_nav_menus'     => false,
+			'show_in_rest'          => true,
+			'show_admin_column'     => true,
+			'rest_controller_class' => 'WP_REST_Pattern_Categories_Controller',
 		)
 	);
 }

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -303,6 +303,7 @@ require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-widgets-controller.
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-templates-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-url-details-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-navigation-fallback-controller.php';
+require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-pattern-categories-controller.php';
 require ABSPATH . WPINC . '/rest-api/fields/class-wp-rest-meta-fields.php';
 require ABSPATH . WPINC . '/rest-api/fields/class-wp-rest-comment-meta-fields.php';
 require ABSPATH . WPINC . '/rest-api/fields/class-wp-rest-post-meta-fields.php';

--- a/tests/phpunit/tests/rest-api/rest-categories-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-categories-controller.php
@@ -40,7 +40,6 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 			)
 		);
 
-
 		// Set up categories for pagination tests.
 		for ( $i = 0; $i < self::$total_categories - 1; $i++ ) {
 			self::$category_ids[] = $factory->category->create(


### PR DESCRIPTION
Currently in the 6.4 release Author users are able to add new pattern categories, but although pattern categories are a flat taxonomy they should behave like a hierarchical taxonomy and only allow creation by users with the manage taxonomy permissions.

Because the taxonomy capabilities settings are overridden when a taxonomy is not hierarchical the only way we could see to prevent Author level users from adding new categories was by adding a custom endpoint for pattern categories. Let us know if there is an alternative way of doing this that is preferable.

There is a Gutenberg PR open to fix this (https://github.com/WordPress/gutenberg/pull/55379), and this PR copies the REST API changes to core.

Trac ticket: https://core.trac.wordpress.org/ticket/59660

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
