### PR TITLE
Wrap Navigation block in Row within the header.html template part

### DIFF
--- a/src/wp-content/themes/twentytwentyfour/parts/header.html
+++ b/src/wp-content/themes/twentytwentyfour/parts/header.html
@@ -15,7 +15,11 @@
 		</div>
 		<!-- /wp:group -->
 
-		<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"var:preset|spacing|20"},"layout":{"selfStretch":"fit","flexSize":null}}} /-->
+		<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"left"}} -->
+		<div class="wp-block-group">
+			<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"},"blockGap":"var:preset|spacing|20"},"layout":{"selfStretch":"fit","flexSize":null}}} /-->
+		</div>
+		<!-- /wp:group -->
 	</div>
 	<!-- /wp:group -->
 </div>


### PR DESCRIPTION
<!-- Insert a description of your changes here -->

Now that the Block Hooks API has been released as part of WordPress 6.4 3PDs may want to insert their own blocks into the header, specifically after the Navigation block. This currently causes problems because the Navigation block and it's siblings are treated as flex items due to its parent being a Row block.

This PR wraps the Navigation block within a Row block of its own. By default the behaviour of the header should remain the same and introduce no regressions but this now means plugins are able to use the Block Hooks API to automatically insert their own blocks using the Navigation as an anchor block without them being treated as flex items (e.g. Mini Cart or My Account blocks)

Trac ticket: https://core.trac.wordpress.org/ticket/60410#ticket

## Testing instructions

1. Ensure that the TT4 default header behaves the same on various viewport sizes and browsers, and no regressions have been introduced by this change.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
