### PR TITLE
Output theme palette presets when appearance tools are enabled

### DIFF
--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -222,7 +222,13 @@ function wp_get_global_stylesheet( $types = array() ) {
 		 * @see wp_add_global_styles_for_blocks
 		 */
 		$origins = array( 'default', 'theme', 'custom' );
-		if ( ! $supports_theme_json ) {
+		/*
+		* If the theme doesn't have theme.json but supports both appearance tools and color palette,
+		* the 'theme' origin should be included so color palette presets are also output.
+		*/
+		if ( ! $supports_theme_json && ( current_theme_supports( 'appearance-tools' ) || current_theme_supports( 'border' ) ) && current_theme_supports( 'editor-color-palette' ) ) {
+			$origins = array( 'default', 'theme' );
+		} elseif ( ! $supports_theme_json ) {
 			$origins = array( 'default' );
 		}
 		$styles_rest = $tree->get_stylesheet( $types, $origins );

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -127,6 +127,9 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		self::delete_user( self::$subscriber_id );
 		self::delete_user( self::$contributor_id );
 		self::delete_user( self::$admin_id );
+
+		remove_theme_support( 'editor-gradient-presets' );
+		remove_theme_support( 'editor-color-palette' );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -127,9 +127,6 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		self::delete_user( self::$subscriber_id );
 		self::delete_user( self::$contributor_id );
 		self::delete_user( self::$admin_id );
-
-		remove_theme_support( 'editor-gradient-presets' );
-		remove_theme_support( 'editor-color-palette' );
 	}
 
 	/**
@@ -688,6 +685,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'theme_supports', $result[0] );
 		$this->assertSame( array( $wordpress_blue ), $result[0]['theme_supports']['editor-color-palette'] );
+		remove_theme_support( 'editor-color-palette' );
 	}
 
 	/**
@@ -1054,6 +1052,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'theme_supports', $result[0] );
 		$this->assertSame( array( $gradient ), $result[0]['theme_supports']['editor-gradient-presets'] );
+		remove_theme_support( 'editor-gradient-presets' );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -127,6 +127,9 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		self::delete_user( self::$subscriber_id );
 		self::delete_user( self::$contributor_id );
 		self::delete_user( self::$admin_id );
+
+		remove_theme_support( 'editor-gradient-presets' );
+		remove_theme_support( 'editor-color-palette' );
 	}
 
 	/**
@@ -685,7 +688,6 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'theme_supports', $result[0] );
 		$this->assertSame( array( $wordpress_blue ), $result[0]['theme_supports']['editor-color-palette'] );
-		remove_theme_support( 'editor-color-palette' );
 	}
 
 	/**
@@ -1052,7 +1054,6 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'theme_supports', $result[0] );
 		$this->assertSame( array( $gradient ), $result[0]['theme_supports']['editor-gradient-presets'] );
-		remove_theme_support( 'editor-gradient-presets' );
 	}
 
 	/**

--- a/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
+++ b/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
@@ -19,13 +19,6 @@ class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 	private $remove_theme_support_at_teardown = false;
 
 	/**
-	 * Flag to indicate whether to remove 'border' theme support at tear_down().
-	 *
-	 * @var bool
-	 */
-	private $remove_border_support_at_teardown = false;
-
-	/**
 	 * Flag to indicate whether to switch back to the default theme at tear down.
 	 *
 	 * @var bool
@@ -45,12 +38,6 @@ class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 		if ( $this->switch_to_default_theme_at_teardown ) {
 			$this->switch_to_default_theme_at_teardown = false;
 			switch_theme( WP_DEFAULT_THEME );
-		}
-
-		if ( $this->remove_border_support_at_teardown ) {
-			$this->remove_border_support_at_teardown = false;
-			remove_theme_support( 'border' );
-			remove_theme_support( 'editor-color-palette' );
 		}
 
 		parent::tear_down();
@@ -294,10 +281,9 @@ class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 			),
 		);
 
-		// Add theme support for appearance tools.
+		// Add theme support for border and color palette.
 		add_theme_support( 'border' );
 		add_theme_support( 'editor-color-palette', $args );
-		$this->remove_border_support_at_teardown = true;
 
 		// Check for both the variable declaration and its use as a value.
 		$variables = wp_get_global_stylesheet( array( 'variables' ) );
@@ -315,6 +301,10 @@ class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 		$this->assertStringContainsString( 'var(--wp--preset--color--haunted-green)', $presets );
 		$this->assertStringContainsString( 'var(--wp--preset--color--soft-blue)', $presets );
 		$this->assertStringContainsString( 'var(--wp--preset--color--cool-purple)', $presets );
+
+		// Remove theme support for border and color palette.
+		remove_theme_support( 'border' );
+		remove_theme_support( 'editor-color-palette' );
 	}
 
 	/**

--- a/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
+++ b/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
@@ -20,7 +20,7 @@ class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 
 	/**
 	 * Flag to indicate whether to remove 'border' theme support at tear_down().
-	 * 
+	 *
 	 * @var bool
 	 */
 	private $remove_border_support_at_teardown = false;
@@ -261,7 +261,7 @@ class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 
 	/**
 	 * Tests that theme color palette presets are output when appearance tools are enabled via theme support.
-	 * 
+	 *
 	 * @ticket 60134
 	 */
 	public function test_theme_color_palette_presets_output_when_border_support_enabled() {
@@ -292,11 +292,11 @@ class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 				'slug'  => 'cool-purple',
 				'color' => '#D1D1E4',
 			),
-		);				
+		);			
 
 		// Add theme support for appearance tools.
 		add_theme_support( 'border' );
