### PR TITLE
Font library: Format and sanitize font family name according the CSS spec

### DIFF
--- a/src/wp-includes/fonts/class-wp-font-collection.php
+++ b/src/wp-includes/fonts/class-wp-font-collection.php
@@ -219,8 +219,10 @@ final class WP_Font_Collection {
 				array(
 					'font_family_settings' => array(
 						'name'       => 'sanitize_text_field',
-						'slug'       => 'sanitize_title',
-						'fontFamily' => 'sanitize_text_field',
+						'slug'       => static function ( $value ) {
+							return _wp_to_kebab_case( sanitize_title( $value ) );
+						},
+						'fontFamily' => 'WP_Font_Utils::sanitize_font_family',
 						'preview'    => 'sanitize_url',
 						'fontFace'   => array(
 							array(

--- a/tests/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
+++ b/tests/phpunit/tests/fonts/font-library/wpFontCollection/getData.php
@@ -159,7 +159,7 @@ class Tests_Fonts_WpFontCollection_GetData extends WP_UnitTestCase {
 					'font_families' => array(
 						array(
 							'font_family_settings' => array(
-								'fontFamily' => 'Open Sans, sans-serif',
+								'fontFamily' => '"Open Sans", sans-serif',
 								'slug'       => 'open-sans',
 								'name'       => 'Open Sans',
 								'fontFace'   => array(

--- a/tests/phpunit/tests/fonts/font-library/wpFontUtils/sanitizeFontFamily.php
+++ b/tests/phpunit/tests/fonts/font-library/wpFontUtils/sanitizeFontFamily.php
@@ -35,16 +35,12 @@ class Tests_Fonts_WpFontUtils_SanitizeFontFamily extends WP_UnitTestCase {
 	public function data_should_sanitize_font_family() {
 		return array(
 			'data_families_with_spaces_and_numbers' => array(
-				'font_family' => 'Rock 3D , Open Sans,serif',
-				'expected'    => '"Rock 3D", "Open Sans", serif',
+				'font_family' => 'Arial, Rock 3D , Open Sans,serif',
+				'expected'    => 'Arial, "Rock 3D", "Open Sans", serif',
 			),
 			'data_single_font_family'               => array(
 				'font_family' => 'Rock 3D',
 				'expected'    => '"Rock 3D"',
-			),
-			'data_no_spaces'                        => array(
-				'font_family' => 'Rock3D',
-				'expected'    => 'Rock3D',
 			),
 			'data_many_spaces_and_existing_quotes'  => array(
 				'font_family' => 'Rock 3D serif, serif,sans-serif, "Open Sans"',
@@ -57,6 +53,10 @@ class Tests_Fonts_WpFontUtils_SanitizeFontFamily extends WP_UnitTestCase {
 			'data_font_family_with_whitespace_tags_new_lines' => array(
 				'font_family' => "   Rock      3D</style><script>alert('XSS');</script>\n    ",
 				'expected'    => '"Rock 3D"',
+			),
+			'data_font_family_with_generic_names' => array(
+				'font_family' => "generic(kai), generic(font[name]), generic(fangsong), Rock 3D",
+				'expected'    => 'generic(kai), "generic(font[name])", generic(fangsong), "Rock 3D"',
 			),
 		);
 	}

--- a/tests/phpunit/tests/fonts/font-library/wpFontUtils/sanitizeFontFamily.php
+++ b/tests/phpunit/tests/fonts/font-library/wpFontUtils/sanitizeFontFamily.php
@@ -55,7 +55,7 @@ class Tests_Fonts_WpFontUtils_SanitizeFontFamily extends WP_UnitTestCase {
 				'expected'    => '"Rock 3D"',
 			),
 			'data_font_family_with_generic_names' => array(
-				'font_family' => "generic(kai), generic(font[name]), generic(fangsong), Rock 3D",
+				'font_family' => 'generic(kai), generic(font[name]), generic(fangsong), Rock 3D',
 				'expected'    => 'generic(kai), "generic(font[name])", generic(fangsong), "Rock 3D"',
 			),
 		);

--- a/tests/phpunit/tests/fonts/font-library/wpFontUtils/sanitizeFontFamily.php
+++ b/tests/phpunit/tests/fonts/font-library/wpFontUtils/sanitizeFontFamily.php
@@ -54,7 +54,7 @@ class Tests_Fonts_WpFontUtils_SanitizeFontFamily extends WP_UnitTestCase {
 				'font_family' => "   Rock      3D</style><script>alert('XSS');</script>\n    ",
 				'expected'    => '"Rock 3D"',
 			),
-			'data_font_family_with_generic_names' => array(
+			'data_font_family_with_generic_names'   => array(
 				'font_family' => 'generic(kai), generic(font[name]), generic(fangsong), Rock 3D',
 				'expected'    => 'generic(kai), "generic(font[name])", generic(fangsong), "Rock 3D"',
 			),

--- a/tests/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
+++ b/tests/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
@@ -681,7 +681,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 
 		$settings = array(
 			'name'       => 'Open Sans',
-			'fontFamily' => '"Open Sans, "Noto Sans", sans-serif',
+			'fontFamily' => 'Open Sans, "Noto Sans", sans-serif',
 			'preview'    => 'https://s.w.org/images/fonts/16.9/previews/open-sans/open-sans-400-normal.svg',
 		);
 
@@ -700,7 +700,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 		$expected_settings = array(
 			'name'       => $settings['name'],
 			'slug'       => 'open-sans-2',
-			'fontFamily' => $settings['fontFamily'],
+			'fontFamily' => '"Open Sans", "Noto Sans", sans-serif',
 			'preview'    => $settings['preview'],
 		);
 		$this->assertSame( $expected_settings, $data['font_family_settings'], 'The response font_family_settings should match expected settings.' );


### PR DESCRIPTION
## What?
Port changes from Gutenberg:
- https://github.com/WordPress/gutenberg/pull/59019
- https://github.com/WordPress/gutenberg/pull/59103



Trac ticket: https://core.trac.wordpress.org/ticket/60537

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
