### PR TITLE
Autoload some options

### DIFF
--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -843,6 +843,10 @@ function upgrade_all() {
 		upgrade_640();
 	}
 
+	if ( $wp_current_db_version < 57500 ) {
+		upgrade_650();
+	}
+
 	maybe_disable_link_manager();
 
 	maybe_disable_automattic_widgets();
@@ -2345,6 +2349,33 @@ function upgrade_640() {
 		$scheduled = wp_get_scheduled_event( 'wp_https_detection' );
 		if ( $scheduled ) {
 			wp_clear_scheduled_hook( 'wp_https_detection' );
+		}
+	}
+}
+
+/**
+ * Executes changes made in WordPress 6.5.0.
+ *
+ * @ignore
+ * @since 6.5.0
+ *
+ * @global int $wp_current_db_version The old (current) database version.
+ */
+function upgrade_650() {
+	global $wp_current_db_version;
+
+	if ( $wp_current_db_version < 57500 ) {
+		$update_options = array(
+			'medium_crop',
+			'medium_large_crop',
+			'large_crop',
+			'site_logo',
+		);
+
+		foreach ( $update_options as $option ) {
+			$value = get_option( $option );
+			delete_option( $option );
+			add_option( $option, $value, '', 'yes' );
 		}
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/56912

This PR includes setting the `autoload` attribute for certain options that were previously missing it. While in r55854, we already enabled autoload for the `can_compress_scripts` option, this PR extends that to include other missing options.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
