### PR TITLE
Reorganize hooks tests to coding standards and consistency

### DIFF
--- a/tests/phpunit/tests/hooks/addAction.php
+++ b/tests/phpunit/tests/hooks/addAction.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Test add_action().
+ *
+ * @group hooks
+ * @covers ::add_action
+ */
+class Tests_Hooks_AddAction extends WP_UnitTestCase {
+	/**
+	 * @ticket 23265
+	 */
+	public function test_action_callback_representations() {
+		$hook_name = __FUNCTION__;
+
+		$this->assertFalse( has_action( $hook_name ) );
+
+		add_action( $hook_name, array( 'Class', 'method' ) );
+
+		$this->assertSame( 10, has_action( $hook_name, array( 'Class', 'method' ) ) );
+
+		$this->assertSame( 10, has_action( $hook_name, 'Class::method' ) );
+	}
+}

--- a/tests/phpunit/tests/hooks/applyFiltersDeprecated.php
+++ b/tests/phpunit/tests/hooks/applyFiltersDeprecated.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Test apply_filters_deprecated().
+ *
+ * @group hooks
+ * @covers ::apply_filters_deprecated
+ */
+class Tests_Hooks_ApplyFiltersDeprecated extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 10441
+	 * @expectedDeprecated tests_apply_filters_deprecated
+	 */
+	public function test_apply_filters_deprecated() {
+		$p = 'Foo';
+
+		add_filter( 'tests_apply_filters_deprecated', array( __CLASS__, 'deprecated_filter_callback' ) );
+		$p = apply_filters_deprecated( 'tests_apply_filters_deprecated', array( $p ), '4.6.0' );
+		remove_filter( 'tests_apply_filters_deprecated', array( __CLASS__, 'deprecated_filter_callback' ) );
+
+		$this->assertSame( 'Bar', $p );
+	}
+
+	public static function deprecated_filter_callback( $p ) {
+		$p = 'Bar';
+		return $p;
+	}
+
+	/**
+	 * @ticket 10441
+	 * @expectedDeprecated tests_apply_filters_deprecated
+	 */
+	public function test_apply_filters_deprecated_with_multiple_params() {
+		$p1 = 'Foo1';
+		$p2 = 'Foo2';
+
+		add_filter( 'tests_apply_filters_deprecated', array( __CLASS__, 'deprecated_filter_callback_multiple_params' ), 10, 2 );
+		$p1 = apply_filters_deprecated( 'tests_apply_filters_deprecated', array( $p1, $p2 ), '4.6.0' );
+		remove_filter( 'tests_apply_filters_deprecated', array( __CLASS__, 'deprecated_filter_callback_multiple_params' ), 10, 2 );
+
+		$this->assertSame( 'Bar1', $p1 );
+
+		// Not passed by reference, so not modified.
+		$this->assertSame( 'Foo2', $p2 );
+	}
+
+	public static function deprecated_filter_callback_multiple_params( $p1, $p2 ) {
+		$p1 = 'Bar1';
+		$p2 = 'Bar2';
+
+		return $p1;
+	}
+
+	/**
+	 * @ticket 10441
+	 */
+	public function test_apply_filters_deprecated_without_filter() {
+		$val = 'Foobar';
+
+		$this->assertSame( $val, apply_filters_deprecated( 'tests_apply_filters_deprecated', array( $val ), '4.6.0' ) );
+	}
+}

