### PR TITLE
Script Modules API: Backport - Add import map polyfill

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1559,7 +1559,10 @@ module.exports = function(grunt) {
 	} );
 
 	/**
-	 * Build assertions for the lack of source maps in JavaScript files.
+	 * Compiled JavaScript files may link to sourcemaps. In some cases,
+	 * the source map may not be available, which can cause 404 errors when
+	 * browsers try to download the sourcemap from the referenced URLs.
+	 * Ensure that sourcemap links are not included in JavaScript files.
 	 *
 	 * @ticket 24994
 	 * @ticket 46218

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1567,10 +1567,6 @@ module.exports = function(grunt) {
 	grunt.registerTask( 'verify:source-maps', function() {
 		const ignoredFiles = [
 			'build/wp-includes/js/dist/components.js',
-			'build/wp-includes/js/dist/block-editor.js',
-			'build/wp-includes/js/dist/block-editor.min.js',
-			'build/wp-includes/js/dist/vendor/wp-polyfill-importmap.js',
-			'build/wp-includes/js/dist/vendor/wp-polyfill-importmap.min.js'
 		];
 		const files = buildFiles.reduce( ( acc, path ) => {
 			// Skip excluded paths and any path that isn't a file.
@@ -1593,10 +1589,10 @@ module.exports = function(grunt) {
 					encoding: 'utf8',
 				} );
 				// `data:` URLs are allowed:
-				const match = contents.match( /sourceMappingURL=((?!data:).)/ );
+				const doesNotHaveSourceMap = ! /^\/\/# sourceMappingURL=((?!data:).)/m.test(contents);
 
 				assert(
-					match === null,
+					doesNotHaveSourceMap,
 					`The ${ file } file must not contain a sourceMappingURL.`
 				);
 			} );

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1563,6 +1563,7 @@ module.exports = function(grunt) {
 	 *
 	 * @ticket 24994
 	 * @ticket 46218
+	 * @ticket 60348
 	 */
 	grunt.registerTask( 'verify:source-maps', function() {
 		const ignoredFiles = [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1568,7 +1568,9 @@ module.exports = function(grunt) {
 		const ignoredFiles = [
 			'build/wp-includes/js/dist/components.js',
 			'build/wp-includes/js/dist/block-editor.js',
-			'build/wp-includes/js/dist/block-editor.min.js'
+			'build/wp-includes/js/dist/block-editor.min.js',
+			'build/wp-includes/js/dist/vendor/wp-polyfill-importmap.js',
+			'build/wp-includes/js/dist/vendor/wp-polyfill-importmap.min.js'
 		];
 		const files = buildFiles.reduce( ( acc, path ) => {
 			// Skip excluded paths and any path that isn't a file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
 				"clipboard": "2.0.11",
 				"core-js-url-browser": "3.6.4",
 				"element-closest": "^3.0.2",
+				"es-module-shims": "1.8.2",
 				"formdata-polyfill": "4.0.10",
 				"framer-motion": "10.16.4",
 				"hoverintent": "2.2.1",
@@ -13348,6 +13349,11 @@
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.0.tgz",
 			"integrity": "sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==",
 			"dev": true
+		},
+		"node_modules/es-module-shims": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-1.8.2.tgz",
+			"integrity": "sha512-7vIYVzpOhXtpc3Yn03itB+GSgVZFW7oL4kdydA+iL+IEi7HiSLBUxM05QFw4SxTl6e++pMpGqZPo2+vdNs3TbA=="
 		},
 		"node_modules/es-set-tostringtag": {
 			"version": "2.0.1",
@@ -43315,6 +43321,11 @@
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.0.tgz",
 			"integrity": "sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==",
 			"dev": true
+		},
+		"es-module-shims": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-1.8.2.tgz",
+			"integrity": "sha512-7vIYVzpOhXtpc3Yn03itB+GSgVZFW7oL4kdydA+iL+IEi7HiSLBUxM05QFw4SxTl6e++pMpGqZPo2+vdNs3TbA=="
 		},
 		"es-set-tostringtag": {
 			"version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
 		"clipboard": "2.0.11",
 		"core-js-url-browser": "3.6.4",
 		"element-closest": "^3.0.2",
+		"es-module-shims": "1.8.2",
 		"formdata-polyfill": "4.0.10",
 		"framer-motion": "10.16.4",
 		"hoverintent": "2.2.1",

--- a/src/wp-includes/.wp-env.override.json
+++ b/src/wp-includes/.wp-env.override.json
@@ -1,6 +1,0 @@
-{
-	"config": {
-		"WP_HOME": "http://bs-local.com",
-		"WP_SITEURL": "http://bs-local.com"
-	}
-}

--- a/src/wp-includes/.wp-env.override.json
+++ b/src/wp-includes/.wp-env.override.json
@@ -1,0 +1,6 @@
+{
+	"config": {
+		"WP_HOME": "http://bs-local.com",
+		"WP_SITEURL": "http://bs-local.com"
+	}
+}

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -236,8 +236,7 @@ class WP_Script_Modules {
 		$import_map = $this->get_import_map();
 		if ( ! empty( $import_map['imports'] ) ) {
 			$test = 'HTMLScriptElement.supports && HTMLScriptElement.supports("importmap")';
-			$src  = includes_url( 'js/dist/vendor/wp-polyfill-importmap.min.js' );
-
+			$src  = add_query_arg( 'ver', get_bloginfo( 'version' ), includes_url( 'js/dist/vendor/wp-polyfill-importmap.min.js' ) );
 			echo (
 			// Test presence of feature...
 			'<script>( ' . $test . ' ) || ' .

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -233,21 +233,24 @@ class WP_Script_Modules {
 	 * @since 6.5.0
 	 */
 	public function print_import_map_polyfill() {
-		$test = 'HTMLScriptElement.supports && HTMLScriptElement.supports("importmap")';
-		$src  = includes_url( 'js/dist/vendor/wp-polyfill-importmap.min.js' );
+		$import_map = $this->get_import_map();
+		if ( ! empty( $import_map['imports'] ) ) {
+			$test = 'HTMLScriptElement.supports && HTMLScriptElement.supports("importmap")';
+			$src  = includes_url( 'js/dist/vendor/wp-polyfill-importmap.min.js' );
 
-		echo (
-		// Test presence of feature...
-		'<script>( ' . $test . ' ) || ' .
-		/*
-		 * ...appending polyfill on any failures. Cautious viewers may balk
-		 * at the `document.write`. Its caveat of synchronous mid-stream
-		 * blocking write is exactly the behavior we need though.
-		 */
-		'document.write( \'<script src="' .
-		$src .
-		'"></scr\' + \'ipt>\' );</script>'
-		);
+			echo (
+			// Test presence of feature...
+			'<script>( ' . $test . ' ) || ' .
+			/*
+			* ...appending polyfill on any failures. Cautious viewers may balk
+			* at the `document.write`. Its caveat of synchronous mid-stream
+			* blocking write is exactly the behavior we need though.
+			*/
+			'document.write( \'<script src="' .
+			$src .
+			'"></scr\' + \'ipt>\' );</script>'
+			);
+		}
 	}
 
 

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -166,6 +166,7 @@ class WP_Script_Modules {
 		add_action( $position, array( $this, 'print_import_map' ) );
 		add_action( $position, array( $this, 'print_enqueued_script_modules' ) );
 		add_action( $position, array( $this, 'print_script_module_preloads' ) );
+		add_action( 'wp_footer', array( $this, 'print_import_map_polyfill' ), 11 );
 	}
 
 	/**
@@ -224,6 +225,32 @@ class WP_Script_Modules {
 			);
 		}
 	}
+
+	/**
+	 * Prints the necessary script to load import map polyfill for browsers that
+	 * do not support import maps.
+	 *
+	 * @since 6.5.0
+	 */
+	public function print_import_map_polyfill() {
+		$test = 'HTMLScriptElement.supports && HTMLScriptElement.supports("importmap")';
+		$src  = includes_url( 'js/dist/vendor/wp-polyfill-importmap.min.js' );
+
+		echo (
+		// Test presence of feature...
+		'<script>( ' . $test . ' ) || ' .
+		/*
+		 * ...appending polyfill on any failures. Cautious viewers may balk
+		 * at the `document.write`. Its caveat of synchronous mid-stream
+		 * blocking write is exactly the behavior we need though.
+		 */
+		'document.write( \'<script src="' .
+		$src .
+		'"></scr\' + \'ipt>\' );</script>'
+		);
+	}
+
+
 
 	/**
 	 * Returns the import map array.

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -246,7 +246,7 @@ class WP_Script_Modules {
 			* at the `document.write`. Its caveat of synchronous mid-stream
 			* blocking write is exactly the behavior we need though.
 			*/
-			'document.write( \'<script src="' .
+			'document.write( \'<script id="wp-js-module-importmap" src="' .
 			$src .
 			'"></scr\' + \'ipt>\' );</script>'
 			);

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -166,7 +166,6 @@ class WP_Script_Modules {
 		add_action( $position, array( $this, 'print_import_map' ) );
 		add_action( $position, array( $this, 'print_enqueued_script_modules' ) );
 		add_action( $position, array( $this, 'print_script_module_preloads' ) );
-		add_action( 'wp_footer', array( $this, 'print_import_map_polyfill' ), 11 );
 	}
 
 	/**
@@ -211,30 +210,10 @@ class WP_Script_Modules {
 	/**
 	 * Prints the import map using a script tag with a type="importmap" attribute.
 	 *
+	 * @global WP_Scripts $wp_scripts The WP_Scripts object for printing the polyfill.
 	 * @since 6.5.0
 	 */
 	public function print_import_map() {
-		$import_map = $this->get_import_map();
-		if ( ! empty( $import_map['imports'] ) ) {
-			wp_print_inline_script_tag(
-				wp_json_encode( $import_map, JSON_HEX_TAG | JSON_HEX_AMP ),
-				array(
-					'type' => 'importmap',
-					'id'   => 'wp-importmap',
-				)
-			);
-		}
-	}
-
-	/**
-	 * Prints the necessary script to load import map polyfill for browsers that
-	 * do not support import maps. It is only printed when there is an import
-	 * map to print.
-	 *
-	 * @global WP_Scripts $wp_scripts The WP_Scripts object for printing inline scripts.
-	 * @since 6.5.0
-	 */
-	public function print_import_map_polyfill() {
 		$import_map = $this->get_import_map();
 		if ( ! empty( $import_map['imports'] ) ) {
 			global $wp_scripts;
@@ -247,6 +226,13 @@ class WP_Script_Modules {
 				),
 				array(
 					'id' => 'wp-load-polyfill-importmap',
+				)
+			);
+			wp_print_inline_script_tag(
+				wp_json_encode( $import_map, JSON_HEX_TAG | JSON_HEX_AMP ),
+				array(
+					'type' => 'importmap',
+					'id'   => 'wp-importmap',
 				)
 			);
 		}

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -235,19 +235,17 @@ class WP_Script_Modules {
 	public function print_import_map_polyfill() {
 		$import_map = $this->get_import_map();
 		if ( ! empty( $import_map['imports'] ) ) {
-			$test = 'HTMLScriptElement.supports && HTMLScriptElement.supports("importmap")';
-			$src  = add_query_arg( 'ver', get_bloginfo( 'version' ), includes_url( 'js/dist/vendor/wp-polyfill-importmap.min.js' ) );
-			echo (
-			// Test presence of feature...
-			'<script>( ' . $test . ' ) || ' .
-			/*
-			* ...appending polyfill on any failures. Cautious viewers may balk
-			* at the `document.write`. Its caveat of synchronous mid-stream
-			* blocking write is exactly the behavior we need though.
-			*/
-			'document.write( \'<script id="wp-js-module-importmap" src="' .
-			$src .
-			'"></scr\' + \'ipt>\' );</script>'
+			global $wp_scripts;
+			wp_print_inline_script_tag(
+				wp_get_script_polyfill(
+					$wp_scripts,
+					array(
+						'HTMLScriptElement.supports && HTMLScriptElement.supports("importmap")' => 'wp-polyfill-importmap',
+					)
+				),
+				array(
+					'id' => 'wp-polyfill-importmap',
+				)
 			);
 		}
 	}

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -244,7 +244,7 @@ class WP_Script_Modules {
 					)
 				),
 				array(
-					'id' => 'wp-polyfill-importmap',
+					'id' => 'wp-load-polyfill-importmap',
 				)
 			);
 		}

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -231,6 +231,7 @@ class WP_Script_Modules {
 	 * do not support import maps. It is only printed when there is an import
 	 * map to print.
 	 *
+	 * @global WP_Scripts $wp_scripts The WP_Scripts object for printing inline scripts.
 	 * @since 6.5.0
 	 */
 	public function print_import_map_polyfill() {

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -228,7 +228,8 @@ class WP_Script_Modules {
 
 	/**
 	 * Prints the necessary script to load import map polyfill for browsers that
-	 * do not support import maps.
+	 * do not support import maps. It is only printed when there is an import
+	 * map to print.
 	 *
 	 * @since 6.5.0
 	 */
@@ -249,8 +250,6 @@ class WP_Script_Modules {
 			);
 		}
 	}
-
-
 
 	/**
 	 * Returns the import map array.

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -217,17 +217,19 @@ class WP_Script_Modules {
 		$import_map = $this->get_import_map();
 		if ( ! empty( $import_map['imports'] ) ) {
 			global $wp_scripts;
-			wp_print_inline_script_tag(
-				wp_get_script_polyfill(
-					$wp_scripts,
+			if ( isset( $wp_scripts ) ) {
+				wp_print_inline_script_tag(
+					wp_get_script_polyfill(
+						$wp_scripts,
+						array(
+							'HTMLScriptElement.supports && HTMLScriptElement.supports("importmap")' => 'wp-polyfill-importmap',
+						)
+					),
 					array(
-						'HTMLScriptElement.supports && HTMLScriptElement.supports("importmap")' => 'wp-polyfill-importmap',
+						'id' => 'wp-load-polyfill-importmap',
 					)
-				),
-				array(
-					'id' => 'wp-load-polyfill-importmap',
-				)
-			);
+				);
+			}
 			wp_print_inline_script_tag(
 				wp_json_encode( $import_map, JSON_HEX_TAG | JSON_HEX_AMP ),
 				array(

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -96,6 +96,7 @@ function wp_default_packages_vendor( $scripts ) {
 		'lodash',
 		'wp-polyfill-fetch',
 		'wp-polyfill-formdata',
+		'wp-polyfill-importmap',
 		'wp-polyfill-node-contains',
 		'wp-polyfill-url',
 		'wp-polyfill-dom-rect',
@@ -120,6 +121,7 @@ function wp_default_packages_vendor( $scripts ) {
 		'wp-polyfill-object-fit'      => '2.3.5',
 		'wp-polyfill-inert'           => '3.1.2',
 		'wp-polyfill'                 => '3.15.0',
+		'wp-polyfill-importmap'       => get_bloginfo( 'version' ),
 	);
 
 	foreach ( $vendor_scripts as $handle => $dependencies ) {

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -121,7 +121,7 @@ function wp_default_packages_vendor( $scripts ) {
 		'wp-polyfill-object-fit'      => '2.3.5',
 		'wp-polyfill-inert'           => '3.1.2',
 		'wp-polyfill'                 => '3.15.0',
-		'wp-polyfill-importmap'       => get_bloginfo( 'version' ),
+		'wp-polyfill-importmap'       => '1.8.2',
 	);
 
 	foreach ( $vendor_scripts as $handle => $dependencies ) {

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -3110,15 +3110,16 @@ HTML
 	 * @ticket 60348
 	 *
 	 * @covers ::wp_get_script_polyfill
-	 * @dataProvider data_wp_get_script_polyfill
 	 *
 	 * @param string $script_name Script name.
 	 * @param string $test_script Conditional that checks browser compatibility.
 	 * @param string $script_url  Script source URL.
 	 */
-
-	public function test_wp_get_script_polyfill( $script_name, $test_script, $script_url ) {
+	public function test_wp_get_script_polyfill() {
 		global $wp_scripts;
+		$script_name = 'wp-polyfill-importmap';
+		$test_script = 'HTMLScriptElement.supports && HTMLScriptElement.supports("importmap")';
+		$script_url  = 'https://example.com/wp-polyfill-importmap.js';
 		wp_register_script( $script_name, $script_url, array(), null, true );
 
 		$polyfill = wp_get_script_polyfill(
@@ -3130,22 +3131,6 @@ HTML
 		$expected = '( ' . $test_script . ' ) || document.write( \'<script src="' . $script_url . '"></scr\' + \'ipt>\' );';
 
 		$this->assertEquals( $expected, $polyfill );
-	}
-
-	/**
-	 * Data provider for test_wp_get_script_polyfill.
-	 *
-	 * @ticket 60348
-	 * @return array[]
-	 */
-	public function data_wp_get_script_polyfill() {
-		return array(
-			array(
-				'script_name' => 'wp-polyfill-importmap',
-				'test_script' => 'HTMLScriptElement.supports && HTMLScriptElement.supports("importmap")',
-				'script_url'  => 'https://example.com/wp-polyfill-importmap.js',
-			),
-		);
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -3111,6 +3111,7 @@ HTML
 	 *
 	 * @covers ::wp_get_script_polyfill
 	 *
+	 * @global WP_Scripts $wp_scripts WP_Scripts instance.
 	 * @param string $script_name Script name.
 	 * @param string $test_script Conditional that checks browser compatibility.
 	 * @param string $script_url  Script source URL.

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -3105,6 +3105,50 @@ HTML
 	}
 
 	/**
+	 * Test that get_script_polyfill() returns the correct polyfill.
+	 *
+	 * @ticket 60348
+	 *
+	 * @covers ::wp_get_script_polyfill
+	 * @dataProvider data_wp_get_script_polyfill
+	 *
+	 * @param string $script_name Script name.
+	 * @param string $test_script Conditional that checks browser compatibility.
+	 * @param string $script_url  Script source URL.
+	 */
+
+	public function test_wp_get_script_polyfill( $script_name, $test_script, $script_url ) {
+		global $wp_scripts;
+		wp_register_script( $script_name, $script_url, array(), null, true );
+
+		$polyfill = wp_get_script_polyfill(
+			$wp_scripts,
+			array(
+				$test_script => $script_name,
+			)
+		);
+		$expected = '( ' . $test_script . ' ) || document.write( \'<script src="' . $script_url . '"></scr\' + \'ipt>\' );';
+
+		$this->assertEquals( $expected, $polyfill );
+	}
+
+	/**
+	 * Data provider for test_wp_get_script_polyfill.
+	 *
+	 * @ticket 60348
+	 * @return array[]
+	 */
+	public function data_wp_get_script_polyfill() {
+		return array(
+			array(
+				'script_name' => 'wp-polyfill-importmap',
+				'test_script' => 'HTMLScriptElement.supports && HTMLScriptElement.supports("importmap")',
+				'script_url'  => 'https://example.com/wp-polyfill-importmap.js',
+			),
+		);
+	}
+
+	/**
 	 * Data provider for test_wp_scripts_move_to_footer.
 	 *
 	 * @return array[]

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -13,8 +13,6 @@
  */
 class Tests_WpScriptModules extends WP_UnitTestCase {
 
-	private $old_wp_scripts;
-
 	/**
 	 * Instance of WP_Script_Modules.
 	 *
@@ -27,21 +25,8 @@ class Tests_WpScriptModules extends WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
-
-		// Set up the WP_Scripts instance.
-		$this->old_wp_scripts = isset( $GLOBALS['wp_scripts'] ) ? $GLOBALS['wp_scripts'] : null;
-		remove_action( 'wp_default_scripts', 'wp_default_scripts' );
-		$GLOBALS['wp_scripts']                  = new WP_Scripts();
-		$GLOBALS['wp_scripts']->default_version = get_bloginfo( 'version' );
-
 		// Set up the WP_Script_Modules instance.
 		$this->script_modules = new WP_Script_Modules();
-	}
-
-	public function tear_down() {
-		$GLOBALS['wp_scripts'] = $this->old_wp_scripts;
-		add_action( 'wp_default_scripts', 'wp_default_scripts' );
-		parent::tear_down();
 	}
 
 	/**

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -617,6 +617,7 @@ class Tests_WpScriptModules extends WP_UnitTestCase {
 		$this->assertEquals( '', $import_map_polyfill );
 
 		// Polyfill is not empty when a module is registered.
+		wp_register_script( 'wp-polyfill-importmap', '/wp-polyfill-importmap.js', array(), '1.0' );
 		$this->script_modules->enqueue( 'foo', '/foo.js', array( 'dep' ), '1.0' );
 		$this->script_modules->register( 'dep', '/dep.js' );
 		$import_map_polyfill = get_echo( array( $this->script_modules, 'print_import_map_polyfill' ) );
@@ -625,5 +626,6 @@ class Tests_WpScriptModules extends WP_UnitTestCase {
 		$id = $p->get_attribute( 'id' );
 
 		$this->assertEquals( 'wp-load-polyfill-importmap', $id );
+		wp_deregister_script( 'wp-polyfill-importmap' );
 	}
 }

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -11,7 +11,7 @@
  *
  * @coversDefaultClass WP_Script_Modules
  */
-class Tests_WpScriptModules extends WP_UnitTestCase {
+class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 
 	/**
 	 * Instance of WP_Script_Modules.

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -604,11 +604,26 @@ class Tests_WpScriptModules extends WP_UnitTestCase {
 	/**
 	 * Tests that the import map polyfill is not enqueued when there are no
 	 * modules registered.
+	 *
+	 * @ticket 60348
+	 *
+	 * @covers ::print_import_map_polyfill()
 	 */
 
 	public function test_wp_print_import_map_polyfill() {
 		// Polyfill is empty when no modules are registered.
 		$import_map_polyfill = get_echo( array( $this->script_modules, 'print_import_map_polyfill' ) );
-		$this->assertEmpty( $import_map_polyfill );
+
+		$this->assertEquals( '', $import_map_polyfill );
+
+		// Polyfill is not empty when a module is registered.
+		$this->script_modules->enqueue( 'foo', '/foo.js', array( 'dep' ), '1.0' );
+		$this->script_modules->register( 'dep', '/dep.js' );
+		$import_map_polyfill = get_echo( array( $this->script_modules, 'print_import_map_polyfill' ) );
+		$p                   = new WP_HTML_Tag_Processor( $import_map_polyfill );
+		$p->next_tag( array( 'tag' => 'SCRIPT' ) );
+		$id = $p->get_attribute( 'id' );
+
+		$this->assertEquals( 'wp-load-polyfill-importmap', $id );
 	}
 }

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -40,6 +40,7 @@ class Tests_WpScriptModules extends WP_UnitTestCase {
 
 	public function tear_down() {
 		$GLOBALS['wp_scripts'] = $this->old_wp_scripts;
+		add_action( 'wp_default_scripts', 'wp_default_scripts' );
 		parent::tear_down();
 	}
 

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -612,9 +612,9 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 	 * @covers ::print_import_map_polyfill()
 	 */
 
-	public function test_wp_print_import_map_polyfill() {
+	public function test_wp_print_import_map_has_polyfill() {
 		// Polyfill is empty when no modules are registered.
-		$import_map_polyfill = get_echo( array( $this->script_modules, 'print_import_map_polyfill' ) );
+		$import_map_polyfill = get_echo( array( $this->script_modules, 'print_import_map' ) );
 
 		$this->assertEquals( '', $import_map_polyfill );
 
@@ -623,7 +623,7 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 
 		$this->script_modules->enqueue( 'foo', '/foo.js', array( 'dep' ), '1.0' );
 		$this->script_modules->register( 'dep', '/dep.js' );
-		$import_map_polyfill = get_echo( array( $this->script_modules, 'print_import_map_polyfill' ) );
+		$import_map_polyfill = get_echo( array( $this->script_modules, 'print_import_map' ) );
 		$p                   = new WP_HTML_Tag_Processor( $import_map_polyfill );
 		$p->next_tag( array( 'tag' => 'SCRIPT' ) );
 		$id = $p->get_attribute( 'id' );

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -12,6 +12,9 @@
  * @coversDefaultClass WP_Script_Modules
  */
 class Tests_WpScriptModules extends WP_UnitTestCase {
+
+	private $old_wp_scripts;
+
 	/**
 	 * Instance of WP_Script_Modules.
 	 *
@@ -24,7 +27,20 @@ class Tests_WpScriptModules extends WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
+
+		// Set up the WP_Scripts instance.
+		$this->old_wp_scripts = isset( $GLOBALS['wp_scripts'] ) ? $GLOBALS['wp_scripts'] : null;
+		remove_action( 'wp_default_scripts', 'wp_default_scripts' );
+		$GLOBALS['wp_scripts']                  = new WP_Scripts();
+		$GLOBALS['wp_scripts']->default_version = get_bloginfo( 'version' );
+
+		// Set up the WP_Script_Modules instance.
 		$this->script_modules = new WP_Script_Modules();
+	}
+
+	public function tear_down() {
+		$GLOBALS['wp_scripts'] = $this->old_wp_scripts;
+		parent::tear_down();
 	}
 
 	/**
@@ -618,6 +634,7 @@ class Tests_WpScriptModules extends WP_UnitTestCase {
 
 		// Polyfill is not empty when a module is registered.
 		wp_register_script( 'wp-polyfill-importmap', '/wp-polyfill-importmap.js', array(), '1.0' );
+
 		$this->script_modules->enqueue( 'foo', '/foo.js', array( 'dep' ), '1.0' );
 		$this->script_modules->register( 'dep', '/dep.js' );
 		$import_map_polyfill = get_echo( array( $this->script_modules, 'print_import_map_polyfill' ) );

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -11,7 +11,7 @@
  *
  * @coversDefaultClass WP_Script_Modules
  */
-class Tests_WP_Script_Modules extends WP_UnitTestCase {
+class Tests_WpScriptModules extends WP_UnitTestCase {
 	/**
 	 * Instance of WP_Script_Modules.
 	 *
@@ -599,5 +599,16 @@ class Tests_WP_Script_Modules extends WP_UnitTestCase {
 		$this->assertEquals( '/foo.js?ver=1.0', $enqueued_script_modules['foo'] );
 		$this->assertCount( 1, $import_map );
 		$this->assertStringStartsWith( '/dep.js', $import_map['dep'] );
+	}
+
+	/**
+	 * Tests that the import map polyfill is not enqueued when there are no
+	 * modules registered.
+	 */
+
+	public function test_wp_print_import_map_polyfill() {
+		// Polyfill is empty when no modules are registered.
+		$import_map_polyfill = get_echo( array( $this->script_modules, 'print_import_map_polyfill' ) );
+		$this->assertEmpty( $import_map_polyfill );
 	}
 }

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -122,8 +122,6 @@ module.exports = function (
 			'polyfill-library/polyfills/__dist/Node.prototype.contains/raw.js',
 		'wp-polyfill-dom-rect.min.js':
 			'polyfill-library/polyfills/__dist/DOMRect/raw.js',
-		'wp-polyfill-node-contains.min.js': 'polyfill-library/polyfills/__dist/Node.prototype.contains/raw.js',
-		'wp-polyfill-dom-rect.min.js': 'polyfill-library/polyfills/__dist/DOMRect/raw.js',
 		'wp-polyfill-importmap.min.js': 'es-module-shims/dist/es-module-shims.wasm.js',
 	};
 

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -93,6 +93,7 @@ module.exports = function (
 		'wp-polyfill-object-fit.js':
 			'objectFitPolyfill/src/objectFitPolyfill.js',
 		'wp-polyfill-inert.js': 'wicg-inert/dist/inert.js',
+		'wp-polyfill-importmap.js': 'es-module-shims/dist/es-module-shims.wasm.js',
 		'moment.js': 'moment/moment.js',
 		'react.js': 'react/umd/react.development.js',
 		'react-dom.js': 'react-dom/umd/react-dom.development.js',
@@ -121,6 +122,9 @@ module.exports = function (
 			'polyfill-library/polyfills/__dist/Node.prototype.contains/raw.js',
 		'wp-polyfill-dom-rect.min.js':
 			'polyfill-library/polyfills/__dist/DOMRect/raw.js',
+		'wp-polyfill-node-contains.min.js': 'polyfill-library/polyfills/__dist/Node.prototype.contains/raw.js',
+		'wp-polyfill-dom-rect.min.js': 'polyfill-library/polyfills/__dist/DOMRect/raw.js',
+		'wp-polyfill-importmap.min.js': 'es-module-shims/dist/es-module-shims.wasm.js',
 	};
 
 	const phpFiles = {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
Syncs the changes from https://github.com/WordPress/gutenberg/pull/58263 to core.
Adds a polyfill to make import maps compatible with Safari old versions (under 15).

Trac ticket: https://core.trac.wordpress.org/ticket/60348

Screenshots:
![Screenshot 2024-01-25 at 19 25 10](https://github.com/WordPress/wordpress-develop/assets/37012961/03cb3163-c9e3-458e-a216-463ab98f5039)
![Screenshot 2024-01-25 at 18 57 42](https://github.com/WordPress/wordpress-develop/assets/37012961/ba09e4f3-d349-4bfc-b7a3-924746abd909)



---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
