### PR TITLE
Try fixing inadequate check for block theme

### DIFF
--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -317,7 +317,7 @@ class Tests_Theme extends WP_UnitTestCase {
 				$this->assertSame( $root_uri . '/' . get_template(), get_template_directory_uri() );
 
 				// Skip block themes for get_query_template() tests since this test is focused on classic templates.
-				if ( wp_is_block_theme() && current_theme_supports( 'block-templates' ) ) {
+				if ( wp_is_block_theme() || wp_theme_has_theme_json() ) {
 					continue;
 				}
 


### PR DESCRIPTION
The check for whether a theme shouldn't be covered in the old `test_switch_theme()` method may be inaccurate because:
* The `block-templates` theme support for block themes is added dynamically via `wp_enable_block_templates()`, so checking for that isn't reliable.
* The conditions used in `wp_enable_block_templates()` should be used instead.

Related to #5634.

Trac ticket: https://core.trac.wordpress.org/ticket/59881

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
