### PR TITLE
HTML API: Fix typo in documentation example.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -116,7 +116,7 @@
  *
  * Example:
  *
- *     if ( $tags->next_tag( array( 'class' => 'wp-group-block' ) ) ) {
+ *     if ( $tags->next_tag( array( 'class_name' => 'wp-group-block' ) ) ) {
  *         $tags->set_attribute( 'title', 'This groups the contained content.' );
  *         $tags->remove_attribute( 'data-test-id' );
  *     }


### PR DESCRIPTION
Trac ticket: Core-59891
Resolves: https://github.com/WordPress/Documentation-Issue-Tracker/issues/1362

The example code in the PHPDoc comment for the HTML Tag Processor class previously showed calling `next_tag()` with an array containing a `class` key, which should have been `class_name`. This patch fixes this by using the appropriate `class_name` key.

Props: @gaambo, @crstauf, @atachibana

As a documentation change this should have no impact on any code and should need no testing.