### PR TITLE
Add MacOS and Windows testing to the theme workflow

### DIFF
--- a/.github/workflows/test-and-zip-default-themes.yml
+++ b/.github/workflows/test-and-zip-default-themes.yml
@@ -129,6 +129,10 @@ jobs:
         working-directory: src/wp-content/themes/${{ matrix.theme }}
 
     steps:
+      - name: Configure Git
+        if: ${{ 'windows-latest' == matrix.os }}
+        run: git config core.autocrlf true
+
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:

--- a/.github/workflows/test-and-zip-default-themes.yml
+++ b/.github/workflows/test-and-zip-default-themes.yml
@@ -104,7 +104,7 @@ jobs:
   # - Runs the theme build script.
   # - Ensures version-controlled files are not modified or deleted.
   test-build-scripts:
-    name: Test ${{ matrix.theme }} build script
+    name: Test ${{ matrix.theme }} build script on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/test-and-zip-default-themes.yml
+++ b/.github/workflows/test-and-zip-default-themes.yml
@@ -105,7 +105,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   test-build-scripts:
     name: Test ${{ matrix.theme }} build script
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     timeout-minutes: 10
@@ -117,6 +117,11 @@ jobs:
             'twentytwentyone',
             'twentytwenty',
             'twentynineteen',
+        ]
+        os: [
+          'ubuntu-latest',
+          'windows-latest',
+          'macos-latest',
         ]
 
     defaults:

--- a/.github/workflows/test-and-zip-default-themes.yml
+++ b/.github/workflows/test-and-zip-default-themes.yml
@@ -129,6 +129,10 @@ jobs:
         working-directory: src/wp-content/themes/${{ matrix.theme }}
 
     steps:
+      - name: Configure Git
+        if: ${{ 'windows-latest' == matrix.os }}
+        run: git config --global core.autocrlf false
+
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:

--- a/.github/workflows/test-and-zip-default-themes.yml
+++ b/.github/workflows/test-and-zip-default-themes.yml
@@ -129,15 +129,15 @@ jobs:
         working-directory: src/wp-content/themes/${{ matrix.theme }}
 
     steps:
-      - name: Configure Git
-        if: ${{ 'windows-latest' == matrix.os }}
-        run: git config core.autocrlf true
-
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.ref }}
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+
+      - name: Configure Git
+        if: ${{ 'windows-latest' == matrix.os }}
+        run: git config core.autocrlf true
 
       - name: Set up Node.js
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1

--- a/.github/workflows/test-and-zip-default-themes.yml
+++ b/.github/workflows/test-and-zip-default-themes.yml
@@ -135,10 +135,6 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.ref }}
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
-      - name: Configure Git
-        if: ${{ 'windows-latest' == matrix.os }}
-        run: git config core.autocrlf true
-
       - name: Set up Node.js
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:


### PR DESCRIPTION
Similar to how different operating systems are tested for the general Core build process, the individual default theme build processes should also be tested.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
