### PR TITLE
Update the minimum required version of MySQL.

### DIFF
--- a/src/readme.html
+++ b/src/readme.html
@@ -52,7 +52,7 @@
 <h2>System Requirements</h2>
 <ul>
 	<li><a href="https://secure.php.net/">PHP</a> version <strong>7.0</strong> or greater.</li>
-	<li><a href="https://www.mysql.com/">MySQL</a> version <strong>5.0</strong> or greater.</li>
+	<li><a href="https://www.mysql.com/">MySQL</a> version <strong>5.5.5</strong> or greater.</li>
 </ul>
 
 <h3>Recommendations</h3>

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -44,4 +44,4 @@ $required_php_version = '7.0.0';
  *
  * @global string $required_mysql_version
  */
-$required_mysql_version = '5.0';
+$required_mysql_version = '5.5.5';


### PR DESCRIPTION
Raises the minimum version of MySQL required to run WordPress to 5.5.5.

Trac ticket: core.trac.wordpress.org/ticket/60036

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
