### PR TITLE
Expose serialized template content on WP_Block_Template.

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -532,6 +532,7 @@ function _build_block_template_result_from_file( $template_file, $template_type 
 	$template->has_theme_file = true;
 	$template->is_custom      = true;
 	$template->modified       = null;
+	$template->content        = $template_content;
 
 	if ( 'wp_template' === $template_type && isset( $default_template_types[ $template_file['slug'] ] ) ) {
 		$template->description = $default_template_types[ $template_file['slug'] ]['description'];

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -518,7 +518,6 @@ function _remove_theme_attribute_from_template_part_block( &$block ) {
  */
 function _build_block_template_result_from_file( $template_file, $template_type ) {
 	$default_template_types = get_default_block_template_types();
-	$template_content       = file_get_contents( $template_file['path'] );
 	$theme                  = get_stylesheet();
 
 	$template                 = new WP_Block_Template();
@@ -532,7 +531,7 @@ function _build_block_template_result_from_file( $template_file, $template_type 
 	$template->has_theme_file = true;
 	$template->is_custom      = true;
 	$template->modified       = null;
-	$template->content        = $template_content;
+	$template->content        = file_get_contents( $template_file['path'] );
 
 	if ( 'wp_template' === $template_type && isset( $default_template_types[ $template_file['slug'] ] ) ) {
 		$template->description = $default_template_types[ $template_file['slug'] ]['description'];
@@ -555,7 +554,7 @@ function _build_block_template_result_from_file( $template_file, $template_type 
 		$before_block_visitor = make_before_block_visitor( $hooked_blocks, $template );
 		$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $template );
 	}
-	$blocks            = parse_blocks( $template_content );
+	$blocks            = parse_blocks( $template->content );
 	$template->content = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
 
 	return $template;


### PR DESCRIPTION
When building the template, initialize WP_Block_Template with the serialized block content so callbacks registered to the `hooked_block_types` filter can access the content.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

If you registered a callback to `hooked_block_types` when the callback receives an instance of a template or template_part via the `$context` argument, the `$content` property will be null. Minimally reproducible example:

```php
<?php
add_action( 'hooked_block_types', 'testing_auto_hook', 10, 4 );
function testing_auto_hook( $hooked_blocks, $position, $anchor_block, $context ) {
   if ( $context instanceof \WP_Block_Template ) {
	$content = $context instanceof \WP_Block_Template && $context->content ? $context->content : '';
	if ( strpos( $content, 'wp:post-title' ) !== false ) {
		// the `core/post-title` block already exists in content so abort.
		return $hooked_blocks;
	}
	if (
		$context instanceof \WP_Block_Template &&
		'after' === $position &&
		'core/post-title' === $anchor_block
	) {
		$hooked_blocks[] = 'core/navigation';
	}
   }
   return $hooked_blocks;
}
```

In the above example, the code is checking to see if the `$context` is an instance of `WP_Block_Template` and if it is, looks in the `$content` property for the serialized representation of the `core/post-title` block. If it's present, then bail early and don't inject navigation. For the pages template, I'd _expect_ this to not inject `core/navigation` because the `core/post-title` block is present in the content, but in fact, it does get injected because `WP_Block_Template::$content === null`.

Screenshots:

| Before | After (with this PR/patch) |
| ----- | ------ |
| ![CleanShot 2023-11-10 at 14 50 39@2x](https://github.com/nerrad/wordpress-develop/assets/1429108/4958e2f9-f67b-435c-9cd0-c06bef472b0d) |  ![CleanShot 2023-11-10 at 14 50 13@2x](https://github.com/nerrad/wordpress-develop/assets/1429108/b6c78b55-f93b-431c-bcae-7eaa8739f54e) |


Trac ticket: https://core.trac.wordpress.org/ticket/59882

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
