### PR TITLE
Block Hooks: Allow passing block definitions to `hooked_block_types` filter (and thus, hooking patterns)

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -760,7 +760,7 @@ function get_hooked_blocks() {
 /**
  * Conditionally returns the markup for a given hooked block.
  *
- * Accepts two arguments: A reference to an anchor block, and hooked block.
+ * Accepts two arguments: A hooked block, and a reference to an anchor block.
  * If the anchor block has already been processed, and the given hooked block type is in the list
  * of ignored hooked blocks, an empty string is returned.
  *
@@ -769,11 +769,11 @@ function get_hooked_blocks() {
  * @since 6.5.0
  * @access private
  *
- * @param array $anchor_block The anchor block. Passed by reference.
  * @param array $hooked_block The hooked block, represented as a parsed block array.
+ * @param array $anchor_block The anchor block. Passed by reference.
  * @return string The markup for the given hooked block, or an empty string if the block is ignored.
  */
-function get_hooked_block_markup( &$anchor_block, $hooked_block ) {
+function get_hooked_block_markup( $hooked_block, &$anchor_block ) {
 	if ( ! isset( $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] ) ) {
 		$anchor_block['attrs']['metadata']['ignoredHookedBlocks'] = array();
 	}
@@ -840,7 +840,7 @@ function insert_hooked_blocks( &$anchor_block, $relative_position, $hooked_block
 		 */
 		$hooked_block = apply_filters( 'hooked_block', $hooked_block, $hooked_block_type, $relative_position, $anchor_block, $context );
 
-		$markup .= get_hooked_block_markup( $anchor_block, $hooked_block );
+		$markup .= get_hooked_block_markup( $hooked_block, $anchor_block );
 	}
 
 	return $markup;

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -827,19 +827,6 @@ function insert_hooked_blocks( &$anchor_block, $relative_position, $hooked_block
 			'blockName' => $hooked_block_type,
 		);
 
-		/**
-		 * Filters the parsed block array for a given hooked block.
-		 *
-		 * @since 6.5.0
-		 *
-		 * @param array                   $hooked_block      The parsed block array for the given hooked block type.
-		 * @param string                  $hooked_block_type The hooked block type name.
-		 * @param string                  $relative_position The relative position of the hooked block.
-		 * @param array                   $anchor_block      The anchor block.
-		 * @param WP_Block_Template|array $context           The block template, template part, or pattern that the anchor block belongs to.
-		 */
-		$hooked_block = apply_filters( 'hooked_block', $hooked_block, $hooked_block_type, $relative_position, $anchor_block, $context );
-
 		$markup .= get_hooked_block_markup( $hooked_block, $anchor_block );
 	}
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -828,6 +828,7 @@ function insert_hooked_blocks( &$anchor_block, $relative_position, $hooked_block
 		} else {
 			$hooked_block = array(
 				'blockName' => $hooked_block_type,
+				'attrs'     => array(),
 			);
 		}
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -823,9 +823,13 @@ function insert_hooked_blocks( &$anchor_block, $relative_position, $hooked_block
 
 	$markup = '';
 	foreach ( $hooked_block_types as $hooked_block_type ) {
-		$hooked_block = array(
-			'blockName' => $hooked_block_type,
-		);
+		if ( is_array( $hooked_block_type ) && isset( $hooked_block_type['blockName'] ) && isset( $hooked_block_type['attrs'] ) ) {
+			$hooked_block = $hooked_block_type;
+		} else {
+			$hooked_block = array(
+				'blockName' => $hooked_block_type,
+			);
+		}
 
 		$markup .= get_hooked_block_markup( $hooked_block, $anchor_block );
 	}

--- a/tests/phpunit/tests/blocks/getHookedBlockMarkup.php
+++ b/tests/phpunit/tests/blocks/getHookedBlockMarkup.php
@@ -17,11 +17,15 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 	 * @covers ::get_hooked_block_markup
 	 */
 	public function test_get_hooked_block_markup_adds_metadata() {
+		$hooked_block = array(
+			'blockName' => 'tests/hooked-block',
+		);
+
 		$anchor_block = array(
 			'blockName' => 'tests/anchor-block',
 		);
 
-		$actual = get_hooked_block_markup( $anchor_block, 'tests/hooked-block' );
+		$actual = get_hooked_block_markup( $hooked_block, $anchor_block );
 		$this->assertSame( array( 'tests/hooked-block' ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
 		$this->assertSame( '<!-- wp:tests/hooked-block /-->', $actual );
 	}
@@ -32,6 +36,10 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 	 * @covers ::get_hooked_block_markup
 	 */
 	public function test_get_hooked_block_markup_if_block_is_already_hooked() {
+		$hooked_block = array(
+			'blockName' => 'tests/hooked-block',
+		);
+
 		$anchor_block = array(
 			'blockName' => 'tests/anchor-block',
 			'attrs'     => array(
@@ -41,7 +49,7 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 			),
 		);
 
-		$actual = get_hooked_block_markup( $anchor_block, 'tests/hooked-block' );
+		$actual = get_hooked_block_markup( $hooked_block, $anchor_block );
 		$this->assertSame( array( 'tests/hooked-block' ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
 		$this->assertSame( '', $actual );
 	}
@@ -52,6 +60,10 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 	 * @covers ::get_hooked_block_markup
 	 */
 	public function test_get_hooked_block_markup_adds_to_ignored_hooked_blocks() {
+		$other_hooked_block = array(
+			'blockName' => 'tests/other-hooked-block',
+		);
+
 		$anchor_block = array(
 			'blockName' => 'tests/anchor-block',
 			'attrs'     => array(
@@ -61,7 +73,7 @@ class Tests_Blocks_GetHookedBlockMarkup extends WP_UnitTestCase {
 			),
 		);
 
-		$actual = get_hooked_block_markup( $anchor_block, 'tests/other-hooked-block' );
+		$actual = get_hooked_block_markup( $other_hooked_block, $anchor_block );
 		$this->assertSame( array( 'tests/hooked-block', 'tests/other-hooked-block' ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
 		$this->assertSame( '<!-- wp:tests/other-hooked-block /-->', $actual );
 	}

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Tests for the insert_hooked_blocks function.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @since 6.5.0
+ *
+ * @group blocks
+ * @group block-hooks
+ */
+class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
+	/**
+	 * @covers ::insert_hooked_blocks
+	 */
+	public function test_insert_hooked_blocks() {
+		$anchor_block_name = 'tests/anchor-block';
+		$anchor_block      = array(
+			'blockName' => $anchor_block_name,
+		);
+
+		// Maybe move to class level and include other relative positions?
+		// And/or data provider?
+		$hooked_blocks = array(
+			$anchor_block_name => array(
+				'after' => array( 'tests/hooked-before' ),
+			),
+		);
+
+		$actual = insert_hooked_blocks( $anchor_block, 'after', $hooked_blocks, array() );
+		$this->assertSame( '<!-- wp:tests/hooked-before /-->', $actual );
+	}
+}


### PR DESCRIPTION
Another alternative to https://github.com/WordPress/wordpress-develop/pull/5811 and https://github.com/WordPress/wordpress-develop/pull/5835. Uses some code from https://github.com/WordPress/wordpress-develop/pull/5609.

Implements an idea originally conceived of in https://core.trac.wordpress.org/ticket/59572:

> We might want to allow providing a full, parsed-block style, block definition, at least for the filter:
> 
> ```php
> array( 'mycommerce/mini-cart', array(
>         'isPreview'    => true,
>         'miniCartIcon' => 'bag',
> ) )
> ```

In addition, this PR seeks to also explore a possible solution for https://core.trac.wordpress.org/ticket/60126: With the ability to pass attributes for hooked blocks, we can now hook patterns (by giving `core/pattern` as the block type, and setting the `slug` attribute to the desired pattern).

To demonstrate the latter, apply the following patch to the [Like Button block](https://github.com/ockham/like-button) code:

```diff
diff --git a/like-button.php b/like-button.php
index 65acbc3..08a54c1 100644
--- a/like-button.php
+++ b/like-button.php
@@ -22,5 +22,35 @@
  */
 function create_block_like_button_block_init() {
 	register_block_type( __DIR__ . '/build' );
+
+	register_block_pattern(
+		'ockham/like-button-wrapper',
+		array(
+			'title'       => __( 'Like Button', 'like-button' ),
+			'description' => _x( 'A button to like content.', 'Block pattern description', 'like-button' ),
+			'content'     => '<!-- wp:group {"layout":{"type":"constrained"}} --><div class="wp-block-group"><!-- wp:ockham/like-button /--></div><!-- /wp:group -->',
+			'inserter'    => false
+		)
+	);
 }
 add_action( 'init', 'create_block_like_button_block_init' );
+
+function insert_like_button_pattern_after_post_content( $hooked_blocks, $position, $anchor_block ) {
+	if ( 'after' !== $position ) {
+		return $hooked_blocks;
+	}
+
+	if ( 'core/post-content' !== $anchor_block ) {
+		return $hooked_blocks;
+	}
+
+	$hooked_blocks[] = array(
+		'blockName' => 'core/pattern',
+		'attrs'     => array(
+			'slug' => 'ockham/like-button-wrapper',
+		),
+	);
+
+	return $hooked_blocks;
+}
+add_filter( 'hooked_block_types', 'insert_like_button_pattern_after_post_content', 10, 3 );
diff --git a/src/block.json b/src/block.json
index 99660d4..1cd5685 100644
--- a/src/block.json
+++ b/src/block.json
@@ -19,7 +19,6 @@
 	"viewScript": "file:./view.js",
 	"usesContext": [ "postType", "postId", "commentId" ],
 	"blockHooks": {
-		"core/comment-template": "lastChild",
-		"core/post-content": "after"
+		"core/comment-template": "lastChild"
 	}
 }
```

TODO:
- [ ] Think about downsides: Still doesn't allow flexible setting of the layout type depending on adjacent blocks (only hard-wired). Or do patterns support anything of the sort?
- [ ] Allow specifying attributes for hooked blocks in `block.json` after all?

Trac ticket: https://core.trac.wordpress.org/ticket/59572

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
