### PR TITLE
Experiment: Run the Tag Processor on every tag on output.

### DIFF
--- a/src/_index.php
+++ b/src/_index.php
@@ -13,5 +13,98 @@
  */
 define( 'WP_USE_THEMES', true );
 
+ob_start( 'dms_everything' );
+
+function dms_parse_url( $url ) {
+	$url                  = empty( $url ) ? '' : $url;
+	$fragment_at          = strpos( $url, '#' );
+	$fragment             = false !== $fragment_at ? substr( $url, $fragment_at + 1 ) : '';
+	$url_without_fragment = false !== $fragment_at ? substr( $url, 0, $fragment_at ) : $url;
+	$query_at             = strpos( $url_without_fragment, '?' );
+
+	$query = false !== $query_at ? substr( $url_without_fragment, $query_at + 1 ) : '';
+	$pairs = explode( '&', $query );
+	$args  = [];
+	foreach ( $pairs as $pair ) {
+		if ( '' === $pair ) {
+			continue;
+		}
+		if ( false === strpos( $pair, '=' ) ) {
+			$args[ $pair ] = true;
+		} else {
+			list( $key, $value ) = explode( '=', $pair );
+			$args[ $key ] = urldecode( $value );
+		}
+	}
+
+	$url_without_query = false !== $query_at ? substr( $url_without_fragment, 0, $query_at ) : $url_without_fragment;
+	$is_relative       = 0 === strlen( $url_without_query ) || '/' === $url_without_query[0];
+	$has_schema        = preg_match( '~^([a-z]+)://~i', $url_without_query, $schema_match );
+	$schema            = $has_schema ? $schema_match[1] : '';
+	$domain_path       = $has_schema ? substr( $url_without_query, strlen( $schema_match[0] ) ) : $url_without_query;
+
+	if ( ! $is_relative ) {
+		$first_slash = strpos( $domain_path, '/' );
+		$domain      = false !== $first_slash ? substr( $domain_path, 0, $first_slash ) : '';
+		$path        = false !== $first_slash ? substr( $domain_path, $first_slash ) : $domain_path;
+	} else {
+		$domain      = '';
+		$path        = $domain_path;
+	}
+
+	return [
+		'schema'   => $schema,
+		'domain'   => $domain,
+		'path'     => $path,
+		'query'    => count( $args ) > 0 ? $args : null,
+		'fragment' => $fragment,
+	];
+}
+
+function dms_everything( $html ) {
+	$processor = new WP_HTML_Tag_Processor( $html );
+	$tag_count = 0;
+	$seen_ids = [];
+
+	$errors = [];
+
+	while ( $processor->next_tag() ) {
+		$tag_count++;
+		$tag_name = $processor->get_tag();
+
+		$id = $processor->get_attribute( 'id' );
+		if ( is_string( $id ) ) {
+			if ( isset( $seen_ids[ $id ] ) ) {
+				$errors[] = "Repeated id = <{$tag_name} id=\"{$id}\">; seen first in {$seen_ids[$id]} tag.";
+			} else {
+				$seen_ids[ $id ] = $tag_name;
+			}
+		}
+
+		$src = $processor->get_attribute( 'src' );
+		if ( is_string( $src ) ) {
+			$url = dms_parse_url( $src );
+			$errors[] = "Found URL in <{$tag_name} src=\"{$src}\">.";
+			$errors[] = print_r( $url, true );
+			$errors[] = "\n";
+		}
+
+		$href = $processor->get_attribute( 'href' );
+		if ( is_string( $href ) ) {
+			$url = dms_parse_url( $href );
+			$errors[] = "Found URL in <{$tag_name} href=\"{$href}\">.";
+			$errors[] = print_r( $url, true );
+			$errors[] = "\n";
+		}
+	}
+
+	return $html;
+//	return count( $errors ) > 0
+//		? '<plaintext>' . "Found {$tag_count} tags.\n\n" . implode( "\n", array_map( function( $e ) { return print_r( $e, true ); }, $errors ) )
+//		: $html;
+}
+
 /** Loads the WordPress Environment and Template */
 require __DIR__ . '/wp-blog-header.php';
+
+ob_end_flush();


### PR DESCRIPTION
Using this to get a baseline measurement on a kind of "worst case" scenario with the HTML Tag Processor: how much delay do we incur if we're running the processor over the final page output and processing every tag?

Why would this be useful information or a useful practice?
 - a new set of WordPress filters to adjust attribute values more robustly
 - look for security issues in URLs sent to the browser
 - look for accessibility issues
 - append extras like `srcset` values in one final go
 - check for duplicate `id` values

In this experiment every `src` and `href` attribute value is parsed.

### Initial results

 - very promising: no measurable impact on the page render for `twentytwentyfour`'s homepage
 - on my laptop it's processing at around 100 MB/s for the `twentytwentyfour` homepage, the speed improvement probably due to the large inline stylesheet on the page

![html-all-the-things-lt120](https://github.com/WordPress/wordpress-develop/assets/5431237/46663dbc-5e89-4a7f-bf2a-6265026a3be2)

From my estimates this should be adding around at least 1ms of page render time, but we aren't able to statistically infer that from the results. Why this is I'm not sure because I would expect a 1% change to certainly appear, but something else might be masking the impact.