### PR TITLE
Prevent redirect loops

### DIFF
--- a/tests/phpunit/tests/pluggable/signatures.php
+++ b/tests/phpunit/tests/pluggable/signatures.php
@@ -188,6 +188,7 @@ class Tests_Pluggable_Signatures extends WP_UnitTestCase {
 				'location',
 				'fallback_url' => '',
 			),
+			'_wp_is_self_redirect'            => array( 'location' ),
 			'wp_notify_postauthor'            => array(
 				'comment_id',
 				'deprecated' => null,


### PR DESCRIPTION
Prevent redirect loops when trying to redirect to the current URL, except when changing http to https

It's not possible to create tests for this, since phpunit runs in CLI and PHP will always return null for `filter_input` in CLI

Trac ticket: https://core.trac.wordpress.org/ticket/60208
