### PR TITLE
Twenty Twenty-One: Fix typography settings for the quote block

### DIFF
--- a/src/wp-content/themes/twentytwentyone/assets/sass/04-elements/blockquote.scss
+++ b/src/wp-content/themes/twentytwentyone/assets/sass/04-elements/blockquote.scss
@@ -2,6 +2,12 @@ blockquote {
 	padding: 0;
 	position: relative;
 	margin: var(--global--spacing-vertical) 0 var(--global--spacing-vertical) var(--global--spacing-horizontal);
+	letter-spacing: var(--heading--letter-spacing-h4);
+	font-family: var(--quote--font-family);
+	font-size: var(--quote--font-size);
+	font-style: var(--quote--font-style);
+	font-weight: var(--quote--font-weight);
+	line-height: var(--quote--line-height);
 
 	> * {
 		margin-top: var(--global--spacing-unit);
@@ -17,19 +23,18 @@ blockquote {
 	}
 
 	p {
-		letter-spacing: var(--heading--letter-spacing-h4);
-		font-family: var(--quote--font-family);
-		font-size: var(--quote--font-size);
-		font-style: var(--quote--font-style);
-		font-weight: var(--quote--font-weight);
-		line-height: var(--quote--line-height);
+		letter-spacing: inherit;
+		font-family: inherit;
+		font-size: inherit;
+		font-style: inherit;
+		font-weight: inherit;
+		line-height: inherit;
 	}
 
 	cite,
 	footer {
 		font-weight: normal;
 		color: var(--global--color-primary);
-		font-size: var(--global--font-size-xs);
 		letter-spacing: var(--global--letter-spacing);
 	}
 
@@ -57,8 +62,6 @@ blockquote {
 
 	&:before {
 		content: "\201C";
-		font-size: var(--quote--font-size);
-		line-height: var(--quote--line-height);
 		position: absolute;
 		left: calc(-0.5 * var(--global--spacing-horizontal));
 	}
@@ -67,7 +70,6 @@ blockquote {
 	cite,
 	footer {
 		color: var(--global--color-primary);
-		font-size: var(--global--font-size-xs);
 		font-style: var(--quote--font-style-cite);
 	}
 

--- a/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/quote/_editor.scss
+++ b/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/quote/_editor.scss
@@ -3,13 +3,18 @@
 	border-left: none;
 	margin: var(--global--spacing-vertical) auto var(--global--spacing-vertical) var(--global--spacing-horizontal);
 	padding-left: 1em;
+	font-family: var(--quote--font-family);
+	font-size: var(--quote--font-size);
+	font-style: var(--quote--font-style);
+	font-weight: var(--quote--font-weight);
+	line-height: var(--quote--line-height);
 
 	p {
-		font-family: var(--quote--font-family);
-		font-size: var(--quote--font-size);
-		font-style: var(--quote--font-style);
-		font-weight: var(--quote--font-weight);
-		line-height: var(--quote--line-height);
+		font-family: inherit;
+		font-size: inherit;
+		font-style: inherit;
+		font-weight: inherit;
+		line-height: inherit;
 	}
 
 	strong {
@@ -18,15 +23,16 @@
 
 	&:before {
 		content: "\201C";
-		font-size: var(--quote--font-size);
-		line-height: var(--quote--line-height);
 		left: 8px;
 	}
 
 	.wp-block-quote__citation {
 		color: currentColor;
-		font-size: var(--global--font-size-xs);
-		font-style: var(--quote--font-style-cite);
+		font-family: inherit;
+		font-style: inherit;
+		font-weight: inherit;
+		line-height: inherit;
+		letter-spacing: inherit;
 
 		.has-background &,
 		[class*="background-color"] &,
@@ -34,6 +40,14 @@
 		.wp-block-cover[style*="background-image"] & {
 			color: currentColor;
 		}
+	}
+
+	&:where(:not([style*="font-style"])) .wp-block-quote__citation {
+		font-style: var(--quote--font-style-cite);
+	}
+	// The cite has a lighter font-weight than the rest of the quote.
+	&:where(:not([style*="font-weight"])) .wp-block-quote__citation {
+		font-weight: normal;
 	}
 
 	&.has-text-align-right {
@@ -49,9 +63,6 @@
 		// Align the quote left of the text.
 		p:before {
 			content: "\201D";
-			font-size: var(--quote--font-size);
-			font-weight: normal;
-			line-height: var(--quote--line-height);
 			margin-right: 5px;
 		}
 	}
@@ -64,6 +75,7 @@
 		}
 	}
 
+	// The large style has been removed but the CSS is kept for backwards compatibility.
 	&.is-large,
 	&.is-style-large {
 		padding-left: 0;

--- a/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/quote/_style.scss
+++ b/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/quote/_style.scss
@@ -3,14 +3,17 @@
 
 	&:before {
 		content: "\201C";
-		font-size: var(--quote--font-size);
-		line-height: var(--quote--line-height);
 		left: 8px;
 	}
 
 	.wp-block-quote__citation,
 	cite,
 	footer {
+		font-family: inherit;
+		font-style: inherit;
+		font-weight: inherit;
+		line-height: inherit;
+		letter-spacing: inherit;
 
 		.has-background &,
 		[class*="background-color"] &,
@@ -18,6 +21,19 @@
 		.wp-block-cover[style*="background-image"] & {
 			color: currentColor;
 		}
+	}
+
+	&:where(:not([style*="font-style"])) .wp-block-quote__citation,
+	&:where(:not([style*="font-style"])) cite,
+	&:where(:not([style*="font-style"])) footer {
+		font-style: var(--quote--font-style-cite);
+	}
+
+	// The cite has a lighter font-weight than the rest of the quote.
+	&:where(:not([style*="font-weight"])) .wp-block-quote__citation,
+	&:where(:not([style*="font-weight"])) cite,
+	&:where(:not([style*="font-weight"])) footer {
+		font-weight: normal;
 	}
 
 	/**
@@ -36,9 +52,6 @@
 		// Align the quote left of the text.
 		p:before {
 			content: "\201D";
-			font-size: var(--quote--font-size);
-			font-weight: normal;
-			line-height: var(--quote--line-height);
 			margin-right: 5px;
 		}
 	}
@@ -51,6 +64,7 @@
 		}
 	}
 
+	// The large style has been removed but the CSS is kept for backwards compatibility.
 	&.is-large,
 	&.is-style-large {
 		padding-left: 0;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->
https://core.trac.wordpress.org/ticket/57854

Yet another attempt at making the typography settings work with the Quote block in Twenty Twenty-One.
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
