### PR TITLE
#59960 - Replace em-based line-height with unitless values in CSS

### DIFF
--- a/src/js/_enqueues/vendor/thickbox/thickbox.css
+++ b/src/js/_enqueues/vendor/thickbox/thickbox.css
@@ -80,7 +80,7 @@
 	padding: 2px 15px 15px 15px;
 	overflow: auto;
 	text-align: left;
-	line-height: 1.4em;
+	line-height: 1.4;
 }
 
 #TB_ajaxContent.TB_modal {

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -225,7 +225,7 @@ body {
 	color: #3c434a;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 13px;
-	line-height: 1.4em;
+	line-height: 1.4;
 	min-width: 600px;
 }
 
@@ -510,14 +510,14 @@ code {
 .widefat td ol,
 .widefat td ul {
 	font-size: 13px;
-	line-height: 1.5em;
+	line-height: 1.5;
 }
 
 .widefat th,
 .widefat thead td,
 .widefat tfoot td {
 	text-align: left;
-	line-height: 1.3em;
+	line-height: 1.3;
 	font-size: 14px;
 }
 
@@ -779,7 +779,7 @@ img.emoji {
 .widefat thead td,
 .widefat tfoot th,
 .widefat tfoot td {
-	line-height: 1.4em;
+	line-height: 1.4;
 }
 
 .widget .widget-top,

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -1415,7 +1415,7 @@ p.description code {
 
 p.popular-tags {
 	border: none;
-	line-height: 2em;
+	line-height: 2;
 	padding: 8px 12px 12px;
 	text-align: justify;
 }

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -1415,7 +1415,7 @@ p.description code {
 
 p.popular-tags {
 	border: none;
-	line-height: 2;
+	line-height: 2em; /* keep the em unit because tag links use multiple font sizes */
 	padding: 8px 12px 12px;
 	text-align: justify;
 }

--- a/src/wp-admin/css/install.css
+++ b/src/wp-admin/css/install.css
@@ -90,7 +90,7 @@ label {
 	color: #3c434a; /* same as login.css */
 	font-size: 20px;
 	font-weight: 400;
-	line-height: 1.3em;
+	line-height: 1.3;
 	text-decoration: none;
 	text-align: center;
 	text-indent: -9999px;

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -2249,7 +2249,7 @@ div.action-links,
 
 	table.plugin-install td.column-name strong {
 		font-size: 1.4em;
-		line-height: 1.6em;
+		line-height: 1.6;
 	}
 
 	table.plugin-install #the-list td {

--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -200,7 +200,7 @@
 	height: 22px;
 	margin: 7px 6px;
 	width: 200px;
-	line-height: 2em;
+	line-height: 2;
 	padding: 0;
 	overflow: hidden;
 	border-radius: 22px;

--- a/src/wp-admin/css/nav-menus.css
+++ b/src/wp-admin/css/nav-menus.css
@@ -178,7 +178,7 @@ input.bulk-select-switcher:focus + .bulk-select-button-label {
 	appearance: none;
 	font-size: inherit;
 	border: 0;
-	line-height: 2.1em;
+	line-height: 2.1;
 	background: none;
 	cursor: pointer;
 	text-decoration: underline;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This commit addresses ticket #59960, which identified issues with em-based line-height values in various CSS files within the WordPress Administration interface. Following the suggestion in the ticket, the em-based line-heights are replaced with unitless values while keeping their numeric value the same.

This change primarily affects the 'common.css' file but also includes updates in 'edit.css', 'install.css', 'list-tables.css', 'media.css', 'nav-menus.css', and the Thickbox styles. The update aims to enhance the consistency and scalability of the CSS and resolve issues particularly noted in iframe-based editors.

Referencing the follow-up to ticket #44643, this update aligns with the focus on coding standards and CSS improvements within the WordPress administration environment. By making line-heights unitless, we ensure better adaptability across different font sizes and display environments.

Files updated:
- wp-admin/css/common.css
- wp-admin/css/edit.css
- wp-admin/css/install.css
- wp-admin/css/list-tables.css
- wp-admin/css/media.css
- wp-admin/css/nav-menus.css
- Compiled Thickbox styles (thickbox.css)

Trac ticket: [https://core.trac.wordpress.org/ticket/59960](https://core.trac.wordpress.org/ticket/59960)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
