### PR TITLE
Your provided diffs and commit message don't match. Based on the prov…

### DIFF
--- a/src/wp-includes/class-wp-image-editor-gd.php
+++ b/src/wp-includes/class-wp-image-editor-gd.php
@@ -533,11 +533,11 @@ class WP_Image_Editor_GD extends WP_Image_Editor {
 			if ( ! $this->make_image( $filename, 'imagejpeg', array( $image, $filename, $this->get_quality() ) ) ) {
 				return new WP_Error( 'image_save_error', __( 'Image Editor Save Failed' ) );
 			}
-		} elseif ( 'image/webp' == $mime_type ) {
+		} elseif ( 'image/webp' === $mime_type ) {
 			if ( ! function_exists( 'imagewebp' ) || ! $this->make_image( $filename, 'imagewebp', array( $image, $filename, $this->get_quality() ) ) ) {
 				return new WP_Error( 'image_save_error', __( 'Image Editor Save Failed' ) );
 			}
-		} elseif ( 'image/avif' == $mime_type ) {
+		} elseif ( 'image/avif' === $mime_type ) {
 			if ( ! function_exists( 'imageavif' ) || ! $this->make_image( $filename, 'imageavif', array( $image, $filename, $this->get_quality() ) ) ) {
 				return new WP_Error( 'image_save_error', __( 'Image Editor Save Failed' ) );
 			}


### PR DESCRIPTION
…ided diffs, here is the appropriate commit message:

Change comparison operator to strict in mime_type checks

The operator in the mime_type checks has been switched from '==' to '===' for 'image/webp' and 'image/avif' in the class-wp-image-editor-gd.php file. This change ensures a stricter comparison, improving code reliability and reducing potential bugs.

Trac ticket: 60643