### PR TITLE
fix: `rest_pre_serve_request` needs to run after `rest_send_nocache_h…

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -467,22 +467,6 @@ class WP_REST_Server {
 		$this->set_status( $code );
 
 		/**
-		 * Filters whether the REST API request has already been served.
-		 *
-		 * Allow sending the request manually - by returning true, the API result
-		 * will not be sent to the client.
-		 *
-		 * @since 4.4.0
-		 *
-		 * @param bool             $served  Whether the request has already been served.
-		 *                                           Default false.
-		 * @param WP_HTTP_Response $result  Result to send to the client. Usually a `WP_REST_Response`.
-		 * @param WP_REST_Request  $request Request used to generate the response.
-		 * @param WP_REST_Server   $server  Server instance.
-		 */
-		$served = apply_filters( 'rest_pre_serve_request', false, $result, $request, $this );
-
-		/**
 		 * Filters whether to send nocache headers on a REST API request.
 		 *
 		 * @since 4.4.0
@@ -503,6 +487,22 @@ class WP_REST_Server {
 				}
 			}
 		}
+
+		/**
+		 * Filters whether the REST API request has already been served.
+		 *
+		 * Allow sending the request manually - by returning true, the API result
+		 * will not be sent to the client.
+		 *
+		 * @since 4.4.0
+		 *
+		 * @param bool             $served  Whether the request has already been served.
+		 *                                           Default false.
+		 * @param WP_HTTP_Response $result  Result to send to the client. Usually a `WP_REST_Response`.
+		 * @param WP_REST_Request  $request Request used to generate the response.
+		 * @param WP_REST_Server   $server  Server instance.
+		 */
+		$served = apply_filters( 'rest_pre_serve_request', false, $result, $request, $this );
 
 		if ( ! $served ) {
 			if ( 'HEAD' === $request->get_method() ) {


### PR DESCRIPTION
The `rest_send_nocache_headers` block was moved after `rest_pre_serve_request` in https://github.com/WordPress/WordPress/commit/3f1e6a6a5031b319fd5ebfaaf6598fec3fe78fb1.

This renders `rest_pre_serve_request` useless because `rest_send_nocache_headers` sends / removes http headers. As a result, using `rest_pre_serve_request` for it's intended purpose (to manually send the request) results in:

`Cannot modify header information - headers already sent.`

Suggest moving the `rest_send_nocache_headers` block before the `rest_pre_serve_request` filter.

Trac ticket: https://core.trac.wordpress.org/ticket/59722#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
