### PR TITLE
HTML API: Ensure that breadcrumbs are properly retained after seeking.

### DIFF
--- a/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
@@ -545,4 +545,26 @@ HTML
 		$processor->seek( 'second' );
 		$this->assertTrue( $processor->get_attribute( 'two' ) );
 	}
+
+	/**
+	 * Ensures that breadcrumbs are properly reported after seeking backward to a location
+	 * inside an element which has been fully closed before the seek.
+	 *
+	 * @ticket 60687
+	 */
+	public function test_retains_proper_bookmarks_after_seeking_back_to_closed_element() {
+		$processor = WP_HTML_Processor::create_fragment( '<div><img></div><div><hr></div>' );
+
+		$processor->next_tag( 'IMG' );
+		$processor->set_bookmark( 'first' );
+
+		$processor->next_tag( 'HR' );
+
+		$processor->seek( 'first' );
+		$this->assertSame(
+			array( 'HTML', 'BODY', 'DIV', 'IMG' ),
+			$processor->get_breadcrumbs(),
+			'Should have retained breadcrumbs from bookmarked location after seeking backwards to it.'
+		);
+	}
 }


### PR DESCRIPTION
Trac ticket: Core-60687

In some cases, it's possible to seek back into a location found inside an element which has been completely closed before the seek. In these cases the breadcrumb stack is lost, and calling `get_breadcrumbs()` after the seek will return the wrong information.

This patch changes the `seek()` behavior to rewind to the start of the document and re-parse everything up until the sought-after bookmark location. This is a drastic choice but maintains the accuracy of the breadcrumbs. While slow, this can be later optimized in a way that preserves the parser state.