### PR TITLE
Plugins: Disable bulk action for dependencies.

### DIFF
--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1080,7 +1080,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 		$checkbox_id = 'checkbox_' . md5( $plugin_file );
 		$disabled    = '';
 
-		if ( $has_active_dependents || $has_unmet_dependencies ) {
+		if ( $has_dependents || $has_unmet_dependencies ) {
 			$disabled = 'disabled';
 		}
 


### PR DESCRIPTION
The intended behaviour of Plugin Dependencies is that dependencies cannot be deleted until their dependents are deleted.

While the 'Delete' link was removed from the plugin row, the bulk actions checkbox remained enabled, allowing for deletion of dependencies through bulk actions.

This was unintended behaviour and the bulk actions checkbox is now disabled as intended.

### Before
![image](https://github.com/WordPress/wordpress-develop/assets/79332690/6367e6b6-4e57-48f6-8be6-c88baa2c62a3)

### After
![image](https://github.com/WordPress/wordpress-develop/assets/79332690/ff161083-2a32-411f-a305-b4dc33a98d4c)

Trac ticket: https://core.trac.wordpress.org/ticket/60471
