### PR TITLE
Backport background size and repeat block support features from Gutenberg

### DIFF
--- a/src/wp-includes/block-supports/background.php
+++ b/src/wp-includes/block-supports/background.php
@@ -40,8 +40,7 @@ function wp_register_background_support( $block_type ) {
  * it is also applied to non-server-rendered blocks.
  *
  * @since 6.4.0
- * @since 6.5.0 Added support for `backgroundSize`, `backgroundPosition`,
- *              and `backgroundRepeat` output.
+ * @since 6.5.0 Added support for `backgroundPosition` and `backgroundRepeat` output.
  * @access private
  *
  * @param  string $block_content Rendered block content.

--- a/src/wp-includes/block-supports/background.php
+++ b/src/wp-includes/block-supports/background.php
@@ -69,7 +69,7 @@ function wp_render_background_support( $block_content, $block ) {
 	$background_size         = isset( $block_attributes['style']['background']['backgroundSize'] )
 		? $block_attributes['style']['background']['backgroundSize']
 		: 'cover';
-	$background_position	 = isset( $block_attributes['style']['background']['backgroundPosition'] )
+	$background_position     = isset( $block_attributes['style']['background']['backgroundPosition'] )
 		? $block_attributes['style']['background']['backgroundPosition']
 		: null;
 	$background_repeat       = isset( $block_attributes['style']['background']['backgroundRepeat'] )

--- a/src/wp-includes/block-supports/background.php
+++ b/src/wp-includes/block-supports/background.php
@@ -72,7 +72,7 @@ function wp_render_background_support( $block_content, $block ) {
 	$background_position	 = isset( $block_attributes['style']['background']['backgroundPosition'] )
 		? $block_attributes['style']['background']['backgroundPosition']
 		: null;
-	$background_repeat	   = isset( $block_attributes['style']['background']['backgroundRepeat'] )
+	$background_repeat       = isset( $block_attributes['style']['background']['backgroundRepeat'] )
 		? $block_attributes['style']['background']['backgroundRepeat']
 		: null;
 

--- a/src/wp-includes/block-supports/background.php
+++ b/src/wp-includes/block-supports/background.php
@@ -113,6 +113,7 @@ function wp_render_background_support( $block_content, $block ) {
 
 			$updated_style .= $styles['css'];
 			$tags->set_attribute( 'style', $updated_style );
+			$tags->add_class( 'has-background' );
 		}
 
 		return $tags->get_updated_html();

--- a/src/wp-includes/block-supports/background.php
+++ b/src/wp-includes/block-supports/background.php
@@ -65,6 +65,11 @@ function wp_render_background_support( $block_content, $block ) {
 	$background_image_url    = isset( $block_attributes['style']['background']['backgroundImage']['url'] )
 		? $block_attributes['style']['background']['backgroundImage']['url']
 		: null;
+
+	if ( ! $background_image_source && ! $background_image_url ) {
+		return $block_content;
+	}
+
 	$background_size         = isset( $block_attributes['style']['background']['backgroundSize'] )
 		? $block_attributes['style']['background']['backgroundSize']
 		: 'cover';

--- a/src/wp-includes/block-supports/background.php
+++ b/src/wp-includes/block-supports/background.php
@@ -40,6 +40,8 @@ function wp_register_background_support( $block_type ) {
  * it is also applied to non-server-rendered blocks.
  *
  * @since 6.4.0
+ * @since 6.5.0 Added support for `backgroundSize`, `backgroundPosition`,
+ *              and `backgroundRepeat` output.
  * @access private
  *
  * @param  string $block_content Rendered block content.
@@ -67,6 +69,12 @@ function wp_render_background_support( $block_content, $block ) {
 	$background_size         = isset( $block_attributes['style']['background']['backgroundSize'] )
 		? $block_attributes['style']['background']['backgroundSize']
 		: 'cover';
+	$background_position	 = isset( $block_attributes['style']['background']['backgroundPosition'] )
+		? $block_attributes['style']['background']['backgroundPosition']
+		: null;
+	$background_repeat	   = isset( $block_attributes['style']['background']['backgroundRepeat'] )
+		? $block_attributes['style']['background']['backgroundRepeat']
+		: null;
 
 	$background_block_styles = array();
 
@@ -76,8 +84,15 @@ function wp_render_background_support( $block_content, $block ) {
 	) {
 		// Set file based background URL.
 		$background_block_styles['backgroundImage']['url'] = $background_image_url;
-		// Only output the background size when an image url is set.
-		$background_block_styles['backgroundSize'] = $background_size;
+		// Only output the background size and repeat when an image url is set.
+		$background_block_styles['backgroundSize']     = $background_size;
+		$background_block_styles['backgroundRepeat']   = $background_repeat;
+		$background_block_styles['backgroundPosition'] = $background_position;
+
+		// If the background size is set to `contain` and no position is set, set the position to `center`.
+		if ( 'contain' === $background_size && ! isset( $background_position ) ) {
+			$background_block_styles['backgroundPosition'] = 'center';
+		}
 	}
 
 	$styles = wp_style_engine_get_styles( array( 'background' => $background_block_styles ) );

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -344,7 +344,8 @@ class WP_Theme_JSON {
 	 * @since 6.3.0 Added support for `typography.textColumns`, removed `layout.definitions`.
 	 * @since 6.4.0 Added support for `layout.allowEditing`, `background.backgroundImage`,
 	 *              `typography.writingMode`, `lightbox.enabled` and `lightbox.allowEditing`.
-	 * @since 6.5.0 Added support for `layout.allowCustomContentAndWideSize`.
+	 * @since 6.5.0 Added support for `layout.allowCustomContentAndWideSize` and
+	 *              `background.backgroundSize`.
 	 * @var array
 	 */
 	const VALID_SETTINGS = array(
@@ -352,6 +353,7 @@ class WP_Theme_JSON {
 		'useRootPaddingAwareAlignments' => null,
 		'background'                    => array(
 			'backgroundImage' => null,
+			'backgroundSize'  => null,
 		),
 		'border'                        => array(
 			'color'  => null,
@@ -573,10 +575,12 @@ class WP_Theme_JSON {
 	 * @since 6.0.0
 	 * @since 6.2.0 Added `dimensions.minHeight` and `position.sticky`.
 	 * @since 6.4.0 Added `background.backgroundImage`.
+	 * @since 6.5.0 Added `background.backgroundSize`.
 	 * @var array
 	 */
 	const APPEARANCE_TOOLS_OPT_INS = array(
 		array( 'background', 'backgroundImage' ),
+		array( 'background', 'backgroundSize' ),
 		array( 'border', 'color' ),
 		array( 'border', 'radius' ),
 		array( 'border', 'style' ),

--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -23,7 +23,7 @@
  * @since 6.1.0
  * @since 6.3.0 Added support for text-columns.
  * @since 6.4.0 Added support for background.backgroundImage.
- * @since 6.5.0 Added support for background.backgroundPosition, background.backgroundRepeat.
+ * @since 6.5.0 Added support for background.backgroundPosition and background.backgroundRepeat.
  */
 #[AllowDynamicProperties]
 final class WP_Style_Engine {

--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -23,6 +23,7 @@
  * @since 6.1.0
  * @since 6.3.0 Added support for text-columns.
  * @since 6.4.0 Added support for background.backgroundImage.
+ * @since 6.5.0 Added support for background.backgroundPosition, background.backgroundRepeat.
  */
 #[AllowDynamicProperties]
 final class WP_Style_Engine {
@@ -48,14 +49,26 @@ final class WP_Style_Engine {
 	 */
 	const BLOCK_STYLE_DEFINITIONS_METADATA = array(
 		'background' => array(
-			'backgroundImage' => array(
+			'backgroundImage'    => array(
 				'property_keys' => array(
 					'default' => 'background-image',
 				),
 				'value_func'    => array( self::class, 'get_url_or_value_css_declaration' ),
 				'path'          => array( 'background', 'backgroundImage' ),
 			),
-			'backgroundSize'  => array(
+			'backgroundPosition' => array(
+				'property_keys' => array(
+					'default' => 'background-position',
+				),
+				'path'          => array( 'background', 'backgroundPosition' ),
+			),
+			'backgroundRepeat'   => array(
+				'property_keys' => array(
+					'default' => 'background-repeat',
+				),
+				'path'          => array( 'background', 'backgroundRepeat' ),
+			),
+			'backgroundSize'     => array(
 				'property_keys' => array(
 					'default' => 'background-size',
 				),

--- a/tests/phpunit/tests/block-supports/wpRenderBackgroundSupport.php
+++ b/tests/phpunit/tests/block-supports/wpRenderBackgroundSupport.php
@@ -67,6 +67,7 @@ class Tests_Block_Supports_WpRenderBackgroundSupport extends WP_UnitTestCase {
 	 * Tests that background image block support works as expected.
 	 *
 	 * @ticket 59357
+	 * @ticket 60175
 	 *
 	 * @covers ::wp_render_background_support
 	 *

--- a/tests/phpunit/tests/block-supports/wpRenderBackgroundSupport.php
+++ b/tests/phpunit/tests/block-supports/wpRenderBackgroundSupport.php
@@ -138,6 +138,23 @@ class Tests_Block_Supports_WpRenderBackgroundSupport extends WP_UnitTestCase {
 				'expected_wrapper'    => '<div style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
+			'background image style with contain, position, and repeat is applied' => array(
+				'theme_name'          => 'block-theme-child-with-fluid-typography',
+				'block_name'          => 'test/background-rules-are-output',
+				'background_settings' => array(
+					'backgroundImage' => true,
+				),
+				'background_style'    => array(
+					'backgroundImage'  => array(
+						'url'    => 'https://example.com/image.jpg',
+						'source' => 'file',
+					),
+					'backgroundRepeat' => 'no-repeat',
+					'backgroundSize'   => 'contain',
+				),
+				'expected_wrapper'    => '<div style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-position:center;background-repeat:no-repeat;background-size:contain;">Content</div>',
+				'wrapper'             => '<div>Content</div>',
+			),
 			'background image style is appended if a style attribute already exists' => array(
 				'theme_name'          => 'block-theme-child-with-fluid-typography',
 				'block_name'          => 'test/background-rules-are-output',

--- a/tests/phpunit/tests/block-supports/wpRenderBackgroundSupport.php
+++ b/tests/phpunit/tests/block-supports/wpRenderBackgroundSupport.php
@@ -136,7 +136,7 @@ class Tests_Block_Supports_WpRenderBackgroundSupport extends WP_UnitTestCase {
 						'source' => 'file',
 					),
 				),
-				'expected_wrapper'    => '<div style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background image style with contain, position, and repeat is applied' => array(
@@ -153,7 +153,7 @@ class Tests_Block_Supports_WpRenderBackgroundSupport extends WP_UnitTestCase {
 					'backgroundRepeat' => 'no-repeat',
 					'backgroundSize'   => 'contain',
 				),
-				'expected_wrapper'    => '<div style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-position:center;background-repeat:no-repeat;background-size:contain;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-position:center;background-repeat:no-repeat;background-size:contain;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background image style is appended if a style attribute already exists' => array(
@@ -168,8 +168,8 @@ class Tests_Block_Supports_WpRenderBackgroundSupport extends WP_UnitTestCase {
 						'source' => 'file',
 					),
 				),
-				'expected_wrapper'    => '<div classname="wp-block-test" style="color: red;background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
-				'wrapper'             => '<div classname="wp-block-test" style="color: red">Content</div>',
+				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
+				'wrapper'             => '<div class="wp-block-test" style="color: red">Content</div>',
 			),
 			'background image style is appended if a style attribute containing multiple styles already exists' => array(
 				'theme_name'          => 'block-theme-child-with-fluid-typography',
@@ -183,8 +183,8 @@ class Tests_Block_Supports_WpRenderBackgroundSupport extends WP_UnitTestCase {
 						'source' => 'file',
 					),
 				),
-				'expected_wrapper'    => '<div classname="wp-block-test" style="color: red;font-size: 15px;background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
-				'wrapper'             => '<div classname="wp-block-test" style="color: red;font-size: 15px;">Content</div>',
+				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;font-size: 15px;background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
+				'wrapper'             => '<div class="wp-block-test" style="color: red;font-size: 15px;">Content</div>',
 			),
 			'background image style is not applied if the block does not support background image' => array(
 				'theme_name'          => 'block-theme-child-with-fluid-typography',

--- a/tests/phpunit/tests/style-engine/styleEngine.php
+++ b/tests/phpunit/tests/style-engine/styleEngine.php
@@ -27,6 +27,7 @@ class Tests_wpStyleEngine extends WP_UnitTestCase {
 	 * @ticket 56467
 	 * @ticket 58549
 	 * @ticket 58590
+	 * @ticket 60175
 	 *
 	 * @covers ::wp_style_engine_get_styles
 	 *

--- a/tests/phpunit/tests/style-engine/styleEngine.php
+++ b/tests/phpunit/tests/style-engine/styleEngine.php
@@ -513,18 +513,22 @@ class Tests_wpStyleEngine extends WP_UnitTestCase {
 			'inline_background_image_url_with_background_size' => array(
 				'block_styles'    => array(
 					'background' => array(
-						'backgroundImage' => array(
+						'backgroundImage'    => array(
 							'url' => 'https://example.com/image.jpg',
 						),
-						'backgroundSize'  => 'cover',
+						'backgroundPosition' => 'center',
+						'backgroundRepeat'   => 'no-repeat',
+						'backgroundSize'     => 'cover',
 					),
 				),
 				'options'         => array(),
 				'expected_output' => array(
-					'css'          => "background-image:url('https://example.com/image.jpg');background-size:cover;",
+					'css'          => "background-image:url('https://example.com/image.jpg');background-position:center;background-repeat:no-repeat;background-size:cover;",
 					'declarations' => array(
-						'background-image' => "url('https://example.com/image.jpg')",
-						'background-size'  => 'cover',
+						'background-image'    => "url('https://example.com/image.jpg')",
+						'background-position' => 'center',
+						'background-repeat'   => 'no-repeat',
+						'background-size'     => 'cover',
 					),
 				),
 			),

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -264,6 +264,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		$expected = array(
 			'background' => array(
 				'backgroundImage' => true,
+				'backgroundSize'  => true,
 			),
 			'border'     => array(
 				'width'  => true,
@@ -300,6 +301,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 				'core/group'     => array(
 					'background' => array(
 						'backgroundImage' => true,
+						'backgroundSize'  => true,
 					),
 					'border'     => array(
 						'width'  => true,


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Add support for background size and background repeat to the background image block support, as used by the Group block.

This PR backports the PHP parts of the following Gutenberg PRs: https://github.com/WordPress/gutenberg/pull/57005, https://github.com/WordPress/gutenberg/pull/57474, and https://github.com/WordPress/gutenberg/pull/57495

This PR only backports the PHP parts of the feature, however it can safely land prior to the JS packages updates for WP 6.5 as users will not be able to manually use these features in the editor until the JS packages are updated.

### Testing instructions

In a post or page of a site running TT4 theme, add the following markup in the code editor view. It contains a Group block with a background image set to a size of `contain` and a repeat of `no-repeat`:

```html
<!-- wp:group {"style":{"background":{"backgroundImage":{"url":"https://i0.wp.com/wordpress.org/files/2022/10/community-photo-2-q50-unscaled.webp?w=2642","source":"file"},"backgroundSize":"contain","backgroundRepeat":"no-repeat"}},"backgroundColor":"cyan-bluish-gray","layout":{"type":"constrained"}} -->
<div class="wp-block-group has-cyan-bluish-gray-background-color has-background"><!-- wp:heading -->
<h2 class="wp-block-heading">A group block with a background image</h2>
<!-- /wp:heading --></div>
<!-- /wp:group -->
```

The view in the editor will not reflect the background size and repeat rules yet, however with this PR, the site frontend's view should reflect that the image is contained within the area of the Group, is centered by default, and is set to not repeat:

<img width="635" alt="image" src="https://github.com/WordPress/wordpress-develop/assets/14988353/8971a96f-3359-4f01-98bd-420f916a6583">

Trac ticket: https://core.trac.wordpress.org/ticket/60175

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
