### PR TITLE
Add PHPUnit test for wp_ob_end_flush_all function

### DIFF
--- a/tests/phpunit/tests/functions/wpObEndFlushAll.php
+++ b/tests/phpunit/tests/functions/wpObEndFlushAll.php
@@ -18,7 +18,7 @@ class Tests_Functions_wpObEndFlushAll extends WP_UnitTestCase {
 		echo 'output';
 
 		wp_ob_end_flush_all();
-		$this->assertEmpty( ob_get_contents() );
+		$this->assertEmpty( ob_get_contents(), 'All output buffers should be empty after wp_ob_end_flush_all()' );
 
 		// re-start ob as wp_ob_end_flush_all clears all the OB's and PHPunit has one open
 		ob_start();

--- a/tests/phpunit/tests/functions/wpObEndFlushAll.php
+++ b/tests/phpunit/tests/functions/wpObEndFlushAll.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Tests for the wp_ob_end_flush_all function.
+ *
+ * @group Functions
+ *
+ * @covers ::wp_ob_end_flush_all
+ */
+class Tests_Functions_wpObEndFlushAll extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 60177
+	 */
+	public function test_wp_ob_end_flush_all() {
+
+		ob_start();
+		echo( 'output' );
+
+		wp_ob_end_flush_all();
+		$this->assertEmpty( ob_get_contents() );
+
+		// re-start ob as wp_ob_end_flush_all clears all the OB's and PHPunit has one open
+		ob_start();
+	}
+}

--- a/tests/phpunit/tests/functions/wpObEndFlushAll.php
+++ b/tests/phpunit/tests/functions/wpObEndFlushAll.php
@@ -15,7 +15,7 @@ class Tests_Functions_wpObEndFlushAll extends WP_UnitTestCase {
 	public function test_wp_ob_end_flush_all() {
 
 		ob_start();
-		echo( 'output' );
+		echo 'output';
 
 		wp_ob_end_flush_all();
 		$this->assertEmpty( ob_get_contents() );

--- a/tests/phpunit/tests/functions/wpObEndFlushAll.php
+++ b/tests/phpunit/tests/functions/wpObEndFlushAll.php
@@ -3,7 +3,7 @@
 /**
  * Tests for the wp_ob_end_flush_all function.
  *
- * @group Functions
+ * @group functions
  *
  * @covers ::wp_ob_end_flush_all
  */


### PR DESCRIPTION
This commit introduces a new PHPUnit test for the wp_ob_end_flush_all function. The function test is implemented in a new class, Tests_Functions_wpObEndFlushAll, and it will verify the correct behavior of wp_ob_end_flush_all by asserting the flushing of output buffering.

Trac ticket: https://core.trac.wordpress.org/ticket/60177