### PR TITLE
Fix undefined index/array key warning in `WP_Duotone::colord_parse_hue`

### DIFF
--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -209,10 +209,7 @@ class WP_Duotone {
 			'rad'  => 360 / ( M_PI * 2 ),
 		);
 
-		$factor = $angle_units[ $unit ];
-		if ( ! $factor ) {
-			$factor = 1;
-		}
+		$factor = $angle_units[ $unit ] ?? 1;
 
 		return (float) $value * $factor;
 	}

--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -209,7 +209,7 @@ class WP_Duotone {
 			'rad'  => 360 / ( M_PI * 2 ),
 		);
 
-		$factor = $angle_units[ $unit ] ?? 1;
+		$factor = isset( $angle_units[ $unit ] ) ? $angle_units[ $unit ] : 1;
 
 		return (float) $value * $factor;
 	}

--- a/tests/phpunit/tests/block-supports/duotone.php
+++ b/tests/phpunit/tests/block-supports/duotone.php
@@ -127,6 +127,7 @@ class Tests_Block_Supports_DuoTones extends WP_UnitTestCase {
 
 	/**
 	 * @dataProvider data_colord_parse_hue
+	 * @ticket 59496
 	 */
 	public function test_colord_parse_hue( $value, $unit, $expected ) {
 		$reflection = new ReflectionMethod( 'WP_Duotone', 'colord_parse_hue' );

--- a/tests/phpunit/tests/block-supports/duotone.php
+++ b/tests/phpunit/tests/block-supports/duotone.php
@@ -133,7 +133,6 @@ class Tests_Block_Supports_DuoTones extends WP_UnitTestCase {
 		$reflection->setAccessible( true );
 
 		$this->assertSame( $expected, $reflection->invoke( null, $value, $unit ) );
-
 	}
 
 	/**

--- a/tests/phpunit/tests/block-supports/duotone.php
+++ b/tests/phpunit/tests/block-supports/duotone.php
@@ -142,12 +142,12 @@ class Tests_Block_Supports_DuoTones extends WP_UnitTestCase {
 	 */
 	public function data_colord_parse_hue() {
 		return array(
-			'deg-angle-unit' => array( 120, 'deg', 120.0 ),
-			'grad-angle-unit' => array( 120, 'grad', 108.0 ),
-			'turn-angle-unit' => array( 120, 'turn', 43200.0 ),
-			'rad-angle-unit' => array( 120, 'rad', 6875.493541569878 ),
-			'empty-angle-unit' => array( 120, '', 120.0 ),
-			'invalid-angle-unit' => array( 120, 'invalid', 120.0 ),
+			'deg-angle-unit'                => array( 120, 'deg', 120.0 ),
+			'grad-angle-unit'               => array( 120, 'grad', 108.0 ),
+			'turn-angle-unit'               => array( 120, 'turn', 43200.0 ),
+			'rad-angle-unit'                => array( 120, 'rad', 6875.493541569878 ),
+			'empty-angle-unit'              => array( 120, '', 120.0 ),
+			'invalid-angle-unit'            => array( 120, 'invalid', 120.0 ),
 			'negative-value-deg-angle-unit' => array( -120, 'deg', -120.0 ),
 		);
 	}

--- a/tests/phpunit/tests/block-supports/duotone.php
+++ b/tests/phpunit/tests/block-supports/duotone.php
@@ -124,4 +124,32 @@ class Tests_Block_Supports_DuoTones extends WP_UnitTestCase {
 			'invalid'                         => array( 'not a valid attribute', false ),
 		);
 	}
+
+	/**
+	 * @dataProvider data_colord_parse_hue
+	 */
+	public function test_colord_parse_hue( $value, $unit, $expected ) {
+		$reflection = new ReflectionMethod( 'WP_Duotone', 'colord_parse_hue' );
+		$reflection->setAccessible( true );
+
+		$this->assertSame( $expected, $reflection->invoke( null, $value, $unit ) );
+
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[].
+	 */
+	public function data_colord_parse_hue() {
+		return array(
+			'deg-angle-unit' => array( 120, 'deg', 120.0 ),
+			'grad-angle-unit' => array( 120, 'grad', 108.0 ),
+			'turn-angle-unit' => array( 120, 'turn', 43200.0 ),
+			'rad-angle-unit' => array( 120, 'rad', 6875.493541569878 ),
+			'empty-angle-unit' => array( 120, '', 120.0 ),
+			'invalid-angle-unit' => array( 120, 'invalid', 120.0 ),
+			'negative-value-deg-angle-unit' => array( -120, 'deg', -120.0 ),
+		);
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/59496

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
