### PR TITLE
Block Hooks: Introduce a new `hooked_block_{$block_type}` filter

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -760,7 +760,7 @@ function get_hooked_blocks() {
 /**
  * Conditionally returns the markup for a given hooked block.
  *
- * Accepts two arguments: A reference to an anchor block, and hooked block.
+ * Accepts two arguments: A hooked block, and a reference to an anchor block.
  * If the anchor block has already been processed, and the given hooked block type is in the list
  * of ignored hooked blocks, an empty string is returned.
  *
@@ -769,11 +769,11 @@ function get_hooked_blocks() {
  * @since 6.5.0
  * @access private
  *
- * @param array $anchor_block The anchor block. Passed by reference.
  * @param array $hooked_block The hooked block, represented as a parsed block array.
+ * @param array $anchor_block The anchor block. Passed by reference.
  * @return string The markup for the given hooked block, or an empty string if the block is ignored.
  */
-function get_hooked_block_markup( &$anchor_block, $hooked_block ) {
+function get_hooked_block_markup( $hooked_block, &$anchor_block ) {
 	if ( ! isset( $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] ) ) {
 		$anchor_block['attrs']['metadata']['ignoredHookedBlocks'] = array();
 	}
@@ -840,7 +840,7 @@ function insert_hooked_blocks( &$anchor_block, $relative_position, $hooked_block
 		 */
 		$hooked_block = apply_filters( 'hooked_block', $hooked_block, $hooked_block_type, $relative_position, $anchor_block, $context );
 
-		$markup .= get_hooked_block_markup( $anchor_block, $hooked_block );
+		$markup .= get_hooked_block_markup( $hooked_block, $anchor_block );
 	}
 
 	return $markup;

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -845,7 +845,7 @@ function insert_hooked_blocks( &$parsed_anchor_block, $relative_position, $hooke
 		 * @param array                   $parsed_anchor_block The anchor block, in parsed block array format.
 		 * @param WP_Block_Template|array $context             The block template, template part, or pattern that the anchor block belongs to.
 		 */
-		$hooked_block = apply_filters( "hooked_block_{$hooked_block_type}", $parsed_hooked_block, $relative_position, $parsed_anchor_block, $context );
+		$parsed_hooked_block = apply_filters( "hooked_block_{$hooked_block_type}", $parsed_hooked_block, $relative_position, $parsed_anchor_block, $context );
 
 		// It's possible that the `hooked_block_{$hooked_block_type}` filter returned a block of a different type,
 		// so we need to pass the original $hooked_block_type as well.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -775,7 +775,8 @@ function get_hooked_blocks() {
  * @param array  $hooked_block      The hooked block, represented as a parsed block array.
  * @param string $hooked_block_type The type of the hooked block. This could be different from
  *                                  $hooked_block['blockName'], as a filter might've modified the latter.
- * @param array  $anchor_block      The anchor block. Passed by reference.
+ * @param array  $anchor_block      The anchor block, represented as a parsed block array.
+ *                                  Passed by reference.
  * @return string The markup for the given hooked block, or an empty string if the block is ignored.
  */
 function get_hooked_block_markup( $hooked_block, $hooked_block_type, &$anchor_block ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -804,7 +804,7 @@ function get_hooked_block_markup( $hooked_block, $hooked_block_type, &$anchor_bl
  * @param array                   $parsed_anchor_block The anchor block, in parsed block array format.
  * @param string                  $relative_position   The relative position of the hooked blocks.
  *                                                     Can be one of 'before', 'after', 'first_child', or 'last_child'.
- * @param array                   $hooked_blocks       An array of hooked blocks, grouped by anchor block and relative position.
+ * @param array                   $hooked_blocks       An array of hooked block types, grouped by anchor block and relative position.
  * @param WP_Block_Template|array $context             The block template, template part, or pattern that the anchor block belongs to.
  * @return string
  */

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -800,15 +800,15 @@ function get_hooked_block_markup( $hooked_block, $hooked_block_type, &$anchor_bl
  * @since 6.5.0
  * @access private
  *
- * @param array                   $anchor_block      The anchor block.
- * @param string                  $relative_position The relative position of the hooked blocks.
- *                                                   Can be one of 'before', 'after', 'first_child', or 'last_child'.
- * @param array                   $hooked_blocks     An array of hooked blocks, grouped by anchor block and relative position.
- * @param WP_Block_Template|array $context           The block template, template part, or pattern that the anchor block belongs to.
+ * @param array                   $parsed_anchor_block The anchor block, in parsed block array format.
+ * @param string                  $relative_position   The relative position of the hooked blocks.
+ *                                                     Can be one of 'before', 'after', 'first_child', or 'last_child'.
+ * @param array                   $hooked_blocks       An array of hooked blocks, grouped by anchor block and relative position.
+ * @param WP_Block_Template|array $context             The block template, template part, or pattern that the anchor block belongs to.
  * @return string
  */
-function insert_hooked_blocks( &$anchor_block, $relative_position, $hooked_blocks, $context ) {
-	$anchor_block_type  = $anchor_block['blockName'];
+function insert_hooked_blocks( &$parsed_anchor_block, $relative_position, $hooked_blocks, $context ) {
+	$anchor_block_type  = $parsed_anchor_block['blockName'];
 	$hooked_block_types = isset( $hooked_blocks[ $anchor_block_type ][ $relative_position ] )
 		? $hooked_blocks[ $anchor_block_type ][ $relative_position ]
 		: array();
@@ -828,7 +828,7 @@ function insert_hooked_blocks( &$anchor_block, $relative_position, $hooked_block
 
 	$markup = '';
 	foreach ( $hooked_block_types as $hooked_block_type ) {
-		$hooked_block = array(
+		$parsed_hooked_block = array(
 			'blockName'    => $hooked_block_type,
 			'attrs'        => array(),
 			'innerBlocks'  => array(),
@@ -840,16 +840,16 @@ function insert_hooked_blocks( &$anchor_block, $relative_position, $hooked_block
 		 *
 		 * @since 6.5.0
 		 *
-		 * @param array                   $hooked_block      The parsed block array for the given hooked block type.
-		 * @param string                  $relative_position The relative position of the hooked block.
-		 * @param array                   $anchor_block      The anchor block, in parsed block array format.
-		 * @param WP_Block_Template|array $context           The block template, template part, or pattern that the anchor block belongs to.
+		 * @param array                   $parsed_hooked_block The parsed block array for the given hooked block type.
+		 * @param string                  $relative_position   The relative position of the hooked block.
+		 * @param array                   $parsed_anchor_block The anchor block, in parsed block array format.
+		 * @param WP_Block_Template|array $context             The block template, template part, or pattern that the anchor block belongs to.
 		 */
-		$hooked_block = apply_filters( "hooked_block_{$hooked_block_type}", $hooked_block, $relative_position, $anchor_block, $context );
+		$hooked_block = apply_filters( "hooked_block_{$hooked_block_type}", $parsed_hooked_block, $relative_position, $parsed_anchor_block, $context );
 
 		// It's possible that the `hooked_block_{$hooked_block_type}` filter returned a block of a different type,
 		// so we need to pass the original $hooked_block_type as well.
-		$markup .= get_hooked_block_markup( $hooked_block, $hooked_block_type, $anchor_block );
+		$markup .= get_hooked_block_markup( $parsed_hooked_block, $hooked_block_type, $parsed_anchor_block );
 	}
 
 	return $markup;

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -848,7 +848,7 @@ function insert_hooked_blocks( &$anchor_block, $relative_position, $hooked_block
 		$hooked_block = apply_filters( "hooked_block_{$hooked_block_type}", $hooked_block, $relative_position, $anchor_block, $context );
 
 		// It's possible that the `hooked_block_{$hooked_block_type}` filter returned a block of a different type,
-		// so we pass the original $hooked_block_type as well.
+		// so we need to pass the original $hooked_block_type as well.
 		$markup .= get_hooked_block_markup( $hooked_block, $hooked_block_type, $anchor_block );
 	}
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -842,7 +842,7 @@ function insert_hooked_blocks( &$anchor_block, $relative_position, $hooked_block
 		 *
 		 * @param array                   $hooked_block      The parsed block array for the given hooked block type.
 		 * @param string                  $relative_position The relative position of the hooked block.
-		 * @param array                   $anchor_block      The anchor block.
+		 * @param array                   $anchor_block      The anchor block, in parsed block array format.
 		 * @param WP_Block_Template|array $context           The block template, template part, or pattern that the anchor block belongs to.
 		 */
 		$hooked_block = apply_filters( "hooked_block_{$hooked_block_type}", $hooked_block, $relative_position, $anchor_block, $context );

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -760,9 +760,12 @@ function get_hooked_blocks() {
 /**
  * Conditionally returns the markup for a given hooked block.
  *
- * Accepts two arguments: A hooked block, and a reference to an anchor block.
+ * Accepts three arguments: A hooked block, its type, and a reference to an anchor block.
  * If the anchor block has already been processed, and the given hooked block type is in the list
  * of ignored hooked blocks, an empty string is returned.
+ *
+ * The hooked block type is specified separately as it's possible that a filter might've modified
+ * the hooked block such that `$hooked_block['blockName']` does no longer reflect the original type.
  *
  * This function is meant for internal use only.
  *

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -803,7 +803,7 @@ function get_hooked_block_markup( $hooked_block, $hooked_block_type, &$anchor_bl
  * @param array                   $anchor_block      The anchor block.
  * @param string                  $relative_position The relative position of the hooked blocks.
  *                                                   Can be one of 'before', 'after', 'first_child', or 'last_child'.
- * @param array                   $hooked_blocks     An array of blocks hooked to the given anchor block.
+ * @param array                   $hooked_blocks     An array of hooked blocks, grouped by anchor block and relative position.
  * @param WP_Block_Template|array $context           The block template, template part, or pattern that the anchor block belongs to.
  * @return string
  */

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -825,6 +825,7 @@ function insert_hooked_blocks( &$anchor_block, $relative_position, $hooked_block
 	foreach ( $hooked_block_types as $hooked_block_type ) {
 		$hooked_block = array(
 			'blockName' => $hooked_block_type,
+			'attrs'     => array(),
 		);
 
 		/**

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -769,16 +769,17 @@ function get_hooked_blocks() {
  * @since 6.5.0
  * @access private
  *
- * @param array $hooked_block The hooked block, represented as a parsed block array.
- * @param array $anchor_block The anchor block. Passed by reference.
+ * @param array  $hooked_block      The hooked block, represented as a parsed block array.
+ * @param string $hooked_block_type The type of the hooked block. This could be different from
+ *                                  $hooked_block['blockName'], as a filter might've modified the latter.
+ * @param array  $anchor_block      The anchor block. Passed by reference.
  * @return string The markup for the given hooked block, or an empty string if the block is ignored.
  */
-function get_hooked_block_markup( $hooked_block, &$anchor_block ) {
+function get_hooked_block_markup( $hooked_block, $hooked_block_type, &$anchor_block ) {
 	if ( ! isset( $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] ) ) {
 		$anchor_block['attrs']['metadata']['ignoredHookedBlocks'] = array();
 	}
 
-	$hooked_block_type = $hooked_block['blockName'];
 	if ( in_array( $hooked_block_type, $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] ) ) {
 		return '';
 	}
@@ -842,7 +843,9 @@ function insert_hooked_blocks( &$anchor_block, $relative_position, $hooked_block
 		 */
 		$hooked_block = apply_filters( "hooked_block_{$hooked_block_type}", $hooked_block, $relative_position, $anchor_block, $context );
 
-		$markup .= get_hooked_block_markup( $hooked_block, $anchor_block );
+		// It's possible that the `hooked_block_{$hooked_block_type}` filter returned a block of a different type,
+		// so we pass the original $hooked_block_type as well.
+		$markup .= get_hooked_block_markup( $hooked_block, $hooked_block_type, $anchor_block );
 	}
 
 	return $markup;

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -833,12 +833,11 @@ function insert_hooked_blocks( &$anchor_block, $relative_position, $hooked_block
 		 * @since 6.5.0
 		 *
 		 * @param array                   $hooked_block      The parsed block array for the given hooked block type.
-		 * @param string                  $hooked_block_type The hooked block type name.
 		 * @param string                  $relative_position The relative position of the hooked block.
 		 * @param array                   $anchor_block      The anchor block.
 		 * @param WP_Block_Template|array $context           The block template, template part, or pattern that the anchor block belongs to.
 		 */
-		$hooked_block = apply_filters( 'hooked_block', $hooked_block, $hooked_block_type, $relative_position, $anchor_block, $context );
+		$hooked_block = apply_filters( "hooked_block_{$hooked_block_type}", $hooked_block, $relative_position, $anchor_block, $context );
 
 		$markup .= get_hooked_block_markup( $hooked_block, $anchor_block );
 	}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -798,6 +798,7 @@ function get_hooked_block_markup( $hooked_block, $hooked_block_type, &$anchor_bl
  * Returns the markup for blocks hooked to the given anchor block in a specific relative position.
  *
  * @since 6.5.0
+ * @access private
  *
  * @param array                   $anchor_block      The anchor block.
  * @param string                  $relative_position The relative position of the hooked blocks.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -787,7 +787,7 @@ function get_hooked_block_markup( $hooked_block, &$anchor_block ) {
 	// However, its presence does not affect the frontend.
 	$anchor_block['attrs']['metadata']['ignoredHookedBlocks'][] = $hooked_block_type;
 
-	return get_comment_delimited_block_content( $hooked_block_type, $hooked_block['attrs'], '' );
+	return serialize_block( $hooked_block );
 }
 
 /**
@@ -824,8 +824,10 @@ function insert_hooked_blocks( &$anchor_block, $relative_position, $hooked_block
 	$markup = '';
 	foreach ( $hooked_block_types as $hooked_block_type ) {
 		$hooked_block = array(
-			'blockName' => $hooked_block_type,
-			'attrs'     => array(),
+			'blockName'    => $hooked_block_type,
+			'attrs'        => array(),
+			'innerBlocks'  => array(),
+			'innerContent' => array(),
 		);
 
 		/**

--- a/tests/phpunit/tests/blocks/getHookedBlockMarkup.php
+++ b/tests/phpunit/tests/blocks/getHookedBlockMarkup.php
@@ -17,11 +17,15 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 	 * @covers ::get_hooked_block_markup
 	 */
 	public function test_get_hooked_block_markup_adds_metadata() {
+		$hooked_block = array(
+			'blockName' => 'tests/hooked-block',
+		);
+
 		$anchor_block = array(
 			'blockName' => 'tests/anchor-block',
 		);
 
-		$actual = get_hooked_block_markup( $anchor_block, 'tests/hooked-block' );
+		$actual = get_hooked_block_markup( $hooked_block, $anchor_block );
 		$this->assertSame( array( 'tests/hooked-block' ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
 		$this->assertSame( '<!-- wp:tests/hooked-block /-->', $actual );
 	}
@@ -32,6 +36,10 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 	 * @covers ::get_hooked_block_markup
 	 */
 	public function test_get_hooked_block_markup_if_block_is_already_hooked() {
+		$hooked_block = array(
+			'blockName' => 'tests/hooked-block',
+		);
+
 		$anchor_block = array(
 			'blockName' => 'tests/anchor-block',
 			'attrs'     => array(
@@ -41,7 +49,7 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 			),
 		);
 
-		$actual = get_hooked_block_markup( $anchor_block, 'tests/hooked-block' );
+		$actual = get_hooked_block_markup( $hooked_block, $anchor_block );
 		$this->assertSame( array( 'tests/hooked-block' ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
 		$this->assertSame( '', $actual );
 	}
@@ -52,6 +60,10 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 	 * @covers ::get_hooked_block_markup
 	 */
 	public function test_get_hooked_block_markup_adds_to_ignored_hooked_blocks() {
+		$other_hooked_block = array(
+			'blockName' => 'tests/other-hooked-block',
+		);
+
 		$anchor_block = array(
 			'blockName' => 'tests/anchor-block',
 			'attrs'     => array(
@@ -61,7 +73,7 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 			),
 		);
 
-		$actual = get_hooked_block_markup( $anchor_block, 'tests/other-hooked-block' );
+		$actual = get_hooked_block_markup( $other_hooked_block, $anchor_block );
 		$this->assertSame( array( 'tests/hooked-block', 'tests/other-hooked-block' ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
 		$this->assertSame( '<!-- wp:tests/other-hooked-block /-->', $actual );
 	}

--- a/tests/phpunit/tests/blocks/getHookedBlockMarkup.php
+++ b/tests/phpunit/tests/blocks/getHookedBlockMarkup.php
@@ -19,6 +19,7 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 	);
 
 	/**
+	 * @ticket 59572
 	 * @ticket 60008
 	 * @ticket 60126
 	 *
@@ -35,6 +36,7 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 59572
 	 * @ticket 60008
 	 * @ticket 60126
 	 *
@@ -56,6 +58,7 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 59572
 	 * @ticket 60008
 	 * @ticket 60126
 	 *

--- a/tests/phpunit/tests/blocks/getHookedBlockMarkup.php
+++ b/tests/phpunit/tests/blocks/getHookedBlockMarkup.php
@@ -13,7 +13,7 @@
 class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 	const HOOKED_BLOCK_TYPE = 'tests/hooked-block';
 	const HOOKED_BLOCK      = array(
-		'blockName'    => 'tests/hooked-block',
+		'blockName'    => 'tests/different-hooked-block',
 		'attrs'        => array(),
 		'innerContent' => array(),
 	);
@@ -30,7 +30,7 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 
 		$actual = get_hooked_block_markup( self::HOOKED_BLOCK, self::HOOKED_BLOCK_TYPE, $anchor_block );
 		$this->assertSame( array( self::HOOKED_BLOCK_TYPE ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
-		$this->assertSame( '<!-- wp:' . self::HOOKED_BLOCK_TYPE . ' /-->', $actual );
+		$this->assertSame( '<!-- wp:' . self::HOOKED_BLOCK['blockName'] . ' /-->', $actual );
 	}
 
 	/**
@@ -77,6 +77,6 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 
 		$actual = get_hooked_block_markup( $other_hooked_block, $other_hooked_block_type, $anchor_block );
 		$this->assertSame( array( self::HOOKED_BLOCK_TYPE, $other_hooked_block_type ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
-		$this->assertSame( '<!-- wp:' . $other_hooked_block_type. ' /-->', $actual );
+		$this->assertSame( '<!-- wp:' . $other_hooked_block_type . ' /-->', $actual );
 	}
 }

--- a/tests/phpunit/tests/blocks/getHookedBlockMarkup.php
+++ b/tests/phpunit/tests/blocks/getHookedBlockMarkup.php
@@ -11,23 +11,26 @@
  * @group block-hooks
  */
 class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
+	const HOOKED_BLOCK_TYPE = 'tests/hooked-block';
+	const HOOKED_BLOCK      = array(
+		'blockName'    => 'tests/hooked-block',
+		'attrs'        => array(),
+		'innerContent' => array(),
+	);
+
 	/**
 	 * @ticket 60008
 	 *
 	 * @covers ::get_hooked_block_markup
 	 */
 	public function test_get_hooked_block_markup_adds_metadata() {
-		$hooked_block = array(
-			'blockName' => 'tests/hooked-block',
-		);
-
 		$anchor_block = array(
 			'blockName' => 'tests/anchor-block',
 		);
 
-		$actual = get_hooked_block_markup( $hooked_block, $anchor_block );
-		$this->assertSame( array( 'tests/hooked-block' ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
-		$this->assertSame( '<!-- wp:tests/hooked-block /-->', $actual );
+		$actual = get_hooked_block_markup( self::HOOKED_BLOCK, self::HOOKED_BLOCK_TYPE, $anchor_block );
+		$this->assertSame( array( self::HOOKED_BLOCK_TYPE ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
+		$this->assertSame( '<!-- wp:' . self::HOOKED_BLOCK_TYPE . ' /-->', $actual );
 	}
 
 	/**
@@ -36,21 +39,17 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 	 * @covers ::get_hooked_block_markup
 	 */
 	public function test_get_hooked_block_markup_if_block_is_already_hooked() {
-		$hooked_block = array(
-			'blockName' => 'tests/hooked-block',
-		);
-
 		$anchor_block = array(
 			'blockName' => 'tests/anchor-block',
 			'attrs'     => array(
 				'metadata' => array(
-					'ignoredHookedBlocks' => array( 'tests/hooked-block' ),
+					'ignoredHookedBlocks' => array( self::HOOKED_BLOCK_TYPE ),
 				),
 			),
 		);
 
-		$actual = get_hooked_block_markup( $hooked_block, $anchor_block );
-		$this->assertSame( array( 'tests/hooked-block' ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
+		$actual = get_hooked_block_markup( self::HOOKED_BLOCK, self::HOOKED_BLOCK_TYPE, $anchor_block );
+		$this->assertSame( array( self::HOOKED_BLOCK_TYPE ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
 		$this->assertSame( '', $actual );
 	}
 
@@ -60,21 +59,24 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 	 * @covers ::get_hooked_block_markup
 	 */
 	public function test_get_hooked_block_markup_adds_to_ignored_hooked_blocks() {
-		$other_hooked_block = array(
-			'blockName' => 'tests/other-hooked-block',
+		$other_hooked_block_type = 'tests/other-hooked-block';
+		$other_hooked_block      = array(
+			'blockName'    => $other_hooked_block_type,
+			'attrs'        => array(),
+			'innerContent' => array(),
 		);
 
 		$anchor_block = array(
 			'blockName' => 'tests/anchor-block',
 			'attrs'     => array(
 				'metadata' => array(
-					'ignoredHookedBlocks' => array( 'tests/hooked-block' ),
+					'ignoredHookedBlocks' => array( self::HOOKED_BLOCK_TYPE ),
 				),
 			),
 		);
 
-		$actual = get_hooked_block_markup( $other_hooked_block, $anchor_block );
-		$this->assertSame( array( 'tests/hooked-block', 'tests/other-hooked-block' ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
-		$this->assertSame( '<!-- wp:tests/other-hooked-block /-->', $actual );
+		$actual = get_hooked_block_markup( $other_hooked_block, $other_hooked_block_type, $anchor_block );
+		$this->assertSame( array( self::HOOKED_BLOCK_TYPE, $other_hooked_block_type ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
+		$this->assertSame( '<!-- wp:' . $other_hooked_block_type. ' /-->', $actual );
 	}
 }

--- a/tests/phpunit/tests/blocks/getHookedBlockMarkup.php
+++ b/tests/phpunit/tests/blocks/getHookedBlockMarkup.php
@@ -31,8 +31,16 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 		);
 
 		$actual = get_hooked_block_markup( self::HOOKED_BLOCK, self::HOOKED_BLOCK_TYPE, $anchor_block );
-		$this->assertSame( array( self::HOOKED_BLOCK_TYPE ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
-		$this->assertSame( '<!-- wp:' . self::HOOKED_BLOCK['blockName'] . ' /-->', $actual );
+		$this->assertSame(
+			array( self::HOOKED_BLOCK_TYPE ),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'],
+			"Hooked block type wasn't added to ignoredHookedBlocks metadata."
+		);
+		$this->assertSame(
+			'<!-- wp:' . self::HOOKED_BLOCK['blockName'] . ' /-->',
+			$actual,
+			"Markup for hooked block wasn't generated correctly."
+		);
 	}
 
 	/**
@@ -53,8 +61,16 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 		);
 
 		$actual = get_hooked_block_markup( self::HOOKED_BLOCK, self::HOOKED_BLOCK_TYPE, $anchor_block );
-		$this->assertSame( array( self::HOOKED_BLOCK_TYPE ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
-		$this->assertSame( '', $actual );
+		$this->assertSame(
+			array( self::HOOKED_BLOCK_TYPE ),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'],
+			"ignoredHookedBlocks metadata shouldn't have been modified."
+		);
+		$this->assertSame(
+			'',
+			$actual,
+			"No markup should've been generated for ignored hooked block."
+		);
 	}
 
 	/**
@@ -82,7 +98,15 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 		);
 
 		$actual = get_hooked_block_markup( $other_hooked_block, $other_hooked_block_type, $anchor_block );
-		$this->assertSame( array( self::HOOKED_BLOCK_TYPE, $other_hooked_block_type ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
-		$this->assertSame( '<!-- wp:' . $other_hooked_block_type . ' /-->', $actual );
+		$this->assertSame(
+			array( self::HOOKED_BLOCK_TYPE, $other_hooked_block_type ),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'],
+			"Newly hooked block should've been added to ignoredHookedBlocks metadata while retaining previously ignored one."
+		);
+		$this->assertSame(
+			'<!-- wp:' . $other_hooked_block_type . ' /-->',
+			$actual,
+			"Markup for newly hooked block should've been generated."
+		);
 	}
 }

--- a/tests/phpunit/tests/blocks/getHookedBlockMarkup.php
+++ b/tests/phpunit/tests/blocks/getHookedBlockMarkup.php
@@ -20,6 +20,7 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 60008
+	 * @ticket 60126
 	 *
 	 * @covers ::get_hooked_block_markup
 	 */
@@ -35,6 +36,7 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 60008
+	 * @ticket 60126
 	 *
 	 * @covers ::get_hooked_block_markup
 	 */
@@ -55,6 +57,7 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 60008
+	 * @ticket 60126
 	 *
 	 * @covers ::get_hooked_block_markup
 	 */

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Tests for the insert_hooked_blocks function.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @since 6.5.0
+ *
+ * @group blocks
+ * @group block-hooks
+ */
+class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
+	/**
+	 * @covers ::insert_hooked_blocks
+	 */
+	public function test_insert_hooked_blocks() {
+		$anchor_block_name = 'tests/anchor-block';
+		$anchor_block      = array(
+			'blockName' => $anchor_block_name,
+		);
+
+		// Maybe move to class level and include other relative positions?
+		// And/or data provider?
+		$hooked_blocks = array(
+			$anchor_block_name => array(
+				'after' => array( 'tests/hooked-before' ),
+			),
+		);
+
+		$actual = insert_hooked_blocks( $anchor_block, 'after', $hooked_blocks, array() );
+		$this->assertSame( '<!-- wp:tests/hooked-before /-->', $actual );
+	}
+}

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -175,9 +175,9 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 
 			// Wrap the block in a Group block.
 			return array(
-				'blockName' => 'core/group',
-				'attrs'     => array(),
-				'innerBlocks' => array( $parsed_hooked_block ),
+				'blockName'    => 'core/group',
+				'attrs'        => array(),
+				'innerBlocks'  => array( $parsed_hooked_block ),
 				'innerContent' => array(
 					'<div class="wp-block-group">',
 					null,

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -31,6 +31,7 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 		);
 
 		$actual = insert_hooked_blocks( $anchor_block, 'after', $hooked_blocks, array() );
+		$this->assertSame( array( 'tests/hooked-before' ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
 		$this->assertSame( '<!-- wp:tests/hooked-before /-->', $actual );
 	}
 }

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -34,8 +34,16 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 		);
 
 		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
-		$this->assertSame( array( self::HOOKED_BLOCK_TYPE ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
-		$this->assertSame( '<!-- wp:' . self::HOOKED_BLOCK_TYPE . ' /-->', $actual );
+		$this->assertSame(
+			array( self::HOOKED_BLOCK_TYPE ),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'],
+			"Hooked block type wasn't added to ignoredHookedBlocks metadata."
+		);
+		$this->assertSame(
+			'<!-- wp:' . self::HOOKED_BLOCK_TYPE . ' /-->',
+			$actual,
+			"Markup for hooked block wasn't generated correctly."
+		);
 	}
 
 	/**
@@ -55,8 +63,16 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 		);
 
 		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
-		$this->assertSame( array( self::HOOKED_BLOCK_TYPE ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
-		$this->assertSame( '', $actual );
+		$this->assertSame(
+			array( self::HOOKED_BLOCK_TYPE ),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'],
+			"ignoredHookedBlocks metadata shouldn't have been modified."
+		);
+		$this->assertSame(
+			'',
+			$actual,
+			"No markup should've been generated for ignored hooked block."
+		);
 	}
 
 	/**
@@ -76,8 +92,16 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 		);
 
 		$actual = insert_hooked_blocks( $anchor_block, 'before', self::HOOKED_BLOCKS, array() );
-		$this->assertSame( array( self::HOOKED_BLOCK_TYPE, self::OTHER_HOOKED_BLOCK_TYPE ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
-		$this->assertSame( '<!-- wp:' . self::OTHER_HOOKED_BLOCK_TYPE . ' /-->', $actual );
+		$this->assertSame(
+			array( self::HOOKED_BLOCK_TYPE, self::OTHER_HOOKED_BLOCK_TYPE ),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'],
+			"Newly hooked block should've been added to ignoredHookedBlocks metadata while retaining previously ignored one."
+		);
+		$this->assertSame(
+			'<!-- wp:' . self::OTHER_HOOKED_BLOCK_TYPE . ' /-->',
+			$actual,
+			"Markup for newly hooked block should've been generated."
+		);
 	}
 
 	/**
@@ -115,8 +139,16 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
 		remove_filter( 'hooked_block_' . SELF::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
 
-		$this->assertSame( array( self::HOOKED_BLOCK_TYPE ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
-		$this->assertSame( '<!-- wp:' . self::HOOKED_BLOCK_TYPE . ' {"layout":{"type":"constrained"}} /-->', $actual );
+		$this->assertSame(
+			array( self::HOOKED_BLOCK_TYPE ),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'],
+			"Hooked block type wasn't added to ignoredHookedBlocks metadata."
+		);
+		$this->assertSame(
+			'<!-- wp:' . self::HOOKED_BLOCK_TYPE . ' {"layout":{"type":"constrained"}} /-->',
+			$actual,
+			"Markup wasn't generated correctly for hooked block with attribute set by filter."
+		);
 	}
 
 	/**
@@ -157,10 +189,15 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
 		remove_filter( 'hooked_block_' . SELF::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
 
-		$this->assertSame( array( self::HOOKED_BLOCK_TYPE ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
+		$this->assertSame(
+			array( self::HOOKED_BLOCK_TYPE ),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'],
+			"Hooked block type wasn't added to ignoredHookedBlocks metadata."
+		);
 		$this->assertSame(
 			'<!-- wp:group --><div class="wp-block-group"><!-- wp:' . self::HOOKED_BLOCK_TYPE . ' /--></div><!-- /wp:group -->',
-			$actual
+			$actual,
+			"Markup wasn't generated correctly for hooked block wrapped in Group block by filter."
 		);
 	}
 }

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -11,27 +11,33 @@
  * @group block-hooks
  */
 class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
+	const ANCHOR_BLOCK_TYPE = 'tests/anchor-block';
+
+	const HOOKED_BLOCK_TYPE = 'tests/hooked-block';
+	const HOOKED_BLOCK      = array(
+		'blockName'    => 'tests/different-hooked-block',
+		'attrs'        => array(),
+		'innerContent' => array(),
+	);
+
+	const HOOKED_BLOCKS = array(
+		self::ANCHOR_BLOCK_TYPE => array(
+			'after' => array( self::HOOKED_BLOCK_TYPE ),
+		),
+	);
+
 	/**
 	 * @ticket 60126
 	 *
 	 * @covers ::insert_hooked_blocks
 	 */
-	public function test_insert_hooked_blocks() {
-		$anchor_block_name = 'tests/anchor-block';
-		$anchor_block      = array(
-			'blockName' => $anchor_block_name,
+	public function test_insert_hooked_blocks_adds_metadata() {
+		$anchor_block = array(
+			'blockName' => self::ANCHOR_BLOCK_TYPE,
 		);
 
-		// Maybe move to class level and include other relative positions?
-		// And/or data provider?
-		$hooked_blocks = array(
-			$anchor_block_name => array(
-				'after' => array( 'tests/hooked-before' ),
-			),
-		);
-
-		$actual = insert_hooked_blocks( $anchor_block, 'after', $hooked_blocks, array() );
-		$this->assertSame( array( 'tests/hooked-before' ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
-		$this->assertSame( '<!-- wp:tests/hooked-before /-->', $actual );
+		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		$this->assertSame( array( self::HOOKED_BLOCK_TYPE ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
+		$this->assertSame( '<!-- wp:' . self::HOOKED_BLOCK_TYPE . ' /-->', $actual );
 	}
 }

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -79,4 +79,43 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 		$this->assertSame( array( self::HOOKED_BLOCK_TYPE, self::OTHER_HOOKED_BLOCK_TYPE ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
 		$this->assertSame( '<!-- wp:' . self::OTHER_HOOKED_BLOCK_TYPE . ' /-->', $actual );
 	}
+
+	/**
+	 * @ticket 59572
+	 * @ticket 60126
+	 *
+	 * @covers ::insert_hooked_blocks
+	 */
+	public function test_insert_hooked_blocks_filter_can_set_attributes() {
+		$anchor_block = array(
+			'blockName'    => self::ANCHOR_BLOCK_TYPE,
+			'attrs'        => array(
+				'layout' => array(
+					'type' => 'constrained',
+				)
+			),
+			'innerContent' => array(),
+		);
+
+		$filter = function( $parsed_hooked_block, $relative_position, $parsed_anchor_block ) {
+			// Is the hooked block adjacent to the anchor block?
+			if ( 'before' !== $relative_position && 'after' !== $relative_position ) {
+				return $parsed_hooked_block;
+			}
+
+			// Does the anchor block have a layout attribute?
+			if ( isset( $parsed_anchor_block['attrs']['layout'] ) ) {
+				// Copy the anchor block's layout attribute to the hooked block.
+				$parsed_hooked_block['attrs']['layout'] = $parsed_anchor_block['attrs']['layout'];
+			}
+
+			return $parsed_hooked_block;
+		};
+		add_filter( 'hooked_block_' . SELF::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
+		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		remove_filter( 'hooked_block_' . SELF::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
+
+		$this->assertSame( array( self::HOOKED_BLOCK_TYPE ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
+		$this->assertSame( '<!-- wp:' . self::HOOKED_BLOCK_TYPE . ' {"layout":{"type":"constrained"}} /-->', $actual );
+	}
 }

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -116,12 +116,12 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 			'attrs'        => array(
 				'layout' => array(
 					'type' => 'constrained',
-				)
+				),
 			),
 			'innerContent' => array(),
 		);
 
-		$filter = function( $parsed_hooked_block, $relative_position, $parsed_anchor_block ) {
+		$filter = function ( $parsed_hooked_block, $relative_position, $parsed_anchor_block ) {
 			// Is the hooked block adjacent to the anchor block?
 			if ( 'before' !== $relative_position && 'after' !== $relative_position ) {
 				return $parsed_hooked_block;
@@ -135,9 +135,9 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 
 			return $parsed_hooked_block;
 		};
-		add_filter( 'hooked_block_' . SELF::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
+		add_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
 		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
-		remove_filter( 'hooked_block_' . SELF::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
+		remove_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
 
 		$this->assertSame(
 			array( self::HOOKED_BLOCK_TYPE ),
@@ -163,13 +163,13 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 			'attrs'        => array(
 				'layout' => array(
 					'type' => 'constrained',
-				)
+				),
 			),
 			'innerContent' => array(),
 		);
 
-		$filter = function( $parsed_hooked_block ) {
-			if ( SELF::HOOKED_BLOCK_TYPE !== $parsed_hooked_block['blockName'] ) {
+		$filter = function ( $parsed_hooked_block ) {
+			if ( self::HOOKED_BLOCK_TYPE !== $parsed_hooked_block['blockName'] ) {
 				return $parsed_hooked_block;
 			}
 
@@ -181,13 +181,13 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 				'innerContent' => array(
 					'<div class="wp-block-group">',
 					null,
-					'</div>'
+					'</div>',
 				),
 			);
 		};
-		add_filter( 'hooked_block_' . SELF::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
+		add_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
 		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
-		remove_filter( 'hooked_block_' . SELF::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
+		remove_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
 
 		$this->assertSame(
 			array( self::HOOKED_BLOCK_TYPE ),

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -35,6 +35,7 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 	);
 
 	/**
+	 * @ticket 59572
 	 * @ticket 60126
 	 *
 	 * @covers ::insert_hooked_blocks
@@ -50,6 +51,7 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 59572
 	 * @ticket 60126
 	 *
 	 * @covers ::insert_hooked_blocks
@@ -70,6 +72,7 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 59572
 	 * @ticket 60126
 	 *
 	 * @covers ::insert_hooked_blocks

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -11,21 +11,9 @@
  * @group block-hooks
  */
 class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
-	const ANCHOR_BLOCK_TYPE = 'tests/anchor-block';
-
-	const HOOKED_BLOCK_TYPE = 'tests/hooked-block';
-	const HOOKED_BLOCK      = array(
-		'blockName'    => 'tests/different-hooked-block',
-		'attrs'        => array(),
-		'innerContent' => array(),
-	);
-
+	const ANCHOR_BLOCK_TYPE       = 'tests/anchor-block';
+	const HOOKED_BLOCK_TYPE       = 'tests/hooked-block';
 	const OTHER_HOOKED_BLOCK_TYPE = 'tests/other-hooked-block';
-	const OTHER_HOOKED_BLOCK      = array(
-		'blockName'    => self::OTHER_HOOKED_BLOCK_TYPE,
-		'attrs'        => array(),
-		'innerContent' => array(),
-	);
 
 	const HOOKED_BLOCKS = array(
 		self::ANCHOR_BLOCK_TYPE => array(

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -20,9 +20,17 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 		'innerContent' => array(),
 	);
 
+	const OTHER_HOOKED_BLOCK_TYPE = 'tests/other-hooked-block';
+	const OTHER_HOOKED_BLOCK      = array(
+		'blockName'    => self::OTHER_HOOKED_BLOCK_TYPE,
+		'attrs'        => array(),
+		'innerContent' => array(),
+	);
+
 	const HOOKED_BLOCKS = array(
 		self::ANCHOR_BLOCK_TYPE => array(
-			'after' => array( self::HOOKED_BLOCK_TYPE ),
+			'after'  => array( self::HOOKED_BLOCK_TYPE ),
+			'before' => array( self::OTHER_HOOKED_BLOCK_TYPE ),
 		),
 	);
 
@@ -39,5 +47,45 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
 		$this->assertSame( array( self::HOOKED_BLOCK_TYPE ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
 		$this->assertSame( '<!-- wp:' . self::HOOKED_BLOCK_TYPE . ' /-->', $actual );
+	}
+
+	/**
+	 * @ticket 60126
+	 *
+	 * @covers ::insert_hooked_blocks
+	 */
+	public function test_insert_hooked_blocks_if_block_is_already_hooked() {
+		$anchor_block = array(
+			'blockName' => 'tests/anchor-block',
+			'attrs'     => array(
+				'metadata' => array(
+					'ignoredHookedBlocks' => array( self::HOOKED_BLOCK_TYPE ),
+				),
+			),
+		);
+
+		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		$this->assertSame( array( self::HOOKED_BLOCK_TYPE ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
+		$this->assertSame( '', $actual );
+	}
+
+	/**
+	 * @ticket 60126
+	 *
+	 * @covers ::insert_hooked_blocks
+	 */
+	public function test_insert_hooked_blocks_adds_to_ignored_hooked_blocks() {
+		$anchor_block = array(
+			'blockName' => 'tests/anchor-block',
+			'attrs'     => array(
+				'metadata' => array(
+					'ignoredHookedBlocks' => array( self::HOOKED_BLOCK_TYPE ),
+				),
+			),
+		);
+
+		$actual = insert_hooked_blocks( $anchor_block, 'before', self::HOOKED_BLOCKS, array() );
+		$this->assertSame( array( self::HOOKED_BLOCK_TYPE, self::OTHER_HOOKED_BLOCK_TYPE ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
+		$this->assertSame( '<!-- wp:' . self::OTHER_HOOKED_BLOCK_TYPE . ' /-->', $actual );
 	}
 }

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -12,6 +12,8 @@
  */
 class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 	/**
+	 * @ticket 60126
+	 *
 	 * @covers ::insert_hooked_blocks
 	 */
 	public function test_insert_hooked_blocks() {


### PR DESCRIPTION
Add a new `hooked_block_{$block_type}` filter that allows changing a hooked block (in parsed block format), while providing read access to its anchor block (in the same format).

```php
/**
 * Filters the parsed block array for a given hooked block.
 *
 * @since 6.5.0
 *
 * @param array                   $hooked_block      The parsed block array for the given hooked block type.
 * @param string                  $relative_position The relative position of the hooked block.
 * @param array                   $anchor_block      The anchor block.
 * @param WP_Block_Template|array $context           The block template, template part, or pattern that the anchor block belongs to.
 */
$hooked_block = apply_filters( "hooked_block_{$hooked_block_type}", $hooked_block, $relative_position, $anchor_block, $context );
```

This allows block authors to e.g. set a hooked block's attributes; the filter can peruse information about the anchor block when doing so. As such, this PR provides a solution to both [`#59572`](https://core.trac.wordpress.org/ticket/59572) and [`#60126`](https://core.trac.wordpress.org/ticket/60126).

This seems to strike a good balance and separation of concerns with the existing [`hooked_block_types` filter](https://developer.wordpress.org/reference/hooks/hooked_block_types/), which allows addition or removal of a block to the list of hooked blocks for a given hooked blocks -- all of which are identified only by their block _types_. This new filter, OTOH, only applies to one hooked block at a time, and allows modifying the entire (parsed) hooked block; it also gives (read) access to the parsed anchor block.

This PR also introduces a new `insert_hooked_blocks` helper function (as originally explored in #5609). This is mostly to avoid code duplication; in particular, we’d otherwise be applying both the `hooked_block_types` and the newly introduced `hooked_block_{$hooked_block_type}` filter four times.

Furthermore, the new filter requires some changes to the `get_hooked_block_markup()` function, which now also has to accept the entire hooked block (as a parsed block array); for more consistency, we also change the argument order.

The following three snippets demonstrate how this new filter can be used (to solve [`#60126`](https://core.trac.wordpress.org/ticket/60126)). To try them out, apply the respective patch to the [Like Button block](https://github.com/ockham/like-button) code.

<details>
<summary>
Copy `layout.type` attribute from anchor block to hooked block.
</summary>

```diff
diff --git a/like-button.php b/like-button.php
index 65acbc3..d416218 100644
--- a/like-button.php
+++ b/like-button.php
@@ -24,3 +24,19 @@ function create_block_like_button_block_init() {
        register_block_type( __DIR__ . '/build' );
 }
 add_action( 'init', 'create_block_like_button_block_init' );
+
+function set_like_button_block_layout_attribute_based_on_adjacent_block( $hooked_block, $relative_position, $anchor_block ) {
+       // Is the hooked block adjacent to the anchor block?
+       if ( 'before' !== $relative_position && 'after' !== $relative_position ) {
+               return $hooked_block;
+       }
+
+       // Does the anchor block have a layout attribute?
+       if ( isset( $anchor_block['attrs']['layout'] ) ) {
+               // Copy the anchor block's layout attribute to the hooked block.
+               $hooked_block['attrs']['layout'] = $anchor_block['attrs']['layout'];
+       }
+
+       return $hooked_block;
+}
+add_filter( 'hooked_block_ockham/like-button', 'set_like_button_block_layout_attribute_based_on_adjacent_block', 10, 3 );
```
</details>

<details>
<summary>
Replace Like Button block with a pattern (that wraps the block in a Group block).
</summary>

```diff
diff --git a/like-button.php b/like-button.php
index 65acbc3..4728ce1 100644
--- a/like-button.php
+++ b/like-button.php
@@ -22,5 +22,34 @@
  */
 function create_block_like_button_block_init() {
        register_block_type( __DIR__ . '/build' );
+
+       register_block_pattern(
+               'ockham/like-button-wrapper',
+               array(
+                       'title'       => __( 'Like Button', 'like-button' ),
+                       'description' => _x( 'A button to like content.', 'Block pattern description', 'like-button' ),
+                       'content'     => '<!-- wp:group {"layout":{"type":"constrained"}} --><div class="wp-block-group"><!-- wp:ockham/like-button /--></div><!-- /wp:group -->',
+                       'inserter'    => false
+               )
+       );
 }
 add_action( 'init', 'create_block_like_button_block_init' );
+
+function insert_like_button_pattern_after_post_content( $hooked_block, $position, $anchor_block ) {
+       if ( 'before' !== $position && 'after' !== $position ) {
+               return $hooked_block;
+       }
+
+       if ( 'core/post-content' !== $anchor_block['blockName'] ) {
+               return $hooked_block;
+       }
+
+       // We replace the "simple" block with a pattern that contains a Group block wrapper.
+       return array(
+               'blockName' => 'core/pattern',
+               'attrs'     => array(
+                       'slug' => 'ockham/like-button-wrapper',
+               ),
+       );
+}
+add_filter( 'hooked_block_ockham/like-button', 'insert_like_button_pattern_after_post_content', 10, 3 );
```

Branch: https://github.com/ockham/like-button/tree/try/hooked-block-filter-with-pattern

_Note that this approach doesn't allow setting the `layout` attribute dynamically (and instead hard-wires it to be `"type": "constrained"`)._
</details>

<details>
<summary>
Manually wrap the Like Button block in a Group block and copy its `layout.type` attribute from the anchor block.
</summary>

Per https://github.com/WordPress/wordpress-develop/pull/5835/commits/b34e2cf374d4acb128f2e63ed70de3282b9cc6ff (which I just worked on with @c4rl0sbr4v0), it is now possible to pass a block that has inner blocks:

```diff
diff --git a/like-button.php b/like-button.php
index 65acbc3..4122d3c 100644
--- a/like-button.php
+++ b/like-button.php
@@ -24,3 +24,34 @@ function create_block_like_button_block_init() {
 	register_block_type( __DIR__ . '/build' );
 }
 add_action( 'init', 'create_block_like_button_block_init' );
+
+function insert_like_button_after_post_content( $hooked_block, $position, $anchor_block ) {
+	if ( 'before' !== $position && 'after' !== $position ) {
+		return $hooked_block;
+	}
+
+	if ( 'core/post-content' !== $anchor_block['blockName'] ) {
+		return $hooked_block;
+	}
+
+	$attrs = isset( $anchor_block['attrs']['layout']['type'] )
+		? array(
+			'layout' => array(
+				'type' => $anchor_block['attrs']['layout']['type']
+			)
+		)
+		: array();
+
+	// Wrap the Like Button block in a Group block.
+	return array(
+		'blockName' => 'core/group',
+		'attrs'     => $attrs,
+		'innerBlocks' => array( $hooked_block ),
+		'innerContent' => array(
+			'<div class="wp-block-group">',
+			null,
+			'</div>'
+		),
+	);
+}
+add_filter( 'hooked_block_ockham/like-button', 'insert_like_button_after_post_content', 10, 3 );
```

Branch: https://github.com/ockham/like-button/tree/try/hooked-block-filter-with-group-block-wrapper

Not exactly pretty 😬 
</details>

---

| Before | After |
|-------|-------|
| ![image](https://github.com/WordPress/wordpress-develop/assets/96308/64bf3e81-3ab8-4d10-9ff3-1295dddaa21c) | ![image](https://github.com/WordPress/wordpress-develop/assets/96308/193b01a7-85b9-4744-bbf8-8e5ef066302d) |

Trac ticket: https://core.trac.wordpress.org/ticket/60126

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
