### PR TITLE
wp_get_font_dir():  Bail if the 'font_dir' filter is already running.

### DIFF
--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -118,6 +118,16 @@ function wp_unregister_font_collection( string $slug ) {
  * }
  */
 function wp_get_font_dir( $defaults = array() ) {
+	/*
+	* Bail if the 'font_dir' filter is already running.
+	*
+	* This avoids an infinite loop that can occur
+	* if wp_upload_dir() is called inside a 'font_dir' callback.
+	*/
+	if ( doing_filter( 'font_dir' ) ) {
+		return $defaults;
+	}
+	
 	$site_path = '';
 	if ( is_multisite() && ! ( is_main_network() && is_main_site() ) ) {
 		$site_path = '/sites/' . get_current_blog_id();
@@ -140,7 +150,7 @@ function wp_get_font_dir( $defaults = array() ) {
 	 *
 	 * @param array $defaults The original fonts directory data.
 	 */
-	return apply_filters( 'font_dir', $defaults );
+	return doing_filter( 'font_dir' ) ? $defaults : apply_filters( 'font_dir', $defaults );
 }
 
 /**

--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -119,11 +119,11 @@ function wp_unregister_font_collection( string $slug ) {
  */
 function wp_get_font_dir( $defaults = array() ) {
 	/*
-	* Bail if the 'font_dir' filter is already running.
-	*
-	* This avoids an infinite loop that can occur
-	* if wp_upload_dir() is called inside a 'font_dir' callback.
-	*/
+	 * Bail if the 'font_dir' filter is already running.
+	 *
+	 * This avoids an infinite loop that can occur
+	 * if wp_upload_dir() is called inside a 'font_dir' callback.
+	 */
 	if ( doing_filter( 'font_dir' ) ) {
 		return $defaults;
 	}

--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -127,7 +127,7 @@ function wp_get_font_dir( $defaults = array() ) {
 	if ( doing_filter( 'font_dir' ) ) {
 		return $defaults;
 	}
-	
+
 	$site_path = '';
 	if ( is_multisite() && ! ( is_main_network() && is_main_site() ) ) {
 		$site_path = '/sites/' . get_current_blog_id();


### PR DESCRIPTION
## What?
`wp_get_font_dir()`: Bail if the `font_dir` filter is already running.

Props to @costdev for [proposing](https://wordpress.slack.com/archives/C02RQBWTW/p1709082902708339?thread_ts=1708987810.984969&cid=C02RQBWTW) this solution.


## Why?
This avoids an infinite loop that can occur if wp_upload_dir() is called inside a 'font_dir' callback.

## Testing instructions
1. Use `wp_get_upload_dir()` inside a function used to filter `upload_dir` as in the following example:

```php
 function alter_wp_fonts_dir( $defaults ) {
	$wp_upload_dir = wp_get_upload_dir();
	$uploads_basedir = $wp_upload_dir['basedir'];
	$uploads_baseurl = $wp_upload_dir['baseurl'];

	$fonts_dir = $uploads_basedir . '/fonts';
	// Generate the URL for the fonts directory from the font dir.
	$fonts_url = str_replace( $uploads_basedir, $uploads_baseurl, $fonts_dir );

	$defaults['path'] = $fonts_dir;
	$defaults['url']  = $fonts_url;

	return $defaults;
}
add_filter( 'font_dir', 'alter_wp_fonts_dir' );
```
2. Upload fonts using the font library
3. Check that the fonsts were successfully uploaded to the path set by the filter.
(`wp-content/uploads/fonts` in the example provided).

---

Trac ticket: https://core.trac.wordpress.org/ticket/60652

