### PR TITLE
Update the MariaDB version strategy matrix

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -99,7 +99,7 @@ jobs:
         os: [ ubuntu-latest ]
         php: [ '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
         db-type: [ 'mariadb' ]
-        db-version: [ '10.4', '10.6', '10.11', '11.0' ]
+        db-version: [ '10.4', '10.6', '10.11', '11.0', '11.1' ]
         multisite: [ false, true ]
         memcached: [ false ]
 

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -99,7 +99,7 @@ jobs:
         os: [ ubuntu-latest ]
         php: [ '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
         db-type: [ 'mariadb' ]
-        db-version: [ '10.4', '10.6', '10.11', '11.0', '11.1' ]
+        db-version: [ '10.4', '10.6', '10.11', '11.2' ]
         multisite: [ false, true ]
         memcached: [ false ]
 
@@ -108,13 +108,13 @@ jobs:
         - os: ubuntu-latest
           php: '7.4'
           db-type: 'mariadb'
-          db-version: '11.0'
+          db-version: '11.2'
           multisite: false
           memcached: true
         - os: ubuntu-latest
           php: '7.4'
           db-type: 'mariadb'
-          db-version: '11.0'
+          db-version: '11.2'
           multisite: true
           memcached: true
     with:


### PR DESCRIPTION
This updates the unit test matrix strategy for MariaDB to include the latest short-term stable release, 11.2. Though 11.0 and 11.1 are still maintained (until June and August of 2024 respectively), testing only against the most recent short-term release should suffice until a broader discussion can be had around support for short-term or innovation releases in database software for the project.

Trac ticket: https://core.trac.wordpress.org/ticket/59806

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
