### PR TITLE
Block Hooks: Make work with modified templates/parts/patterns

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -894,6 +894,14 @@ function _build_block_template_result_from_post( $post ) {
 		}
 	}
 
+	$hooked_blocks = get_hooked_blocks();
+	if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
+		$before_block_visitor = make_before_block_visitor( $hooked_blocks, $template );
+		$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $template );
+		$blocks               = parse_blocks( $post->post_content );
+		$template->content    = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
+	}
+
 	return $template;
 }
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -757,7 +757,7 @@ function get_hooked_blocks() {
 	return $hooked_blocks;
 }
 
-function insert_hooked_blocks( $relative_position, &$anchor_block, $hooked_blocks, $context ) {
+function insert_hooked_blocks( &$anchor_block, $relative_position, $hooked_blocks, $context ) {
 	$anchor_block_type  = $anchor_block['blockName'];
 	$hooked_block_types = isset( $hooked_blocks[ $anchor_block_type ][ $relative_position ] )
 		? $hooked_blocks[ $anchor_block_type ][ $relative_position ]
@@ -833,10 +833,10 @@ function make_before_block_visitor( $hooked_blocks, $context ) {
 
 		if ( $parent_block && ! $prev ) {
 			// Candidate for first-child insertion.
-			$markup .= insert_hooked_blocks( 'first_child', $parent_block, $hooked_blocks, $context );
+			$markup .= insert_hooked_blocks( $parent_block, 'first_child', $hooked_blocks, $context );
 		}
 
-		$markup .= insert_hooked_blocks( 'before', $block, $hooked_blocks, $context );
+		$markup .= insert_hooked_blocks( $block, 'before', $hooked_blocks, $context );
 
 		return $markup;
 	};
@@ -872,11 +872,11 @@ function make_after_block_visitor( $hooked_blocks, $context ) {
 	 * @return string The serialized markup for the given block, with the markup for any hooked blocks appended to it.
 	 */
 	return function ( &$block, &$parent_block = null, $next = null ) use ( $hooked_blocks, $context ) {
-		$markup = insert_hooked_blocks( 'after', $block, $hooked_blocks, $context );
+		$markup = insert_hooked_blocks( $block, 'after', $hooked_blocks, $context );
 
 		if ( $parent_block && ! $next ) {
 			// Candidate for last-child insertion.
-			$markup .= insert_hooked_blocks( 'last_child', $parent_block, $hooked_blocks, $context );
+			$markup .= insert_hooked_blocks( $parent_block, 'last_child', $hooked_blocks, $context );
 		}
 
 		return $markup;

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -757,6 +757,18 @@ function get_hooked_blocks() {
 	return $hooked_blocks;
 }
 
+/**
+ * Returns the markup for blocks hooked to the given anchor block in a specific relative position.
+ *
+ * @since 6.5.0
+ *
+ * @param array                   $anchor_block      The anchor block.
+ * @param string                  $relative_position The relative position of the hooked blocks.
+ * 								                     Can be one of 'before', 'after', 'first_child', or 'last_child'.
+ * @param array                   $hooked_blocks     An array of blocks hooked to the given anchor block.
+ * @param WP_Block_Template|array $context           The block template, template part, or pattern that the anchor block belongs to.
+ * @return string
+ */
 function insert_hooked_blocks( &$anchor_block, $relative_position, $hooked_blocks, $context ) {
 	$anchor_block_type  = $anchor_block['blockName'];
 	$hooked_block_types = isset( $hooked_blocks[ $anchor_block_type ][ $relative_position ] )
@@ -769,11 +781,11 @@ function insert_hooked_blocks( &$anchor_block, $relative_position, $hooked_block
 	 *
 	 * @since 6.4.0
 	 *
-	 * @param string[]                $hooked_block_types  The list of hooked block types.
-	 * @param string                  $relative_position   The relative position of the hooked blocks.
-	 *                                                     Can be one of 'before', 'after', 'first_child', or 'last_child'.
-	 * @param string                  $anchor_block_type   The anchor block type.
-	 * @param WP_Block_Template|array $context             The block template, template part, or pattern that the anchor block belongs to.
+	 * @param string[]                $hooked_block_types The list of hooked block types.
+	 * @param string                  $relative_position  The relative position of the hooked blocks.
+	 *                                                    Can be one of 'before', 'after', 'first_child', or 'last_child'.
+	 * @param string                  $anchor_block_type  The anchor block type.
+	 * @param WP_Block_Template|array $context            The block template, template part, or pattern that the anchor block belongs to.
 	 */
 	$hooked_block_types = apply_filters( 'hooked_block_types', $hooked_block_types, $relative_position, $anchor_block_type, $context );
 	foreach ( $hooked_block_types as $hooked_block_type ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -778,11 +778,13 @@ function insert_hooked_blocks( $relative_position, &$anchor_block, $hooked_block
 	$hooked_block_types = apply_filters( 'hooked_block_types', $hooked_block_types, $relative_position, $anchor_block_type, $context );
 	foreach ( $hooked_block_types as $hooked_block_type ) {
 		if (
-			! isset( $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] ) ||
-			! in_array( $hooked_block_type, $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] )
+			isset( $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] ) &&
+			in_array( $hooked_block_type, $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] )
 		) {
-			$markup .= get_comment_delimited_block_content( $hooked_block_type, array(), '' );
+			continue;
 		}
+
+		$markup .= get_comment_delimited_block_content( $hooked_block_type, array(), '' );
 
 		// TODO: The following is only needed for the REST API endpoint.
 		// Ideally, the code should thus be moved into the controller.
@@ -790,7 +792,6 @@ function insert_hooked_blocks( $relative_position, &$anchor_block, $hooked_block
 			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'] = array();
 		}
 		$anchor_block['attrs']['metadata']['ignoredHookedBlocks'][] = $hooked_block_type;
-
 	}
 	return $markup;
 }

--- a/src/wp-includes/blocks/template-part.php
+++ b/src/wp-includes/blocks/template-part.php
@@ -43,10 +43,10 @@ function render_block_core_template_part( $attributes ) {
 		if ( $template_part_post ) {
 			// A published post might already exist if this template part was customized elsewhere
 			// or if it's part of a customized template.
-			$content    = $template_part_post->post_content;
-			$area_terms = get_the_terms( $template_part_post, 'wp_template_part_area' );
-			if ( ! is_wp_error( $area_terms ) && false !== $area_terms ) {
-				$area = $area_terms[0]->name;
+			$block_template = _build_block_template_result_from_post( $template_part_post );
+			$content        = $block_template->content;
+			if ( isset( $block_template->area ) ) {
+				$area = $block_template->area;
 			}
 			/**
 			 * Fires when a block template part is loaded from a template post stored in the database.

--- a/tests/phpunit/tests/blocks/getHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/getHookedBlocks.php
@@ -176,7 +176,7 @@ class Tests_Blocks_GetHookedBlocks extends WP_UnitTestCase {
 
 		$this->assertStringContainsString(
 			'<!-- wp:tests/hooked-before /-->'
-			. '<!-- wp:navigation ',
+			. '<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"},"metadata":{"ignoredHookedBlocks":["tests/hooked-before"]}} /-->',
 			$template->content
 		);
 		$this->assertStringNotContainsString(

--- a/tests/phpunit/tests/blocks/getHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/getHookedBlocks.php
@@ -176,7 +176,7 @@ class Tests_Blocks_GetHookedBlocks extends WP_UnitTestCase {
 
 		$this->assertStringContainsString(
 			'<!-- wp:tests/hooked-before /-->'
-			. '<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} /-->',
+			. '<!-- wp:navigation ',
 			$template->content
 		);
 		$this->assertStringNotContainsString(

--- a/tests/phpunit/tests/blocks/getHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/getHookedBlocks.php
@@ -149,7 +149,7 @@ class Tests_Blocks_GetHookedBlocks extends WP_UnitTestCase {
 			$template->content
 		);
 		$this->assertStringContainsString(
-			'<!-- wp:post-content {"layout":{"type":"constrained"}} /-->'
+			'<!-- wp:post-content {"layout":{"type":"constrained"},"metadata":{"ignoredHookedBlocks":["tests/hooked-after"]}} /-->'
 			. '<!-- wp:tests/hooked-after /-->',
 			$template->content
 		);
@@ -215,7 +215,7 @@ class Tests_Blocks_GetHookedBlocks extends WP_UnitTestCase {
 			$pattern['content']
 		);
 		$this->assertStringContainsString(
-			'<!-- wp:comments -->'
+			'<!-- wp:comments {"metadata":{"ignoredHookedBlocks":["tests/hooked-first-child"]}} -->'
 			. '<div class="wp-block-comments">'
 			. '<!-- wp:tests/hooked-first-child /-->',
 			str_replace( array( "\n", "\t" ), '', $pattern['content'] )

--- a/tests/phpunit/tests/blocks/wpBlockPatternsRegistry.php
+++ b/tests/phpunit/tests/blocks/wpBlockPatternsRegistry.php
@@ -384,7 +384,9 @@ class Tests_Blocks_wpBlockPattersRegistry extends WP_UnitTestCase {
 		$registered = $this->registry->get_all_registered();
 		$this->assertCount( 3, $registered );
 		$this->assertStringEndsWith( '<!-- wp:tests/my-block /-->', $registered[1]['content'] );
+		$this->assertStringContainsString( '"metadata":{"ignoredHookedBlocks":["tests/my-block"]}', $registered[1]['content'] );
 		$this->assertStringEndsWith( '<!-- wp:tests/my-block /-->', $registered[2]['content'] );
+		$this->assertStringContainsString( '"metadata":{"ignoredHookedBlocks":["tests/my-block"]}', $registered[2]['content'] );
 	}
 
 	/**
@@ -442,6 +444,7 @@ class Tests_Blocks_wpBlockPattersRegistry extends WP_UnitTestCase {
 
 		$pattern = $this->registry->get_registered( 'test/one' );
 		$this->assertStringStartsWith( '<!-- wp:tests/my-block /-->', $pattern['content'] );
+		$this->assertStringContainsString( '"metadata":{"ignoredHookedBlocks":["tests/my-block"]}', $pattern['content'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/blocks/wpBlockPatternsRegistry.php
+++ b/tests/phpunit/tests/blocks/wpBlockPatternsRegistry.php
@@ -381,14 +381,10 @@ class Tests_Blocks_wpBlockPattersRegistry extends WP_UnitTestCase {
 		$pattern_three['name']     = 'test/three';
 		$pattern_three['content'] .= '<!-- wp:tests/my-block /-->';
 
-		$expected = array(
-			$pattern_one,
-			$pattern_two,
-			$pattern_three,
-		);
-
 		$registered = $this->registry->get_all_registered();
-		$this->assertSame( $expected, $registered );
+		$this->assertCount( 3, $registered );
+		$this->assertStringEndsWith( '<!-- wp:tests/my-block /-->', $registered[1]['content'] );
+		$this->assertStringEndsWith( '<!-- wp:tests/my-block /-->', $registered[2]['content'] );
 	}
 
 	/**
@@ -444,11 +440,8 @@ class Tests_Blocks_wpBlockPattersRegistry extends WP_UnitTestCase {
 		);
 		$this->registry->register( 'test/two', $pattern_two );
 
-		$pattern_one['name']    = 'test/one';
-		$pattern_one['content'] = '<!-- wp:tests/my-block /-->' . $pattern_one['content'];
-
 		$pattern = $this->registry->get_registered( 'test/one' );
-		$this->assertSame( $pattern_one, $pattern );
+		$this->assertStringStartsWith( '<!-- wp:tests/my-block /-->', $pattern['content'] );
 	}
 
 	/**


### PR DESCRIPTION
From a pair-programming session with @gziolo.

The biggest tradeoff we made in the implementation of Block Hooks was that we had to limit them to templates, template parts, and patterns that _didn't have any user modifications_ (see [`#59313`](https://core.trac.wordpress.org/ticket/59313) for the reason). We would like to remove this limitation, so they’ll also work with user-modified templates, parts, and patterns.

The crucial problem we need to solve is to acknowledge if a user has opted to remove or persist a hooked block, so that the auto-insertion mechanism won't run again and inject an extraneous hooked block on the frontend when none is solicited.

TODO:
- [x] https://github.com/WordPress/wordpress-develop/pull/5525
- [ ] Make sure `hookedBlocks` global attribute default is set correctly (to empty array).
- [ ] Make sure hooked block is correctly added to parent's `hookedBlocks` attribute for first and last child cases.
- [x] Inject hooked blocks into DB-based templates.
- [ ] Add unit tests to make sure `ignoredHookedBlocks` is added to the correct block.

Consider this PR experimental; we might want to break it down into smaller pieces to land invididually:

- [x] https://github.com/WordPress/gutenberg/pull/55811
- [x] https://github.com/WordPress/wordpress-develop/pull/5608
- [ ] https://github.com/WordPress/wordpress-develop/pull/5609

Trac ticket: https://core.trac.wordpress.org/ticket/59646

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
