### PR TITLE
Block Hooks: Inject hooked blocks into modified templates and parts

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -901,6 +901,14 @@ function _build_block_template_result_from_post( $post ) {
 		}
 	}
 
+	$hooked_blocks = get_hooked_blocks();
+	if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
+		$before_block_visitor = make_before_block_visitor( $hooked_blocks, $template );
+		$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $template );
+		$blocks               = parse_blocks( $template->content );
+		$template->content    = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
+	}
+
 	return $template;
 }
 

--- a/tests/phpunit/tests/block-templates/base.php
+++ b/tests/phpunit/tests/block-templates/base.php
@@ -39,7 +39,7 @@ abstract class WP_Block_Templates_UnitTestCase extends WP_UnitTestCase {
 				'post_type'    => 'wp_template',
 				'post_name'    => 'my_template',
 				'post_title'   => 'My Template',
-				'post_content' => 'Content',
+				'post_content' => '<!-- wp:heading {"level":1} --><h1>Template</h1><!-- /wp:heading -->' ,
 				'post_excerpt' => 'Description of my template',
 				'tax_input'    => array(
 					'wp_theme' => array(
@@ -57,7 +57,7 @@ abstract class WP_Block_Templates_UnitTestCase extends WP_UnitTestCase {
 				'post_type'    => 'wp_template_part',
 				'post_name'    => 'my_template_part',
 				'post_title'   => 'My Template Part',
-				'post_content' => 'Content',
+				'post_content' => '<!-- wp:heading {"level":2} --><h2>Template Part</h2><!-- /wp:heading -->' ,
 				'post_excerpt' => 'Description of my template part',
 				'tax_input'    => array(
 					'wp_theme'              => array(

--- a/tests/phpunit/tests/block-templates/base.php
+++ b/tests/phpunit/tests/block-templates/base.php
@@ -39,7 +39,7 @@ abstract class WP_Block_Templates_UnitTestCase extends WP_UnitTestCase {
 				'post_type'    => 'wp_template',
 				'post_name'    => 'my_template',
 				'post_title'   => 'My Template',
-				'post_content' => '<!-- wp:heading {"level":1} --><h1>Template</h1><!-- /wp:heading -->' ,
+				'post_content' => '<!-- wp:heading {"level":1} --><h1>Template</h1><!-- /wp:heading -->',
 				'post_excerpt' => 'Description of my template',
 				'tax_input'    => array(
 					'wp_theme' => array(
@@ -57,7 +57,7 @@ abstract class WP_Block_Templates_UnitTestCase extends WP_UnitTestCase {
 				'post_type'    => 'wp_template_part',
 				'post_name'    => 'my_template_part',
 				'post_title'   => 'My Template Part',
-				'post_content' => '<!-- wp:heading {"level":2} --><h2>Template Part</h2><!-- /wp:heading -->' ,
+				'post_content' => '<!-- wp:heading {"level":2} --><h2>Template Part</h2><!-- /wp:heading -->',
 				'post_excerpt' => 'Description of my template part',
 				'tax_input'    => array(
 					'wp_theme'              => array(

--- a/tests/phpunit/tests/block-templates/buildBlockTemplateResultFromPost.php
+++ b/tests/phpunit/tests/block-templates/buildBlockTemplateResultFromPost.php
@@ -9,6 +9,21 @@ require_once __DIR__ . '/base.php';
 class Tests_Block_Templates_BuildBlockTemplateResultFromPost extends WP_Block_Templates_UnitTestCase {
 
 	/**
+	 * Tear down each test method.
+	 *
+	 * @since 6.5.0
+	 */
+	public function tear_down() {
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		if ( $registry->is_registered( 'tests/my-block' ) ) {
+			$registry->unregister( 'tests/my-block' );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
 	 * @ticket 54335
 	 */
 	public function test_should_build_template() {
@@ -48,5 +63,47 @@ class Tests_Block_Templates_BuildBlockTemplateResultFromPost extends WP_Block_Te
 		$this->assertSame( 'wp_template_part', $template_part->type );
 		$this->assertSame( WP_TEMPLATE_PART_AREA_HEADER, $template_part->area );
 		$this->assertSame( self::$template_part_post->post_modified, $template_part->modified, 'Template part result properties match' );
+	}
+
+	/**
+	 * @ticket 59646
+	 */
+	public function test_should_inject_hooked_block_into_template() {
+		register_block_type(
+			'tests/my-block',
+			array(
+				'block_hooks' => array(
+					'core/heading' => 'before',
+				),
+			)
+		);
+
+		$template = _build_block_template_result_from_post(
+			self::$template_post,
+			'wp_template'
+		);
+		$this->assertStringStartsWith( '<!-- wp:tests/my-block /-->', $template->content );
+		$this->assertStringContainsString( '"metadata":{"ignoredHookedBlocks":["tests/my-block"]}', $template->content );
+	}
+
+	/**
+	 * @ticket 59646
+	 */
+	public function test_should_inject_hooked_block_into_template_part() {
+		register_block_type(
+			'tests/my-block',
+			array(
+				'block_hooks' => array(
+					'core/heading' => 'after',
+				),
+			)
+		);
+
+		$template_part = _build_block_template_result_from_post(
+			self::$template_part_post,
+			'wp_template_part'
+		);
+		$this->assertStringEndsWith( '<!-- wp:tests/my-block /-->', $template_part->content );
+		$this->assertStringContainsString( '"metadata":{"ignoredHookedBlocks":["tests/my-block"]}', $template_part->content );
 	}
 }


### PR DESCRIPTION
Using the new technique of storing information about whether or not a hooked block should be considered for injection or not, extend said injection to encompass _modified_ templates and parts.

Follow-up to https://github.com/WordPress/wordpress-develop/pull/5712.

Trac ticket: https://core.trac.wordpress.org/ticket/59646

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
