### PR TITLE
Docs: update submit_button function docs to match implementation

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2549,10 +2549,10 @@ function compression_test() {
  * @param bool         $wrap             True if the output button should be wrapped in a paragraph tag,
  *                                       false otherwise. Defaults to true.
  * @param array|string $other_attributes Other attributes that should be output with the button, mapping
- *                                       attributes to their values, such as setting tabindex to 1, etc.
+ *                                       attributes to their values, such as setting the id attribute, etc.
  *                                       These key/value attribute pairs will be output as attribute="value",
  *                                       where attribute is the key. Other attributes can also be provided
- *                                       as a string such as 'tabindex="1"', though the array format is
+ *                                       as a string such as 'id="search-submit"', though the array format is
  *                                       preferred. Default null.
  */
 function submit_button( $text = null, $type = 'primary', $name = 'submit', $wrap = true, $other_attributes = null ) {
@@ -2573,10 +2573,10 @@ function submit_button( $text = null, $type = 'primary', $name = 'submit', $wrap
  * @param bool         $wrap             Optional. True if the output button should be wrapped in a paragraph
  *                                       tag, false otherwise. Default true.
  * @param array|string $other_attributes Optional. Other attributes that should be output with the button,
- *                                       mapping attributes to their values, such as `array( 'tabindex' => '1' )`.
+ *                                       mapping attributes to their values, such as `array( 'id' => 'search-submit' )`.
  *                                       These attributes will be output as `attribute="value"`, such as
- *                                       `tabindex="1"`. Other attributes can also be provided as a string such
- *                                       as `tabindex="1"`, though the array format is typically cleaner.
+ *                                       `id="search-submit"`. Other attributes can also be provided as a string such
+ *                                       as `id="search-submit"`, though the array format is typically cleaner.
  *                                       Default empty.
  * @return string Submit button HTML.
  */


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Updates the docs on `submit_button` and `get_submit_button` function to match the general implementation used in wordpress. In https://core.trac.wordpress.org/changeset/21311 the usage of `tabindex="1"` was removed and it was suggested that another example be used. This PR switches the docs to use the `id` attribute as an example instead.

Trac ticket: https://core.trac.wordpress.org/ticket/59768

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
