### PR TITLE
Add: Footnotes support in core.

### DIFF
--- a/src/wp-includes/class-wp-post-type.php
+++ b/src/wp-includes/class-wp-post-type.php
@@ -669,6 +669,9 @@ final class WP_Post_Type {
 					add_post_type_support( $this->name, $args );
 				}
 			}
+			if ( post_type_supports( $this->name, 'editor' ) && post_type_supports( $this->name, 'custom-fields' ) && post_type_supports( $this->name, 'revisions' ) && ! post_type_supports( $this->name, 'footnotes' ) ) {
+				add_post_type_support( $this->name, 'footnotes' );
+			}
 			unset( $this->supports );
 		} elseif ( false !== $this->supports ) {
 			// Add default features.

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -734,6 +734,9 @@ add_action( 'init', 'wp_register_persisted_preferences_meta' );
 // CPT wp_block custom postmeta field.
 add_action( 'init', 'wp_create_initial_post_meta' );
 
+// Registers the footnotes meta field for post types that support it.
+add_action( 'init', '_wp_register_footnotes_meta_field', 100 );
+
 // Include revisioned meta when considering whether a post revision has changed.
 add_filter( 'wp_save_post_revision_post_has_changed', 'wp_check_revisioned_meta_fields_have_changed', 10, 3 );
 

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -8150,3 +8150,38 @@ function wp_create_initial_post_meta() {
 		)
 	);
 }
+
+/**
+ * Registers the footnotes meta field for post types that support it.
+ *
+ * @internal
+ * @since 6.5.0
+ *
+ * @link https://github.com/WordPress/gutenberg/pull/57353
+ */
+function _wp_register_footnotes_meta_field() {
+	$post_types = get_post_types(
+		array(
+			'show_in_rest' => true,
+			'public'       => true,
+		)
+	);
+	foreach ( $post_types as $post_type ) {
+		// Only register the meta field if the post type supports the editor, custom fields, and revisions.
+		if ( post_type_supports( $post_type, 'editor' ) && post_type_supports( $post_type, 'custom-fields' ) && post_type_supports( $post_type, 'revisions' ) && post_type_supports( $post_type, 'footnotes' ) ) {
+			$post_type_meta_keys = get_registered_meta_keys( 'post', $post_type );
+			if ( ! isset( $post_type_meta_keys['footnotes'] ) ) {
+				register_post_meta(
+					$post_type,
+					'footnotes',
+					array(
+						'show_in_rest'      => true,
+						'single'            => true,
+						'type'              => 'string',
+						'revisions_enabled' => true,
+					)
+				);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Core version of https://github.com/WordPress/gutenberg/pull/58573.

Adds footnote support for custom post types in the core. Creates a new footnotes support key.
By default, every post that meets footnotes requirements has support for footnotes.
Developers can now remove footnotes support with:
```
remove_post_type_support( 'my_type', 'footnotes' );
```

## Testing

Added the following post type:
```

function cptui_register_my_cpts_testfootnotes() {

	/**
	 * Post Type: Test foot notes.
	 */

	$labels = [
		"name" => esc_html__( "Test foot notes", "twentytwentyfour" ),
		"singular_name" => esc_html__( "Test foot note", "twentytwentyfour" ),
	];

	$args = [
		"label" => esc_html__( "Test foot notes", "twentytwentyfour" ),
		"labels" => $labels,
		"description" => "",
		"public" => true,
		"publicly_queryable" => true,
		"show_ui" => true,
		"show_in_rest" => true,
		"rest_base" => "",
		"rest_controller_class" => "WP_REST_Posts_Controller",
		"rest_namespace" => "wp/v2",
		"has_archive" => false,
		"show_in_menu" => true,
		"show_in_nav_menus" => true,
		"delete_with_user" => false,
		"exclude_from_search" => false,
		"capability_type" => "post",
		"map_meta_cap" => true,
		"hierarchical" => false,
		"can_export" => false,
		"rewrite" => [ "slug" => "testfootnotes", "with_front" => true ],
		"query_var" => true,
		"supports" => [ "title", "editor", "thumbnail", "custom-fields", "revisions" ],
		"show_in_graphql" => false,
	];

	register_post_type( "testfootnotes", $args );
}

add_action( 'init', 'cptui_register_my_cpts_testfootnotes' );
```

I have confirmed that the footnotes are functioning correctly on the specified post type.

Furthermore, I have removed the "custom-fields" support from the post type and confirmed that the footnotes are no longer available on the post type.

In addition, I have verified that `remove_post_type_support( 'page', 'footnotes' );` successfully removes footnotes support from pages.
