### PR TITLE
Disambiguate translator comments context

### DIFF
--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -649,11 +649,20 @@ if ( post_type_supports( $post_type, 'editor' ) ) {
 		echo '<span id="last-edit">';
 		$last_user = get_userdata( get_post_meta( $post->ID, '_edit_last', true ) );
 		if ( $last_user ) {
-			/* translators: 1: Name of most recent post author, 2: Post edited date, 3: Post edited time. */
-			printf( __( 'Last edited by %1$s on %2$s at %3$s' ), esc_html( $last_user->display_name ), mysql2date( __( 'F j, Y' ), $post->post_modified ), mysql2date( __( 'g:i a' ), $post->post_modified ) );
+			printf(
+				/* translators: 1: Name of most recent post author, 2: Post edited date, 3: Post edited time. */
+				__( 'Last edited by %1$s on %2$s at %3$s' ),
+				esc_html( $last_user->display_name ),
+				mysql2date( __( 'F j, Y' ), $post->post_modified ),
+				mysql2date( __( 'g:i a' ), $post->post_modified )
+			);
 		} else {
-			/* translators: 1: Post edited date, 2: Post edited time. */
-			printf( __( 'Last edited on %1$s at %2$s' ), mysql2date( __( 'F j, Y' ), $post->post_modified ), mysql2date( __( 'g:i a' ), $post->post_modified ) );
+			printf(
+				/* translators: 1: Post edited date, 2: Post edited time. */
+				__( 'Last edited on %1$s at %2$s' ),
+				mysql2date( __( 'F j, Y' ), $post->post_modified ),
+				mysql2date( __( 'g:i a' ), $post->post_modified )
+			);
 		}
 		echo '</span>';
 	}

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -1628,8 +1628,13 @@ function wp_ajax_add_meta() {
 			$post_data['post_type']   = $post->post_type;
 			$post_data['post_status'] = 'draft';
 			$now                      = time();
-			/* translators: 1: Post creation date, 2: Post creation time. */
-			$post_data['post_title'] = sprintf( __( 'Draft created on %1$s at %2$s' ), gmdate( __( 'F j, Y' ), $now ), gmdate( __( 'g:i a' ), $now ) );
+
+			$post_data['post_title'] = sprintf(
+				/* translators: 1: Post creation date, 2: Post creation time. */
+				__( 'Draft created on %1$s at %2$s' ),
+				gmdate( __( 'F j, Y' ), $now ),
+				gmdate( __( 'g:i a' ), $now )
+			);
 
 			$pid = edit_post( $post_data );
 

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -434,7 +434,7 @@ function attachment_submit_meta_box( $post ) {
 		<span id="timestamp">
 			<?php
 			$uploaded_on = sprintf(
-				/* translators: Publish box date string. 1: Date, 2: Time. See https://www.php.net/manual/datetime.format.php */
+				/* translators: Publish box date string. 1: Date, 2: Time. */
 				__( '%1$s at %2$s' ),
 				/* translators: Publish box date format, see https://www.php.net/manual/datetime.format.php */
 				date_i18n( _x( 'M j, Y', 'publish box date format' ), strtotime( $post->post_date ) ),

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -1105,8 +1105,13 @@ if ( 'upgrade-core' === $action ) {
 	echo '</h2>';
 
 	echo '<p class="update-last-checked">';
-	/* translators: 1: Date, 2: Time. */
-	printf( __( 'Last checked on %1$s at %2$s.' ), date_i18n( __( 'F j, Y' ), $last_update_check ), date_i18n( __( 'g:i a T' ), $last_update_check ) );
+
+	printf(
+		/* translators: 1: Date, 2: Time. */
+		__( 'Last checked on %1$s at %2$s.' ),
+		date_i18n( __( 'F j, Y' ), $last_update_check ),
+		date_i18n( __( 'g:i a T' ), $last_update_check )
+	);
 	echo ' <a href="' . esc_url( self_admin_url( 'update-core.php?force-check=1' ) ) . '">' . __( 'Check again.' ) . '</a>';
 	echo '</p>';
 

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -1109,7 +1109,9 @@ if ( 'upgrade-core' === $action ) {
 	printf(
 		/* translators: 1: Date, 2: Time. */
 		__( 'Last checked on %1$s at %2$s.' ),
+		/* translators: Last update date format. See https://www.php.net/manual/datetime.format.php */
 		date_i18n( __( 'F j, Y' ), $last_update_check ),
+		/* translators: Last update time format. See https://www.php.net/manual/datetime.format.php */
 		date_i18n( __( 'g:i a T' ), $last_update_check )
 	);
 	echo ' <a href="' . esc_url( self_admin_url( 'update-core.php?force-check=1' ) ) . '">' . __( 'Check again.' ) . '</a>';

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -1715,12 +1715,15 @@ function get_the_archive_title() {
 		$title  = get_the_author();
 		$prefix = _x( 'Author:', 'author archive title prefix' );
 	} elseif ( is_year() ) {
+		/* translators: See https://www.php.net/manual/datetime.format.php */
 		$title  = get_the_date( _x( 'Y', 'yearly archives date format' ) );
 		$prefix = _x( 'Year:', 'date archive title prefix' );
 	} elseif ( is_month() ) {
+		/* translators: See https://www.php.net/manual/datetime.format.php */
 		$title  = get_the_date( _x( 'F Y', 'monthly archives date format' ) );
 		$prefix = _x( 'Month:', 'date archive title prefix' );
 	} elseif ( is_day() ) {
+		/* translators: See https://www.php.net/manual/datetime.format.php */
 		$title  = get_the_date( _x( 'F j, Y', 'daily archives date format' ) );
 		$prefix = _x( 'Day:', 'date archive title prefix' );
 	} elseif ( is_tax( 'post_format' ) ) {

--- a/src/wp-includes/theme-compat/sidebar.php
+++ b/src/wp-includes/theme-compat/sidebar.php
@@ -56,6 +56,7 @@ _deprecated_file(
 						/* translators: 1: Site link, 2: Archive date. */
 						__( 'You are currently browsing the %1$s blog archives for the day %2$s.' ),
 						sprintf( '<a href="%1$s/">%2$s</a>', get_bloginfo( 'url' ), get_bloginfo( 'name' ) ),
+						/* translators: Daily archives date format. See https://www.php.net/manual/datetime.format.php */
 						get_the_time( __( 'l, F jS, Y' ) )
 					);
 				?>
@@ -68,6 +69,7 @@ _deprecated_file(
 						/* translators: 1: Site link, 2: Archive month. */
 						__( 'You are currently browsing the %1$s blog archives for %2$s.' ),
 						sprintf( '<a href="%1$s/">%2$s</a>', get_bloginfo( 'url' ), get_bloginfo( 'name' ) ),
+						/* translators: Monthly archives date format. See https://www.php.net/manual/datetime.format.php */
 						get_the_time( __( 'F, Y' ) )
 					);
 				?>


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Disambiguate usage of translator comments for `sprintf()` calls with multiple translated strings.
Writing the code on multiple lines makes it clearer which string the comment is intended for.

Trac ticket: https://core.trac.wordpress.org/ticket/59947

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
