### PR TITLE
Poc/early cache return

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1895,14 +1895,14 @@ class WP_Query {
 		}
 
 		$q['cache_early'] = $q['cache_results'] && $q['cache_early'];
-		if( $q['cache_early'] ) {
-			$q = $this->get_get_posts_filter_pattern( $q );
-			$early_hash = md5( serialize( $q ) );
-			$last_changed = wp_cache_get_last_changed( 'posts' );
+		if ( $q['cache_early'] ) {
+			$q               = $this->get_get_posts_filter_pattern( $q );
+			$early_hash      = md5( serialize( $q ) );
+			$last_changed    = wp_cache_get_last_changed( 'posts' );
 			$early_cache_key = "get_posts:$early_hash:$last_changed";
-			$cache_key = wp_cache_get( $early_cache_key, 'post-cache-keys', true );
-			$cache_found = false;
-			if ( !empty( $cache_key ) && null === $this->posts ) {
+			$cache_key       = wp_cache_get( $early_cache_key, 'post-cache-keys', true );
+			$cache_found     = false;
+			if ( ! empty( $cache_key ) && null === $this->posts ) {
 				$cached_results = wp_cache_get( $cache_key, 'post-queries', false, $cache_found );
 
 				if ( $cached_results ) {
@@ -3228,7 +3228,7 @@ class WP_Query {
 		if ( $q['cache_results'] && $id_query_is_cacheable ) {
 			$new_request = str_replace( $fields, "{$wpdb->posts}.*", $this->request );
 			$cache_key   = $this->generate_cache_key( $q, $new_request );
-			if( $q['cache_early'] ) {
+			if ( $q['cache_early'] ) {
 				wp_cache_add( $early_cache_key, $cache_key, 'posts-cache-keys' );
 			}
 
@@ -3628,11 +3628,11 @@ class WP_Query {
 
 	/**
 	 * Capture signature of filter from get_posts in $args.
-	 * 
+	 *
 	 * @param array $args query args.
 	 * @return array $args
 	 */
-	public function get_get_posts_filter_pattern( $args ){
+	public function get_get_posts_filter_pattern( $args ) {
 		global $wp_filter;
 		$filters = array(
 			'wp_allow_query_attachment_by_filename',
@@ -3670,8 +3670,8 @@ class WP_Query {
 			'the_posts',
 		);
 
-		foreach( $filters as $filter ){
-			if( has_filter( $filter ) ){
+		foreach ( $filters as $filter ) {
+			if ( has_filter( $filter ) ) {
 				$args['args_filters'][ $filter ] = $wp_filter[ $filter ];
 			}
 		}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1886,6 +1886,62 @@ class WP_Query {
 		// Fill again in case 'pre_get_posts' unset some vars.
 		$q = $this->fill_query_vars( $q );
 
+		if ( ! isset( $q['cache_results'] ) ) {
+			$q['cache_results'] = true;
+		}
+
+		if ( ! isset( $q['cache_early'] ) ) {
+			$q['cache_early'] = false;
+		}
+
+		$q['cache_early'] = $q['cache_results'] && $q['cache_early'];
+		if( $q['cache_early'] ) {
+			$q = $this->get_get_posts_filter_pattern( $q );
+			$early_hash = md5( serialize( $q ) );
+			$last_changed = wp_cache_get_last_changed( 'posts' );
+			$early_cache_key = "get_posts:$early_hash:$last_changed";
+			$cache_key = wp_cache_get( $early_cache_key, 'post-cache-keys', true );
+			$cache_found = false;
+			if ( !empty( $cache_key ) && null === $this->posts ) {
+				$cached_results = wp_cache_get( $cache_key, 'post-queries', false, $cache_found );
+
+				if ( $cached_results ) {
+					/** @var int[] */
+					$post_ids = array_map( 'intval', $cached_results['posts'] );
+
+					$this->post_count    = count( $post_ids );
+					$this->found_posts   = $cached_results['found_posts'];
+					$this->max_num_pages = $cached_results['max_num_pages'];
+
+					if ( 'ids' === $q['fields'] ) {
+						$this->posts = $post_ids;
+
+						return $this->posts;
+					} elseif ( 'id=>parent' === $q['fields'] ) {
+						_prime_post_parent_id_caches( $post_ids );
+
+						$post_parent_cache_keys = array();
+						foreach ( $post_ids as $post_id ) {
+							$post_parent_cache_keys[] = 'post_parent:' . (string) $post_id;
+						}
+
+						/** @var int[] */
+						$post_parents = wp_cache_get_multiple( $post_parent_cache_keys, 'posts' );
+
+						foreach ( $post_parents as $cache_key => $post_parent ) {
+							$obj              = new stdClass();
+							$obj->ID          = (int) str_replace( 'post_parent:', '', $cache_key );
+							$obj->post_parent = (int) $post_parent;
+
+							$this->posts[] = $obj;
+						}
+
+						return $post_parents;
+					}
+				}
+			}
+		}
+
 		/**
 		 * Filters whether an attachment query should include filenames or not.
 		 *
@@ -3172,6 +3228,9 @@ class WP_Query {
 		if ( $q['cache_results'] && $id_query_is_cacheable ) {
 			$new_request = str_replace( $fields, "{$wpdb->posts}.*", $this->request );
 			$cache_key   = $this->generate_cache_key( $q, $new_request );
+			if( $q['cache_early'] ) {
+				wp_cache_add( $early_cache_key, $cache_key, 'posts-cache-keys' );
+			}
 
 			$cache_found = false;
 			if ( null === $this->posts ) {
@@ -3565,6 +3624,58 @@ class WP_Query {
 		}
 
 		return $this->posts;
+	}
+
+	/**
+	 * Capture signature of filter from get_posts in $args.
+	 * 
+	 * @param array $args query args.
+	 * @return array $args
+	 */
+	public function get_get_posts_filter_pattern( $args ){
+		global $wp_filter;
+		$filters = array(
+			'wp_allow_query_attachment_by_filename',
+			'posts_search',
+			'posts_search_orderby',
+			'posts_where',
+			'posts_join',
+			'comment_feed_join',
+			'comment_feed_where',
+			'comment_feed_groupby',
+			'comment_feed_orderby',
+			'comment_feed_limits',
+			'posts_where_paged',
+			'posts_groupby',
+			'posts_join_paged',
+			'posts_orderby',
+			'posts_distinct',
+			'post_limits',
+			'posts_fields',
+			'posts_clauses',
+			'posts_where_request',
+			'posts_groupby_request',
+			'posts_join_request',
+			'posts_orderby_request',
+			'posts_distinct_request',
+			'posts_fields_request',
+			'post_limits_request',
+			'posts_clauses_request',
+			'posts_request',
+			'posts_pre_query',
+			'split_the_query',
+			'posts_request_ids',
+			'posts_results',
+			'the_preview',
+			'the_posts',
+		);
+
+		foreach( $filters as $filter ){
+			if( has_filter( $filter ) ){
+				$args['args_filters'][ $filter ] = $wp_filter[ $filter ];
+			}
+		}
+		return $args;
 	}
 
 	/**


### PR DESCRIPTION
This PR is a POC for early caching for WP_Query. 

We have 38 filters in `get_posts`. Even though we have caching implemented, caching doesn't actively skip all the filters. 

In most cases, these filters are only used for static modification of queries, so handling caching early using only the filter signature would let us skip all the filters for cached content.


Know issues which prevent caching from being moved on top for all the queries ->
- Filters can be used for dynamic modification of queries like `current date` or `current user` based changes to the query or any other form of dynamic changes that cannot be recorded by filter signature alone.
- Filters can also be used as actions, preventing us from skipping them.


I have also done a performance test for this PoC, keeping `cache_early` active by default for all the queries.  Even though the code could return the cache early, there wasn't any performance benefit as themes had 0 to no modification done to the query.  However, this option could benefit a site using query filters for static changes alone and then use caching. 

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
