### PR TITLE
HTML API: Move test @covers annotations to classes

### DIFF
--- a/tests/phpunit/tests/html-api/wpHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor.php
@@ -9,8 +9,14 @@
  *
  * @group html-api
  *
+ * @covers WP_HTML_Active_Formatting_Elements
+ * @covers WP_HTML_Open_Elements
  * @covers WP_HTML_Processor
+ * @covers WP_HTML_Processor_State
+ * @covers WP_HTML_Token
  */
+
+
 class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 	/**
 	 * Ensure that the HTML Processor's public constructor function warns a developer to call

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor.php
@@ -9,7 +9,7 @@
  *
  * @group html-api
  *
- * @coversDefaultClass WP_HTML_Processor
+ * @covers WP_HTML_Processor
  */
 class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 	/**
@@ -28,8 +28,6 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 	 * the callee that it should be using those static methods instead.
 	 *
 	 * @ticket 58517
-	 *
-	 * @covers WP_HTML_Processor::__construct
 	 */
 	public function test_warns_that_the_static_creator_methods_should_be_called_instead_of_the_public_constructor() {
 		$this->setExpectedIncorrectUsage( 'WP_HTML_Processor::__construct' );
@@ -48,8 +46,6 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 	 * is no tag matched or open.
 	 *
 	 * @ticket 59167
-	 *
-	 * @covers WP_HTML_Processor::get_tag
 	 */
 	public function test_get_tag_is_null_once_document_is_finished() {
 		$p = WP_HTML_Processor::create_fragment( '<div class="test">Test</div>' );
@@ -72,9 +68,6 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 	 * inside an open LI element.
 	 *
 	 * @ticket 58517
-	 *
-	 * @covers WP_HTML_Processor::next_tag
-	 * @covers WP_HTML_Processor::seek
 	 */
 	public function test_clear_to_navigate_after_seeking() {
 		$p = WP_HTML_Processor::create_fragment( '<div one><strong></strong></div><p><strong two></strong></p>' );
@@ -122,8 +115,6 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 	 * before the HTML Processor handles situations with unclosed formats requiring it.
 	 *
 	 * @ticket 58517
-	 *
-	 * @covers WP_HTML_Processor::reconstruct_active_formatting_elements
 	 */
 	public function test_fails_to_reconstruct_formatting_elements() {
 		$p = WP_HTML_Processor::create_fragment( '<p><em>One<p><em>Two<p><em>Three<p><em>Four' );
@@ -136,9 +127,6 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 	 * Ensure non-nesting tags do not nest.
 	 *
 	 * @ticket 60283
-	 *
-	 * @covers WP_HTML_Processor::step_in_body
-	 * @covers WP_HTML_Processor::is_void
 	 *
 	 * @dataProvider data_void_tags
 	 *
@@ -221,8 +209,6 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 	 * @ticket 60092
 	 *
 	 * @dataProvider data_unsupported_special_in_body_tags
-	 *
-	 * @covers WP_HTML_Processor::step_in_body
 	 *
 	 * @param string $tag_name Name of the tag to test.
 	 */

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
@@ -9,13 +9,12 @@
  *
  * @group html-api
  *
- * @coversDefaultClass WP_HTML_Processor
+ * @covers WP_HTML_Processor
+ * @covers WP_HTML_Tag_Processor
  */
 class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 	/**
 	 * @ticket 58517
-	 *
-	 * @covers WP_HTML_Processor::step
 	 *
 	 * @dataProvider data_single_tag_of_supported_elements
 	 *
@@ -148,8 +147,6 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 	 *
 	 * @ticket 58517
 	 *
-	 * @covers WP_HTML_Processor::step
-	 *
 	 * @dataProvider data_unsupported_elements
 	 *
 	 * @param string $html HTML string containing unsupported elements.
@@ -261,8 +258,6 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 	/**
 	 * @ticket 58517
 	 *
-	 * @covers WP_HTML_Processor::next_tag
-	 *
 	 * @dataProvider data_html_target_with_breadcrumbs
 	 *
 	 * @param string $html        HTML string with tags in it, one of which contains the "target" attribute.
@@ -285,8 +280,6 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 58517
-	 *
-	 * @covers WP_HTML_Processor::get_breadcrumbs
 	 *
 	 * @dataProvider data_html_target_with_breadcrumbs
 	 *
@@ -429,8 +422,6 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 	 * @since 6.4.0
 	 *
 	 * @ticket 59607
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_updated_html
 	 */
 	public function test_remains_stable_when_editing_attributes() {
 		$p = WP_HTML_Processor::create_fragment( '<div><button>First<button><b here>Second' );
@@ -475,8 +466,6 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 	 * @since 6.4.0
 	 *
 	 * @ticket 58517
-	 *
-	 * @covers WP_HTML_Tag_Processor::set_attribute
 	 */
 	public function test_can_modify_attributes_after_finding_tag() {
 		$p = WP_HTML_Processor::create_fragment( '<div><figure><img><figcaption>test</figcaption></figure>' );
@@ -493,8 +482,6 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 	 * @since 6.4.0
 	 *
 	 * @ticket 58517
-	 *
-	 * @covers WP_HTML_Processor::next_tag
 	 */
 	public function test_can_query_an_element_by_tag_name() {
 		$p = WP_HTML_Processor::create_fragment( '<div><DIV><strong><img></strong></DIV>' );
@@ -510,8 +497,6 @@ class Tests_HtmlApi_WpHtmlProcessorBreadcrumbs extends WP_UnitTestCase {
 	 * @since 6.4.0
 	 *
 	 * @ticket 58517
-	 *
-	 * @covers WP_HTML_Processor::seek
 	 */
 	public function test_can_seek_back_and_forth() {
 		$p = WP_HTML_Processor::create_fragment(

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRules.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRules.php
@@ -9,7 +9,7 @@
  *
  * @group html-api
  *
- * @coversDefaultClass WP_HTML_Processor
+ * @covers WP_HTML_Processor
  */
 class Tests_HtmlApi_WpHtmlProcessorSemanticRules extends WP_UnitTestCase {
 	/*******************************************************************
@@ -19,8 +19,6 @@ class Tests_HtmlApi_WpHtmlProcessorSemanticRules extends WP_UnitTestCase {
 	/**
 	 * Verifies that tags in the container group, including the ARTICLE element,
 	 * close out an open P element if one exists.
-	 *
-	 * @covers WP_HTML_Processor::step_in_body
 	 *
 	 * @ticket 59914
 	 *
@@ -51,8 +49,6 @@ class Tests_HtmlApi_WpHtmlProcessorSemanticRules extends WP_UnitTestCase {
 	/**
 	 * Verifies that tags in the container group, including the ARTICLE element,
 	 * nest inside each other despite being invalid in most cases.
-	 *
-	 * @covers WP_HTML_Processor::step_in_body
 	 *
 	 * @ticket 59914
 	 *
@@ -348,8 +344,6 @@ class Tests_HtmlApi_WpHtmlProcessorSemanticRules extends WP_UnitTestCase {
 	 * that the HTML processor ignores the end tag if there's a special
 	 * element on the stack of open elements before the matching opening.
 	 *
-	 * @covers WP_HTML_Processor::step_in_body
-	 *
 	 * @ticket 58907
 	 *
 	 * @since 6.4.0
@@ -370,8 +364,6 @@ class Tests_HtmlApi_WpHtmlProcessorSemanticRules extends WP_UnitTestCase {
 	 * Verifies that when "in body" and encountering "any other end tag"
 	 * that the HTML processor closes appropriate elements on the stack of
 	 * open elements up to the matching opening.
-	 *
-	 * @covers WP_HTML_Processor::step_in_body
 	 *
 	 * @ticket 58907
 	 *
@@ -406,8 +398,6 @@ class Tests_HtmlApi_WpHtmlProcessorSemanticRules extends WP_UnitTestCase {
 	 * When this handling is implemented, this test should be removed. It's not incorporated
 	 * into the existing unsupported tag behavior test because the opening tag is supported;
 	 * only the closing tag isn't.
-	 *
-	 * @covers WP_HTML_Processor::step_in_body
 	 *
 	 * @ticket 60283
 	 */

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRulesHeadingElements.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRulesHeadingElements.php
@@ -10,7 +10,7 @@
  *
  * @group html-api
  *
- * @coversDefaultClass WP_HTML_Processor
+ * @covers WP_HTML_Processor
  */
 class Tests_HtmlApi_WpHtmlProcessorSemanticRulesHeadingElements extends WP_UnitTestCase {
 	/*******************************************************************
@@ -21,8 +21,6 @@ class Tests_HtmlApi_WpHtmlProcessorSemanticRulesHeadingElements extends WP_UnitT
 	 * Verifies that H1 through H6 elements generate implied end tags.
 	 *
 	 * @ticket 60060
-	 *
-	 * @covers WP_HTML_Processor::step
 	 *
 	 * @dataProvider data_heading_elements
 	 *
@@ -68,8 +66,6 @@ class Tests_HtmlApi_WpHtmlProcessorSemanticRulesHeadingElements extends WP_UnitT
 	 * Verifies that H1 through H6 elements close an open H1 through H6 element.
 	 *
 	 * @ticket 60060
-	 *
-	 * @covers WP_HTML_Processor::step
 	 *
 	 * @dataProvider data_heading_combinations
 	 *

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRulesListElements.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRulesListElements.php
@@ -10,7 +10,7 @@
  *
  * @group html-api
  *
- * @coversDefaultClass WP_HTML_Processor
+ * @covers WP_HTML_Processor
  */
 class Tests_HtmlApi_WpHtmlProcessorSemanticRulesListElements extends WP_UnitTestCase {
 	/*******************************************************************

--- a/tests/phpunit/tests/html-api/wpHtmlSupportRequiredHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlSupportRequiredHtmlProcessor.php
@@ -21,7 +21,7 @@
  *
  * @group html-api
  *
- * @coversDefaultClass WP_HTML_Processor
+ * @covers WP_HTML_Processor
  */
 class Tests_HtmlApi_WpHtmlSupportRequiredHtmlProcessor extends WP_UnitTestCase {
 	/**
@@ -54,8 +54,6 @@ class Tests_HtmlApi_WpHtmlSupportRequiredHtmlProcessor extends WP_UnitTestCase {
 	 * @since 6.4.0
 	 *
 	 * @ticket 58907
-	 *
-	 * @covers WP_HTML_Processor::generate_implied_end_tags
 	 */
 	public function test_generate_implied_end_tags_needs_support() {
 		$this->ensure_support_is_added_everywhere( 'OPTGROUP' );
@@ -73,8 +71,6 @@ class Tests_HtmlApi_WpHtmlSupportRequiredHtmlProcessor extends WP_UnitTestCase {
 	 * @since 6.4.0
 	 *
 	 * @ticket 58907
-	 *
-	 * @covers WP_HTML_Processor::generate_implied_end_tags_thoroughly
 	 */
 	public function test_generate_implied_end_tags_thoroughly_needs_support() {
 		$this->ensure_support_is_added_everywhere( 'CAPTION' );

--- a/tests/phpunit/tests/html-api/wpHtmlSupportRequiredOpenElements.php
+++ b/tests/phpunit/tests/html-api/wpHtmlSupportRequiredOpenElements.php
@@ -23,7 +23,7 @@
  *
  * @group html-api
  *
- * @coversDefaultClass WP_HTML_Processor
+ * @covers WP_HTML_Processor
  */
 class Tests_HtmlApi_WpHtmlSupportRequiredOpenElements extends WP_UnitTestCase {
 	/**
@@ -95,8 +95,6 @@ class Tests_HtmlApi_WpHtmlSupportRequiredOpenElements extends WP_UnitTestCase {
 	 * @since 6.4.0
 	 *
 	 * @ticket 58517
-	 *
-	 * @covers WP_HTML_Open_Elements::has_element_in_list_item_scope
 	 */
 	public function test_has_element_in_list_item_scope_needs_support() {
 		// These elements impact all scopes.
@@ -129,8 +127,6 @@ class Tests_HtmlApi_WpHtmlSupportRequiredOpenElements extends WP_UnitTestCase {
 	 * @since 6.4.0
 	 *
 	 * @ticket 58517
-	 *
-	 * @covers WP_HTML_Open_Elements::has_element_in_button_scope
 	 */
 	public function test_has_element_in_button_scope_needs_support() {
 		// These elements impact all scopes.
@@ -164,8 +160,6 @@ class Tests_HtmlApi_WpHtmlSupportRequiredOpenElements extends WP_UnitTestCase {
 	 * @since 6.4.0
 	 *
 	 * @ticket 58517
-	 *
-	 * @covers WP_HTML_Open_Elements::after_element_pop
 	 */
 	public function test_after_element_pop_must_maintain_p_in_button_scope_flag() {
 		// These elements impact all scopes.
@@ -199,8 +193,6 @@ class Tests_HtmlApi_WpHtmlSupportRequiredOpenElements extends WP_UnitTestCase {
 	 * @since 6.4.0
 	 *
 	 * @ticket 58517
-	 *
-	 * @covers WP_HTML_Open_Elements::after_element_push
 	 */
 	public function test_after_element_push_must_maintain_p_in_button_scope_flag() {
 		// These elements impact all scopes.
@@ -233,8 +225,6 @@ class Tests_HtmlApi_WpHtmlSupportRequiredOpenElements extends WP_UnitTestCase {
 	 * @since 6.4.0
 	 *
 	 * @ticket 58517
-	 *
-	 * @covers WP_HTML_Open_Elements::has_element_in_table_scope
 	 */
 	public function test_has_element_in_table_scope_needs_support() {
 		// These elements impact all scopes.
@@ -283,8 +273,6 @@ class Tests_HtmlApi_WpHtmlSupportRequiredOpenElements extends WP_UnitTestCase {
 	 * @since 6.4.0
 	 *
 	 * @ticket 58517
-	 *
-	 * @covers WP_HTML_Open_Elements::has_element_in_select_scope
 	 */
 	public function test_has_element_in_select_scope_needs_support() {
 		// These elements impact all scopes.

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-bookmark.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-bookmark.php
@@ -9,14 +9,12 @@
 /**
  * @group html-api
  *
- * @coversDefaultClass WP_HTML_Tag_Processor
+ * @covers WP_HTML_Tag_Processor
  */
 class Tests_HtmlApi_WpHtmlTagProcessor_Bookmark extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::set_bookmark
 	 */
 	public function test_set_bookmark() {
 		$p = new WP_HTML_Tag_Processor( '<ul><li>One</li><li>Two</li><li>Three</li></ul>' );
@@ -29,8 +27,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor_Bookmark extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::release_bookmark
 	 */
 	public function test_release_bookmark() {
 		$p = new WP_HTML_Tag_Processor( '<ul><li>One</li><li>Two</li><li>Three</li></ul>' );
@@ -42,8 +38,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor_Bookmark extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 57788
-	 *
-	 * @covers WP_HTML_Tag_Processor::has_bookmark
 	 */
 	public function test_has_bookmark_returns_false_if_bookmark_does_not_exist() {
 		$p = new WP_HTML_Tag_Processor( '<div>Test</div>' );
@@ -52,8 +46,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor_Bookmark extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 57788
-	 *
-	 * @covers WP_HTML_Tag_Processor::has_bookmark
 	 */
 	public function test_has_bookmark_returns_true_if_bookmark_exists() {
 		$p = new WP_HTML_Tag_Processor( '<div>Test</div>' );
@@ -64,8 +56,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor_Bookmark extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 57788
-	 *
-	 * @covers WP_HTML_Tag_Processor::has_bookmark
 	 */
 	public function test_has_bookmark_returns_false_if_bookmark_has_been_released() {
 		$p = new WP_HTML_Tag_Processor( '<div>Test</div>' );
@@ -77,8 +67,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor_Bookmark extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::seek
 	 */
 	public function test_seek() {
 		$p = new WP_HTML_Tag_Processor( '<ul><li>One</li><li>Two</li><li>Three</li></ul>' );
@@ -100,8 +88,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor_Bookmark extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 57787
-	 *
-	 * @covers WP_HTML_Tag_Processor::seek
 	 */
 	public function test_seeks_to_tag_closer_bookmark() {
 		$p = new WP_HTML_Tag_Processor( '<div>First</div><span>Second</span>' );
@@ -154,9 +140,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor_Bookmark extends WP_UnitTestCase {
 	 * the erroneous behavior accidentally returning one day.
 	 *
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::seek
-	 * @covers WP_HTML_Tag_Processor::set_bookmark
 	 */
 	public function test_removing_long_attributes_doesnt_break_seek() {
 		$input = <<<HTML
@@ -183,9 +166,6 @@ HTML;
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::seek
-	 * @covers WP_HTML_Tag_Processor::set_bookmark
 	 */
 	public function test_bookmarks_complex_use_case() {
 		$input           = <<<HTML
@@ -293,8 +273,6 @@ HTML;
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::seek
 	 */
 	public function test_updates_bookmark_for_additions_after_both_sides() {
 		$p = new WP_HTML_Tag_Processor( '<div>First</div><div>Second</div>' );
@@ -315,8 +293,6 @@ HTML;
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::seek
 	 */
 	public function test_updates_bookmark_for_additions_before_both_sides() {
 		$p = new WP_HTML_Tag_Processor( '<div>First</div><div>Second</div>' );
@@ -340,8 +316,6 @@ HTML;
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::seek
 	 */
 	public function test_updates_bookmark_for_deletions_after_both_sides() {
 		$p = new WP_HTML_Tag_Processor( '<div>First</div><div disabled>Second</div>' );
@@ -370,8 +344,6 @@ HTML;
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::seek
 	 */
 	public function test_updates_bookmark_for_deletions_before_both_sides() {
 		$p = new WP_HTML_Tag_Processor( '<div disabled>First</div><div>Second</div>' );
@@ -403,8 +375,6 @@ HTML;
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::set_bookmark
 	 */
 	public function test_limits_the_number_of_bookmarks() {
 		$p = new WP_HTML_Tag_Processor( '<ul><li>One</li><li>Two</li><li>Three</li></ul>' );
@@ -420,8 +390,6 @@ HTML;
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::seek
 	 */
 	public function test_limits_the_number_of_seek_calls() {
 		$p = new WP_HTML_Tag_Processor( '<ul><li>One</li><li>Two</li><li>Three</li></ul>' );

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-token-scanning.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-token-scanning.php
@@ -9,7 +9,7 @@
  *
  * @group html-api
  *
- * @coversDefaultClass WP_HTML_Tag_Processor
+ * @covers WP_HTML_Tag_Processor
  */
 class Tests_HtmlApi_WpHtmlProcessor_Token_Scanning extends WP_UnitTestCase {
 	/**
@@ -18,8 +18,6 @@ class Tests_HtmlApi_WpHtmlProcessor_Token_Scanning extends WP_UnitTestCase {
 	 * @ticket 60170
 	 *
 	 * @since 6.5.0
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_token
 	 */
 	public function test_completes_empty_document() {
 		$processor = new WP_HTML_Tag_Processor( '' );
@@ -36,8 +34,6 @@ class Tests_HtmlApi_WpHtmlProcessor_Token_Scanning extends WP_UnitTestCase {
 	 * @ticket 60170
 	 *
 	 * @since 6.5.0
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_token
 	 */
 	public function test_basic_assertion_text_node() {
 		$processor = new WP_HTML_Tag_Processor( 'Hello, World!' );
@@ -62,8 +58,6 @@ class Tests_HtmlApi_WpHtmlProcessor_Token_Scanning extends WP_UnitTestCase {
 	 * @ticket 60170
 	 *
 	 * @since 6.5.0
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_token
 	 */
 	public function test_basic_assertion_element() {
 		$processor = new WP_HTML_Tag_Processor( '<div id="test" inert>Hello, World!</div>' );
@@ -107,8 +101,6 @@ class Tests_HtmlApi_WpHtmlProcessor_Token_Scanning extends WP_UnitTestCase {
 	 * @ticket 60170
 	 *
 	 * @since 6.5.0
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_token
 	 */
 	public function test_basic_assertion_script_element() {
 		$processor = new WP_HTML_Tag_Processor( '<script type="module">console.log( "Hello, World!" );</script>' );
@@ -147,8 +139,6 @@ class Tests_HtmlApi_WpHtmlProcessor_Token_Scanning extends WP_UnitTestCase {
 	 * @ticket 60170
 	 *
 	 * @since 6.5.0
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_token
 	 */
 	public function test_basic_assertion_textarea_element() {
 		$processor = new WP_HTML_Tag_Processor(
@@ -200,8 +190,6 @@ HTML
 	 * @ticket 60170
 	 *
 	 * @since 6.5.0
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_token
 	 */
 	public function test_basic_assertion_title_element() {
 		$processor = new WP_HTML_Tag_Processor(
@@ -246,8 +234,6 @@ HTML
 	 * @ticket 60170
 	 *
 	 * @since 6.5.0
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_token
 	 *
 	 * @dataProvider data_rawtext_elements
 	 *
@@ -311,8 +297,6 @@ HTML
 	 * @ticket 60170
 	 *
 	 * @since 6.5.0
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_token
 	 */
 	public function test_basic_assertion_cdata_section() {
 		$processor = new WP_HTML_Tag_Processor( '<![CDATA[this is a comment]]>' );
@@ -353,8 +337,6 @@ HTML
 	 * @ticket 60170
 	 *
 	 * @since 6.5.0
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_token
 	 */
 	public function test_basic_assertion_abruptly_closed_cdata_section() {
 		$processor = new WP_HTML_Tag_Processor( '<![CDATA[this is > a comment]]>' );
@@ -403,8 +385,6 @@ HTML
 	 * @ticket 60170
 	 *
 	 * @since 6.5.0
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_token
 	 */
 	public function test_basic_assertion_processing_instruction() {
 		$processor = new WP_HTML_Tag_Processor( '<?wp-bit {"just": "kidding"}?>' );
@@ -446,8 +426,6 @@ HTML
 	 * @ticket 60170
 	 *
 	 * @since 6.5.0
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_token
 	 */
 	public function test_basic_assertion_abruptly_closed_processing_instruction() {
 		$processor = new WP_HTML_Tag_Processor( '<?version=">=5.3.6"?>' );
@@ -498,8 +476,6 @@ HTML
 	 * @since 6.5.0
 	 *
 	 * @dataProvider data_common_comments
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_token
 	 *
 	 * @param string $html Contains the comment in full.
 	 * @param string $text Contains the appropriate modifiable text.
@@ -560,8 +536,6 @@ HTML
 	 * @ticket 60170
 	 *
 	 * @since 6.5.0
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_token
 	 */
 	public function test_basic_assertion_html_comment() {
 		$processor = new WP_HTML_Tag_Processor( '<!-- wp:paragraph -->' );
@@ -602,8 +576,6 @@ HTML
 	 * @ticket 60170
 	 *
 	 * @since 6.5.0
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_token
 	 */
 	public function test_basic_assertion_doctype() {
 		$processor = new WP_HTML_Tag_Processor( '<!DOCTYPE html>' );
@@ -644,8 +616,6 @@ HTML
 	 * @ticket 60170
 	 *
 	 * @since 6.5.0
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_token
 	 */
 	public function test_basic_assertion_presumptuous_tag() {
 		$processor = new WP_HTML_Tag_Processor( '</>' );
@@ -686,8 +656,6 @@ HTML
 	 * @ticket 60170
 	 *
 	 * @since 6.5.0
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_token
 	 */
 	public function test_basic_assertion_funky_comment() {
 		$processor = new WP_HTML_Tag_Processor( '</%url>' );

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -9,6 +9,8 @@
 /**
  * @group html-api
  *
+ * @covers WP_HTML_Attribute_Token
+ * @covers WP_HTML_Span
  * @covers WP_HTML_Tag_Processor
  */
 class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -9,7 +9,7 @@
 /**
  * @group html-api
  *
- * @coversDefaultClass WP_HTML_Tag_Processor
+ * @covers WP_HTML_Tag_Processor
  */
 class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 	const HTML_SIMPLE       = '<div id="first"><span id="second">Text</span></div>';
@@ -18,8 +18,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_tag
 	 */
 	public function test_get_tag_returns_null_before_finding_tags() {
 		$p = new WP_HTML_Tag_Processor( '<div>Test</div>' );
@@ -29,8 +27,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_tag
 	 */
 	public function test_get_tag_returns_null_when_not_in_open_tag() {
 		$p = new WP_HTML_Tag_Processor( '<div>Test</div>' );
@@ -41,8 +37,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_tag
 	 */
 	public function test_get_tag_returns_open_tag_name() {
 		$p = new WP_HTML_Tag_Processor( '<div>Test</div>' );
@@ -53,8 +47,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 58009
-	 *
-	 * @covers WP_HTML_Tag_Processor::has_self_closing_flag
 	 *
 	 * @dataProvider data_has_self_closing_flag
 	 *
@@ -103,8 +95,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute
 	 */
 	public function test_get_attribute_returns_null_before_finding_tags() {
 		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
@@ -114,8 +104,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute
 	 */
 	public function test_get_attribute_returns_null_when_not_in_open_tag() {
 		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
@@ -126,8 +114,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute
 	 */
 	public function test_get_attribute_returns_null_when_in_closing_tag() {
 		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
@@ -139,8 +125,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute
 	 */
 	public function test_get_attribute_returns_null_when_attribute_missing() {
 		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
@@ -151,8 +135,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute
 	 */
 	public function test_get_attribute_returns_attribute_value() {
 		$p = new WP_HTML_Tag_Processor( '<div class="test">Test</div>' );
@@ -163,8 +145,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute
 	 */
 	public function test_get_attribute_returns_true_for_boolean_attribute() {
 		$p = new WP_HTML_Tag_Processor( '<div enabled class="test">Test</div>' );
@@ -175,8 +155,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute
 	 */
 	public function test_get_attribute_returns_string_for_truthy_attributes() {
 		$p = new WP_HTML_Tag_Processor( '<div enabled=enabled checked=1 hidden="true" class="test">Test</div>' );
@@ -189,8 +167,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute
 	 */
 	public function test_get_attribute_decodes_html_character_references() {
 		$p = new WP_HTML_Tag_Processor( '<div id="the &quot;grande&quot; is &lt; &#x033;&#50;oz&dagger;"></div>' );
@@ -201,8 +177,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute
 	 */
 	public function test_attributes_parser_treats_slash_as_attribute_separator() {
 		$p = new WP_HTML_Tag_Processor( '<div a/b/c/d/e="test">Test</div>' );
@@ -217,8 +191,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute
 	 *
 	 * @dataProvider data_attribute_name_case_variants
 	 *
@@ -237,8 +209,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute
 	 *
 	 * @dataProvider data_attribute_name_case_variants
 	 *
@@ -270,8 +240,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::remove_attribute
 	 */
 	public function test_remove_attribute_is_case_insensitive() {
 		$p = new WP_HTML_Tag_Processor( '<div DATA-enabled="true">Test</div>' );
@@ -283,8 +251,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::set_attribute
 	 */
 	public function test_set_attribute_is_case_insensitive() {
 		$p = new WP_HTML_Tag_Processor( '<div DATA-enabled="true">Test</div>' );
@@ -296,8 +262,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute_names_with_prefix
 	 */
 	public function test_get_attribute_names_with_prefix_returns_null_before_finding_tags() {
 		$p = new WP_HTML_Tag_Processor( '<div data-foo="bar">Test</div>' );
@@ -309,8 +273,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute_names_with_prefix
 	 */
 	public function test_get_attribute_names_with_prefix_returns_null_when_not_in_open_tag() {
 		$p = new WP_HTML_Tag_Processor( '<div data-foo="bar">Test</div>' );
@@ -320,8 +282,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute_names_with_prefix
 	 */
 	public function test_get_attribute_names_with_prefix_returns_null_when_in_closing_tag() {
 		$p = new WP_HTML_Tag_Processor( '<div data-foo="bar">Test</div>' );
@@ -333,8 +293,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute_names_with_prefix
 	 */
 	public function test_get_attribute_names_with_prefix_returns_empty_array_when_no_attributes_present() {
 		$p = new WP_HTML_Tag_Processor( '<div>Test</div>' );
@@ -345,8 +303,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute_names_with_prefix
 	 */
 	public function test_get_attribute_names_with_prefix_returns_matching_attribute_names_in_lowercase() {
 		$p = new WP_HTML_Tag_Processor( '<div DATA-enabled class="test" data-test-ID="14">Test</div>' );
@@ -361,8 +317,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute_names_with_prefix
 	 */
 	public function test_get_attribute_names_with_prefix_returns_attribute_added_by_set_attribute() {
 		$p = new WP_HTML_Tag_Processor( '<div data-foo="bar">Test</div>' );
@@ -383,8 +337,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::__toString
 	 */
 	public function test_to_string_returns_updated_html() {
 		$p = new WP_HTML_Tag_Processor( '<hr id="remove" /><div enabled class="test">Test</div><span id="span-id"></span>' );
@@ -404,8 +356,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_updated_html
 	 */
 	public function test_get_updated_html_applies_the_updates_so_far_and_keeps_the_processor_on_the_current_tag() {
 		$p = new WP_HTML_Tag_Processor( '<hr id="remove" /><div enabled class="test">Test</div><span id="span-id"></span>' );
@@ -443,8 +393,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_updated_html
 	 */
 	public function test_get_updated_html_without_updating_any_attributes_returns_the_original_html() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
@@ -478,8 +426,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_tag
 	 */
 	public function test_next_tag_with_no_arguments_should_find_the_next_existing_tag() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
@@ -489,8 +435,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_tag
 	 */
 	public function test_next_tag_should_return_false_for_a_non_existing_tag() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
@@ -500,8 +444,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 59209
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_tag
 	 */
 	public function test_next_tag_matches_decoded_class_names() {
 		$p = new WP_HTML_Tag_Processor( '<div class="&lt;egg&gt;">' );
@@ -512,9 +454,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 	/**
 	 * @ticket 56299
 	 * @ticket 57852
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_tag
-	 * @covers WP_HTML_Tag_Processor::is_tag_closer
 	 */
 	public function test_next_tag_should_stop_on_closers_only_when_requested() {
 		$p = new WP_HTML_Tag_Processor( '<div><img /></div>' );
@@ -549,9 +488,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 57852
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_tag
-	 * @covers WP_HTML_Tag_Processor::is_tag_closer
 	 */
 	public function test_next_tag_should_stop_on_rcdata_and_script_tag_closers_when_requested() {
 		$p = new WP_HTML_Tag_Processor( '<script>abc</script>' );
@@ -593,8 +529,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 	 * lead to the Tag Processor jumping to the wrong tag after the updates.
 	 *
 	 * @ticket 58179
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_updated_html
 	 */
 	public function test_internal_pointer_returns_to_original_spot_after_inserting_content_before_cursor() {
 		$tags = new WP_HTML_Tag_Processor( '<div>outside</div><section><div><img>inside</div></section>' );
@@ -616,8 +550,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::set_attribute
 	 */
 	public function test_set_attribute_on_a_non_existing_tag_does_not_change_the_markup() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
@@ -636,11 +568,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::set_attribute
-	 * @covers WP_HTML_Tag_Processor::remove_attribute
-	 * @covers WP_HTML_Tag_Processor::add_class
-	 * @covers WP_HTML_Tag_Processor::remove_class
 	 */
 	public function test_attribute_ops_on_tag_closer_do_not_change_the_markup() {
 		$p = new WP_HTML_Tag_Processor( '<div id=3></div invalid-id=4>' );
@@ -692,7 +619,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 	 * @ticket 56299
 	 *
 	 * @dataProvider data_set_attribute_prevents_xss
-	 * @covers WP_HTML_Tag_Processor::set_attribute
 	 *
 	 * @param string $attribute_value A value with potential XSS exploit.
 	 */
@@ -740,8 +666,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::set_attribute
 	 */
 	public function test_set_attribute_with_a_non_existing_attribute_adds_a_new_attribute_to_the_markup() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
@@ -762,8 +686,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute
 	 */
 	public function test_get_attribute_returns_updated_values_before_they_are_applied() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
@@ -784,8 +706,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute
 	 */
 	public function test_get_attribute_returns_updated_values_before_they_are_applied_with_different_name_casing() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
@@ -806,8 +726,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute
 	 */
 	public function test_get_attribute_reflects_added_class_names_before_they_are_applied() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
@@ -828,8 +746,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute
 	 */
 	public function test_get_attribute_reflects_added_class_names_before_they_are_applied_and_retains_classes_from_previous_add_class_calls() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
@@ -858,8 +774,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute
 	 */
 	public function test_get_attribute_reflects_removed_attribute_before_it_is_applied() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
@@ -879,8 +793,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute
 	 */
 	public function test_get_attribute_reflects_adding_and_then_removing_an_attribute_before_those_updates_are_applied() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
@@ -901,8 +813,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute
 	 */
 	public function test_get_attribute_reflects_setting_and_then_removing_an_existing_attribute_before_those_updates_are_applied() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
@@ -923,8 +833,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute
 	 */
 	public function test_get_attribute_reflects_removed_class_names_before_they_are_applied() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_WITH_CLASSES );
@@ -945,8 +853,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute
 	 */
 	public function test_get_attribute_reflects_setting_and_then_removing_a_class_name_before_those_updates_are_applied() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_WITH_CLASSES );
@@ -968,8 +874,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::get_attribute
 	 */
 	public function test_get_attribute_reflects_duplicating_and_then_removing_an_existing_class_name_before_those_updates_are_applied() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_WITH_CLASSES );
@@ -994,8 +898,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 	 * The other ones are ignored.
 	 *
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::set_attribute
 	 */
 	public function test_update_first_attribute_when_duplicated_attributes_exist() {
 		$p = new WP_HTML_Tag_Processor( '<div id="update-me" id="ignored-id"><span id="second">Text</span></div>' );
@@ -1011,8 +913,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::set_attribute
 	 */
 	public function test_set_attribute_with_an_existing_attribute_name_updates_its_value_in_the_markup() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
@@ -1030,8 +930,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 	 * one update flushes out into the updated HTML.
 	 *
 	 * @ticket 58146
-	 *
-	 * @covers WP_HTML_Tag_Processor::set_attribute
 	 */
 	public function test_set_attribute_with_case_variants_updates_only_the_original_first_copy() {
 		$p = new WP_HTML_Tag_Processor( '<div data-enabled="5">' );
@@ -1045,9 +943,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_tag
-	 * @covers WP_HTML_Tag_Processor::set_attribute
 	 */
 	public function test_next_tag_and_set_attribute_in_a_loop_update_all_tags_in_the_markup() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
@@ -1069,8 +964,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 	 * @since 6.3.2 Removes all duplicated attributes as expected.
 	 *
 	 * @ticket 58119
-	 *
-	 * @covers WP_HTML_Tag_Processor::remove_attribute
 	 */
 	public function test_remove_first_when_duplicated_attribute() {
 		$p = new WP_HTML_Tag_Processor( '<div id="update-me" id="ignored-id"><span id="second">Text</span></div>' );
@@ -1086,8 +979,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::remove_attribute
 	 */
 	public function test_remove_attribute_with_an_existing_attribute_name_removes_it_from_the_markup() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
@@ -1105,8 +996,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 	 * @ticket 58119
 	 *
 	 * @since 6.3.2 Removes all duplicated attributes as expected.
-	 *
-	 * @covers WP_HTML_Tag_Processor::remove_attribute
 	 *
 	 * @dataProvider data_html_with_duplicated_attributes
 	 */
@@ -1127,8 +1016,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 	 * @ticket 58119
 	 *
 	 * @since 6.3.2 Removes all duplicated attributes as expected.
-	 *
-	 * @covers WP_HTML_Tag_Processor::remove_attribute
 	 */
 	public function test_previous_duplicated_attributes_are_not_removed_on_successive_tag_removal() {
 		$p = new WP_HTML_Tag_Processor( '<span id=one id=two id=three><span id=four>' );
@@ -1158,8 +1045,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::remove_attribute
 	 */
 	public function test_remove_attribute_with_a_non_existing_attribute_name_does_not_change_the_markup() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
@@ -1175,8 +1060,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::add_class
 	 */
 	public function test_add_class_creates_a_class_attribute_when_there_is_none() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
@@ -1197,8 +1080,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::add_class
 	 */
 	public function test_calling_add_class_twice_creates_a_class_attribute_with_both_class_names_when_there_is_no_class_attribute() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
@@ -1220,8 +1101,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::remove_class
 	 */
 	public function test_remove_class_does_not_change_the_markup_when_there_is_no_class_attribute() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
@@ -1241,8 +1120,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::add_class
 	 */
 	public function test_add_class_appends_class_names_to_the_existing_class_attribute_when_one_already_exists() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_WITH_CLASSES );
@@ -1264,8 +1141,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::remove_class
 	 */
 	public function test_remove_class_removes_a_single_class_from_the_class_attribute_when_one_exists() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_WITH_CLASSES );
@@ -1286,8 +1161,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::remove_class
 	 */
 	public function test_calling_remove_class_with_all_listed_class_names_removes_the_existing_class_attribute_from_the_markup() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_WITH_CLASSES );
@@ -1308,8 +1181,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::add_class
 	 */
 	public function test_add_class_does_not_add_duplicate_class_names() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_WITH_CLASSES );
@@ -1330,8 +1201,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::add_class
 	 */
 	public function test_add_class_preserves_class_name_order_when_a_duplicate_class_name_is_added() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_WITH_CLASSES );
@@ -1352,8 +1221,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::add_class
 	 */
 	public function test_add_class_when_there_is_a_class_attribute_with_excessive_whitespaces() {
 		$p = new WP_HTML_Tag_Processor(
@@ -1376,8 +1243,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::remove_class
 	 */
 	public function test_remove_class_preserves_whitespaces_when_there_is_a_class_attribute_with_excessive_whitespaces() {
 		$p = new WP_HTML_Tag_Processor(
@@ -1400,8 +1265,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::remove_class
 	 */
 	public function test_removing_all_classes_removes_the_existing_class_attribute_from_the_markup_even_when_excessive_whitespaces_are_present() {
 		$p = new WP_HTML_Tag_Processor(
@@ -1430,9 +1293,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 	 * via the class builder methods.
 	 *
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::add_class
-	 * @covers WP_HTML_Tag_Processor::set_attribute
 	 */
 	public function test_set_attribute_takes_priority_over_add_class() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_WITH_CLASSES );
@@ -1477,9 +1337,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 	 * This is still true when reading enqueued updates before calling `get_updated_html()`.
 	 *
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::add_class
-	 * @covers WP_HTML_Tag_Processor::set_attribute
 	 */
 	public function test_set_attribute_takes_priority_over_add_class_even_before_updating() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_WITH_CLASSES );
@@ -1515,8 +1372,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::add_class
 	 */
 	public function test_add_class_overrides_boolean_class_attribute() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
@@ -1537,8 +1392,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::add_class
 	 */
 	public function test_add_class_overrides_boolean_class_attribute_even_before_updating() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_SIMPLE );
@@ -1559,12 +1412,6 @@ class Tests_HtmlApi_WpHtmlTagProcessor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::set_attribute
-	 * @covers WP_HTML_Tag_Processor::remove_attribute
-	 * @covers WP_HTML_Tag_Processor::add_class
-	 * @covers WP_HTML_Tag_Processor::remove_class
-	 * @covers WP_HTML_Tag_Processor::get_updated_html
 	 */
 	public function test_advanced_use_case() {
 		$input = <<<HTML
@@ -1659,8 +1506,6 @@ HTML;
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_tag
 	 */
 	public function test_correctly_parses_html_attributes_wrapped_in_single_quotation_marks() {
 		$p = new WP_HTML_Tag_Processor(
@@ -1689,8 +1534,6 @@ HTML;
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::set_attribute
 	 */
 	public function test_set_attribute_with_value_equal_to_true_adds_a_boolean_html_attribute_with_implicit_value() {
 		$p = new WP_HTML_Tag_Processor(
@@ -1707,8 +1550,6 @@ HTML;
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::set_attribute
 	 */
 	public function test_setting_a_boolean_attribute_to_false_removes_it_from_the_markup() {
 		$p = new WP_HTML_Tag_Processor(
@@ -1725,8 +1566,6 @@ HTML;
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::set_attribute
 	 */
 	public function test_setting_a_missing_attribute_to_false_does_not_change_the_markup() {
 		$html_input = '<form action="/action_page.php"><input type="checkbox" name="vehicle" value="Bike"><label for="vehicle">I have a bike</label></form>';
@@ -1742,8 +1581,6 @@ HTML;
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::set_attribute
 	 */
 	public function test_setting_a_boolean_attribute_to_a_string_value_adds_explicit_value_to_the_markup() {
 		$p = new WP_HTML_Tag_Processor(
@@ -1760,9 +1597,6 @@ HTML;
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_tag
-	 * @covers WP_HTML_Tag_Processor::paused_at_incomplete_token
 	 */
 	public function test_unclosed_script_tag_should_not_cause_an_infinite_loop() {
 		$p = new WP_HTML_Tag_Processor( '<script><div>' );
@@ -1781,8 +1615,6 @@ HTML;
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_tag
 	 *
 	 * @dataProvider data_next_tag_ignores_script_tag_contents
 	 *
@@ -1897,8 +1729,6 @@ HTML;
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers WP_HTML_Tag_Processor::next_tag
-	 *
 	 * @dataProvider data_next_tag_ignores_contents_of_rcdata_tag
 	 *
 	 * @param string $rcdata_then_div HTML with RCDATA before a DIV.
@@ -1960,8 +1790,6 @@ HTML;
 	 * other tags in the RAW TEXT special group, e.g. NOEMBED or STYLE.
 	 *
 	 * @ticket 60122
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_tag
 	 */
 	public function test_processes_inside_of_noscript_elements() {
 		$p = new WP_HTML_Tag_Processor( '<noscript><input type="submit"></noscript><div>' );
@@ -1972,8 +1800,6 @@ HTML;
 
 	/**
 	 * @ticket 59292
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_tag
 	 *
 	 * @dataProvider data_next_tag_ignores_contents_of_rawtext_tags
 	 *
@@ -2008,8 +1834,6 @@ HTML;
 
 	/**
 	 * @ticket 59209
-	 *
-	 * @covers WP_HTML_Tag_Processor::class_list
 	 */
 	public function test_class_list_empty_when_missing_class() {
 		$p = new WP_HTML_Tag_Processor( '<div>' );
@@ -2025,8 +1849,6 @@ HTML;
 
 	/**
 	 * @ticket 59209
-	 *
-	 * @covers WP_HTML_Tag_Processor::class_list
 	 */
 	public function test_class_list_empty_when_class_is_boolean() {
 		$p = new WP_HTML_Tag_Processor( '<div class>' );
@@ -2042,8 +1864,6 @@ HTML;
 
 	/**
 	 * @ticket 59209
-	 *
-	 * @covers WP_HTML_Tag_Processor::class_list
 	 */
 	public function test_class_list_empty_when_class_is_empty() {
 		$p = new WP_HTML_Tag_Processor( '<div class="">' );
@@ -2059,8 +1879,6 @@ HTML;
 
 	/**
 	 * @ticket 59209
-	 *
-	 * @covers WP_HTML_Tag_Processor::class_list
 	 */
 	public function test_class_list_visits_each_class_in_order() {
 		$p = new WP_HTML_Tag_Processor( '<div class="one two three">' );
@@ -2076,8 +1894,6 @@ HTML;
 
 	/**
 	 * @ticket 59209
-	 *
-	 * @covers WP_HTML_Tag_Processor::class_list
 	 */
 	public function test_class_list_decodes_class_names() {
 		$p = new WP_HTML_Tag_Processor( '<div class="&notin;-class &lt;egg&gt; &#xff03;">' );
@@ -2093,8 +1909,6 @@ HTML;
 
 	/**
 	 * @ticket 59209
-	 *
-	 * @covers WP_HTML_Tag_Processor::class_list
 	 */
 	public function test_class_list_visits_unique_class_names_only_once() {
 		$p = new WP_HTML_Tag_Processor( '<div class="one one &#x6f;ne">' );
@@ -2110,8 +1924,6 @@ HTML;
 
 	/**
 	 * @ticket 59209
-	 *
-	 * @covers WP_HTML_Tag_Processor::has_class
 	 *
 	 * @dataProvider data_html_with_variations_of_class_values_and_sought_class_names
 	 *
@@ -2155,8 +1967,6 @@ HTML;
 	 *
 	 * @ticket 58007
 	 *
-	 * @covers WP_HTML_Tag_Processor::next_tag
-	 *
 	 */
 	public function test_allows_incorrectly_closed_comments() {
 		$p = new WP_HTML_Tag_Processor( '<img id=before><!-- <img id=inside> --!><img id=after>--><img id=final>' );
@@ -2175,9 +1985,6 @@ HTML;
 	 * Ensures that unclosed and invalid comments don't trigger warnings or errors.
 	 *
 	 * @ticket 58007
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_tag
-	 * @covers WP_HTML_Tag_Processor::paused_at_incomplete_token
 	 *
 	 * @dataProvider data_html_with_unclosed_comments
 	 *
@@ -2218,8 +2025,6 @@ HTML;
 	 *
 	 * @ticket 58007
 	 *
-	 * @covers WP_HTML_Tag_Processor::next_tag
-	 *
 	 * @dataProvider data_abruptly_closed_empty_comments
 	 *
 	 * @param string $html_with_after_marker HTML to test with "id=after" on element immediately following an abruptly closed comment.
@@ -2255,8 +2060,6 @@ HTML;
 	/**
 	 * @ticket 56299
 	 *
-	 * @covers WP_HTML_Tag_Processor::next_tag
-	 *
 	 * @dataProvider data_skips_contents_of_script_and_rcdata_regions
 	 *
 	 * @param $input_html HTML with multiple divs, one of which carries the "target" attribute.
@@ -2290,9 +2093,6 @@ HTML;
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_tag
-	 * @covers WP_HTML_Tag_Processor::set_attribute
 	 */
 	public function test_can_query_and_update_wrongly_nested_tags() {
 		$p = new WP_HTML_Tag_Processor(
@@ -2311,9 +2111,6 @@ HTML;
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_tag
-	 * @covers WP_HTML_Tag_Processor::remove_attribute
 	 */
 	public function test_removing_specific_attributes_in_malformed_html() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_MALFORMED );
@@ -2330,9 +2127,6 @@ HTML;
 	 * Ensures that no tags are matched in a document containing only non-tag content.
 	 *
 	 * @ticket 60122
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_tag
-	 * @covers WP_HTML_Tag_Processor::paused_at_incomplete_token
 	 *
 	 * @dataProvider data_html_without_tags
 	 *
@@ -2373,9 +2167,6 @@ HTML;
 	 * Ensures that the processor doesn't attempt to match an incomplete token.
 	 *
 	 * @ticket 58637
-	 *
-	 * @covers WP_HTML_Tag_Processor::next_tag
-	 * @covers WP_HTML_Tag_Processor::paused_at_incomplete_token
 	 *
 	 * @dataProvider data_incomplete_syntax_elements
 	 *
@@ -2438,8 +2229,6 @@ HTML;
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::set_attribute
 	 */
 	public function test_updating_specific_attributes_in_malformed_html() {
 		$p = new WP_HTML_Tag_Processor( self::HTML_MALFORMED );
@@ -2456,9 +2245,6 @@ HTML;
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::add_class
-	 * @covers WP_HTML_Tag_Processor::set_attribute
 	 *
 	 * @dataProvider data_updating_attributes
 	 *
@@ -2520,9 +2306,6 @@ HTML;
 
 	/**
 	 * @ticket 56299
-	 *
-	 * @covers WP_HTML_Tag_Processor::add_class
-	 * @covers WP_HTML_Tag_Processor::set_attribute
 	 *
 	 * @dataProvider data_updating_attributes_in_malformed_html
 	 *
@@ -2698,18 +2481,12 @@ HTML
 		);
 	}
 
-	/**
-	 * @covers WP_HTML_Tag_Processor::next_tag
-	 */
 	public function test_handles_malformed_taglike_open_short_html() {
 		$p      = new WP_HTML_Tag_Processor( '<' );
 		$result = $p->next_tag();
 		$this->assertFalse( $result, 'Did not handle "<" html properly.' );
 	}
 
-	/**
-	 * @covers WP_HTML_Tag_Processor::next_tag
-	 */
 	public function test_handles_malformed_taglike_close_short_html() {
 		$p      = new WP_HTML_Tag_Processor( '</ ' );
 		$result = $p->next_tag();


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
