### PR TITLE
Plugins: Prevent links with `button-disabled` from being clickable.

### DIFF
--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -2675,6 +2675,17 @@
 		});
 
 		/**
+		 * Click handler for disabled links.
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param {Event} event Event interface.
+		 */
+		$document.on( 'click', '.button-disabled', function( event ) {
+			event.preventDefault();
+		} );
+
+		/**
 		 * Click handler for importer plugins installs in the Import screen.
 		 *
 		 * @since 4.6.0


### PR DESCRIPTION
Previously, links with a `href` attribute and the `.button-disabled` class were still clickable.

This prevents the default handling for elements with the `.button-disabled` class.

Remember to run `npm run build:dev` after applying the patch. 🙂 

Trac ticket: https://core.trac.wordpress.org/ticket/60663
