### PR TITLE
Add AVIF support check in WP_Image_Editor_GD::supports_mime_type

### DIFF
--- a/src/wp-includes/class-wp-image-editor-gd.php
+++ b/src/wp-includes/class-wp-image-editor-gd.php
@@ -71,6 +71,8 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 				return ( $image_types & IMG_GIF ) != 0;
 			case 'image/webp':
 				return ( $image_types & IMG_WEBP ) != 0;
+			case 'image/avif':
+				return ( $image_types & IMG_AVIF ) != 0;
 		}
 
 		return false;

--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -497,3 +497,13 @@ if ( ! defined( 'IMAGETYPE_WEBP' ) ) {
 if ( ! defined( 'IMG_WEBP' ) ) {
 	define( 'IMG_WEBP', IMAGETYPE_WEBP );
 }
+
+// IMAGETYPE_AVIF constant is only defined in PHP 8.x or later.
+if ( ! defined( 'IMAGETYPE_AVIF' ) ) {
+	define( 'IMAGETYPE_AVIF', 19 );
+}
+
+// IMG_AVIF constant is only defined in PHP 8.x or later.
+if ( ! defined( 'IMG_AVIF' ) ) {
+	define( 'IMG_AVIF', IMAGETYPE_AVIF );
+}

--- a/tests/phpunit/tests/image/editorGd.php
+++ b/tests/phpunit/tests/image/editorGd.php
@@ -51,6 +51,18 @@ class Tests_Image_Editor_GD extends WP_Image_UnitTestCase {
 		$this->assertSame( $expected, $gd_image_editor->supports_mime_type( 'image/gif' ) );
 	}
 
+	public function test_supports_mime_type_webp() {
+		$gd_image_editor = new WP_Image_Editor_GD( null );
+		$expected        = (bool) ( imagetypes() & IMG_WEBP );
+		$this->assertSame( $expected, $gd_image_editor->supports_mime_type( 'image/webp' ) );
+	}
+
+	public function test_supports_mime_type_avif() {
+		$gd_image_editor = new WP_Image_Editor_GD( null );
+		$expected        = (bool) ( imagetypes() & IMG_AVIF );
+		$this->assertSame( $expected, $gd_image_editor->supports_mime_type( 'image/avif' ) );
+	}
+
 	/**
 	 * Tests resizing an image, not using crop.
 	 *


### PR DESCRIPTION
Enable support for AVIF images when PHP GD supports it. Note that `WP_Image_Editor_Imagick::supports_mime_type` already detects AVIF support correctly. 

Before this change, WordPress did not properly detect GD support for AVIF when available in PHP 8.1 and above.

Trac ticket: https://core.trac.wordpress.org/ticket/59760

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
