### PR TITLE
Only emit CDATA wrappers for inline scripts for JavaScript

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2879,7 +2879,17 @@ function wp_get_inline_script_tag( $javascript, $attributes = array() ) {
 	 *
 	 * @see https://www.w3.org/TR/xhtml1/#h-4.8
 	 */
-	if ( ! $is_html5 ) {
+	if (
+		! $is_html5 &&
+		(
+			! isset( $attributes['type'] ) ||
+			'module' === $attributes['type'] ||
+			str_contains( $attributes['type'], 'javascript' ) ||
+			str_contains( $attributes['type'], 'ecmascript' ) ||
+			str_contains( $attributes['type'], 'jscript' ) ||
+			str_contains( $attributes['type'], 'livescript' )
+		)
+	) {
 		/*
 		 * If the string `]]>` exists within the JavaScript it would break
 		 * out of any wrapping CDATA section added here, so to start, it's

--- a/tests/phpunit/tests/dependencies/wpInlineScriptTag.php
+++ b/tests/phpunit/tests/dependencies/wpInlineScriptTag.php
@@ -10,6 +10,20 @@
  */
 class Tests_Functions_wpInlineScriptTag extends WP_UnitTestCase {
 
+	private $original_theme_features = array();
+
+	public function set_up() {
+		global $_wp_theme_features;
+		parent::set_up();
+		$this->original_theme_features = $_wp_theme_features;
+	}
+
+	public function tear_down() {
+		global $_wp_theme_features;
+		$_wp_theme_features = $this->original_theme_features;
+		parent::tear_down();
+	}
+
 	private $event_handler = <<<'JS'
 document.addEventListener( 'DOMContentLoaded', function () {
 	document.getElementById( 'elementID' )

--- a/tests/phpunit/tests/dependencies/wpInlineScriptTag.php
+++ b/tests/phpunit/tests/dependencies/wpInlineScriptTag.php
@@ -133,4 +133,59 @@ JS;
 			wp_get_inline_script_tag( "/* <![CDATA[ */ console.log( 'Hello World!' ); /* ]]> */" )
 		);
 	}
+
+	public function data_provider_to_test_cdata_wrapper_omitted_for_non_javascript_scripts() {
+		return array(
+			'no-type'  => array(
+				'type'           => null,
+				'data'           => 'alert("hello")',
+				'expected_cdata' => true,
+			),
+			'js-type'  => array(
+				'type'           => 'text/javascript',
+				'data'           => 'alert("hello")',
+				'expected_cdata' => true,
+			),
+			'js-alt-type'  => array(
+				'type'           => 'application/javascript',
+				'data'           => 'alert("hello")',
+				'expected_cdata' => true,
+			),
+			'module'  => array(
+				'type'           => 'module',
+				'data'           => 'alert("hello")',
+				'expected_cdata' => true,
+			),
+			'impotmap' => array(
+				'type'           => 'importmap',
+				'data'           => 'alert("hello")',
+				'expected_cdata' => false,
+			),
+			'html'     => array(
+				'type'           => 'text/html',
+				'data'           => '<div>template code</div>',
+				'expected_cdata' => false,
+			),
+		);
+	}
+
+	/**
+	 * Tests that CDATA wrapper is not added for non-JavaScript scripts.
+	 *
+	 * @ticket 60320
+	 *
+	 * @dataProvider data_provider_to_test_cdata_wrapper_omitted_for_non_javascript_scripts
+	 */
+	public function test_cdata_wrapper_omitted_for_non_javascript_scripts( $type, $data, $expected_cdata ) {
+		remove_theme_support( 'html5' );
+
+		$attrs = array();
+		if ( $type ) {
+			$attrs['type'] = $type;
+		}
+		$script = wp_get_inline_script_tag( $data, $attrs );
+		$this->assertSame( $expected_cdata, str_contains( $script, '/* <![CDATA[ */' ) );
+		$this->assertSame( $expected_cdata, str_contains( $script, '/* ]]> */' ) );
+		$this->assertStringContainsString( $data, $script );
+	}
 }

--- a/tests/phpunit/tests/dependencies/wpInlineScriptTag.php
+++ b/tests/phpunit/tests/dependencies/wpInlineScriptTag.php
@@ -156,14 +156,29 @@ JS;
 				'data'           => 'alert("hello")',
 				'expected_cdata' => true,
 			),
-			'impotmap'    => array(
+			'importmap'   => array(
 				'type'           => 'importmap',
-				'data'           => 'alert("hello")',
+				'data'           => '{"imports":{"bar":"http:\/\/localhost:10023\/bar.js?ver=6.5-alpha-57321"}}',
 				'expected_cdata' => false,
 			),
 			'html'        => array(
 				'type'           => 'text/html',
 				'data'           => '<div>template code</div>',
+				'expected_cdata' => false,
+			),
+			'json'        => array(
+				'type'           => 'application/json',
+				'data'           => '{}',
+				'expected_cdata' => false,
+			),
+			'ld'          => array(
+				'type'           => 'application/ld+json',
+				'data'           => '{}',
+				'expected_cdata' => false,
+			),
+			'specrules'   => array(
+				'type'           => 'speculationrules',
+				'data'           => '{}',
 				'expected_cdata' => false,
 			),
 		);

--- a/tests/phpunit/tests/dependencies/wpInlineScriptTag.php
+++ b/tests/phpunit/tests/dependencies/wpInlineScriptTag.php
@@ -136,32 +136,32 @@ JS;
 
 	public function data_provider_to_test_cdata_wrapper_omitted_for_non_javascript_scripts() {
 		return array(
-			'no-type'  => array(
+			'no-type'     => array(
 				'type'           => null,
 				'data'           => 'alert("hello")',
 				'expected_cdata' => true,
 			),
-			'js-type'  => array(
+			'js-type'     => array(
 				'type'           => 'text/javascript',
 				'data'           => 'alert("hello")',
 				'expected_cdata' => true,
 			),
-			'js-alt-type'  => array(
+			'js-alt-type' => array(
 				'type'           => 'application/javascript',
 				'data'           => 'alert("hello")',
 				'expected_cdata' => true,
 			),
-			'module'  => array(
+			'module'      => array(
 				'type'           => 'module',
 				'data'           => 'alert("hello")',
 				'expected_cdata' => true,
 			),
-			'impotmap' => array(
+			'impotmap'    => array(
 				'type'           => 'importmap',
 				'data'           => 'alert("hello")',
 				'expected_cdata' => false,
 			),
-			'html'     => array(
+			'html'        => array(
 				'type'           => 'text/html',
 				'data'           => '<div>template code</div>',
 				'expected_cdata' => false,


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60320

# Commit message

Script Loader: Only emit CDATA wrapper comments in `wp_get_inline_script_tag()` for JavaScript.

This avoids erroneously adding CDATA wrapper comments for non-JavaScript scripts, including those for JSON such as the `importmap` for script modules in #56313.

Props westonruter, flixos90, mukesh27, dmsnell.
Fixes #60320.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
