### PR TITLE
Post a Playground link on every PR using the pull_request_target workflow

### DIFF
--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -89,7 +89,7 @@ jobs:
             const commentInfo = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.event.number
+              issue_number: ${{ github.event.number }}
             };
             const comments = ( await github.rest.issues.listComments( commentInfo ) ).data;
 
@@ -115,7 +115,7 @@ jobs:
 
             For more details about these limitations and more, check out the [Limitations page](https://wordpress.github.io/wordpress-playground/limitations/) in the WordPress Playground documentation.
 
-            [Test this pull request with WordPress Playground](https://playground.wordpress.net/wordpress.html?pr=${ context.payload.event.number }).
+            [Test this pull request with WordPress Playground](https://playground.wordpress.net/wordpress.html?pr=${{ github.event.number }}).
             `;
 
             github.rest.issues.createComment( commentInfo );

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -3,7 +3,8 @@ name: Pull Request Comments
 
 on:
   pull_request:
-    types: [ 'opened', 'edited' ]
+    branches:
+      - trunk
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -26,7 +26,7 @@ jobs:
       issues: write
       pull-requests: write
     timeout-minutes: 5
-    # if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name == 'pull_request' }}
+    if: ${{ github.repository == 'adam/wordpress-develop' && github.event_name == 'pull_request' }}
     steps:
       - uses: wow-actions/welcome@72817eb31cda1de60f51893d80e2e82ce57f7e76 # v1.3.0
         with:
@@ -82,7 +82,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    # if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'adam/wordpress-develop' && github.event_name == 'pull_request' }}
     steps:
       - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -3,7 +3,7 @@ name: Pull Request Comments
 
 on:
   pull_request:
-    types: [ 'opened' ]
+    types: [ 'opened', 'edited' ]
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -2,8 +2,7 @@
 name: Pull Request Comments
 
 on:
-  pull_request_target:
-    types: [ 'opened' ]
+  pull_request:
   workflow_dispatch:
     inputs:
       pr_number:
@@ -15,8 +14,7 @@ on:
 concurrency:
   # The concurrency group contains the workflow name and the branch name for pull requests
   # or the commit hash for any other events.
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.event_name == 'workflow_dispatch' && inputs.pr_number || github.sha }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.event_name == 'workflow_dispatch' && inputs.pr_number || github.sha }}
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
@@ -30,8 +28,7 @@ jobs:
       issues: write
       pull-requests: write
     timeout-minutes: 5
-    if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name == 'pull_request_target' }}
-
+    if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name == 'pull_request' }}
     steps:
       - uses: wow-actions/welcome@72817eb31cda1de60f51893d80e2e82ce57f7e76 # v1.3.0
         with:

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -2,7 +2,7 @@
 name: Pull Request Comments
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
     branches:
       - trunk
@@ -12,7 +12,7 @@ on:
 concurrency:
   # The concurrency group contains the workflow name and the branch name for pull requests
   # or the commit hash for any other events.
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.event_name == 'workflow_dispatch' && github.event.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.event_name == 'workflow_dispatch' && github.event.number || github.sha }}
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
@@ -26,7 +26,7 @@ jobs:
       issues: write
       pull-requests: write
     timeout-minutes: 5
-    if: ${{ github.repository == 'adamziel/wordpress-develop' && github.event_name == 'pull_request' }}
+    if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name == 'pull_request_target' }}
     steps:
       - uses: wow-actions/welcome@72817eb31cda1de60f51893d80e2e82ce57f7e76 # v1.3.0
         with:
@@ -82,7 +82,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: ${{ github.repository == 'adamziel/wordpress-develop' && github.event_name == 'pull_request' }}
+    if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name == 'pull_request_target' }}
     steps:
       - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -29,7 +29,7 @@ jobs:
       issues: write
       pull-requests: write
     timeout-minutes: 5
-    if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name == 'pull_request' }}
+    # if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name == 'pull_request' }}
     steps:
       - uses: wow-actions/welcome@72817eb31cda1de60f51893d80e2e82ce57f7e76 # v1.3.0
         with:
@@ -85,7 +85,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name == 'workflow_dispatch' }}
+    # if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -3,6 +3,7 @@ name: Pull Request Comments
 
 on:
   pull_request:
+    types: [ 'opened' ]
   workflow_dispatch:
     inputs:
       pr_number:

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -3,8 +3,10 @@ name: Pull Request Comments
 
 on:
   pull_request:
+    types: [opened]
     branches:
       - trunk
+    
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -26,7 +26,7 @@ jobs:
       issues: write
       pull-requests: write
     timeout-minutes: 5
-    if: ${{ github.repository == 'adam/wordpress-develop' && github.event_name == 'pull_request' }}
+    if: ${{ github.repository == 'adamziel/wordpress-develop' && github.event_name == 'pull_request' }}
     steps:
       - uses: wow-actions/welcome@72817eb31cda1de60f51893d80e2e82ce57f7e76 # v1.3.0
         with:
@@ -82,7 +82,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: ${{ github.repository == 'adam/wordpress-develop' && github.event_name == 'pull_request' }}
+    if: ${{ github.repository == 'adamziel/wordpress-develop' && github.event_name == 'pull_request' }}
     steps:
       - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -3,7 +3,7 @@ name: Pull Request Comments
 
 on:
   pull_request_target:
-    types: [opened]
+    types: [ 'opened' ]
     branches:
       - trunk
     

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -4,18 +4,12 @@ name: Pull Request Comments
 on:
   pull_request:
     types: [ 'opened' ]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: 'The pull request number to process.'
-        required: true
-        type: string
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
   # The concurrency group contains the workflow name and the branch name for pull requests
   # or the commit hash for any other events.
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.event_name == 'workflow_dispatch' && inputs.pr_number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.event_name == 'workflow_dispatch' && github.event.number || github.sha }}
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
@@ -94,7 +88,7 @@ jobs:
             const commentInfo = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.inputs.pr_number
+              issue_number: context.payload.event.number
             };
             const comments = ( await github.rest.issues.listComments( commentInfo ) ).data;
 
@@ -120,7 +114,7 @@ jobs:
 
             For more details about these limitations and more, check out the [Limitations page](https://wordpress.github.io/wordpress-playground/limitations/) in the WordPress Playground documentation.
 
-            [Test this pull request with WordPress Playground](https://playground.wordpress.net/wordpress.html?pr=${ context.payload.inputs.pr_number }).
+            [Test this pull request with WordPress Playground](https://playground.wordpress.net/wordpress.html?pr=${ context.payload.event.number }).
             `;
 
             github.rest.issues.createComment( commentInfo );

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -128,6 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
+    needs: [ slack-notifications ]
     if: |
       always() &&
       github.repository == 'WordPress/wordpress-develop' &&

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -106,32 +106,6 @@ jobs:
       os: ${{ matrix.os }}
       directory: ${{ matrix.directory }}
 
-  # Calls the Pull Request Commenting workflow to leave a comment detailing how to test the PR within WordPress Playground.
-  playground-comment:
-    name: Leave WordPress Playground details
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    continue-on-error: true
-    needs: [ test-core-build-process, test-core-build-process-macos, test-gutenberg-build-process, test-gutenberg-build-process-macos ]
-    if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name == 'pull_request' }}
-
-    steps:
-      - name: Dispatch workflow run
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
-        with:
-          retries: 2
-          retry-exempt-status-codes: 418
-          script: |
-            github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'pull-request-comments.yml',
-              ref: 'trunk',
-              inputs: {
-                pr_number: '${{ github.event.number }}'
-              }
-            });
 
   slack-notifications:
     name: Slack Notifications
