### PR TITLE
Fix PHP fatal in rest_filter_response_fields when dealing with scalar values

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -898,7 +898,7 @@ function rest_filter_response_fields( $response, $server, $request ) {
 
 	$fields = wp_parse_list( $request['_fields'] );
 
-	if ( 0 === count( $fields ) || ! is_array( $data ) ) {
+	if ( 0 === count( $fields ) || is_scalar( $data ) ) {
 		return $response;
 	}
 

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -898,7 +898,7 @@ function rest_filter_response_fields( $response, $server, $request ) {
 
 	$fields = wp_parse_list( $request['_fields'] );
 
-	if ( 0 === count( $fields ) ) {
+	if ( 0 === count( $fields ) || ! is_array( $data ) ) {
 		return $response;
 	}
 

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -442,7 +442,7 @@ class Tests_REST_API extends WP_UnitTestCase {
 	public function test_rest_filter_response_fields_single_filter_scalar_response() {
 		$response = new WP_REST_Response();
 		$response->set_data( 200 );
-		$request = array(
+		$request  = array(
 			'_fields' => 'b',
 		);
 		$response = rest_filter_response_fields( $response, null, $request );

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -435,6 +435,21 @@ class Tests_REST_API extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure that result fields do not interfere on scalar values.
+	 *
+	 * @ticket 60599
+	 */
+	public function test_rest_filter_response_fields_single_filter_scalar_response() {
+		$response = new WP_REST_Response();
+		$response->set_data( 200 );
+		$request = array(
+			'_fields' => 'b',
+		);
+		$response = rest_filter_response_fields( $response, null, $request );
+		$this->assertSame( 200, $response->get_data() );
+	}
+
+	/**
 	 * Ensure that multiple comma-separated fields may be allowed with request['_fields'].
 	 */
 	public function test_rest_filter_response_fields_multi_field_filter() {


### PR DESCRIPTION
`rest_filter_response_fields()` does not currently work if a given API endpoint returns an scalar value.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60599

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
