### PR TITLE
[60446] Added application/json due to a bug in is_json.c

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3207,6 +3207,7 @@ function wp_check_filetype_and_ext( $file, $filename, $mimes = null ) {
 					'text/richtext',
 					'text/tsv',
 					'text/vtt',
+					'application/json',
 				),
 				true
 			)


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/60446

WordPress uses the function `finfo_file` to detect the mime type of the file if it’s not an image.
PHP uses the file library from here: https://github.com/file/file/ which is a core of the file command we use in most of the Linux based systems.
Issue resides in that library. It expects values inside an array. If empty array is found, then it doesn’t detect it as JSON.
For example:
```
[
  {
    "id": "123",
    "labels": []
  }
]
```
Above string is valid JSON according to RFC-7159/RFC-8259 standards. But due to the issue within that library, it doesn’t detect as JSON.

Looks like WP team knew about the issues within that library. That’s why they have explicitly added other file types that were detected as text/plain by that library and whitelisted it here: https://github.com/WordPress/WordPress/blob/ea8080d8c80c124f9d1a6e42d6e95a785231f661/wp-includes/functions.php#L3204-L3209

Following Comment confirms it: https://github.com/WordPress/WordPress/blob/ea8080d8c80c124f9d1a6e42d6e95a785231f661/wp-includes/functions.php#L3200C4-L3201C1

Therefore it's better if we can add `application/json` too since it will cover edge cases like above.
