### PR TITLE
Update the `array_is_list` compat function, add tests

### DIFF
--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -428,8 +428,6 @@ if ( ! function_exists( 'array_is_list' ) ) {
 	 *
 	 * An array is considered a list if its keys consist of consecutive numbers from 0 to count($array)-1.
 	 *
-	 * @see https://github.com/symfony/polyfill-php81/tree/main
-	 *
 	 * @since 6.5.0
 	 *
 	 * @param array<mixed> $arr The array being evaluated.
@@ -440,15 +438,7 @@ if ( ! function_exists( 'array_is_list' ) ) {
 			return true;
 		}
 
-		$next_key = -1;
-
-		foreach ( $arr as $k => $v ) {
-			if ( ++$next_key !== $k ) {
-				return false;
-			}
-		}
-
-		return true;
+		return false;
 	}
 }
 

--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -438,7 +438,15 @@ if ( ! function_exists( 'array_is_list' ) ) {
 			return true;
 		}
 
-		return false;
+		$next_key = -1;
+
+		foreach ( $arr as $k => $v ) {
+			if ( ++$next_key !== $k ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 }
 

--- a/tests/phpunit/tests/compat/arrayIsList.php
+++ b/tests/phpunit/tests/compat/arrayIsList.php
@@ -25,7 +25,7 @@ class Tests_Compat_arrayIsList extends WP_UnitTestCase {
 	 * @param array $arr      The array.
 	 */
 	public function test_array_is_list( $expected, $arr ) {
-		$this->assertSame( $expected, array_is_list2( $arr ) );
+		$this->assertSame( $expected, array_is_list( $arr ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/compat/arrayIsList.php
+++ b/tests/phpunit/tests/compat/arrayIsList.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * @group compat
+ *
+ * @covers ::array_is_list
+ */
+class Tests_Compat_arrayIsList extends WP_UnitTestCase {
+
+	/**
+	 * Test that array_is_list() is always available (either from PHP or WP).
+	 *
+	 * @ticket 55105
+	 */
+	public function test_array_is_list_availability() {
+		$this->assertTrue( function_exists( 'array_is_list' ) );
+	}
+
+	/**
+	 * @dataProvider data_array_is_list
+	 *
+	 * @ticket 55105
+	 *
+	 * @param bool  $expected Whether the array is a list.
+	 * @param array $arr      The array.
+	 */
+	public function test_array_is_list( $expected, $arr ) {
+		$this->assertSame( $expected, array_is_list2( $arr ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_array_is_list() {
+		return array(
+			'empty array'                   => array(
+				'expected' => true,
+				'arr'      => array(),
+			),
+			'array(NAN)'                    => array(
+				'expected' => true,
+				'arr'      => array( NAN ),
+			),
+			'array( INF )'                  => array(
+				'expected' => true,
+				'arr'      => array( INF ),
+			),
+			'consecutive int keys from 0'   => array(
+				'expected' => true,
+				'arr'      => array(
+					0 => 'one',
+					1 => 'two',
+				),
+			),
+			'consecutive float keys from 0' => array(
+				'expected' => true,
+				'arr'      => array(
+					0.0 => 'one',
+					1.0 => 'two',
+				),
+			),
+			'consecutive str keys from 0'   => array(
+				'expected' => true,
+				'arr'      => array(
+					'0' => 'one',
+					'1' => 'two',
+				),
+			),
+			'consecutive int keys from 1'   => array(
+				'expected' => false,
+				'arr'      => array(
+					1 => 'one',
+					2 => 'two',
+				),
+			),
+			'consecutive float keys from 1' => array(
+				'expected' => false,
+				'arr'      => array(
+					1.0 => 'one',
+					2.0 => 'two',
+				),
+			),
+			'consecutive str keys from 1'   => array(
+				'expected' => false,
+				'arr'      => array(
+					'1' => 'one',
+					'2' => 'two',
+				),
+			),
+			'non-consecutive int keys'      => array(
+				'expected' => false,
+				'arr'      => array(
+					1 => 'one',
+					0 => 'two',
+				),
+			),
+			'non-consecutive float keys'    => array(
+				'expected' => false,
+				'arr'      => array(
+					1.0 => 'one',
+					0.0 => 'two',
+				),
+			),
+			'non-consecutive string keys'   => array(
+				'expected' => false,
+				'arr'      => array(
+					'1' => 'one',
+					'0' => 'two',
+				),
+			),
+		);
+	}
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

The function was polyfilled via another ticket.

This adds tests that were originally added and simplifies the polyfill (assuming the tests still pass)

Trac ticket: https://core.trac.wordpress.org/ticket/55105

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
