### PR TITLE
Add missing `theme-compat` path check.

### DIFF
--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -344,6 +344,8 @@ class Tests_Theme extends WP_UnitTestCase {
 						$this->assertSame( $child_theme_file, get_query_template( $file ) );
 					} elseif ( file_exists( $parent_theme_file ) ) {
 						$this->assertSame( $parent_theme_file, get_query_template( $file ) );
+					} elseif ( file_exists( ABSPATH . WPINC . '/theme-compat/' . $file . '.php' ) ) {
+						$this->assertSame( ABSPATH . WPINC . '/theme-compat/' . $file . '.php', get_query_template( $file ) );
 					} else {
 						$this->assertSame( '', get_query_template( $file ) );
 					}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: 

Followup for [#18298](https://core.trac.wordpress.org/ticket/18298) / [[56635](https://core.trac.wordpress.org/changeset/56635)]

While I was working on another ticket, I came across this issue.

When i run unit test for [test_switch_theme](https://github.com/WordPress/wordpress-develop/blob/1eed1269eb708f8054da69221411727764670b93/tests/phpunit/tests/theme.php#L278) using `npm run test:php -- --filter test_switch_theme` i found that it show me below error. They error comes from the TT4 theme, the tests did not run checks for block theme per [this line of code](https://github.com/WordPress/wordpress-develop/blob/1eed1269eb708f8054da69221411727764670b93/tests/phpunit/tests/theme.php#L320) but when we run single unit test `current_theme_supports( 'block-templates' )` return `false` due to some global updates in other unit tests.

### Error:
```
1) Tests_Theme::test_switch_theme
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-''
+'/var/www/src/wp-includes/theme-compat/footer.php'
```

This PR add the missing `theme-compat` check similar to [locate_template](https://github.com/WordPress/wordpress-develop/blob/6.4/src/wp-includes/template.php#L718-L721) function so it will not failed.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
