### PR TITLE
Mark `traverse_and_serialize_block(s)` as `@access private`

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1035,6 +1035,8 @@ function serialize_blocks( $blocks ) {
  * This function should be used when there is a need to modify the saved block, or to inject markup
  * into the return value. Prefer `serialize_block` when preparing a block to be saved to post content.
  *
+ * This function is meant for internal use only.
+ *
  * @since 6.4.0
  * @access private
  *
@@ -1117,6 +1119,8 @@ function traverse_and_serialize_block( $block, $pre_callback = null, $post_callb
  *
  * This function should be used when there is a need to modify the saved blocks, or to inject markup
  * into the return value. Prefer `serialize_blocks` when preparing blocks to be saved to post content.
+ *
+ * This function is meant for internal use only.
  *
  * @since 6.4.0
  * @access private

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -764,6 +764,8 @@ function get_hooked_blocks() {
  * where it will inject the `theme` attribute into all Template Part blocks, and prepend the markup for
  * any blocks hooked `before` the given block and as its parent's `first_child`, respectively.
  *
+ * This function is meant for internal use only.
+ *
  * @since 6.4.0
  * @access private
  *
@@ -837,6 +839,8 @@ function make_before_block_visitor( $hooked_blocks, $context ) {
  * The returned function can be used as `$post_callback` argument to `traverse_and_serialize_block(s)`,
  * where it will append the markup for any blocks hooked `after` the given block and as its parent's
  * `last_child`, respectively.
+ *
+ * This function is meant for internal use only.
  *
  * @since 6.4.0
  * @access private

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1036,6 +1036,7 @@ function serialize_blocks( $blocks ) {
  * into the return value. Prefer `serialize_block` when preparing a block to be saved to post content.
  *
  * @since 6.4.0
+ * @access private
  *
  * @see serialize_block()
  *
@@ -1118,6 +1119,7 @@ function traverse_and_serialize_block( $block, $pre_callback = null, $post_callb
  * into the return value. Prefer `serialize_blocks` when preparing blocks to be saved to post content.
  *
  * @since 6.4.0
+ * @access private
  *
  * @see serialize_blocks()
  *


### PR DESCRIPTION
Change the PHPDoc for `traverse_and_serialize_block` and `traverse_and_serialize_blocks` to:

* Mark them as with `@access private`.
* Add an explanation to the DocBlock to better document they are intended for Core only usage.
* Consider renaming with the private `_` prefix to further denote these are for Core only.

Trac ticket: https://core.trac.wordpress.org/ticket/59783

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
