### PR TITLE
[Draft] Fix - Indirect modification of overloaded property WP_Block_Type::$variations has no effect

### DIFF
--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -334,9 +334,10 @@ class WP_Block_Type {
 	 * @return string|string[]|null|void The value read from the new property if the first item in the array provided,
 	 *                                   null when value not found, or void when unknown property name provided.
 	 */
-	public function __get( $name ) {
+	public function &__get( $name ) {
 		if ( 'variations' === $name ) {
-			return $this->get_variations();
+			$this->variations = $this->get_variations();
+			return $this->variations;
 		}
 
 		if ( ! in_array( $name, $this->deprecated_properties, true ) ) {

--- a/tests/phpunit/tests/blocks/wpBlockType.php
+++ b/tests/phpunit/tests/blocks/wpBlockType.php
@@ -642,6 +642,20 @@ class Tests_Blocks_wpBlockType extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 60309
+	 */
+	public function test_can_access_original_varations_variable() {
+		$block_type               = new WP_Block_Type(
+			'test/block',
+			array(
+				'title' => 'Test title',
+			)
+		);
+		$block_type->variations[] = array( 'name' => 'var1' );
+		$this->assertSameSets( array( array( 'name' => 'var1' ) ), $block_type->variations );
+	}
+
+	/**
 	 * Mock variation callback.
 	 *
 	 * @return array


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: [https://core.trac.wordpress.org/ticket/59969](https://core.trac.wordpress.org/ticket/59969)


This ticket addresses  - https://core.trac.wordpress.org/ticket/59969#comment:63

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
