### PR TITLE
Add Test for wp_default_packages_vendor

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -110,7 +110,7 @@ function wp_default_packages_vendor( $scripts ) {
 		'react-dom'                   => '18.2.0',
 		'regenerator-runtime'         => '0.14.0',
 		'moment'                      => '2.29.4',
-		'lodash'                      => '4.17.19',
+		'lodash'                      => '4.17.21',
 		'wp-polyfill-fetch'           => '3.6.17',
 		'wp-polyfill-formdata'        => '4.0.10',
 		'wp-polyfill-node-contains'   => '4.8.0',

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -3352,4 +3352,41 @@ HTML
 
 		);
 	}
+
+	/**
+	 * @ticket 60048
+	 *
+	 * @covers ::wp_default_packages_vendor
+	 *
+	 * @dataProvider data_wp_default_packages_vendor
+	 */
+	public function test_wp_default_packages_vendor_lodash( $script ) {
+		global $wp_scripts;
+		$package_json = $this->_scripts_from_package_json();
+
+		wp_default_packages_vendor( $wp_scripts );
+
+		$this->assertEquals( $package_json[ $script ], $wp_scripts->query( $script, 'registered' )->ver );
+	}
+
+	public function data_wp_default_packages_vendor() {
+		return array(
+			array( 'script' => 'lodash' ),
+			array( 'script' => 'moment' ),
+			array( 'script' => 'react' ),
+			array( 'script' => 'react-dom' ),
+			array( 'script' => 'regenerator-runtime' ),
+		);
+	}
+
+	/**
+	 * Helper to return dependencies from package.json.
+	 */
+	private function _scripts_from_package_json() {
+		$package = file_get_contents( ABSPATH . '../package.json' );
+		$data    = json_decode( $package, true );
+
+		$provider = array();
+		return $data['dependencies'];
+	}
 }


### PR DESCRIPTION
See: https://core.trac.wordpress.org/ticket/60048


Based on @swissspidy's suggestion, I added a simple test to ensure the registered version is the same as the version loaded via package.json. 

The test only includes a subset of scripts since the others are renamed. Rather than adjusting the way scripts are loaded, this makes the list of which scripts to test a hard-coded version. 

This incorporates the fix from #5755.