### PR TITLE
Block Hooks: Set hooked block's layout attribute based on anchor block's

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -918,7 +918,7 @@ function make_after_block_visitor( $hooked_blocks, $context ) {
 				// Has the hooked block type opted into layout block support?
 				$hooked_block_type_obj = WP_Block_Type_Registry::get_instance()->get_registered( $hooked_block_type );
 				if ( $hooked_block_type_obj && $hooked_block_type_obj instanceof WP_Block_Type ) {
-					if( $hooked_block_type_obj->attributes && isset( $hooked_block_type_obj->attributes['layout'] ) ) {
+					if ( $hooked_block_type_obj->attributes && isset( $hooked_block_type_obj->attributes['layout'] ) ) {
 						// Copy the anchor block's layout attribute to the hooked block.
 						$attributes['layout'] = $layout;
 					}


### PR DESCRIPTION
This is a proof-of-concept to explore setting a hooked block's `layout` block support attribute to the same value as its anchor block, if the hooked block is inserted `before` or `after` the anchor block.

The motivation for this are scenarios like inserting a 'Like' button block after the Post Content block. It's been brought to my attention that this currently doesn't work well for e.g. the TT3 and TT4 Block Themes. The reason for this is that those Block Themes use `layout` block-support on their Post Content block and post meta Group block (i.e. the Group block that typically contains the post date, byline, categories, and sometimes also the Featured Image block) to set their layout to `constrained` -- which sets a certain margin and padding to center those blocks horizontally.

OTOH, an automatically inserted (hooked) Like button block -- with no attributes set -- will sit at the very left of the viewport.

To solve that issue, this fix makes it so that a hooked block that has opted into `layout` block support will get its `layout` attribute set to the same value as its anchor block's.

| Before | After |
|-------|-------|
| ![image](https://github.com/WordPress/wordpress-develop/assets/96308/64bf3e81-3ab8-4d10-9ff3-1295dddaa21c) | ![image](https://github.com/WordPress/wordpress-develop/assets/96308/193b01a7-85b9-4744-bbf8-8e5ef066302d) |

### Testing instructions

Use the [latest version (0.6.0) of my demo Like button block plugin](https://github.com/ockham/like-button/releases/tag/v0.6.0) for testing. Try both with `trunk`, and with this PR. (Use the WordPress Playground for easy testing.)

### Notes

It seems like the concept of different `layout`s (as used in this context) is somewhat incompatible with Block Hooks, as it means that a hooked block needs to have an attribute set -- or needs to be wrapped in another block with that attribute -- neither of which is currently supported by Block Hooks; otherwise it won't be displayed with the desired margins.

This is probably not going to be the final version of the fix for this issue. While it tries to be fairly cautious when setting the `layout` attribute, I still find that it might make too many assumptions about the hooked block.

Instead, it probably makes sense to expose the necessary information (i.e. the anchor block's attributes), and allow setting the hooked block's attributes (see [`#59572`](https://core.trac.wordpress.org/ticket/59572)), so that extenders can implement the required logic in "user space", i.e. inside of the [`hooked_block_types` filter](https://developer.wordpress.org/reference/hooks/hooked_block_types/).

Trac ticket: https://core.trac.wordpress.org/ticket/60126

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
