### PR TITLE
restore error handler to the previus state

### DIFF
--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -4304,6 +4304,9 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		);
 
 		$theme_json->set_spacing_sizes();
+
+		restore_error_handler();
+
 		$this->assertSame( $expected_output, _wp_array_get( $theme_json->get_raw_data(), array( 'settings', 'spacing', 'spacingSizes', 'default' ) ) );
 	}
 


### PR DESCRIPTION
set_error_handler is a global change that should be cleaned up

Trac ticket: https://core.trac.wordpress.org/ticket/60305

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
