### PR TITLE
Theme JSON: Check for null values to cater for blockGap

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -3857,12 +3857,18 @@ class WP_Theme_JSON {
 	 * Replaces CSS variables with their values in place.
 	 *
 	 * @since 6.3.0
+	 * @since 6.5.0 Check for empty style before processing its value.
+	 *
 	 * @param array $styles CSS declarations to convert.
 	 * @param array $values key => value pairs to use for replacement.
 	 * @return array
 	 */
 	private static function convert_variables_to_value( $styles, $values ) {
 		foreach ( $styles as $key => $style ) {
+			if ( empty( $style ) ) {
+				continue;
+			}
+
 			if ( is_array( $style ) ) {
 				$styles[ $key ] = self::convert_variables_to_value( $style, $values );
 				continue;

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -5092,10 +5092,11 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		$this->assertEquals( 'var(--wp--preset--color--s)', $styles['blocks']['core/quote']['variations']['plain']['color']['background'], 'Style variations: Assert the internal variables are convert to CSS custom variables.' );
 	}
 
-	/*
+	/**
 	 * Tests that the theme.json file is correctly parsed and the variables are resolved.
 	 *
 	 * @ticket 58588
+	 * @ticket 60613
 	 *
 	 * @covers WP_Theme_JSON_Gutenberg::resolve_variables
 	 * @covers WP_Theme_JSON_Gutenberg::convert_variables_to_value

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -5276,8 +5276,15 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		 * As with wp_get_global_styles(), WP_Theme_JSON::resolve_variables may be called with merged data from
 		 * WP_Theme_JSON_Resolver. WP_Theme_JSON_Resolver::get_block_data() sets blockGap for supported blocks to `null` if the value is not defined.
 		 */
-		$this->assertNull( $styles['blocks']['core/post-template']['spacing']['blockGap'], 'core/post-template block: blockGap' );
-		$this->assertEquals( $spacing, $styles['blocks']['core/columns']['spacing']['blockGap'], 'core/columns block: blockGap' );
+		$this->assertNull(
+			$styles['blocks']['core/post-template']['spacing']['blockGap'],
+			'Blocks: Post Template spacing.blockGap should be null'
+		);
+		$this->assertEquals(
+			$spacing,
+			$styles['blocks']['core/columns']['spacing']['blockGap'],
+			'Blocks: Columns spacing.blockGap should match'
+		);
 	}
 
 	/**


### PR DESCRIPTION
Syncs changes from

- https://github.com/WordPress/gutenberg/pull/59258

When resolving theme.json preset variables, add a check to make sure the value is not empty before we run it through `strpos()` and `preg_match_all()`.


Run the tests:

`npm run test:php -- --filter Tests_Theme_wpThemeJson`


Trac ticket: https://core.trac.wordpress.org/ticket/60613

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
