### PR TITLE
Always output core block global styles after base global styles.

### DIFF
--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -298,7 +298,7 @@ function wp_get_global_styles_custom_css() {
  * Adds global style rules to the inline style for each block.
  *
  * @since 6.1.0
- * 
+ *
  * @global WP_Styles $wp_styles
  */
 function wp_add_global_styles_for_blocks() {
@@ -318,7 +318,7 @@ function wp_add_global_styles_for_blocks() {
 
 		/*
 		 * When `wp_should_load_separate_core_block_assets()` is true, block styles are
-		 * enqueued for each block on the page in class WP_Block's render function. 
+		 * enqueued for each block on the page in class WP_Block's render function.
 		 * This means there will be a handle in the styles queue for each of those blocks.
 		 * Block-specific global styles should be attached to the global-styles handle, but
 		 * only for blocks on the page, thus we check if the block's handle is in the queue
@@ -327,9 +327,9 @@ function wp_add_global_styles_for_blocks() {
 		 */
 		if ( isset( $metadata['name'] ) ) {
 			if ( str_starts_with( $metadata['name'], 'core/' ) ) {
-				$block_name        = str_replace( 'core/', '', $metadata['name'] );
+				$block_name   = str_replace( 'core/', '', $metadata['name'] );
 				$block_handle = 'wp-block-' . $block_name;
-				if (in_array($block_handle, $wp_styles->queue)) {
+				if ( in_array( $block_handle, $wp_styles->queue ) ) {
 					wp_add_inline_style( $stylesheet_handle, $block_css );
 				}
 			} else {
@@ -342,9 +342,9 @@ function wp_add_global_styles_for_blocks() {
 			$block_name = wp_get_block_name_from_theme_json_path( $metadata['path'] );
 			if ( $block_name ) {
 				if ( str_starts_with( $block_name, 'core/' ) ) {
-					$block_name        = str_replace( 'core/', '', $block_name );
+					$block_name   = str_replace( 'core/', '', $block_name );
 					$block_handle = 'wp-block-' . $block_name;
-					if (in_array($block_handle, $wp_styles->queue)) {
+					if ( in_array( $block_handle, $wp_styles->queue ) ) {
 						wp_add_inline_style( $stylesheet_handle, $block_css );
 					}
 				} else {

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -298,8 +298,12 @@ function wp_get_global_styles_custom_css() {
  * Adds global style rules to the inline style for each block.
  *
  * @since 6.1.0
+ * 
+ * @global WP_Styles $wp_styles
  */
 function wp_add_global_styles_for_blocks() {
+	global $wp_styles;
+
 	$tree        = WP_Theme_JSON_Resolver::get_merged_data();
 	$block_nodes = $tree->get_styles_block_nodes();
 	foreach ( $block_nodes as $metadata ) {
@@ -311,17 +315,26 @@ function wp_add_global_styles_for_blocks() {
 		}
 
 		$stylesheet_handle = 'global-styles';
+
+		/*
+		 * When `wp_should_load_separate_core_block_assets()` is true, block styles are
+		 * enqueued for each block on the page in class WP_Block's render function. 
+		 * This means there will be a handle in the styles queue for each of those blocks.
+		 * Block-specific global styles should be attached to the global-styles handle, but
+		 * only for blocks on the page, thus we check if the block's handle is in the queue
+		 * before adding the inline style.
+		 * This conditional loading only applies to core blocks.
+		 */
 		if ( isset( $metadata['name'] ) ) {
-			/*
-			 * These block styles are added on block_render.
-			 * This hooks inline CSS to them so that they are loaded conditionally
-			 * based on whether or not the block is used on the page.
-			 */
 			if ( str_starts_with( $metadata['name'], 'core/' ) ) {
 				$block_name        = str_replace( 'core/', '', $metadata['name'] );
-				$stylesheet_handle = 'wp-block-' . $block_name;
+				$block_handle = 'wp-block-' . $block_name;
+				if (in_array($block_handle, $wp_styles->queue)) {
+					wp_add_inline_style( $stylesheet_handle, $block_css );
+				}
+			} else {
+				wp_add_inline_style( $stylesheet_handle, $block_css );
 			}
-			wp_add_inline_style( $stylesheet_handle, $block_css );
 		}
 
 		// The likes of block element styles from theme.json do not have  $metadata['name'] set.
@@ -330,9 +343,13 @@ function wp_add_global_styles_for_blocks() {
 			if ( $block_name ) {
 				if ( str_starts_with( $block_name, 'core/' ) ) {
 					$block_name        = str_replace( 'core/', '', $block_name );
-					$stylesheet_handle = 'wp-block-' . $block_name;
+					$block_handle = 'wp-block-' . $block_name;
+					if (in_array($block_handle, $wp_styles->queue)) {
+						wp_add_inline_style( $stylesheet_handle, $block_css );
+					}
+				} else {
+					wp_add_inline_style( $stylesheet_handle, $block_css );
 				}
-				wp_add_inline_style( $stylesheet_handle, $block_css );
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60280

Alternative to #5892.

Given that it's undesirable to have base global styles load before block-library styles, this PR changes just the block global styles so they load after the base global styles.

The order of loading should now be:

* Block library styles
* Base global styles (element styles, etc)
* Block-specific global styles

This order should be the same regardless of whether `should_load_separate_core_block_assets` is true or false.

This addresses part of @oandregal's feedback [here](https://github.com/WordPress/wordpress-develop/pull/5892#issuecomment-1903821634). It doesn't touch on custom CSS yet. To fix the existing bug and keep this change small, I'll address the custom CSS separately (it's not really the same issue, because the _order_ of custom CSS is fine, the problem is that it's always loading whether the target blocks are on the page or not)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
