### PR TITLE
Add PHPUnit tests for wp_parse_slug_list function

### DIFF
--- a/tests/phpunit/tests/functions/wpParseSlugList.php
+++ b/tests/phpunit/tests/functions/wpParseSlugList.php
@@ -19,6 +19,13 @@ class Tests_functions_wpParseSlugList extends WP_UnitTestCase {
 		$this->assertSameSets( $expected, wp_parse_slug_list( $input_list ) );
 	}
 
+	/**
+	 * data for test_wp_parse_slug_list
+	 *
+	 * @ticket 60217
+	 *
+	 * @return array[]
+	 */
 	public function data_wp_parse_slug_list() {
 		return array(
 			'simple'             => array(

--- a/tests/phpunit/tests/functions/wpParseSlugList.php
+++ b/tests/phpunit/tests/functions/wpParseSlugList.php
@@ -14,36 +14,40 @@ class Tests_functions_wpParseSlugList extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_wp_parse_slug_list
 	 */
-	public function test_wp_parse_slug_list( $list, $expected ) {
+	public function test_wp_parse_slug_list( $input_list, $expected ) {
 
-		$this->assertSameSets( $expected, wp_parse_slug_list( $list ) );
+		$this->assertSameSets( $expected, wp_parse_slug_list( $input_list ) );
 	}
 
 	public function data_wp_parse_slug_list() {
 		return array(
 			'simple'             => array(
-				'list'     => array( '1', 2, 'string with spaces' ),
-				'expected' => array( '1', '2', 'string-with-spaces' ),
+				'input_list' => array( '1', 2, 'string with spaces' ),
+				'expected'   => array( '1', '2', 'string-with-spaces' ),
 			),
 			'simple_with_comma'  => array(
-				'list'     => '1,2,string with spaces',
-				'expected' => array( '1', '2', 'string', 'with', 'spaces' ),
+				'input_list' => '1,2,string with spaces',
+				'expected'   => array( '1', '2', 'string', 'with', 'spaces' ),
 			),
 			'array_with_spaces'  => array(
-				'list'     => array( '1 2 string with spaces' ),
-				'expected' => array( '1-2-string-with-spaces' ),
+				'input_list' => array( '1 2 string with spaces' ),
+				'expected'   => array( '1-2-string-with-spaces' ),
 			),
 			'simple_with_spaces' => array(
-				'list'     => '1 2 string with spaces',
-				'expected' => array( '1', '2', 'string', 'with', 'spaces' ),
+				'input_list' => '1 2 string with spaces',
+				'expected'   => array( '1', '2', 'string', 'with', 'spaces' ),
 			),
 			'array_html'         => array(
-				'list'     => array( '1', 2, 'string <strong>with</strong> <h1>HEADING</h1>' ),
-				'expected' => array( '1', '2', 'string-with-heading' ),
+				'input_list' => array( '1', 2, 'string <strong>with</strong> <h1>HEADING</h1>' ),
+				'expected'   => array( '1', '2', 'string-with-heading' ),
 			),
 			'simple_html_spaces' => array(
-				'list'     => '1 2 string <strong>with</strong> <h1>HEADING</h1>',
-				'expected' => array( '1', '2', 'string', 'with', 'heading' ),
+				'input_list' => '1 2 string <strong>with</strong> <h1>HEADING</h1>',
+				'expected'   => array( '1', '2', 'string', 'with', 'heading' ),
+			),
+			'dup_id'             => array(
+				'input_list' => '1 1 string string',
+				'expected'   => array( '1', 'string' ),
 			),
 		);
 	}

--- a/tests/phpunit/tests/functions/wpParseSlugList.php
+++ b/tests/phpunit/tests/functions/wpParseSlugList.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Tests for the wp_parse_slug_list function.
+ *
+ * @group functions
+ *
+ * @covers ::wp_parse_slug_list
+ */
+class Tests_functions_wpParseSlugList extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 60217
+	 *
+	 * @dataProvider data_wp_parse_slug_list
+	 */
+	public function test_wp_parse_slug_list( $list, $expected ) {
+
+		$this->assertSameSets( $expected, wp_parse_slug_list( $list ) );
+	}
+
+	public function data_wp_parse_slug_list() {
+		return array(
+			'simple'             => array(
+				'list'     => array( '1', 2, 'string with spaces' ),
+				'expected' => array( '1', '2', 'string-with-spaces' ),
+			),
+			'simple_with_comma'  => array(
+				'list'     => '1,2,string with spaces',
+				'expected' => array( '1', '2', 'string', 'with', 'spaces' ),
+			),
+			'array_with_spaces'  => array(
+				'list'     => array( '1 2 string with spaces' ),
+				'expected' => array( '1-2-string-with-spaces' ),
+			),
+			'simple_with_spaces' => array(
+				'list'     => '1 2 string with spaces',
+				'expected' => array( '1', '2', 'string', 'with', 'spaces' ),
+			),
+			'array_html'         => array(
+				'list'     => array( '1', 2, 'string <strong>with</strong> <h1>HEADING</h1>' ),
+				'expected' => array( '1', '2', 'string-with-heading' ),
+			),
+			'simple_html_spaces' => array(
+				'list'     => '1 2 string <strong>with</strong> <h1>HEADING</h1>',
+				'expected' => array( '1', '2', 'string', 'with', 'heading' ),
+			),
+		);
+	}
+}


### PR DESCRIPTION
A new phpunit test file is added specifically for testing the 'wp_parse_slug_list' function. Different scenarios are covered including handling of plain numbers, strings with spaces, strings with commas, and HTML. This ensures that the function responds correctly to a wide array of inputs, improving overall software reliability and stability.

Trac ticket: https://core.trac.wordpress.org/ticket/60217
