### PR TITLE
Register the default theme directory root earlier

### DIFF
--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -389,9 +389,6 @@ require ABSPATH . WPINC . '/interactivity-api/class-wp-interactivity-api.php';
 require ABSPATH . WPINC . '/interactivity-api/class-wp-interactivity-api-directives-processor.php';
 require ABSPATH . WPINC . '/interactivity-api/interactivity-api.php';
 
-wp_script_modules()->add_hooks();
-wp_interactivity()->add_hooks();
-
 $GLOBALS['wp_embed'] = new WP_Embed();
 
 /**
@@ -491,7 +488,12 @@ create_initial_post_types();
 wp_start_scraping_edited_file_errors();
 
 // Register the default theme directory root.
+// This has to happen before wp_script_modules is registered
+// because wp_script_modules needs to know if the current theme is a block theme.
 register_theme_directory( get_theme_root() );
+
+wp_script_modules()->add_hooks();
+wp_interactivity()->add_hooks();
 
 if ( ! is_multisite() && wp_is_fatal_error_handler_enabled() ) {
 	// Handle users requesting a recovery mode link and initiating recovery mode.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->
This PR registers the default theme directory root earlier in wp-settings. Since https://github.com/WordPress/wordpress-develop/commit/03cb3e30f20b1cdff0c4b0fb3bde2bcd3c4a1c30 we need to move this earlier in the load so that when `wp_script_modules()->add_hooks() runs it is able to determine what the parent theme is.

Fixes https://github.com/WordPress/gutenberg/issues/58549

Trac ticket: https://core.trac.wordpress.org/ticket/60411

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
