### PR TITLE
Generate both `clover` and `html` test coverage reports

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -67,6 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         multisite: [ false, true ]
+        coverage-format: [ clover, html ]
 
     steps:
       - name: Configure environment variables
@@ -144,7 +145,7 @@ jobs:
 
       - name: Run tests as a single site
         if: ${{ ! matrix.multisite }}
-        run: npm run test:php -- --verbose -c phpunit.xml.dist --coverage-clover wp-code-coverage-single-clover-${{ github.sha }}.xml
+        run: npm run test:php -- --verbose -c phpunit.xml.dist --coverage-${{ 'html' == matrix.coverage-format && 'html' || 'clover' }} wp-code-coverage-single-${{ github.sha }}${{ 'clover' == matrix.coverage-format && '.xml' || '' }}
 
       - name: Ensure version-controlled files are not modified during the tests
         run: git diff --exit-code
@@ -154,13 +155,21 @@ jobs:
         uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: wp-code-coverage-single-clover-${{ github.sha }}.xml
+          file: wp-code-coverage-single-${{ github.sha }}${{ 'clover' == matrix.coverage-format && '.xml' || '' }}
           flags: single,php
           fail_ci_if_error: true
 
+      - name: Upload single site HTML report as artifact
+        if: ${{ ! matrix.multisite && matrix.coverage-format == 'html' }}
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: wp-code-coverage-single-${{ github.sha }}
+          path: wp-code-coverage-single-${{ github.sha }}
+          overwrite: true
+
       - name: Run tests as a multisite install
         if: ${{ matrix.multisite }}
-        run: npm run test:php -- --verbose -c tests/phpunit/multisite.xml --coverage-clover wp-code-coverage-multisite-clover-${{ github.sha }}.xml
+        run: npm run test:php -- --verbose -c tests/phpunit/multisite.xml --coverage-${{ 'html' == matrix.coverage-format && 'html' || 'clover' }} wp-code-coverage-multisite-${{ github.sha }}${{ 'clover' == matrix.coverage-format && '.xml' || '' }}
 
       - name: Ensure version-controlled files are not modified during the tests
         run: git diff --exit-code
@@ -170,9 +179,17 @@ jobs:
         uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: wp-code-coverage-multisite-clover-${{ github.sha }}.xml
+          file: wp-code-coverage-multisite-${{ github.sha }}${{ 'clover' == matrix.coverage-format && '.xml' || '' }}
           flags: multisite,php
           fail_ci_if_error: true
+
+      - name: Upload multisite HTML report as artifact
+        if: ${{ matrix.multisite && matrix.coverage-format == 'html' }}
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: wp-code-coverage-multisite-${{ github.sha }}
+          path: wp-code-coverage-multisite-${{ github.sha }}
+          overwrite: true
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -57,7 +57,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   # - Upload the multisite code coverage report to Codecov.io.
   test-coverage-report:
-    name: ${{ matrix.multisite && 'Multisite' || 'Single site' }} report
+    name: ${{ matrix.multisite && 'Multisite' || 'Single site' }} report (${{ matrix.format }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         multisite: [ false, true ]
-        coverage-format: [ clover, html ]
+        format: [ clover, html ]
 
     steps:
       - name: Configure environment variables
@@ -145,7 +145,7 @@ jobs:
 
       - name: Run tests as a single site
         if: ${{ ! matrix.multisite }}
-        run: npm run test:php -- --verbose -c phpunit.xml.dist --coverage-${{ 'html' == matrix.coverage-format && 'html' || 'clover' }} wp-code-coverage-single-${{ github.sha }}${{ 'clover' == matrix.coverage-format && '.xml' || '' }}
+        run: npm run test:php -- --verbose -c phpunit.xml.dist --coverage-${{ 'html' == matrix.format && 'html' || 'clover' }} wp-code-coverage-single-${{ github.sha }}${{ 'clover' == matrix.format && '.xml' || '' }}
 
       - name: Ensure version-controlled files are not modified during the tests
         run: git diff --exit-code
@@ -155,12 +155,12 @@ jobs:
         uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: wp-code-coverage-single-${{ github.sha }}${{ 'clover' == matrix.coverage-format && '.xml' || '' }}
+          file: wp-code-coverage-single-${{ github.sha }}${{ 'clover' == matrix.format && '.xml' || '' }}
           flags: single,php
           fail_ci_if_error: true
 
       - name: Upload single site HTML report as artifact
-        if: ${{ ! matrix.multisite && matrix.coverage-format == 'html' }}
+        if: ${{ ! matrix.multisite && matrix.format == 'html' }}
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: wp-code-coverage-single-${{ github.sha }}
@@ -169,7 +169,7 @@ jobs:
 
       - name: Run tests as a multisite install
         if: ${{ matrix.multisite }}
-        run: npm run test:php -- --verbose -c tests/phpunit/multisite.xml --coverage-${{ 'html' == matrix.coverage-format && 'html' || 'clover' }} wp-code-coverage-multisite-${{ github.sha }}${{ 'clover' == matrix.coverage-format && '.xml' || '' }}
+        run: npm run test:php -- --verbose -c tests/phpunit/multisite.xml --coverage-${{ 'html' == matrix.format && 'html' || 'clover' }} wp-code-coverage-multisite-${{ github.sha }}${{ 'clover' == matrix.format && '.xml' || '' }}
 
       - name: Ensure version-controlled files are not modified during the tests
         run: git diff --exit-code
@@ -179,12 +179,12 @@ jobs:
         uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: wp-code-coverage-multisite-${{ github.sha }}${{ 'clover' == matrix.coverage-format && '.xml' || '' }}
+          file: wp-code-coverage-multisite-${{ github.sha }}${{ 'clover' == matrix.format && '.xml' || '' }}
           flags: multisite,php
           fail_ci_if_error: true
 
       - name: Upload multisite HTML report as artifact
-        if: ${{ matrix.multisite && matrix.coverage-format == 'html' }}
+        if: ${{ matrix.multisite && matrix.format == 'html' }}
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: wp-code-coverage-multisite-${{ github.sha }}

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -57,7 +57,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   # - Upload the multisite code coverage report to Codecov.io.
   test-coverage-report:
-    name: ${{ matrix.multisite && 'Multisite' || 'Single site' }} report (${{ matrix.format }}
+    name: ${{ matrix.multisite && 'Multisite' || 'Single site' }} report (${{ matrix.format }})
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60476

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
