### PR TITLE
Revisions Controller: return single revision only when it matches the parent id

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -403,7 +403,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 			return $revision;
 		}
 
-		if ( $parent->ID !== $revision->post_parent ) {
+		if ( (int) $parent->ID !== (int) $revision->post_parent ) {
 			return new WP_Error(
 				'rest_post_invalid_parent',
 				/* translators: %s: A post revision id. */

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -406,8 +406,8 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 		if ( (int) $parent->ID !== (int) $revision->post_parent ) {
 			return new WP_Error(
 				'rest_post_invalid_parent',
-				/* translators: %s: A post revision id. */
-				sprintf( __( 'Parent post does not have a revision with id of "%s"' ), $request['id'] ),
+				/* translators: %d: A post revision id. */
+				sprintf( __( 'Parent post does not have a revision with id of "%d"' ), $request['id'] ),
 				array( 'status' => 404 )
 			);
 		}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -407,7 +407,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 			return new WP_Error(
 				'rest_revision_parent_id_mismatch',
 				/* translators: %d: A post revision id. */
-				sprintf( __( 'Parent does not have a revision with id of "%d"' ), $request['id'] ),
+				sprintf( __( 'The revision does not belong to the specified parent with id of "%d"' ), $parent->ID ),
 				array( 'status' => 404 )
 			);
 		}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -387,6 +387,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	 * Retrieves one revision from the collection.
 	 *
 	 * @since 4.7.0
+	 * @since 6.5.0 Added a condition to check that parent id matches revision parent id.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
@@ -400,6 +401,15 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 		$revision = $this->get_revision( $request['id'] );
 		if ( is_wp_error( $revision ) ) {
 			return $revision;
+		}
+
+		if ( $parent->ID !== $revision->post_parent ) {
+			return new WP_Error(
+				'rest_post_invalid_parent',
+				/* translators: %s: A post revision id. */
+				sprintf( __( 'Parent post does not have a revision with id of "%s"' ), $request['id'] ),
+				array( 'status' => 404 )
+			);
 		}
 
 		$response = $this->prepare_item_for_response( $revision, $request );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -406,7 +406,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 		if ( (int) $parent->ID !== (int) $revision->post_parent ) {
 			return new WP_Error(
 				'rest_revision_parent_id_mismatch',
-				/* translators: %d: A post revision id. */
+				/* translators: %d: A post id. */
 				sprintf( __( 'The revision does not belong to the specified parent with id of "%d"' ), $parent->ID ),
 				array( 'status' => 404 )
 			);

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -405,9 +405,9 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 
 		if ( (int) $parent->ID !== (int) $revision->post_parent ) {
 			return new WP_Error(
-				'rest_post_invalid_parent',
+				'rest_revision_parent_id_mismatch',
 				/* translators: %d: A post revision id. */
-				sprintf( __( 'Parent post does not have a revision with id of "%d"' ), $request['id'] ),
+				sprintf( __( 'Parent does not have a revision with id of "%d"' ), $request['id'] ),
 				array( 'status' => 404 )
 			);
 		}

--- a/tests/phpunit/tests/rest-api/rest-revisions-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-revisions-controller.php
@@ -23,7 +23,6 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 	private $revision_id2;
 	private $revision_3;
 	private $revision_id3;
-	private $revision_2_1;
 	private $revision_2_1_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {

--- a/tests/phpunit/tests/rest-api/rest-revisions-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-revisions-controller.php
@@ -276,6 +276,9 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions/' . $this->revision_2_1_id );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_revision_parent_id_mismatch', $response, 404 );
+
+		$expected_message = 'The revision does not belong to the specified parent with id of "' . self::$post_id . '"';
+		$this->assertSame( $expected_message, $response->as_error()->get_error_messages()[0], 'The message must contain the correct parent ID.' );
 	}
 
 	public function test_delete_item() {

--- a/tests/phpunit/tests/rest-api/rest-revisions-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-revisions-controller.php
@@ -8,24 +8,29 @@
  * @group restapi
  */
 class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase {
-	protected static $post_id;
+	protected static $post_id_1;
+	protected static $post_id_2;
 	protected static $page_id;
 
 	protected static $editor_id;
 	protected static $contributor_id;
 
 	private $total_revisions;
-	private $revisions;
-	private $revision_1;
-	private $revision_id1;
-	private $revision_2;
-	private $revision_id2;
-	private $revision_3;
-	private $revision_id3;
+	private $revision_1_1;
+	private $revision_1_1_id;
+	private $revision_1_2;
+	private $revision_1_2_id;
+	private $revision_1_3;
+	private $revision_1_3_id;
+	private $revision_2_1;
+	private $revision_2_1_id;
+	private $revision_2_2;
+	private $revision_2_2_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		self::$post_id = $factory->post->create();
-		self::$page_id = $factory->post->create( array( 'post_type' => 'page' ) );
+		self::$post_id_1 = $factory->post->create();
+		self::$post_id_2 = $factory->post->create();
+		self::$page_id   = $factory->post->create( array( 'post_type' => 'page' ) );
 
 		self::$editor_id      = $factory->user->create(
 			array(
@@ -42,19 +47,31 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		wp_update_post(
 			array(
 				'post_content' => 'This content is better.',
-				'ID'           => self::$post_id,
+				'ID'           => self::$post_id_1,
 			)
 		);
 		wp_update_post(
 			array(
 				'post_content' => 'This content is marvelous.',
-				'ID'           => self::$post_id,
+				'ID'           => self::$post_id_1,
 			)
 		);
 		wp_update_post(
 			array(
 				'post_content' => 'This content is fantastic.',
-				'ID'           => self::$post_id,
+				'ID'           => self::$post_id_1,
+			)
+		);
+		wp_update_post(
+			array(
+				'post_content' => 'A second post.',
+				'ID'           => self::$post_id_2,
+			)
+		);
+		wp_update_post(
+			array(
+				'post_content' => 'A second post. How prolific.',
+				'ID'           => self::$post_id_2,
 			)
 		);
 		wp_set_current_user( 0 );
@@ -62,7 +79,8 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 
 	public static function wpTearDownAfterClass() {
 		// Also deletes revisions.
-		wp_delete_post( self::$post_id, true );
+		wp_delete_post( self::$post_id_1, true );
+		wp_delete_post( self::$post_id_2, true );
 		wp_delete_post( self::$page_id, true );
 
 		self::delete_user( self::$editor_id );
@@ -72,15 +90,22 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 	public function set_up() {
 		parent::set_up();
 
-		$revisions             = wp_get_post_revisions( self::$post_id );
+		// Set first post revision vars.
+		$revisions             = wp_get_post_revisions( self::$post_id_1 );
 		$this->total_revisions = count( $revisions );
-		$this->revisions       = $revisions;
-		$this->revision_1      = array_pop( $revisions );
-		$this->revision_id1    = $this->revision_1->ID;
-		$this->revision_2      = array_pop( $revisions );
-		$this->revision_id2    = $this->revision_2->ID;
-		$this->revision_3      = array_pop( $revisions );
-		$this->revision_id3    = $this->revision_3->ID;
+		$this->revision_1_1    = array_pop( $revisions );
+		$this->revision_1_1_id = $this->revision_1_1->ID;
+		$this->revision_1_2    = array_pop( $revisions );
+		$this->revision_1_2_id = $this->revision_1_2->ID;
+		$this->revision_1_3    = array_pop( $revisions );
+		$this->revision_1_3_id = $this->revision_1_3->ID;
+
+		// Set second post revision vars.
+		$revisions             = wp_get_post_revisions( self::$post_id_2 );
+		$this->revision_2_1    = array_pop( $revisions );
+		$this->revision_2_1_id = $this->revision_2_1->ID;
+		$this->revision_2_2    = array_pop( $revisions );
+		$this->revision_2_2_id = $this->revision_2_2->ID;
 	}
 
 	public function _filter_map_meta_cap_remove_no_allow_revisions( $caps, $cap, $user_id, $args ) {
@@ -108,13 +133,13 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 
 	public function test_context_param() {
 		// Collection.
-		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts/' . self::$post_id . '/revisions' );
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts/' . self::$post_id_1 . '/revisions' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertSame( 'view', $data['endpoints'][0]['args']['context']['default'] );
 		$this->assertSameSets( array( 'view', 'edit', 'embed' ), $data['endpoints'][0]['args']['context']['enum'] );
 		// Single.
-		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts/' . self::$post_id . '/revisions/' . $this->revision_1->ID );
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts/' . self::$post_id_1 . '/revisions/' . $this->revision_1_1->ID );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertSame( 'view', $data['endpoints'][0]['args']['context']['default'] );
@@ -123,26 +148,26 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 
 	public function test_get_items() {
 		wp_set_current_user( self::$editor_id );
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertCount( $this->total_revisions, $data );
 
 		// Reverse chronology.
-		$this->assertSame( $this->revision_id3, $data[0]['id'] );
-		$this->check_get_revision_response( $data[0], $this->revision_3 );
+		$this->assertSame( $this->revision_1_3_id, $data[0]['id'] );
+		$this->check_get_revision_response( $data[0], $this->revision_1_3 );
 
-		$this->assertSame( $this->revision_id2, $data[1]['id'] );
-		$this->check_get_revision_response( $data[1], $this->revision_2 );
+		$this->assertSame( $this->revision_1_2_id, $data[1]['id'] );
+		$this->check_get_revision_response( $data[1], $this->revision_1_2 );
 
-		$this->assertSame( $this->revision_id1, $data[2]['id'] );
-		$this->check_get_revision_response( $data[2], $this->revision_1 );
+		$this->assertSame( $this->revision_1_1_id, $data[2]['id'] );
+		$this->check_get_revision_response( $data[2], $this->revision_1_1 );
 	}
 
 	public function test_get_items_no_permission() {
 		wp_set_current_user( 0 );
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions' );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_cannot_read', $response, 401 );
@@ -167,10 +192,10 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 
 	public function test_get_item() {
 		wp_set_current_user( self::$editor_id );
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions/' . $this->revision_id1 );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions/' . $this->revision_1_1_id );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertSame( 200, $response->get_status() );
-		$this->check_get_revision_response( $response, $this->revision_1 );
+		$this->check_get_revision_response( $response, $this->revision_1_1 );
 		$fields = array(
 			'author',
 			'date',
@@ -193,7 +218,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 
 	public function test_get_item_embed_context() {
 		wp_set_current_user( self::$editor_id );
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions/' . $this->revision_id1 );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions/' . $this->revision_1_1_id );
 		$request->set_param( 'context', 'embed' );
 		$response = rest_get_server()->dispatch( $request );
 		$fields   = array(
@@ -211,7 +236,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 
 	public function test_get_item_no_permission() {
 		wp_set_current_user( 0 );
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions/' . $this->revision_id1 );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions/' . $this->revision_1_1_id );
 
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_read', $response, 401 );
@@ -222,25 +247,53 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 
 	public function test_get_item_missing_parent() {
 		wp_set_current_user( self::$editor_id );
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER . '/revisions/' . $this->revision_id1 );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER . '/revisions/' . $this->revision_1_1_id );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_post_invalid_parent', $response, 404 );
 	}
 
 	public function test_get_item_invalid_parent_post_type() {
 		wp_set_current_user( self::$editor_id );
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$page_id . '/revisions/' . $this->revision_id1 );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$page_id . '/revisions/' . $this->revision_1_1_id );
 		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_post_invalid_parent', $response, 404 );
+	}
+
+	public function test_get_item_valid_parent_id() {
+		wp_set_current_user( self::$editor_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions/' . $this->revision_1_1_id );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertSame( self::$post_id_1, $data['parent'] );
+	}
+
+	public function test_get_item_invalid_parent_id() {
+		wp_set_current_user( self::$editor_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions/' . $this->revision_2_1_id );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Temporary - testing a failing state here.
+		if ( ! empty( $data['parent'] ) ) {
+			$revision = get_post( $data['id'] );
+			$this->assertSame( 'revision', $revision->post_type, 'This test should fail.' );
+			$parent = get_post( $data['parent'] );
+			$this->assertSame( self::$post_id_1, $parent->ID, 'This test will fail but should not if there is a valid response.' );
+		}
+
+		$this->assertEmpty( $data['id'], 'The response should be empty.' );
+		$this->assertEmpty( $data['parent'], 'The response should be empty.' );
+
 		$this->assertErrorResponse( 'rest_post_invalid_parent', $response, 404 );
 	}
 
 	public function test_delete_item() {
 		wp_set_current_user( self::$editor_id );
-		$request = new WP_REST_Request( 'DELETE', '/wp/v2/posts/' . self::$post_id . '/revisions/' . $this->revision_id1 );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/posts/' . self::$post_id_1 . '/revisions/' . $this->revision_1_1_id );
 		$request->set_param( 'force', true );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_delete', $response, 403 );
-		$this->assertNotNull( get_post( $this->revision_id1 ) );
+		$this->assertNotNull( get_post( $this->revision_1_1_id ) );
 	}
 
 	/**
@@ -248,11 +301,11 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 	 */
 	public function test_delete_item_parent_check() {
 		wp_set_current_user( self::$contributor_id );
-		$request = new WP_REST_Request( 'DELETE', '/wp/v2/posts/' . self::$post_id . '/revisions/' . $this->revision_id1 );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/posts/' . self::$post_id_1 . '/revisions/' . $this->revision_1_1_id );
 		$request->set_param( 'force', true );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_delete', $response, 403 );
-		$this->assertNotNull( get_post( $this->revision_id1 ) );
+		$this->assertNotNull( get_post( $this->revision_1_1_id ) );
 	}
 
 	/**
@@ -261,11 +314,11 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 	public function test_delete_item_remove_do_not_allow() {
 		wp_set_current_user( self::$editor_id );
 		add_filter( 'map_meta_cap', array( $this, '_filter_map_meta_cap_remove_no_allow_revisions' ), 10, 4 );
-		$request = new WP_REST_Request( 'DELETE', '/wp/v2/posts/' . self::$post_id . '/revisions/' . $this->revision_id1 );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/posts/' . self::$post_id_1 . '/revisions/' . $this->revision_1_1_id );
 		$request->set_param( 'force', true );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertSame( 200, $response->get_status() );
-		$this->assertNull( get_post( $this->revision_id1 ) );
+		$this->assertNull( get_post( $this->revision_1_1_id ) );
 	}
 
 	/**
@@ -273,11 +326,11 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 	 */
 	public function test_delete_item_cannot_delete_parent() {
 		wp_set_current_user( self::$editor_id );
-		$request = new WP_REST_Request( 'DELETE', '/wp/v2/posts/' . self::$post_id . '/revisions/' . $this->revision_id1 );
+		$request = new WP_REST_Request( 'DELETE', '/wp/v2/posts/' . self::$post_id_1 . '/revisions/' . $this->revision_1_1_id );
 		$request->set_param( 'force', true );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_delete', $response, 403 );
-		$this->assertNotNull( get_post( $this->revision_id1 ) );
+		$this->assertNotNull( get_post( $this->revision_1_1_id ) );
 	}
 
 	/**
@@ -287,7 +340,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 	public function test_delete_item_no_trash() {
 		wp_set_current_user( self::$editor_id );
 		add_filter( 'map_meta_cap', array( $this, '_filter_map_meta_cap_remove_no_allow_revisions' ), 10, 4 );
-		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/posts/' . self::$post_id . '/revisions/' . $this->revision_id1 );
+		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/posts/' . self::$post_id_1 . '/revisions/' . $this->revision_1_1_id );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_trash_not_supported', $response, 501 );
 
@@ -296,31 +349,31 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		$this->assertErrorResponse( 'rest_trash_not_supported', $response, 501 );
 
 		// Ensure the revision still exists.
-		$this->assertNotNull( get_post( $this->revision_id1 ) );
+		$this->assertNotNull( get_post( $this->revision_1_1_id ) );
 	}
 
 	public function test_delete_item_no_permission() {
 		wp_set_current_user( self::$contributor_id );
-		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/posts/' . self::$post_id . '/revisions/' . $this->revision_id1 );
+		$request  = new WP_REST_Request( 'DELETE', '/wp/v2/posts/' . self::$post_id_1 . '/revisions/' . $this->revision_1_1_id );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_delete', $response, 403 );
 	}
 
 	public function test_prepare_item() {
 		wp_set_current_user( self::$editor_id );
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions/' . $this->revision_id1 );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions/' . $this->revision_1_1_id );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertSame( 200, $response->get_status() );
-		$this->check_get_revision_response( $response, $this->revision_1 );
+		$this->check_get_revision_response( $response, $this->revision_1_1 );
 	}
 
 	public function test_prepare_item_limit_fields() {
 		wp_set_current_user( self::$editor_id );
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions/' . $this->revision_id1 );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions/' . $this->revision_1_1_id );
 		$endpoint = new WP_REST_Revisions_Controller( 'post' );
 		$request->set_param( 'context', 'edit' );
 		$request->set_param( '_fields', 'id,slug' );
-		$revision = get_post( $this->revision_id1 );
+		$revision = get_post( $this->revision_1_1_id );
 		$response = $endpoint->prepare_item_for_response( $revision, $request );
 		$this->assertSame(
 			array(
@@ -332,7 +385,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 	}
 
 	public function test_get_item_schema() {
-		$request    = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts/' . self::$post_id . '/revisions' );
+		$request    = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts/' . self::$post_id_1 . '/revisions' );
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
@@ -353,13 +406,13 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 	}
 
 	public function test_create_item() {
-		$request  = new WP_REST_Request( 'POST', '/wp/v2/posts/' . self::$post_id . '/revisions' );
+		$request  = new WP_REST_Request( 'POST', '/wp/v2/posts/' . self::$post_id_1 . '/revisions' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_no_route', $response, 404 );
 	}
 
 	public function test_update_item() {
-		$request  = new WP_REST_Request( 'POST', '/wp/v2/posts/' . self::$post_id . '/revisions/' . $this->revision_id1 );
+		$request  = new WP_REST_Request( 'POST', '/wp/v2/posts/' . self::$post_id_1 . '/revisions/' . $this->revision_1_1_id );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_no_route', $response, 404 );
 	}
@@ -383,7 +436,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 			)
 		);
 
-		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts/' . self::$post_id . '/revisions' );
+		$request = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts/' . self::$post_id_1 . '/revisions' );
 
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
@@ -393,7 +446,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 
 		wp_set_current_user( 1 );
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions/' . $this->revision_id1 );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions/' . $this->revision_1_1_id );
 
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertArrayHasKey( 'my_custom_int', $response->data );
@@ -450,14 +503,14 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 
 	public function test_get_item_sets_up_postdata() {
 		wp_set_current_user( self::$editor_id );
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions/' . $this->revision_id1 );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions/' . $this->revision_1_1_id );
 		rest_get_server()->dispatch( $request );
 
 		$post           = get_post();
 		$parent_post_id = wp_is_post_revision( $post->ID );
 
-		$this->assertSame( $post->ID, $this->revision_id1 );
-		$this->assertSame( $parent_post_id, self::$post_id );
+		$this->assertSame( $post->ID, $this->revision_1_1_id );
+		$this->assertSame( $parent_post_id, self::$post_id_1 );
 	}
 
 	/**
@@ -468,7 +521,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 	public function test_get_items_pagination_header_of_the_first_page() {
 		wp_set_current_user( self::$editor_id );
 
-		$rest_route  = '/wp/v2/posts/' . self::$post_id . '/revisions';
+		$rest_route  = '/wp/v2/posts/' . self::$post_id_1 . '/revisions';
 		$per_page    = 2;
 		$total_pages = (int) ceil( $this->total_revisions / $per_page );
 		$page        = 1;  // First page.
@@ -503,7 +556,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 	public function test_get_items_pagination_header_of_the_last_page() {
 		wp_set_current_user( self::$editor_id );
 
-		$rest_route  = '/wp/v2/posts/' . self::$post_id . '/revisions';
+		$rest_route  = '/wp/v2/posts/' . self::$post_id_1 . '/revisions';
 		$per_page    = 2;
 		$total_pages = (int) ceil( $this->total_revisions / $per_page );
 		$page        = 2;  // Last page.
@@ -541,7 +594,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		$expected_error  = 'rest_invalid_param';
 		$expected_status = 400;
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions' );
 		$request->set_param( 'per_page', $per_page );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( $expected_error, $response, $expected_status );
@@ -561,7 +614,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		$expected_error  = 'rest_revision_invalid_page_number';
 		$expected_status = 400;
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions' );
 		$request->set_query_params(
 			array(
 				'per_page' => $per_page,
@@ -585,7 +638,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		$expected_error  = 'rest_revision_invalid_page_number';
 		$expected_status = 400;
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions' );
 		$request->set_query_params(
 			array(
 				'per_page' => $per_page,
@@ -608,7 +661,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		$expected_count   = 1;
 		$expected_content = 'This content is better.';
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions' );
 		$request->set_param( 'search', $search_string );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
@@ -626,7 +679,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 
 		$expected_count = $this->total_revisions;
 
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertCount( $expected_count, $response->get_data() );
 	}
@@ -642,7 +695,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		$offset         = 1;
 		$expected_count = $this->total_revisions;
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions' );
 		$request->set_param( 'offset', $offset );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertCount( $expected_count, $response->get_data() );
@@ -660,7 +713,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		$offset         = 1;
 		$expected_count = 2;
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions' );
 		$request->set_query_params(
 			array(
 				'offset'   => $offset,
@@ -684,7 +737,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		$page           = 1;
 		$expected_count = 2;
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions' );
 		$request->set_query_params(
 			array(
 				'offset'   => $offset,
@@ -709,7 +762,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		$expected_error  = 'rest_revision_invalid_offset_number';
 		$expected_status = 400;
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions' );
 		$request->set_query_params(
 			array(
 				'offset'   => $offset,
@@ -733,7 +786,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		$expected_error  = 'rest_revision_invalid_offset_number';
 		$expected_status = 400;
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions' );
 		$request->set_query_params(
 			array(
 				'offset'   => $offset,
@@ -757,7 +810,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		$expected_error  = 'rest_revision_invalid_offset_number';
 		$expected_status = 400;
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions' );
 		$request->set_query_params(
 			array(
 				'offset'   => $offset,
@@ -781,7 +834,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		$expected_error  = 'rest_invalid_param';
 		$expected_status = 400;
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions' );
 		$request->set_query_params(
 			array(
 				'offset'   => $offset,
@@ -806,7 +859,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		$page           = $total_pages + 1; // Out of bound page.
 		$expected_count = 2;
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id_1 . '/revisions' );
 		$request->set_query_params(
 			array(
 				'offset'   => 1,

--- a/tests/phpunit/tests/rest-api/rest-revisions-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-revisions-controller.php
@@ -275,7 +275,7 @@ class WP_Test_REST_Revisions_Controller extends WP_Test_REST_Controller_Testcase
 		wp_set_current_user( self::$editor_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts/' . self::$post_id . '/revisions/' . $this->revision_2_1_id );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_post_invalid_parent', $response, 404 );
+		$this->assertErrorResponse( 'rest_revision_parent_id_mismatch', $response, 404 );
 	}
 
 	public function test_delete_item() {

--- a/tests/phpunit/tests/rest-api/wpRestTemplateRevisionsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplateRevisionsController.php
@@ -382,6 +382,9 @@ class Tests_REST_wpRestTemplateRevisionsController extends WP_Test_REST_Controll
 
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_revision_parent_id_mismatch', $response, 404 );
+
+		$expected_message = 'The revision does not belong to the specified parent with id of "' . self::$template_post_2->ID . '"';
+		$this->assertSame( $expected_message, $response->as_error()->get_error_messages()[0], 'The message must contain the correct parent ID.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/wpRestTemplateRevisionsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplateRevisionsController.php
@@ -22,6 +22,11 @@ class Tests_REST_wpRestTemplateRevisionsController extends WP_Test_REST_Controll
 	/**
 	 * @var string
 	 */
+	const TEMPLATE_NAME_2 = 'my_template_2';
+
+	/**
+	 * @var string
+	 */
 	const PARENT_POST_TYPE = 'wp_template';
 
 	/**
@@ -50,6 +55,15 @@ class Tests_REST_wpRestTemplateRevisionsController extends WP_Test_REST_Controll
 	 * @var WP_Post
 	 */
 	private static $template_post;
+
+	/**
+	 * Template post.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @var WP_Post
+	 */
+	private static $template_post_2;
 
 	/**
 	 * @var array
@@ -123,6 +137,26 @@ class Tests_REST_wpRestTemplateRevisionsController extends WP_Test_REST_Controll
 				'post_content' => 'Content revision #5',
 			)
 		);
+
+		// Create a new template post to test the get_item method.
+		self::$template_post_2 = $factory->post->create_and_get(
+			array(
+				'post_type'    => self::PARENT_POST_TYPE,
+				'post_name'    => self::TEMPLATE_NAME_2,
+				'post_title'   => 'My Template 2',
+				'post_content' => 'Content 2',
+				'post_excerpt' => 'Description of my template 2',
+				'tax_input'    => array(
+					'wp_theme' => array(
+						self::TEST_THEME,
+					),
+				),
+			)
+		);
+		wp_set_post_terms( self::$template_post_2->ID, self::TEST_THEME, 'wp_theme' );
+
+		var_dump( self::$template_post->ID );
+		var_dump( self::$template_post_2->ID );
 	}
 
 	/**
@@ -334,6 +368,20 @@ class Tests_REST_wpRestTemplateRevisionsController extends WP_Test_REST_Controll
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/templates/invalid//parent/revisions/' . $revision_id );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_post_invalid_parent', $response, WP_Http::NOT_FOUND );
+	}
+
+	/**
+	 * @ticket 59875
+	 */
+	public function test_get_item_invalid_parent_id() {
+		wp_set_current_user( self::$admin_id );
+		$revisions   = wp_get_post_revisions( self::$template_post, array( 'fields' => 'ids' ) );
+		$revision_id = array_shift( $revisions );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/templates/' . self::TEST_THEME . '/' . self::TEMPLATE_NAME_2 . '/revisions/' . $revision_id );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_revision_parent_id_mismatch', $response, 404 );
 	}
 
 	/**


### PR DESCRIPTION
This patch adds a condition to `WP_REST_Revisions_Controller->get_item` that checks the revision parent id against the supplied parent id. 

If it doesn't match, the method returns a 404.

This is to ensure that  `get_item` does not return a revision whose parent does not match the `parent` route fragment.

Test coverage added.

Run tests: `npm run test:php -- --filter WP_Test_REST_Revisions_Controller`

Commit 1a7ff6c75c79398bec9504b4e70d4f2f95e9c310 demonstrates that currently, `get_item()` can return the revision of different parent post of that same type.


Trac ticket: https://core.trac.wordpress.org/ticket/59875

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
