### PR TITLE
init

### DIFF
--- a/src/wp-content/themes/twentytwenty/style-rtl.css
+++ b/src/wp-content/themes/twentytwenty/style-rtl.css
@@ -960,17 +960,17 @@ th {
 }
 
 .screen-height {
-	min-height: 100vh;
+	min-height: 100dvh;
 }
 
 .admin-bar .screen-height {
-	min-height: calc(100vh - 32px);
+	min-height: calc(100dvh - 32px);
 }
 
 @media (max-width: 782px) {
 
 	.admin-bar .screen-height {
-		min-height: calc(100vh - 46px);
+		min-height: calc(100dvh - 46px);
 	}
 }
 

--- a/src/wp-content/themes/twentytwenty/style.css
+++ b/src/wp-content/themes/twentytwenty/style.css
@@ -966,17 +966,17 @@ th {
 }
 
 .screen-height {
-	min-height: 100vh;
+	min-height: 100dvh;
 }
 
 .admin-bar .screen-height {
-	min-height: calc(100vh - 32px);
+	min-height: calc(100dvh - 32px);
 }
 
 @media (max-width: 782px) {
 
 	.admin-bar .screen-height {
-		min-height: calc(100vh - 46px);
+		min-height: calc(100dvh - 46px);
 	}
 }
 


### PR DESCRIPTION


Hey there! :wave: 

Twenty Twenty's cover template fills the whole background with the article image. This works as expected on desktop. On mobile however, some content gets covered by the browser bar.

Replacing `vh` with `dvh` fixes that:

```css
.screen-height {
   min-height: 100dvh;
}
```



Trac ticket: https://core.trac.wordpress.org/ticket/60462

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
