### PR TITLE
Fix var types of parameters in `sanitize_option()` and `sanitize_option_{$option}` filter

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4846,8 +4846,8 @@ function wp_make_link_relative( $link ) {
  * @global wpdb $wpdb WordPress database abstraction object.
  *
  * @param string $option The name of the option.
- * @param string $value  The unsanitized value.
- * @return string Sanitized value.
+ * @param mixed $value  The unsanitized value.
+ * @return mixed Sanitized value.
  */
 function sanitize_option( $option, $value ) {
 	global $wpdb;

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5119,9 +5119,9 @@ function sanitize_option( $option, $value ) {
 	 * @since 2.3.0
 	 * @since 4.3.0 Added the `$original_value` parameter.
 	 *
-	 * @param string $value          The sanitized option value.
-	 * @param string $option         The option name.
-	 * @param string $original_value The original value passed to the function.
+	 * @param mixed $value          The sanitized option value.
+	 * @param string $option        The option name.
+	 * @param mixed $original_value The original value passed to the function.
 	 */
 	return apply_filters( "sanitize_option_{$option}", $value, $option, $original_value );
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Fixes the documentation of the parameters used in `sanitize_option_{$option}` filter.

Reported by `gerardreches` via User Contributed Notes.

Trac ticket: https://core.trac.wordpress.org/ticket/60214

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
