### PR TITLE
Improve test coverage for sanitize text field functions

### DIFF
--- a/tests/phpunit/tests/formatting/sanitizeTextField.php
+++ b/tests/phpunit/tests/formatting/sanitizeTextField.php
@@ -13,6 +13,7 @@ class Tests_Formatting_SanitizeTextField extends WP_UnitTestCase {
 	 * @dataProvider data_sanitize_text_field
 	 */
 	public function test_sanitize_text_field( $str, $expected ) {
+		$filter = new MockAction();
 		if ( is_array( $expected ) ) {
 			$expected_oneline   = $expected['oneline'];
 			$expected_multiline = $expected['multiline'];
@@ -20,8 +21,12 @@ class Tests_Formatting_SanitizeTextField extends WP_UnitTestCase {
 			$expected_oneline   = $expected;
 			$expected_multiline = $expected;
 		}
+		add_filter( 'sanitize_text_field', array( $filter, 'filter' ) );
 		$this->assertSame( $expected_oneline, sanitize_text_field( $str ) );
+		$this->assertSame( 1, $filter->get_call_count(), 'The sanitize_text_field filter was not called'  );
+		add_filter( 'sanitize_textarea_field', array( $filter, 'filter' ) );
 		$this->assertSameIgnoreEOL( $expected_multiline, sanitize_textarea_field( $str ) );
+		$this->assertSame( 2, $filter->get_call_count(), 'The sanitize_textarea_field filter was not called' );
 	}
 
 	public function data_sanitize_text_field() {

--- a/tests/phpunit/tests/formatting/sanitizeTextField.php
+++ b/tests/phpunit/tests/formatting/sanitizeTextField.php
@@ -23,7 +23,7 @@ class Tests_Formatting_SanitizeTextField extends WP_UnitTestCase {
 		}
 		add_filter( 'sanitize_text_field', array( $filter, 'filter' ) );
 		$this->assertSame( $expected_oneline, sanitize_text_field( $str ) );
-		$this->assertSame( 1, $filter->get_call_count(), 'The sanitize_text_field filter was not called'  );
+		$this->assertSame( 1, $filter->get_call_count(), 'The sanitize_text_field filter was not called' );
 		add_filter( 'sanitize_textarea_field', array( $filter, 'filter' ) );
 		$this->assertSameIgnoreEOL( $expected_multiline, sanitize_textarea_field( $str ) );
 		$this->assertSame( 2, $filter->get_call_count(), 'The sanitize_textarea_field filter was not called' );


### PR DESCRIPTION
The updated PHPUnit test now includes more robust checks on the sanitize text field and sanitize textarea field functions. This change also ensures that the filters for each function are correctly invoked with the addition of the MockAction class and get_call_count tests.

Trac ticket: https://core.trac.wordpress.org/ticket/60357