### PR TITLE
Avoid overriding `excerpt_length` when doing ajax

### DIFF
--- a/src/wp-includes/blocks/post-excerpt.php
+++ b/src/wp-includes/blocks/post-excerpt.php
@@ -83,7 +83,7 @@ add_action( 'init', 'register_block_core_post_excerpt' );
  * the excerpt length block setting has no effect.
  * Returns 100 because 100 is the max length in the setting.
  */
-if ( is_admin() ||
+if ( ( is_admin() && ! wp_doing_ajax() ) ||
 	defined( 'REST_REQUEST' ) && REST_REQUEST ) {
 	add_filter(
 		'excerpt_length',


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

 A filter added to make post excerpt length to 100 in the context of block editor ([see here](https://github.com/WordPress/wordpress-develop/commit/a710b97e7c7463d663664f7266ce6d72eb95238c#diff-662eebf6d91c9208094ca7df3c7a1e26d3dd96162004d3291a84a5a0aef705c9R86-R95)) makes it impossible for excerpt_length to be overridden when doing ajax.
This PR opts out when doing ajax, allowing themes, plugins override the `excerpt_length` when doing ajax (for example fetching a post template via ajax)

Trac ticket: https://core.trac.wordpress.org/ticket/59714

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
