### PR TITLE
Fix line breaks in columns with quick edit mode (any post). #58909

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1039,6 +1039,7 @@ tr.inline-edit-row td {
 	float: left;
 	width: 6em;
 	line-height: 2.5;
+	hyphens: auto;
 }
 
 #posts-filter fieldset.inline-edit-date legend {


### PR DESCRIPTION

Line breaks in columns on quick edit mode (any post) if the translation of the label becomes too long in any language. 

Adds `hyphens: auto`  

### With issue

![width-issue](https://github.com/WordPress/wordpress-develop/assets/28216793/85c1ad66-3671-4342-978c-5c38e1036331)


### After issue fixed

![width-issues-solution](https://github.com/WordPress/wordpress-develop/assets/28216793/ae079ea0-8932-44cc-8e93-e02cf0a8ae0b)



Trac ticket: [https://core.trac.wordpress.org/ticket/58909](url)

