### PR TITLE
PHP 8.1 was the highest version of PHP supported by WP 6.0.

### DIFF
--- a/.env
+++ b/.env
@@ -15,7 +15,7 @@ LOCAL_PORT=8889
 LOCAL_DIR=src
 
 # The PHP version to use. Valid options are 'latest', and '{version}-fpm'.
-LOCAL_PHP=latest
+LOCAL_PHP=8.1-fpm
 
 # Whether or not to enable XDebug.
 LOCAL_PHP_XDEBUG=false

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -26,6 +26,7 @@ concurrency:
 
 env:
   LOCAL_DIR: build
+  LOCAL_PHP: 8.0-fpm
 
 jobs:
   # Runs the end-to-end test suite.


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/60095