### PR TITLE
Backport: Elements - Merge element style and classname generation to single filter

### DIFF
--- a/src/wp-includes/block-supports/elements.php
+++ b/src/wp-includes/block-supports/elements.php
@@ -22,7 +22,7 @@ function wp_get_elements_class_name( $block ) {
 /**
  * Updates the block content with elements class names.
  *
- * @deprecated 6.5.0 Generation of element class name is handled via `render_block_data` filter.
+ * @deprecated 6.6.0 Generation of element class name is handled via `render_block_data` filter.
  *
  * @since 5.8.0
  * @since 6.4.0 Added support for button and heading element styling.
@@ -33,14 +33,14 @@ function wp_get_elements_class_name( $block ) {
  * @return string Filtered block content.
  */
 function wp_render_elements_support( $block_content, $block ) {
-	_deprecated_function( __FUNCTION__, '6.5.0', 'wp_render_elements_support' );
+	_deprecated_function( __FUNCTION__, '6.6.0', 'wp_render_elements_support' );
 	return $block_content;
 }
 
 /**
  * Determines whether an elements class name should be added to the block.
  *
- * @since 6.5.0
+ * @since 6.6.0
  * @access private
  *
  * @param  array $block   Block object.
@@ -122,7 +122,7 @@ function wp_should_add_elements_class_name( $block, $options ) {
  *
  * @since 6.0.0
  * @since 6.1.0 Implemented the style engine to generate CSS and classnames.
- * @since 6.5.0 Element block support class and styles are generated via the `render_block_data` filter instead of `pre_render_block`.
+ * @since 6.6.0 Element block support class and styles are generated via the `render_block_data` filter instead of `pre_render_block`.
  * @access private
  *
  * @param array $parsed_block The parsed block.
@@ -131,7 +131,7 @@ function wp_should_add_elements_class_name( $block, $options ) {
 function wp_render_elements_support_styles( $parsed_block ) {
 	/*
 	 * The generation of element styles and classname were moved to the
-	 * `render_block_data` filter in 6.5.0 to avoid filtered attributes
+	 * `render_block_data` filter in 6.6.0 to avoid filtered attributes
 	 * breaking the application of the elements CSS class.
 	 *
 	 * @see https://github.com/WordPress/gutenberg/pull/59535.
@@ -142,7 +142,7 @@ function wp_render_elements_support_styles( $parsed_block ) {
 	if ( is_string( $parsed_block ) ) {
 		_deprecated_argument(
 			__FUNCTION__,
-			'6.5.0',
+			'6.6.0',
 			__( 'Use as a `pre_render_block` filter is deprecated. Use with `render_block_data` instead.' )
 		);
 	}

--- a/src/wp-includes/block-supports/elements.php
+++ b/src/wp-includes/block-supports/elements.php
@@ -22,6 +22,8 @@ function wp_get_elements_class_name( $block ) {
 /**
  * Updates the block content with elements class names.
  *
+ * @deprecated 6.5.0 Generation of element class name is handled via `render_block_data` filter.
+ *
  * @since 5.8.0
  * @since 6.4.0 Added support for button and heading element styling.
  * @access private
@@ -31,18 +33,28 @@ function wp_get_elements_class_name( $block ) {
  * @return string Filtered block content.
  */
 function wp_render_elements_support( $block_content, $block ) {
-	if ( ! $block_content || ! isset( $block['attrs']['style']['elements'] ) ) {
-		return $block_content;
-	}
+	_deprecated_function( __FUNCTION__, '6.5.0', 'wp_render_elements_support' );
+	return $block_content;
+}
 
-	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
-	if ( ! $block_type ) {
-		return $block_content;
+/**
+ * Determines whether an elements class name should be added to the block.
+ *
+ * @since 6.5.0
+ * @access private
+ *
+ * @param  array $block   Block object.
+ * @param  array $options Per element type options e.g. whether to skip serialization.
+ * @return boolean Whether the block needs an elements class name.
+ */
+function wp_should_add_elements_class_name( $block, $options ) {
+	if ( ! isset( $block['attrs']['style']['elements'] ) ) {
+		return false;
 	}
 
 	$element_color_properties = array(
 		'button'  => array(
-			'skip'  => wp_should_skip_block_supports_serialization( $block_type, 'color', 'button' ),
+			'skip'  => isset( $options['button']['skip'] ) ? $options['button']['skip'] : false,
 			'paths' => array(
 				array( 'button', 'color', 'text' ),
 				array( 'button', 'color', 'background' ),
@@ -50,14 +62,14 @@ function wp_render_elements_support( $block_content, $block ) {
 			),
 		),
 		'link'    => array(
-			'skip'  => wp_should_skip_block_supports_serialization( $block_type, 'color', 'link' ),
+			'skip'  => isset( $options['link']['skip'] ) ? $options['link']['skip'] : false,
 			'paths' => array(
 				array( 'link', 'color', 'text' ),
 				array( 'link', ':hover', 'color', 'text' ),
 			),
 		),
 		'heading' => array(
-			'skip'  => wp_should_skip_block_supports_serialization( $block_type, 'color', 'heading' ),
+			'skip'  => isset( $options['link']['skip'] ) ? $options['heading']['skip'] : false,
 			'paths' => array(
 				array( 'heading', 'color', 'text' ),
 				array( 'heading', 'color', 'background' ),
@@ -84,14 +96,6 @@ function wp_render_elements_support( $block_content, $block ) {
 		),
 	);
 
-	$skip_all_element_color_serialization = $element_color_properties['button']['skip'] &&
-		$element_color_properties['link']['skip'] &&
-		$element_color_properties['heading']['skip'];
-
-	if ( $skip_all_element_color_serialization ) {
-		return $block_content;
-	}
-
 	$elements_style_attributes = $block['attrs']['style']['elements'];
 
 	foreach ( $element_color_properties as $element_config ) {
@@ -101,31 +105,16 @@ function wp_render_elements_support( $block_content, $block ) {
 
 		foreach ( $element_config['paths'] as $path ) {
 			if ( null !== _wp_array_get( $elements_style_attributes, $path, null ) ) {
-				/*
-				 * It only takes a single custom attribute to require that the custom
-				 * class name be added to the block, so once one is found there's no
-				 * need to continue looking for others.
-				 *
-				 * As is done with the layout hook, this code assumes that the block
-				 * contains a single wrapper and that it's the first element in the
-				 * rendered output. That first element, if it exists, gets the class.
-				 */
-				$tags = new WP_HTML_Tag_Processor( $block_content );
-				if ( $tags->next_tag() ) {
-					$tags->add_class( wp_get_elements_class_name( $block ) );
-				}
-
-				return $tags->get_updated_html();
+				return true;
 			}
 		}
 	}
 
-	// If no custom attributes were found then there's nothing to modify.
-	return $block_content;
+	return false;
 }
 
 /**
- * Renders the elements stylesheet.
+ * Render the elements stylesheet and adds elements class name to block as required.
  *
  * In the case of nested blocks we want the parent element styles to be rendered before their descendants.
  * This solves the issue of an element (e.g.: link color) being styled in both the parent and a descendant:
@@ -133,18 +122,36 @@ function wp_render_elements_support( $block_content, $block ) {
  *
  * @since 6.0.0
  * @since 6.1.0 Implemented the style engine to generate CSS and classnames.
+ * @since 6.5.0 Element block support class and styles are generated via the `render_block_data` filter instead of `pre_render_block`.
  * @access private
  *
- * @param string|null $pre_render The pre-rendered content. Default null.
- * @param array       $block      The block being rendered.
- * @return null
+ * @param array $parsed_block The parsed block.
+ * @return array The same parsed block with elements classname added if appropriate.
  */
-function wp_render_elements_support_styles( $pre_render, $block ) {
-	$block_type           = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
-	$element_block_styles = isset( $block['attrs']['style']['elements'] ) ? $block['attrs']['style']['elements'] : null;
+function wp_render_elements_support_styles( $parsed_block ) {
+	/*
+	 * The generation of element styles and classname were moved to the
+	 * `render_block_data` filter in 6.5.0 to avoid filtered attributes
+	 * breaking the application of the elements CSS class.
+	 *
+	 * @see https://github.com/WordPress/gutenberg/pull/59535.
+	 *
+	 * The change in filter means, the argument types for this function
+	 * have changed and require deprecating.
+	 */
+	if ( is_string( $parsed_block ) ) {
+		_deprecated_argument(
+			__FUNCTION__,
+			'6.5.0',
+			__( 'Use as a `pre_render_block` filter is deprecated. Use with `render_block_data` instead.' )
+		);
+	}
+
+	$block_type           = WP_Block_Type_Registry::get_instance()->get_registered( $parsed_block['blockName'] );
+	$element_block_styles = isset( $parsed_block['attrs']['style']['elements'] ) ? $parsed_block['attrs']['style']['elements'] : null;
 
 	if ( ! $element_block_styles ) {
-		return null;
+		return $parsed_block;
 	}
 
 	$skip_link_color_serialization         = wp_should_skip_block_supports_serialization( $block_type, 'color', 'link' );
@@ -155,11 +162,25 @@ function wp_render_elements_support_styles( $pre_render, $block ) {
 		$skip_button_color_serialization;
 
 	if ( $skips_all_element_color_serialization ) {
-		return null;
+		return $parsed_block;
 	}
 
-	$class_name = wp_get_elements_class_name( $block );
+	$options = array(
+		'button'  => array( 'skip' => $skip_button_color_serialization ),
+		'link'    => array( 'skip' => $skip_link_color_serialization ),
+		'heading' => array( 'skip' => $skip_heading_color_serialization ),
+	);
 
+	if ( ! wp_should_add_elements_class_name( $parsed_block, $options ) ) {
+		return $parsed_block;
+	}
+
+	$class_name         = wp_get_elements_class_name( $parsed_block );
+	$updated_class_name = isset( $parsed_block['attrs']['className'] ) ? $parsed_block['attrs']['className'] . " $class_name" : $class_name;
+
+	_wp_array_set( $parsed_block, array( 'attrs', 'className' ), $updated_class_name );
+
+	// Generate element styles based on selector and store in style engine for enqueuing.
 	$element_types = array(
 		'button'  => array(
 			'selector' => ".$class_name .wp-element-button, .$class_name .wp-block-button__link",
@@ -225,8 +246,37 @@ function wp_render_elements_support_styles( $pre_render, $block ) {
 		}
 	}
 
-	return null;
+	return $parsed_block;
 }
 
-add_filter( 'render_block', 'wp_render_elements_support', 10, 2 );
-add_filter( 'pre_render_block', 'wp_render_elements_support_styles', 10, 2 );
+/**
+ * Ensure the elements block support class name generated, and added to
+ * block attributes, in the `render_block_data` filter gets applied to the
+ * block's markup.
+ *
+ * @see gutenberg_render_elements_support_styles
+ *
+ * @param  string $block_content Rendered block content.
+ * @param  array  $block         Block object.
+ *
+ * @return string                Filtered block content.
+ */
+function wp_render_elements_class_name( $block_content, $block ) {
+	$class_string = $block['attrs']['className'] ?? '';
+	preg_match( '/\bwp-elements-\S+\b/', $class_string, $matches );
+
+	if ( empty( $matches ) ) {
+		return $block_content;
+	}
+
+	$tags = new WP_HTML_Tag_Processor( $block_content );
+
+	if ( $tags->next_tag() ) {
+		$tags->add_class( $matches[0] );
+	}
+
+	return $tags->get_updated_html();
+}
+
+add_filter( 'render_block', 'wp_render_elements_class_name', 10, 2 );
+add_filter( 'render_block_data', 'wp_render_elements_support_styles', 10, 1 );

--- a/src/wp-includes/block-supports/elements.php
+++ b/src/wp-includes/block-supports/elements.php
@@ -254,7 +254,7 @@ function wp_render_elements_support_styles( $parsed_block ) {
  * block attributes, in the `render_block_data` filter gets applied to the
  * block's markup.
  *
- * @see gutenberg_render_elements_support_styles
+ * @see wp_render_elements_support_styles
  *
  * @param  string $block_content Rendered block content.
  * @param  array  $block         Block object.

--- a/src/wp-includes/block-supports/elements.php
+++ b/src/wp-includes/block-supports/elements.php
@@ -33,7 +33,7 @@ function wp_get_elements_class_name( $block ) {
  * @return string Filtered block content.
  */
 function wp_render_elements_support( $block_content, $block ) {
-	_deprecated_function( __FUNCTION__, '6.6.0', 'wp_render_elements_support' );
+	_deprecated_function( __FUNCTION__, '6.6.0', 'wp_render_elements_class_name' );
 	return $block_content;
 }
 

--- a/src/wp-includes/block-supports/elements.php
+++ b/src/wp-includes/block-supports/elements.php
@@ -255,6 +255,7 @@ function wp_render_elements_support_styles( $parsed_block ) {
  * block's markup.
  *
  * @see wp_render_elements_support_styles
+ * @since 6.6.0
  *
  * @param  string $block_content Rendered block content.
  * @param  array  $block         Block object.

--- a/src/wp-includes/block-supports/elements.php
+++ b/src/wp-includes/block-supports/elements.php
@@ -69,7 +69,7 @@ function wp_should_add_elements_class_name( $block, $options ) {
 			),
 		),
 		'heading' => array(
-			'skip'  => isset( $options['link']['skip'] ) ? $options['heading']['skip'] : false,
+			'skip'  => isset( $options['heading']['skip'] ) ? $options['heading']['skip'] : false,
 			'paths' => array(
 				array( 'heading', 'color', 'text' ),
 				array( 'heading', 'color', 'background' ),

--- a/tests/phpunit/tests/block-supports/wpRenderElementsSupport.php
+++ b/tests/phpunit/tests/block-supports/wpRenderElementsSupport.php
@@ -44,7 +44,7 @@ class Tests_Block_Supports_WpRenderElementsSupport extends WP_UnitTestCase {
 		);
 
 		$block_markup = '<p>Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>';
-		$actual       = wp_render_elements_support( $block_markup, $block );
+		$actual       = wp_render_elements_class_name( $block_markup, $block );
 
 		$this->assertSame( $block_markup, $actual, 'Expected to leave block content unmodified, but found changes.' );
 	}
@@ -90,7 +90,14 @@ class Tests_Block_Supports_WpRenderElementsSupport extends WP_UnitTestCase {
 			),
 		);
 
-		$actual = wp_render_elements_support( $block_markup, $block );
+		/*
+		 * To ensure a consistent elements class name it is generated within a
+		 * `render_block_data` filter and stored in the `className` attribute.
+		 * As a result, the block data needs to be passed through the same
+		 * function for this test.
+		 */
+		$filtered_block = wp_render_elements_support_styles( $block );
+		$actual         = wp_render_elements_class_name( $block_markup, $filtered_block );
 
 		$this->assertMatchesRegularExpression(
 			$expected_markup,

--- a/tests/phpunit/tests/block-supports/wpRenderElementsSupportStyles.php
+++ b/tests/phpunit/tests/block-supports/wpRenderElementsSupportStyles.php
@@ -59,7 +59,7 @@ class Tests_Block_Supports_WpRenderElementsSupportStyles extends WP_UnitTestCase
 			),
 		);
 
-		wp_render_elements_support_styles( null, $block );
+		wp_render_elements_support_styles( $block );
 		$actual_stylesheet = wp_style_engine_get_stylesheet_from_context( 'block-supports', array( 'prettify' => false ) );
 
 		$this->assertMatchesRegularExpression(


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Syncs the changes from https://github.com/WordPress/gutenberg/pull/59535 and https://github.com/WordPress/gutenberg/pull/59538.

These change update the elements block support filters such that the elements class name is only generated in a single location. This avoids conflicts between class names and makes the block support robust in the face of a block's data being filtered via other `render_block_data` filters.

To test:

Confirm https://github.com/WordPress/gutenberg/issues/59462 is still resolved

1. Edit a post and add a paragraph
2. Create a link with the paragraph
3. Via the block inspector apply a link color to the paragraph
4. Save and view the frontend confirming the correct link color is shown
5. Confirm nested applications of the same element styles work correctly:

Create some nested blocks containing links

1. Apply a set of element styles to the parent block
2. Apply different styles to a child block
3. Apply the first set of element styles to a grand-child block
4. Confirm the correct display of element styles

Unit tests:

```
npm run test:php -- --filter Tests_Block_Supports_WpRenderElementsSupport
npm run test:php -- --filter Tests_Block_Supports_WpRenderElementsSupportStyles
```

Trac ticket: https://core.trac.wordpress.org/ticket/60681

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
