### PR TITLE
Editor: Disable Gutenberg plugin prior to 17.6 version

### DIFF
--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1848,13 +1848,14 @@ function _upgrade_440_force_deactivate_incompatible_plugins() {
  * @since 5.9.0 The minimum compatible version of Gutenberg is 11.9.
  * @since 6.1.1 The minimum compatible version of Gutenberg is 14.1.
  * @since 6.4.0 The minimum compatible version of Gutenberg is 16.5.
+ * @since 6.5.0 The minimum compatible version of Gutenberg is 17.6.
  */
 function _upgrade_core_deactivate_incompatible_plugins() {
-	if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '16.5', '<' ) ) {
+	if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '17.6', '<' ) ) {
 		$deactivated_gutenberg['gutenberg'] = array(
 			'plugin_name'         => 'Gutenberg',
 			'version_deactivated' => GUTENBERG_VERSION,
-			'version_compatible'  => '16.5',
+			'version_compatible'  => '17.6',
 		);
 		if ( is_plugin_active_for_network( 'gutenberg/gutenberg.php' ) ) {
 			$deactivated_plugins = get_site_option( 'wp_force_deactivated_plugins', array() );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/60315

Currently, Gutenberg's latest version is not compatible with WordPress trunk. The following issue triggers.

```
PHP Fatal error: Cannot declare class WP_Navigation_Block_Renderer, because the name is already in use in plugins/gutenberg/lib/compat/wordpress-6.5/class-wp-navigation-block-renderer.php on line 16
```

This issue is already solved in Gutenberg trunk and will be included in tomorrow's 17.6 stable release.

This changes the Gutenberg minimum compatible version number from 16.5 to 17.6. For versions older than 16.5, the plugin will deactivate when upgrading WordPress to 6.5 beta1 or newer.

Changes are done within Core's `_upgrade_core_deactivate_incompatible_plugins()` which is invoked during WordPress' upgrade process.

