### PR TITLE
Taxonomy:  Check for empty term after DB sanitization in wp_insert_term

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2434,7 +2434,7 @@ function wp_insert_term( $term, $taxonomy, $args = array() ) {
 	$description = wp_unslash( $args['description'] );
 	$parent      = (int) $args['parent'];
 
-	// Santiziation could clean the name to an empty string that must be checked again. See https://core.trac.wordpress.org/ticket/59995
+	// Sanitization could clean the name to an empty string that must be checked again. See https://core.trac.wordpress.org/ticket/59995
 	if ( '' === $name ) {
 		return new WP_Error( 'invalid_term_name', __( 'Invalid term name.' ) );
 	}

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2434,6 +2434,10 @@ function wp_insert_term( $term, $taxonomy, $args = array() ) {
 	$description = wp_unslash( $args['description'] );
 	$parent      = (int) $args['parent'];
 
+	if ( '' === $name ) {
+		return new WP_Error( 'invalid_term_name', __( 'Invalid term name.' ) );
+	}
+
 	$slug_provided = ! empty( $args['slug'] );
 	if ( ! $slug_provided ) {
 		$slug = sanitize_title( $name );

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2434,6 +2434,7 @@ function wp_insert_term( $term, $taxonomy, $args = array() ) {
 	$description = wp_unslash( $args['description'] );
 	$parent      = (int) $args['parent'];
 
+	// Santiziation could clean the name to an empty string that must be checked again. See https://core.trac.wordpress.org/ticket/59995
 	if ( '' === $name ) {
 		return new WP_Error( 'invalid_term_name', __( 'Invalid term name.' ) );
 	}

--- a/tests/phpunit/tests/term/wpInsertTerm.php
+++ b/tests/phpunit/tests/term/wpInsertTerm.php
@@ -897,7 +897,7 @@ class Tests_Term_WpInsertTerm extends WP_UnitTestCase {
 
 	public function test_wp_insert_term_with_empty_name_after_db_sanitization() {
 		$term = wp_insert_term(
-			'<script>alert("hello")</script>',
+			'<script>onclick=alert("hello")</script>',
 			'post_tag'
 		);
 

--- a/tests/phpunit/tests/term/wpInsertTerm.php
+++ b/tests/phpunit/tests/term/wpInsertTerm.php
@@ -897,7 +897,7 @@ class Tests_Term_WpInsertTerm extends WP_UnitTestCase {
 
 	public function test_wp_insert_term_with_empty_name_after_db_sanitization() {
 		$term = wp_insert_term(
-			'<script>Hello</script>',
+			'<script>alert("hello")</script>',
 			'post_tag'
 		);
 

--- a/tests/phpunit/tests/term/wpInsertTerm.php
+++ b/tests/phpunit/tests/term/wpInsertTerm.php
@@ -902,7 +902,7 @@ class Tests_Term_WpInsertTerm extends WP_UnitTestCase {
 		);
 
 		$this->assertWPError( $term );
-		$this->assertSame( 'invalid_term_name', $found->get_error_code() );
+		$this->assertSame( 'invalid_term_name', $term->get_error_code() );
 	}
 
 	/** Helpers */

--- a/tests/phpunit/tests/term/wpInsertTerm.php
+++ b/tests/phpunit/tests/term/wpInsertTerm.php
@@ -895,6 +895,16 @@ class Tests_Term_WpInsertTerm extends WP_UnitTestCase {
 		$this->assertSame( '', $term_object->description );
 	}
 
+	public function test_wp_insert_term_with_empty_name_after_db_sanitization() {
+		$term = wp_insert_term(
+			'<script>Hello</script>',
+			'post_tag'
+		);
+
+		$this->assertWPError( $term );
+		$this->assertSame( 'invalid_term_name', $found->get_error_code() );
+	}
+
 	/** Helpers */
 
 	public function deleted_term_cb( $term, $tt_id, $taxonomy, $deleted_term, $object_ids ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

When inserting a new term in the database, `wp_insert_term` will check if the term is empty and return a corresponding error.
Afterwards the term is sanitized and inserted in the database. However, there's a chance the term is empty after the DB sanitization.
This is never checked though and will result in 1) empty terms in the DB and 2) possible OOM issues in `wp_insert_term` when checking if the term name matches an existing one because of using `get_terms` with an empty name argument

The current PR:
- Adds a check for empty term name after the term is sanitized and returns an error if the term is empty.
- Adds a corresponding unit test

Trac ticket: https://core.trac.wordpress.org/ticket/59995

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
