### PR TITLE
Prevent deprecated print_emoji_styles deprecation notice in embeds.

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -687,6 +687,7 @@ add_action( 'embed_head', 'wp_print_styles', 20 );
 add_action( 'embed_head', 'wp_robots' );
 add_action( 'embed_head', 'rel_canonical' );
 add_action( 'embed_head', 'locale_stylesheet', 30 );
+add_action( 'enqueue_embed_scripts', 'wp_enqueue_emoji_styles' );
 
 add_action( 'embed_content_meta', 'print_embed_comments_button' );
 add_action( 'embed_content_meta', 'print_embed_sharing_button' );

--- a/tests/phpunit/tests/oembed/template.php
+++ b/tests/phpunit/tests/oembed/template.php
@@ -10,8 +10,6 @@ class Tests_Embed_Template extends WP_UnitTestCase {
 
 		global $wp_scripts;
 		$wp_scripts = null;
-
-		remove_action( 'wp_print_styles', 'print_emoji_styles' );
 	}
 
 	public function tear_down() {


### PR DESCRIPTION
Initial push is just the tests.

https://core.trac.wordpress.org/ticket/59892