### PR TITLE
Update Strings used in site icon in customizer.

### DIFF
--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -5198,10 +5198,9 @@ final class WP_Customize_Manager {
 				array(
 					'label'       => __( 'Site Icon' ),
 					'description' => sprintf(
-						'<p>' . __( 'Site Icons are what you see in browser tabs, bookmark bars, and within the WordPress mobile apps. Upload one here!' ) . '</p>' .
-						/* translators: %s: Site icon size in pixels. */
-						'<p>' . __( 'Site Icons should be square and at least %s pixels.' ) . '</p>',
-						'<strong>512 &times; 512</strong>'
+						/* translators: %s: Site Icon size in pixels. */
+						'<p>' . __( 'Site Icons are what you see in browser tabs, bookmark bars, and within the WordPress mobile apps. They should be square and at least %s pixels.' ) . '</p>',
+						'<code>512 &times; 512</code>'
 					),
 					'section'     => 'title_tagline',
 					'priority'    => 60,

--- a/src/wp-includes/customize/class-wp-customize-site-icon-control.php
+++ b/src/wp-includes/customize/class-wp-customize-site-icon-control.php
@@ -72,14 +72,16 @@ class WP_Customize_Site_Icon_Control extends WP_Customize_Cropped_Image_Control 
 											<?php
 											/* translators: %s: The selected image alt text. */
 											echo wp_json_encode( __( 'Browser icon preview: Current image: %s' ) );
-											?>,
+											?>
+											,
 											data.attachment.alt
 										) :
 										wp.i18n.sprintf(
 											<?php
 											/* translators: %s: The selected image filename. */
 											echo wp_json_encode( __( 'Browser icon preview: The current image has no alternative text. The file name is: %s' ) );
-											?>,
+											?>
+											,
 											data.attachment.filename
 										)
 								}}" />
@@ -92,14 +94,16 @@ class WP_Customize_Site_Icon_Control extends WP_Customize_Cropped_Image_Control 
 									<?php
 									/* translators: %s: The selected image alt text. */
 									echo wp_json_encode( __( 'App icon preview: Current image: %s' ) )
-									?>,
+									?>
+									,
 									data.attachment.alt
 								) :
 								wp.i18n.sprintf(
 									<?php
 									/* translators: %s: The selected image filename. */
 									echo wp_json_encode( __( 'App icon preview: The current image has no alternative text. The file name is: %s' ) );
-									?>,
+									?>
+									,
 									data.attachment.filename
 								)
 						}}"/>

--- a/src/wp-includes/customize/class-wp-customize-site-icon-control.php
+++ b/src/wp-includes/customize/class-wp-customize-site-icon-control.php
@@ -69,15 +69,17 @@ class WP_Customize_Site_Icon_Control extends WP_Customize_Cropped_Image_Control 
 								<img src="{{ data.attachment.sizes.full ? data.attachment.sizes.full.url : data.attachment.url }}" alt="{{
 									data.attachment.alt ?
 										wp.i18n.sprintf(
+											<?php
 											/* translators: %s: The selected image alt text. */
-											wp.i18n.__( 'Browser icon preview: Current image: %s' ),
+											echo wp_json_encode( __( 'Browser icon preview: Current image: %s' ) );
+											?>,
 											data.attachment.alt
 										) :
 										wp.i18n.sprintf(
+											<?php
 											/* translators: %s: The selected image filename. */
-											wp.i18n.__(
-												'Browser icon preview: The current image has no alternative text. The file name is: %s'
-											),
+											echo wp_json_encode( __( 'Browser icon preview: The current image has no alternative text. The file name is: %s' ) );
+											?>,
 											data.attachment.filename
 										)
 								}}" />
@@ -87,15 +89,17 @@ class WP_Customize_Site_Icon_Control extends WP_Customize_Cropped_Image_Control 
 						<img class="app-icon-preview" src="{{ data.attachment.sizes.full ? data.attachment.sizes.full.url : data.attachment.url }}" alt="{{
 							data.attachment.alt ?
 								wp.i18n.sprintf(
+									<?php
 									/* translators: %s: The selected image alt text. */
-									wp.i18n.__( 'App icon preview: Current image: %s' ),
+									echo wp_json_encode( __( 'App icon preview: Current image: %s' ) )
+									?>,
 									data.attachment.alt
 								) :
 								wp.i18n.sprintf(
+									<?php
 									/* translators: %s: The selected image filename. */
-									wp.i18n.__(
-										'App icon preview: The current image has no alternative text. The file name is: %s'
-									),
+									echo wp_json_encode( __( 'App icon preview: The current image has no alternative text. The file name is: %s' ) );
+									?>,
 									data.attachment.filename
 								)
 						}}"/>

--- a/src/wp-includes/customize/class-wp-customize-site-icon-control.php
+++ b/src/wp-includes/customize/class-wp-customize-site-icon-control.php
@@ -66,11 +66,39 @@ class WP_Customize_Site_Icon_Control extends WP_Customize_Cropped_Image_Control 
 							<img src="<?php echo esc_url( admin_url( 'images/' . ( is_rtl() ? 'browser-rtl.png' : 'browser.png' ) ) ); ?>" class="browser-preview" width="182" alt="" />
 
 							<div class="favicon">
-								<img src="{{ data.attachment.sizes.full ? data.attachment.sizes.full.url : data.attachment.url }}" alt="<?php esc_attr_e( 'Preview as a browser icon' ); ?>" />
+								<img src="{{ data.attachment.sizes.full ? data.attachment.sizes.full.url : data.attachment.url }}" alt="{{
+									data.attachment.alt ?
+										wp.i18n.sprintf(
+											/* translators: %s: The selected image alt text. */
+											wp.i18n.__( 'Browser icon preview: Current image: %s' ),
+											data.attachment.alt
+										) :
+										wp.i18n.sprintf(
+											/* translators: %s: The selected image filename. */
+											wp.i18n.__(
+												'Browser icon preview: The current image has no alternative text. The file name is: %s'
+											),
+											data.attachment.filename
+										)
+								}}" />
 							</div>
 							<span class="browser-title" aria-hidden="true"><# print( '<?php echo esc_js( get_bloginfo( 'name' ) ); ?>' ) #></span>
 						</div>
-						<img class="app-icon-preview" src="{{ data.attachment.sizes.full ? data.attachment.sizes.full.url : data.attachment.url }}" alt="<?php esc_attr_e( 'Preview as an app icon' ); ?>" />
+						<img class="app-icon-preview" src="{{ data.attachment.sizes.full ? data.attachment.sizes.full.url : data.attachment.url }}" alt="{{
+							data.attachment.alt ?
+								wp.i18n.sprintf(
+									/* translators: %s: The selected image alt text. */
+									wp.i18n.__( 'App icon preview: Current image: %s' ),
+									data.attachment.alt
+								) :
+								wp.i18n.sprintf(
+									/* translators: %s: The selected image filename. */
+									wp.i18n.__(
+										'App icon preview: The current image has no alternative text. The file name is: %s'
+									),
+									data.attachment.filename
+								)
+						}}"/>
 					</div>
 				<# } #>
 				<div class="actions">


### PR DESCRIPTION
Updates both alt text and the description string to match the general settings page.

Trac ticket: https://core.trac.wordpress.org/ticket/60641

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
