### PR TITLE
Use option for temporarily storing plugin deletion results

### DIFF
--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -427,8 +427,9 @@ if ( $action ) {
 
 			$delete_result = delete_plugins( $plugins );
 
-			// Store the result in a cache rather than a URL param due to object type & length.
-			set_transient( 'plugins_delete_result_' . $user_ID, $delete_result );
+			// Store the result in an option rather than a URL param due to object type & length.
+			// Cannot use transient/cache, as that could get flushed if any plugin flushes data on uninstall/delete.
+			update_option( 'plugins_delete_result_' . $user_ID, $delete_result, false );
 			wp_redirect( self_admin_url( "plugins.php?deleted=$plugins_to_delete&plugin_status=$status&paged=$page&s=$s" ) );
 			exit;
 		case 'clear-recent-list':
@@ -690,9 +691,9 @@ if ( isset( $_GET['error'] ) ) {
 	);
 
 } elseif ( isset( $_GET['deleted'] ) ) {
-	$delete_result = get_transient( 'plugins_delete_result_' . $user_ID );
+	$delete_result = get_option( 'plugins_delete_result_' . $user_ID );
 	// Delete it once we're done.
-	delete_transient( 'plugins_delete_result_' . $user_ID );
+	delete_option( 'plugins_delete_result_' . $user_ID );
 
 	if ( is_wp_error( $delete_result ) ) {
 		$plugin_not_deleted_message = sprintf(


### PR DESCRIPTION
Store delete result in non-autoloaded option instead of cache/transient to ensure it cannot be accidentally removed by other plugins that flush the cache.

Trac ticket: https://core.trac.wordpress.org/ticket/59433
