### PR TITLE
Shadow: add shadow/defaultPresets to apperance tools opt ins

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -679,6 +679,7 @@ class WP_Theme_JSON {
 		array( 'spacing', 'margin' ),
 		array( 'spacing', 'padding' ),
 		array( 'typography', 'lineHeight' ),
+		array( 'shadow', 'defaultPresets' ),
 	);
 
 	/**

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -293,6 +293,9 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			'typography' => array(
 				'lineHeight' => true,
 			),
+			'shadow'     => array(
+				'defaultPresets' => true,
+			),
 			'blocks'     => array(
 				'core/paragraph' => array(
 					'typography' => array(
@@ -330,6 +333,9 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 					),
 					'typography' => array(
 						'lineHeight' => false,
+					),
+					'shadow'     => array(
+						'defaultPresets' => true,
 					),
 				),
 			),


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60633

It is a backport change for the following Gutenberg change:

https://github.com/WordPress/gutenberg/pull/58766

It adds `array( 'shadow', 'defaultPresets' )` to appearance tools opt ins. and is also expected to merge in WordPress 6.5 (Beta 3)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
