### PR TITLE
Adds markup and filters for post password message

### DIFF
--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -1771,6 +1771,35 @@ function get_the_password_form( $post = 0 ) {
 	';
 
 	/**
+	 * Filters the incorrect password message shown on password-protected posts.
+	 * The filter is only applied if the post is password protected.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param string The message shown to users when entering an incorrect password.
+	 * @param WP_Post $post   Post object.
+	 */
+	$incorrect_password = apply_filters( 'the_password_form_incorrect_password_output', '<p class="post-password-form-incorrect-message">' . __( 'Incorrect password.' ) . '</p>', $post );
+
+	// If the referrer is the same as the current request, the user has entered an incorrect password.
+	if ( ! empty( $post->ID ) && wp_get_raw_referer() === get_permalink( $post->ID ) && isset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] ) ) {
+
+		/**
+		 * Filters the HTML output for the protected post password form when the password is incorrect.
+		 *
+		 * Gives the ability to re-order the incorrect password message and the form.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param string The incorrect password message and form output.
+		 * @param string $incorrect_password The incorrect password message.
+		 * @param string $output The password form output.
+		 * @param WP_Post $post   Post object.
+		 */
+		$output = apply_filters( 'the_password_form', $incorrect_password . $output, $incorrect_password, $output, $post );
+	}
+
+	/**
 	 * Filters the HTML output for the protected post password form.
 	 *
 	 * If modifying the password field, please note that the core database schema


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Adds filters and markup to handle showing an "incorrect post password" message whenever using the post password system and the user enters a wrong password.

There is a current edge case where the "incorrect post password" message will show if:

- The user visits the page and enters and incorrect post password.
- "incorrect post password" message shown as expected.
- The user then clicks a navigation link to the same page.
- "incorrect post password" message shown again because the referrer was the current page, even though the form wasn't submitted.

Trac ticket: https://core.trac.wordpress.org/ticket/37332

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
