### PR TITLE
Fix deprecated parameter default value of unregister_setting() to be correct type

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2797,7 +2797,7 @@ function register_setting( $option_group, $option_name, $args = array() ) {
  * @param string   $option_name  The name of the option to unregister.
  * @param callable $deprecated   Optional. Deprecated.
  */
-function unregister_setting( $option_group, $option_name, $deprecated = '' ) {
+function unregister_setting( $option_group, $option_name, $deprecated = null ) {
 	global $new_allowed_options, $wp_registered_settings;
 
 	/*


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

> The parameter callable `$deprecated` cannot default to an empty string. It must either default to `null` or the type has to be changed to `callable|string`.

-- Reported by gerardreches via User Contributed Notes.

Trac ticket: https://core.trac.wordpress.org/ticket/60328

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
