### PR TITLE
Block: Give `traverse_and_serialize_block(s)`' post-callback access to block instance

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1062,18 +1062,20 @@ function traverse_and_serialize_block( $block, $pre_callback = null, $post_callb
 				);
 			}
 
-			$block_content .= traverse_and_serialize_block( $inner_block, $pre_callback, $post_callback );
-
 			if ( is_callable( $post_callback ) ) {
 				$next = count( $block['innerBlocks'] ) - 1 === $block_index
 					? null
 					: $block['innerBlocks'][ $block_index + 1 ];
 
-				$block_content .= call_user_func_array(
+					$post_markup = call_user_func_array(
 					$post_callback,
 					array( &$inner_block, $block, $next )
 				);
 			}
+
+			$block_content .= traverse_and_serialize_block( $inner_block, $pre_callback, $post_callback );
+			$block_content .= isset( $post_markup ) ? $post_markup : '';
+
 			++$block_index;
 		}
 	}
@@ -1135,18 +1137,19 @@ function traverse_and_serialize_blocks( $blocks, $pre_callback = null, $post_cal
 			);
 		}
 
-		$result .= traverse_and_serialize_block( $block, $pre_callback, $post_callback );
-
 		if ( is_callable( $post_callback ) ) {
 			$next = count( $blocks ) - 1 === $index
 				? null
 				: $blocks[ $index + 1 ];
 
-			$result .= call_user_func_array(
+			$post_markup = call_user_func_array(
 				$post_callback,
 				array( &$block, null, $next ) // At the top level, there is no parent block to pass to the callback.
 			);
 		}
+
+		$result .= traverse_and_serialize_block( $block, $pre_callback, $post_callback );
+		$result .= isset( $post_markup ) ? $post_markup : '';
 	}
 
 	return $result;

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1067,7 +1067,7 @@ function traverse_and_serialize_block( $block, $pre_callback = null, $post_callb
 					? null
 					: $block['innerBlocks'][ $block_index + 1 ];
 
-					$post_markup = call_user_func_array(
+				$post_markup = call_user_func_array(
 					$post_callback,
 					array( &$inner_block, $block, $next )
 				);

--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -74,6 +74,21 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @covers ::traverse_and_serialize_blocks
+	 */
+	public function test_traverse_and_serialize_blocks_post_callback_modifies_current_block() {
+		$markup = "<!-- wp:outer --><!-- wp:inner {\"key\":\"value\"} -->Example.<!-- /wp:inner -->\n\nExample.\n\n<!-- wp:void /--><!-- /wp:outer -->";
+		$blocks = parse_blocks( $markup );
+
+		$actual = traverse_and_serialize_blocks( $blocks, null, array( __CLASS__, 'add_attribute_to_inner_block' ) );
+
+		$this->assertSame(
+			"<!-- wp:outer --><!-- wp:inner {\"key\":\"value\",\"myattr\":\"myvalue\"} -->Example.<!-- /wp:inner -->\n\nExample.\n\n<!-- wp:void /--><!-- /wp:outer -->",
+			$actual
+		);
+	}
+
 	public static function add_attribute_to_inner_block( &$block ) {
 		if ( 'core/inner' === $block['blockName'] ) {
 			$block['attrs']['myattr'] = 'myvalue';

--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -75,6 +75,8 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 59669
+	 *
 	 * @covers ::traverse_and_serialize_blocks
 	 */
 	public function test_traverse_and_serialize_blocks_post_callback_modifies_current_block() {


### PR DESCRIPTION
Both the `$pre_` and `$post_callback` functions that are given as arguments to `traverse_and_serialize_block(s)` receive a reference to the current block as its first argument. However, while any changes that the "pre" callback makes to the block are actually respected during serialization, the same isn't true for the "post" callback: Any changes that it makes are only applied after the block has already been serialized. For applications like [`#59412`](https://core.trac.wordpress.org/ticket/59412), we probably want to change that.

## Testing instructions

The behavior is covered by the newly added unit test. You can verify that it fails on `trunk` by cherry-picking https://github.com/WordPress/wordpress-develop/pull/5525/commits/a8c66337d0e095be95155cc4efc739312e89abc6 there, and running `npm run test:php -- --group=blocks`.

Trac ticket: https://core.trac.wordpress.org/ticket/59669

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
