### PR TITLE
Twenty Nineteen: Navigation block submenu toggle button styles

### DIFF
--- a/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
+++ b/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
@@ -1046,3 +1046,16 @@
 		color: #FFF;
 	}
 }
+
+.wp-block-navigation-item {
+
+	.wp-block-navigation-submenu__toggle {
+		background: transparent;
+		outline-offset: 0;
+		border-radius: 0;
+	}
+
+	&.open-on-click .wp-block-navigation-submenu__toggle {
+		padding: 0 0.85em 0 0;
+	}
+}

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -6431,6 +6431,16 @@ body.page .main-navigation {
   color: #FFF;
 }
 
+.wp-block-navigation-item .wp-block-navigation-submenu__toggle {
+  background: transparent;
+  outline-offset: 0;
+  border-radius: 0;
+}
+
+.wp-block-navigation-item.open-on-click .wp-block-navigation-submenu__toggle {
+  padding: 0 0 0 0.85em;
+}
+
 /* Media */
 .page-content .wp-smiley,
 .entry-content .wp-smiley,

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -6443,6 +6443,16 @@ body.page .main-navigation {
   color: #FFF;
 }
 
+.wp-block-navigation-item .wp-block-navigation-submenu__toggle {
+  background: transparent;
+  outline-offset: 0;
+  border-radius: 0;
+}
+
+.wp-block-navigation-item.open-on-click .wp-block-navigation-submenu__toggle {
+  padding: 0 0.85em 0 0;
+}
+
 /* Media */
 .page-content .wp-smiley,
 .entry-content .wp-smiley,


### PR DESCRIPTION
This keeps the background color transparent when hovering or focusing on the toggle button.

It also removes the padding and resets the focus outline offset and border radius.

Below are images showing the focus outline for both the arrow button and the toggle button that includes the text.

![Focus outline on arrow toggle button in English menu](https://github.com/WordPress/wordpress-develop/assets/17100257/1f0110f2-3b57-4165-8f98-4947f187e28d)

![Focus outline around text button toggle in English menu](https://github.com/WordPress/wordpress-develop/assets/17100257/4a2b0ba5-09be-4e7e-ab86-a26e817fa1aa)

![Focus outline on arrow toggle button in Arabic menu](https://github.com/WordPress/wordpress-develop/assets/17100257/1ba750fe-8338-4ba9-b5be-5386a6f41983)

![Focus outline around text button toggle in Arabic menu](https://github.com/WordPress/wordpress-develop/assets/17100257/4ea65887-169e-41b2-8529-c80f141e2a36)

[Trac 59924](https://core.trac.wordpress.org/ticket/59924)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
