### PR TITLE
HTML API: Cleanup tests and list of void elements.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1002,7 +1002,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		 */
 		switch ( $tag_name ) {
 			case 'APPLET':
-			case 'AREA':
 			case 'BASE':
 			case 'BASEFONT':
 			case 'BGSOUND':
@@ -1010,8 +1009,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case 'CAPTION':
 			case 'COL':
 			case 'COLGROUP':
-			case 'DD':
-			case 'DT':
 			case 'FORM':
 			case 'FRAME':
 			case 'FRAMESET':
@@ -1019,7 +1016,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case 'HTML':
 			case 'IFRAME':
 			case 'INPUT':
-			case 'LI':
 			case 'LINK':
 			case 'MARQUEE':
 			case 'MATH':
@@ -1029,7 +1025,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case 'NOFRAMES':
 			case 'NOSCRIPT':
 			case 'OBJECT':
-			case 'OL':
 			case 'OPTGROUP':
 			case 'OPTION':
 			case 'PARAM':
@@ -1055,7 +1050,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case 'TITLE':
 			case 'TR':
 			case 'TRACK':
-			case 'UL':
 			case 'XMP':
 				$this->last_error = self::ERROR_UNSUPPORTED;
 				throw new WP_HTML_Unsupported_Exception( "Cannot process {$tag_name} element." );
@@ -1709,15 +1703,19 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		return (
 			'AREA' === $tag_name ||
 			'BASE' === $tag_name ||
+			'BASEFONT' === $tag_name || // Obsolete but still treated as void.
+			'BGSOUND' === $tag_name || // Obsolete but still treated as void.
 			'BR' === $tag_name ||
 			'COL' === $tag_name ||
 			'EMBED' === $tag_name ||
+			'FRAME' === $tag_name ||
 			'HR' === $tag_name ||
 			'IMG' === $tag_name ||
 			'INPUT' === $tag_name ||
 			'LINK' === $tag_name ||
 			'KEYGEN' === $tag_name || // Obsolete but still treated as void.
 			'META' === $tag_name ||
+			'PARAM' === $tag_name || // Obsolete but still treated as void.
 			'SOURCE' === $tag_name ||
 			'TRACK' === $tag_name ||
 			'WBR' === $tag_name

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
@@ -40,6 +40,7 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 			'ABBR',
 			'ACRONYM', // Neutralized.
 			'ADDRESS',
+			'AREA',
 			'ARTICLE',
 			'ASIDE',
 			'AUDIO',
@@ -48,6 +49,7 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 			'BDO',
 			'BIG',
 			'BLINK', // Deprecated.
+			'BR',
 			'BUTTON',
 			'CANVAS',
 			'CENTER', // Neutralized.
@@ -65,6 +67,7 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 			'DL',
 			'DT',
 			'EM',
+			'EMBED',
 			'FIELDSET',
 			'FIGCAPTION',
 			'FIGURE',
@@ -78,22 +81,25 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 			'H6',
 			'HEADER',
 			'HGROUP',
+			'HR',
 			'I',
 			'IMG',
 			'INS',
 			'LI',
-			'ISINDEX', // Deprecated
+			'ISINDEX', // Deprecated.
 			'KBD',
+			'KEYGEN', // Deprecated.
 			'LABEL',
 			'LEGEND',
+			'LISTING', // Deprecated.
 			'MAIN',
 			'MAP',
 			'MARK',
 			'MENU',
 			'METER',
-			'MULTICOL', // Deprecated
+			'MULTICOL', // Deprecated.
 			'NAV',
-			'NEXTID', // Deprecated
+			'NEXTID', // Deprecated.
 			'OL',
 			'OUTPUT',
 			'P',
@@ -106,7 +112,7 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 			'SECTION',
 			'SLOT',
 			'SMALL',
-			'SPACER', // Deprecated
+			'SPACER', // Deprecated.
 			'SPAN',
 			'STRIKE',
 			'STRONG',


### PR DESCRIPTION
Trac ticket: Core-60307

This patch adds newly supported elements to tests that should have been updated in recent PRs, but which were merged without that. Those PRs removed failing tests showing that the elements were unsupported, but did not add the elements to the list of supported ones.

It also removes some elements from the special-exclusion list of unsupported IN BODY elements. These did not present in failing tests because earlier conditions in the switch structure caught the tags before hitting the default block.

Finally it adds some missing elements to the list of void elements. These elements are not listed as void in the HTML specification because they are deprecated. However, they are treated as void for the sake of HTML serialization and the parsing rules indicate that they behave as void elements, so it's safe to list them within the HTML API as void.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
