### PR TITLE
wp_list_pluck(): Fix regression with magic method / dynamic property objects

### DIFF
--- a/src/wp-includes/class-wp-list-util.php
+++ b/src/wp-includes/class-wp-list-util.php
@@ -165,7 +165,7 @@ class WP_List_Util {
 			 */
 			foreach ( $this->output as $key => $value ) {
 				if ( is_object( $value ) ) {
-					if ( property_exists( $value, $field ) ) {
+					if ( property_exists( $value, $field ) || isset( $value->$field ) ) {
 						$newlist[ $key ] = $value->$field;
 					}
 				} elseif ( is_array( $value ) ) {
@@ -192,8 +192,8 @@ class WP_List_Util {
 		 */
 		foreach ( $this->output as $value ) {
 			if ( is_object( $value ) ) {
-				if ( property_exists( $value, $field ) ) {
-					if ( property_exists( $value, $index_key ) ) {
+				if ( property_exists( $value, $field ) || isset( $value->$field ) ) {
+					if ( property_exists( $value, $index_key ) || isset( $value->$index_key ) ) {
 						$newlist[ $value->$index_key ] = $value->$field;
 					} else {
 						$newlist[] = $value->$field;


### PR DESCRIPTION
r[57698](https://core.trac.wordpress.org/changeset/57698) introduced a regression with objects with magic methods and/or dynamic properties.

This PR seeks to resolve the resolve.

* [X] Add tests for different combinations of classes.
* [X] Add the `|| isset()` conditional fix which solves most of the issues.
* [ ] Figure out how to solve scenarios where the `__get()` magically sets a dynamic property but `__isset()` does not detect it.

`WP_Block::$attributes` is an example for the last bullet task.

Trac ticket: https://core.trac.wordpress.org/ticket/59774

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
