### PR TITLE
60391 links add base url fix

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5423,10 +5423,11 @@ function wp_html_excerpt( $str, $count, $more = null ) {
  * @param array  $attrs   The attributes which should be processed.
  * @return string The processed content.
  */
-function links_add_base_url( $content, $base, $attrs = array( 'src', 'href' ) ) {
+function links_add_base_url( $content, $base, $attrs = null ) {
 	global $_links_add_base;
 	$_links_add_base = $base;
-	$attrs           = implode( '|', (array) $attrs );
+
+	$attrs = implode( '|', ( is_array( $attrs ) && ! empty( $attrs ) ) ? $attrs : array( 'src', 'href' ) );
 	return preg_replace_callback( "!($attrs)=(['\"])(.+?)\\2!i", '_links_add_base', $content );
 }
 

--- a/tests/phpunit/tests/formatting/linksAddBaseUrl.php
+++ b/tests/phpunit/tests/formatting/linksAddBaseUrl.php
@@ -7,7 +7,7 @@
  *
  * @covers ::links_add_base_url
  */
-class Tests_formatting_linksAddBaseUrl extends WP_UnitTestCase{
+class Tests_formatting_linksAddBaseUrl extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 60389

--- a/tests/phpunit/tests/formatting/linksAddBaseUrl.php
+++ b/tests/phpunit/tests/formatting/linksAddBaseUrl.php
@@ -14,7 +14,7 @@ class Tests_formatting_linksAddBaseUrl extends WP_UnitTestCase{
 	 *
 	 * @dataProvider data_links_add_base_url
 	 */
-	public function test_links_add_base_url($content, $base, $attrs, $expected) {
+	public function test_links_add_base_url( $content, $base, $attrs, $expected ) {
 		$this->assertSame( $expected, links_add_base_url( $content, $base, $attrs ) );
 	}
 
@@ -57,6 +57,5 @@ class Tests_formatting_linksAddBaseUrl extends WP_UnitTestCase{
 				'expected' => '<img src="https://localhost/url" />',
 			),
 		);
-
 	}
 }

--- a/tests/phpunit/tests/formatting/linksAddBaseUrl.php
+++ b/tests/phpunit/tests/formatting/linksAddBaseUrl.php
@@ -15,12 +15,7 @@ class Tests_formatting_linksAddBaseUrl extends WP_UnitTestCase{
 	 * @dataProvider data_links_add_base_url
 	 */
 	public function test_links_add_base_url($content, $base, $attrs, $expected) {
-		if( $attrs ){
-			$this->assertSame( $expected, links_add_base_url( $content, $base, $attrs ) );
-		} else {
-			$this->assertSame( $expected, links_add_base_url( $content, $base ) );
-		}
-
+		$this->assertSame( $expected, links_add_base_url( $content, $base, $attrs ) );
 	}
 
 	public function data_links_add_base_url() {

--- a/tests/phpunit/tests/formatting/linksAddBaseUrl.php
+++ b/tests/phpunit/tests/formatting/linksAddBaseUrl.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Tests for the links_add_base_url function.
+ *
+ * @group formatting
+ *
+ * @covers ::links_add_base_url
+ */
+class Tests_formatting_linksAddBaseUrl extends WP_UnitTestCase{
+
+	/**
+	 * @ticket 60389
+	 *
+	 * @dataProvider data_links_add_base_url
+	 */
+	public function test_links_add_base_url($content, $base, $attrs, $expected) {
+		if( $attrs ){
+			$this->assertSame( $expected, links_add_base_url( $content, $base, $attrs ) );
+		} else {
+			$this->assertSame( $expected, links_add_base_url( $content, $base ) );
+		}
+
+	}
+
+	public function data_links_add_base_url() {
+		return array(
+			'default' => array(
+				'content' => '<a href="url" />',
+				'base' => 'https://localhost',
+				'attrs' => null,
+				'expected' => '<a href="https://localhost/url" />',
+			),
+			'empty_array' => array(
+				'content' => '<a href="url" target="_blank" />',
+				'base' => 'https://localhost',
+				'attrs' => array(),
+				'expected' => '<a href="https://localhost/url" target="_blank" />',
+			),
+			'data_url' => array(
+				'content' => '<a href="url" data-url="url" />',
+				'base' => 'https://localhost',
+				'attrs' => array( 'data-url', 'href' ),
+				'expected' => '<a href="https://localhost/url" data-url="https://localhost/url" />',
+			),
+			'not relative' => array(
+				'content' => '<a href="https://localhost/url" />',
+				'base' => 'https://localbase',
+				'attrs' => null,
+				'expected' => '<a href="https://localhost/url" />',
+			),
+			'no_href' => array(
+				'content' => '<a data-url="/url" />',
+				'base' => 'https://localhost',
+				'attrs' => null,
+				'expected' => '<a data-url="/url" />',
+			),
+			'img' => array(
+				'content' => '<img src="/url" />',
+				'base' => 'https://localhost',
+				'attrs' => null,
+				'expected' => '<img src="https://localhost/url" />',
+			),
+		);
+
+	}
+}


### PR DESCRIPTION
The links_add_base_url function has been refactored to handle null attribute values without throwing errors. This change necessitated modifications within the test_links_add_base_url PHPUnit test, simplifying the test scenario to always include attribute values when calling the function.

Trac ticket: https://core.trac.wordpress.org/ticket/60391