### PR TITLE
Add PHPUnit tests for wp_maybe_load_widgets function

### DIFF
--- a/tests/phpunit/tests/functions/wpMaybeLoadWidgets.php
+++ b/tests/phpunit/tests/functions/wpMaybeLoadWidgets.php
@@ -7,7 +7,7 @@
  *
  * @covers ::wp_maybe_load_widgets
  */
-class Tests_Functions_wpMaybeLoadWidgete extends WP_UnitTestCase {
+class Tests_Functions_wpMaybeLoadWidgets extends WP_UnitTestCase {
 
 	public $submenu;
 

--- a/tests/phpunit/tests/functions/wpMaybeLoadWidgets.php
+++ b/tests/phpunit/tests/functions/wpMaybeLoadWidgets.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Tests for the wp_maybe_load_widgets function.
+ *
+ * @group Functions
+ *
+ * @covers ::wp_maybe_load_widgets
+ */
+class Tests_Functions_wpMaybeLoadWidgete extends WP_UnitTestCase {
+
+	public $submenu;
+
+	public function set_up() {
+		global $submenu;
+		$this->submenu = $submenu;
+		$submenu       = null;
+	}
+
+	public function tear_down() {
+		global $submenu;
+		$submenu = $this->submenu;
+	}
+
+	/**
+	 * @ticket 60180
+	 */
+	public function test_wp_maybe_load_widgets() {
+
+		wp_maybe_load_widgets();
+
+		$this->assertSame( 10, has_action( '_admin_menu', 'wp_widgets_add_menu' ) );
+	}
+
+	public function test_wp_maybe_load_widgets_no_default_widgets() {
+		global $submenu;
+
+		add_filter( 'load_default_widgets', '__return_false' );
+
+		wp_maybe_load_widgets();
+
+		remove_filter( 'load_default_widgets', '__return_false' );
+
+		$this->assertSame( 10, has_action( '_admin_menu', 'wp_widgets_add_menu' ) );
+	}
+
+}


### PR DESCRIPTION
This commit introduces PHPUnit tests for the wp_maybe_load_widgets function. The tests are implemented in a new file, wpMaybeLoadWidgets.php, inside the tests/phpunit/tests/functions/ directory and cover different cases and scenarios to ensure proper functionality of the wp_maybe_load_widgets function.

Trac ticket: https://core.trac.wordpress.org/ticket/60180