### PR TITLE
Bundled themes: cast font URL functions to string for add_editor_style

### DIFF
--- a/src/wp-content/themes/twentyfifteen/functions.php
+++ b/src/wp-content/themes/twentyfifteen/functions.php
@@ -184,7 +184,7 @@ if ( ! function_exists( 'twentyfifteen_setup' ) ) :
 		$font_stylesheet = str_replace(
 			array( get_template_directory_uri() . '/', get_stylesheet_directory_uri() . '/' ),
 			'',
-			twentyfifteen_fonts_url()
+			(string) twentyfifteen_fonts_url()
 		);
 		add_editor_style( array( 'css/editor-style.css', 'genericons/genericons.css', $font_stylesheet ) );
 

--- a/src/wp-content/themes/twentyfourteen/functions.php
+++ b/src/wp-content/themes/twentyfourteen/functions.php
@@ -81,7 +81,7 @@ if ( ! function_exists( 'twentyfourteen_setup' ) ) :
 		$font_stylesheet = str_replace(
 			array( get_template_directory_uri() . '/', get_stylesheet_directory_uri() . '/' ),
 			'',
-			twentyfourteen_font_url()
+			(string) twentyfourteen_font_url()
 		);
 		add_editor_style( array( 'css/editor-style.css', $font_stylesheet, 'genericons/genericons.css' ) );
 

--- a/src/wp-content/themes/twentyseventeen/functions.php
+++ b/src/wp-content/themes/twentyseventeen/functions.php
@@ -120,7 +120,7 @@ function twentyseventeen_setup() {
 	$font_stylesheet = str_replace(
 		array( get_template_directory_uri() . '/', get_stylesheet_directory_uri() . '/' ),
 		'',
-		twentyseventeen_fonts_url()
+		(string) twentyseventeen_fonts_url()
 	);
 	add_editor_style( array( 'assets/css/editor-style.css', $font_stylesheet ) );
 

--- a/src/wp-content/themes/twentysixteen/functions.php
+++ b/src/wp-content/themes/twentysixteen/functions.php
@@ -147,7 +147,7 @@ if ( ! function_exists( 'twentysixteen_setup' ) ) :
 		$font_stylesheet = str_replace(
 			array( get_template_directory_uri() . '/', get_stylesheet_directory_uri() . '/' ),
 			'',
-			twentysixteen_fonts_url()
+			(string) twentysixteen_fonts_url()
 		);
 		add_editor_style( array( 'css/editor-style.css', $font_stylesheet ) );
 

--- a/src/wp-content/themes/twentythirteen/functions.php
+++ b/src/wp-content/themes/twentythirteen/functions.php
@@ -93,7 +93,7 @@ function twentythirteen_setup() {
 	$font_stylesheet = str_replace(
 		array( get_template_directory_uri() . '/', get_stylesheet_directory_uri() . '/' ),
 		'',
-		twentythirteen_fonts_url()
+		(string) twentythirteen_fonts_url()
 	);
 	add_editor_style( array( 'css/editor-style.css', 'genericons/genericons.css', $font_stylesheet ) );
 


### PR DESCRIPTION
Avoid PHP type errors with `str_replace()` when removing directory from font functions.
- `twentythirteen_fonts_url()`
- `twentyfourteen_font_url()`
- `twentyfifteen_fonts_url()`
- `twentysixteen_fonts_url()`
- `twentyseventeen_fonts_url()`

[Trac 59704](https://core.trac.wordpress.org/ticket/59704)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
