### PR TITLE
HTML Api: Fix out of bounds string access

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1290,6 +1290,11 @@ class WP_HTML_Tag_Processor {
 			 * See https://html.spec.whatwg.org/#parse-error-invalid-first-character-of-tag-name
 			 */
 			if ( $this->is_closing_tag ) {
+				// No chance of finding a closer
+				if ( $at + 3 > $doc_length ) {
+					return false;
+				}
+
 				$closer_at = strpos( $html, '>', $at + 3 );
 				if ( false === $closer_at ) {
 					return false;

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1147,7 +1147,7 @@ class WP_HTML_Tag_Processor {
 			 * Abort if no tag is found before the end of
 			 * the document. There is nothing left to parse.
 			 */
-			if ( $at + 1 >= strlen( $html ) ) {
+			if ( $at + 1 >= $doc_length ) {
 				return false;
 			}
 
@@ -1161,13 +1161,13 @@ class WP_HTML_Tag_Processor {
 				 * https://html.spec.whatwg.org/multipage/parsing.html#tag-open-state
 				 */
 				if (
-					strlen( $html ) > $at + 3 &&
+					$doc_length > $at + 3 &&
 					'-' === $html[ $at + 2 ] &&
 					'-' === $html[ $at + 3 ]
 				) {
 					$closer_at = $at + 4;
 					// If it's not possible to close the comment then there is nothing more to scan.
-					if ( strlen( $html ) <= $closer_at ) {
+					if ( $doc_length <= $closer_at ) {
 						return false;
 					}
 
@@ -1185,18 +1185,18 @@ class WP_HTML_Tag_Processor {
 					 * See https://html.spec.whatwg.org/#parse-error-incorrectly-closed-comment
 					 */
 					--$closer_at; // Pre-increment inside condition below reduces risk of accidental infinite looping.
-					while ( ++$closer_at < strlen( $html ) ) {
+					while ( ++$closer_at < $doc_length ) {
 						$closer_at = strpos( $html, '--', $closer_at );
 						if ( false === $closer_at ) {
 							return false;
 						}
 
-						if ( $closer_at + 2 < strlen( $html ) && '>' === $html[ $closer_at + 2 ] ) {
+						if ( $closer_at + 2 < $doc_length && '>' === $html[ $closer_at + 2 ] ) {
 							$at = $closer_at + 3;
 							continue 2;
 						}
 
-						if ( $closer_at + 3 < strlen( $html ) && '!' === $html[ $closer_at + 2 ] && '>' === $html[ $closer_at + 3 ] ) {
+						if ( $closer_at + 3 < $doc_length && '!' === $html[ $closer_at + 2 ] && '>' === $html[ $closer_at + 3 ] ) {
 							$at = $closer_at + 4;
 							continue 2;
 						}
@@ -1209,7 +1209,7 @@ class WP_HTML_Tag_Processor {
 				 * https://html.spec.whatwg.org/multipage/parsing.html#tag-open-state
 				 */
 				if (
-					strlen( $html ) > $at + 8 &&
+					$doc_length > $at + 8 &&
 					'[' === $html[ $at + 2 ] &&
 					'C' === $html[ $at + 3 ] &&
 					'D' === $html[ $at + 4 ] &&
@@ -1233,7 +1233,7 @@ class WP_HTML_Tag_Processor {
 				 * https://html.spec.whatwg.org/multipage/parsing.html#tag-open-state
 				 */
 				if (
-					strlen( $html ) > $at + 8 &&
+					$doc_length > $at + 8 &&
 					( 'D' === $html[ $at + 2 ] || 'd' === $html[ $at + 2 ] ) &&
 					( 'O' === $html[ $at + 3 ] || 'o' === $html[ $at + 3 ] ) &&
 					( 'C' === $html[ $at + 4 ] || 'c' === $html[ $at + 4 ] ) &&

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1113,7 +1113,7 @@ class WP_HTML_Tag_Processor {
 
 			$this->token_starts_at = $at;
 
-			if ( '/' === $this->html[ $at + 1 ] ) {
+			if ( $doc_length > $at + 1 && '/' === $this->html[ $at + 1 ] ) {
 				$this->is_closing_tag = true;
 				++$at;
 			} else {

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2432,7 +2432,7 @@ HTML;
 	 * @covers WP_HTML_Tag_Processor::next_tag
 	 */
 	public function test_handles_malformed_taglike_open_short_html() {
-		$p = new WP_HTML_Tag_Processor( '<' );
+		$p      = new WP_HTML_Tag_Processor( '<' );
 		$result = $p->next_tag();
 		$this->assertFalse( $result, 'Did not handle "<" html properly.' );
 	}
@@ -2441,7 +2441,7 @@ HTML;
 	 * @covers WP_HTML_Tag_Processor::next_tag
 	 */
 	public function test_handles_malformed_taglike_close_short_html() {
-		$p = new WP_HTML_Tag_Processor( '</ ' );
+		$p      = new WP_HTML_Tag_Processor( '</ ' );
 		$result = $p->next_tag();
 		$this->assertFalse( $result, 'Did not handle "</ " html properly.' );
 	}

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2429,6 +2429,15 @@ HTML;
 	}
 
 	/**
+	 * @covers WP_HTML_Tag_Processor::next_tag
+	 */
+	public function test_handles_malformed_taglike_open_short_html() {
+		$p = new WP_HTML_Tag_Processor( "<" );
+		$result = $p->next_tag();
+		$this->assertFalse( $result, 'Did not handle "<" html properly.' );
+	}
+
+	/**
 	 * Data provider.
 	 *
 	 * @return array[]

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2432,7 +2432,7 @@ HTML;
 	 * @covers WP_HTML_Tag_Processor::next_tag
 	 */
 	public function test_handles_malformed_taglike_open_short_html() {
-		$p = new WP_HTML_Tag_Processor( "<" );
+		$p = new WP_HTML_Tag_Processor( '<' );
 		$result = $p->next_tag();
 		$this->assertFalse( $result, 'Did not handle "<" html properly.' );
 	}

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2438,6 +2438,15 @@ HTML;
 	}
 
 	/**
+	 * @covers WP_HTML_Tag_Processor::next_tag
+	 */
+	public function test_handles_malformed_taglike_close_short_html() {
+		$p = new WP_HTML_Tag_Processor( '</ ' );
+		$result = $p->next_tag();
+		$this->assertFalse( $result, 'Did not handle "</ " html properly.' );
+	}
+
+	/**
 	 * Data provider.
 	 *
 	 * @return array[]


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60108

The HTML API Tag Processor may attempt to perform out of range string index access, which may manifest as:

> ValueError: strpos(): Argument #3 ($offset) must be contained in argument #1 ($haystack)

- Add tests (failing on current trunk) to Tag Processor test suite that demonstrate the issue.
- Fix out of range checks.

This PR also reuses a `$doc_length` variable. There's a `strlen( $html )` performed at the top of the function and the result can be reused instead of calling `strlen` repeatedly.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
