### PR TITLE
Editor: Fix back to items label case

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -235,7 +235,7 @@ function create_initial_taxonomies() {
 				'singular_name'              => _x( 'Pattern Category', 'taxonomy singular name' ),
 				'add_new_item'               => __( 'Add New Category' ),
 				'add_or_remove_items'        => __( 'Add or remove pattern categories' ),
-				'back_to_items'              => __( '&larr; Go to pattern categories' ),
+				'back_to_items'              => __( '&larr; Go to Pattern Categories' ),
 				'choose_from_most_used'      => __( 'Choose from the most used pattern categories' ),
 				'edit_item'                  => __( 'Edit Pattern Category' ),
 				'item_link'                  => __( 'Pattern Category Link' ),


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/60322

Follow-up to #5929 

Addresses this comment https://github.com/WordPress/wordpress-develop/pull/5929#discussion_r1462997045 

This uses the same capitalization that we're using for other taxonomies.