### PR TITLE
Fluid typography: do not calculate fluid font size when min and max viewport widths are equal

### DIFF
--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -398,6 +398,7 @@ function wp_get_typography_value_and_unit( $raw_value, $options = array() ) {
  *
  * @since 6.1.0
  * @since 6.3.0 Checks for unsupported min/max viewport values that cause invalid clamp values.
+ * @since 6.5.0 Use linear scale factor fallback of `1` to avoid division by zero.
  * @access private
  *
  * @param array $args {

--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -468,12 +468,16 @@ function wp_get_computed_fluid_typography_value( $args = array() ) {
 		return null;
 	}
 
+	// Build CSS rule.
+	// Borrowed from https://websemantics.uk/tools/responsive-font-calculator/.
+	$view_port_width_offset    = round( $minimum_viewport_width['value'] / 100, 3 ) . $font_size_unit;
+	$linear_factor_denominator = $maximum_viewport_width['value'] - $minimum_viewport_width['value'];
+
 	/*
-	 * Build CSS rule.
-	 * Borrowed from https://websemantics.uk/tools/responsive-font-calculator/.
+	 * If the linear factor denominator is 0, we cannot calculate a fluid value.
+	 * Setting $linear_factor to 0 will cause $linear_factor_scaled to default to 1.
 	 */
-	$view_port_width_offset = round( $minimum_viewport_width['value'] / 100, 3 ) . $font_size_unit;
-	$linear_factor          = 100 * ( ( $maximum_font_size['value'] - $minimum_font_size['value'] ) / ( $maximum_viewport_width['value'] - $minimum_viewport_width['value'] ) );
+	$linear_factor          = ! empty( $linear_factor_denominator ) ? 100 * ( ( $maximum_font_size['value'] - $minimum_font_size['value'] ) / ( $linear_factor_denominator ) ) : 0;
 	$linear_factor_scaled   = round( $linear_factor * $scale_factor, 3 );
 	$linear_factor_scaled   = empty( $linear_factor_scaled ) ? 1 : $linear_factor_scaled;
 	$fluid_target_font_size = implode( '', $minimum_font_size_rem ) . " + ((1vw - $view_port_width_offset) * $linear_factor_scaled)";

--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -398,7 +398,7 @@ function wp_get_typography_value_and_unit( $raw_value, $options = array() ) {
  *
  * @since 6.1.0
  * @since 6.3.0 Checks for unsupported min/max viewport values that cause invalid clamp values.
- * @since 6.5.0 Use linear scale factor fallback of `1` to avoid division by zero.
+ * @since 6.5.0 Returns early when min and max viewport subtraction is zero to avoid division by zero.
  * @access private
  *
  * @param array $args {
@@ -469,16 +469,16 @@ function wp_get_computed_fluid_typography_value( $args = array() ) {
 		return null;
 	}
 
+	// Calculates the linear factor denominator. If it's 0, we cannot calculate a fluid value.
+	$linear_factor_denominator = $maximum_viewport_width['value'] - $minimum_viewport_width['value'];
+	if ( empty( $linear_factor_denominator ) ) {
+		return null;
+	}
+
 	// Build CSS rule.
 	// Borrowed from https://websemantics.uk/tools/responsive-font-calculator/.
-	$view_port_width_offset    = round( $minimum_viewport_width['value'] / 100, 3 ) . $font_size_unit;
-	$linear_factor_denominator = $maximum_viewport_width['value'] - $minimum_viewport_width['value'];
-
-	/*
-	 * If the linear factor denominator is 0, we cannot calculate a fluid value.
-	 * Setting $linear_factor to 0 will cause $linear_factor_scaled to default to 1.
-	 */
-	$linear_factor          = ! empty( $linear_factor_denominator ) ? 100 * ( ( $maximum_font_size['value'] - $minimum_font_size['value'] ) / ( $linear_factor_denominator ) ) : 0;
+	$view_port_width_offset = round( $minimum_viewport_width['value'] / 100, 3 ) . $font_size_unit;
+	$linear_factor          = 100 * ( ( $maximum_font_size['value'] - $minimum_font_size['value'] ) / ( $linear_factor_denominator ) );
 	$linear_factor_scaled   = round( $linear_factor * $scale_factor, 3 );
 	$linear_factor_scaled   = empty( $linear_factor_scaled ) ? 1 : $linear_factor_scaled;
 	$fluid_target_font_size = implode( '', $minimum_font_size_rem ) . " + ((1vw - $view_port_width_offset) * $linear_factor_scaled)";

--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -475,8 +475,10 @@ function wp_get_computed_fluid_typography_value( $args = array() ) {
 		return null;
 	}
 
-	// Build CSS rule.
-	// Borrowed from https://websemantics.uk/tools/responsive-font-calculator/.
+	/*
+	 * Build CSS rule.
+	 * Borrowed from https://websemantics.uk/tools/responsive-font-calculator/.
+	 */
 	$view_port_width_offset = round( $minimum_viewport_width['value'] / 100, 3 ) . $font_size_unit;
 	$linear_factor          = 100 * ( ( $maximum_font_size['value'] - $minimum_font_size['value'] ) / ( $linear_factor_denominator ) );
 	$linear_factor_scaled   = round( $linear_factor * $scale_factor, 3 );

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -951,6 +951,16 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 				),
 				'expected_output' => 'clamp(50px, 3.125rem + ((1vw - 3.2px) * 7.353), 100px)',
 			),
+			'returns default linear factor of `1` when maximum and minimum viewport width are equal' => array(
+				'args'            => array(
+					'minimum_viewport_width' => '800px',
+					'maximum_viewport_width' => '800px',
+					'minimum_font_size'      => '50px',
+					'maximum_font_size'      => '100px',
+					'scale_factor'           => 1,
+				),
+				'expected_output' => 'clamp(50px, 3.125rem + ((1vw - 8px) * 1), 100px)',
+			),
 			'returns `null` when `maximum_viewport_width` is an unsupported unit' => array(
 				'args'            => array(
 					'minimum_viewport_width' => '320px',

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -952,7 +952,7 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 				),
 				'expected_output' => 'clamp(50px, 3.125rem + ((1vw - 3.2px) * 7.353), 100px)',
 			),
-			'returns default linear factor of `1` when maximum and minimum viewport width are equal' => array(
+			'returns `null` when maximum and minimum viewport width are equal' => array(
 				'args'            => array(
 					'minimum_viewport_width' => '800px',
 					'maximum_viewport_width' => '800px',
@@ -960,7 +960,7 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 					'maximum_font_size'      => '100px',
 					'scale_factor'           => 1,
 				),
-				'expected_output' => 'clamp(50px, 3.125rem + ((1vw - 8px) * 1), 100px)',
+				'expected_output' => null,
 			),
 			'returns `null` when `maximum_viewport_width` is an unsupported unit' => array(
 				'args'            => array(

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -913,6 +913,7 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	 * Tests computed font size values.
 	 *
 	 * @ticket 58522
+	 * @ticket 60263
 	 *
 	 * @covers ::wp_get_computed_fluid_typography_value
 	 *


### PR DESCRIPTION
Syncs:

- https://github.com/WordPress/gutenberg/pull/57866

When the same value is provided for min and max viewport widths in the fluid typography config, return early.

The consequence is that fluid font sizes will not be calculated.

To avoid dividing by zero values. PHP will throw an error and, besides, the fluid typography clamp rule needs valid max and min viewport constraints.

### Testing

See https://github.com/WordPress/gutenberg/pull/57866 for testing instructions.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60263

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
