### PR TITLE
Add unit tests for deadDb function

### DIFF
--- a/tests/phpunit/tests/functions/deadDb.php
+++ b/tests/phpunit/tests/functions/deadDb.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Tests for the dead_db function.
+ *
+ * @group Functions
+ *
+ * @covers ::dead_db
+ */
+class Tests_Functions_deadDb extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 60102
+	 */
+	public function test_dead_db_admin() {
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionMessage( '0' ); // no error so returns 0
+
+		define( 'WP_ADMIN', true );
+
+		dead_db();
+
+		$this->assertEmpty( $this->caught_doing_it_wrong );
+	}
+
+	/**
+	 * @ticket 60102
+	 */
+	public function test_dead_db() {
+		$this->expectException( 'WPDieException' );
+		$this->expectExceptionMessage( '<h1>Error establishing a database connection</h1>' );
+
+		dead_db();
+
+		$this->assertEmpty( $this->caught_doing_it_wrong );
+	}
+}


### PR DESCRIPTION
New unit tests have been added for the "deadDb" function in the WordPress PHPUnit suite. These tests strive to ensure the function is running as intended by checking its exceptions and outcomes. This helps to maintain functionality and reduces the risk of unnoticed issues in future updates.

Trac ticket: https://core.trac.wordpress.org/ticket/60102