### PR TITLE
Restore This Revision" button in wp-admin revision page can become hi…

### DIFF
--- a/src/wp-admin/css/revisions.css
+++ b/src/wp-admin/css/revisions.css
@@ -578,7 +578,7 @@ div.revisions-controls > .wp-slider > .ui-slider-handle {
 
 	.revisions-controls,
 	.comparing-two-revisions .revisions-controls {
-		height: auto;
+		height: auto; 
 	}
 
 	.revisions-tooltip {

--- a/src/wp-admin/css/revisions.css
+++ b/src/wp-admin/css/revisions.css
@@ -578,7 +578,7 @@ div.revisions-controls > .wp-slider > .ui-slider-handle {
 
 	.revisions-controls,
 	.comparing-two-revisions .revisions-controls {
-		height: 170px;
+		height: auto;
 	}
 
 	.revisions-tooltip {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review for more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar-related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Fix this issue on mobile "Restore This Revision" button in the wp-admin revision page can become hidden behind the diff panel in mobile view, particularly if the post author has a longer name.

Trac ticket: https://core.trac.wordpress.org/ticket/58844

---
**This Pull Request is for code review only. Please keep all other discussions in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
