### PR TITLE
Add $schema to block and theme JSON

### DIFF
--- a/src/wp-content/themes/twentytwentytwo/theme.json
+++ b/src/wp-content/themes/twentytwentytwo/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
 	"customTemplates": [
 		{

--- a/src/wp-includes/blocks/legacy-widget/block.json
+++ b/src/wp-includes/blocks/legacy-widget/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "core/legacy-widget",
 	"title": "Legacy Widget",

--- a/src/wp-includes/blocks/legacy-widget/block.json
+++ b/src/wp-includes/blocks/legacy-widget/block.json
@@ -1,5 +1,4 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "core/legacy-widget",
 	"title": "Legacy Widget",

--- a/src/wp-includes/blocks/widget-group/block.json
+++ b/src/wp-includes/blocks/widget-group/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "core/widget-group",
 	"category": "widgets",

--- a/src/wp-includes/blocks/widget-group/block.json
+++ b/src/wp-includes/blocks/widget-group/block.json
@@ -1,5 +1,4 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "core/widget-group",
 	"category": "widgets",

--- a/src/wp-includes/theme.json
+++ b/src/wp-includes/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
 	"settings": {
 		"appearanceTools": false,

--- a/tests/phpunit/data/blocks/hooked-block-error/block.json
+++ b/tests/phpunit/data/blocks/hooked-block-error/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"name": "tests/hooked-block-error",
 	"description": "A block that throws an error because it tries to hook a block to itself.",
 	"blockHooks": {

--- a/tests/phpunit/data/blocks/notice/block.json
+++ b/tests/phpunit/data/blocks/notice/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "tests/notice",
 	"title": "Notice",

--- a/tests/phpunit/data/themedir1/block-theme-child-deprecated-path/theme.json
+++ b/tests/phpunit/data/themedir1/block-theme-child-deprecated-path/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 1,
 	"settings": {
 		"color": {

--- a/tests/phpunit/data/themedir1/block-theme-child-with-fluid-layout/theme.json
+++ b/tests/phpunit/data/themedir1/block-theme-child-with-fluid-layout/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
 	"settings": {
 		"appearanceTools": true,

--- a/tests/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/theme.json
+++ b/tests/phpunit/data/themedir1/block-theme-child-with-fluid-typography-config/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
 	"settings": {
 		"appearanceTools": true,

--- a/tests/phpunit/data/themedir1/block-theme-child-with-fluid-typography/theme.json
+++ b/tests/phpunit/data/themedir1/block-theme-child-with-fluid-typography/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
 	"settings": {
 		"appearanceTools": true,

--- a/tests/phpunit/data/themedir1/block-theme-child/blocks/example-block/block.json
+++ b/tests/phpunit/data/themedir1/block-theme-child/blocks/example-block/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"title": "Example Theme Block",
 	"name": "block-theme/example-block",

--- a/tests/phpunit/data/themedir1/block-theme-child/theme.json
+++ b/tests/phpunit/data/themedir1/block-theme-child/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 1,
 	"settings": {
 		"color": {

--- a/tests/phpunit/data/themedir1/block-theme-deprecated-path/theme.json
+++ b/tests/phpunit/data/themedir1/block-theme-deprecated-path/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 1,
 	"settings": {
 		"color": {

--- a/tests/phpunit/data/themedir1/block-theme-non-latin/theme.json
+++ b/tests/phpunit/data/themedir1/block-theme-non-latin/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 1,
 	"settings": {
 		"color": {

--- a/tests/phpunit/data/themedir1/block-theme-post-content-default/theme.json
+++ b/tests/phpunit/data/themedir1/block-theme-post-content-default/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 1,
 	"title": "Block theme",
 	"settings": {

--- a/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-after/block.json
+++ b/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-after/block.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"title": "Hooked Block After",
 	"name": "tests/hooked-after",
 	"blockHooks": {
 		"core/post-content": "after"

--- a/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-after/block.json
+++ b/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-after/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"name": "tests/hooked-after",
 	"blockHooks": {
 		"core/post-content": "after"

--- a/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-after/block.json
+++ b/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-after/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"title": "Hooked Block After",
+	"title": "Hooked Block (after)",
 	"name": "tests/hooked-after",
 	"blockHooks": {
 		"core/post-content": "after"

--- a/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-before/block.json
+++ b/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-before/block.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"title": "Hooked Block Before",
 	"name": "tests/hooked-before",
 	"blockHooks": {
 		"core/navigation": "before"

--- a/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-before/block.json
+++ b/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-before/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"name": "tests/hooked-before",
 	"blockHooks": {
 		"core/navigation": "before"

--- a/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-before/block.json
+++ b/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-before/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"title": "Hooked Block Before",
+	"title": "Hooked Block (before)",
 	"name": "tests/hooked-before",
 	"blockHooks": {
 		"core/navigation": "before"

--- a/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-first-child/block.json
+++ b/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-first-child/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"name": "tests/hooked-first-child",
 	"blockHooks": {
 		"core/comments": "firstChild"

--- a/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-first-child/block.json
+++ b/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-first-child/block.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"title": "Hooked Block First Child",
 	"name": "tests/hooked-first-child",
 	"blockHooks": {
 		"core/comments": "firstChild"

--- a/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-first-child/block.json
+++ b/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-first-child/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"title": "Hooked Block First Child",
+	"title": "Hooked Block (first child)",
 	"name": "tests/hooked-first-child",
 	"blockHooks": {
 		"core/comments": "firstChild"

--- a/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-last-child/block.json
+++ b/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-last-child/block.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"title": "Hooked Block Last Child",
 	"name": "tests/hooked-last-child",
 	"blockHooks": {
 		"core/comment-template": "lastChild"

--- a/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-last-child/block.json
+++ b/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-last-child/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"name": "tests/hooked-last-child",
 	"blockHooks": {
 		"core/comment-template": "lastChild"

--- a/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-last-child/block.json
+++ b/tests/phpunit/data/themedir1/block-theme-with-hooked-blocks/blocks/hooked-last-child/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"title": "Hooked Block Last Child",
+	"title": "Hooked Block (last child)",
 	"name": "tests/hooked-last-child",
 	"blockHooks": {
 		"core/comment-template": "lastChild"

--- a/tests/phpunit/data/themedir1/block-theme/blocks/example-block/block.json
+++ b/tests/phpunit/data/themedir1/block-theme/blocks/example-block/block.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"title": "Example Theme Block",
 	"name": "block-theme/example-block",

--- a/tests/phpunit/data/themedir1/block-theme/theme.json
+++ b/tests/phpunit/data/themedir1/block-theme/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 1,
 	"title": "Block theme",
 	"settings": {

--- a/tests/phpunit/data/themedir1/block_theme-[0.4.0]/theme.json
+++ b/tests/phpunit/data/themedir1/block_theme-[0.4.0]/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 1,
 	"settings": {
 		"color": {

--- a/tests/phpunit/data/themedir1/empty-fontface-theme/theme.json
+++ b/tests/phpunit/data/themedir1/empty-fontface-theme/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
   "version": 2,
   "customTemplates": [
 	{

--- a/tests/phpunit/data/themedir1/fonts-block-theme/theme.json
+++ b/tests/phpunit/data/themedir1/fonts-block-theme/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
 	"settings": {
 		"appearanceTools": true,

--- a/tests/phpunit/data/themedir1/subdir/block_theme-[1.0.0]/theme.json
+++ b/tests/phpunit/data/themedir1/subdir/block_theme-[1.0.0]/theme.json
@@ -1,4 +1,5 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 1,
 	"settings": {
 		"color": {


### PR DESCRIPTION
Add $schema to block.json and theme.json files.


Note that not all files are valid according to the schema. I'm working on those fixes in https://github.com/WordPress/gutenberg/pull/57374 and will port those changes when they're finished.

Some of the invalid (according to the schema) block and theme json files are in phpunit tests were invalid due to missing `title` properties. In those cases I've fixed the json to satisfy the schema. Those changes have no impact on the runtime whatsoever and do not change the result of unit tests.

This is a port of https://github.com/WordPress/gutenberg/pull/57201

Trac ticket: https://core.trac.wordpress.org/ticket/60255


> Add $schema to block.json and theme.json files to leverage JSON schema support.
>
> Schemas help ensure that these files conform to expectations. They can help provide autocomplete and documentation if editors are configured to do so.
>
> We provide and maintain these schemas, we should be using them. This can help to ensure that our own declarations are correct and that the schemas are also correct.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
