### PR TITLE
Plugin Dependencies: Support Must-Use plugins as dependencies.

### DIFF
--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -533,7 +533,8 @@ class WP_Plugin_Dependencies {
 		}
 
 		require_once ABSPATH . '/wp-admin/includes/plugin.php';
-		self::$plugins = get_plugins();
+		self::$mustuse_plugins = get_mu_plugins();
+		self::$plugins         = array_merge( get_plugins(), self::$mustuse_plugins );
 
 		return self::$plugins;
 	}

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -597,7 +597,7 @@ class WP_Plugin_Dependencies {
 			$slug = apply_filters( 'wp_plugin_dependencies_slug', $slug );
 
 			// Match to WordPress.org slug format.
-			if ( preg_match( '/^[a-z0-9]+(-[a-z0-9]+)*$/mu', $slug ) ) {
+			if ( preg_match( '/^[a-z0-9]+(-[a-z0-9]+)*?(\.php)?$/mu', $slug ) ) {
 				$sanitized_slugs[] = $slug;
 			}
 		}
@@ -864,9 +864,12 @@ class WP_Plugin_Dependencies {
 	 * @return string The plugin's slug.
 	 */
 	protected static function convert_to_slug( $plugin_file ) {
+		$plugin_file = trim( $plugin_file, " \n\r\t\v\x00./" );
+
 		if ( 'hello.php' === $plugin_file ) {
 			return 'hello-dolly';
 		}
-		return str_contains( $plugin_file, '/' ) ? dirname( $plugin_file ) : str_replace( '.php', '', $plugin_file );
+
+		return str_contains( $plugin_file, '/' ) ? dirname( $plugin_file ) : basename( $plugin_file );
 	}
 }

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -249,7 +249,10 @@ class WP_Plugin_Dependencies {
 		foreach ( self::$dependencies[ $plugin_file ] as $dependency ) {
 			$dependency_filepath = self::get_dependency_filepath( $dependency );
 
-			if ( false === $dependency_filepath || is_plugin_inactive( $dependency_filepath ) ) {
+			if (
+				false === $dependency_filepath ||
+				( ! isset( self::$mustuse_plugins[ $dependency_filepath ] ) && is_plugin_inactive( $dependency_filepath ) )
+			) {
 				return true;
 			}
 		}

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -16,7 +16,16 @@
 class WP_Plugin_Dependencies {
 
 	/**
-	 * Holds 'get_plugins()'.
+	 * Holds Must-Use plugins.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @var array
+	 */
+	protected static $mustuse_plugins;
+
+	/**
+	 * Holds plugins and Must-Use plugins.
 	 *
 	 * @since 6.5.0
 	 *

--- a/tests/phpunit/tests/admin/plugin-dependencies/base.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/base.php
@@ -23,6 +23,7 @@ abstract class WP_PluginDependencies_UnitTestCase extends WP_UnitTestCase {
 	 * @var array
 	 */
 	protected static $static_properties = array(
+		'mustuse_plugins'             => null,
 		'plugins'                     => null,
 		'plugin_dirnames'             => null,
 		'dependencies'                => null,

--- a/tests/phpunit/tests/admin/plugin-dependencies/hasDependents.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/hasDependents.php
@@ -22,8 +22,8 @@ class Tests_Admin_WPPluginDependencies_HasDependents extends WP_PluginDependenci
 	 * @ticket 22316
 	 */
 	public function test_should_return_true_when_a_plugin_has_dependents() {
-		$this->set_property_value( 'dependency_slugs', array( 'dependent' ) );
-		$this->assertTrue( self::$instance::has_dependents( 'dependent/dependent.php' ) );
+		$this->set_property_value( 'dependency_slugs', array( 'dependency' ) );
+		$this->assertTrue( self::$instance::has_dependents( 'dependency/dependency.php' ) );
 	}
 
 	/**
@@ -42,8 +42,8 @@ class Tests_Admin_WPPluginDependencies_HasDependents extends WP_PluginDependenci
 	 * @ticket 22316
 	 */
 	public function test_should_return_false_when_a_plugin_has_no_dependents() {
-		$this->set_property_value( 'dependency_slugs', array( 'dependent2' ) );
-		$this->assertFalse( self::$instance::has_dependents( 'dependent/dependent.php' ) );
+		$this->set_property_value( 'dependency_slugs', array( 'dependency2' ) );
+		$this->assertFalse( self::$instance::has_dependents( 'dependency/dependency.php' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/admin/plugin-dependencies/hasDependents.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/hasDependents.php
@@ -32,8 +32,8 @@ class Tests_Admin_WPPluginDependencies_HasDependents extends WP_PluginDependenci
 	 * @ticket 22316
 	 */
 	public function test_should_return_true_when_a_single_file_plugin_has_dependents() {
-		$this->set_property_value( 'dependency_slugs', array( 'dependent' ) );
-		$this->assertTrue( self::$instance::has_dependents( 'dependent.php' ) );
+		$this->set_property_value( 'dependency_slugs', array( 'dependency.php' ) );
+		$this->assertTrue( self::$instance::has_dependents( 'dependency.php' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/admin/plugin-dependencies/initialize.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/initialize.php
@@ -272,6 +272,7 @@ class Tests_Admin_WPPluginDependencies_Initialize extends WP_PluginDependencies_
 	 * Tests that dependent files are loaded and slugified.
 	 *
 	 * @ticket 22316
+	 * @ticket 60504
 	 *
 	 * @covers WP_Plugin_Dependencies::read_dependencies_from_plugin_headers
 	 * @covers WP_Plugin_Dependencies::convert_to_slug
@@ -285,7 +286,7 @@ class Tests_Admin_WPPluginDependencies_Initialize extends WP_PluginDependencies_
 			if ( 'hello.php' === $plugin_file ) {
 				$slug = 'hello-dolly';
 			} else {
-				$slug = str_replace( '.php', '', explode( '/', $plugin_file )[0] );
+				$slug = explode( '/', $plugin_file )[0];
 			}
 
 			$expected_slugs[ $plugin_file ] = $slug;

--- a/tests/phpunit/tests/admin/plugin-dependencies/initialize.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/initialize.php
@@ -69,6 +69,7 @@ class Tests_Admin_WPPluginDependencies_Initialize extends WP_PluginDependencies_
 		 */
 		return self::text_array_to_dataprovider(
 			array(
+				'mustuse_plugins',
 				'plugins',
 				'dependencies',
 				'dependency_slugs',

--- a/tests/phpunit/tests/admin/plugin-dependencies/initialize.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/initialize.php
@@ -368,4 +368,127 @@ class Tests_Admin_WPPluginDependencies_Initialize extends WP_PluginDependencies_
 			),
 		);
 	}
+
+	/**
+	 * Tests that Must-Use plugins that are dependencies are detected.
+	 *
+	 * @ticket 60504
+	 *
+	 * @covers WP_Plugin_Dependencies::read_dependencies_from_plugin_headers
+	 * @covers WP_Plugin_Dependencies::sanitize_dependency_slugs
+	 */
+	public function test_should_detect_mustuse_plugins_that_are_dependencies() {
+		$mustuse_plugins = array(
+			'woocommerce-loader.php' => array(
+				'Name'            => 'WooCommerce',
+				'RequiresPlugins' => '',
+			),
+		);
+
+		$plugins = array(
+			'dependent/dependent.php' => array(
+				'Name'            => 'Dependent 1',
+				'RequiresPlugins' => 'woocommerce',
+			),
+			// Must-Use plugins are merged into the plugins property.
+			'woocommerce-loader.php'  => array(
+				'Name'            => 'WooCommerce',
+				'RequiresPlugins' => '',
+			),
+		);
+
+		$this->set_property_value( 'mustuse_plugins', $mustuse_plugins );
+		$this->set_property_value( 'plugins', $plugins );
+
+		add_filter(
+			'wp_plugin_dependencies_slug',
+			static function ( $slug ) {
+				if ( 'woocommerce' === $slug ) {
+					$slug = 'woocommerce-loader.php';
+				}
+
+				return $slug;
+			}
+		);
+
+		self::$instance->initialize();
+		$this->assertSame(
+			array( 'woocommerce-loader.php' ),
+			$this->get_property_value( 'dependency_slugs' ),
+			'The Must-Use plugin was not detected.'
+		);
+
+		$this->assertFalse(
+			self::$instance->has_unmet_dependencies( 'dependent/dependent.php' ),
+			'The Must-Use plugin was not considered when checking for unmet dependencies.'
+		);
+	}
+
+	/**
+	 * Tests that a "normal" install of a dependency is ignored as a dependency when
+	 * a Must-Use version is installed.
+	 *
+	 * @ticket 60504
+	 *
+	 * @covers WP_Plugin_Dependencies::read_dependencies_from_plugin_headers
+	 * @covers WP_Plugin_Dependencies::sanitize_dependency_slugs
+	 */
+	public function test_normal_plugin_install_is_ignored_when_a_mustuse_plugin_exists() {
+		$mustuse_plugins = array(
+			'woocommerce-loader.php' => array(
+				'Name'            => 'WooCommerce',
+				'RequiresPlugins' => '',
+			),
+		);
+
+		$plugins = array(
+			'dependent/dependent.php'     => array(
+				'Name'            => 'Dependent 1',
+				'RequiresPlugins' => 'woocommerce',
+			),
+			// Must-Use plugins are merged into the plugins property.
+			'woocommerce-loader.php'      => array(
+				'Name'            => 'WooCommerce',
+				'RequiresPlugins' => '',
+			),
+			'woocommerce/woocommerce.php' => array(
+				'Name'            => 'WooCommerce',
+				'RequiresPlugins' => '',
+			),
+		);
+
+		$this->set_property_value( 'mustuse_plugins', $mustuse_plugins );
+		$this->set_property_value( 'plugins', $plugins );
+
+		add_filter(
+			'wp_plugin_dependencies_slug',
+			static function ( $slug ) {
+				if ( 'woocommerce' === $slug ) {
+					$slug = 'woocommerce-loader.php';
+				}
+
+				return $slug;
+			}
+		);
+
+		self::$instance->initialize();
+		$dependency_slugs = $this->get_property_value( 'dependency_slugs' );
+
+		$this->assertContains(
+			'woocommerce-loader.php',
+			$dependency_slugs,
+			'The Must-Use plugin was not detected.'
+		);
+
+		$this->assertNotContains(
+			'woocommerce',
+			$dependency_slugs,
+			'The "normal" plugin install was not ignored.'
+		);
+
+		$this->assertFalse(
+			self::$instance->has_unmet_dependencies( 'dependent/dependent.php' ),
+			'The dependent plugin has unmet dependencies.'
+		);
+	}
 }


### PR DESCRIPTION
Previously, Must-Use plugins were not taken into account as dependencies. This meant that dependents could only be installed if their dependencies were installed as "normal" plugins.

This adds support for detecting Must-Use plugins as dependencies.

Note:
Must-Use plugins are loaded by a "loader" file in `wp-content/mu-plugins/`, such as `woocommerce-loader.php`. WordPress Core does not know that this file is connected to the dependency plugin.

To tell WordPress Core that the loader file should be considered the dependency plugin's "main" file, a filter must be used in the loader file.

Example:
```php
// Load the dependency plugin's file.
require_once __DIR__ . '/woocommerce/woocommerce.php';

add_filter(
	'wp_plugin_dependencies_slug',
	static function ( $slug ) {
		if ( 'woocommerce' === $slug ) {
			// Tell WordPress Core to consider this file to be the dependency's "main" plugin file.
			$slug = basename( __FILE__ );
		}
		return $slug;
	}
);
```

Trac ticket: https://core.trac.wordpress.org/ticket/60504