### PR TITLE
HTML API: Fix splitting single text node

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1536,7 +1536,7 @@ class WP_HTML_Tag_Processor {
 				 * @see https://html.spec.whatwg.org/#tag-open-state
 				 */
 				if ( strlen( $html ) > $at + 1 ) {
-					$next_character = $html[ $at + 1 ];
+					$next_character  = $html[ $at + 1 ];
 					$at_another_node =
 						$next_character === '!' ||
 						$next_character === '/' ||

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1538,9 +1538,9 @@ class WP_HTML_Tag_Processor {
 				if ( strlen( $html ) > $at + 1 ) {
 					$next_character  = $html[ $at + 1 ];
 					$at_another_node =
-						$next_character === '!' ||
-						$next_character === '/' ||
-						$next_character === '?' ||
+						'!' === $next_character ||
+						'/' === $next_character ||
+						'?' === $next_character ||
 						( 'A' <= $next_character && $next_character <= 'z' );
 					if ( ! $at_another_node ) {
 						++$at;

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1512,16 +1512,6 @@ class WP_HTML_Tag_Processor {
 		while ( false !== $at && $at < $doc_length ) {
 			$at = strpos( $html, '<', $at );
 
-			if ( $at > $was_at ) {
-				$this->parser_state         = self::STATE_TEXT_NODE;
-				$this->token_starts_at      = $was_at;
-				$this->token_length         = $at - $was_at;
-				$this->text_starts_at       = $was_at;
-				$this->text_length          = $this->token_length;
-				$this->bytes_already_parsed = $at;
-				return true;
-			}
-
 			/*
 			 * This does not imply an incomplete parse; it indicates that there
 			 * can be nothing left in the document other than a #text node.
@@ -1533,6 +1523,37 @@ class WP_HTML_Tag_Processor {
 				$this->text_starts_at       = $was_at;
 				$this->text_length          = $this->token_length;
 				$this->bytes_already_parsed = strlen( $html );
+				return true;
+			}
+
+			if ( $at > $was_at ) {
+				/*
+				 * A "<" has been found in the document. That may be the start of another node, or
+				 * it may be an "ivalid-first-character-of-tag-name" error. If this is not the start
+				 * of another node the "<" should be included in this text node and another
+				 * termination point should be found for the text node.
+				 *
+				 * @see https://html.spec.whatwg.org/#tag-open-state
+				 */
+				if ( strlen( $html ) > $at + 1 ) {
+					$next_character = $html[ $at + 1 ];
+					$at_another_node =
+						$next_character === '!' ||
+						$next_character === '/' ||
+						$next_character === '?' ||
+						( 'A' <= $next_character && $next_character <= 'z' );
+					if ( ! $at_another_node ) {
+						++$at;
+						continue;
+					}
+				}
+
+				$this->parser_state         = self::STATE_TEXT_NODE;
+				$this->token_starts_at      = $was_at;
+				$this->token_length         = $at - $was_at;
+				$this->text_starts_at       = $was_at;
+				$this->text_length          = $this->token_length;
+				$this->bytes_already_parsed = $at;
 				return true;
 			}
 

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2717,6 +2717,8 @@ HTML
 	}
 
 	/**
+	 * Ensures that non-tag syntax starting with `<` is consumed inside a text node.
+	 *
 	 * @ticket 60385
 	 */
 	public function test_single_text_node_with_taglike_text() {

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2715,4 +2715,14 @@ HTML
 		$result = $p->next_tag();
 		$this->assertFalse( $result, 'Did not handle "</ " html properly.' );
 	}
+
+	/**
+	 * @ticket 60385
+	 */
+	public function test_single_text_node_with_taglike_text() {
+		$p = new WP_HTML_Tag_Processor( 'test< /A>' );
+		$p->next_token();
+		$this->assertSame( '#text', $p->get_token_type(), 'Did not find text node.' );
+		$this->assertSame( 'test< /A>', $p->get_modifiable_text(), 'Did not find complete text node.' );
+	}
 }


### PR DESCRIPTION
Fix an issue where a `<` character will always break a text node.

It should not break a text node if we will not start another node type, i.e. we find `<` followed by `!`, `/`, `?` or an ascii alpha character.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60385

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
