### PR TITLE
About: use flex for align-items and justify-content

### DIFF
--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -534,8 +534,8 @@
 	position: relative;
 	display: flex;
 	flex-direction: column;
-	align-items: start;
-	justify-content: end;
+	align-items: flex-start;
+	justify-content: flex-end;
 	box-sizing: border-box;
 	padding: var(--gap) 0;
 	height: clamp(12.5rem, -1.25rem + 36.67vw, 26.25rem);
@@ -1126,7 +1126,7 @@
 }
 
 .about-wrap .is-vertically-aligned-top {
-	align-self: start;
+	align-self: flex-start;
 }
 
 .about-wrap .is-vertically-aligned-center {


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/59819

PR is addressing the warnings running `npm run grunt prerelease`.

- Line `96` has `align-self: start;` but renders no warning.
- Line `107` has `align-self: end;` but renders no warning.
- Line `1137` has `align-self: end;` but renders no warning.

How come?