### PR TITLE
#59715: Fix blocks RTL style loading issue

### DIFF
--- a/src/wp-includes/blocks/index.php
+++ b/src/wp-includes/blocks/index.php
@@ -106,11 +106,11 @@ function register_core_block_style_handles() {
 		$wp_styles->add( $style_handle, $blocks_url . $style_path );
 		$wp_styles->add_data( $style_handle, 'path', $path );
 
-		$rtl_file = str_replace( "{$suffix}.css", "-rtl{$suffix}.css", $path );
+		$rtl_file = "{$name}/{$filename}-rtl{$suffix}.css";
 		if ( is_rtl() && in_array( $rtl_file, $files, true ) ) {
 			$wp_styles->add_data( $style_handle, 'rtl', 'replace' );
 			$wp_styles->add_data( $style_handle, 'suffix', $suffix );
-			$wp_styles->add_data( $style_handle, 'path', $rtl_file );
+			$wp_styles->add_data( $style_handle, 'path', str_replace( "{$suffix}.css", "-rtl{$suffix}.css", $path ) );
 		}
 	};
 

--- a/tests/phpunit/tests/blocks/registerCoreBlockStyleHandles.php
+++ b/tests/phpunit/tests/blocks/registerCoreBlockStyleHandles.php
@@ -132,6 +132,41 @@ class Tests_Blocks_registerCoreBlockStyleHandles extends WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * @ticket 59715
+	 *
+	 * @dataProvider data_block_data
+	 *
+	 * @param string $name The block name.
+	 */
+	public function test_register_core_block_style_handles_should_load_rtl_stylesheets_for_rtl_text_direction( $name ) {
+		global $wp_locale;
+
+		$orig_text_dir             = $wp_locale->text_direction;
+		$wp_locale->text_direction = 'rtl';
+
+		add_filter( 'should_load_separate_core_block_assets', '__return_true' );
+		add_theme_support( 'wp-block-styles' );
+		register_core_block_style_handles();
+
+		$wp_styles = $GLOBALS['wp_styles'];
+
+		$style_handle = "wp-block-{$name}-theme";
+
+		$wp_locale->text_direction = $orig_text_dir;
+
+		$this->assertArrayHasKey( $style_handle, $wp_styles->registered, 'The key should exist, as this style should be registered' );
+		if ( false === $wp_styles->registered[ $style_handle ]->src ) {
+			$this->assertEmpty( $wp_styles->registered[ $style_handle ]->extra, 'If source is false, not style path should be set' );
+		} else {
+			$this->assertStringContainsString( $this->includes_url, $wp_styles->registered[ $style_handle ]->src, 'Source of style should contain the includes url' );
+			$this->assertNotEmpty( $wp_styles->registered[ $style_handle ]->extra, 'The path of the style should exist' );
+			$this->assertArrayHasKey( 'path', $wp_styles->registered[ $style_handle ]->extra, 'The path key of the style should exist in extra array' );
+			$this->assertArrayHasKey( 'rtl', $wp_styles->registered[ $style_handle ]->extra, 'The rtl key of the style should exist in extra array' );
+			$this->assertNotEmpty( $wp_styles->registered[ $style_handle ]->extra['path'], 'The path key of the style should not be empty' );
+		}
+	}
+
 	public function data_block_data() {
 		$core_blocks_meta = require ABSPATH . WPINC . '/blocks/blocks-json.php';
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/59715


The RTL style issue emerged following the r56524 commit in 6.3.2. Following this commit, the full path for the RTL style is now being used, as exemplified by `/var/www/src/wp-includes/blocks/navigation/style-rtl.css`.

Within the `$files` variable, we maintain a list of styles that must be loaded alongside the block path, for instance, `blockname/blockstyle.css`.

However, an issue arises with the condition:

```php
if ( is_rtl() && in_array( $rtl_file, $files, true ) ) {
```

This condition is failing, leading to the failure to load the RTL style. Instead, the normal style for the block is loaded.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
