### PR TITLE
Add a `label` field in the search controller to return localized type for each item

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -299,6 +299,7 @@ function create_initial_rest_routes() {
 		new WP_REST_Post_Search_Handler(),
 		new WP_REST_Term_Search_Handler(),
 		new WP_REST_Post_Format_Search_Handler(),
+		new WP_REST_Media_Search_Handler(),
 	);
 
 	/**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-search-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-search-controller.php
@@ -42,6 +42,11 @@ class WP_REST_Search_Controller extends WP_REST_Controller {
 	const PROP_SUBTYPE = 'subtype';
 
 	/**
+	 * Label property name.
+	 */
+	const PROP_LABEL = 'label';
+
+	/**
 	 * Identifier for the 'any' type.
 	 */
 	const TYPE_ANY = 'any';
@@ -280,6 +285,12 @@ class WP_REST_Search_Controller extends WP_REST_Controller {
 					'description' => __( 'Object subtype.' ),
 					'type'        => 'string',
 					'enum'        => $subtypes,
+					'context'     => array( 'view', 'embed' ),
+					'readonly'    => true,
+				),
+				self::PROP_LABEL   => array(
+					'description' => __( 'Object human readable subtype.' ),
+					'type'        => 'string',
 					'context'     => array( 'view', 'embed' ),
 					'readonly'    => true,
 				),

--- a/src/wp-includes/rest-api/search/class-wp-rest-media-search-handler.php
+++ b/src/wp-includes/rest-api/search/class-wp-rest-media-search-handler.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * REST API: WP_REST_Media_Search_Handler class
+ *
+ * @package WordPress
+ * @subpackage REST_API
+ * @since 6.6.0
+ */
+
+/**
+ * Core class representing a search handler for attachments in the REST API.
+ *
+ * @since 6.6.0
+ *
+ * @see WP_REST_Search_Handler
+ */
+class WP_REST_Media_Search_Handler extends WP_REST_Post_Search_Handler {
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 6.6.0
+	 */
+	public function __construct() {
+		parent::__construct();
+		$this->type     = 'media';
+		$this->subtypes = array();
+	}
+
+	/**
+	 * Searches the object type content for a given search request.
+	 *
+	 * @param WP_REST_Request $request Full REST request.
+	 *
+	 * @return array Associative array containing an `WP_REST_Search_Handler::RESULT_IDS` containing
+	 *               an array of found IDs and `WP_REST_Search_Handler::RESULT_TOTAL` containing the
+	 *               total count for the matching search results.
+	 * @since 6.6.0
+	 *
+	 */
+	public function search_items( WP_REST_Request $request ) {
+
+		$query_args = array(
+			'post_type'      => 'attachment',
+			'post_status'    => 'inherit',
+			'paged'          => (int) $request['page'],
+			'posts_per_page' => (int) $request['per_page'],
+		);
+
+		if ( ! empty( $request['search'] ) ) {
+			$query_args['s'] = $request['search'];
+
+			// Filter query clauses to include filenames.
+			add_filter( 'wp_allow_query_attachment_by_filename', '__return_true' );
+		}
+
+		if ( ! empty( $request['exclude'] ) ) {
+			$query_args['post__not_in'] = $request['exclude'];
+		}
+
+		if ( ! empty( $request['include'] ) ) {
+			$query_args['post__in'] = $request['include'];
+		}
+
+		/**
+		 * Filters the query arguments for a REST API search request.
+		 *
+		 * Enables adding extra arguments or setting defaults for a media search request.
+		 *
+		 * @param array $query_args Key value array of query var to query value.
+		 * @param WP_REST_Request $request The request used.
+		 *
+		 * @since 6.6.0
+		 *
+		 */
+		$query_args = apply_filters( 'rest_media_search_query', $query_args, $request );
+
+		$query = new WP_Query();
+		$posts = $query->query( $query_args );
+		// Querying the whole post object will warm the object cache, avoiding an extra query per result.
+		$found_ids = wp_list_pluck( $posts, 'ID' );
+		$total     = $query->found_posts;
+
+		return array(
+			self::RESULT_IDS   => $found_ids,
+			self::RESULT_TOTAL => $total,
+		);
+	}
+
+	/**
+	 * Prepares the search result for a given ID.
+	 *
+	 * @param int $id Item ID.
+	 * @param array $fields Fields to include for the item.
+	 *
+	 * @return array Associative array containing all fields for the item.
+	 * @since 6.6.0
+	 *
+	 */
+	public function prepare_item( $id, array $fields ) {
+		$data = parent::prepare_item( $id, $fields );
+
+		if ( isset( $data[ WP_REST_Search_Controller::PROP_SUBTYPE ] ) ) {
+			unset( $data[ WP_REST_Search_Controller::PROP_SUBTYPE ] );
+		}
+
+		return $data;
+	}
+}

