### PR TITLE
Add cast to string for cookie name inside normalize_cookies

### DIFF
--- a/src/wp-includes/class-wp-http.php
+++ b/src/wp-includes/class-wp-http.php
@@ -467,9 +467,9 @@ class WP_Http {
 						return null !== $attr;
 					}
 				);
-				$cookie_jar[ $value->name ] = new WpOrg\Requests\Cookie( $value->name, $value->value, $attributes, array( 'host-only' => $value->host_only ) );
+				$cookie_jar[ $value->name ] = new WpOrg\Requests\Cookie( (string) $value->name, $value->value, $attributes, array( 'host-only' => $value->host_only ) );
 			} elseif ( is_scalar( $value ) ) {
-				$cookie_jar[ $name ] = new WpOrg\Requests\Cookie( $name, (string) $value );
+				$cookie_jar[ $name ] = new WpOrg\Requests\Cookie( (string) $name, (string) $value );
 			}
 		}
 

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -661,4 +661,55 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 		$this->assertSame( 'PASS', wp_remote_retrieve_body( $redirect_response ), 'Redirect response body is expected to be PASS.' );
 		$this->assertTrue( $pre_http_request_filter_has_run, 'The pre_http_request filter is expected to run.' );
 	}
+
+	/**
+	 * Test that WP_Http::normalize_cookies method correctly casts integer keys to string.
+	 * @ticket 58566
+	 *
+	 * @covers WP_Http::normalize_cookies
+	 */
+	public function test_normalize_cookies_casts_integer_keys_to_string() {
+		$http = _wp_http_get_object();
+
+		$cookies = array(
+			'1'   => 'foo',
+			2     => 'bar',
+			'qux' => 7
+		);
+
+		$cookie_jar = $http->normalize_cookies( $cookies );
+
+		$this->assertInstanceOf( 'WpOrg\Requests\Cookie\Jar', $cookie_jar );
+
+		foreach ( array_keys( $cookies ) as $cookie ) {
+			if ( is_string( $cookie ) ){
+				$this->assertInstanceOf( 'WpOrg\Requests\Cookie', $cookie_jar[ $cookie ] );
+			} else {
+				$this->assertInstanceOf( 'WpOrg\Requests\Cookie', $cookie_jar[ (string) $cookie ] );
+			}
+		}
+	}
+
+	/**
+	 * Test that WP_Http::normalize_cookies method correctly casts integer cookie names to strings.
+	 * @ticket 58566
+	 *
+	 * @covers WP_Http::normalize_cookies
+	 */
+	public function test_normalize_cookies_casts_cookie_name_integer_to_string() {
+		$http = _wp_http_get_object();
+
+		$cookies = array(
+			'foo'   => new WP_Http_Cookie( array(
+					'name'  => 1,
+					'value' => 'foo',
+				)
+			),
+		);
+
+		$cookie_jar = $http->normalize_cookies( $cookies );
+
+		$this->assertInstanceOf( 'WpOrg\Requests\Cookie\Jar', $cookie_jar );
+		$this->assertInstanceOf( 'WpOrg\Requests\Cookie', $cookie_jar[ '1' ] );
+	}
 }

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -674,7 +674,7 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 		$cookies = array(
 			'1'   => 'foo',
 			2     => 'bar',
-			'qux' => 7
+			'qux' => 7,
 		);
 
 		$cookie_jar = $http->normalize_cookies( $cookies );
@@ -682,7 +682,7 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'WpOrg\Requests\Cookie\Jar', $cookie_jar );
 
 		foreach ( array_keys( $cookies ) as $cookie ) {
-			if ( is_string( $cookie ) ){
+			if ( is_string( $cookie ) ) {
 				$this->assertInstanceOf( 'WpOrg\Requests\Cookie', $cookie_jar[ $cookie ] );
 			} else {
 				$this->assertInstanceOf( 'WpOrg\Requests\Cookie', $cookie_jar[ (string) $cookie ] );
@@ -700,7 +700,8 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 		$http = _wp_http_get_object();
 
 		$cookies = array(
-			'foo'   => new WP_Http_Cookie( array(
+			'foo' => new WP_Http_Cookie(
+				array(
 					'name'  => 1,
 					'value' => 'foo',
 				)
@@ -710,6 +711,6 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 		$cookie_jar = $http->normalize_cookies( $cookies );
 
 		$this->assertInstanceOf( 'WpOrg\Requests\Cookie\Jar', $cookie_jar );
-		$this->assertInstanceOf( 'WpOrg\Requests\Cookie', $cookie_jar[ '1' ] );
+		$this->assertInstanceOf( 'WpOrg\Requests\Cookie', $cookie_jar['1'] );
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This pull request addresses an issue encountered when integer-named cookies are submitted using `wp_remote_post` and `wp_remote_get` . The underlying problem stems from the `Requests\Cookie::construct()` method, which requires cookie names to be of type string. 

The primary change in this pull request is the addition casting within the `WP_Http::normalize_cookies()` function. This update explicitly casts cookie names to strings.

Unit tests have been added to test the offending scenario.

Trac ticket: https://core.trac.wordpress.org/ticket/58566

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
