### PR TITLE
Use button instead of a tag if there is href is empty in submenu block

### DIFF
--- a/src/wp-includes/blocks/navigation-submenu.php
+++ b/src/wp-includes/blocks/navigation-submenu.php
@@ -113,8 +113,14 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	// If submenu icons are set to show, we also render a submenu button, so the submenu can be opened on click.
 	if ( ! $open_on_click ) {
 		$item_url = isset( $attributes['url'] ) ? $attributes['url'] : '';
-		// Start appending HTML attributes to anchor tag.
-		$html .= '<a class="wp-block-navigation-item__content"';
+		if ( empty( $item_url ) ) {
+			$tag = 'button';
+		} else {
+			$tag = 'a';
+		}
+
+		// Start appending HTML attributes.
+		$html .= '<' . $tag . ' class="wp-block-navigation-item__content"';
 
 		// The href attribute on a and area elements is not required;
 		// when those elements do not have href attributes they do not create hyperlinks.
@@ -148,8 +154,8 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 
 		$html .= $label;
 
-		$html .= '</a>';
-		// End anchor tag content.
+		$html .= '</' . $tag . '>';
+		// End tag content.
 
 		if ( $show_submenu_indicators ) {
 			// The submenu icon is rendered in a button here


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60351

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