--- a/tests/phpunit/tests/hooks/applyFiltersRefArray.php
+++ b/tests/phpunit/tests/hooks/applyFiltersRefArray.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Test apply_filters_ref_array().
+ *
+ * @group hooks
+ * @covers ::apply_filters_ref_array
+ */
+class Tests_Hooks_ApplyFiltersRefArray extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 9886
+	 */
+	public function test_filter_ref_array() {
+		$obj       = new stdClass();
+		$a         = new MockAction();
+		$hook_name = __FUNCTION__;
+
+		add_action( $hook_name, array( $a, 'filter' ) );
+
+		apply_filters_ref_array( $hook_name, array( &$obj ) );
+
+		$args = $a->get_args();
+		$this->assertSame( $args[0][0], $obj );
+		// Just in case we don't trust assertSame().
+		$obj->foo = true;
+		$this->assertNotEmpty( $args[0][0]->foo );
+	}
+
+	/**
+	 * @ticket 12723
+	 */
+	public function test_filter_ref_array_result() {
+		$obj       = new stdClass();
+		$a         = new MockAction();
+		$b         = new MockAction();
+		$hook_name = __FUNCTION__;
+
+		add_action( $hook_name, array( $a, 'filter_append' ), 10, 2 );
+		add_action( $hook_name, array( $b, 'filter_append' ), 10, 2 );
+
+		$result = apply_filters_ref_array( $hook_name, array( 'string', &$obj ) );
+
+		$this->assertSame( $result, 'string_append_append' );
+
+		$args = $a->get_args();
+		$this->assertSame( $args[0][1], $obj );
+		// Just in case we don't trust assertSame().
+		$obj->foo = true;
+		$this->assertNotEmpty( $args[0][1]->foo );
+
+		$args = $b->get_args();
+		$this->assertSame( $args[0][1], $obj );
+		// Just in case we don't trust assertSame().
+		$obj->foo = true;
+		$this->assertNotEmpty( $args[0][1]->foo );
+	}
+}

--- a/tests/phpunit/tests/hooks/currentAction.php
+++ b/tests/phpunit/tests/hooks/currentAction.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Test current_action().
+ *
+ * @group hooks
+ * @covers ::current_action
+ */
+class Tests_Hooks_CurrentAction extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 14994
+	 */
+	public function test_behaves_as_current_filter() {
+		global $wp_current_filter;
+
+		$wp_current_filter[] = 'first';
+		$wp_current_filter[] = 'second'; // Let's say a second action was invoked.
+
+		$this->assertSame( 'second', current_action() );
+	}
+}

--- a/tests/phpunit/tests/hooks/didAction.php
+++ b/tests/phpunit/tests/hooks/didAction.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Test did_action().
+ *
+ * @group hooks
+ * @covers ::did_action
+ */
+class Tests_Hooks_DidAction extends WP_UnitTestCase {
+
+	public function test_did_action() {
+		$hook_name1 = 'action1';
+		$hook_name2 = 'action2';
+
+		// Do action $hook_name1 but not $hook_name2.
+		do_action( $hook_name1 );
+		$this->assertSame( 1, did_action( $hook_name1 ) );
+		$this->assertSame( 0, did_action( $hook_name2 ) );
+
+		// Do action $hook_name2 10 times.
+		$count = 10;
+		for ( $i = 0; $i < $count; $i++ ) {
+			do_action( $hook_name2 );
+		}
+
+		// $hook_name1's count hasn't changed, $hook_name2 should be correct.
+		$this->assertSame( 1, did_action( $hook_name1 ) );
+		$this->assertSame( $count, did_action( $hook_name2 ) );
+	}
+}

--- a/tests/phpunit/tests/hooks/didFilter.php
+++ b/tests/phpunit/tests/hooks/didFilter.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Test did_filter().
+ *
+ * @group hooks
+ * @covers ::did_filter
+ */
+class Tests_Hooks_DidFilter extends WP_UnitTestCase {
+
+	public function test_did_filter() {
+		$hook_name1 = 'filter1';
+		$hook_name2 = 'filter2';
+		$val        = __FUNCTION__ . '_val';
+
+		// Apply filter $hook_name1 but not $hook_name2.
+		apply_filters( $hook_name1, $val );
+		$this->assertSame( 1, did_filter( $hook_name1 ) );
+		$this->assertSame( 0, did_filter( $hook_name2 ) );
+
+		// Apply filter $hook_name2 10 times.
+		$count = 10;
+		for ( $i = 0; $i < $count; $i++ ) {
+			apply_filters( $hook_name2, $val );
+		}
+
+		// $hook_name1's count hasn't changed, $hook_name2 should be correct.
+		$this->assertSame( 1, did_filter( $hook_name1 ) );
+		$this->assertSame( $count, did_filter( $hook_name2 ) );
+	}
+}