@@ -139,7 +113,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-    needs: [ test-core-build-process, test-core-build-process-macos, test-gutenberg-build-process, test-gutenberg-build-process-macos, playground-comment ]
+    needs: [ test-core-build-process, test-core-build-process-macos, test-gutenberg-build-process, test-gutenberg-build-process-macos ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name != 'pull_request' && always() }}
     with:
       calling_status: ${{ contains( needs.*.result, 'cancelled' ) && 'cancelled' || contains( needs.*.result, 'failure' ) && 'failure' || 'success' }}
@@ -154,7 +128,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
-    needs: [ playground-comment ]
     if: |
       always() &&
       github.repository == 'WordPress/wordpress-develop' &&


### PR DESCRIPTION
Follows up on https://github.com/WordPress/wordpress-develop/pull/5526

Related:

* https://github.com/WordPress/wordpress-develop/pull/5742
* https://github.com/WordPress/wordpress-playground/pull/853

Updates the `pull-request-comments.yml` workflow to post the Playground comment on the `pull_request_target` trigger, not on the `workflow_dispatch` trigger.

Here's how it works in my fork: https://github.com/adamziel/wordpress-develop/pull/11

The previous attempt leaned on [workflow_dispatch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch). The goal was to only post a comment once the build workflow creates the `wordpress.zip` artifact required by the PR previewer. However, `workflow_dispatch` seems to have less permissions than the `pull_request_target` trigger. The workflows dispatched that way fail with a 403 error and the following error message:

