### PR TITLE
Update pattern overrides block bindings callback to use block metadata name

### DIFF
--- a/src/wp-includes/block-bindings/pattern-overrides.php
+++ b/src/wp-includes/block-bindings/pattern-overrides.php
@@ -20,11 +20,11 @@
  * @return mixed The value computed for the source.
  */
 function _block_bindings_pattern_overrides_get_value( array $source_args, $block_instance, string $attribute_name ) {
-	if ( empty( $block_instance->attributes['metadata']['id'] ) ) {
+	if ( empty( $block_instance->attributes['metadata']['name'] ) ) {
 		return null;
 	}
-	$block_id = $block_instance->attributes['metadata']['id'];
-	return _wp_array_get( $block_instance->context, array( 'pattern/overrides', $block_id, 'values', $attribute_name ), null );
+	$metadata_name = $block_instance->attributes['metadata']['name'];
+	return _wp_array_get( $block_instance->context, array( 'pattern/overrides', $metadata_name, $attribute_name ), null );
 }
 
 /**


### PR DESCRIPTION

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Backports the PHP changes from https://github.com/WordPress/gutenberg/pull/59268

Trac ticket: https://core.trac.wordpress.org/ticket/60665

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
