### PR TITLE
Only apply normalize_whitespace to string

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5503,7 +5503,7 @@ function _links_add_target( $m ) {
  * @return string The normalized string.
  */
 function normalize_whitespace( $str ) {
-	if( !is_string( $str ) ) {
+	if ( ! is_string( $str ) ) {
 		return $str;
 	}
 

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5503,6 +5503,10 @@ function _links_add_target( $m ) {
  * @return string The normalized string.
  */
 function normalize_whitespace( $str ) {
+	if( !is_string( $str ) ) {
+		return $str;
+	}
+
 	$str = trim( $str );
 	$str = str_replace( "\r", "\n", $str );
 	$str = preg_replace( array( '/\n+/', '/[ \t]+/' ), array( "\n", ' ' ), $str );


### PR DESCRIPTION
Add a check to normalize_whitespace so that it will only run on strings, this prevents a fatal error if a post meta is stored in revisions that isn't just a string.

Trac ticket: https://core.trac.wordpress.org/ticket/59827