### PR TITLE
Add PHPUnit test for _mce_set_direction function

### DIFF
--- a/tests/phpunit/tests/functions/mceSetDirection.php
+++ b/tests/phpunit/tests/functions/mceSetDirection.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Tests for the _mce_set_direction function.
+ *
+ * @group functions
+ *
+ * @covers ::_mce_set_direction
+ */
+class Tests_functions_mceSetDirection extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 60219
+	 */
+	public function test__mce_set_direction() {
+		global $wp_locale;
+
+		$mce_init = array(
+			'directionality' => 'ltr',
+			'rtl_ui'         => false,
+			'plugins'        => 'plugins',
+			'toolbar1'       => 'toolbar1',
+		);
+
+		$expected = array(
+			'directionality' => 'rtl',
+			'rtl_ui'         => true,
+			'plugins'        => 'plugins,directionality',
+			'toolbar1'       => 'toolbar1,ltr',
+		);
+
+		$this->assertSameSets( $mce_init, _mce_set_direction( $mce_init ) );
+		$wp_locale->text_direction = 'rtl';
+		$this->assertSameSets( $expected, _mce_set_direction( $mce_init ) );
+		$wp_locale->text_direction = 'ltr';
+	}
+}

--- a/tests/phpunit/tests/functions/mceSetDirection.php
+++ b/tests/phpunit/tests/functions/mceSetDirection.php
@@ -29,9 +29,14 @@ class Tests_functions_mceSetDirection extends WP_UnitTestCase {
 			'toolbar1'       => 'toolbar1,ltr',
 		);
 
-		$this->assertSameSets( $mce_init, _mce_set_direction( $mce_init ) );
+		$actual = _mce_set_direction( $mce_init );
+		$this->assertSameSets( $mce_init, $actual );
+
+		$orig_text_dir             = $wp_locale->text_direction;
 		$wp_locale->text_direction = 'rtl';
-		$this->assertSameSets( $expected, _mce_set_direction( $mce_init ) );
-		$wp_locale->text_direction = 'ltr';
+		$actual                    = _mce_set_direction( $mce_init );
+		$wp_locale->text_direction = $orig_text_dir;
+
+		$this->assertSameSets( $expected, $actual );
 	}
 }


### PR DESCRIPTION
This commit introduces a new PHPUnit test for the _mce_set_direction function within WordPress. The test checks the functionality of the text direction setting, ensuring it correctly switches between 'rtl' and 'ltr' options. Furthermore, the changes improve code traceability by linking the test to ticket 60219.


Trac ticket: https://core.trac.wordpress.org/ticket/60219