--- a/tests/phpunit/tests/hooks/doActionDeprecated.php
+++ b/tests/phpunit/tests/hooks/doActionDeprecated.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Test do_action_deprecated().
+ *
+ * @group hooks
+ * @covers ::do_action_deprecated
+ */
+class Tests_Hooks_DoActionDeprecated extends WP_UnitTestCase {
+	/**
+	 * @ticket 10441
+	 * @expectedDeprecated tests_do_action_deprecated
+	 */
+	public function test_do_action_deprecated() {
+		$p = new WP_Post( (object) array( 'post_title' => 'Foo' ) );
+
+		add_action( 'tests_do_action_deprecated', array( __CLASS__, 'deprecated_action_callback' ) );
+		do_action_deprecated( 'tests_do_action_deprecated', array( $p ), '4.6.0' );
+		remove_action( 'tests_do_action_deprecated', array( __CLASS__, 'deprecated_action_callback' ) );
+
+		$this->assertSame( 'Bar', $p->post_title );
+	}
+
+	public static function deprecated_action_callback( $p ) {
+		$p->post_title = 'Bar';
+	}
+
+	/**
+	 * @ticket 10441
+	 * @expectedDeprecated tests_do_action_deprecated
+	 */
+	public function test_do_action_deprecated_with_multiple_params() {
+		$p1 = new WP_Post( (object) array( 'post_title' => 'Foo1' ) );
+		$p2 = new WP_Post( (object) array( 'post_title' => 'Foo2' ) );
+
+		add_action( 'tests_do_action_deprecated', array( __CLASS__, 'deprecated_action_callback_multiple_params' ), 10, 2 );
+		do_action_deprecated( 'tests_do_action_deprecated', array( $p1, $p2 ), '4.6.0' );
+		remove_action( 'tests_do_action_deprecated', array( __CLASS__, 'deprecated_action_callback_multiple_params' ), 10, 2 );
+
+		$this->assertSame( 'Bar1', $p1->post_title );
+		$this->assertSame( 'Bar2', $p2->post_title );
+	}
+
+	public static function deprecated_action_callback_multiple_params( $p1, $p2 ) {
+		$p1->post_title = 'Bar1';
+		$p2->post_title = 'Bar2';
+	}
+}

--- a/tests/phpunit/tests/hooks/doActionRefArray.php
+++ b/tests/phpunit/tests/hooks/doActionRefArray.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Test do_action_ref_array().
+ *
+ * @group hooks
+ * @covers ::do_action_ref_array
+ */
+class Tests_Hooks_DoActionRefArray extends WP_UnitTestCase {
+
+	public function test_action_ref_array() {
+		$obj       = new stdClass();
+		$a         = new MockAction();
+		$hook_name = __FUNCTION__;
+
+		add_action( $hook_name, array( &$a, 'action' ) );
+
+		do_action_ref_array( $hook_name, array( &$obj ) );
+
+		$args = $a->get_args();
+		$this->assertSame( $args[0][0], $obj );
+
+		// Just in case we don't trust assertSame().
+		$obj->foo = true;
+		$this->assertNotEmpty( $args[0][0]->foo );
+	}
+}

--- a/tests/phpunit/tests/hooks/doingAction.php
+++ b/tests/phpunit/tests/hooks/doingAction.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Test doing_action().
+ *
+ * @group hooks
+ * @covers ::doing_action
+ */
+class Tests_Hooks_DoingAction extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 14994
+	 */
+	public function test_doing_action() {
+		global $wp_current_filter;
+
+		$wp_current_filter = array(); // Set to an empty array first.
+
+		$this->assertFalse( doing_action() );            // No action is passed in, and no filter is being processed.
+		$this->assertFalse( doing_action( 'testing' ) ); // Action is passed in but not being processed.
+
+		$wp_current_filter[] = 'testing';
+
+		$this->assertTrue( doing_action() );                    // No action is passed in, and a filter is being processed.
+		$this->assertTrue( doing_action( 'testing' ) );         // Action is passed in and is being processed.
+		$this->assertFalse( doing_action( 'something_else' ) ); // Action is passed in but not being processed.
+
+		$wp_current_filter = array();
+	}
+}

