### PR TITLE
Add PHPUnit tests for wp_parse_id_list function

### DIFF
--- a/tests/phpunit/tests/wpParseIdList.php
+++ b/tests/phpunit/tests/wpParseIdList.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Tests for the wp_parse_id_list function.
+ *
+ * @group functions
+ *
+ * @covers ::wp_parse_id_list
+ */
+class Tests_functions_wpParseIdList extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 60218
+	 *
+	 * @dataProvider data_wp_parse_id_list
+	 */
+	public function test_wp_parse_id_list( $list, $expected ) {
+
+		$this->assertSameSets( $expected, wp_parse_id_list( $list ) );
+	}
+
+	public function data_wp_parse_id_list() {
+		return array(
+			'simple'             => array(
+				'list'     => array( '1', 2, 'string with spaces' ),
+				'expected' => array( 0, 1, 2 ),
+			),
+			'simple_with_comma'  => array(
+				'list'     => '1,2,string with spaces',
+				'expected' => array( 0, 1, 2 ),
+			),
+			'array_with_spaces'  => array(
+				'list'     => array( '1 2 string with spaces' ),
+				'expected' => array( 1 ),
+			),
+			'simple_with_spaces' => array(
+				'list'     => '1 2 string with spaces',
+				'expected' => array( 0, 1, 2 ),
+			),
+			'array_html'         => array(
+				'list'     => array( '1', 2, 'string <strong>with</strong> <h1>HEADING</h1>' ),
+				'expected' => array( 0, 1, 2 ),
+			),
+			'simple_html_spaces' => array(
+				'list'     => '1 2 string <strong>with</strong> <h1>HEADING</h1>',
+				'expected' => array( 0, 1, 2 ),
+			),
+			'dup_id'             => array(
+				'list'     => '1 1 string string',
+				'expected' => array( 0, 1 ),
+			),
+		);
+	}
+}

--- a/tests/phpunit/tests/wpParseIdList.php
+++ b/tests/phpunit/tests/wpParseIdList.php
@@ -14,40 +14,47 @@ class Tests_functions_wpParseIdList extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_wp_parse_id_list
 	 */
-	public function test_wp_parse_id_list( $list, $expected ) {
+	public function test_wp_parse_id_list( $input_list, $expected ) {
 
-		$this->assertSameSets( $expected, wp_parse_id_list( $list ) );
+		$this->assertSameSets( $expected, wp_parse_id_list( $input_list ) );
 	}
 
+	/**
+	 * data for test_wp_parse_id_list
+	 *
+	 * @ticket 60218
+	 *
+	 * @return array[]
+	 */
 	public function data_wp_parse_id_list() {
 		return array(
 			'simple'             => array(
-				'list'     => array( '1', 2, 'string with spaces' ),
-				'expected' => array( 0, 1, 2 ),
+				'input_list' => array( '1', 2, 'string with spaces' ),
+				'expected'   => array( 0, 1, 2 ),
 			),
 			'simple_with_comma'  => array(
-				'list'     => '1,2,string with spaces',
-				'expected' => array( 0, 1, 2 ),
+				'input_list' => '1,2,string with spaces',
+				'expected'   => array( 0, 1, 2 ),
 			),
 			'array_with_spaces'  => array(
-				'list'     => array( '1 2 string with spaces' ),
-				'expected' => array( 1 ),
+				'input_list' => array( '1 2 string with spaces' ),
+				'expected'   => array( 1 ),
 			),
 			'simple_with_spaces' => array(
-				'list'     => '1 2 string with spaces',
-				'expected' => array( 0, 1, 2 ),
+				'input_list' => '1 2 string with spaces',
+				'expected'   => array( 0, 1, 2 ),
 			),
 			'array_html'         => array(
-				'list'     => array( '1', 2, 'string <strong>with</strong> <h1>HEADING</h1>' ),
-				'expected' => array( 0, 1, 2 ),
+				'input_list' => array( '1', 2, 'string <strong>with</strong> <h1>HEADING</h1>' ),
+				'expected'   => array( 0, 1, 2 ),
 			),
 			'simple_html_spaces' => array(
-				'list'     => '1 2 string <strong>with</strong> <h1>HEADING</h1>',
-				'expected' => array( 0, 1, 2 ),
+				'input_list' => '1 2 string <strong>with</strong> <h1>HEADING</h1>',
+				'expected'   => array( 0, 1, 2 ),
 			),
 			'dup_id'             => array(
-				'list'     => '1 1 string string',
-				'expected' => array( 0, 1 ),
+				'input_list' => '1 1 string string',
+				'expected'   => array( 0, 1 ),
 			),
 		);
 	}


### PR DESCRIPTION
A new PHPUnit test file for the 'wp_parse_id_list' function is introduced. It includes various scenarios ranging from plain numbers, strings with spaces, and HTML to strings with commas. This is crucial to guarantee the function's accurate response to a variety of inputs, enhancing software reliability and stability.


Trac ticket: https://core.trac.wordpress.org/ticket/60218