### PR TITLE
Cropping site icon should preserve attachment properties

### DIFF
--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -4035,7 +4035,7 @@ function wp_ajax_crop_image() {
 			}
 
 			/** This filter is documented in wp-admin/includes/class-custom-image-header.php */
-			$cropped    = apply_filters( 'wp_create_file_in_uploads', $cropped, $attachment_id ); // For replication.
+			$cropped = apply_filters( 'wp_create_file_in_uploads', $cropped, $attachment_id ); // For replication.
 
 			// Copy attachment properties.
 			$attachment = wp_copy_parent_attachment_properties( $cropped, $attachment_id, $context );

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -4035,10 +4035,10 @@ function wp_ajax_crop_image() {
 			}
 
 			/** This filter is documented in wp-admin/includes/class-custom-image-header.php */
-			$cropped    = apply_filters( 'wp_create_file_in_uploads', $cropped, $attachment_id, $context ); // For replication.
+			$cropped    = apply_filters( 'wp_create_file_in_uploads', $cropped, $attachment_id ); // For replication.
 
 			/* Copy attachment properties */
-			$attachment = wp_copy_parent_attachment_properties( $cropped, $attachment_id );
+			$attachment = wp_copy_parent_attachment_properties( $cropped, $attachment_id, $context );
 
 			// Update the attachment.
 			add_filter( 'intermediate_image_sizes_advanced', array( $wp_site_icon, 'additional_sizes' ) );

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -4037,7 +4037,7 @@ function wp_ajax_crop_image() {
 			/** This filter is documented in wp-admin/includes/class-custom-image-header.php */
 			$cropped    = apply_filters( 'wp_create_file_in_uploads', $cropped, $attachment_id ); // For replication.
 
-			/* Copy attachment properties */
+			// Copy attachment properties.
 			$attachment = wp_copy_parent_attachment_properties( $cropped, $attachment_id, $context );
 
 			// Update the attachment.
@@ -4066,7 +4066,7 @@ function wp_ajax_crop_image() {
 			/** This filter is documented in wp-admin/includes/class-custom-image-header.php */
 			$cropped = apply_filters( 'wp_create_file_in_uploads', $cropped, $attachment_id ); // For replication.
 
-			/* Copy attachment properties */
+			// Copy attachment properties.
 			$attachment = wp_copy_parent_attachment_properties( $cropped, $attachment_id, $context );
 
 			$attachment_id = wp_insert_attachment( $attachment, $cropped );

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -4035,9 +4035,10 @@ function wp_ajax_crop_image() {
 			}
 
 			/** This filter is documented in wp-admin/includes/class-custom-image-header.php */
-			$cropped    = apply_filters( 'wp_create_file_in_uploads', $cropped, $attachment_id ); // For replication.
-			$attachment = $wp_site_icon->create_attachment_object( $cropped, $attachment_id );
-			unset( $attachment['ID'] );
+			$cropped    = apply_filters( 'wp_create_file_in_uploads', $cropped, $attachment_id, $context ); // For replication.
+
+			/* Copy attachment properties */
+			$attachment = wp_copy_parent_attachment_properties( $cropped, $attachment_id );
 
 			// Update the attachment.
 			add_filter( 'intermediate_image_sizes_advanced', array( $wp_site_icon, 'additional_sizes' ) );
@@ -4065,46 +4066,8 @@ function wp_ajax_crop_image() {
 			/** This filter is documented in wp-admin/includes/class-custom-image-header.php */
 			$cropped = apply_filters( 'wp_create_file_in_uploads', $cropped, $attachment_id ); // For replication.
 
-			$parent_url      = wp_get_attachment_url( $attachment_id );
-			$parent_basename = wp_basename( $parent_url );
-			$url             = str_replace( $parent_basename, wp_basename( $cropped ), $parent_url );
-
-			$size       = wp_getimagesize( $cropped );
-			$image_type = ( $size ) ? $size['mime'] : 'image/jpeg';
-
-			// Get the original image's post to pre-populate the cropped image.
-			$original_attachment  = get_post( $attachment_id );
-			$sanitized_post_title = sanitize_file_name( $original_attachment->post_title );
-			$use_original_title   = (
-				( '' !== trim( $original_attachment->post_title ) ) &&
-				/*
-				 * Check if the original image has a title other than the "filename" default,
-				 * meaning the image had a title when originally uploaded or its title was edited.
-				 */
-				( $parent_basename !== $sanitized_post_title ) &&
-				( pathinfo( $parent_basename, PATHINFO_FILENAME ) !== $sanitized_post_title )
-			);
-			$use_original_description = ( '' !== trim( $original_attachment->post_content ) );
-
-			$attachment = array(
-				'post_title'     => $use_original_title ? $original_attachment->post_title : wp_basename( $cropped ),
-				'post_content'   => $use_original_description ? $original_attachment->post_content : $url,
-				'post_mime_type' => $image_type,
-				'guid'           => $url,
-				'context'        => $context,
-			);
-
-			// Copy the image caption attribute (post_excerpt field) from the original image.
-			if ( '' !== trim( $original_attachment->post_excerpt ) ) {
-				$attachment['post_excerpt'] = $original_attachment->post_excerpt;
-			}
-
-			// Copy the image alt text attribute from the original image.
-			if ( '' !== trim( $original_attachment->_wp_attachment_image_alt ) ) {
-				$attachment['meta_input'] = array(
-					'_wp_attachment_image_alt' => wp_slash( $original_attachment->_wp_attachment_image_alt ),
-				);
-			}
+			/* Copy attachment properties */
+			$attachment = wp_copy_parent_attachment_properties( $cropped, $attachment_id, $context );
 
 			$attachment_id = wp_insert_attachment( $attachment, $cropped );
 			$metadata      = wp_generate_attachment_metadata( $attachment_id, $cropped );

--- a/src/wp-admin/includes/class-custom-image-header.php
+++ b/src/wp-admin/includes/class-custom-image-header.php
@@ -1077,7 +1077,11 @@ endif;
 		/** This filter is documented in wp-admin/includes/class-custom-image-header.php */
 		$cropped = apply_filters( 'wp_create_file_in_uploads', $cropped, $attachment_id ); // For replication.
 
-		$attachment = $this->create_attachment_object( $cropped, $attachment_id );
+		$context = 'custom-header';
+
+		$attachment = wp_copy_parent_attachment_properties( $cropped, $attachment_id, $context );
+
+		$attachment['post_parent'] = $attachment_id;
 
 		if ( ! empty( $_POST['create-new-attachment'] ) ) {
 			unset( $attachment['ID'] );
@@ -1421,7 +1425,11 @@ endif;
 		/** This filter is documented in wp-admin/includes/class-custom-image-header.php */
 		$cropped = apply_filters( 'wp_create_file_in_uploads', $cropped, $attachment_id ); // For replication.
 
-		$attachment = $this->create_attachment_object( $cropped, $attachment_id );
+		$context = 'custom-header';
+
+		$attachment = wp_copy_parent_attachment_properties( $cropped, $attachment_id, $context );
+
+		$attachment['post_parent'] = $attachment_id;
 
 		$previous = $this->get_previous_crop( $attachment );
 

--- a/src/wp-admin/includes/class-custom-image-header.php
+++ b/src/wp-admin/includes/class-custom-image-header.php
@@ -1423,9 +1423,7 @@ endif;
 		/** This filter is documented in wp-admin/includes/class-custom-image-header.php */
 		$cropped = apply_filters( 'wp_create_file_in_uploads', $cropped, $attachment_id ); // For replication.
 
-		$context = 'custom-header';
-
-		$attachment = wp_copy_parent_attachment_properties( $cropped, $attachment_id, $context );
+		$attachment = wp_copy_parent_attachment_properties( $cropped, $attachment_id, 'custom-header' );
 
 		$attachment['post_parent'] = $attachment_id;
 

--- a/src/wp-admin/includes/class-custom-image-header.php
+++ b/src/wp-admin/includes/class-custom-image-header.php
@@ -1316,12 +1316,23 @@ endif;
 	 * Creates an attachment 'object'.
 	 *
 	 * @since 3.9.0
+	 * @deprecated 6.5.0
 	 *
 	 * @param string $cropped              Cropped image URL.
 	 * @param int    $parent_attachment_id Attachment ID of parent image.
 	 * @return array An array with attachment object data.
 	 */
 	final public function create_attachment_object( $cropped, $parent_attachment_id ) {
+		_doing_it_wrong(
+			'custom_image_header_create_attachment_object',
+			sprintf(
+			// translators: 1: The Custom_Image_Header method that is no longer used by core. 2: The new function that replaces it.
+				__( 'The %1$s method has been replaced with %2$s.' ),
+				'Custom_Image_Header::create_attachment_object',
+				'wp_copy_parent_attachment_properties'
+			),
+			'6.5.0'
+		);
 		$parent     = get_post( $parent_attachment_id );
 		$parent_url = wp_get_attachment_url( $parent->ID );
 		$url        = str_replace( wp_basename( $parent_url ), wp_basename( $cropped ), $parent_url );

--- a/src/wp-admin/includes/class-custom-image-header.php
+++ b/src/wp-admin/includes/class-custom-image-header.php
@@ -1079,8 +1079,6 @@ endif;
 
 		$attachment = wp_copy_parent_attachment_properties( $cropped, $attachment_id, 'custom-header' );
 
-		$attachment['post_parent'] = $attachment_id;
-
 		if ( ! empty( $_POST['create-new-attachment'] ) ) {
 			unset( $attachment['ID'] );
 		}
@@ -1435,8 +1433,6 @@ endif;
 		$cropped = apply_filters( 'wp_create_file_in_uploads', $cropped, $attachment_id ); // For replication.
 
 		$attachment = wp_copy_parent_attachment_properties( $cropped, $attachment_id, 'custom-header' );
-
-		$attachment['post_parent'] = $attachment_id;
 
 		$previous = $this->get_previous_crop( $attachment );
 

--- a/src/wp-admin/includes/class-custom-image-header.php
+++ b/src/wp-admin/includes/class-custom-image-header.php
@@ -1077,9 +1077,7 @@ endif;
 		/** This filter is documented in wp-admin/includes/class-custom-image-header.php */
 		$cropped = apply_filters( 'wp_create_file_in_uploads', $cropped, $attachment_id ); // For replication.
 
-		$context = 'custom-header';
-
-		$attachment = wp_copy_parent_attachment_properties( $cropped, $attachment_id, $context );
+		$attachment = wp_copy_parent_attachment_properties( $cropped, $attachment_id, 'custom-header' );
 
 		$attachment['post_parent'] = $attachment_id;
 

--- a/src/wp-admin/includes/class-custom-image-header.php
+++ b/src/wp-admin/includes/class-custom-image-header.php
@@ -1321,16 +1321,7 @@ endif;
 	 * @return array An array with attachment object data.
 	 */
 	final public function create_attachment_object( $cropped, $parent_attachment_id ) {
-		_doing_it_wrong(
-			'custom_image_header_create_attachment_object',
-			sprintf(
-			// translators: 1: The Custom_Image_Header method that is no longer used by core. 2: The new function that replaces it.
-				__( 'The %1$s method has been replaced with %2$s.' ),
-				'Custom_Image_Header::create_attachment_object',
-				'wp_copy_parent_attachment_properties'
-			),
-			'6.5.0'
-		);
+		_deprecated_function( __METHOD__, '6.5.0', 'wp_copy_parent_attachment_properties()' );
 		$parent     = get_post( $parent_attachment_id );
 		$parent_url = wp_get_attachment_url( $parent->ID );
 		$url        = str_replace( wp_basename( $parent_url ), wp_basename( $cropped ), $parent_url );

--- a/src/wp-admin/includes/class-wp-site-icon.php
+++ b/src/wp-admin/includes/class-wp-site-icon.php
@@ -91,38 +91,14 @@ class WP_Site_Icon {
 		$size       = wp_getimagesize( $cropped );
 		$image_type = ( $size ) ? $size['mime'] : 'image/jpeg';
 
-		$sanitized_post_title = sanitize_file_name( $parent->post_title );
-		$use_original_title   = (
-			( '' !== trim( $parent->post_title ) ) &&
-			/*
-			 * Check if the original image has a title other than the "filename" default,
-			 * meaning the image had a title when originally uploaded or its title was edited.
-			 */
-			( $parent_basename !== $sanitized_post_title ) &&
-			( pathinfo( $parent_basename, PATHINFO_FILENAME ) !== $sanitized_post_title )
-		);
-		$use_original_description = ( '' !== trim( $parent->post_content ) );
-
 		$attachment = array(
 			'ID'             => $parent_attachment_id,
-			'post_title'     => $use_original_title ? $parent->post_title : wp_basename( $cropped ),
-			'post_content'   => $use_original_description ? $parent->post_content : $url,
+			'post_title'     => wp_basename( $cropped ),
+			'post_content'   => $url,
 			'post_mime_type' => $image_type,
 			'guid'           => $url,
 			'context'        => 'site-icon',
 		);
-
-		// Copy the image caption attribute (post_excerpt field) from the original image.
-		if ( '' !== trim( $parent->post_excerpt ) ) {
-			$attachment['post_excerpt'] = $parent->post_excerpt;
-		}
-
-		// Copy the image alt text attribute from the original image.
-		if ( '' !== trim( $parent->_wp_attachment_image_alt ) ) {
-			$attachment['meta_input'] = array(
-				'_wp_attachment_image_alt' => wp_slash( $parent->_wp_attachment_image_alt ),
-			);
-		}	
 
 		return $attachment;
 	}

--- a/src/wp-admin/includes/class-wp-site-icon.php
+++ b/src/wp-admin/includes/class-wp-site-icon.php
@@ -85,16 +85,8 @@ class WP_Site_Icon {
 	 * @return array An array with attachment object data.
 	 */
 	public function create_attachment_object( $cropped, $parent_attachment_id ) {
-		_doing_it_wrong(
-			'wp_site_icon_create_attachment_object',
-			sprintf(
-			// translators: 1: The Custom_Site_Icon method that is no longer used by core. 2: The new function that replaces it.
-				__( 'The %1$s method has been replaced with %2$s.' ),
-				'WP_Site_Icon::create_attachment_object',
-				'wp_copy_parent_attachment_properties'
-			),
-			'6.5.0'
-		);
+		_deprecated_function( __METHOD__, '6.5.0', 'wp_copy_parent_attachment_properties()' );
+
 		$parent     = get_post( $parent_attachment_id );
 		$parent_url = wp_get_attachment_url( $parent->ID );
 		$url        = str_replace( wp_basename( $parent_url ), wp_basename( $cropped ), $parent_url );

--- a/src/wp-admin/includes/class-wp-site-icon.php
+++ b/src/wp-admin/includes/class-wp-site-icon.php
@@ -78,12 +78,23 @@ class WP_Site_Icon {
 	 * Creates an attachment 'object'.
 	 *
 	 * @since 4.3.0
+	 * @deprecated 6.5.0
 	 *
 	 * @param string $cropped              Cropped image URL.
 	 * @param int    $parent_attachment_id Attachment ID of parent image.
 	 * @return array An array with attachment object data.
 	 */
 	public function create_attachment_object( $cropped, $parent_attachment_id ) {
+		_doing_it_wrong(
+			'wp_site_icon_create_attachment_object',
+			sprintf(
+			// translators: 1: The Custom_Site_Icon method that is no longer used by core. 2: The new function that replaces it.
+				__( 'The %1$s method has been replaced with %2$s.' ),
+				'WP_Site_Icon::create_attachment_object',
+				'wp_copy_parent_attachment_properties'
+			),
+			'6.5.0'
+		);
 		$parent     = get_post( $parent_attachment_id );
 		$parent_url = wp_get_attachment_url( $parent->ID );
 		$url        = str_replace( wp_basename( $parent_url ), wp_basename( $cropped ), $parent_url );

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -495,6 +495,7 @@ function wp_copy_parent_attachment_properties( $cropped, $parent_attachment_id, 
 
 	$parent     = get_post( $parent_attachment_id );
 	$parent_url = wp_get_attachment_url( $parent->ID );
+	$parent_basename = wp_basename( $parent_url );
 	$url        = str_replace( wp_basename( $parent_url ), wp_basename( $cropped ), $parent_url );
 
 	$size       = wp_getimagesize( $cropped );

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -485,6 +485,7 @@ function _wp_make_subsizes( $new_sizes, $file, $image_meta, $attachment_id ) {
 /**
  * Copy parent attachment properties to newly cropped image.
  *
+ * @since 6.5.0
  *
  * @param string $cropped Path to the cropped image file.
  * @param int    $parent_attachment_id Parent file Attachment ID.

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -499,7 +499,7 @@ function wp_copy_parent_attachment_properties( $cropped, $parent_attachment_id, 
 	$url             = str_replace( wp_basename( $parent_url ), wp_basename( $cropped ), $parent_url );
 
 	$size       = wp_getimagesize( $cropped );
-	$image_type = ( $size ) ? $size['mime'] : 'image/jpeg';
+	$image_type = $size ? $size['mime'] : 'image/jpeg';
 
 	$sanitized_post_title = sanitize_file_name( $parent->post_title );
 	$use_original_title   = (

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -533,6 +533,8 @@ function wp_copy_parent_attachment_properties( $cropped, $parent_attachment_id, 
 		);
 	}
 
+	$attachment['post_parent'] = $parent_attachment_id;
+
 	return $attachment;
 }
 

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -487,9 +487,9 @@ function _wp_make_subsizes( $new_sizes, $file, $image_meta, $attachment_id ) {
  *
  * @since 6.5.0
  *
- * @param string $cropped Path to the cropped image file.
+ * @param string $cropped              Path to the cropped image file.
  * @param int    $parent_attachment_id Parent file Attachment ID.
- * @param string $context Control calling the function.
+ * @param string $context              Control calling the function.
  * @return array Properties of attachment.
  */
 function wp_copy_parent_attachment_properties( $cropped, $parent_attachment_id, $context ) {

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -493,11 +493,10 @@ function _wp_make_subsizes( $new_sizes, $file, $image_meta, $attachment_id ) {
  * @return array Properties of attachment.
  */
 function wp_copy_parent_attachment_properties( $cropped, $parent_attachment_id, $context ) {
-
-	$parent     = get_post( $parent_attachment_id );
-	$parent_url = wp_get_attachment_url( $parent->ID );
+	$parent          = get_post( $parent_attachment_id );
+	$parent_url      = wp_get_attachment_url( $parent->ID );
 	$parent_basename = wp_basename( $parent_url );
-	$url        = str_replace( wp_basename( $parent_url ), wp_basename( $cropped ), $parent_url );
+	$url             = str_replace( wp_basename( $parent_url ), wp_basename( $cropped ), $parent_url );
 
 	$size       = wp_getimagesize( $cropped );
 	$image_type = ( $size ) ? $size['mime'] : 'image/jpeg';

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -492,7 +492,7 @@ function _wp_make_subsizes( $new_sizes, $file, $image_meta, $attachment_id ) {
  * @param string $context              Control calling the function.
  * @return array Properties of attachment.
  */
-function wp_copy_parent_attachment_properties( $cropped, $parent_attachment_id, $context ) {
+function wp_copy_parent_attachment_properties( $cropped, $parent_attachment_id, $context = '' ) {
 	$parent          = get_post( $parent_attachment_id );
 	$parent_url      = wp_get_attachment_url( $parent->ID );
 	$parent_basename = wp_basename( $parent_url );

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -499,7 +499,7 @@ function wp_copy_parent_attachment_properties( $cropped, $parent_attachment_id, 
 	$url             = str_replace( wp_basename( $parent_url ), wp_basename( $cropped ), $parent_url );
 
 	$size       = wp_getimagesize( $cropped );
-	$image_type = $size ? $size['mime'] : 'image/jpeg';
+	$image_type = ( $size ) ? $size['mime'] : 'image/jpeg';
 
 	$sanitized_post_title = sanitize_file_name( $parent->post_title );
 	$use_original_title   = (

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -489,7 +489,7 @@ function _wp_make_subsizes( $new_sizes, $file, $image_meta, $attachment_id ) {
  *
  * @param string $cropped Path to the cropped image file.
  * @param int    $parent_attachment_id Parent file Attachment ID.
- * @param string $context Context of the image.
+ * @param string $context Control calling the function.
  * @return array Properties of attachment.
  */
 function wp_copy_parent_attachment_properties( $cropped, $parent_attachment_id, $context ) {

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -483,6 +483,60 @@ function _wp_make_subsizes( $new_sizes, $file, $image_meta, $attachment_id ) {
 }
 
 /**
+ * Copy parent attachment properties to newly cropped image.
+ *
+ *
+ * @param string $cropped Path to the cropped image file.
+ * @param int 	 $parent_attachment_id Parent file Attachment ID.
+ * @param string $context Context of the image.
+ * @return array Properties of attachment.
+ */
+function wp_copy_parent_attachment_properties( $cropped, $parent_attachment_id, $context ) {
+
+	$parent     = get_post( $parent_attachment_id );
+	$parent_url = wp_get_attachment_url( $parent->ID );
+	$url        = str_replace( wp_basename( $parent_url ), wp_basename( $cropped ), $parent_url );
+
+	$size       = wp_getimagesize( $cropped );
+	$image_type = ( $size ) ? $size['mime'] : 'image/jpeg';
+
+	$sanitized_post_title = sanitize_file_name( $parent->post_title );
+	$use_original_title   = (
+		( '' !== trim( $parent->post_title ) ) &&
+		/*
+		 * Check if the original image has a title other than the "filename" default,
+		 * meaning the image had a title when originally uploaded or its title was edited.
+		 */
+		( $parent_basename !== $sanitized_post_title ) &&
+		( pathinfo( $parent_basename, PATHINFO_FILENAME ) !== $sanitized_post_title )
+	);
+	$use_original_description = ( '' !== trim( $parent->post_content ) );
+
+	$attachment = array(
+		'post_title'     => $use_original_title ? $parent->post_title : wp_basename( $cropped ),
+		'post_content'   => $use_original_description ? $parent->post_content : $url,
+		'post_mime_type' => $image_type,
+		'guid'           => $url,
+		'context'        => $context,
+	);
+
+	// Copy the image caption attribute (post_excerpt field) from the original image.
+	if ( '' !== trim( $parent->post_excerpt ) ) {
+		$attachment['post_excerpt'] = $parent->post_excerpt;
+	}
+
+	// Copy the image alt text attribute from the original image.
+	if ( '' !== trim( $parent->_wp_attachment_image_alt ) ) {
+		$attachment['meta_input'] = array(
+			'_wp_attachment_image_alt' => wp_slash( $parent->_wp_attachment_image_alt ),
+		);
+	}	
+
+	return $attachment;
+}
+
+
+/**
  * Generates attachment meta data and create image sub-sizes for images.
  *
  * @since 2.1.0

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -487,7 +487,7 @@ function _wp_make_subsizes( $new_sizes, $file, $image_meta, $attachment_id ) {
  *
  *
  * @param string $cropped Path to the cropped image file.
- * @param int 	 $parent_attachment_id Parent file Attachment ID.
+ * @param int    $parent_attachment_id Parent file Attachment ID.
  * @param string $context Context of the image.
  * @return array Properties of attachment.
  */

--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -530,11 +530,10 @@ function wp_copy_parent_attachment_properties( $cropped, $parent_attachment_id, 
 		$attachment['meta_input'] = array(
 			'_wp_attachment_image_alt' => wp_slash( $parent->_wp_attachment_image_alt ),
 		);
-	}	
+	}
 
 	return $attachment;
 }
-
 
 /**
  * Generates attachment meta data and create image sub-sizes for images.

--- a/tests/phpunit/tests/image/header.php
+++ b/tests/phpunit/tests/image/header.php
@@ -108,25 +108,6 @@ class Tests_Image_Header extends WP_UnitTestCase {
 		$this->assertSame( 1200, $dimensions['dst_height'] );
 	}
 
-	public function test_create_attachment_object() {
-		$id = wp_insert_attachment(
-			array(
-				'post_status' => 'publish',
-				'post_title'  => 'foo.png',
-				'post_type'   => 'post',
-				'guid'        => 'http://localhost/foo.png',
-			)
-		);
-
-		$cropped = 'foo-cropped.png';
-
-		$object = $this->custom_image_header->create_attachment_object( $cropped, $id );
-		$this->assertSame( 'foo-cropped.png', $object['post_title'] );
-		$this->assertSame( 'http://localhost/' . $cropped, $object['guid'] );
-		$this->assertSame( 'custom-header', $object['context'] );
-		$this->assertSame( 'image/jpeg', $object['post_mime_type'] );
-	}
-
 	public function test_insert_cropped_attachment() {
 		$id = wp_insert_attachment(
 			array(
@@ -138,7 +119,7 @@ class Tests_Image_Header extends WP_UnitTestCase {
 		);
 
 		$cropped = 'foo-cropped.png';
-		$object  = $this->custom_image_header->create_attachment_object( $cropped, $id );
+		$object  = wp_copy_parent_attachment_properties( $cropped, $id );
 
 		$cropped_id = $this->custom_image_header->insert_attachment( $object, $cropped );
 
@@ -161,7 +142,7 @@ class Tests_Image_Header extends WP_UnitTestCase {
 
 		// Create inital crop object.
 		$cropped_1 = 'foo-cropped-1.png';
-		$object    = $this->custom_image_header->create_attachment_object( $cropped_1, $id );
+		$object    = wp_copy_parent_attachment_properties( $cropped_1, $id );
 
 		// Ensure no previous crop exists.
 		$previous = $this->custom_image_header->get_previous_crop( $object );

--- a/tests/phpunit/tests/image/header.php
+++ b/tests/phpunit/tests/image/header.php
@@ -119,7 +119,7 @@ class Tests_Image_Header extends WP_UnitTestCase {
 		);
 
 		$cropped = 'foo-cropped.png';
-		$object  = wp_copy_parent_attachment_properties( $cropped, $id );
+		$object  = wp_copy_parent_attachment_properties( $cropped, $id, 'custom-header' );
 
 		$cropped_id = $this->custom_image_header->insert_attachment( $object, $cropped );
 
@@ -142,7 +142,7 @@ class Tests_Image_Header extends WP_UnitTestCase {
 
 		// Create inital crop object.
 		$cropped_1 = 'foo-cropped-1.png';
-		$object    = wp_copy_parent_attachment_properties( $cropped_1, $id );
+		$object    = wp_copy_parent_attachment_properties( $cropped_1, $id, 'custom-header' );
 
 		// Ensure no previous crop exists.
 		$previous = $this->custom_image_header->get_previous_crop( $object );

--- a/tests/phpunit/tests/image/header.php
+++ b/tests/phpunit/tests/image/header.php
@@ -156,7 +156,7 @@ class Tests_Image_Header extends WP_UnitTestCase {
 
 		// Create second crop.
 		$cropped_2 = 'foo-cropped-2.png';
-		$object    = $this->custom_image_header->create_attachment_object( $cropped_2, $id );
+		$object    = wp_copy_parent_attachment_properties( $cropped_2, $id );
 
 		// Test that a previous crop is found.
 		$previous = $this->custom_image_header->get_previous_crop( $object );

--- a/tests/phpunit/tests/image/siteIcon.php
+++ b/tests/phpunit/tests/image/siteIcon.php
@@ -98,26 +98,12 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 		unset( $this->wp_site_icon->site_icon_sizes[ array_search( 321, $this->wp_site_icon->site_icon_sizes, true ) ] );
 	}
 
-	public function test_create_attachment_object() {
-		$attachment_id = $this->insert_attachment();
-		$parent_url    = get_post( $attachment_id )->guid;
-		$cropped       = str_replace( wp_basename( $parent_url ), 'cropped-test-image.jpg', $parent_url );
-
-		$object = $this->wp_site_icon->create_attachment_object( $cropped, $attachment_id );
-
-		$this->assertSame( $object['post_title'], 'cropped-test-image.jpg' );
-		$this->assertSame( $object['context'], 'site-icon' );
-		$this->assertSame( $object['post_mime_type'], 'image/jpeg' );
-		$this->assertSame( $object['post_content'], $cropped );
-		$this->assertSame( $object['guid'], $cropped );
-	}
-
 	public function test_insert_cropped_attachment() {
 		$attachment_id = $this->insert_attachment();
 		$parent_url    = get_post( $attachment_id )->guid;
 		$cropped       = str_replace( wp_basename( $parent_url ), 'cropped-test-image.jpg', $parent_url );
 
-		$object     = $this->wp_site_icon->create_attachment_object( $cropped, $attachment_id );
+		$object     = wp_copy_parent_attachment_properties( $cropped, $attachment_id );
 		$cropped_id = $this->wp_site_icon->insert_attachment( $object, $cropped );
 
 		$this->assertIsInt( $cropped_id );

--- a/tests/phpunit/tests/image/siteIcon.php
+++ b/tests/phpunit/tests/image/siteIcon.php
@@ -103,7 +103,7 @@ class Tests_WP_Site_Icon extends WP_UnitTestCase {
 		$parent_url    = get_post( $attachment_id )->guid;
 		$cropped       = str_replace( wp_basename( $parent_url ), 'cropped-test-image.jpg', $parent_url );
 
-		$object     = wp_copy_parent_attachment_properties( $cropped, $attachment_id );
+		$object     = wp_copy_parent_attachment_properties( $cropped, $attachment_id, 'site-icon' );
 		$cropped_id = $this->wp_site_icon->insert_attachment( $object, $cropped );
 
 		$this->assertIsInt( $cropped_id );

--- a/tests/phpunit/tests/media/wpCopyParentAttachmentProperties.php
+++ b/tests/phpunit/tests/media/wpCopyParentAttachmentProperties.php
@@ -35,7 +35,7 @@ class Tests_Media_wpCopyParentAttachmentProperties extends WP_UnitTestCase {
 			100
 		);
 
-		$object  = wp_copy_parent_attachment_properties( $cropped, $attachment );
+		$object = wp_copy_parent_attachment_properties( $cropped, $attachment );
 
 		$this->assertSame( $object['post_title'], 'cropped-canola.jpg' );
 		$this->assertSame( $object['context'], '' );

--- a/tests/phpunit/tests/media/wpCopyParentAttachmentProperties.php
+++ b/tests/phpunit/tests/media/wpCopyParentAttachmentProperties.php
@@ -48,5 +48,4 @@ class Tests_Media_wpCopyParentAttachmentProperties extends WP_UnitTestCase {
 
 		unlink( $cropped );
 	}
-
 }

--- a/tests/phpunit/tests/media/wpCopyParentAttachmentProperties.php
+++ b/tests/phpunit/tests/media/wpCopyParentAttachmentProperties.php
@@ -35,7 +35,6 @@ class Tests_Media_wpCopyParentAttachmentProperties extends WP_UnitTestCase {
 			100
 		);
 
-		$cropped = str_replace( wp_basename( $parent_url ), 'cropped-test-image.jpg', $parent_url );
 		$object  = wp_copy_parent_attachment_properties( $cropped, $attachment );
 
 		$this->assertSame( $object['post_title'], 'cropped-canola.jpg' );

--- a/tests/phpunit/tests/media/wpCopyParentAttachmentProperties.php
+++ b/tests/phpunit/tests/media/wpCopyParentAttachmentProperties.php
@@ -16,6 +16,7 @@ class Tests_Media_wpCopyParentAttachmentProperties extends WP_UnitTestCase {
 
 	public function test_wp_copy_parent_attachment_properties() {
 		$attachment = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg' );
+		$parent_url = get_post( $attachment )->guid;
 		// Add alternative text.
 		update_post_meta( $attachment, '_wp_attachment_image_alt', 'Alt text' );
 		// Add image description.
@@ -35,15 +36,16 @@ class Tests_Media_wpCopyParentAttachmentProperties extends WP_UnitTestCase {
 			100
 		);
 
-		$object = wp_copy_parent_attachment_properties( $cropped, $attachment );
+		$object  = wp_copy_parent_attachment_properties( $cropped, $attachment );
+		$cropped = str_replace( wp_basename( $parent_url ), 'cropped-canola.jpg', $parent_url );
 
-		$this->assertSame( $object['post_title'], 'cropped-canola.jpg' );
-		$this->assertSame( $object['context'], '' );
-		$this->assertSame( $object['post_mime_type'], 'image/jpeg' );
-		$this->assertSame( $object['post_content'], $cropped );
-		$this->assertSame( $object['guid'], $cropped );
-		$this->assertSame( $object['meta_input']['_wp_attachment_image_alt'], 'Alt text' );
-		$this->assertSame( $object['post_excerpt'], 'Image description' );
+		$this->assertSame( $object['post_title'], 'cropped-canola.jpg', 'Attachment title is not identical' );
+		$this->assertSame( $object['context'], '', 'Attachment context is not identical' );
+		$this->assertSame( $object['post_mime_type'], 'image/jpeg', 'Attachment mime type is not identical' );
+		$this->assertSame( $object['post_content'], $cropped, 'Attachment content is not identical' );
+		$this->assertSame( $object['guid'], $cropped, 'Attachment GUID is not identical' );
+		$this->assertSame( $object['meta_input']['_wp_attachment_image_alt'], 'Alt text', 'Attachment alt text is not identical' );
+		$this->assertSame( $object['post_excerpt'], 'Image description', 'Attachment description is not identical' );
 
 		unlink( $cropped );
 	}

--- a/tests/phpunit/tests/media/wpCopyParentAttachmentProperties.php
+++ b/tests/phpunit/tests/media/wpCopyParentAttachmentProperties.php
@@ -36,7 +36,7 @@ class Tests_Media_wpCopyParentAttachmentProperties extends WP_UnitTestCase {
 			100
 		);
 
-		$object  = wp_copy_parent_attachment_properties( $cropped, $attachment );
+		$object  = wp_copy_parent_attachment_properties( $file, $attachment );
 		$cropped = str_replace( wp_basename( $parent_url ), 'cropped-canola.jpg', $parent_url );
 
 		$this->assertSame( $object['post_title'], 'cropped-canola.jpg', 'Attachment title is not identical' );

--- a/tests/phpunit/tests/media/wpCopyParentAttachmentProperties.php
+++ b/tests/phpunit/tests/media/wpCopyParentAttachmentProperties.php
@@ -26,7 +26,7 @@ class Tests_Media_wpCopyParentAttachmentProperties extends WP_UnitTestCase {
 				'post_excerpt' => 'Image description',
 			)
 		);
-		$cropped = wp_crop_image(
+		$file = wp_crop_image(
 			DIR_TESTDATA . '/images/canola.jpg',
 			0,
 			0,
@@ -47,6 +47,6 @@ class Tests_Media_wpCopyParentAttachmentProperties extends WP_UnitTestCase {
 		$this->assertSame( $object['meta_input']['_wp_attachment_image_alt'], 'Alt text', 'Attachment alt text is not identical' );
 		$this->assertSame( $object['post_excerpt'], 'Image description', 'Attachment description is not identical' );
 
-		unlink( $cropped );
+		unlink( $file );
 	}
 }

--- a/tests/phpunit/tests/media/wpCopyParentAttachmentProperties.php
+++ b/tests/phpunit/tests/media/wpCopyParentAttachmentProperties.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Tests for the `wp_copy_parent_attachment_properties()` function.
+ *
+ * @group media
+ * @covers ::wp_copy_parent_attachment_properties
+ */
+class Tests_Media_wpCopyParentAttachmentProperties extends WP_UnitTestCase {
+
+	public function tear_down() {
+		$this->remove_added_uploads();
+
+		parent::tear_down();
+	}
+
+	public function test_wp_copy_parent_attachment_properties() {
+		$attachment = $this->factory->attachment->create_upload_object( DIR_TESTDATA . '/images/canola.jpg' );
+		// Add alternative text.
+		update_post_meta( $attachment, '_wp_attachment_image_alt', 'Alt text' );
+		// Add image description.
+		wp_update_post(
+			array(
+				'ID'           => $attachment,
+				'post_excerpt' => 'Image description',
+			)
+		);
+		$cropped = wp_crop_image(
+			DIR_TESTDATA . '/images/canola.jpg',
+			0,
+			0,
+			100,
+			100,
+			100,
+			100
+		);
+
+		$cropped = str_replace( wp_basename( $parent_url ), 'cropped-test-image.jpg', $parent_url );
+		$object  = wp_copy_parent_attachment_properties( $cropped, $attachment );
+
+		$this->assertSame( $object['post_title'], 'cropped-canola.jpg' );
+		$this->assertSame( $object['context'], '' );
+		$this->assertSame( $object['post_mime_type'], 'image/jpeg' );
+		$this->assertSame( $object['post_content'], $cropped );
+		$this->assertSame( $object['guid'], $cropped );
+		$this->assertSame( $object['meta_input']['_wp_attachment_image_alt'], 'Alt text' );
+		$this->assertSame( $object['post_excerpt'], 'Image description' );
+
+		unlink( $cropped );
+	}
+
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

As per the discussion over the ticket, Created the function wp_copy_parent_attachment_properties() in image.php file and called it in ajax-actions.php file.

Trac ticket: https://core.trac.wordpress.org/ticket/60524

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
