### PR TITLE
Rename `data_wp_context` to `wp_interactivity_data_wp_context`

### DIFF
--- a/src/wp-includes/interactivity-api/interactivity-api.php
+++ b/src/wp-includes/interactivity-api/interactivity-api.php
@@ -149,7 +149,7 @@ function wp_interactivity_config( string $store_namespace, array $config = array
  *
  * Example:
  *
- *     <div <?php echo data_wp_context( array( 'isOpen' => true, 'count' => 0 ) ); ?>>
+ *     <div <?php echo wp_interactivity_data_wp_context( array( 'isOpen' => true, 'count' => 0 ) ); ?>>
  *
  * @since 6.5.0
  *
@@ -158,7 +158,7 @@ function wp_interactivity_config( string $store_namespace, array $config = array
  * @return string A complete `data-wp-context` directive with a JSON encoded value representing the context array and
  *                the store namespace if specified.
  */
-function data_wp_context( array $context, string $store_namespace = '' ): string {
+function wp_interactivity_data_wp_context( array $context, string $store_namespace = '' ): string {
 	return 'data-wp-context=\'' .
 		( $store_namespace ? $store_namespace . '::' : '' ) .
 		( empty( $context ) ? '{}' : wp_json_encode( $context, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ) ) .

--- a/tests/phpunit/tests/interactivity-api/interactivity-api.php
+++ b/tests/phpunit/tests/interactivity-api/interactivity-api.php
@@ -314,18 +314,18 @@ class Tests_Interactivity_API_Functions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that data_wp_context function correctly converts different array
+	 * Tests that wp_interactivity_wp_interactivity_data_wp_context function correctly converts different array
 	 * structures to a JSON string.
 	 *
 	 * @ticket 60356
 	 *
-	 * @covers ::data_wp_context
+	 * @covers ::wp_interactivity_wp_interactivity_data_wp_context
 	 */
-	public function test_data_wp_context_with_different_arrays() {
-		$this->assertEquals( 'data-wp-context=\'{}\'', data_wp_context( array() ) );
+	public function test_wp_interactivity_data_wp_context_with_different_arrays() {
+		$this->assertEquals( 'data-wp-context=\'{}\'', wp_interactivity_data_wp_context( array() ) );
 		$this->assertEquals(
 			'data-wp-context=\'{"a":1,"b":"2","c":true}\'',
-			data_wp_context(
+			wp_interactivity_data_wp_context(
 				array(
 					'a' => 1,
 					'b' => '2',
@@ -335,27 +335,27 @@ class Tests_Interactivity_API_Functions extends WP_UnitTestCase {
 		);
 		$this->assertEquals(
 			'data-wp-context=\'{"a":[1,2]}\'',
-			data_wp_context( array( 'a' => array( 1, 2 ) ) )
+			wp_interactivity_data_wp_context( array( 'a' => array( 1, 2 ) ) )
 		);
 		$this->assertEquals(
 			'data-wp-context=\'[1,2]\'',
-			data_wp_context( array( 1, 2 ) )
+			wp_interactivity_data_wp_context( array( 1, 2 ) )
 		);
 	}
 
 	/**
-	 * Tests that data_wp_context function correctly converts different array
+	 * Tests that wp_interactivity_data_wp_context function correctly converts different array
 	 * structures to a JSON string and adds a namespace.
 	 *
 	 * @ticket 60356
 	 *
-	 * @covers ::data_wp_context
+	 * @covers ::wp_interactivity_data_wp_context
 	 */
-	public function test_data_wp_context_with_different_arrays_and_a_namespace() {
-		$this->assertEquals( 'data-wp-context=\'myPlugin::{}\'', data_wp_context( array(), 'myPlugin' ) );
+	public function test_wp_interactivity_data_wp_context_with_different_arrays_and_a_namespace() {
+		$this->assertEquals( 'data-wp-context=\'myPlugin::{}\'', wp_interactivity_data_wp_context( array(), 'myPlugin' ) );
 		$this->assertEquals(
 			'data-wp-context=\'myPlugin::{"a":1,"b":"2","c":true}\'',
-			data_wp_context(
+			wp_interactivity_data_wp_context(
 				array(
 					'a' => 1,
 					'b' => '2',
@@ -366,28 +366,28 @@ class Tests_Interactivity_API_Functions extends WP_UnitTestCase {
 		);
 		$this->assertEquals(
 			'data-wp-context=\'myPlugin::{"a":[1,2]}\'',
-			data_wp_context( array( 'a' => array( 1, 2 ) ), 'myPlugin' )
+			wp_interactivity_data_wp_context( array( 'a' => array( 1, 2 ) ), 'myPlugin' )
 		);
 		$this->assertEquals(
 			'data-wp-context=\'myPlugin::[1,2]\'',
-			data_wp_context( array( 1, 2 ), 'myPlugin' )
+			wp_interactivity_data_wp_context( array( 1, 2 ), 'myPlugin' )
 		);
 	}
 
 	/**
-	 * Tests that data_wp_context function correctly applies the JSON encoding
+	 * Tests that wp_interactivity_data_wp_context function correctly applies the JSON encoding
 	 * flags. This ensures that characters like `<`, `>`, `'`, or `&` are
 	 * properly escaped in the JSON-encoded string to prevent potential XSS
 	 * attacks.
 	 *
 	 * @ticket 60356
 	 *
-	 * @covers ::data_wp_context
+	 * @covers ::wp_interactivity_data_wp_context
 	 */
-	public function test_data_wp_context_with_json_flags() {
-		$this->assertEquals( 'data-wp-context=\'{"tag":"\u003Cfoo\u003E"}\'', data_wp_context( array( 'tag' => '<foo>' ) ) );
-		$this->assertEquals( 'data-wp-context=\'{"apos":"\u0027bar\u0027"}\'', data_wp_context( array( 'apos' => "'bar'" ) ) );
-		$this->assertEquals( 'data-wp-context=\'{"quot":"\u0022baz\u0022"}\'', data_wp_context( array( 'quot' => '"baz"' ) ) );
-		$this->assertEquals( 'data-wp-context=\'{"amp":"T\u0026T"}\'', data_wp_context( array( 'amp' => 'T&T' ) ) );
+	public function test_wp_interactivity_data_wp_context_with_json_flags() {
+		$this->assertEquals( 'data-wp-context=\'{"tag":"\u003Cfoo\u003E"}\'', wp_interactivity_data_wp_context( array( 'tag' => '<foo>' ) ) );
+		$this->assertEquals( 'data-wp-context=\'{"apos":"\u0027bar\u0027"}\'', wp_interactivity_data_wp_context( array( 'apos' => "'bar'" ) ) );
+		$this->assertEquals( 'data-wp-context=\'{"quot":"\u0022baz\u0022"}\'', wp_interactivity_data_wp_context( array( 'quot' => '"baz"' ) ) );
+		$this->assertEquals( 'data-wp-context=\'{"amp":"T\u0026T"}\'', wp_interactivity_data_wp_context( array( 'amp' => 'T&T' ) ) );
 	}
 }

--- a/tests/phpunit/tests/interactivity-api/interactivity-api.php
+++ b/tests/phpunit/tests/interactivity-api/interactivity-api.php
@@ -314,12 +314,12 @@ class Tests_Interactivity_API_Functions extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that wp_interactivity_wp_interactivity_data_wp_context function correctly converts different array
+	 * Tests that wp_interactivity_data_wp_context function correctly converts different array
 	 * structures to a JSON string.
 	 *
 	 * @ticket 60356
 	 *
-	 * @covers ::wp_interactivity_wp_interactivity_data_wp_context
+	 * @covers ::wp_interactivity_data_wp_context
 	 */
 	public function test_wp_interactivity_data_wp_context_with_different_arrays() {
 		$this->assertEquals( 'data-wp-context=\'{}\'', wp_interactivity_data_wp_context( array() ) );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Renames the function for more clarity.

**Important:** requires a corresponding change to the block render callbacks in Gutenberg

Trac ticket: https://core.trac.wordpress.org/ticket/60575

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
