### PR TITLE
Add viewStyle property for block metadata

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -64,6 +64,7 @@ function generate_block_asset_handle( $block_name, $field_name, $index = 0 ) {
 		'viewScript'   => 'view-script',
 		'editorStyle'  => 'editor-style',
 		'style'        => 'style',
+		'viewStyle'    => 'view-style',
 	);
 	$asset_handle   = str_replace( '/', '-', $block_name ) .
 		'-' . $field_mappings[ $field_name ];
@@ -326,6 +327,7 @@ function get_block_metadata_i18n_schema() {
  * @since 6.1.0 Added support for `render` field.
  * @since 6.3.0 Added `selectors` field.
  * @since 6.4.0 Added support for `blockHooks` field.
+ * @since 6.x.x Added support for `viewStyle` field.
  *
  * @param string $file_or_folder Path to the JSON file with metadata definition for
  *                               the block or path to the folder where the `block.json` file is located.
@@ -468,6 +470,7 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 	$style_fields = array(
 		'editorStyle' => 'editor_style_handles',
 		'style'       => 'style_handles',
+		'viewStyle'	  => 'view_style_handles',
 	);
 	foreach ( $style_fields as $metadata_field_name => $settings_field_name ) {
 		if ( ! empty( $metadata[ $metadata_field_name ] ) ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -470,7 +470,7 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 	$style_fields = array(
 		'editorStyle' => 'editor_style_handles',
 		'style'       => 'style_handles',
-		'viewStyle'	  => 'view_style_handles',
+		'viewStyle'   => 'view_style_handles',
 	);
 	foreach ( $style_fields as $metadata_field_name => $settings_field_name ) {
 		if ( ! empty( $metadata[ $metadata_field_name ] ) ) {
@@ -1964,7 +1964,7 @@ function get_comments_pagination_arrow( $block, $pagination_type = 'next' ) {
  * @return string Filtered content without any HTML on the footnote content and with the sanitized id.
  */
 function _wp_filter_post_meta_footnotes( $footnotes ) {
-	$footnotes_decoded   = json_decode( $footnotes, true );
+	$footnotes_decoded = json_decode( $footnotes, true );
 	if ( ! is_array( $footnotes_decoded ) ) {
 		return '';
 	}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -327,7 +327,7 @@ function get_block_metadata_i18n_schema() {
  * @since 6.1.0 Added support for `render` field.
  * @since 6.3.0 Added `selectors` field.
  * @since 6.4.0 Added support for `blockHooks` field.
- * @since 6.x.x Added support for `viewStyle` field.
+ * @since 6.5.0 Added support for `viewStyle` field.
  *
  * @param string $file_or_folder Path to the JSON file with metadata definition for
  *                               the block or path to the folder where the `block.json` file is located.

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -226,6 +226,14 @@ class WP_Block_Type {
 	public $style_handles = array();
 
 	/**
+	 * Block type front end only style handles.
+	 *
+	 * @since 6.x.x
+	 * @var string[]
+	 */
+	public $view_style_handles = array();
+
+	/**
 	 * Deprecated block type properties for script and style handles.
 	 *
 	 * @since 6.1.0
@@ -267,6 +275,7 @@ class WP_Block_Type {
 	 *              Deprecated the `editor_script`, `script`, `view_script`, `editor_style`, and `style` properties.
 	 * @since 6.3.0 Added the `selectors` property.
 	 * @since 6.4.0 Added the `block_hooks` property.
+	 * @since 6.x.x Added the `view_style_handles` property.
 	 *
 	 * @see register_block_type()
 	 *
@@ -303,6 +312,7 @@ class WP_Block_Type {
 	 *     @type string[]      $view_script_handles      Block type front end only script handles.
 	 *     @type string[]      $editor_style_handles     Block type editor only style handles.
 	 *     @type string[]      $style_handles            Block type front end and editor style handles.
+	 * 	   @type string[]      $view_style_handles		 Block type front end only style handles.
 	 * }
 	 */
 	public function __construct( $block_type, $args = array() ) {

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -312,7 +312,7 @@ class WP_Block_Type {
 	 *     @type string[]      $view_script_handles      Block type front end only script handles.
 	 *     @type string[]      $editor_style_handles     Block type editor only style handles.
 	 *     @type string[]      $style_handles            Block type front end and editor style handles.
-	 * 	   @type string[]      $view_style_handles		 Block type front end only style handles.
+	 *     @type string[]      $view_style_handles       Block type front end only style handles.
 	 * }
 	 */
 	public function __construct( $block_type, $args = array() ) {

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -228,7 +228,7 @@ class WP_Block_Type {
 	/**
 	 * Block type front end only style handles.
 	 *
-	 * @since 6.x.x
+	 * @since 6.5.0
 	 * @var string[]
 	 */
 	public $view_style_handles = array();
@@ -275,7 +275,7 @@ class WP_Block_Type {
 	 *              Deprecated the `editor_script`, `script`, `view_script`, `editor_style`, and `style` properties.
 	 * @since 6.3.0 Added the `selectors` property.
 	 * @since 6.4.0 Added the `block_hooks` property.
-	 * @since 6.x.x Added the `view_style_handles` property.
+	 * @since 6.5.0 Added the `view_style_handles` property.
 	 *
 	 * @see register_block_type()
 	 *

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -280,6 +280,12 @@ class WP_Block {
 			}
 		}
 
+		if ( ( ! empty( $this->block_type->view_style_handles ) ) ) {
+			foreach ( $this->block_type->view_style_handles as $view_style_handle ) {
+				wp_enqueue_style( $view_style_handle );
+			}
+		}
+
 		/**
 		 * Filters the content of a single block.
 		 *

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -292,6 +292,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 				'view_script_handles',
 				'editor_style_handles',
 				'style_handles',
+				'view_style_handles',
 				'variations',
 				'block_hooks',
 			),
@@ -594,6 +595,16 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 				),
 				'style_handles'         => array(
 					'description' => __( 'Public facing and editor style handles.' ),
+					'type'        => array( 'array' ),
+					'default'     => array(),
+					'items'       => array(
+						'type' => 'string',
+					),
+					'context'     => array( 'embed', 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'view_style_handles'   => array(
+					'description' => __( 'Public facing style handles.' ),
 					'type'        => array( 'array' ),
 					'default'     => array(),
 					'items'       => array(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -603,7 +603,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'view_style_handles'   => array(
+				'view_style_handles'    => array(
 					'description' => __( 'Public facing style handles.' ),
 					'type'        => array( 'array' ),
 					'default'     => array(),

--- a/tests/phpunit/data/blocks/notice/block-view.css
+++ b/tests/phpunit/data/blocks/notice/block-view.css
@@ -1,0 +1,1 @@
+/* Test front end only CSS file */

--- a/tests/phpunit/data/blocks/notice/block.json
+++ b/tests/phpunit/data/blocks/notice/block.json
@@ -69,5 +69,6 @@
 	"viewScript": [ "tests-notice-view-script", "tests-notice-view-script-2" ],
 	"editorStyle": "tests-notice-editor-style",
 	"style": [ "tests-notice-style", "tests-notice-style-2" ],
+	"viewStyle": [ "tests-notice-view-style" ],
 	"render": "file:./render.php"
 }

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -462,7 +462,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		);
 
 		// Test viewStyle property
-		$result   = register_block_style_handle( $metadata, 'viewStyle' );
+		$result = register_block_style_handle( $metadata, 'viewStyle' );
 		$this->assertSame( 'unit-tests-test-block-view-style', $result );
 
 		// @ticket 59673

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -159,7 +159,8 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		// @ticket 59673
 		$this->assertSame(
 			'unit-tests-my-block-view-style',
-			generate_block_asset_handle( $block_name, 'viewStyle' )
+			generate_block_asset_handle( $block_name, 'viewStyle' ),
+			'asset handle for viewStyle is not generated correctly'
 		);
 	}
 
@@ -467,7 +468,8 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		// @ticket 59673
 		$this->assertSame(
 			wp_normalize_path( realpath( DIR_TESTDATA . '/blocks/notice/block-view.css' ) ),
-			wp_normalize_path( wp_styles()->get_data( 'unit-tests-test-block-view-style', 'path' ) )
+			wp_normalize_path( wp_styles()->get_data( 'unit-tests-test-block-view-style', 'path' ) ),
+			'viewStyle asset path is not correct'
 		);
 
 		// Test the behavior directly within the unit test
@@ -734,7 +736,8 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		// @ticket 59673
 		$this->assertSameSets(
 			array( 'tests-notice-view-style' ),
-			$result->view_style_handles
+			$result->view_style_handles,
+			'parsed view_style_handles is not correct'
 		);
 
 		// @ticket 50328
@@ -746,7 +749,8 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		// @ticket 59673
 		$this->assertSame(
 			wp_normalize_path( realpath( DIR_TESTDATA . '/blocks/notice/block-view.css' ) ),
-			wp_normalize_path( wp_styles()->get_data( 'unit-tests-test-block-view-style', 'path' ) )
+			wp_normalize_path( wp_styles()->get_data( 'unit-tests-test-block-view-style', 'path' ) ),
+			'viewStyle asset path is not correct'
 		);
 
 		// @ticket 53148

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -156,6 +156,11 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 			'unit-tests-my-block-style',
 			generate_block_asset_handle( $block_name, 'style' )
 		);
+		// @ticket 59673
+		$this->assertSame(
+			'unit-tests-my-block-view-style',
+			generate_block_asset_handle( $block_name, 'viewStyle' )
+		);
 	}
 
 	/**
@@ -439,9 +444,10 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 */
 	public function test_success_register_block_style_handle() {
 		$metadata = array(
-			'file'  => DIR_TESTDATA . '/blocks/notice/block.json',
-			'name'  => 'unit-tests/test-block',
-			'style' => 'file:./block.css',
+			'file'      => DIR_TESTDATA . '/blocks/notice/block.json',
+			'name'      => 'unit-tests/test-block',
+			'style'     => 'file:./block.css',
+			'viewStyle' => 'file:./block-view.css',
 		);
 		$result   = register_block_style_handle( $metadata, 'style' );
 
@@ -452,6 +458,16 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		$this->assertSame(
 			wp_normalize_path( realpath( DIR_TESTDATA . '/blocks/notice/block.css' ) ),
 			wp_normalize_path( wp_styles()->get_data( 'unit-tests-test-block-style', 'path' ) )
+		);
+
+		// Test viewStyle property
+		$result   = register_block_style_handle( $metadata, 'viewStyle' );
+		$this->assertSame( 'unit-tests-test-block-view-style', $result );
+
+		// @ticket 59673
+		$this->assertSame(
+			wp_normalize_path( realpath( DIR_TESTDATA . '/blocks/notice/block-view.css' ) ),
+			wp_normalize_path( wp_styles()->get_data( 'unit-tests-test-block-view-style', 'path' ) )
 		);
 
 		// Test the behavior directly within the unit test
@@ -715,11 +731,22 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 			array( 'tests-notice-style', 'tests-notice-style-2' ),
 			$result->style_handles
 		);
+		// @ticket 59673
+		$this->assertSameSets(
+			array( 'tests-notice-view-style' ),
+			$result->view_style_handles
+		);
 
 		// @ticket 50328
 		$this->assertSame(
 			wp_normalize_path( realpath( DIR_TESTDATA . '/blocks/notice/block.css' ) ),
 			wp_normalize_path( wp_styles()->get_data( 'unit-tests-test-block-style', 'path' ) )
+		);
+
+		// @ticket 59673
+		$this->assertSame(
+			wp_normalize_path( realpath( DIR_TESTDATA . '/blocks/notice/block-view.css' ) ),
+			wp_normalize_path( wp_styles()->get_data( 'unit-tests-test-block-view-style', 'path' ) )
 		);
 
 		// @ticket 53148

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -553,7 +553,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertCount( 30, $properties );
+		$this->assertCount( 31, $properties );
 		$this->assertArrayHasKey( 'api_version', $properties );
 		$this->assertArrayHasKey( 'name', $properties );
 		$this->assertArrayHasKey( 'title', $properties );
@@ -578,6 +578,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'view_script_handles', $properties );
 		$this->assertArrayHasKey( 'editor_style_handles', $properties );
 		$this->assertArrayHasKey( 'style_handles', $properties );
+		$this->assertArrayHasKey( 'view_style_handles', $properties, 'schema must contain view_style_handles' );
 		$this->assertArrayHasKey( 'is_dynamic', $properties );
 		// Deprecated properties.
 		$this->assertArrayHasKey( 'editor_script', $properties );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Adds a `viewStyle` property for block metadata to allow registering stylesheets/handles, that will only be enqueued on the frontend if a block is rendered (not in the backend). Similar to `viewScript`.
See trac ticket for more information.

Trac ticket: [59673](https://core.trac.wordpress.org/ticket/59673)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
