### PR TITLE
HTML API: Remove superfluous type-coercing empty() check.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2810,10 +2810,6 @@ class WP_HTML_Tag_Processor {
 
 		$decoded = html_entity_decode( $text, ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE );
 
-		if ( empty( $decoded ) ) {
-			return '';
-		}
-
 		/*
 		 * TEXTAREA skips a leading newline, but this newline may appear not only as the
 		 * literal character `\n`, but also as a character reference, such as in the


### PR DESCRIPTION
When returning modifiable text in the HTML API, if the text segment coerces to `false` inside `empty()`, then an empty string has been returned instead of the string itself. For example, the text node in the following HTML snippet:

```html
<div>0</div>
```

In this patch the `empty()` check is removed. The purpose of the original check was to skip further processing if the text content were empty, but the check is not needed and the additioanl processing is minimal. Removing the code removes the defect and leaves a cleaner method in its absence.

Follow-up to [57348]