### PR TITLE
Update wp_attachment_is() documentation to reflect support for all file types

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6663,7 +6663,7 @@ function wp_get_attachment_thumb_url( $post_id = 0 ) {
  *
  * @since 4.2.0
  *
- * @param string      $type Attachment type. Accepts 'image', 'audio', or 'video'.
+ * @param string      $type The type of attachment to check. Valid values are `image`, `audio`, `video`, or any file extension.
  * @param int|WP_Post $post Optional. Attachment ID or object. Default is global $post.
  * @return bool True if one of the accepted types, false otherwise.
  */


### PR DESCRIPTION
- [x] https://core.trac.wordpress.org/ticket/59698
------
This pull request updates the wp_attachment_is() function documentation to reflect the fact that the function can now be used to check if an attachment is of any type, not just image, audio, or video.

This change is necessary because the wp_attachment_is() function has been updated in recent versions of WordPress to support more types of attachments, such as PDFs, documents, and archives. However, the function documentation has not been updated to reflect this change.

This pull request updates the function documentation to reflect the current capabilities of the function and to make it more accurate and informative for users.
