### PR TITLE
Block Hooks: Extract `insert_hooked_blocks()` function

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -757,7 +757,7 @@ function get_hooked_blocks() {
 	return $hooked_blocks;
 }
 
-function insert_hooked_blocks( &$block, $relative_position, &$anchor_block, $hooked_blocks, $context ) {
+function insert_hooked_blocks( $relative_position, &$anchor_block, $hooked_blocks, $context ) {
 	$anchor_block_type  = $anchor_block['blockName'];
 	$hooked_block_types = isset( $hooked_blocks[ $anchor_block_type ][ $relative_position ] )
 		? $hooked_blocks[ $anchor_block_type ][ $relative_position ]
@@ -821,10 +821,10 @@ function make_before_block_visitor( $hooked_blocks, $context ) {
 
 		if ( $parent_block && ! $prev ) {
 			// Candidate for first-child insertion.
-			$markup .= insert_hooked_blocks( $block, 'first_child', $parent_block, $hooked_blocks, $context );
+			$markup .= insert_hooked_blocks( 'first_child', $parent_block, $hooked_blocks, $context );
 		}
 
-		$markup .= insert_hooked_blocks( $block, 'before', $block, $hooked_blocks, $context );
+		$markup .= insert_hooked_blocks( 'before', $block, $hooked_blocks, $context );
 
 		return $markup;
 	};
@@ -860,11 +860,11 @@ function make_after_block_visitor( $hooked_blocks, $context ) {
 	 * @return string The serialized markup for the given block, with the markup for any hooked blocks appended to it.
 	 */
 	return function ( &$block, &$parent_block = null, $next = null ) use ( $hooked_blocks, $context ) {
-		$markup = insert_hooked_blocks( $block, 'after', $block, $hooked_blocks, $context );
+		$markup = insert_hooked_blocks( 'after', $block, $hooked_blocks, $context );
 
 		if ( $parent_block && ! $next ) {
 			// Candidate for last-child insertion.
-			$markup .= insert_hooked_blocks( $block, 'last_child', $parent_block, $hooked_blocks, $context );
+			$markup .= insert_hooked_blocks( 'last_child', $parent_block, $hooked_blocks, $context );
 		}
 
 		return $markup;

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -757,6 +757,33 @@ function get_hooked_blocks() {
 	return $hooked_blocks;
 }
 
+function insert_hooked_blocks( &$block, $relative_position, &$anchor_block, $hooked_blocks, $context ) {
+	$anchor_block_type  = $anchor_block['blockName'];
+	$hooked_block_types = isset( $hooked_blocks[ $anchor_block_type ][ $relative_position ] )
+		? $hooked_blocks[ $anchor_block_type ][ $relative_position ]
+		: array();
+
+	/**
+	 * Filters the list of hooked block types for a given anchor block type and relative position.
+	 *
+	 * @since 6.4.0
+	 *
+	 * @param string[]                $hooked_block_types  The list of hooked block types.
+	 * @param string                  $relative_position   The relative position of the hooked blocks.
+	 *                                                     Can be one of 'before', 'after', 'first_child', or 'last_child'.
+	 * @param string                  $anchor_block_type   The anchor block type.
+	 * @param WP_Block_Template|array $context             The block template, template part, or pattern that the anchor block belongs to.
+	 */
+	$hooked_block_types = apply_filters( 'hooked_block_types', $hooked_block_types, $relative_position, $anchor_block_type, $context );
+
+	$markup = '';
+	foreach ( $hooked_block_types as $hooked_block_type ) {
+		$markup .= get_comment_delimited_block_content( $hooked_block_type, array(), '' );
+	}
+
+	return $markup;
+}
+
 /**
  * Returns a function that injects the theme attribute into, and hooked blocks before, a given block.
  *
@@ -794,40 +821,10 @@ function make_before_block_visitor( $hooked_blocks, $context ) {
 
 		if ( $parent_block && ! $prev ) {
 			// Candidate for first-child insertion.
-			$relative_position  = 'first_child';
-			$anchor_block_type  = $parent_block['blockName'];
-			$hooked_block_types = isset( $hooked_blocks[ $anchor_block_type ][ $relative_position ] )
-				? $hooked_blocks[ $anchor_block_type ][ $relative_position ]
-				: array();
-
-			/**
-			 * Filters the list of hooked block types for a given anchor block type and relative position.
-			 *
-			 * @since 6.4.0
-			 *
-			 * @param string[]                $hooked_block_types  The list of hooked block types.
-			 * @param string                  $relative_position   The relative position of the hooked blocks.
-			 *                                                     Can be one of 'before', 'after', 'first_child', or 'last_child'.
-			 * @param string                  $anchor_block_type   The anchor block type.
-			 * @param WP_Block_Template|array $context             The block template, template part, or pattern that the anchor block belongs to.
-			 */
-			$hooked_block_types = apply_filters( 'hooked_block_types', $hooked_block_types, $relative_position, $anchor_block_type, $context );
-			foreach ( $hooked_block_types as $hooked_block_type ) {
-				$markup .= get_comment_delimited_block_content( $hooked_block_type, array(), '' );
-			}
+			$markup .= insert_hooked_blocks( $block, 'first_child', $parent_block, $hooked_blocks, $context );
 		}
 
-		$relative_position  = 'before';
-		$anchor_block_type  = $block['blockName'];
-		$hooked_block_types = isset( $hooked_blocks[ $anchor_block_type ][ $relative_position ] )
-			? $hooked_blocks[ $anchor_block_type ][ $relative_position ]
-			: array();
-
-		/** This filter is documented in wp-includes/blocks.php */
-		$hooked_block_types = apply_filters( 'hooked_block_types', $hooked_block_types, $relative_position, $anchor_block_type, $context );
-		foreach ( $hooked_block_types as $hooked_block_type ) {
-			$markup .= get_comment_delimited_block_content( $hooked_block_type, array(), '' );
-		}
+		$markup .= insert_hooked_blocks( $block, 'before', $block, $hooked_blocks, $context );
 
 		return $markup;
 	};
@@ -863,33 +860,11 @@ function make_after_block_visitor( $hooked_blocks, $context ) {
 	 * @return string The serialized markup for the given block, with the markup for any hooked blocks appended to it.
 	 */
 	return function ( &$block, &$parent_block = null, $next = null ) use ( $hooked_blocks, $context ) {
-		$markup = '';
-
-		$relative_position  = 'after';
-		$anchor_block_type  = $block['blockName'];
-		$hooked_block_types = isset( $hooked_blocks[ $anchor_block_type ][ $relative_position ] )
-				? $hooked_blocks[ $anchor_block_type ][ $relative_position ]
-				: array();
-
-		/** This filter is documented in wp-includes/blocks.php */
-		$hooked_block_types = apply_filters( 'hooked_block_types', $hooked_block_types, $relative_position, $anchor_block_type, $context );
-		foreach ( $hooked_block_types as $hooked_block_type ) {
-			$markup .= get_comment_delimited_block_content( $hooked_block_type, array(), '' );
-		}
+		$markup = insert_hooked_blocks( $block, 'after', $block, $hooked_blocks, $context );
 
 		if ( $parent_block && ! $next ) {
 			// Candidate for last-child insertion.
-			$relative_position  = 'last_child';
-			$anchor_block_type  = $parent_block['blockName'];
-			$hooked_block_types = isset( $hooked_blocks[ $anchor_block_type ][ $relative_position ] )
-				? $hooked_blocks[ $anchor_block_type ][ $relative_position ]
-				: array();
-
-			/** This filter is documented in wp-includes/blocks.php */
-			$hooked_block_types = apply_filters( 'hooked_block_types', $hooked_block_types, $relative_position, $anchor_block_type, $context );
-			foreach ( $hooked_block_types as $hooked_block_type ) {
-				$markup .= get_comment_delimited_block_content( $hooked_block_type, array(), '' );
-			}
+			$markup .= insert_hooked_blocks( $block, 'last_child', $parent_block, $hooked_blocks, $context );
 		}
 
 		return $markup;

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -757,6 +757,18 @@ function get_hooked_blocks() {
 	return $hooked_blocks;
 }
 
+/**
+ * Returns the markup for blocks hooked to the given anchor block in a specific relative position.
+ *
+ * @since 6.5.0
+ *
+ * @param array                   $anchor_block      The anchor block.
+ * @param string                  $relative_position The relative position of the hooked blocks.
+ * 								                     Can be one of 'before', 'after', 'first_child', or 'last_child'.
+ * @param array                   $hooked_blocks     An array of blocks hooked to the given anchor block.
+ * @param WP_Block_Template|array $context           The block template, template part, or pattern that the anchor block belongs to.
+ * @return string
+ */
 function insert_hooked_blocks( &$anchor_block, $relative_position, $hooked_blocks, $context ) {
 	$anchor_block_type  = $anchor_block['blockName'];
 	$hooked_block_types = isset( $hooked_blocks[ $anchor_block_type ][ $relative_position ] )
@@ -768,11 +780,11 @@ function insert_hooked_blocks( &$anchor_block, $relative_position, $hooked_block
 	 *
 	 * @since 6.4.0
 	 *
-	 * @param string[]                $hooked_block_types  The list of hooked block types.
-	 * @param string                  $relative_position   The relative position of the hooked blocks.
-	 *                                                     Can be one of 'before', 'after', 'first_child', or 'last_child'.
-	 * @param string                  $anchor_block_type   The anchor block type.
-	 * @param WP_Block_Template|array $context             The block template, template part, or pattern that the anchor block belongs to.
+	 * @param string[]                $hooked_block_types The list of hooked block types.
+	 * @param string                  $relative_position  The relative position of the hooked blocks.
+	 *                                                    Can be one of 'before', 'after', 'first_child', or 'last_child'.
+	 * @param string                  $anchor_block_type  The anchor block type.
+	 * @param WP_Block_Template|array $context            The block template, template part, or pattern that the anchor block belongs to.
 	 */
 	$hooked_block_types = apply_filters( 'hooked_block_types', $hooked_block_types, $relative_position, $anchor_block_type, $context );
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -757,7 +757,7 @@ function get_hooked_blocks() {
 	return $hooked_blocks;
 }
 
-function insert_hooked_blocks( $relative_position, &$anchor_block, $hooked_blocks, $context ) {
+function insert_hooked_blocks( &$anchor_block, $relative_position, $hooked_blocks, $context ) {
 	$anchor_block_type  = $anchor_block['blockName'];
 	$hooked_block_types = isset( $hooked_blocks[ $anchor_block_type ][ $relative_position ] )
 		? $hooked_blocks[ $anchor_block_type ][ $relative_position ]
@@ -821,10 +821,10 @@ function make_before_block_visitor( $hooked_blocks, $context ) {
 
 		if ( $parent_block && ! $prev ) {
 			// Candidate for first-child insertion.
-			$markup .= insert_hooked_blocks( 'first_child', $parent_block, $hooked_blocks, $context );
+			$markup .= insert_hooked_blocks( $parent_block, 'first_child', $hooked_blocks, $context );
 		}
 
-		$markup .= insert_hooked_blocks( 'before', $block, $hooked_blocks, $context );
+		$markup .= insert_hooked_blocks( $block, 'before', $hooked_blocks, $context );
 
 		return $markup;
 	};
@@ -860,11 +860,11 @@ function make_after_block_visitor( $hooked_blocks, $context ) {
 	 * @return string The serialized markup for the given block, with the markup for any hooked blocks appended to it.
 	 */
 	return function ( &$block, &$parent_block = null, $next = null ) use ( $hooked_blocks, $context ) {
-		$markup = insert_hooked_blocks( 'after', $block, $hooked_blocks, $context );
+		$markup = insert_hooked_blocks( $block, 'after', $hooked_blocks, $context );
 
 		if ( $parent_block && ! $next ) {
 			// Candidate for last-child insertion.
-			$markup .= insert_hooked_blocks( 'last_child', $parent_block, $hooked_blocks, $context );
+			$markup .= insert_hooked_blocks( $parent_block, 'last_child', $hooked_blocks, $context );
 		}
 
 		return $markup;

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Tests for the insert_hooked_blocks function.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @since 6.5.0
+ *
+ * @group blocks
+ * @group block-hooks
+ */
+class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
+	/**
+	 * @covers ::insert_hooked_blocks
+	 */
+	public function test_insert_hooked_blocks() {
+		$anchor_block_name = 'tests/anchor-block';
+		$anchor_block      = array(
+			'blockName' => $anchor_block_name,
+		);
+
+		// Maybe move to class level and include other relative positions?
+		// And/or data provider?
+		$hooked_blocks = array(
+			$anchor_block_name => array(
+				'after' => array( 'tests/hooked-before' ),
+			)
+		);
+
+		$actual = insert_hooked_blocks( $anchor_block, 'after', $hooked_blocks, array() );
+		$this->assertSame( '<!-- wp:tests/hooked-before /-->', $actual );
+	}
+}


### PR DESCRIPTION
Spun off from https://github.com/WordPress/wordpress-develop/pull/5523.

TODO:
- [ ] Add test coverage for `insert_hooked_blocks()`.

Trac ticket: TBD

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
