### PR TITLE
HTML API: Fix P end tag may not adding P element

### DIFF
--- a/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRules.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRules.php
@@ -225,6 +225,18 @@ class Tests_HtmlApi_WpHtmlProcessorSemanticRules extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures that a P end tag with no open P element adds a P element.
+	 *
+	 * @ticket @todo
+	 */
+	public function test_p_end_tag_without_p_element_adds_p_element() {
+		$p = WP_HTML_Processor::create_fragment( '</p>' );
+		$this->assertTrue( $p->next_tag(), 'Failed to find a P tag.' );
+		$this->assertSame( 'P', $p->get_tag(), 'Failed to find expected P tag name.' );
+		$this->assertFalse( $p->is_tag_closer(), 'We should find a P tag opener.' );
+	}
+
+	/**
 	 * Verifies that H1 through H6 elements close an open P element.
 	 *
 	 * @ticket 60215


### PR DESCRIPTION
WIP: Currently this only adds a failing test.

Trac ticket: https://core.trac.wordpress.org/ticket/60287

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
