### PR TITLE
PHP 8.0 was the highest version of PHP supported by WP 5.8.

### DIFF
--- a/.env
+++ b/.env
@@ -16,7 +16,7 @@ LOCAL_PORT=8889
 LOCAL_DIR=src
 
 # The PHP version to use. Valid options are 'latest', and '{version}-fpm'.
-LOCAL_PHP=latest
+LOCAL_PHP=8.0-fpm
 
 ##
 # The PHPUnit version to use when running tests.


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/60095

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
