### PR TITLE
Ensure valid HTML is properly processed by refining regex handling

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -657,13 +657,22 @@ function get_html_split_regex() {
 			.     $cdata
 			. ')';
 
+		$attribute =
+			'[^>"\']*'         // Match any character except >, ", or '
+			. '(?:(?:'         // Start of non-capturing group.
+			.     '"[^"]*"'    // Double-quoted attribute value.
+			. '|'              // or
+			.     '\'[^\']*\'' // Single-quoted attribute value.
+			. '))*';           // End of attribute value. Proceed to next regex.
+
 		$regex =
-			'/('                // Capture the entire match.
-			.     '<'           // Find start of element.
-			.     '(?'          // Conditional expression follows.
-			.         $escaped  // Find end of escaped element.
-			.     '|'           // ...else...
-			.         '[^>]*>?' // Find end of normal element.
+			'/('                 // Capture the entire match.
+			.     '<'            // Find start of element.
+			.     '(?'           // Conditional expression follows.
+			.         $escaped   // Find end of escaped element.
+			.     '|'            // ...else...
+			.         $attribute // Exclude matching within attribute values.
+			.         '[^>]*>?'  // Find end of normal element.
 			.     ')'
 			. ')/';
 		// phpcs:enable
@@ -700,17 +709,20 @@ function _get_wptexturize_split_regex( $shortcode_regex = '' ) {
 		 * @see https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
 		 */
 		$attribute_regex =
-			'[^>"\']*'                  // Find before end of element, or before start of attribute value.
-			. '(?:"[^"]*"[^>"]*)*'      // Double-quoted attribute value
-			. '(?:\'[^\']*\'[^>\']*)*'; // Single-quoted attribute value
+			'[^>"\']*'         // Match any character except >, ", or '
+			. '(?:(?:'         // Start of non-capturing group.
+			.     '"[^"]*"'    // Double-quoted attribute value.
+			. '|'              // or
+			.     '\'[^\']*\'' // Single-quoted attribute value.
+			. '))*';           // End of attribute value. Proceed to next regex.
 
 		$html_regex = // Needs replaced with wp_html_split() per Shortcode API Roadmap.
-			'<'                  // Find start of element.
-			. '(?(?=!--)'        // Is this a comment?
-			.     $comment_regex // Find end of comment.
+			'<'                    // Find start of element.
+			. '(?(?=!--)'          // Is this a comment?
+			.     $comment_regex   // Find end of comment.
 			. '|'
 			.     $attribute_regex // Exclude matching within attribute values.
-			.     '[^>]*>?'      // Find end of element. If not found, match all input.
+			.     '[^>]*>?'        // Find end of element. If not found, match all input.
 			. ')';
 		// phpcs:enable
 	}

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -249,10 +249,6 @@ function wptexturize( $text, $reset = false ) {
 				continue;
 			} else {
 				// This is an HTML element delimiter.
-
-				// Replace each & with &#038; unless it already looks like an entity.
-				$curl = preg_replace( '/&(?!#(?:\d+|x[a-f0-9]+);|[a-z1-4]{1,8};)/i', '&#038;', $curl );
-
 				_wptexturize_pushpop_element( $curl, $no_texturize_tags_stack, $no_texturize_tags );
 			}
 		} elseif ( '' === trim( $curl ) ) {

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -696,11 +696,20 @@ function _get_wptexturize_split_regex( $shortcode_regex = '' ) {
 			. ')*+'         // Loop possessively.
 			. '(?:-->)?';   // End of comment. If not found, match all input.
 
+		/**
+		 * @see https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
+		 */
+		$attribute_regex =
+			'[^>"\']*'                  // Find before end of element, or before start of attribute value.
+			. '(?:"[^"]*"[^>"]*)*'      // Double-quoted attribute value
+			. '(?:\'[^\']*\'[^>\']*)*'; // Single-quoted attribute value
+
 		$html_regex = // Needs replaced with wp_html_split() per Shortcode API Roadmap.
 			'<'                  // Find start of element.
 			. '(?(?=!--)'        // Is this a comment?
 			.     $comment_regex // Find end of comment.
 			. '|'
+			.     $attribute_regex // Exclude matching within attribute values.
 			.     '[^>]*>?'      // Find end of element. If not found, match all input.
 			. ')';
 		// phpcs:enable

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -657,22 +657,24 @@ function get_html_split_regex() {
 			.     $cdata
 			. ')';
 
-		$attribute =
-			'[^>"\']*'         // Match any character except >, ", or '
-			. '(?:(?:'         // Start of non-capturing group.
-			.     '"[^"]*"'    // Double-quoted attribute value.
-			. '|'              // or
-			.     '\'[^\']*\'' // Single-quoted attribute value.
-			. '))*';           // End of attribute value. Proceed to next regex.
+		$ignore_attr =
+			'(?:'
+			.     '[^>"\']*'       // Match any characters except >, " or '.
+			.     '(?:'
+			.         '"[^"]*"'    // Double-quoted attribute value.
+			.     '|'
+			.         '\'[^\']*\'' // Single-quoted attribute value.
+			.     ')?'
+			. ')*';                // End of attribute value.
 
 		$regex =
-			'/('                 // Capture the entire match.
-			.     '<'            // Find start of element.
-			.     '(?'           // Conditional expression follows.
-			.         $escaped   // Find end of escaped element.
-			.     '|'            // ...else...
-			.         $attribute // Exclude matching within attribute values.
-			.         '[^>]*>?'  // Find end of normal element.
+			'/('                   // Capture the entire match.
+			.     '<'              // Find start of element.
+			.     '(?'             // Conditional expression follows.
+			.         $escaped     // Find end of escaped element.
+			.     '|'              // ...else...
+			.         $ignore_attr // Exclude matching within attribute values.
+			.         '[^>]*>?'    // Find end of normal element.
 			.     ')'
 			. ')/';
 		// phpcs:enable
@@ -708,21 +710,23 @@ function _get_wptexturize_split_regex( $shortcode_regex = '' ) {
 		/**
 		 * @see https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
 		 */
-		$attribute_regex =
-			'[^>"\']*'         // Match any character except >, ", or '
-			. '(?:(?:'         // Start of non-capturing group.
-			.     '"[^"]*"'    // Double-quoted attribute value.
-			. '|'              // or
-			.     '\'[^\']*\'' // Single-quoted attribute value.
-			. '))*';           // End of attribute value. Proceed to next regex.
+		$ignore_attr_regex =
+			'(?:'
+			.     '[^>"\']*'       // Match any characters except >, " or '.
+			.     '(?:'
+			.         '"[^"]*"'    // Double-quoted attribute value.
+			.     '|'
+			.         '\'[^\']*\'' // Single-quoted attribute value.
+			.     ')?'
+			. ')*';                // End of attribute value.
 
 		$html_regex = // Needs replaced with wp_html_split() per Shortcode API Roadmap.
-			'<'                    // Find start of element.
-			. '(?(?=!--)'          // Is this a comment?
-			.     $comment_regex   // Find end of comment.
+			'<'                      // Find start of element.
+			. '(?(?=!--)'            // Is this a comment?
+			.     $comment_regex     // Find end of comment.
 			. '|'
-			.     $attribute_regex // Exclude matching within attribute values.
-			.     '[^>]*>?'        // Find end of element. If not found, match all input.
+			.     $ignore_attr_regex // Ignore matching of element end within attribute values.
+			.     '[^>]*>?'          // Find end of element. If not found, match all input.
 			. ')';
 		// phpcs:enable
 	}

--- a/tests/phpunit/tests/formatting/wpHtmlSplit.php
+++ b/tests/phpunit/tests/formatting/wpHtmlSplit.php
@@ -34,6 +34,14 @@ class Tests_Formatting_wpHtmlSplit extends WP_UnitTestCase {
 				'abcd <![CDATA[ <html> ]]> efgh',
 				array( 'abcd ', '<![CDATA[ <html> ]]>', ' efgh' ),
 			),
+			array(
+				'abcd <input placeholder="foo>bar" /> efgh',
+				array( 'abcd ', '<input placeholder="foo>bar" />', ' efgh' ),
+			),
+			array(
+				'abcd <input placeholder=\'foo>bar\' /> efgh',
+				array( 'abcd ', '<input placeholder=\'foo>bar\' />', ' efgh' ),
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/formatting/wpHtmlSplit.php
+++ b/tests/phpunit/tests/formatting/wpHtmlSplit.php
@@ -42,6 +42,16 @@ class Tests_Formatting_wpHtmlSplit extends WP_UnitTestCase {
 				'abcd <input placeholder=\'foo>bar\' /> efgh',
 				array( 'abcd ', '<input placeholder=\'foo>bar\' />', ' efgh' ),
 			),
+			array(
+				'<p foo="" bar="2 > 1">numbers</p>',
+				array(
+					'',
+					'<p foo="" bar="2 > 1">',
+					'numbers',
+					'</p>',
+					'',
+				),
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/formatting/wpTexturize.php
+++ b/tests/phpunit/tests/formatting/wpTexturize.php
@@ -1278,11 +1278,11 @@ class Tests_Formatting_wpTexturize extends WP_UnitTestCase {
 			),
 			array(
 				'[ photos by <a href="http://example.com/?a[]=1&a[]=2"> this guy & that guy </a> ]',
-				'[ photos by <a href="http://example.com/?a[]=1&#038;a[]=2"> this guy &#038; that guy </a> ]',
+				'[ photos by <a href="http://example.com/?a[]=1&a[]=2"> this guy &#038; that guy </a> ]',
 			),
 			array(
 				'[photos by <a href="http://example.com/?a[]=1&a[]=2"> this guy & that guy </a>]',
-				'[photos by <a href="http://example.com/?a[]=1&#038;a[]=2"> this guy &#038; that guy </a>]',
+				'[photos by <a href="http://example.com/?a[]=1&a[]=2"> this guy &#038; that guy </a>]',
 			),
 			array(
 				'& <script>&&</script>',
@@ -2134,7 +2134,7 @@ String with a number followed by a single quote !q1!Expendables 3!q1! vestibulum
 				<input placeholder="foo<->bar" />
 				',
 				'
-				<label class="[&#038;>span]:font-bold">&#8220;foo&#8221; or &#8220;bar&#8221;</label>
+				<label class="[&>span]:font-bold">&#8220;foo&#8221; or &#8220;bar&#8221;</label>
 				<input placeholder="foo<->bar" />
 				',
 			),
@@ -2144,7 +2144,7 @@ String with a number followed by a single quote !q1!Expendables 3!q1! vestibulum
 				<input placeholder=\'foo<->bar\' />
 				',
 				'
-				<label class=\'[&#038;>span]:font-bold\'>&#8216;foo&#8217; or &#8216;bar&#8217;</label>
+				<label class=\'[&>span]:font-bold\'>&#8216;foo&#8217; or &#8216;bar&#8217;</label>
 				<input placeholder=\'foo<->bar\' />
 				',
 			),

--- a/tests/phpunit/tests/formatting/wpTexturize.php
+++ b/tests/phpunit/tests/formatting/wpTexturize.php
@@ -2115,4 +2115,37 @@ String with a number followed by a single quote !q1!Expendables 3!q1! vestibulum
 		require_once DIR_TESTDATA . '/formatting/whole-posts.php';
 		return data_whole_posts();
 	}
+
+	/**
+	 * @ticket 57381
+	 * @dataProvider data_greater_than_in_attribute_value
+	 */
+	public function test_greater_than_in_attribute_value( $input, $output ) {
+		$this->assertSame( $output, wptexturize( $input ) );
+	}
+
+	public function data_greater_than_in_attribute_value() {
+		return array(
+			array(
+				'
+				<label class="[&>span]:font-bold">"foo" or "bar"</label>
+				<input placeholder="foo<->bar" />
+				',
+				'
+				<label class="[&#038;>span]:font-bold">&#8220;foo&#8221; or &#8220;bar&#8221;</label>
+				<input placeholder="foo<->bar" />
+				',
+			),
+			array(
+				'
+				<label class=\'[&>span]:font-bold\'>\'foo\' or \'bar\'</label>
+				<input placeholder=\'foo<->bar\' />
+				',
+				'
+				<label class=\'[&#038;>span]:font-bold\'>&#8216;foo&#8217; or &#8216;bar&#8217;</label>
+				<input placeholder=\'foo<->bar\' />
+				',
+			),
+		);
+	}
 }

--- a/tests/phpunit/tests/formatting/wpTexturize.php
+++ b/tests/phpunit/tests/formatting/wpTexturize.php
@@ -2117,6 +2117,8 @@ String with a number followed by a single quote !q1!Expendables 3!q1! vestibulum
 	}
 
 	/**
+	 * @ticket 43457
+	 * @ticket 45387
 	 * @ticket 57381
 	 * @dataProvider data_greater_than_in_attribute_value
 	 */
@@ -2145,6 +2147,14 @@ String with a number followed by a single quote !q1!Expendables 3!q1! vestibulum
 				<label class=\'[&#038;>span]:font-bold\'>&#8216;foo&#8217; or &#8216;bar&#8217;</label>
 				<input placeholder=\'foo<->bar\' />
 				',
+			),
+			array(
+				'<span data-content="<p>abcd</p>">loading...</span>',
+				'<span data-content="<p>abcd</p>">loading&#8230;</span>',
+			),
+			array(
+				'<p>Go to <a href="https://wordpress.org" target="_blank" rel="noreferrer noopener" aria-label="WordPress ->">WordPress -></a></p>',
+				'<p>Go to <a href="https://wordpress.org" target="_blank" rel="noreferrer noopener" aria-label="WordPress ->">WordPress -></a></p>',
 			),
 		);
 	}


