### PR TITLE
60212

### DIFF
--- a/src/wp-includes/class-wp-hook.php
+++ b/src/wp-includes/class-wp-hook.php
@@ -19,6 +19,14 @@
 final class WP_Hook implements Iterator, ArrayAccess {
 
 	/**
+	 * Hook callers.
+	 *
+	 * @since 6.5.0
+	 * @var array
+	 */
+	public $callers = array();
+
+	/**
 	 * Hook callbacks.
 	 *
 	 * @since 4.7.0
@@ -98,6 +106,18 @@ final class WP_Hook implements Iterator, ArrayAccess {
 
 		if ( $this->nesting_level > 0 ) {
 			$this->resort_active_iterations( $priority, $priority_existed );
+		}
+
+		// Check if a plugins are loaded
+		if( defined('WP_PLUGIN_DIR')){
+			// Get the caller file path
+			$caller = debug_backtrace()[1]['file'];
+			// Check if a plugin is adding this filter
+			if (substr($caller, 0, strlen(WP_PLUGIN_DIR)) == WP_PLUGIN_DIR) {
+				// Strip the WP_PLUGIN_DIR from the caller path
+				$caller = substr($caller, strlen(WP_PLUGIN_DIR));
+				array_push($this->callers, $caller);
+			} 
 		}
 	}
 

--- a/src/wp-includes/plugin.php
+++ b/src/wp-includes/plugin.php
@@ -714,6 +714,13 @@ function apply_filters_deprecated( $hook_name, $args, $version, $replacement = '
 		return $args[0];
 	}
 
+	// Filters added by plugins have a caller to easily identify the source
+	global $wp_filter;
+	if(isset( $wp_filter[ $hook_name ] )){
+		$callers = implode(", ", $wp_filter[ $hook_name ]->callers);
+		$message .= ' ' . __('used by') . ' ' . $callers;
+	}
+
 	_deprecated_hook( $hook_name, $version, $replacement, $message );
 
 	return apply_filters_ref_array( $hook_name, $args );


### PR DESCRIPTION
Introduces a 'callers' property to WP_Hook and assigns it to filters utilized by plugins. This enhancement facilitates distinguishing those called by plugins from those invoked by the core.

Trac ticket: https://core.trac.wordpress.org/ticket/60212

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
