### PR TITLE
Allow default duotone styles in themes that don't disable them.

### DIFF
--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -312,9 +312,6 @@ class WP_Theme_JSON_Resolver {
 			}
 			$theme_support_data['settings']['color']['defaultGradients'] = $default_gradients;
 
-			// Classic themes without a theme.json don't support global duotone.
-			$theme_support_data['settings']['color']['defaultDuotone'] = false;
-
 			// Allow themes to enable link color setting via theme_support.
 			if ( current_theme_supports( 'link-color' ) ) {
 				$theme_support_data['settings']['color']['link'] = true;

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -479,6 +479,7 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 	 */
 	public function test_core_default_settings_are_loaded_for_themes_without_theme_json() {
 		switch_theme( 'default' );
+		remove_theme_support( 'editor-gradient-presets' );
 
 		$settings = WP_Theme_JSON_Resolver::get_merged_data( 'theme' )->get_settings();
 

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -479,7 +479,6 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 	 */
 	public function test_core_default_settings_are_loaded_for_themes_without_theme_json() {
 		switch_theme( 'default' );
-		remove_theme_support( 'editor-gradient-presets' );
 
 		$settings = WP_Theme_JSON_Resolver::get_merged_data( 'theme' )->get_settings();
 

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -473,6 +473,22 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that classic themes still get core default settings such as color palette and duotone.
+	 * 
+	 * @ticket 60136
+	 */
+	public function test_core_default_settings_are_loaded_for_themes_without_theme_json() {
+		switch_theme('default');
+
+		$settings = WP_Theme_JSON_Resolver::get_merged_data( 'theme' )->get_settings();
+
+		$this->assertFalse( wp_theme_has_theme_json() );
+		$this->assertTrue( $settings['color']['defaultPalette'] );
+		$this->assertTrue( $settings['color']['defaultDuotone'] );
+		$this->assertTrue( $settings['color']['defaultGradients'] );
+	}
+
+	/**
 	 * @ticket 54336
 	 * @ticket 56611
 	 */

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -474,11 +474,11 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 
 	/**
 	 * Tests that classic themes still get core default settings such as color palette and duotone.
-	 * 
+	 *
 	 * @ticket 60136
 	 */
 	public function test_core_default_settings_are_loaded_for_themes_without_theme_json() {
-		switch_theme('default');
+		switch_theme( 'default' );
 
 		$settings = WP_Theme_JSON_Resolver::get_merged_data( 'theme' )->get_settings();
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60136

Syncs changes from https://github.com/WordPress/gutenberg/pull/57191.

Added a unit test. 

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
