### PR TITLE
HTML API: Provide mechanism to scan all tokens in an HTML document, not only the tags.

### DIFF
--- a/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
@@ -514,7 +514,11 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 	 * @covers WP_HTML_Processor::seek
 	 */
 	public function test_can_seek_back_and_forth() {
-		$p = WP_HTML_Processor::create_fragment( '<div><p one><div><p><div two><p><div><p><div><p three>' );
+		$p = WP_HTML_Processor::create_fragment(
+			<<<'HTML'
+<div>text<p one>more stuff<div><![CDATA[this is not real CDATA]]><p><!-- hi --><div two><p><div><p>three comes soon<div><p three>' );
+HTML
+		);
 
 		// Find first tag of interest.
 		while ( $p->next_tag() && null === $p->get_attribute( 'one' ) ) {

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-token-scanning.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-token-scanning.php
@@ -1,0 +1,734 @@
+<?php
+/**
+ * Unit tests covering WP_HTML_Tag_Processor token-scanning functionality.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ *
+ * @since 6.5.0
+ *
+ * @group html-api
+ *
+ * @coversDefaultClass WP_HTML_Tag_Processor
+ */
+class Tests_HtmlApi_WpHtmlProcessor_Token_Scanning extends WP_UnitTestCase {
+	/**
+	 * Ensures that scanning finishes in a complete form when the document is empty.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_completes_empty_document() {
+		$processor = new WP_HTML_Tag_Processor( '' );
+
+		$this->assertFalse(
+			$processor->next_token(),
+			"Should not have found any tokens but found {$processor->get_token_type()}."
+		);
+	}
+
+	/**
+	 * Ensures that normative text nodes are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_text_node() {
+		$processor = new WP_HTML_Tag_Processor( 'Hello, World!' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#text',
+			$processor->get_token_type(),
+			"Should have found #text token type but found {$processor->get_token_type()} instead."
+		);
+
+		$this->assertSame(
+			'Hello, World!',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Ensures that normative Elements are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_element() {
+		$processor = new WP_HTML_Tag_Processor( '<div id="test" inert>Hello, World!</div>' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'DIV',
+			$processor->get_token_name(),
+			"Should have found DIV tag name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertSame(
+			'test',
+			$processor->get_attribute( 'id' ),
+			"Should have found id attribute value 'test' but found {$processor->get_attribute( 'id' )} instead."
+		);
+
+		$this->assertTrue(
+			$processor->get_attribute( 'inert' ),
+			"Should have found boolean attribute 'inert' but didn't."
+		);
+
+		$attributes     = $processor->get_attribute_names_with_prefix( '' );
+		$attribute_list = array_map( 'Tests_HtmlApi_WpHtmlProcessor_Token_Scanning::quoted', $attributes );
+		$this->assertSame(
+			array( 'id', 'inert' ),
+			$attributes,
+			'Should have found only two attributes but found ' . implode( ', ', $attribute_list ) . ' instead.'
+		);
+
+		$this->assertSame(
+			'',
+			$processor->get_modifiable_text(),
+			"Should have found empty modifiable text but found '{$processor->get_modifiable_text()}' instead."
+		);
+	}
+
+	/**
+	 * Ensures that normative SCRIPT elements are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_script_element() {
+		$processor = new WP_HTML_Tag_Processor( '<script type="module">console.log( "Hello, World!" );</script>' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'SCRIPT',
+			$processor->get_token_name(),
+			"Should have found SCRIPT tag name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertSame(
+			'module',
+			$processor->get_attribute( 'type' ),
+			"Should have found type attribute value 'module' but found {$processor->get_attribute( 'type' )} instead."
+		);
+
+		$attributes     = $processor->get_attribute_names_with_prefix( '' );
+		$attribute_list = array_map( 'Tests_HtmlApi_WpHtmlProcessor_Token_Scanning::quoted', $attributes );
+		$this->assertSame(
+			array( 'type' ),
+			$attributes,
+			"Should have found single 'type' attribute but found " . implode( ', ', $attribute_list ) . ' instead.'
+		);
+
+		$this->assertSame(
+			'console.log( "Hello, World!" );',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Ensures that normative TEXTAREA elements are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_textarea_element() {
+		$processor = new WP_HTML_Tag_Processor(
+			<<<HTML
+<textarea rows=30 cols="80">
+Is <HTML> &gt; XHTML?
+</textarea>
+HTML
+		);
+		$processor->next_token();
+
+		$this->assertSame(
+			'TEXTAREA',
+			$processor->get_token_name(),
+			"Should have found TEXTAREA tag name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertSame(
+			'30',
+			$processor->get_attribute( 'rows' ),
+			"Should have found rows attribute value 'module' but found {$processor->get_attribute( 'rows' )} instead."
+		);
+
+		$this->assertSame(
+			'80',
+			$processor->get_attribute( 'cols' ),
+			"Should have found cols attribute value 'module' but found {$processor->get_attribute( 'cols' )} instead."
+		);
+
+		$attributes     = $processor->get_attribute_names_with_prefix( '' );
+		$attribute_list = array_map( 'Tests_HtmlApi_WpHtmlProcessor_Token_Scanning::quoted', $attributes );
+		$this->assertSame(
+			array( 'rows', 'cols' ),
+			$attributes,
+			'Should have found only two attributes but found ' . implode( ', ', $attribute_list ) . ' instead.'
+		);
+
+		// Note that the leading newline should be removed from the TEXTAREA contents.
+		$this->assertSame(
+			"Is <HTML> > XHTML?\n",
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Ensures that normative TITLE elements are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_title_element() {
+		$processor = new WP_HTML_Tag_Processor(
+			<<<HTML
+<title class="multi-line-title">
+Is <HTML> &gt; XHTML?
+</title>
+HTML
+		);
+		$processor->next_token();
+
+		$this->assertSame(
+			'TITLE',
+			$processor->get_token_name(),
+			"Should have found TITLE tag name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertSame(
+			'multi-line-title',
+			$processor->get_attribute( 'class' ),
+			"Should have found class attribute value 'multi-line-title' but found {$processor->get_attribute( 'rows' )} instead."
+		);
+
+		$attributes     = $processor->get_attribute_names_with_prefix( '' );
+		$attribute_list = array_map( 'Tests_HtmlApi_WpHtmlProcessor_Token_Scanning::quoted', $attributes );
+		$this->assertSame(
+			array( 'class' ),
+			$attributes,
+			'Should have found only one attribute but found ' . implode( ', ', $attribute_list ) . ' instead.'
+		);
+
+		$this->assertSame(
+			"\nIs <HTML> > XHTML?\n",
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Ensures that normative RAWTEXT elements are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 *
+	 * @dataProvider data_rawtext_elements
+	 *
+	 * @param string $tag_name The name of the RAWTEXT tag to test.
+	 */
+	public function test_basic_assertion_rawtext_elements( $tag_name ) {
+		$processor = new WP_HTML_Tag_Processor(
+			<<<HTML
+<{$tag_name} class="multi-line-title">
+Is <HTML> &gt; XHTML?
+</{$tag_name}>
+HTML
+		);
+		$processor->next_token();
+
+		$this->assertSame(
+			$tag_name,
+			$processor->get_token_name(),
+			"Should have found {$tag_name} tag name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertSame(
+			'multi-line-title',
+			$processor->get_attribute( 'class' ),
+			"Should have found class attribute value 'multi-line-title' but found {$processor->get_attribute( 'rows' )} instead."
+		);
+
+		$attributes     = $processor->get_attribute_names_with_prefix( '' );
+		$attribute_list = array_map( 'Tests_HtmlApi_WpHtmlProcessor_Token_Scanning::quoted', $attributes );
+		$this->assertSame(
+			array( 'class' ),
+			$attributes,
+			'Should have found only one attribute but found ' . implode( ', ', $attribute_list ) . ' instead.'
+		);
+
+		$this->assertSame(
+			"\nIs <HTML> &gt; XHTML?\n",
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[].
+	 */
+	public function data_rawtext_elements() {
+		return array(
+			'IFRAME'   => array( 'IFRAME' ),
+			'NOEMBED'  => array( 'NOEMBED' ),
+			'NOFRAMES' => array( 'NOFRAMES' ),
+			'STYLE'    => array( 'STYLE' ),
+			'XMP'      => array( 'XMP' ),
+		);
+	}
+
+	/**
+	 * Ensures that normative CDATA sections are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_cdata_section() {
+		$processor = new WP_HTML_Tag_Processor( '<![CDATA[this is a comment]]>' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#comment',
+			$processor->get_token_name(),
+			"Should have found comment token but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertSame(
+			WP_HTML_Processor::COMMENT_AS_CDATA_LOOKALIKE,
+			$processor->get_comment_type(),
+			'Should have detected a CDATA-like invalid comment.'
+		);
+
+		$this->assertNull(
+			$processor->get_tag(),
+			'Should not have been able to query tag name on non-element token.'
+		);
+
+		$this->assertNull(
+			$processor->get_attribute( 'type' ),
+			'Should not have been able to query attributes on non-element token.'
+		);
+
+		$this->assertSame(
+			'this is a comment',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Ensures that abruptly-closed CDATA sections are properly parsed as comments.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_abruptly_closed_cdata_section() {
+		$processor = new WP_HTML_Tag_Processor( '<![CDATA[this is > a comment]]>' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#comment',
+			$processor->get_token_name(),
+			"Should have found a bogus comment but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertNull(
+			$processor->get_tag(),
+			'Should not have been able to query tag name on non-element token.'
+		);
+
+		$this->assertNull(
+			$processor->get_attribute( 'type' ),
+			'Should not have been able to query attributes on non-element token.'
+		);
+
+		$this->assertSame(
+			'[CDATA[this is ',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+
+		$processor->next_token();
+
+		$this->assertSame(
+			'#text',
+			$processor->get_token_name(),
+			"Should have found text node but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertSame(
+			' a comment]]>',
+			$processor->get_modifiable_text(),
+			'Should have found remaining syntax from abruptly-closed CDATA section.'
+		);
+	}
+
+	/**
+	 * Ensures that normative Processing Instruction nodes are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_processing_instruction() {
+		$processor = new WP_HTML_Tag_Processor( '<?wp-bit {"just": "kidding"}?>' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#comment',
+			$processor->get_token_name(),
+			"Should have found comment token but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertSame(
+			WP_HTML_Processor::COMMENT_AS_PI_NODE_LOOKALIKE,
+			$processor->get_comment_type(),
+			'Should have detected a Processing Instruction-like invalid comment.'
+		);
+
+		$this->assertSame(
+			'wp-bit',
+			$processor->get_tag(),
+			"Should have found PI target as tag name but found {$processor->get_tag()} instead."
+		);
+
+		$this->assertNull(
+			$processor->get_attribute( 'type' ),
+			'Should not have been able to query attributes on non-element token.'
+		);
+
+		$this->assertSame(
+			' {"just": "kidding"}',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Ensures that abruptly-closed Processing Instruction nodes are properly parsed as comments.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_abruptly_closed_processing_instruction() {
+		$processor = new WP_HTML_Tag_Processor( '<?version=">=5.3.6"?>' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#comment',
+			$processor->get_token_type(),
+			"Should have found bogus comment but found {$processor->get_token_type()} instead."
+		);
+
+		$this->assertSame(
+			'#comment',
+			$processor->get_token_name(),
+			"Should have found #comment as name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertNull(
+			$processor->get_tag(),
+			'Should not have been able to query tag name on non-element token.'
+		);
+
+		$this->assertNull(
+			$processor->get_attribute( 'type' ),
+			'Should not have been able to query attributes on non-element token.'
+		);
+
+		$this->assertSame(
+			'version="',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+
+		$processor->next_token();
+
+		$this->assertSame(
+			'=5.3.6"?>',
+			$processor->get_modifiable_text(),
+			'Should have found remaining syntax from abruptly-closed Processing Instruction.'
+		);
+	}
+
+	/**
+	 * Ensures that common comments are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @dataProvider data_common_comments
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 *
+	 * @param string $html Contains the comment in full.
+	 * @param string $text Contains the appropriate modifiable text.
+	 */
+	public function test_basic_assertion_common_comments( $html, $text ) {
+		$processor = new WP_HTML_Tag_Processor( $html );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#comment',
+			$processor->get_token_type(),
+			"Should have found comment but found {$processor->get_token_type()} instead."
+		);
+
+		$this->assertSame(
+			'#comment',
+			$processor->get_token_name(),
+			"Should have found #comment as name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertNull(
+			$processor->get_tag(),
+			'Should not have been able to query tag name on non-element token.'
+		);
+
+		$this->assertNull(
+			$processor->get_attribute( 'type' ),
+			'Should not have been able to query attributes on non-element token.'
+		);
+
+		$this->assertSame(
+			$text,
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[].
+	 */
+	public function data_common_comments() {
+		return array(
+			'Shortest comment'        => array( '<!-->', '' ),
+			'Short comment'           => array( '<!--->', '' ),
+			'Short comment w/o text'  => array( '<!---->', '' ),
+			'Short comment with text' => array( '<!----->', '-' ),
+			'PI node without target'  => array( '<? missing?>', ' missing?' ),
+			'Invalid PI node'         => array( '<?/missing/>', '/missing/' ),
+			'Invalid ! directive'     => array( '<!something else>', 'something else' ),
+		);
+	}
+
+	/**
+	 * Ensures that normative HTML comments are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_html_comment() {
+		$processor = new WP_HTML_Tag_Processor( '<!-- wp:paragraph -->' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#comment',
+			$processor->get_token_type(),
+			"Should have found comment but found {$processor->get_token_type()} instead."
+		);
+
+		$this->assertSame(
+			'#comment',
+			$processor->get_token_name(),
+			"Should have found #comment as name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertNull(
+			$processor->get_tag(),
+			'Should not have been able to query tag name on non-element token.'
+		);
+
+		$this->assertNull(
+			$processor->get_attribute( 'type' ),
+			'Should not have been able to query attributes on non-element token.'
+		);
+
+		$this->assertSame(
+			' wp:paragraph ',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Ensures that normative DOCTYPE elements are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_doctype() {
+		$processor = new WP_HTML_Tag_Processor( '<!DOCTYPE html>' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#doctype',
+			$processor->get_token_type(),
+			"Should have found DOCTYPE but found {$processor->get_token_type()} instead."
+		);
+
+		$this->assertSame(
+			'html',
+			$processor->get_token_name(),
+			"Should have found 'html' as name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertNull(
+			$processor->get_tag(),
+			'Should not have been able to query tag name on non-element token.'
+		);
+
+		$this->assertNull(
+			$processor->get_attribute( 'type' ),
+			'Should not have been able to query attributes on non-element token.'
+		);
+
+		$this->assertSame(
+			' html',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Ensures that normative presumptuous tag closers (empty closers) are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_presumptuous_tag() {
+		$processor = new WP_HTML_Tag_Processor( '</>' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#presumptuous-tag',
+			$processor->get_token_type(),
+			"Should have found presumptuous tag but found {$processor->get_token_type()} instead."
+		);
+
+		$this->assertSame(
+			'#presumptuous-tag',
+			$processor->get_token_name(),
+			"Should have found #presumptuous-tag as name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertNull(
+			$processor->get_tag(),
+			'Should not have been able to query tag name on non-element token.'
+		);
+
+		$this->assertNull(
+			$processor->get_attribute( 'type' ),
+			'Should not have been able to query attributes on non-element token.'
+		);
+
+		$this->assertSame(
+			'',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Ensures that normative funky comments are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_funky_comment() {
+		$processor = new WP_HTML_Tag_Processor( '</%url>' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#funky-comment',
+			$processor->get_token_type(),
+			"Should have found funky comment but found {$processor->get_token_type()} instead."
+		);
+
+		$this->assertSame(
+			'#funky-comment',
+			$processor->get_token_name(),
+			"Should have found #funky-comment as name but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertNull(
+			$processor->get_tag(),
+			'Should not have been able to query tag name on non-element token.'
+		);
+
+		$this->assertNull(
+			$processor->get_attribute( 'type' ),
+			'Should not have been able to query attributes on non-element token.'
+		);
+
+		$this->assertSame(
+			'%url',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Test helper that wraps a string in double quotes.
+	 *
+	 * @param string $s The string to wrap in double-quotes.
+	 * @return string The string wrapped in double-quotes.
+	 */
+	private static function quoted( $s ) {
+		return "\"$s\"";
+	}
+}

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -557,8 +557,10 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 		$p = new WP_HTML_Tag_Processor( '<script>abc</script>' );
 
 		$p->next_tag();
-		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the </script> tag closer' );
-		$this->assertTrue( $p->is_tag_closer(), 'Indicated a <script> tag opener is a tag closer' );
+		$this->assertFalse(
+			$p->next_tag( array( 'tag_closers' => 'visit' ) ),
+			'Should not have found closing SCRIPT tag when closing an opener.'
+		);
 
 		$p = new WP_HTML_Tag_Processor( 'abc</script>' );
 		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the </script> tag closer when there was no tag opener' );
@@ -566,8 +568,10 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 		$p = new WP_HTML_Tag_Processor( '<textarea>abc</textarea>' );
 
 		$p->next_tag();
-		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the </textarea> tag closer' );
-		$this->assertTrue( $p->is_tag_closer(), 'Indicated a <textarea> tag opener is a tag closer' );
+		$this->assertFalse(
+			$p->next_tag( array( 'tag_closers' => 'visit' ) ),
+			'Should not have found closing TEXTAREA when closing an opener.'
+		);
 
 		$p = new WP_HTML_Tag_Processor( 'abc</textarea>' );
 		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the </textarea> tag closer when there was no tag opener' );
@@ -575,8 +579,10 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 		$p = new WP_HTML_Tag_Processor( '<title>abc</title>' );
 
 		$p->next_tag();
-		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the </title> tag closer' );
-		$this->assertTrue( $p->is_tag_closer(), 'Indicated a <title> tag opener is a tag closer' );
+		$this->assertFalse(
+			$p->next_tag( array( 'tag_closers' => 'visit' ) ),
+			'Should not have found closing TITLE when closing an opener.'
+		);
 
 		$p = new WP_HTML_Tag_Processor( 'abc</title>' );
 		$this->assertTrue( $p->next_tag( array( 'tag_closers' => 'visit' ) ), 'Did not find the </title> tag closer when there was no tag opener' );
@@ -2357,6 +2363,7 @@ HTML;
 			'No tags'                => array( 'this is nothing more than a text node' ),
 			'Text with comments'     => array( 'One <!-- sneaky --> comment.' ),
 			'Empty tag closer'       => array( '</>' ),
+			'CDATA as HTML comment'  => array( '<![CDATA[this closes at the first &gt;]>' ),
 			'Processing instruction' => array( '<?xml version="1.0"?>' ),
 			'Combination XML-like'   => array( '<!DOCTYPE xml><?xml version=""?><!-- this is not a real document. --><![CDATA[it only serves as a test]]>' ),
 		);
@@ -2410,7 +2417,6 @@ HTML;
 			'Incomplete CDATA'                     => array( '<![CDATA[something inside of here needs to get out' ),
 			'Partial CDATA'                        => array( '<![CDA' ),
 			'Partially closed CDATA]'              => array( '<![CDATA[cannot escape]' ),
-			'Partially closed CDATA]>'             => array( '<![CDATA[cannot escape]>' ),
 			'Unclosed IFRAME'                      => array( '<iframe><div>' ),
 			'Unclosed NOEMBED'                     => array( '<noembed><div>' ),
 			'Unclosed NOFRAMES'                    => array( '<noframes><div>' ),
@@ -2507,7 +2513,7 @@ HTML;
 			),
 			'tag inside of CDATA'      => array(
 				'input'    => '<![CDATA[This <is> a <strong id="yes">HTML Tag</strong>]]><span>test</span>',
-				'expected' => '<![CDATA[This <is> a <strong id="yes">HTML Tag</strong>]]><span class="firstTag" foo="bar">test</span>',
+				'expected' => '<![CDATA[This <is> a <strong class="firstTag" foo="bar" id="yes">HTML Tag</strong>]]><span class="secondTag">test</span>',
 			),
 		);
 	}


### PR DESCRIPTION
Trac ticket: Core-60170
Companion port into Gutenberg: WordPress/gutenberg#58107 (contains additional porting code)

This PR provides full tokenization scanning of an HTML document. This is being added into the Tag Processor and will be a necessary component for a number of related changes to the HTML API:

 - Reading and modifying inner and outer content.
 - Serializing HTML.
 - Methods to transform text content while preserving or stripping away markup.

Enables syntax-aware processing such as `wp_truncate_html()` [[gist](https://gist.github.com/dmsnell/11f7165f5c7cd3ca69e4b9d751ff093e)]
Replaces/incorporates chunked/extended processing in #5050 
Replaces/incorporates stopping at comments in dmsnell/wordpress-develop#7
Provides critical functionality for inner/outer getter/setter in [dmsnell/wordpress-develop#10, #4965]

Depends on #5721 ✅ 
Depends on #5725 ✅ 


## Todo


 - [x] Change CDATA sections and PI Nodes into comments with a new "comment type" flag.
 - [ ] Ensure HTML Processor can seek around without messing up.
 - [x] Review all `$this->bytes_already_parsed` assignments and make sure they are proper. I think half of them are one off.
 - [x] Add function docblocks.
 - [ ] Review what this enables in the html5lib test suite.
 - [x] Use this internally in the HTML Processor to ensure that breadcrumbs are generated.
 - [x] Explore using combinable bit flags for the token types instead of string constants. This would allow for things like `MATCHED_TAG | TEXT_NODE` and `INCOMPLETE | COMPLETE`, which could simplify some logic that's spread in `if` statements.
     - For this PR it's not worth moving to boolean logic like this. The existing code is clearer for review.
 - [x] Add test suite.
 - [x] Distinguish too-short HTML comments that may cause trouble when modifying. E.g. `<!--->`.
 - [x] Discuss **what to do about PI Nodes and CDATA sections**
    - It's possible to identify these _after_ identifying the bogus comment span, but we can't look for the ending syntax of these sections because HTML stipulates that they end at the first `>`, not the closing `]]>` or the closing `?>`. So we can find all HTML comments, and then determine _if they would have been a CDATA or PI Node if HTML supported those_.
    - We can also ignore them all, but we lose knowledge about the HTML stream that we could recover (e.g. distinguish `<?for-each?>` from `<--for-each-->`.

## Design Changes

In this change we're introducing two features stemming from two internal changes:

 - `next_token()` provides the ability to scan every token in the HTML stream.
 - it is possible to parse HTML in chunks without having the entire document in memory.

The internal changes powering this are:

 - internal state adopts a new parsing mode which allows resuming from the middle of a previous match.
 - the new concept of _modifiable text_ and a _token_ proper tracks the bounds of the currently-matched token as well as a safe region that can be changed without impacting the document syntax, if one exists.

For example, when encountering an HTML comment the parser will track the following token information:

```
This <!-- is a comment -->.
     │   │            │  └ end of token
     │   │            └─── end of text
     │   └──────────────── start of text
     └──────────────────── start of token
```

Not every token will have a text region, but it's important to track the entire token and any text region because similar tokens may have different syntax. For example, an invalid comment is still a comment.

```
This <? is also a comment --!>.
     │ │                 │   └ end of token
     │ │                 └──── end of text
     │ └────────────────────── start of text
     └──────────────────────── start of token
```

This holds for tokens whose entire content is text, such as with the `#text` node.

```
<div>This is text.</div>
     │           ├ end of token
     │           └ end of text
     ├──────────── start of text
     └──────────── start of token
```

Special HTML tags have modifiable text and that isn't part of `.textConent` or `.innerText`. For example, the `TITLE` element contains no HTML inside of it and everything is plaintext and its contents don't appear in the page. The same is true for `TEXTAREA` and `SCRIPT` and `STYLE` and a few more elements.

```
<title>This is text <em>Not HTML</em>.</title>
│      │                             │       └ end of token
│      └ start of text               └ end of text
└──────────── start of token
```

### Scanning tokens

In order to keep the `next_tag()` interface and use clear, it is left unchanged. For operations needing access to the token stream, there is no built-in query mechanism and querying ought to be performed inside a `next_token()` loop. `get_token_type()` indicates what kind of token is currently matched, `get_token_name()` returns something that more closely matches what a DOM API would return, and `get_modifiable_text()` returns the modifiable text if available.

```php
function wp_strip_all_tags( $html, $remove_breaks ) {
	$processor = new WP_HTML_Processor( $html );

	$text_content = '';
	while ( $processor->next_token() ) {
		if ( '#text' === $processor->get_token_name() ) {
			$text_content .= $processor->get_node_text();
		}
	}

	return $remove_breaks
		? trim( preg_replace( '/[\r\n\t ]+/', ' ', $text_content ) )
		: $text_content;
}
```

 - Most tags have no modifiable content.
 - The inner contents of special tags whose contents cannot contain HTML is their modifiable content. The inner contents of these tags are not rendered in the page.
     - IFRAME
     - NOEMBED, NOFRAMES
     - SCRIPT
     - STYLE
     - TEXTAREA [character references are decoded]
     - TITLE [character references are decoded]
     - XMP


## TODO

 - [x] Add `next_token()` method to scan each token.
 - [x] Stop at RCDATA sections and `SCRIPT`, `STYLE`, `TITLE`, `TEXTAREA`, etc…
 - [x] Stop at text nodes.
 - [x] Indicate a continuation state to support resumable parsing. This is necessary for stopping at `SCRIPT` tags and other tags with special closing rules. These are currently handled by skipping to the end of the element when finding the starting tag, but this has introduced a few challenges and bugs (for example, the Tag Processor fails to stop at a `<title>` tag if the document ends before the `</title>` closer is found).
 - [x] Add `rewind()` method to reverse to the start of the document.