### PR TITLE
Docs: various fixes (Trac 59651)

### DIFF
--- a/src/wp-admin/includes/class-wp-filesystem-ssh2.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ssh2.php
@@ -4,7 +4,7 @@
  *
  * To use this class you must follow these steps for PHP 5.2.6+
  *
- * @contrib http://kevin.vanzonneveld.net/techblog/article/make_ssh_connections_with_php/ - Installation Notes
+ * {@link http://kevin.vanzonneveld.net/techblog/article/make_ssh_connections_with_php/ - Installation Notes}
  *
  * Compile libssh2 (Note: Only 0.14 is officaly working with PHP 5.2.6+ right now, But many users have found the latest versions work)
  *

--- a/src/wp-admin/includes/menu.php
+++ b/src/wp-admin/includes/menu.php
@@ -13,8 +13,8 @@ if ( is_network_admin() ) {
 	 *
 	 * The hook fires before menus and sub-menus are removed based on user privileges.
 	 *
-	 * @private
-	 * @since 3.1.0
+	 * @access private
+	 * @since  3.1.0
 	 */
 	do_action( '_network_admin_menu' );
 } elseif ( is_user_admin() ) {
@@ -24,8 +24,8 @@ if ( is_network_admin() ) {
 	 *
 	 * The hook fires before menus and sub-menus are removed based on user privileges.
 	 *
-	 * @private
-	 * @since 3.1.0
+	 * @access private
+	 * @since  3.1.0
 	 */
 	do_action( '_user_admin_menu' );
 } else {
@@ -35,8 +35,8 @@ if ( is_network_admin() ) {
 	 *
 	 * The hook fires before menus and sub-menus are removed based on user privileges.
 	 *
-	 * @private
-	 * @since 2.2.0
+	 * @access private
+	 * @since  2.2.0
 	 */
 	do_action( '_admin_menu' );
 }

--- a/src/wp-content/themes/twentynineteen/inc/template-functions.php
+++ b/src/wp-content/themes/twentynineteen/inc/template-functions.php
@@ -100,7 +100,7 @@ add_filter( 'get_the_archive_title', 'twentynineteen_get_the_archive_title' );
 /**
  * Adds custom 'sizes' attribute to responsive image functionality for post thumbnails.
  *
- * @origin Twenty Nineteen 1.0
+ * @since Twenty Nineteen 1.0
  *
  * @param string[] $attr Array of attribute values for the image markup, keyed by attribute name.
  *                       See wp_get_attachment_image().
@@ -163,7 +163,8 @@ add_filter( 'wp_nav_menu', 'twentynineteen_add_ellipses_to_nav', 10, 2 );
  * Adjustments to menu attributes to support WCAG 2.0 recommendations
  * for flyout and dropdown menus.
  *
- * @ref https://www.w3.org/WAI/tutorials/menus/flyout/
+ * @link https://www.w3.org/WAI/tutorials/menus/flyout/
+ *
  * @param array   $atts {
  *     The HTML attributes applied to the menu item's `<a>` element, empty strings are ignored.
  *

--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -796,12 +796,12 @@ function wp_render_layout_support_flag( $block_content, $block ) {
 	 * are still present in the wrapper as they are in this example. Frequently, additional classes
 	 * will also be present; rarely should classes be removed.
 	 *
-	 * @TODO: Find a better way to match the first inner block. If it's possible to identify where the
-	 *        first inner block starts, then it will be possible to find the last tag before it starts
-	 *        and then that tag, if an opening tag, can be solidly identified as a wrapping element.
-	 *        Can some unique value or class or ID be added to the inner blocks when they process
-	 *        so that they can be extracted here safely without guessing? Can the block rendering function
-	 *        return information about where the rendered inner blocks start?
+	 * @todo Find a better way to match the first inner block. If it's possible to identify where the
+	 *       first inner block starts, then it will be possible to find the last tag before it start
+	 *       and then that tag, if an opening tag, can be solidly identified as a wrapping element.
+	 *       Can some unique value or class or ID be added to the inner blocks when they process
+	 *       so that they can be extracted here safely without guessing? Can the block rendering function
+	 *       return information about where the rendered inner blocks start?
 	 *
 	 * @var string|null
 	 */

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1188,8 +1188,8 @@ function filter_block_content( $text, $allowed_html = 'post', $allowed_protocols
 /**
  * Callback used for regular expression replacement in filter_block_content().
  *
- * @private
- * @since 6.2.1
+ * @access private
+ * @since  6.2.1
  *
  * @param array $matches Array of preg_replace_callback matches.
  * @return string Replacement string.

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -342,7 +342,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Finds the next tag matching the $query.
 	 *
-	 * @TODO: Support matching the class name and tag name.
+	 * @todo Support matching the class name and tag name.
 	 *
 	 * @since 6.4.0
 	 *
@@ -551,9 +551,9 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * Breadcrumbs start at the outermost parent and descend toward the matched element.
 	 * They always include the entire path from the root HTML node to the matched element.
 	 *
-	 * @TODO: It could be more efficient to expose a generator-based version of this function
-	 *        to avoid creating the array copy on tag iteration. If this is done, it would likely
-	 *        be more useful to walk up the stack when yielding instead of starting at the top.
+	 * @todo It could be more efficient to expose a generator-based version of this function
+	 *       to avoid creating the array copy on tag iteration. If this is done, it would likely
+	 *       be more useful to walk up the stack when yielding instead of starting at the top.
 	 *
 	 * Example
 	 *

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2031,7 +2031,7 @@ class WP_HTML_Tag_Processor {
 		 *
 		 * @see https://html.spec.whatwg.org/#attributes-2
 		 *
-		 * @TODO as the only regex pattern maybe we should take it out? are
+		 * @todo As the only regex pattern maybe we should take it out? are
 		 *       Unicode patterns available broadly in Core?
 		 */
 		if ( preg_match(

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -2082,8 +2082,6 @@ function redirect_this_site( $deprecated = '' ) {
  *
  * @since MU (3.0.0)
  *
- * @blessed
- *
  * @param array $upload An array of information about the newly-uploaded file.
  * @return string|array If the upload is under the size limit, $upload is returned. Otherwise returns an error message.
  */

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3355,8 +3355,8 @@ function wp_add_editor_classic_theme_styles( $editor_settings ) {
  *     $js = '<script type="text/javascript">console.log( "hi" );</script>';
  *     'console.error( ... )' === wp_remove_surrounding_empty_script_tags( $js );
  *
- * @private
- * @since 6.4.0
+ * @access private
+ * @since  6.4.0
  *
  * @see wp_print_inline_script_tag()
  * @see wp_get_inline_script_tag()

--- a/src/wp-includes/theme-previews.php
+++ b/src/wp-includes/theme-previews.php
@@ -63,8 +63,8 @@ function wp_attach_theme_preview_middleware() {
  *
  * @see https://github.com/WordPress/gutenberg/pull/41836.
  *
- * @since 6.3.0
- * @private
+ * @since  6.3.0
+ * @access private
  */
 function wp_block_theme_activate_nonce() {
 	$nonce_handle = 'switch-theme_' . wp_get_theme_preview_path();

--- a/tests/phpunit/tests/ajax/wpCustomizeNavMenus.php
+++ b/tests/phpunit/tests/ajax/wpCustomizeNavMenus.php
@@ -119,8 +119,8 @@ class Tests_Ajax_wpCustomizeNavMenus extends WP_Ajax_UnitTestCase {
 	 *
 	 * @return array {
 	 *     @type array {
-	 *         @string string $role             The role that will test caps for.
-	 *         @array  array  $expected_results The expected results from the Ajax call.
+	 *         @type string $role             The role that will test caps for.
+	 *         @type array  $expected_results The expected results from the Ajax call.
 	 *     }
 	 * }
 	 */
@@ -191,8 +191,8 @@ class Tests_Ajax_wpCustomizeNavMenus extends WP_Ajax_UnitTestCase {
 	 *
 	 * @return array {
 	 *     @type array {
-	 * @array array $post_args        The arguments that will merged with the $_POST array.
-	 * @array array $expected_results The expected results from the Ajax call.
+	 *         @type array $post_args        The arguments that will merged with the $_POST array.
+	 *         @type array $expected_results The expected results from the Ajax call.
 	 *     }
 	 * }
 	 */
@@ -515,8 +515,8 @@ class Tests_Ajax_wpCustomizeNavMenus extends WP_Ajax_UnitTestCase {
 	 *
 	 * @return array {
 	 *     @type array {
-	 * @string string $role             The role that will test caps for.
-	 * @array  array  $expected_results The expected results from the Ajax call.
+	 *         @type string $role             The role that will test caps for.
+	 *         @type array  $expected_results The expected results from the Ajax call.
 	 *     }
 	 * }
 	 */
@@ -610,8 +610,8 @@ class Tests_Ajax_wpCustomizeNavMenus extends WP_Ajax_UnitTestCase {
 	 *
 	 * @return array {
 	 *     @type array {
-	 * @string string $post_args        The args that will be passed to Ajax.
-	 * @array  array  $expected_results The expected results from the Ajax call.
+	 *         @type string $post_args        The args that will be passed to Ajax.
+	 *         @type array  $expected_results The expected results from the Ajax call.
 	 *     }
 	 * }
 	 */

--- a/tests/phpunit/tests/functions/anonymization.php
+++ b/tests/phpunit/tests/functions/anonymization.php
@@ -41,8 +41,8 @@ class Tests_Functions_Anonymization extends WP_UnitTestCase {
 	 *
 	 * @return array {
 	 *     @type array {
-	 *         @string string $raw_ip          Raw IP address.
-	 *         @string string $expected_result Expected result.
+	 *         @type string $raw_ip          Raw IP address.
+	 *         @type string $expected_result Expected result.
 	 *     }
 	 * }
 	 */
@@ -195,8 +195,8 @@ class Tests_Functions_Anonymization extends WP_UnitTestCase {
 	 *
 	 * @return array {
 	 *     @type array {
-	 *         @string string $raw_ip          Raw IP address.
-	 *         @string string $expected_result Expected result.
+	 *         @type string $raw_ip          Raw IP address.
+	 *         @type string $expected_result Expected result.
 	 *     }
 	 * }
 	 */

--- a/tests/phpunit/tests/functions/wpCheckFiletype.php
+++ b/tests/phpunit/tests/functions/wpCheckFiletype.php
@@ -28,7 +28,7 @@ class Tests_Functions_WpCheckFiletype extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return[]
+	 * @return array[]
 	 */
 	public function data_wp_check_filetype() {
 		return array(
@@ -105,7 +105,6 @@ class Tests_Functions_WpCheckFiletype extends WP_UnitTestCase {
 					'type' => false,
 				),
 			),
-
 		);
 	}
 }

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -952,8 +952,8 @@ EOF;
 	 *
 	 * @return array {
 	 *     @type array {
-	 *         @string string $css      A string of CSS rules.
-	 *         @string string $expected Expected string of CSS rules.
+	 *         @type string $css      A string of CSS rules.
+	 *         @type string $expected Expected string of CSS rules.
 	 *     }
 	 * }
 	 */
@@ -1614,8 +1614,8 @@ EOF;
 	 *
 	 * @return array {
 	 *     @type array {
-	 *         @string string $css      A string of CSS rules.
-	 *         @string string $expected Expected string of CSS rules.
+	 *         @type string $css      A string of CSS rules.
+	 *         @type string $expected Expected string of CSS rules.
 	 *     }
 	 * }
 	 */

--- a/tests/phpunit/tests/post/thumbnails.php
+++ b/tests/phpunit/tests/post/thumbnails.php
@@ -455,7 +455,7 @@ class Tests_Post_Thumbnail_Template extends WP_UnitTestCase {
 	 *
 	 * @ticket 58212
 	 *
-	 * @covers::_wp_post_thumbnail_context_filter
+	 * @covers ::_wp_post_thumbnail_context_filter
 	 */
 	public function test_wp_post_thumbnail_context_filter_should_return_the_post_thumbnail() {
 		$this->assertSame( 'the_post_thumbnail', _wp_post_thumbnail_context_filter( 'wp_get_attachment_image' ) );

--- a/tests/phpunit/tests/privacy/wpPrivacyProcessPersonalDataExportPage.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyProcessPersonalDataExportPage.php
@@ -626,12 +626,12 @@ class Tests_Privacy_wpPrivacyProcessPersonalDataExportPage extends WP_UnitTestCa
 	 *
 	 * @return array {
 	 *     @type array {
-	 *         @string string $expected_status The expected post status after calling the function.
-	 *         @string string $response_page   The exporter page to pass. Options are 'first' and 'last'. Default 'first'.
-	 *         @string string $exporter_index  The exporter index to pass. Options are 'first' and 'last'. Default 'first'.
-	 *         @string string $page_index      The page index to pass. Options are 'first' and 'last'. Default 'first'.
-	 *         @bool   bool   $send_as_email   If the response should be sent as an email.
-	 *         @string string $exporter_key    The slug (key) of the exporter to pass.
+	 *         @type string $expected_status The expected post status after calling the function.
+	 *         @type string $response_page   The exporter page to pass. Options are 'first' and 'last'. Default 'first'.
+	 *         @type string $exporter_index  The exporter index to pass. Options are 'first' and 'last'. Default 'first'.
+	 *         @type string $page_index      The page index to pass. Options are 'first' and 'last'. Default 'first'.
+	 *         @type bool   $send_as_email   If the response should be sent as an email.
+	 *         @type string $exporter_key    The slug (key) of the exporter to pass.
 	 *     }
 	 * }
 	 */

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -256,7 +256,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	/**
 	 * A valid query that returns 0 results should return an empty JSON list.
 	 *
-	 * @issue 862
+	 * @ticket 862
 	 */
 	public function test_get_items_empty_query() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );

--- a/tests/phpunit/tests/theme/wpThemeGetAllowedFilters.php
+++ b/tests/phpunit/tests/theme/wpThemeGetAllowedFilters.php
@@ -8,7 +8,7 @@ if ( is_multisite() ) :
 	 */
 	class Tests_Theme_wpThemeGetAllowedFilters extends WP_UnitTestCase {
 		/**
-		 * @array List of themes allowed before filters are applied.
+		 * @var array List of themes allowed before filters are applied.
 		 */
 		protected $default_allowed;
 


### PR DESCRIPTION
### Docs: fix incorrect `@private` tags

The `@private` tag doesn't exist and isn't supported. To indicate something is `private` when in the global namespace, `@access private` should be used instead.

Ref: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#phpdoc-tags

### Docs: use proper case for `@todo` tags

The correct tag is `@todo`, not `@TODO` or `@todo:` (note the trailing colon).

Ref: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#phpdoc-tags

### Docs: fix various incorrect WP-flavoured array specifications

Tags like `@string` or `@array` do not exist and are not supported. The way these were used here, also meant duplicate information being documented.

Fixed now by using the `@type` tag as per the WP flavour of array documentation.

Includes some fixes to the documentation formatting.

Ref: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#1-1-parameters-that-are-arrays

### Docs: fix incorrect `@return` tag

`@return[]` is not a valid tag. Fixed now, though without further specification.

Ref: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#phpdoc-tags

### Docs: fix broken `@covers` tag

Without the space between the tag and the "description", the tag will not be recognized and the test will not record coverage correctly.

Ref: https://docs.phpunit.de/en/9.6/annotations.html#covers

### Docs: fix incorrect property doc

The `@array` tag does not exist. This should be `@var array`.

Ref: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#2-1-class-members

### Docs: miscellaneous other doc fixes

* `@contrib` is not a valid tag.
* `@origin` is not a valid tag.
* `@ref` is not a valid tag.
* `@blessed` is not a valid tag and doesn't convey any meaningful information.
* `@issue` is not a valid tag.

Ref: Ref: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/#phpdoc-tags

Trac ticket: https://core.trac.wordpress.org/ticket/59651

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
