### PR TITLE
DO NOT MERGE: `wp_list_pluck()` object regression tests - before and after r57698

### DIFF
--- a/src/wp-includes/class-wp-list-util.php
+++ b/src/wp-includes/class-wp-list-util.php
@@ -165,11 +165,15 @@ class WP_List_Util {
 			 */
 			foreach ( $this->output as $key => $value ) {
 				if ( is_object( $value ) ) {
-					if ( property_exists( $value, $field ) ) {
+					if ( isset( $GLOBALS['before_r57698'] ) ) {
+						$newlist[ $key ] = $value->$field;
+					} elseif ( property_exists( $value, $field ) ) {
 						$newlist[ $key ] = $value->$field;
 					}
 				} elseif ( is_array( $value ) ) {
-					if ( array_key_exists( $field, $value ) ) {
+					if ( isset( $GLOBALS['before_r57698'] ) ) {
+						$newlist[ $key ] = $value[ $field ];
+					} elseif ( array_key_exists( $field, $value ) ) {
 						$newlist[ $key ] = $value[ $field ];
 					}
 				} else {
@@ -192,7 +196,13 @@ class WP_List_Util {
 		 */
 		foreach ( $this->output as $value ) {
 			if ( is_object( $value ) ) {
-				if ( property_exists( $value, $field ) ) {
+				if ( isset( $GLOBALS['before_r57698'] ) ) {
+					if ( isset( $value->$index_key ) ) {
+						$newlist[ $value->$index_key ] = $value->$field;
+					} else {
+						$newlist[] = $value->$field;
+					}
+				} elseif ( property_exists( $value, $field ) ) {
 					if ( property_exists( $value, $index_key ) ) {
 						$newlist[ $value->$index_key ] = $value->$field;
 					} else {
@@ -200,7 +210,13 @@ class WP_List_Util {
 					}
 				}
 			} elseif ( is_array( $value ) ) {
-				if ( array_key_exists( $field, $value ) ) {
+				if ( isset( $GLOBALS['before_r57698'] ) ) {
+					if ( isset( $value->$index_key ) ) {
+						$newlist[ $value[ $index_key ] ] = $value[ $field ];
+					} else {
+						$newlist[] = $value[ $field ];
+					}
+				} elseif ( array_key_exists( $field, $value ) ) {
 					if ( array_key_exists( $index_key, $value ) ) {
 						$newlist[ $value[ $index_key ] ] = $value[ $field ];
 					} else {


### PR DESCRIPTION
DO NOT REVIEW OR COMMIT THIS PR. 

Purpose: to better understand and demonstrate how `wp_list_pluck()` used to and now should handle different object scenarios, such as:

- Class with both a `__get()` and `__isset()`.
- Class with a `__get()` but no `__isset()`.
- A `__isset()` that does not handle `null`.
- Dynamic properties.
- "compat_fields" (compatible but no intended for public) properties.

The original code before r57698 is run via a global `$GLOBALS['before_r57698']`. 

Trac ticket: https://core.trac.wordpress.org/ticket/59774

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
