### PR TITLE
add test for attachment page redirects for visitor

### DIFF
--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -548,13 +548,18 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 	$is_attachment_redirect = false;
 
 	if ( is_attachment() && ! get_option( 'wp_attachment_pages_enabled' ) ) {
-		$attachment_id = get_query_var( 'attachment_id' );
+		$attachment_id        = get_query_var( 'attachment_id' );
+		$attachment_post      = get_post( $attachment_id );
+		$attachment_parent_id = $attachment_post ? $attachment_post->post_parent : 0;
 
-		if ( current_user_can( 'read_post', $attachment_id ) ) {
-			$redirect_url = wp_get_attachment_url( $attachment_id );
-
-			$is_attachment_redirect = true;
+		// If attachment is attached to a post, attachment page inherits parent post's private status,
+		// so fetch the post to have its private status checked later.
+		if ( $attachment_parent_id ) {
+			$redirect_obj = get_post ( $attachment_parent_id );
 		}
+		$redirect_url = wp_get_attachment_url( $attachment_id );
+
+		$is_attachment_redirect = true;
 	}
 
 	$redirect['query'] = preg_replace( '#^\??&*?#', '', $redirect['query'] );

--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -555,7 +555,7 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 		// If attachment is attached to a post, attachment page inherits parent post's private status,
 		// so fetch the post to have its private status checked later.
 		if ( $attachment_parent_id ) {
-			$redirect_obj = get_post ( $attachment_parent_id );
+			$redirect_obj = get_post( $attachment_parent_id );
 		}
 		$redirect_url = wp_get_attachment_url( $attachment_id );
 

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -425,4 +425,29 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 
 		$this->assertSame( $expected, $url );
 	}
+
+	/**
+	 * @ticket 59866
+	 */
+	public function test_canonical_attachment_page_redirect_with_option_disabled_for_visitors()
+	{
+		add_filter('pre_option_wp_attachment_pages_enabled', '__return_false');
+
+		$filename = DIR_TESTDATA . '/images/test-image.jpg';
+		$contents = file_get_contents($filename);
+		$upload   = wp_upload_bits(wp_basename($filename), null, $contents);
+
+		$attachment_id   = $this->_make_attachment($upload);
+		$attachment_page = get_permalink($attachment_id);
+
+		// Unset current user to test as visitor.
+		wp_set_current_user(0);
+
+		$this->go_to($attachment_page);
+
+		$url      = redirect_canonical($attachment_page, false);
+		$expected = wp_get_attachment_url($attachment_id);
+
+		$this->assertSame($expected, $url);
+	}
 }

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -429,7 +429,7 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 	/**
 	 * @ticket 59866
 	 */
-	public function test_canonical_attachment_page_redirect_with_option_disabled_for_visitors(){
+	public function test_canonical_attachment_page_redirect_with_option_disabled_for_visitors() {
 		add_filter( 'pre_option_wp_attachment_pages_enabled', '__return_false' );
 
 		$filename = DIR_TESTDATA . '/images/test-image.jpg';

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -429,25 +429,24 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 	/**
 	 * @ticket 59866
 	 */
-	public function test_canonical_attachment_page_redirect_with_option_disabled_for_visitors()
-	{
-		add_filter('pre_option_wp_attachment_pages_enabled', '__return_false');
+	public function test_canonical_attachment_page_redirect_with_option_disabled_for_visitors(){
+		add_filter( 'pre_option_wp_attachment_pages_enabled', '__return_false' );
 
 		$filename = DIR_TESTDATA . '/images/test-image.jpg';
-		$contents = file_get_contents($filename);
-		$upload   = wp_upload_bits(wp_basename($filename), null, $contents);
+		$contents = file_get_contents( $filename );
+		$upload   = wp_upload_bits( wp_basename( $filename ), null, $contents );
 
-		$attachment_id   = $this->_make_attachment($upload);
-		$attachment_page = get_permalink($attachment_id);
+		$attachment_id   = $this->_make_attachment( $upload );
+		$attachment_page = get_permalink( $attachment_id );
 
 		// Unset current user to test as visitor.
-		wp_set_current_user(0);
+		wp_set_current_user( 0 );
 
-		$this->go_to($attachment_page);
+		$this->go_to( $attachment_page );
 
-		$url      = redirect_canonical($attachment_page, false);
-		$expected = wp_get_attachment_url($attachment_id);
+		$url      = redirect_canonical( $attachment_page, false );
+		$expected = wp_get_attachment_url( $attachment_id );
 
-		$this->assertSame($expected, $url);
+		$this->assertSame( $expected, $url );
 	}
 }


### PR DESCRIPTION
Trac ticket: [59866](https://core.trac.wordpress.org/ticket/59866)

This PR adds a test for checking the attachment page redirection to the attachment file for the visitors.

Props  👏  @chesio for the patch @mukeshpanchal27 PR review and @joppuyo @afercia @SergeyBiryukov