```
data: {
      message: 'Resource not accessible by integration',
      documentation_url: 'https://docs.github.com/rest/actions/workflows#create-a-workflow-dispatch-event'
}
```

Since there doesn't seem to be a straightforward way to only post the comment when the build artifact is ready, I propose posting it immediately and then handling the UX on the PR previewer side. It could display a progress indicator and say "That Pull Request is still being built on GitHub, you'll be redirected to the preview as soon as it's ready!"

See how the commenting workflow failed on all these PRs:

<img width="400" alt="CleanShot 2023-12-07 at 21 34 00@2x" src="https://github.com/WordPress/wordpress-develop/assets/205419/640b8fb8-e864-4e34-883b-23452f2c219b">

## Testing instructions

* Confirm the Playground comment is intact in this PR on Adam's fork: https://github.com/adamziel/wordpress-develop/pull/11
* Confirm the change looks good and makes sense
* Hope for the best since we can't test in the wordpress-develop repo without merging

## Security implications

The `playground-details` workflow follows the pattern established by the `post-welcome-message` workflow:

* It's triggered by the `pull_request_target` trigger on the `trunk` branch.
* It uses the same `if` condition and `permissions` clause.
* It performs the same task of posting a comment using the GITHUB_TOKEN to access the repo.

Therefore, it shouldn't introduce any security risks.

## Alternatives considered

### Passing the GITHUB_TOKEN via `inputs`

The following dispatch call worked in my private fork, which made me hopeful. However, if I ran it without passing the `github_token`, it also worked. This is the how the original [403 error](https://github.com/WordPress/wordpress-develop/actions/runs/6572036562/job/17852349020?pr=5526) got merged via PR #5526. We would have to essentially merge this change and test it in production, which I'm not too excited about.

```
          script: |
            github.rest.actions.createWorkflowDispatch({
              owner: context.repo.owner,
              repo: context.repo.repo,
              workflow_id: 'pull-request-comments.yml',
              ref: 'trunk',
              inputs: {
                pr_number: '${{ github.event.number }}',
                github_token: '${{ secrets.GITHUB_TOKEN }}'
              }
            });
```

### Moving the commenting action to the same workflow as the build jobs

The job responsible for commenting could be moved into `test-build-processes.yml` and run after the build workflows, avoiding this entire conundrum. However, a large point of splitting the jobs into multiple files, was to maintain the separation between the build jobs and the commenting jobs. Therefore, I propose to keep these separate.

### Using `on: workflow_run`

@swissspidy proposed the following trigger in https://github.com/WordPress/wordpress-develop/pull/5738:

```yml
on:
  workflow_run:
    workflows:
      - Test Build Processes
    types:
      - completed
```

Unfortunately, I could not get that to run on my fork. I suspect this might be related to this note in the workflows documentation:

> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run.

https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow

## Before merging

~~Let's do the reviewing and approving here, but let's hold off with merging until the related progress indicator work is shipped in the WordPress Playground repo.~~

The required changes in Playground were merged in https://github.com/WordPress/wordpress-playground/pull/853

Trac Ticket: https://core.trac.wordpress.org/ticket/59416.

cc @desrosj @swissspidy 