### PR TITLE
Export font families and font faces post on site export

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -592,6 +592,7 @@ function create_initial_post_types() {
 			'show_in_rest'                   => true,
 			'rest_base'                      => 'font-families',
 			'rest_controller_class'          => 'WP_REST_Font_Families_Controller',
+			'can_export'                     => true,
 			// Disable autosave endpoints for font families.
 			'autosave_rest_controller_class' => 'stdClass',
 		)
@@ -625,6 +626,7 @@ function create_initial_post_types() {
 			'show_in_rest'                   => true,
 			'rest_base'                      => 'font-families/(?P<font_family_id>[\d]+)/font-faces',
 			'rest_controller_class'          => 'WP_REST_Font_Faces_Controller',
+			'can_export'                     => true,
 			// Disable autosave endpoints for font faces.
 			'autosave_rest_controller_class' => 'stdClass',
 		)


### PR DESCRIPTION
## What?
Export font families (`wp_font_family` post type) and font faces (`wp_font_face` post type) posts when exporting a site.


## Why?
To export this new type of content handled by Wordpress.


## How?
Exporting `wp_font_family` and `wp_font_face` post types when exporting a site.


## Note
This is just the export part. The import part will be implemented in the `wordpress-importer` repo: https://github.com/WordPress/wordpress-importer/pull/160

---


Trac ticket: https://core.trac.wordpress.org/ticket/60626



---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
