### PR TITLE
Clear stylesheet and template cache when switching sites

### DIFF
--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -532,8 +532,10 @@ function switch_to_blog( $new_blog_id, $deprecated = null ) {
 	}
 
 	$wpdb->set_blog_id( $new_blog_id );
-	$GLOBALS['table_prefix'] = $wpdb->get_blog_prefix();
-	$GLOBALS['blog_id']      = $new_blog_id;
+	$GLOBALS['table_prefix']       = $wpdb->get_blog_prefix();
+	$GLOBALS['blog_id']            = $new_blog_id;
+	$GLOBALS['wp_template_path']   = null;
+	$GLOBALS['wp_stylesheet_path'] = null;
 
 	if ( function_exists( 'wp_cache_switch_to_blog' ) ) {
 		wp_cache_switch_to_blog( $new_blog_id );
@@ -625,8 +627,10 @@ function restore_current_blog() {
 	}
 
 	$wpdb->set_blog_id( $new_blog_id );
-	$GLOBALS['blog_id']      = $new_blog_id;
-	$GLOBALS['table_prefix'] = $wpdb->get_blog_prefix();
+	$GLOBALS['blog_id']            = $new_blog_id;
+	$GLOBALS['table_prefix']       = $wpdb->get_blog_prefix();
+	$GLOBALS['wp_template_path']   = null;
+	$GLOBALS['wp_stylesheet_path'] = null;
 
 	if ( function_exists( 'wp_cache_switch_to_blog' ) ) {
 		wp_cache_switch_to_blog( $new_blog_id );

--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -491,6 +491,8 @@ function update_blog_option( $id, $option, $value, $deprecated = null ) {
  * @global array           $_wp_switched_stack
  * @global bool            $switched
  * @global string          $table_prefix
+ * @global string          $wp_template_path
+ * @global string          $wp_stylesheet_path
  * @global WP_Object_Cache $wp_object_cache
  *
  * @param int  $new_blog_id The ID of the blog to switch to. Default: current blog.
@@ -602,6 +604,8 @@ function switch_to_blog( $new_blog_id, $deprecated = null ) {
  * @global int             $blog_id
  * @global bool            $switched
  * @global string          $table_prefix
+ * @global string          $wp_template_path
+ * @global string          $wp_stylesheet_path
  * @global WP_Object_Cache $wp_object_cache
  *
  * @return bool True on success, false if we're already on the current blog.

--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -1059,6 +1059,106 @@ class Tests_Theme extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test whether a switched site retrieves the correct stylesheet directory.
+	 *
+	 * @ticket 59677
+	 */
+	public function test_get_stylesheet_directory_with_switched_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Test only runs on multisite.' );
+		}
+
+		$blog_id = self::factory()->blog->create();
+
+		update_blog_option( $blog_id, 'stylesheet', 'switched_stylesheet' );
+
+		// Prime global storage with the current site's data.
+		get_stylesheet_directory();
+
+		switch_to_blog( $blog_id );
+		$switched_stylesheet = get_stylesheet_directory();
+		restore_current_blog();
+
+		$this->assertSame( WP_CONTENT_DIR . '/themes/switched_stylesheet', $switched_stylesheet );
+	}
+
+	/**
+	 * Test whether a switched site retrieves the correct template directory.
+	 *
+	 * @ticket 59677
+	 */
+	public function test_get_template_directory_with_switched_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Test only runs on multisite.' );
+		}
+
+		$blog_id = self::factory()->blog->create();
+
+		update_blog_option( $blog_id, 'template', 'switched_template' );
+
+		// Prime global storage with the current site's data.
+		get_template_directory();
+
+		switch_to_blog( $blog_id );
+		$switched_template = get_template_directory();
+		restore_current_blog();
+
+		$this->assertSame( WP_CONTENT_DIR . '/themes/switched_template', $switched_template );
+	}
+
+	/**
+	 * Test whether a restored site retrieves the correct stylesheet directory.
+	 *
+	 * @ticket 59677
+	 */
+	public function test_get_stylesheet_directory_with_restored_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Test only runs on multisite.' );
+		}
+
+		$blog_id = self::factory()->blog->create();
+
+		update_option( 'stylesheet', 'original_stylesheet' );
+		update_blog_option( $blog_id, 'stylesheet', 'switched_stylesheet' );
+
+		$stylesheet = get_stylesheet_directory();
+
+		switch_to_blog( $blog_id );
+
+		// Prime global storage with the restored site's data.
+		get_stylesheet_directory();
+		restore_current_blog();
+
+		$this->assertSame( WP_CONTENT_DIR . '/themes/original_stylesheet', $stylesheet );
+	}
+
+	/**
+	 * Test whether a restored site retrieves the correct template directory.
+	 *
+	 * @ticket 59677
+	 */
+	public function test_get_template_directory_with_restored_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Test only runs on multisite.' );
+		}
+
+		$blog_id = self::factory()->blog->create();
+
+		update_option( 'template', 'original_template' );
+		update_blog_option( $blog_id, 'template', 'switched_template' );
+
+		$template = get_template_directory();
+
+		switch_to_blog( $blog_id );
+
+		// Prime global storage with the switched site's data.
+		get_template_directory();
+		restore_current_blog();
+
+		$this->assertSame( WP_CONTENT_DIR . '/themes/original_template', $template );
+	}
+
+	/**
 	 * Helper function to ensure that a block theme is available and active.
 	 */
 	private function helper_requires_block_theme() {

--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -1059,7 +1059,7 @@ class Tests_Theme extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test whether a switched site retrieves the correct stylesheet directory.
+	 * Tests whether a switched site retrieves the correct stylesheet directory.
 	 *
 	 * @ticket 59677
 	 * @group ms-required
@@ -1082,7 +1082,7 @@ class Tests_Theme extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test whether a switched site retrieves the correct template directory.
+	 * Tests whether a switched site retrieves the correct template directory.
 	 *
 	 * @ticket 59677
 	 * @group ms-required
@@ -1105,7 +1105,7 @@ class Tests_Theme extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test whether a restored site retrieves the correct stylesheet directory.
+	 * Tests whether a restored site retrieves the correct stylesheet directory.
 	 *
 	 * @ticket 59677
 	 * @group ms-required
@@ -1130,7 +1130,7 @@ class Tests_Theme extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test whether a restored site retrieves the correct template directory.
+	 * Tests whether a restored site retrieves the correct template directory.
 	 *
 	 * @ticket 59677
 	 * @group ms-required

--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -1062,12 +1062,11 @@ class Tests_Theme extends WP_UnitTestCase {
 	 * Test whether a switched site retrieves the correct stylesheet directory.
 	 *
 	 * @ticket 59677
+	 * @group ms-required
+	 *
+	 * @covers ::get_stylesheet_directory
 	 */
 	public function test_get_stylesheet_directory_with_switched_site() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'Test only runs on multisite.' );
-		}
-
 		$blog_id = self::factory()->blog->create();
 
 		update_blog_option( $blog_id, 'stylesheet', 'switched_stylesheet' );
