### PR TITLE
Rename to remove instead of deregister

### DIFF
--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -158,7 +158,7 @@ class WP_Script_Modules {
 	 *
 	 * @param string $id The identifier of the script module.
 	 */
-	public function deregister( string $id ) {
+	public function remove( string $id ) {
 		unset( $this->registered[ $id ] );
 		unset( $this->enqueued_before_registered[ $id ] );
 	}

--- a/src/wp-includes/script-modules.php
+++ b/src/wp-includes/script-modules.php
@@ -121,5 +121,5 @@ function wp_dequeue_script_module( string $id ) {
  * @param string $id The identifier of the script module.
  */
 function wp_deregister_script_module( string $id ) {
-	wp_script_modules()->deregister( $id );
+	wp_script_modules()->remove( $id );
 }

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -128,7 +128,7 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 
 
 	/**
-	 * Tests that a script module can be deregistered
+	 * Tests that a script module can be removed
 	 * after being enqueued, and that will be removed
 	 * from the enqueue list too.
 	 *
@@ -136,15 +136,15 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 	 *
 	 * @covers ::register()
 	 * @covers ::enqueue()
-	 * @covers ::deregister()
+	 * @covers ::remove()
 	 * @covers ::get_enqueued_script_modules()
 	 */
-	public function test_wp_deregister_script_module() {
+	public function test_wp_remove_script_module() {
 		$this->script_modules->register( 'foo', '/foo.js' );
 		$this->script_modules->register( 'bar', '/bar.js' );
 		$this->script_modules->enqueue( 'foo' );
 		$this->script_modules->enqueue( 'bar' );
-		$this->script_modules->deregister( 'foo' ); // Dequeued.
+		$this->script_modules->remove( 'foo' ); // Dequeued.
 
 		$enqueued_script_modules = $this->get_enqueued_script_modules();
 
@@ -154,17 +154,17 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that a script module is not deregistered
+	 * Tests that a script module is not removed
 	 * if it has not been registered before, causing
 	 * no errors.
 	 *
 	 * @ticket 60463
 	 *
-	 * @covers ::deregister()
+	 * @covers ::remove()
 	 * @covers ::get_enqueued_script_modules()
 	 */
-	public function test_wp_deregister_unexistent_script_module() {
-		$this->script_modules->deregister( 'unexistent' );
+	public function test_wp_remove_unexistent_script_module() {
+		$this->script_modules->remove( 'unexistent' );
 		$enqueued_script_modules = $this->get_enqueued_script_modules();
 
 		$this->assertCount( 0, $enqueued_script_modules );
@@ -172,27 +172,27 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that a script module is not deregistered
-	 * if it has been deregistered previously, causing
+	 * Tests that a script module is not removed
+	 * if it has been removed previously, causing
 	 * no errors.
 	 *
 	 * @ticket 60463
 	 *
 	 * @covers ::get_enqueued_script_modules()
 	 * @covers ::register()
-	 * @covers ::deregister()
+	 * @covers ::remove()
 	 * @covers ::enqueue()
 	 */
-	public function test_wp_deregister_already_deregistered_script_module() {
+	public function test_wp_remove_already_removed_script_module() {
 		$this->script_modules->register( 'foo', '/foo.js' );
 		$this->script_modules->enqueue( 'foo' );
-		$this->script_modules->deregister( 'foo' ); // Dequeued.
+		$this->script_modules->remove( 'foo' ); // Dequeued.
 		$enqueued_script_modules = $this->get_enqueued_script_modules();
 
 		$this->assertCount( 0, $enqueued_script_modules );
 		$this->assertFalse( isset( $enqueued_script_modules['foo'] ) );
 
-		$this->script_modules->deregister( 'foo' ); // Dequeued.
+		$this->script_modules->remove( 'foo' ); // Dequeued.
 		$enqueued_script_modules = $this->get_enqueued_script_modules();
 
 		$this->assertCount( 0, $enqueued_script_modules );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Changes script module deregister internal function name to `remove`, to keep consistency with the other scripts and styles functions.

Trac ticket: https://core.trac.wordpress.org/ticket/56313
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
