### PR TITLE
Set `autoload=no` for previous theme after switching themes

### DIFF
--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -847,9 +847,6 @@ function switch_theme( $stylesheet ) {
 	);
 	wp_set_option_autoload_values( $theme_mods_options );
 
-	// Reload autoload options.
-	wp_load_alloptions();
-
 	/**
 	 * Fires after the theme is switched.
 	 *

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -748,12 +748,11 @@ function locale_stylesheet() {
  * @global WP_Customize_Manager $wp_customize
  * @global array                $sidebars_widgets
  * @global array                $wp_registered_sidebars
- * @global wpdb                 $wpdb                   WordPress database abstraction object.
  *
  * @param string $stylesheet Stylesheet name.
  */
 function switch_theme( $stylesheet ) {
-	global $wp_theme_directories, $wp_customize, $sidebars_widgets, $wp_registered_sidebars, $wpdb;
+	global $wp_theme_directories, $wp_customize, $sidebars_widgets, $wp_registered_sidebars;
 
 	$requirements = validate_theme_requirements( $stylesheet );
 	if ( is_wp_error( $requirements ) ) {
@@ -841,18 +840,12 @@ function switch_theme( $stylesheet ) {
 	$new_theme->delete_pattern_cache();
 	$old_theme->delete_pattern_cache();
 
-	// Set autoload=no for the previous all themes.
-	$theme_mods_options = $wpdb->get_col(
-		$wpdb->prepare(
-			"SELECT option_name FROM $wpdb->options WHERE autoload = 'yes' AND option_name != %s AND option_name LIKE %s",
-			"theme_mods_$stylesheet",
-			$wpdb->esc_like( 'theme_mods_' ) . '%'
-		)
+	// Set autoload=no for the old theme, autoload=yes for the switched theme.
+	$theme_mods_options = array(
+		'theme_mods_' . $stylesheet                  => 'yes',
+		'theme_mods_' . $old_theme->get_stylesheet() => 'no',
 	);
-
-	$autoload = array_fill_keys( $theme_mods_options, 'no' );
-	$autoload[ "theme_mods_$stylesheet" ] = 'yes';
-	wp_set_option_autoload_values( $autoload );
+	wp_set_option_autoload_values( $theme_mods_options );
 
 	// Reload autoload options.
 	wp_load_alloptions();

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -842,21 +842,17 @@ function switch_theme( $stylesheet ) {
 	$old_theme->delete_pattern_cache();
 
 	// Set autoload=no for the previous all themes.
-	$theme_mods_compare_value = '%' . $wpdb->esc_like( 'theme_mods_' ) . '%';
-	$theme_mods_options       = $wpdb->get_results( $wpdb->prepare( "SELECT option_name FROM $wpdb->options WHERE autoload = 'yes' AND option_name LIKE %s", $theme_mods_compare_value ) );
+	$theme_mods_options = $wpdb->get_col( 
+		$wpdb->prepare( 
+			"SELECT option_name FROM $wpdb->options WHERE autoload = 'yes' AND option_name != %s AND option_name LIKE %s", 
+			"theme_mods_$stylesheet", 
+			$wpdb->esc_like( 'theme_mods_' ) . '%' 
+		) 
+	);
 
-	// Loop through fetched options to manage autoload settings.
-	foreach ( (array) $theme_mods_options as $option ) {
-		if ( "theme_mods_$stylesheet" === $option->option_name ) {
-			continue;
-		}
-
-		// Disable autoload for previous all themes.
-		wp_set_option_autoload( $option->option_name, 'no' );
-	}
-
-	// Set autoload=yes for the switched theme if not already set.
-	wp_set_option_autoload( "theme_mods_$stylesheet", 'yes' );
+	$autoload = array_fill_keys( $theme_mods_options, 'no' );
+	$autoload[ "theme_mods_$stylesheet" ] = 'yes';
+	wp_set_option_autoload_values( $autoload );
 
 	// Reload autoload options.
 	wp_load_alloptions();

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -842,12 +842,12 @@ function switch_theme( $stylesheet ) {
 	$old_theme->delete_pattern_cache();
 
 	// Set autoload=no for the previous all themes.
-	$theme_mods_options = $wpdb->get_col( 
-		$wpdb->prepare( 
-			"SELECT option_name FROM $wpdb->options WHERE autoload = 'yes' AND option_name != %s AND option_name LIKE %s", 
-			"theme_mods_$stylesheet", 
-			$wpdb->esc_like( 'theme_mods_' ) . '%' 
-		) 
+	$theme_mods_options = $wpdb->get_col(
+		$wpdb->prepare(
+			"SELECT option_name FROM $wpdb->options WHERE autoload = 'yes' AND option_name != %s AND option_name LIKE %s",
+			"theme_mods_$stylesheet",
+			$wpdb->esc_like( 'theme_mods_' ) . '%'
+		)
 	);
 
 	$autoload = array_fill_keys( $theme_mods_options, 'no' );

--- a/tests/phpunit/tests/theme/autoloadThemeMods.php
+++ b/tests/phpunit/tests/theme/autoloadThemeMods.php
@@ -1,0 +1,52 @@
+<?php
+
+require_once __DIR__ . '/base.php';
+
+/**
+ * Test autoload for theme mods.
+ *
+ * @package WordPress
+ * @subpackage Theme
+ *
+ * @group themes
+ */
+class Tests_Autoload_Theme_Mods extends WP_Theme_UnitTestCase {
+
+	/**
+	 * Tests that theme mods should not autoloaded after switch_theme.
+	 *
+	 * @ticket 39537
+	 */
+	public function test_that_on_switch_theme_previous_theme_mods_should_not_be_autoload() {
+		global $wpdb;
+
+		$current_theme_stylesheet = get_stylesheet();
+
+		// Set a theme mod for the current theme.
+		$new_theme_stylesheet = 'block-theme';
+		set_theme_mod( 'foo-bar-option', 'a-value' );
+
+		switch_theme( $new_theme_stylesheet );
+
+		$this->assertSame( 'no', $wpdb->get_var( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name = %s", "theme_mods_$current_theme_stylesheet" ) ), 'Theme mods autoload value not set to no in database' );
+		$this->assertSame( 'yes', $wpdb->get_var( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name = %s", "theme_mods_$new_theme_stylesheet" ) ), 'Theme mods autoload value not set to yes in database' );
+
+		// Make sure that autoloaded options are cached properly.
+		$autoloaded_options = wp_cache_get( 'alloptions', 'options' );
+		$this->assertArrayHasKey( "theme_mods_$new_theme_stylesheet", $autoloaded_options, "Option theme_mods_$current_theme_stylesheet unexpectedly deleted from alloptions cache" );
+		$this->assertArrayNotHasKey( "theme_mods_$current_theme_stylesheet", $autoloaded_options, "Option theme_mods_$new_theme_stylesheet not deleted from alloptions cache" );
+
+		switch_theme( $current_theme_stylesheet );
+
+		$this->assertSame( 'yes', $wpdb->get_var( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name = %s", "theme_mods_$current_theme_stylesheet" ) ), 'Theme mods autoload value not set to yes in database' );
+		$this->assertSame( 'no', $wpdb->get_var( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name = %s", "theme_mods_$new_theme_stylesheet" ) ), 'Theme mods autoload value not set to no in database' );
+
+		// Make sure that autoloaded options are cached properly.
+		$autoloaded_options = wp_cache_get( 'alloptions', 'options' );
+		$this->assertArrayNotHasKey( "theme_mods_$new_theme_stylesheet", $autoloaded_options, "Option theme_mods_$new_theme_stylesheet not deleted from alloptions cache" );
+		$this->assertArrayHasKey( "theme_mods_$current_theme_stylesheet", $autoloaded_options, "Option theme_mods_$current_theme_stylesheet unexpectedly deleted from alloptions cache" );
+
+		// And that we haven't lost the mods.
+		$this->assertSame( 'a-value', get_theme_mod( 'foo-bar-option' ) );
+	}
+}

--- a/tests/phpunit/tests/theme/autoloadThemeMods.php
+++ b/tests/phpunit/tests/theme/autoloadThemeMods.php
@@ -31,22 +31,12 @@ class Tests_Autoload_Theme_Mods extends WP_Theme_UnitTestCase {
 		$this->assertSame( 'no', $wpdb->get_var( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name = %s", "theme_mods_$current_theme_stylesheet" ) ), 'Theme mods autoload value not set to no in database' );
 		$this->assertSame( 'yes', $wpdb->get_var( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name = %s", "theme_mods_$new_theme_stylesheet" ) ), 'Theme mods autoload value not set to yes in database' );
 
-		// Make sure that autoloaded options are cached properly.
-		$autoloaded_options = wp_cache_get( 'alloptions', 'options' );
-		$this->assertArrayHasKey( "theme_mods_$new_theme_stylesheet", $autoloaded_options, "Option theme_mods_$current_theme_stylesheet unexpectedly deleted from alloptions cache" );
-		$this->assertArrayNotHasKey( "theme_mods_$current_theme_stylesheet", $autoloaded_options, "Option theme_mods_$new_theme_stylesheet not deleted from alloptions cache" );
-
 		switch_theme( $current_theme_stylesheet );
 
 		$this->assertSame( 'yes', $wpdb->get_var( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name = %s", "theme_mods_$current_theme_stylesheet" ) ), 'Theme mods autoload value not set to yes in database' );
 		$this->assertSame( 'no', $wpdb->get_var( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name = %s", "theme_mods_$new_theme_stylesheet" ) ), 'Theme mods autoload value not set to no in database' );
 
-		// Make sure that autoloaded options are cached properly.
-		$autoloaded_options = wp_cache_get( 'alloptions', 'options' );
-		$this->assertArrayNotHasKey( "theme_mods_$new_theme_stylesheet", $autoloaded_options, "Option theme_mods_$new_theme_stylesheet not deleted from alloptions cache" );
-		$this->assertArrayHasKey( "theme_mods_$current_theme_stylesheet", $autoloaded_options, "Option theme_mods_$current_theme_stylesheet unexpectedly deleted from alloptions cache" );
-
-		// And that we haven't lost the mods.
+		// Basic assertion to make sure that we haven't lost the mods.
 		$this->assertSame( 'a-value', get_theme_mod( 'foo-bar-option' ) );
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/39537

This PR sets `autoload=no` for the old themes after switching between different themes, utilizing the [wp_set_option_autoload_values](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/option.php#L387) function.

> Within the `switch_theme` function, we retrieve two themes: the current theme and the previous theme. However, there isn't a direct method to obtain all previously activated themes. For instance, if a user has used 4-5 themes and all of these themes have `theme_mods_*` options autoloaded, this method involves querying to retrieve all the `theme_mods_*` and subsequently setting `autoload=no` for all themes except the current one.

This will be done using separate ticket: 59975

This PR only updates the autoload value for old and new themes.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
