### PR TITLE
Make sure base global styles are loaded before block styles.

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1201,44 +1201,6 @@ class WP_Theme_JSON {
 	}
 
 	/**
-	 * Returns the global styles base custom CSS.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @return string The global styles base custom CSS.
-	 */
-	public function get_custom_base_css() {
-		return isset( $this->theme_json['styles']['css'] ) ? $this->theme_json['styles']['css'] : '';
-	}
-
-
-	/**
-	 * Returns the global styles per-block custom CSS.
-	 *
-	 * @since 6.5.0
-	 *
-	 * @return string The global styles per-block custom CSS.
-	 */
-	public function get_custom_block_css() {
-		$stylesheet = '';
-
-		// Add the global styles block CSS.
-		if ( isset( $this->theme_json['styles']['blocks'] ) ) {
-			foreach ( $this->theme_json['styles']['blocks'] as $name => $node ) {
-				$custom_block_css = isset( $this->theme_json['styles']['blocks'][ $name ]['css'] )
-					? $this->theme_json['styles']['blocks'][ $name ]['css']
-					: null;
-				if ( $custom_block_css ) {
-					$selector    = static::$blocks_metadata[ $name ]['selector'];
-					$stylesheet .= $this->process_blocks_custom_css( $custom_block_css, $selector );
-				}
-			}
-		}
-
-		return $stylesheet;
-	}
-
-	/**
 	 * Returns the page templates of the active theme.
 	 *
 	 * @since 5.9.0

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1201,6 +1201,45 @@ class WP_Theme_JSON {
 	}
 
 	/**
+	 * Returns the global styles base custom CSS.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @return string The global styles base custom CSS.
+	 */
+	public function get_custom_base_css() {
+		return isset( $this->theme_json['styles']['css'] ) ? $this->theme_json['styles']['css'] : '';
+	}
+
+
+	/**
+	 * Returns the global styles per-block custom CSS.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @return string The global styles per-block custom CSS.
+	 */
+	public function get_custom_block_css() {
+		$stylesheet = '';
+
+		// Add the global styles block CSS.
+		if ( isset( $this->theme_json['styles']['blocks'] ) ) {
+			foreach ( $this->theme_json['styles']['blocks'] as $name => $node ) {
+				$custom_block_css = isset( $this->theme_json['styles']['blocks'][ $name ]['css'] )
+					? $this->theme_json['styles']['blocks'][ $name ]['css']
+					: null;
+				if ( $custom_block_css ) {
+					$selector    = static::$blocks_metadata[ $name ]['selector'];
+					$stylesheet .= $this->process_blocks_custom_css( $custom_block_css, $selector );
+				}
+			}
+		}
+
+		return $stylesheet;
+
+	}
+
+	/**
 	 * Returns the page templates of the active theme.
 	 *
 	 * @since 5.9.0

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1236,7 +1236,6 @@ class WP_Theme_JSON {
 		}
 
 		return $stylesheet;
-
 	}
 
 	/**

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -596,8 +596,10 @@ add_action( 'admin_head', 'wp_check_widget_editor_deps' );
 add_filter( 'block_editor_settings_all', 'wp_add_editor_classic_theme_styles' );
 
 // Global styles can be enqueued in both the header and the footer. See https://core.trac.wordpress.org/ticket/53494.
-add_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' );
+add_action( 'init', 'wp_enqueue_global_styles', 1 );
 add_action( 'wp_footer', 'wp_enqueue_global_styles', 1 );
+
+add_action( 'wp_enqueue_scripts', 'wp_add_global_styles_for_blocks' );
 
 // Global styles custom CSS.
 add_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles_custom_css' );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -601,6 +601,8 @@ add_action( 'wp_footer', 'wp_enqueue_global_styles', 1 );
 
 add_action( 'wp_enqueue_scripts', 'wp_add_global_styles_for_blocks' );
 
+add_action( 'wp_enqueue_scripts', 'wp_enqueue_block_global_styles' );
+
 // Global styles custom CSS.
 add_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles_custom_css' );
 

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -295,6 +295,74 @@ function wp_get_global_styles_custom_css() {
 }
 
 /**
+ * Gets the global styles base custom CSS from theme.json.
+ * Logic should follow wp_get_global_styles_custom_css.
+ *
+ * @since 6.5.0
+ *
+ * @return string The global base custom CSS.
+ */
+function wp_get_global_styles_base_custom_css() {
+	if ( ! wp_theme_has_theme_json() ) {
+		return '';
+	}
+
+	$can_use_cached = ! wp_is_development_mode( 'theme' );
+
+	$cache_key   = 'wp_get_global_styles_base_custom_css';
+	$cache_group = 'theme_json';
+	if ( $can_use_cached ) {
+		$cached = wp_cache_get( $cache_key, $cache_group );
+		if ( $cached ) {
+			return $cached;
+		}
+	}
+
+	$tree       = WP_Theme_JSON_Resolver::get_merged_data();
+	$stylesheet = $tree->get_custom_base_css();
+
+	if ( $can_use_cached ) {
+		wp_cache_set( $cache_key, $stylesheet, $cache_group );
+	}
+
+	return $stylesheet;
+}
+
+/**
+ * Gets the global styles per-block custom CSS from theme.json.
+ * Logic should follow wp_get_global_styles_custom_css.
+ *
+ * @since 6.5.0
+ *
+ * @return string The global per-block custom CSS.
+ */
+function wp_get_global_styles_block_custom_css() {
+	if ( ! wp_theme_has_theme_json() ) {
+		return '';
+	}
+
+	$can_use_cached = ! wp_is_development_mode( 'theme' );
+
+	$cache_key   = 'wp_get_global_styles_block_custom_css';
+	$cache_group = 'theme_json';
+	if ( $can_use_cached ) {
+		$cached = wp_cache_get( $cache_key, $cache_group );
+		if ( $cached ) {
+			return $cached;
+		}
+	}
+
+	$tree       = WP_Theme_JSON_Resolver::get_merged_data();
+	$stylesheet = $tree->get_custom_block_css();
+
+	if ( $can_use_cached ) {
+		wp_cache_set( $cache_key, $stylesheet, $cache_group );
+	}
+
+	return $stylesheet;
+}
+
+/**
  * Adds global style rules to the inline style for each block.
  *
  * @since 6.1.0
@@ -439,6 +507,8 @@ function wp_clean_theme_json_cache() {
 	wp_cache_delete( 'wp_get_global_settings_custom', 'theme_json' );
 	wp_cache_delete( 'wp_get_global_settings_theme', 'theme_json' );
 	wp_cache_delete( 'wp_get_global_styles_custom_css', 'theme_json' );
+	wp_cache_delete( 'wp_get_global_styles_base_custom_css', 'theme_json' );
+	wp_cache_delete( 'wp_get_global_styles_block_custom_css', 'theme_json' );
 	wp_cache_delete( 'wp_get_theme_data_template_parts', 'theme_json' );
 	WP_Theme_JSON_Resolver::clean_cached_data();
 }

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -302,11 +302,15 @@ function wp_get_global_styles_custom_css() {
 function wp_add_global_styles_for_blocks() {
 	$tree        = WP_Theme_JSON_Resolver::get_merged_data();
 	$block_nodes = $tree->get_styles_block_nodes();
+
+	if ( ! wp_should_load_separate_core_block_assets() ) {
+		wp_register_style( 'global-styles-blocks', false );
+	}
 	foreach ( $block_nodes as $metadata ) {
 		$block_css = $tree->get_styles_for_block( $metadata );
 
 		if ( ! wp_should_load_separate_core_block_assets() ) {
-			wp_add_inline_style( 'global-styles', $block_css );
+			wp_add_inline_style( 'global-styles-blocks', $block_css );
 			continue;
 		}
 
@@ -335,6 +339,10 @@ function wp_add_global_styles_for_blocks() {
 				wp_add_inline_style( $stylesheet_handle, $block_css );
 			}
 		}
+	}
+
+	if ( ! wp_should_load_separate_core_block_assets() ) {
+		wp_enqueue_style( 'global-styles-blocks' );
 	}
 }
 

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -54,7 +54,7 @@ function wp_get_global_settings( $path = array(), $context = array() ) {
 	 * is always fresh from the potential modifications done via hooks
 	 * that can use dynamic data (modify the stylesheet depending on some option,
 	 * settings depending on user permissions, etc.).
-	 * See some of the existing hooks to modify theme.json behaviour:
+	 * See some of the existing hooks to modify theme.json behavior:
 	 * https://make.wordpress.org/core/2022/10/10/filters-for-theme-json-data/
 	 *
 	 * A different alternative considered was to invalidate the cache upon certain
@@ -295,92 +295,19 @@ function wp_get_global_styles_custom_css() {
 }
 
 /**
- * Gets the global styles base custom CSS from theme.json.
- * Logic should follow wp_get_global_styles_custom_css.
- *
- * @since 6.5.0
- *
- * @return string The global base custom CSS.
- */
-function wp_get_global_styles_base_custom_css() {
-	if ( ! wp_theme_has_theme_json() ) {
-		return '';
-	}
-
-	$can_use_cached = ! wp_is_development_mode( 'theme' );
-
-	$cache_key   = 'wp_get_global_styles_base_custom_css';
-	$cache_group = 'theme_json';
-	if ( $can_use_cached ) {
-		$cached = wp_cache_get( $cache_key, $cache_group );
-		if ( $cached ) {
-			return $cached;
-		}
-	}
-
-	$tree       = WP_Theme_JSON_Resolver::get_merged_data();
-	$stylesheet = $tree->get_custom_base_css();
-
-	if ( $can_use_cached ) {
-		wp_cache_set( $cache_key, $stylesheet, $cache_group );
-	}
-
-	return $stylesheet;
-}
-
-/**
- * Gets the global styles per-block custom CSS from theme.json.
- * Logic should follow wp_get_global_styles_custom_css.
- *
- * @since 6.5.0
- *
- * @return string The global per-block custom CSS.
- */
-function wp_get_global_styles_block_custom_css() {
-	if ( ! wp_theme_has_theme_json() ) {
-		return '';
-	}
-
-	$can_use_cached = ! wp_is_development_mode( 'theme' );
-
-	$cache_key   = 'wp_get_global_styles_block_custom_css';
-	$cache_group = 'theme_json';
-	if ( $can_use_cached ) {
-		$cached = wp_cache_get( $cache_key, $cache_group );
-		if ( $cached ) {
-			return $cached;
-		}
-	}
-
-	$tree       = WP_Theme_JSON_Resolver::get_merged_data();
-	$stylesheet = $tree->get_custom_block_css();
-
-	if ( $can_use_cached ) {
-		wp_cache_set( $cache_key, $stylesheet, $cache_group );
-	}
-
-	return $stylesheet;
-}
-
-/**
  * Adds global style rules to the inline style for each block.
  *
  * @since 6.1.0
  */
 function wp_add_global_styles_for_blocks() {
+	if ( ! wp_should_load_separate_core_block_assets() ) {
+		return;
+	}
+	
 	$tree        = WP_Theme_JSON_Resolver::get_merged_data();
 	$block_nodes = $tree->get_styles_block_nodes();
-
-	if ( ! wp_should_load_separate_core_block_assets() ) {
-		wp_register_style( 'global-styles-blocks', false );
-	}
 	foreach ( $block_nodes as $metadata ) {
 		$block_css = $tree->get_styles_for_block( $metadata );
-
-		if ( ! wp_should_load_separate_core_block_assets() ) {
-			wp_add_inline_style( 'global-styles-blocks', $block_css );
-			continue;
-		}
 
 		$stylesheet_handle = 'global-styles';
 		if ( isset( $metadata['name'] ) ) {
@@ -407,10 +334,6 @@ function wp_add_global_styles_for_blocks() {
 				wp_add_inline_style( $stylesheet_handle, $block_css );
 			}
 		}
-	}
-
-	if ( ! wp_should_load_separate_core_block_assets() ) {
-		wp_enqueue_style( 'global-styles-blocks' );
 	}
 }
 
