### PR TITLE
Block Bindings: Don't show protected fields that are bound to blocks and post meta 

### DIFF
--- a/src/wp-includes/block-bindings/post-meta.php
+++ b/src/wp-includes/block-bindings/post-meta.php
@@ -39,6 +39,14 @@ function _block_bindings_post_meta_get_value( array $source_args, $block_instanc
 		return null;
 	}
 
+	// Check if the meta field is registered to be shown in REST.
+	$meta_keys = get_registered_meta_keys( 'post', $block_instance->context['postType'] );
+	// Add fields registered for all subtypes.
+	$meta_keys = array_merge( $meta_keys, get_registered_meta_keys( 'post', '' ) );
+	if ( empty( $meta_keys[ $source_attrs['key'] ]['show_in_rest'] ) || false === $meta_keys[ $source_attrs['key'] ]['show_in_rest'] ) {
+		return null;
+	}
+
 	return get_post_meta( $post_id, $source_args['key'], true );
 }
 

--- a/src/wp-includes/block-bindings/post-meta.php
+++ b/src/wp-includes/block-bindings/post-meta.php
@@ -34,6 +34,11 @@ function _block_bindings_post_meta_get_value( array $source_args, $block_instanc
 		return null;
 	}
 
+	// Check if the meta field is protected.
+	if ( is_protected_meta( $source_attrs['key'], 'post' ) ) {
+		return null;
+	}
+
 	return get_post_meta( $post_id, $source_args['key'], true );
 }
 