-		add_theme_support('editor-color-palette', $args);
+		add_theme_support( 'editor-color-palette', $args );
 		$this->remove_border_support_at_teardown = true;
 
 		// Check for both the variable declaration and its use as a value.
@@ -313,7 +313,7 @@ class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 		$this->assertStringContainsString( 'var(--wp--preset--color--nice-black)', $presets );
 		$this->assertStringContainsString( 'var(--wp--preset--color--dark-gray)', $presets );
 		$this->assertStringContainsString( 'var(--wp--preset--color--haunted-green)', $presets );
-		$this->assertStringContainsString( 'var(--wp--preset--color--soft-blue)', $presets );	
+		$this->assertStringContainsString( 'var(--wp--preset--color--soft-blue)', $presets );
 		$this->assertStringContainsString( 'var(--wp--preset--color--cool-purple)', $presets );
 	}
 

--- a/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
+++ b/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
@@ -269,7 +269,7 @@ class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 		$args = array(
 			array(
 				'name'  => 'Black',
-				'slug'  => 'black',
+				'slug'  => 'nice-black',
 				'color' => '#000000',
 			),
 			array(
@@ -279,17 +279,17 @@ class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 			),
 			array(
 				'name'  => 'Green',
-				'slug'  => 'green',
+				'slug'  => 'haunted-green',
 				'color' => '#D1E4DD',
 			),
 			array(
 				'name'  => 'Blue',
-				'slug'  => 'blue',
+				'slug'  => 'soft-blue',
 				'color' => '#D1DFE4',
 			),
 			array(
 				'name'  => 'Purple',
-				'slug'  => 'purple',
+				'slug'  => 'cool-purple',
 				'color' => '#D1D1E4',
 			),
 		);				
@@ -299,13 +299,22 @@ class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 		add_theme_support('editor-color-palette', $args);
 		$this->remove_border_support_at_teardown = true;
 
-		$styles = wp_get_global_stylesheet( array( 'presets' ) );
+		// Check for both the variable declaration and its use as a value.
+		$variables = wp_get_global_stylesheet( array( 'variables' ) );
 
