### PR TITLE
HTML API: Add debug methods for inspecting internal state.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -3503,6 +3503,15 @@ class WP_HTML_Tag_Processor {
 	/*
 	 * Debug helpers.
 	 */
+
+	public function debug_classname_updates() {
+		echo "\n\e[31m\"\e[35mclass\e[31m\" Updates\e[m\n";
+		foreach ( $this->classname_updates as $name => $change ) {
+			$op = $change === true ? 'added' : 'removed';
+			echo "  \e[32m{$name}\e[90m should be \e[35m{$op}\e[m\n";
+		}
+	}
+
 	public function debug_lexical_updates() {
 		echo "\n\e[31mLexical Updates\e[m\n";
 		foreach ( $this->lexical_updates as $index => $update ) {

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -3504,6 +3504,13 @@ class WP_HTML_Tag_Processor {
 	 * Debug helpers.
 	 */
 
+	public function debug_current_position() {
+		echo "\n\e[31mCurrent Position\e[m\n";
+		echo "\e[32m{$this->html}\e[m\n";
+		echo str_pad( '', $this->bytes_already_parsed, ' ' );
+		echo "\e[33m^\e[m\n";
+	}
+
 	public function debug_classname_updates() {
 		echo "\n\e[31m\"\e[35mclass\e[31m\" Updates\e[m\n";
 		foreach ( $this->classname_updates as $name => $change ) {

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -3499,4 +3499,15 @@ class WP_HTML_Tag_Processor {
 	 * @since 6.5.0
 	 */
 	const COMMENT_AS_INVALID_HTML = 'COMMENT_AS_INVALID_HTML';
+
+	/*
+	 * Debug helpers.
+	 */
+	public function debug_lexical_updates() {
+		echo "\n\e[31mLexical Updates\e[m\n";
+		foreach ( $this->lexical_updates as $index => $update ) {
+			$old = substr( $this->html, $update->start, $update->length );
+			echo "  \e[32m{$index}\e[90m changes (\e[34m{$update->start}\e[90m, \e[34m{$update->length}\e[90m) from \"\e[35m{$old}\e[90m\" to \"\e[31m{$update->text}\e[90m\"\e[m\n";
+		}
+	}
 }


### PR DESCRIPTION
**DO NOT MERGE**

These methods may be useful for diagnosing failures or for learning how the HTML API works internally.