### PR TITLE
Accessibility: #31356 Compound settings confusing with screen readers

### DIFF
--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -722,7 +722,7 @@ $permalinkStructure.on( 'focus', function( event ) {
 } );
 
 // Check if the custom permalink checkbox has selected
-$permalinkCustomSelectionCheckbox.on( 'change', function( event ) {
+$permalinkCustomSelectionCheckbox.on( 'change', function() {
 	if(this.checked){
 		$permalinkStructureInputs.prop( 'checked', false );
 		$permalinkStructure.attr('readonly', false);

--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -726,11 +726,13 @@ $permalinkCustomSelectionCheckbox.on( 'change', function() {
 	if(this.checked){
 		$permalinkStructureInputs.prop( 'checked', false );
 		$permalinkStructure.attr('readonly', false);
+		$permalinkStructure.attr('tabindex', 0);
 		for (let i = 0; i < $availableStructureTags.length; i++) {
 			$availableStructureTags[i].disabled = false;
 		}
 	} else {
 		$permalinkStructure.attr('readonly', true);
+		$permalinkStructure.attr('tabindex', -1);
 		for (let i = 0; i < $availableStructureTags.length; i++) {
 			$availableStructureTags[i].disabled = true;
 		}

--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -688,12 +688,19 @@ var permalinkStructureFocused = false,
     $permalinkStructure       = $( '#permalink_structure' ),
     $permalinkStructureInputs = $( '.permalink-structure input:radio' ),
     $permalinkCustomSelection = $( '#custom_selection' ),
+    $permalinkCustomSelectionCheckbox = $( '#custom_selection_checkbox' ),
     $availableStructureTags   = $( '.form-table.permalink-structure .available-structure-tags button' );
 
 // Change permalink structure input when selecting one of the common structures.
 $permalinkStructureInputs.on( 'change', function() {
 	if ( 'custom' === this.value ) {
 		return;
+	}
+
+	$permalinkCustomSelectionCheckbox.prop( 'checked', false );
+	$permalinkStructure.attr('readonly', true);
+	for (let i = 0; i < $availableStructureTags.length; i++) {
+		$availableStructureTags[i].disabled = true;
 	}
 
 	$permalinkStructure.val( this.value );
@@ -712,6 +719,22 @@ $permalinkStructure.on( 'click input', function() {
 $permalinkStructure.on( 'focus', function( event ) {
 	permalinkStructureFocused = true;
 	$( this ).off( event );
+} );
+
+// Check if the custom permalink checkbox has selected
+$permalinkCustomSelectionCheckbox.on( 'change', function( event ) {
+	if(this.checked){
+		$permalinkStructureInputs.prop( 'checked', false );
+		$permalinkStructure.attr('readonly', false);
+		for (let i = 0; i < $availableStructureTags.length; i++) {
+			$availableStructureTags[i].disabled = false;
+		}
+	} else {
+		$permalinkStructure.attr('readonly', true);
+		for (let i = 0; i < $availableStructureTags.length; i++) {
+			$availableStructureTags[i].disabled = true;
+		}
+	}
 } );
 
 /**

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -374,12 +374,23 @@ foreach ( $date_formats as $format ) {
 			/* translators: Hidden accessibility text. */
 			__( 'Custom date format:' ) .
 		'</label>' .
-		'<input type="text" name="date_format_custom" id="date_format_custom" value="' . esc_attr( get_option( 'date_format' ) ) . '" class="small-text" />' .
+		'<input type="text" disabled name="date_format_custom" id="date_format_custom" value="' . esc_attr( get_option( 'date_format' ) ) . '" class="small-text" />' .
 		'<br />' .
 		'<p><strong>' . __( 'Preview:' ) . '</strong> <span class="example">' . date_i18n( get_option( 'date_format' ) ) . '</span>' .
 		"<span class='spinner'></span>\n" . '</p>';
 ?>
 	</fieldset>
+	<script>
+		jQuery('input[name="date_format"]').on('change', function(e) {
+			var dateFormat = e.target.value;
+			dateFormat = dateFormat.replace(/\\/g, '');
+			if(dateFormat == "custom"){
+				document.querySelector('input[name="date_format_custom"]').disabled = false;
+			} else {
+				document.querySelector('input[name="date_format_custom"]').disabled = true;
+			}
+		});
+	</script>
 </td>
 </tr>
 <tr>
@@ -422,7 +433,7 @@ foreach ( $time_formats as $format ) {
 			/* translators: Hidden accessibility text. */
 			__( 'Custom time format:' ) .
 		'</label>' .
-		'<input type="text" name="time_format_custom" id="time_format_custom" value="' . esc_attr( get_option( 'time_format' ) ) . '" class="small-text" />' .
+		'<input type="text" disabled name="time_format_custom" id="time_format_custom" value="' . esc_attr( get_option( 'time_format' ) ) . '" class="small-text" />' .
 		'<br />' .
 		'<p><strong>' . __( 'Preview:' ) . '</strong> <span class="example">' . date_i18n( get_option( 'time_format' ) ) . '</span>' .
 		"<span class='spinner'></span>\n" . '</p>';
@@ -430,6 +441,17 @@ foreach ( $time_formats as $format ) {
 	echo "\t<p class='date-time-doc'>" . __( '<a href="https://wordpress.org/documentation/article/customize-date-and-time-format/">Documentation on date and time formatting</a>.' ) . "</p>\n";
 ?>
 	</fieldset>
+	<script>
+		jQuery('input[name="time_format"]').on('change', function(e) {
+			var timeFormat = e.target.value;
+			timeFormat = timeFormat.replace(/\\/g, '');
+			if(timeFormat == "custom"){
+				document.querySelector('input[name="time_format_custom"]').disabled = false;
+			} else {
+				document.querySelector('input[name="time_format_custom"]').disabled = true;
+			}
+		});
+	</script>
 </td>
 </tr>
 <tr>

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -374,23 +374,12 @@ foreach ( $date_formats as $format ) {
 			/* translators: Hidden accessibility text. */
 			__( 'Custom date format:' ) .
 		'</label>' .
-		'<input type="text" disabled name="date_format_custom" id="date_format_custom" value="' . esc_attr( get_option( 'date_format' ) ) . '" class="small-text" />' .
+		'<input type="text" name="date_format_custom" id="date_format_custom" value="' . esc_attr( get_option( 'date_format' ) ) . '" class="small-text" />' .
 		'<br />' .
 		'<p><strong>' . __( 'Preview:' ) . '</strong> <span class="example">' . date_i18n( get_option( 'date_format' ) ) . '</span>' .
 		"<span class='spinner'></span>\n" . '</p>';
 ?>
 	</fieldset>
-	<script>
-		jQuery('input[name="date_format"]').on('change', function(e) {
-			var dateFormat = e.target.value;
-			dateFormat = dateFormat.replace(/\\/g, '');
-			if(dateFormat == "custom"){
-				document.querySelector('input[name="date_format_custom"]').disabled = false;
-			} else {
-				document.querySelector('input[name="date_format_custom"]').disabled = true;
-			}
-		});
-	</script>
 </td>
 </tr>
 <tr>
@@ -433,7 +422,7 @@ foreach ( $time_formats as $format ) {
 			/* translators: Hidden accessibility text. */
 			__( 'Custom time format:' ) .
 		'</label>' .
-		'<input type="text" disabled name="time_format_custom" id="time_format_custom" value="' . esc_attr( get_option( 'time_format' ) ) . '" class="small-text" />' .
+		'<input type="text" name="time_format_custom" id="time_format_custom" value="' . esc_attr( get_option( 'time_format' ) ) . '" class="small-text" />' .
 		'<br />' .
 		'<p><strong>' . __( 'Preview:' ) . '</strong> <span class="example">' . date_i18n( get_option( 'time_format' ) ) . '</span>' .
 		"<span class='spinner'></span>\n" . '</p>';
@@ -441,17 +430,6 @@ foreach ( $time_formats as $format ) {
 	echo "\t<p class='date-time-doc'>" . __( '<a href="https://wordpress.org/documentation/article/customize-date-and-time-format/">Documentation on date and time formatting</a>.' ) . "</p>\n";
 ?>
 	</fieldset>
-	<script>
-		jQuery('input[name="time_format"]').on('change', function(e) {
-			var timeFormat = e.target.value;
-			timeFormat = timeFormat.replace(/\\/g, '');
-			if(timeFormat == "custom"){
-				document.querySelector('input[name="time_format_custom"]').disabled = false;
-			} else {
-				document.querySelector('input[name="time_format_custom"]').disabled = true;
-			}
-		});
-	</script>
 </td>
 </tr>
 <tr>

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -373,7 +373,7 @@ printf(
 						<span class="code">
 							<code id="permalink-custom"><?php echo esc_url( $url_base ); ?></code>
 							<input name="permalink_structure" id="permalink_structure"
-								type="text" value="<?php echo esc_attr( $permalink_structure ); ?>"
+								type="text" disabled value="<?php echo esc_attr( $permalink_structure ); ?>"
 								aria-describedby="permalink-custom" class="regular-text code"
 							/>
 						</span>
@@ -387,7 +387,7 @@ printf(
 							<ul role="list">
 							<?php foreach ( $available_tags as $tag => $explanation ) : ?>
 								<li>
-									<button type="button"
+									<button disabled type="button"
 										class="button button-secondary"
 										aria-label="<?php echo esc_attr( sprintf( $explanation, $tag ) ); ?>"
 										data-added="<?php echo esc_attr( sprintf( $tag_added, $tag ) ); ?>"
@@ -403,6 +403,24 @@ printf(
 					</div><!-- .available-structure-tags -->
 				</div>
 			</div><!-- .row -->
+			<script>
+				let permalinkRadio = document.querySelector('input[name="selection"]');
+				document.body.addEventListener('change', function (e) {
+		            var strctureType = e.target.value;
+		            const structureButtons = document.querySelectorAll('.button-secondary');
+		            if(strctureType == 'custom'){
+		            	document.querySelector('input[name="permalink_structure"]').disabled = false;
+		            	for (let i = 0; i < structureButtons.length; i++) {
+						  structureButtons[i].disabled = false;
+						}
+		            } else {
+		            	document.querySelector('input[name="permalink_structure"]').disabled = true;
+		            	for (let i = 0; i < structureButtons.length; i++) {
+						  structureButtons[i].disabled = true;
+						}
+		            }
+		        });
+			</script>
 		</fieldset><!-- .structure-selection -->
 	</td>
 </tr>

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -358,8 +358,8 @@ printf(
 		</fieldset><!-- .structure-selection -->
 	</td>
 </tr>
-<?php 
-if(!in_array( $permalink_structure, $default_structure_values, true )){
+<?php
+if ( ! in_array( $permalink_structure, $default_structure_values, true ) ) {
 	$disabled = '';
 	$readonly = '';
 } else {

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -404,8 +404,7 @@ printf(
 				</div>
 			</div><!-- .row -->
 			<script>
-				let permalinkRadio = document.querySelector('input[name="selection"]');
-				document.body.addEventListener('change', function (e) {
+				jQuery('input[name="selection"]').on('change', function(e) {
 					var strctureType = e.target.value;
 					const structureButtons = document.querySelectorAll('.button-secondary');
 					if(strctureType == 'custom'){

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -362,9 +362,11 @@ printf(
 if ( ! in_array( $permalink_structure, $default_structure_values, true ) ) {
 	$disabled = '';
 	$readonly = '';
+	$tabIndex = 'tabindex="0"';
 } else {
 	$disabled = 'disabled';
 	$readonly = 'readonly';
+	$tabIndex = 'tabindex="-1"';
 }
 ?>
 <tr>
@@ -394,7 +396,7 @@ if ( ! in_array( $permalink_structure, $default_structure_values, true ) ) {
 						<span class="code">
 							<code id="permalink-custom"><?php echo esc_url( $url_base ); ?></code>
 							<input name="permalink_structure" id="permalink_structure"
-								type="text" <?php echo $readonly; ?> value="<?php echo esc_attr( $permalink_structure ); ?>"
+								type="text" <?php echo $readonly; ?> <?php echo $tabIndex; ?> value="<?php echo esc_attr( $permalink_structure ); ?>"
 								aria-describedby="permalink-custom" class="regular-text code"
 							/>
 						</span>

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -406,20 +406,20 @@ printf(
 			<script>
 				let permalinkRadio = document.querySelector('input[name="selection"]');
 				document.body.addEventListener('change', function (e) {
-		            var strctureType = e.target.value;
-		            const structureButtons = document.querySelectorAll('.button-secondary');
-		            if(strctureType == 'custom'){
-		            	document.querySelector('input[name="permalink_structure"]').disabled = false;
-		            	for (let i = 0; i < structureButtons.length; i++) {
-						  structureButtons[i].disabled = false;
+					var strctureType = e.target.value;
+					const structureButtons = document.querySelectorAll('.button-secondary');
+					if(strctureType == 'custom'){
+						document.querySelector('input[name="permalink_structure"]').disabled = false;
+						for (let i = 0; i < structureButtons.length; i++) {
+							structureButtons[i].disabled = false;
 						}
-		            } else {
-		            	document.querySelector('input[name="permalink_structure"]').disabled = true;
-		            	for (let i = 0; i < structureButtons.length; i++) {
-						  structureButtons[i].disabled = true;
+					} else {
+						document.querySelector('input[name="permalink_structure"]').disabled = true;
+						for (let i = 0; i < structureButtons.length; i++) {
+							structureButtons[i].disabled = true;
 						}
-		            }
-		        });
+					}
+				});
 			</script>
 		</fieldset><!-- .structure-selection -->
 	</td>

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -355,10 +355,31 @@ printf(
 				</div>
 			</div><!-- .row -->
 			<?php endforeach; ?>
-
+		</fieldset><!-- .structure-selection -->
+	</td>
+</tr>
+<?php 
+if(!in_array( $permalink_structure, $default_structure_values, true )){
+	$disabled = '';
+	$readonly = '';
+} else {
+	$disabled = 'disabled';
+	$readonly = 'readonly';
+}
+?>
+<tr>
+	<th scope="row"><?php _e( 'Custom permalink structure' ); ?></th>
+	<td>		
+		<fieldset class="structure-selection">
+			<legend class="screen-reader-text">
+				<?php
+				/* translators: Hidden accessibility text. */
+				_e( 'Custom permalink structure' );	
+				?>
+			</legend>
 			<div class="row">
-				<input id="custom_selection"
-					name="selection" type="radio" value="custom"
+				<input id="custom_selection_checkbox"
+					name="selection_custom" type="checkbox" value="custom"
 					<?php checked( ! in_array( $permalink_structure, $default_structure_values, true ) ); ?>
 				/>
 				<div>
@@ -373,7 +394,7 @@ printf(
 						<span class="code">
 							<code id="permalink-custom"><?php echo esc_url( $url_base ); ?></code>
 							<input name="permalink_structure" id="permalink_structure"
-								type="text" value="<?php echo esc_attr( $permalink_structure ); ?>"
+								type="text" <?php echo $readonly; ?> value="<?php echo esc_attr( $permalink_structure ); ?>"
 								aria-describedby="permalink-custom" class="regular-text code"
 							/>
 						</span>
@@ -387,7 +408,7 @@ printf(
 							<ul role="list">
 							<?php foreach ( $available_tags as $tag => $explanation ) : ?>
 								<li>
-									<button type="button"
+									<button <?php echo $disabled; ?> type="button"
 										class="button button-secondary"
 										aria-label="<?php echo esc_attr( sprintf( $explanation, $tag ) ); ?>"
 										data-added="<?php echo esc_attr( sprintf( $tag_added, $tag ) ); ?>"

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -374,7 +374,7 @@ if ( ! in_array( $permalink_structure, $default_structure_values, true ) ) {
 			<legend class="screen-reader-text">
 				<?php
 				/* translators: Hidden accessibility text. */
-				_e( 'Custom permalink structure' );	
+				_e( 'Custom permalink structure' );
 				?>
 			</legend>
 			<div class="row">

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -373,7 +373,7 @@ printf(
 						<span class="code">
 							<code id="permalink-custom"><?php echo esc_url( $url_base ); ?></code>
 							<input name="permalink_structure" id="permalink_structure"
-								type="text" disabled value="<?php echo esc_attr( $permalink_structure ); ?>"
+								type="text" value="<?php echo esc_attr( $permalink_structure ); ?>"
 								aria-describedby="permalink-custom" class="regular-text code"
 							/>
 						</span>
@@ -387,7 +387,7 @@ printf(
 							<ul role="list">
 							<?php foreach ( $available_tags as $tag => $explanation ) : ?>
 								<li>
-									<button disabled type="button"
+									<button type="button"
 										class="button button-secondary"
 										aria-label="<?php echo esc_attr( sprintf( $explanation, $tag ) ); ?>"
 										data-added="<?php echo esc_attr( sprintf( $tag_added, $tag ) ); ?>"
@@ -403,23 +403,6 @@ printf(
 					</div><!-- .available-structure-tags -->
 				</div>
 			</div><!-- .row -->
-			<script>
-				jQuery('input[name="selection"]').on('change', function(e) {
-					var strctureType = e.target.value;
-					const structureButtons = document.querySelectorAll('.button-secondary');
-					if(strctureType == 'custom'){
-						document.querySelector('input[name="permalink_structure"]').disabled = false;
-						for (let i = 0; i < structureButtons.length; i++) {
-							structureButtons[i].disabled = false;
-						}
-					} else {
-						document.querySelector('input[name="permalink_structure"]').disabled = true;
-						for (let i = 0; i < structureButtons.length; i++) {
-							structureButtons[i].disabled = true;
-						}
-					}
-				});
-			</script>
 		</fieldset><!-- .structure-selection -->
 	</td>
 </tr>


### PR DESCRIPTION
Updated Option-permalink.php file code. So now by default custom permalink input and below tags will be disabled. So when users with a keyboard use the tab key, it will take them directly to the next section rather than custom input. Also if the user selects the custom permalink option, it will enable the input field. So with the tab, they can use the input field as well as the below button tags. 

https://screenpal.com/watch/cZnilqVdrTp

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/31356

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
