### PR TITLE
r56991 Test 2: Fixes static property handling. 

### DIFF
--- a/tests/phpunit/tests/block-supports/duotone.php
+++ b/tests/phpunit/tests/block-supports/duotone.php
@@ -119,11 +119,11 @@ class Tests_Block_Supports_Duotone extends WP_UnitTestCase {
 		$wp_block = new WP_Block( $block );
 
 		/*
-		 * Handling to access the static WP_Duotone::#block_css_declarations property.
+		 * Handling to access the static WP_Duotone::$block_css_declarations property.
 		 *
 		 * Why is an instance needed?
 		 * WP_Duotone is a static class by design, meaning it only contains static properties and methods.
-		 * In production, it should not be instantiated. However, as PHP 8.3, ReflectionProperty::setValue() needs
+		 * In production, it should not be instantiated. However, as of PHP 8.3, ReflectionProperty::setValue() needs
 		 * an object.
 		 */
 		$wp_duotone                      = new WP_Duotone();

--- a/tests/phpunit/tests/block-supports/duotone.php
+++ b/tests/phpunit/tests/block-supports/duotone.php
@@ -123,12 +123,11 @@ class Tests_Block_Supports_Duotone extends WP_UnitTestCase {
 		 *
 		 * Why is an instance needed?
 		 * WP_Duotone is a static class by design, meaning it only contains static properties and methods.
-		 * In production, it should not be instantiated. However, as of PHP 8.3, ReflectionProperty::setValue() needs
-		 * an object.
+		 * In production, it should not be instantiated. However, as of PHP 8.3, ReflectionProperty::setValue()
+		 * needs an object.
 		 */
 		$wp_duotone                      = new WP_Duotone();
-		$wp_duotone_reflected_class      = new ReflectionClass( WP_Duotone::class );
-		$block_css_declarations_property = $wp_duotone_reflected_class->getProperty( 'block_css_declarations' );
+		$block_css_declarations_property = new ReflectionProperty( 'WP_Duotone', 'block_css_declarations' );
 		$block_css_declarations_property->setAccessible( true );
 		$previous_value = $block_css_declarations_property->getValue();
 		$block_css_declarations_property->setValue( $wp_duotone, array() );


### PR DESCRIPTION
@costdev found the test in [r56991](https://core.trac.wordpress.org/changeset/56991) did not properly handle the private static property:

* It set the object using `WP_Block` 🤦‍♀️ 
* It needs to also reset to the original value when done.

This PR fixes both of these issues.

It also addresses handling issues.

It also adds an inline comment to explain why an instance of `WP_Duotone` is needed. IMO having an instance is confusing. 
 Why? `WP_Duotone` is a static class by design (as noted above), meaning it's not intended to be an object.  But as of PHP 8.3, not passing an instance to `ReflectionProperty::setValue()` is deprecated. Therefore, an instance is needed to run in all Core supported PHP versions.

Trac ticket: https://core.trac.wordpress.org/ticket/59694

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
