### PR TITLE
Fix WP_Term::$data dynamic property - declare and deprecate prop, move to constructor.

### DIFF
--- a/src/wp-includes/class-wp-term.php
+++ b/src/wp-includes/class-wp-term.php
@@ -100,6 +100,15 @@ final class WP_Term {
 	public $filter = 'raw';
 
 	/**
+	 * Deprecated data property.
+	 *
+	 * @since 4.4.0
+	 * @deprecated 6.5.0 Use WP_Term::to_array() or wp_update_term() instead.
+	 * @var stdClass
+	 */
+	public $data;
+
+	/**
 	 * Retrieve WP_Term instance.
 	 *
 	 * @since 4.4.0
@@ -198,6 +207,15 @@ final class WP_Term {
 		foreach ( get_object_vars( $term ) as $key => $value ) {
 			$this->$key = $value;
 		}
+
+		// Populating the data property here is for backward compatibility.
+		$data    = new stdClass();
+		$columns = array( 'term_id', 'name', 'slug', 'term_group', 'term_taxonomy_id', 'taxonomy', 'description', 'parent', 'count' );
+		foreach ( $columns as $column ) {
+			$data->{$column} = isset( $this->{$column} ) ? $this->{$column} : null;
+		}
+
+		$this->data = sanitize_term( $data, $data->taxonomy, 'raw' );
 	}
 
 	/**
@@ -219,27 +237,11 @@ final class WP_Term {
 	 * @return array Object as array.
 	 */
 	public function to_array() {
-		return get_object_vars( $this );
-	}
+		$term = get_object_vars( $this );
 
-	/**
-	 * Getter.
-	 *
-	 * @since 4.4.0
-	 *
-	 * @param string $key Property to get.
-	 * @return mixed Property value.
-	 */
-	public function __get( $key ) {
-		switch ( $key ) {
-			case 'data':
-				$data    = new stdClass();
-				$columns = array( 'term_id', 'name', 'slug', 'term_group', 'term_taxonomy_id', 'taxonomy', 'description', 'parent', 'count' );
-				foreach ( $columns as $column ) {
-					$data->{$column} = isset( $this->{$column} ) ? $this->{$column} : null;
-				}
+		// Remove the deprecated data property.
+		unset( $term['data'] );
 
-				return sanitize_term( $data, $data->taxonomy, 'raw' );
-		}
+		return $term;
 	}
 }

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -3210,7 +3210,7 @@ function wp_update_term( $term_id, $taxonomy, $args = array() ) {
 		return new WP_Error( 'invalid_term', __( 'Empty Term.' ) );
 	}
 
-	$term = (array) $term->data;
+	$term = $term->to_array();
 
 	// Escape data pulled from DB.
 	$term = wp_slash( $term );

--- a/tests/phpunit/tests/term/wpUpdateTerm.php
+++ b/tests/phpunit/tests/term/wpUpdateTerm.php
@@ -802,4 +802,67 @@ class Tests_Term_WpUpdateTerm extends WP_UnitTestCase {
 		$this->assertWPError( $found );
 		$this->assertSame( 'invalid_term', $found->get_error_code() );
 	}
+
+	/**
+	 * Tests a directly modified property of a term object gets properly updated.
+	 *
+	 * @ticket 58087
+	 */
+	public function test_description_updates_after_directly_changing_object_description() {
+		register_taxonomy( 'wptests_tax', 'post' );
+		$t = self::factory()->term->create_and_get(
+			array(
+				'taxonomy'    => 'wptests_tax',
+				'slug'        => 'test',
+				'description' => 'Test',
+			)
+		);
+
+		$expected_description = 'Did it update to this description?';
+		$t->description       = 'Test directly changing the description property';
+
+		$found = wp_update_term(
+			$t->term_id,
+			'wptests_tax',
+			array(
+				'description' => $expected_description,
+			)
+		);
+
+		$term = get_term( $found['term_id'], 'wptests_tax' );
+		_unregister_taxonomy( 'wptests_tax' );
+
+		$this->assertSame( $expected_description, $term->description );
+	}
+
+	/**
+	 * @ticket 58087
+	 */
+	public function test_term_properties_update() {
+		register_taxonomy( 'wptests_tax', 'post' );
+		$t = self::factory()->term->create(
+			array(
+				'taxonomy'    => 'wptests_tax',
+				'slug'        => 'test',
+				'description' => 'Test',
+			)
+		);
+
+		$found = wp_update_term(
+			$t,
+			'wptests_tax',
+			array(
+				'name'        => 'Updated test',
+				'slug'        => 'updated-test',
+				'description' => 'Updated description',
+			)
+		);
+
+		$term = get_term( $found['term_id'], 'wptests_tax' );
+		_unregister_taxonomy( 'wptests_tax' );
+
+		$this->assertSame( 'Updated test', $term->name, 'The term name should update' );
+		$this->assertSame( 'updated-test', $term->slug, 'The term slug should update' );
+		$this->assertSame( 'Updated description', $term->description, 'The term description should update' );
+	}
 }


### PR DESCRIPTION
Fixes the dynamic property by:

- Declaring it on the class.
- Deprecating it.
- Moving its code to the constructor.
- Removing the `__get()`.
- Replacing the property's usage in `wp_update_term()`.

Trac ticket: https://core.trac.wordpress.org/ticket/58087

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
