### PR TITLE
Fix typo

### DIFF
--- a/src/wp-includes/fonts/class-wp-font-utils.php
+++ b/src/wp-includes/fonts/class-wp-font-utils.php
@@ -141,7 +141,7 @@ class WP_Font_Utils {
 	 * The schema structure should mirror the data tree. Each value provided in the
 	 * schema should be a callable that will be applied to sanitize the corresponding
 	 * value in the data tree. Keys that are in the data tree, but not present in the
-	 * schema, will be removed in the santized data. Nested arrays are traversed recursively.
+	 * schema, will be removed in the sanitized data. Nested arrays are traversed recursively.
 	 *
 	 * @since 6.5.0
 	 *


### PR DESCRIPTION
[[r57539]](https://core.trac.wordpress.org/changeset/57539) introduced a typo in the docblock for sanitize_from_schema on line 144 in class-wp-font-utils.php
[Link to line](https://github.com/WordPress/wordpress-develop/blob/a770c6da8dee44a060427fa82aac7acf25ff5a44/src/wp-includes/fonts/class-wp-font-utils.php#L144)

santized should be sanitized.

https://core.trac.wordpress.org/ticket/59166
https://core.trac.wordpress.org/ticket/59651