### PR TITLE
Trac 60510: Micro-optimization to improve finding plugin's file relative to the plugins' directory.

### DIFF
--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -499,11 +499,11 @@ if ( ! is_multisite() && wp_is_fatal_error_handler_enabled() ) {
 }
 
 // Load active plugins.
-$all_plugin_data = get_option( 'plugin_data', array() );
-$failed_plugins  = array();
-$plugins_dir     = trailingslashit( WP_PLUGIN_DIR );
+$all_plugin_data    = get_option( 'plugin_data', array() );
+$failed_plugins     = array();
+$plugins_dir_strlen = strlen( trailingslashit( WP_PLUGIN_DIR ) );
 foreach ( wp_get_active_and_valid_plugins() as $plugin ) {
-	$plugin_file    = str_replace( $plugins_dir, '', $plugin );
+	$plugin_file    = substr( $plugin, $plugins_dir_strlen );
 	$plugin_headers = $all_plugin_data[ $plugin_file ];
 	$errors         = array();
 	$requirements   = array(

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -501,8 +501,9 @@ if ( ! is_multisite() && wp_is_fatal_error_handler_enabled() ) {
 // Load active plugins.
 $all_plugin_data = get_option( 'plugin_data', array() );
 $failed_plugins  = array();
+$plugins_dir     = trailingslashit( WP_PLUGIN_DIR );
 foreach ( wp_get_active_and_valid_plugins() as $plugin ) {
-	$plugin_file    = str_replace( trailingslashit( WP_PLUGIN_DIR ), '', $plugin );
+	$plugin_file    = str_replace( $plugins_dir, '', $plugin );
 	$plugin_headers = $all_plugin_data[ $plugin_file ];
 	$errors         = array();
 	$requirements   = array(


### PR DESCRIPTION
For the Plugins Dependencies additions to the plugins' loader loop in `wp-settings.php`, there are micro-optimization improvements for finding each plugin's file relative to the plugins' directory:

* Micro-optimization 1:
>The path to the plugin directory is a constant. Invoking the `trailingslashit()` within the loop for each plugin is unnecessary and less performant. 

Move the plugin directory logic to before the loop.

* Micro-optimization 2:
>`str_replace()` is less performant than `substr()`

Calculate the plugins' directory path string length `strlen()` before the loop and then switch to using `substr()` instead of `str_replace()`. See the performance differences in action https://3v4l.org/TbQ9U).

Trac ticket: https://core.trac.wordpress.org/ticket/60510

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**