### PR TITLE
HTML API: Introduce safe HTML templating.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2899,14 +2899,37 @@ class WP_HTML_Tag_Processor {
 		 * > To represent a false value, the attribute has to be omitted altogether.
 		 *     - HTML5 spec, https://html.spec.whatwg.org/#boolean-attributes
 		 */
-		if ( false === $value ) {
+		if ( false === $value || null === $value ) {
 			return $this->remove_attribute( $name );
 		}
 
 		if ( true === $value ) {
 			$updated_attribute = $name;
 		} else {
-			$escaped_new_value = esc_attr( $value );
+			$tag_name        = $this->get_tag();
+			$comparable_name = strtolower( $name );
+
+			/*
+			 * Escape URL attributes.
+			 *
+			 * @see https://html.spec.whatwg.org/#attributes-3
+			 */
+			if (
+				! str_starts_with( $value, 'data:' ) && (
+					'cite' === $comparable_name ||
+					'formaction' === $comparable_name ||
+					'href' === $comparable_name ||
+					'ping' === $comparable_name ||
+					'src' === $comparable_name ||
+					( 'FORM' === $tag_name && 'action' === $comparable_name ) ||
+					( 'OBJECT' === $tag_name && 'data' === $comparable_name ) ||
+					( 'VIDEO' === $tag_name && 'poster' === $comparable_name )
+				)
+			) {
+				$escaped_new_value = esc_url( $value );
+			} else {
+				$escaped_new_value = esc_attr( $value );
+			}
 			$updated_attribute = "{$name}=\"{$escaped_new_value}\"";
 		}
 

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2038,8 +2038,8 @@ class WP_HTML_Tag_Processor {
 		$this->token_length         = null;
 		$this->tag_name_starts_at   = null;
 		$this->tag_name_length      = null;
-		$this->text_starts_at       = 0;
-		$this->text_length          = 0;
+		$this->text_starts_at       = null;
+		$this->text_length          = null;
 		$this->is_closing_tag       = null;
 		$this->attributes           = array();
 		$this->comment_type         = null;

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2827,6 +2827,50 @@ class WP_HTML_Tag_Processor {
 	}
 
 	/**
+	 * Sets the modifiable text for the matched token, if possible.
+	 *
+	 * @param string $text Replace the modifiable text with this string.
+	 * @return bool Whether the modifiable text was updated.
+	 */
+	public function set_modifiable_text( $text ) {
+		if ( null === $this->text_starts_at || ! is_string( $text ) ) {
+			return false;
+		}
+
+		switch ( $this->get_token_name() ) {
+			case '#text':
+				$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+					$this->text_starts_at,
+					$this->text_length,
+					esc_html( $text )
+				);
+				break;
+
+			case 'TEXTAREA':
+				$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+					$this->text_starts_at,
+					$this->text_length,
+					preg_replace( '~</textarea~i', '&lt;/textarea', $text )
+				);
+				break;
+
+			case 'TITLE':
+				$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+					$this->text_starts_at,
+					$this->text_length,
+					preg_replace( '~</title~i', '&lt;/title', $text )
+				);
+				break;
+
+			default:
+				return false;
+		}
+
+		$this->get_updated_html();
+		return true;
+	}
+
+	/**
 	 * Updates or creates a new attribute on the currently matched tag with the passed value.
 	 *
 	 * For boolean attributes special handling is provided:

--- a/src/wp-includes/html-api/class-wp-html-template.php
+++ b/src/wp-includes/html-api/class-wp-html-template.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * HTML API: WP_HTML_Template helper class
+ *
+ * Provides the rendering code for the WP_HTML class. This needs to exist separately as
+ * implemented so that it can subclass the WP_HTML_Tag_Processor class and gain access
+ * to the bookmarks and lexical updates, which it uses to perform string operations.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ * @since 6.5.0
+ */
+
+/**
+ * WP_HTML_Template class.
+ *
+ * To be used only by the WP_HTML class.
+ *
+ * @since 6.5.0
+ *
+ * @access private
+ */
+class WP_HTML_Template extends WP_HTML_Tag_Processor {
+	/**
+	 * Renders an HTML template, replacing the placeholders with the provided values.
+	 *
+	 * This function looks for placeholders in the template string and will replace
+	 * them with appropriately-escaped substitutions from the given arguments, if
+	 * provided and if those arguments are strings or valid attribute values.
+	 *
+	 * Example:
+	 *
+	 *     echo WP_HTML_Template::render(
+	 *         '<a href="</%profile_url>"></%name></a>',
+	 *         array(
+	 *             'profile_url' => 'https://profiles.example.com/username',
+	 *             'name'        => $user->display_name
+	 *         )
+	 *     );
+	 *     // Outputs: <a href="https://profiles.example.com/username">Bobby Tables</a>
+	 *
+	 * Do not escape the values supplied to the argument array! This function will escape each
+	 * parameter's value as needed and additional manual escaping may lead to incorrect output.
+	 *
+	 * ## Syntax.
+	 *
+	 * ### Substitution Placeholders.
+	 *
+	 *  - `</%named_arg>` finds `named_arg` in the arguments array, escapes its value if possible,
+	 *    and replaces the placeholder with the escaped value. These may exist inside double-quoted
+	 *    HTML tag attributes or in HTML text content between tags. They cannot be used to output a tag
+	 *    name or content inside a comment.
+	 *
+	 * ### Spread Attributes.
+	 *
+	 *  - `...named_arg` when found within an HTML tag will lookup `named_arg` in the arguments array
+	 *    and, if it's an array, will set the attribute on the tag for each key/value pair whose value
+	 *    is a string, boolean, or `null`.
+	 *
+	 * ## Notes.
+	 *
+	 *  - Attributes may only be supplied for a limited set of types: a string value assigns a double-quoted
+	 *    attribute value; `true` sets the attribute as a boolean attribute; `null` removes the attribute.
+	 *    If provided any other type of value the attribute will be ignored and its existing value persists.
+	 *
+	 *  - If multiple HTML attributes are specified for a given tag they will be applied as if calling
+	 *    `set_attribute()` in the order they are specified in the template. This includes any attributes
+	 *    assigned through the attribute spread syntax.
+	 *
+	 *  - Substitutions in text nodes may only contain string values. If provided any other type of value
+	 *    the placeholder will be removed with nothing in its place.
+	 *
+	 *  - This function currently escapes all value provided in the arguments array. In the future
+	 *    it may provide the ability to nest pre-rendered HTML into the template, but this functionality
+	 *    is deferred for a future update.
+	 *
+	 *  - This function will not replace content inside of SCRIPT, or STYLE elements.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @access private
+	 *
+	 * @param string $template The HTML template.
+	 * @param string $args     Array of key/value pairs providing substitue values for the placeholders.
+	 * @return string The rendered HTML.
+	 */
+	public static function render( $template, $args = array() ) {
+		$processor = new self( $template );
+		while ( $processor->next_token() ) {
+			$type = $processor->get_token_type();
+			$text = $processor->get_modifiable_text();
+
+			// Replace placeholders that are found inside #text nodes.
+			if ( '#funky-comment' === $type && strlen( $text ) > 0 && '%' === $text[0] ) {
+				$name  = substr( $text, 1 );
+				$value = isset( $args[ $name ] ) && is_string( $args[ $name ] ) ? $args[ $name ] : null;
+				$processor->set_bookmark( 'here' );
+				$processor->lexical_updates[] = new WP_HTML_Text_Replacement(
+					$processor->bookmarks['here']->start,
+					$processor->bookmarks['here']->length,
+					null === $value ? '' : esc_html( $value )
+				);
+				continue;
+			}
+
+			// For every tag, scan the attributes to look for placeholders.
+			if ( '#tag' === $type ) {
+				foreach ( $processor->get_attribute_names_with_prefix( '' ) ?? array() as $attribute_name ) {
+					if ( str_starts_with( $attribute_name, '...' ) ) {
+						$spread_name = substr( $attribute_name, 3 );
+						if ( isset( $args[ $spread_name ] ) && is_array( $args[ $spread_name ] ) ) {
+							foreach ( $args[ $spread_name ] as $key => $value ) {
+								if ( true === $value || null === $value || is_string( $value ) ) {
+									$processor->set_attribute( $key, $value );
+								}
+							}
+						}
+						$processor->remove_attribute( $attribute_name );
+					}
+
+					$value = $processor->get_attribute( $attribute_name );
+
+					if ( ! is_string( $value ) ) {
+						continue;
+					}
+
+					// Replace entire attributes if their content is exclusively a placeholder, e.g. `title="</%title>"`.
+					$full_match = null;
+					if ( preg_match( '~^</%([^>]+)>$~', $value, $full_match ) ) {
+						$name = $full_match[1];
+
+						if ( array_key_exists( $name, $args ) ) {
+							$value = $args[ $name ];
+							if ( null === $value ) {
+								$processor->remove_attribute( $attribute_name );
+							} elseif ( true === $value ) {
+								$processor->set_attribute( $attribute_name, true );
+							} elseif ( is_string( $value ) ) {
+								$processor->set_attribute( $attribute_name, $args[ $name ] );
+							} else {
+								$processor->remove_attribute( $attribute_name );
+							}
+						} else {
+							$processor->remove_attribute( $attribute_name );
+						}
+
+						continue;
+					}
+
+					// Replace placeholders embedded in otherwise-static attribute values, e.g. `title="Post: </%title>"`.
+					$new_value = preg_replace_callback(
+						'~</%([^>]+)>~',
+						static function ( $matches ) use ( $args ) {
+							return is_string( $args[ $matches[1] ] )
+								? esc_attr( $args[ $matches[1] ] )
+								: '';
+						},
+						$value
+					);
+
+					if ( $new_value !== $value ) {
+						$processor->set_attribute( $attribute_name, $new_value );
+					}
+				}
+
+				// Update TEXTAREA and TITLE contents.
+				$tag_name = $processor->get_tag();
+				if ( 'TEXTAREA' === $tag_name || 'TITLE' === $tag_name ) {
+					// Replace placeholders inside these RCDATA tags.
+					$new_text = preg_replace_callback(
+						'~</%([^>]+)>~',
+						static function ( $matches ) use ( $args ) {
+							return is_string( $args[ $matches[1] ] )
+								? $args[ $matches[1] ]
+								: '';
+						},
+						$text
+					);
+
+					if ( $new_text !== $text ) {
+						$processor->set_modifiable_text( $new_text );
+					}
+				}
+			}
+		}
+
+		return $processor->get_updated_html();
+	}
+}

