### PR TITLE
Font Library: PHP 8.1.12 check for woff/woff2 mime types

### DIFF
--- a/src/wp-includes/fonts/class-wp-font-utils.php
+++ b/src/wp-includes/fonts/class-wp-font-utils.php
@@ -231,8 +231,8 @@ class WP_Font_Utils {
 		return array(
 			'otf'   => 'application/vnd.ms-opentype',
 			'ttf'   => PHP_VERSION_ID >= 70400 ? 'font/sfnt' : $php_7_ttf_mime_type,
-			'woff'  => PHP_VERSION_ID >= 80100 ? 'font/woff' : 'application/font-woff',
-			'woff2' => PHP_VERSION_ID >= 80100 ? 'font/woff2' : 'application/font-woff2',
+			'woff'  => PHP_VERSION_ID >= 80112 ? 'font/woff' : 'application/font-woff',
+			'woff2' => PHP_VERSION_ID >= 80112 ? 'font/woff2' : 'application/font-woff2',
 		);
 	}
 }


### PR DESCRIPTION
Fixes a bug where fonts could not be installed in PHP 8.1.0 through 8.1.11 due to incorrect MIME type assignment.

While `WP_Font_Utils::get_allowed_font_mime_types()` conditionally sets the MIME type for woff and woff2, it incorrectly checks against PHP 8.1.0. The MIME type change did not occur until PHP 8.1.12.

References:

* PHP-src: finfo returns wrong mime type for woff/woff2 files https://github.com/php/php-src/issues/8805
* PHP 8.1.12 changelog https://www.php.net/ChangeLog-8.php#8.1.12
* Tests: Adjust the expected mime type for WOFF fonts on PHP 8.1.12+ https://github.com/WordPress/wordpress-develop/commit/5eefddf4afcd738abd52fe5b7ebbe163412532ad
* Gutenberg PR 59015 https://github.com/WordPress/gutenberg/pull/59015

Co-authored-by: costdev <costdev@git.wordpress.org>

Trac ticket: https://core.trac.wordpress.org/ticket/60536

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
