### PR TITLE
Plugins: Update error message on failed plugin activation.

### DIFF
--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1229,7 +1229,7 @@ function validate_plugin_requirements( $plugin ) {
 			),
 			$plugin_headers['Name'],
 			count( $unmet_dependency_names ),
-			implode( ', ', $unmet_dependency_names ),
+			implode( wp_get_list_item_separator(), $unmet_dependency_names ),
 			esc_url( $plugins_page )
 		);
 

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1228,7 +1228,7 @@ function validate_plugin_requirements( $plugin ) {
 				count( $unmet_dependency_names )
 			),
 			$plugin_headers['Name'],
-			count( $unmet_dependency_names )
+			count( $unmet_dependency_names ),
 			implode( ', ', $unmet_dependency_names ),
 			esc_url( $plugins_page )
 		);

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1219,18 +1219,23 @@ function validate_plugin_requirements( $plugin ) {
 			}
 		}
 
-		$plugins_page = is_multisite() ? network_admin_url( 'plugins' ) : admin_url( 'plugins' );
+		$plugins_page  = is_multisite() ? network_admin_url( 'plugins' ) : admin_url( 'plugins' );
+		$error_message = sprintf(
+			/* translators: 1: Plugin name, 2: A comma-separated list of plugin names, 3: The start of a link to the plugins page, 4: The end of the link. */
+			_n(
+				'<strong>Error:</strong> %1$s requires the following plugin to be installed and activated: %2$s. %3$sManage plugins%4$s',
+				'<strong>Error:</strong> %1$s requires the following plugins to be installed and activated: %2$s. %3$sManage plugins%4$s',
+				count( $unmet_dependency_names )
+			),
+			$plugin_headers['Name'],
+			implode( ', ', $unmet_dependency_names ),
+			'<a href="' . esc_url( $plugins_page ) . '">',
+			'</a>'
+		);
 
 		return new WP_Error(
 			'plugin_missing_dependencies',
-			'<p>' . sprintf(
-				/* translators: 1: Plugin name, 2: A comma-separated list of plugin names, 3: The start of a link to the plugins page, 4: The end of the link. */
-				_x( '<strong>Error:</strong> %1$s requires the following plugin(s) to be installed and activated: %2$s. %3$sReview your plugins%4$s', 'plugin' ),
-				$plugin_headers['Name'],
-				implode( ', ', $unmet_dependency_names ),
-				'<a href="' . esc_url( $plugins_page ) . '">',
-				'</a>'
-			) . '</p>',
+			"<p>{$error_message}</p>",
 			$unmet_dependencies
 		);
 	}

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1221,16 +1221,16 @@ function validate_plugin_requirements( $plugin ) {
 
 		$plugins_page  = is_multisite() ? network_admin_url( 'plugins' ) : admin_url( 'plugins' );
 		$error_message = sprintf(
-			/* translators: 1: Plugin name, 2: A comma-separated list of plugin names, 3: The start of a link to the plugins page, 4: The end of the link. */
+			/* translators: 1: Plugin name, 2: Number of plugins, 3: A comma-separated list of plugin names, 4: Link to the plugins page. */
 			_n(
-				'<strong>Error:</strong> %1$s requires the following plugin to be installed and activated: %2$s. %3$sManage plugins%4$s',
-				'<strong>Error:</strong> %1$s requires the following plugins to be installed and activated: %2$s. %3$sManage plugins%4$s',
+				'<strong>Error:</strong> %1$s requires %2$d plugin to be installed and activated: %3$s. <a href="%4$s>"Manage plugins</a>',
+				'<strong>Error:</strong> %1$s requires %2$d plugins to be installed and activated: %3$s. <a href="%4$s>"Manage plugins</a>',
 				count( $unmet_dependency_names )
 			),
 			$plugin_headers['Name'],
+			count( $unmet_dependency_names )
 			implode( ', ', $unmet_dependency_names ),
-			'<a href="' . esc_url( $plugins_page ) . '">',
-			'</a>'
+			esc_url( $plugins_page )
 		);
 
 		return new WP_Error(

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1223,8 +1223,8 @@ function validate_plugin_requirements( $plugin ) {
 		$error_message = sprintf(
 			/* translators: 1: Plugin name, 2: Number of plugins, 3: A comma-separated list of plugin names, 4: Link to the plugins page. */
 			_n(
-				'<strong>Error:</strong> %1$s requires %2$d plugin to be installed and activated: %3$s. <a href="%4$s>"Manage plugins</a>',
-				'<strong>Error:</strong> %1$s requires %2$d plugins to be installed and activated: %3$s. <a href="%4$s>"Manage plugins</a>',
+				'<strong>Error:</strong> %1$s requires %2$d plugin to be installed and activated: %3$s. <a href="%4$s">Manage plugins</a>',
+				'<strong>Error:</strong> %1$s requires %2$d plugins to be installed and activated: %3$s. <a href="%4$s">Manage plugins</a>',
 				count( $unmet_dependency_names )
 			),
 			$plugin_headers['Name'],

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1239,7 +1239,7 @@ function validate_plugin_requirements( $plugin ) {
 					esc_url( network_admin_url( 'plugins.php' ) )
 				);
 			} else {
-				$error_message .= __( 'Please contact your network administrator.' );
+				$error_message .= ' ' . __( 'Please contact your network administrator.' );
 			}
 		} else {
 			$error_message .= ' ' . sprintf(

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1219,19 +1219,35 @@ function validate_plugin_requirements( $plugin ) {
 			}
 		}
 
-		$plugins_page  = is_multisite() ? network_admin_url( 'plugins' ) : admin_url( 'plugins' );
 		$error_message = sprintf(
-			/* translators: 1: Plugin name, 2: Number of plugins, 3: A comma-separated list of plugin names, 4: Link to the plugins page. */
+			/* translators: 1: Plugin name, 2: Number of plugins, 3: A comma-separated list of plugin names. */
 			_n(
-				'<strong>Error:</strong> %1$s requires %2$d plugin to be installed and activated: %3$s. <a href="%4$s">Manage plugins</a>',
-				'<strong>Error:</strong> %1$s requires %2$d plugins to be installed and activated: %3$s. <a href="%4$s">Manage plugins</a>',
+				'<strong>Error:</strong> %1$s requires %2$d plugin to be installed and activated: %3$s.',
+				'<strong>Error:</strong> %1$s requires %2$d plugins to be installed and activated: %3$s.',
 				count( $unmet_dependency_names )
 			),
 			$plugin_headers['Name'],
 			count( $unmet_dependency_names ),
-			implode( wp_get_list_item_separator(), $unmet_dependency_names ),
-			esc_url( $plugins_page )
+			implode( wp_get_list_item_separator(), $unmet_dependency_names )
 		);
+
+		if ( is_multisite() ) {
+			if ( current_user_can( 'manage_network_plugins' ) ) {
+				$error_message .= ' ' . sprintf(
+					/* translators: %s: Link to the plugins page. */
+					__( '<a href="%s">Manage plugins</a>' ),
+					esc_url( network_admin_url( 'plugins.php' ) )
+				);
+			} else {
+				$error_message .= __( 'Please contact your network administrator.' );
+			}
+		} else {
+			$error_message .= ' ' . sprintf(
+				/* translators: %s: Link to the plugins page. */
+				__( '<a href="%s">Manage plugins</a>' ),
+				esc_url( admin_url( 'plugins.php' ) )
+			);
+		}
 
 		return new WP_Error(
 			'plugin_missing_dependencies',


### PR DESCRIPTION
Previously, the message returned when `validate_plugin_requirements()` detects unmet plugin dependencies was not clear for users and did not detail the dependencies that were not installed and active.

This adds extra information to the error message to list the name(s) of the plugin(s) that need to be installed and activated.

Note: If the plugin is not installed and its name cannot be retrieved from the WordPress.org Plugins Repository, its slug will be displayed.

This PR does not add direction as this error message is only displayed

### Before

#### Dashboard (added as a notice via DevTools for illustration)
![image](https://github.com/WordPress/wordpress-develop/assets/79332690/8dd6e51a-9172-4c99-afbb-6908da784f8e)

#### WP-CLI
![image](https://github.com/WordPress/wordpress-develop/assets/79332690/057a3e75-354a-4bb6-a7eb-4090e8ebbb17)


### After
### Dashboard (added as a notice via DevTools for illustration)
![image](https://github.com/WordPress/wordpress-develop/assets/79332690/7b2c4ec2-7d2d-4ebe-859e-f77419a8f9b5)

### WP-CLI
![image](https://github.com/WordPress/wordpress-develop/assets/79332690/b709b8e1-81df-44ef-8d0d-a7e48104fe90)

Note: WP-CLI strips HTML from the message, so the link doesn't appear. This is also why there is no period at the end of the error message, after the link.

Trac ticket: https://core.trac.wordpress.org/ticket/60472