### PR TITLE
Plugin Dependencies: Don't assume API response has a `slug` property.

### DIFF
--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -694,7 +694,7 @@ class WP_Plugin_Dependencies {
 
 			self::$dependency_api_data[ $slug ] = (array) $information;
 			// plugins_api() returns 'name' not 'Name'.
-			self::$dependency_api_data[ $information->slug ]['Name'] = self::$dependency_api_data[ $information->slug ]['name'];
+			self::$dependency_api_data[ $slug ]['Name'] = self::$dependency_api_data[ $slug ]['name'];
 			set_site_transient( 'wp_plugin_dependencies_plugin_data', self::$dependency_api_data, 0 );
 		}
 

--- a/tests/phpunit/tests/admin/plugin-dependencies/getDependencyData.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/getDependencyData.php
@@ -70,4 +70,55 @@ class Tests_Admin_WPPluginDependencies_GetDependencyData extends WP_PluginDepend
 
 		$this->assertFalse( $actual );
 	}
+
+	public function test_should_not_assume_a_slug_key_exists_in_the_response() {
+		global $pagenow;
+
+		// Backup $pagenow.
+		$old_pagenow = $pagenow;
+
+		// Ensure is_admin() and screen checks pass.
+		$pagenow = 'plugins.php';
+		set_current_screen( 'plugins.php' );
+
+		add_filter(
+			'plugins_api',
+			static function ( $bypass, $action, $args ) {
+				if ( 'plugin_information' === $action && isset( $args->slug ) && 'dependency' === $args->slug ) {
+					$bypass = (object) array( 'name' => 'Dependency 1' );
+				}
+				return $bypass;
+			},
+			10,
+			3
+		);
+
+		$this->set_property_value(
+			'plugins',
+			array(
+				'dependent/dependent.php' => array(
+					'Name'            => 'Dependent',
+					'RequiresPlugins' => 'dependency',
+				),
+			)
+		);
+
+		self::$instance->initialize();
+
+		$actual = $this->get_property_value( 'dependency_api_data' );
+
+		// Restore $pagenow.
+		$pagenow = $old_pagenow;
+
+		$this->assertSame(
+			array(
+				'dependency' => array(
+					'name'     => 'Dependency 1',
+					'external' => true,
+					'Name'     => 'Dependency 1',
+				),
+			),
+			$actual
+		);
+	}
 }

--- a/tests/phpunit/tests/admin/plugin-dependencies/getDependencyData.php
+++ b/tests/phpunit/tests/admin/plugin-dependencies/getDependencyData.php
@@ -71,6 +71,11 @@ class Tests_Admin_WPPluginDependencies_GetDependencyData extends WP_PluginDepend
 		$this->assertFalse( $actual );
 	}
 
+	/**
+	 * Tests that a 'slug' key in the Plugins API response object is not assumed.
+	 *
+	 * @ticket 60540
+	 */
 	public function test_should_not_assume_a_slug_key_exists_in_the_response() {
 		global $pagenow;
 


### PR DESCRIPTION
Previously, `WP_Plugin_Dependencies::get_dependency_api_data()` attempted to set an array key using the `slug` property returned in a Plugins API response. However, the Plugins API response is filterable and may not contain a `slug` property.

Earlier in the method, a local `$slug` variable is used as a key for the same array.

For safety and consistency, this replaces array key references to `$information->slug` with `$slug`.

Trac ticket: https://core.trac.wordpress.org/ticket/60540