### PR TITLE
HTML API: Add PLAINTEXT tag handling

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -863,6 +863,19 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				return true;
 
 			/*
+			 * > A start tag whose tag name is "plaintext"
+			 */
+			case '+PLAINTEXT':
+				if ( ! $this->state->stack_of_open_elements->has_p_in_button_scope() ) {
+					$this->close_a_p_element();
+				}
+
+				$this->insert_html_element( $this->state->current_token );
+				$this->state->insertion_mode;
+				return true;
+
+
+			/*
 			 * > An end tag whose tag name is "p"
 			 */
 			case '-P':
@@ -997,7 +1010,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case 'OPTGROUP':
 			case 'OPTION':
 			case 'PARAM':
-			case 'PLAINTEXT':
 			case 'PRE':
 			case 'RB':
 			case 'RP':

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor.php
@@ -191,7 +191,6 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 			'OPTGROUP'  => array( 'OPTGROUP' ),
 			'OPTION'    => array( 'OPTION' ),
 			'PARAM'     => array( 'PARAM' ),
-			'PLAINTEXT' => array( 'PLAINTEXT' ),
 			'PRE'       => array( 'PRE' ),
 			'RB'        => array( 'RB' ),
 			'RP'        => array( 'RP' ),


### PR DESCRIPTION
> A start tag whose tag name is "plaintext"
> If the [stack of open elements](https://html.spec.whatwg.org/multipage/parsing.html#stack-of-open-elements) [has a p element in button scope](https://html.spec.whatwg.org/multipage/parsing.html#has-an-element-in-button-scope), then [close a p element](https://html.spec.whatwg.org/multipage/parsing.html#close-a-p-element).
> 
> [Insert an HTML element](https://html.spec.whatwg.org/multipage/parsing.html#insert-an-html-element) for the token.
> 
> Switch the tokenizer to the [PLAINTEXT state](https://html.spec.whatwg.org/multipage/parsing.html#plaintext-state).

Once a start tag with the tag name "plaintext" has been seen, that will be the last token ever seen other than character tokens (and the end-of-file token), because there is no way to switch out of the [PLAINTEXT state](https://html.spec.whatwg.org/multipage/parsing.html#plaintext-state).

I started work on `<plaintext>` tags, but they don't make much sense until we can support text nodes (https://github.com/WordPress/wordpress-develop/pull/5683). Pausing this work for now.

Trac ticket: https://core.trac.wordpress.org/ticket/60283

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
