### PR TITLE
Fix infinite loop when calling wp_get_upload_dir in a function that's used to filter font_dir

### DIFF
--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -96,16 +96,6 @@ function wp_unregister_font_collection( string $slug ) {
  *
  * @since 6.5.0
  *
- * @param array $defaults {
- *     Array of information about the upload directory.
- *
- *     @type string       $path    Base directory and subdirectory or full path to the fonts upload directory.
- *     @type string       $url     Base URL and subdirectory or absolute URL to the fonts upload directory.
- *     @type string       $subdir  Subdirectory
- *     @type string       $basedir Path without subdir.
- *     @type string       $baseurl URL path without subdir.
- *     @type string|false $error   False or error message.
- * }
  * @return array $defaults {
  *     Array of information about the upload directory.
  *
@@ -117,19 +107,20 @@ function wp_unregister_font_collection( string $slug ) {
  *     @type string|false $error   False or error message.
  * }
  */
-function wp_get_font_dir( $defaults = array() ) {
+function wp_get_font_dir() {
 	$site_path = '';
 	if ( is_multisite() && ! ( is_main_network() && is_main_site() ) ) {
 		$site_path = '/sites/' . get_current_blog_id();
 	}
 
-	// Sets the defaults.
-	$defaults['path']    = path_join( WP_CONTENT_DIR, 'fonts' ) . $site_path;
-	$defaults['url']     = untrailingslashit( content_url( 'fonts' ) ) . $site_path;
-	$defaults['subdir']  = '';
-	$defaults['basedir'] = path_join( WP_CONTENT_DIR, 'fonts' ) . $site_path;
-	$defaults['baseurl'] = untrailingslashit( content_url( 'fonts' ) ) . $site_path;
-	$defaults['error']   = false;
+	$defaults = array(
+		'path'    => path_join( WP_CONTENT_DIR, 'fonts' ) . $site_path,
+		'url'     => untrailingslashit( content_url( 'fonts' ) ) . $site_path,
+		'subdir'  => '',
+		'basedir' => path_join( WP_CONTENT_DIR, 'fonts' ) . $site_path,
+		'baseurl' => untrailingslashit( content_url( 'fonts' ) ) . $site_path,
+		'error'   => false,
+	);
 
 	/**
 	 * Filters the fonts directory data.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-font-faces-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-font-faces-controller.php
@@ -858,14 +858,14 @@ class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
 		add_filter( 'upload_mimes', array( 'WP_Font_Utils', 'get_allowed_font_mime_types' ) );
 
 		/*
-			* Set the upload directory to the fonts directory.
-			*
-			* wp_get_font_dir() contains the 'font_dir' hook, whose callbacks are
-			* likely to call wp_get_upload_dir().
-			*
-			* To avoid an infinite loop, don't hook wp_get_font_dir() to 'upload_dir'.
-			* Instead, just pass its return value to the 'upload_dir' callback.
-			*/
+		 * Set the upload directory to the fonts directory.
+		 *
+		 * wp_get_font_dir() contains the 'font_dir' hook, whose callbacks are
+		 * likely to call wp_get_upload_dir().
+		 *
+		 * To avoid an infinite loop, don't hook wp_get_font_dir() to 'upload_dir'.
+		 * Instead, just pass its return value to the 'upload_dir' callback.
+		 */
 		$font_dir       = wp_get_font_dir();
 		$set_upload_dir = function () use ( $font_dir ) {
 			return $font_dir;

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-font-faces-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-font-faces-controller.php
@@ -856,7 +856,7 @@ class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
 	 */
 	protected function handle_font_file_upload( $file ) {
 		add_filter( 'upload_mimes', array( 'WP_Font_Utils', 'get_allowed_font_mime_types' ) );
-		
+
 		/*
 			* Set the upload directory to the fonts directory.
 			*
@@ -916,16 +916,16 @@ class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
 	}
 
 	/**
-	* Returns relative path to an uploaded font file.
-	*
-	* The path is relative to the current fonts directory.
-	*
-	* @since 6.5.0
-	* @access private
-	*
-	* @param string $path Full path to the file.
-	* @return string Relative path on success, unchanged path on failure.
-	*/
+	 * Returns relative path to an uploaded font file.
+	 *
+	 * The path is relative to the current fonts directory.
+	 *
+	 * @since 6.5.0
+	 * @access private
+	 *
+	 * @param string $path Full path to the file.
+	 * @return string Relative path on success, unchanged path on failure.
+	 */
 	protected function relative_fonts_path( $path ) {
 		$new_path = $path;
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-font-faces-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-font-faces-controller.php
@@ -856,7 +856,21 @@ class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
 	 */
 	protected function handle_font_file_upload( $file ) {
 		add_filter( 'upload_mimes', array( 'WP_Font_Utils', 'get_allowed_font_mime_types' ) );
-		add_filter( 'upload_dir', 'wp_get_font_dir' );
+		
+		/*
+			* Set the upload directory to the fonts directory.
+			*
+			* wp_get_font_dir() contains the 'font_dir' hook, whose callbacks are
+			* likely to call wp_get_upload_dir().
+			*
+			* To avoid an infinite loop, don't hook wp_get_font_dir() to 'upload_dir'.
+			* Instead, just pass its return value to the 'upload_dir' callback.
+			*/
+		$font_dir       = wp_get_font_dir();
+		$set_upload_dir = function () use ( $font_dir ) {
+			return $font_dir;
+		};
+		add_filter( 'upload_dir', $set_upload_dir );
 
 		$overrides = array(
 			'upload_error_handler' => array( $this, 'handle_font_file_upload_error' ),
@@ -874,7 +888,7 @@ class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
 
 		$uploaded_file = wp_handle_upload( $file, $overrides );
 
-		remove_filter( 'upload_dir', 'wp_get_font_dir' );
+		remove_filter( 'upload_dir', $set_upload_dir );
 		remove_filter( 'upload_mimes', array( 'WP_Font_Utils', 'get_allowed_font_mime_types' ) );
 
 		return $uploaded_file;


### PR DESCRIPTION
:information_source: **Porting https://github.com/WordPress/gutenberg/pull/58839 already merged in from Gutenberg repo.**

## What?
Fix infinite loop when calling `wp_get_upload_dir` in a function that's used to filter `font_dir`.
An alternative approach to: https://github.com/WordPress/wordpress-develop/pull/6198

## Why?
This avoids an infinite loop that can occur if `wp_upload_dir()` is called inside a 'font_dir' callback.

## Testing instructions
1. Use `wp_get_upload_dir()` inside a function used to filter `upload_dir` as in the following example:

```php
 function alter_wp_fonts_dir( $defaults ) {
	$wp_upload_dir = wp_get_upload_dir();
	$uploads_basedir = $wp_upload_dir['basedir'];
	$uploads_baseurl = $wp_upload_dir['baseurl'];

	$fonts_dir = $uploads_basedir . '/fonts';
	// Generate the URL for the fonts directory from the font dir.
	$fonts_url = str_replace( $uploads_basedir, $uploads_baseurl, $fonts_dir );

	$defaults['path'] = $fonts_dir;
	$defaults['url']  = $fonts_url;

	return $defaults;
}
add_filter( 'font_dir', 'alter_wp_fonts_dir' );
```
2. Upload fonts using the font library
3. Check that the fonts were successfully uploaded to the path set by the filter.
(`wp-content/uploads/fonts` in the example provided).

---

Trac ticket: https://core.trac.wordpress.org/ticket/60652

