### PR TITLE
Block Parser: Explore a streaming lazy interface

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -543,7 +543,8 @@ function _inject_theme_attribute_in_template_part_block( &$block ) {
 		'core/template-part' === $block['blockName'] &&
 		! isset( $block['attrs']['theme'] )
 	) {
-		$block['attrs']['theme'] = get_stylesheet();
+		$attrs = $block['attrs'];
+		$attrs['theme'] = get_stylesheet();
 	}
 }
 

--- a/src/wp-includes/blocks/navigation.php
+++ b/src/wp-includes/blocks/navigation.php
@@ -1200,7 +1200,8 @@ function block_core_navigation_typographic_presets_backcompatibility( $parsed_bl
 		foreach ( $attribute_to_prefix_map as $style_attribute => $prefix ) {
 			if ( ! empty( $parsed_block['attrs']['style']['typography'][ $style_attribute ] ) ) {
 				$prefix_len      = strlen( $prefix );
-				$attribute_value = &$parsed_block['attrs']['style']['typography'][ $style_attribute ];
+				$attrs           = $parsed_block['attrs'];
+				$attribute_value = &$attrs['style']['typography'][ $style_attribute ];
 				if ( 0 === strncmp( $attribute_value, $prefix, $prefix_len ) ) {
 					$attribute_value = substr( $attribute_value, $prefix_len );
 				}

--- a/src/wp-includes/class-wp-block-list.php
+++ b/src/wp-includes/class-wp-block-list.php
@@ -92,7 +92,7 @@ class WP_Block_List implements Iterator, ArrayAccess, Countable {
 	public function offsetGet( $offset ) {
 		$block = $this->blocks[ $offset ];
 
-		if ( isset( $block ) && is_array( $block ) ) {
+		if ( isset( $block ) && ( is_array( $block ) || $block instanceof WP_Parsed_Block ) ) {
 			$block = new WP_Block( $block, $this->available_context, $this->registry );
 
 			$this->blocks[ $offset ] = $block;

--- a/src/wp-includes/class-wp-block-parser.php
+++ b/src/wp-includes/class-wp-block-parser.php
@@ -5,6 +5,275 @@
  * @package WordPress
  */
 
+class WP_Span {
+	public $at;
+	public $length;
+
+	public function __construct( $at, $length ) {
+		$this->at = $at;
+		$this->length = $length;
+	}
+}
+
+class WP_Parsed_Block implements ArrayAccess {
+	/**
+	 * Offset into name list where block name starts.
+	 *
+	 * @var int
+	 */
+	public $name_at;
+
+	/**
+	 * Override when setting block name.
+	 *
+	 * @var string|null
+	 */
+	private $name = null;
+
+	/**
+	 * Source of block attributes
+	 *
+	 * @var WP_Span|null
+	 */
+	public $attrs;
+
+	/**
+	 * Override when setting attributes.
+	 *
+	 * @var array|null
+	 */
+	public $parsed_attrs = null;
+
+	/**
+	 * List of inner content.
+	 *
+	 * @var array
+	 */
+	public $inner_content = array();
+
+	/**
+	 * Refers to the parent post for this block.
+	 *
+	 * @var WP_Parsed_Blocks
+	 */
+	public $post;
+
+	/**
+	 * Constructor function.
+	 *
+	 * @param WP_Parsed_Blocks $post Parent post for this block.
+	 */
+	public function __construct( $post ) {
+		$this->post = $post;
+	}
+
+	#[ReturnTypeWillChange]
+	public function &offsetGet( $offset ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		switch ( $offset ) {
+			case 'blockName':
+				if ( null !== $this->name ) {
+					return $this->name;
+				}
+
+				$name_end = strpos( $this->post->seen_block_types, "\x00", $this->name_at );
+				$name     = substr( $this->post->seen_block_types, $this->name_at, $name_end - $this->name_at );
+				return $name;
+
+			case 'attrs':
+				if ( null !== $this->parsed_attrs ) {
+					return $this->parsed_attrs;
+				}
+
+				if ( ! isset( $this->attrs ) || 0 === $this->attrs->length ) {
+					$this->parsed_attrs = null;
+				} else {
+					$this->parsed_attrs = json_decode( substr( $this->post->html, $this->attrs->at, $this->attrs->length ), true );
+				}
+
+				if ( null === $this->parsed_attrs ) {
+					$this->parsed_attrs = array();
+				}
+
+				return $this->parsed_attrs;
+
+			case 'innerHTML':
+				$html = '';
+				foreach ( $this->inner_content as $chunk ) {
+					if ( $chunk instanceof WP_Span ) {
+						$html .= substr( $this->post->html, $chunk->at, $chunk->length );
+					}
+				}
+				return $html;
+
+			case 'innerBlocks':
+				$blocks = array();
+				foreach ( $this->inner_content as $chunk ) {
+					if ( $chunk instanceof WP_Parsed_Block ) {
+						$blocks[] = $chunk;
+					}
+				}
+				return $blocks;
+
+			case 'innerContent':
+				$chunks = array();
+				foreach ( $this->inner_content as $chunk ) {
+					if ( $chunk instanceof WP_Span ) {
+						$chunks[] = substr( $this->post->html, $chunk->at, $chunk->length );
+					} elseif ( $chunk instanceof WP_Parsed_Block ) {
+						$chunks[] = null;
+					}
+				}
+
+				return $chunks;
+		}
+	}
+
+	#[ReturnTypeWillChange]
+	public function offsetExists( $offset ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		// TODO: Implement offsetExists() method.
+		return (
+			'blockName' === $offset ||
+			'attrs' === $offset ||
+			'innerHTML' === $offset ||
+			'innerBlocks' === $offset ||
+			'innerContent' === $offset
+		);
+	}
+
+	#[ReturnTypeWillChange]
+	public function offsetSet( $offset, $value ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		switch ( $offset ) {
+			case 'blockName':
+				if ( $value !== $this['blockName'] ) {
+					$this->name = $value;
+				}
+				break;
+
+			default:
+				throw new Exception( 'Does any code modify these?' );
+		}
+	}
+
+	#[ReturnTypeWillChange]
+	public function offsetUnset( $offset ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		// TODO: Implement offsetUnset() method.
+	}
+}
+
+class WP_Parsed_Blocks {
+	/**
+	 * Original HTML from which the blocks were parsed.
+	 *
+	 * @var string
+	 */
+	public $html;
+
+	/**
+	 * Tracks internal pointer into HTML.
+	 *
+	 * @var int
+	 */
+	public $at = 0;
+
+	/**
+	 * Concatenated block names, as parsed. Used for quick lookup
+	 * of existing names.
+	 *
+	 * @var string
+	 */
+	public $seen_block_types = "\x00";
+
+	/**
+	 * Tracks blocks while parsing.
+	 *
+	 * @var array
+	 */
+	public $stack;
+
+	/**
+	 * @var WP_Parsed_Block
+	 */
+	public $root;
+
+	public function __construct( $html ) {
+		$this->html  = $html;
+		$this->root  = new WP_Parsed_Block( $this );
+		$this->root->inner_content = array();
+		$this->stack = array( $this->root );
+	}
+
+	private function add_inner_chunk( $chunk ) {
+		$bottom = end( $this->stack );
+		$bottom->inner_content[] = $chunk;
+	}
+
+	/**
+	 * Generator function which returns each block and the stack as it parses.
+	 */
+	public function step() {
+		if ( $this->at >= strlen( $this->html ) ) {
+			return false;
+		}
+
+		$has_match = preg_match(
+			'/<!--\s+(?P<closer>\/)?wp:(?P<namespace>[a-z][a-z0-9_-]*\/)?(?P<name>[a-z][a-z0-9_-]*)\s+(?P<attrs>{(?:(?:[^}]+|}+(?=})|(?!}\s+\/?-->).)*+)?}\s+)?(?P<void>\/)?-->/s',
+			$this->html,
+			$matches,
+			PREG_OFFSET_CAPTURE,
+			$this->at
+		);
+
+		if ( ! $has_match ) {
+			$this->at = strlen( $this->html );
+			return false;
+		}
+
+		list( $match, $started_at ) = $matches[0];
+
+		$is_closer = isset( $matches['closer'] ) && -1 !== $matches['closer'][1];
+		$is_void   = isset( $matches['void'] ) && -1 !== $matches['void'][1];
+		$namespace = $matches['namespace'];
+		$namespace = ( isset( $namespace ) && -1 !== $namespace[1] ) ? $namespace[0] : 'core/';
+		$name      = $namespace . $matches['name'][0];
+		$has_attrs = isset( $matches['attrs'] ) && -1 !== $matches['attrs'][1];
+
+		if ( $started_at > $this->at ) {
+			$this->add_inner_chunk( new WP_Span( $this->at, $started_at - $this->at ) );
+		}
+
+		$this->at = $started_at + strlen( $match );
+
+		if ( $is_closer ) {
+			array_pop( $this->stack );
+			return true;
+		}
+
+		$block = new WP_Parsed_Block( $this );
+
+		// Block name.
+		$name_search  = "\x00{$name}\x00";
+		$seen_name_at = strpos( $this->seen_block_types, $name_search );
+		if ( false === $seen_name_at ) {
+			$block->name_at          = strlen( $this->seen_block_types );
+			$this->seen_block_types .= "{$name}\x00";
+		} else {
+			$block->name_at = $seen_name_at + 1;
+		}
+
+		// Block attrs.
+		if ( $has_attrs ) {
+			$block->attrs = new WP_Span( $matches['attrs'][1], strlen( $matches['attrs'][0] ) );
+		}
+
+		$this->add_inner_chunk( $block );
+
+		if ( ! $is_void ) {
+			$this->stack[] = $block;
+		}
+		return true;
+	}
+}
+
 /**
  * Class WP_Block_Parser
  *
@@ -15,390 +284,17 @@
  */
 class WP_Block_Parser {
 	/**
-	 * Input document being parsed
+	 * Parses blocks from an HTML string, deferring computation where possible.
 	 *
-	 * @example "Pre-text\n<!-- wp:paragraph -->This is inside a block!<!-- /wp:paragraph -->"
-	 *
-	 * @since 5.0.0
-	 * @var string
+	 * @param string $html Contains block content.
+	 * @return array[] List of blocks in the HTML.
 	 */
-	public $document;
-
-	/**
-	 * Tracks parsing progress through document
-	 *
-	 * @since 5.0.0
-	 * @var int
-	 */
-	public $offset;
-
-	/**
-	 * List of parsed blocks
-	 *
-	 * @since 5.0.0
-	 * @var WP_Block_Parser_Block[]
-	 */
-	public $output;
-
-	/**
-	 * Stack of partially-parsed structures in memory during parse
-	 *
-	 * @since 5.0.0
-	 * @var WP_Block_Parser_Frame[]
-	 */
-	public $stack;
-
-	/**
-	 * Parses a document and returns a list of block structures
-	 *
-	 * When encountering an invalid parse will return a best-effort
-	 * parse. In contrast to the specification parser this does not
-	 * return an error on invalid inputs.
-	 *
-	 * @since 5.0.0
-	 *
-	 * @param string $document Input document being parsed.
-	 * @return array[]
-	 */
-	public function parse( $document ) {
-		$this->document = $document;
-		$this->offset   = 0;
-		$this->output   = array();
-		$this->stack    = array();
-
-		while ( $this->proceed() ) {
+	public function parse( $html ) {
+		$lazy = new WP_Parsed_Blocks( $html );
+		while ( $lazy->step() ) {
 			continue;
 		}
 
-		return $this->output;
-	}
-
-	/**
-	 * Processes the next token from the input document
-	 * and returns whether to proceed eating more tokens
-	 *
-	 * This is the "next step" function that essentially
-	 * takes a token as its input and decides what to do
-	 * with that token before descending deeper into a
-	 * nested block tree or continuing along the document
-	 * or breaking out of a level of nesting.
-	 *
-	 * @internal
-	 * @since 5.0.0
-	 * @return bool
-	 */
-	public function proceed() {
-		$next_token = $this->next_token();
-		list( $token_type, $block_name, $attrs, $start_offset, $token_length ) = $next_token;
-		$stack_depth = count( $this->stack );
-
-		// we may have some HTML soup before the next block.
-		$leading_html_start = $start_offset > $this->offset ? $this->offset : null;
-
-		switch ( $token_type ) {
-			case 'no-more-tokens':
-				// if not in a block then flush output.
-				if ( 0 === $stack_depth ) {
-					$this->add_freeform();
-					return false;
-				}
-
-				/*
-				 * Otherwise we have a problem
-				 * This is an error
-				 *
-				 * we have options
-				 * - treat it all as freeform text
-				 * - assume an implicit closer (easiest when not nesting)
-				 */
-
-				// for the easy case we'll assume an implicit closer.
-				if ( 1 === $stack_depth ) {
-					$this->add_block_from_stack();
-					return false;
-				}
-
-				/*
-				 * for the nested case where it's more difficult we'll
-				 * have to assume that multiple closers are missing
-				 * and so we'll collapse the whole stack piecewise
-				 */
-				while ( 0 < count( $this->stack ) ) {
-					$this->add_block_from_stack();
-				}
-				return false;
-
-			case 'void-block':
-				/*
-				 * easy case is if we stumbled upon a void block
-				 * in the top-level of the document
-				 */
-				if ( 0 === $stack_depth ) {
-					if ( isset( $leading_html_start ) ) {
-						$this->output[] = (array) $this->freeform(
-							substr(
-								$this->document,
-								$leading_html_start,
-								$start_offset - $leading_html_start
-							)
-						);
-					}
-
-					$this->output[] = (array) new WP_Block_Parser_Block( $block_name, $attrs, array(), '', array() );
-					$this->offset   = $start_offset + $token_length;
-					return true;
-				}
-
-				// otherwise we found an inner block.
-				$this->add_inner_block(
-					new WP_Block_Parser_Block( $block_name, $attrs, array(), '', array() ),
-					$start_offset,
-					$token_length
-				);
-				$this->offset = $start_offset + $token_length;
-				return true;
-
-			case 'block-opener':
-				// track all newly-opened blocks on the stack.
-				array_push(
-					$this->stack,
-					new WP_Block_Parser_Frame(
-						new WP_Block_Parser_Block( $block_name, $attrs, array(), '', array() ),
-						$start_offset,
-						$token_length,
-						$start_offset + $token_length,
-						$leading_html_start
-					)
-				);
-				$this->offset = $start_offset + $token_length;
-				return true;
-
-			case 'block-closer':
-				/*
-				 * if we're missing an opener we're in trouble
-				 * This is an error
-				 */
-				if ( 0 === $stack_depth ) {
-					/*
-					 * we have options
-					 * - assume an implicit opener
-					 * - assume _this_ is the opener
-					 * - give up and close out the document
-					 */
-					$this->add_freeform();
-					return false;
-				}
-
-				// if we're not nesting then this is easy - close the block.
-				if ( 1 === $stack_depth ) {
-					$this->add_block_from_stack( $start_offset );
-					$this->offset = $start_offset + $token_length;
-					return true;
-				}
-
-				/*
-				 * otherwise we're nested and we have to close out the current
-				 * block and add it as a new innerBlock to the parent
-				 */
-				$stack_top                        = array_pop( $this->stack );
-				$html                             = substr( $this->document, $stack_top->prev_offset, $start_offset - $stack_top->prev_offset );
-				$stack_top->block->innerHTML     .= $html;
-				$stack_top->block->innerContent[] = $html;
-				$stack_top->prev_offset           = $start_offset + $token_length;
-
-				$this->add_inner_block(
-					$stack_top->block,
-					$stack_top->token_start,
-					$stack_top->token_length,
-					$start_offset + $token_length
-				);
-				$this->offset = $start_offset + $token_length;
-				return true;
-
-			default:
-				// This is an error.
-				$this->add_freeform();
-				return false;
-		}
-	}
-
-	/**
-	 * Scans the document from where we last left off
-	 * and finds the next valid token to parse if it exists
-	 *
-	 * Returns the type of the find: kind of find, block information, attributes
-	 *
-	 * @internal
-	 * @since 5.0.0
-	 * @since 4.6.1 fixed a bug in attribute parsing which caused catastrophic backtracking on invalid block comments
-	 * @return array
-	 */
-	public function next_token() {
-		$matches = null;
-
-		/*
-		 * aye the magic
-		 * we're using a single RegExp to tokenize the block comment delimiters
-		 * we're also using a trick here because the only difference between a
-		 * block opener and a block closer is the leading `/` before `wp:` (and
-		 * a closer has no attributes). we can trap them both and process the
-		 * match back in PHP to see which one it was.
-		 */
-		$has_match = preg_match(
-			'/<!--\s+(?P<closer>\/)?wp:(?P<namespace>[a-z][a-z0-9_-]*\/)?(?P<name>[a-z][a-z0-9_-]*)\s+(?P<attrs>{(?:(?:[^}]+|}+(?=})|(?!}\s+\/?-->).)*+)?}\s+)?(?P<void>\/)?-->/s',
-			$this->document,
-			$matches,
-			PREG_OFFSET_CAPTURE,
-			$this->offset
-		);
-
-		// if we get here we probably have catastrophic backtracking or out-of-memory in the PCRE.
-		if ( false === $has_match ) {
-			return array( 'no-more-tokens', null, null, null, null );
-		}
-
-		// we have no more tokens.
-		if ( 0 === $has_match ) {
-			return array( 'no-more-tokens', null, null, null, null );
-		}
-
-		list( $match, $started_at ) = $matches[0];
-
-		$length    = strlen( $match );
-		$is_closer = isset( $matches['closer'] ) && -1 !== $matches['closer'][1];
-		$is_void   = isset( $matches['void'] ) && -1 !== $matches['void'][1];
-		$namespace = $matches['namespace'];
-		$namespace = ( isset( $namespace ) && -1 !== $namespace[1] ) ? $namespace[0] : 'core/';
-		$name      = $namespace . $matches['name'][0];
-		$has_attrs = isset( $matches['attrs'] ) && -1 !== $matches['attrs'][1];
-
-		/*
-		 * Fun fact! It's not trivial in PHP to create "an empty associative array" since all arrays
-		 * are associative arrays. If we use `array()` we get a JSON `[]`
-		 */
-		$attrs = $has_attrs
-			? json_decode( $matches['attrs'][0], /* as-associative */ true )
-			: array();
-
-		/*
-		 * This state isn't allowed
-		 * This is an error
-		 */
-		if ( $is_closer && ( $is_void || $has_attrs ) ) {
-			// we can ignore them since they don't hurt anything.
-		}
-
-		if ( $is_void ) {
-			return array( 'void-block', $name, $attrs, $started_at, $length );
-		}
-
-		if ( $is_closer ) {
-			return array( 'block-closer', $name, null, $started_at, $length );
-		}
-
-		return array( 'block-opener', $name, $attrs, $started_at, $length );
-	}
-
-	/**
-	 * Returns a new block object for freeform HTML
-	 *
-	 * @internal
-	 * @since 3.9.0
-	 *
-	 * @param string $inner_html HTML content of block.
-	 * @return WP_Block_Parser_Block freeform block object.
-	 */
-	public function freeform( $inner_html ) {
-		return new WP_Block_Parser_Block( null, array(), array(), $inner_html, array( $inner_html ) );
-	}
-
-	/**
-	 * Pushes a length of text from the input document
-	 * to the output list as a freeform block.
-	 *
-	 * @internal
-	 * @since 5.0.0
-	 * @param null $length how many bytes of document text to output.
-	 */
-	public function add_freeform( $length = null ) {
-		$length = $length ? $length : strlen( $this->document ) - $this->offset;
-
-		if ( 0 === $length ) {
-			return;
-		}
-
-		$this->output[] = (array) $this->freeform( substr( $this->document, $this->offset, $length ) );
-	}
-
-	/**
-	 * Given a block structure from memory pushes
-	 * a new block to the output list.
-	 *
-	 * @internal
-	 * @since 5.0.0
-	 * @param WP_Block_Parser_Block $block        The block to add to the output.
-	 * @param int                   $token_start  Byte offset into the document where the first token for the block starts.
-	 * @param int                   $token_length Byte length of entire block from start of opening token to end of closing token.
-	 * @param int|null              $last_offset  Last byte offset into document if continuing form earlier output.
-	 */
-	public function add_inner_block( WP_Block_Parser_Block $block, $token_start, $token_length, $last_offset = null ) {
-		$parent                       = $this->stack[ count( $this->stack ) - 1 ];
-		$parent->block->innerBlocks[] = (array) $block;
-		$html                         = substr( $this->document, $parent->prev_offset, $token_start - $parent->prev_offset );
-
-		if ( ! empty( $html ) ) {
-			$parent->block->innerHTML     .= $html;
-			$parent->block->innerContent[] = $html;
-		}
-
-		$parent->block->innerContent[] = null;
-		$parent->prev_offset           = $last_offset ? $last_offset : $token_start + $token_length;
-	}
-
-	/**
-	 * Pushes the top block from the parsing stack to the output list.
-	 *
-	 * @internal
-	 * @since 5.0.0
-	 * @param int|null $end_offset byte offset into document for where we should stop sending text output as HTML.
-	 */
-	public function add_block_from_stack( $end_offset = null ) {
-		$stack_top   = array_pop( $this->stack );
-		$prev_offset = $stack_top->prev_offset;
-
-		$html = isset( $end_offset )
-			? substr( $this->document, $prev_offset, $end_offset - $prev_offset )
-			: substr( $this->document, $prev_offset );
-
-		if ( ! empty( $html ) ) {
-			$stack_top->block->innerHTML     .= $html;
-			$stack_top->block->innerContent[] = $html;
-		}
-
-		if ( isset( $stack_top->leading_html_start ) ) {
-			$this->output[] = (array) $this->freeform(
-				substr(
-					$this->document,
-					$stack_top->leading_html_start,
-					$stack_top->token_start - $stack_top->leading_html_start
-				)
-			);
-		}
-
-		$this->output[] = (array) $stack_top->block;
+		return $lazy->root['innerBlocks'];
 	}
 }
-
-/**
- * WP_Block_Parser_Block class.
- *
- * Required for backward compatibility in WordPress Core.
- */
-require_once __DIR__ . '/class-wp-block-parser-block.php';
-
-/**
- * WP_Block_Parser_Frame class.
- *
- * Required for backward compatibility in WordPress Core.
- */
-require_once __DIR__ . '/class-wp-block-parser-frame.php';

--- a/src/wp-includes/class-wp-block-supports.php
+++ b/src/wp-includes/class-wp-block-supports.php
@@ -103,7 +103,7 @@ class WP_Block_Supports {
 			return array();
 		}
 
-		$block_attributes = array_key_exists( 'attrs', self::$block_to_render ) && is_array( self::$block_to_render['attrs'] )
+		$block_attributes = isset( self::$block_to_render['attrs'] )
 			? self::$block_to_render['attrs']
 			: array();
 

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -186,9 +186,7 @@ class WP_Block {
 	 */
 	public function __get( $name ) {
 		if ( 'attributes' === $name ) {
-			$this->attributes = isset( $this->parsed_block['attrs'] ) ?
-				$this->parsed_block['attrs'] :
-				array();
+			$this->attributes = $this->parsed_block['attrs'];
 
 			if ( ! is_null( $this->block_type ) ) {
 				$this->attributes = $this->block_type->prepare_attributes_for_render( $this->attributes );


### PR DESCRIPTION
Augmented but not replaced entirely by the Unified Block Parser in [#6381](https://github.com/WordPress/wordpress-develop/pull/6381)
Alternatively provided by the block-delimiter-finder in https://github.com/WordPress/wordpress-develop/pull/6760

For a 3 MB document which took 5 seconds and 14 GB to parse, this version of the parser parsed it in 27 ms and 20 MB.

<details><summary>Initial testing</summary>
This version is slower for the home page render of `twentytwentyfour`. While unfortunate, this is not entirely surprising as this was designed to fix the catastrophically bad cases.

![lazy-block-parser-slower-for-tt4-home-page](https://github.com/WordPress/wordpress-develop/assets/5431237/dd9af78b-048a-401f-8b2a-e89e8367066b)

However, in catastrophic cases it's wildly better than `trunk`. The following was tested for a 15 KB / 400 line chunk of the 3 MB post mentioned above.

![lazy-block-parser-faster-for-large-page](https://github.com/WordPress/wordpress-develop/assets/5431237/1be0d6fb-e459-446a-bb27-e0212784e3bb)

The algorithm has wild complexity too. For the same post, including the first 599 lines (only 23 KB of HTML), `trunk` consumes 520 MB or memory while this branch only consumes 10 MB. With no more than 15 samples the data is extremely significant.

![lazy-block-parser-faster-for-very-large-page](https://github.com/WordPress/wordpress-develop/assets/5431237/313137e5-2aa8-4bbb-bbfb-140026da3337)
</details>

## Testing Results

This _may_ be slightly slower for a number of normal posts. For the home page render of `twentytwentyfour` it rendered 3.7 ms slower than `trunk`. However, for my catastrophically-broken test post, the impact of the lazy parsing is dramatic and significant after only a single request.

The lazy parser is still _slow_ for really pathological cases, but unlike `trunk` it runs within a mostly bounded memory footprint. The more pathological the post, the more dramatic the improvement in both runtime and memory use becomes. Below is a chart comparing slices of my test file against both parsers. Between each test run the database is reset. The number of lines reported is the count of how many of the original 3 MB document lines were extracted as the test post.

Of particular note is that this lazy parser allows for more control over the performance threshold still. Further expansion would allow setting a time limit, an upper bound on m emory usage, and a content length threshold after which the parser could pause and/or collapse the remainder of the post into a single unparsed block, essentially turning everything after the limit into a chunk of raw HTML (the static fallback render).

| Lines | max depth | KB | `trunk` ms | branch ms | Δ | speedup | `trunk` MB | branch MB |
|---|---|---|---|---|---|---|---|---|
| (tt4) | 25 | | 92.6 | 96.1 | +3.78% | x0.96 | | |
| 400 | 124 | 15 | 1,170 | 624 | -47% | x1.88 | | |
| 600 | 187 | 23 | 4.82 s | 968 | -80% | x5.00 | 520 | 10 |
| 792 | 248 | 30 | 16.7 s | 3.53 s | -79% | x4.73 | 1.8 GB | 14 |
| 1000 | 316 | 38 | 118 s | 10.1 s | -91% | x11.7 | 6.5 GB | 23 |
| 1200 | 380 | 46 | 8.01 min | 22 s| -95% | x22 | 13.9 GB | 32 |
| 79k (all) | 25683 | 3 MB |  | |  |  |  | 30 |

With `memory_limit=55G` on a `60 GB` system I was unable to create the post via `wp_insert_post()` and it failed after some number of tens of minutes.

on this branch the post inserted after a few seconds and used a peak memory of 64 MB