### PR DESCRIPTION
Ensures valid HTML is worked correctly by [wptexturize()](https://developer.wordpress.org/reference/functions/wptexturize/), [wp_html_split()](https://developer.wordpress.org/reference/functions/wp_html_split/), etc.
I started working on this PR when I noticed that using TailwindCSS children selector would break the layout of block theme (also reported in `Trac ticket: 57381`).

I have identified a problem with the regular expression defined in `_get_wptexturize_split_regex()` used in `wptexturize()`.
This problem seemed to be affecting [get_the_block_template_html()](https://developer.wordpress.org/reference/functions/get_the_block_template_html/) and causing the block theme layout collapse described above.
Changing this regex fixes the layout issue.

Also, `wp_html_split()` uses almost the same regex.
Other trac tickets caused by this function will also be fixed by updating to a similar regex.

According to the HTML reference at [html.spec.whatwg.org](https://html.spec.whatwg.org/multipage/syntax.html#attributes-2), attribute values can contain a variety of characters.
With this in mind, I have modified the regex to exclude matching characters within quotation marks.
This fixes the misplacement of `GREATER-THAN SIGN(>)` and prevents other valid HTML structures from being mishandled.

I've included tests to cover these changes in `tests/phpunit/tests/formatting/wpTexturize.php` and `tests/phpunit/tests/formatting/wpHtmlSplit.php`. If there's anything I've missed, please let me know.

Trac ticket: https://core.trac.wordpress.org/ticket/57381
Trac ticket: https://core.trac.wordpress.org/ticket/45387
Trac ticket: https://core.trac.wordpress.org/ticket/43457

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
