### PR TITLE
Add unit tests for apache_mod_loaded function

### DIFF
--- a/tests/phpunit/tests/functions/apacheModLoaded.php
+++ b/tests/phpunit/tests/functions/apacheModLoaded.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Tests for the apache_mod_loaded function.
+ *
+ * @group Functions.php
+ *
+ * @covers ::apache_mod_loaded
+ */
+class Tests_Functions_apacheModLoaded extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 60054
+	 *
+	 * @dataProvider data_apache_mod_loaded
+	 */
+	public function test_apache_mod_loaded( $mod, $default_value, $expected ) {
+
+		$this->assertSame( $expected, apache_mod_loaded( $mod, $default_value ) );
+	}
+
+	/**
+	 * Returns the data provider array for the test function test_apache_mod_loaded.
+	 *
+	 * @return array The data provider array.
+	 */
+	public function data_apache_mod_loaded() {
+		global $is_apache;
+
+		return array(
+			'default'       => array(
+				'mod'      => 'mod_rewrite',
+				'default'  => null,
+				'expected' => $is_apache,
+			),
+			'missing_mod'   => array(
+				'mod'      => 'missing_mod',
+				'default'  => null,
+				'expected' => false,
+			),
+			'default_value' => array(
+				'mod'      => 'missing_mod',
+				'default'  => 'default_value',
+				'expected' => ( ! $is_apache ) ? false : 'default_value',
+			),
+		);
+	}
+}


### PR DESCRIPTION
The commit introduces tests for the apache_mod_loaded function in the WordPress codebase. These PHPUnit tests ensure the function's reliability and correctness by testing various scenarios, including presence of 'mod_rewrite', missing modules, and default values.

Trac ticket: https://core.trac.wordpress.org/ticket/60054