### PR TITLE
Remove unneeded dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
 			"version": "6.5.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@emotion/is-prop-valid": "0.8.8",
-				"@emotion/memoize": "0.7.4",
 				"@wordpress/a11y": "3.51.0",
 				"@wordpress/annotations": "2.51.0",
 				"@wordpress/api-fetch": "6.48.0",
@@ -83,7 +81,6 @@
 				"element-closest": "^3.0.2",
 				"es-module-shims": "1.8.2",
 				"formdata-polyfill": "4.0.10",
-				"framer-motion": "10.16.4",
 				"hoverintent": "2.2.1",
 				"imagesloaded": "5.0.0",
 				"is-plain-object": "5.0.0",
@@ -2245,6 +2242,7 @@
 			"version": "0.8.8",
 			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
 			"integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+			"optional": true,
 			"dependencies": {
 				"@emotion/memoize": "0.7.4"
 			}
@@ -2252,7 +2250,8 @@
 		"node_modules/@emotion/memoize": {
 			"version": "0.7.4",
 			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+			"optional": true
 		},
 		"node_modules/@emotion/react": {
 			"version": "11.10.6",
@@ -34849,6 +34848,7 @@
 			"version": "0.8.8",
 			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
 			"integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+			"optional": true,
 			"requires": {
 				"@emotion/memoize": "0.7.4"
 			}
@@ -34856,7 +34856,8 @@
 		"@emotion/memoize": {
 			"version": "0.7.4",
 			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
-			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+			"optional": true
 		},
 		"@emotion/react": {
 			"version": "11.10.6",

--- a/package.json
+++ b/package.json
@@ -78,8 +78,6 @@
 		"webpack-livereload-plugin": "3.0.2"
 	},
 	"dependencies": {
-		"@emotion/is-prop-valid": "0.8.8",
-		"@emotion/memoize": "0.7.4",
 		"@wordpress/a11y": "3.51.0",
 		"@wordpress/annotations": "2.51.0",
 		"@wordpress/api-fetch": "6.48.0",
@@ -152,7 +150,6 @@
 		"element-closest": "^3.0.2",
 		"es-module-shims": "1.8.2",
 		"formdata-polyfill": "4.0.10",
-		"framer-motion": "10.16.4",
 		"hoverintent": "2.2.1",
 		"imagesloaded": "5.0.0",
 		"is-plain-object": "5.0.0",


### PR DESCRIPTION
While looking at #6090, I noticed that a few dependencies were out of date, but had no use within the actual code base or build scripts. Looking further, it seems that they are also dependencies for `@wordpress` block editor related packages. That should make them unnecessary as direct dependencies here.

Trac ticket: https://core.trac.wordpress.org/ticket/59658

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
