### PR TITLE
r56991 Test: Fixes static property handling.

### DIFF
--- a/tests/phpunit/tests/block-supports/duotone.php
+++ b/tests/phpunit/tests/block-supports/duotone.php
@@ -112,18 +112,24 @@ class Tests_Block_Supports_Duotone extends WP_UnitTestCase {
 	 * @covers ::render_duotone_support
 	 */
 	public function test_css_declarations_are_generated_even_with_empty_block_content() {
-		$block                           = array(
+		$block    = array(
 			'blockName' => 'core/image',
 			'attrs'     => array( 'style' => array( 'color' => array( 'duotone' => 'var:preset|duotone|blue-orange' ) ) ),
 		);
-		$wp_block                        = new WP_Block( $block );
-		$block_css_declarations_property = new ReflectionProperty( 'WP_Duotone', 'block_css_declarations' );
+		$wp_block = new WP_Block( $block );
+
+		// Work with the static private property.
+		$wp_duotone_reflected_class      = new ReflectionClass( WP_Duotone::class );
+		$block_css_declarations_property = $wp_duotone_reflected_class->getProperty( 'block_css_declarations' );
 		$block_css_declarations_property->setAccessible( true );
-		$block_css_declarations_property->setValue( $wp_block, array() );
+		$previous_value = $wp_duotone_reflected_class->getStaticPropertyValue( 'block_css_declarations' );
+		$wp_duotone_reflected_class->setStaticPropertyValue( 'block_css_declarations', array() );
 
 		WP_Duotone::render_duotone_support( '', $block, $wp_block );
-		$actual = $block_css_declarations_property->getValue();
-		// Reset the property's visibility.
+		$actual = $wp_duotone_reflected_class->getStaticPropertyValue( 'block_css_declarations' );
+
+		// Reset the static property's visibility.
+		$wp_duotone_reflected_class->setStaticPropertyValue( 'block_css_declarations', $previous_value );
 		$block_css_declarations_property->setAccessible( false );
 
 		$this->assertNotEmpty( $actual );


### PR DESCRIPTION
@costdev found the test in [r56991](https://core.trac.wordpress.org/changeset/56991) did not properly handle the private static property:

* It set the object using `WP_Block` 🤦‍♀️ 
* It needs to also reset to the original value when done.

As this property is `static` and the class is also static by design, an object cannot be passed when setting the value. Instead, `ReflectionClass` is needed, which exposes a getter (`getStaticPropertyValue()`) and setter (`setStaticPropertyValue()`) for static properties.

Why use `ReflectionClass::getStaticPropertyValue()` and `ReflectionClass::setStaticPropertyValue()` instead of the `ReflectionProperty:: getProperty()` and `ReflectionProperty:: setProperty()`?

IMO these 2 methods are more readable and understandable as they make clear: "Hey, this is for a static property".

Trac ticket: https://core.trac.wordpress.org/ticket/59694

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
