### PR TITLE
CREATE TABLE, INSERT, UPDATE setup queries doesn't work if in lower case - Fix

### DIFF
--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2800,23 +2800,23 @@ function dbDelta( $queries = '', $execute = true ) { // phpcs:ignore WordPress.N
 
 	// Create a tablename index for an array ($cqueries) of recognized query types.
 	foreach ( $queries as $qry ) {
-		if ( preg_match( '|CREATE TABLE ([^ ]*)|/i', $qry, $matches ) ) {
+		if ( preg_match( '|CREATE TABLE ([^ ]*)|i', $qry, $matches ) ) {
 			$cqueries[ trim( $matches[1], '`' ) ] = $qry;
 			$for_update[ $matches[1] ]            = 'Created table ' . $matches[1];
 			continue;
 		}
 
-		if ( preg_match( '|CREATE DATABASE ([^ ]*)|/i', $qry, $matches ) ) {
+		if ( preg_match( '|CREATE DATABASE ([^ ]*)|i', $qry, $matches ) ) {
 			array_unshift( $cqueries, $qry );
 			continue;
 		}
 
-		if ( preg_match( '|INSERT INTO ([^ ]*)|/i', $qry, $matches ) ) {
+		if ( preg_match( '|INSERT INTO ([^ ]*)|i', $qry, $matches ) ) {
 			$iqueries[] = $qry;
 			continue;
 		}
 
-		if ( preg_match( '|UPDATE ([^ ]*)|/i', $qry, $matches ) ) {
+		if ( preg_match( '|UPDATE ([^ ]*)|i', $qry, $matches ) ) {
 			$iqueries[] = $qry;
 			continue;
 		}

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2800,23 +2800,23 @@ function dbDelta( $queries = '', $execute = true ) { // phpcs:ignore WordPress.N
 
 	// Create a tablename index for an array ($cqueries) of recognized query types.
 	foreach ( $queries as $qry ) {
-		if ( preg_match( '|CREATE TABLE ([^ ]*)|', $qry, $matches ) ) {
+		if ( preg_match( '|CREATE TABLE ([^ ]*)|/i', $qry, $matches ) ) {
 			$cqueries[ trim( $matches[1], '`' ) ] = $qry;
 			$for_update[ $matches[1] ]            = 'Created table ' . $matches[1];
 			continue;
 		}
 
-		if ( preg_match( '|CREATE DATABASE ([^ ]*)|', $qry, $matches ) ) {
+		if ( preg_match( '|CREATE DATABASE ([^ ]*)|/i', $qry, $matches ) ) {
 			array_unshift( $cqueries, $qry );
 			continue;
 		}
 
-		if ( preg_match( '|INSERT INTO ([^ ]*)|', $qry, $matches ) ) {
+		if ( preg_match( '|INSERT INTO ([^ ]*)|/i', $qry, $matches ) ) {
 			$iqueries[] = $qry;
 			continue;
 		}
 
-		if ( preg_match( '|UPDATE ([^ ]*)|', $qry, $matches ) ) {
+		if ( preg_match( '|UPDATE ([^ ]*)|/i', $qry, $matches ) ) {
 			$iqueries[] = $qry;
 			continue;
 		}


### PR DESCRIPTION
This will fix an issue ([already reported on trac](https://core.trac.wordpress.org/ticket/59481)), where queries ran by calling `dbDelta($sql)` are not executed if they start in lowercase. For example: `create table foo...`, `insert into ...`


<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/59481

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
