### PR TITLE
Tests: expand hooks priority tests to further check call order for happy and unhappy paths

### DIFF
--- a/tests/phpunit/tests/actions.php
+++ b/tests/phpunit/tests/actions.php
@@ -232,8 +232,8 @@ class Tests_Actions extends WP_UnitTestCase {
 	/**
 	 * @ticket 60193
 	 *
-	 * @dataProvider data_action_priority_integers
-	 * @dataProvider data_action_priority_unhappy_path_nonintegers
+	 * @dataProvider data_priority_callback_order_with_integers
+	 * @dataProvider data_priority_callback_order_with_unhappy_path_nonintegers
 	 *
 	 * @covers ::do_action
 	 *
@@ -246,7 +246,7 @@ class Tests_Actions extends WP_UnitTestCase {
 	 * @param array  $expected_call_order  An array of callback names in expected call order.
 	 * @param string $expected_deprecation Optional. Deprecation message. Default ''.
 	 */
-	public function test_action_priority( $priorities, $expected_call_order, $expected_deprecation = '' ) {
+	public function test_priority_callback_order( $priorities, $expected_call_order, $expected_deprecation = '' ) {
 		$mock      = new MockAction();
 		$hook_name = __FUNCTION__;
 
@@ -270,7 +270,7 @@ class Tests_Actions extends WP_UnitTestCase {
 	 *
 	 * @return array[]
 	 */
-	public function data_action_priority_integers() {
+	public function data_priority_callback_order_with_integers() {
 		return array(
 			'int DESC' => array(
 				'priorities'          => array( 10, 9 ),
@@ -288,7 +288,7 @@ class Tests_Actions extends WP_UnitTestCase {
 	 *
 	 * @return array[]
 	 */
-	public function data_action_priority_unhappy_path_nonintegers() {
+	public function data_priority_callback_order_with_unhappy_path_nonintegers() {
 		return array(
 			// Numbers as strings and floats.
 			'int as string DESC'               => array(

--- a/tests/phpunit/tests/actions.php
+++ b/tests/phpunit/tests/actions.php
@@ -229,35 +229,133 @@ class Tests_Actions extends WP_UnitTestCase {
 		$this->assertSame( array( $val ), array_pop( $argsvar ) );
 	}
 
-	public function test_action_priority() {
-		$a         = new MockAction();
+	/**
+	 * @ticket 60193
+	 *
+	 * @dataProvider data_action_priority_integers
+	 * @dataProvider data_action_priority_unhappy_path_nonintegers
+	 *
+	 * @covers ::do_action
+	 *
+	 * @param array $priorities {
+	 *     Indexed array of the priorities for the MockAction callbacks.
+	 *
+	 *     @type mixed $0 Priority for 'action' callback.
+	 *     @type mixed $1 Priority for 'action2' callback.
+	 * }
+	 * @param array  $expected_call_order  An array of callback names in expected call order.
+	 * @param string $expected_deprecation Optional. Deprecation message. Default ''.
+	 */
+	public function test_action_priority( $priorities, $expected_call_order, $expected_deprecation = '' ) {
+		$mock      = new MockAction();
 		$hook_name = __FUNCTION__;
 
-		add_action( $hook_name, array( &$a, 'action' ), 10 );
-		add_action( $hook_name, array( &$a, 'action2' ), 9 );
+		if ( $expected_deprecation && PHP_VERSION_ID >= 80100 ) {
+			$this->expectDeprecation();
+			$this->expectDeprecationMessage( $expected_deprecation );
+		}
+
+		add_action( $hook_name, array( $mock, 'action' ), $priorities[0] );
+		add_action( $hook_name, array( $mock, 'action2' ), $priorities[1] );
 		do_action( $hook_name );
 
-		// Two events, one per action.
-		$this->assertSame( 2, $a->get_call_count() );
+		$this->assertSame( 2, $mock->get_call_count(), 'The number of call counts does not match' );
 
-		$expected = array(
-			// 'action2' is called first because it has priority 9.
-			array(
-				'action'    => 'action2',
-				'hook_name' => $hook_name,
-				'tag'       => $hook_name, // Back compat.
-				'args'      => array( '' ),
+		$actual_call_order = wp_list_pluck( $mock->get_events(), 'action' );
+		$this->assertSame( $expected_call_order, $actual_call_order, 'The action callback order does not match the expected order' );
+	}
+
+	/**
+	 * Happy path data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_action_priority_integers() {
+		return array(
+			'int DESC' => array(
+				'priorities'          => array( 10, 9 ),
+				'expected_call_order' => array( 'action2', 'action' ),
 			),
-			// 'action' is called second.
-			array(
-				'action'    => 'action',
-				'hook_name' => $hook_name,
-				'tag'       => $hook_name, // Back compat.
-				'args'      => array( '' ),
+			'int ASC'  => array(
+				'priorities'          => array( 9, 10 ),
+				'expected_call_order' => array( 'action', 'action2' ),
 			),
 		);
+	}
 
-		$this->assertSame( $expected, $a->get_events() );
+	/**
+	 * Unhappy path data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_action_priority_unhappy_path_nonintegers() {
+		return array(
+			// Numbers as strings and floats.
+			'int as string DESC'               => array(
+				'priorities'          => array( '10', '9' ),
+				'expected_call_order' => array( 'action2', 'action' ),
+			),
+			'int as string ASC'                => array(
+				'priorities'          => array( '9', '10' ),
+				'expected_call_order' => array( 'action', 'action2' ),
+			),
+			'float DESC'                       => array(
+				'priorities'           => array( 10.0, 9.5 ),
+				'expected_call_order'  => array( 'action2', 'action' ),
+				'expected_deprecation' => 'Implicit conversion from float 9.5 to int loses precision',
+			),
+			'float ASC'                        => array(
+				'priorities'           => array( 9.5, 10.0 ),
+				'expected_call_order'  => array( 'action', 'action2' ),
+				'expected_deprecation' => 'Implicit conversion from float 9.5 to int loses precision',
+			),
+			'float as string DESC'             => array(
+				'priorities'          => array( '10.0', '9.5' ),
+				'expected_call_order' => array( 'action2', 'action' ),
+			),
+			'float as string ASC'              => array(
+				'priorities'          => array( '9.5', '10.0' ),
+				'expected_call_order' => array( 'action', 'action2' ),
+			),
+
+			// Non-numeric.
+			'null'                             => array(
+				'priorities'          => array( null, null ),
+				'expected_call_order' => array( 'action', 'action2' ),
+			),
+			'bool DESC'                        => array(
+				'priorities'          => array( true, false ),
+				'expected_call_order' => array( 'action2', 'action' ),
+			),
+			'bool ASC'                         => array(
+				'priorities'          => array( false, true ),
+				'expected_call_order' => array( 'action', 'action2' ),
+			),
+			'non-numerical string DESC'        => array(
+				'priorities'          => array( 'test1', 'test2' ),
+				'expected_call_order' => array( 'action', 'action2' ),
+			),
+			'non-numerical string ASC'         => array(
+				'priorities'          => array( 'test1', 'test2' ),
+				'expected_call_order' => array( 'action', 'action2' ),
+			),
+			'int, non-numerical string DESC'   => array(
+				'priorities'          => array( 10, 'test' ),
+				'expected_call_order' => array( 'action2', 'action' ),
+			),
+			'int, non-numerical string ASC'    => array(
+				'priorities'          => array( 'test', 10 ),
+				'expected_call_order' => array( 'action', 'action2' ),
+			),
+			'float, non-numerical string DESC' => array(
+				'priorities'          => array( 10.0, 'test' ),
+				'expected_call_order' => array( 'action2', 'action' ),
+			),
+			'float, non-numerical string ASC'  => array(
+				'priorities'          => array( 'test', 10.0 ),
+				'expected_call_order' => array( 'action', 'action2' ),
+			),
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/filters.php
+++ b/tests/phpunit/tests/filters.php
@@ -121,8 +121,8 @@ class Tests_Filters extends WP_UnitTestCase {
 	/**
 	 * @ticket 60193
 	 *
-	 * @dataProvider data_filter_priority_integers
-	 * @dataProvider data_filter_priority_unhappy_path_nonintegers
+	 * @dataProvider data_priority_callback_order_with_integers
+	 * @dataProvider data_priority_callback_order_with_unhappy_path_nonintegers
 	 *
 	 * @covers ::apply_filters
 	 *
@@ -135,7 +135,7 @@ class Tests_Filters extends WP_UnitTestCase {
 	 * @param array  $expected_call_order  An array of callback names in expected call order.
 	 * @param string $expected_deprecation Optional. Deprecation message. Default ''.
 	 */
-	public function test_filter_priority( $priorities, $expected_call_order, $expected_deprecation = '' ) {
+	public function test_priority_callback_order( $priorities, $expected_call_order, $expected_deprecation = '' ) {
 		$mock      = new MockAction();
 		$hook_name = __FUNCTION__;
 
@@ -159,7 +159,7 @@ class Tests_Filters extends WP_UnitTestCase {
 	 *
 	 * @return array[]
 	 */
-	public function data_filter_priority_integers() {
+	public function data_priority_callback_order_with_integers() {
 		return array(
 			'int DESC' => array(
 				'priorities'          => array( 10, 9 ),
@@ -177,7 +177,7 @@ class Tests_Filters extends WP_UnitTestCase {
 	 *
 	 * @return array[]
 	 */
-	public function data_filter_priority_unhappy_path_nonintegers() {
+	public function data_priority_callback_order_with_unhappy_path_nonintegers() {
 		return array(
 			// Numbers as strings and floats.
 			'int as string DESC'               => array(

--- a/tests/phpunit/tests/filters.php
+++ b/tests/phpunit/tests/filters.php
@@ -118,37 +118,133 @@ class Tests_Filters extends WP_UnitTestCase {
 		$this->assertSame( array( $val ), array_pop( $argsvar2 ) );
 	}
 
-	public function test_filter_priority() {
-		$a         = new MockAction();
+	/**
+	 * @ticket 60193
+	 *
+	 * @dataProvider data_filter_priority_integers
+	 * @dataProvider data_filter_priority_unhappy_path_nonintegers
+	 *
+	 * @covers ::apply_filters
+	 *
+	 * @param array $priorities {
+	 *     Indexed array of the priorities for the MockAction callbacks.
+	 *
+	 *     @type mixed $0 Priority for 'action' callback.
+	 *     @type mixed $1 Priority for 'action2' callback.
+	 * }
+	 * @param array  $expected_call_order  An array of callback names in expected call order.
+	 * @param string $expected_deprecation Optional. Deprecation message. Default ''.
+	 */
+	public function test_filter_priority( $priorities, $expected_call_order, $expected_deprecation = '' ) {
+		$mock      = new MockAction();
 		$hook_name = __FUNCTION__;
-		$val       = __FUNCTION__ . '_val';
 
-		// Make two filters with different priorities.
-		add_filter( $hook_name, array( $a, 'filter' ), 10 );
-		add_filter( $hook_name, array( $a, 'filter2' ), 9 );
-		$this->assertSame( $val, apply_filters( $hook_name, $val ) );
+		if ( $expected_deprecation && PHP_VERSION_ID >= 80100 ) {
+			$this->expectDeprecation();
+			$this->expectDeprecationMessage( $expected_deprecation );
+		}
 
-		// There should be two events, one per filter.
-		$this->assertSame( 2, $a->get_call_count() );
+		add_filter( $hook_name, array( $mock, 'filter' ), $priorities[0] );
+		add_filter( $hook_name, array( $mock, 'filter2' ), $priorities[1] );
+		apply_filters( $hook_name, __FUNCTION__ . '_val' );
 
-		$expected = array(
-			// 'filter2' is called first because it has priority 9.
-			array(
-				'filter'    => 'filter2',
-				'hook_name' => $hook_name,
-				'tag'       => $hook_name, // Back compat.
-				'args'      => array( $val ),
+		$this->assertSame( 2, $mock->get_call_count(), 'The number of call counts does not match' );
+
+		$actual_call_order = wp_list_pluck( $mock->get_events(), 'filter' );
+		$this->assertSame( $expected_call_order, $actual_call_order, 'The filter callback order does not match the expected order' );
+	}
+
+	/**
+	 * Happy path data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_filter_priority_integers() {
+		return array(
+			'int DESC' => array(
+				'priorities'          => array( 10, 9 ),
+				'expected_call_order' => array( 'filter2', 'filter' ),
 			),
-			// 'filter' is called second.
-			array(
-				'filter'    => 'filter',
-				'hook_name' => $hook_name,
-				'tag'       => $hook_name, // Back compat.
-				'args'      => array( $val ),
+			'int ASC'  => array(
+				'priorities'          => array( 9, 10 ),
+				'expected_call_order' => array( 'filter', 'filter2' ),
 			),
 		);
+	}
 
-		$this->assertSame( $expected, $a->get_events() );
+	/**
+	 * Unhappy path data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_filter_priority_unhappy_path_nonintegers() {
+		return array(
+			// Numbers as strings and floats.
+			'int as string DESC'               => array(
+				'priorities'          => array( '10', '9' ),
+				'expected_call_order' => array( 'filter2', 'filter' ),
+			),
+			'int as string ASC'                => array(
+				'priorities'          => array( '9', '10' ),
+				'expected_call_order' => array( 'filter', 'filter2' ),
+			),
+			'float DESC'                       => array(
+				'priorities'           => array( 10.0, 9.5 ),
+				'expected_call_order'  => array( 'filter2', 'filter' ),
+				'expected_deprecation' => 'Implicit conversion from float 9.5 to int loses precision',
+			),
+			'float ASC'                        => array(
+				'priorities'           => array( 9.5, 10.0 ),
+				'expected_call_order'  => array( 'filter', 'filter2' ),
+				'expected_deprecation' => 'Implicit conversion from float 9.5 to int loses precision',
+			),
+			'float as string DESC'             => array(
+				'priorities'          => array( '10.0', '9.5' ),
+				'expected_call_order' => array( 'filter2', 'filter' ),
+			),
+			'float as string ASC'              => array(
+				'priorities'          => array( '9.5', '10.0' ),
+				'expected_call_order' => array( 'filter', 'filter2' ),
+			),
+
+			// Non-numeric.
+			'null'                             => array(
+				'priorities'          => array( null, null ),
+				'expected_call_order' => array( 'filter', 'filter2' ),
+			),
+			'bool DESC'                        => array(
+				'priorities'          => array( true, false ),
+				'expected_call_order' => array( 'filter2', 'filter' ),
+			),
+			'bool ASC'                         => array(
+				'priorities'          => array( false, true ),
+				'expected_call_order' => array( 'filter', 'filter2' ),
+			),
+			'non-numerical string DESC'        => array(
+				'priorities'          => array( 'test1', 'test2' ),
+				'expected_call_order' => array( 'filter', 'filter2' ),
+			),
+			'non-numerical string ASC'         => array(
+				'priorities'          => array( 'test1', 'test2' ),
+				'expected_call_order' => array( 'filter', 'filter2' ),
+			),
+			'int, non-numerical string DESC'   => array(
+				'priorities'          => array( 10, 'test' ),
+				'expected_call_order' => array( 'filter2', 'filter' ),
+			),
+			'int, non-numerical string ASC'    => array(
+				'priorities'          => array( 'test', 10 ),
+				'expected_call_order' => array( 'filter', 'filter2' ),
+			),
+			'float, non-numerical string DESC' => array(
+				'priorities'          => array( 10.0, 'test' ),
+				'expected_call_order' => array( 'filter2', 'filter' ),
+			),
+			'float, non-numerical string ASC'  => array(
+				'priorities'          => array( 'test', 10.0 ),
+				'expected_call_order' => array( 'filter', 'filter2' ),
+			),
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/hooks/applyFilters.php
+++ b/tests/phpunit/tests/hooks/applyFilters.php
@@ -42,4 +42,132 @@ class Tests_Hooks_ApplyFilters extends WP_UnitTestCase {
 		$this->assertSame( $returned_two, $arg );
 		$this->assertSame( 2, $a->get_call_count() );
 	}
+
+	/**
+	 * @ticket 60193
+	 *
+	 * @dataProvider data_priority_callback_order_with_integers
+	 * @dataProvider data_priority_callback_order_with_unhappy_path_nonintegers
+	 *
+	 * @param array $priorities {
+	 *     Indexed array of the priorities for the MockAction callbacks.
+	 *
+	 *     @type mixed $0 Priority for 'action' callback.
+	 *     @type mixed $1 Priority for 'action2' callback.
+	 * }
+	 * @param array  $expected_call_order  An array of callback names in expected call order.
+	 * @param string $expected_deprecation Optional. Deprecation message. Default ''.
+	 */
+	public function test_priority_callback_order( $priorities, $expected_call_order, $expected_deprecation = '' ) {
+		$mock      = new MockAction();
+		$hook      = new WP_Hook();
+		$hook_name = __FUNCTION__;
+
+		if ( $expected_deprecation && PHP_VERSION_ID >= 80100 ) {
+			$this->expectDeprecation();
+			$this->expectDeprecationMessage( $expected_deprecation );
+		}
+
+		$hook->add_filter( $hook_name, array( $mock, 'filter' ), $priorities[0], 1 );
+		$hook->add_filter( $hook_name, array( $mock, 'filter2' ), $priorities[1], 1 );
+		$hook->apply_filters( __FUNCTION__ . '_val', array( '' ) );
+
+		$this->assertSame( 2, $mock->get_call_count(), 'The number of call counts does not match' );
+
+		$actual_call_order = wp_list_pluck( $mock->get_events(), 'filter' );
+		$this->assertSame( $expected_call_order, $actual_call_order, 'The filter callback order does not match the expected order' );
+	}
+
+	/**
+	 * Happy path data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_priority_callback_order_with_integers() {
+		return array(
+			'int DESC' => array(
+				'priorities'          => array( 10, 9 ),
+				'expected_call_order' => array( 'filter2', 'filter' ),
+			),
+			'int ASC'  => array(
+				'priorities'          => array( 9, 10 ),
+				'expected_call_order' => array( 'filter', 'filter2' ),
+			),
+		);
+	}
+
+	/**
+	 * Unhappy path data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_priority_callback_order_with_unhappy_path_nonintegers() {
+		return array(
+			// Numbers as strings and floats.
+			'int as string DESC'               => array(
+				'priorities'          => array( '10', '9' ),
+				'expected_call_order' => array( 'filter2', 'filter' ),
+			),
+			'int as string ASC'                => array(
+				'priorities'          => array( '9', '10' ),
+				'expected_call_order' => array( 'filter', 'filter2' ),
+			),
+			'float DESC'                       => array(
+				'priorities'           => array( 10.0, 9.5 ),
+				'expected_call_order'  => array( 'filter2', 'filter' ),
+				'expected_deprecation' => 'Implicit conversion from float 9.5 to int loses precision',
+			),
+			'float ASC'                        => array(
+				'priorities'           => array( 9.5, 10.0 ),
+				'expected_call_order'  => array( 'filter', 'filter2' ),
+				'expected_deprecation' => 'Implicit conversion from float 9.5 to int loses precision',
+			),
+			'float as string DESC'             => array(
+				'priorities'          => array( '10.0', '9.5' ),
+				'expected_call_order' => array( 'filter2', 'filter' ),
+			),
+			'float as string ASC'              => array(
+				'priorities'          => array( '9.5', '10.0' ),
+				'expected_call_order' => array( 'filter', 'filter2' ),
+			),
+
+			// Non-numeric.
+			'null'                             => array(
+				'priorities'          => array( null, null ),
+				'expected_call_order' => array( 'filter', 'filter2' ),
+			),
+			'bool DESC'                        => array(
+				'priorities'          => array( true, false ),
+				'expected_call_order' => array( 'filter2', 'filter' ),
+			),
+			'bool ASC'                         => array(
+				'priorities'          => array( false, true ),
+				'expected_call_order' => array( 'filter', 'filter2' ),
+			),
+			'non-numerical string DESC'        => array(
+				'priorities'          => array( 'test1', 'test2' ),
+				'expected_call_order' => array( 'filter', 'filter2' ),
+			),
+			'non-numerical string ASC'         => array(
+				'priorities'          => array( 'test1', 'test2' ),
+				'expected_call_order' => array( 'filter', 'filter2' ),
+			),
+			'int, non-numerical string DESC'   => array(
+				'priorities'          => array( 10, 'test' ),
+				'expected_call_order' => array( 'filter2', 'filter' ),
+			),
+			'int, non-numerical string ASC'    => array(
+				'priorities'          => array( 'test', 10 ),
+				'expected_call_order' => array( 'filter', 'filter2' ),
+			),
+			'float, non-numerical string DESC' => array(
+				'priorities'          => array( 10.0, 'test' ),
+				'expected_call_order' => array( 'filter2', 'filter' ),
+			),
+			'float, non-numerical string ASC'  => array(
+				'priorities'          => array( 'test', 10.0 ),
+				'expected_call_order' => array( 'filter', 'filter2' ),
+			),
+		);
+	}
 }

--- a/tests/phpunit/tests/hooks/doAction.php
+++ b/tests/phpunit/tests/hooks/doAction.php
@@ -85,6 +85,134 @@ class Tests_Hooks_DoAction extends WP_UnitTestCase {
 		$this->assertSame( 1, $a->get_call_count() );
 	}
 
+	/**
+	 * @ticket 60193
+	 *
+	 * @dataProvider data_priority_callback_order_with_integers
+	 * @dataProvider data_priority_callback_order_with_unhappy_path_nonintegers
+	 *
+	 * @param array $priorities {
+	 *     Indexed array of the priorities for the MockAction callbacks.
+	 *
+	 *     @type mixed $0 Priority for 'action' callback.
+	 *     @type mixed $1 Priority for 'action2' callback.
+	 * }
+	 * @param array  $expected_call_order  An array of callback names in expected call order.
+	 * @param string $expected_deprecation Optional. Deprecation message. Default ''.
+	 */
+	public function test_priority_callback_order( $priorities, $expected_call_order, $expected_deprecation = '' ) {
+		$mock      = new MockAction();
+		$hook      = new WP_Hook();
+		$hook_name = __FUNCTION__;
+
+		if ( $expected_deprecation && PHP_VERSION_ID >= 80100 ) {
+			$this->expectDeprecation();
+			$this->expectDeprecationMessage( $expected_deprecation );
+		}
+
+		$hook->add_filter( $hook_name, array( $mock, 'action' ), $priorities[0], 1 );
+		$hook->add_filter( $hook_name, array( $mock, 'action2' ), $priorities[1], 1 );
+		$hook->do_action( array( '' ) );
+
+		$this->assertSame( 2, $mock->get_call_count(), 'The number of call counts does not match' );
+
+		$actual_call_order = wp_list_pluck( $mock->get_events(), 'action' );
+		$this->assertSame( $expected_call_order, $actual_call_order, 'The action callback order does not match the expected order' );
+	}
+
+	/**
+	 * Happy path data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_priority_callback_order_with_integers() {
+		return array(
+			'int DESC' => array(
+				'priorities'          => array( 10, 9 ),
+				'expected_call_order' => array( 'action2', 'action' ),
+			),
+			'int ASC'  => array(
+				'priorities'          => array( 9, 10 ),
+				'expected_call_order' => array( 'action', 'action2' ),
+			),
+		);
+	}
+
+	/**
+	 * Unhappy path data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_priority_callback_order_with_unhappy_path_nonintegers() {
+		return array(
+			// Numbers as strings and floats.
+			'int as string DESC'               => array(
+				'priorities'          => array( '10', '9' ),
+				'expected_call_order' => array( 'action2', 'action' ),
+			),
+			'int as string ASC'                => array(
+				'priorities'          => array( '9', '10' ),
+				'expected_call_order' => array( 'action', 'action2' ),
+			),
+			'float DESC'                       => array(
+				'priorities'           => array( 10.0, 9.5 ),
+				'expected_call_order'  => array( 'action2', 'action' ),
+				'expected_deprecation' => 'Implicit conversion from float 9.5 to int loses precision',
+			),
+			'float ASC'                        => array(
+				'priorities'           => array( 9.5, 10.0 ),
+				'expected_call_order'  => array( 'action', 'action2' ),
+				'expected_deprecation' => 'Implicit conversion from float 9.5 to int loses precision',
+			),
+			'float as string DESC'             => array(
+				'priorities'          => array( '10.0', '9.5' ),
+				'expected_call_order' => array( 'action2', 'action' ),
+			),
+			'float as string ASC'              => array(
+				'priorities'          => array( '9.5', '10.0' ),
+				'expected_call_order' => array( 'action', 'action2' ),
+			),
+
+			// Non-numeric.
+			'null'                             => array(
+				'priorities'          => array( null, null ),
+				'expected_call_order' => array( 'action', 'action2' ),
+			),
+			'bool DESC'                        => array(
+				'priorities'          => array( true, false ),
+				'expected_call_order' => array( 'action2', 'action' ),
+			),
+			'bool ASC'                         => array(
+				'priorities'          => array( false, true ),
+				'expected_call_order' => array( 'action', 'action2' ),
+			),
+			'non-numerical string DESC'        => array(
+				'priorities'          => array( 'test1', 'test2' ),
+				'expected_call_order' => array( 'action', 'action2' ),
+			),
+			'non-numerical string ASC'         => array(
+				'priorities'          => array( 'test1', 'test2' ),
+				'expected_call_order' => array( 'action', 'action2' ),
+			),
+			'int, non-numerical string DESC'   => array(
+				'priorities'          => array( 10, 'test' ),
+				'expected_call_order' => array( 'action2', 'action' ),
+			),
+			'int, non-numerical string ASC'    => array(
+				'priorities'          => array( 'test', 10 ),
+				'expected_call_order' => array( 'action', 'action2' ),
+			),
+			'float, non-numerical string DESC' => array(
+				'priorities'          => array( 10.0, 'test' ),
+				'expected_call_order' => array( 'action2', 'action' ),
+			),
+			'float, non-numerical string ASC'  => array(
+				'priorities'          => array( 'test', 10.0 ),
+				'expected_call_order' => array( 'action', 'action2' ),
+			),
+		);
+	}
+
 	public function test_do_action_with_no_accepted_args() {
 		$callback      = array( $this, '_action_callback' );
 		$hook          = new WP_Hook();


### PR DESCRIPTION
Expand the existing tests for hooks priority tests to futher check the call order for happy (numeric priorities) and unhappy (non-numeric priorities) paths.

Call order tests added to:

- [X] `do_action()`
- [X] `WP_Hook::do_action()`
- [X] `apply_filters()`
- [X] `WP_Hook::apply_filters()`

The tests are redundant, yes, but necessary to test at least functional level, given there's different logic in each of these functions.

Trac ticket: https://core.trac.wordpress.org/ticket/60193

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
