### PR TITLE
Script Modules API: Add deregister module function

### DIFF
--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -152,6 +152,20 @@ class WP_Script_Modules {
 	}
 
 	/**
+	 * Deregister the script module so it will no longer be registered.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param string $id The identifier of the script module.
+	 */
+	public function deregister( string $id ) {
+		if ( isset( $this->registered[ $id ] ) ) {
+			unset( $this->registered[ $id ] );
+		}
+		unset( $this->enqueued_before_registered[ $id ] );
+	}
+
+	/**
 	 * Adds the hooks to print the import map, enqueued script modules and script
 	 * module preloads.
 	 *

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -152,16 +152,14 @@ class WP_Script_Modules {
 	}
 
 	/**
-	 * Deregister the script module so it will no longer be registered.
+	 * Removes a registered script module.
 	 *
 	 * @since 6.5.0
 	 *
 	 * @param string $id The identifier of the script module.
 	 */
 	public function deregister( string $id ) {
-		if ( isset( $this->registered[ $id ] ) ) {
-			unset( $this->registered[ $id ] );
-		}
+		unset( $this->registered[ $id ] );
 		unset( $this->enqueued_before_registered[ $id ] );
 	}
 

--- a/src/wp-includes/script-modules.php
+++ b/src/wp-includes/script-modules.php
@@ -114,7 +114,7 @@ function wp_dequeue_script_module( string $id ) {
 }
 
 /**
- * Unregisters the script module.
+ * Deregisters the script module.
  *
  * @since 6.5.0
  *

--- a/src/wp-includes/script-modules.php
+++ b/src/wp-includes/script-modules.php
@@ -112,3 +112,14 @@ function wp_enqueue_script_module( string $id, string $src = '', array $deps = a
 function wp_dequeue_script_module( string $id ) {
 	wp_script_modules()->dequeue( $id );
 }
+
+/**
+ * Unregisters the script module.
+ *
+ * @since 6.5.0
+ *
+ * @param string $id The identifier of the script module.
+ */
+function wp_deregister_script_module( string $id ) {
+	wp_script_modules()->deregister( $id );
+}

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -128,17 +128,17 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 
 
 	/**
-	* Tests that a script module can be deregistered
-	* after being enqueued, and that will be removed
-	* from the enqueue list too.
-	*
-	* @ticket 60463
-	*
-	* @covers ::register()
-	* @covers ::enqueue()
-	* @covers ::deregister()
-	* @covers ::print_enqueued_script_modules()
-	*/
+	 * Tests that a script module can be deregistered
+	 * after being enqueued, and that will be removed
+	 * from the enqueue list too.
+	 *
+	 * @ticket 60463
+	 *
+	 * @covers ::register()
+	 * @covers ::enqueue()
+	 * @covers ::deregister()
+	 * @covers ::get_enqueued_script_modules()
+	 */
 	public function test_wp_deregister_script_module() {
 		$this->script_modules->register( 'foo', '/foo.js' );
 		$this->script_modules->register( 'bar', '/bar.js' );
@@ -151,6 +151,52 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 		$this->assertCount( 1, $enqueued_script_modules );
 		$this->assertFalse( isset( $enqueued_script_modules['foo'] ) );
 		$this->assertTrue( isset( $enqueued_script_modules['bar'] ) );
+	}
+
+	/**
+	 * Tests that a script module cannot be deregistered
+	 * if it has not been registered before, causing
+	 * no errors.
+	 *
+	 * @ticket 60463
+	 *
+	 * @covers ::deregister()
+	 * @covers ::get_enqueued_script_modules()
+	 */
+	public function test_wp_deregister_unexistent_script_module() {
+		$this->script_modules->deregister( 'unexistent' );
+		$enqueued_script_modules = $this->get_enqueued_script_modules();
+
+		$this->assertCount( 0, $enqueued_script_modules );
+		$this->assertFalse( isset( $enqueued_script_modules['unexistent'] ) );
+	}
+
+	/**
+	 * Tests that a script module cannot be deregistered
+	 * if it has not been registered before, causing
+	 * no errors.
+	 *
+	 * @ticket 60463
+	 *
+	 * @covers ::get_enqueued_script_modules()
+	 * @covers ::register()
+	 * @covers ::deregister()
+	 * @covers ::enqueue()
+	 */
+	public function test_wp_deregister_already_deregistered_script_module() {
+		$this->script_modules->register( 'foo', '/foo.js' );
+		$this->script_modules->enqueue( 'foo' );
+		$this->script_modules->deregister( 'foo' ); // Dequeued.
+		$enqueued_script_modules = $this->get_enqueued_script_modules();
+
+		$this->assertCount( 0, $enqueued_script_modules );
+		$this->assertFalse( isset( $enqueued_script_modules['foo'] ) );
+
+		$this->script_modules->deregister( 'foo' ); // Dequeued.
+		$enqueued_script_modules = $this->get_enqueued_script_modules();
+
+		$this->assertCount( 0, $enqueued_script_modules );
+		$this->assertFalse( isset( $enqueued_script_modules['foo'] ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -126,6 +126,34 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 		$this->assertTrue( isset( $enqueued_script_modules['bar'] ) );
 	}
 
+
+	/**
+	* Tests that a script module can be deregistered
+	* after being enqueued, and that will be removed
+	* from the enqueue list too.
+	*
+	* @ticket
+	*
+	* @covers ::register()
+	* @covers ::enqueue()
+	* @covers ::dequeue()
+	* @covers ::deregister()
+	* @covers ::print_enqueued_script_modules()
+	*/
+	public function test_wp_deregister_script_module() {
+		$this->script_modules->register( 'foo', '/foo.js' );
+		$this->script_modules->register( 'bar', '/bar.js' );
+		$this->script_modules->enqueue( 'foo' );
+		$this->script_modules->enqueue( 'bar' );
+		$this->script_modules->deregister( 'foo' ); // Dequeued.
+
+		$enqueued_script_modules = $this->get_enqueued_script_modules();
+
+		$this->assertCount( 1, $enqueued_script_modules );
+		$this->assertFalse( isset( $enqueued_script_modules['foo'] ) );
+		$this->assertTrue( isset( $enqueued_script_modules['bar'] ) );
+	}
+
 	/**
 	* Tests that a script module can be enqueued before it is registered, and will
 	* be handled correctly once registered.

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -154,7 +154,7 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that a script module cannot be deregistered
+	 * Tests that a script module is not deregistered
 	 * if it has not been registered before, causing
 	 * no errors.
 	 *
@@ -172,8 +172,8 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that a script module cannot be deregistered
-	 * if it has not been registered before, causing
+	 * Tests that a script module is not deregistered
+	 * if it has been deregistered previously, causing
 	 * no errors.
 	 *
 	 * @ticket 60463

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -132,11 +132,10 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 	* after being enqueued, and that will be removed
 	* from the enqueue list too.
 	*
-	* @ticket
+	* @ticket 60463
 	*
 	* @covers ::register()
 	* @covers ::enqueue()
-	* @covers ::dequeue()
 	* @covers ::deregister()
 	* @covers ::print_enqueued_script_modules()
 	*/


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60463

Right now is impossible to deregister a script module. This can cause problems for extenders that want to override any Core script module.

It will eventually happen in Gutenberg once 6.5 is out. We already had dequeue, but also, being consistent with script_register, style_register, there should be a script_module_register.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