@@ -507,8 +430,6 @@ function wp_clean_theme_json_cache() {
 	wp_cache_delete( 'wp_get_global_settings_custom', 'theme_json' );
 	wp_cache_delete( 'wp_get_global_settings_theme', 'theme_json' );
 	wp_cache_delete( 'wp_get_global_styles_custom_css', 'theme_json' );
-	wp_cache_delete( 'wp_get_global_styles_base_custom_css', 'theme_json' );
-	wp_cache_delete( 'wp_get_global_styles_block_custom_css', 'theme_json' );
 	wp_cache_delete( 'wp_get_theme_data_template_parts', 'theme_json' );
 	WP_Theme_JSON_Resolver::clean_cached_data();
 }

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -303,7 +303,7 @@ function wp_add_global_styles_for_blocks() {
 	if ( ! wp_should_load_separate_core_block_assets() ) {
 		return;
 	}
-	
+
 	$tree        = WP_Theme_JSON_Resolver::get_merged_data();
 	$block_nodes = $tree->get_styles_block_nodes();
 	foreach ( $block_nodes as $metadata ) {

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2512,9 +2512,6 @@ function wp_enqueue_global_styles() {
 	wp_register_style( 'global-styles', false );
 	wp_add_inline_style( 'global-styles', $stylesheet );
 	wp_enqueue_style( 'global-styles' );
-
-	// Add each block as an inline css.
-	wp_add_global_styles_for_blocks();
 }
 
 /**

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2528,12 +2528,20 @@ function wp_enqueue_global_styles_custom_css() {
 	remove_action( 'wp_head', 'wp_custom_css_cb', 101 );
 
 	$custom_css  = wp_get_custom_css();
-	$custom_css .= wp_get_global_styles_custom_css();
+	$custom_css .= wp_get_global_styles_base_custom_css();
 
 	if ( ! empty( $custom_css ) ) {
 		wp_add_inline_style( 'global-styles', $custom_css );
 	}
+	$block_custom_css .= wp_get_global_styles_block_custom_css();
+
+	if ( ! empty( $block_custom_css ) ) {
+		wp_register_style( 'global-styles-block-custom', false );
+		wp_add_inline_style( 'global-styles-block-custom', $block_custom_css );
+		wp_enqueue_style( 'global-styles-block-custom' );
+	}
 }
+
 
 /**
  * Checks if the editor scripts and styles for all registered block types

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2515,6 +2515,31 @@ function wp_enqueue_global_styles() {
 }
 
 /**
+ * Enqueues block global styles when separate core block assets are disabled.
+ * 
+ * @since 6.5.0
+ */
+function wp_enqueue_block_global_styles() {
+	if ( wp_should_load_separate_core_block_assets() ) {
+		return;
+	}
+
+	$tree        = WP_Theme_JSON_Resolver::get_merged_data();
+	$block_nodes = $tree->get_styles_block_nodes();
+
+	wp_register_style( 'global-styles-blocks', false );
+
+	foreach ( $block_nodes as $metadata ) {
+		$block_css = $tree->get_styles_for_block( $metadata );
+		wp_add_inline_style( 'global-styles-blocks', $block_css );
+	}
+
+	wp_enqueue_style( 'global-styles-blocks' );
+
+	wp_enqueue_global_styles();
+}
+
+/**
  * Enqueues the global styles custom css defined via theme.json.
  *
  * @since 6.2.0
@@ -2528,17 +2553,10 @@ function wp_enqueue_global_styles_custom_css() {
 	remove_action( 'wp_head', 'wp_custom_css_cb', 101 );
 
 	$custom_css  = wp_get_custom_css();
-	$custom_css .= wp_get_global_styles_base_custom_css();
+	$custom_css .= wp_get_global_styles_custom_css();
 
 	if ( ! empty( $custom_css ) ) {
 		wp_add_inline_style( 'global-styles', $custom_css );
-	}
-	$block_custom_css = wp_get_global_styles_block_custom_css();
-
-	if ( ! empty( $block_custom_css ) ) {
-		wp_register_style( 'global-styles-block-custom', false );
-		wp_add_inline_style( 'global-styles-block-custom', $block_custom_css );
-		wp_enqueue_style( 'global-styles-block-custom' );
 	}
 }
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2516,7 +2516,7 @@ function wp_enqueue_global_styles() {
 
 /**
  * Enqueues block global styles when separate core block assets are disabled.
- * 
+ *
  * @since 6.5.0
  */
 function wp_enqueue_block_global_styles() {

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2533,7 +2533,7 @@ function wp_enqueue_global_styles_custom_css() {
 	if ( ! empty( $custom_css ) ) {
 		wp_add_inline_style( 'global-styles', $custom_css );
 	}
-	$block_custom_css .= wp_get_global_styles_block_custom_css();
+	$block_custom_css = wp_get_global_styles_block_custom_css();
 
 	if ( ! empty( $block_custom_css ) ) {
 		wp_register_style( 'global-styles-block-custom', false );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2500,13 +2500,6 @@ function wp_enqueue_global_styles() {
 		return;
 	}
 
-	/*
-	 * If loading the CSS for each block separately, then load the theme.json CSS conditionally.
-	 * This removes the CSS from the global-styles stylesheet and adds it to the inline CSS for each block.
-	 * This filter must be registered before calling wp_get_global_stylesheet();
-	 */
-	add_filter( 'wp_theme_json_get_style_nodes', 'wp_filter_out_block_nodes' );
-
 	$stylesheet = wp_get_global_stylesheet();
 
 	if ( empty( $stylesheet ) ) {
@@ -2539,8 +2532,6 @@ function wp_enqueue_block_global_styles() {
 	}
 
 	wp_enqueue_style( 'global-styles-blocks' );
-
-	wp_enqueue_global_styles();
 }
 
 /**

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2478,6 +2478,10 @@ function wp_filter_out_block_nodes( $nodes ) {
  * @since 5.8.0
  */
 function wp_enqueue_global_styles() {
+	if ( is_admin() ) {
+		return;
+	}
+
 	$separate_assets  = wp_should_load_separate_core_block_assets();
 	$is_block_theme   = wp_is_block_theme();
 	$is_classic_theme = ! $is_block_theme;

--- a/tests/phpunit/tests/theme/wpAddGlobalStylesForBlocks.php
+++ b/tests/phpunit/tests/theme/wpAddGlobalStylesForBlocks.php
@@ -21,6 +21,7 @@ class Tests_Theme_WpAddGlobalStylesForBlocks extends WP_Theme_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 		remove_action( 'wp_print_styles', 'print_emoji_styles' );
+		add_filter( 'should_load_separate_core_block_assets', '__return_true' );
 	}
 
 	public function tear_down() {
@@ -31,6 +32,8 @@ class Tests_Theme_WpAddGlobalStylesForBlocks extends WP_Theme_UnitTestCase {
 			}
 			$this->test_blocks = array();
 		}
+
+		remove_filter( 'should_load_separate_core_block_assets', '__return_true' );
 
 		parent::tear_down();
 	}
@@ -53,32 +56,8 @@ class Tests_Theme_WpAddGlobalStylesForBlocks extends WP_Theme_UnitTestCase {
 	/**
 	 * @ticket 56915
 	 */
-	public function test_third_party_blocks_inline_styles_get_registered_to_global_styles() {
-		$this->set_up_third_party_block();
-
-		wp_register_style( 'global-styles', false, array(), true, true );
-
-		$this->assertNotContains(
-			'.wp-block-my-third-party-block{background-color: hotpink;}',
-			$this->get_global_styles(),
-			'Third party block inline style should not be registered before running wp_add_global_styles_for_blocks()'
-		);
-
-		wp_add_global_styles_for_blocks();
-
-		$this->assertContains(
-			'.wp-block-my-third-party-block{background-color: hotpink;}',
-			$this->get_global_styles(),
-			'Third party block inline style should be registered after running wp_add_global_styles_for_blocks()'
-		);
-	}
-
-	/**
-	 * @ticket 56915
-	 */
 	public function test_third_party_blocks_inline_styles_get_registered_to_global_styles_when_per_block() {
 		$this->set_up_third_party_block();
-		add_filter( 'should_load_separate_core_block_assets', '__return_true' );
 
 		wp_register_style( 'global-styles', false, array(), true, true );
 
@@ -102,7 +81,6 @@ class Tests_Theme_WpAddGlobalStylesForBlocks extends WP_Theme_UnitTestCase {
 	 */
 	public function test_third_party_blocks_inline_styles_get_rendered_when_per_block() {
 		$this->set_up_third_party_block();
-		add_filter( 'should_load_separate_core_block_assets', '__return_true' );
 
 		wp_register_style( 'global-styles', false, array(), true, true );
 		wp_enqueue_style( 'global-styles' );
@@ -123,50 +101,11 @@ class Tests_Theme_WpAddGlobalStylesForBlocks extends WP_Theme_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 56915
-	 */
-	public function test_blocks_inline_styles_get_rendered() {
-		wp_register_style( 'global-styles', false, array(), true, true );
-		wp_enqueue_style( 'global-styles' );
-		wp_add_global_styles_for_blocks();
-
-		$actual = get_echo( 'wp_print_styles' );
-
-		$this->assertStringContainsString(
-			'.wp-block-my-third-party-block{background-color: hotpink;}',
-			$actual,
-			'Third party block inline style should render'
-		);
-		$this->assertStringContainsString(
-			'.wp-block-post-featured-image',
-			$actual,
-			'Core block should render'
-		);
-	}
-
-	/**
 	 * @ticket 57868
 	 */
 	public function test_third_party_blocks_inline_styles_for_elements_get_rendered_when_per_block() {
 		$this->set_up_third_party_block();
-		add_filter( 'should_load_separate_core_block_assets', '__return_true' );
 
-		wp_register_style( 'global-styles', false, array(), true, true );
-		wp_enqueue_style( 'global-styles' );
-		wp_add_global_styles_for_blocks();
-
-		$actual = get_echo( 'wp_print_styles' );
-
-		$this->assertStringContainsString(
-			'.wp-block-my-third-party-block cite{color: white;}',
-			$actual
-		);
-	}
-
-	/**
-	 * @ticket 57868
-	 */
-	public function test_third_party_blocks_inline_styles_for_elements_get_rendered() {
 		wp_register_style( 'global-styles', false, array(), true, true );
 		wp_enqueue_style( 'global-styles' );
 		wp_add_global_styles_for_blocks();

--- a/tests/phpunit/tests/theme/wpEnqueueBlockGlobalStyles.php
+++ b/tests/phpunit/tests/theme/wpEnqueueBlockGlobalStyles.php
@@ -11,58 +11,56 @@ require_once __DIR__ . '/base.php';
  */
 
 class Tests_Theme_WpEnqueueBlockGlobalStyles extends WP_Theme_UnitTestCase {
-            
-    /**
-    * Test blocks to unregister at cleanup.
-    *
-    * @var array
-    */
-    private $test_blocks = array();
 
-    public function set_up() {
-        parent::set_up();
-        remove_action( 'wp_print_styles', 'print_emoji_styles' );
-    }
+	/**
+	* Test blocks to unregister at cleanup.
+	*
+	* @var array
+	*/
+	private $test_blocks = array();
 
-    public function tear_down() {
-        // Unregister test blocks.
-        if ( ! empty( $this->test_blocks ) ) {
-            foreach ( $this->test_blocks as $test_block ) {
-                unregister_block_type( $test_block );
-            }
-            $this->test_blocks = array();
-        }
+	public function set_up() {
+		parent::set_up();
+		remove_action( 'wp_print_styles', 'print_emoji_styles' );
+	}
 
-        parent::tear_down();
-    }
+	public function tear_down() {
+		// Unregister test blocks.
+		if ( ! empty( $this->test_blocks ) ) {
+			foreach ( $this->test_blocks as $test_block ) {
+				unregister_block_type( $test_block );
+			}
+			$this->test_blocks = array();
+		}
 
-    /**
-     * @ticket 56915
-     * @ticket 60280
-     */
-    public function test_third_party_blocks_inline_styles_get_registered_to_global_styles() {
-        $this->set_up_third_party_block();
+		parent::tear_down();
+	}
 
-
-        $this->assertNotContains(
-            '.wp-block-my-third-party-block{background-color: hotpink;}',
-            $this->get_global_styles_blocks(),
-            'Third party block inline style should not be registered before running wp_enqueue_block_global_styles()'
-        );
-
-        wp_enqueue_block_global_styles();
-
-        $this->assertContains(
-            '.wp-block-my-third-party-block{background-color: hotpink;}',
-            $this->get_global_styles_blocks(),
-            'Third party block inline style should be registered after running wp_enqueue_block_global_styles()'
-        );
-
-    }
-
-    /**
+	/**
 	 * @ticket 56915
-     * @ticket 60280
+	 * @ticket 60280
+	 */
+	public function test_third_party_blocks_inline_styles_get_registered_to_global_styles() {
+		$this->set_up_third_party_block();
+
+		$this->assertNotContains(
+			'.wp-block-my-third-party-block{background-color: hotpink;}',
+			$this->get_global_styles_blocks(),
+			'Third party block inline style should not be registered before running wp_enqueue_block_global_styles()'
+		);
+
+		wp_enqueue_block_global_styles();
+
+		$this->assertContains(
+			'.wp-block-my-third-party-block{background-color: hotpink;}',
+			$this->get_global_styles_blocks(),
+			'Third party block inline style should be registered after running wp_enqueue_block_global_styles()'
+		);
+	}
+
+	/**
+	 * @ticket 56915
+	 * @ticket 60280
 	 */
 	public function test_blocks_inline_styles_get_rendered() {
 		wp_enqueue_block_global_styles();
@@ -81,12 +79,12 @@ class Tests_Theme_WpEnqueueBlockGlobalStyles extends WP_Theme_UnitTestCase {
 		);
 	}
 
-    /**
+	/**
 	 * @ticket 57868
-     * @ticket 60280
+	 * @ticket 60280
 	 */
 	public function test_third_party_blocks_inline_styles_for_elements_get_rendered() {
-        wp_enqueue_block_global_styles();
+		wp_enqueue_block_global_styles();
 
 		$actual = get_echo( 'wp_print_styles' );
 
@@ -97,7 +95,7 @@ class Tests_Theme_WpEnqueueBlockGlobalStyles extends WP_Theme_UnitTestCase {
 	}
 
 
-    private function set_up_third_party_block() {
+	private function set_up_third_party_block() {
 		switch_theme( 'block-theme' );
 
 		$name     = 'my/third-party-block';
@@ -111,8 +109,8 @@ class Tests_Theme_WpEnqueueBlockGlobalStyles extends WP_Theme_UnitTestCase {
 		$this->test_blocks[] = $name;
 	}
 
-    private function get_global_styles_blocks() {
-        $actual = wp_styles()->get_data( 'global-styles-blocks', 'after' );
-        return is_array( $actual ) ? $actual : array();
-    }
+	private function get_global_styles_blocks() {
+		$actual = wp_styles()->get_data( 'global-styles-blocks', 'after' );
+		return is_array( $actual ) ? $actual : array();
+	}
 }

--- a/tests/phpunit/tests/theme/wpEnqueueBlockGlobalStyles.php
+++ b/tests/phpunit/tests/theme/wpEnqueueBlockGlobalStyles.php
@@ -40,21 +40,6 @@ class Tests_Theme_WpEnqueueBlockGlobalStyles extends WP_Theme_UnitTestCase {
      * @ticket 56915
      * @ticket 60280
      */
-    public function test_third_party_blocks_inline_styles_not_register_to_global_styles() {
-        switch_theme( 'block-theme' );
-
-        wp_enqueue_block_global_styles();
-
-        $this->assertNotContains(
-            '.wp-block-my-third-party-block{background-color: hotpink;}',
-            $this->get_global_styles_blocks()
-        );
-    }
-
-    /**
-     * @ticket 56915
-     * @ticket 60280
-     */
     public function test_third_party_blocks_inline_styles_get_registered_to_global_styles() {
         $this->set_up_third_party_block();
 

--- a/tests/phpunit/tests/theme/wpEnqueueBlockGlobalStyles.php
+++ b/tests/phpunit/tests/theme/wpEnqueueBlockGlobalStyles.php
@@ -1,0 +1,133 @@
+<?php
+
+require_once __DIR__ . '/base.php';
+
+/**
+ * Tests wp_enqueue_block_global_styles().
+ *
+ * @group themes
+ *
+ * @covers ::wp_enqueue_block_global_styles
+ */
+
+class Tests_Theme_WpEnqueueBlockGlobalStyles extends WP_Theme_UnitTestCase {
+            
+    /**
+    * Test blocks to unregister at cleanup.
+    *
+    * @var array
+    */
+    private $test_blocks = array();
+
+    public function set_up() {
+        parent::set_up();
+        remove_action( 'wp_print_styles', 'print_emoji_styles' );
+    }
+
+    public function tear_down() {
+        // Unregister test blocks.
+        if ( ! empty( $this->test_blocks ) ) {
+            foreach ( $this->test_blocks as $test_block ) {
+                unregister_block_type( $test_block );
+            }
+            $this->test_blocks = array();
+        }
+
+        parent::tear_down();
+    }
+
+    /**
+     * @ticket 56915
+     * @ticket 60280
+     */
+    public function test_third_party_blocks_inline_styles_not_register_to_global_styles() {
+        switch_theme( 'block-theme' );
+
+        wp_enqueue_block_global_styles();
+
+        $this->assertNotContains(
+            '.wp-block-my-third-party-block{background-color: hotpink;}',
+            $this->get_global_styles_blocks()
+        );
+    }
+
+    /**
+     * @ticket 56915
+     * @ticket 60280
+     */
+    public function test_third_party_blocks_inline_styles_get_registered_to_global_styles() {
+        $this->set_up_third_party_block();
+
+
+        $this->assertNotContains(
+            '.wp-block-my-third-party-block{background-color: hotpink;}',
+            $this->get_global_styles_blocks(),
+            'Third party block inline style should not be registered before running wp_enqueue_block_global_styles()'
+        );
+
+        wp_enqueue_block_global_styles();
+
+        $this->assertContains(
+            '.wp-block-my-third-party-block{background-color: hotpink;}',
+            $this->get_global_styles_blocks(),
+            'Third party block inline style should be registered after running wp_enqueue_block_global_styles()'
+        );
+
+    }
+
+    /**
+	 * @ticket 56915
+     * @ticket 60280
+	 */
+	public function test_blocks_inline_styles_get_rendered() {
+		wp_enqueue_block_global_styles();
+
+		$actual = get_echo( 'wp_print_styles' );
+
+		$this->assertStringContainsString(
+			'.wp-block-my-third-party-block{background-color: hotpink;}',
+			$actual,
+			'Third party block inline style should render'
+		);
+		$this->assertStringContainsString(
+			'.wp-block-post-featured-image',
+			$actual,
+			'Core block should render'
+		);
+	}
+
+    /**
+	 * @ticket 57868
+     * @ticket 60280
+	 */
+	public function test_third_party_blocks_inline_styles_for_elements_get_rendered() {
+        wp_enqueue_block_global_styles();
+
+		$actual = get_echo( 'wp_print_styles' );
+
+		$this->assertStringContainsString(
+			'.wp-block-my-third-party-block cite{color: white;}',
+			$actual
+		);
+	}
+
+
+    private function set_up_third_party_block() {
+		switch_theme( 'block-theme' );
+
+		$name     = 'my/third-party-block';
+		$settings = array(
+			'icon'            => 'text',
+			'category'        => 'common',
+			'render_callback' => 'foo',
+		);
+		register_block_type( $name, $settings );
+
+		$this->test_blocks[] = $name;
+	}
+
+    private function get_global_styles_blocks() {
+        $actual = wp_styles()->get_data( 'global-styles-blocks', 'after' );
+        return is_array( $actual ) ? $actual : array();
+    }
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60280

Not sure if this is the best approach so would appreciate feedback on that! I'm seeing some weirdness in the editor where the theme heading font family is overriding the default editor one, which is a bit unexpected:

<img width="281" alt="Screenshot 2024-01-18 at 4 47 53 pm" src="https://github.com/WordPress/wordpress-develop/assets/8096000/e9c548b4-c4cd-4035-8d00-a7b4b995d3ec">


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
