### PR TITLE
Undefined array key when using wp_list_pluck function

### DIFF
--- a/src/wp-includes/class-wp-list-util.php
+++ b/src/wp-includes/class-wp-list-util.php
@@ -165,9 +165,9 @@ class WP_List_Util {
 			 */
 			foreach ( $this->output as $key => $value ) {
 				if ( is_object( $value ) ) {
-					$newlist[ $key ] = $value->$field;
+					$newlist[ $key ] = $value->$field ?? array();
 				} elseif ( is_array( $value ) ) {
-					$newlist[ $key ] = $value[ $field ];
+					$newlist[ $key ] = $value[ $field ] ?? array();
 				} else {
 					_doing_it_wrong(
 						__METHOD__,


### PR DESCRIPTION
In this PR, we use coalescing operator `??` to check if the key `$field` exists in either the object or the array. If the key exists, it assigns the value to `$newlist[$key]`. If the key doesn't exist, it assigns empty `array()`.
This modification will prevent the code from triggering an error when attempting to access non-existent keys in an array or object. Instead, it will gracefully assign empty `array()`.

Trac ticket: https://core.trac.wordpress.org/ticket/59774

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
