### PR TITLE
Block Hooks: Allow traversal callbacks to modify parent block

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -785,7 +785,7 @@ function make_before_block_visitor( $hooked_blocks, $context ) {
 	 * @param array $prev         The previous sibling block of the given block.
 	 * @return string The serialized markup for the given block, with the markup for any hooked blocks prepended to it.
 	 */
-	return function ( &$block, $parent_block = null, $prev = null ) use ( $hooked_blocks, $context ) {
+	return function ( &$block, &$parent_block = null, $prev = null ) use ( $hooked_blocks, $context ) {
 		_inject_theme_attribute_in_template_part_block( $block );
 
 		$markup = '';
@@ -858,7 +858,7 @@ function make_after_block_visitor( $hooked_blocks, $context ) {
 	 * @param array $next         The next sibling block of the given block.
 	 * @return string The serialized markup for the given block, with the markup for any hooked blocks appended to it.
 	 */
-	return function ( &$block, $parent_block = null, $next = null ) use ( $hooked_blocks, $context ) {
+	return function ( &$block, &$parent_block = null, $next = null ) use ( $hooked_blocks, $context ) {
 		$markup = '';
 
 		$relative_position  = 'after';
@@ -1065,7 +1065,7 @@ function traverse_and_serialize_block( $block, $pre_callback = null, $post_callb
 
 				$block_content .= call_user_func_array(
 					$pre_callback,
-					array( &$inner_block, $block, $prev )
+					array( &$inner_block, &$block, $prev )
 				);
 			}
 
@@ -1076,7 +1076,7 @@ function traverse_and_serialize_block( $block, $pre_callback = null, $post_callb
 
 				$post_markup = call_user_func_array(
 					$post_callback,
-					array( &$inner_block, $block, $next )
+					array( &$inner_block, &$block, $next )
 				);
 			}
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -780,8 +780,8 @@ function make_before_block_visitor( $hooked_blocks, $context ) {
 	 * Furthermore, prepend the markup for any blocks hooked `before` the given block and as its parent's
 	 * `first_child`, respectively, to the serialized markup for the given block.
 	 *
-	 * @param array $block        The block to inject the theme attribute into, and hooked blocks before.
-	 * @param array $parent_block The parent block of the given block.
+	 * @param array $block        The block to inject the theme attribute into, and hooked blocks before. Passed by reference.
+	 * @param array $parent_block The parent block of the given block. Passed by reference.
 	 * @param array $prev         The previous sibling block of the given block.
 	 * @return string The serialized markup for the given block, with the markup for any hooked blocks prepended to it.
 	 */
@@ -853,8 +853,8 @@ function make_after_block_visitor( $hooked_blocks, $context ) {
 	 * Append the markup for any blocks hooked `after` the given block and as its parent's
 	 * `last_child`, respectively, to the serialized markup for the given block.
 	 *
-	 * @param array $block        The block to inject the hooked blocks after.
-	 * @param array $parent_block The parent block of the given block.
+	 * @param array $block        The block to inject the hooked blocks after. Passed by reference.
+	 * @param array $parent_block The parent block of the given block. Passed by reference.
 	 * @param array $next         The next sibling block of the given block.
 	 * @return string The serialized markup for the given block, with the markup for any hooked blocks appended to it.
 	 */

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1132,7 +1132,7 @@ function traverse_and_serialize_block( $block, $pre_callback = null, $post_callb
  */
 function traverse_and_serialize_blocks( $blocks, $pre_callback = null, $post_callback = null ) {
 	$result = '';
-	$parent = null; // At the top level, there is no parent block to pass to the callback; yet the callback expects a reference.
+	$parent = null; // At the top level, there is no parent block to pass to the callbacks; yet the callbacks expect a reference.
 	foreach ( $blocks as $index => $block ) {
 		if ( is_callable( $pre_callback ) ) {
 			$prev = 0 === $index

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1141,7 +1141,7 @@ function traverse_and_serialize_blocks( $blocks, $pre_callback = null, $post_cal
 
 			$result .= call_user_func_array(
 				$pre_callback,
-				array( &$block, $parent, $prev )
+				array( &$block, &$parent, $prev )
 			);
 		}
 
@@ -1152,7 +1152,7 @@ function traverse_and_serialize_blocks( $blocks, $pre_callback = null, $post_cal
 
 			$post_markup = call_user_func_array(
 				$post_callback,
-				array( &$block, $parent, $next )
+				array( &$block, &$parent, $next )
 			);
 		}
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -781,8 +781,8 @@ function make_before_block_visitor( $hooked_blocks, $context ) {
 	 * `first_child`, respectively, to the serialized markup for the given block.
 	 *
 	 * @param array $block        The block to inject the theme attribute into, and hooked blocks before. Passed by reference.
-	 * @param array $parent_block The parent block of the given block. Passed by reference.
-	 * @param array $prev         The previous sibling block of the given block.
+	 * @param array $parent_block The parent block of the given block. Passed by reference. Default null.
+	 * @param array $prev         The previous sibling block of the given block. Default null.
 	 * @return string The serialized markup for the given block, with the markup for any hooked blocks prepended to it.
 	 */
 	return function ( &$block, &$parent_block = null, $prev = null ) use ( $hooked_blocks, $context ) {
@@ -854,8 +854,8 @@ function make_after_block_visitor( $hooked_blocks, $context ) {
 	 * `last_child`, respectively, to the serialized markup for the given block.
 	 *
 	 * @param array $block        The block to inject the hooked blocks after. Passed by reference.
-	 * @param array $parent_block The parent block of the given block. Passed by reference.
-	 * @param array $next         The next sibling block of the given block.
+	 * @param array $parent_block The parent block of the given block. Passed by reference. Default null.
+	 * @param array $next         The next sibling block of the given block. Default null.
 	 * @return string The serialized markup for the given block, with the markup for any hooked blocks appended to it.
 	 */
 	return function ( &$block, &$parent_block = null, $next = null ) use ( $hooked_blocks, $context ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1132,6 +1132,7 @@ function traverse_and_serialize_block( $block, $pre_callback = null, $post_callb
  */
 function traverse_and_serialize_blocks( $blocks, $pre_callback = null, $post_callback = null ) {
 	$result = '';
+	$parent = null; // At the top level, there is no parent block to pass to the callback; yet the callback expects a reference.
 	foreach ( $blocks as $index => $block ) {
 		if ( is_callable( $pre_callback ) ) {
 			$prev = 0 === $index
@@ -1140,7 +1141,7 @@ function traverse_and_serialize_blocks( $blocks, $pre_callback = null, $post_cal
 
 			$result .= call_user_func_array(
 				$pre_callback,
-				array( &$block, null, $prev ) // At the top level, there is no parent block to pass to the callback.
+				array( &$block, $parent, $prev )
 			);
 		}
 
@@ -1151,7 +1152,7 @@ function traverse_and_serialize_blocks( $blocks, $pre_callback = null, $post_cal
 
 			$post_markup = call_user_func_array(
 				$post_callback,
-				array( &$block, null, $next ) // At the top level, there is no parent block to pass to the callback.
+				array( &$block, $parent, $next )
 			);
 		}
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1131,8 +1131,9 @@ function traverse_and_serialize_block( $block, $pre_callback = null, $post_callb
  * @return string Serialized block markup.
  */
 function traverse_and_serialize_blocks( $blocks, $pre_callback = null, $post_callback = null ) {
-	$result = '';
-	$parent = null; // At the top level, there is no parent block to pass to the callbacks; yet the callbacks expect a reference.
+	$result       = '';
+	$parent_block = null; // At the top level, there is no parent block to pass to the callbacks; yet the callbacks expect a reference.
+
 	foreach ( $blocks as $index => $block ) {
 		if ( is_callable( $pre_callback ) ) {
 			$prev = 0 === $index
@@ -1141,7 +1142,7 @@ function traverse_and_serialize_blocks( $blocks, $pre_callback = null, $post_cal
 
 			$result .= call_user_func_array(
 				$pre_callback,
-				array( &$block, &$parent, $prev )
+				array( &$block, &$parent_block, $prev )
 			);
 		}
 
@@ -1152,7 +1153,7 @@ function traverse_and_serialize_blocks( $blocks, $pre_callback = null, $post_cal
 
 			$post_markup = call_user_func_array(
 				$post_callback,
-				array( &$block, &$parent, $next )
+				array( &$block, &$parent_block, $next )
 			);
 		}
 


### PR DESCRIPTION
_tl;dr:_ In 6.5, we'll need arguments to two functions introduced during the 6.4 cycle to become references. Since that can be deemed a back-compat breaking change, I'm suggesting to make that change already.

----

The callbacks returned by `make_before_block_visitor` and `make_after_block_visitor`, respectively (which are passed as arguments to `traverse_and_serialize_block(s)`) currently accept three arguments, all of which are block arrays (i.e. with properties `blockName`, `attrs`, etc.):
- A _reference_ to the block they're currently visiting, `&$block`;
- the block's `$parent_block`; and
- the `$prev`ious block (for `make_before_block_visitor`), or the `$next` block (for `make_after_block_visitor`), respectively.

Those arguments are passed to the "block visitor" callbacks by `traverse_and_serialize_block(s)` during traversal. The block that the callback is currently visiting is passed _by reference_ to allow modifying it, which is e.g. used to inject the `theme` attribute into Template Part blocks.

One major limitation with Block Hooks is that they currently only work with templates, parts, and patterns that _don't have any user modifications_ (i.e. that come straight from the corresponding theme files, rather than the DB). For WP 6.5, we're planning to change that to also make Block Hooks work for templates, parts, and patterns that _do_ have user modifications: [`#59646`](https://core.trac.wordpress.org/ticket/59646).

The way we'll make this work is by storing an attribute on the "anchor" block. This is currently being developed in https://github.com/WordPress/wordpress-develop/pull/5523.

While working on that PR, I noticed that that means that we'll also need to allow the aforementioned callbacks to modify not only the currently visited `$block`, but also the `$parent_block` -- i.e. to pass the latter argument by reference, too. This is consistent with the requirement of adding an attribute to an anchor block, as it's not only the currently visited block that can serve as an anchor block (in the case of `before` or `after` sibling insertion), but also its parent (for `first_child` and `last_child` insertion).

Per [discussion](https://wordpress.slack.com/archives/C02RQBWTW/p1698765741579409) with @hellofromtonya, changing the `$parent_block` argument to become a reference can be considered a backwards-compatibility breaking change. I'm thus suggesting to make that change already as part of 6.4, which is the cycle where the relevant functions were first introduced. This should have no impact on existing code, since nothing currently relies on `$parent_block` remaining unmodified by the respective callback, nor is anything currently modifying that argument.

Trac ticket: https://core.trac.wordpress.org/ticket/59776

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
