### PR TITLE
Block Hooks: Add new `hooked_block` filter

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -895,20 +895,36 @@ function insert_hooked_blocks( &$parsed_anchor_block, $relative_position, $hooke
 		/**
 		 * Filters the parsed block array for a given hooked block.
 		 *
-		 * The dynamic portion of the hook name, `$hooked_block_type`, refers to the block type name of the specific hooked block.
-		 *
 		 * @since 6.5.0
 		 *
 		 * @param array                           $parsed_hooked_block The parsed block array for the given hooked block type.
+		 * @param string                          $hooked_block_type   The hooked block type name.
 		 * @param string                          $relative_position   The relative position of the hooked block.
 		 * @param array                           $parsed_anchor_block The anchor block, in parsed block array format.
 		 * @param WP_Block_Template|WP_Post|array $context             The block template, template part, `wp_navigation` post type,
 		 *                                                             or pattern that the anchor block belongs to.
 		 */
-		$parsed_hooked_block = apply_filters( "hooked_block_{$hooked_block_type}", $parsed_hooked_block, $relative_position, $parsed_anchor_block, $context );
+		$parsed_hooked_block = apply_filters( "hooked_block", $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block, $context );
 
-		// It's possible that the `hooked_block_{$hooked_block_type}` filter returned a block of a different type,
-		// so we explicitly look for the original `$hooked_block_type` in the `ignoredHookedBlocks` metadata.
+
+		/**
+		 * Filters the parsed block array for a given hooked block.
+		 *
+		 * The dynamic portion of the hook name, `$hooked_block_type`, refers to the block type name of the specific hooked block.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param array                           $parsed_hooked_block The parsed block array for the given hooked block type.
+		 * @param string                          $hooked_block_type   The hooked block type name.
+		 * @param string                          $relative_position   The relative position of the hooked block.
+		 * @param array                           $parsed_anchor_block The anchor block, in parsed block array format.
+		 * @param WP_Block_Template|WP_Post|array $context             The block template, template part, `wp_navigation` post type,
+		 *                                                             or pattern that the anchor block belongs to.
+		 */
+		$parsed_hooked_block = apply_filters( "hooked_block_{$hooked_block_type}", $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block, $context );
+
+		// It's possible that the filter returned a block of a different type, so we explicitly
+		// look for the original `$hooked_block_type` in the `ignoredHookedBlocks` metadata.
 		if (
 			! isset( $parsed_anchor_block['attrs']['metadata']['ignoredHookedBlocks'] ) ||
 			! in_array( $hooked_block_type, $parsed_anchor_block['attrs']['metadata']['ignoredHookedBlocks'], true )

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -904,8 +904,7 @@ function insert_hooked_blocks( &$parsed_anchor_block, $relative_position, $hooke
 		 * @param WP_Block_Template|WP_Post|array $context             The block template, template part, `wp_navigation` post type,
 		 *                                                             or pattern that the anchor block belongs to.
 		 */
-		$parsed_hooked_block = apply_filters( "hooked_block", $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block, $context );
-
+		$parsed_hooked_block = apply_filters( 'hooked_block', $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block, $context );
 
 		/**
 		 * Filters the parsed block array for a given hooked block.

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -126,7 +126,7 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 		};
 		add_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 4 );
 		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
-		remove_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 4 );
+		remove_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10 );
 
 		$this->assertSame(
 			'<!-- wp:' . self::HOOKED_BLOCK_TYPE . ' {"layout":{"type":"constrained"}} /-->',
@@ -172,7 +172,7 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 		};
 		add_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
 		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
-		remove_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
+		remove_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10 );
 
 		$this->assertSame(
 			'<!-- wp:group --><div class="wp-block-group"><!-- wp:' . self::HOOKED_BLOCK_TYPE . ' /--></div><!-- /wp:group -->',

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -110,7 +110,7 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 			'innerContent' => array(),
 		);
 
-		$filter = function ( $parsed_hooked_block, $relative_position, $parsed_anchor_block ) {
+		$filter = function ( $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block ) {
 			// Is the hooked block adjacent to the anchor block?
 			if ( 'before' !== $relative_position && 'after' !== $relative_position ) {
 				return $parsed_hooked_block;
@@ -124,9 +124,9 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 
 			return $parsed_hooked_block;
 		};
-		add_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
+		add_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 4 );
 		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
-		remove_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
+		remove_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 4 );
 
 		$this->assertSame(
 			'<!-- wp:' . self::HOOKED_BLOCK_TYPE . ' {"layout":{"type":"constrained"}} /-->',


### PR DESCRIPTION
In [`[57354]`](https://core.trac.wordpress.org/changeset/57354) (https://github.com/WordPress/wordpress-develop/pull/5835), a new `hooked_block_{$block_type}` filter was introduced that allowed extenders to specify attributes and inner blocks for hooked blocks.

@swissspidy [pointed out](https://wordpress.slack.com/archives/C02RQBWTW/p1706191528327749?thread_ts=1706190426.390279&cid=C02RQBWTW) that for filters with a dynamic name portion like this, it is customary to have a "non-dynamic" counterpart filter (i.e. `hooked_block`, in this case).

There are [a few concerns](https://wordpress.slack.com/archives/C02RQBWTW/p1706191801996019?thread_ts=1706190426.390279&cid=C02RQBWTW) around the implications for the function signatures for each filter. We can discuss them here (or on a PR that implements this feature) and decide how to proceed.

Trac ticket: https://core.trac.wordpress.org/ticket/60574

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