--- a/tests/phpunit/tests/hooks/doingFilter.php
+++ b/tests/phpunit/tests/hooks/doingFilter.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * Test doing_filter().
+ *
+ * @group hooks
+ * @covers ::doing_filter
+ */
+class Tests_Hooks_DoingFilter extends WP_UnitTestCase {
+
+	/**
+	 * Flag to keep track whether a certain filter has been applied.
+	 *
+	 * Used in the `test_doing_filter_real()` test method.
+	 *
+	 * @var bool
+	 */
+	protected $apply_testing_filter = false;
+
+	/**
+	 * Flag to keep track whether a certain filter has been applied.
+	 *
+	 * Used in the `test_doing_filter_real()` test method.
+	 *
+	 * @var bool
+	 */
+	protected $apply_testing_nested_filter = false;
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		// Make sure potentially changed properties are reverted to their default value.
+		$this->apply_testing_filter        = false;
+		$this->apply_testing_nested_filter = false;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @ticket 14994
+	 */
+	public function test_doing_filter() {
+		global $wp_current_filter;
+
+		$wp_current_filter = array(); // Set to an empty array first.
+
+		$this->assertFalse( doing_filter() );            // No filter is passed in, and no filter is being processed.
+		$this->assertFalse( doing_filter( 'testing' ) ); // Filter is passed in but not being processed.
+
+		$wp_current_filter[] = 'testing';
+
+		$this->assertTrue( doing_filter() );                    // No action is passed in, and a filter is being processed.
+		$this->assertTrue( doing_filter( 'testing' ) );         // Filter is passed in and is being processed.
+		$this->assertFalse( doing_filter( 'something_else' ) ); // Filter is passed in but not being processed.
+
+		$wp_current_filter = array();
+	}
+
+	/**
+	 * @ticket 14994
+	 */
+	public function test_doing_filter_real() {
+		$this->assertFalse( doing_filter() );            // No filter is passed in, and no filter is being processed.
+		$this->assertFalse( doing_filter( 'testing' ) ); // Filter is passed in but not being processed.
+
+		add_filter( 'testing', array( $this, 'apply_testing_filter' ) );
+		$this->assertTrue( has_action( 'testing' ) );
+		$this->assertSame( 10, has_action( 'testing', array( $this, 'apply_testing_filter' ) ) );
+
+		apply_filters( 'testing', '' );
+
+		// Make sure it ran.
+		$this->assertTrue( $this->apply_testing_filter );
+
+		$this->assertFalse( doing_filter() );            // No longer doing any filters.
+		$this->assertFalse( doing_filter( 'testing' ) ); // No longer doing this filter.
+	}
+
+	public function apply_testing_filter() {
+		$this->apply_testing_filter = true;
+
+		$this->assertTrue( doing_filter() );
+		$this->assertTrue( doing_filter( 'testing' ) );
+		$this->assertFalse( doing_filter( 'something_else' ) );
+		$this->assertFalse( doing_filter( 'testing_nested' ) );
+
+		add_filter( 'testing_nested', array( $this, 'apply_testing_nested_filter' ) );
+		$this->assertTrue( has_action( 'testing_nested' ) );
+		$this->assertSame( 10, has_action( 'testing_nested', array( $this, 'apply_testing_nested_filter' ) ) );
+
+		apply_filters( 'testing_nested', '' );
+
+		// Make sure it ran.
+		$this->assertTrue( $this->apply_testing_nested_filter );
+
+		$this->assertFalse( doing_filter( 'testing_nested' ) );
+		$this->assertFalse( doing_filter( 'testing_nested' ) );
+	}
+
+	public function apply_testing_nested_filter() {
+		$this->apply_testing_nested_filter = true;
+		$this->assertTrue( doing_filter() );
+		$this->assertTrue( doing_filter( 'testing' ) );
+		$this->assertTrue( doing_filter( 'testing_nested' ) );
+		$this->assertFalse( doing_filter( 'something_else' ) );
+	}
+}

