### PR TITLE
Add support for fetchpriority attribute in wp_preload_resources()

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -3586,14 +3586,15 @@ function wp_preload_resources() {
 	 *     @type array ...$0 {
 	 *         Array of resource attributes.
 	 *
-	 *         @type string $href        URL to include in resource preloads. Required.
-	 *         @type string $as          How the browser should treat the resource
+	 *         @type string $href          URL to include in resource preloads. Required.
+	 *         @type string $as            How the browser should treat the resource
 	 *                                   (`script`, `style`, `image`, `document`, etc).
-	 *         @type string $crossorigin Indicates the CORS policy of the specified resource.
-	 *         @type string $type        Type of the resource (`text/html`, `text/css`, etc).
-	 *         @type string $media       Accepts media types or media queries. Allows responsive preloading.
-	 *         @type string $imagesizes  Responsive source size to the source Set.
-	 *         @type string $imagesrcset Responsive image sources to the source set.
+	 *         @type string $crossorigin   Indicates the CORS policy of the specified resource.
+	 *         @type string $type          Type of the resource (`text/html`, `text/css`, etc).
+	 *         @type string $media         Accepts media types or media queries. Allows responsive preloading.
+	 *         @type string $imagesizes    Responsive source size to the source Set.
+	 *         @type string $imagesrcset   Responsive image sources to the source set.
+	 *         @type string $fetchpriority Fetchpriority value for the resource.
 	 *     }
 	 * }
 	 */
@@ -3641,7 +3642,7 @@ function wp_preload_resources() {
 			}
 
 			// Ignore non-supported attributes.
-			$non_supported_attributes = array( 'as', 'crossorigin', 'href', 'imagesrcset', 'imagesizes', 'type', 'media' );
+			$non_supported_attributes = array( 'as', 'crossorigin', 'href', 'imagesrcset', 'imagesizes', 'type', 'media', 'fetchpriority' );
 			if ( ! in_array( $resource_key, $non_supported_attributes, true ) && ! is_numeric( $resource_key ) ) {
 				continue;
 			}

--- a/tests/phpunit/tests/general/wpPreloadResources.php
+++ b/tests/phpunit/tests/general/wpPreloadResources.php
@@ -256,7 +256,7 @@ class Tests_General_wpPreloadResources extends WP_UnitTestCase {
 						'fetchpriority' => 'high',
 					),
 				),
-			)
+			),
 		);
 	}
 }

--- a/tests/phpunit/tests/general/wpPreloadResources.php
+++ b/tests/phpunit/tests/general/wpPreloadResources.php
@@ -247,6 +247,16 @@ class Tests_General_wpPreloadResources extends WP_UnitTestCase {
 					),
 				),
 			),
+			'fetchpriority' => array(
+				'expected' => "<link rel='preload' href='https://example.com/image.jpg' as='image' fetchpriority='high' />\n",
+				'resources' => array(
+					array(
+						'href'          => 'https://example.com/image.jpg',
+						'as'            => 'image',
+						'fetchpriority' => 'high',
+					),
+				),
+			)
 		);
 	}
 }

--- a/tests/phpunit/tests/general/wpPreloadResources.php
+++ b/tests/phpunit/tests/general/wpPreloadResources.php
@@ -247,8 +247,8 @@ class Tests_General_wpPreloadResources extends WP_UnitTestCase {
 					),
 				),
 			),
-			'fetchpriority' => array(
-				'expected' => "<link rel='preload' href='https://example.com/image.jpg' as='image' fetchpriority='high' />\n",
+			'fetchpriority'          => array(
+				'expected'  => "<link rel='preload' href='https://example.com/image.jpg' as='image' fetchpriority='high' />\n",
 				'resources' => array(
 					array(
 						'href'          => 'https://example.com/image.jpg',


### PR DESCRIPTION
Add support for the `fetchpriority` attribute in `wp_preload_resources()`

Trac ticket: https://core.trac.wordpress.org/ticket/58510

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
