### PR TITLE
Composer: update PHPCS to v 3.8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		"ext-dom": "*"
 	},
 	"require-dev": {
-		"squizlabs/php_codesniffer": "3.7.2",
+		"squizlabs/php_codesniffer": "3.8.1",
 		"wp-coding-standards/wpcs": "~3.0.1",
 		"phpcompatibility/phpcompatibility-wp": "~2.1.3",
 		"yoast/phpunit-polyfills": "^1.1.0"

--- a/src/wp-includes/block-supports/background.php
+++ b/src/wp-includes/block-supports/background.php
@@ -70,13 +70,13 @@ function wp_render_background_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$background_size         = isset( $block_attributes['style']['background']['backgroundSize'] )
+	$background_size     = isset( $block_attributes['style']['background']['backgroundSize'] )
 		? $block_attributes['style']['background']['backgroundSize']
 		: 'cover';
-	$background_position     = isset( $block_attributes['style']['background']['backgroundPosition'] )
+	$background_position = isset( $block_attributes['style']['background']['backgroundPosition'] )
 		? $block_attributes['style']['background']['backgroundPosition']
 		: null;
-	$background_repeat       = isset( $block_attributes['style']['background']['backgroundRepeat'] )
+	$background_repeat   = isset( $block_attributes['style']['background']['backgroundRepeat'] )
 		? $block_attributes['style']['background']['backgroundRepeat']
 		: null;
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -778,7 +778,7 @@ function get_hooked_block_markup( &$anchor_block, $hooked_block_type ) {
 		$anchor_block['attrs']['metadata']['ignoredHookedBlocks'] = array();
 	}
 
-	if ( in_array( $hooked_block_type, $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] ) ) {
+	if ( in_array( $hooked_block_type, $anchor_block['attrs']['metadata']['ignoredHookedBlocks'], true ) ) {
 		return '';
 	}
 


### PR DESCRIPTION
### Composer: update PHPCS to v 3.8.1

PHPCS has seen two new releases since the update to WPCS 3.0, with especially the 3.8.0 version containing a huge number of improvements.

Refs:
* https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/3.8.0
* https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/3.8.1

Also note that PHPCSUtils and PHPCSExtra, both dependencies of WPCS 3.0+, are not locked down, meaning that the version used by contributors _may_ not always be the same. I don't expect any significant problems with that, but we may want to consider locking them down anyway.
Both projects have had releases since the original update to WPCS 3.0.

Refs:
* https://github.com/PHPCSStandards/PHPCSUtils/releases/tag/1.0.9
* https://github.com/PHPCSStandards/PHPCSExtra/releases/tag/1.2.1

Previous: Trac 59161

### CS: fix up assignment operator alignment

These keep sneaking in, what with them being warnings ;-)

### QA: use strict in_array() calls

.. to prevent type juggling causing incorrect results.

Trac ticket: https://core.trac.wordpress.org/ticket/60279

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
