### PR TITLE
Script Modules API: Move the script modules to the footer in classic themes

### DIFF
--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -164,8 +164,8 @@ class WP_Script_Modules {
 	public function add_hooks() {
 		$position = wp_is_block_theme() ? 'wp_head' : 'wp_footer';
 		add_action( $position, array( $this, 'print_import_map' ) );
-		add_action( $position, array( $this, 'print_enqueued_modules' ) );
-		add_action( $position, array( $this, 'print_module_preloads' ) );
+		add_action( $position, array( $this, 'print_enqueued_script_modules' ) );
+		add_action( $position, array( $this, 'print_script_module_preloads' ) );
 	}
 
 	/**

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -89,15 +89,12 @@ class WP_Script_Modules {
 				'version'      => $version,
 				'enqueue'      => isset( $this->enqueued_before_registered[ $id ] ),
 				'dependencies' => $dependencies,
-				'enqueued'     => false,
-				'preloaded'    => false,
 			);
 		}
 	}
 
 	/**
-	 * Marks the script module to be enqueued in the page the next time
-	 * `print_enqueued_script_modules` is called.
+	 * Marks the script module to be enqueued in the page.
 	 *
 	 * If a src is provided and the script module has not been registered yet, it
 	 * will be registered.
@@ -158,54 +155,34 @@ class WP_Script_Modules {
 	 * Adds the hooks to print the import map, enqueued script modules and script
 	 * module preloads.
 	 *
-	 * It adds the actions to print the enqueued script modules and script module
-	 * preloads to both `wp_head` and `wp_footer` because in classic themes, the
-	 * script modules used by the theme and plugins will likely be able to be
-	 * printed in the `head`, but the ones used by the blocks will need to be
-	 * enqueued in the `footer`.
-	 *
-	 * As all script modules are deferred and dependencies are handled by the
-	 * browser, the order of the script modules is not important, but it's still
-	 * better to print the ones that are available when the `wp_head` is rendered,
-	 * so the browser starts downloading those as soon as possible.
-	 *
-	 * The import map is also printed in the footer to be able to include the
-	 * dependencies of all the script modules, including the ones printed in the
+	 * In classic themes, the script modules used by the blocks are not yet known
+	 * when the `wp_head` actions is fired, so it needs to print everything in the
 	 * footer.
 	 *
 	 * @since 6.5.0
 	 */
 	public function add_hooks() {
-		add_action( 'wp_head', array( $this, 'print_enqueued_script_modules' ) );
-		add_action( 'wp_head', array( $this, 'print_script_module_preloads' ) );
-		add_action( 'wp_footer', array( $this, 'print_enqueued_script_modules' ) );
-		add_action( 'wp_footer', array( $this, 'print_script_module_preloads' ) );
-		add_action( 'wp_footer', array( $this, 'print_import_map' ) );
+		$position = wp_is_block_theme() ? 'wp_head' : 'wp_footer';
+		add_action( $position, array( $this, 'print_import_map' ) );
+		add_action( $position, array( $this, 'print_enqueued_modules' ) );
+		add_action( $position, array( $this, 'print_module_preloads' ) );
 	}
 
 	/**
 	 * Prints the enqueued script modules using script tags with type="module"
 	 * attributes.
 	 *
-	 * If a enqueued script module has already been printed, it will not be
-	 * printed again on subsequent calls to this function.
-	 *
 	 * @since 6.5.0
 	 */
 	public function print_enqueued_script_modules() {
 		foreach ( $this->get_marked_for_enqueue() as $id => $script_module ) {
-			if ( false === $script_module['enqueued'] ) {
-				// Mark it as enqueued so it doesn't get enqueued again.
-				$this->registered[ $id ]['enqueued'] = true;
-
-				wp_print_script_tag(
-					array(
-						'type' => 'module',
-						'src'  => $this->get_versioned_src( $script_module ),
-						'id'   => $id . '-js-module',
-					)
-				);
-			}
+			wp_print_script_tag(
+				array(
+					'type' => 'module',
+					'src'  => $this->get_versioned_src( $script_module ),
+					'id'   => $id . '-js-module',
+				)
+			);
 		}
 	}
 
@@ -213,19 +190,14 @@ class WP_Script_Modules {
 	 * Prints the the static dependencies of the enqueued script modules using
 	 * link tags with rel="modulepreload" attributes.
 	 *
-	 * If a script module is marked for enqueue, it will not be preloaded. If a
-	 * preloaded script module has already been printed, it will not be printed
-	 * again on subsequent calls to this function.
+	 * If a script module is marked for enqueue, it will not be preloaded.
 	 *
 	 * @since 6.5.0
 	 */
 	public function print_script_module_preloads() {
 		foreach ( $this->get_dependencies( array_keys( $this->get_marked_for_enqueue() ), array( 'static' ) ) as $id => $script_module ) {
-			// Don't preload if it's marked for enqueue or has already been preloaded.
-			if ( true !== $script_module['enqueue'] && false === $script_module['preloaded'] ) {
-				// Mark it as preloaded so it doesn't get preloaded again.
-				$this->registered[ $id ]['preloaded'] = true;
-
+			// Don't preload if it's marked for enqueue.
+			if ( true !== $script_module['enqueue'] ) {
 				echo sprintf(
 					'<link rel="modulepreload" href="%s" id="%s">',
 					esc_url( $this->get_versioned_src( $script_module ) ),

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -517,68 +517,6 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that it can print the enqueued script modules multiple times, and it
-	 * will only print the script modules that have not been printed before.
-	 *
-	 * @ticket 56313
-	 *
-	 * @covers ::register()
-	 * @covers ::enqueue()
-	 * @covers ::print_enqueued_script_modules()
-	 */
-	public function test_print_enqueued_script_modules_can_be_called_multiple_times() {
-		$this->script_modules->register( 'foo', '/foo.js' );
-		$this->script_modules->register( 'bar', '/bar.js' );
-		$this->script_modules->enqueue( 'foo' );
-
-		$enqueued_script_modules = $this->get_enqueued_script_modules();
-		$this->assertCount( 1, $enqueued_script_modules );
-		$this->assertTrue( isset( $enqueued_script_modules['foo'] ) );
-
-		$this->script_modules->enqueue( 'bar' );
-
-		$enqueued_script_modules = $this->get_enqueued_script_modules();
-		$this->assertCount( 1, $enqueued_script_modules );
-		$this->assertTrue( isset( $enqueued_script_modules['bar'] ) );
-
-		$enqueued_script_modules = $this->get_enqueued_script_modules();
-		$this->assertCount( 0, $enqueued_script_modules );
-	}
-
-	/**
-	 * Tests that it can print the preloaded script modules multiple times, and it
-	 * will only print the script modules that have not been printed before.
-	 *
-	 * @ticket 56313
-	 *
-	 * @covers ::register()
-	 * @covers ::enqueue()
-	 * @covers ::print_script_module_preloads()
-	 */
-	public function test_print_preloaded_script_modules_can_be_called_multiple_times() {
-		$this->script_modules->register( 'foo', '/foo.js', array( 'static-dep-1', 'static-dep-2' ) );
-		$this->script_modules->register( 'bar', '/bar.js', array( 'static-dep-3' ) );
-		$this->script_modules->register( 'static-dep-1', '/static-dep-1.js' );
-		$this->script_modules->register( 'static-dep-3', '/static-dep-3.js' );
-		$this->script_modules->enqueue( 'foo' );
-
-		$preloaded_script_modules = $this->get_preloaded_script_modules();
-		$this->assertCount( 1, $preloaded_script_modules );
-		$this->assertTrue( isset( $preloaded_script_modules['static-dep-1'] ) );
-
-		$this->script_modules->register( 'static-dep-2', '/static-dep-2.js' );
-		$this->script_modules->enqueue( 'bar' );
-
-		$preloaded_script_modules = $this->get_preloaded_script_modules();
-		$this->assertCount( 2, $preloaded_script_modules );
-		$this->assertTrue( isset( $preloaded_script_modules['static-dep-2'] ) );
-		$this->assertTrue( isset( $preloaded_script_modules['static-dep-3'] ) );
-
-		$preloaded_script_modules = $this->get_preloaded_script_modules();
-		$this->assertCount( 0, $preloaded_script_modules );
-	}
-
-	/**
 	 * Tests that a script module is not registered when calling enqueue without a
 	 * valid src.
 	 *


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/60240

---

## What

Moves the script module prints to the footer in classic themes. It also removes the ability to call the print functions more than once because it's now unnecessary.

## Why

In the ticket that introduced the Script Modules API ([#56313](https://core.trac.wordpress.org/ticket/56313 "#56313: enhancement: Add the ability to handle ES Modules and Import Maps (reopened)")), I added a logic that prints as many enqueued and preloads as possible in the head, then prints the remaining ones in the footer and includes the import map. I explain my reasoning [​in this comment](https://github.com/WordPress/wordpress-develop/pull/5818#discussion_r1446384970).

But [@cbravobernal](https://profiles.wordpress.org/cbravobernal) realized that [import maps fail if they appear after the modules](https://github.com/WordPress/gutenberg/pull/57778#discussion_r1449482982). That means that there's no other way but printing the import map first, and then all the modules and preloads (yes, preloads also fail!). So we need to check if we are on a classic or block theme, and if we are in a classic theme, move everything to the footer.

## How

By leveraging `wp_is_block_theme()` and moving everything to the footer in classic themes:

```php
public function add_hooks() {
  $position = wp_is_block_theme() ? 'wp_head' : 'wp_footer';
  add_action( $position, array( $this, 'print_import_map' ) );
  add_action( $position, array( $this, 'print_enqueued_modules' ) );
  add_action( $position, array( $this, 'print_module_preloads' ) );
}
```

## Additional comments

@westonruter mentioned that we could optimize this in the future if we have a way to filter the output before sending the response to the client:

- https://github.com/WordPress/gutenberg/pull/57778#discussion_r1450806250

## Testing instructions

To check that this fixes the order of the import map:

1. Create a new plugin with three files:
   ```php
   // test-plugin/test.php
   <?php
   /*
   Plugin Name: Test Script Modules
   Version: 1.0.0
   */

   wp_register_script_module(
     'bar',
     plugins_url( '/bar.js', __FILE__ )
   );

   wp_enqueue_script_module(
     'foo',
     plugins_url( '/foo.js', __FILE__ ),
     array( 'bar' )
   );
   ```
   ```js
   // test-plugin/foo.js
   import bar from "bar";

   bar();
   ```
   ```js
   // test-plugin/bar.js
   export default function bar() {
     console.log("bar");
   }
   ```
2. Activate the plugin.
3. Open the site (frontend).
4. Check that `"bar"` was printed in the console.

To check that this fixes the positioning of the scripts/link in the classic themes:

1. Load a block theme.
2. Check that the scripts with `type="importmap"` and `type="module"`, and the link with `rel="modulepreload"` are printed in the head.
3. Load a classic theme.
4. Check that the scripts with `type="importmap"` and `type="module"`, and the link with `rel="modulepreload"` are printed in the footer.
