### PR TITLE
Build Tools: Add the correct prettier config to WordPress

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,3 @@
+// Import the default config file and expose it in the project root.
+// Useful for editor integrations.
+module.exports = require( '@wordpress/prettier-config' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,6 +112,7 @@
 				"@wordpress/dependency-extraction-webpack-plugin": "4.25.13",
 				"@wordpress/e2e-test-utils": "10.13.13",
 				"@wordpress/e2e-test-utils-playwright": "0.10.13",
+				"@wordpress/prettier-config": "2.25.13",
 				"@wordpress/scripts": "26.13.13",
 				"autoprefixer": "10.4.16",
 				"chalk": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"@wordpress/dependency-extraction-webpack-plugin": "4.25.13",
 		"@wordpress/e2e-test-utils": "10.13.13",
 		"@wordpress/e2e-test-utils-playwright": "0.10.13",
+		"@wordpress/prettier-config": "2.25.13",
 		"@wordpress/scripts": "26.13.13",
 		"autoprefixer": "10.4.16",
 		"chalk": "5.3.0",


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/60316

The config has just been copied from Gutenberg Repo.

**Testing instructions**

 - Open VSCore and have the prettier extension installed
 - Open any js file (like webpack.config.js)
 - Format the file
 - Prettier should use the right prettier config

