### PR TITLE
Zip WordPress files before npm run clean

### DIFF
--- a/.github/workflows/callable-test-core-build-process.yml
+++ b/.github/workflows/callable-test-core-build-process.yml
@@ -68,6 +68,10 @@ jobs:
       - name: Ensure version-controlled files are not modified or deleted during building
         run: git diff --exit-code
 
+      - name: Create ZIP of built files
+        if: ${{ inputs.directory == 'build' && 'ubuntu-latest' == inputs.os }}
+        run: zip -r wordpress.zip build/.
+
       - name: Clean after building to run from ${{ inputs.directory }}
         run: npm run grunt clean${{ inputs.directory == 'src' && ' -- --dev' || '' }}
 

--- a/.github/workflows/callable-test-core-build-process.yml
+++ b/.github/workflows/callable-test-core-build-process.yml
@@ -78,10 +78,6 @@ jobs:
       - name: Ensure version-controlled files are not modified or deleted during cleaning
         run: git diff --exit-code
 
-      - name: Create ZIP of built files
-        if: ${{ inputs.directory == 'build' && 'ubuntu-latest' == inputs.os }}
-        run: zip -r wordpress.zip build/.
-
       - name: Upload ZIP as a GitHub Actions artifact
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         if: ${{ inputs.directory == 'build' && 'ubuntu-latest' == inputs.os }}


### PR DESCRIPTION
Moves the zipping step before cleaning the dist directory.

The callable-test-core-build-process.yml zips the WordPress dist directory *after* `npm run grunt clean` runs. This produces a mostly empty zip artifact that's only 332 bytes.

## Testing instructions:

A single CI check called "Test Build Processes / Leave WordPress Playground details (pull_request)" is red in this PR, that's expected – that's explained in details in here: https://github.com/WordPress/wordpress-develop/pull/5737 

Confirm the zip artifact does contain the WordPress build directory in [PR 16 in Adam's fork](https://github.com/adamziel/wordpress-develop/pull/16) ([link to the workflow run](https://github.com/adamziel/wordpress-develop/actions/runs/7142763501?pr=16)).

<img width="1044" alt="CleanShot 2023-12-08 at 16 07 30@2x" src="https://github.com/WordPress/wordpress-develop/assets/205419/c7da7855-2366-4d23-9939-142e95c1f20e">


Trac Ticket: https://core.trac.wordpress.org/ticket/59416
