### PR TITLE
Block Types: Add `metadata` global attribute

### DIFF
--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -242,7 +242,7 @@ class WP_Block_Type {
 	/**
 	 * Attributes supported by every block.
 	 *
-	 * @since 6.0.0
+	 * @since 6.0.0 Added lock global attribute.
 	 * @since 6.5.0 Added metadata global attribute.
 	 * @var array
 	 */

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -242,8 +242,8 @@ class WP_Block_Type {
 	/**
 	 * Attributes supported by every block.
 	 *
-	 * @since 6.0.0 Added lock global attribute.
-	 * @since 6.5.0 Added metadata global attribute.
+	 * @since 6.0.0 Added `lock`.
+	 * @since 6.5.0 Added `metadata`.
 	 * @var array
 	 */
 	const GLOBAL_ATTRIBUTES = array(

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -243,10 +243,12 @@ class WP_Block_Type {
 	 * Attributes supported by every block.
 	 *
 	 * @since 6.0.0
+	 * @since 6.5.0 Added metadata global attribute.
 	 * @var array
 	 */
 	const GLOBAL_ATTRIBUTES = array(
-		'lock' => array( 'type' => 'object' ),
+		'lock'     => array( 'type' => 'object' ),
+		'metadata' => array( 'type' => 'object' ),
 	);
 
 	/**

--- a/tests/phpunit/tests/admin/includesPost.php
+++ b/tests/phpunit/tests/admin/includesPost.php
@@ -935,7 +935,8 @@ class Tests_Admin_IncludesPost extends WP_UnitTestCase {
 				'description' => '',
 				'icon'        => 'text',
 				'attributes'  => array(
-					'lock' => array( 'type' => 'object' ),
+					'lock'     => array( 'type' => 'object' ),
+					'metadata' => array( 'type' => 'object' ),
 				),
 				'usesContext' => array(),
 				'blockHooks'  => array( 'core/post-content' => 'before' ),

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -726,6 +726,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 * @ticket 50263
 	 * @ticket 50328
 	 * @ticket 57585
+	 * @ticket 59797
 	 */
 	public function test_block_registers_with_metadata_fixture() {
 		$result = register_block_type_from_metadata(

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -744,10 +744,11 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		$this->assertSameSets( array( 'alert', 'message' ), $result->keywords );
 		$this->assertSame(
 			array(
-				'message' => array(
+				'message'  => array(
 					'type' => 'string',
 				),
-				'lock'    => array( 'type' => 'object' ),
+				'lock'     => array( 'type' => 'object' ),
+				'metadata' => array( 'type' => 'object' ),
 			),
 			$result->attributes
 		);

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -83,6 +83,7 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 					'default' => 10,
 				),
 				'lock'      => array( 'type' => 'object' ),
+				'metadata'  => array( 'type' => 'object' ),
 			),
 			$block->block_type->attributes
 		);

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -59,6 +59,7 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 49927
+	 * @ticket 59797
 	 */
 	public function test_constructor_assigns_block_type_from_registry() {
 		$block_type_settings = array(

--- a/tests/phpunit/tests/blocks/wpBlockType.php
+++ b/tests/phpunit/tests/blocks/wpBlockType.php
@@ -80,6 +80,7 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 
 	/*
 	 * @ticket 55567
+	 * @ticket 59797
 	 * @covers WP_Block_Type::set_props
 	 */
 	public function test_core_attributes() {
@@ -96,6 +97,7 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 
 	/*
 	 * @ticket 55567
+	 * @ticket 59797
 	 * @covers WP_Block_Type::set_props
 	 */
 	public function test_core_attributes_matches_custom() {

--- a/tests/phpunit/tests/blocks/wpBlockType.php
+++ b/tests/phpunit/tests/blocks/wpBlockType.php
@@ -87,7 +87,8 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 
 		$this->assertSameSetsWithIndex(
 			array(
-				'lock' => array( 'type' => 'object' ),
+				'lock'     => array( 'type' => 'object' ),
+				'metadata' => array( 'type' => 'object' ),
 			),
 			$block_type->attributes
 		);
@@ -105,6 +106,9 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 					'lock' => array(
 						'type' => 'string',
 					),
+					'metadata' => array(
+						'type' => 'number',
+					)
 				),
 			)
 		);
@@ -112,7 +116,8 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 		// Backward compatibility: Don't override attributes with the same name.
 		$this->assertSameSetsWithIndex(
 			array(
-				'lock' => array( 'type' => 'string' ),
+				'lock'     => array( 'type' => 'string' ),
+				'metadata' => array( 'type' => 'number' ),
 			),
 			$block_type->attributes
 		);

--- a/tests/phpunit/tests/blocks/wpBlockType.php
+++ b/tests/phpunit/tests/blocks/wpBlockType.php
@@ -108,7 +108,7 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 					),
 					'metadata' => array(
 						'type' => 'number',
-					)
+					),
 				),
 			)
 		);

--- a/tests/phpunit/tests/blocks/wpBlockType.php
+++ b/tests/phpunit/tests/blocks/wpBlockType.php
@@ -105,7 +105,7 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 			'core/fake',
 			array(
 				'attributes' => array(
-					'lock' => array(
+					'lock'     => array(
 						'type' => 'string',
 					),
 					'metadata' => array(

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -242,7 +242,8 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertNull( $data['textdomain'] );
 		$this->assertSameSetsWithIndex(
 			array(
-				'lock' => array( 'type' => 'object' ),
+				'lock'     => array( 'type' => 'object' ),
+				'metadata' => array( 'type' => 'object' ),
 			),
 			$data['attributes']
 		);
@@ -316,7 +317,8 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertNull( $data['textdomain'] );
 		$this->assertSameSetsWithIndex(
 			array(
-				'lock' => array( 'type' => 'object' ),
+				'lock'     => array( 'type' => 'object' ),
+				'metadata' => array( 'type' => 'object' ),
 			),
 			$data['attributes']
 		);

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -198,6 +198,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 * @ticket 47620
 	 * @ticket 57585
 	 * @ticket 59346
+	 * @ticket 59797
 	 */
 	public function test_get_item_invalid() {
 		$block_type = 'fake/invalid';
@@ -273,6 +274,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 * @ticket 47620
 	 * @ticket 57585
 	 * @ticket 59346
+	 * @ticket 59797
 	 */
 	public function test_get_item_defaults() {
 		$block_type = 'fake/false';


### PR DESCRIPTION
For use cases such as allowing the user to [assign custom names to blocks](https://make.wordpress.org/core/2023/10/25/whats-new-in-gutenberg-16-9-25-october-2/#rename-almost-all-blocks-from-the-editor) or for making Block Hooks work with user-modified templates/parts/patterns ([`#59646`](https://core.trac.wordpress.org/ticket/59646)), there's a requirement for a new global attribute (i.e. an attribute that can be added to all and any blocks) to hold that sort of `metadata`. 

See https://github.com/WordPress/wordpress-develop/pull/2615 for precedent for registering a global attribute.

Spun off from https://github.com/WordPress/wordpress-develop/pull/5523.
Fixes https://github.com/WordPress/gutenberg/issues/55194.

Trac ticket: https://core.trac.wordpress.org/ticket/59797

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
