### PR TITLE
Add viewScriptModule handling to block.json metadata

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -140,27 +140,27 @@ function get_block_asset_url( $path ) {
  * @return string|false Script handle provided directly or created through
  *                      script's registration, or false on failure.
  */
-function register_block_module_handle( $metadata, $field_name, $index = 0 ) {
+function register_block_module_id( $metadata, $field_name, $index = 0 ) {
 	if ( empty( $metadata[ $field_name ] ) ) {
 		return false;
 	}
 
-	$module_handle = $metadata[ $field_name ];
-	if ( is_array( $module_handle ) ) {
-		if ( empty( $module_handle[ $index ] ) ) {
+	$module_id = $metadata[ $field_name ];
+	if ( is_array( $module_id ) ) {
+		if ( empty( $module_id[ $index ] ) ) {
 			return false;
 		}
-		$module_handle = $module_handle[ $index ];
+		$module_id = $module_id[ $index ];
 	}
 
-	$module_path = remove_block_asset_path_prefix( $module_handle );
-	if ( $module_handle === $module_path ) {
-		return $module_handle;
+	$module_path = remove_block_asset_path_prefix( $module_id );
+	if ( $module_id === $module_path ) {
+		return $module_id;
 	}
 
 	$path                  = dirname( $metadata['file'] );
 	$module_asset_raw_path = $path . '/' . substr_replace( $module_path, '.asset.php', - strlen( '.js' ) );
-	$module_handle         = generate_block_asset_handle( $metadata['name'], $field_name, $index );
+	$module_id             = generate_block_asset_handle( $metadata['name'], $field_name, $index );
 	$module_asset_path     = wp_normalize_path(
 		realpath( $module_asset_raw_path )
 	);
@@ -186,7 +186,7 @@ function register_block_module_handle( $metadata, $field_name, $index = 0 ) {
 	$module_asset        = require $module_asset_path;
 	$module_dependencies = isset( $module_asset['dependencies'] ) ? $module_asset['dependencies'] : array();
 	$result              = wp_register_module(
-		$module_handle,
+		$module_id,
 		$module_uri,
 		$module_dependencies,
 		isset( $module_asset['version'] ) ? $module_asset['version'] : false,
@@ -194,10 +194,10 @@ function register_block_module_handle( $metadata, $field_name, $index = 0 ) {
 
 	if ( ! empty( $metadata['textdomain'] ) && in_array( 'wp-i18n', $module_dependencies, true ) ) {
 		// script translations?
-		wp_set_script_translations( $module_handle, $metadata['textdomain'] );
+		wp_set_script_translations( $module_id, $metadata['textdomain'] );
 	}
 
-	return $module_handle;
+	return $module_id;
 }
 
 /**
@@ -569,7 +569,7 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 	}
 
 	$module_fields = array(
-		'viewModule'   => 'view_module_handles',
+		'viewModule'   => 'view_module_ids',
 	);
 	foreach ( $module_fields as $metadata_field_name => $settings_field_name ) {
 
@@ -581,7 +581,7 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 			$processed_modules = array();
 			if ( is_array( $modules ) ) {
 				for ( $index = 0; $index < count( $modules ); $index++ ) {
-					$result = register_block_module_handle(
+					$result = register_block_module_id(
 						$metadata,
 						$metadata_field_name,
 						$index
@@ -591,7 +591,7 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 					}
 				}
 			} else {
-				$result = register_block_module_handle(
+				$result = register_block_module_id(
 					$metadata,
 					$metadata_field_name
 				);

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -129,9 +129,10 @@ function get_block_asset_url( $path ) {
 
 /**
  * Finds a script module ID for the selected block metadata field. It detects
- * when a path to file was provided and finds a corresponding asset file
- * with details necessary to register the script module under an automatically
- * generated handle name. It returns unprocessed script module ID otherwise.
+ * when a path to file was provided and optionally finds a corresponding asset
+ * file with details necessary to register the script module under with an
+ * automatically generated module ID. It returns unprocessed script module
+ * ID otherwise.
  *
  * @since 6.5.0
  *

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -128,14 +128,14 @@ function get_block_asset_url( $path ) {
  * Finds a script module ID for the selected block metadata field. It detects
  * when a path to file was provided and finds a corresponding asset file
  * with details necessary to register the script module under an automatically
- * generated handle name. It returns unprocessed script handle otherwise.
+ * generated handle name. It returns unprocessed script module ID otherwise.
  *
  * @since 6.5.0
  *
  * @param array  $metadata   Block metadata.
  * @param string $field_name Field name to pick from metadata.
- * @param int    $index      Optional. Index of the script to register when multiple items passed.
- *                           Default 0.
+ * @param int    $index      Optional. Index of the script module ID to register when multiple
+ *                           items passed. Default 0.
  * @return string|false Script module ID or false on failure.
  */
 function register_block_script_module_id( $metadata, $field_name, $index = 0 ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -169,7 +169,7 @@ function register_block_script_module_id( $metadata, $field_name, $index = 0 ) {
 	$module_path_norm = wp_normalize_path( realpath( $path . '/' . $module_path ) );
 	$module_uri       = get_block_asset_url( $module_path_norm );
 
-	$module_asset        = @include $module_asset_path;
+	$module_asset        = ! empty( $module_asset_path ) ? require $module_asset_path : array();
 	$module_dependencies = isset( $module_asset['dependencies'] ) ? $module_asset['dependencies'] : array();
 
 	wp_register_script_module(

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -63,13 +63,13 @@ function generate_block_asset_handle( $block_name, $field_name, $index = 0 ) {
 	}
 
 	$field_mappings = array(
-		'editorScript' => 'editor-script',
-		'editorStyle'  => 'editor-style',
-		'script'       => 'script',
-		'style'        => 'style',
-		'viewScript'   => 'view-script',
+		'editorScript'     => 'editor-script',
+		'editorStyle'      => 'editor-style',
+		'script'           => 'script',
+		'style'            => 'style',
+		'viewScript'       => 'view-script',
 		'viewScriptModule' => 'view-script-module',
-		'viewStyle'    => 'view-style',
+		'viewStyle'        => 'view-style',
 	);
 	$asset_handle   = str_replace( '/', '-', $block_name ) .
 		'-' . $field_mappings[ $field_name ];

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -36,7 +36,7 @@ function remove_block_asset_path_prefix( $asset_handle_or_path ) {
  *
  * @since 5.5.0
  * @since 6.1.0 Added `$index` parameter.
- * @since 6.5.0 Add support for `viewModule` field.
+ * @since 6.5.0 Add support for `viewScriptModule` field.
  *
  * @param string $block_name Name of the block.
  * @param string $field_name Name of the metadata field.
@@ -60,12 +60,12 @@ function generate_block_asset_handle( $block_name, $field_name, $index = 0 ) {
 	}
 
 	$field_mappings = array(
-		'viewModule'   => 'view-module',
 		'editorScript' => 'editor-script',
-		'script'       => 'script',
-		'viewScript'   => 'view-script',
 		'editorStyle'  => 'editor-style',
+		'script'       => 'script',
 		'style'        => 'style',
+		'viewScript'   => 'view-script',
+		'viewScriptModule' => 'view-script-module',
 		'viewStyle'    => 'view-style',
 	);
 	$asset_handle   = str_replace( '/', '-', $block_name ) .
@@ -386,7 +386,7 @@ function get_block_metadata_i18n_schema() {
  * @since 6.1.0 Added support for `render` field.
  * @since 6.3.0 Added `selectors` field.
  * @since 6.4.0 Added support for `blockHooks` field.
- * @since 6.5.0 Added support for `allowedBlocks`, `viewModule`, and `viewStyle` fields.
+ * @since 6.5.0 Added support for `allowedBlocks`, `viewScriptModule`, and `viewStyle` fields.
  *
  * @param string $file_or_folder Path to the JSON file with metadata definition for
  *                               the block or path to the folder where the `block.json` file is located.
@@ -563,10 +563,9 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 	}
 
 	$module_fields = array(
-		'viewModule'   => 'view_module_ids',
+		'viewScriptModule' => 'view_script_module_ids',
 	);
 	foreach ( $module_fields as $metadata_field_name => $settings_field_name ) {
-
 		if ( ! empty( $settings[ $metadata_field_name ] ) ) {
 			$metadata[ $metadata_field_name ] = $settings[ $metadata_field_name ];
 		}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -183,17 +183,13 @@ function register_block_script_module_id( $metadata, $field_name, $index = 0 ) {
 
 	$module_asset        = require $module_asset_path;
 	$module_dependencies = isset( $module_asset['dependencies'] ) ? $module_asset['dependencies'] : array();
-	$result              = wp_register_script_module(
+
+	wp_register_script_module(
 		$module_id,
 		$module_uri,
 		$module_dependencies,
-		isset( $module_asset['version'] ) ? $module_asset['version'] : false,
+		isset( $module_asset['version'] ) ? $module_asset['version'] : false
 	);
-
-	if ( ! empty( $metadata['textdomain'] ) && in_array( 'wp-i18n', $module_dependencies, true ) ) {
-		// script translations?
-		wp_set_script_translations( $module_id, $metadata['textdomain'] );
-	}
 
 	return $module_id;
 }

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -36,7 +36,7 @@ function remove_block_asset_path_prefix( $asset_handle_or_path ) {
  *
  * @since 5.5.0
  * @since 6.1.0 Added `$index` parameter.
- * @since 6.5.0 Add support for `viewScriptModule` field.
+ * @since 6.5.0 Added support for `viewScriptModule` field.
  *
  * @param string $block_name Name of the block.
  * @param string $field_name Name of the metadata field.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -166,25 +166,10 @@ function register_block_script_module_id( $metadata, $field_name, $index = 0 ) {
 		realpath( $module_asset_raw_path )
 	);
 
-	if ( empty( $module_asset_path ) ) {
-		_doing_it_wrong(
-			__FUNCTION__,
-			sprintf(
-				/* translators: 1: Asset file location, 2: Field name, 3: Block name.  */
-				__( 'The asset file (%1$s) for the "%2$s" defined in "%3$s" block definition is missing.' ),
-				$module_asset_raw_path,
-				$field_name,
-				$metadata['name']
-			),
-			'6.5.0'
-		);
-		return false;
-	}
-
 	$module_path_norm = wp_normalize_path( realpath( $path . '/' . $module_path ) );
 	$module_uri       = get_block_asset_url( $module_path_norm );
 
-	$module_asset        = require $module_asset_path;
+	$module_asset        = @include $module_asset_path;
 	$module_dependencies = isset( $module_asset['dependencies'] ) ? $module_asset['dependencies'] : array();
 
 	wp_register_script_module(

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -53,6 +53,9 @@ function generate_block_asset_handle( $block_name, $field_name, $index = 0 ) {
 		if ( str_starts_with( $field_name, 'view' ) ) {
 			$asset_handle .= '-view';
 		}
+		if ( str_ends_with( strtolower( $field_name ), 'scriptmodule' ) ) {
+			$asset_handle .= '-script-module';
+		}
 		if ( $index > 0 ) {
 			$asset_handle .= '-' . ( $index + 1 );
 		}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -59,8 +59,6 @@ function generate_block_asset_handle( $block_name, $field_name, $index = 0 ) {
 	}
 
 	$field_mappings = array(
-		'editorModule' => 'editor-module',
-		'module'       => 'module',
 		'viewModule'   => 'view-module',
 		'editorScript' => 'editor-script',
 		'script'       => 'script',
@@ -571,8 +569,6 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 	}
 
 	$module_fields = array(
-		'editorModule' => 'editor_module_handles',
-		'module'       => 'module_handles',
 		'viewModule'   => 'view_module_handles',
 	);
 	foreach ( $module_fields as $metadata_field_name => $settings_field_name ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -185,7 +185,7 @@ function register_block_module_id( $metadata, $field_name, $index = 0 ) {
 
 	$module_asset        = require $module_asset_path;
 	$module_dependencies = isset( $module_asset['dependencies'] ) ? $module_asset['dependencies'] : array();
-	$result              = wp_register_module(
+	$result              = wp_register_script_module(
 		$module_id,
 		$module_uri,
 		$module_dependencies,

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -36,6 +36,7 @@ function remove_block_asset_path_prefix( $asset_handle_or_path ) {
  *
  * @since 5.5.0
  * @since 6.1.0 Added `$index` parameter.
+ * @since 6.5.0 Add support for `viewModule` field.
  *
  * @param string $block_name Name of the block.
  * @param string $field_name Name of the metadata field.
@@ -124,23 +125,20 @@ function get_block_asset_url( $path ) {
 }
 
 /**
- * Finds a script handle for the selected block metadata field. It detects
- * when a path to file was provided and optionally finds a corresponding asset
- * file with details necessary to register the script under automatically
+ * Finds a script module ID for the selected block metadata field. It detects
+ * when a path to file was provided and finds a corresponding asset file
+ * with details necessary to register the script module under an automatically
  * generated handle name. It returns unprocessed script handle otherwise.
  *
- * @since 5.5.0
- * @since 6.1.0 Added `$index` parameter.
- * @since 6.5.0 The asset file is optional.
+ * @since 6.5.0
  *
  * @param array  $metadata   Block metadata.
  * @param string $field_name Field name to pick from metadata.
  * @param int    $index      Optional. Index of the script to register when multiple items passed.
  *                           Default 0.
- * @return string|false Script handle provided directly or created through
- *                      script's registration, or false on failure.
+ * @return string|false Script module ID or false on failure.
  */
-function register_block_module_id( $metadata, $field_name, $index = 0 ) {
+function register_block_script_module_id( $metadata, $field_name, $index = 0 ) {
 	if ( empty( $metadata[ $field_name ] ) ) {
 		return false;
 	}
@@ -392,7 +390,7 @@ function get_block_metadata_i18n_schema() {
  * @since 6.1.0 Added support for `render` field.
  * @since 6.3.0 Added `selectors` field.
  * @since 6.4.0 Added support for `blockHooks` field.
- * @since 6.5.0 Added support for `allowedBlocks` and `viewStyle` fields.
+ * @since 6.5.0 Added support for `allowedBlocks`, `viewModule`, and `viewStyle` fields.
  *
  * @param string $file_or_folder Path to the JSON file with metadata definition for
  *                               the block or path to the folder where the `block.json` file is located.
@@ -581,7 +579,7 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 			$processed_modules = array();
 			if ( is_array( $modules ) ) {
 				for ( $index = 0; $index < count( $modules ); $index++ ) {
-					$result = register_block_module_id(
+					$result = register_block_script_module_id(
 						$metadata,
 						$metadata_field_name,
 						$index
@@ -591,7 +589,7 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 					}
 				}
 			} else {
-				$result = register_block_module_id(
+				$result = register_block_script_module_id(
 					$metadata,
 					$metadata_field_name
 				);

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -227,22 +227,6 @@ class WP_Block_Type {
 	public $view_script_handles = array();
 
 	/**
-	 * Block type editor only module handles.
-	 *
-	 * @since 6.5.0
-	 * @var string[]
-	 */
-	public $editor_module_handles = array();
-
-	/**
-	 * Block type front end and editor module handles.
-	 *
-	 * @since 6.5.0
-	 * @var string[]
-	 */
-	public $module_handles = array();
-
-	/**
 	 * Block type front end only module handles.
 	 *
 	 * @since 6.5.0

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -227,12 +227,12 @@ class WP_Block_Type {
 	public $view_script_handles = array();
 
 	/**
-	 * Block type front end only module handles.
+	 * Block type front end only module IDs.
 	 *
 	 * @since 6.5.0
 	 * @var string[]
 	 */
-	public $view_module_handles = array();
+	public $view_module_ids = array();
 
 	/**
 	 * Block type editor only style handles.

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -227,6 +227,30 @@ class WP_Block_Type {
 	public $view_script_handles = array();
 
 	/**
+	 * Block type editor only module handles.
+	 *
+	 * @since 6.5.0
+	 * @var string[]
+	 */
+	public $editor_module_handles = array();
+
+	/**
+	 * Block type front end and editor module handles.
+	 *
+	 * @since 6.5.0
+	 * @var string[]
+	 */
+	public $module_handles = array();
+
+	/**
+	 * Block type front end only module handles.
+	 *
+	 * @since 6.5.0
+	 * @var string[]
+	 */
+	public $view_module_handles = array();
+
+	/**
 	 * Block type editor only style handles.
 	 *
 	 * @since 6.1.0

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -227,12 +227,12 @@ class WP_Block_Type {
 	public $view_script_handles = array();
 
 	/**
-	 * Block type front end only module IDs.
+	 * Block type front end only script module IDs.
 	 *
 	 * @since 6.5.0
 	 * @var string[]
 	 */
-	public $view_module_ids = array();
+	public $view_script_module_ids = array();
 
 	/**
 	 * Block type editor only style handles.

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -470,9 +470,9 @@ class WP_Block {
 			}
 		}
 
-		if ( ! empty( $this->block_type->view_module_handles ) ) {
-			foreach ( $this->block_type->view_module_handles as $view_module_handle ) {
-				wp_enqueue_module( $view_module_handle );
+		if ( ! empty( $this->block_type->view_module_ids ) ) {
+			foreach ( $this->block_type->view_module_ids as $view_module_id ) {
+				wp_enqueue_module( $view_module_id );
 			}
 		}
 

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -470,9 +470,9 @@ class WP_Block {
 			}
 		}
 
-		if ( ! empty( $this->block_type->view_module_ids ) ) {
-			foreach ( $this->block_type->view_module_ids as $view_module_id ) {
-				wp_enqueue_script_module( $view_module_id );
+		if ( ! empty( $this->block_type->view_script_module_ids ) ) {
+			foreach ( $this->block_type->view_script_module_ids as $view_script_module_id ) {
+				wp_enqueue_script_module( $view_script_module_id );
 			}
 		}
 

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -470,12 +470,6 @@ class WP_Block {
 			}
 		}
 
-		if ( ( ! empty( $this->block_type->module_handles ) ) ) {
-			foreach ( $this->block_type->module_handles as $module_handle ) {
-				wp_enqueue_module( $module_handle );
-			}
-		}
-
 		if ( ! empty( $this->block_type->view_module_handles ) ) {
 			foreach ( $this->block_type->view_module_handles as $view_module_handle ) {
 				wp_enqueue_module( $view_module_handle );

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -470,6 +470,18 @@ class WP_Block {
 			}
 		}
 
+		if ( ( ! empty( $this->block_type->module_handles ) ) ) {
+			foreach ( $this->block_type->module_handles as $module_handle ) {
+				wp_enqueue_module( $module_handle );
+			}
+		}
+
+		if ( ! empty( $this->block_type->view_module_handles ) ) {
+			foreach ( $this->block_type->view_module_handles as $view_module_handle ) {
+				wp_enqueue_module( $view_module_handle );
+			}
+		}
+
 		if ( ( ! empty( $this->block_type->style_handles ) ) ) {
 			foreach ( $this->block_type->style_handles as $style_handle ) {
 				wp_enqueue_style( $style_handle );

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -472,7 +472,7 @@ class WP_Block {
 
 		if ( ! empty( $this->block_type->view_module_ids ) ) {
 			foreach ( $this->block_type->view_module_ids as $view_module_id ) {
-				wp_enqueue_module( $view_module_id );
+				wp_enqueue_script_module( $view_module_id );
 			}
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -291,7 +291,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 				'editor_script_handles',
 				'script_handles',
 				'view_script_handles',
-				'view_script_modules_ids',
+				'view_script_module_ids',
 				'editor_style_handles',
 				'style_handles',
 				'view_style_handles',

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -291,6 +291,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 				'editor_script_handles',
 				'script_handles',
 				'view_script_handles',
+				'view_script_modules_ids',
 				'editor_style_handles',
 				'style_handles',
 				'view_style_handles',
@@ -576,6 +577,16 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 				),
 				'view_script_handles'   => array(
 					'description' => __( 'Public facing script handles.' ),
+					'type'        => array( 'array' ),
+					'default'     => array(),
+					'items'       => array(
+						'type' => 'string',
+					),
+					'context'     => array( 'embed', 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'view_script_module_ids'   => array(
+					'description' => __( 'Public facing script module IDs.' ),
 					'type'        => array( 'array' ),
 					'default'     => array(),
 					'items'       => array(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -240,6 +240,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 	 * @since 5.5.0
 	 * @since 5.9.0 Renamed `$block_type` to `$item` to match parent class for PHP 8 named parameter support.
 	 * @since 6.3.0 Added `selectors` field.
+	 * @since 6.5.0 Added `view_script_module_ids` field.
 	 *
 	 * @param WP_Block_Type   $item    Block type data.
 	 * @param WP_REST_Request $request Full details about the request.

--- a/tests/phpunit/data/blocks/notice/block.json
+++ b/tests/phpunit/data/blocks/notice/block.json
@@ -68,6 +68,7 @@
 	"editorScript": "tests-notice-editor-script",
 	"script": "tests-notice-script",
 	"viewScript": [ "tests-notice-view-script", "tests-notice-view-script-2" ],
+	"viewScriptModule": [ "tests-notice-view-script-module", "tests-notice-view-script-module-2" ],
 	"editorStyle": "tests-notice-editor-style",
 	"style": [ "tests-notice-style", "tests-notice-style-2" ],
 	"viewStyle": [ "tests-notice-view-style" ],

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -138,6 +138,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 50263
+	 * @ticket 60233
 	 */
 	public function test_generate_block_asset_handle() {
 		$block_name = 'unit-tests/my-block';
@@ -153,6 +154,18 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		$this->assertSame(
 			'unit-tests-my-block-view-script-100',
 			generate_block_asset_handle( $block_name, 'viewScript', 99 )
+		);
+		$this->assertSame(
+			'unit-tests-my-block-view-script-module',
+			generate_block_asset_handle( $block_name, 'viewScriptModule' )
+		);
+		$this->assertSame(
+			'unit-tests-my-block-view-script-module-2',
+			generate_block_asset_handle( $block_name, 'viewScriptModule', 1 )
+		);
+		$this->assertSame(
+			'unit-tests-my-block-view-script-module-100',
+			generate_block_asset_handle( $block_name, 'viewScriptModule', 99 )
 		);
 		$this->assertSame(
 			'unit-tests-my-block-editor-style-2',
@@ -172,6 +185,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 50328
+	 * @ticket 60233
 	 */
 	public function test_generate_block_asset_handle_core_block() {
 		$block_name = 'core/paragraph';
@@ -187,6 +201,18 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		$this->assertSame(
 			'wp-block-paragraph-view-100',
 			generate_block_asset_handle( $block_name, 'viewScript', 99 )
+		);
+		$this->assertSame(
+			'unit-tests-my-block-view-script-module',
+			generate_block_asset_handle( $block_name, 'viewScriptModule' )
+		);
+		$this->assertSame(
+			'unit-tests-my-block-view-script-module-2',
+			generate_block_asset_handle( $block_name, 'viewScriptModule', 1 )
+		);
+		$this->assertSame(
+			'unit-tests-my-block-view-script-module-100',
+			generate_block_asset_handle( $block_name, 'viewScriptModule', 99 )
 		);
 		$this->assertSame(
 			'wp-block-paragraph-editor-2',
@@ -229,6 +255,77 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		$result   = register_block_script_handle( $metadata, 'script', 1 );
 
 		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @expectedIncorrectUsage register_block_script_module_id
+	 * @ticket 60233
+	 */
+	public function test_missing_asset_file_register_block_script_module_id() {
+		$metadata = array(
+			'file'   => __FILE__,
+			'name'   => 'unit-tests/test-block',
+			'viewScriptModule' => 'file:./blocks/notice/missing-asset.js',
+		);
+		$result   = register_block_script_module_id( $metadata, 'viewScriptModule' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @ticket 60233
+	 */
+	public function test_handle_passed_register_block_script_module_id() {
+		$metadata = array(
+			'viewScriptModule' => 'test-id',
+		);
+		$result   = register_block_script_module_id( $metadata, 'viewScriptModule' );
+
+		$this->assertSame( 'test-script-handle', $result );
+	}
+
+	/**
+	 * @ticket 60233
+	 */
+	public function test_handles_passed_register_block_script_module_ids() {
+		$metadata = array(
+			'script' => array( 'test-id', 'test-id-1' ),
+		);
+
+		$result = register_block_script_handle( $metadata, 'viewScriptModule' );
+		$this->assertSame( 'test-id', $result );
+
+		$result = register_block_script_handle( $metadata, 'viewScriptModule', 1 );
+		$this->assertSame( 'test-id-2', $result, 1 );
+	}
+
+	/**
+	 * @ticket 60233
+	 */
+	public function test_success_register_block_script_module_id() {
+		$metadata = array(
+			'file'   => DIR_TESTDATA . '/blocks/notice/block.json',
+			'name'   => 'unit-tests/test-block',
+			'viewScriptModule' => 'file:./block.js',
+		);
+		$result   = register_block_script_module_id( $metadata, 'viewScriptModule' );
+
+		$this->assertSame( 'tests-notice-view-script-module', $result );
+
+		// Test the behavior directly within the unit test
+		$this->assertFalse(
+			strpos(
+				wp_normalize_path( realpath( dirname( $metadata['file'] ) . '/' . $metadata['viewScriptModule'] ) ),
+				trailingslashit( wp_normalize_path( get_template_directory() ) )
+			) === 0
+		);
+
+		$this->assertFalse(
+			strpos(
+				wp_normalize_path( realpath( dirname( $metadata['file'] ) . '/' . $metadata['viewScriptModule'] ) ),
+				trailingslashit( wp_normalize_path( get_stylesheet_directory() ) )
+			) === 0
+		);
 	}
 
 	/**
@@ -751,6 +848,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 * @ticket 50328
 	 * @ticket 57585
 	 * @ticket 59797
+	 * @ticket 60233
 	 */
 	public function test_block_registers_with_metadata_fixture() {
 		$result = register_block_type_from_metadata(
@@ -852,6 +950,10 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		$this->assertSameSets(
 			array( 'tests-notice-view-script', 'tests-notice-view-script-2' ),
 			$result->view_script_handles
+		);
+		$this->assertSameSets(
+			array( 'tests-notice-view-script-module', 'tests-notice-view-script-module-2' ),
+			$result->view_script_module_ids
 		);
 		$this->assertSameSets(
 			array( 'tests-notice-editor-style' ),

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -330,7 +330,6 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @expectedIncorrectUsage register_block_script_module_id
 	 * @ticket 60233
 	 */
 	public function test_missing_asset_file_register_block_script_module_id() {
@@ -341,7 +340,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		);
 		$result   = register_block_script_module_id( $metadata, 'viewScriptModule' );
 
-		$this->assertFalse( $result );
+		$this->assertSame( 'unit-tests-test-block-view-script-module', $result );
 	}
 
 	/**

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -185,7 +185,6 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 50328
-	 * @ticket 60233
 	 */
 	public function test_generate_block_asset_handle_core_block() {
 		$block_name = 'core/paragraph';
@@ -203,6 +202,35 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 			generate_block_asset_handle( $block_name, 'viewScript', 99 )
 		);
 		$this->assertSame(
+			'wp-block-paragraph-editor-2',
+			generate_block_asset_handle( $block_name, 'editorStyle', 1 )
+		);
+		$this->assertSame(
+			'wp-block-paragraph',
+			generate_block_asset_handle( $block_name, 'style' )
+		);
+	}
+
+	/**
+	 * @ticket 60233
+	 */
+	public function test_generate_block_asset_handle_core_block_module() {
+		$block_name = 'core/paragraph';
+
+		$this->assertSame(
+			'wp-block-paragraph-editor-script-module',
+			generate_block_asset_handle( $block_name, 'editorScriptModule' )
+		);
+		$this->assertSame(
+			'wp-block-paragraph-editor-script-module-2',
+			generate_block_asset_handle( $block_name, 'editorScriptModule', 1 )
+		);
+		$this->assertSame(
+			'wp-block-paragraph-editor-script-module-100',
+			generate_block_asset_handle( $block_name, 'editorScriptModule', 99 )
+		);
+
+		$this->assertSame(
 			'wp-block-paragraph-view-script-module',
 			generate_block_asset_handle( $block_name, 'viewScriptModule' )
 		);
@@ -214,13 +242,18 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 			'wp-block-paragraph-view-script-module-100',
 			generate_block_asset_handle( $block_name, 'viewScriptModule', 99 )
 		);
+
 		$this->assertSame(
-			'wp-block-paragraph-editor-2',
-			generate_block_asset_handle( $block_name, 'editorStyle', 1 )
+			'wp-block-paragraph-script-module',
+			generate_block_asset_handle( $block_name, 'scriptModule' )
 		);
 		$this->assertSame(
-			'wp-block-paragraph',
-			generate_block_asset_handle( $block_name, 'style' )
+			'wp-block-paragraph-script-module-2',
+			generate_block_asset_handle( $block_name, 'scriptModule', 1 )
+		);
+		$this->assertSame(
+			'wp-block-paragraph-script-module-100',
+			generate_block_asset_handle( $block_name, 'scriptModule', 99 )
 		);
 	}
 

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -303,8 +303,8 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 * @ticket 60233
 	 */
 	public function test_empty_string_value_do_not_register_block_script_module_id() {
-		$metadata = array( 'viewScriptHandle' => '' );
-		$result   = register_block_script_module_id( $metadata, 'viewScriptHandle' );
+		$metadata = array( 'viewScriptModule' => '' );
+		$result   = register_block_script_module_id( $metadata, 'viewScriptModule' );
 
 		$this->assertFalse( $result );
 	}

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -263,8 +263,8 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 */
 	public function test_missing_asset_file_register_block_script_module_id() {
 		$metadata = array(
-			'file'   => __FILE__,
-			'name'   => 'unit-tests/test-block',
+			'file'             => __FILE__,
+			'name'             => 'unit-tests/test-block',
 			'viewScriptModule' => 'file:./blocks/notice/missing-asset.js',
 		);
 		$result   = register_block_script_module_id( $metadata, 'viewScriptModule' );
@@ -304,8 +304,8 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 */
 	public function test_success_register_block_script_module_id() {
 		$metadata = array(
-			'file'   => DIR_TESTDATA . '/blocks/notice/block.json',
-			'name'   => 'unit-tests/test-block',
+			'file'             => DIR_TESTDATA . '/blocks/notice/block.json',
+			'name'             => 'unit-tests/test-block',
 			'viewScriptModule' => 'file:./block.js',
 		);
 		$result   = register_block_script_module_id( $metadata, 'viewScriptModule' );

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -258,6 +258,45 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 60233
+	 */
+	public function test_field_not_found_register_block_script_module_id() {
+		$result = register_block_script_module_id( array(), 'viewScriptModule' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @ticket 60233
+	 */
+	public function test_empty_string_value_do_not_register_block_script_module_id() {
+		$metadata = array( 'viewScriptHandle' => '' );
+		$result   = register_block_script_module_id( $metadata, 'viewScriptHandle' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @ticket 60233
+	 */
+	public function test_empty_array_value_do_not_register_block_script_module_id() {
+		$metadata = array( 'viewScriptModule' => array() );
+		$result   = register_block_script_module_id( $metadata, 'viewScriptModule' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @ticket 60233
+	 */
+	public function test_wrong_array_index_do_not_register_block_script_module_id() {
+		$metadata = array( 'viewScriptModule' => array( 'test-module_id' ) );
+		$result   = register_block_script_module_id( $metadata, 'script', 1 );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
 	 * @expectedIncorrectUsage register_block_script_module_id
 	 * @ticket 60233
 	 */

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -289,14 +289,14 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 */
 	public function test_handles_passed_register_block_script_module_ids() {
 		$metadata = array(
-			'script' => array( 'test-id', 'test-id-1' ),
+			'script' => array( 'test-id', 'test-id-other' ),
 		);
 
-		$result = register_block_script_handle( $metadata, 'viewScriptModule' );
+		$result = register_block_script_module_id( $metadata, 'viewScriptModule' );
 		$this->assertSame( 'test-id', $result );
 
-		$result = register_block_script_handle( $metadata, 'viewScriptModule', 1 );
-		$this->assertSame( 'test-id-2', $result, 1 );
+		$result = register_block_script_module_id( $metadata, 'viewScriptModule', 1 );
+		$this->assertSame( 'test-id-other', $result );
 	}
 
 	/**
@@ -342,14 +342,14 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 
 	public function test_handles_passed_register_block_script_handles() {
 		$metadata = array(
-			'script' => array( 'test-script-handle', 'test-script-handle-2' ),
+			'script' => array( 'test-script-handle', 'test-script-handle-other' ),
 		);
 
 		$result = register_block_script_handle( $metadata, 'script' );
 		$this->assertSame( 'test-script-handle', $result );
 
 		$result = register_block_script_handle( $metadata, 'script', 1 );
-		$this->assertSame( 'test-script-handle-2', $result, 1 );
+		$this->assertSame( 'test-script-handle-other', $result );
 	}
 
 	/**

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -203,15 +203,15 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 			generate_block_asset_handle( $block_name, 'viewScript', 99 )
 		);
 		$this->assertSame(
-			'unit-tests-my-block-view-script-module',
+			'wp-block-paragraph-view-script-module',
 			generate_block_asset_handle( $block_name, 'viewScriptModule' )
 		);
 		$this->assertSame(
-			'unit-tests-my-block-view-script-module-2',
+			'wp-block-paragraph-view-script-module-2',
 			generate_block_asset_handle( $block_name, 'viewScriptModule', 1 )
 		);
 		$this->assertSame(
-			'unit-tests-my-block-view-script-module-100',
+			'wp-block-paragraph-view-script-module-100',
 			generate_block_asset_handle( $block_name, 'viewScriptModule', 99 )
 		);
 		$this->assertSame(
@@ -316,11 +316,11 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 */
 	public function test_handle_passed_register_block_script_module_id() {
 		$metadata = array(
-			'viewScriptModule' => 'test-id',
+			'viewScriptModule' => 'test-script-module-id',
 		);
 		$result   = register_block_script_module_id( $metadata, 'viewScriptModule' );
 
-		$this->assertSame( 'test-script-handle', $result );
+		$this->assertSame( 'test-script-module-id', $result );
 	}
 
 	/**
@@ -328,7 +328,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 */
 	public function test_handles_passed_register_block_script_module_ids() {
 		$metadata = array(
-			'script' => array( 'test-id', 'test-id-other' ),
+			'viewScriptModule' => array( 'test-id', 'test-id-other' ),
 		);
 
 		$result = register_block_script_module_id( $metadata, 'viewScriptModule' );
@@ -349,7 +349,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		);
 		$result   = register_block_script_module_id( $metadata, 'viewScriptModule' );
 
-		$this->assertSame( 'tests-notice-view-script-module', $result );
+		$this->assertSame( 'unit-tests-test-block-view-script-module', $result );
 
 		// Test the behavior directly within the unit test
 		$this->assertFalse(

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -261,6 +261,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertSameSets( array(), $data['editor_script_handles'] );
 		$this->assertSameSets( array(), $data['script_handles'] );
 		$this->assertSameSets( array(), $data['view_script_handles'] );
+		$this->assertSameSets( array(), $data['view_script_module_ids'] );
 		$this->assertSameSets( array(), $data['editor_style_handles'] );
 		$this->assertSameSets( array(), $data['style_handles'] );
 		$this->assertFalse( $data['is_dynamic'] );
@@ -339,6 +340,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertSameSets( array(), $data['editor_script_handles'] );
 		$this->assertSameSets( array(), $data['script_handles'] );
 		$this->assertSameSets( array(), $data['view_script_handles'] );
+		$this->assertSameSets( array(), $data['view_script_module_ids'] );
 		$this->assertSameSets( array(), $data['editor_style_handles'] );
 		$this->assertSameSets( array(), $data['style_handles'] );
 		$this->assertFalse( $data['is_dynamic'] );
@@ -586,6 +588,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'editor_script_handles', $properties );
 		$this->assertArrayHasKey( 'script_handles', $properties );
 		$this->assertArrayHasKey( 'view_script_handles', $properties );
+		$this->assertArrayHasKey( 'view_script_module_ids', $properties );
 		$this->assertArrayHasKey( 'editor_style_handles', $properties );
 		$this->assertArrayHasKey( 'style_handles', $properties );
 		$this->assertArrayHasKey( 'view_style_handles', $properties, 'schema must contain view_style_handles' );
@@ -718,6 +721,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 			'editor_script_handles',
 			'script_handles',
 			'view_script_handles',
+			'view_script_module_ids',
 			'editor_style_handles',
 			'style_handles',
 			// Deprecated fields.

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -564,7 +564,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertCount( 32, $properties );
+		$this->assertCount( 33, $properties );
 		$this->assertArrayHasKey( 'api_version', $properties );
 		$this->assertArrayHasKey( 'name', $properties );
 		$this->assertArrayHasKey( 'title', $properties );


### PR DESCRIPTION
Add handling for `viewScriptModule` block.json metadata when registering blocks.

This can be tested with [this demo plugin](https://gist.github.com/sirreal/346b46f61396a47c040f487a7940bf80).

The block can be added in the editor. On the frontend, the module is enqueued when viewing a page with the block:

```js
document.querySelectorAll('[type=module]')
// NodeList [script#jon-the-block-view-script-module-js-module]
```

Trac ticket: https://core.trac.wordpress.org/ticket/60233

This is a port from Gutenberg: https://github.com/WordPress/gutenberg/issues/57959
It was implemented with `viewModule` in https://github.com/WordPress/gutenberg/pull/57437
Gutenberg PR to switch to `viewScriptModule`: https://github.com/WordPress/gutenberg/pull/58731

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
