### PR TITLE
WP Query: Fix term array in custom taxonomy query (avoiding a fatal error PHP >= 8.0)

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1175,7 +1175,7 @@ class WP_Query {
 					'field'    => 'slug',
 				);
 
-				if ( ! empty( $t->rewrite['hierarchical'] ) ) {
+				if ( ! empty( $t->rewrite['hierarchical'] ) && ! is_array( $q[ $t->query_var ] ) ) {
 					$q[ $t->query_var ] = wp_basename( $q[ $t->query_var ] );
 				}
 


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/59826 and also see https://core.trac.wordpress.org/ticket/57300.