### PR TITLE
Backport aspect ratio block support

### DIFF
--- a/src/wp-includes/block-supports/dimensions.php
+++ b/src/wp-includes/block-supports/dimensions.php
@@ -83,6 +83,86 @@ function wp_apply_dimensions_support( $block_type, $block_attributes ) {
 	return $attributes;
 }
 
+/**
+ * Renders server-side dimensions styles to the block wrapper.
+ * This block support uses the `render_block` hook to ensure that
+ * it is also applied to non-server-rendered blocks.
+ *
+ * @since 6.5.0
+ * @access private
+ *
+ * @param  string $block_content Rendered block content.
+ * @param  array  $block         Block object.
+ * @return string                Filtered block content.
+ */
+function wp_render_dimensions_support( $block_content, $block ) {
+	$block_type               = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	$block_attributes         = ( isset( $block['attrs'] ) && is_array( $block['attrs'] ) ) ? $block['attrs'] : array();
+	$has_aspect_ratio_support = block_has_support( $block_type, array( 'dimensions', 'aspectRatio' ), false );
+
+	if (
+		! $has_aspect_ratio_support ||
+		wp_should_skip_block_supports_serialization( $block_type, 'dimensions', 'aspectRatio' )
+	) {
+		return $block_content;
+	}
+
+	$dimensions_block_styles                = array();
+	$dimensions_block_styles['aspectRatio'] = $block_attributes['style']['dimensions']['aspectRatio'] ?? null;
+
+	// To ensure the aspect ratio does not get overridden by `minHeight` unset any existing rule.
+	if (
+		isset( $dimensions_block_styles['aspectRatio'] )
+	) {
+		$dimensions_block_styles['minHeight'] = 'unset';
+	} elseif (
+		isset( $block_attributes['style']['dimensions']['minHeight'] ) ||
+		isset( $block_attributes['minHeight'] )
+	) {
+		$dimensions_block_styles['aspectRatio'] = 'unset';
+	}
+
+	$styles = wp_style_engine_get_styles( array( 'dimensions' => $dimensions_block_styles ) );
+
+	if ( ! empty( $styles['css'] ) ) {
+		// Inject dimensions styles to the first element, presuming it's the wrapper, if it exists.
+		$tags = new WP_HTML_Tag_Processor( $block_content );
+
+		if ( $tags->next_tag() ) {
+			$existing_style = $tags->get_attribute( 'style' );
+			$updated_style  = '';
+
+			if ( ! empty( $existing_style ) ) {
+				$updated_style = $existing_style;
+				if ( ! str_ends_with( $existing_style, ';' ) ) {
+					$updated_style .= ';';
+				}
+			}
+
+			$updated_style .= $styles['css'];
+			$tags->set_attribute( 'style', $updated_style );
+
+			if ( ! empty( $styles['classnames'] ) ) {
+				foreach ( explode( ' ', $styles['classnames'] ) as $class_name ) {
+					if (
+						str_contains( $class_name, 'aspect-ratio' ) &&
+						! isset( $block_attributes['style']['dimensions']['aspectRatio'] )
+					) {
+						continue;
+					}
+					$tags->add_class( $class_name );
+				}
+			}
+		}
+
+		return $tags->get_updated_html();
+	}
+
+	return $block_content;
+}
+
+add_filter( 'render_block', 'wp_render_dimensions_support', 10, 2 );
+
 // Register the block support.
 WP_Block_Supports::get_instance()->register(
 	'dimensions',

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -204,10 +204,12 @@ class WP_Theme_JSON {
 	 * @since 6.2.0 Added `outline-*`, and `min-height` properties.
 	 * @since 6.3.0 Added `column-count` property.
 	 * @since 6.4.0 Added `writing-mode` property.
+	 * @since 6.5.0 Added `aspect-ratio` property.
 	 *
 	 * @var array
 	 */
 	const PROPERTIES_METADATA = array(
+		'aspect-ratio'                      => array( 'dimensions', 'aspectRatio' ),
 		'background'                        => array( 'color', 'gradient' ),
 		'background-color'                  => array( 'color', 'background' ),
 		'border-radius'                     => array( 'border', 'radius' ),
@@ -344,8 +346,8 @@ class WP_Theme_JSON {
 	 * @since 6.3.0 Added support for `typography.textColumns`, removed `layout.definitions`.
 	 * @since 6.4.0 Added support for `layout.allowEditing`, `background.backgroundImage`,
 	 *              `typography.writingMode`, `lightbox.enabled` and `lightbox.allowEditing`.
-	 * @since 6.5.0 Added support for `layout.allowCustomContentAndWideSize` and
-	 *              `background.backgroundSize`.
+	 * @since 6.5.0 Added support for `layout.allowCustomContentAndWideSize`,
+	 *              `background.backgroundSize` and `dimensions.aspectRatio`.
 	 * @var array
 	 */
 	const VALID_SETTINGS = array(
@@ -380,7 +382,8 @@ class WP_Theme_JSON {
 		),
 		'custom'                        => null,
 		'dimensions'                    => array(
-			'minHeight' => null,
+			'aspectRatio' => null,
+			'minHeight'   => null,
 		),
 		'layout'                        => array(
 			'contentSize'                   => null,
@@ -438,6 +441,7 @@ class WP_Theme_JSON {
 	 *              updated `blockGap` to be allowed at any level.
 	 * @since 6.2.0 Added `outline`, and `minHeight` properties.
 	 * @since 6.3.0 Added support for `typography.textColumns`.
+	 * @since 6.5.0 Added support for `dimensions.aspectRatio`.
 	 *
 	 * @var array
 	 */
@@ -458,7 +462,8 @@ class WP_Theme_JSON {
 			'text'       => null,
 		),
 		'dimensions' => array(
-			'minHeight' => null,
+			'aspectRatio' => null,
+			'minHeight'   => null,
 		),
 		'filter'     => array(
 			'duotone' => null,
@@ -575,7 +580,7 @@ class WP_Theme_JSON {
 	 * @since 6.0.0
 	 * @since 6.2.0 Added `dimensions.minHeight` and `position.sticky`.
 	 * @since 6.4.0 Added `background.backgroundImage`.
-	 * @since 6.5.0 Added `background.backgroundSize`.
+	 * @since 6.5.0 Added `background.backgroundSize` and `dimensions.aspectRatio`.
 	 * @var array
 	 */
 	const APPEARANCE_TOOLS_OPT_INS = array(
@@ -589,6 +594,7 @@ class WP_Theme_JSON {
 		array( 'color', 'heading' ),
 		array( 'color', 'button' ),
 		array( 'color', 'caption' ),
+		array( 'dimensions', 'aspectRatio' ),
 		array( 'dimensions', 'minHeight' ),
 		array( 'position', 'sticky' ),
 		array( 'spacing', 'blockGap' ),
@@ -1990,6 +1996,15 @@ class WP_Theme_JSON {
 				 * and therefore the original $value will be returned.
 				 */
 				$value = wp_get_typography_font_size_value( array( 'size' => $value ) );
+			}
+
+			if ( 'aspect-ratio' === $css_property ) {
+				// For aspect ratio to work, other dimensions rules must be unset.
+				// This ensures that a fixed height does not override the aspect ratio.
+				$declarations[] = array(
+					'name'  => 'min-height',
+					'value' => 'unset',
+				);
 			}
 
 			$declarations[] = array(

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1927,6 +1927,7 @@ class WP_Theme_JSON {
 	 * @since 5.8.0
 	 * @since 5.9.0 Added the `$settings` and `$properties` parameters.
 	 * @since 6.1.0 Added `$theme_json`, `$selector`, and `$use_root_padding` parameters.
+	 * @since 6.5.0 Output a `min-height: unset` rule when `aspect-ratio` is set.
 	 *
 	 * @param array   $styles Styles to process.
 	 * @param array   $settings Theme settings.

--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -23,7 +23,8 @@
  * @since 6.1.0
  * @since 6.3.0 Added support for text-columns.
  * @since 6.4.0 Added support for background.backgroundImage.
- * @since 6.5.0 Added support for background.backgroundPosition and background.backgroundRepeat.
+ * @since 6.5.0 Added support for background.backgroundPosition,
+ *              background.backgroundRepeat and dimensions.aspectRatio.
  */
 #[AllowDynamicProperties]
 final class WP_Style_Engine {
@@ -190,7 +191,16 @@ final class WP_Style_Engine {
 			),
 		),
 		'dimensions' => array(
-			'minHeight' => array(
+			'aspectRatio' => array(
+				'property_keys' => array(
+					'default' => 'aspect-ratio',
+				),
+				'path'          => array( 'dimensions', 'aspectRatio' ),
+				'classnames'    => array(
+					'has-aspect-ratio' => true,
+				),
+			),
+			'minHeight'   => array(
 				'property_keys' => array(
 					'default' => 'min-height',
 				),

--- a/tests/phpunit/tests/block-supports/wpRenderDimensionsSupport.php
+++ b/tests/phpunit/tests/block-supports/wpRenderDimensionsSupport.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * @group block-supports
+ *
+ * @covers ::wp_render_dimensions_support
+ */
+class Tests_Block_Supports_WpRenderDimensionsSupport extends WP_UnitTestCase {
+	/**
+	 * @var string|null
+	 */
+	private $test_block_name;
+
+	/**
+	 * Theme root directory.
+	 *
+	 * @var string
+	 */
+	private $theme_root;
+
+	/**
+	 * Original theme directory.
+	 *
+	 * @var string
+	 */
+	private $orig_theme_dir;
+
+	public function set_up() {
+		parent::set_up();
+		$this->test_block_name = null;
+		$this->theme_root      = realpath( DIR_TESTDATA . '/themedir1' );
+		$this->orig_theme_dir  = $GLOBALS['wp_theme_directories'];
+
+		// /themes is necessary as theme.php functions assume /themes is the root if there is only one root.
+		$GLOBALS['wp_theme_directories'] = array( WP_CONTENT_DIR . '/themes', $this->theme_root );
+
+		add_filter( 'theme_root', array( $this, 'filter_set_theme_root' ) );
+		add_filter( 'stylesheet_root', array( $this, 'filter_set_theme_root' ) );
+		add_filter( 'template_root', array( $this, 'filter_set_theme_root' ) );
+
+		// Clear caches.
+		wp_clean_themes_cache();
+		unset( $GLOBALS['wp_themes'] );
+		WP_Style_Engine_CSS_Rules_Store::remove_all_stores();
+	}
+
+	public function tear_down() {
+		$GLOBALS['wp_theme_directories'] = $this->orig_theme_dir;
+
+		// Clear up the filters to modify the theme root.
+		remove_filter( 'theme_root', array( $this, 'filter_set_theme_root' ) );
+		remove_filter( 'stylesheet_root', array( $this, 'filter_set_theme_root' ) );
+		remove_filter( 'template_root', array( $this, 'filter_set_theme_root' ) );
+
+		wp_clean_themes_cache();
+		unset( $GLOBALS['wp_themes'] );
+		WP_Style_Engine_CSS_Rules_Store::remove_all_stores();
+		unregister_block_type( $this->test_block_name );
+		$this->test_block_name = null;
+		parent::tear_down();
+	}
+
+	public function filter_set_theme_root() {
+		return $this->theme_root;
+	}
+
+	/**
+	 * Tests that dimensions block support works as expected.
+	 *
+	 * @ticket 60365
+	 *
+	 * @covers ::wp_render_dimensions_support
+	 *
+	 * @dataProvider data_dimensions_block_support
+	 *
+	 * @param string $theme_name          The theme to switch to.
+	 * @param string $block_name          The test block name to register.
+	 * @param mixed  $dimensions_settings The dimensions block support settings.
+	 * @param mixed  $dimensions_style    The dimensions styles within the block attributes.
+	 * @param string $expected_wrapper    Expected markup for the block wrapper.
+	 * @param string $wrapper             Existing markup for the block wrapper.
+	 */
+	public function test_dimensions_block_support( $theme_name, $block_name, $dimensions_settings, $dimensions_style, $expected_wrapper, $wrapper ) {
+		switch_theme( $theme_name );
+		$this->test_block_name = $block_name;
+
+		register_block_type(
+			$this->test_block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'dimensions' => $dimensions_settings,
+				),
+			)
+		);
+
+		$block = array(
+			'blockName' => $block_name,
+			'attrs'     => array(
+				'style' => array(
+					'dimensions' => $dimensions_style,
+				),
+			),
+		);
+
+		$actual = wp_render_dimensions_support( $wrapper, $block );
+
+		$this->assertEquals(
+			$expected_wrapper,
+			$actual,
+			'Dimensions block wrapper markup should be correct'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_dimensions_block_support() {
+		return array(
+			'aspect ratio style is applied, with min-height unset' => array(
+				'theme_name'          => 'block-theme-child-with-fluid-typography',
+				'block_name'          => 'test/dimensions-rules-are-output',
+				'dimensions_settings' => array(
+					'aspectRatio' => true,
+				),
+				'dimensions_style'    => array(
+					'aspectRatio' => '16/9',
+				),
+				'expected_wrapper'    => '<div class="has-aspect-ratio" style="aspect-ratio:16/9;min-height:unset;">Content</div>',
+				'wrapper'             => '<div>Content</div>',
+			),
+			'dimensions style is appended if a style attribute already exists' => array(
+				'theme_name'          => 'block-theme-child-with-fluid-typography',
+				'block_name'          => 'test/dimensions-rules-are-output',
+				'dimensions_settings' => array(
+					'aspectRatio' => true,
+				),
+				'dimensions_style'    => array(
+					'aspectRatio' => '16/9',
+				),
+				'expected_wrapper'    => '<div class="wp-block-test has-aspect-ratio" style="color:red;aspect-ratio:16/9;min-height:unset;">Content</div>',
+				'wrapper'             => '<div class="wp-block-test" style="color:red;">Content</div>',
+			),
+			'aspect ratio style is unset if block has min-height set' => array(
+				'theme_name'          => 'block-theme-child-with-fluid-typography',
+				'block_name'          => 'test/dimensions-rules-are-output',
+				'dimensions_settings' => array(
+					'aspectRatio' => true,
+				),
+				'dimensions_style'    => array(
+					'minHeight' => '100px',
+				),
+				'expected_wrapper'    => '<div style="min-height:100px;aspect-ratio:unset;">Content</div>',
+				'wrapper'             => '<div style="min-height:100px">Content</div>',
+			),
+			'aspect ratio style is not applied if the block does not support aspect ratio' => array(
+				'theme_name'          => 'block-theme-child-with-fluid-typography',
+				'block_name'          => 'test/background-rules-are-not-output',
+				'dimensions_settings' => array(
+					'aspectRatio' => false,
+				),
+				'dimensions_style'    => array(
+					'aspectRatio' => '16/9',
+				),
+				'expected_wrapper'    => '<div>Content</div>',
+				'wrapper'             => '<div>Content</div>',
+			),
+		);
+	}
+}

--- a/tests/phpunit/tests/style-engine/styleEngine.php
+++ b/tests/phpunit/tests/style-engine/styleEngine.php
@@ -184,6 +184,23 @@ class Tests_wpStyleEngine extends WP_UnitTestCase {
 				),
 			),
 
+			'inline_valid_aspect_ratio_style'              => array(
+				'block_styles'    => array(
+					'dimensions' => array(
+						'aspectRatio' => '4/3',
+						'minHeight'   => 'unset',
+					),
+				),
+				'options'         => null,
+				'expected_output' => array(
+					'css'          => 'aspect-ratio:4/3;min-height:50vh;',
+					'declarations' => array(
+						'aspect-ratio' => '4/3',
+						'min-height'   => 'unset',
+					),
+				),
+			),
+
 			'inline_valid_shadow_style'                    => array(
 				'block_styles'    => array(
 					'shadow' => 'inset 5em 1em gold',

--- a/tests/phpunit/tests/style-engine/styleEngine.php
+++ b/tests/phpunit/tests/style-engine/styleEngine.php
@@ -193,7 +193,8 @@ class Tests_wpStyleEngine extends WP_UnitTestCase {
 				),
 				'options'         => null,
 				'expected_output' => array(
-					'css'          => 'aspect-ratio:4/3;min-height:50vh;',
+					'classnames'   => 'has-aspect-ratio',
+					'css'          => 'aspect-ratio:4/3;min-height:unset;',
 					'declarations' => array(
 						'aspect-ratio' => '4/3',
 						'min-height'   => 'unset',

--- a/tests/phpunit/tests/style-engine/styleEngine.php
+++ b/tests/phpunit/tests/style-engine/styleEngine.php
@@ -193,12 +193,12 @@ class Tests_wpStyleEngine extends WP_UnitTestCase {
 				),
 				'options'         => null,
 				'expected_output' => array(
-					'classnames'   => 'has-aspect-ratio',
 					'css'          => 'aspect-ratio:4/3;min-height:unset;',
 					'declarations' => array(
 						'aspect-ratio' => '4/3',
 						'min-height'   => 'unset',
 					),
+					'classnames'   => 'has-aspect-ratio',
 				),
 			),
 

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -279,7 +279,8 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 				'caption' => true,
 			),
 			'dimensions' => array(
-				'minHeight' => true,
+				'aspectRatio' => true,
+				'minHeight'   => true,
 			),
 			'position'   => array(
 				'sticky' => true,
@@ -316,7 +317,8 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 						'caption' => true,
 					),
 					'dimensions' => array(
-						'minHeight' => true,
+						'aspectRatio' => true,
+						'minHeight'   => true,
 					),
 					'position'   => array(
 						'sticky' => true,
@@ -495,6 +497,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	 * @ticket 56611
 	 * @ticket 58549
 	 * @ticket 58550
+	 * @ticket 60365
 	 */
 	public function test_get_stylesheet() {
 		$theme_json = new WP_Theme_JSON(
@@ -567,6 +570,11 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 						),
 					),
 					'blocks'   => array(
+						'core/cover'        => array(
+							'dimensions' => array(
+								'aspectRatio' => '16/9',
+							),
+						),
 						'core/group'        => array(
 							'color'    => array(
 								'gradient' => 'var:preset|gradient|custom-gradient',
@@ -645,7 +653,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		);
 
 		$variables = 'body{--wp--preset--color--grey: grey;--wp--preset--gradient--custom-gradient: linear-gradient(135deg,rgba(0,0,0) 0%,rgb(0,0,0) 100%);--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}';
-		$styles    = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap: 0.5em;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-constrained > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-constrained > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)){max-width: var(--wp--style--global--content-size);margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > .alignwide{max-width: var(--wp--style--global--wide-size);}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}body .is-layout-flex > *{margin: 0;}body .is-layout-grid{display: grid;}body .is-layout-grid > *{margin: 0;}body{color: var(--wp--preset--color--grey);}a:where(:not(.wp-element-button)){background-color: #333;color: #111;}.wp-element-button, .wp-block-button__link{box-shadow: 10px 10px 5px 0px rgba(0,0,0,0.66);}.wp-block-group{background: var(--wp--preset--gradient--custom-gradient);border-radius: 10px;padding: 24px;}.wp-block-group a:where(:not(.wp-element-button)){color: #111;}.wp-block-heading{color: #123456;}.wp-block-heading a:where(:not(.wp-element-button)){background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a:where(:not(.wp-element-button)){background-color: #777;color: #555;}.wp-block-post-excerpt{column-count: 2;}.wp-block-image{margin-bottom: 30px;}.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder{border-top-left-radius: 10px;border-bottom-right-radius: 1em;}.wp-block-image img, .wp-block-image .components-placeholder{filter: var(--wp--preset--duotone--custom-duotone);}';
+		$styles    = 'body { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap: 0.5em;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-constrained > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-constrained > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)){max-width: var(--wp--style--global--content-size);margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > .alignwide{max-width: var(--wp--style--global--wide-size);}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}body .is-layout-flex > *{margin: 0;}body .is-layout-grid{display: grid;}body .is-layout-grid > *{margin: 0;}body{color: var(--wp--preset--color--grey);}a:where(:not(.wp-element-button)){background-color: #333;color: #111;}.wp-element-button, .wp-block-button__link{box-shadow: 10px 10px 5px 0px rgba(0,0,0,0.66);}.wp-block-cover{min-height: unset;aspect-ratio: 16/9;}.wp-block-group{background: var(--wp--preset--gradient--custom-gradient);border-radius: 10px;padding: 24px;}.wp-block-group a:where(:not(.wp-element-button)){color: #111;}.wp-block-heading{color: #123456;}.wp-block-heading a:where(:not(.wp-element-button)){background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a:where(:not(.wp-element-button)){background-color: #777;color: #555;}.wp-block-post-excerpt{column-count: 2;}.wp-block-image{margin-bottom: 30px;}.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder{border-top-left-radius: 10px;border-bottom-right-radius: 1em;}.wp-block-image img, .wp-block-image .components-placeholder{filter: var(--wp--preset--duotone--custom-duotone);}';
 		$presets   = '.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}.has-custom-gradient-gradient-background{background: var(--wp--preset--gradient--custom-gradient) !important;}.has-small-font-family{font-family: var(--wp--preset--font-family--small) !important;}.has-big-font-family{font-family: var(--wp--preset--font-family--big) !important;}';
 		$all       = $variables . $styles . $presets;
 		$this->assertSame( $all, $theme_json->get_stylesheet() );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Backport the aspect ratio block support feature from the Gutenberg plugin, that originally landed in: https://github.com/WordPress/gutenberg/pull/56897 and https://github.com/WordPress/gutenberg/pull/58414

Note this PR backports the PHP parts of the block support. This can be safely done prior to the JS packages landing for core, as the UI for the feature will not be exposed until the JS packages are updated.

* In a post or page add the following markup that contains a Cover block with an aspect-ratio set:

```
<!-- wp:cover {"customOverlayColor":"#bd6c6c","isUserOverlayColor":true,"isDark":false,"style":{"dimensions":{"aspectRatio":"16/9"}},"layout":{"type":"constrained"}} -->
<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#bd6c6c"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">A cover block in 16:9</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->
```

* Note: at this stage you won't yet see the aspect ratio rendered in the editor — this is to be expected as JS rendering will only happen once the JS packages are updated.
* Save the post or page and load the post on the site frontend. You should see that the aspect ratio rules are output for this block, along with a `min-height:unset` rule:

<img width="1112" alt="image" src="https://github.com/WordPress/wordpress-develop/assets/14988353/2e5ed191-10e0-48d6-8495-bd9fa6808025">

Trac ticket: https://core.trac.wordpress.org/ticket/60365

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