--- a/src/wp-includes/html-api/class-wp-html-template.php
+++ b/src/wp-includes/html-api/class-wp-html-template.php
@@ -110,7 +110,7 @@ class WP_HTML_Template extends WP_HTML_Tag_Processor {
 						$spread_name = substr( $attribute_name, 3 );
 						if ( isset( $args[ $spread_name ] ) && is_array( $args[ $spread_name ] ) ) {
 							foreach ( $args[ $spread_name ] as $key => $value ) {
-								if ( true === $value || null === $value || is_string( $value ) ) {
+								if ( true === $value || false === $value || null === $value || is_string( $value ) ) {
 									$processor->set_attribute( $key, $value );
 								}
 							}
@@ -131,7 +131,7 @@ class WP_HTML_Template extends WP_HTML_Tag_Processor {
 
 						if ( array_key_exists( $name, $args ) ) {
 							$value = $args[ $name ];
-							if ( null === $value ) {
+							if ( false === $value || null === $value ) {
 								$processor->remove_attribute( $attribute_name );
 							} elseif ( true === $value ) {
 								$processor->set_attribute( $attribute_name, true );

--- a/src/wp-includes/html-api/class-wp-html.php
+++ b/src/wp-includes/html-api/class-wp-html.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * HTML API: WP_HTML class
+ *
+ * Provides a public interface for HTML-related functionality in WordPress.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ * @since 6.5.0
+ */
+
+/**
+ * WP_HTML class.
+ *
+ * @since 6.5.0
+ */
+class WP_HTML {
+	/**
+	 * Renders an HTML template, replacing the placeholders with the provided values.
+	 *
+	 * This function looks for placeholders in the template string and will replace
+	 * them with appropriately-escaped substitutions from the given arguments, if
+	 * provided and if those arguments are strings or valid attribute values.
+	 *
+	 * Example:
+	 *
+	 *     echo WP_HTML::render(
+	 *         '<a href="</%profile_url>"></%name></a>',
+	 *         array(
+	 *             'profile_url' => 'https://profiles.example.com/username',
+	 *             'name'        => $user->display_name
+	 *         )
+	 *     );
+	 *     // Outputs: <a href="https://profiles.example.com/username">Bobby Tables</a>
+	 *
+	 * Do not escape the values supplied to the argument array! This function will escape each
+	 * parameter's value as needed and additional manual escaping may lead to incorrect output.
+	 *
+	 * ## Syntax.
+	 *
+	 * ### Substitution Placeholders.
+	 *
+	 *  - `</%named_arg>` finds `named_arg` in the arguments array, escapes its value if possible,
+	 *    and replaces the placeholder with the escaped value. These may exist inside double-quoted
+	 *    HTML tag attributes or in HTML text content between tags. They cannot be used to output a tag
+	 *    name or content inside a comment.
+	 *
+	 * ### Spread Attributes.
+	 *
+	 *  - `...named_arg` when found within an HTML tag will lookup `named_arg` in the arguments array
+	 *    and, if it's an array, will set the attribute on the tag for each key/value pair whose value
+	 *    is a string. The
+	 *
+	 * ## Notes.
+	 *
+	 *  - Attributes may only be supplied for a limited set of types: a string value assigns a double-quoted
+	 *    attribute value; `true` sets the attribute as a boolean attribute; `null` removes the attribute.
+	 *    If provided any other type of value the attribute will be ignored and its existing value persists.
+	 *
+	 *  - If multiple HTML attributes are specified for a given tag they will be applied as if calling
+	 *    `set_attribute()` in the order they are specified in the template. This includes any attributes
+	 *    assigned through the attribute spread syntax.
+	 *
+	 *  - Substitutions in text nodes may only contain string values. If provided any other type of value
+	 *    the placeholder will be removed with nothing in its place.
+	 *
+	 *  - This function currently escapes all value provided in the arguments array. In the future
+	 *    it may provide the ability to nest pre-rendered HTML into the template, but this functionality
+	 *    is deferred for a future update.
+	 *
+	 *  - This function will not replace content inside of SCRIPT, or STYLE elements.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @access private
+	 *
+	 * @param string $template The HTML template.
+	 * @param string $args     Array of key/value pairs providing substitue values for the placeholders.
+	 * @return string The rendered HTML.
+	 */
+	public static function render( $template, $args ) {
+		return WP_HTML_Template::render( $template, $args );
+	}
+}

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -381,14 +381,10 @@ function set_post_thumbnail_size( $width = 0, $height = 0, $crop = false ) {
  * @return string HTML IMG element for given image attachment.
  */
 function get_image_tag( $id, $alt, $title, $align, $size = 'medium' ) {
-
 	list( $img_src, $width, $height ) = image_downsize( $id, $size );
-	$hwstring                         = image_hwstring( $width, $height );
-
-	$title = $title ? 'title="' . esc_attr( $title ) . '" ' : '';
 
 	$size_class = is_array( $size ) ? implode( 'x', $size ) : $size;
-	$class      = 'align' . esc_attr( $align ) . ' size-' . esc_attr( $size_class ) . ' wp-image-' . $id;
+	$class      = "align{$align} size-{$size_class} wp-image-{$id}";
 
 	/**
 	 * Filters the value of the attachment's image tag class attribute.
@@ -403,7 +399,19 @@ function get_image_tag( $id, $alt, $title, $align, $size = 'medium' ) {
 	 */
 	$class = apply_filters( 'get_image_tag_class', $class, $id, $align, $size );
 
-	$html = '<img src="' . esc_url( $img_src ) . '" alt="' . esc_attr( $alt ) . '" ' . $title . $hwstring . 'class="' . $class . '" />';
+	$html = WP_HTML::render(
+		<<<'HTML'
+<img src="</%src>" alt="</%alt>" title="</%title>" class="</%class>" height="</%height>" width="</%width>">
+HTML,
+		array(
+			'alt'    => $alt,
+			'class'  => $class,
+			'height' => (string) $height,
+			'src'    => $img_src,
+			'title'  => empty( $title ) ? null : $title,
+			'width'  => (string) $width,
+		)
+	);
 
 	/**
 	 * Filters the HTML content for the image tag.
@@ -3603,26 +3611,14 @@ function wp_video_shortcode( $attr, $content = '' ) {
 	$html_atts = array(
 		'class'    => $atts['class'],
 		'id'       => sprintf( 'video-%d-%d', $post_id, $instance ),
-		'width'    => absint( $atts['width'] ),
-		'height'   => absint( $atts['height'] ),
-		'poster'   => esc_url( $atts['poster'] ),
+		'width'    => (string) absint( $atts['width'] ),
+		'height'   => (string) absint( $atts['height'] ),
+		'poster'   => empty( $atts['poster'] ) ? null : $atts['poster'],
 		'loop'     => wp_validate_boolean( $atts['loop'] ),
 		'autoplay' => wp_validate_boolean( $atts['autoplay'] ),
 		'muted'    => wp_validate_boolean( $atts['muted'] ),
-		'preload'  => $atts['preload'],
+		'preload'  => empty( $atts['preload'] ) ? null : $attr['preload'],
 	);
-
-	// These ones should just be omitted altogether if they are blank.
-	foreach ( array( 'poster', 'loop', 'autoplay', 'preload', 'muted' ) as $a ) {
-		if ( empty( $html_atts[ $a ] ) ) {
-			unset( $html_atts[ $a ] );
-		}
-	}
-
-	$attr_strings = array();
-	foreach ( $html_atts as $k => $v ) {
-		$attr_strings[] = $k . '="' . esc_attr( $v ) . '"';
-	}
 
 	$html = '';
 
@@ -3630,10 +3626,9 @@ function wp_video_shortcode( $attr, $content = '' ) {
 		$html .= "<!--[if lt IE 9]><script>document.createElement('video');</script><![endif]-->\n";
 	}
 
-	$html .= sprintf( '<video %s controls="controls">', implode( ' ', $attr_strings ) );
+	$html .= WP_HTML::render( '<video controls="controls" ...args>', array( 'args' => $html_atts ) );
 
 	$fileurl = '';
-	$source  = '<source type="%s" src="%s" />';
 
 	foreach ( $default_types as $fallback ) {
 		if ( ! empty( $atts[ $fallback ] ) ) {
@@ -3647,8 +3642,14 @@ function wp_video_shortcode( $attr, $content = '' ) {
 			} else {
 				$type = wp_check_filetype( $atts[ $fallback ], wp_get_mime_types() );
 			}
-			$url   = add_query_arg( '_', $instance, $atts[ $fallback ] );
-			$html .= sprintf( $source, $type['type'], esc_url( $url ) );
+
+			$html .= WP_HTML::render(
+				'<source type="</%source>" src="</%src>">',
+				array(
+					'source' => $type['type'],
+					'src'    => add_query_arg( '_', $instance, $atts[ $fallback ] ),
+				)
+			);
 		}
 	}
 
@@ -3664,11 +3665,16 @@ function wp_video_shortcode( $attr, $content = '' ) {
 	}
 	$html .= '</video>';
 
-	$width_rule = '';
-	if ( ! empty( $atts['width'] ) ) {
-		$width_rule = sprintf( 'width: %dpx;', $atts['width'] );
-	}
-	$output = sprintf( '<div style="%s" class="wp-video">%s</div>', $width_rule, $html );
+	$output = (
+		WP_HTML::render(
+			'<div class="wp-video" style="</%width>">',
+			array(
+				'width' => ! empty( $atts['width'] ) ? "width: {$atts['width']}px;" : null,
+			)
+		) .
+		$html .
+		'</div>'
+	);
 
 	/**
 	 * Filters the output of the video shortcode.

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -296,19 +296,21 @@ function get_the_content( $more_link_text = null, $strip_teaser = false, $post =
 	}
 
 	if ( null === $more_link_text ) {
-		$more_link_text = sprintf(
-			'<span aria-label="%1$s">%2$s</span>',
-			sprintf(
-				/* translators: %s: Post title. */
-				__( 'Continue reading %s' ),
-				the_title_attribute(
-					array(
-						'echo' => false,
-						'post' => $_post,
+		$more_link_text = WP_HTML::render(
+			'<span aria-label="</%label>"></%title></span>',
+			array(
+				'label' => sprintf(
+					/* translators: %s: Post title. */
+					__( 'Continue reading %s' ),
+					the_title_attribute(
+						array(
+							'echo' => false,
+							'post' => $_post,
+						)
 					)
-				)
-			),
-			__( '(more&hellip;)' )
+				),
+				'title' => __( '(more&hellip;)' ),
+			)
 		);
 	}
 
@@ -359,9 +361,17 @@ function get_the_content( $more_link_text = null, $strip_teaser = false, $post =
 
 	if ( count( $content ) > 1 ) {
 		if ( $elements['more'] ) {
-			$output .= '<span id="more-' . $_post->ID . '"></span>' . $content[1];
+			$output .= WP_HTML::render( '<span id="more-</%id>"></span>', array( 'id' => $_post->ID ) );
+			$output .= $content[1];
 		} else {
 			if ( ! empty( $more_link_text ) ) {
+				$link_html = WP_HTML::render(
+					'<a href="</%post_link>" class="more-link"></%link_text></a>',
+					array(
+						'post_link' => get_permalink( $_post ) . "#more-{$_post->ID}",
+						'link_text' => $more_link_text,
+					)
+				);
 
 				/**
 				 * Filters the Read More link text.
@@ -371,7 +381,7 @@ function get_the_content( $more_link_text = null, $strip_teaser = false, $post =
 				 * @param string $more_link_element Read More link element.
 				 * @param string $more_link_text    Read More text.
 				 */
-				$output .= apply_filters( 'the_content_more_link', ' <a href="' . get_permalink( $_post ) . "#more-{$_post->ID}\" class=\"more-link\">$more_link_text</a>", $more_link_text );
+				$output .= apply_filters( 'the_content_more_link', $link_html, $more_link_text );
 			}
 			$output = force_balance_tags( $output );
 		}

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -252,6 +252,8 @@ require ABSPATH . WPINC . '/html-api/class-wp-html-open-elements.php';
 require ABSPATH . WPINC . '/html-api/class-wp-html-token.php';
 require ABSPATH . WPINC . '/html-api/class-wp-html-processor-state.php';
 require ABSPATH . WPINC . '/html-api/class-wp-html-processor.php';
+require ABSPATH . WPINC . '/html-api/class-wp-html-template.php';
+require ABSPATH . WPINC . '/html-api/class-wp-html.php';
 require ABSPATH . WPINC . '/class-wp-http.php';
 require ABSPATH . WPINC . '/class-wp-http-streams.php';
 require ABSPATH . WPINC . '/class-wp-http-curl.php';

--- a/tests/phpunit/tests/html-api/wpHtmlTemplate.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTemplate.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Unit tests covering WP_HTML_Template functionality.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ *
+ * @since 6.5.0
+ *
+ * @group html-api
+ *
+ * @coversDefaultClass WP_HTML_Template
+ */
+
+class Tests_HtmlApi_WpHtmlTemplate extends WP_UnitTestCase {
+	/**
+	 * Demonstrates how to pass values into an HTML template.
+	 *
+	 * @ticket 60229
+	 */
+	public function test_basic_render() {
+		$html = WP_HTML_Template::render(
+			'<div class="is-test </%class>" ...div-args inert="</%is_inert>">Just a </%count> test</div>',
+			array(
+				'count'    => '<strong>Hi <3</strong>',
+				'class'    => '5>4',
+				'is_inert' => 'inert',
+				'div-args' => array(
+					'class'    => 'hoover',
+					'disabled' => true,
+				),
+			)
+		);
+
+		$this->assertSame(
+			'<div disabled class="hoover"  inert="inert">Just a &lt;strong&gt;Hi &lt;3&lt;/strong&gt; test</div>',
+			$html,
+			'Failed to properly render template.'
+		);
+	}
+
+	/**
+	 * Ensures that basic attacks on attribute names and values are blocked.
+	 *
+	 * @ticket 60229
+	 *
+	 * @covers WP_HTML::render
+	 */
+	public function test_cannot_break_out_of_tag_with_malicious_attribute_name() {
+		$html = WP_HTML_Template::render(
+			'<div class="</%class>" ...args>',
+			array(
+				'class' => '"><script>alert("hi")</script>',
+				'args'  => array(
+					'"> double-quoted escape' => 'busted!',
+					'> tag escape'            => 'busted!',
+				),
+			)
+		);
+
+		// The output here should include an escaped `class` attribute and no others, also no other tags.
+		$processor = new WP_HTML_Tag_Processor( $html );
+		$processor->next_tag();
+
+		$this->assertSame(
+			'DIV',
+			$processor->get_tag(),
+			"Expected to find DIV tag but found {$processor->get_tag()} instead."
+		);
+
+		$this->assertSame(
+			'"><script>alert("hi")</script>',
+			$processor->get_attribute( 'class' ),
+			'Should have found escaped `class` attribute.'
+		);
+
+		$this->assertSame(
+			array( 'class' ),
+			$processor->get_attribute_names_with_prefix( '' ),
+			'Should have set `class` attribute and no others.'
+		);
+
+		$this->assertFalse(
+			$processor->next_tag(),
+			"Should not have found any other tags but found {$processor->get_tag()} instead."
+		);
+	}
+
+	/**
+	 * Ensures that basic replacement inside a TEXTAREA subtitutes placeholders.
+	 *
+	 * @ticket 60229
+	 */
+	public function test_replaces_textarea_placeholders() {
+		$html = WP_HTML_Template::render(
+			'<textarea>The </%big> one.</textarea>',
+			array( 'big' => '<HUGE> (</textarea>)' )
+		);
+
+		$this->assertSame(
+			'<textarea>The <HUGE> (&lt;/textarea>) one.</textarea>',
+			$html,
+			'Should have replaced placeholder with RCDATA escaping rules.'
+		);
+	}
+}


### PR DESCRIPTION
Trac ticket: Core-60229

🚧👷‍♂️🏗️ This feature is currently being proposed for the *WordPress 6.6* release cycle, being pushed back from 6.5 to allow for more time to let the design work proceed.

## Todo

 - [ ] embed replacement inside the Tag Processor
 - [ ] don't allow replacement of escaped funky comment syntax (currently occurs inside attribute value based on how this is built at the moment)
 - [ ] figure out what rules need to apply for nested HTML
 - [ ] figure out how to differentiate nested HTML without requiring sigils or other extra syntax
 - [ ] add `->final_output_to_browser()`, `->final_output_to_plaintext()`, `->final_output_to_ansi_terminal()`, `->final_output_to_markdown()` methods.

## Description

Introduces a function providing _context-aware auto-escaping_ HTML templating.

 - generate HTML markup in PHP without needing to escape anything.
 - replace placeholder content with data provided by PHP.
 - supply `true` to create a boolean attribute or `false`/`null` remove an attribute.

### Why use these strange funky comments?

A funky comment looks like a tag closer, but the first character of what would be the tag name is a symbol. This was first mentioned in [an HTML API progress report](https://make.wordpress.org/core/2023/08/19/progress-report-html-api/#templating): there's a particular kind of HTML syntax error that meets a number of needs we have seen in attempting to [replace dynamic content on the server](https://github.com/WordPress/gutenberg/discussions/39831#discussioncomment-7516498). Namely:

 - Funky comments cannot be nested, by construction.
 - once inside a funky comment, all bytes are allowed until the first ASCII `>`, making parsing trivial and reliable.
 - The first symbol provides a very convenient sigil form to differentiate multiple kinds of bits of content: a placeholder, a shortcode, a translation, etc…
 - These are pure HTML and not a new superset syntax of HTML, meaning that when editing in an HTML editor they should stand out properly.
 - Being existing HTML syntax, they cannot break syntax boundaries and cause further parsing problems down the line
 - They are concise and easily hand-written.

### What's in this patch?

This preliminary PR only renders child text and doesn't provide a mechanism for composing rendered HTML or rendering pre-processed HTML. That means everything passed as a child will be escaped to render verbatim in the browser. There are open questions about how best to represent nested HTML, and without a clear answer, this code prefers trust and safety over features.

 - does not render nested HTML (escapes everything)
 - relies on `esc_attr()` and `esc_html()` which today are the same thing in WordPress, but which could be greatly expanded to improve the overall escaping situation

```php
echo WP_HTML_Template::render(
	<<<HTML
<a href="</%url>">
	<img src="</%url>">
	</%url>
</a>
HTML,
	array( 'url' => 'https://s.wp.com/i/atat.png?w=640&h=480&alt="atat>atst"' ),
);
```

outputs

```html
<a href="https://s.wp.com/i/atat.png?w=640&amp;h=480&amp;alt=&quot;atat&gt;atst&quot;">
<img src="https://s.wp.com/i/atat.png?w=640&amp;h=480&amp;alt=&quot;atat&gt;atst&quot;">
https://s.wp.com/i/atat.png?w=640&amp;h=480&amp;alt=&quot;atat&gt;atst&quot;
</a>
```

This proposed templating syntax uses closing tags containing invalid tag names, so-called "funky comments," as placeholders, because they are converted to HTML comments in the DOM and because there is near universal existing support for them in all browsers, and because the syntax cannot be nested. The % at the front indicates that the value for the placeholder should come from the args array with a key named according to what follows the %.