### PR TITLE
Sanitize apostrophe characters in post slug

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2335,6 +2335,13 @@ function sanitize_title_with_dashes( $title, $raw_title = '', $context = 'displa
 				'%cc%80',
 				'%cc%84',
 				'%cc%8c',
+				// Apostrophes.
+				'%ca%bc',
+				'%cb%ae',
+				'%d5%9a',
+				'%df%b4',
+				'%df%b5',
+				'%ef%bc%87',
 				// Non-visible characters that display without a width.
 				'%e2%80%8b', // Zero width space.
 				'%e2%80%8c', // Zero width non-joiner.


### PR DESCRIPTION
Added apostrophe character codes to the list of symbols which must be stripped from post URL slug

It replaces characters:

`ʼ` (U+02BC);
`ˮ` (U+02EE);
`՚` (U+055A);
`ߴ` (U+07F5);
`ߵ` (U+07F4);
`＇` (U+FF07)

with empty string.

Trac ticket: https://core.trac.wordpress.org/ticket/59691
