### PR TITLE
Build/Test Tools: Comment on a PR when no Trac ticket is included

### DIFF
--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -163,3 +163,46 @@ jobs:
             `;
 
             github.rest.issues.createComment( commentInfo );
+
+  # Leaves a comment on a pull request when no Trac ticket is included in the pull request description.
+  trac-ticket-check:
+    name: Comment on a pull request when no Trac ticket is included
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name == 'pull_request_target' }}
+    steps:
+      - name: Check for Trac ticket and comment if missing
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const pr = await github.rest.pulls.get( {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            } );
+
+            const prBody = pr.data.body ?? '';
+
+            const tracTicketRegex = new RegExp( 'https?://core.trac.wordpress.org/ticket/([0-9]+)', 'g' );
+            const tracTicketMatches = prBody.match( tracTicketRegex );
+
+            if ( ! tracTicketMatches ) {
+              github.rest.issues.createComment( {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `## Trac Ticket Missing
+            Hi @${{ github.actor }}! 👋
+
+            It looks like the pull request does not contain the full URL for the Trac ticket in the pull request body.
+
+            When contributing to WordPress Core using a pull request on GitHub, a Trac ticket is required for the contribution to be considered.
+
+            To attach a pull request to a Trac ticket, please include the ticket's full URL in your pull request description.
+
+            More information about how GitHub pull requests can be used to contribute to WordPress can be found in [this blog post](https://make.wordpress.org/core/2020/02/21/working-on-trac-tickets-using-github-pull-requests/).
+            `,
+              } );
+            }

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -177,37 +177,32 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
-            // Check for the presence of a comment and bail early.
-            const comments = ( await github.rest.issues.listComments( {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            } ) ).data;
+            const { owner, repo } = context.repo;
+            const { number } = context.issue;
 
-            for ( const currentComment of comments ) {
-              if ( currentComment.user.type === 'Bot' && currentComment.body.includes( 'Trac Ticket Missing' ) ) {
-                return;
-              }
-            }
+            // Check for the presence of a comment and bail early.
+            const comments = ( await github.rest.issues.listComments( { owner, repo, issue_number: number } ) ).data;
+
+            const hasMissingTicketComment = comments.some( comment =>
+              comment.user.type === 'Bot' && comment.body.includes( 'Trac Ticket Missing' )
+            );
+
+            if ( hasMissingTicketComment ) return;
 
             // No comment was found. Create one.
-            const pr = await github.rest.pulls.get( {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-            } );
+            const pr = ( await github.rest.pulls.get( { owner, repo, pull_number: number } ) ).data;
 
-            const prBody = pr.data.body ?? '';
-            const prTitle = pr.data.title ?? '';
+            const prBody = pr.body ?? '';
+            const prTitle = pr.title ?? '';
 
             const tracTicketRegex = new RegExp( 'https?://core.trac.wordpress.org/ticket/([0-9]+)', 'g' );
             const tracTicketMatches = prBody.match( tracTicketRegex ) || prTitle.match( tracTicketRegex );
 
             if ( ! tracTicketMatches ) {
               github.rest.issues.createComment( {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
+                owner,
+                repo,
+                issue_number: number,
                 body: `## Trac Ticket Missing
             This pull request is missing a Trac ticket link. For a contribution to be considered, there must be a corresponding ticket in Trac.
 

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -195,15 +195,9 @@ jobs:
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
                 body: `## Trac Ticket Missing
-            Hi @${{ github.actor }}! 👋
+            This pull request is missing a Trac ticket link. For a contribution to be considered, there must be a corresponding ticket in Trac.
 
-            It looks like the pull request does not contain the full URL for the Trac ticket in the pull request body.
-
-            When contributing to WordPress Core using a pull request on GitHub, a Trac ticket is required for the contribution to be considered.
-
-            To attach a pull request to a Trac ticket, please include the ticket's full URL in your pull request description.
-
-            More information about how GitHub pull requests can be used to contribute to WordPress can be found in [the Core Handbook](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/).
+            To attach a pull request to a Trac ticket, please include the ticket's full URL in your pull request description. More information about contributing to WordPress on GitHub can be found in [the Core Handbook](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/).
             `,
               } );
             }

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -49,7 +49,7 @@ jobs:
             **Pull requests are never merged on GitHub.** The WordPress codebase continues to be managed through the SVN repository that this GitHub repository mirrors. Please feel free to open pull requests to work on any contribution you are making.
 
 
-            More information about how GitHub pull requests can be used to contribute to WordPress can be found in [this blog post](https://make.wordpress.org/core/2020/02/21/working-on-trac-tickets-using-github-pull-requests/).
+            More information about how GitHub pull requests can be used to contribute to WordPress can be found in [the Core Handbook](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/).
 
 
             **Please include automated tests.** Including tests in your pull request is one way to help your patch be considered faster. To learn about WordPress' test suites, visit the [Automated Testing](https://make.wordpress.org/core/handbook/testing/automated-testing/) page in the handbook.
@@ -203,7 +203,7 @@ jobs:
 
             To attach a pull request to a Trac ticket, please include the ticket's full URL in your pull request description.
 
-            More information about how GitHub pull requests can be used to contribute to WordPress can be found in [this blog post](https://make.wordpress.org/core/2020/02/21/working-on-trac-tickets-using-github-pull-requests/).
+            More information about how GitHub pull requests can be used to contribute to WordPress can be found in [the Core Handbook](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/).
             `,
               } );
             }

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -177,6 +177,20 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
+            // Check for the presence of a comment and bail early.
+            const comments = ( await github.rest.issues.listComments( {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            } ) ).data;
+
+            for ( const currentComment of comments ) {
+              if ( currentComment.user.type === 'Bot' && currentComment.body.includes( 'Trac Ticket Missing' ) ) {
+                return;
+              }
+            }
+
+            // No comment was found. Create one.
             const pr = await github.rest.pulls.get( {
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -184,9 +184,10 @@ jobs:
             } );
 
             const prBody = pr.data.body ?? '';
+            const prTitle = pr.data.title ?? '';
 
             const tracTicketRegex = new RegExp( 'https?://core.trac.wordpress.org/ticket/([0-9]+)', 'g' );
-            const tracTicketMatches = prBody.match( tracTicketRegex );
+            const tracTicketMatches = prBody.match( tracTicketRegex ) || prTitle.match( tracTicketRegex );
 
             if ( ! tracTicketMatches ) {
               github.rest.issues.createComment( {

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -171,7 +171,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name == 'pull_request_target' }}
+    if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name == 'pull_request_target' && ! github.event.pull_request.draft && github.event.pull_request.state == 'open' }}
     steps:
       - name: Check for Trac ticket and comment if missing
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

When contributing to Core using a pull request on GitHub, a [Trac ticket is required for the contribution to be considered](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/).

Even though the pull request template notes this, it's easy to forget or overlook.

Adding a job in the Pull Request Comments workflow to add a reminder comment when a Trac ticket link is missing is an easy way to help avoid contributions being lost in the shuffle.

Trac ticket: https://core.trac.wordpress.org/ticket/60129

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
