### PR TITLE
HTML API: Add support for the rest of the common IN BODY tags.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-active-formatting-elements.php
+++ b/src/wp-includes/html-api/class-wp-html-active-formatting-elements.php
@@ -87,6 +87,16 @@ class WP_HTML_Active_Formatting_Elements {
 	}
 
 	/**
+	 * Inserts a marker at the end of the list of active formatting elements.
+	 *
+	 * @since 6.5.0
+	 */
+	public function insert_marker() {
+		$marker = new WP_HTML_Token( null, 'marker', false );
+		$this->push( $marker );
+	}
+
+	/**
 	 * Pushes a node onto the stack of active formatting elements.
 	 *
 	 * @since 6.4.0

--- a/src/wp-includes/html-api/class-wp-html-open-elements.php
+++ b/src/wp-includes/html-api/class-wp-html-open-elements.php
@@ -150,14 +150,9 @@ class WP_HTML_Open_Elements {
 		return $this->has_element_in_specific_scope(
 			$tag_name,
 			array(
-
-				/*
-				 * Because it's not currently possible to encounter
-				 * one of the termination elements, they don't need
-				 * to be listed here. If they were, they would be
-				 * unreachable and only waste CPU cycles while
-				 * scanning through HTML.
-				 */
+				'APPLET',
+				'MARQUEE',
+				'OBJECT',
 			)
 		);
 	}
@@ -421,7 +416,10 @@ class WP_HTML_Open_Elements {
 		 * cases where the precalculated value needs to change.
 		 */
 		switch ( $item->node_name ) {
+			case 'APPLET':
 			case 'BUTTON':
+			case 'MARQUEE':
+			case 'OBJECT':
 				$this->has_p_in_button_scope = false;
 				break;
 

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor.php
@@ -238,7 +238,6 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 	 */
 	public function data_unsupported_special_in_body_tags() {
 		return array(
-			'APPLET'    => array( 'APPLET' ),
 			'BASE'      => array( 'BASE' ),
 			'BASEFONT'  => array( 'BASEFONT' ),
 			'BGSOUND'   => array( 'BGSOUND' ),
@@ -251,17 +250,13 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 			'FRAMESET'  => array( 'FRAMESET' ),
 			'HEAD'      => array( 'HEAD' ),
 			'HTML'      => array( 'HTML' ),
-			'IFRAME'    => array( 'IFRAME' ),
 			'INPUT'     => array( 'INPUT' ),
 			'LINK'      => array( 'LINK' ),
-			'MARQUEE'   => array( 'MARQUEE' ),
 			'MATH'      => array( 'MATH' ),
 			'META'      => array( 'META' ),
 			'NOBR'      => array( 'NOBR' ),
-			'NOEMBED'   => array( 'NOEMBED' ),
 			'NOFRAMES'  => array( 'NOFRAMES' ),
 			'NOSCRIPT'  => array( 'NOSCRIPT' ),
-			'OBJECT'    => array( 'OBJECT' ),
 			'OPTGROUP'  => array( 'OPTGROUP' ),
 			'OPTION'    => array( 'OPTION' ),
 			'PARAM'     => array( 'PARAM' ),
@@ -280,14 +275,12 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 			'TBODY'     => array( 'TBODY' ),
 			'TD'        => array( 'TD' ),
 			'TEMPLATE'  => array( 'TEMPLATE' ),
-			'TEXTAREA'  => array( 'TEXTAREA' ),
 			'TFOOT'     => array( 'TFOOT' ),
 			'TH'        => array( 'TH' ),
 			'THEAD'     => array( 'THEAD' ),
 			'TITLE'     => array( 'TITLE' ),
 			'TR'        => array( 'TR' ),
 			'TRACK'     => array( 'TRACK' ),
-			'XMP'       => array( 'XMP' ),
 		);
 	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
@@ -40,6 +40,7 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 			'ABBR',
 			'ACRONYM', // Neutralized.
 			'ADDRESS',
+			'APPLET', // Deprecated.
 			'AREA',
 			'ARTICLE',
 			'ASIDE',
@@ -85,8 +86,8 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 			'I',
 			'IMG',
 			'INS',
+			'ISINDEX', // Deprecated
 			'LI',
-			'ISINDEX', // Deprecated.
 			'KBD',
 			'KEYGEN', // Deprecated.
 			'LABEL',
@@ -95,15 +96,18 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 			'MAIN',
 			'MAP',
 			'MARK',
+			'MARQUEE', // Deprecated.
 			'MENU',
 			'METER',
 			'MULTICOL', // Deprecated.
 			'NAV',
 			'NEXTID', // Deprecated.
+			'OBJECT',
 			'OL',
 			'OUTPUT',
 			'P',
 			'PICTURE',
+			'PRE',
 			'PROGRESS',
 			'Q',
 			'RUBY',
@@ -125,6 +129,7 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 			'UL',
 			'VAR',
 			'VIDEO',
+			'WBR',
 		);
 
 		$data = array();
@@ -132,7 +137,11 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 			$data[ $tag_name ] = array( "<{$tag_name}>", $tag_name );
 		}
 
+		$data['IFRAME']                    = array( '<iframe></iframe>', 'IFRAME' );
 		$data['IMAGE (treated as an IMG)'] = array( '<image>', 'IMG' );
+		$data['NOEMBED']                   = array( '<noembed></noembed>', 'NOEMBED' ); // Neutralized.
+		$data['TEXTAREA']                  = array( '<textarea></textarea>', 'TEXTAREA' );
+		$data['XMP']                       = array( '<xmp></xmp>', 'XMP' ); // Deprecated, use PRE instead.
 
 		return $data;
 	}