--- a/src/wp-includes/rest-api/search/class-wp-rest-post-format-search-handler.php
+++ b/src/wp-includes/rest-api/search/class-wp-rest-post-format-search-handler.php
@@ -121,6 +121,10 @@ class WP_REST_Post_Format_Search_Handler extends WP_REST_Search_Handler {
 			$data[ WP_REST_Search_Controller::PROP_TYPE ] = $this->type;
 		}
 
+		if ( in_array( WP_REST_Search_Controller::PROP_LABEL, $fields, true ) ) {
+			$data[ WP_REST_Search_Controller::PROP_LABEL ] = get_post_format_string( $id );
+		}
+
 		return $data;
 	}
 

--- a/src/wp-includes/rest-api/search/class-wp-rest-post-search-handler.php
+++ b/src/wp-includes/rest-api/search/class-wp-rest-post-search-handler.php
@@ -151,6 +151,12 @@ class WP_REST_Post_Search_Handler extends WP_REST_Search_Handler {
 			$data[ WP_REST_Search_Controller::PROP_SUBTYPE ] = $post->post_type;
 		}
 
+		if ( in_array( WP_REST_Search_Controller::PROP_LABEL, $fields, true ) ) {
+			$ptype                                         = get_post_type_object( $post->post_type );
+			$label                                         = $ptype ? $ptype->labels->singular_name : $post->post_type;
+			$data[ WP_REST_Search_Controller::PROP_LABEL ] = $label;
+		}
+
 		return $data;
 	}
 

--- a/src/wp-includes/rest-api/search/class-wp-rest-term-search-handler.php
+++ b/src/wp-includes/rest-api/search/class-wp-rest-term-search-handler.php
@@ -143,6 +143,12 @@ class WP_REST_Term_Search_Handler extends WP_REST_Search_Handler {
 			$data[ WP_REST_Search_Controller::PROP_TYPE ] = $term->taxonomy;
 		}
 
+		if ( in_array( WP_REST_Search_Controller::PROP_LABEL, $fields, true ) ) {
+			$taxonomy                                      = get_taxonomy( $term->taxonomy );
+			$label                                         = $taxonomy ? $taxonomy->labels->singular_name : $term->taxonomy;
+			$data[ WP_REST_Search_Controller::PROP_LABEL ] = $label;
+		}
+
 		return $data;
 	}
 

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -328,6 +328,7 @@ require ABSPATH . WPINC . '/rest-api/search/class-wp-rest-search-handler.php';
 require ABSPATH . WPINC . '/rest-api/search/class-wp-rest-post-search-handler.php';
 require ABSPATH . WPINC . '/rest-api/search/class-wp-rest-term-search-handler.php';
 require ABSPATH . WPINC . '/rest-api/search/class-wp-rest-post-format-search-handler.php';
+require ABSPATH . WPINC . '/rest-api/search/class-wp-rest-media-search-handler.php';
 require ABSPATH . WPINC . '/sitemaps.php';
 require ABSPATH . WPINC . '/sitemaps/class-wp-sitemaps.php';
 require ABSPATH . WPINC . '/sitemaps/class-wp-sitemaps-index.php';

