### PR TITLE
Add deprecated functions from interactivity core blocks

### DIFF
--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -6239,3 +6239,60 @@ function the_block_template_skip_link() {
 	</script>
 	<?php
 }
+
+/**
+ * Ensure that the view script has the `wp-interactivity` dependency.
+ *
+ * @since 6.4.0
+ * @deprecated 6.5.0
+ *
+ * @global WP_Scripts $wp_scripts
+ */
+function block_core_query_ensure_interactivity_dependency() {
+	_deprecated_function( __FUNCTION__, '6.5.0', 'Used wp_register_script_module instead' );
+	global $wp_scripts;
+	if (
+		isset( $wp_scripts->registered['wp-block-query-view'] ) &&
+		! in_array( 'wp-interactivity', $wp_scripts->registered['wp-block-query-view']->deps, true )
+	) {
+		$wp_scripts->registered['wp-block-query-view']->deps[] = 'wp-interactivity';
+	}
+}
+
+/**
+ * Ensure that the view script has the `wp-interactivity` dependency.
+ *
+ * @since 6.4.0
+ * @deprecated 6.5.0
+ *
+ * @global WP_Scripts $wp_scripts
+ */
+function block_core_file_ensure_interactivity_dependency() {
+	_deprecated_function( __FUNCTION__, '6.5.0', 'Used wp_register_script_module instead' );
+	global $wp_scripts;
+	if (
+		isset( $wp_scripts->registered['wp-block-file-view'] ) &&
+		! in_array( 'wp-interactivity', $wp_scripts->registered['wp-block-file-view']->deps, true )
+	) {
+		$wp_scripts->registered['wp-block-file-view']->deps[] = 'wp-interactivity';
+	}
+}
+
+/**
+ * Ensures that the view script has the `wp-interactivity` dependency.
+ *
+ * @since 6.4.0
+ * @deprecated 6.5.0
+ *
+ * @global WP_Scripts $wp_scripts
+ */
+function block_core_image_ensure_interactivity_dependency() {
+	_deprecated_function( __FUNCTION__, '6.5.0', 'Used wp_register_script_module instead' );
+	global $wp_scripts;
+	if (
+		isset( $wp_scripts->registered['wp-block-image-view'] ) &&
+		! in_array( 'wp-interactivity', $wp_scripts->registered['wp-block-image-view']->deps, true )
+	) {
+		$wp_scripts->registered['wp-block-image-view']->deps[] = 'wp-interactivity';
+	}
+}

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -6249,7 +6249,7 @@ function the_block_template_skip_link() {
  * @global WP_Scripts $wp_scripts
  */
 function block_core_query_ensure_interactivity_dependency() {
-	_deprecated_function( __FUNCTION__, '6.5.0', 'Used wp_register_script_module instead' );
+	_deprecated_function( __FUNCTION__, '6.5.0', 'wp_register_script_module' );
 	global $wp_scripts;
 	if (
 		isset( $wp_scripts->registered['wp-block-query-view'] ) &&
@@ -6268,7 +6268,7 @@ function block_core_query_ensure_interactivity_dependency() {
  * @global WP_Scripts $wp_scripts
  */
 function block_core_file_ensure_interactivity_dependency() {
-	_deprecated_function( __FUNCTION__, '6.5.0', 'Used wp_register_script_module instead' );
+	_deprecated_function( __FUNCTION__, '6.5.0', 'wp_register_script_module' );
 	global $wp_scripts;
 	if (
 		isset( $wp_scripts->registered['wp-block-file-view'] ) &&
@@ -6287,7 +6287,7 @@ function block_core_file_ensure_interactivity_dependency() {
  * @global WP_Scripts $wp_scripts
  */
 function block_core_image_ensure_interactivity_dependency() {
-	_deprecated_function( __FUNCTION__, '6.5.0', 'Used wp_register_script_module instead' );
+	_deprecated_function( __FUNCTION__, '6.5.0', 'wp_register_script_module' );
 	global $wp_scripts;
 	if (
 		isset( $wp_scripts->registered['wp-block-image-view'] ) &&


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->
Add Interactivity functions to deprecated file.

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60380

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
