### PR TITLE
Avoid errors in `add_submenu_page()` if `$parent_slug` or `$menu_slug` is `null`

### DIFF
--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1406,6 +1406,10 @@ function add_submenu_page( $parent_slug, $page_title, $menu_title, $capability, 
 	global $submenu, $menu, $_wp_real_parent_file, $_wp_submenu_nopriv,
 		$_registered_pages, $_parent_pages;
 
+	if ( empty( $parent_slug ) || empty( $menu_slug ) ) {
+		return false;
+	}
+
 	$menu_slug   = plugin_basename( $menu_slug );
 	$parent_slug = plugin_basename( $parent_slug );
 

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1400,12 +1400,14 @@ function add_menu_page( $page_title, $menu_title, $capability, $menu_slug, $call
  *                               to be compatible with sanitize_key().
  * @param callable  $callback    Optional. The function to be called to output the content for this page.
  * @param int|float $position    Optional. The position in the menu order this item should appear.
- * @return string|false The resulting page's hook_suffix, or false if the user does not have the capability required.
+ * @return string|false The resulting page's hook_suffix. False if the user does not have the capability
+ *                      required or if a slug parameter is empty.
  */
 function add_submenu_page( $parent_slug, $page_title, $menu_title, $capability, $menu_slug, $callback = '', $position = null ) {
 	global $submenu, $menu, $_wp_real_parent_file, $_wp_submenu_nopriv,
 		$_registered_pages, $_parent_pages;
 
+	// Return if one of the slug parameters is empty.
 	if ( empty( $parent_slug ) || empty( $menu_slug ) ) {
 		return false;
 	}


### PR DESCRIPTION
Return early if `$parent_slug` or `$menu_slug` is empty.

[Trac 57580](https://core.trac.wordpress.org/ticket/57580)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
