### PR TITLE
 Introduced separate variables for checking inclusion of site_logo and site_icon fields.

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -1291,10 +1291,22 @@ class WP_REST_Server {
 			$fields[] = '_embedded';
 		}
 
-		if ( rest_is_field_included( '_links', $fields ) || rest_is_field_included( '_embedded', $fields ) ) {
+		$links_or_embedded_included = rest_is_field_included( '_links', $fields ) || rest_is_field_included( '_embedded', $fields );
+
+		$site_logo_included     = rest_is_field_included( 'site_logo', $fields );
+		$site_icon_included     = rest_is_field_included( 'site_icon', $fields );
+		$site_icon_url_included = rest_is_field_included( 'site_icon_url', $fields );
+
+		if ( $links_or_embedded_included ) {
 			$response->add_link( 'help', 'https://developer.wordpress.org/rest-api/' );
 			$this->add_active_theme_link_to_index( $response );
+		}
+
+		if ( $links_or_embedded_included || $site_logo_included ) {
 			$this->add_site_logo_to_index( $response );
+		}
+
+		if ( $links_or_embedded_included || $site_icon_included || $site_icon_url_included ) {
 			$this->add_site_icon_to_index( $response );
 		}
 

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -1296,10 +1296,13 @@ class WP_REST_Server {
 			$this->add_active_theme_link_to_index( $response );
 			$this->add_site_logo_to_index( $response );
 			$this->add_site_icon_to_index( $response );
-		} elseif ( rest_is_field_included( 'site_logo', $fields ) ) {
-			$this->add_site_logo_to_index( $response );
-		} elseif ( rest_is_field_included( 'site_icon', $fields ) || rest_is_field_included( 'site_icon_url', $fields ) ) {
-			$this->add_site_icon_to_index( $response );
+		} else {
+			if ( rest_is_field_included( 'site_logo', $fields ) ) {
+				$this->add_site_logo_to_index( $response );
+			}
+			if ( rest_is_field_included( 'site_icon', $fields ) || rest_is_field_included( 'site_icon_url', $fields ) ) {
+				$this->add_site_icon_to_index( $response );
+			}
 		}
 
 		/**

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -1291,22 +1291,14 @@ class WP_REST_Server {
 			$fields[] = '_embedded';
 		}
 
-		$links_or_embedded_included = rest_is_field_included( '_links', $fields ) || rest_is_field_included( '_embedded', $fields );
-
-		$site_logo_included     = rest_is_field_included( 'site_logo', $fields );
-		$site_icon_included     = rest_is_field_included( 'site_icon', $fields );
-		$site_icon_url_included = rest_is_field_included( 'site_icon_url', $fields );
-
-		if ( $links_or_embedded_included ) {
+		if ( rest_is_field_included( '_links', $fields ) || rest_is_field_included( '_embedded', $fields ) ) {
 			$response->add_link( 'help', 'https://developer.wordpress.org/rest-api/' );
 			$this->add_active_theme_link_to_index( $response );
-		}
-
-		if ( $links_or_embedded_included || $site_logo_included ) {
 			$this->add_site_logo_to_index( $response );
-		}
-
-		if ( $links_or_embedded_included || $site_icon_included || $site_icon_url_included ) {
+			$this->add_site_icon_to_index( $response );
+		} else if ( rest_is_field_included( 'site_logo', $fields ) ) {
+			$this->add_site_logo_to_index( $response );
+		} else if ( rest_is_field_included( 'site_icon', $fields ) || rest_is_field_included( 'site_icon_url', $fields ) ) {
 			$this->add_site_icon_to_index( $response );
 		}
 

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -1296,9 +1296,9 @@ class WP_REST_Server {
 			$this->add_active_theme_link_to_index( $response );
 			$this->add_site_logo_to_index( $response );
 			$this->add_site_icon_to_index( $response );
-		} else if ( rest_is_field_included( 'site_logo', $fields ) ) {
+		} elseif ( rest_is_field_included( 'site_logo', $fields ) ) {
 			$this->add_site_logo_to_index( $response );
-		} else if ( rest_is_field_included( 'site_icon', $fields ) || rest_is_field_included( 'site_icon_url', $fields ) ) {
+		} elseif ( rest_is_field_included( 'site_icon', $fields ) || rest_is_field_included( 'site_icon_url', $fields ) ) {
 			$this->add_site_icon_to_index( $response );
 		}
 

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -2371,40 +2371,52 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 	 */
 	public function data_get_index_should_return_site_icon_and_site_logo_fields() {
 		return array(
-			'no site_logo or site_icon fields' => array(
+			'no site_logo or site_icon fields'   => array(
 				'name',
 				'',
 				'site_logo,site_icon,site_icon_url',
 				false,
 			),
-			'_links request parameter'         => array(
+			'_links request parameter'           => array(
 				'_links',
 				'site_logo,site_icon,site_icon_url',
 				'',
 				false,
 			),
-			'_embed request parameter'         => array(
+			'_embed request parameter'           => array(
 				'_embed',
 				'site_logo,site_icon,site_icon_url',
 				'',
 				true,
 			),
-			'site_logo field'                  => array(
+			'site_logo field'                    => array(
 				'site_logo',
 				'site_logo',
 				'site_icon,site_icon_url',
 				false,
 			),
-			'site_icon field'                  => array(
+			'site_icon field'                    => array(
 				'site_icon',
 				'site_icon,site_icon_url',
 				'site_logo',
 				false,
 			),
-			'site_icon_url field'              => array(
+			'site_icon_url field'                => array(
 				'site_icon_url',
 				'site_icon,site_icon_url',
 				'site_logo',
+				false,
+			),
+			'site_logo and site_icon fields'     => array(
+				'site_logo,site_icon',
+				'site_logo,site_icon,site_icon_url',
+				'',
+				false,
+			),
+			'site_logo and site_icon_url fields' => array(
+				'site_logo,site_icon_url',
+				'site_logo,site_icon,site_icon_url',
+				'',
 				false,
 			),
 		);

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -2365,12 +2365,12 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 	 *
 	 * @dataProvider data_get_index_should_return_site_icon_and_site_logo_fields
 	 *
-	 * @param string $fields              List of fields to use in the request.
-	 * @param string $expected_result     Expected fields.
-	 * @param string $not_expected_result Not expected fields.
-	 * @param bool   $is_embed            Whether to use the "_embed" request parameter.
+	 * @param string $fields            List of fields to use in the request.
+	 * @param array  $expected_fields   Expected fields.
+	 * @param array  $unexpected_fields Optional. Fields that should not be in the results. Default array().
+	 * @param bool   $is_embed          Optional. Whether to use the "_embed" request parameter. Default false.
 	 */
-	public function test_get_index_should_return_site_icon_and_site_logo_fields( $fields, $expected_fields, $not_expected_fields, $is_embed ) {
+	public function test_get_index_should_return_site_icon_and_site_logo_fields( $fields, $expected_fields, $unexpected_fields = array(), $is_embed = false ) {
 		$server  = new WP_REST_Server();
 		$request = new WP_REST_Request( 'GET', '/', array() );
 		$request->set_param( '_fields', $fields );
@@ -2378,16 +2378,13 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 			$request->set_param( '_embed', true );
 		}
 
-		$expected_fields     = wp_parse_list( $expected_fields );
-		$not_expected_fields = wp_parse_list( $not_expected_fields );
-
 		$response = $server->get_index( $request )->get_data();
 
 		foreach ( $expected_fields as $expected_field ) {
 			$this->assertArrayHasKey( $expected_field, $response, "Expected \"{$expected_field}\" field is missing in the response." );
 		}
 
-		foreach ( $not_expected_fields as $not_expected_field ) {
+		foreach ( $unexpected_fields as $not_expected_field ) {
 			$this->assertArrayNotHasKey( $not_expected_field, $response, "Response must not contain the \"{$not_expected_field}\" field." );
 		}
 	}
@@ -2395,57 +2392,47 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array[]
+	 * @return array
 	 */
 	public function data_get_index_should_return_site_icon_and_site_logo_fields() {
 		return array(
 			'no site_logo or site_icon fields'   => array(
-				'name',
-				'',
-				'site_logo,site_icon,site_icon_url',
-				false,
+				'fields'            => 'name',
+				'expected_fields'   => array(),
+				'unexpected_fields' => array( 'site_logo', 'site_icon', 'site_icon_url' ),
 			),
 			'_links request parameter'           => array(
-				'_links',
-				'site_logo,site_icon,site_icon_url',
-				'',
-				false,
+				'fields'          => '_links',
+				'expected_fields' => array( 'site_logo', 'site_icon', 'site_icon_url' ),
 			),
 			'_embed request parameter'           => array(
-				'_embed',
-				'site_logo,site_icon,site_icon_url',
-				'',
-				true,
+				'field'             => '_embed',
+				'expected_fields'   => array( 'site_logo', 'site_icon', 'site_icon_url' ),
+				'unexpected_fields' => array(),
+				'is_embed'          => true,
 			),
 			'site_logo field'                    => array(
-				'site_logo',
-				'site_logo',
-				'site_icon,site_icon_url',
-				false,
+				'fields'            => 'site_logo',
+				'expected_fields'   => array( 'site_logo' ),
+				'unexpected_fields' => array( 'site_icon', 'site_icon_url' ),
 			),
 			'site_icon field'                    => array(
-				'site_icon',
-				'site_icon,site_icon_url',
-				'site_logo',
-				false,
+				'fields'            => 'site_icon',
+				'expected_fields'   => array( 'site_icon', 'site_icon_url' ),
+				'unexpected_fields' => array( 'site_logo' ),
 			),
 			'site_icon_url field'                => array(
-				'site_icon_url',
-				'site_icon,site_icon_url',
-				'site_logo',
-				false,
+				'fields'            => 'site_icon_url',
+				'expected_fields'   => array( 'site_icon', 'site_icon_url' ),
+				'unexpected_fields' => array( 'site_logo' ),
 			),
 			'site_logo and site_icon fields'     => array(
-				'site_logo,site_icon',
-				'site_logo,site_icon,site_icon_url',
-				'',
-				false,
+				'fields'          => 'site_logo,site_icon',
+				'expected_fields' => array( 'site_logo', 'site_icon', 'site_icon_url' ),
 			),
 			'site_logo and site_icon_url fields' => array(
-				'site_logo,site_icon_url',
-				'site_logo,site_icon,site_icon_url',
-				'',
-				false,
+				'fields'          => 'site_logo,site_icon_url',
+				'expected_fields' => array( 'site_logo', 'site_icon', 'site_icon_url' ),
 			),
 		);
 	}

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -2330,6 +2330,34 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * Helper to make the request and get the headers for the
+	 * rest_send_refreshed_nonce related tests.
+	 *
+	 * @return array
+	 */
+	protected function helper_make_request_and_return_headers_for_rest_send_refreshed_nonce_tests() {
+		$request = new WP_REST_Request( 'GET', '/', array() );
+		$result  = rest_get_server()->serve_request( '/' );
+
+		return rest_get_server()->sent_headers;
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_envelope_params() {
+		return array(
+			array( '1' ),
+			array( 'true' ),
+			array( false ),
+			array( 'alternate' ),
+			array( array( 'alternate' ) ),
+		);
+	}
+
+	/**
 	 * Test that the "get_index" method returns the expected site_icon*
 	 * and site_logo fields based on the specified request parameters.
 	 *
@@ -2419,34 +2447,6 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 				'',
 				false,
 			),
-		);
-	}
-
-	/**
-	 * Helper to make the request and get the headers for the
-	 * rest_send_refreshed_nonce related tests.
-	 *
-	 * @return array
-	 */
-	protected function helper_make_request_and_return_headers_for_rest_send_refreshed_nonce_tests() {
-		$request = new WP_REST_Request( 'GET', '/', array() );
-		$result  = rest_get_server()->serve_request( '/' );
-
-		return rest_get_server()->sent_headers;
-	}
-
-	/**
-	 * Data provider.
-	 *
-	 * @return array
-	 */
-	public function data_envelope_params() {
-		return array(
-			array( '1' ),
-			array( 'true' ),
-			array( false ),
-			array( 'alternate' ),
-			array( array( 'alternate' ) ),
 		);
 	}
 }

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -1253,8 +1253,8 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 			$this->assertArrayHasKey( $expected_field, $response, "Expected \"{$expected_field}\" field is missing in the response." );
 		}
 
-		foreach ( $unexpected_fields as $not_expected_field ) {
-			$this->assertArrayNotHasKey( $not_expected_field, $response, "Response must not contain the \"{$not_expected_field}\" field." );
+		foreach ( $unexpected_fields as $unexpected_field ) {
+			$this->assertArrayNotHasKey( $unexpected_field, $response, "Response must not contain the \"{$unexpected_field}\" field." );
 		}
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -1200,6 +1200,95 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 		$this->assertSame( self::$icon_id, $data['site_icon'] );
 	}
 
+	/**
+	 * Test that the "get_index" method returns the expected site_icon*
+	 * and site_logo fields based on the specified request parameters.
+	 *
+	 * @ticket 59935
+	 *
+	 * @dataProvider data_get_index_should_return_site_icon_and_site_logo_fields
+	 *
+	 * @param string $fields            List of fields to use in the request.
+	 * @param array  $expected_fields   Expected fields.
+	 * @param array  $unexpected_fields Optional. Fields that should not be in the results. Default array().
+	 * @param bool   $is_embed          Optional. Whether to use the "_embed" request parameter. Default false.
+	 */
+	public function test_get_index_should_return_site_icon_and_site_logo_fields( $fields, $expected_fields, $unexpected_fields = array(), $is_embed = false ) {
+		$server  = new WP_REST_Server();
+		$request = new WP_REST_Request( 'GET', '/', array() );
+		$request->set_param( '_fields', $fields );
+		if ( $is_embed ) {
+			$request->set_param( '_embed', true );
+		}
+
+		$response = $server->get_index( $request )->get_data();
+
+		foreach ( $expected_fields as $expected_field ) {
+			$this->assertArrayHasKey( $expected_field, $response, "Expected \"{$expected_field}\" field is missing in the response." );
+		}
+
+		foreach ( $unexpected_fields as $not_expected_field ) {
+			$this->assertArrayNotHasKey( $not_expected_field, $response, "Response must not contain the \"{$not_expected_field}\" field." );
+		}
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_get_index_should_return_site_icon_and_site_logo_fields() {
+		return array(
+			'no site_logo or site_icon fields'   => array(
+				'fields'            => 'name',
+				'expected_fields'   => array(),
+				'unexpected_fields' => array( 'site_logo', 'site_icon', 'site_icon_url' ),
+			),
+			'_links request parameter'           => array(
+				'fields'          => '_links',
+				'expected_fields' => array( 'site_logo', 'site_icon', 'site_icon_url' ),
+			),
+			'_embed request parameter'           => array(
+				'field'             => '_embed',
+				'expected_fields'   => array( 'site_logo', 'site_icon', 'site_icon_url' ),
+				'unexpected_fields' => array(),
+				'is_embed'          => true,
+			),
+			'site_logo field'                    => array(
+				'fields'            => 'site_logo',
+				'expected_fields'   => array( 'site_logo' ),
+				'unexpected_fields' => array( 'site_icon', 'site_icon_url' ),
+			),
+			'site_icon field'                    => array(
+				'fields'            => 'site_icon',
+				'expected_fields'   => array( 'site_icon', 'site_icon_url' ),
+				'unexpected_fields' => array( 'site_logo' ),
+			),
+			'site_icon_url field'                => array(
+				'fields'            => 'site_icon_url',
+				'expected_fields'   => array( 'site_icon', 'site_icon_url' ),
+				'unexpected_fields' => array( 'site_logo' ),
+			),
+			'site_icon and site_icon_url field'  => array(
+				'fields'            => 'site_icon_url',
+				'expected_fields'   => array( 'site_icon', 'site_icon_url' ),
+				'unexpected_fields' => array( 'site_logo' ),
+			),
+			'site_logo and site_icon fields'     => array(
+				'fields'          => 'site_logo,site_icon',
+				'expected_fields' => array( 'site_logo', 'site_icon', 'site_icon_url' ),
+			),
+			'site_logo and site_icon_url fields' => array(
+				'fields'          => 'site_logo,site_icon_url',
+				'expected_fields' => array( 'site_logo', 'site_icon', 'site_icon_url' ),
+			),
+			'site_logo, site_icon, and site_icon_url fields' => array(
+				'fields'          => 'site_logo,site_icon,site_icon_url',
+				'expected_fields' => array( 'site_logo', 'site_icon', 'site_icon_url' ),
+			),
+		);
+	}
+
 	public function test_get_namespace_index() {
 		$server = new WP_REST_Server();
 		$server->register_route(
@@ -2354,95 +2443,6 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 			array( false ),
 			array( 'alternate' ),
 			array( array( 'alternate' ) ),
-		);
-	}
-
-	/**
-	 * Test that the "get_index" method returns the expected site_icon*
-	 * and site_logo fields based on the specified request parameters.
-	 *
-	 * @ticket 59935
-	 *
-	 * @dataProvider data_get_index_should_return_site_icon_and_site_logo_fields
-	 *
-	 * @param string $fields            List of fields to use in the request.
-	 * @param array  $expected_fields   Expected fields.
-	 * @param array  $unexpected_fields Optional. Fields that should not be in the results. Default array().
-	 * @param bool   $is_embed          Optional. Whether to use the "_embed" request parameter. Default false.
-	 */
-	public function test_get_index_should_return_site_icon_and_site_logo_fields( $fields, $expected_fields, $unexpected_fields = array(), $is_embed = false ) {
-		$server  = new WP_REST_Server();
-		$request = new WP_REST_Request( 'GET', '/', array() );
-		$request->set_param( '_fields', $fields );
-		if ( $is_embed ) {
-			$request->set_param( '_embed', true );
-		}
-
-		$response = $server->get_index( $request )->get_data();
-
-		foreach ( $expected_fields as $expected_field ) {
-			$this->assertArrayHasKey( $expected_field, $response, "Expected \"{$expected_field}\" field is missing in the response." );
-		}
-
-		foreach ( $unexpected_fields as $not_expected_field ) {
-			$this->assertArrayNotHasKey( $not_expected_field, $response, "Response must not contain the \"{$not_expected_field}\" field." );
-		}
-	}
-
-	/**
-	 * Data provider.
-	 *
-	 * @return array
-	 */
-	public function data_get_index_should_return_site_icon_and_site_logo_fields() {
-		return array(
-			'no site_logo or site_icon fields'   => array(
-				'fields'            => 'name',
-				'expected_fields'   => array(),
-				'unexpected_fields' => array( 'site_logo', 'site_icon', 'site_icon_url' ),
-			),
-			'_links request parameter'           => array(
-				'fields'          => '_links',
-				'expected_fields' => array( 'site_logo', 'site_icon', 'site_icon_url' ),
-			),
-			'_embed request parameter'           => array(
-				'field'             => '_embed',
-				'expected_fields'   => array( 'site_logo', 'site_icon', 'site_icon_url' ),
-				'unexpected_fields' => array(),
-				'is_embed'          => true,
-			),
-			'site_logo field'                    => array(
-				'fields'            => 'site_logo',
-				'expected_fields'   => array( 'site_logo' ),
-				'unexpected_fields' => array( 'site_icon', 'site_icon_url' ),
-			),
-			'site_icon field'                    => array(
-				'fields'            => 'site_icon',
-				'expected_fields'   => array( 'site_icon', 'site_icon_url' ),
-				'unexpected_fields' => array( 'site_logo' ),
-			),
-			'site_icon_url field'                => array(
-				'fields'            => 'site_icon_url',
-				'expected_fields'   => array( 'site_icon', 'site_icon_url' ),
-				'unexpected_fields' => array( 'site_logo' ),
-			),
-			'site_icon and site_icon_url field'  => array(
-				'fields'            => 'site_icon_url',
-				'expected_fields'   => array( 'site_icon', 'site_icon_url' ),
-				'unexpected_fields' => array( 'site_logo' ),
-			),
-			'site_logo and site_icon fields'     => array(
-				'fields'          => 'site_logo,site_icon',
-				'expected_fields' => array( 'site_logo', 'site_icon', 'site_icon_url' ),
-			),
-			'site_logo and site_icon_url fields' => array(
-				'fields'          => 'site_logo,site_icon_url',
-				'expected_fields' => array( 'site_logo', 'site_icon', 'site_icon_url' ),
-			),
-			'site_logo, site_icon, and site_icon_url fields' => array(
-				'fields'          => 'site_logo,site_icon,site_icon_url',
-				'expected_fields' => array( 'site_logo', 'site_icon', 'site_icon_url' ),
-			),
 		);
 	}
 }

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -1206,6 +1206,8 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 	 *
 	 * @ticket 59935
 	 *
+	 * @covers WP_REST_Server::get_index
+	 *
 	 * @dataProvider data_get_index_should_return_site_icon_and_site_logo_fields
 	 *
 	 * @param string $fields            List of fields to use in the request.

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -2426,12 +2426,21 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 				'expected_fields'   => array( 'site_icon', 'site_icon_url' ),
 				'unexpected_fields' => array( 'site_logo' ),
 			),
+			'site_icon and site_icon_url field'  => array(
+				'fields'            => 'site_icon_url',
+				'expected_fields'   => array( 'site_icon', 'site_icon_url' ),
+				'unexpected_fields' => array( 'site_logo' ),
+			),
 			'site_logo and site_icon fields'     => array(
 				'fields'          => 'site_logo,site_icon',
 				'expected_fields' => array( 'site_logo', 'site_icon', 'site_icon_url' ),
 			),
 			'site_logo and site_icon_url fields' => array(
 				'fields'          => 'site_logo,site_icon_url',
+				'expected_fields' => array( 'site_logo', 'site_icon', 'site_icon_url' ),
+			),
+			'site_logo, site_icon, and site_icon_url fields' => array(
+				'fields'          => 'site_logo,site_icon,site_icon_url',
 				'expected_fields' => array( 'site_logo', 'site_icon', 'site_icon_url' ),
 			),
 		);

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -2399,6 +2399,7 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 				'site_icon',
 				'site_icon,site_icon_url',
 				'site_logo',
+				false,
 			),
 			'site_icon_url field'              => array(
 				'site_icon_url',

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -1187,17 +1187,41 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 
 	/**
 	 * @ticket 52321
+	 * @ticket 59935
+	 *
+	 * @covers WP_REST_Server::get_index
 	 */
-	public function test_index_includes_site_icon() {
-		$server = new WP_REST_Server();
+	public function test_get_index_should_include_site_icon() {
 		update_option( 'site_icon', self::$icon_id );
 
+		$server  = new WP_REST_Server();
 		$request = new WP_REST_Request( 'GET', '/' );
 		$index   = $server->dispatch( $request );
 		$data    = $index->get_data();
 
-		$this->assertArrayHasKey( 'site_icon', $data );
-		$this->assertSame( self::$icon_id, $data['site_icon'] );
+		$this->assertArrayHasKey( 'site_logo', $data, 'The "site_logo" field is missing in the response.' );
+		$this->assertArrayHasKey( 'site_icon', $data, 'The "site_icon" field is missing in the response.' );
+		$this->assertArrayHasKey( 'site_icon_url', $data, 'The "site_icon_url" field is missing in the response.' );
+		$this->assertSame( self::$icon_id, $data['site_icon'], 'The response "site_icon" ID does not match.' );
+		$this->assertStringContainsString( 'test-image-large', $data['site_icon_url'], 'The "site_icon_url" should contain the expected image.' );
+	}
+	/**
+	 * @ticket 52321
+	 * @ticket 59935
+	 *
+	 * @covers WP_REST_Server::get_index
+	 */
+	public function test_get_index_should_not_include_site_icon() {
+		$server  = new WP_REST_Server();
+		$request = new WP_REST_Request( 'GET', '/' );
+		$index   = $server->dispatch( $request );
+		$data    = $index->get_data();
+
+		$this->assertArrayHasKey( 'site_logo', $data, 'The "site_logo" field is missing in the response.' );
+		$this->assertArrayHasKey( 'site_icon', $data, 'The "site_icon" field is missing in the response.' );
+		$this->assertArrayHasKey( 'site_icon_url', $data, 'The "site_icon_url" field is missing in the response.' );
+		$this->assertSame( 0, $data['site_icon'], 'Response "site_icon" should be 0.' );
+		$this->assertSame( '', $data['site_icon_url'], 'Response "site_icon_url" should be an empty string.' );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR aims to implement more granular control over which fields are included in the index response.

Trac ticket: https://core.trac.wordpress.org/ticket/59935

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
