### PR TITLE
Fix line-height for Button blocks in Twenty Nineteen

### DIFF
--- a/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
+++ b/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
@@ -163,7 +163,11 @@
 		}
 	}
 
-	//! Button
+	//! Buttons
+	.wp-block-buttons {
+		line-height: $font__line-height-heading;
+	}
+
 	.wp-block-button {
 
 		.wp-block-button__link {
@@ -171,12 +175,10 @@
 			border: none;
 			font-size: $font__size-sm;
 			@include font-family( $font__heading );
-			line-height: $font__line-height-heading;
 			box-sizing: border-box;
 			font-weight: bold;
 			text-decoration: none;
 			padding: ($size__spacing-unit * .76) $size__spacing-unit;
-			outline: none;
 			outline: none;
 
 			&:not(.has-background) {

--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -1004,8 +1004,11 @@ figcaption,
 }
 
 /** === Button === */
+.wp-block-buttons {
+  line-height: 1.2;
+}
+
 .wp-block-button .wp-block-button__link {
-  line-height: inherit;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 0.88889em;
   font-weight: bold;

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -379,10 +379,13 @@ figcaption,
 
 /** === Button === */
 
+.wp-block-buttons {
+	line-height: $font__line-height-heading;
+}
+
 .wp-block-button {
 
 	.wp-block-button__link {
-		line-height:inherit;
 		@include font-family( $font__heading );
 		font-size: $font__size-sm;
 		font-weight: bold;

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -5484,17 +5484,19 @@ body.page .main-navigation {
   width: 100%;
 }
 
+.entry .entry-content .wp-block-buttons {
+  line-height: 1.2;
+}
+
 .entry .entry-content .wp-block-button .wp-block-button__link {
   transition: background 150ms ease-in-out;
   border: none;
   font-size: 0.88889em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  line-height: 1.2;
   box-sizing: border-box;
   font-weight: bold;
   text-decoration: none;
   padding: 0.76rem 1rem;
-  outline: none;
   outline: none;
 }
 

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -5496,17 +5496,19 @@ body.page .main-navigation {
   width: 100%;
 }
 
+.entry .entry-content .wp-block-buttons {
+  line-height: 1.2;
+}
+
 .entry .entry-content .wp-block-button .wp-block-button__link {
   transition: background 150ms ease-in-out;
   border: none;
   font-size: 0.88889em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  line-height: 1.2;
   box-sizing: border-box;
   font-weight: bold;
   text-decoration: none;
   padding: 0.76rem 1rem;
-  outline: none;
   outline: none;
 }
 


### PR DESCRIPTION
Moves `line-height` to Buttons container and removes the duplicate `outline`

[Trac 58443](https://core.trac.wordpress.org/ticket/58443)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
