### PR TITLE
TESTING: `switch_theme` behaviour

### DIFF
--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -275,7 +275,7 @@ class Tests_Theme extends WP_UnitTestCase {
 	 * @expectedDeprecated get_themes
 	 * @expectedDeprecated get_current_theme
 	 */
-	public function switch_theme() {
+	public function test_switch_theme() {
 		$themes = get_themes();
 
 		// Switch to each theme in sequence.

--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -370,7 +370,22 @@ class Tests_Theme extends WP_UnitTestCase {
 		}
 	}
 
-	public function test_switch_theme_bogus() {
+	public function test_switch_theme_behaviour_with_theme_supports() {
+		foreach ( $this->default_themes as $theme ) {
+			if ( wp_get_theme( $theme )->exists() ) {
+				switch_theme( $theme );
+				if ( wp_is_block_theme() && current_theme_supports( 'block-templates' ) ) {
+					$this->assertTrue( wp_is_block_theme(), "$theme is block theme." );
+					$this->assertTrue( current_theme_supports( 'block-templates' ), "$theme support block templates." );
+				} else {
+					$this->assertFalse( wp_is_block_theme(), "$theme is classic theme." );
+					$this->assertFalse( current_theme_supports( 'block-templates' ), "$theme did not support block templates." );
+				}
+			}
+		}
+	}
+
+	public function test_switchsss_theme_bogus() {
 		// Try switching to a theme that doesn't exist.
 		$template = 'some_template';
 		$style    = 'some_style';

--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -275,7 +275,7 @@ class Tests_Theme extends WP_UnitTestCase {
 	 * @expectedDeprecated get_themes
 	 * @expectedDeprecated get_current_theme
 	 */
-	public function test_switch_theme() {
+	public function switch_theme() {
 		$themes = get_themes();
 
 		// Switch to each theme in sequence.


### PR DESCRIPTION
<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

This PR demonstrate `switch_theme` behaviour in which `current_theme_supports( 'block-templates' )` shows `false` for the block theme.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
