### PR TITLE
Lazy Loading block-patterns - Trac 59532

### DIFF
--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -378,12 +378,10 @@ function _register_theme_block_patterns() {
 			}
 
 			// The actual pattern content is the output of the file.
-			ob_start();
-			include $file_path;
-			$pattern_data['content'] = ob_get_clean();
-			if ( ! $pattern_data['content'] ) {
+			if ( ! file_exists( $file_path ) ) {
 				continue;
 			}
+			$pattern_data['file_path'] = $file_path;
 
 			// Translate the pattern metadata.
 			// phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText,WordPress.WP.I18n.NonSingularStringLiteralDomain,WordPress.WP.I18n.LowLevelTranslationFunction

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -377,10 +377,6 @@ function _register_theme_block_patterns() {
 				continue;
 			}
 
-			// The actual pattern content is the output of the file.
-			if ( ! file_exists( $file_path ) ) {
-				continue;
-			}
 			$pattern_data['file_path'] = $file_path;
 
 			// Translate the pattern metadata.

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -223,6 +223,12 @@ final class WP_Block_Patterns_Registry {
 		$hooked_blocks = get_hooked_blocks();
 		foreach ( $patterns as $index => $pattern ) {
 			if ( ! isset( $pattern['name'] ) ) {
+				unset( $patterns[ $index ] );
+				if ( $outside_init_only ) {
+					unset( $this->registered_patterns_outside_init[ $index ] );
+				} else {
+					unset( $this->registered_patterns[ $index ] );
+				}
 				continue;
 			}
 			if ( ! isset( $pattern['content'] ) && isset( $pattern['file_path'] ) ) {

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -227,33 +227,26 @@ final class WP_Block_Patterns_Registry {
 	 *                 and per style.
 	 */
 	public function get_all_registered( $outside_init_only = false ) {
-		$patterns      = array_values(
-			$outside_init_only
+		$patterns      = $outside_init_only
 				? $this->registered_patterns_outside_init
-				: $this->registered_patterns
-		);
+				: $this->registered_patterns;
 		$hooked_blocks = get_hooked_blocks();
+
 		foreach ( $patterns as $index => $pattern ) {
-			if ( ! isset( $pattern['name'] ) ) {
-				unset( $patterns[ $index ] );
-				if ( $outside_init_only ) {
-					unset( $this->registered_patterns_outside_init[ $index ] );
-				} else {
-					unset( $this->registered_patterns[ $index ] );
-				}
-				continue;
-			}
 			if ( ! isset( $pattern['content'] ) && isset( $pattern['file_path'] ) ) {
 				$pattern['content'] = $this->load_content_from_file_path( $pattern['file_path'] );
 				if ( $outside_init_only ) {
 					$this->registered_patterns_outside_init[ $index ]['content'] = $pattern['content'];
+					unset( $this->registered_patterns_outside_init[ $index ]['file_path'] );
 				} else {
 					$this->registered_patterns[ $index ]['content'] = $pattern['content'];
+					unset( $this->registered_patterns[ $index ]['file_path'] );
 				}
 			}
 			$patterns[ $index ]['content'] = $this->prepare_content( $pattern, $hooked_blocks );
 		}
-		return $patterns;
+
+		return array_values( $patterns );
 	}
 
 	/**

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -222,6 +222,9 @@ final class WP_Block_Patterns_Registry {
 		);
 		$hooked_blocks = get_hooked_blocks();
 		foreach ( $patterns as $index => $pattern ) {
+			if ( ! isset( $pattern['name'] ) ) {
+				continue;
+			}
 			if ( ! isset( $pattern['content'] ) && isset( $pattern['file_path'] ) ) {
 				ob_start();
 				include $pattern['file_path'];

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -180,6 +180,20 @@ final class WP_Block_Patterns_Registry {
 	}
 
 	/**
+	 * Retrieves the content of a block pattern from a file path.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param string $file_path The file path to the block pattern.
+	 * @return string The content of the block pattern.
+	 */
+	private function load_content_from_file_path( $file_path ) {
+		ob_start();
+		include $file_path;
+		return ob_get_clean();
+	}
+
+	/**
 	 * Retrieves an array containing the properties of a registered block pattern.
 	 *
 	 * @since 5.5.0
@@ -194,9 +208,7 @@ final class WP_Block_Patterns_Registry {
 
 		$pattern = $this->registered_patterns[ $pattern_name ];
 		if ( ! isset( $pattern['content'] ) && isset( $pattern['file_path'] ) ) {
-			ob_start();
-			include $pattern['file_path'];
-			$pattern['content']                                    = ob_get_clean();
+			$pattern['content']                                    = $this->load_content_from_file_path( $pattern['file_path'] );
 			$this->registered_patterns[ $pattern_name ]['content'] = $pattern['content'];
 		}
 
@@ -232,9 +244,7 @@ final class WP_Block_Patterns_Registry {
 				continue;
 			}
 			if ( ! isset( $pattern['content'] ) && isset( $pattern['file_path'] ) ) {
-				ob_start();
-				include $pattern['file_path'];
-				$pattern['content'] = ob_get_clean();
+				$pattern['content'] = $this->load_content_from_file_path( $pattern['file_path'] );
 				if ( $outside_init_only ) {
 					$this->registered_patterns_outside_init[ $index ]['content'] = $pattern['content'];
 				} else {

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -184,8 +184,8 @@ final class WP_Block_Patterns_Registry {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param string $pattern_name     Block pattern name including namespace.
-	 * @param bool   $outside_init_only Return only patterns registered outside the `init` action.
+	 * @param string $pattern_name      Block pattern name including namespace.
+	 * @param bool   $outside_init_only Optional. Return only patterns registered outside the `init` action. Default false.
 	 * @return string The content of the block pattern.
 	 */
 	private function get_content( $pattern_name, $outside_init_only = false ) {

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -190,11 +190,11 @@ final class WP_Block_Patterns_Registry {
 			return null;
 		}
 
-		$pattern            = $this->registered_patterns[ $pattern_name ];
+		$pattern = $this->registered_patterns[ $pattern_name ];
 		if ( ! isset( $pattern['content'] ) && isset( $pattern['file_path'] ) ) {
 			ob_start();
 			include $pattern['file_path'];
-			$pattern['content'] = ob_get_clean();
+			$pattern['content']                                    = ob_get_clean();
 			$this->registered_patterns[ $pattern_name ]['content'] = $pattern['content'];
 		}
 
@@ -220,7 +220,7 @@ final class WP_Block_Patterns_Registry {
 		);
 		$hooked_blocks = get_hooked_blocks();
 		foreach ( $patterns as $index => $pattern ) {
-			if ( ! $pattern['content'] && isset( $pattern['file_path'] ) ) {
+			if ( ! isset( $pattern['content'] ) && isset( $pattern['file_path'] ) ) {
 				ob_start();
 				include $pattern['file_path'];
 				$pattern['content'] = ob_get_clean();

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -101,13 +101,15 @@ final class WP_Block_Patterns_Registry {
 			return false;
 		}
 
-		if ( ! isset( $pattern_properties['file_path'] ) && ( ! isset( $pattern_properties['content'] ) || ! is_string( $pattern_properties['content'] ) ) ) {
-			_doing_it_wrong(
-				__METHOD__,
-				__( 'Pattern content must be a string.' ),
-				'5.5.0'
-			);
-			return false;
+		if ( ! isset( $pattern_properties['file_path'] ) ) {
+			if ( ! isset( $pattern_properties['content'] ) || ! is_string( $pattern_properties['content'] ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'Pattern content must be a string.' ),
+					'5.5.0'
+				);
+				return false;
+			}
 		}
 
 		$pattern = array_merge(

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -182,7 +182,7 @@ final class WP_Block_Patterns_Registry {
 	/**
 	 * Retrieves the content of a registered block pattern.
 	 *
-	 * @since 5.5.0
+	 * @since 6.5.0
 	 *
 	 * @param string $pattern_name     Block pattern name including namespace.
 	 * @param bool   $outside_init_only Return only patterns registered outside the `init` action.

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -101,7 +101,7 @@ final class WP_Block_Patterns_Registry {
 			return false;
 		}
 
-		if ( ! isset( $pattern_properties['file_path'] ) || ! isset( $pattern_properties['content'] ) || ! is_string( $pattern_properties['content'] ) ) {
+		if ( ! isset( $pattern_properties['file_path'] ) && ( ! isset( $pattern_properties['content'] ) || ! is_string( $pattern_properties['content'] ) ) ) {
 			_doing_it_wrong(
 				__METHOD__,
 				__( 'Pattern content must be a string.' ),
@@ -191,7 +191,7 @@ final class WP_Block_Patterns_Registry {
 		}
 
 		$pattern            = $this->registered_patterns[ $pattern_name ];
-		if ( ! $pattern['content'] && isset( $pattern['file_path'] ) ) {
+		if ( ! isset( $pattern['content'] ) && isset( $pattern['file_path'] ) ) {
 			ob_start();
 			include $pattern['file_path'];
 			$pattern['content'] = ob_get_clean();


### PR DESCRIPTION
This is an enhancement to original PR  - https://github.com/WordPress/wordpress-develop/pull/5398, to adapt to the new changes in the trunk and fix some BC issues.

The idea is to load the pattern file's content only when the pattern is required. 

Trac ticket: https://core.trac.wordpress.org/ticket/59532


## Performance Improvement 

We do see an improvement of `~5 ms` for TT4. This improvement mainly comes from running `include $files_path` only when we need the content. In terms of lazy loading, I feel this is the best we can do for now as the function is optimised at the registration end and content parsing of blocks is already happening in a JIT fashion.  

One improvement we can make is caching the output of parsed content along with caching `$file_paths` modification time `stats( $file_path )['mtime']`. This might be a problem for a system using multiple copies of servers (like in Kubernetes), as each node will have a different file timestamp making it hard to cache. To avoid that we can use  `filesize` from stats instead with an assumption that any changes made to the file will change the file by at least a byte, which can be combined with the expiry time. 


| Metric                            | PR (mean) TT4 | Trunk (mean) TT4 |
|-----------------------------------|---------------|------------------|
| Response Time (median)            | 413.06        | 418.38           |
| wp-load-alloptions-query (median) | 3.05          | 3.065            |
| wp-before-template (median)       | 190.84        | 196.95           |



There is not much change observed for TT3.

| Metric                            | PR (mean) TT3 | Trunk (mean) TT3 |
|-----------------------------------|---------------|------------------|
| Response Time (median)            | 302.82        | 300.23           |
| wp-load-alloptions-query (median) | 3.02          | 2.99             |
| wp-before-template (median)       | 143.68        | 142.98           |



---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
