### PR TITLE
HTML API: Add HR tag handling

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -950,6 +950,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					$this->close_a_p_element();
 				}
 				$this->insert_html_element( $this->state->current_token );
+				$this->state->stack_of_open_elements->pop();
 				$this->state->frameset_ok = false;
 				return true;
 		}

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -950,7 +950,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					$this->close_a_p_element();
 				}
 				$this->insert_html_element( $this->state->current_token );
-				$this->state->stack_of_open_elements->pop();
 				$this->state->frameset_ok = false;
 				return true;
 		}

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -941,6 +941,17 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				$this->reconstruct_active_formatting_elements();
 				$this->insert_html_element( $this->state->current_token );
 				return true;
+
+			/*
+			 * > A start tag whose tag name is "hr"
+			 */
+			case '+HR':
+				if ( $this->state->stack_of_open_elements->has_p_in_button_scope() ) {
+					$this->close_a_p_element();
+				}
+				$this->insert_html_element( $this->state->current_token );
+				$this->state->frameset_ok = false;
+				return true;
 		}
 
 		/*
@@ -977,7 +988,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case 'FRAME':
 			case 'FRAMESET':
 			case 'HEAD':
-			case 'HR':
 			case 'HTML':
 			case 'IFRAME':
 			case 'INPUT':

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -109,7 +109,7 @@
  *  - Media elements: AUDIO, CANVAS, FIGCAPTION, FIGURE, IMG, MAP, PICTURE, VIDEO.
  *  - Paragraph: P.
  *  - Phrasing elements: ABBR, BDI, BDO, CITE, DATA, DEL, DFN, INS, MARK, OUTPUT, Q, SAMP, SUB, SUP, TIME, VAR.
- *  - Sectioning elements: ARTICLE, ASIDE, NAV, SECTION.
+ *  - Sectioning elements: ARTICLE, ASIDE, HR, NAV, SECTION.
  *  - Templating elements: SLOT.
  *  - Text decoration: RUBY.
  *  - Deprecated elements: ACRONYM, BLINK, CENTER, DIR, ISINDEX, MULTICOL, NEXTID, SPACER.

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor.php
@@ -173,7 +173,6 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 			'FRAME'     => array( 'FRAME' ),
 			'FRAMESET'  => array( 'FRAMESET' ),
 			'HEAD'      => array( 'HEAD' ),
-			'HR'        => array( 'HR' ),
 			'HTML'      => array( 'HTML' ),
 			'IFRAME'    => array( 'IFRAME' ),
 			'INPUT'     => array( 'INPUT' ),

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
@@ -175,7 +175,6 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 			'FRAME',
 			'FRAMESET',
 			'HEAD',
-			'HR',
 			'HTML',
 			'IFRAME',
 			'INPUT',

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRules.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRules.php
@@ -229,7 +229,7 @@ class Tests_HtmlApi_WpHtmlProcessorSemanticRules extends WP_UnitTestCase {
 	 *
 	 * @ticket 60283
 	 */
-	public function test_in_body_hr_element_closes_open_p_tag( $tag_name ) {
+	public function test_in_body_hr_element_closes_open_p_tag() {
 		$processor = WP_HTML_Processor::create_fragment( '<p><hr>' );
 
 		$processor->next_tag( 'HR' );

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRules.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRules.php
@@ -225,6 +225,22 @@ class Tests_HtmlApi_WpHtmlProcessorSemanticRules extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Verifies that HR closes an open p tag
+	 *
+	 * @ticket 60283
+	 */
+	public function test_in_body_hr_element_closes_open_p_tag( $tag_name ) {
+		$processor = WP_HTML_Processor::create_fragment( "<p><hr>" );
+
+		$processor->next_tag( 'HR' );
+		$this->assertSame(
+			array( 'HTML', 'BODY', 'HR' ),
+			$processor->get_breadcrumbs(),
+			"Expected HR to be a direct child of the BODY, having closed the open P element."
+		);
+	}
+
+	/**
 	 * Verifies that H1 through H6 elements close an open P element.
 	 *
 	 * @ticket 60215

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRules.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRules.php
@@ -230,13 +230,13 @@ class Tests_HtmlApi_WpHtmlProcessorSemanticRules extends WP_UnitTestCase {
 	 * @ticket 60283
 	 */
 	public function test_in_body_hr_element_closes_open_p_tag( $tag_name ) {
-		$processor = WP_HTML_Processor::create_fragment( "<p><hr>" );
+		$processor = WP_HTML_Processor::create_fragment( '<p><hr>' );
 
 		$processor->next_tag( 'HR' );
 		$this->assertSame(
 			array( 'HTML', 'BODY', 'HR' ),
 			$processor->get_breadcrumbs(),
-			"Expected HR to be a direct child of the BODY, having closed the open P element."
+			'Expected HR to be a direct child of the BODY, having closed the open P element.'
 		);
 	}
 


### PR DESCRIPTION
Implement HR tag handling

> A start tag whose tag name is "hr"
> If the [stack of open elements](https://html.spec.whatwg.org/multipage/parsing.html#stack-of-open-elements) [has a p element in button scope](https://html.spec.whatwg.org/multipage/parsing.html#has-an-element-in-button-scope), then [close a p element](https://html.spec.whatwg.org/multipage/parsing.html#close-a-p-element).
> 
> [Insert an HTML element](https://html.spec.whatwg.org/multipage/parsing.html#insert-an-html-element) for the token. Immediately pop the [current node](https://html.spec.whatwg.org/multipage/parsing.html#current-node) off the [stack of open elements](https://html.spec.whatwg.org/multipage/parsing.html#stack-of-open-elements).
> 
> [Acknowledge the token's self-closing flag](https://html.spec.whatwg.org/multipage/parsing.html#acknowledge-self-closing-flag), if it is set.
> 
> Set the [frameset-ok flag](https://html.spec.whatwg.org/multipage/parsing.html#frameset-ok-flag) to "not ok".

Trac ticket: https://core.trac.wordpress.org/ticket/60283

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
