### PR TITLE
object cache stats report hit percentage and remove meaningless Group size data

### DIFF
--- a/src/wp-includes/class-wp-object-cache.php
+++ b/src/wp-includes/class-wp-object-cache.php
@@ -624,22 +624,16 @@ class WP_Object_Cache {
 	}
 
 	/**
-	 * Echoes the stats of the caching.
-	 *
-	 * Gives the cache hits, and cache misses. Also prints every cached group,
-	 * key and the data.
+	 * Displays the number of cache hits and misses of the current request so far.
 	 *
 	 * @since 2.0.0
 	 */
 	public function stats() {
+		$hit_percentage = 0 === $this->cache_hits ? 0 : round( $this->cache_hits / ( $this->cache_hits + $this->cache_misses ) * 100, 2 );
 		echo '<p>';
-		echo "<strong>Cache Hits:</strong> {$this->cache_hits}<br />";
-		echo "<strong>Cache Misses:</strong> {$this->cache_misses}<br />";
+		echo "<strong>Cache Hits:</strong> {$this->cache_hits}<br>";
+		echo "<strong>Cache Misses:</strong> {$this->cache_misses}<br>";
+		echo "<strong>Hit Percentage:</strong> {$hit_percentage}%<br>";
 		echo '</p>';
-		echo '<ul>';
-		foreach ( $this->cache as $group => $cache ) {
-			echo '<li><strong>Group:</strong> ' . esc_html( $group ) . ' - ( ' . number_format( strlen( serialize( $cache ) ) / KB_IN_BYTES, 2 ) . 'k )</li>';
-		}
-		echo '</ul>';
 	}
 }


### PR DESCRIPTION
* fix stats() description which didn't match the function anymore since https://core.trac.wordpress.org/changeset/16288
* remove meaningless size data https://core.trac.wordpress.org/ticket/55856
* display Hit percentage as this is a useful metric

Trac ticket: https://core.trac.wordpress.org/ticket/55856
