### PR TITLE
`get_terms()` with `child_of` and `childless` combined

### DIFF
--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -861,6 +861,64 @@ class Tests_Term_Query extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 44279
+	 */
+	public function test_childless_with_child_of() {
+		register_taxonomy(
+			'wptests_tax',
+			'post',
+			array(
+				'hierarchical' => true,
+			)
+		);
+
+		$parent = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax',
+			)
+		);
+
+		$childless_parent = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax',
+				'parent'   => $parent,
+			)
+		);
+
+		$child_with_children = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax',
+				'parent'   => $parent,
+			)
+		);
+
+		$other_parent = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax',
+			)
+		);
+
+		$grand_child = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax',
+				'parent'   => $child_with_children,
+			)
+		);
+
+		$q = new WP_Term_Query(
+			array(
+				'taxonomy'   => 'wptests_tax',
+				'childless'  => true,
+				'child_of'   => $parent,
+				'hide_empty' => false,
+				'fields'     => 'ids',
+			)
+		);
+
+		$this->assertEqualSets( array( $childless_parent, $grand_child ), $q->terms );
+	}
+
+	/**
 	 * @ticket 42691
 	 */
 	public function test_error_term_object_should_be_discarded() {


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/44279

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