--- a/tests/phpunit/tests/hooks/hasAction.php
+++ b/tests/phpunit/tests/hooks/hasAction.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Test has_action().
+ *
+ * @group hooks
+ * @covers ::has_action
+ */
+class Tests_Hooks_HasAction extends WP_UnitTestCase {
+
+	public function test_has_action() {
+		$hook_name = __FUNCTION__;
+		$callback  = __FUNCTION__ . '_func';
+
+		$this->assertFalse( has_action( $hook_name, $callback ) );
+		$this->assertFalse( has_action( $hook_name ) );
+
+		add_action( $hook_name, $callback );
+		$this->assertSame( 10, has_action( $hook_name, $callback ) );
+		$this->assertTrue( has_action( $hook_name ) );
+
+		remove_action( $hook_name, $callback );
+		$this->assertFalse( has_action( $hook_name, $callback ) );
+		$this->assertFalse( has_action( $hook_name ) );
+	}
+}

--- a/tests/phpunit/tests/hooks/hasFilter.php
+++ b/tests/phpunit/tests/hooks/hasFilter.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Test has_filter().
+ *
+ * @group hooks
+ * @covers ::has_filter
+ */
+class Tests_Hooks_HasFilter extends WP_UnitTestCase {
+
+	public function test_has_filter() {
+		$hook_name = __FUNCTION__;
+		$callback  = __FUNCTION__ . '_func';
+
+		$this->assertFalse( has_filter( $hook_name, $callback ) );
+		$this->assertFalse( has_filter( $hook_name ) );
+
+		add_filter( $hook_name, $callback );
+		$this->assertSame( 10, has_filter( $hook_name, $callback ) );
+		$this->assertTrue( has_filter( $hook_name ) );
+
+		remove_filter( $hook_name, $callback );
+		$this->assertFalse( has_filter( $hook_name, $callback ) );
+		$this->assertFalse( has_filter( $hook_name ) );
+	}
+}

--- a/tests/phpunit/tests/hooks/removeAction.php
+++ b/tests/phpunit/tests/hooks/removeAction.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Test remove_action().
+ *
+ * @group hooks
+ * @covers ::remove_action
+ */
+class Tests_Hooks_RemoveAction extends WP_UnitTestCase {
+
+	/**
+	 * @covers ::remove_action
+	 */
+	public function test_remove_all_action() {
+		$a         = new MockAction();
+		$hook_name = __FUNCTION__;
+
+		add_action( 'all', array( &$a, 'action' ) );
+		$this->assertSame( 10, has_filter( 'all', array( &$a, 'action' ) ) );
+		do_action( $hook_name );
+
+		// Make sure our hook was called correctly.
+		$this->assertSame( 1, $a->get_call_count() );
+		$this->assertSame( array( $hook_name ), $a->get_hook_names() );
+
+		// Now remove the action, do it again, and make sure it's not called this time.
+		remove_action( 'all', array( &$a, 'action' ) );
+		$this->assertFalse( has_filter( 'all', array( &$a, 'action' ) ) );
+		do_action( $hook_name );
+		$this->assertSame( 1, $a->get_call_count() );
+		$this->assertSame( array( $hook_name ), $a->get_hook_names() );
+	}
+
+	public function test_action_self_removal() {
+		add_action( 'test_action_self_removal', array( $this, 'action_self_removal' ) );
+		do_action( 'test_action_self_removal' );
+
+		$this->assertSame( 1, did_action( 'test_action_self_removal' ) );
+	}
+
+	public function action_self_removal() {
+		remove_action( 'test_action_self_removal', array( $this, 'action_self_removal' ) );
+	}
+
+	public function test_remove_action() {
+		$a         = new MockAction();
+		$hook_name = __FUNCTION__;
+
+		add_action( $hook_name, array( &$a, 'action' ) );
+		do_action( $hook_name );
+
+		// Make sure our hook was called correctly.
+		$this->assertSame( 1, $a->get_call_count() );
+		$this->assertSame( array( $hook_name ), $a->get_hook_names() );
+
+		// Now remove the action, do it again, and make sure it's not called this time.
+		remove_action( $hook_name, array( &$a, 'action' ) );
+		do_action( $hook_name );
+		$this->assertSame( 1, $a->get_call_count() );
+		$this->assertSame( array( $hook_name ), $a->get_hook_names() );
+	}
+}