--- a/src/wp-includes/block-bindings/post-meta.php
+++ b/src/wp-includes/block-bindings/post-meta.php
@@ -43,7 +43,7 @@ function _block_bindings_post_meta_get_value( array $source_args, $block_instanc
 	$meta_keys = get_registered_meta_keys( 'post', $block_instance->context['postType'] );
 	// Add fields registered for all subtypes.
 	$meta_keys = array_merge( $meta_keys, get_registered_meta_keys( 'post', '' ) );
-	if ( empty( $meta_keys[ $source_attrs['key'] ]['show_in_rest'] ) || false === $meta_keys[ $source_attrs['key'] ]['show_in_rest'] ) {
+	if ( empty( $meta_keys[ $source_attrs['key'] ]['show_in_rest'] ) ) {
 		return null;
 	}
 

--- a/src/wp-includes/block-bindings/post-meta.php
+++ b/src/wp-includes/block-bindings/post-meta.php
@@ -35,7 +35,7 @@ function _block_bindings_post_meta_get_value( array $source_args, $block_instanc
 	}
 
 	// Check if the meta field is protected.
-	if ( is_protected_meta( $source_attrs['key'], 'post' ) ) {
+	if ( is_protected_meta( $source_args['key'], 'post' ) ) {
 		return null;
 	}
 
@@ -43,7 +43,7 @@ function _block_bindings_post_meta_get_value( array $source_args, $block_instanc
 	$meta_keys = get_registered_meta_keys( 'post', $block_instance->context['postType'] );
 	// Add fields registered for all subtypes.
 	$meta_keys = array_merge( $meta_keys, get_registered_meta_keys( 'post', '' ) );
-	if ( empty( $meta_keys[ $source_attrs['key'] ]['show_in_rest'] ) ) {
+	if ( empty( $meta_keys[ $source_args['key'] ]['show_in_rest'] ) ) {
 		return null;
 	}
 

--- a/tests/phpunit/tests/block-bindings/postMetaSource.php
+++ b/tests/phpunit/tests/block-bindings/postMetaSource.php
@@ -76,6 +76,31 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that an html attribute connected to a custom field renders its value.
+	 *
+	 * @ticket 60651
+	 */
+	public function test_html_attribute_connected_to_custom_field_value_is_rendered() {
+		register_meta(
+			'post',
+			'tests_url_custom_field',
+			array(
+				'show_in_rest' => true,
+				'single'       => true,
+				'type'         => 'string',
+				'default'      => 'https://example.com/foo.png',
+			)
+		);
+
+		$content = $this->get_modified_post_content( '<!-- wp:image {"metadata":{"bindings":{"url":{"source":"core/post-meta","args":{"key":"tests_url_custom_field"}}}}} --><figure class="wp-block-image"><img alt=""/></figure><!-- /wp:image -->' );
+		$this->assertSame(
+			'<figure class="wp-block-image"><img decoding="async" src="https://example.com/foo.png" alt=""/></figure>',
+			$content,
+			'The image src should point to the value of the custom field . '
+		);
+	}
+
+	/**
 	 * Tests that a blocks connected in a password protected post don't render the value.
 	 *
 	 * @ticket 60651

--- a/tests/phpunit/tests/block-bindings/postMetaSource.php
+++ b/tests/phpunit/tests/block-bindings/postMetaSource.php
@@ -18,7 +18,7 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 	 *
 	 * @param string $content The new content.
 	 */
-	private function getModifiedPostContent( $content ) {
+	private function get_modified_post_content( $content ) {
 		$GLOBALS['post']->post_content = $content;
 		return apply_filters( 'the_content', $GLOBALS['post']->post_content );
 	}
@@ -66,7 +66,7 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			)
 		);
 
-		$content = $this->getModifiedPostContent( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+		$content = $this->get_modified_post_content( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
 		$this->assertSame(
 			'<p>Custom field value</p>',
 			$content,
@@ -100,7 +100,7 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			'wp_tests_require_post_password'
 		);
 
-		$content = $this->getModifiedPostContent( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+		$content = $this->get_modified_post_content( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
 
 		remove_filter(
 			'post_password_required',
@@ -140,7 +140,7 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			'wp_tests_make_post_status_not_viewable'
 		);
 
-		$content = $this->getModifiedPostContent( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+		$content = $this->get_modified_post_content( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
 
 		remove_filter(
 			'is_post_status_viewable',
@@ -160,7 +160,7 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 	 * @ticket 60651
 	 */
 	public function test_binding_to_non_existing_meta_key() {
-		$content = $this->getModifiedPostContent( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_non_existing_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+		$content = $this->get_modified_post_content( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_non_existing_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
 
 		$this->assertSame(
 			'<p>Fallback value</p>',
@@ -175,7 +175,7 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 	 * @ticket 60651
 	 */
 	public function test_binding_without_key_renders_the_fallback() {
-		$content = $this->getModifiedPostContent( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta"}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+		$content = $this->get_modified_post_content( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta"}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
 
 		$this->assertSame(
 			'<p>Fallback value</p>',
@@ -201,7 +201,7 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			)
 		);
 
-		$content = $this->getModifiedPostContent( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"_tests_protected_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+		$content = $this->get_modified_post_content( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"_tests_protected_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
 
 		$this->assertSame(
 			'<p>Fallback value</p>',
@@ -227,7 +227,7 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			)
 		);
 
-		$content = $this->getModifiedPostContent( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_show_in_rest_false_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+		$content = $this->get_modified_post_content( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_show_in_rest_false_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
 
 		$this->assertSame(
 			'<p>Fallback value</p>',
@@ -253,7 +253,7 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			)
 		);
 
-		$content = $this->getModifiedPostContent( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_unsafe_html_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+		$content = $this->get_modified_post_content( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_unsafe_html_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
 
 		$this->assertSame(
 			'<p>alert(&#8220;Unsafe HTML&#8221;)</p>',

--- a/tests/phpunit/tests/block-bindings/postMetaSource.php
+++ b/tests/phpunit/tests/block-bindings/postMetaSource.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Tests for Block Bindings API "core/post-meta" source.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ * @since 6.5.0
+ *
+ * @group blocks
+ * @group block-bindings
+ */
+class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
+
+	/**
+	 * Sets up each test method.
+	 */
+	public function set_up() {
+		global $post;
+
+		parent::set_up();
+
+		$post = self::factory()->post->create_and_get( array() );
+		setup_postdata( $post );
+	}
+
+	/**
+	 * Tear down each test method.
+	 */
+	public function tear_down() {
+		// Removes custom fields registered by test cases.
+		$meta_keys = get_registered_meta_keys( 'post', '' );
+		foreach ( $meta_keys as $meta_key_name => $meta_key_value ) {
+			unregister_meta_key( 'post', $meta_key_name );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that a block connected to a custom field renders its value.
+	 *
+	 * @ticket 60651
+	 */
+	public function test_custom_field_value_is_rendered() {
+		register_meta(
+			'post',
+			'custom_field',
+			array(
+				'show_in_rest' => true,
+				'single'       => true,
+				'type'         => 'string',
+				'default'      => 'Custom field value',
+			)
+		);
+
+		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+
+		$this->assertSame(
+			'<p>Custom field value</p>',
+			trim( $content ),
+			'The post content should show the value of the custom field.'
+		);
+	}
+
+	/**
+	 * Tests that a block connected without specifying the custom field renders the fallback.
+	 *
+	 * @ticket 60651
+	 */
+	public function test_binding_without_key_renders_the_fallback() {
+		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta"}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+
+		$this->assertSame(
+			'<p>Fallback value</p>',
+			trim( $content ),
+			'The post content should show the fallback value.'
+		);
+	}
+
+	/**
+	 * Tests that a block connected to a protected field doesn't show the value.
+	 *
+	 * @ticket 60651
+	 */
+	public function test_protected_field_value_is_not_shown() {
+		register_meta(
+			'post',
+			'_protected_field',
+			array(
+				'show_in_rest' => true,
+				'single'       => true,
+				'type'         => 'string',
+				'default'      => 'Protected value',
+			)
+		);
+
+		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"_protected_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+
+		$this->assertSame(
+			'<p>Fallback value</p>',
+			trim( $content ),
+			'The post content should show the fallback value instead of the protected value.'
+		);
+	}
+
+	/**
+	 * Tests that a block connected to a field not exposed in the REST API doesn't show the value.
+	 *
+	 * @ticket 60651
+	 */
+	public function test_custom_field_not_exposed_in_rest_api_is_not_shown() {
+		register_meta(
+			'post',
+			'show_in_rest_false_field',
+			array(
+				'show_in_rest' => false,
+				'single'       => true,
+				'type'         => 'string',
+				'default'      => 'Protected value',
+			)
+		);
+
+		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"show_in_rest_false_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+
+		$this->assertSame(
+			'<p>Fallback value</p>',
+			trim( $content ),
+			'The post content should show the fallback value instead of the protected value.'
+		);
+	}
+}

--- a/tests/phpunit/tests/block-bindings/postMetaSource.php
+++ b/tests/phpunit/tests/block-bindings/postMetaSource.php
@@ -19,18 +19,8 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 	 * @param string $content The new content.
 	 */
 	private function getModifiedPostContent( $content ) {
-		self::$post->post_content = $content;
-		// Update the global $post variable to ensure all tests get the correct $post context.
-		$this->updateGlobalPost();
-		return apply_filters( 'the_content', self::$post->post_content );
-	}
-
-	/**
-	 * Update the global $post variable.
-	 */
-	private function updateGlobalPost() {
-		global $post;
-		$post = self::$post;
+		$GLOBALS['post']->post_content = $content;
+		return apply_filters( 'the_content', $GLOBALS['post']->post_content );
 	}
 
 	/**
@@ -46,6 +36,17 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 	 */
 	public static function wpTearDownAfterClass() {
 		$GLOBALS['wp_meta_keys'] = self::$wp_meta_keys_saved;
+	}
+
+	/**
+	 * Set up before each test.
+	 *
+	 * @since 6.5.0
+	 */
+	public function set_up() {
+		parent::set_up();
+		// This seems to be needed to ensure that $GLOBALS['post'] is not null in all the tests.
+		$GLOBALS['post'] = self::$post;
 	}
 
 	/**

--- a/tests/phpunit/tests/block-bindings/postMetaSource.php
+++ b/tests/phpunit/tests/block-bindings/postMetaSource.php
@@ -10,14 +10,34 @@
  * @group block-bindings
  */
 class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
+	protected static $post;
 	protected static $wp_meta_keys_saved;
+
+	/**
+	 * Modify the post content.
+	 *
+	 * @param string $content The new content.
+	 */
+	private function getModifiedPostContent( $content ) {
+		self::$post->post_content = $content;
+		// Update the global $post variable to ensure all tests get the correct $post context.
+		$this->updateGlobalPost();
+		return apply_filters( 'the_content', self::$post->post_content );
+	}
+
+	/**
+	 * Update the global $post variable.
+	 */
+	private function updateGlobalPost() {
+		global $post;
+		$post = self::$post;
+	}
 
 	/**
 	 * Set up for every method.
 	 */
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		global $post;
-		$post                     = $factory->post->create_and_get();
+		self::$post               = $factory->post->create_and_get();
 		self::$wp_meta_keys_saved = isset( $GLOBALS['wp_meta_keys'] ) ? $GLOBALS['wp_meta_keys'] : array();
 	}
 
@@ -45,12 +65,11 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			)
 		);
 
-		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
-
+		$content = $this->getModifiedPostContent( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
 		$this->assertSame(
 			'<p>Custom field value</p>',
-			trim( $content ),
-			'The post content should show the value of the custom field.'
+			$content,
+			'The post content should show the value of the custom field . '
 		);
 	}
 
@@ -80,11 +99,10 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			'wp_tests_require_post_password'
 		);
 
-		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
-
+		$content = $this->getModifiedPostContent( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
 		$this->assertSame(
 			'<p>Fallback value</p>',
-			trim( $content ),
+			$content,
 			'The post content should show the fallback value instead of the custom field value.'
 		);
 
@@ -120,11 +138,10 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			'wp_tests_make_post_status_not_viewable'
 		);
 
-		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
-
+		$content = $this->getModifiedPostContent( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
 		$this->assertSame(
 			'<p>Fallback value</p>',
-			trim( $content ),
+			$content,
 			'The post content should show the fallback value instead of the custom field value.'
 		);
 
@@ -140,11 +157,11 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 	 * @ticket 60651
 	 */
 	public function test_binding_to_non_existing_meta_key() {
-		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_non_existing_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+		$content = $this->getModifiedPostContent( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_non_existing_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
 
 		$this->assertSame(
 			'<p>Fallback value</p>',
-			trim( $content ),
+			$content,
 			'The post content should show the fallback value.'
 		);
 	}
@@ -155,11 +172,11 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 	 * @ticket 60651
 	 */
 	public function test_binding_without_key_renders_the_fallback() {
-		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta"}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+		$content = $this->getModifiedPostContent( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta"}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
 
 		$this->assertSame(
 			'<p>Fallback value</p>',
-			trim( $content ),
+			$content,
 			'The post content should show the fallback value.'
 		);
 	}
@@ -181,11 +198,11 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			)
 		);
 
-		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"_tests_protected_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+		$content = $this->getModifiedPostContent( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"_tests_protected_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
 
 		$this->assertSame(
 			'<p>Fallback value</p>',
-			trim( $content ),
+			$content,
 			'The post content should show the fallback value instead of the protected value.'
 		);
 	}
@@ -207,11 +224,11 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			)
 		);
 
-		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_show_in_rest_false_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+		$content = $this->getModifiedPostContent( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_show_in_rest_false_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
 
 		$this->assertSame(
 			'<p>Fallback value</p>',
-			trim( $content ),
+			$content,
 			'The post content should show the fallback value instead of the protected value.'
 		);
 	}

--- a/tests/phpunit/tests/block-bindings/postMetaSource.php
+++ b/tests/phpunit/tests/block-bindings/postMetaSource.php
@@ -10,32 +10,22 @@
  * @group block-bindings
  */
 class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
+	protected static $wp_meta_keys_saved;
 
 	/**
-	 * Sets up each test method.
+	 * Set up for every method.
 	 */
-	public function set_up() {
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		global $post;
-
-		parent::set_up();
-
-		$post = self::factory()->post->create_and_get( array() );
-		setup_postdata( $post );
+		$post                     = $factory->post->create_and_get();
+		self::$wp_meta_keys_saved = isset( $GLOBALS['wp_meta_keys'] ) ? $GLOBALS['wp_meta_keys'] : array();
 	}
 
 	/**
-	 * Tear down each test method.
+	 * Tear down for every method.
 	 */
-	public function tear_down() {
-		// Removes custom fields registered by test cases.
-		$meta_keys = get_registered_meta_keys( 'post', '' );
-		foreach ( $meta_keys as $meta_key_name => $meta_key_value ) {
-			if ( str_contains( $meta_key_name, 'tests' ) ) {
-				unregister_meta_key( 'post', $meta_key_name );
-			}
-		}
-
-		parent::tear_down();
+	public static function wpTearDownAfterClass() {
+		$GLOBALS['wp_meta_keys'] = self::$wp_meta_keys_saved;
 	}
 
 	/**

--- a/tests/phpunit/tests/block-bindings/postMetaSource.php
+++ b/tests/phpunit/tests/block-bindings/postMetaSource.php
@@ -100,15 +100,16 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 		);
 
 		$content = $this->getModifiedPostContent( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
-		$this->assertSame(
-			'<p>Fallback value</p>',
-			$content,
-			'The post content should show the fallback value instead of the custom field value.'
-		);
 
 		remove_filter(
 			'post_password_required',
 			'wp_tests_post_password_required'
+		);
+
+		$this->assertSame(
+			'<p>Fallback value</p>',
+			$content,
+			'The post content should show the fallback value instead of the custom field value.'
 		);
 	}
 
@@ -139,15 +140,16 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 		);
 
 		$content = $this->getModifiedPostContent( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
-		$this->assertSame(
-			'<p>Fallback value</p>',
-			$content,
-			'The post content should show the fallback value instead of the custom field value.'
-		);
 
 		remove_filter(
 			'is_post_status_viewable',
 			'wp_tests_make_post_status_not_viewable'
+		);
+
+		$this->assertSame(
+			'<p>Fallback value</p>',
+			$content,
+			'The post content should show the fallback value instead of the custom field value.'
 		);
 	}
 
@@ -230,6 +232,32 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			'<p>Fallback value</p>',
 			$content,
 			'The post content should show the fallback value instead of the protected value.'
+		);
+	}
+
+	/**
+	 * Tests that meta key with unsafe HTML is sanitized.
+	 *
+	 * @ticket 60651
+	 */
+	public function test_custom_field_with_unsafe_html_is_sanitized() {
+		register_meta(
+			'post',
+			'tests_unsafe_html_field',
+			array(
+				'show_in_rest' => true,
+				'single'       => true,
+				'type'         => 'string',
+				'default'      => '<script>alert("Unsafe HTML")</script>',
+			)
+		);
+
+		$content = $this->getModifiedPostContent( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_unsafe_html_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+
+		$this->assertSame(
+			'<p>alert(&#8220;Unsafe HTML&#8221;)</p>',
+			$content,
+			'The post content should not include the script tag.'
 		);
 	}
 }

--- a/tests/phpunit/tests/block-bindings/postMetaSource.php
+++ b/tests/phpunit/tests/block-bindings/postMetaSource.php
@@ -36,6 +36,7 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 	 */
 	public static function wpTearDownAfterClass() {
 		$GLOBALS['wp_meta_keys'] = self::$wp_meta_keys_saved;
+		unset( $GLOBALS['post'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/block-bindings/postMetaSource.php
+++ b/tests/phpunit/tests/block-bindings/postMetaSource.php
@@ -24,7 +24,7 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Set up for every method.
+	 * Sets up shared fixtures.
 	 */
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$post               = $factory->post->create_and_get();
@@ -32,7 +32,7 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tear down for every method.
+	 * Tear down after class.
 	 */
 	public static function wpTearDownAfterClass() {
 		$GLOBALS['wp_meta_keys'] = self::$wp_meta_keys_saved;

--- a/tests/phpunit/tests/block-bindings/postMetaSource.php
+++ b/tests/phpunit/tests/block-bindings/postMetaSource.php
@@ -121,10 +121,6 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			)
 		);
 
-		function wp_tests_make_post_status_not_viewable() {
-			return false;
-		}
-
 		add_filter( 'is_post_status_viewable', '__return_false' );
 
 		$content = $this->get_modified_post_content( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );

--- a/tests/phpunit/tests/block-bindings/postMetaSource.php
+++ b/tests/phpunit/tests/block-bindings/postMetaSource.php
@@ -91,21 +91,11 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			)
 		);
 
-		function wp_tests_require_post_password() {
-			return true;
-		}
-
-		add_filter(
-			'post_password_required',
-			'wp_tests_require_post_password'
-		);
+		add_filter( 'post_password_required', '__return_true' );
 
 		$content = $this->get_modified_post_content( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
 
-		remove_filter(
-			'post_password_required',
-			'wp_tests_post_password_required'
-		);
+		remove_filter( 'post_password_required', '__return_true' );
 
 		$this->assertSame(
 			'<p>Fallback value</p>',
@@ -135,17 +125,11 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			return false;
 		}
 
-		add_filter(
-			'is_post_status_viewable',
-			'wp_tests_make_post_status_not_viewable'
-		);
+		add_filter( 'is_post_status_viewable', '__return_false' );
 
 		$content = $this->get_modified_post_content( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
 
-		remove_filter(
-			'is_post_status_viewable',
-			'wp_tests_make_post_status_not_viewable'
-		);
+		remove_filter( 'is_post_status_viewable', '__return_false' );
 
 		$this->assertSame(
 			'<p>Fallback value</p>',

--- a/tests/phpunit/tests/block-bindings/postMetaSource.php
+++ b/tests/phpunit/tests/block-bindings/postMetaSource.php
@@ -234,30 +234,4 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			'The post content should show the fallback value instead of the protected value.'
 		);
 	}
-
-	/**
-	 * Tests that meta key with unsafe HTML is sanitized.
-	 *
-	 * @ticket 60651
-	 */
-	public function test_custom_field_with_unsafe_html_is_sanitized() {
-		register_meta(
-			'post',
-			'tests_unsafe_html_field',
-			array(
-				'show_in_rest' => true,
-				'single'       => true,
-				'type'         => 'string',
-				'default'      => '<script>alert("Unsafe HTML")</script>',
-			)
-		);
-
-		$content = $this->getModifiedPostContent( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_unsafe_html_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
-
-		$this->assertSame(
-			'<p>alert(&#8220;Unsafe HTML&#8221;)</p>',
-			$content,
-			'The post content should not include the script tag.'
-		);
-	}
 }

--- a/tests/phpunit/tests/block-bindings/postMetaSource.php
+++ b/tests/phpunit/tests/block-bindings/postMetaSource.php
@@ -65,6 +65,39 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a blocks connected in a password protected post don't render the value.
+	 *
+	 * @ticket 60651
+	 */
+	public function test_custom_field_value_is_not_shown_in_password_protected_posts() {
+		register_meta(
+			'post',
+			'tests_custom_field',
+			array(
+				'show_in_rest' => true,
+				'single'       => true,
+				'type'         => 'string',
+				'default'      => 'Custom field value',
+			)
+		);
+
+		add_filter(
+			'post_password_required',
+			function () {
+				return true;
+			}
+		);
+
+		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+
+		$this->assertSame(
+			'<p>Fallback value</p>',
+			trim( $content ),
+			'The post content should show the fallback value instead of the custom field value.'
+		);
+	}
+
+	/**
 	 * Tests that a block connected without specifying the custom field renders the fallback.
 	 *
 	 * @ticket 60651

--- a/tests/phpunit/tests/block-bindings/postMetaSource.php
+++ b/tests/phpunit/tests/block-bindings/postMetaSource.php
@@ -36,7 +36,6 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 	 */
 	public static function wpTearDownAfterClass() {
 		$GLOBALS['wp_meta_keys'] = self::$wp_meta_keys_saved;
-		unset( $GLOBALS['post'] );
 	}
 
 	/**
@@ -46,7 +45,7 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
-		// This seems to be needed to ensure that $GLOBALS['post'] is not null in all the tests.
+		// Needed because tear_down() will reset it between tests.
 		$GLOBALS['post'] = self::$post;
 	}
 

--- a/tests/phpunit/tests/block-bindings/postMetaSource.php
+++ b/tests/phpunit/tests/block-bindings/postMetaSource.php
@@ -71,11 +71,13 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			)
 		);
 
+		function wp_tests_require_post_password() {
+			return true;
+		}
+
 		add_filter(
 			'post_password_required',
-			function () {
-				return true;
-			}
+			'wp_tests_require_post_password'
 		);
 
 		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
@@ -84,6 +86,11 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			'<p>Fallback value</p>',
 			trim( $content ),
 			'The post content should show the fallback value instead of the custom field value.'
+		);
+
+		remove_filter(
+			'post_password_required',
+			'wp_tests_post_password_required'
 		);
 	}
 
@@ -104,11 +111,13 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			)
 		);
 
+		function wp_tests_make_post_status_not_viewable() {
+			return false;
+		}
+
 		add_filter(
 			'is_post_status_viewable',
-			function () {
-				return false;
-			}
+			'wp_tests_make_post_status_not_viewable'
 		);
 
 		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
@@ -117,6 +126,11 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			'<p>Fallback value</p>',
 			trim( $content ),
 			'The post content should show the fallback value instead of the custom field value.'
+		);
+
+		remove_filter(
+			'is_post_status_viewable',
+			'wp_tests_make_post_status_not_viewable'
 		);
 	}
 

--- a/tests/phpunit/tests/block-bindings/postMetaSource.php
+++ b/tests/phpunit/tests/block-bindings/postMetaSource.php
@@ -234,4 +234,30 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			'The post content should show the fallback value instead of the protected value.'
 		);
 	}
+
+	/**
+	 * Tests that meta key with unsafe HTML is sanitized.
+	 *
+	 * @ticket 60651
+	 */
+	public function test_custom_field_with_unsafe_html_is_sanitized() {
+		register_meta(
+			'post',
+			'tests_unsafe_html_field',
+			array(
+				'show_in_rest' => true,
+				'single'       => true,
+				'type'         => 'string',
+				'default'      => '<script>alert("Unsafe HTML")</script>',
+			)
+		);
+
+		$content = $this->getModifiedPostContent( '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_unsafe_html_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+
+		$this->assertSame(
+			'<p>alert(&#8220;Unsafe HTML&#8221;)</p>',
+			$content,
+			'The post content should not include the script tag.'
+		);
+	}
 }

--- a/tests/phpunit/tests/block-bindings/postMetaSource.php
+++ b/tests/phpunit/tests/block-bindings/postMetaSource.php
@@ -98,6 +98,39 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a blocks connected in a post that is not publicly viewable don't render the value.
+	 *
+	 * @ticket 60651
+	 */
+	public function test_custom_field_value_is_not_shown_in_non_viewable_posts() {
+		register_meta(
+			'post',
+			'tests_custom_field',
+			array(
+				'show_in_rest' => true,
+				'single'       => true,
+				'type'         => 'string',
+				'default'      => 'Custom field value',
+			)
+		);
+
+		add_filter(
+			'is_post_status_viewable',
+			function () {
+				return false;
+			}
+		);
+
+		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+
+		$this->assertSame(
+			'<p>Fallback value</p>',
+			trim( $content ),
+			'The post content should show the fallback value instead of the custom field value.'
+		);
+	}
+
+	/**
 	 * Tests that a block connected without specifying the custom field renders the fallback.
 	 *
 	 * @ticket 60651

--- a/tests/phpunit/tests/block-bindings/postMetaSource.php
+++ b/tests/phpunit/tests/block-bindings/postMetaSource.php
@@ -30,7 +30,9 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 		// Removes custom fields registered by test cases.
 		$meta_keys = get_registered_meta_keys( 'post', '' );
 		foreach ( $meta_keys as $meta_key_name => $meta_key_value ) {
-			unregister_meta_key( 'post', $meta_key_name );
+			if ( str_contains( $meta_key_name, 'tests' ) ) {
+				unregister_meta_key( 'post', $meta_key_name );
+			}
 		}
 
 		parent::tear_down();
@@ -44,7 +46,7 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 	public function test_custom_field_value_is_rendered() {
 		register_meta(
 			'post',
-			'custom_field',
+			'tests_custom_field',
 			array(
 				'show_in_rest' => true,
 				'single'       => true,
@@ -53,7 +55,7 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			)
 		);
 
-		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_custom_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
 
 		$this->assertSame(
 			'<p>Custom field value</p>',
@@ -85,7 +87,7 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 	public function test_protected_field_value_is_not_shown() {
 		register_meta(
 			'post',
-			'_protected_field',
+			'_tests_protected_field',
 			array(
 				'show_in_rest' => true,
 				'single'       => true,
@@ -94,7 +96,7 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			)
 		);
 
-		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"_protected_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"_tests_protected_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
 
 		$this->assertSame(
 			'<p>Fallback value</p>',
@@ -111,7 +113,7 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 	public function test_custom_field_not_exposed_in_rest_api_is_not_shown() {
 		register_meta(
 			'post',
-			'show_in_rest_false_field',
+			'tests_show_in_rest_false_field',
 			array(
 				'show_in_rest' => false,
 				'single'       => true,
@@ -120,7 +122,7 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 			)
 		);
 
-		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"show_in_rest_false_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_show_in_rest_false_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
 
 		$this->assertSame(
 			'<p>Fallback value</p>',

--- a/tests/phpunit/tests/block-bindings/postMetaSource.php
+++ b/tests/phpunit/tests/block-bindings/postMetaSource.php
@@ -121,6 +121,21 @@ class Tests_Block_Bindings_Post_Meta_Source extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a block connected to a meta key that doesn't exist renders the fallback.
+	 *
+	 * @ticket 60651
+	 */
+	public function test_binding_to_non_existing_meta_key() {
+		$content = apply_filters( 'the_content', '<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"tests_non_existing_field"}}}}} --><p>Fallback value</p><!-- /wp:paragraph -->' );
+
+		$this->assertSame(
+			'<p>Fallback value</p>',
+			trim( $content ),
+			'The post content should show the fallback value.'
+		);
+	}
+
+	/**
 	 * Tests that a block connected without specifying the custom field renders the fallback.
 	 *
 	 * @ticket 60651

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -198,4 +198,40 @@ HTML;
 			'The block content should be updated with the value returned by the source.'
 		);
 	}
+
+	/**
+	 * Tests if the block content is sanitized when unsafe HTML is passed.
+	 *
+	 * @ticket 60651
+	 *
+	 * @covers ::register_block_bindings_source
+	 */
+	public function test_source_value_with_unsafe_html_is_sanitized() {
+		$get_value_callback = function () {
+			return '<script>alert("Unsafe HTML")</script>';
+		};
+
+		register_block_bindings_source(
+			self::SOURCE_NAME,
+			array(
+				'label'              => self::SOURCE_LABEL,
+				'get_value_callback' => $get_value_callback,
+			)
+		);
+
+		$block_content = <<<HTML
+<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"test/source"}}}} -->
+<p>This should not appear</p>
+<!-- /wp:paragraph -->
+HTML;
+		$parsed_blocks = parse_blocks( $block_content );
+		$block         = new WP_Block( $parsed_blocks[0] );
+		$result        = $block->render();
+
+		$this->assertSame(
+			'<p>alert("Unsafe HTML")</p>',
+			trim( $result ),
+			'The block content should be updated with the value returned by the source.'
+		);
+	}
 }


### PR DESCRIPTION
As [discussed in Gutenberg plugin](https://github.com/WordPress/gutenberg/pull/59326), this pull request adds two safety checks to ensure block bindings don't leak private post meta:

* Check if the meta field is protected.
* Check if the meta field is available through the REST API.

It seems safer to add these limitations to ensure no unwanted data is leaked. And it can be explored later how to loosen these restrictions.

To do that this pull request:
* Use the [is_protected_meta function](https://developer.wordpress.org/reference/functions/is_protected_meta/) to check if it is protected.
* Access the `$meta_keys `through [get_registered_meta_keys function](https://developer.wordpress.org/reference/functions/get_registered_meta_keys/) to check if the specific key has the `show_in_rest` property enabled.

## Testing Instructions

**Test it doesn't show the protected value when `show_in_rest` is false**


1. Register a custom field with `show_in_rest` set to false:

```PHP
register_meta(
	'post',
	'protected',
	array(
		'show_in_rest'   => false,
		'single'         => true,
		'type'           => 'string',
		'default'        => 'Protected value',
	)
);
```

3. Add a paragraph block in a page pointing to the protected block:

```html
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"protected"}}}}} -->
<p>Text</p>
<!-- /wp:paragraph -->
```

4. Save the page, go to the front and check it doesn't show the protected value.

**Test protected custom field**

1. Change the register source to `show_in_rest` true but protect it. It can be done adding a `_` at the beginning of the key or using a filter like this one:

```php
function protect_meta( $protected, $meta_key, $meta_type ) {
        return true;
}
add_filter( 'is_protected_meta', 'protect_meta', 10, 3 );
```

2. Check that the paragraph bound to the protected field doesn't show the protected value in the frontend.

---

Trac ticket: https://core.trac.wordpress.org/ticket/60651

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