@@ -167,7 +176,6 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 	 */
 	public function data_unsupported_elements() {
 		$unsupported_elements = array(
-			'APPLET', // Deprecated.
 			'BASE',
 			'BGSOUND', // Deprecated; self-closing if self-closing flag provided, otherwise normal.
 			'BODY',
@@ -179,17 +187,13 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 			'FRAMESET',
 			'HEAD',
 			'HTML',
-			'IFRAME',
 			'INPUT',
 			'LINK',
-			'MARQUEE', // Deprecated.
 			'MATH',
 			'META',
 			'NOBR', // Neutralized.
-			'NOEMBED', // Neutralized.
 			'NOFRAMES', // Neutralized.
 			'NOSCRIPT',
-			'OBJECT',
 			'OPTGROUP',
 			'OPTION',
 			'PLAINTEXT', // Neutralized.
@@ -206,14 +210,12 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 			'TBODY',
 			'TD',
 			'TEMPLATE',
-			'TEXTAREA',
 			'TFOOT',
 			'TH',
 			'THEAD',
 			'TITLE',
 			'TR',
 			'TRACK',
-			'XMP', // Deprecated, use PRE instead.
 		);
 
 		$data = array();

--- a/tests/phpunit/tests/html-api/wpHtmlSupportRequiredOpenElements.php
+++ b/tests/phpunit/tests/html-api/wpHtmlSupportRequiredOpenElements.php
@@ -62,14 +62,11 @@ class Tests_HtmlApi_WpHtmlSupportRequiredOpenElements extends WP_UnitTestCase {
 	 */
 	public function test_has_element_in_scope_needs_support() {
 		// These elements impact all scopes.
-		$this->ensure_support_is_added_everywhere( 'APPLET' );
 		$this->ensure_support_is_added_everywhere( 'CAPTION' );
 		$this->ensure_support_is_added_everywhere( 'HTML' );
 		$this->ensure_support_is_added_everywhere( 'TABLE' );
 		$this->ensure_support_is_added_everywhere( 'TD' );
 		$this->ensure_support_is_added_everywhere( 'TH' );
-		$this->ensure_support_is_added_everywhere( 'MARQUEE' );
-		$this->ensure_support_is_added_everywhere( 'OBJECT' );
 		$this->ensure_support_is_added_everywhere( 'TEMPLATE' );
 
 		// MathML Elements: MI, MO, MN, MS, MTEXT, ANNOTATION-XML.
@@ -100,14 +97,11 @@ class Tests_HtmlApi_WpHtmlSupportRequiredOpenElements extends WP_UnitTestCase {
 	 */
 	public function test_has_element_in_list_item_scope_needs_support() {
 		// These elements impact all scopes.
-		$this->ensure_support_is_added_everywhere( 'APPLET' );
 		$this->ensure_support_is_added_everywhere( 'CAPTION' );
 		$this->ensure_support_is_added_everywhere( 'HTML' );
 		$this->ensure_support_is_added_everywhere( 'TABLE' );
 		$this->ensure_support_is_added_everywhere( 'TD' );
 		$this->ensure_support_is_added_everywhere( 'TH' );
-		$this->ensure_support_is_added_everywhere( 'MARQUEE' );
-		$this->ensure_support_is_added_everywhere( 'OBJECT' );
 		$this->ensure_support_is_added_everywhere( 'TEMPLATE' );
 
 		// MathML Elements: MI, MO, MN, MS, MTEXT, ANNOTATION-XML.
@@ -134,14 +128,11 @@ class Tests_HtmlApi_WpHtmlSupportRequiredOpenElements extends WP_UnitTestCase {
 	 */
 	public function test_has_element_in_button_scope_needs_support() {
 		// These elements impact all scopes.
-		$this->ensure_support_is_added_everywhere( 'APPLET' );
 		$this->ensure_support_is_added_everywhere( 'CAPTION' );
 		$this->ensure_support_is_added_everywhere( 'HTML' );
 		$this->ensure_support_is_added_everywhere( 'TABLE' );
 		$this->ensure_support_is_added_everywhere( 'TD' );
 		$this->ensure_support_is_added_everywhere( 'TH' );
-		$this->ensure_support_is_added_everywhere( 'MARQUEE' );
-		$this->ensure_support_is_added_everywhere( 'OBJECT' );
 		$this->ensure_support_is_added_everywhere( 'TEMPLATE' );
 
 		// MathML Elements: MI, MO, MN, MS, MTEXT, ANNOTATION-XML.
@@ -169,14 +160,11 @@ class Tests_HtmlApi_WpHtmlSupportRequiredOpenElements extends WP_UnitTestCase {
 	 */
 	public function test_after_element_pop_must_maintain_p_in_button_scope_flag() {
 		// These elements impact all scopes.
-		$this->ensure_support_is_added_everywhere( 'APPLET' );
 		$this->ensure_support_is_added_everywhere( 'CAPTION' );
 		$this->ensure_support_is_added_everywhere( 'HTML' );
 		$this->ensure_support_is_added_everywhere( 'TABLE' );
 		$this->ensure_support_is_added_everywhere( 'TD' );
 		$this->ensure_support_is_added_everywhere( 'TH' );
-		$this->ensure_support_is_added_everywhere( 'MARQUEE' );
-		$this->ensure_support_is_added_everywhere( 'OBJECT' );
 		$this->ensure_support_is_added_everywhere( 'TEMPLATE' );
 
 		// MathML Elements: MI, MO, MN, MS, MTEXT, ANNOTATION-XML.
@@ -204,14 +192,11 @@ class Tests_HtmlApi_WpHtmlSupportRequiredOpenElements extends WP_UnitTestCase {
 	 */
 	public function test_after_element_push_must_maintain_p_in_button_scope_flag() {
 		// These elements impact all scopes.
-		$this->ensure_support_is_added_everywhere( 'APPLET' );
 		$this->ensure_support_is_added_everywhere( 'CAPTION' );
 		$this->ensure_support_is_added_everywhere( 'HTML' );
 		$this->ensure_support_is_added_everywhere( 'TABLE' );
 		$this->ensure_support_is_added_everywhere( 'TD' );
 		$this->ensure_support_is_added_everywhere( 'TH' );
-		$this->ensure_support_is_added_everywhere( 'MARQUEE' );
-		$this->ensure_support_is_added_everywhere( 'OBJECT' );
 		$this->ensure_support_is_added_everywhere( 'TEMPLATE' );
 
 		// MathML Elements: MI, MO, MN, MS, MTEXT, ANNOTATION-XML.
@@ -238,14 +223,11 @@ class Tests_HtmlApi_WpHtmlSupportRequiredOpenElements extends WP_UnitTestCase {
 	 */
 	public function test_has_element_in_table_scope_needs_support() {
 		// These elements impact all scopes.
-		$this->ensure_support_is_added_everywhere( 'APPLET' );
 		$this->ensure_support_is_added_everywhere( 'CAPTION' );
 		$this->ensure_support_is_added_everywhere( 'HTML' );
 		$this->ensure_support_is_added_everywhere( 'TABLE' );
 		$this->ensure_support_is_added_everywhere( 'TD' );
 		$this->ensure_support_is_added_everywhere( 'TH' );
-		$this->ensure_support_is_added_everywhere( 'MARQUEE' );
-		$this->ensure_support_is_added_everywhere( 'OBJECT' );
 		$this->ensure_support_is_added_everywhere( 'TEMPLATE' );
 
 		// MathML Elements: MI, MO, MN, MS, MTEXT, ANNOTATION-XML.
@@ -288,14 +270,11 @@ class Tests_HtmlApi_WpHtmlSupportRequiredOpenElements extends WP_UnitTestCase {
 	 */
 	public function test_has_element_in_select_scope_needs_support() {
 		// These elements impact all scopes.
-		$this->ensure_support_is_added_everywhere( 'APPLET' );
 		$this->ensure_support_is_added_everywhere( 'CAPTION' );
 		$this->ensure_support_is_added_everywhere( 'HTML' );
 		$this->ensure_support_is_added_everywhere( 'TABLE' );
 		$this->ensure_support_is_added_everywhere( 'TD' );
 		$this->ensure_support_is_added_everywhere( 'TH' );
-		$this->ensure_support_is_added_everywhere( 'MARQUEE' );
-		$this->ensure_support_is_added_everywhere( 'OBJECT' );
 		$this->ensure_support_is_added_everywhere( 'TEMPLATE' );
 
 		// MathML Elements: MI, MO, MN, MS, MTEXT, ANNOTATION-XML.


### PR DESCRIPTION
## TODO

 - [ ] Run the html5lib tests against these updated elements
 - [ ] Generate unit tests to cover these updated elements
 - [ ] Handle closing tags for the special elements? These might be covered already by the "any other end tag" section.

## Description

Adds support for the rest of the "easy" and common tags to support within the IN BODY insertion mode. The goal of this patch is to unlock as many posts for full support as possible without requiring that we add too much additional complexity into the HTML Processor. In other words: what can we support in 6.5 without putting too much pressure on review and testing?

Adds support for the following elements:

 - `APPLET`
 - `IFRAME`
 - `MARQUEE`
 - `NOEMBED`
 - `OBJECT`
 - `TEXTAREA`
 - `WBR`
 - `XMP`
