### PR TITLE
Font Library: Ensure name/description are localized

### DIFF
--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -65,15 +65,12 @@ function wp_print_font_faces( $fonts = array() ) {
  * @param array  $args {
  *     Font collection data.
  *
- *     @type string $name           Required. Name of the font collection shown in the Font Library.
- *     @type string $description    Optional. A short descriptive summary of the font collection. Default empty.
- *     @type string $src            Optional. Path or URL to a JSON file containing the font collection. Default empty.
- *                                  Required if `$font_families` is not provided.
- *     @type array  $font_families  Optional. Array of font family definitions that are in the collection.
- *                                  Required if `src` is not provided.
- *     @type array  $categories     Optional. Array of categories, each with a name and slug, that are used by the
- *                                  fonts in the collection. Default empty.
- *                                  Required if `src` is not provided.
+ *     @type string       $name          Required. Name of the font collection shown in the Font Library.
+ *     @type string       $description   Optional. A short descriptive summary of the font collection. Default empty.
+ *     @type array|string $font_families Required. Array of font family definitions that are in the collection,
+ *                                       or a string containing the path or URL to a JSON file containing the font collection.
+ *     @type array        $categories    Optional. Array of categories, each with a name and slug, that are used by the
+ *                                       fonts in the collection. Default empty.
  * }
  * @return WP_Font_Collection|WP_Error A font collection if it was registered
  *                                     successfully, or WP_Error object on failure.
@@ -204,10 +201,10 @@ function _wp_register_default_font_collections() {
 	wp_register_font_collection(
 		'google-fonts',
 		array(
-			'src'         => 'https://s.w.org/images/fonts/17.7/collections/google-fonts-with-preview.json',
-			'name'        => _x( 'Google Fonts', 'font collection name' ),
-			'description' => __( 'Install from Google Fonts. Fonts are copied to and served from your site.' ),
-			'categories'  => array(
+			'name'          => _x( 'Google Fonts', 'font collection name' ),
+			'description'   => __( 'Install from Google Fonts. Fonts are copied to and served from your site.' ),
+			'font_families' => 'https://raw.githubusercontent.com/WordPress/google-fonts-to-wordpress-collection/e9037d48ec56988dbaa7036186619415ef6761f7/releases/core-6.5.beta/google-fonts-with-preview.json',
+			'categories'    => array(
 				array(
 					'name' => _x( 'Sans Serif', 'font category' ),
 					'slug' => 'sans-serif',

--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -205,8 +205,30 @@ function _wp_register_default_font_collections() {
 		'google-fonts',
 		array(
 			'src'         => 'https://s.w.org/images/fonts/17.7/collections/google-fonts-with-preview.json',
-			'name'        => __( 'Google Fonts' ),
+			'name'        => _x( 'Google Fonts', 'font collection name' ),
 			'description' => __( 'Install from Google Fonts. Fonts are copied to and served from your site.' ),
+			'categories'  => array(
+				array(
+					'name' => _x( 'Sans Serif', 'font category' ),
+					'slug' => 'sans-serif',
+				),
+				array(
+					'name' => _x( 'Display', 'font category' ),
+					'slug' => 'display',
+				),
+				array(
+					'name' => _x( 'Serif', 'font category' ),
+					'slug' => 'serif',
+				),
+				array(
+					'name' => _x( 'Handwriting', 'font category' ),
+					'slug' => 'handwriting',
+				),
+				array(
+					'name' => _x( 'Monospace', 'font category' ),
+					'slug' => 'monospace',
+				),
+			),
 		)
 	);
 }

--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -53,28 +53,33 @@ function wp_print_font_faces( $fonts = array() ) {
 }
 
 /**
- * Registers a new Font Collection in the Font Library.
+ * Registers a new font collection in the font library.
+ *
+ * See {@link https://schemas.wp.org/trunk/font-collection.json} for the schema
+ * the font collection data must adhere to.
  *
  * @since 6.5.0
  *
- * @param string       $slug Font collection slug. May only contain alphanumeric characters, dashes,
+ * @param string $slug Font collection slug. May only contain alphanumeric characters, dashes,
  *                     and underscores. See sanitize_title().
- * @param array|string $data_or_file {
- *     Font collection data array or a path/URL to a JSON file containing the font collection.
- *
- *     @link https://schemas.wp.org/trunk/font-collection.json
+ * @param array  $args {
+ *     Font collection data.
  *
  *     @type string $name           Required. Name of the font collection shown in the Font Library.
  *     @type string $description    Optional. A short descriptive summary of the font collection. Default empty.
- *     @type array  $font_families  Required. Array of font family definitions that are in the collection.
+ *     @type string $src            Optional. Path or URL to a JSON file containing the font collection. Default empty.
+ *                                  Required if `$font_families` is not provided.
+ *     @type array  $font_families  Optional. Array of font family definitions that are in the collection.
+ *                                  Required if `src` is not provided.
  *     @type array  $categories     Optional. Array of categories, each with a name and slug, that are used by the
  *                                  fonts in the collection. Default empty.
+ *                                  Required if `src` is not provided.
  * }
  * @return WP_Font_Collection|WP_Error A font collection if it was registered
  *                                     successfully, or WP_Error object on failure.
  */
-function wp_register_font_collection( $slug, $data_or_file ) {
-	return WP_Font_Library::get_instance()->register_font_collection( $slug, $data_or_file );
+function wp_register_font_collection( string $slug, array $args ) {
+	return WP_Font_Library::get_instance()->register_font_collection( $slug, $args );
 }
 
 /**
@@ -85,7 +90,7 @@ function wp_register_font_collection( $slug, $data_or_file ) {
  * @param string $slug Font collection slug.
  * @return bool True if the font collection was unregistered successfully, else false.
  */
-function wp_unregister_font_collection( $slug ) {
+function wp_unregister_font_collection( string $slug ) {
 	return WP_Font_Library::get_instance()->unregister_font_collection( $slug );
 }
 
@@ -196,5 +201,12 @@ function _wp_before_delete_font_face( $post_id, $post ) {
  * @since 6.5.0
  */
 function _wp_register_default_font_collections() {
-	wp_register_font_collection( 'google-fonts', 'https://s.w.org/images/fonts/17.7/collections/google-fonts-with-preview.json' );
+	wp_register_font_collection(
+		'google-fonts',
+		array(
+			'src'         => 'https://s.w.org/images/fonts/17.7/collections/google-fonts-with-preview.json',
+			'name'        => __( 'Google Fonts' ),
+			'description' => __( 'Install from Google Fonts. Fonts are copied to and served from your site.' ),
+		)
+	);
 }

--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -203,7 +203,7 @@ function _wp_register_default_font_collections() {
 		array(
 			'name'          => _x( 'Google Fonts', 'font collection name' ),
 			'description'   => __( 'Install from Google Fonts. Fonts are copied to and served from your site.' ),
-			'font_families' => 'https://raw.githubusercontent.com/WordPress/google-fonts-to-wordpress-collection/e9037d48ec56988dbaa7036186619415ef6761f7/releases/core-6.5.beta/google-fonts-with-preview.json',
+			'font_families' => 'https://s.w.org/images/fonts/17.7/collections/google-fonts-with-preview.json',
 			'categories'    => array(
 				array(
 					'name' => _x( 'Sans Serif', 'font category' ),

--- a/src/wp-includes/fonts/class-wp-font-collection.php
+++ b/src/wp-includes/fonts/class-wp-font-collection.php
@@ -130,6 +130,10 @@ final class WP_Font_Collection {
 			$data['description'] = $this->data['description'];
 		}
 
+		if ( isset( $this->data['categories'] ) ) {
+			$data['categories'] = $this->data['categories'];
+		}
+
 		return $this->sanitize_and_validate_data( $data );
 	}
 
@@ -165,13 +169,17 @@ final class WP_Font_Collection {
 				return $data;
 			}
 
-			$data['name'] = $this->data['name'];
-
-			if ( isset( $this->data['description'] ) ) {
-				$data['description'] = $this->data['description'];
-			}
-
 			set_site_transient( $transient_key, $data, DAY_IN_SECONDS );
+		}
+
+		$data['name'] = $this->data['name'];
+
+		if ( isset( $this->data['description'] ) ) {
+			$data['description'] = $this->data['description'];
+		}
+
+		if ( isset( $this->data['categories'] ) ) {
+			$data['categories'] = $this->data['categories'];
 		}
 
 		return $data;
@@ -206,15 +214,6 @@ final class WP_Font_Collection {
 				__( 'Font collection must only provide "%1$s" or "%2$s", not both.' ),
 				'src',
 				'font_families'
-			);
-			_doing_it_wrong( __METHOD__, $message, '6.5.0' );
-			return new WP_Error( 'font_collection_mutually_exclusive_property', $message );
-		} elseif ( isset( $data['src'], $data['categories'] ) ) {
-			$message = sprintf(
-				// translators: 1: src. 2: font_families or categories.
-				__( 'Font collection must only provide "%1$s" or "%2$s", not both.' ),
-				'src',
-				'categories'
 			);
 			_doing_it_wrong( __METHOD__, $message, '6.5.0' );
 			return new WP_Error( 'font_collection_mutually_exclusive_property', $message );

--- a/src/wp-includes/fonts/class-wp-font-collection.php
+++ b/src/wp-includes/fonts/class-wp-font-collection.php
@@ -124,7 +124,26 @@ final class WP_Font_Collection {
 			return new WP_Error( 'font_collection_json_missing', $message );
 		}
 
-		return $url ? $this->load_from_url( $url ) : $this->load_from_file( $file );
+		$data = $url ? $this->load_from_url( $url ) : $this->load_from_file( $file );
+
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
+
+		$data = array(
+			'name'          => $this->data['name'],
+			'font_families' => $data['font_families'],
+		);
+
+		if ( isset( $this->data['description'] ) ) {
+			$data['description'] = $this->data['description'];
+		}
+
+		if ( isset( $this->data['categories'] ) ) {
+			$data['categories'] = $this->data['categories'];
+		}
+
+		return $data;
 	}
 
 	/**
@@ -140,16 +159,6 @@ final class WP_Font_Collection {
 		$data = wp_json_file_decode( $file, array( 'associative' => true ) );
 		if ( empty( $data ) ) {
 			return new WP_Error( 'font_collection_decode_error', __( 'Error decoding the font collection JSON file contents.' ) );
-		}
-
-		$data['name'] = $this->data['name'];
-
-		if ( isset( $this->data['description'] ) ) {
-			$data['description'] = $this->data['description'];
-		}
-
-		if ( isset( $this->data['categories'] ) ) {
-			$data['categories'] = $this->data['categories'];
 		}
 
 		return $this->sanitize_and_validate_data( $data, array( 'font_families' ) );
@@ -194,16 +203,6 @@ final class WP_Font_Collection {
 			}
 
 			set_site_transient( $transient_key, $data, DAY_IN_SECONDS );
-		}
-
-		$data['name'] = $this->data['name'];
-
-		if ( isset( $this->data['description'] ) ) {
-			$data['description'] = $this->data['description'];
-		}
-
-		if ( isset( $this->data['categories'] ) ) {
-			$data['categories'] = $this->data['categories'];
 		}
 
 		return $data;

--- a/src/wp-includes/fonts/class-wp-font-collection.php
+++ b/src/wp-includes/fonts/class-wp-font-collection.php
@@ -152,7 +152,7 @@ final class WP_Font_Collection {
 			$data['categories'] = $this->data['categories'];
 		}
 
-		return $this->sanitize_and_validate_data( $data );
+		return $this->sanitize_and_validate_data( $data, array( 'font_families' ) );
 	}
 
 	/**
@@ -172,8 +172,14 @@ final class WP_Font_Collection {
 		if ( false === $data ) {
 			$response = wp_safe_remote_get( $url );
 			if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-				// translators: %s: Font collection URL.
-				return new WP_Error( 'font_collection_request_error', sprintf( __( 'Error fetching the font collection data from "%s".' ), $url ) );
+				return new WP_Error(
+					'font_collection_request_error',
+					sprintf(
+						// translators: %s: Font collection URL.
+						__( 'Error fetching the font collection data from "%s".' ),
+						$url
+					)
+				);
 			}
 
 			$data = json_decode( wp_remote_retrieve_body( $response ), true );
@@ -182,7 +188,7 @@ final class WP_Font_Collection {
 			}
 
 			// Make sure the data is valid before storing it in a transient.
-			$data = $this->sanitize_and_validate_data( $data );
+			$data = $this->sanitize_and_validate_data( $data, array( 'font_families' ) );
 			if ( is_wp_error( $data ) ) {
 				return $data;
 			}
@@ -212,7 +218,7 @@ final class WP_Font_Collection {
 	 * @param array $required_properties Required properties that must exist in the passed data.
 	 * @return array|WP_Error Sanitized data if valid, otherwise a WP_Error instance.
 	 */
-	private function sanitize_and_validate_data( $data, $required_properties = array( 'name', 'font_families' ) ) {
+	private function sanitize_and_validate_data( $data, $required_properties = array() ) {
 		$schema = self::get_sanitization_schema();
 		$data   = WP_Font_Utils::sanitize_from_schema( $data, $schema );
 

--- a/src/wp-includes/fonts/class-wp-font-collection.php
+++ b/src/wp-includes/fonts/class-wp-font-collection.php
@@ -202,13 +202,22 @@ final class WP_Font_Collection {
 
 		if ( isset( $data['src'], $data['font_families'] ) ) {
 			$message = sprintf(
-			// translators: 1: src. 2: font_families.
+				// translators: 1: src. 2: font_families or categories.
 				__( 'Font collection must only provide "%2$s" or "%2$s", not both.' ),
 				'src',
 				'font_families'
 			);
 			_doing_it_wrong( __METHOD__, $message, '6.5.0' );
-			return new WP_Error( 'font_collection_duplicate_property', $message );
+			return new WP_Error( 'font_collection_mutually_exclusive_property', $message );
+		} elseif ( isset( $data['src'], $data['categories'] ) ) {
+			$message = sprintf(
+				// translators: 1: src. 2: font_families or categories.
+				__( 'Font collection must only provide "%2$s" or "%2$s", not both.' ),
+				'src',
+				'categories'
+			);
+			_doing_it_wrong( __METHOD__, $message, '6.5.0' );
+			return new WP_Error( 'font_collection_mutually_exclusive_property', $message );
 		}
 
 		$required_properties = array( 'name' );

--- a/src/wp-includes/fonts/class-wp-font-collection.php
+++ b/src/wp-includes/fonts/class-wp-font-collection.php
@@ -203,7 +203,7 @@ final class WP_Font_Collection {
 		if ( isset( $data['src'], $data['font_families'] ) ) {
 			$message = sprintf(
 				// translators: 1: src. 2: font_families or categories.
-				__( 'Font collection must only provide "%2$s" or "%2$s", not both.' ),
+				__( 'Font collection must only provide "%1$s" or "%2$s", not both.' ),
 				'src',
 				'font_families'
 			);
@@ -212,7 +212,7 @@ final class WP_Font_Collection {
 		} elseif ( isset( $data['src'], $data['categories'] ) ) {
 			$message = sprintf(
 				// translators: 1: src. 2: font_families or categories.
-				__( 'Font collection must only provide "%2$s" or "%2$s", not both.' ),
+				__( 'Font collection must only provide "%1$s" or "%2$s", not both.' ),
 				'src',
 				'categories'
 			);

--- a/src/wp-includes/fonts/class-wp-font-library.php
+++ b/src/wp-includes/fonts/class-wp-font-library.php
@@ -37,15 +37,14 @@ class WP_Font_Library {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param string $slug         Font collection slug.
-	 * @param array  $data_or_file Font collection data array or a path/URL to a JSON file
-	 *                             containing the font collection.
-	 *                             See {@see wp_register_font_collection()} for the supported fields.
+	 * @param string $slug Font collection slug. May only contain alphanumeric characters, dashes,
+	 *                     and underscores. See sanitize_title().
+	 * @param array  $args Font collection data. See {@see wp_register_font_collection()} for the supported fields.
 	 * @return WP_Font_Collection|WP_Error A font collection if it was registered successfully,
 	 *                                     or WP_Error object on failure.
 	 */
-	public function register_font_collection( $slug, $data_or_file ) {
-		$new_collection = new WP_Font_Collection( $slug, $data_or_file );
+	public function register_font_collection( string $slug, array $args ) {
+		$new_collection = new WP_Font_Collection( $slug, $args );
 
 		if ( $this->is_collection_registered( $new_collection->slug ) ) {
 			$error_message = sprintf(
@@ -72,7 +71,7 @@ class WP_Font_Library {
 	 * @param string $slug Font collection slug.
 	 * @return bool True if the font collection was unregistered successfully and false otherwise.
 	 */
-	public function unregister_font_collection( $slug ) {
+	public function unregister_font_collection( string $slug ) {
 		if ( ! $this->is_collection_registered( $slug ) ) {
 			_doing_it_wrong(
 				__METHOD__,
@@ -94,7 +93,7 @@ class WP_Font_Library {
 	 * @param string $slug Font collection slug.
 	 * @return bool True if the font collection is registered and false otherwise.
 	 */
-	private function is_collection_registered( $slug ) {
+	private function is_collection_registered( string $slug ) {
 		return array_key_exists( $slug, $this->collections );
 	}
 
@@ -117,7 +116,7 @@ class WP_Font_Library {
 	 * @param string $slug Font collection slug.
 	 * @return WP_Font_Collection|null Font collection object, or null if the font collection doesn't exist.
 	 */
-	public function get_font_collection( $slug ) {
+	public function get_font_collection( string $slug ) {
 		if ( $this->is_collection_registered( $slug ) ) {
 			return $this->collections[ $slug ];
 		}

--- a/src/wp-includes/fonts/class-wp-font-library.php
+++ b/src/wp-includes/fonts/class-wp-font-library.php
@@ -39,7 +39,7 @@ class WP_Font_Library {
 	 *
 	 * @param string $slug Font collection slug. May only contain alphanumeric characters, dashes,
 	 *                     and underscores. See sanitize_title().
-	 * @param array  $args Font collection data. See {@see wp_register_font_collection()} for the supported fields.
+	 * @param array  $args Font collection data. See wp_register_font_collection() for information on accepted arguments.
 	 * @return WP_Font_Collection|WP_Error A font collection if it was registered successfully,
 	 *                                     or WP_Error object on failure.
 	 */

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-font-collections-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-font-collections-controller.php
@@ -104,7 +104,7 @@ class WP_REST_Font_Collections_Controller extends WP_REST_Controller {
 		$response = rest_ensure_response( $items );
 
 		$response->header( 'X-WP-Total', (int) $total_items );
-		$response->header( 'X-WP-TotalPages', (int) $max_pages );
+		$response->header( 'X-WP-TotalPages', $max_pages );
 
 		$request_params = $request->get_query_params();
 		$collection_url = rest_url( $this->namespace . '/' . $this->rest_base );

--- a/tests/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
+++ b/tests/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
@@ -251,46 +251,25 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 	}
 
 
-	/**
-	 * @dataProvider data_mutually_exclusive_properties
-	 *
-	 * @param array $config Font collection config.
-	 */
-	public function test_should_error_for_mutually_exclusive_properties( $config ) {
+	public function test_should_error_for_mutually_exclusive_properties() {
 		$this->setExpectedIncorrectUsage( 'WP_Font_Collection::sanitize_and_validate_data' );
 
-		$collection = new WP_Font_Collection( 'my-collection', $config );
-		$data       = $collection->get_data();
+		$collection = new WP_Font_Collection(
+			'my-collection',
+			array(
+				'name'          => 'My collection',
+				'src'           => 'foo',
+				'font_families' => array( array() ),
+			)
+		);
+
+		$data = $collection->get_data();
 
 		$this->assertWPError( $data, 'Error is not returned when property is missing or invalid.' );
 		$this->assertSame(
 			'font_collection_mutually_exclusive_property',
 			$data->get_error_code(),
 			'Incorrect error code when property is missing or invalid.'
-		);
-	}
-
-	/**
-	 * Data provider.
-	 *
-	 * @return array
-	 */
-	public function data_mutually_exclusive_properties() {
-		return array(
-			'src and font_families' => array(
-				'config' => array(
-					'name'          => 'My collection',
-					'src'           => 'foo',
-					'font_families' => array( array() ),
-				),
-			),
-			'src and categories'    => array(
-				'config' => array(
-					'name'       => 'My collection',
-					'src'        => 'foo',
-					'categories' => array( array() ),
-				),
-			),
 		);
 	}
 

--- a/tests/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
+++ b/tests/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
@@ -99,7 +99,7 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 					'font_families' => array( array() ),
 				),
 			),
-//
+
 			'font collection with all data'      => array(
 				'slug'          => 'my-collection',
 				'config'        => array(

--- a/tests/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
+++ b/tests/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
@@ -42,15 +42,15 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 
 		$collection = new WP_Font_Collection(
 			$slug,
-			array(
-				'name'          => $config['name'],
-				'font_families' => $mock_file,
+			array_merge(
+				$config,
+				array( 'font_families' => $mock_file )
 			)
 		);
 		$data       = $collection->get_data();
 
 		$this->assertSame( $slug, $collection->slug, 'The slug should match.' );
-		$this->assertSame( $expected_data, $data, 'The collection data should match.' );
+		$this->assertEqualSetsWithIndex( $expected_data, $data, 'The collection data should match.' );
 	}
 
 	/**
@@ -66,9 +66,11 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 		self::$mock_collection_data = $config;
 		$collection                 = new WP_Font_Collection(
 			$slug,
-			array(
-				'name'          => 'My Collection',
-				'font_families' => 'https://example.com/fonts/mock-font-collection.json',
+			array_merge(
+				$config,
+				array(
+					'font_families' => 'https://example.com/fonts/mock-font-collection.json',
+				)
 			)
 		);
 		$data                       = $collection->get_data();
@@ -76,7 +78,7 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 		remove_filter( 'pre_http_request', array( $this, 'mock_request' ) );
 
 		$this->assertSame( $slug, $collection->slug, 'The slug should match.' );
-		$this->assertSame( $expected_data, $data, 'The collection data should match.' );
+		$this->assertEqualSetsWithIndex( $expected_data, $data, 'The collection data should match.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
+++ b/tests/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
@@ -250,6 +250,50 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 		);
 	}
 
+
+	/**
+	 * @dataProvider data_mutually_exclusive_properties
+	 *
+	 * @param array $config Font collection config.
+	 */
+	public function test_should_error_for_mutually_exclusive_properties( $config ) {
+		$this->setExpectedIncorrectUsage( 'WP_Font_Collection::sanitize_and_validate_data' );
+
+		$collection = new WP_Font_Collection( 'my-collection', $config );
+		$data       = $collection->get_data();
+
+		$this->assertWPError( $data, 'Error is not returned when property is missing or invalid.' );
+		$this->assertSame(
+			'font_collection_mutually_exclusive_property',
+			$data->get_error_code(),
+			'Incorrect error code when property is missing or invalid.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_mutually_exclusive_properties() {
+		return array(
+			'src and font_families' => array(
+				'config' => array(
+					'name'          => 'My collection',
+					'src'           => 'foo',
+					'font_families' => array( array() ),
+				),
+			),
+			'src and categories'    => array(
+				'config' => array(
+					'name'       => 'My collection',
+					'src'        => 'foo',
+					'categories' => array( array() ),
+				),
+			),
+		);
+	}
+
 	public function test_should_error_with_invalid_json_file_path() {
 		$this->setExpectedIncorrectUsage( 'WP_Font_Collection::load_from_json' );
 

--- a/tests/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
+++ b/tests/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
@@ -43,8 +43,8 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 		$collection = new WP_Font_Collection(
 			$slug,
 			array(
-				'name' => $config['name'],
-				'src'  => $mock_file,
+				'name'          => $config['name'],
+				'font_families' => $mock_file,
 			)
 		);
 		$data       = $collection->get_data();
@@ -67,8 +67,8 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 		$collection                 = new WP_Font_Collection(
 			$slug,
 			array(
-				'name' => 'My Collection',
-				'src'  => 'https://example.com/fonts/mock-font-collection.json',
+				'name'          => 'My Collection',
+				'font_families' => 'https://example.com/fonts/mock-font-collection.json',
 			)
 		);
 		$data                       = $collection->get_data();
@@ -250,37 +250,14 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 		);
 	}
 
-
-	public function test_should_error_for_mutually_exclusive_properties() {
-		$this->setExpectedIncorrectUsage( 'WP_Font_Collection::sanitize_and_validate_data' );
-
-		$collection = new WP_Font_Collection(
-			'my-collection',
-			array(
-				'name'          => 'My collection',
-				'src'           => 'foo',
-				'font_families' => array( array() ),
-			)
-		);
-
-		$data = $collection->get_data();
-
-		$this->assertWPError( $data, 'Error is not returned when property is missing or invalid.' );
-		$this->assertSame(
-			'font_collection_mutually_exclusive_property',
-			$data->get_error_code(),
-			'Incorrect error code when property is missing or invalid.'
-		);
-	}
-
 	public function test_should_error_with_invalid_json_file_path() {
 		$this->setExpectedIncorrectUsage( 'WP_Font_Collection::load_from_json' );
 
 		$collection = new WP_Font_Collection(
 			'my-collection',
 			array(
-				'name' => 'My collection',
-				'src'  => 'non-existing.json',
+				'name'          => 'My collection',
+				'font_families' => 'non-existing.json',
 			)
 		);
 		$data       = $collection->get_data();
@@ -300,8 +277,8 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 		$collection = new WP_Font_Collection(
 			'my-collection',
 			array(
-				'name' => 'Invalid collection',
-				'src'  => $mock_file,
+				'name'          => 'Invalid collection',
+				'font_families' => $mock_file,
 			)
 		);
 
@@ -322,8 +299,8 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 		$collection = new WP_Font_Collection(
 			'my-collection',
 			array(
-				'name' => 'Invalid collection',
-				'src'  => 'not-a-url',
+				'name'          => 'Invalid collection',
+				'font_families' => 'not-a-url',
 			)
 		);
 		$data       = $collection->get_data();
@@ -342,8 +319,8 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 		$collection = new WP_Font_Collection(
 			'my-collection',
 			array(
-				'name' => 'Missing collection',
-				'src'  => 'https://example.com/fonts/missing-collection.json',
+				'name'          => 'Missing collection',
+				'font_families' => 'https://example.com/fonts/missing-collection.json',
 			)
 		);
 		$data       = $collection->get_data();
@@ -364,8 +341,8 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 		$collection = new WP_Font_Collection(
 			'my-collection',
 			array(
-				'name' => 'Invalid collection',
-				'src'  => 'https://example.com/fonts/invalid-collection.json',
+				'name'          => 'Invalid collection',
+				'font_families' => 'https://example.com/fonts/invalid-collection.json',
 			)
 		);
 		$data       = $collection->get_data();

--- a/tests/phpunit/tests/fonts/font-library/wpRestFontCollectionsController.php
+++ b/tests/phpunit/tests/fonts/font-library/wpRestFontCollectionsController.php
@@ -38,7 +38,13 @@ class Tests_REST_WpRestFontCollectionsController extends WP_Test_REST_Controller
 		$mock_file       = wp_tempnam( 'my-collection-data-' );
 		file_put_contents( $mock_file, '{"name": "Mock Collection", "font_families": [ "mock" ], "categories": [ "mock" ] }' );
 
-		wp_register_font_collection( 'mock-col-slug', $mock_file );
+		wp_register_font_collection(
+			'mock-col-slug',
+			array(
+				'name' => 'My collection',
+				'src'  => $mock_file,
+			)
+		);
 	}
 
 	public static function wpTearDownAfterClass() {
@@ -78,7 +84,13 @@ class Tests_REST_WpRestFontCollectionsController extends WP_Test_REST_Controller
 		$this->setExpectedIncorrectUsage( 'WP_Font_Collection::load_from_json' );
 
 		wp_set_current_user( self::$admin_id );
-		wp_register_font_collection( 'invalid-collection', 'invalid-collection-file' );
+		wp_register_font_collection(
+			'invalid-collection',
+			array(
+				'name' => 'My collection',
+				'src'  => 'invalid-collection-file',
+			)
+		);
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/font-collections' );
 		$response = rest_get_server()->dispatch( $request );
@@ -132,7 +144,13 @@ class Tests_REST_WpRestFontCollectionsController extends WP_Test_REST_Controller
 
 		wp_set_current_user( self::$admin_id );
 		$slug = 'invalid-collection';
-		wp_register_font_collection( $slug, 'invalid-collection-file' );
+		wp_register_font_collection(
+		$slug,
+			array(
+				'name' => 'My collection',
+				'src'  => 'invalid-collection-file',
+			)
+		);
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/font-collections/' . $slug );
 		$response = rest_get_server()->dispatch( $request );

--- a/tests/phpunit/tests/fonts/font-library/wpRestFontCollectionsController.php
+++ b/tests/phpunit/tests/fonts/font-library/wpRestFontCollectionsController.php
@@ -145,7 +145,7 @@ class Tests_REST_WpRestFontCollectionsController extends WP_Test_REST_Controller
 		wp_set_current_user( self::$admin_id );
 		$slug = 'invalid-collection';
 		wp_register_font_collection(
-		$slug,
+			$slug,
 			array(
 				'name' => 'My collection',
 				'src'  => 'invalid-collection-file',

--- a/tests/phpunit/tests/fonts/font-library/wpRestFontCollectionsController.php
+++ b/tests/phpunit/tests/fonts/font-library/wpRestFontCollectionsController.php
@@ -41,8 +41,8 @@ class Tests_REST_WpRestFontCollectionsController extends WP_Test_REST_Controller
 		wp_register_font_collection(
 			'mock-col-slug',
 			array(
-				'name' => 'My collection',
-				'src'  => $mock_file,
+				'name'          => 'My collection',
+				'font_families' => $mock_file,
 			)
 		);
 	}
@@ -87,8 +87,8 @@ class Tests_REST_WpRestFontCollectionsController extends WP_Test_REST_Controller
 		wp_register_font_collection(
 			'invalid-collection',
 			array(
-				'name' => 'My collection',
-				'src'  => 'invalid-collection-file',
+				'name'          => 'My collection',
+				'font_families' => 'invalid-collection-file',
 			)
 		);
 
@@ -147,8 +147,8 @@ class Tests_REST_WpRestFontCollectionsController extends WP_Test_REST_Controller
 		wp_register_font_collection(
 			$slug,
 			array(
-				'name' => 'My collection',
-				'src'  => 'invalid-collection-file',
+				'name'          => 'My collection',
+				'font_families' => 'invalid-collection-file',
 			)
 		);
 
@@ -157,7 +157,7 @@ class Tests_REST_WpRestFontCollectionsController extends WP_Test_REST_Controller
 
 		wp_unregister_font_collection( $slug );
 
-		$this->assertErrorResponse( 'font_collection_json_missing', $response, 500, 'When the collection json file is invalid, the response should return an error for "font_collection_json_missing" with 500 status.' );
+		$this->assertErrorResponse( 'font_collection_json_missing', $response, 500 );
 	}
 
 	/**
@@ -168,11 +168,11 @@ class Tests_REST_WpRestFontCollectionsController extends WP_Test_REST_Controller
 
 		wp_set_current_user( 0 );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_cannot_read', $response, 401, 'The response status should be 401 for non-authenticated users.' );
+		$this->assertErrorResponse( 'rest_cannot_read', $response, 401 );
 
 		wp_set_current_user( self::$editor_id );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_cannot_read', $response, 403, 'The response status should be 403 for users without the right permissions.' );
+		$this->assertErrorResponse( 'rest_cannot_read', $response, 403 );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Changes the data format as per the suggestion on the ticket.

In practice not really a fan of using `_doing_it_wrong()` everywhere instead of using proper exceptions, but alas.

Trac ticket: https://core.trac.wordpress.org/ticket/60509

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
