### PR TITLE
Initialize $url variable later in get_bloginfo()

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -906,17 +906,12 @@ function get_bloginfo( $show = '', $filter = 'raw' ) {
 			break;
 	}
 
-	$url = true;
-
-	if ( ! str_contains( $show, 'url' )
-		&& ! str_contains( $show, 'directory' )
-		&& ! str_contains( $show, 'home' )
-	) {
-		$url = false;
-	}
-
 	if ( 'display' === $filter ) {
-		if ( $url ) {
+		if (
+			str_contains( $show, 'url' )
+			|| str_contains( $show, 'directory' )
+			|| str_contains( $show, 'home' )
+		) {
 			/**
 			 * Filters the URL returned by get_bloginfo().
 			 *


### PR DESCRIPTION
Based on https://core.trac.wordpress.org/attachment/ticket/59450/general-template.php.patch, see https://core.trac.wordpress.org/ticket/59450#comment:5.

Trac ticket: https://core.trac.wordpress.org/ticket/59450

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
