### PR TITLE
tweak to translation prompt in wp_site_admin_email_change_notification

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7945,7 +7945,7 @@ function wp_site_admin_email_change_notification( $old_email, $new_email, $optio
 		return;
 	}
 
-	/* translators: Do not translate OLD_EMAIL, NEW_EMAIL, SITENAME, SITEURL: those are placeholders. */
+	/* translators: Do not translate ###OLD_EMAIL###, ###NEW_EMAIL###, ###SITENAME###, ###SITEURL###: those are placeholders. */
 	$email_change_text = __(
 		'Hi,
 


### PR DESCRIPTION
the tweak to translation prompt in wp_site_admin_email_change_notification only showed the LABEL not the ###FULL_PLACEHODER###

Trac ticket: https://core.trac.wordpress.org/ticket/59724