### PR TITLE
Prevent double-processing new option values/settings

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -927,7 +927,7 @@ function update_option( $option, $value, $autoload = null ) {
 
 	/** This filter is documented in wp-includes/option.php */
 	if ( apply_filters( "default_option_{$option}", false, $option, false ) === $old_value ) {
-		return add_option( $option, $value, '', $autoload );
+		return _add_option( $option, $value, $autoload );
 	}
 
 	$serialized_value = maybe_serialize( $value );
@@ -1049,8 +1049,6 @@ function update_option( $option, $value, $autoload = null ) {
  * @since 6.6.0 The $autoload parameter's default value was changed to null.
  * @since 6.7.0 The autoload values 'yes' and 'no' are deprecated.
  *
- * @global wpdb $wpdb WordPress database abstraction object.
- *
  * @param string    $option     Name of the option to add. Expected to not be SQL-escaped.
  * @param mixed     $value      Optional. Option value. Must be serializable if non-scalar.
  *                              Expected to not be SQL-escaped.
@@ -1068,7 +1066,6 @@ function update_option( $option, $value, $autoload = null ) {
  * @return bool True if the option was added, false otherwise.
  */
 function add_option( $option, $value = '', $deprecated = '', $autoload = null ) {
-	global $wpdb;
 
 	if ( ! empty( $deprecated ) ) {
 		_deprecated_argument( __FUNCTION__, '2.3.0' );
@@ -1112,6 +1109,40 @@ function add_option( $option, $value = '', $deprecated = '', $autoload = null ) 
 	}
 
 	$value = sanitize_option( $option, $value );
+
+	return _add_option( $option, $value, $autoload );
+}
+
+/**
+ * Adds a new option.
+ *
+ * Warning: This is an internal function solely to prevent double-processing the
+ * value when update_option() detects the option does not yet exist. You should
+ * use add_option() instead. Checks to ensure you aren't adding a protected
+ * WordPress option should already have been performed. Do not use those which
+ * are protected. The value is expected to be filtered and sanitized.
+ *
+ * @since X.X.X
+ * @access private
+ *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ *
+ * @param string    $option     Name of the option to add. Expected to not be SQL-escaped.
+ * @param mixed     $value      Optional. Option value. Must be serializable if non-scalar.
+ *                              Expected to not be SQL-escaped.
+ * @param bool|null $autoload   Optional. Whether to load the option when WordPress starts up.
+ *                              Accepts a boolean, or `null` to leave the decision up to default heuristics in WordPress.
+ *                              For backward compatibility 'yes' and 'no' are also accepted.
+ *                              Autoloading too many options can lead to performance problems, especially if the
+ *                              options are not frequently used. For options which are accessed across several places
+ *                              in the frontend, it is recommended to autoload them, by using 'yes'|true.
+ *                              For options which are accessed only on few specific URLs, it is recommended
+ *                              to not autoload them, by using false.
+ *                              Default is null, which means WordPress will determine the autoload value.
+ * @return bool True if the option was added, false otherwise.
+ */
+function _add_option( $option, $value = '', $autoload = null ) {
+	global $wpdb;
 
 	/*
 	 * Make sure the option doesn't already exist.

--- a/tests/phpunit/tests/option/updateOption.php
+++ b/tests/phpunit/tests/option/updateOption.php
@@ -220,9 +220,47 @@ class Tests_Option_UpdateOption extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 21989
+	 *
+	 * @covers ::add_option
+	 * @covers ::add_filter
+	 * @covers ::update_option
+	 * @covers ::remove_filter
+	 * @covers ::get_option
+	 */
+	public function test_stored_sanitized_value_from_update_of_nonexistent_option_should_be_same_as_that_from_add_option() {
+		$before    = 'x';
+		$sanitized = $this->__append_y( $before );
+
+		// Add the comparison option, it did not exist before this.
+		add_filter( 'sanitize_option_doesnotexist_filtered_add', array( $this, '__append_y' ) );
+		add_option( 'doesnotexist_filtered_add', $before );
+		remove_filter( 'sanitize_option_doesnotexist_filtered_add', array( $this, '__append_y' ) );
+
+		// Add the option, it did not exist before this.
+		add_filter( 'sanitize_option_doesnotexist_filtered_update', array( $this, '__append_y' ) );
+		$added = update_option( 'doesnotexist_filtered_update', $before );
+		remove_filter( 'sanitize_option_doesnotexist_filtered_update', array( $this, '__append_y' ) );
+
+		$after = get_option( 'doesnotexist_filtered_update' );
+
+		// Check all values match.
+		$this->assertTrue( $added );
+		$this->assertSame( get_option( 'doesnotexist_filtered_add' ), $after );
+		$this->assertSame( $sanitized, $after );
+	}
+
+	/**
 	 * `add_filter()` callback for test_should_respect_default_option_filter_when_option_does_not_yet_exist_in_database().
 	 */
 	public function __return_foo() {
 		return 'foo';
+	}
+
+	/**
+	 * `add_filter()` callback for test_stored_sanitized_value_from_update_of_nonexistent_option_should_be_same_as_that_from_add_option().
+	 */
+	public function __append_y( $value ) {
+		return $value . '_y';
 	}
 }


### PR DESCRIPTION
A possible solution to the gotcha of relying on the behaviour of `update_option()`, which `register_setting()` does:
>If the option does not exist, it will be created.

It is not obvious to developers that their option will, currently, be sanitised twice in that case. This can easily lead to data corruption, plugin crashes, etc.

This patch is a little bit of a hack inasmuch as any other underscore-prefixed private function, but I don't see another DRY way to bypass only that processing which has already been done.

Trac ticket: https://core.trac.wordpress.org/ticket/21989

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
