### PR TITLE
Remove memoization

### DIFF
--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -491,8 +491,6 @@ function update_blog_option( $id, $option, $value, $deprecated = null ) {
  * @global array           $_wp_switched_stack
  * @global bool            $switched
  * @global string          $table_prefix
- * @global string          $wp_template_path
- * @global string          $wp_stylesheet_path
  * @global WP_Object_Cache $wp_object_cache
  *
  * @param int  $new_blog_id The ID of the blog to switch to. Default: current blog.
@@ -534,10 +532,8 @@ function switch_to_blog( $new_blog_id, $deprecated = null ) {
 	}
 
 	$wpdb->set_blog_id( $new_blog_id );
-	$GLOBALS['table_prefix']       = $wpdb->get_blog_prefix();
-	$GLOBALS['blog_id']            = $new_blog_id;
-	$GLOBALS['wp_template_path']   = null;
-	$GLOBALS['wp_stylesheet_path'] = null;
+	$GLOBALS['table_prefix'] = $wpdb->get_blog_prefix();
+	$GLOBALS['blog_id']      = $new_blog_id;
 
 	if ( function_exists( 'wp_cache_switch_to_blog' ) ) {
 		wp_cache_switch_to_blog( $new_blog_id );
@@ -604,8 +600,6 @@ function switch_to_blog( $new_blog_id, $deprecated = null ) {
  * @global int             $blog_id
  * @global bool            $switched
  * @global string          $table_prefix
- * @global string          $wp_template_path
- * @global string          $wp_stylesheet_path
  * @global WP_Object_Cache $wp_object_cache
  *
  * @return bool True on success, false if we're already on the current blog.
@@ -631,10 +625,8 @@ function restore_current_blog() {
 	}
 
 	$wpdb->set_blog_id( $new_blog_id );
-	$GLOBALS['blog_id']            = $new_blog_id;
-	$GLOBALS['table_prefix']       = $wpdb->get_blog_prefix();
-	$GLOBALS['wp_template_path']   = null;
-	$GLOBALS['wp_stylesheet_path'] = null;
+	$GLOBALS['blog_id']      = $new_blog_id;
+	$GLOBALS['table_prefix'] = $wpdb->get_blog_prefix();
 
 	if ( function_exists( 'wp_cache_switch_to_blog' ) ) {
 		wp_cache_switch_to_blog( $new_blog_id );

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -188,7 +188,7 @@ function get_stylesheet() {
  *
  * @since 1.5.0
  * @since 6.4.0 Memoizes filter execution so that it only runs once for the current theme.
- * @since 6.4.1 Memoization removed.
+ * @since 6.4.2 Memoization removed.
  *
  * @global string $wp_stylesheet_path Current theme stylesheet directory path.
  *

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -328,8 +328,6 @@ function get_template() {
  * @since 6.4.0 Memoizes filter execution so that it only runs once for the current theme.
  * @since 6.4.1 Memoization removed.
  *
- * @global string $wp_template_path Current theme template directory path.
- *
  * @return string Path to active theme's template directory.
  */
 function get_template_directory() {
@@ -752,13 +750,11 @@ function locale_stylesheet() {
  * @global WP_Customize_Manager $wp_customize
  * @global array                $sidebars_widgets
  * @global array                $wp_registered_sidebars
- * @global string               $wp_stylesheet_path
- * @global string               $wp_template_path
  *
  * @param string $stylesheet Stylesheet name.
  */
 function switch_theme( $stylesheet ) {
-	global $wp_theme_directories, $wp_customize, $sidebars_widgets, $wp_registered_sidebars, $wp_stylesheet_path, $wp_template_path;
+	global $wp_theme_directories, $wp_customize, $sidebars_widgets, $wp_registered_sidebars;
 
 	$requirements = validate_theme_requirements( $stylesheet );
 	if ( is_wp_error( $requirements ) ) {
@@ -841,13 +837,6 @@ function switch_theme( $stylesheet ) {
 	}
 
 	update_option( 'theme_switched', $old_theme->get_stylesheet() );
-
-	/*
-	 * Reset globals to force refresh the next time these directories are
-	 * accessed via `get_stylesheet_directory()` / `get_template_directory()`.
-	 */
-	$wp_stylesheet_path = null;
-	$wp_template_path   = null;
 
 	// Clear pattern caches.
 	$new_theme->delete_pattern_cache();

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -188,39 +188,27 @@ function get_stylesheet() {
  *
  * @since 1.5.0
  * @since 6.4.0 Memoizes filter execution so that it only runs once for the current theme.
+ * @since 6.4.1 Memoization removed.
  *
  * @global string $wp_stylesheet_path Current theme stylesheet directory path.
  *
  * @return string Path to active theme's stylesheet directory.
  */
 function get_stylesheet_directory() {
-	global $wp_stylesheet_path;
+	$stylesheet     = get_stylesheet();
+	$theme_root     = get_theme_root( $stylesheet );
+	$stylesheet_dir = "$theme_root/$stylesheet";
 
-	if ( null === $wp_stylesheet_path ) {
-		$stylesheet     = get_stylesheet();
-		$theme_root     = get_theme_root( $stylesheet );
-		$stylesheet_dir = "$theme_root/$stylesheet";
-
-		/**
-		 * Filters the stylesheet directory path for the active theme.
-		 *
-		 * @since 1.5.0
-		 *
-		 * @param string $stylesheet_dir Absolute path to the active theme.
-		 * @param string $stylesheet     Directory name of the active theme.
-		 * @param string $theme_root     Absolute path to themes directory.
-		 */
-		$stylesheet_dir = apply_filters( 'stylesheet_directory', $stylesheet_dir, $stylesheet, $theme_root );
-
-		// If there are filter callbacks, force the logic to execute on every call.
-		if ( has_filter( 'stylesheet' ) || has_filter( 'theme_root' ) || has_filter( 'stylesheet_directory' ) ) {
-			return $stylesheet_dir;
-		}
-
-		$wp_stylesheet_path = $stylesheet_dir;
-	}
-
-	return $wp_stylesheet_path;
+	/**
+	 * Filters the stylesheet directory path for the active theme.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $stylesheet_dir Absolute path to the active theme.
+	 * @param string $stylesheet     Directory name of the active theme.
+	 * @param string $theme_root     Absolute path to themes directory.
+	 */
+	return apply_filters( 'stylesheet_directory', $stylesheet_dir, $stylesheet, $theme_root );
 }
 
 /**
@@ -338,39 +326,27 @@ function get_template() {
  *
  * @since 1.5.0
  * @since 6.4.0 Memoizes filter execution so that it only runs once for the current theme.
+ * @since 6.4.1 Memoization removed.
  *
  * @global string $wp_template_path Current theme template directory path.
  *
  * @return string Path to active theme's template directory.
  */
 function get_template_directory() {
-	global $wp_template_path;
+	$template     = get_template();
+	$theme_root   = get_theme_root( $template );
+	$template_dir = "$theme_root/$template";
 
-	if ( null === $wp_template_path ) {
-		$template     = get_template();
-		$theme_root   = get_theme_root( $template );
-		$template_dir = "$theme_root/$template";
-
-		/**
-		 * Filters the active theme directory path.
-		 *
-		 * @since 1.5.0
-		 *
-		 * @param string $template_dir The path of the active theme directory.
-		 * @param string $template     Directory name of the active theme.
-		 * @param string $theme_root   Absolute path to the themes directory.
-		 */
-		$template_dir = apply_filters( 'template_directory', $template_dir, $template, $theme_root );
-
-		// If there are filter callbacks, force the logic to execute on every call.
-		if ( has_filter( 'template' ) || has_filter( 'theme_root' ) || has_filter( 'template_directory' ) ) {
-			return $template_dir;
-		}
-
-		$wp_template_path = $template_dir;
-	}
-
-	return $wp_template_path;
+	/**
+	 * Filters the active theme directory path.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $template_dir The path of the active theme directory.
+	 * @param string $template     Directory name of the active theme.
+	 * @param string $theme_root   Absolute path to the themes directory.
+	 */
+	return apply_filters( 'template_directory', $template_dir, $template, $theme_root );
 }
 
 /**

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -190,8 +190,6 @@ function get_stylesheet() {
  * @since 6.4.0 Memoizes filter execution so that it only runs once for the current theme.
  * @since 6.4.2 Memoization removed.
  *
- * @global string $wp_stylesheet_path Current theme stylesheet directory path.
- *
  * @return string Path to active theme's stylesheet directory.
  */
 function get_stylesheet_directory() {

--- a/tests/phpunit/data/themedir2/test-parent/functions.php
+++ b/tests/phpunit/data/themedir2/test-parent/functions.php
@@ -1,0 +1,7 @@
+<?php
+
+// Dummy theme.
+
+echo __DIR__ . '/' . basename(__FILE__);
+
+?>

--- a/tests/phpunit/data/themedir2/test-parent/index.php
+++ b/tests/phpunit/data/themedir2/test-parent/index.php
@@ -1,0 +1,7 @@
+<?php
+
+// Dummy theme.
+
+echo __DIR__ . '/' . basename(__FILE__);
+
+?>

--- a/tests/phpunit/data/themedir2/test-parent/style.css
+++ b/tests/phpunit/data/themedir2/test-parent/style.css
@@ -1,0 +1,12 @@
+/*
+Theme Name: Test Parent Theme
+Theme URI: http://example.org/
+Description: An example parent theme
+Version: 1.3
+Author: Minnie Bannister
+Author URI: http://example.com/
+Template: test-parent
+*/
+
+
+

--- a/tests/phpunit/data/themedir2/test/functions.php
+++ b/tests/phpunit/data/themedir2/test/functions.php
@@ -1,0 +1,7 @@
+<?php
+
+// Dummy theme.
+
+echo __DIR__ . '/' . basename(__FILE__);
+
+?>

--- a/tests/phpunit/data/themedir2/test/index.php
+++ b/tests/phpunit/data/themedir2/test/index.php
@@ -1,0 +1,7 @@
+<?php
+
+// Dummy theme.
+
+echo __DIR__ . '/' . basename(__FILE__);
+
+?>

--- a/tests/phpunit/data/themedir2/test/style.css
+++ b/tests/phpunit/data/themedir2/test/style.css
@@ -1,0 +1,12 @@
+/*
+Theme Name: Test Theme
+Theme URI: http://example.org/
+Description: An example theme
+Version: 1.3
+Author: Minnie Bannister
+Author URI: http://example.com/
+Template: test-parent
+*/
+
+
+

--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -1179,4 +1179,118 @@ class Tests_Theme extends WP_UnitTestCase {
 			$this->markTestSkipped( "Could not switch to $block_theme." );
 		}
 	}
+
+	/**
+	 * Make sure filters added after the initial call are fired.
+	 *
+	 * @ticket 59847
+	 */
+	public function test_get_stylesheet_directory_filters_apply() {
+		// Call the function prior to the filter being added.
+		get_stylesheet_directory();
+
+		$expected = 'test_root/dir';
+
+		// Add the filer.
+		add_filter(
+			'stylesheet_directory',
+			function () use ( $expected ) {
+				return $expected;
+			}
+		);
+
+		$this->assertSame( $expected, get_stylesheet_directory() );
+	}
+
+	/**
+	 * Make sure filters added after the initial call are fired.
+	 *
+	 * @ticket 59847
+	 */
+	public function test_get_template_directory_filters_apply() {
+		// Call the function prior to the filter being added.
+		get_template_directory();
+
+		$expected = 'test_root/dir';
+
+		// Add the filer.
+		add_filter(
+			'template_directory',
+			function () use ( $expected ) {
+				return $expected;
+			}
+		);
+
+		$this->assertSame( $expected, get_template_directory() );
+	}
+
+	/**
+	 * @ticket 59847
+	 */
+	public function test_get_stylesheet_directory_uses_registered_theme_dir() {
+		$old_theme = wp_get_theme();
+
+		switch_theme( 'test' );
+
+		$old_root = get_theme_root( 'test' );
+		$path1    = get_stylesheet_directory();
+
+		$new_root = DIR_TESTDATA . '/themedir2';
+		register_theme_directory( $new_root );
+
+		// Mock the stylesheet root option to mimic that the active root has changed.
+		add_filter(
+			'pre_option_stylesheet_root',
+			function () use ( $new_root ) {
+				return $new_root;
+			}
+		);
+
+		$path2 = get_stylesheet_directory();
+
+		// Cleanup.
+		switch_theme( $old_theme->get_stylesheet() );
+
+		$this->assertEquals( $old_root . '/test', $path1, 'The original stylesheet path is not correct' );
+		$this->assertEquals( $new_root . '/test', $path2, 'The new stylesheet path is not correct' );
+	}
+
+	/**
+	 * @ticket 59847
+	 */
+	public function test_get_template_directory_uses_registered_theme_dir() {
+		$old_theme = wp_get_theme();
+
+		switch_theme( 'test' );
+
+		// Mock parent theme to be returned as the template.
+		add_filter(
+			'pre_option_template',
+			function () {
+				return 'test-parent';
+			}
+		);
+
+		$old_root = get_theme_root( 'test' );
+		$path1    = get_template_directory();
+
+		$new_root = DIR_TESTDATA . '/themedir2';
+		register_theme_directory( $new_root );
+
+		// Mock the template root option to mimic that the active root has changed.
+		add_filter(
+			'pre_option_template_root',
+			function () use ( $new_root ) {
+				return $new_root;
+			}
+		);
+
+		$path2 = get_template_directory();
+
+		// Cleanup.
+		switch_theme( $old_theme->get_stylesheet() );
+
+		$this->assertEquals( $old_root . '/test-parent', $path1, 'The original template path is not correct' );
+		$this->assertEquals( $new_root . '/test-parent', $path2, 'The new template path is not correct' );
+	}
 }

--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -1184,6 +1184,8 @@ class Tests_Theme extends WP_UnitTestCase {
 	 * Make sure filters added after the initial call are fired.
 	 *
 	 * @ticket 59847
+	 *
+	 * @covers ::get_stylesheet_directory
 	 */
 	public function test_get_stylesheet_directory_filters_apply() {
 		// Call the function prior to the filter being added.
@@ -1206,6 +1208,8 @@ class Tests_Theme extends WP_UnitTestCase {
 	 * Make sure filters added after the initial call are fired.
 	 *
 	 * @ticket 59847
+	 *
+	 * @covers ::get_template_directory
 	 */
 	public function test_get_template_directory_filters_apply() {
 		// Call the function prior to the filter being added.
@@ -1225,7 +1229,11 @@ class Tests_Theme extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Make sure get_stylesheet_directory uses the correct path when the root theme dir changes.
+	 *
 	 * @ticket 59847
+	 *
+	 * @covers ::get_stylesheet_directory
 	 */
 	public function test_get_stylesheet_directory_uses_registered_theme_dir() {
 		$old_theme = wp_get_theme();
@@ -1256,7 +1264,11 @@ class Tests_Theme extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Make sure get_template_directory uses the correct path when the root theme dir changes.
+	 *
 	 * @ticket 59847
+	 *
+	 * @covers ::get_template_directory
 	 */
 	public function test_get_template_directory_uses_registered_theme_dir() {
 		$old_theme = wp_get_theme();


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
An alternative approach to #5642 is to remove the memoization completely, which reverts these functions to their 6.3 behavior.

Trac ticket: https://core.trac.wordpress.org/ticket/59847

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
