### PR TITLE
WIP: HTML API: Add function to balance tags ala `force_balance_tags()`

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-open-elements.php
+++ b/src/wp-includes/html-api/class-wp-html-open-elements.php
@@ -52,6 +52,13 @@ class WP_HTML_Open_Elements {
 	private $has_p_in_button_scope = false;
 
 	/**
+	 * Called when an element is popped from the stack of open elements.
+	 *
+	 * @var callable|null
+	 */
+	public $on_pop = null;
+
+	/**
 	 * Reports if a specific node is in the stack of open elements.
 	 *
 	 * @since 6.4.0
@@ -427,6 +434,10 @@ class WP_HTML_Open_Elements {
 			case 'P':
 				$this->has_p_in_button_scope = $this->has_element_in_button_scope( 'P' );
 				break;
+		}
+
+		if ( $this->on_pop ) {
+			call_user_func( $this->on_pop, $item );
 		}
 	}
 }

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -474,6 +474,60 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	}
 
 	/**
+	 * Balances tags
+	 *
+	 * @throws Exception When bookmarks can't be created.
+	 *
+	 * @param string $html HTML to balance.
+	 *
+	 * @return string
+	 */
+	public static function balance_tags( $html ) {
+		$processor = self::create_fragment( $html );
+		$output    = '';
+		$at        = 0;
+
+		/**
+		 * Adds closing tags.
+		 *
+		 * @param WP_HTML_Token $item Item popped off of stack.
+		 *
+		 * @return void
+		 */
+		$close_tag = function ( $item ) use ( &$at, $html, &$output, $processor ) {
+			if ( $processor->is_tag_closer() ) {
+				return;
+			}
+			$token    = $processor->bookmarks[ $processor->state->current_token->bookmark_name ];
+			$output  .= substr( $html, $at, $token->start - $at );
+			$tag_name = substr( $html, $processor->bookmarks[ $item->bookmark_name ]->start + 1, strlen( $item->node_name ) );
+			if ( null === $processor->get_last_error() ) {
+				$output .= "</{$tag_name}>";
+			}
+			$at = $token->start;
+		};
+
+		$processor->state->stack_of_open_elements->on_pop = $close_tag;
+		while ( $processor->next_tag() ) {
+			continue;
+		}
+
+		$output .= substr( $html, $at );
+
+		foreach ( $processor->state->stack_of_open_elements->walk_up() as $item ) {
+			if ( 'context-node' === $item->bookmark_name ) {
+				break;
+			}
+			$tag_name = substr( $html, $processor->bookmarks[ $item->bookmark_name ]->start + 1, strlen( $item->node_name ) );
+			if ( null === $processor->get_last_error() ) {
+				$output .= "</{$tag_name}>";
+			}
+		}
+
+		return $output;
+	}
+
+	/**
 	 * Steps through the HTML document and stop at the next tag, if any.
 	 *
 	 * @since 6.4.0


### PR DESCRIPTION
 - adds closing tags to open elements _when they implicitly close_
 - does not add closing tag when hitting unsupported content that would require reconstructing active formatting elements

```html
<p><div><button>First<button><b here>Second
↧
<p></p><div><button>First</button><button><b here>Second</b></button></div>
```

```html
<p><div>asdf</p><p>Inside</p></figcaption><button>First<button><b here>Second</span></button>
↧
<p></p><div>asdf<p>Inside</p><button>First</button><button><b here>Second</button></div>
```