### PR TITLE
Add unit test for `wp_match_mime_types` function

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3286,13 +3286,18 @@ function wp_match_mime_types( $wildcard_mime_types, $real_mime_types ) {
 		$real_mime_types = array_map( 'trim', explode( ',', $real_mime_types ) );
 	}
 
+	if ( empty( $wildcard_mime_types ) || empty( $real_mime_types ) ) {
+
+		return $matches;
+	}
+
 	$patternses = array();
 	$wild       = '[-._a-z0-9]*';
 
 	foreach ( (array) $wildcard_mime_types as $type ) {
 		$mimes = array_map( 'trim', explode( ',', $type ) );
 		foreach ( $mimes as $mime ) {
-			$regex = str_replace( '__wildcard__', $wild, preg_quote( str_replace( '*', '__wildcard__', $mime ) ) );
+			$regex = str_replace( '__wildcard__', $wild, preg_quote( str_replace( '*', '__wildcard__', $mime ), null ) );
 
 			$patternses[][ $type ] = "^$regex$";
 

--- a/tests/phpunit/tests/post/wp_match_mime_types.php
+++ b/tests/phpunit/tests/post/wp_match_mime_types.php
@@ -15,7 +15,7 @@ class Tests_Post_wp_match_mime_type extends WP_UnitTestCase {
 	 * @dataProvider data_wp_match_mime_types
 	 */
 	public function test_wp_match_mime_types( $wildcard_mime_types, $real_mime_types, $expected ) {
-//		var_dump($real_mime_types);
+
 		$this->assertEqualSets( $expected, wp_match_mime_types( $wildcard_mime_types, $real_mime_types ) );
 	}
 

--- a/tests/phpunit/tests/post/wp_match_mime_types.php
+++ b/tests/phpunit/tests/post/wp_match_mime_types.php
@@ -3,7 +3,7 @@
 /**
  * Tests for the wp_match_mime_types function.
  *
- * @group Post.php
+ * @group post
  *
  * @covers ::wp_match_mime_types
  */

--- a/tests/phpunit/tests/post/wp_match_mime_types.php
+++ b/tests/phpunit/tests/post/wp_match_mime_types.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Tests for the wp_match_mime_types function.
+ *
+ * @group Post.php
+ *
+ * @covers ::wp_match_mime_types
+ */
+class Tests_Post_wp_match_mime_type extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 60003
+	 *
+	 * @dataProvider data_wp_match_mime_types
+	 */
+	public function test_wp_match_mime_types( $wildcard_mime_types, $real_mime_types, $expected ) {
+//		var_dump($real_mime_types);
+		$this->assertEqualSets( $expected, wp_match_mime_types( $wildcard_mime_types, $real_mime_types ) );
+	}
+
+	/**
+	 * Returns an array of test cases for the data_wp_match_mime_types method.
+	 *
+	 * @return array An array of test cases, each containing 'wildcard_mime_types', 'real_mime_types',
+	 *                and 'expected' keys representing the input values and the expected output.
+	 */
+	public function data_wp_match_mime_types() {
+
+		return array(
+			'default'      => array(
+				'wildcard_mime_types' => 'image',
+				'real_mime_types'     => 'image/jpeg',
+				'expected'            => array( array( 'image/jpeg' ) ),
+			),
+			'null'         => array(
+				'wildcard_mime_types' => 'image',
+				'real_mime_types'     => null,
+				'expected'            => array(), // return early
+			),
+			'missing_parm' => array(
+				'wildcard_mime_types' => null,
+				'real_mime_types'     => 'image/jpeg',
+				'expected'            => array(), // return early
+			),
+			'null_string'  => array(
+				'wildcard_mime_types' => 'image',
+				'real_mime_types'     => 'null',
+				'expected'            => array(), // not found
+			),
+			'png'          => array(
+				'wildcard_mime_types' => 'png',
+				'real_mime_types'     => 'image/jpeg, image/png',
+				'expected'            => array( array( 'image/png' ) ),
+			),
+		);
+	}
+}


### PR DESCRIPTION
A PHPUnit test for the `wp_match_mime_types` function has been added to ensure that it behaves as expected in different scenarios. The function has also been refactored to better handle empty input, improving its robustness and reliability. Moreover, the usage of `preg_quote` has been tweaked to avoid potential issues with MIME type matching.

Trac ticket: https://core.trac.wordpress.org/ticket/60003
