### PR TITLE
PHP 8.3 was the highest version of PHP supported by WP 6.4.

### DIFF
--- a/.env
+++ b/.env
@@ -15,7 +15,7 @@ LOCAL_PORT=8889
 LOCAL_DIR=src
 
 # The PHP version to use. Valid options are 'latest', and '{version}-fpm'.
-LOCAL_PHP=latest
+LOCAL_PHP=8.3-fpm
 
 # Whether or not to enable Xdebug.
 LOCAL_PHP_XDEBUG=false


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/60095