### PR TITLE
Backport/55415 make duotone support compatible with enhanced pagination

### DIFF
--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -1074,7 +1074,7 @@ class WP_Duotone {
 	 * @return string Filtered block content.
 	 */
 	public static function render_duotone_support( $block_content, $block, $wp_block ) {
-		if ( empty( $block_content ) || ! $block['blockName'] ) {
+		if ( ! $block['blockName'] ) {
 			return $block_content;
 		}
 		$duotone_selector = self::get_selector( $wp_block->block_type );

--- a/tests/phpunit/tests/block-supports/duotone.php
+++ b/tests/phpunit/tests/block-supports/duotone.php
@@ -119,7 +119,7 @@ class Tests_Block_Supports_Duotone extends WP_UnitTestCase {
 		$wp_block                        = new WP_Block( $block );
 		$block_css_declarations_property = new ReflectionProperty( 'WP_Duotone', 'block_css_declarations' );
 		$block_css_declarations_property->setAccessible( true );
-		$block_css_declarations_property->setValue( array() );
+		$block_css_declarations_property->setValue( $wp_block, array() );
 
 		WP_Duotone::render_duotone_support( '', $block, $wp_block );
 		$actual = $block_css_declarations_property->getValue();

--- a/tests/phpunit/tests/block-supports/duotone.php
+++ b/tests/phpunit/tests/block-supports/duotone.php
@@ -84,6 +84,29 @@ class Tests_Block_Supports_Duotone extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests whether the CSS declarations are generated even if the block content is
+	 * empty. We need this to make the CSS output stable across paginations for
+	 * features like the enhanced pagination of the Query block.
+	 *
+	 * @ticket 59694
+	 *
+	 * @covers ::render_duotone_support
+	 */
+	public function test_css_declarations_are_generated_even_with_empty_block_content() {
+		$block                           = array(
+			'blockName' => 'core/image',
+			'attrs'     => array( 'style' => array( 'color' => array( 'duotone' => 'var:preset|duotone|blue-orange' ) ) ),
+		);
+		$wp_block                        = new WP_Block( $block );
+		$block_css_declarations_property = new ReflectionProperty( 'WP_Duotone', 'block_css_declarations' );
+		$block_css_declarations_property->setAccessible( true );
+		$block_css_declarations_property->setValue( array() );
+		WP_Duotone::render_duotone_support( '', $block, $wp_block );
+		$this->assertNotEmpty( $block_css_declarations_property->getValue() );
+	}
+
+
+	/**
 	 * Data provider.
 	 *
 	 * @return array[].

--- a/tests/phpunit/tests/block-supports/duotone.php
+++ b/tests/phpunit/tests/block-supports/duotone.php
@@ -85,7 +85,7 @@ class Tests_Block_Supports_Duotone extends WP_UnitTestCase {
 
 	/**
 	 * Tests whether the CSS declarations are generated even if the block content is
-	 * empty. We need this to make the CSS output stable across paginations for
+	 * empty. This is needed to make the CSS output stable across paginations for
 	 * features like the enhanced pagination of the Query block.
 	 *
 	 * @ticket 59694
@@ -104,7 +104,6 @@ class Tests_Block_Supports_Duotone extends WP_UnitTestCase {
 		WP_Duotone::render_duotone_support( '', $block, $wp_block );
 		$this->assertNotEmpty( $block_css_declarations_property->getValue() );
 	}
-
 
 	/**
 	 * Data provider.

--- a/tests/phpunit/tests/block-supports/duotone.php
+++ b/tests/phpunit/tests/block-supports/duotone.php
@@ -84,6 +84,25 @@ class Tests_Block_Supports_Duotone extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Data provider.
+	 *
+	 * @return array[].
+	 */
+	public function data_get_slug_from_attribute() {
+		return array(
+			'pipe-slug'                       => array( 'var:preset|duotone|blue-orange', 'blue-orange' ),
+			'css-var'                         => array( 'var(--wp--preset--duotone--blue-orange)', 'blue-orange' ),
+			'css-var-invalid-slug-chars'      => array( 'var(--wp--preset--duotone--.)', '.' ),
+			'css-var-missing-end-parenthesis' => array( 'var(--wp--preset--duotone--blue-orange', '' ),
+			'invalid'                         => array( 'not a valid attribute', '' ),
+			'css-var-no-value'                => array( 'var(--wp--preset--duotone--)', '' ),
+			'pipe-slug-no-value'              => array( 'var:preset|duotone|', '' ),
+			'css-var-spaces'                  => array( 'var(--wp--preset--duotone--    ', '' ),
+			'pipe-slug-spaces'                => array( 'var:preset|duotone|  ', '' ),
+		);
+	}
+
+	/**
 	 * Tests whether the CSS declarations are generated even if the block content is
 	 * empty. This is needed to make the CSS output stable across paginations for
 	 * features like the enhanced pagination of the Query block.
@@ -103,25 +122,6 @@ class Tests_Block_Supports_Duotone extends WP_UnitTestCase {
 		$block_css_declarations_property->setValue( array() );
 		WP_Duotone::render_duotone_support( '', $block, $wp_block );
 		$this->assertNotEmpty( $block_css_declarations_property->getValue() );
-	}
-
-	/**
-	 * Data provider.
-	 *
-	 * @return array[].
-	 */
-	public function data_get_slug_from_attribute() {
-		return array(
-			'pipe-slug'                       => array( 'var:preset|duotone|blue-orange', 'blue-orange' ),
-			'css-var'                         => array( 'var(--wp--preset--duotone--blue-orange)', 'blue-orange' ),
-			'css-var-invalid-slug-chars'      => array( 'var(--wp--preset--duotone--.)', '.' ),
-			'css-var-missing-end-parenthesis' => array( 'var(--wp--preset--duotone--blue-orange', '' ),
-			'invalid'                         => array( 'not a valid attribute', '' ),
-			'css-var-no-value'                => array( 'var(--wp--preset--duotone--)', '' ),
-			'pipe-slug-no-value'              => array( 'var:preset|duotone|', '' ),
-			'css-var-spaces'                  => array( 'var(--wp--preset--duotone--    ', '' ),
-			'pipe-slug-spaces'                => array( 'var:preset|duotone|  ', '' ),
-		);
 	}
 
 	/**

--- a/tests/phpunit/tests/block-supports/duotone.php
+++ b/tests/phpunit/tests/block-supports/duotone.php
@@ -120,8 +120,13 @@ class Tests_Block_Supports_Duotone extends WP_UnitTestCase {
 		$block_css_declarations_property = new ReflectionProperty( 'WP_Duotone', 'block_css_declarations' );
 		$block_css_declarations_property->setAccessible( true );
 		$block_css_declarations_property->setValue( array() );
+
 		WP_Duotone::render_duotone_support( '', $block, $wp_block );
-		$this->assertNotEmpty( $block_css_declarations_property->getValue() );
+		$actual = $block_css_declarations_property->getValue();
+		// Reset the property's visibility.
+		$block_css_declarations_property->setAccessible( false );
+
+		$this->assertNotEmpty( $actual );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
Co-authored with @luisherranz

Trac ticket: https://core.trac.wordpress.org/ticket/59694

This PR backports [#55415](https://github.com/WordPress/gutenberg/pull/55415) that fixes an issue with duotone and enhanced pagination. All the context is inside Gutenberg PR.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
