### PR TITLE
55962 upgrade `sanitize hex color()` to css color level 4

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -6214,15 +6214,22 @@ function url_shorten( $url, $length = 35 ) {
  * @since 3.4.0
  *
  * @param string $color
+ * @param bool $maybe_alpha optional: allows you support alpa colors default is fasle Since 6.5.0
+ *
  * @return string|void
+ *
  */
-function sanitize_hex_color( $color ) {
+function sanitize_hex_color( $color, bool $maybe_alpha = false ) {
 	if ( '' === $color ) {
 		return '';
 	}
 
-	// 3 or 6 hex digits, or the empty string.
-	if ( preg_match( '|^#([A-Fa-f0-9]{3}){1,2}$|', $color ) ) {
+
+	$allowed_lengths = $maybe_alpha ? array( 4, 5, 7, 9 ) : array( 4, 7 );
+	$correct_length  = in_array( strlen( $color ), $allowed_lengths, true );
+
+	if ( $correct_length && preg_replace( '|^#([^A-Fa-f0-9]+)$|', '', $color ) === $color ) {
+
 		return $color;
 	}
 }
@@ -6239,16 +6246,18 @@ function sanitize_hex_color( $color ) {
  * @since 3.4.0
  *
  * @param string $color
+ * @param bool $maybe_alpha optional: allows you support alpa colors default is fasle Since 6.5.0
+ *
  * @return string|null
  */
-function sanitize_hex_color_no_hash( $color ) {
+function sanitize_hex_color_no_hash( $color, $maybe_alpha = false ) {
 	$color = ltrim( $color, '#' );
 
 	if ( '' === $color ) {
 		return '';
 	}
 
-	return sanitize_hex_color( '#' . $color ) ? $color : null;
+	return sanitize_hex_color( '#' . $color, $maybe_alpha ) ? $color : null;
 }
 
 /**
@@ -6260,10 +6269,12 @@ function sanitize_hex_color_no_hash( $color ) {
  * @since 3.4.0
  *
  * @param string $color
+ * @param bool $maybe_alpha optional: allows you support alpa colors default is fasle Since 6.5.0
+ *
  * @return string
  */
-function maybe_hash_hex_color( $color ) {
-	$unhashed = sanitize_hex_color_no_hash( $color );
+function maybe_hash_hex_color( $color, $maybe_alpha = false ) {
+	$unhashed = sanitize_hex_color_no_hash( $color, $maybe_alpha );
 	if ( $unhashed ) {
 		return '#' . $unhashed;
 	}

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -6224,7 +6224,6 @@ function sanitize_hex_color( $color, bool $maybe_alpha = false ) {
 		return '';
 	}
 
-
 	$allowed_lengths = $maybe_alpha ? array( 4, 5, 7, 9 ) : array( 4, 7 );
 	$correct_length  = in_array( strlen( $color ), $allowed_lengths, true );
 

--- a/tests/phpunit/tests/formatting/maybeHashHexColor.php
+++ b/tests/phpunit/tests/formatting/maybeHashHexColor.php
@@ -5,17 +5,17 @@
  *
  * @group formatting
  *
- * @covers ::sanitize_hex_color_no_hash
+ * @covers ::maybe_hash_hex_color
  */
-class Tests_formating_sanitizeHexColorNoHash extends WP_UnitTestCase {
+class Tests_formating_maybeHashHexColor extends WP_UnitTestCase {
 
 	/**
-	 * @ticket 60271
+	 * @ticket 60272
 	 *
 	 * @dataProvider date_sanitize_hex_color_no_hash
 	 */
-	public function test_sanitize_hex_color_no_hash( $color, $expected ) {
-		$this->assertSame( $expected, sanitize_hex_color_no_hash( $color ) );
+	public function test_maybe_hash_hex_color( $color, $expected ) {
+		$this->assertSame( $expected, maybe_hash_hex_color( $color ) );
 	}
 
 	/**
@@ -25,27 +25,27 @@ class Tests_formating_sanitizeHexColorNoHash extends WP_UnitTestCase {
 		return array(
 			'$maybe_alpha = false, 3 digit'               => array(
 				'color'    => '#123',
-				'expected' => '123',
+				'expected' => '#123',
 			),
 			'$maybe_alpha = false, 3 letter'              => array(
 				'color'    => '#abc',
-				'expected' => 'abc',
+				'expected' => '#abc',
 			),
 			'$maybe_alpha = false, 3 mixed'               => array(
 				'color'    => '#0ab',
-				'expected' => '0ab',
+				'expected' => '#0ab',
 			),
 			'$maybe_alpha = false, 6 digit'               => array(
 				'color'    => '#123456',
-				'expected' => '123456',
+				'expected' => '#123456',
 			),
 			'$maybe_alpha = false, 6 letter'              => array(
 				'color'    => '#abcdef',
-				'expected' => 'abcdef',
+				'expected' => '#abcdef',
 			),
 			'$maybe_alpha = false, 6 mixed'               => array(
 				'color'    => '#abc123',
-				'expected' => 'abc123',
+				'expected' => '#abc123',
 			),
 			'empty string'                                => array(
 				'color'    => '',
@@ -53,116 +53,116 @@ class Tests_formating_sanitizeHexColorNoHash extends WP_UnitTestCase {
 			),
 			'just #'                                      => array(
 				'color'    => '#',
-				'expected' => '',
+				'expected' => '#',
 			),
 			'no hash'                                     => array(
 				'color'    => '123',
-				'expected' => '123',
+				'expected' => '#123',
 			),
 			'not a-f'                                     => array(
 				'color'    => '#hjg',
-				'expected' => null,
+				'expected' => '#hjg',
 			),
 			'not upper A-F'                               => array(
 				'color'    => '#HJG',
-				'expected' => null,
+				'expected' => '#HJG',
 			),
 			'$maybe_alpha = false, 3 digit with 1 alpha'  => array(
 				'color'    => '#123f',
-				'expected' => null,
+				'expected' => '#123f',
 			),
 			'$maybe_alpha = false, 3 letter with 1 alpha' => array(
 				'color'    => '#abcf',
-				'expected' => null,
+				'expected' => '#abcf',
 			),
 			'$maybe_alpha = false, 3 mixed with 1 alpha'  => array(
 				'color'    => '#0abf',
-				'expected' => null,
+				'expected' => '#0abf',
 			),
 			'$maybe_alpha = false, 6 digit with 2 alpha'  => array(
 				'color'    => '#123456ff',
-				'expected' => null,
+				'expected' => '#123456ff',
 			),
 			'$maybe_alpha = false, 6 letter with 2 alpha' => array(
 				'color'    => '#abcdefff',
-				'expected' => null,
+				'expected' => '#abcdefff',
 			),
 			'$maybe_alpha = false, 6 mixed with 2 alpha'  => array(
 				'color'    => '#abc123ff',
-				'expected' => null,
+				'expected' => '#abc123ff',
 			),
 			// Happy.
 			'$maybe_alpha = true, 3 digit'                => array(
 				'color'    => '#123',
-				'expected' => '123',
+				'expected' => '#123',
 			),
 			'$maybe_alpha = true, 3 letter'               => array(
 				'color'    => '#abc',
-				'expected' => 'abc',
+				'expected' => '#abc',
 			),
 			'$maybe_alpha = true, 3 mixed'                => array(
-				'color'    => '#0ab',
-				'expected' => '0ab',
+				'color'    => '0ab',
+				'expected' => '#0ab',
 			),
 			'$maybe_alpha = true, 6 digit'                => array(
-				'color'    => '#123456',
-				'expected' => '123456',
+				'color'    => '123456',
+				'expected' => '#123456',
 			),
 			'$maybe_alpha = true, 6 letter'               => array(
-				'color'    => '#abcdef',
-				'expected' => 'abcdef',
+				'color'    => 'abcdef',
+				'expected' => '#abcdef',
 			),
 			'$maybe_alpha = true, 6 mixed'                => array(
-				'color'    => '#abc123',
-				'expected' => 'abc123',
+				'color'    => 'abc123',
+				'expected' => '#abc123',
 			),
 			'$maybe_alpha = true, 3 digit with 1 alpha'   => array(
-				'color'    => '#123f',
-				'expected' => null,
+				'color'    => '123f',
+				'expected' => '123f',
 			),
 			'$maybe_alpha = true, 3 letter with 1 alpha'  => array(
-				'color'    => '#abcf',
-				'expected' => null,
+				'color'    => 'abcf',
+				'expected' => 'abcf',
 			),
 			'$maybe_alpha = true, 3 mixed with 1 alpha'   => array(
-				'color'    => '#0abf',
-				'expected' => null,
+				'color'    => '0abf',
+				'expected' => '0abf',
 			),
 			'$maybe_alpha = true, 6 digit with 2 alpha'   => array(
-				'color'    => '#123456ff',
-				'expected' => null,
+				'color'    => '123456ff',
+				'expected' => '123456ff',
 			),
 			'$maybe_alpha = true, 6 letter with 2 alpha'  => array(
-				'color'    => '#abcdefff',
-				'expected' => null,
+				'color'    => 'abcdefff',
+				'expected' => 'abcdefff',
 			),
 			'$maybe_alpha = true, 6 mixed with 2 alpha'   => array(
-				'color'    => '#abc123ff',
-				'expected' => null,
+				'color'    => 'abc123ff',
+				'expected' => 'abc123ff',
 			),
 			'$maybe_alpha = true, 3 digit with 2 alpha'   => array(
-				'color'    => '#123ff',
-				'expected' => null,
+				'color'    => '123ff',
+				'expected' => '123ff',
 			),
 			'$maybe_alpha = true, 3 letter with 2 alpha'  => array(
-				'color'    => '#abcff',
-				'expected' => null,
+				'color'    => 'abcff',
+				'expected' => 'abcff',
 			),
 			'$maybe_alpha = true, 3 mixed with 2 alpha'   => array(
-				'color'    => '#0abff',
-				'expected' => null,
+				'color'    => '0abff',
+				'expected' => '0abff',
 			),
 			'$maybe_alpha = true, 6 digit with 1 alpha'   => array(
-				'color'    => '#123456f',
-				'expected' => null,
+				'color'    => '123456f',
+				'expected' => '123456f',
 			),
 			'$maybe_alpha = true, 6 letter with 1 alpha'  => array(
-				'color'    => '#abcff',
-				'expected' => null,
+				'color'    => 'abcff',
+				'expected' => 'abcff',
 			),
 			'$maybe_alpha = true, 6 mixed with 1 alpha'   => array(
-				'color'    => '#0abff',
-				'expected' => null,
+				'color'    => '0abff',
+				'expected' => '0abff',
 			),
 		);
 	}

--- a/tests/phpunit/tests/formatting/sanitizeHexColor.php
+++ b/tests/phpunit/tests/formatting/sanitizeHexColor.php
@@ -3,25 +3,25 @@
 /**
  * Tests for the sanitize_hex_color function.
  *
- * @group formatting
+ * @group formating
  *
- * @covers ::maybe_hash_hex_color
+ * @covers ::sanitize_hex_color
  */
-class Tests_formating_maybeHashHexColor extends WP_UnitTestCase {
+class Tests_formating_sanitizeHexColor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 55962
 	 *
-	 * @dataProvider date_sanitize_hex_color_no_hash
+	 * @dataProvider date_sanitize_hex_color
 	 */
-	public function test_maybe_hash_hex_color( $color, $expected, $maybe_alpha ) {
-		$this->assertSame( $expected, maybe_hash_hex_color( $color, $maybe_alpha ) );
+	public function test_sanitize_hex_color( $color, $expected, $maybe_alpha ) {
+		$this->assertSame( $expected, sanitize_hex_color( $color, $maybe_alpha ) );
 	}
 
 	/**
 	 * @return array
 	 */
-	public function date_sanitize_hex_color_no_hash() {
+	public function date_sanitize_hex_color() {
 		return array(
 			'$maybe_alpha = false, 3 digit'               => array(
 				'color'       => '#123',
@@ -58,54 +58,49 @@ class Tests_formating_maybeHashHexColor extends WP_UnitTestCase {
 				'expected'    => '',
 				'maybe_alpha' => false,
 			),
-			'just #'                                      => array(
-				'color'       => '#',
-				'expected'    => '#',
-				'maybe_alpha' => false,
-			),
 			'no hash'                                     => array(
 				'color'       => '123',
-				'expected'    => '#123',
+				'expected'    => null,
 				'maybe_alpha' => false,
 			),
 			'not a-f'                                     => array(
 				'color'       => '#hjg',
-				'expected'    => '#hjg',
+				'expected'    => null,
 				'maybe_alpha' => false,
 			),
 			'not upper A-F'                               => array(
 				'color'       => '#HJG',
-				'expected'    => '#HJG',
+				'expected'    => null,
 				'maybe_alpha' => false,
 			),
 			'$maybe_alpha = false, 3 digit with 1 alpha'  => array(
 				'color'       => '#123f',
-				'expected'    => '#123f',
+				'expected'    => null,
 				'maybe_alpha' => false,
 			),
 			'$maybe_alpha = false, 3 letter with 1 alpha' => array(
 				'color'       => '#abcf',
-				'expected'    => '#abcf',
+				'expected'    => null,
 				'maybe_alpha' => false,
 			),
 			'$maybe_alpha = false, 3 mixed with 1 alpha'  => array(
 				'color'       => '#0abf',
-				'expected'    => '#0abf',
+				'expected'    => null,
 				'maybe_alpha' => false,
 			),
 			'$maybe_alpha = false, 6 digit with 2 alpha'  => array(
 				'color'       => '#123456ff',
-				'expected'    => '#123456ff',
+				'expected'    => null,
 				'maybe_alpha' => false,
 			),
 			'$maybe_alpha = false, 6 letter with 2 alpha' => array(
 				'color'       => '#abcdefff',
-				'expected'    => '#abcdefff',
+				'expected'    => null,
 				'maybe_alpha' => false,
 			),
 			'$maybe_alpha = false, 6 mixed with 2 alpha'  => array(
 				'color'       => '#abc123ff',
-				'expected'    => '#abc123ff',
+				'expected'    => null,
 				'maybe_alpha' => false,
 			),
 			// Happy.
@@ -120,85 +115,91 @@ class Tests_formating_maybeHashHexColor extends WP_UnitTestCase {
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 3 mixed'                => array(
-				'color'       => '0ab',
+				'color'       => '#0ab',
 				'expected'    => '#0ab',
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 6 digit'                => array(
-				'color'       => '123456',
+				'color'       => '#123456',
 				'expected'    => '#123456',
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 6 letter'               => array(
-				'color'       => 'abcdef',
+				'color'       => '#abcdef',
 				'expected'    => '#abcdef',
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 6 mixed'                => array(
-				'color'       => 'abc123',
+				'color'       => '#abc123',
 				'expected'    => '#abc123',
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 3 digit with 1 alpha'   => array(
-				'color'       => '123f',
+				'color'       => '#123f',
 				'expected'    => '#123f',
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 3 letter with 1 alpha'  => array(
-				'color'       => 'abcf',
+				'color'       => '#abcf',
 				'expected'    => '#abcf',
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 3 mixed with 1 alpha'   => array(
-				'color'       => '0abf',
+				'color'       => '#0abf',
 				'expected'    => '#0abf',
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 6 digit with 2 alpha'   => array(
-				'color'       => '123456ff',
+				'color'       => '#123456ff',
 				'expected'    => '#123456ff',
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 6 letter with 2 alpha'  => array(
-				'color'       => 'abcdefff',
+				'color'       => '#abcdefff',
 				'expected'    => '#abcdefff',
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 6 mixed with 2 alpha'   => array(
-				'color'       => 'abc123ff',
+				'color'       => '#abc123ff',
 				'expected'    => '#abc123ff',
 				'maybe_alpha' => true,
 			),
+			'not A-F'                                     => array(
+				'color'       => '#HJG',
+				'expected'    => null,
+				'maybe_alpha' => false,
+			),
 			'$maybe_alpha = true, 3 digit with 2 alpha'   => array(
-				'color'       => '123ff',
-				'expected'    => '123ff',
+				'color'       => '#123ff',
+				'expected'    => null,
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 3 letter with 2 alpha'  => array(
-				'color'       => 'abcff',
-				'expected'    => 'abcff',
+				'color'       => '#abcff',
+				'expected'    => null,
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 3 mixed with 2 alpha'   => array(
-				'color'       => '0abff',
-				'expected'    => '0abff',
+				'color'       => '#0abff',
+				'expected'    => null,
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 6 digit with 1 alpha'   => array(
-				'color'       => '123456f',
-				'expected'    => '123456f',
+				'color'       => '#123456f',
+				'expected'    => null,
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 6 letter with 1 alpha'  => array(
-				'color'       => 'abcff',
-				'expected'    => 'abcff',
+				'color'       => '#abcff',
+				'expected'    => null,
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 6 mixed with 1 alpha'   => array(
-				'color'       => '0abff',
-				'expected'    => '0abff',
+				'color'       => '#0abff',
+				'expected'    => null,
 				'maybe_alpha' => true,
 			),
 		);
 	}
 }
+

--- a/tests/phpunit/tests/formatting/sanitizeHexColor.php
+++ b/tests/phpunit/tests/formatting/sanitizeHexColor.php
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * Tests for the sanitize_hex_color function.
+ *
+ * @group formating
+ *
+ * @covers ::sanitize_hex_color
+ */
+class Tests_formating_sanitizeHexColor extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 60270
+	 *
+	 * @dataProvider date_sanitize_hex_color
+	 */
+	public function test_sanitize_hex_color( $color, $expected ) {
+		$this->assertSame( $expected, sanitize_hex_color( $color ) );
+	}
+
+	/**
+	 * @return array
+	 */
+	public function date_sanitize_hex_color() {
+		return array(
+			'$maybe_alpha = false, 3 digit'               => array(
+				'color'    => '#123',
+				'expected' => '#123',
+			),
+			'$maybe_alpha = false, 3 letter'              => array(
+				'color'    => '#abc',
+				'expected' => '#abc',
+			),
+			'$maybe_alpha = false, 3 mixed'               => array(
+				'color'    => '#0ab',
+				'expected' => '#0ab',
+			),
+			'$maybe_alpha = false, 6 digit'               => array(
+				'color'    => '#123456',
+				'expected' => '#123456',
+			),
+			'$maybe_alpha = false, 6 letter'              => array(
+				'color'    => '#abcdef',
+				'expected' => '#abcdef',
+			),
+			'$maybe_alpha = false, 6 mixed'               => array(
+				'color'    => '#abc123',
+				'expected' => '#abc123',
+			),
+			'empty string'                                => array(
+				'color'    => '',
+				'expected' => '',
+			),
+			'no hash'                                     => array(
+				'color'    => '123',
+				'expected' => null,
+			),
+			'not a-f'                                     => array(
+				'color'    => '#hjg',
+				'expected' => null,
+			),
+			'not upper A-F'                               => array(
+				'color'    => '#HJG',
+				'expected' => null,
+			),
+			'$maybe_alpha = false, 3 digit with 1 alpha'  => array(
+				'color'    => '#123f',
+				'expected' => null,
+			),
+			'$maybe_alpha = false, 3 letter with 1 alpha' => array(
+				'color'    => '#abcf',
+				'expected' => null,
+			),
+			'$maybe_alpha = false, 3 mixed with 1 alpha'  => array(
+				'color'    => '#0abf',
+				'expected' => null,
+			),
+			'$maybe_alpha = false, 6 digit with 2 alpha'  => array(
+				'color'    => '#123456ff',
+				'expected' => null,
+			),
+			'$maybe_alpha = false, 6 letter with 2 alpha' => array(
+				'color'    => '#abcdefff',
+				'expected' => null,
+			),
+			'$maybe_alpha = false, 6 mixed with 2 alpha'  => array(
+				'color'    => '#abc123ff',
+				'expected' => null,
+			),
+			// Happy.
+			'$maybe_alpha = true, 3 digit'                => array(
+				'color'    => '#123',
+				'expected' => '#123',
+			),
+			'$maybe_alpha = true, 3 letter'               => array(
+				'color'    => '#abc',
+				'expected' => '#abc',
+			),
+			'$maybe_alpha = true, 3 mixed'                => array(
+				'color'    => '#0ab',
+				'expected' => '#0ab',
+			),
+			'$maybe_alpha = true, 6 digit'                => array(
+				'color'    => '#123456',
+				'expected' => '#123456',
+			),
+			'$maybe_alpha = true, 6 letter'               => array(
+				'color'    => '#abcdef',
+				'expected' => '#abcdef',
+			),
+			'$maybe_alpha = true, 6 mixed'                => array(
+				'color'    => '#abc123',
+				'expected' => '#abc123',
+			),
+			'$maybe_alpha = true, 3 digit with 1 alpha'   => array(
+				'color'    => '#123f',
+				'expected' => null,
+			),
+			'$maybe_alpha = true, 3 letter with 1 alpha'  => array(
+				'color'    => '#abcf',
+				'expected' => null,
+			),
+			'$maybe_alpha = true, 3 mixed with 1 alpha'   => array(
+				'color'    => '#0abf',
+				'expected' => null,
+			),
+			'$maybe_alpha = true, 6 digit with 2 alpha'   => array(
+				'color'    => '#123456ff',
+				'expected' => null,
+			),
+			'$maybe_alpha = true, 6 letter with 2 alpha'  => array(
+				'color'    => '#abcdefff',
+				'expected' => null,
+			),
+			'$maybe_alpha = true, 6 mixed with 2 alpha'   => array(
+				'color'    => '#abc123ff',
+				'expected' => null,
+			),
+			'$maybe_alpha = true, 3 digit with 2 alpha'   => array(
+				'color'    => '#123ff',
+				'expected' => null,
+			),
+			'$maybe_alpha = true, 3 letter with 2 alpha'  => array(
+				'color'    => '#abcff',
+				'expected' => null,
+			),
+			'$maybe_alpha = true, 3 mixed with 2 alpha'   => array(
+				'color'    => '#0abff',
+				'expected' => null,
+			),
+			'$maybe_alpha = true, 6 digit with 1 alpha'   => array(
+				'color'    => '#123456f',
+				'expected' => null,
+			),
+			'$maybe_alpha = true, 6 letter with 1 alpha'  => array(
+				'color'    => '#abcff',
+				'expected' => null,
+			),
+			'$maybe_alpha = true, 6 mixed with 1 alpha'   => array(
+				'color'    => '#0abff',
+				'expected' => null,
+			),
+		);
+	}
+}

--- a/tests/phpunit/tests/formatting/sanitizeHexColor.php
+++ b/tests/phpunit/tests/formatting/sanitizeHexColor.php
@@ -3,7 +3,7 @@
 /**
  * Tests for the sanitize_hex_color function.
  *
- * @group formating
+ * @group formatting
  *
  * @covers ::sanitize_hex_color
  */

--- a/tests/phpunit/tests/formatting/sanitizeHexColor.php
+++ b/tests/phpunit/tests/formatting/sanitizeHexColor.php
@@ -202,4 +202,3 @@ class Tests_formating_sanitizeHexColor extends WP_UnitTestCase {
 		);
 	}
 }
-

--- a/tests/phpunit/tests/formatting/sanitizeHexColorNoHash.php
+++ b/tests/phpunit/tests/formatting/sanitizeHexColorNoHash.php
@@ -3,57 +3,61 @@
 /**
  * Tests for the sanitize_hex_color function.
  *
- * @group formating
+ * @group formatting
  *
- * @covers ::sanitize_hex_color
+ * @covers ::sanitize_hex_color_no_hash
  */
-class Tests_formating_sanitizeHexColor extends WP_UnitTestCase {
+class Tests_formating_sanitizeHexColorNoHash extends WP_UnitTestCase {
 
 	/**
-	 * @ticket 60270
+	 * @ticket 60271
 	 *
-	 * @dataProvider date_sanitize_hex_color
+	 * @dataProvider date_sanitize_hex_color_no_hash
 	 */
-	public function test_sanitize_hex_color( $color, $expected ) {
-		$this->assertSame( $expected, sanitize_hex_color( $color ) );
+	public function test_sanitize_hex_color_no_hash( $color, $expected ) {
+		$this->assertSame( $expected, sanitize_hex_color_no_hash( $color ) );
 	}
 
 	/**
 	 * @return array
 	 */
-	public function date_sanitize_hex_color() {
+	public function date_sanitize_hex_color_no_hash() {
 		return array(
 			'$maybe_alpha = false, 3 digit'               => array(
 				'color'    => '#123',
-				'expected' => '#123',
+				'expected' => '123',
 			),
 			'$maybe_alpha = false, 3 letter'              => array(
 				'color'    => '#abc',
-				'expected' => '#abc',
+				'expected' => 'abc',
 			),
 			'$maybe_alpha = false, 3 mixed'               => array(
 				'color'    => '#0ab',
-				'expected' => '#0ab',
+				'expected' => '0ab',
 			),
 			'$maybe_alpha = false, 6 digit'               => array(
 				'color'    => '#123456',
-				'expected' => '#123456',
+				'expected' => '123456',
 			),
 			'$maybe_alpha = false, 6 letter'              => array(
 				'color'    => '#abcdef',
-				'expected' => '#abcdef',
+				'expected' => 'abcdef',
 			),
 			'$maybe_alpha = false, 6 mixed'               => array(
 				'color'    => '#abc123',
-				'expected' => '#abc123',
+				'expected' => 'abc123',
 			),
 			'empty string'                                => array(
 				'color'    => '',
 				'expected' => '',
 			),
+			'just #'                                      => array(
+				'color'    => '#',
+				'expected' => '',
+			),
 			'no hash'                                     => array(
 				'color'    => '123',
-				'expected' => null,
+				'expected' => '123',
 			),
 			'not a-f'                                     => array(
 				'color'    => '#hjg',
@@ -90,27 +94,27 @@ class Tests_formating_sanitizeHexColor extends WP_UnitTestCase {
 			// Happy.
 			'$maybe_alpha = true, 3 digit'                => array(
 				'color'    => '#123',
-				'expected' => '#123',
+				'expected' => '123',
 			),
 			'$maybe_alpha = true, 3 letter'               => array(
 				'color'    => '#abc',
-				'expected' => '#abc',
+				'expected' => 'abc',
 			),
 			'$maybe_alpha = true, 3 mixed'                => array(
 				'color'    => '#0ab',
-				'expected' => '#0ab',
+				'expected' => '0ab',
 			),
 			'$maybe_alpha = true, 6 digit'                => array(
 				'color'    => '#123456',
-				'expected' => '#123456',
+				'expected' => '123456',
 			),
 			'$maybe_alpha = true, 6 letter'               => array(
 				'color'    => '#abcdef',
-				'expected' => '#abcdef',
+				'expected' => 'abcdef',
 			),
 			'$maybe_alpha = true, 6 mixed'                => array(
 				'color'    => '#abc123',
-				'expected' => '#abc123',
+				'expected' => 'abc123',
 			),
 			'$maybe_alpha = true, 3 digit with 1 alpha'   => array(
 				'color'    => '#123f',

--- a/tests/phpunit/tests/formatting/sanitizeHexColorNoHash.php
+++ b/tests/phpunit/tests/formatting/sanitizeHexColorNoHash.php
@@ -5,17 +5,17 @@
  *
  * @group formatting
  *
- * @covers ::maybe_hash_hex_color
+ * @covers ::sanitize_hex_color_no_hash
  */
-class Tests_formating_maybeHashHexColor extends WP_UnitTestCase {
+class Tests_formating_sanitizeHexColorNoHash extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 55962
 	 *
 	 * @dataProvider date_sanitize_hex_color_no_hash
 	 */
-	public function test_maybe_hash_hex_color( $color, $expected, $maybe_alpha ) {
-		$this->assertSame( $expected, maybe_hash_hex_color( $color, $maybe_alpha ) );
+	public function test_sanitize_hex_color_no_hash( $color, $expected, $maybe_alpha  ) {
+		$this->assertSame( $expected, sanitize_hex_color_no_hash( $color, $maybe_alpha  ) );
 	}
 
 	/**
@@ -25,32 +25,32 @@ class Tests_formating_maybeHashHexColor extends WP_UnitTestCase {
 		return array(
 			'$maybe_alpha = false, 3 digit'               => array(
 				'color'       => '#123',
-				'expected'    => '#123',
+				'expected'    => '123',
 				'maybe_alpha' => false,
 			),
 			'$maybe_alpha = false, 3 letter'              => array(
 				'color'       => '#abc',
-				'expected'    => '#abc',
+				'expected'    => 'abc',
 				'maybe_alpha' => false,
 			),
 			'$maybe_alpha = false, 3 mixed'               => array(
 				'color'       => '#0ab',
-				'expected'    => '#0ab',
+				'expected'    => '0ab',
 				'maybe_alpha' => false,
 			),
 			'$maybe_alpha = false, 6 digit'               => array(
 				'color'       => '#123456',
-				'expected'    => '#123456',
+				'expected'    => '123456',
 				'maybe_alpha' => false,
 			),
 			'$maybe_alpha = false, 6 letter'              => array(
 				'color'       => '#abcdef',
-				'expected'    => '#abcdef',
+				'expected'    => 'abcdef',
 				'maybe_alpha' => false,
 			),
 			'$maybe_alpha = false, 6 mixed'               => array(
 				'color'       => '#abc123',
-				'expected'    => '#abc123',
+				'expected'    => 'abc123',
 				'maybe_alpha' => false,
 			),
 			'empty string'                                => array(
@@ -60,143 +60,143 @@ class Tests_formating_maybeHashHexColor extends WP_UnitTestCase {
 			),
 			'just #'                                      => array(
 				'color'       => '#',
-				'expected'    => '#',
+				'expected'    => '',
 				'maybe_alpha' => false,
 			),
 			'no hash'                                     => array(
 				'color'       => '123',
-				'expected'    => '#123',
+				'expected'    => '123',
 				'maybe_alpha' => false,
 			),
 			'not a-f'                                     => array(
 				'color'       => '#hjg',
-				'expected'    => '#hjg',
+				'expected'    => null,
 				'maybe_alpha' => false,
 			),
 			'not upper A-F'                               => array(
 				'color'       => '#HJG',
-				'expected'    => '#HJG',
+				'expected'    => null,
 				'maybe_alpha' => false,
 			),
 			'$maybe_alpha = false, 3 digit with 1 alpha'  => array(
 				'color'       => '#123f',
-				'expected'    => '#123f',
+				'expected'    => null,
 				'maybe_alpha' => false,
 			),
 			'$maybe_alpha = false, 3 letter with 1 alpha' => array(
 				'color'       => '#abcf',
-				'expected'    => '#abcf',
+				'expected'    => null,
 				'maybe_alpha' => false,
 			),
 			'$maybe_alpha = false, 3 mixed with 1 alpha'  => array(
 				'color'       => '#0abf',
-				'expected'    => '#0abf',
+				'expected'    => null,
 				'maybe_alpha' => false,
 			),
 			'$maybe_alpha = false, 6 digit with 2 alpha'  => array(
 				'color'       => '#123456ff',
-				'expected'    => '#123456ff',
+				'expected'    => null,
 				'maybe_alpha' => false,
 			),
 			'$maybe_alpha = false, 6 letter with 2 alpha' => array(
 				'color'       => '#abcdefff',
-				'expected'    => '#abcdefff',
+				'expected'    => null,
 				'maybe_alpha' => false,
 			),
 			'$maybe_alpha = false, 6 mixed with 2 alpha'  => array(
 				'color'       => '#abc123ff',
-				'expected'    => '#abc123ff',
+				'expected'    => null,
 				'maybe_alpha' => false,
 			),
 			// Happy.
 			'$maybe_alpha = true, 3 digit'                => array(
 				'color'       => '#123',
-				'expected'    => '#123',
+				'expected'    => '123',
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 3 letter'               => array(
 				'color'       => '#abc',
-				'expected'    => '#abc',
+				'expected'    => 'abc',
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 3 mixed'                => array(
-				'color'       => '0ab',
-				'expected'    => '#0ab',
+				'color'       => '#0ab',
+				'expected'    => '0ab',
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 6 digit'                => array(
-				'color'       => '123456',
-				'expected'    => '#123456',
+				'color'       => '#123456',
+				'expected'    => '123456',
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 6 letter'               => array(
-				'color'       => 'abcdef',
-				'expected'    => '#abcdef',
+				'color'       => '#abcdef',
+				'expected'    => 'abcdef',
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 6 mixed'                => array(
-				'color'       => 'abc123',
-				'expected'    => '#abc123',
+				'color'       => '#abc123',
+				'expected'    => 'abc123',
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 3 digit with 1 alpha'   => array(
-				'color'       => '123f',
-				'expected'    => '#123f',
+				'color'       => '#123f',
+				'expected'    => '123f',
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 3 letter with 1 alpha'  => array(
-				'color'       => 'abcf',
-				'expected'    => '#abcf',
+				'color'       => '#abcf',
+				'expected'    => 'abcf',
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 3 mixed with 1 alpha'   => array(
-				'color'       => '0abf',
-				'expected'    => '#0abf',
+				'color'       => '#0abf',
+				'expected'    => '0abf',
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 6 digit with 2 alpha'   => array(
-				'color'       => '123456ff',
-				'expected'    => '#123456ff',
+				'color'       => '#123456ff',
+				'expected'    => '123456ff',
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 6 letter with 2 alpha'  => array(
-				'color'       => 'abcdefff',
-				'expected'    => '#abcdefff',
+				'color'       => '#abcdefff',
+				'expected'    => 'abcdefff',
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 6 mixed with 2 alpha'   => array(
-				'color'       => 'abc123ff',
-				'expected'    => '#abc123ff',
+				'color'       => '#abc123ff',
+				'expected'    => 'abc123ff',
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 3 digit with 2 alpha'   => array(
-				'color'       => '123ff',
-				'expected'    => '123ff',
+				'color'       => '#123ff',
+				'expected'    => null,
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 3 letter with 2 alpha'  => array(
-				'color'       => 'abcff',
-				'expected'    => 'abcff',
+				'color'       => '#abcff',
+				'expected'    => null,
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 3 mixed with 2 alpha'   => array(
-				'color'       => '0abff',
-				'expected'    => '0abff',
+				'color'       => '#0abff',
+				'expected'    => null,
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 6 digit with 1 alpha'   => array(
-				'color'       => '123456f',
-				'expected'    => '123456f',
+				'color'       => '#123456f',
+				'expected'    => null,
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 6 letter with 1 alpha'  => array(
-				'color'       => 'abcff',
-				'expected'    => 'abcff',
+				'color'       => '#abcff',
+				'expected'    => null,
 				'maybe_alpha' => true,
 			),
 			'$maybe_alpha = true, 6 mixed with 1 alpha'   => array(
-				'color'       => '0abff',
-				'expected'    => '0abff',
+				'color'       => '#0abff',
+				'expected'    => null,
 				'maybe_alpha' => true,
 			),
 		);

--- a/tests/phpunit/tests/formatting/sanitizeHexColorNoHash.php
+++ b/tests/phpunit/tests/formatting/sanitizeHexColorNoHash.php
@@ -14,8 +14,8 @@ class Tests_formating_sanitizeHexColorNoHash extends WP_UnitTestCase {
 	 *
 	 * @dataProvider date_sanitize_hex_color_no_hash
 	 */
-	public function test_sanitize_hex_color_no_hash( $color, $expected, $maybe_alpha  ) {
-		$this->assertSame( $expected, sanitize_hex_color_no_hash( $color, $maybe_alpha  ) );
+	public function test_sanitize_hex_color_no_hash( $color, $expected, $maybe_alpha ) {
+		$this->assertSame( $expected, sanitize_hex_color_no_hash( $color, $maybe_alpha ) );
 	}
 
 	/**


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/55962