### PR TITLE
Check if key exists

### DIFF
--- a/src/wp-includes/class-wp-roles.php
+++ b/src/wp-includes/class-wp-roles.php
@@ -290,7 +290,7 @@ class WP_Roles {
 		$this->role_names   = array();
 		foreach ( array_keys( $this->roles ) as $role ) {
 			$this->role_objects[ $role ] = new WP_Role( $role, $this->roles[ $role ]['capabilities'] );
-			$this->role_names[ $role ]   = $this->roles[ $role ]['name'];
+			$this->role_names[ $role ]   = ( isset( $this->roles[ $role ]['name'] ) ) ? $this->roles[ $role ]['name'] : 'undefined';
 		}
 
 		/**


### PR DESCRIPTION
We have a problem when we register roles without 'name', as shown in the image, an error is generated.

![image](https://github.com/WordPress/wordpress-develop/assets/252078/6ae6f2a8-ef91-4dab-b6ec-b30af1b53a77)

I will make other proposals below:

```php
foreach ( array_keys( $this->roles ) as $role ) {
	if( ! isset( $this->roles[ $role ]['name'] ) ){
		$this->roles[ $role ]['name'] = 'undefined'
	}

	$this->role_objects[ $role ] = new WP_Role( $role, $this->roles[ $role ]['capabilities'] );
	$this->role_names[ $role ]   = $this->roles[ $role ]['name'];
}
````

I don't have context on what the best way is, if anyone could help me I would be very grateful :bowtie:

Trac ticket: [https://core.trac.wordpress.org/ticket/60579](https://core.trac.wordpress.org/ticket/60579)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
