### PR TITLE
Fix warning on revision fields

### DIFF
--- a/src/wp-includes/revision.php
+++ b/src/wp-includes/revision.php
@@ -1107,12 +1107,11 @@ function _wp_upgrade_revisions_of_post( $post, $revisions ) {
  * @param mixed  $value     Meta value to filter.
  * @param int    $object_id Object ID.
  * @param string $meta_key  Meta key to filter a value for.
- * @param bool   $single    Whether to return a single value. Default false.
  * @return mixed Original meta value if the meta key isn't revisioned, the object doesn't exist,
  *               the post type is a revision or the post ID doesn't match the object ID.
  *               Otherwise, the revisioned meta value is returned for the preview.
  */
-function _wp_preview_meta_filter( $value, $object_id, $meta_key, $single ) {
+function _wp_preview_meta_filter( $value, $object_id, $meta_key ) {
 
 	$post = get_post();
 	if (
@@ -1129,5 +1128,5 @@ function _wp_preview_meta_filter( $value, $object_id, $meta_key, $single ) {
 		return $value;
 	}
 
-	return get_post_meta( $preview->ID, $meta_key, $single );
+	return get_post_meta( $preview->ID, $meta_key );
 }


### PR DESCRIPTION
I've removed the single parameter so that it is handled in a single place:- https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/meta.php#L637

Currently, it is handled in two places, leading to a PHP notice when the meta value is an associative array.

Trac ticket: https://core.trac.wordpress.org/ticket/60314

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
