### PR TITLE
General: Add allowed_blocks field to block registration and REST API

### DIFF
--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -2303,6 +2303,7 @@ function get_block_editor_server_block_settings() {
 		'keywords'         => 'keywords',
 		'example'          => 'example',
 		'variations'       => 'variations',
+		'allowed_blocks'   => 'allowedBlocks',
 	);
 
 	foreach ( $block_registry->get_all_registered() as $block_name => $block_type ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -424,6 +424,7 @@ function register_block_type_from_metadata( $file_or_folder, $args = array() ) {
 		'styles'          => 'styles',
 		'variations'      => 'variations',
 		'example'         => 'example',
+		'allowedBlocks'   => 'allowed_blocks',
 	);
 	$textdomain        = ! empty( $metadata['textdomain'] ) ? $metadata['textdomain'] : null;
 	$i18n_schema       = get_block_metadata_i18n_schema();

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -69,6 +69,14 @@ class WP_Block_Type {
 	public $ancestor = null;
 
 	/**
+	 * Limits which block types can be inserted as children of this block type.
+	 *
+	 * @since 6.5.0
+	 * @var string[]|null
+	 */
+	public allowed_blocks = null;
+
+	/**
 	 * Block type icon.
 	 *
 	 * @since 5.5.0
@@ -303,6 +311,7 @@ class WP_Block_Type {
 	 *                                                   available when nested within the specified blocks.
 	 *     @type string[]|null $ancestor                 Setting ancestor makes a block available only inside the specified
 	 *                                                   block types at any position of the ancestor's block subtree.
+	 *     @type string[]|null $allowed_blocks           Limits which block types can be inserted as children of this block type.
 	 *     @type string|null   $icon                     Block type icon.
 	 *     @type string        $description              A detailed block type description.
 	 *     @type string[]      $keywords                 Additional keywords to produce block type as

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -74,7 +74,7 @@ class WP_Block_Type {
 	 * @since 6.5.0
 	 * @var string[]|null
 	 */
-	public allowed_blocks = null;
+	public $allowed_blocks = null;
 
 	/**
 	 * Block type icon.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-types-controller.php
@@ -295,6 +295,7 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 				'view_style_handles',
 				'variations',
 				'block_hooks',
+				'allowed_blocks',
 			),
 			$deprecated_fields
 		);
@@ -737,6 +738,17 @@ class WP_REST_Block_Types_Controller extends WP_REST_Controller {
 					'default'           => array(),
 					'context'           => array( 'embed', 'view', 'edit' ),
 					'readonly'          => true,
+				),
+				'allowed_blocks'        => array(
+					'description' => __( 'Allowed child block types.' ),
+					'type'        => array( 'array', 'null' ),
+					'items'       => array(
+						'type'    => 'string',
+						'pattern' => self::NAME_PATTERN,
+					),
+					'default'     => null,
+					'context'     => array( 'embed', 'view', 'edit' ),
+					'readonly'    => true,
 				),
 			),
 		);

--- a/tests/phpunit/tests/rest-api/rest-block-type-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-block-type-controller.php
@@ -550,6 +550,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	 * @ticket 47620
 	 * @ticket 57585
 	 * @ticket 59346
+	 * @ticket 60403
 	 */
 	public function test_get_item_schema() {
 		wp_set_current_user( self::$admin_id );
@@ -557,7 +558,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertCount( 31, $properties );
+		$this->assertCount( 32, $properties );
 		$this->assertArrayHasKey( 'api_version', $properties );
 		$this->assertArrayHasKey( 'name', $properties );
 		$this->assertArrayHasKey( 'title', $properties );
@@ -577,6 +578,7 @@ class REST_Block_Type_Controller_Test extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'example', $properties );
 		$this->assertArrayHasKey( 'variations', $properties );
 		$this->assertArrayHasKey( 'block_hooks', $properties );
+		$this->assertArrayHasKey( 'allowed_blocks', $properties );
 		$this->assertArrayHasKey( 'editor_script_handles', $properties );
 		$this->assertArrayHasKey( 'script_handles', $properties );
 		$this->assertArrayHasKey( 'view_script_handles', $properties );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->



There is a new block.json field called `allowedBlocks`, added in Gutenberg in https://github.com/WordPress/gutenberg/pull/58262. This is a companion patch to support this new field also on the server. It ensures that the following works:

1.  If the `allowedBlocks` field is defined in block's `block.json`, the objects registered in `WP_Block_Type_Registry` will have the `allowed_blocks` field.
2. The `allowed_blocks` field is returned by the `/wp/v2/block-types` REST endpoint.
3. The `allowedBlocks` field will be included in the boostrapped block registration data in the `unstable__bootstrapServerSideBlockDefinitions` inline script. 



Trac ticket: [https://core.trac.wordpress.org/ticket/60403](https://core.trac.wordpress.org/ticket/60403)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
