### PR TITLE
Improve inline documentation and avoid escaping values passed to `$processor->set_attribute()`

### DIFF
--- a/src/wp-includes/block-bindings.php
+++ b/src/wp-includes/block-bindings.php
@@ -30,7 +30,9 @@
  *     function my_plugin_get_custom_source_value( array $source_args, $block_instance, string $attribute_name ) {
  *       // Your custom logic to get the value from the source.
  *       // For example, you can use the `$source_args` to look up a value in a custom table or get it from an external API.
- *       return 'my custom value';
+ *       $value = $source_args['key'];
+ *
+ *       return "The value passed to the block is: $value"
  *     }
  *
  * The `$source_args` will contain the arguments passed to the source in the block's

--- a/src/wp-includes/block-bindings.php
+++ b/src/wp-includes/block-bindings.php
@@ -12,10 +12,46 @@
 /**
  * Registers a new block bindings source.
  *
- * Sources are used to override block's original attributes with a value
- * coming from the source. Once a source is registered, it can be used by a
- * block by setting its `metadata.bindings` attribute to a value that refers
- * to the source.
+ * Registering a source consists of defining a **name** for that source as well as a callback function
+ * which specifies how to get a value from that source and pass it to a block attribute.
+ *
+ * Once a source is registered, any block that supports the Block Bindings API can use a value
+ * from that source by setting its `metadata.bindings` attribute to a value that refers to the source.
+ *
+ * Note that `register_block_bindings_source()` should be called from a handler attached to the `init` hook.
+ *
+ * ## Example
+ *
+ *     function my_plugin_register_block_bindings_sources() {
+ *       register_block_bindings_source( 'my-plugin/my-custom-source', array(
+ *         'label'              => __( 'My Custom Source', 'my-plugin' ),
+ *         'get_value_callback' => 'my_plugin_get_custom_source_value',
+ *       ) );
+ *     }
+ *     add_action( 'init', 'my_plugin_register_block_bindings_sources' );
+ *
+ *     function my_plugin_get_custom_source_value( array $source_args, $block_instance, string $attribute_name ) {
+ *       // Your custom logic to get the value from the source.
+ *     }
+ *
+ * ### Usage in a block
+ *
+ * In a block's `metadata.bindings` attribute, you can specify the source and
+ * its arguments. Such a block will use the source to override the block
+ * attribute's value. For example:
+ *
+ *     <!-- wp:paragraph {
+ *       "metadata": {
+ *         "bindings": {
+ *           "content": {
+ *             "source": "my-plugin/my-custom-source",
+ *             "args": {
+ *               "key": "you can pass any custom arguments here"
+ *             }
+ *           }
+ *         }
+ *       }
+ *     } --><!-- /wp:paragraph -->
  *
  * @since 6.5.0
  *

--- a/src/wp-includes/block-bindings.php
+++ b/src/wp-includes/block-bindings.php
@@ -12,8 +12,8 @@
 /**
  * Registers a new block bindings source.
  *
- * Registering a source consists of defining a **name** for that source as well as a callback function
- * which specifies how to get a value from that source and pass it to a block attribute.
+ * Registering a source consists of defining a **name** for that source and a callback function specifying
+ * how to get a value from that source and pass it to a block attribute.
  *
  * Once a source is registered, any block that supports the Block Bindings API can use a value
  * from that source by setting its `metadata.bindings` attribute to a value that refers to the source.

--- a/src/wp-includes/block-bindings.php
+++ b/src/wp-includes/block-bindings.php
@@ -20,7 +20,21 @@
  *
  * Note that `register_block_bindings_source()` should be called from a handler attached to the `init` hook.
  *
+ *
  * ## Example
+ *
+ * ### Registering a source
+ *
+ * First, you need to define a function that will be used to get the value from the source.
+ *
+ *     function my_plugin_get_custom_source_value( array $source_args, $block_instance, string $attribute_name ) {
+ *       // Your custom logic to get the value from the source.
+ *       // For example, you can use the `$source_args` to look up a value in a custom table or get it from an external API.
+ *       return 'my custom value';
+ *     }
+ *
+ * The `$source_args` will contain the arguments passed to the source in the block's
+ * `metadata.bindings` attribute. See the example in the "Usage in a block" section below.
  *
  *     function my_plugin_register_block_bindings_sources() {
  *       register_block_bindings_source( 'my-plugin/my-custom-source', array(
@@ -29,10 +43,6 @@
  *       ) );
  *     }
  *     add_action( 'init', 'my_plugin_register_block_bindings_sources' );
- *
- *     function my_plugin_get_custom_source_value( array $source_args, $block_instance, string $attribute_name ) {
- *       // Your custom logic to get the value from the source.
- *     }
  *
  * ### Usage in a block
  *

--- a/src/wp-includes/block-bindings.php
+++ b/src/wp-includes/block-bindings.php
@@ -61,7 +61,9 @@
  *           }
  *         }
  *       }
- *     } --><!-- /wp:paragraph -->
+ *     } -->
+ *     <p>Fallback text that gets replaced.</p>
+ *     <!-- /wp:paragraph -->
  *
  * @since 6.5.0
  *

--- a/src/wp-includes/class-wp-block-bindings-registry.php
+++ b/src/wp-includes/class-wp-block-bindings-registry.php
@@ -35,6 +35,11 @@ final class WP_Block_Bindings_Registry {
 	/**
 	 * Registers a new block bindings source.
 	 *
+	 * This is a low-level method. For most use cases, it is recommended to use
+	 * the `register_block_bindings_source()` function instead.
+	 *
+	 * @see register_block_bindings_source()
+	 *
 	 * Sources are used to override block's original attributes with a value
 	 * coming from the source. Once a source is registered, it can be used by a
 	 * block by setting its `metadata.bindings` attribute to a value that refers

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -376,7 +376,7 @@ class WP_Block {
 				) ) {
 					return $block_content;
 				}
-				$amended_content->set_attribute( $block_type->attributes[ $attribute_name ]['attribute'], esc_attr( $source_value ) );
+				$amended_content->set_attribute( $block_type->attributes[ $attribute_name ]['attribute'], $source_value );
 				return $amended_content->get_updated_html();
 				break;
 


### PR DESCRIPTION
This PR improves the inline documentation for the Block Bindings API. 

It also implements a minor improvement from https://github.com/WordPress/wordpress-develop/pull/5888#discussion_r1476793062. The values passed to `$processor->set_attribute()` should not be escaped.


Trac ticket: https://core.trac.wordpress.org/ticket/60282

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
