### PR TITLE
HTML API: Refactor wp_targeted_link_rel

### DIFF
--- a/tests/phpunit/tests/formatting/wpTargetedLinkRel.php
+++ b/tests/phpunit/tests/formatting/wpTargetedLinkRel.php
@@ -11,61 +11,61 @@ class Tests_Formatting_wpTargetedLinkRel extends WP_UnitTestCase {
 	public function test_add_to_links_with_target_blank() {
 		$content  = '<p>Links: <a href="/" target="_blank">No rel</a></p>';
 		$expected = '<p>Links: <a href="/" target="_blank" rel="noopener">No rel</a></p>';
-		$this->assertSame( $expected, wp_targeted_link_rel( $content ) );
+		$this->assertEqualMarkup( $expected, wp_targeted_link_rel( $content ) );
 	}
 
 	public function test_add_to_links_with_target_foo() {
 		$content  = '<p>Links: <a href="/" target="foo">No rel</a></p>';
 		$expected = '<p>Links: <a href="/" target="foo" rel="noopener">No rel</a></p>';
-		$this->assertSame( $expected, wp_targeted_link_rel( $content ) );
+		$this->assertEqualMarkup( $expected, wp_targeted_link_rel( $content ) );
 	}
 
 	public function test_target_as_first_attribute() {
 		$content  = '<p>Links: <a target="_blank" href="#">No rel</a></p>';
 		$expected = '<p>Links: <a target="_blank" href="#" rel="noopener">No rel</a></p>';
-		$this->assertSame( $expected, wp_targeted_link_rel( $content ) );
+		$this->assertEqualMarkup( $expected, wp_targeted_link_rel( $content ) );
 	}
 
 	public function test_add_to_existing_rel() {
 		$content  = '<p>Links: <a href="/" rel="existing values" target="_blank">Existing rel</a></p>';
 		$expected = '<p>Links: <a href="/" rel="existing values noopener" target="_blank">Existing rel</a></p>';
-		$this->assertSame( $expected, wp_targeted_link_rel( $content ) );
+		$this->assertEqualMarkup( $expected, wp_targeted_link_rel( $content ) );
 	}
 
 	public function test_no_duplicate_values_added() {
 		$content  = '<p>Links: <a href="/" rel="existing noopener values" target="_blank">Existing rel</a></p>';
 		$expected = '<p>Links: <a href="/" rel="existing noopener values" target="_blank">Existing rel</a></p>';
-		$this->assertSame( $expected, wp_targeted_link_rel( $content ) );
+		$this->assertEqualMarkup( $expected, wp_targeted_link_rel( $content ) );
 	}
 
 	public function test_rel_with_single_quote_delimiter() {
 		$content  = '<p>Links: <a href="/" rel=\'existing values\' target="_blank">Existing rel</a></p>';
 		$expected = '<p>Links: <a href="/" rel="existing values noopener" target="_blank">Existing rel</a></p>';
-		$this->assertSame( $expected, wp_targeted_link_rel( $content ) );
+		$this->assertEqualMarkup( $expected, wp_targeted_link_rel( $content ) );
 	}
 
 	public function test_rel_with_no_delimiter() {
 		$content  = '<p>Links: <a href="/" rel=existing target="_blank">Existing rel</a></p>';
 		$expected = '<p>Links: <a href="/" rel="existing noopener" target="_blank">Existing rel</a></p>';
-		$this->assertSame( $expected, wp_targeted_link_rel( $content ) );
+		$this->assertEqualMarkup( $expected, wp_targeted_link_rel( $content ) );
 	}
 
 	public function test_rel_value_spaced_and_no_delimiter() {
 		$content  = '<p>Links: <a href="/" rel = existing target="_blank">Existing rel</a></p>';
 		$expected = '<p>Links: <a href="/" rel="existing noopener" target="_blank">Existing rel</a></p>';
-		$this->assertSame( $expected, wp_targeted_link_rel( $content ) );
+		$this->assertEqualMarkup( $expected, wp_targeted_link_rel( $content ) );
 	}
 
 	public function test_escaped_quotes() {
 		$content  = '<p>Links: <a href=\"/\" rel=\"existing values\" target=\"_blank\">Existing rel</a></p>';
 		$expected = '<p>Links: <a href=\"/\" rel=\"existing values noopener\" target=\"_blank\">Existing rel</a></p>';
-		$this->assertSame( $expected, wp_targeted_link_rel( $content ) );
+		$this->assertEqualMarkup( $expected, wp_targeted_link_rel( $content ) );
 	}
 
 	public function test_ignore_links_with_no_target() {
 		$content  = '<p>Links: <a href="/" target="_blank">Change me</a> <a href="/">Do not change me</a></p>';
 		$expected = '<p>Links: <a href="/" target="_blank" rel="noopener">Change me</a> <a href="/">Do not change me</a></p>';
-		$this->assertSame( $expected, wp_targeted_link_rel( $content ) );
+		$this->assertEqualMarkup( $expected, wp_targeted_link_rel( $content ) );
 	}
 
 	/**
@@ -77,7 +77,7 @@ class Tests_Formatting_wpTargetedLinkRel extends WP_UnitTestCase {
 		add_filter( 'wp_targeted_link_rel', '__return_empty_string' );
 		$content  = '<p>Links: <a href="/" target="_blank">Do not change me</a></p>';
 		$expected = '<p>Links: <a href="/" target="_blank">Do not change me</a></p>';
-		$this->assertSame( $expected, wp_targeted_link_rel( $content ) );
+		$this->assertEqualMarkup( $expected, wp_targeted_link_rel( $content ) );
 	}
 
 	/**
@@ -95,7 +95,7 @@ class Tests_Formatting_wpTargetedLinkRel extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSame( $expected, $post->post_content );
+		$this->assertEqualMarkup( $expected, $post->post_content );
 	}
 
 	/**
@@ -106,7 +106,7 @@ class Tests_Formatting_wpTargetedLinkRel extends WP_UnitTestCase {
 	public function test_wp_targeted_link_rel_should_preserve_json() {
 		$content  = '<p>Links: <a href=\"\/\" target=\"_blank\">No rel<\/a><\/p>';
 		$expected = '<p>Links: <a href=\"\/\" target=\"_blank\" rel=\"noopener\">No rel<\/a><\/p>';
-		$this->assertSame( $expected, wp_targeted_link_rel( $content ) );
+		$this->assertEqualMarkup( $expected, wp_targeted_link_rel( $content ) );
 	}
 
 	/**
@@ -117,7 +117,7 @@ class Tests_Formatting_wpTargetedLinkRel extends WP_UnitTestCase {
 	public function test_wp_targeted_link_rel_skips_style_and_scripts() {
 		$content  = '<style><a href="/" target=a></style><p>Links: <script>console.log("<a href=\'/\' target=a>hi</a>");</script><script>alert(1);</script>here <a href="/" target=_blank>aq</a></p><script>console.log("<a href=\'last\' target=\'_blank\'")</script>';
 		$expected = '<style><a href="/" target=a></style><p>Links: <script>console.log("<a href=\'/\' target=a>hi</a>");</script><script>alert(1);</script>here <a href="/" target="_blank" rel="noopener">aq</a></p><script>console.log("<a href=\'last\' target=\'_blank\'")</script>';
-		$this->assertSame( $expected, wp_targeted_link_rel( $content ) );
+		$this->assertEqualMarkup( $expected, wp_targeted_link_rel( $content ) );
 	}
 
 	/**
@@ -134,6 +134,6 @@ class Tests_Formatting_wpTargetedLinkRel extends WP_UnitTestCase {
 	public function test_wp_targeted_link_rel_tab_separated_values_are_split() {
 		$content  = "<p>Links: <a href=\"/\" target=\"_blank\" rel=\"ugc\t\tnoopener\t\">No rel</a></p>";
 		$expected = '<p>Links: <a href="/" target="_blank" rel="ugc noopener">No rel</a></p>';
-		$this->assertSame( $expected, wp_targeted_link_rel( $content ) );
+		$this->assertEqualMarkup( $expected, wp_targeted_link_rel( $content ) );
 	}
 }

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1211,18 +1211,18 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		}
 
 		// Compare expected API output to actual API output.
-		$this->assertSame( $expected_output['title']['raw'], $actual_output['title']['raw'] );
-		$this->assertSame( $expected_output['title']['rendered'], trim( $actual_output['title']['rendered'] ) );
-		$this->assertSame( $expected_output['description']['raw'], $actual_output['description']['raw'] );
-		$this->assertSame( $expected_output['description']['rendered'], trim( $actual_output['description']['rendered'] ) );
-		$this->assertSame( $expected_output['caption']['raw'], $actual_output['caption']['raw'] );
-		$this->assertSame( $expected_output['caption']['rendered'], trim( $actual_output['caption']['rendered'] ) );
+		$this->assertEqualMarkup( $expected_output['title']['raw'], $actual_output['title']['raw'] );
+		$this->assertEqualMarkup( $expected_output['title']['rendered'], trim( $actual_output['title']['rendered'] ) );
+		$this->assertEqualMarkup( $expected_output['description']['raw'], $actual_output['description']['raw'] );
+		$this->assertEqualMarkup( $expected_output['description']['rendered'], trim( $actual_output['description']['rendered'] ) );
+		$this->assertEqualMarkup( $expected_output['caption']['raw'], $actual_output['caption']['raw'] );
+		$this->assertEqualMarkup( $expected_output['caption']['rendered'], trim( $actual_output['caption']['rendered'] ) );
 
 		// Compare expected API output to WP internal values.
 		$post = get_post( $actual_output['id'] );
-		$this->assertSame( $expected_output['title']['raw'], $post->post_title );
-		$this->assertSame( $expected_output['description']['raw'], $post->post_content );
-		$this->assertSame( $expected_output['caption']['raw'], $post->post_excerpt );
+		$this->assertEqualMarkup( $expected_output['title']['raw'], $post->post_title );
+		$this->assertEqualMarkup( $expected_output['description']['raw'], $post->post_content );
+		$this->assertEqualMarkup( $expected_output['caption']['raw'], $post->post_excerpt );
 
 		// Update the post.
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/media/%d', $actual_output['id'] ) );
@@ -1243,18 +1243,18 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		}
 
 		// Compare expected API output to actual API output.
-		$this->assertSame( $expected_output['title']['raw'], $actual_output['title']['raw'] );
-		$this->assertSame( $expected_output['title']['rendered'], trim( $actual_output['title']['rendered'] ) );
-		$this->assertSame( $expected_output['description']['raw'], $actual_output['description']['raw'] );
-		$this->assertSame( $expected_output['description']['rendered'], trim( $actual_output['description']['rendered'] ) );
-		$this->assertSame( $expected_output['caption']['raw'], $actual_output['caption']['raw'] );
-		$this->assertSame( $expected_output['caption']['rendered'], trim( $actual_output['caption']['rendered'] ) );
+		$this->assertEqualMarkup( $expected_output['title']['raw'], $actual_output['title']['raw'] );
+		$this->assertEqualMarkup( $expected_output['title']['rendered'], trim( $actual_output['title']['rendered'] ) );
+		$this->assertEqualMarkup( $expected_output['description']['raw'], $actual_output['description']['raw'] );
+		$this->assertEqualMarkup( $expected_output['description']['rendered'], trim( $actual_output['description']['rendered'] ) );
+		$this->assertEqualMarkup( $expected_output['caption']['raw'], $actual_output['caption']['raw'] );
+		$this->assertEqualMarkup( $expected_output['caption']['rendered'], trim( $actual_output['caption']['rendered'] ) );
 
 		// Compare expected API output to WP internal values.
 		$post = get_post( $actual_output['id'] );
-		$this->assertSame( $expected_output['title']['raw'], $post->post_title );
-		$this->assertSame( $expected_output['description']['raw'], $post->post_content );
-		$this->assertSame( $expected_output['caption']['raw'], $post->post_excerpt );
+		$this->assertEqualMarkup( $expected_output['title']['raw'], $post->post_title );
+		$this->assertEqualMarkup( $expected_output['description']['raw'], $post->post_content );
+		$this->assertEqualMarkup( $expected_output['caption']['raw'], $post->post_excerpt );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -3995,18 +3995,18 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$actual_output = $response->get_data();
 
 		// Compare expected API output to actual API output.
-		$this->assertSame( $expected_output['title']['raw'], $actual_output['title']['raw'] );
-		$this->assertSame( $expected_output['title']['rendered'], trim( $actual_output['title']['rendered'] ) );
-		$this->assertSame( $expected_output['content']['raw'], $actual_output['content']['raw'] );
-		$this->assertSame( $expected_output['content']['rendered'], trim( $actual_output['content']['rendered'] ) );
-		$this->assertSame( $expected_output['excerpt']['raw'], $actual_output['excerpt']['raw'] );
-		$this->assertSame( $expected_output['excerpt']['rendered'], trim( $actual_output['excerpt']['rendered'] ) );
+		$this->assertEqualMarkup( $expected_output['title']['raw'], $actual_output['title']['raw'] );
+		$this->assertEqualMarkup( $expected_output['title']['rendered'], trim( $actual_output['title']['rendered'] ) );
+		$this->assertEqualMarkup( $expected_output['content']['raw'], $actual_output['content']['raw'] );
+		$this->assertEqualMarkup( $expected_output['content']['rendered'], trim( $actual_output['content']['rendered'] ) );
+		$this->assertEqualMarkup( $expected_output['excerpt']['raw'], $actual_output['excerpt']['raw'] );
+		$this->assertEqualMarkup( $expected_output['excerpt']['rendered'], trim( $actual_output['excerpt']['rendered'] ) );
 
 		// Compare expected API output to WP internal values.
 		$post = get_post( $actual_output['id'] );
-		$this->assertSame( $expected_output['title']['raw'], $post->post_title );
-		$this->assertSame( $expected_output['content']['raw'], $post->post_content );
-		$this->assertSame( $expected_output['excerpt']['raw'], $post->post_excerpt );
+		$this->assertEqualMarkup( $expected_output['title']['raw'], $post->post_title );
+		$this->assertEqualMarkup( $expected_output['content']['raw'], $post->post_content );
+		$this->assertEqualMarkup( $expected_output['excerpt']['raw'], $post->post_excerpt );
 
 		// Update the post.
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/posts/%d', $actual_output['id'] ) );
@@ -4018,18 +4018,18 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$actual_output = $response->get_data();
 
 		// Compare expected API output to actual API output.
-		$this->assertSame( $expected_output['title']['raw'], $actual_output['title']['raw'] );
-		$this->assertSame( $expected_output['title']['rendered'], trim( $actual_output['title']['rendered'] ) );
-		$this->assertSame( $expected_output['content']['raw'], $actual_output['content']['raw'] );
-		$this->assertSame( $expected_output['content']['rendered'], trim( $actual_output['content']['rendered'] ) );
-		$this->assertSame( $expected_output['excerpt']['raw'], $actual_output['excerpt']['raw'] );
-		$this->assertSame( $expected_output['excerpt']['rendered'], trim( $actual_output['excerpt']['rendered'] ) );
+		$this->assertEqualMarkup( $expected_output['title']['raw'], $actual_output['title']['raw'] );
+		$this->assertEqualMarkup( $expected_output['title']['rendered'], trim( $actual_output['title']['rendered'] ) );
+		$this->assertEqualMarkup( $expected_output['content']['raw'], $actual_output['content']['raw'] );
+		$this->assertEqualMarkup( $expected_output['content']['rendered'], trim( $actual_output['content']['rendered'] ) );
+		$this->assertEqualMarkup( $expected_output['excerpt']['raw'], $actual_output['excerpt']['raw'] );
+		$this->assertEqualMarkup( $expected_output['excerpt']['rendered'], trim( $actual_output['excerpt']['rendered'] ) );
 
 		// Compare expected API output to WP internal values.
 		$post = get_post( $actual_output['id'] );
-		$this->assertSame( $expected_output['title']['raw'], $post->post_title );
-		$this->assertSame( $expected_output['content']['raw'], $post->post_content );
-		$this->assertSame( $expected_output['excerpt']['raw'], $post->post_excerpt );
+		$this->assertEqualMarkup( $expected_output['title']['raw'], $post->post_title );
+		$this->assertEqualMarkup( $expected_output['content']['raw'], $post->post_content );
+		$this->assertEqualMarkup( $expected_output['excerpt']['raw'], $post->post_excerpt );
 	}
 
 	/**

--- a/tests/phpunit/tests/widgets/wpWidgetMediaImage.php
+++ b/tests/phpunit/tests/widgets/wpWidgetMediaImage.php
@@ -542,9 +542,12 @@ class Tests_Widgets_wpWidgetMediaImage extends WP_UnitTestCase {
 		);
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( '<a href="https://example.org"', $output );
-		$this->assertStringContainsString( 'target="_blank"', $output );
-		$this->assertStringContainsString( 'rel="noopener"', $output );
+		$dom = new DOMDocument();
+		$dom->loadHTML( '<html><meta charset="utf-8">' . $output );
+		$a = $dom->getElementsByTagName( 'A' )->item( 0 );
+		$this->assertEquals( 'https://example.org', $a->attributes['href'] );
+		$this->assertEquals( '_blank', $a->attributes['target'] );
+		$this->assertEquals( 'noopener', $a->attributes['rel'] );
 
 		// Populate caption in attachment.
 		wp_update_post(


### PR DESCRIPTION
See #5143

 - [ ] Propose a kind of `assertEqualMarkup` on `WP_UnitTestCase`
 - [ ] Update all the tests
 - [ ] Talk about back-compat issue with filter.

This patch refactors `wp_targeted_link_rel` to be more reliable and clear by using the HTML API to replace existing PCRE code. It provides backwards compatability for the `rel` filter by creating a quick HTML string representing the opening A tag for the matched element and providing the `href`, `rel`, and `target` attributes on that tag.