### PR TITLE
Ignore case if matching post type archive slugs

### DIFF
--- a/src/wp-includes/class-wp-post-type.php
+++ b/src/wp-includes/class-wp-post-type.php
@@ -705,7 +705,7 @@ final class WP_Post_Type {
 				} else {
 					$archive_slug = $wp_rewrite->root . $archive_slug;
 				}
-
+				$archive_slug = "(?i)$archive_slug";
 				add_rewrite_rule( "{$archive_slug}/?$", "index.php?post_type=$this->name", 'top' );
 				if ( $this->rewrite['feeds'] && $wp_rewrite->feeds ) {
 					$feeds = '(' . trim( implode( '|', $wp_rewrite->feeds ) ) . ')';


### PR DESCRIPTION
Matches the archive slug of custom post type archives case-insensitive, so that existing pages with the same slug don't take precedence. 

**The Problem**

- Have a page "Projects" with a slug of `/projects/`
- Have a custom post type with an archive slug of `/projects/`
- Visit `/Projects/` in your frontend (with a capital P)
- Observe how WordPress resolves to the single page instead of the archive page

**Proposed Solution**

Make the rewrite rule for post type archives case-insensitive using the inline modifier `(?i)` [as described here](https://wordpress.stackexchange.com/a/311069/18713).

Trac ticket: https://core.trac.wordpress.org/ticket/59766#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
