### PR TITLE
use sprint for wp_remove_surrounding_empty_script_tags

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3391,6 +3391,15 @@ function wp_remove_surrounding_empty_script_tags( $contents ) {
 	} else {
 		$error_message = __( 'Expected string to start with script tag (without attributes) and end with script tag, with optional whitespace.' );
 		_doing_it_wrong( __FUNCTION__, $error_message, '6.4' );
-		return sprintf( 'console.error(%s)', wp_json_encode( __( 'Function wp_remove_surrounding_empty_script_tags() used incorrectly in PHP.' ) . ' ' . $error_message ) );
+		return sprintf(
+			'console.error(%s)',
+			wp_json_encode(
+				sprintf(
+					/* translators: %s: wp_remove_surrounding_empty_script_tags() */
+					__( 'Function %s used incorrectly in PHP.' ),
+					'wp_remove_surrounding_empty_script_tags()'
+				) . ' ' . $error_message
+			)
+		);
 	}
 }


### PR DESCRIPTION
I use sprint to prevent to translate "wp_remove_surrounding_empty_script_tags".

The detailed explanation is as follows, quoted from the track.

> The function wp_remove_surrounding_empty_script_tags() currently uses the following function call:
__( 'Function wp_remove_surrounding_empty_script_tags() used incorrectly in PHP.' )
wp_remove_surrounding_empty_script_tags() should not be translatable.

Trac ticket: https://core.trac.wordpress.org/ticket/60590

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