--- a/tests/phpunit/tests/hooks/removeAllFilters.php
+++ b/tests/phpunit/tests/hooks/removeAllFilters.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Test remove_all_filters().
+ *
+ * @group hooks
+ * @covers ::remove_all_filters
+ */
+class Tests_Hooks_RemoveAllFilters extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 20920
+	 */
+	public function test_should_respect_the_priority_argument() {
+		$a         = new MockAction();
+		$hook_name = __FUNCTION__;
+
+		add_filter( $hook_name, array( $a, 'filter' ), 12 );
+		$this->assertTrue( has_filter( $hook_name ) );
+
+		// Should not be removed.
+		remove_all_filters( $hook_name, 11 );
+		$this->assertTrue( has_filter( $hook_name ) );
+
+		remove_all_filters( $hook_name, 12 );
+		$this->assertFalse( has_filter( $hook_name ) );
+	}
+
+	/**
+	 * @ticket 29070
+	 */
+	public function test_has_filter_after_remove_all_filters() {
+		$a         = new MockAction();
+		$hook_name = __FUNCTION__;
+
+		// No priority.
+		add_filter( $hook_name, array( $a, 'filter' ), 11 );
+		add_filter( $hook_name, array( $a, 'filter' ), 12 );
+		$this->assertTrue( has_filter( $hook_name ) );
+
+		remove_all_filters( $hook_name );
+		$this->assertFalse( has_filter( $hook_name ) );
+
+		// Remove priorities one at a time.
+		add_filter( $hook_name, array( $a, 'filter' ), 11 );
+		add_filter( $hook_name, array( $a, 'filter' ), 12 );
+		$this->assertTrue( has_filter( $hook_name ) );
+
+		remove_all_filters( $hook_name, 11 );
+		remove_all_filters( $hook_name, 12 );
+		$this->assertFalse( has_filter( $hook_name ) );
+	}
+}

--- a/tests/phpunit/tests/hooks/removeFilter.php
+++ b/tests/phpunit/tests/hooks/removeFilter.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Test remove_filter().
+ *
+ * @group hooks
+ * @covers ::remove_filter
+ */
+class Tests_Hooks_RemoveFilter extends WP_UnitTestCase {
+
+	public function test_remove_filter() {
+		$a         = new MockAction();
+		$hook_name = __FUNCTION__;
+		$val       = __FUNCTION__ . '_val';
+
+		add_filter( $hook_name, array( $a, 'filter' ) );
+		$this->assertSame( $val, apply_filters( $hook_name, $val ) );
+
+		// Make sure our hook was called correctly.
+		$this->assertSame( 1, $a->get_call_count() );
+		$this->assertSame( array( $hook_name ), $a->get_hook_names() );
+
+		// Now remove the filter, do it again, and make sure it's not called this time.
+		remove_filter( $hook_name, array( $a, 'filter' ) );
+		$this->assertSame( $val, apply_filters( $hook_name, $val ) );
+		$this->assertSame( 1, $a->get_call_count() );
+		$this->assertSame( array( $hook_name ), $a->get_hook_names() );
+	}
+
+	public function test_remove_all_filter() {
+		$a         = new MockAction();
+		$hook_name = __FUNCTION__;
+		$val       = __FUNCTION__ . '_val';
+
+		add_filter( 'all', array( $a, 'filterall' ) );
+		$this->assertTrue( has_filter( 'all' ) );
+		$this->assertSame( 10, has_filter( 'all', array( $a, 'filterall' ) ) );
+		$this->assertSame( $val, apply_filters( $hook_name, $val ) );
+
+		// Make sure our hook was called correctly.
+		$this->assertSame( 1, $a->get_call_count() );
+		$this->assertSame( array( $hook_name ), $a->get_hook_names() );
+
+		// Now remove the filter, do it again, and make sure it's not called this time.
+		remove_filter( 'all', array( $a, 'filterall' ) );
+		$this->assertFalse( has_filter( 'all', array( $a, 'filterall' ) ) );
+		$this->assertFalse( has_filter( 'all' ) );
+		$this->assertSame( $val, apply_filters( $hook_name, $val ) );
+		// Call cound should remain at 1.
+		$this->assertSame( 1, $a->get_call_count() );
+		$this->assertSame( array( $hook_name ), $a->get_hook_names() );
+	}
+}

