### PR TITLE
Font face resolver: print font faces from font families defined in all theme.json origins

### DIFF
--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -13,13 +13,13 @@
  * @since 6.4.0
  *
  * @param array[][] $fonts {
- *     Optional. The font-families and their font variations. Default empty array.
+ *     Optional. The font-families and their font faces. Default empty array.
  *
- *     @type string $font-family => array[] $variations {
- *         Optional. An associated array of font variations for this font-family.
- *         Each variation has the following structure.
+ *     @type array {
+ *         Optional. An indexed array of font variations for this font-family.
+ *         Each font face has the following structure.
  *
- *         @type array $font_variation {
+ *         @type array {
  *             @type string          $font-family             The font-family property.
  *             @type string|string[] $src                     The URL(s) to each resource containing the font data.
  *             @type string          $font-style              Optional. The font-style property. Default 'normal'.

--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -16,7 +16,7 @@
  *     Optional. The font-families and their font faces. Default empty array.
  *
  *     @type array {
- *         Optional. An indexed array of font variations for this font-family.
+ *         An indexed or associative (keyed by font-family) array of font variations for this font-family.
  *         Each font face has the following structure.
  *
  *         @type array {

--- a/src/wp-includes/fonts/class-wp-font-face-resolver.php
+++ b/src/wp-includes/fonts/class-wp-font-face-resolver.php
@@ -67,12 +67,7 @@ class WP_Font_Face_Resolver {
 					continue;
 				}
 
-				// Prepare the fonts array structure for this font-family.
-				if ( ! array_key_exists( $font_family_name, $fonts ) ) {
-					$fonts[ $font_family_name ] = array();
-				}
-
-				$fonts[ $font_family_name ] = static::convert_font_face_properties( $definition['fontFace'], $font_family_name );
+				$fonts[] = static::convert_font_face_properties( $definition['fontFace'], $font_family_name );
 			}
 		}
 

--- a/tests/phpunit/tests/fonts/font-face/wp-font-face-tests-dataset.php
+++ b/tests/phpunit/tests/fonts/font-face/wp-font-face-tests-dataset.php
@@ -206,7 +206,7 @@ CSS
 			$uri  = get_stylesheet_directory_uri() . '/assets/fonts/';
 			$data = array(
 				'fonts'            => array(
-					'DM Sans'          => array(
+					array(
 						array(
 							'src'          => array( $uri . 'dm-sans/DMSans-Regular.woff2' ),
 							'font-family'  => 'DM Sans',
@@ -236,7 +236,7 @@ CSS
 							'font-weight'  => '700',
 						),
 					),
-					'Source Serif Pro' => array(
+					array(
 						array(
 							'src'          => array( $uri . 'source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2' ),
 							'font-family'  => 'Source Serif Pro',

--- a/tests/phpunit/tests/fonts/font-face/wp-font-face-tests-dataset.php
+++ b/tests/phpunit/tests/fonts/font-face/wp-font-face-tests-dataset.php
@@ -271,4 +271,93 @@ CSS
 
 		return $data;
 	}
+
+	public function get_custom_font_families( $key = '' ) {
+		static $data = null;
+
+		$custom_theme_json_fonts = array(
+			array(
+				'fontFamily' => 'Piazzolla, serif',
+				'name'       => 'Piazzolla',
+				'slug'       => 'piazzolla',
+				'fontFace'   => array(
+					array(
+						'fontFamily' => 'Piazzolla',
+						'src'        => array( 'https://example.org/fonts/piazzolla400.ttf' ),
+						'fontStyle'  => 'normal',
+						'fontWeight' => '400',
+					),
+					array(
+						'fontFamily' => 'Piazzolla',
+						'src'        => array( 'https://example.org/fonts/piazzolla500.ttf' ),
+						'fontStyle'  => 'normal',
+						'fontWeight' => '400',
+					),
+				),
+			),
+			array(
+				'fontFamily' => 'Lobster, sans-serif',
+				'name'       => 'Lobster',
+				'slug'       => 'lobster',
+				'fontFace'   => array(
+					array(
+						'fontFamily' => 'Lobster',
+						'src'        => array( 'https://example.org/fonts/lobster400.ttf' ),
+						'fontStyle'  => 'normal',
+						'fontWeight' => '400',
+					),
+					array(
+						'fontFamily' => 'Lobster',
+						'src'        => array( 'https://example.org/fonts/lobster500.ttf' ),
+						'fontStyle'  => 'normal',
+						'fontWeight' => '500',
+					),
+				),
+			),
+		);
+
+		$expected_font_faces = array(
+			array(
+				array(
+					'src'         => array( 'https://example.org/fonts/piazzolla400.ttf' ),
+					'font-family' => 'Piazzolla',
+					'font-style'  => 'normal',
+					'font-weight' => '400',
+				),
+				array(
+					'src'         => array( 'https://example.org/fonts/piazzolla500.ttf' ),
+					'font-family' => 'Piazzolla',
+					'font-style'  => 'normal',
+					'font-weight' => '400',
+				),
+			),
+			array(
+				array(
+					'src'         => array( 'https://example.org/fonts/lobster400.ttf' ),
+					'font-family' => 'Lobster',
+					'font-style'  => 'normal',
+					'font-weight' => '400',
+				),
+				array(
+					'src'         => array( 'https://example.org/fonts/lobster500.ttf' ),
+					'font-family' => 'Lobster',
+					'font-style'  => 'normal',
+					'font-weight' => '500',
+				),
+			),
+		);
+
+		if ( null === $data ) {
+			$data = array(
+				'input'    => $custom_theme_json_fonts,
+				'expected' => $expected_font_faces,
+			);
+		}
+
+		if ( isset( $data[ $key ] ) ) {
+			return $data[ $key ];
+		}
+
+		return $data;
+	}
 }

--- a/tests/phpunit/tests/fonts/font-face/wp-font-face-tests-dataset.php
+++ b/tests/phpunit/tests/fonts/font-face/wp-font-face-tests-dataset.php
@@ -315,7 +315,7 @@ CSS
 		return $data;
 	}
 
-	public function get_custom_font_families( $key = '' ) {
+	public static function get_custom_font_families( $key = '' ) {
 		static $data = null;
 
 		$custom_theme_json_fonts = array(

--- a/tests/phpunit/tests/fonts/font-face/wp-font-face-tests-dataset.php
+++ b/tests/phpunit/tests/fonts/font-face/wp-font-face-tests-dataset.php
@@ -92,7 +92,7 @@ CSS
 			,
 			),
 			'multiple woff2 format fonts'    => array(
-				'fonts'    => array(
+				'fonts'                  => array(
 					'DM Sans'       =>
 						array(
 							array(
@@ -184,7 +184,7 @@ CSS
 							),
 						),
 				),
-				'expected' => <<<CSS
+				'expected'               => <<<CSS
 @font-face{font-family:"DM Sans";font-style:normal;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular.woff2') format('woff2');font-stretch:normal;}
 @font-face{font-family:"DM Sans";font-style:italic;font-weight:400;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2') format('woff2');font-stretch:normal;}
 @font-face{font-family:"DM Sans";font-style:normal;font-weight:700;font-display:fallback;src:url('https://example.org/assets/fonts/dm-sans/DMSans-Bold.woff2') format('woff2');font-stretch:normal;}
@@ -195,6 +195,49 @@ CSS
 @font-face{font-family:"IBM Plex Mono";font-style:normal;font-weight:700;font-display:block;src:url('https://example.org/assets/fonts/ibm-plex-mono/IBMPlexMono-Bold.woff2') format('woff2');font-stretch:normal;}
 CSS
 			,
+				'indexed array as input' => array(
+					'fonts'    => array(
+						array(
+							array(
+								'font-family'  => 'Piazzolla',
+								'src'          => array( 'https://example.org/fonts/piazzolla400.ttf' ),
+								'font-style'   => 'normal',
+								'font-weight'  => '400',
+								'font-stretch' => 'normal',
+							),
+							array(
+								'font-family'  => 'Piazzolla',
+								'src'          => array( 'https://example.org/fonts/piazzolla500.ttf' ),
+								'font-style'   => 'normal',
+								'font-weight'  => '400',
+								'font-stretch' => 'normal',
+							),
+						),
+						array(
+							array(
+								'font-family'  => 'Lobster',
+								'src'          => array( 'https://example.org/fonts/lobster400.ttf' ),
+								'font-style'   => 'normal',
+								'font-weight'  => '400',
+								'font-stretch' => 'normal',
+							),
+							array(
+								'font-family'  => 'Lobster',
+								'src'          => array( 'https://example.org/fonts/lobster500.ttf' ),
+								'font-style'   => 'normal',
+								'font-weight'  => '500',
+								'font-stretch' => 'normal',
+							),
+						),
+					),
+					'expected' => <<<CSS
+@font-face{font-family:Piazzolla;font-style:normal;font-weight:400;font-display:fallback;src:url('https://example.org/fonts/piazzolla400.ttf') format('truetype');font-stretch:normal;}
+@font-face{font-family:Piazzolla;font-style:normal;font-weight:400;font-display:fallback;src:url('https://example.org/fonts/piazzolla500.ttf') format('truetype');font-stretch:normal;}
+@font-face{font-family:Lobster;font-style:normal;font-weight:400;font-display:fallback;src:url('https://example.org/fonts/lobster400.ttf') format('truetype');font-stretch:normal;}
+@font-face{font-family:Lobster;font-style:normal;font-weight:500;font-display:fallback;src:url('https://example.org/fonts/lobster500.ttf') format('truetype');font-stretch:normal;}
+CSS
+					,
+				),
 			),
 		);
 	}

--- a/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
+++ b/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
@@ -37,6 +37,32 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Font_Face_
 		$this->assertSame( $expected, $actual );
 	}
 
+	public function test_should_return_all_fonts_from_all_theme_origins() {
+		switch_theme( static::FONTS_THEME );
+
+		// Add a filter to add fonts to the theme.json custom origin.
+		add_filter(
+			'wp_theme_json_data_theme',
+			function ( $theme_json_data ) {
+				$data = $theme_json_data->get_data();
+
+				// Add font families to the custom origin of theme json.
+				$data['settings']['typography']['fontFamilies']['custom'] = $this->get_custom_font_families( 'input' );
+
+				return new WP_Theme_JSON_Data( $data );
+			}
+		);
+
+		$actual = WP_Font_Face_Resolver::get_fonts_from_theme_json();
+
+		$expected = array_merge(
+			$this->get_expected_fonts_for_fonts_block_theme( 'fonts' ),
+			$this->get_custom_font_families( 'expected' )
+		);
+
+		$this->assertSame( $expected, $actual, 'Both the fonts from the theme and the custom origin should be returned.' );
+	}
+
 	/**
 	 * @dataProvider data_should_replace_src_file_placeholder
 	 *

--- a/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
+++ b/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
@@ -46,7 +46,7 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Font_Face_
 		// Add a filter to add fonts to the theme.json custom origin.
 		add_filter(
 			'wp_theme_json_data_theme',
-			function ( $theme_json_data ) {
+			static function ( $theme_json_data ) {
 				$data = $theme_json_data->get_data();
 
 				// Add font families to the custom origin of theme json.

--- a/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
+++ b/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
@@ -82,7 +82,7 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Font_Face_
 
 		$font = array_filter(
 			$fonts,
-			function ( $font ) use ( $font_name, $font_weight, $font_style ) {
+			static function ( $font ) use ( $font_name, $font_weight, $font_style ) {
 				return $font['font-family'] === $font_name
 				&& $font['font-weight'] === $font_weight
 				&& $font['font-style'] === $font_style;

--- a/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
+++ b/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
@@ -49,16 +49,19 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Font_Face_
 		switch_theme( static::FONTS_THEME );
 
 		$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
-		$fonts = array_merge( [], ...array_map( 'array_values', $fonts ) );
+		$fonts = array_merge( array(), ...array_map( 'array_values', $fonts ) );
 
-		$font = array_filter($fonts, function ($font) use ($font_name, $font_weight, $font_style) {
-			return $font['font-family'] === $font_name
+		$font = array_filter(
+			$fonts,
+			function ( $font ) use ( $font_name, $font_weight, $font_style ) {
+				return $font['font-family'] === $font_name
 				&& $font['font-weight'] === $font_weight
 				&& $font['font-style'] === $font_style;
-		});
+			}
+		);
 
-		$font = reset($font);
-	
+		$font = reset( $font );
+
 		$expected = get_stylesheet_directory_uri() . $expected;
 		$actual   = $font['src'][0];
 
@@ -75,40 +78,40 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Font_Face_
 		return array(
 			// Theme's theme.json.
 			'DM Sans: 400 normal'              => array(
-				'font_name'  => 'DM Sans',
+				'font_name'   => 'DM Sans',
 				'font_weight' => '400',
-				'font_style' => 'normal',
-				'expected'   => '/assets/fonts/dm-sans/DMSans-Regular.woff2',
+				'font_style'  => 'normal',
+				'expected'    => '/assets/fonts/dm-sans/DMSans-Regular.woff2',
 			),
 			'DM Sans: 400 italic'              => array(
-				'font_name'  => 'DM Sans',
+				'font_name'   => 'DM Sans',
 				'font_weight' => '400',
-				'font_style' => 'italic',
-				'expected'   => '/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2',
+				'font_style'  => 'italic',
+				'expected'    => '/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2',
 			),
 			'DM Sans: 700 normal'              => array(
-				'font_name'  => 'DM Sans',
+				'font_name'   => 'DM Sans',
 				'font_weight' => '700',
-				'font_style' => 'normal',
-				'expected'   => '/assets/fonts/dm-sans/DMSans-Bold.woff2',
+				'font_style'  => 'normal',
+				'expected'    => '/assets/fonts/dm-sans/DMSans-Bold.woff2',
 			),
 			'DM Sans: 700 italic'              => array(
-				'font_name'  => 'DM Sans',
+				'font_name'   => 'DM Sans',
 				'font_weight' => '700',
-				'font_style' => 'italic',
-				'expected'   => '/assets/fonts/dm-sans/DMSans-Bold-Italic.woff2',
+				'font_style'  => 'italic',
+				'expected'    => '/assets/fonts/dm-sans/DMSans-Bold-Italic.woff2',
 			),
 			'Source Serif Pro: 200-900 normal' => array(
-				'font_name'  => 'Source Serif Pro',
+				'font_name'   => 'Source Serif Pro',
 				'font_weight' => '200 900',
-				'font_style' => 'normal',
-				'expected'   => '/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2',
+				'font_style'  => 'normal',
+				'expected'    => '/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2',
 			),
 			'Source Serif Pro: 200-900 italic' => array(
-				'font_name'  => 'Source Serif Pro',
+				'font_name'   => 'Source Serif Pro',
 				'font_weight' => '200 900',
-				'font_style' => 'italic',
-				'expected'   => '/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2',
+				'font_style'  => 'italic',
+				'expected'    => '/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2',
 			),
 		);
 	}
@@ -135,12 +138,15 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Font_Face_
 		remove_filter( 'wp_theme_json_data_theme', $replace_fonts );
 
 		// flatten the array to make it easier to test.
-		$fonts = array_merge( [], ...array_map( 'array_values', $fonts ) );
+		$fonts = array_merge( array(), ...array_map( 'array_values', $fonts ) );
 
-		$fonts_found = array_filter( $fonts, function ($font) use ( $expected_name ) {
-			return $font['font-family'] === $expected_name;
-		});
-		
+		$fonts_found = array_filter(
+			$fonts,
+			function ( $font ) use ( $expected_name ) {
+				return $font['font-family'] === $expected_name;
+			}
+		);
+
 		$this->assertNotEmpty( $fonts_found, 'Expected font-family name not found in the array' );
 	}
 

--- a/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
+++ b/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
@@ -41,16 +41,26 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Font_Face_
 	 * @dataProvider data_should_replace_src_file_placeholder
 	 *
 	 * @param string $font_name  Font's name.
-	 * @param string $font_index Font's index in the $fonts array.
+	 * @param string $font_weight Font's weight.
+	 * @param string $font_style  Font's style.
 	 * @param string $expected   Expected src.
 	 */
-	public function test_should_replace_src_file_placeholder( $font_name, $font_index, $expected ) {
+	public function test_should_replace_src_file_placeholder( $font_name, $font_weight, $font_style, $expected ) {
 		switch_theme( static::FONTS_THEME );
 
 		$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
+		$fonts = array_merge( [], ...array_map( 'array_values', $fonts ) );
 
-		$actual   = $fonts[ $font_name ][ $font_index ]['src'][0];
+		$font = array_filter($fonts, function ($font) use ($font_name, $font_weight, $font_style) {
+			return $font['font-family'] === $font_name
+				&& $font['font-weight'] === $font_weight
+				&& $font['font-style'] === $font_style;
+		});
+
+		$font = reset($font);
+	
 		$expected = get_stylesheet_directory_uri() . $expected;
+		$actual   = $font['src'][0];
 
 		$this->assertStringNotContainsString( 'file:./', $actual, 'Font src should not contain the "file:./" placeholder' );
 		$this->assertSame( $expected, $actual, 'Font src should be an URL to its file' );
@@ -66,32 +76,38 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Font_Face_
 			// Theme's theme.json.
 			'DM Sans: 400 normal'              => array(
 				'font_name'  => 'DM Sans',
-				'font_index' => 0,
+				'font_weight' => '400',
+				'font_style' => 'normal',
 				'expected'   => '/assets/fonts/dm-sans/DMSans-Regular.woff2',
 			),
 			'DM Sans: 400 italic'              => array(
 				'font_name'  => 'DM Sans',
-				'font_index' => 1,
+				'font_weight' => '400',
+				'font_style' => 'italic',
 				'expected'   => '/assets/fonts/dm-sans/DMSans-Regular-Italic.woff2',
 			),
 			'DM Sans: 700 normal'              => array(
 				'font_name'  => 'DM Sans',
-				'font_index' => 2,
+				'font_weight' => '700',
+				'font_style' => 'normal',
 				'expected'   => '/assets/fonts/dm-sans/DMSans-Bold.woff2',
 			),
 			'DM Sans: 700 italic'              => array(
 				'font_name'  => 'DM Sans',
-				'font_index' => 3,
+				'font_weight' => '700',
+				'font_style' => 'italic',
 				'expected'   => '/assets/fonts/dm-sans/DMSans-Bold-Italic.woff2',
 			),
 			'Source Serif Pro: 200-900 normal' => array(
 				'font_name'  => 'Source Serif Pro',
-				'font_index' => 0,
+				'font_weight' => '200 900',
+				'font_style' => 'normal',
 				'expected'   => '/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2',
 			),
 			'Source Serif Pro: 200-900 italic' => array(
 				'font_name'  => 'Source Serif Pro',
-				'font_index' => 1,
+				'font_weight' => '200 900',
+				'font_style' => 'italic',
 				'expected'   => '/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2',
 			),
 		);
@@ -118,7 +134,14 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Font_Face_
 		$fonts = WP_Font_Face_Resolver::get_fonts_from_theme_json();
 		remove_filter( 'wp_theme_json_data_theme', $replace_fonts );
 
-		$this->assertArrayHasKey( $expected_name, $fonts );
+		// flatten the array to make it easier to test.
+		$fonts = array_merge( [], ...array_map( 'array_values', $fonts ) );
+
+		$fonts_found = array_filter( $fonts, function ($font) use ( $expected_name ) {
+			return $font['font-family'] === $expected_name;
+		});
+		
+		$this->assertNotEmpty( $fonts_found, 'Expected font-family name not found in the array' );
 	}
 
 	/**

--- a/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
+++ b/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
@@ -37,6 +37,9 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Font_Face_
 		$this->assertSame( $expected, $actual );
 	}
 
+	/**
+	 * @ticket 60605
+	 */
 	public function test_should_return_all_fonts_from_all_theme_origins() {
 		switch_theme( static::FONTS_THEME );
 

--- a/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
+++ b/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
@@ -43,10 +43,10 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Font_Face_
 	public function test_should_return_all_fonts_from_all_theme_origins() {
 		switch_theme( static::FONTS_THEME );
 
-		$add_custom_fonts = function ( $theme_json_data ) {
+		$add_custom_fonts = static function ( $theme_json_data ) {
 			$data = $theme_json_data->get_data();
 			// Add font families to the custom origin of theme json.
-			$data['settings']['typography']['fontFamilies']['custom'] = $this->get_custom_font_families( 'input' );
+			$data['settings']['typography']['fontFamilies']['custom'] = self::get_custom_font_families( 'input' );
 			return new WP_Theme_JSON_Data( $data );
 		};
 

--- a/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
+++ b/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromThemeJson.php
@@ -43,20 +43,16 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromThemeJson extends WP_Font_Face_
 	public function test_should_return_all_fonts_from_all_theme_origins() {
 		switch_theme( static::FONTS_THEME );
 
-		// Add a filter to add fonts to the theme.json custom origin.
-		add_filter(
-			'wp_theme_json_data_theme',
-			static function ( $theme_json_data ) {
-				$data = $theme_json_data->get_data();
+		$add_custom_fonts = function ( $theme_json_data ) {
+			$data = $theme_json_data->get_data();
+			// Add font families to the custom origin of theme json.
+			$data['settings']['typography']['fontFamilies']['custom'] = $this->get_custom_font_families( 'input' );
+			return new WP_Theme_JSON_Data( $data );
+		};
 
-				// Add font families to the custom origin of theme json.
-				$data['settings']['typography']['fontFamilies']['custom'] = $this->get_custom_font_families( 'input' );
-
-				return new WP_Theme_JSON_Data( $data );
-			}
-		);
-
+		add_filter( 'wp_theme_json_data_theme', $add_custom_fonts );
 		$actual = WP_Font_Face_Resolver::get_fonts_from_theme_json();
+		remove_filter( 'wp_theme_json_data_theme', $add_custom_fonts );
 
 		$expected = array_merge(
 			$this->get_expected_fonts_for_fonts_block_theme( 'fonts' ),


### PR DESCRIPTION
## What?
Font face resolver: If a font family name is repeated across theme.json origins (default, theme, custom), only the font faces from one origin are rendered, so the site lacks the other font faces added. 

This problem was reported originally here: https://github.com/WordPress/gutenberg/issues/58764

## Why?
To print the missing font faces when a font family is defined in more than one place.

## How ?
The `parse_settings` method of the `WP_Font_Face_Resolver` class uses an associative array to list all the font families that must be printed on the page. This PR replaces it with an indexed array because the associative array prevents having more than one font family with the same name, causing the bug that this PR fixes and seems unnecessary. 

## Testing instruction
1. Use a theme with at least one font family defined with some font faces.
2. Using the font library, install a font family with the same name as the existing in the theme.
3. Navigate the site's public frontend and check that all the font faces were printed to the page in the `<style id="wp-fonts-local"></style>` tag.

## Notes
Note 1: Maybe, in the future, we could add some checking to avoid printing repeated font variants (same weight, style, character set, etc). I'm not completely sure that's needed, though, because the browser handles that. Anyways, that's out of the scope of this PR.

Note 2: this issue isn't related strictly to the Font Library. The font library made it visible because of the use of custom apart from theme theme.json data origin, and because of the existing UI is easy to test this using the Font Library.

Note 3: This is an alternative approach to https://github.com/WordPress/gutenberg/pull/59119

--- 
Trac ticket: https://core.trac.wordpress.org/ticket/60605#ticket
