### PR TITLE
Plugins: Output plugin card elements in the order they're displayed.

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1580,10 +1580,6 @@ div.action-links,
 	margin-top: 0;
 }
 
-.plugin-card .column-description p:empty {
-	display: none;
-}
-
 .plugin-card .plugin-dependencies {
 	background-color: #e5f5fa;
 	border-left: 3px solid #72aee6;
@@ -1624,8 +1620,6 @@ div.action-links,
 @media (max-width: 939px) {
 	.plugin-card .plugin-dependency-name {
 		flex-basis: 69%;
-	}
-	.plugin-card .plugin-dependency .more-details-link {
 	}
 }
 

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1580,14 +1580,6 @@ div.action-links,
 	margin-top: 0;
 }
 
-.plugin-card .column-description .authors {
-	order: 1;
-}
-
-.plugin-card .column-description .plugin-dependencies {
-	order: 2;
-}
-
 .plugin-card .column-description p:empty {
 	display: none;
 }

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1580,6 +1580,10 @@ div.action-links,
 	margin-top: 0;
 }
 
+.plugin-card .column-description p:empty {
+	display: none;
+}
+
 .plugin-card .plugin-dependencies {
 	background-color: #e5f5fa;
 	border-left: 3px solid #72aee6;

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -672,8 +672,8 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 				<div class="desc column-description">
 					<p><?php echo $description; ?></p>
 					<p class="authors"><?php echo $author; ?></p>
-					<?php echo $this->get_dependencies_notice( $plugin ); ?>
 				</div>
+				<?php echo $this->get_dependencies_notice( $plugin ); ?>
 			</div>
 			<div class="plugin-card-bottom">
 				<div class="vers column-rating">

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -525,8 +525,6 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 			// Remove any HTML from the description.
 			$description = strip_tags( $plugin['short_description'] );
 
-			$description .= $this->get_dependencies_notice( $plugin );
-
 			/**
 			 * Filters the plugin card description on the Add Plugins screen.
 			 *
@@ -674,6 +672,7 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 				<div class="desc column-description">
 					<p><?php echo $description; ?></p>
 					<p class="authors"><?php echo $author; ?></p>
+					<?php echo $this->get_dependencies_notice( $plugin ); ?>
 				</div>
 			</div>
 			<div class="plugin-card-bottom">


### PR DESCRIPTION
In [57545](https://core.trac.wordpress.org/changeset/57545), the notice for listing dependencies in a plugin card were styled with the CSS `order` properties. This created a mismatch between the visual order and DOM order of elements in the plugin card.

For accessibility, visual order and DOM order must always match when they affect meaning and functionality.

This removes the CSS `order` properties and outputs the dependencies notice later, making the visual and DOM order match.

Some unused/empty CSS is also removed.

Remember to build when testing this PR as it modifies CSS.

### Before
![image](https://github.com/WordPress/wordpress-develop/assets/79332690/b9b77e06-48a2-47a6-ac5a-da50db8140c8)

### After
![image](https://github.com/WordPress/wordpress-develop/assets/79332690/f68d7ec0-8d16-4798-8810-cd249970e7ab)


Trac ticket: https://core.trac.wordpress.org/ticket/60488