-		$this->assertStringContainsString( 'var(--wp--preset--color--black)', $styles );
-		$this->assertStringContainsString( 'var(--wp--preset--color--dark-gray)', $styles );
-		$this->assertStringContainsString( 'var(--wp--preset--color--green)', $styles );
-		$this->assertStringContainsString( 'var(--wp--preset--color--blue)', $styles );
-		$this->assertStringContainsString( 'var(--wp--preset--color--purple)', $styles );
+		$this->assertStringContainsString( '--wp--preset--color--nice-black: #000000', $variables );
+		$this->assertStringContainsString( '--wp--preset--color--dark-gray: #28303D', $variables );
+		$this->assertStringContainsString( '--wp--preset--color--haunted-green: #D1E4DD', $variables );
+		$this->assertStringContainsString( '--wp--preset--color--soft-blue: #D1DFE4', $variables );
+		$this->assertStringContainsString( '--wp--preset--color--cool-purple: #D1D1E4', $variables );
+
+		$presets = wp_get_global_stylesheet( array( 'presets' ) );
+
+		$this->assertStringContainsString( 'var(--wp--preset--color--nice-black)', $presets );
+		$this->assertStringContainsString( 'var(--wp--preset--color--dark-gray)', $presets );
+		$this->assertStringContainsString( 'var(--wp--preset--color--haunted-green)', $presets );
+		$this->assertStringContainsString( 'var(--wp--preset--color--soft-blue)', $presets );	
+		$this->assertStringContainsString( 'var(--wp--preset--color--cool-purple)', $presets );
 	}
 
 	/**

--- a/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
+++ b/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
@@ -292,7 +292,7 @@ class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 				'slug'  => 'cool-purple',
 				'color' => '#D1D1E4',
 			),
-		);			
+		);
 
 		// Add theme support for appearance tools.
 		add_theme_support( 'border' );

--- a/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
+++ b/tests/phpunit/tests/theme/wpGetGlobalStylesheet.php
@@ -19,6 +19,13 @@ class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 	private $remove_theme_support_at_teardown = false;
 
 	/**
+	 * Flag to indicate whether to remove 'border' theme support at tear_down().
+	 *
+	 * @var bool
+	 */
+	private $remove_border_support_at_teardown = false;
+
+	/**
 	 * Flag to indicate whether to switch back to the default theme at tear down.
 	 *
 	 * @var bool
@@ -38,6 +45,12 @@ class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 		if ( $this->switch_to_default_theme_at_teardown ) {
 			$this->switch_to_default_theme_at_teardown = false;
 			switch_theme( WP_DEFAULT_THEME );
+		}
+
+		if ( $this->remove_border_support_at_teardown ) {
+			$this->remove_border_support_at_teardown = false;
+			remove_theme_support( 'border' );
+			remove_theme_support( 'editor-color-palette' );
 		}
 
 		parent::tear_down();
@@ -281,9 +294,10 @@ class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 			),
 		);
 
-		// Add theme support for border and color palette.
+		// Add theme support for appearance tools.
 		add_theme_support( 'border' );
 		add_theme_support( 'editor-color-palette', $args );
+		$this->remove_border_support_at_teardown = true;
 
 		// Check for both the variable declaration and its use as a value.
 		$variables = wp_get_global_stylesheet( array( 'variables' ) );
@@ -301,10 +315,6 @@ class Tests_Theme_WpGetGlobalStylesheet extends WP_Theme_UnitTestCase {
 		$this->assertStringContainsString( 'var(--wp--preset--color--haunted-green)', $presets );
 		$this->assertStringContainsString( 'var(--wp--preset--color--soft-blue)', $presets );
 		$this->assertStringContainsString( 'var(--wp--preset--color--cool-purple)', $presets );
-
-		// Remove theme support for border and color palette.
-		remove_theme_support( 'border' );
-		remove_theme_support( 'editor-color-palette' );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket:  https://core.trac.wordpress.org/ticket/60134

Syncs the changes from https://github.com/WordPress/gutenberg/pull/57190.

Added a unit test and had to tweak the `WP_Test_REST_Themes_Controller` teardown function to remove an unexpected side-effect.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
