### PR TITLE
Only memoize theme directories after plugins are loaded

### DIFF
--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -217,7 +217,14 @@ function get_stylesheet_directory() {
 			return $stylesheet_dir;
 		}
 
-		$wp_stylesheet_path = $stylesheet_dir;
+		/*
+		 * Only memoize the directory after plugins are loaded so
+		 * early calls to this function don't create stale values.
+		 * @see https://core.trac.wordpress.org/ticket/59847
+		 */
+		if ( did_action( 'plugins_loaded' ) ) {
+			$wp_stylesheet_path = $stylesheet_dir;
+		}
 	}
 
 	return $wp_stylesheet_path;
@@ -367,7 +374,14 @@ function get_template_directory() {
 			return $template_dir;
 		}
 
-		$wp_template_path = $template_dir;
+		/*
+		 * Only memoize the directory after plugins are loaded so
+		 * early calls to this function don't create stale values.
+		 * @see https://core.trac.wordpress.org/ticket/59847
+		 */
+		if ( did_action( 'plugins_loaded' ) ) {
+			$wp_template_path = $template_dir;
+		}
 	}
 
 	return $wp_template_path;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
`get_template_directory` and `get_template_directory` memoize the values for the active theme. However, if a plugin calls these functions before a custom theme directory is registered, a stale value could end up being stored. This ensures that calls to these functions prior to plugins being loaded aren't memoized.

Trac ticket: https://core.trac.wordpress.org/ticket/59847

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
