### PR TITLE
REST API: Fix embedded items 'context' regression

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -743,16 +743,16 @@ class WP_REST_Server {
 						continue;
 					}
 
+					// Embedded resources get passed context=embed.
+					if ( empty( $request['context'] ) ) {
+						$request['context'] = 'embed';
+					}
+
 					if ( empty( $request['per_page'] ) ) {
 						$matched = $this->match_request_to_handler( $request );
 						if ( ! is_wp_error( $matched ) && isset( $matched[1]['args']['per_page']['maximum'] ) ) {
 							$request['per_page'] = (int) $matched[1]['args']['per_page']['maximum'];
 						}
-					}
-
-					// Embedded resources get passed context=embed.
-					if ( empty( $request['context'] ) ) {
-						$request['context'] = 'embed';
 					}
 
 					$response = $this->dispatch( $request );

--- a/tests/phpunit/tests/rest-api/rest-navigation-fallback-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-navigation-fallback-controller.php
@@ -160,30 +160,20 @@ class WP_REST_Navigation_Fallback_Controller_Test extends WP_Test_REST_Controlle
 		// First we'll use the navigation fallback to get a link to the navigation endpoint.
 		$request  = new WP_REST_Request( 'GET', '/wp-block-editor/v1/navigation-fallback' );
 		$response = rest_get_server()->dispatch( $request );
-		$links    = $response->get_links();
-
-		// Extract the navigation endpoint URL from the response.
-		$embedded_navigation_href = $links['self'][0]['href'];
-		preg_match( '/\?rest_route=(.*)/', $embedded_navigation_href, $matches );
-		$navigation_endpoint = $matches[1];
-
-		// Fetch the "linked" navigation post from the endpoint, with the context parameter set to 'embed' to simulate fetching embedded links.
-		$request = new WP_REST_Request( 'GET', $navigation_endpoint );
-		$request->set_param( 'context', 'embed' );
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
+		$data     = rest_get_server()->response_to_data( $response, true );
+		$embedded = $data['_embedded']['self'][0];
 
 		// Verify that the additional status field is present.
-		$this->assertArrayHasKey( 'status', $data, 'Response title should contain a "status" field.' );
+		$this->assertArrayHasKey( 'status', $embedded, 'Response title should contain a "status" field.' );
 
 		// Verify that the additional content fields are present.
-		$this->assertArrayHasKey( 'content', $data, 'Response should contain a "content" field.' );
-		$this->assertArrayHasKey( 'raw', $data['content'], 'Response content should contain a "raw" field.' );
-		$this->assertArrayHasKey( 'rendered', $data['content'], 'Response content should contain a "rendered" field.' );
-		$this->assertArrayHasKey( 'block_version', $data['content'], 'Response should contain a "block_version" field.' );
+		$this->assertArrayHasKey( 'content', $embedded, 'Response should contain a "content" field.' );
+		$this->assertArrayHasKey( 'raw', $embedded['content'], 'Response content should contain a "raw" field.' );
+		$this->assertArrayHasKey( 'rendered', $embedded['content'], 'Response content should contain a "rendered" field.' );
+		$this->assertArrayHasKey( 'block_version', $embedded['content'], 'Response should contain a "block_version" field.' );
 
 		// Verify that the additional title.raw field is present.
-		$this->assertArrayHasKey( 'raw', $data['title'], 'Response title should contain a "raw" key.' );
+		$this->assertArrayHasKey( 'raw', $embedded['title'], 'Response title should contain a "raw" key.' );
 	}
 
 	private function get_navigations_in_database() {


### PR DESCRIPTION
## What
Fixes regression introduced in [#43439](https://core.trac.wordpress.org/ticket/43439), where navigation embed items were missing `raw` property values.

## Why
The `WP_REST_Server::match_request_to_handler` mutates the `$request` object and sets the default `context=view`, which prevents setting `context=embed` as it's appropriate for these requests.

The unit tests missed regression since they didn't mimic the actual requests.

## How
* Update the unit tests to match a request made by the client code.
* Set the `context` before matching a request to the handler.

## Testing instructions
1. Checkout to the test update commit - 2a707e7.
2. Run the unit tests - `npm run test:php -- --filter test_embedded_navigation_post_contains_required_fields`.
3. They will fail.
4. Checkout to the fix commit - a11858d.
5. Rerun the unit tests; they should succeed now.
6. All other tests should be green.

Trac ticket: https://core.trac.wordpress.org/ticket/43439

---
**This Pull Request is for code review only. Please keep all other discussions in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
