### PR TITLE
Font Library: Register the Google Font collection

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -750,5 +750,6 @@ add_action( 'wp_restore_post_revision', 'wp_restore_post_revision_meta', 10, 2 )
 add_action( 'wp_head', 'wp_print_font_faces', 50 );
 add_action( 'deleted_post', '_wp_after_delete_font_family', 10, 2 );
 add_action( 'before_delete_post', '_wp_before_delete_font_face', 10, 2 );
+add_action( 'init', '_register_font_collections' );
 
 unset( $filter, $action );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -750,6 +750,6 @@ add_action( 'wp_restore_post_revision', 'wp_restore_post_revision_meta', 10, 2 )
 add_action( 'wp_head', 'wp_print_font_faces', 50 );
 add_action( 'deleted_post', '_wp_after_delete_font_family', 10, 2 );
 add_action( 'before_delete_post', '_wp_before_delete_font_face', 10, 2 );
-add_action( 'init', '_register_font_collections' );
+add_action( 'init', '_wp_register_default_font_collections' );
 
 unset( $filter, $action );

--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -188,3 +188,13 @@ function _wp_before_delete_font_face( $post_id, $post ) {
 		wp_delete_file( $font_dir . '/' . $font_file );
 	}
 }
+
+/**
+ * Register the default font collections.
+ *
+ * @access private
+ * @since 6.5.0
+ */
+function _register_font_collections() {
+	wp_register_font_collection( 'google-fonts', 'https://s.w.org/images/fonts/17.7/collections/google-fonts-with-preview.json' );
+}

--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -195,6 +195,6 @@ function _wp_before_delete_font_face( $post_id, $post ) {
  * @access private
  * @since 6.5.0
  */
-function _register_font_collections() {
+function _wp_register_default_font_collections() {
 	wp_register_font_collection( 'google-fonts', 'https://s.w.org/images/fonts/17.7/collections/google-fonts-with-preview.json' );
 }

--- a/tests/phpunit/includes/functions.php
+++ b/tests/phpunit/includes/functions.php
@@ -351,3 +351,14 @@ function _unhook_block_registration() {
 	remove_action( 'init', '_register_block_bindings_post_meta_source' );
 }
 tests_add_filter( 'init', '_unhook_block_registration', 1000 );
+
+/**
+ * After the init action has been run once, trying to re-register font collections can cause
+ * errors. To avoid this, unhook the font registration functions.
+ *
+ * @since 6.5.0
+ */
+function _unhook_font_registration() {
+	remove_action( 'init', '_register_font_collections' );
+}
+tests_add_filter( 'init', '_unhook_font_registration', 1000 );

--- a/tests/phpunit/includes/functions.php
+++ b/tests/phpunit/includes/functions.php
@@ -359,6 +359,6 @@ tests_add_filter( 'init', '_unhook_block_registration', 1000 );
  * @since 6.5.0
  */
 function _unhook_font_registration() {
-	remove_action( 'init', '_register_font_collections' );
+	remove_action( 'init', '_wp_register_default_font_collections' );
 }
 tests_add_filter( 'init', '_unhook_font_registration', 1000 );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/59166

This PR register the google fonts collection allowing users to install Google Fonts if they wish to.

### Testing instructions

- Go to the site editor
- Open the global styles panel
- Open typography
- Click on the "Aa" icon to open the font library
- On the third panel, you should be able to enable google fonts and install them properly.

<img width="1470" alt="Screenshot 2024-02-07 at 10 27 14 AM" src="https://github.com/WordPress/wordpress-develop/assets/272444/cbf39608-8bc6-4cad-975f-c171fd1d8aae">
