### PR TITLE
Fix unstable query test

### DIFF
--- a/tests/phpunit/tests/query/results.php
+++ b/tests/phpunit/tests/query/results.php
@@ -156,7 +156,7 @@ class Tests_Query_Results extends WP_UnitTestCase {
 		self::$post_ids[] = $factory->post->create(
 			array(
 				'post_title' => 'no-comments',
-				'post_date'  => '2009-10-01 00:00:00',
+				'post_date'  => '2009-10-15 00:00:00',
 			)
 		);
 		self::$post_ids[] = $factory->post->create(


### PR DESCRIPTION
This PR ensures the post dates are distinct, to avoid randomness in the results order.

With this, the `many-trackbacks` and `no-comments` test posts no longer use the same date.

Trac ticket: https://core.trac.wordpress.org/ticket/60288

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
