### PR TITLE
Add unit tests for is_lighttpd_before_150 function

### DIFF
--- a/tests/phpunit/tests/functions/isLighttpdBefore150.php
+++ b/tests/phpunit/tests/functions/isLighttpdBefore150.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Tests for the is_lighttpd_before_150 function.
+ *
+ * @group Functions.php
+ *
+ * @covers ::is_lighttpd_before_150
+ */
+class Tests_Functions_isLighttpdBefore150 extends WP_UnitTestCase{
+
+	/**
+	 * @ticket 60056
+	 */
+	public function test_is_lighttpd_before_150() {
+		$this->assertFalse(is_lighttpd_before_150());
+	}
+}


### PR DESCRIPTION
The commit introduces a new PHPUnit test for the is_lighttpd_before_150 function in the WordPress codebase. These tests will verify the return of this function, ensuring its correct behavior and improving the robustness of the codebase.

Trac ticket: https://core.trac.wordpress.org/ticket/60056