### PR TITLE
Add tests for wp_spaces_regexp function

### DIFF
--- a/tests/phpunit/tests/formatting/wpSpacesRegexp.php
+++ b/tests/phpunit/tests/formatting/wpSpacesRegexp.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Tests for the wp_spaces_regexp function.
+ *
+ * @group formatting
+ *
+ * @covers ::wp_spaces_regexp
+ */
+class Tests_formatting_wpSpacesRegexp extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 60319
+	 */
+	public function test_wp_spaces_regexp() {
+		$filter = new MockAction();
+		add_filter( 'wp_spaces_regexp', array( $filter, 'filter' ) );
+
+		$this->assertSame( '[\r\n\t ]|\xC2\xA0|&nbsp;', wp_spaces_regexp() );
+		// filter not call as this is set up in the init call for site
+		$this->assertSame( 0, $filter->get_call_count(), '1st call' );
+	}
+}


### PR DESCRIPTION
A new PHPUnit test file is added to check the functionality of the wp_spaces_regexp function in a WordPress application. These tests verify the return value of the function with given input and confirm the filter instantiation calls.

Trac ticket: https://core.trac.wordpress.org/ticket/60319