### PR TITLE
Update validation for get_metadata_raw function

### DIFF
--- a/src/wp-includes/meta.php
+++ b/src/wp-includes/meta.php
@@ -598,7 +598,11 @@ function get_metadata( $meta_type, $object_id, $meta_key = '', $single = false )
  *               Null if the value does not exist.
  */
 function get_metadata_raw( $meta_type, $object_id, $meta_key = '', $single = false ) {
-	if ( ! $meta_type || ! is_numeric( $object_id ) ) {
+	$filter_options = array(
+		'options' => array( 'min_range' => 0 ),
+	);
+
+	if ( ! $meta_type || ! filter_var( $object_id, FILTER_VALIDATE_INT, $filter_options ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
Improved the validation of object_id in the get_metadata_raw function by checking if it's a positive integer. This is done using the filter_var PHP function with FILTER_VALIDATE_INT and specifying a minimum range of 0.

Trac ticket: https://core.trac.wordpress.org/ticket/58619