### PR TITLE
Only start main query loop when block template is associated with the current theme

### DIFF
--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -208,6 +208,7 @@ function _block_template_render_title_tag() {
  * @access private
  * @since 5.8.0
  *
+ * @global string   $_wp_current_template_id
  * @global string   $_wp_current_template_content
  * @global WP_Embed $wp_embed
  * @global WP_Query $wp_query
@@ -215,7 +216,7 @@ function _block_template_render_title_tag() {
  * @return string Block template markup.
  */
 function get_the_block_template_html() {
-	global $_wp_current_template_content, $wp_embed, $wp_query;
+	global $_wp_current_template_id, $_wp_current_template_content, $wp_embed, $wp_query;
 
 	if ( ! $_wp_current_template_content ) {
 		if ( is_user_logged_in() ) {
@@ -223,6 +224,14 @@ function get_the_block_template_html() {
 		}
 		return;
 	}
+
+	/*
+	 * Check whether the current template actually comes from the theme.
+	 * This is generally the case, except when plugins hijack the block template loading process
+	 * to inject a custom template coming from a plugin.
+	 */
+	$current_theme_owns_current_template = $_wp_current_template_id &&
+		str_starts_with( $_wp_current_template_id, get_stylesheet() . '//' );
 
 	$content = $wp_embed->run_shortcode( $_wp_current_template_content );
 	$content = $wp_embed->autoembed( $content );
@@ -242,8 +251,12 @@ function get_the_block_template_html() {
 	 * Even if the block template contained a `core/query` and `core/post-template` block referencing the main query
 	 * loop, it would not cause errors since it would use a cloned instance and go through the same loop of a single
 	 * post, within the actual main query loop.
+	 *
+	 * This special logic should be skipped if the current template does not come from the current theme, in which case
+	 * it has been injected by a plugin by hijacking the block template loader mechanism. In that case, entirely custom
+	 * logic may be applied which is unpredictable and therefore safer to omit this special handling on.
 	 */
-	if ( is_singular() && 1 === $wp_query->post_count && have_posts() ) {
+	if ( $current_theme_owns_current_template && is_singular() && 1 === $wp_query->post_count && have_posts() ) {
 		while ( have_posts() ) {
 			the_post();
 			$content = do_blocks( $content );

--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -225,14 +225,6 @@ function get_the_block_template_html() {
 		return;
 	}
 
-	/*
-	 * Check whether the current template actually comes from the theme.
-	 * This is generally the case, except when plugins hijack the block template loading process
-	 * to inject a custom template coming from a plugin.
-	 */
-	$current_theme_owns_current_template = $_wp_current_template_id &&
-		str_starts_with( $_wp_current_template_id, get_stylesheet() . '//' );
-
 	$content = $wp_embed->run_shortcode( $_wp_current_template_content );
 	$content = $wp_embed->autoembed( $content );
 	$content = shortcode_unautop( $content );
@@ -256,7 +248,13 @@ function get_the_block_template_html() {
 	 * it has been injected by a plugin by hijacking the block template loader mechanism. In that case, entirely custom
 	 * logic may be applied which is unpredictable and therefore safer to omit this special handling on.
 	 */
-	if ( $current_theme_owns_current_template && is_singular() && 1 === $wp_query->post_count && have_posts() ) {
+	if (
+		$_wp_current_template_id &&
+		str_starts_with( $_wp_current_template_id, get_stylesheet() . '//' ) &&
+		is_singular() &&
+		1 === $wp_query->post_count &&
+		have_posts()
+	) {
 		while ( have_posts() ) {
 			the_post();
 			$content = do_blocks( $content );

--- a/tests/phpunit/tests/block-template.php
+++ b/tests/phpunit/tests/block-template.php
@@ -18,8 +18,8 @@ class Tests_Block_Template extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
-		global $_wp_current_template_content;
-		unset( $_wp_current_template_content );
+		global $_wp_current_template_id, $_wp_current_template_content;
+		unset( $_wp_current_template_id, $_wp_current_template_content );
 
 		parent::tear_down();
 	}

--- a/tests/phpunit/tests/block-template.php
+++ b/tests/phpunit/tests/block-template.php
@@ -192,10 +192,11 @@ class Tests_Block_Template extends WP_UnitTestCase {
 	 * since there is only a single post in the main query loop in such cases anyway.
 	 *
 	 * @ticket 58154
+	 * @ticket 59736
 	 * @covers ::get_the_block_template_html
 	 */
 	public function test_get_the_block_template_html_enforces_singular_query_loop() {
-		global $_wp_current_template_content, $wp_query, $wp_the_query;
+		global $_wp_current_template_id, $_wp_current_template_content, $wp_query, $wp_the_query;
 
 		// Register test block to log `in_the_loop()` results.
 		$in_the_loop_logs = array();
@@ -206,6 +207,8 @@ class Tests_Block_Template extends WP_UnitTestCase {
 		$wp_query     = new WP_Query( array( 'p' => $post_id ) );
 		$wp_the_query = $wp_query;
 
+		// Force a template ID that is for the current stylesheet.
+		$_wp_current_template_id = get_stylesheet() . '//single';
 		// Use block template that just renders post title and the above test block.
 		$_wp_current_template_content = '<!-- wp:post-title /--><!-- wp:test/in-the-loop-logger /-->';
 
@@ -226,7 +229,7 @@ class Tests_Block_Template extends WP_UnitTestCase {
 	 * @covers ::get_the_block_template_html
 	 */
 	public function test_get_the_block_template_html_does_not_generally_enforce_loop() {
-		global $_wp_current_template_content, $wp_query, $wp_the_query;
+		global $_wp_current_template_id, $_wp_current_template_content, $wp_query, $wp_the_query;
 
 		// Register test block to log `in_the_loop()` results.
 		$in_the_loop_logs = array();
@@ -246,6 +249,9 @@ class Tests_Block_Template extends WP_UnitTestCase {
 			)
 		);
 		$wp_the_query = $wp_query;
+
+		// Force a template ID that is for the current stylesheet.
+		$_wp_current_template_id = get_stylesheet() . '//home';
 
 		/*
 		 * Use block template that renders the above test block, followed by a main query loop.
@@ -273,6 +279,35 @@ class Tests_Block_Template extends WP_UnitTestCase {
 		$this->unregister_in_the_loop_logger_block();
 		$this->assertSame( $expected, $output, 'Unexpected block template output' );
 		$this->assertSame( array( false, true ), $in_the_loop_logs, 'Main query loop was triggered incorrectly' );
+	}
+
+	/**
+	 * Tests that `get_the_block_template_html()` does not start the main query loop when on a template that is not from the current theme.
+	 *
+	 * @ticket 58154
+	 * @ticket 59736
+	 * @covers ::get_the_block_template_html
+	 */
+	public function test_get_the_block_template_html_skips_singular_query_loop_when_non_theme_template() {
+		global $_wp_current_template_id, $_wp_current_template_content, $wp_query, $wp_the_query;
+
+		// Register test block to log `in_the_loop()` results.
+		$in_the_loop_logs = array();
+		$this->register_in_the_loop_logger_block( $in_the_loop_logs );
+
+		// Set main query to single post.
+		$post_id      = self::factory()->post->create( array( 'post_title' => 'A single post' ) );
+		$wp_query     = new WP_Query( array( 'p' => $post_id ) );
+		$wp_the_query = $wp_query;
+
+		// Force a template ID that is not for the current stylesheet.
+		$_wp_current_template_id = 'some-plugin-slug//single';
+		// Use block template that just renders post title and the above test block.
+		$_wp_current_template_content = '<!-- wp:post-title /--><!-- wp:test/in-the-loop-logger /-->';
+
+		$output = get_the_block_template_html();
+		$this->unregister_in_the_loop_logger_block();
+		$this->assertSame( array( false ), $in_the_loop_logs, 'Main query loop was triggered despite a custom block template outside the current theme being used' );
 	}
 
 	/**

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -3972,7 +3972,7 @@ EOF;
 	 * @covers ::wp_get_loading_optimization_attributes
 	 */
 	public function test_wp_filter_content_tags_does_not_lazy_load_first_image_in_block_theme() {
-		global $_wp_current_template_content, $wp_query, $wp_the_query, $post;
+		global $_wp_current_template_id, $_wp_current_template_content, $wp_query, $wp_the_query, $post;
 
 		// Do not add srcset, sizes, or decoding attributes as they are irrelevant for this test.
 		add_filter( 'wp_img_tag_add_srcset_and_sizes_attr', '__return_false' );
@@ -4001,6 +4001,8 @@ EOF;
 		$wp_the_query = $wp_query;
 		$post         = get_post( self::$post_ids['publish'] );
 
+		// Force a template ID that is for the current stylesheet.
+		$_wp_current_template_id      = get_stylesheet() . '//single';
 		$_wp_current_template_content = '<!-- wp:post-content /-->';
 
 		$html = get_the_block_template_html();
@@ -4020,7 +4022,7 @@ EOF;
 	 * @covers ::wp_get_loading_optimization_attributes
 	 */
 	public function test_wp_filter_content_tags_does_not_lazy_load_first_featured_image_in_block_theme() {
-		global $_wp_current_template_content, $wp_query, $wp_the_query, $post;
+		global $_wp_current_template_id, $_wp_current_template_content, $wp_query, $wp_the_query, $post;
 
 		// Do not add srcset, sizes, or decoding attributes as they are irrelevant for this test.
 		add_filter( 'wp_img_tag_add_srcset_and_sizes_attr', '__return_false' );
@@ -4069,6 +4071,8 @@ EOF;
 		$wp_the_query = $wp_query;
 		$post         = get_post( self::$post_ids['publish'] );
 
+		// Force a template ID that is for the current stylesheet.
+		$_wp_current_template_id      = get_stylesheet() . '//single';
 		$_wp_current_template_content = '<!-- wp:post-featured-image /--> <!-- wp:post-content /-->';
 
 		$html = get_the_block_template_html();
@@ -4087,7 +4091,7 @@ EOF;
 	 * @covers ::wp_get_loading_optimization_attributes
 	 */
 	public function test_wp_filter_content_tags_does_not_lazy_load_images_in_header() {
-		global $_wp_current_template_content;
+		global $_wp_current_template_id, $_wp_current_template_content;
 
 		// Do not add srcset, sizes, or decoding attributes as they are irrelevant for this test.
 		add_filter( 'wp_img_tag_add_srcset_and_sizes_attr', '__return_false' );
@@ -4122,6 +4126,8 @@ EOF;
 		wp_set_post_terms( $footer_post_id, WP_TEMPLATE_PART_AREA_FOOTER, 'wp_template_part_area' );
 		wp_set_post_terms( $footer_post_id, get_stylesheet(), 'wp_theme' );
 
+		// Force a template ID that is for the current stylesheet.
+		$_wp_current_template_id      = get_stylesheet() . '//single';
 		$_wp_current_template_content = '<!-- wp:template-part {"slug":"header","theme":"' . get_stylesheet() . '","tagName":"header"} /--><!-- wp:template-part {"slug":"footer","theme":"' . get_stylesheet() . '","tagName":"footer"} /-->';
 
 		// Header image should not be lazy-loaded, footer image should be lazy-loaded.

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -79,6 +79,9 @@ CAP;
 	 * Ensures that the static content media count, fetchpriority element flag and related filter are reset between tests.
 	 */
 	public function tear_down() {
+		global $_wp_current_template_id, $_wp_current_template_content;
+		unset( $_wp_current_template_id, $_wp_current_template_content );
+
 		parent::tear_down();
 
 		$this->reset_content_media_count();


### PR DESCRIPTION
Generally, the block template loaded should always be associated with the current theme since:
* It either comes from a `WP_Query` that filters to block templates only for the `get_stylesheet()` theme
* Or it comes from the current theme's file system

In both cases, the template ID will begin with `get_stylesheet() . '//'`.

There are rare situations (e.g. the https://wordpress.org/plugins/echo-knowledge-base/ plugin as reported in the Trac ticket) where a plugin hijacks the block template loading mechanism to inject its own block template, which thus comes from outside the theme and may use _any_ logic. In those cases, the situation is unpredictable by core and therefore the assumption that no main query loop will be present for a singular `WP_Query` is no longer reliable. As such, in those cases no main query loop should be started, as that would lead to problems if the custom logic was going to attempt to start the main query loop itself. So for those cases, the PR simply falls back to the original pre-6.4 logic of just parsing blocks.

Trac ticket: https://core.trac.wordpress.org/ticket/59736

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