--- a/tests/phpunit/includes/class-wp-rest-test-search-handler.php
+++ b/tests/phpunit/includes/class-wp-rest-test-search-handler.php
@@ -16,17 +16,28 @@ class WP_REST_Test_Search_Handler extends WP_REST_Search_Handler {
 	public function __construct( $amount = 10 ) {
 		$this->type = 'test';
 
-		$this->subtypes = array( 'test_first_type', 'test_second_type' );
+		$this->subtypes         = array( 'test_first_type', 'test_second_type' );
+		$test_first_type_object = new \WP_Post_Type(
+			'test_first_type',
+			array(
+				'labels' => array(
+					'name' => 'Test first types',
+					'singular_name' => 'Test first type',
+				)
+			)
+		);
 
 		$this->items = array();
-		for ( $i = 1; $i <= $amount; $i++ ) {
-			$subtype = $i > $amount / 2 ? 'test_second_type' : 'test_first_type';
+		for ( $i = 1; $i <= $amount; $i ++ ) {
+			$subtype        = $i > $amount / 2 ? 'test_second_type' : 'test_first_type';
+			$subtype_object = $i > $amount / 2 ? false : $test_first_type_object;
 
 			$this->items[ $i ] = (object) array(
 				'test_id'    => $i,
 				'test_title' => sprintf( 'Title %d', $i ),
 				'test_url'   => sprintf( home_url( '/tests/%d' ), $i ),
 				'test_type'  => $subtype,
+				'test_label' => $subtype_object ? $subtype_object->labels->singular_name : $subtype,
 			);
 		}
 	}
@@ -80,6 +91,10 @@ class WP_REST_Test_Search_Handler extends WP_REST_Search_Handler {
 
 		if ( in_array( WP_REST_Search_Controller::PROP_SUBTYPE, $fields, true ) ) {
 			$data[ WP_REST_Search_Controller::PROP_SUBTYPE ] = $test->test_type;
+		}
+
+		if ( in_array( WP_REST_Search_Controller::PROP_LABEL, $fields, true ) ) {
+			$data[ WP_REST_Search_Controller::PROP_LABEL ] = $test->test_label;
 		}
 
 		return $data;

--- a/tests/phpunit/includes/class-wp-rest-test-search-handler.php
+++ b/tests/phpunit/includes/class-wp-rest-test-search-handler.php
@@ -21,14 +21,14 @@ class WP_REST_Test_Search_Handler extends WP_REST_Search_Handler {
 			'test_first_type',
 			array(
 				'labels' => array(
-					'name' => 'Test first types',
+					'name'          => 'Test first types',
 					'singular_name' => 'Test first type',
-				)
+				),
 			)
 		);
 
 		$this->items = array();
-		for ( $i = 1; $i <= $amount; $i ++ ) {
+		for ( $i = 1; $i <= $amount; $i++ ) {
 			$subtype        = $i > $amount / 2 ? 'test_second_type' : 'test_first_type';
 			$subtype_object = $i > $amount / 2 ? false : $test_first_type_object;
 

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -10202,7 +10202,8 @@ mockedApiResponse.Schema = {
                             "enum": [
                                 "post",
                                 "term",
-                                "post-format"
+                                "post-format",
+                                "media"
                             ],
                             "required": false
                         },


### PR DESCRIPTION
This change is related to a [PR](https://github.com/WordPress/gutenberg/pull/58638) in gutenberg to display localize name for suggestions in the link component.

This change felt too complex to be added to the gutenberg repository and backported afterward. Also I wanted to be able to update existing tests for the REST search handler.

This PR contain two changes :
* Add a new `label` property in the `WP_REST_Search_Controller` and update existing handlers to fill this property accordingly
* Add a new `WP_REST_Media_Search_Handler` handler to uniformize the shape of the data send back by the search endpoint between all types.
 
Trac ticket: https://core.trac.wordpress.org/ticket/61254