@@ -1086,12 +1085,11 @@ class Tests_Theme extends WP_UnitTestCase {
 	 * Test whether a switched site retrieves the correct template directory.
 	 *
 	 * @ticket 59677
+	 * @group ms-required
+	 *
+	 * @covers ::get_template_directory
 	 */
 	public function test_get_template_directory_with_switched_site() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'Test only runs on multisite.' );
-		}
-
 		$blog_id = self::factory()->blog->create();
 
 		update_blog_option( $blog_id, 'template', 'switched_template' );
@@ -1110,12 +1108,11 @@ class Tests_Theme extends WP_UnitTestCase {
 	 * Test whether a restored site retrieves the correct stylesheet directory.
 	 *
 	 * @ticket 59677
+	 * @group ms-required
+	 *
+	 * @covers ::get_stylesheet_directory
 	 */
 	public function test_get_stylesheet_directory_with_restored_site() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'Test only runs on multisite.' );
-		}
-
 		$blog_id = self::factory()->blog->create();
 
 		update_option( 'stylesheet', 'original_stylesheet' );
@@ -1136,12 +1133,11 @@ class Tests_Theme extends WP_UnitTestCase {
 	 * Test whether a restored site retrieves the correct template directory.
 	 *
 	 * @ticket 59677
+	 * @group ms-required
+	 *
+	 * @covers ::get_template_directory
 	 */
 	public function test_get_template_directory_with_restored_site() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'Test only runs on multisite.' );
-		}
-
 		$blog_id = self::factory()->blog->create();
 
 		update_option( 'template', 'original_template' );


### PR DESCRIPTION
This nulls the global `wp_template_path` and `wp_stylesheet_path` data whenever a site is switched or restored so that the next call to `get_stylesheet_directory()` or `get_template_directory()` will provide fresh data.

See https://core.trac.wordpress.org/ticket/59677

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/59677

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
