### PR TITLE
Patterns, Templates: Try conditional `theme` attribute injection

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -547,15 +547,18 @@ function _build_block_template_result_from_file( $template_file, $template_type 
 		$template->area = $template_file['area'];
 	}
 
-	$before_block_visitor = '_inject_theme_attribute_in_template_part_block';
+	$before_block_visitor = ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ? '_inject_theme_attribute_in_template_part_block' : null;
 	$after_block_visitor  = null;
 	$hooked_blocks        = get_hooked_blocks();
 	if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
 		$before_block_visitor = make_before_block_visitor( $hooked_blocks, $template );
 		$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $template );
 	}
-	$blocks            = parse_blocks( $template_content );
-	$template->content = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
+	if ( null !== $before_block_visitor || null !== $after_block_visitor ) {
+		$blocks           = parse_blocks( $template_content );
+		$template_content = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
+	}
+	$template->content = $template_content;
 
 	return $template;
 }

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -779,7 +779,9 @@ function make_before_block_visitor( $hooked_blocks, $context ) {
 	 * @return string The serialized markup for the given block, with the markup for any hooked blocks prepended to it.
 	 */
 	return function ( &$block, $parent_block = null, $prev = null ) use ( $hooked_blocks, $context ) {
-		_inject_theme_attribute_in_template_part_block( $block );
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+			_inject_theme_attribute_in_template_part_block( $block );
+		}
 
 		$markup = '';
 

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -165,14 +165,16 @@ final class WP_Block_Patterns_Registry {
 	private function prepare_content( $pattern, $hooked_blocks ) {
 		$content = $pattern['content'];
 
-		$before_block_visitor = '_inject_theme_attribute_in_template_part_block';
+		$before_block_visitor = ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ? '_inject_theme_attribute_in_template_part_block' : null;
 		$after_block_visitor  = null;
 		if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
 			$before_block_visitor = make_before_block_visitor( $hooked_blocks, $pattern );
 			$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $pattern );
 		}
-		$blocks  = parse_blocks( $content );
-		$content = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
+		if ( null !== $before_block_visitor || null !== $after_block_visitor ) {
+			$blocks  = parse_blocks( $content );
+			$content = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
+		}
 
 		return $content;
 	}

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -171,7 +171,6 @@ final class WP_Block_Patterns_Registry {
 
 			$blocks  = parse_blocks( $content );
 			$content = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
-
 		}
 
 		return $content;

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -165,15 +165,13 @@ final class WP_Block_Patterns_Registry {
 	private function prepare_content( $pattern, $hooked_blocks ) {
 		$content = $pattern['content'];
 
-		$before_block_visitor = ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ? '_inject_theme_attribute_in_template_part_block' : null;
-		$after_block_visitor  = null;
 		if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
 			$before_block_visitor = make_before_block_visitor( $hooked_blocks, $pattern );
 			$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $pattern );
-		}
-		if ( null !== $before_block_visitor || null !== $after_block_visitor ) {
+
 			$blocks  = parse_blocks( $content );
 			$content = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
+
 		}
 
 		return $content;

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
@@ -115,6 +115,7 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 		$patterns = WP_Block_Patterns_Registry::get_instance()->get_all_registered();
 		foreach ( $patterns as $pattern ) {
 			$migrated_pattern = $this->migrate_pattern_categories( $pattern );
+			$prepared_pattern = $this->prepare_pattern_content( $pattern );
 			$prepared_pattern = $this->prepare_item_for_response( $migrated_pattern, $request );
 			$response[]       = $this->prepare_response_for_collection( $prepared_pattern );
 		}
@@ -149,6 +150,11 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 		}
 
 		return $pattern;
