### PR TITLE
Add 'weekly' value to `wp_schedule_event()` function description

### DIFF
--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -206,7 +206,7 @@ function wp_schedule_single_event( $timestamp, $hook, $args = array(), $wp_error
  * The action will trigger when someone visits your WordPress site if the scheduled
  * time has passed.
  *
- * Valid values for the recurrence are 'hourly', 'daily', and 'twicedaily'. These can
+ * Valid values for the recurrence are 'hourly', 'daily', 'twicedaily', and 'weekly'. These can
  * be extended using the {@see 'cron_schedules'} filter in wp_get_schedules().
  *
  * Use wp_next_scheduled() to prevent duplicate events.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

The `wp_get_schedules()` function includes `weekly` as a valid schedule, so update the description of `wp_schedule_event()` to include.

Trac ticket: https://core.trac.wordpress.org/ticket/59888

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
