### PR TITLE
Global styles revisions Controller: return single revision only when it matches the parent id

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-revisions-controller.php
@@ -287,6 +287,15 @@ class WP_REST_Global_Styles_Revisions_Controller extends WP_REST_Controller {
 			return $revision;
 		}
 
+		if ( (int) $parent->ID !== (int) $revision->post_parent ) {
+			return new WP_Error(
+				'rest_revision_parent_id_mismatch',
+				/* translators: %d: A post id. */
+				sprintf( __( 'The revision does not belong to the specified parent with id of "%d"' ), $parent->ID ),
+				array( 'status' => 404 )
+			);
+		}
+
 		$response = $this->prepare_item_for_response( $revision, $request );
 		return rest_ensure_response( $response );
 	}

--- a/tests/phpunit/tests/rest-api/rest-global-styles-revisions-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-global-styles-revisions-controller.php
@@ -34,6 +34,11 @@ class WP_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_REST_Contr
 	/**
 	 * @var int
 	 */
+	protected static $global_styles_id_2;
+
+	/**
+	 * @var int
+	 */
 	private $total_revisions;
 
 	/**
@@ -97,6 +102,20 @@ class WP_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_REST_Contr
 				'post_title'   => __( 'Custom Styles', 'default' ),
 				'post_type'    => 'wp_global_styles',
 				'post_name'    => 'wp-global-styles-tt1-blocks-revisions',
+				'tax_input'    => array(
+					'wp_theme' => 'tt1-blocks',
+				),
+			)
+		);
+
+		// This creates another global styles post for the current theme.
+		self::$global_styles_id_2 = $factory->post->create(
+			array(
+				'post_content' => '{"version": ' . WP_Theme_JSON::LATEST_SCHEMA . ', "isGlobalStylesUserThemeJSON": true }',
+				'post_status'  => 'publish',
+				'post_title'   => __( 'Custom Styles', 'default' ),
+				'post_type'    => 'wp_global_styles',
+				'post_name'    => 'wp-global-styles-tt1-blocks-revisions-2',
 				'tax_input'    => array(
 					'wp_theme' => 'tt1-blocks',
 				),
@@ -254,6 +273,36 @@ class WP_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_REST_Contr
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . REST_TESTS_IMPOSSIBLY_HIGH_NUMBER . '/revisions' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_post_invalid_parent', $response, 404 );
+	}
+
+	/**
+	 * @ticket 59810
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items
+	 */
+	public function test_get_item_valid_parent_id() {
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id . '/revisions/' . $this->revision_1_id );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( self::$global_styles_id, $data['parent'], "The returned revision's id should match the parent id." );
+		$this->check_get_revision_response( $data, $this->revision_1 );
+	}
+
+	/**
+	 * @ticket 59810
+	 *
+	 * @covers WP_REST_Global_Styles_Controller::get_items
+	 */
+	public function test_get_item_invalid_parent_id() {
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . self::$global_styles_id_2 . '/revisions/' . $this->revision_1_id );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_revision_parent_id_mismatch', $response, 404 );
+
+		$expected_message = 'The revision does not belong to the specified parent with id of "' . self::$global_styles_id_2 . '"';
+		$this->assertSame( $expected_message, $response->as_error()->get_error_messages()[0], 'The message must contain the correct parent ID.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-global-styles-revisions-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-global-styles-revisions-controller.php
@@ -113,7 +113,7 @@ class WP_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_REST_Contr
 			array(
 				'post_content' => '{"version": ' . WP_Theme_JSON::LATEST_SCHEMA . ', "isGlobalStylesUserThemeJSON": true }',
 				'post_status'  => 'publish',
-				'post_title'   => __( 'Custom Styles', 'default' ),
+				'post_title'   => __( 'Custom Styles' ),
 				'post_type'    => 'wp_global_styles',
 				'post_name'    => 'wp-global-styles-tt1-blocks-revisions-2',
 				'tax_input'    => array(


### PR DESCRIPTION
Brings global styles revisions controller `WP_REST_Global_Styles_Revisions_Controller` in line with the changes from:

- https://github.com/WordPress/wordpress-develop/pull/5655

This change is required as `WP_REST_Global_Styles_Revisions_Controller` doesn't inherit `WP_REST_Revisions_Controller`... yet. See: https://github.com/WordPress/wordpress-develop/pull/6105

Gutenberg PR: https://github.com/WordPress/gutenberg/pull/59049

` npm run test:php -- --filter WP_REST_Global_Styles_Revisions_Controller_Test`


Trac ticket: https://core.trac.wordpress.org/ticket/59810