+	}
+
+	protected function prepare_pattern_content( $pattern ) {
+		$blocks             = parse_blocks( $pattern['content'] );
+		$pattern['content'] = traverse_and_serialize_blocks( $blocks, '_inject_theme_attribute_in_template_part_block' );
 	}
 
 	/**

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -162,64 +162,6 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 59325
-	 *
-	 * @covers ::_build_block_template_result_from_file
-	 *
-	 * @dataProvider data_build_block_template_result_from_file_injects_theme_attribute
-	 *
-	 * @param string $filename The template's filename.
-	 * @param string $expected The expected block markup.
-	 */
-	public function test_build_block_template_result_from_file_injects_theme_attribute( $filename, $expected ) {
-		$template = _build_block_template_result_from_file(
-			array(
-				'slug' => 'single',
-				'path' => DIR_TESTDATA . "/templates/$filename",
-			),
-			'wp_template'
-		);
-		$this->assertSame( $expected, $template->content );
-	}
-
-	/**
-	 * Data provider.
-	 *
-	 * @return array[]
-	 */
-	public function data_build_block_template_result_from_file_injects_theme_attribute() {
-		$theme = 'block-theme';
-		return array(
-			'a template with a template part block'  => array(
-				'filename' => 'template-with-template-part.html',
-				'expected' => sprintf(
-					'<!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header","theme":"%s"} /-->',
-					$theme
-				),
-			),
-			'a template with a template part block nested inside another block' => array(
-				'filename' => 'template-with-nested-template-part.html',
-				'expected' => sprintf(
-					'<!-- wp:group -->
-<!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header","theme":"%s"} /-->
-<!-- /wp:group -->',
-					$theme
-				),
-			),
-			'a template with a template part block with an existing theme attribute' => array(
-				'filename' => 'template-with-template-part-with-existing-theme-attribute.html',
-				'expected' => '<!-- wp:template-part {"slug":"header","theme":"fake-theme","align":"full","tagName":"header","className":"site-header"} /-->',
-			),
-			'a template with no template part block' => array(
-				'filename' => 'template.html',
-				'expected' => '<!-- wp:paragraph -->
-<p>Just a paragraph</p>
-<!-- /wp:paragraph -->',
-			),
-		);
-	}
-
-	/**
 	 * @ticket 59338
 	 *
 	 * @covers ::_inject_theme_attribute_in_template_part_block

--- a/tests/phpunit/tests/blocks/renderBlockCoreTemplatePart.php
+++ b/tests/phpunit/tests/blocks/renderBlockCoreTemplatePart.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Tests for `render_block_core_template_part()`.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @group blocks
+ */
+class Tests_Blocks_RenderBlockCoreTemplatePart extends WP_UnitTestCase {
+
+	/**
+	 * Temporary storage for original block to render.
+	 *
+	 * @var array|null
+	 */
+	private $original_block_to_render = null;
+
+	/**
+	 * Flag to indicate whether to switch back to the default theme at tear down.
+	 *
+	 * @var bool
+	 */
+	private $switch_to_default_theme_at_teardown = false;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->original_block_to_render = WP_Block_Supports::$block_to_render;
+	}
+
+	public function tear_down() {
+		WP_Block_Supports::$block_to_render = $this->original_block_to_render;
+		$this->original_block_to_render     = null;
+
+		if ( $this->switch_to_default_theme_at_teardown ) {
+			$this->switch_to_default_theme_at_teardown = false;
+			switch_theme( WP_DEFAULT_THEME );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that the core template part block assumes the current theme if no theme attribute provided.
+	 *
+	 * @ticket 59583
+	 */
+	public function test_render_block_core_template_part_without_theme_attribute() {
+		$this->maybe_switch_theme( 'block-theme' );
+
+		WP_Block_Supports::$block_to_render = array( 'blockName' => 'core/template-part' );
+
+		$content = render_block_core_template_part( array( 'slug' => 'small-header' ) );
+
+		$expected  = '<header class="wp-block-template-part">' . "\n";
+		$expected .= '<p>Small Header Template Part</p>' . "\n";
+		$expected .= '</header>';
+
+		$this->assertSame( $expected, $content );
+	}
+
+	/**
+	 * Tests that the core template part block returns the relevant part if current theme attribute provided.
+	 *
+	 * @ticket 59583
+	 */
+	public function test_render_block_core_template_part_with_current_theme_attribute() {
+		$this->maybe_switch_theme( 'block-theme' );
+
+		WP_Block_Supports::$block_to_render = array( 'blockName' => 'core/template-part' );
+
+		$content = render_block_core_template_part(
+			array(
+				'slug'  => 'small-header',
+				'theme' => 'block-theme',
+			)
+		);
+
+		$expected  = '<header class="wp-block-template-part">' . "\n";
+		$expected .= '<p>Small Header Template Part</p>' . "\n";
+		$expected .= '</header>';
+
+		$this->assertSame( $expected, $content );
+	}
+
+	/**
+	 * Tests that the core template part block returns nothing if theme attribute for a different theme provided.
+	 *
+	 * @ticket 59583
+	 */
+	public function test_render_block_core_template_part_with_another_theme_attribute() {
+		$this->maybe_switch_theme( 'block-theme' );
+
+		WP_Block_Supports::$block_to_render = array( 'blockName' => 'core/template-part' );
+
+		$content = render_block_core_template_part(
+			array(
+				'slug'  => 'small-header',
+				'theme' => WP_DEFAULT_THEME,
+			)
+		);
+
+		$expected = 'Template part has been deleted or is unavailable: small-header';
+		$this->assertSame( $expected, $content );
+	}
+
+	/**
+	 * Switches the theme when not the default theme.
+	 *
+	 * @param string $theme Theme name to switch to.
+	 */
+	private function maybe_switch_theme( $theme ) {
+		if ( WP_DEFAULT_THEME === $theme ) {
+			return;
+		}
+
+		switch_theme( $theme );
+		$this->switch_to_default_theme_at_teardown = true;
+	}
+}

--- a/tests/phpunit/tests/blocks/wpBlockPatternsRegistry.php
+++ b/tests/phpunit/tests/blocks/wpBlockPatternsRegistry.php
@@ -317,29 +317,6 @@ class Tests_Blocks_wpBlockPattersRegistry extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Should insert a theme attribute into Template Part blocks in registered patterns.
-	 *
-	 * @ticket 59583
-	 *
-	 * @covers WP_Block_Patterns_Registry::register
-	 * @covers WP_Block_Patterns_Registry::get_all_registered
-	 */
-	public function test_get_all_registered_includes_theme_attribute() {
-		$test_pattern = array(
-			'title'   => 'Test Pattern',
-			'content' => '<!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header"} /-->',
-		);
-		$this->registry->register( 'test/pattern', $test_pattern );
-
-		$expected = sprintf(
-			'<!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header","theme":"%s"} /-->',
-			get_stylesheet()
-		);
-		$patterns = $this->registry->get_all_registered();
-		$this->assertSame( $expected, $patterns[0]['content'] );
-	}
-
-	/**
 	 * Should insert hooked blocks into registered patterns.
 	 *
 	 * @ticket 59476
@@ -389,29 +366,6 @@ class Tests_Blocks_wpBlockPattersRegistry extends WP_UnitTestCase {
 
 		$registered = $this->registry->get_all_registered();
 		$this->assertSame( $expected, $registered );
-	}
-
-	/**
-	 * Should insert a theme attribute into Template Part blocks in registered patterns.
-	 *
-	 * @ticket 59583
-	 *
-	 * @covers WP_Block_Patterns_Registry::register
-	 * @covers WP_Block_Patterns_Registry::get_registered
-	 */
-	public function test_get_registered_includes_theme_attribute() {
-		$test_pattern = array(
-			'title'   => 'Test Pattern',
-			'content' => '<!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header"} /-->',
-		);
-		$this->registry->register( 'test/pattern', $test_pattern );
-
-		$expected = sprintf(
-			'<!-- wp:template-part {"slug":"header","align":"full","tagName":"header","className":"site-header","theme":"%s"} /-->',
-			get_stylesheet()
-		);
-		$pattern  = $this->registry->get_registered( 'test/pattern' );
-		$this->assertSame( $expected, $pattern['content'] );
 	}
 
 	/**


### PR DESCRIPTION
**Not planning to land this for 6.4, it's been too much of a 🎢** 

WIP, early stages.

Since we had to [revert](https://github.com/WordPress/wordpress-develop/pull/5509) our [previous attempt](https://github.com/WordPress/wordpress-develop/pull/5455) at this, I'm starting a new draft PR based on the [notes](https://github.com/WordPress/wordpress-develop/pull/5455/files#r1356697911) I posted here.

TODO:
- [ ] Move hooked blocks insertion to the patterns controller so we can remove it from `WP_Block_Patterns_Registry`
- [ ] Make sure hooked block insertion is run on the frontend. We can probably achieve that through running it in the Pattern block's `render_block`.
- [ ] Apply the same changes to Templates?
- [ ] Add test coverage to avoid the [previous regression](https://core.trac.wordpress.org/ticket/59629). If we manage to move all the REST API specific logic into the respective controllers (and get rid of all `REST_REQUEST` conditionals), it's probably enough to add unit test coverage for those controllers

_When testing, make sure that this doesn't cause [this regression](https://core.trac.wordpress.org/ticket/59629) (it currently still does; needs more tweaking!)_

Trac ticket: TBD

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
