### PR TITLE
Rename `prime_options()` to `wp_load_options()`

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -248,17 +248,17 @@ function get_option( $option, $default_value = false ) {
 }
 
 /**
- * Primes specific options into the cache with a single database query.
+ * Loads specific options into the cache with a single database query.
  *
- * Only options that do not already exist in cache will be primed.
+ * Only options that do not already exist in cache will be loaded.
  *
  * @since 6.4.0
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
- * @param array $options An array of option names to be primed.
+ * @param array $options An array of option names to be loaded.
  */
-function prime_options( $options ) {
+function wp_load_options( $options ) {
 	$alloptions     = wp_load_alloptions();
 	$cached_options = wp_cache_get_multiple( $options, 'options' );
 
@@ -270,7 +270,7 @@ function prime_options( $options ) {
 		}
 	}
 
-	// Bail early if there are no options to be primed.
+	// Bail early if there are no options to be loaded.
 	if ( empty( $options_to_prime ) ) {
 		return;
 	}
@@ -321,26 +321,26 @@ function prime_options( $options ) {
 }
 
 /**
- * Primes all options registered with a specific option group.
+ * Loads all options registered with a specific option group.
  *
  * @since 6.4.0
  *
  * @global array $new_allowed_options
  *
- * @param string $option_group The option group to prime options for.
+ * @param string $option_group The option group to load options for.
  */
-function prime_options_by_group( $option_group ) {
+function wp_load_options_by_group( $option_group ) {
 	global $new_allowed_options;
 
 	if ( isset( $new_allowed_options[ $option_group ] ) ) {
-		prime_options( $new_allowed_options[ $option_group ] );
+		wp_load_options( $new_allowed_options[ $option_group ] );
 	}
 }
 
 /**
  * Retrieves multiple options.
  *
- * Options are primed as necessary first in order to use a single database query at most.
+ * Options are loaded as necessary first in order to use a single database query at most.
  *
  * @since 6.4.0
  *
@@ -348,7 +348,7 @@ function prime_options_by_group( $option_group ) {
  * @return array An array of key-value pairs for the requested options.
  */
 function get_options( $options ) {
-	prime_options( $options );
+	wp_load_options( $options );
 
 	$result = array();
 	foreach ( $options as $option ) {

--- a/tests/phpunit/tests/option/wpLoadOptions.php
+++ b/tests/phpunit/tests/option/wpLoadOptions.php
@@ -1,21 +1,21 @@
 <?php
 /**
- * Test prime_options().
+ * Test wp_load_options().
  *
  * @group option
  *
- * @covers ::prime_options
+ * @covers ::wp_load_options
  */
 class Tests_Option_PrimeOptions extends WP_UnitTestCase {
 
 	/**
-	 * Tests that prime_options() primes multiple options.
+	 * Tests that wp_load_options() loads multiple options.
 	 *
 	 * @ticket 58962
 	 */
-	public function test_prime_options() {
-		// Create some options to prime.
-		$options_to_prime = array(
+	public function test_wp_load_options() {
+		// Create some options to load.
+		$options_to_load = array(
 			'option1',
 			'option2',
 			'option3',
@@ -26,30 +26,30 @@ class Tests_Option_PrimeOptions extends WP_UnitTestCase {
 		 * clear the cache for the options,
 		 * check options are not in cache initially.
 		 */
-		foreach ( $options_to_prime as $option ) {
+		foreach ( $options_to_load as $option ) {
 			update_option( $option, "value_$option", false );
 			wp_cache_delete( $option, 'options' );
 			$this->assertFalse( wp_cache_get( $option, 'options' ), "$option was not deleted from the cache." );
 		}
 
-		// Call the prime_options function to prime the options.
-		prime_options( $options_to_prime );
+		// Call the wp_load_options function to load the options.
+		wp_load_options( $options_to_load );
 
 		// Store the initial database query count.
 		$initial_query_count = get_num_queries();
 
 		// Check that options are only in the 'options' cache group.
-		foreach ( $options_to_prime as $option ) {
+		foreach ( $options_to_load as $option ) {
 			$this->assertSame(
 				wp_cache_get( $option, 'options' ),
 				get_option( $option ),
-				"$option was not primed to the 'options' cache group."
+				"$option was not loaded to the 'options' cache group."
 			);
 
 			$this->assertFalse(
 				wp_cache_get( $option, 'notoptions' ),
 				get_option( $option ),
-				"$option was primed to the 'notoptions' cache group."
+				"$option was loaded to the 'notoptions' cache group."
 			);
 		}
 
@@ -62,13 +62,13 @@ class Tests_Option_PrimeOptions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests prime_options() with options that do not exist in the database.
+	 * Tests wp_load_options() with options that do not exist in the database.
 	 *
 	 * @ticket 58962
 	 */
-	public function test_prime_options_with_nonexistent_options() {
-		// Create some options to prime.
-		$options_to_prime = array(
+	public function test_wp_load_options_with_nonexistent_options() {
+		// Create some options to load.
+		$options_to_load = array(
 			'option1',
 			'option2',
 		);
@@ -78,50 +78,50 @@ class Tests_Option_PrimeOptions extends WP_UnitTestCase {
 		 * clear the cache for the options,
 		 * check options are not in cache initially.
 		 */
-		foreach ( $options_to_prime as $option ) {
+		foreach ( $options_to_load as $option ) {
 			$this->assertFalse( wp_cache_get( $option, 'options' ), "$option was not deleted from the cache." );
 		}
 
-		// Call the prime_options function to prime the options.
-		prime_options( $options_to_prime );
+		// Call the wp_load_options function to load the options.
+		wp_load_options( $options_to_load );
 
 		// Check that options are not in the cache or database.
-		foreach ( $options_to_prime as $option ) {
+		foreach ( $options_to_load as $option ) {
 			$this->assertFalse( wp_cache_get( $option, 'options' ), "$option was not deleted from the cache." );
 		}
 
 		// Check that options are present in the notoptions cache.
 		$new_notoptions = wp_cache_get( 'notoptions', 'options' );
 		$this->assertIsArray( $new_notoptions, 'The notoptions cache should be an array.' );
-		foreach ( $options_to_prime as $option ) {
+		foreach ( $options_to_load as $option ) {
 			$this->assertArrayHasKey( $option, $new_notoptions, "$option was not added to the notoptions cache." );
 		}
 	}
 
 	/**
-	 * Tests prime_options() with an empty array.
+	 * Tests wp_load_options() with an empty array.
 	 *
 	 * @ticket 58962
 	 */
-	public function test_prime_options_with_empty_array() {
+	public function test_wp_load_options_with_empty_array() {
 		$alloptions = wp_load_alloptions();
 		$notoptions = wp_cache_get( 'notoptions', 'options' );
 
-		prime_options( array() );
+		wp_load_options( array() );
 
 		$this->assertSame( $alloptions, wp_cache_get( 'alloptions', 'options' ), 'The alloptions cache was modified.' );
 		$this->assertSame( $notoptions, wp_cache_get( 'notoptions', 'options' ), 'The notoptions cache was modified.' );
 	}
 
 	/**
-	 * Tests that prime_options handles an empty "notoptions" cache.
+	 * Tests that wp_load_options handles an empty "notoptions" cache.
 	 *
 	 * @ticket 58962
 	 */
-	public function test_prime_options_handles_empty_notoptions_cache() {
+	public function test_wp_load_options_handles_empty_notoptions_cache() {
 		wp_cache_delete( 'notoptions', 'options' );
 
-		prime_options( array( 'nonexistent_option' ) );
+		wp_load_options( array( 'nonexistent_option' ) );
 
 		$notoptions = wp_cache_get( 'notoptions', 'options' );
 		$this->assertIsArray( $notoptions, 'The notoptions cache should be an array.' );

--- a/tests/phpunit/tests/option/wpLoadOptionsByGroup.php
+++ b/tests/phpunit/tests/option/wpLoadOptionsByGroup.php
@@ -1,22 +1,22 @@
 <?php
 /**
- * Test prime_options_by_group().
+ * Test wp_load_options_by_group().
  *
  * @group option
  *
- * @covers ::prime_options_by_group
+ * @covers ::wp_load_options_by_group
  */
 class Tests_Option_PrimeOptionsByGroup extends WP_UnitTestCase {
 
 	/**
-	 * Tests that prime_options_by_group() only primes options in the specified group.
+	 * Tests that wp_load_options_by_group() only loads options in the specified group.
 	 *
 	 * @ticket 58962
 	 */
-	public function test_prime_options_by_group() {
+	public function test_wp_load_options_by_group() {
 		global $new_allowed_options;
 
-		// Create some options to prime.
+		// Create some options to load.
 		$new_allowed_options = array(
 			'group1' => array(
 				'option1',
@@ -27,7 +27,7 @@ class Tests_Option_PrimeOptionsByGroup extends WP_UnitTestCase {
 			),
 		);
 
-		$options_to_prime = array(
+		$options_to_load = array(
 			'option1',
 			'option2',
 			'option3',
@@ -38,35 +38,35 @@ class Tests_Option_PrimeOptionsByGroup extends WP_UnitTestCase {
 		 * clear the cache for the options,
 		 * check options are not in cache initially.
 		 */
-		foreach ( $options_to_prime as $option ) {
+		foreach ( $options_to_load as $option ) {
 			update_option( $option, "value_$option", false );
 			wp_cache_delete( $option, 'options' );
 			$this->assertFalse( wp_cache_get( $option, 'options' ), "$option was not deleted from the cache." );
 		}
 
-		// Call the prime_options_by_group function to prime the options.
-		prime_options_by_group( 'group1' );
+		// Call the wp_load_options_by_group function to load the options.
+		wp_load_options_by_group( 'group1' );
 
 		// Check that options are now in the cache.
-		$this->assertSame( get_option( 'option1' ), wp_cache_get( 'option1', 'options' ), 'option1 was not primed.' );
-		$this->assertSame( get_option( 'option2' ), wp_cache_get( 'option2', 'options' ), 'option2 was not primed.' );
+		$this->assertSame( get_option( 'option1' ), wp_cache_get( 'option1', 'options' ), 'option1 was not loaded.' );
+		$this->assertSame( get_option( 'option2' ), wp_cache_get( 'option2', 'options' ), 'option2 was not loaded.' );
 
 		// Make sure option3 is still not in cache.
 		$this->assertFalse( wp_cache_get( 'option3', 'options' ), 'option3 was not deleted from the cache.' );
 	}
 
 	/**
-	 * Tests prime_options_by_group() with a nonexistent option group.
+	 * Tests wp_load_options_by_group() with a nonexistent option group.
 	 *
 	 * @ticket 58962
 	 */
-	public function test_prime_options_by_group_with_nonexistent_group() {
+	public function test_wp_load_options_by_group_with_nonexistent_group() {
 		// Make sure options are not in cache or database initially.
 		$this->assertFalse( wp_cache_get( 'option1', 'options' ), 'option1 was not deleted from the cache.' );
 		$this->assertFalse( wp_cache_get( 'option2', 'options' ), 'option2 was not deleted from the cache.' );
 
-		// Call the prime_options_by_group function with a nonexistent group.
-		prime_options_by_group( 'nonexistent_group' );
+		// Call the wp_load_options_by_group function with a nonexistent group.
+		wp_load_options_by_group( 'nonexistent_group' );
 
 		// Check that options are still not in the cache or database.
 		$this->assertFalse( wp_cache_get( 'option1', 'options' ), 'option1 was not deleted from the cache.' );


### PR DESCRIPTION
Per the latest discussion on the ticket, this PR renames the functions:
* `prime_options()` to `wp_load_options()`
* `prime_options_by_group()` to `wp_load_options_by_group()`

Trac ticket: https://core.trac.wordpress.org/ticket/58962

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
