### PR TITLE
Fatal error when someone opens "/wp-includes/blocks" or "/wp-includes/blocks/index.php" directly

### DIFF
--- a/src/wp-includes/blocks/index.php
+++ b/src/wp-includes/blocks/index.php
@@ -5,6 +5,11 @@
  * @package WordPress
  */
 
+// Don't load directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	die( '-1' );
+}
+
 define( 'BLOCKS_PATH', ABSPATH . WPINC . '/blocks/' );
 
 // Include files required for core blocks registration.


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/60237

## Description
- This PR adds a conditional check for the `ABSPATH` constant in the `wp-includes/blocks/index.php` file to prevent `Undefined constant "ABSPATH"` fatal error when someone opens `/wp-includes/blocks/` or `/wp-includes/blocks/index.php` directly.

## Steps to reproduce
- Create a fresh WordPress site & try opening "{site's domain}/wp-includes/blocks" or "{site's domain}/wp-includes/blocks/index.php".

## Screenshots

### Before

#### When opened `/wp-includes/blocks`

![Screenshot 2024-01-12 at 11 49 17 AM (1)](https://github.com/Pathan-Amaankhan/wordpress-develop/assets/63953699/f5ab1041-3b94-4e34-bfd9-8500655667c4)

#### When opened `/wp-includes/blocks/index.php`

![Screenshot 2024-01-12 at 11 52 56 AM](https://github.com/Pathan-Amaankhan/wordpress-develop/assets/63953699/c7c5d4e3-6f21-4683-b9cd-01b5e9565151)


### After

#### When opened `/wp-includes/blocks`

![Screenshot 2024-01-12 at 11 54 40 AM](https://github.com/Pathan-Amaankhan/wordpress-develop/assets/63953699/844b8acc-6a87-417e-b33d-3369a86efa1b)

#### When opened `/wp-includes/blocks/index.php`

![Screenshot 2024-01-12 at 11 55 28 AM](https://github.com/Pathan-Amaankhan/wordpress-develop/assets/63953699/5545ba4c-3ca6-4825-a1ad-745b53c905c6)


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