--- a/tests/phpunit/tests/hooks/wpHook/addFilter.php
+++ b/tests/phpunit/tests/hooks/wpHook/addFilter.php
@@ -6,7 +6,7 @@
  * @group hooks
  * @covers WP_Hook::add_filter
  */
-class Tests_Hooks_AddFilter extends WP_UnitTestCase {
+class Tests_Hooks_WpHook_AddFilter extends WP_UnitTestCase {
 
 	public $hook;
 

--- a/tests/phpunit/tests/hooks/wpHook/applyFilters.php
+++ b/tests/phpunit/tests/hooks/wpHook/applyFilters.php
@@ -6,7 +6,7 @@
  * @group hooks
  * @covers WP_Hook::apply_filters
  */
-class Tests_Hooks_ApplyFilters extends WP_UnitTestCase {
+class Tests_Hooks_WpHook_ApplyFilters extends WP_UnitTestCase {
 
 	public function test_apply_filters_with_callback() {
 		$a             = new MockAction();

--- a/tests/phpunit/tests/hooks/wpHook/arrayAccess.php
+++ b/tests/phpunit/tests/hooks/wpHook/arrayAccess.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Test ArrayAccess methods of WP_Hook.
+ *
+ * @group hooks
+ * @covers WP_Hook::offsetGet
+ * @covers WP_Hook::offsetSet
+ * @covers WP_Hook::offsetUnset
+ */
+class Tests_Hooks_WpHook_ArrayAccess extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 17817
+	 */
+	public function test_array_access() {
+		global $wp_filter;
+
+		$hook_name = __FUNCTION__;
+
+		add_action( $hook_name, '__return_null', 11, 1 );
+
+		$this->assertArrayHasKey( 11, $wp_filter[ $hook_name ] );
+		$this->assertArrayHasKey( '__return_null', $wp_filter[ $hook_name ][11] );
+
+		unset( $wp_filter[ $hook_name ][11] );
+		$this->assertFalse( has_action( $hook_name, '__return_null' ) );
+
+		$wp_filter[ $hook_name ][11] = array(
+			'__return_null' => array(
+				'function'      => '__return_null',
+				'accepted_args' => 1,
+			),
+		);
+		$this->assertSame( 11, has_action( $hook_name, '__return_null' ) );
+	}
+}

--- a/tests/phpunit/tests/hooks/wpHook/buildPreinitializedHooks.php
+++ b/tests/phpunit/tests/hooks/wpHook/buildPreinitializedHooks.php
@@ -6,7 +6,7 @@
  * @group hooks
  * @covers WP_Hook::build_preinitialized_hooks
  */
-class Tests_Hooks_PreinitHooks extends WP_UnitTestCase {
+class Tests_Hooks_WpHook_BuildPreinitializedHooks extends WP_UnitTestCase {
 
 	public function test_array_to_hooks() {
 		$hook_name1 = __FUNCTION__ . '_1';

--- a/tests/phpunit/tests/hooks/wpHook/doAction.php
+++ b/tests/phpunit/tests/hooks/wpHook/doAction.php
@@ -6,7 +6,7 @@
  * @group hooks
  * @covers WP_Hook::do_action
  */
-class Tests_Hooks_DoAction extends WP_UnitTestCase {
+class Tests_Hooks_WpHook_DoAction extends WP_UnitTestCase {
 	private $events        = array();
 	private $action_output = '';
 	private $hook;

--- a/tests/phpunit/tests/hooks/wpHook/doAllHook.php
+++ b/tests/phpunit/tests/hooks/wpHook/doAllHook.php
@@ -6,7 +6,7 @@
  * @group hooks
  * @covers WP_Hook::do_all_hook
  */
-class Tests_Hooks_DoAllHook extends WP_UnitTestCase {
+class Tests_Hooks_WpHook_DoAllHook extends WP_UnitTestCase {
 
 	public function test_do_all_hook_with_multiple_calls() {
 		$a             = new MockAction();

--- a/tests/phpunit/tests/hooks/wpHook/hasFilter.php
+++ b/tests/phpunit/tests/hooks/wpHook/hasFilter.php
@@ -6,7 +6,7 @@
  * @group hooks
  * @covers WP_Hook::has_filter
  */
-class Tests_Hooks_HasFilter extends WP_UnitTestCase {
+class Tests_Hooks_WpHook_HasFilter extends WP_UnitTestCase {
 
 	public function test_has_filter_with_function() {
 		$callback      = '__return_null';

--- a/tests/phpunit/tests/hooks/wpHook/hasFilters.php
+++ b/tests/phpunit/tests/hooks/wpHook/hasFilters.php
@@ -6,7 +6,7 @@
  * @group hooks
  * @covers WP_Hook::has_filters
  */
-class Tests_Hooks_HasFilters extends WP_UnitTestCase {
+class Tests_Hooks_WpHook_HasFilters extends WP_UnitTestCase {
 
 	public function test_has_filters_with_callback() {
 		$callback      = '__return_null';

--- a/tests/phpunit/tests/hooks/wpHook/iterator.php
+++ b/tests/phpunit/tests/hooks/wpHook/iterator.php
@@ -6,7 +6,7 @@
  * @group hooks
  * @covers WP_Hook::add_filter
  */
-class Tests_Hooks_Iterator extends WP_UnitTestCase {
+class Tests_Hooks_WpHook_Iterator extends WP_UnitTestCase {
 
 	public function test_foreach() {
 		$callback_one  = '__return_null';

--- a/tests/phpunit/tests/hooks/wpHook/removeAllFilters.php
+++ b/tests/phpunit/tests/hooks/wpHook/removeAllFilters.php
@@ -6,7 +6,7 @@
  * @group hooks
  * @covers WP_Hook::remove_all_filters
  */
-class Tests_Hooks_RemoveAllFilters extends WP_UnitTestCase {
+class Tests_Hooks_WpHook_RemoveAllFilters extends WP_UnitTestCase {
 
 	public function test_remove_all_filters() {
 		$callback      = '__return_null';

--- a/tests/phpunit/tests/hooks/wpHook/removeFilter.php
+++ b/tests/phpunit/tests/hooks/wpHook/removeFilter.php
@@ -6,7 +6,7 @@
  * @group hooks
  * @covers WP_Hook::remove_filter
  */
-class Tests_Hooks_RemoveFilter extends WP_UnitTestCase {
+class Tests_Hooks_WpHook_RemoveFilter extends WP_UnitTestCase {
 
 	public function test_remove_filter_with_function() {
 		$callback      = '__return_null';


### PR DESCRIPTION
Reorganizes the hooks tests to align to coding standards and consistency within the test suite.

- [X] Moves `WP_Hooks` method tests to into separate directory `<GroupName>/<className>/<methodName>.php`.
- [X] Splits the function tests in `actions.php` and `filters.php` into separate test classes within the `tests/hooks`/  directory.
- [ ] Add assertion failure message to each instance where there are more than 1 assertion in the test method.

Trac ticket:
https://core.trac.wordpress.org/ticket/60705
https://core.trac.wordpress.org/ticket/59647

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
