### PR TITLE
Layout: backport fix to ensure blocks without layout support do not receive layout classnames

### DIFF
--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -615,6 +615,9 @@ function wp_render_layout_support_flag( $block_content, $block ) {
 			$processor->add_class( $class_name );
 		}
 		return $processor->get_updated_html();
+	} elseif ( ! $block_supports_layout ) {
+		// Ensure layout classnames are not injected if there is no layout support.
+		return $block_content;
 	}
 
 	$global_settings = wp_get_global_settings();

--- a/tests/phpunit/tests/block-supports/layout.php
+++ b/tests/phpunit/tests/block-supports/layout.php
@@ -171,6 +171,7 @@ class Test_Block_Supports_Layout extends WP_UnitTestCase {
 	/**
 	 * @ticket 57584
 	 * @ticket 58548
+	 * @ticket 60292
 	 *
 	 * @dataProvider data_layout_support_flag_renders_classnames_on_wrapper
 	 *
@@ -258,8 +259,8 @@ class Test_Block_Supports_Layout extends WP_UnitTestCase {
 						'attrs'        => array(
 							'style' => array(
 								'layout' => array(
-									'selfStretch' => 'fit'
-								)
+									'selfStretch' => 'fit',
+								),
 							),
 						),
 						'innerBlocks'  => array(),
@@ -268,7 +269,7 @@ class Test_Block_Supports_Layout extends WP_UnitTestCase {
 					),
 				),
 				'expected_output' => '<p>A paragraph</p>',
-			)
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/block-supports/layout.php
+++ b/tests/phpunit/tests/block-supports/layout.php
@@ -250,6 +250,25 @@ class Test_Block_Supports_Layout extends WP_UnitTestCase {
 				),
 				'expected_output' => '<div class="wp-block-group"><div class="wp-block-group__inner-wrapper is-layout-flow wp-block-group-is-layout-flow"></div></div>',
 			),
+			'skip classname output if block does not support layout and there are no child layout classes to be output' => array(
+				'args'            => array(
+					'block_content' => '<p>A paragraph</p>',
+					'block'         => array(
+						'blockName'    => 'core/paragraph',
+						'attrs'        => array(
+							'style' => array(
+								'layout' => array(
+									'selfStretch' => 'fit'
+								)
+							),
+						),
+						'innerBlocks'  => array(),
+						'innerHTML'    => '<p>A paragraph</p>',
+						'innerContent' => array( '<p>A paragraph</p>' ),
+					),
+				),
+				'expected_output' => '<p>A paragraph</p>',
+			)
 		);
 	}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Backport changes from the Gutenberg plugin in: https://github.com/WordPress/gutenberg/pull/56187

Prevent layout classnames from being output on blocks where there is no layout support _and_ child layout classnames are not being output. An example is a paragraph that is a child of a group block, and that has `selfStretch` set to `fit`. In this case, no layout classnames should be added to the paragraph block, but prior to https://github.com/WordPress/gutenberg/pull/56187 they were being added unexpectedly.

This PR also adds a test to cover the fix. For further context and sample test markup, see the PR description of https://github.com/WordPress/gutenberg/pull/56187

Trac ticket: https://core.trac.wordpress.org/ticket/60292

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
