### PR TITLE
Add linkTarget and rel support to button pattern overrides

### DIFF
--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -241,7 +241,7 @@ class WP_Block {
 			'core/paragraph' => array( 'content' ),
 			'core/heading'   => array( 'content' ),
 			'core/image'     => array( 'url', 'title', 'alt' ),
-			'core/button'    => array( 'url', 'text' ),
+			'core/button'    => array( 'url', 'text', 'linkTarget', 'rel' ),
 		);
 
 		// If the block doesn't have the bindings property, isn't one of the allowed


### PR DESCRIPTION
Ports changes from https://github.com/WordPress/gutenberg/pull/58587

Trac ticket: https://core.trac.wordpress.org/ticket/60481


## Testing

See https://github.com/WordPress/gutenberg/pull/58587
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
