### PR TITLE
Style engine: add CSS var parsing capability to fontSize and fontFamily

### DIFF
--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -215,6 +215,9 @@ final class WP_Style_Engine {
 					'default' => 'font-size',
 				),
 				'path'          => array( 'typography', 'fontSize' ),
+				'css_vars'      => array(
+					'font-size' => '--wp--preset--font-size--$slug',
+				),
 				'classnames'    => array(
 					'has-$slug-font-size' => 'font-size',
 				),
@@ -222,6 +225,9 @@ final class WP_Style_Engine {
 			'fontFamily'     => array(
 				'property_keys' => array(
 					'default' => 'font-family',
+				),
+				'css_vars'      => array(
+					'font-family' => '--wp--preset--font-family--$slug',
 				),
 				'path'          => array( 'typography', 'fontFamily' ),
 				'classnames'    => array(

--- a/tests/phpunit/tests/style-engine/styleEngine.php
+++ b/tests/phpunit/tests/style-engine/styleEngine.php
@@ -252,19 +252,26 @@ class Tests_wpStyleEngine extends WP_UnitTestCase {
 
 			'elements_with_css_var_value'                  => array(
 				'block_styles'    => array(
-					'color' => array(
+					'color'      => array(
 						'text' => 'var:preset|color|my-little-pony',
+					),
+					'typography' => array(
+						'fontSize'   => 'var:preset|font-size|cabbage-patch',
+						'fontFamily' => 'var:preset|font-family|transformers',
 					),
 				),
 				'options'         => array(
 					'selector' => '.wp-selector',
 				),
 				'expected_output' => array(
-					'css'          => '.wp-selector{color:var(--wp--preset--color--my-little-pony);}',
+					'css'          => '.wp-selector{color:var(--wp--preset--color--my-little-pony);font-size:var(--wp--preset--font-size--cabbage-patch);font-family:var(--wp--preset--font-family--transformers);}',
 					'declarations' => array(
-						'color' => 'var(--wp--preset--color--my-little-pony)',
+						'color'       => 'var(--wp--preset--color--my-little-pony)',
+						'font-size'   => 'var(--wp--preset--font-size--cabbage-patch)',
+						'font-family' => 'var(--wp--preset--font-family--transformers)',
+
 					),
-					'classnames'   => 'has-text-color has-my-little-pony-color',
+					'classnames'   => 'has-text-color has-my-little-pony-color has-cabbage-patch-font-size has-transformers-font-family',
 				),
 			),
 


### PR DESCRIPTION
### What

Syncs changes from https://github.com/WordPress/gutenberg/pull/56528 by adding CSS var parsing capability to fontSize and fontFamily.

### Testing
Ensure that there are no regressions in block supports styles. Here is some test code:


<details>

<summary>Example block code</summary>

```html
<!-- wp:group {"style":{"border":{"radius":"20px","top":{"width":"14px"},"right":{"color":"#ec0303","width":"46px"},"bottom":{"color":"#d8613c","width":"14px"},"left":{"color":"#636363","width":"46px"}}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group" style="border-radius:20px;border-top-width:14px;border-right-color:#ec0303;border-right-width:46px;border-bottom-color:#d8613c;border-bottom-width:14px;border-left-color:#636363;border-left-width:46px"><!-- wp:heading {"style":{"elements":{"link":{"color":{"text":"var:preset|color|accent-5"}}},"typography":{"fontStyle":"normal","fontWeight":"500","textTransform":"uppercase"},"spacing":{"padding":{"bottom":"var:preset|spacing|40"}}},"textColor":"accent-5","fontSize":"large"} -->
<h2 class="wp-block-heading has-accent-5-color has-text-color has-link-color has-large-font-size" style="padding-bottom:var(--wp--preset--spacing--40);font-style:normal;font-weight:500;text-transform:uppercase">Heading</h2>
<!-- /wp:heading -->

<!-- wp:paragraph {"fontSize":"small"} -->
<p class="has-small-font-size">Paragraph</p>
<!-- /wp:paragraph -->

<!-- wp:list {"style":{"color":{"background":"#e6e3e3"},"spacing":{"margin":{"right":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
<ul style="background-color:#e6e3e3;margin-right:var(--wp--preset--spacing--30);margin-left:var(--wp--preset--spacing--30)" class="has-background"><!-- wp:list-item -->
<li>List</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>List</li>
<!-- /wp:list-item -->

<!-- wp:list-item -->
<li>List</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></div>
<!-- /wp:group -->

<!-- wp:paragraph -->
<p></p>
<!-- /wp:paragraph -->
```

</details>


<details>

<summary>Frontend output</summary>

```html
<div class="wp-block-group has-global-padding is-layout-constrained wp-block-group-is-layout-constrained" style="border-radius:20px;border-top-width:14px;border-right-color:#ec0303;border-right-width:46px;border-bottom-color:#d8613c;border-bottom-width:14px;border-left-color:#636363;border-left-width:46px">
<h2 class="wp-block-heading has-accent-5-color has-text-color has-link-color has-large-font-size wp-elements-0ea8f7f38d9a71fcf3ae556b6ed1adb1" style="padding-bottom:var(--wp--preset--spacing--40);font-style:normal;font-weight:500;text-transform:uppercase">Heading</h2>



<p class="has-small-font-size">Paragraph</p>



<ul style="background-color:#e6e3e3;margin-right:var(--wp--preset--spacing--30);margin-left:var(--wp--preset--spacing--30)" class="has-background">
<li>List</li>



<li>List</li>



<li>List</li>
</ul>
</div>
```

</details>


Run the tests!
`npm run test:php -- --filter Tests_wpStyleEngine`

Trac ticket: https://core.trac.wordpress.org/ticket/59982

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
