### PR TITLE
Fix incorrect usage of setup_theme action for theme supports

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -521,7 +521,7 @@ add_action( 'init', 'wp_sitemaps_get_server' );
  */
 // Theme.
 add_action( 'setup_theme', 'create_initial_theme_features', 0 );
-add_action( 'setup_theme', '_add_default_theme_supports', 1 );
+add_action( 'after_setup_theme', '_add_default_theme_supports', 1 );
 add_action( 'wp_loaded', '_custom_header_background_just_in_time' );
 add_action( 'wp_head', '_custom_logo_header_styles' );
 add_action( 'plugins_loaded', '_wp_customize_include' );
@@ -718,7 +718,7 @@ add_filter( 'pre_wp_unique_post_slug', 'wp_filter_wp_template_unique_post_slug',
 add_action( 'save_post_wp_template_part', 'wp_set_unique_slug_on_create_template_part' );
 add_action( 'wp_enqueue_scripts', 'wp_enqueue_block_template_skip_link' );
 add_action( 'wp_footer', 'the_block_template_skip_link' ); // Retained for backwards-compatibility. Unhooked by wp_enqueue_block_template_skip_link().
-add_action( 'setup_theme', 'wp_enable_block_templates' );
+add_action( 'after_setup_theme', 'wp_enable_block_templates', 1 );
 add_action( 'wp_loaded', '_add_template_loader_filters' );
 
 // wp_navigation post type.

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -4335,9 +4335,9 @@ function wp_theme_get_element_class_name( $element ) {
 }
 
 /**
- * Adds default theme supports for block themes when the 'setup_theme' action fires.
+ * Adds default theme supports for block themes when the 'after_setup_theme' action fires.
  *
- * See {@see 'setup_theme'}.
+ * See {@see 'after_setup_theme'}.
  *
  * @since 5.9.0
  * @access private

--- a/tests/phpunit/tests/block-template.php
+++ b/tests/phpunit/tests/block-template.php
@@ -15,6 +15,7 @@ class Tests_Block_Template extends WP_UnitTestCase {
 		parent::set_up();
 		switch_theme( 'block-theme' );
 		do_action( 'setup_theme' );
+		do_action( 'after_setup_theme' );
 	}
 
 	public function tear_down() {

--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -746,6 +746,7 @@ class Tests_Theme extends WP_UnitTestCase {
 	 *
 	 * @ticket 54597
 	 * @ticket 54731
+	 * @ticket 59732
 	 *
 	 * @dataProvider data_block_theme_has_default_support
 	 *
@@ -774,7 +775,7 @@ class Tests_Theme extends WP_UnitTestCase {
 			"Could not remove support for $support_data_str."
 		);
 
-		do_action( 'setup_theme' );
+		do_action( 'after_setup_theme' );
 
 		$this->assertTrue(
 			current_theme_supports( ...$support_data ),
@@ -858,6 +859,7 @@ class Tests_Theme extends WP_UnitTestCase {
 	 * Tests that block themes load separate core block assets by default.
 	 *
 	 * @ticket 54597
+	 * @ticket 59732
 	 *
 	 * @covers ::_add_default_theme_supports
 	 * @covers ::wp_should_load_separate_core_block_assets
@@ -872,7 +874,7 @@ class Tests_Theme extends WP_UnitTestCase {
 			'Could not disable loading separate core block assets.'
 		);
 
-		do_action( 'setup_theme' );
+		do_action( 'after_setup_theme' );
 
 		$this->assertTrue(
 			wp_should_load_separate_core_block_assets(),


### PR DESCRIPTION
This fixes the bug of using the `setup_theme` action for adding theme support, which is incorrect for such purposes, as at that point the current theme is not set up yet. For example, Customizer previewing, which may exchange the current theme at runtime only fires on `setup_theme`.

Therefore any code depending on the current theme must only run after that, i.e. on `after_setup_theme`. This is also the hook which theme authors have been encouraged for more than a decade to use to add theme supports.

See https://core.trac.wordpress.org/ticket/59732#comment:2 for additional context.

Trac ticket: https://core.trac.wordpress.org/ticket/59732

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
