### PR TITLE
HTML API: Defer applying updates until necessary.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2054,7 +2054,7 @@ class WP_HTML_Tag_Processor {
 			 * before proceeding, otherwise they may be overlooked.
 			 */
 			if ( $update->start >= $this->bytes_already_parsed ) {
-				$this->apply_attributes_updates();
+				$this->get_updated_html();
 				break;
 			}
 

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2067,9 +2067,20 @@ class WP_HTML_Tag_Processor {
 		 * need to be flushed to raw lexical updates.
 		 */
 		$this->class_name_updates_to_attributes_updates();
+
+		/*
+		 * Purge updates if there are too many. The actual count isn't
+		 * scientific, but a few values from 100 to a few thousand were
+		 * tests to find a practially-useful limit.
+		 *
+		 * If the update queue grows too big, then the Tag Processor
+		 * will spend more time iterating through them and lose the
+		 * efficiency gains of deferring applying them.
+		 */
 		if ( 1000 < count( $this->lexical_updates ) ) {
 			$this->get_updated_html();
 		}
+
 		foreach ( $this->lexical_updates as $name => $update ) {
 			/*
 			 * Any updates appearing after the cursor should be applied

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -837,6 +837,10 @@ class WP_HTML_Tag_Processor {
 	 * @return bool Whether a token was parsed.
 	 */
 	public function next_token() {
+		return $this->internal_next_token();
+	}
+
+	private function internal_next_token() {
 		$was_at = $this->bytes_already_parsed;
 		$this->after_tag();
 
@@ -3189,15 +3193,7 @@ class WP_HTML_Tag_Processor {
 		 *                 └←─┘ back up by strlen("em") + 1 ==> 3
 		 */
 		$this->bytes_already_parsed = $before_current_tag;
-		$this->parse_next_tag();
-		// Reparse the attributes.
-		while ( $this->parse_next_attribute() ) {
-			continue;
-		}
-
-		$tag_ends_at                = strpos( $this->html, '>', $this->bytes_already_parsed );
-		$this->token_length         = $tag_ends_at - $this->token_starts_at;
-		$this->bytes_already_parsed = $tag_ends_at;
+		$this->internal_next_token();
 
 		return $this->html;
 	}

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -837,10 +837,25 @@ class WP_HTML_Tag_Processor {
 	 * @return bool Whether a token was parsed.
 	 */
 	public function next_token() {
-		return $this->internal_next_token();
+		return $this->base_class_next_token();
 	}
 
-	private function internal_next_token() {
+	/**
+	 * Internal method which finds the next token in the HTML document.
+	 *
+	 * This method is a protected internal function which implements the logic for
+	 * finding the next token in a document. It's called during `get_updated_html()`
+	 * so that the parser can update its state after applying updates, but without
+	 * affecting the location of the cursor in the document or erroneously triggering
+	 * higher-level logic in subclasses, such as in the HTML Processor.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @access private
+	 *
+	 * @return bool Whether a token was parsed.
+	 */
+	private function base_class_next_token() {
 		$was_at = $this->bytes_already_parsed;
 		$this->after_tag();
 
@@ -3193,7 +3208,7 @@ class WP_HTML_Tag_Processor {
 		 *                 └←─┘ back up by strlen("em") + 1 ==> 3
 		 */
 		$this->bytes_already_parsed = $before_current_tag;
-		$this->internal_next_token();
+		$this->base_class_next_token();
 
 		return $this->html;
 	}

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -844,10 +844,10 @@ class WP_HTML_Tag_Processor {
 	 * Internal method which finds the next token in the HTML document.
 	 *
 	 * This method is a protected internal function which implements the logic for
-	 * finding the next token in a document. It's called during `get_updated_html()`
-	 * so that the parser can update its state after applying updates, but without
-	 * affecting the location of the cursor in the document or erroneously triggering
-	 * higher-level logic in subclasses, such as in the HTML Processor.
+	 * finding the next token in a document. It exists so that the parser can update
+	 * its state without affecting the location of the cursor in the document and
+	 * without triggering subclass methods for things like `next_token()`, e.g. when
+	 * applying patches before searching for the next token.
 	 *
 	 * @since 6.5.0
 	 *

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2067,6 +2067,9 @@ class WP_HTML_Tag_Processor {
 		 * need to be flushed to raw lexical updates.
 		 */
 		$this->class_name_updates_to_attributes_updates();
+		if ( 1000 < count( $this->lexical_updates ) ) {
+			$this->get_updated_html();
+		}
 		foreach ( $this->lexical_updates as $name => $update ) {
 			/*
 			 * Any updates appearing after the cursor should be applied

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-bookmark.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-bookmark.php
@@ -293,21 +293,30 @@ HTML;
 
 	/**
 	 * @ticket 56299
+	 * @ticket 60697 Added additional assertion to verify that a requested update was properly applied.
 	 *
 	 * @covers WP_HTML_Tag_Processor::seek
 	 */
 	public function test_updates_bookmark_for_additions_after_both_sides() {
 		$processor = new WP_HTML_Tag_Processor( '<div>First</div><div>Second</div>' );
 		$processor->next_tag();
+		$processor->set_attribute( 'id', 'one' );
 		$processor->set_bookmark( 'first' );
 		$processor->next_tag();
+		$processor->set_attribute( 'id', 'two' );
 		$processor->add_class( 'second' );
 
 		$processor->seek( 'first' );
 		$processor->add_class( 'first' );
 
 		$this->assertSame(
-			'<div class="first">First</div><div class="second">Second</div>',
+			'one',
+			$processor->get_attribute( 'id' ),
+			'Should have remembered attribute change from before the seek.'
+		);
+
+		$this->assertSame(
+			'<div class="first" id="one">First</div><div class="second" id="two">Second</div>',
 			$processor->get_updated_html(),
 			'The bookmark was updated incorrectly in response to HTML markup updates'
 		);

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-bookmark.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-bookmark.php
@@ -293,7 +293,7 @@ HTML;
 
 	/**
 	 * @ticket 56299
-	 * @ticket 60697 Added additional assertion to verify that a requested update was properly applied.
+	 * @ticket 60697
 	 *
 	 * @covers WP_HTML_Tag_Processor::seek
 	 */


### PR DESCRIPTION
Trac ticket: Core-60697

When making repeated updates to a document, the Tag Processor will end
up copying the entire document once for every update. This can lead to
catastrophic behavior in the worse case.

However, when batch-applying updates it's able to copy chunks of the
document in one thread and only end up copying the entire document once
for the entire batch.

Previously the Tag Processor has been eagerly applying updates, but in
this patch it defers applying those updates as long as is possible.