### PR TITLE
HTML API: Add local testing bootstraps.

### DIFF
--- a/tests/phpunit/tests/html-api/bootstrap.php
+++ b/tests/phpunit/tests/html-api/bootstrap.php
@@ -1,0 +1,66 @@
+<?php
+
+// CSS Processor
+//require_once __DIR__ . '/../../../../src/wp-includes/html-api/class-wp-css.php';
+
+// Tag Processor
+require_once __DIR__ . '/../../../../src/wp-includes/html-api/class-wp-html-attribute-token.php';
+require_once __DIR__ . '/../../../../src/wp-includes/html-api/class-wp-html-span.php';
+require_once __DIR__ . '/../../../../src/wp-includes/html-api/class-wp-html-text-replacement.php';
+require_once __DIR__ . '/../../../../src/wp-includes/html-api/class-wp-html-tag-processor.php';
+
+// HTML Processor
+require_once __DIR__ . '/../../../../src/wp-includes/html-api/class-wp-html-unsupported-exception.php';
+require_once __DIR__ . '/../../../../src/wp-includes/html-api/class-wp-html-active-formatting-elements.php';
+require_once __DIR__ . '/../../../../src/wp-includes/html-api/class-wp-html-open-elements.php';
+require_once __DIR__ . '/../../../../src/wp-includes/html-api/class-wp-html-token.php';
+require_once __DIR__ . '/../../../../src/wp-includes/html-api/class-wp-html-processor-state.php';
+require_once __DIR__ . '/../../../../src/wp-includes/html-api/class-wp-html-processor.php';
+
+// Templating
+//require_once __DIR__ . '/../../../../src/wp-includes/html-api/class-wp-html-template.php';
+//require_once __DIR__ . '/../../../../src/wp-includes/html-api/class-wp-html.php';
+
+if ( ! defined( 'DIR_TESTDATA' ) ) {
+	define( 'DIR_TESTDATA', __DIR__ . '/../../data' );
+}
+
+if ( ! class_exists( 'WP_UnitTestCase' ) ) {
+	class WP_UnitTestCase extends PHPUnit\Framework\TestCase {
+		public $caught_doing_it_wrong = array();
+
+		public function setExpectedIncorrectUsage( $doing_it_wrong ) {
+
+		}
+	}
+}
+
+if ( ! function_exists( 'esc_attr' ) ) {
+	function esc_attr( $s ) {
+		return str_replace( [ '<', '>', '"' ], [ '&lt;', '&gt;', '&quot;' ], $s );
+	}
+}
+
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $s ) {
+		return esc_attr( $s );
+	}
+}
+
+if ( ! function_exists( '__' ) ) {
+	function __( $s ) {
+		return $s;
+	}
+}
+
+if ( ! function_exists( '_doing_it_wrong' ) ) {
+	function _doing_it_wrong( ...$args ) {
+
+	}
+}
+
+if ( ! class_exists( 'HTMLProcessorDebugger' ) ) {
+	class HTMLProcessorDebugger extends WP_HTML_Tag_Processor {
+
+	}
+}

--- a/tests/phpunit/tests/html-api/phpunit.xml
+++ b/tests/phpunit/tests/html-api/phpunit.xml
@@ -19,7 +19,7 @@
 			<file>WpHtmlSupportRequiredOpenElements.php</file>
 			<file>WpHtmlTagProcessor.php</file>
 			<file>WpHtmlTagProcessor-bookmark.php</file>
-			<file>WpHtmlProcessor-bookmark.php</file>
+<!--			<file>WpHtmlProcessor-bookmark.php</file>-->
 <!--			<file>WpHtmlTemplate.php</file>-->
 			<file>WpHtmlTagProcessor-token-scanning.php</file>
 <!--			<file>WpHtmlTagProcessor-internals.php</file>-->

--- a/tests/phpunit/tests/html-api/phpunit.xml
+++ b/tests/phpunit/tests/html-api/phpunit.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<phpunit bootstrap="bootstrap.php" testdox="true" colors="true">
+	<php>
+<!--        <const name="DEBUG" value="FALSE"/>-->
+    </php>
+	<testsuites>
+		<testsuite name="html-api">
+			<file>WpHtmlProcessor.php</file>
+<!--			<file>WpHtmlProcessorHtml5lib.php</file>-->
+			<file>WpHtmlProcessorSemanticRules.php</file>
+			<file>WpHtmlProcessorSemanticRulesHeadingElements.php</file>
+			<file>WpHtmlProcessorSemanticRulesListElements.php</file>
+			<file>WpHtmlProcessorBreadcrumbs.php</file>
+<!--			<file>WpHtmlProcessorGetInnerMarkup.php</file>-->
+<!--			<file>WpHtmlProcessorGetOuterMarkup.php</file>-->
+<!--			<file>WpHtmlProcessorSetInnerMarkup.php</file>-->
+<!--			<file>WpHtmlProcessorSetOuterMarkup.php</file>-->
+			<file>WpHtmlSupportRequiredHtmlProcessor.php</file>
+			<file>WpHtmlSupportRequiredOpenElements.php</file>
+			<file>WpHtmlTagProcessor.php</file>
+			<file>WpHtmlTagProcessor-bookmark.php</file>
+			<file>WpHtmlProcessor-bookmark.php</file>
+<!--			<file>WpHtmlTemplate.php</file>-->
+			<file>WpHtmlTagProcessor-token-scanning.php</file>
+<!--			<file>WpHtmlTagProcessor-internals.php</file>-->
+<!--			<file>WpHtmlProcessor-stringBuilder.php</file>-->
+		</testsuite>
+	</testsuites>
+</phpunit>


### PR DESCRIPTION
Apply this branch to be able to run tests for the HTML API locally and without running any other code outside the directory. This requires you have a supported version of PHP, Composer, and `phpunit` installed.

```bash
cd path/to/wordpress-develop
vendor/bin/phpunit -c tests/phpunit/tests/html-api
```