### PR TITLE
Enforce version checks on Theme bulk_update

### DIFF
--- a/src/wp-admin/includes/class-theme-upgrader.php
+++ b/src/wp-admin/includes/class-theme-upgrader.php
@@ -446,28 +446,28 @@ class Theme_Upgrader extends WP_Upgrader {
 			// Get the URL to the zip file.
 			$r = $current->response[ $theme ];
 
-			if ( isset( $r->requires ) && ! is_wp_version_compatible( $r->requires ) ) {
+			if ( isset( $r['requires'] ) && ! is_wp_version_compatible( $r['requires'] ) ) {
 				$result = new WP_Error(
 					'incompatible_wp_required_version',
 					sprintf(
 						/* translators: 1: Current WordPress version, 2: WordPress version required by the new theme version. */
 						__( 'Your WordPress version is %1$s, however the new theme version requires %2$s.' ),
 						$wp_version,
-						$r->requires
+						$r['requires']
 					)
 				);
 
 				$this->skin->before( $result );
 				$this->skin->error( $result );
 				$this->skin->after();
-			} elseif ( isset( $r->requires_php ) && ! is_php_version_compatible( $r->requires_php ) ) {
+			} elseif ( isset( $r['requires_php'] ) && ! is_php_version_compatible( $r['requires_php'] ) ) {
 				$result = new WP_Error(
 					'incompatible_php_required_version',
 					sprintf(
 						/* translators: 1: Current PHP version, 2: PHP version required by the new theme version. */
 						__( 'The PHP version on your server is %1$s, however the new theme version requires %2$s.' ),
 						PHP_VERSION,
-						$r->requires_php
+						$r['requires_php']
 					)
 				);
 

--- a/src/wp-admin/includes/class-theme-upgrader.php
+++ b/src/wp-admin/includes/class-theme-upgrader.php
@@ -442,6 +442,7 @@ class Theme_Upgrader extends WP_Upgrader {
 			// Get the URL to the zip file.
 			$r = $current->response[ $theme ];
 
+			add_filter( 'upgrader_source_selection', array( $this, 'check_package' ) );
 			$result = $this->run(
 				array(
 					'package'           => $r['package'],
@@ -459,6 +460,7 @@ class Theme_Upgrader extends WP_Upgrader {
 					),
 				)
 			);
+			remove_filter( 'upgrader_source_selection', array( $this, 'check_package' ) );
 
 			$results[ $theme ] = $result;
 

--- a/src/wp-admin/includes/class-theme-upgrader.php
+++ b/src/wp-admin/includes/class-theme-upgrader.php
@@ -371,6 +371,8 @@ class Theme_Upgrader extends WP_Upgrader {
 	 * @since 3.0.0
 	 * @since 3.7.0 The `$args` parameter was added, making clearing the update cache optional.
 	 *
+	 * @global string $wp_version The WordPress version string.
+	 *
 	 * @param string[] $themes Array of the theme slugs.
 	 * @param array    $args {
 	 *     Optional. Other arguments for upgrading several themes at once. Default empty array.
@@ -381,6 +383,8 @@ class Theme_Upgrader extends WP_Upgrader {
 	 * @return array[]|false An array of results, or false if unable to connect to the filesystem.
 	 */
 	public function bulk_upgrade( $themes, $args = array() ) {
+		global $wp_version;
+
 		$defaults    = array(
 			'clear_update_cache' => true,
 		);
@@ -442,25 +446,55 @@ class Theme_Upgrader extends WP_Upgrader {
 			// Get the URL to the zip file.
 			$r = $current->response[ $theme ];
 
-			add_filter( 'upgrader_source_selection', array( $this, 'check_package' ) );
-			$result = $this->run(
-				array(
-					'package'           => $r['package'],
-					'destination'       => get_theme_root( $theme ),
-					'clear_destination' => true,
-					'clear_working'     => true,
-					'is_multi'          => true,
-					'hook_extra'        => array(
-						'theme'       => $theme,
-						'temp_backup' => array(
-							'slug' => $theme,
-							'src'  => get_theme_root( $theme ),
-							'dir'  => 'themes',
+			if ( isset( $r->requires ) && ! is_wp_version_compatible( $r->requires ) ) {
+				$result = new WP_Error(
+					'incompatible_wp_required_version',
+					sprintf(
+						/* translators: 1: Current WordPress version, 2: WordPress version required by the new theme version. */
+						__( 'Your WordPress version is %1$s, however the new theme version requires %2$s.' ),
+						$wp_version,
+						$r->requires
+					)
+				);
+
+				$this->skin->before( $result );
+				$this->skin->error( $result );
+				$this->skin->after();
+			} elseif ( isset( $r->requires_php ) && ! is_php_version_compatible( $r->requires_php ) ) {
+				$result = new WP_Error(
+					'incompatible_php_required_version',
+					sprintf(
+						/* translators: 1: Current PHP version, 2: PHP version required by the new theme version. */
+						__( 'The PHP version on your server is %1$s, however the new theme version requires %2$s.' ),
+						PHP_VERSION,
+						$r->requires_php
+					)
+				);
+
+				$this->skin->before( $result );
+				$this->skin->error( $result );
+				$this->skin->after();
+			} else {
+				add_filter( 'upgrader_source_selection', array( $this, 'check_package' ) );
+				$result = $this->run(
+					array(
+						'package'           => $r['package'],
+						'destination'       => get_theme_root( $theme ),
+						'clear_destination' => true,
+						'clear_working'     => true,
+						'is_multi'          => true,
+						'hook_extra'        => array(
+							'theme'       => $theme,
+							'temp_backup' => array(
+								'slug' => $theme,
+								'src'  => get_theme_root( $theme ),
+								'dir'  => 'themes',
+							),
 						),
-					),
-				)
-			);
-			remove_filter( 'upgrader_source_selection', array( $this, 'check_package' ) );
+					)
+				);
+				remove_filter( 'upgrader_source_selection', array( $this, 'check_package' ) );
+			}
 
 			$results[ $theme ] = $result;
 


### PR DESCRIPTION
Add PHP version and WordPress version checks on bulk theme update.

Trac ticket: [#59758](https://core.trac.wordpress.org/ticket/59758)


