### PR TITLE
Plugins: Only set the card button status on plugin install pages.

### DIFF
--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -519,7 +519,7 @@
 
 		$document.trigger( 'wp-plugin-updating', args );
 
-		if ( isPluginInstall && 'plugin-information-footer' === $card.attr('id' ) ) {
+		if ( isPluginInstall && 'plugin-information-footer' === $card.attr( 'id' ) ) {
 			wp.updates.setCardButtonStatus(
 				{
 					status: 'updating-plugin',

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -478,7 +478,8 @@
 	wp.updates.updatePlugin = function( args ) {
 		var $updateRow, $card, $message, message,
 			$adminBarUpdates = $( '#wp-admin-bar-updates' ),
-			buttonText = __( 'Updating...' );
+			buttonText = __( 'Updating...' ),
+			isPluginInstall = 'plugin-install' === pagenow || 'plugin-install-network' === pagenow;
 
 		args = _.extend( {
 			success: wp.updates.updatePluginSuccess,
@@ -493,7 +494,7 @@
  				_x( 'Updating %s...', 'plugin' ),
 				$updateRow.find( '.plugin-title strong' ).text()
 			);
-		} else if ( 'plugin-install' === pagenow || 'plugin-install-network' === pagenow ) {
+		} else if ( isPluginInstall ) {
 			$card    = $( '.plugin-card-' + args.slug + ', #plugin-information-footer' );
 			$message = $card.find( '.update-now' ).addClass( 'updating-message' );
 			message    = sprintf(
@@ -518,7 +519,7 @@
 
 		$document.trigger( 'wp-plugin-updating', args );
 
-		if ( 'plugin-information-footer' === $card.attr('id' ) ) {
+		if ( isPluginInstall && 'plugin-information-footer' === $card.attr('id' ) ) {
 			wp.updates.setCardButtonStatus(
 				{
 					status: 'updating-plugin',


### PR DESCRIPTION
Previously, the `setCardButtonStatus()` JS function was called when a card had the ID `plugin-information-footer`. However, the card will only exist on plugin install pages. This caused a failure when updating plugins from the plugin row on `plugins.php` due to an undefined card.

This adds a guard to ensure that the current page is one of the plugin install pages, preventing the error and allowing plugin updates from the `plugins.php` rows to work as expected.

Trac ticket: https://core.trac.wordpress.org/ticket/60521