### PR TITLE
Set autoload to 'no' for previously activated themes using upgrade routine

### DIFF
--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2366,7 +2366,6 @@ function upgrade_650() {
 	global $wp_current_db_version, $wpdb;
 
 	if ( $wp_current_db_version < 57200 ) {
-		
 		$stylesheet = get_stylesheet();
 
 		// Set autoload=no for the previous all themes.

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2368,7 +2368,7 @@ function upgrade_650() {
 	if ( $wp_current_db_version < 57200 ) {
 		$stylesheet = get_stylesheet();
 
-		// Set autoload=no for the previous all themes.
+		// Set autoload=no for all themes except the current one.
 		$theme_mods_options = $wpdb->get_col(
 			$wpdb->prepare(
 				"SELECT option_name FROM $wpdb->options WHERE autoload = 'yes' AND option_name != %s AND option_name LIKE %s",

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2378,7 +2378,6 @@ function upgrade_650() {
 		);
 
 		$autoload = array_fill_keys( $theme_mods_options, 'no' );
-		$autoload[ "theme_mods_$stylesheet" ] = 'yes';
 		wp_set_option_autoload_values( $autoload );
 	}
 }

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -843,6 +843,10 @@ function upgrade_all() {
 		upgrade_640();
 	}
 
+	if ( $wp_current_db_version < 57200 ) {
+		upgrade_650();
+	}
+
 	maybe_disable_link_manager();
 
 	maybe_disable_automattic_widgets();
@@ -2346,6 +2350,38 @@ function upgrade_640() {
 		if ( $scheduled ) {
 			wp_clear_scheduled_hook( 'wp_https_detection' );
 		}
+	}
+}
+
+/**
+ * Executes changes made in WordPress 6.5.0.
+ *
+ * @ignore
+ * @since 6.5.0
+ *
+ * @global int $wp_current_db_version The old (current) database version.
+ * @global wpdb $wpdb                  WordPress database abstraction object.
+ */
+function upgrade_650() {
+	global $wp_current_db_version, $wpdb;
+
+	if ( $wp_current_db_version < 57200 ) {
+		
+		$stylesheet = get_stylesheet();
+
+		// Set autoload=no for the previous all themes.
+		$theme_mods_options = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT option_name FROM $wpdb->options WHERE autoload = 'yes' AND option_name != %s AND option_name LIKE %s",
+				"theme_mods_$stylesheet",
+				$wpdb->esc_like( 'theme_mods_' ) . '%'
+			)
+		);
+
+		$autoload = array_fill_keys( $theme_mods_options, 'no' );
+		$autoload[ "theme_mods_$stylesheet" ] = 'yes';
+		var_dump( $autoload );
+		wp_set_option_autoload_values( $autoload );
 	}
 }
 

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2359,7 +2359,7 @@ function upgrade_640() {
  * @ignore
  * @since 6.5.0
  *
- * @global int $wp_current_db_version The old (current) database version.
+ * @global int  $wp_current_db_version The old (current) database version.
  * @global wpdb $wpdb                  WordPress database abstraction object.
  */
 function upgrade_650() {

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2380,7 +2380,6 @@ function upgrade_650() {
 
 		$autoload = array_fill_keys( $theme_mods_options, 'no' );
 		$autoload[ "theme_mods_$stylesheet" ] = 'yes';
-		var_dump( $autoload );
 		wp_set_option_autoload_values( $autoload );
 	}
 }

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -23,7 +23,7 @@ $wp_version = '6.5-alpha-56966-src';
  *
  * @global int $wp_db_version
  */
-$wp_db_version = 56657;
+$wp_db_version = 57200;
 
 /**
  * Holds the TinyMCE version.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/59975

This PR add upgrade routine for 6.5 that set autoload to 'no' for previously activated themes.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
