### PR TITLE
Don't register patterns when `wp_installing()` is true.

### DIFF
--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -328,6 +328,14 @@ function _register_remote_theme_patterns() {
  * @access private
  */
 function _register_theme_block_patterns() {
+
+	/**
+	 * Bail early if WP is installing, since the theme may not be fully loaded at this point.
+	 */
+	if ( wp_installing() ) {
+		return;
+	}
+
 	/*
 	 * Register patterns for the active theme. If the theme is a child theme,
 	 * let it override any patterns from the parent theme that shares the same slug.

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -329,7 +329,7 @@ function _register_remote_theme_patterns() {
  */
 function _register_theme_block_patterns() {
 
-	/**
+	/*
 	 * During the bootstrap process, a check for active and valid themes is run.
 	 * If no themes are returned, the theme's functions.php file will not be loaded,
 	 * which can lead to errors if patterns expect some variables or constants to

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -330,9 +330,12 @@ function _register_remote_theme_patterns() {
 function _register_theme_block_patterns() {
 
 	/**
-	 * Bail early if WP is installing, since the theme may not be fully loaded at this point.
+	 * During the bootstrap process, a check for active and valid themes is run.
+	 * If no themes are returned, the theme's functions.php file will not be loaded,
+	 * which can lead to errors if patterns expect some variables or constants to
+	 * already be set at this point, so bail early if that is the case.
 	 */
-	if ( wp_installing() ) {
+	if ( empty( wp_get_active_and_valid_themes() ) ) {
 		return;
 	}
 

--- a/tests/phpunit/tests/blocks/wpBlockPatternsRegistry.php
+++ b/tests/phpunit/tests/blocks/wpBlockPatternsRegistry.php
@@ -510,7 +510,7 @@ class Tests_Blocks_wpBlockPattersRegistry extends WP_UnitTestCase {
 			$registry->unregister( $pattern );
 		}
 
-		$this->assertEqualSets( $theme_patterns, array_intersect( $theme_patterns, $registered ), 'Could not confirm theme patterns were registered.' );
+		$this->assertSameSets( $theme_patterns, array_intersect( $theme_patterns, $registered ), 'Could not confirm theme patterns were registered.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/blocks/wpBlockPatternsRegistry.php
+++ b/tests/phpunit/tests/blocks/wpBlockPatternsRegistry.php
@@ -482,4 +482,80 @@ class Tests_Blocks_wpBlockPattersRegistry extends WP_UnitTestCase {
 		$result = $this->registry->is_registered( 'test/one' );
 		$this->assertTrue( $result );
 	}
+
+	/**
+	 * Ensures theme patterns are registered on init.
+	 *
+	 * @ticket 59723
+	 *
+	 * @covers ::_register_theme_block_patterns
+	 */
+	public function test_register_theme_block_patterns_on_init() {
+		// This test needs to use access static class properties.
+		$registry = WP_Block_Patterns_Registry::get_instance();
+
+		// Ensure we're using a theme with patterns.
+		switch_theme( 'twentytwentythree' );
+
+		$theme          = wp_get_theme();
+		$theme_patterns = array();
+
+		foreach ( $theme->get_block_patterns() as $pattern ) {
+			$theme_patterns[] = $pattern['slug'];
+		}
+
+		// This helper is fired on the init hook.
+		_register_theme_block_patterns();
+
+		$registered = wp_list_pluck( $registry->get_all_registered(), 'name' );
+
+		// Cleanup patterns registry.
+		foreach ( $theme_patterns as $pattern ) {
+			$registry->unregister( $pattern );
+		}
+
+		foreach ( $theme_patterns as $pattern ) {
+			$this->assertContains( $pattern, $registered, 'Could not confirm theme patterns were registered' );
+		}
+	}
+
+	/**
+	 * Ensures theme patterns are not registered when not themes are active and valid.
+	 *
+	 * @ticket 59723
+	 *
+	 * @covers ::_register_theme_block_patterns
+	 */
+	public function test_register_theme_block_patterns_on_init_skipped_during_install() {
+		// This test needs to use access static class properties.
+		$registry = WP_Block_Patterns_Registry::get_instance();
+
+		// Ensure we're using a theme with patterns.
+		switch_theme( 'twentytwentythree' );
+
+		$theme          = wp_get_theme();
+		$theme_patterns = array();
+
+		foreach ( $theme->get_block_patterns() as $pattern ) {
+			$theme_patterns[] = $pattern['slug'];
+		}
+
+		/**
+		 * This will short-circuit theme activation.
+		 * @see wp_get_active_and_valid_themes().
+		 */
+		wp_installing( true );
+
+		// This helper is fired on the init hook.
+		_register_theme_block_patterns();
+
+		$registered = wp_list_pluck( $registry->get_all_registered(), 'name' );
+
+		// Cleanup.
+		wp_installing( false );
+
+		foreach ( $theme_patterns as $pattern ) {
+			$this->assertNotContains( $pattern, $registered, 'Could not confirm theme patterns were registered' );
+		}
+	}
 }

--- a/tests/phpunit/tests/blocks/wpBlockPatternsRegistry.php
+++ b/tests/phpunit/tests/blocks/wpBlockPatternsRegistry.php
@@ -498,7 +498,7 @@ class Tests_Blocks_wpBlockPattersRegistry extends WP_UnitTestCase {
 		switch_theme( 'twentytwentythree' );
 
 		$theme          = wp_get_theme();
-		$theme_patterns = wp_list_pluck( $theme->get_block_patterns(), 'slug' );
+		$theme_patterns = array_values( wp_list_pluck( $theme->get_block_patterns(), 'slug' ) );
 
 		// This helper is fired on the init hook.
 		_register_theme_block_patterns();
@@ -510,9 +510,7 @@ class Tests_Blocks_wpBlockPattersRegistry extends WP_UnitTestCase {
 			$registry->unregister( $pattern );
 		}
 
-		foreach ( $theme_patterns as $pattern ) {
-			$this->assertContains( $pattern, $registered, 'Could not confirm theme patterns were registered.' );
-		}
+		$this->assertEqualSets( $theme_patterns, array_intersect( $theme_patterns, $registered ), 'Could not confirm theme patterns were registered.' );
 	}
 
 	/**
@@ -530,7 +528,7 @@ class Tests_Blocks_wpBlockPattersRegistry extends WP_UnitTestCase {
 		switch_theme( 'twentytwentythree' );
 
 		$theme          = wp_get_theme();
-		$theme_patterns = wp_list_pluck( $theme->get_block_patterns(), 'slug' );
+		$theme_patterns = array_values( wp_list_pluck( $theme->get_block_patterns(), 'slug' ) );
 
 		/*
 		 * This will short-circuit theme activation.
@@ -546,8 +544,6 @@ class Tests_Blocks_wpBlockPattersRegistry extends WP_UnitTestCase {
 		// Cleanup.
 		wp_installing( false );
 
-		foreach ( $theme_patterns as $pattern ) {
-			$this->assertNotContains( $pattern, $registered, 'Theme patterns were were incorrectly registered.' );
-		}
+		$this->assertEmpty( array_intersect( $theme_patterns, $registered ), 'Theme patterns were were incorrectly registered.' );
 	}
 }

--- a/tests/phpunit/tests/blocks/wpBlockPatternsRegistry.php
+++ b/tests/phpunit/tests/blocks/wpBlockPatternsRegistry.php
@@ -498,11 +498,7 @@ class Tests_Blocks_wpBlockPattersRegistry extends WP_UnitTestCase {
 		switch_theme( 'twentytwentythree' );
 
 		$theme          = wp_get_theme();
-		$theme_patterns = array();
-
-		foreach ( $theme->get_block_patterns() as $pattern ) {
-			$theme_patterns[] = $pattern['slug'];
-		}
+		$theme_patterns = wp_list_pluck( $theme->get_block_patterns(), 'slug' );
 
 		// This helper is fired on the init hook.
 		_register_theme_block_patterns();
@@ -515,12 +511,12 @@ class Tests_Blocks_wpBlockPattersRegistry extends WP_UnitTestCase {
 		}
 
 		foreach ( $theme_patterns as $pattern ) {
-			$this->assertContains( $pattern, $registered, 'Could not confirm theme patterns were registered' );
+			$this->assertContains( $pattern, $registered, 'Could not confirm theme patterns were registered.' );
 		}
 	}
 
 	/**
-	 * Ensures theme patterns are not registered when not themes are active and valid.
+	 * Ensures theme patterns are not registered when no themes are active and valid.
 	 *
 	 * @ticket 59723
 	 *
@@ -534,13 +530,9 @@ class Tests_Blocks_wpBlockPattersRegistry extends WP_UnitTestCase {
 		switch_theme( 'twentytwentythree' );
 
 		$theme          = wp_get_theme();
-		$theme_patterns = array();
+		$theme_patterns = wp_list_pluck( $theme->get_block_patterns(), 'slug' );
 
-		foreach ( $theme->get_block_patterns() as $pattern ) {
-			$theme_patterns[] = $pattern['slug'];
-		}
-
-		/**
+		/*
 		 * This will short-circuit theme activation.
 		 * @see wp_get_active_and_valid_themes().
 		 */
@@ -555,7 +547,7 @@ class Tests_Blocks_wpBlockPattersRegistry extends WP_UnitTestCase {
 		wp_installing( false );
 
 		foreach ( $theme_patterns as $pattern ) {
-			$this->assertNotContains( $pattern, $registered, 'Could not confirm theme patterns were registered' );
+			$this->assertNotContains( $pattern, $registered, 'Theme patterns were were incorrectly registered.' );
 		}
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This fixes a bug on upgrade screens where constants defined in a theme's functions.php file are not defined before the patterns are loaded, leading to potential exceptions.

Trac ticket: https://core.trac.wordpress.org/ticket/59723

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
