### PR TITLE
Bundled themes version bumps for WordPress 6.5

### DIFF
--- a/src/wp-content/themes/twentyeleven/header.php
+++ b/src/wp-content/themes/twentyeleven/header.php
@@ -49,7 +49,7 @@ if ( ( $paged >= 2 || $page >= 2 ) && ! is_404() ) {
 ?>
 	</title>
 <link rel="profile" href="https://gmpg.org/xfn/11" />
-<link rel="stylesheet" type="text/css" media="all" href="<?php echo esc_url( get_stylesheet_uri() ); ?>?ver=20231107" />
+<link rel="stylesheet" type="text/css" media="all" href="<?php echo esc_url( get_stylesheet_uri() ); ?>?ver=20240326" />
 <link rel="pingback" href="<?php echo esc_url( get_bloginfo( 'pingback_url' ) ); ?>">
 <!--[if lt IE 9]>
 <script src="<?php echo esc_url( get_template_directory_uri() ); ?>/js/html5.js?ver=3.7.0" type="text/javascript"></script>

--- a/src/wp-content/themes/twentyeleven/header.php
+++ b/src/wp-content/themes/twentyeleven/header.php
@@ -49,7 +49,7 @@ if ( ( $paged >= 2 || $page >= 2 ) && ! is_404() ) {
 ?>
 	</title>
 <link rel="profile" href="https://gmpg.org/xfn/11" />
-<link rel="stylesheet" type="text/css" media="all" href="<?php echo esc_url( get_stylesheet_uri() ); ?>?ver=20240326" />
+<link rel="stylesheet" type="text/css" media="all" href="<?php echo esc_url( get_stylesheet_uri() ); ?>?ver=20240402" />
 <link rel="pingback" href="<?php echo esc_url( get_bloginfo( 'pingback_url' ) ); ?>">
 <!--[if lt IE 9]>
 <script src="<?php echo esc_url( get_template_directory_uri() ); ?>/js/html5.js?ver=3.7.0" type="text/javascript"></script>

--- a/src/wp-content/themes/twentyeleven/readme.txt
+++ b/src/wp-content/themes/twentyeleven/readme.txt
@@ -49,7 +49,7 @@ Images
 == Changelog ==
 
 = 4.6 =
-* Released: March 26, 2024
+* Released: April 2, 2024
 
 https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_4.6
 

--- a/src/wp-content/themes/twentyeleven/readme.txt
+++ b/src/wp-content/themes/twentyeleven/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Eleven ===
 Contributors: wordpressdotorg
 Requires at least: 3.2
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.2.4
-Stable tag: 4.5
+Stable tag: 4.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: blog, one-column, two-columns, left-sidebar, right-sidebar, custom-background, custom-colors, custom-header, custom-menu, editor-style, featured-image-header, featured-images, flexible-header, footer-widgets, full-width-template, microformats, post-formats, rtl-language-support, sticky-post, theme-options, translation-ready, block-patterns
@@ -48,175 +48,180 @@ Images
 
 == Changelog ==
 
+= 4.6 =
+* Released: March 26, 2024
+
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_4.6
+
 = 4.5 =
 * Released: November 7, 2023
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_4.5
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_4.5
 
 = 4.4 =
 * Released: August 8, 2023
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_4.4
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_4.4
 
 = 4.3 =
 * Released: March 28, 2023
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_4.3
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_4.3
 
 = 4.2 =
 * Released: November 1, 2022
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_4.2
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_4.2
 
 = 4.1 =
 * Released: May 24, 2022
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_4.1
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_4.1
 
 = 4.0 =
 * Released: January 25, 2022
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_4.0
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_4.0
 
 = 3.9 =
 * Released: July 26, 2021
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_3.9
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_3.9
 
 = 3.8 =
 * Released: July 20, 2021
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_3.8
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_3.8
 
 = 3.7 =
 * Released: March 9, 2021
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_3.7
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_3.7
 
 = 3.6 =
 * Released: December 8, 2020
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_3.6
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_3.6
 
 = 3.5 =
 * Released: August 11, 2020
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_3.5
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_3.5
 
 = 3.4 =
 * Released: March 31, 2020
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_3.4
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_3.4
 
 = 3.3 =
 * Released: May 7, 2019
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_3.3
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_3.3
 
 = 3.2 =
 * Released: February 21, 2019
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_3.2
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_3.2
 
 = 3.1 =
 * Released: January 9, 2019
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_3.1
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_3.1
 
 = 3.0 =
 * Released: December 19, 2018
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_3.0
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_3.0
 
 = 2.9 =
 * Released: December 6, 2018
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_2.9
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_2.9
 
 = 2.8 =
 * Released: May 17, 2018
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_2.8
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_2.8
 
 = 2.7 =
 * Released: November 14, 2017
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_2.7
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_2.7
 
 = 2.6 =
 * Released: June 8, 2017
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_2.6
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_2.6
 
 = 2.5 =
 * Released: August 15, 2016
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_2.5
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_2.5
 
 = 2.4 =
 * Released: April 12, 2016
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_2.4
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_2.4
 
 = 2.3 =
 * Released: December 8, 2015
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_2.3
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_2.3
 
 = 2.2 =
 * Released: August 18, 2015
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_2.2
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_2.2
 
 = 2.1 =
 * Released: April 23, 2015
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_2.1
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_2.1
 
 = 2.0 =
 * Released: December 18, 2014
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_2.0
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_2.0
 
 = 1.9 =
 * Released: September 4, 2014
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_1.9
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_1.9
 
 = 1.8 =
 * Released: May 8, 2014
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_1.8
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_1.8
 
 = 1.7 =
 * Released: October 24, 2013
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_1.7
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_1.7
 
 = 1.6 =
 * Released: August 1, 2013
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_1.6
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_1.6
 
 = 1.5 =
 * Released: December 11, 2012
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_1.5
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_1.5
 
 = 1.4 =
 * Released: June 13, 2012
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_1.4
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_1.4
 
 = 1.3 =
 * Released: December 12, 2011
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_1.3
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_1.3
 
 = 1.2 =
 * Released: July 12, 2011
 
-https://codex.wordpress.org/Twenty_Eleven_Theme_Changelog#Version_1.2
+https://wordpress.org/documentation/article/twenty-eleven-changelog/#Version_1.2
 
 = 1.1 =
 * Released: July 4, 2011

--- a/src/wp-content/themes/twentyeleven/style.css
+++ b/src/wp-content/themes/twentyeleven/style.css
@@ -4,9 +4,9 @@ Theme URI: https://wordpress.org/themes/twentyeleven/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: The 2011 theme for WordPress is sophisticated, lightweight, and adaptable. Make it yours with a custom menu, header image, and background -- then go further with available theme options for light or dark color scheme, custom link colors, and three layout choices. Twenty Eleven comes equipped with a Showcase page template that transforms your front page into a showcase to show off your best content, widget support galore (sidebar, three footer areas, and a Showcase page widget area), and a custom "Ephemera" widget to display your Aside, Link, Quote, or Status posts. Included are styles for print and for the admin editor, support for featured images (as custom header images on posts and pages and as large images on featured "sticky" posts), and special styles for six different post formats.
-Version: 4.5
+Version: 4.6
 Requires at least: 3.2
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/src/wp-content/themes/twentyfifteen/functions.php
+++ b/src/wp-content/themes/twentyfifteen/functions.php
@@ -430,7 +430,7 @@ function twentyfifteen_scripts() {
 	wp_enqueue_style( 'genericons', get_template_directory_uri() . '/genericons/genericons.css', array(), '20201026' );
 
 	// Load our main stylesheet.
-	wp_enqueue_style( 'twentyfifteen-style', get_stylesheet_uri(), array(), '20240326' );
+	wp_enqueue_style( 'twentyfifteen-style', get_stylesheet_uri(), array(), '20240402' );
 
 	// Theme block stylesheet.
 	wp_enqueue_style( 'twentyfifteen-block-style', get_template_directory_uri() . '/css/blocks.css', array( 'twentyfifteen-style' ), '20240210' );

--- a/src/wp-content/themes/twentyfifteen/functions.php
+++ b/src/wp-content/themes/twentyfifteen/functions.php
@@ -430,10 +430,10 @@ function twentyfifteen_scripts() {
 	wp_enqueue_style( 'genericons', get_template_directory_uri() . '/genericons/genericons.css', array(), '20201026' );
 
 	// Load our main stylesheet.
-	wp_enqueue_style( 'twentyfifteen-style', get_stylesheet_uri(), array(), '20231107' );
+	wp_enqueue_style( 'twentyfifteen-style', get_stylesheet_uri(), array(), '20240326' );
 
 	// Theme block stylesheet.
-	wp_enqueue_style( 'twentyfifteen-block-style', get_template_directory_uri() . '/css/blocks.css', array( 'twentyfifteen-style' ), '20230623' );
+	wp_enqueue_style( 'twentyfifteen-block-style', get_template_directory_uri() . '/css/blocks.css', array( 'twentyfifteen-style' ), '20240210' );
 
 	// Register the Internet Explorer specific stylesheet.
 	wp_register_style( 'twentyfifteen-ie', get_template_directory_uri() . '/css/ie.css', array( 'twentyfifteen-style' ), '20220908' );
@@ -484,7 +484,7 @@ add_action( 'wp_enqueue_scripts', 'twentyfifteen_scripts' );
  */
 function twentyfifteen_block_editor_styles() {
 	// Block styles.
-	wp_enqueue_style( 'twentyfifteen-block-editor-style', get_template_directory_uri() . '/css/editor-blocks.css', array(), '20230623' );
+	wp_enqueue_style( 'twentyfifteen-block-editor-style', get_template_directory_uri() . '/css/editor-blocks.css', array(), '20240117' );
 	// Add custom fonts.
 	$font_version = ( 0 === strpos( (string) twentyfifteen_fonts_url(), get_template_directory_uri() . '/' ) ) ? '20230328' : null;
 	wp_enqueue_style( 'twentyfifteen-fonts', twentyfifteen_fonts_url(), array(), $font_version );

--- a/src/wp-content/themes/twentyfifteen/readme.txt
+++ b/src/wp-content/themes/twentyfifteen/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Fifteen ===
 Contributors: wordpressdotorg
 Requires at least: 4.1
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.2.4
-Version: 3.6
+Version: 3.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: blog, two-columns, left-sidebar, accessibility-ready, custom-background, custom-colors, custom-header, custom-logo, custom-menu, editor-style, featured-images, microformats, post-formats, rtl-language-support, sticky-post, threaded-comments, translation-ready, block-patterns
@@ -77,135 +77,140 @@ Source: https://stocksnap.io/photo/purple-yellow-ACF0693B9C
 
 == Changelog ==
 
+= 3.7 =
+* Released: March 26, 2024
+
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_3.7
+
 = 3.6 =
 * Released: November 7, 2023
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_3.6
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_3.6
 
 = 3.5 =
 * Released: August 8, 2023
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_3.5
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_3.5
 
 = 3.4 =
 * Released: March 28, 2023
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_3.4
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_3.4
 
 = 3.3 =
 * Released: November 1, 2022
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_3.3
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_3.3
 
 = 3.2 =
 * Released: May 24, 2022
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_3.2
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_3.2
 
 = 3.1 =
 * Released: January 25, 2022
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_3.1
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_3.1
 
 = 3.0 =
 * Released: July 20, 2021
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_3.0
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_3.0
 
 = 2.9 =
 * Released: March 9, 2021
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_2.9
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_2.9
 
 = 2.8 =
 * Released: December 8, 2020
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_2.8
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_2.8
 
 = 2.7 =
 * Released: August 11, 2020
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_2.7
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_2.7
 
 = 2.6 =
 * Released: March 31, 2020
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_2.6
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_2.6
 
 = 2.5 =
 * Released: May 7, 2019
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_2.5
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_2.5
 
 = 2.4 =
 * Released: February 21, 2019
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_2.4
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_2.4
 
 = 2.3 =
 * Released: January 9, 2019
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_2.3
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_2.3
 
 = 2.2 =
 * Released: December 19, 2018
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_2.2
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_2.2
 
 = 2.1 =
 * Released: December 6, 2018
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_2.1
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_2.1
 
 = 2.0 =
 * Released: May 17, 2018
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_2.0
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_2.0
 
 = 1.9 =
 * Released: November 14, 2017
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_1.9
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_1.9
 
 = 1.8 =
 * Released: June 8, 2017
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_1.8
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_1.8
 
 = 1.7 =
 * Released: December 6, 2016
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_1.7
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_1.7
 
 = 1.6 =
 * Released: August 15, 2016
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_1.6
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_1.6
 
 = 1.5 =
 * Released: April 12, 2016
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_1.5
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_1.5
 
 = 1.4 =
 * Released: December 8, 2015
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_1.4
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_1.4
 
 = 1.3 =
 * Released: August 18, 2015
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_1.3
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_1.3
 
 = 1.2 =
 * Released: May 6, 2015
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_1.2
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_1.2
 
 = 1.1 =
 * Released: April 23, 2015
 
-https://codex.wordpress.org/Twenty_Fifteen_Theme_Changelog#Version_1.1
+https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_1.1
 
 = 1.0 =
 * Released: December 18, 2014

--- a/src/wp-content/themes/twentyfifteen/readme.txt
+++ b/src/wp-content/themes/twentyfifteen/readme.txt
@@ -78,7 +78,7 @@ Source: https://stocksnap.io/photo/purple-yellow-ACF0693B9C
 == Changelog ==
 
 = 3.7 =
-* Released: March 26, 2024
+* Released: April 2, 2024
 
 https://wordpress.org/documentation/article/twenty-fifteen-changelog/#Version_3.7
 

--- a/src/wp-content/themes/twentyfifteen/style.css
+++ b/src/wp-content/themes/twentyfifteen/style.css
@@ -4,9 +4,9 @@ Theme URI: https://wordpress.org/themes/twentyfifteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Our 2015 default theme is clean, blog-focused, and designed for clarity. Twenty Fifteen's simple, straightforward typography is readable on a wide variety of screen sizes, and suitable for multiple languages. We designed it using a mobile-first approach, meaning your content takes center-stage, regardless of whether your visitors arrive by smartphone, tablet, laptop, or desktop computer.
-Version: 3.6
+Version: 3.7
 Requires at least: 4.1
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/src/wp-content/themes/twentyfourteen/functions.php
+++ b/src/wp-content/themes/twentyfourteen/functions.php
@@ -345,7 +345,7 @@ function twentyfourteen_scripts() {
 	wp_enqueue_style( 'genericons', get_template_directory_uri() . '/genericons/genericons.css', array(), '3.0.3' );
 
 	// Load our main stylesheet.
-	wp_enqueue_style( 'twentyfourteen-style', get_stylesheet_uri(), array(), '20240326' );
+	wp_enqueue_style( 'twentyfourteen-style', get_stylesheet_uri(), array(), '20240402' );
 
 	// Theme block stylesheet.
 	wp_enqueue_style( 'twentyfourteen-block-style', get_template_directory_uri() . '/css/blocks.css', array( 'twentyfourteen-style' ), '20230630' );

--- a/src/wp-content/themes/twentyfourteen/functions.php
+++ b/src/wp-content/themes/twentyfourteen/functions.php
@@ -345,7 +345,7 @@ function twentyfourteen_scripts() {
 	wp_enqueue_style( 'genericons', get_template_directory_uri() . '/genericons/genericons.css', array(), '3.0.3' );
 
 	// Load our main stylesheet.
-	wp_enqueue_style( 'twentyfourteen-style', get_stylesheet_uri(), array(), '20231107' );
+	wp_enqueue_style( 'twentyfourteen-style', get_stylesheet_uri(), array(), '20240326' );
 
 	// Theme block stylesheet.
 	wp_enqueue_style( 'twentyfourteen-block-style', get_template_directory_uri() . '/css/blocks.css', array( 'twentyfourteen-style' ), '20230630' );

--- a/src/wp-content/themes/twentyfourteen/readme.txt
+++ b/src/wp-content/themes/twentyfourteen/readme.txt
@@ -65,7 +65,7 @@ Source: https://stocksnap.io/photo/fog-mountain-ZKN6UKFKEO
 == Changelog ==
 
 = 3.9 =
-* Released: March 26, 2024
+* Released: April 2, 2024
 
 https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_3.9
 

--- a/src/wp-content/themes/twentyfourteen/readme.txt
+++ b/src/wp-content/themes/twentyfourteen/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Fourteen ===
 Contributors: wordpressdotorg
 Requires at least: 3.6
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.2.4
-Stable tag: 3.8
+Stable tag: 3.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: blog, news, two-columns, three-columns, left-sidebar, right-sidebar, custom-background, custom-header, custom-menu, editor-style, featured-images, flexible-header, footer-widgets, full-width-template, microformats, post-formats, rtl-language-support, sticky-post, theme-options, translation-ready, accessibility-ready, block-patterns
@@ -64,145 +64,150 @@ Source: https://stocksnap.io/photo/fog-mountain-ZKN6UKFKEO
 
 == Changelog ==
 
+= 3.9 =
+* Released: March 26, 2024
+
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_3.9
+
 = 3.8 =
 * Released: November 7, 2023
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_3.8
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_3.8
 
 = 3.7 =
 * Released: August 8, 2023
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_3.7
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_3.7
 
 = 3.6 =
 * Released: March 28, 2023
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_3.6
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_3.6
 
 = 3.5 =
 * Released: November 1, 2022
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_3.5
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_3.5
 
 = 3.4 =
 * Released: May 24, 2022
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_3.4
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_3.4
 
 = 3.3 =
 * Released: January 25, 2022
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_3.3
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_3.3
 
 = 3.2 =
 * Released: July 20, 2021
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_3.2
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_3.2
 
 = 3.1 =
 * Released: March 9, 2021
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_3.1
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_3.1
 
 = 3.0 =
 * Released: December 8, 2020
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_3.0
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_3.0
 
 = 2.9 =
 * Released: August 11, 2020
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_2.9
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_2.9
 
 = 2.8 =
 * Released: March 31, 2020
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_2.8
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_2.8
 
 = 2.7 =
 * Released: May 7, 2019
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_2.7
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_2.7
 
 = 2.6 =
 * Released: February 21, 2019
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_2.6
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_2.6
 
 = 2.5 =
 * Released: January 9, 2019
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_2.5
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_2.5
 
 = 2.4 =
 * Released: December 19, 2018
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_2.4
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_2.4
 
 = 2.3 =
 * Released: December 6, 2018
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_2.3
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_2.3
 
 = 2.2 =
 * Released: May 17, 2018
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_2.2
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_2.2
 
 = 2.1 =
 * Released: November 14, 2017
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_2.1
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_2.1
 
 = 2.0 =
 * Released: June 8, 2017
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_2.0
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_2.0
 
 = 1.9 =
 * Released: December 6, 2016
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_1.9
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_1.9
 
 = 1.8 =
 * Released: August 15, 2016
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_1.8
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_1.8
 
 = 1.7 =
 * Released: April 12, 2016
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_1.7
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_1.7
 
 = 1.6 =
 * Released: December 8, 2015
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_1.6
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_1.6
 
 = 1.5 =
 * Released: August 18, 2015
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_1.5
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_1.5
 
 = 1.4 =
 * Released: April 23, 2015
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_1.4
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_1.4
 
 = 1.3 =
 * Released: December 18, 2014
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_1.3
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_1.3
 
 = 1.2 =
 * Released: September 4, 2014
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_1.2
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_1.2
 
 = 1.1 =
 * Released: May 8, 2014
 
-https://codex.wordpress.org/Twenty_Fourteen_Theme_Changelog#Version_1.1
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_1.1
 
 = 1.0 =
 * Released: December 12, 2013

--- a/src/wp-content/themes/twentyfourteen/style.css
+++ b/src/wp-content/themes/twentyfourteen/style.css
@@ -4,9 +4,9 @@ Theme URI: https://wordpress.org/themes/twentyfourteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: In 2014, our default theme lets you create a responsive magazine website with a sleek, modern design. Feature your favorite homepage content in either a grid or a slider. Use the three widget areas to customize your website, and change your content's layout with a full-width page template and a contributor page to show off your authors. Creating a magazine website with WordPress has never been easier.
-Version: 3.8
+Version: 3.9
 Requires at least: 3.6
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/src/wp-content/themes/twentynineteen/package-lock.json
+++ b/src/wp-content/themes/twentynineteen/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "twentynineteen",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "twentynineteen",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "devDependencies": {
         "@wordpress/browserslist-config": "^5.31.0",
         "autoprefixer": "^10.4.16",

--- a/src/wp-content/themes/twentynineteen/package.json
+++ b/src/wp-content/themes/twentynineteen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twentynineteen",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Default WP Theme",
   "bugs": {
     "url": "https://core.trac.wordpress.org/"

--- a/src/wp-content/themes/twentynineteen/readme.txt
+++ b/src/wp-content/themes/twentynineteen/readme.txt
@@ -2,9 +2,9 @@
 Contributors: wordpressdotorg
 Tags: one-column, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, rtl-language-support, sticky-post, threaded-comments, translation-ready, block-patterns
 Requires at least: 4.7
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.2.4
-Stable tag: 2.7
+Stable tag: 2.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -40,90 +40,95 @@ GNU General Public License for more details.
 
 == Changelog ==
 
+= 2.8 =
+* Released: March 26, 2024
+
+https://wordpress.org/documentation/article/twenty-nineteen-changelog/#Version_2.8
+
 = 2.7 =
 * Released: November 7, 2023
 
-https://codex.wordpress.org/Twenty_Nineteen_Theme_Changelog#Version_2.7
+https://wordpress.org/documentation/article/twenty-nineteen-changelog/#Version_2.7
 
 = 2.6 =
 * Released: August 8, 2023
 
-https://codex.wordpress.org/Twenty_Nineteen_Theme_Changelog#Version_2.6
+https://wordpress.org/documentation/article/twenty-nineteen-changelog/#Version_2.6
 
 = 2.5 =
 * Released: March 28, 2023
 
-https://codex.wordpress.org/Twenty_Nineteen_Theme_Changelog#Version_2.5
+https://wordpress.org/documentation/article/twenty-nineteen-changelog/#Version_2.5
 
 = 2.4 =
 * Released: November 1, 2022
 
-https://codex.wordpress.org/Twenty_Nineteen_Theme_Changelog#Version_2.4
+https://wordpress.org/documentation/article/twenty-nineteen-changelog/#Version_2.4
 
 = 2.3 =
 * Released: May 24, 2022
 
-https://codex.wordpress.org/Twenty_Nineteen_Theme_Changelog#Version_2.3
+https://wordpress.org/documentation/article/twenty-nineteen-changelog/#Version_2.3
 
 = 2.2 =
 * Released: January 25, 2022
 
-https://codex.wordpress.org/Twenty_Nineteen_Theme_Changelog#Version_2.2
+https://wordpress.org/documentation/article/twenty-nineteen-changelog/#Version_2.2
 
 = 2.1 =
 * Released: July 20, 2021
 
-https://codex.wordpress.org/Twenty_Nineteen_Theme_Changelog#Version_2.1
+https://wordpress.org/documentation/article/twenty-nineteen-changelog/#Version_2.1
 
 = 2.0 =
 * Released: March 9, 2021
 
-https://codex.wordpress.org/Twenty_Nineteen_Theme_Changelog#Version_2.0
+https://wordpress.org/documentation/article/twenty-nineteen-changelog/#Version_2.0
 
 = 1.9 =
 * Released: December 22, 2020
 
-https://codex.wordpress.org/Twenty_Nineteen_Theme_Changelog#Version_1.9
+https://wordpress.org/documentation/article/twenty-nineteen-changelog/#Version_1.9
 
 = 1.8 =
 * Released: December 8, 2020
 
-https://codex.wordpress.org/Twenty_Nineteen_Theme_Changelog#Version_1.8
+https://wordpress.org/documentation/article/twenty-nineteen-changelog/#Version_1.8
 
 = 1.7 =
 * Released: August 11, 2020
 
-https://codex.wordpress.org/Twenty_Nineteen_Theme_Changelog#Version_1.7
+https://wordpress.org/documentation/article/twenty-nineteen-changelog/#Version_1.7
 
 = 1.6 =
 * Released: June 10, 2020
 
-https://codex.wordpress.org/Twenty_Nineteen_Theme_Changelog#Version_1.6
+https://wordpress.org/documentation/article/twenty-nineteen-changelog/#Version_1.6
 
 = 1.5 =
 * Released: March 31, 2020
 
-https://codex.wordpress.org/Twenty_Nineteen_Theme_Changelog#Version_1.5
+https://wordpress.org/documentation/article/twenty-nineteen-changelog/#Version_1.5
 
 = 1.4 =
 * Released: May 7, 2019
 
-https://codex.wordpress.org/Twenty_Nineteen_Theme_Changelog#Version_1.4
+https://wordpress.org/documentation/article/twenty-nineteen-changelog/#Version_1.4
 
 = 1.3 =
 * Released: February 21, 2019
 
-https://codex.wordpress.org/Twenty_Nineteen_Theme_Changelog#Version_1.3
+https://wordpress.org/documentation/article/twenty-nineteen-changelog/#Version_1.3
 
 = 1.2 =
 * Released: January 9, 2019
 
-https://codex.wordpress.org/Twenty_Nineteen_Theme_Changelog#Version_1.2
+https://wordpress.org/documentation/article/twenty-nineteen-changelog/#Version_1.2
 
 = 1.1 =
 * Released: December 19, 2018
 
-https://codex.wordpress.org/Twenty_Nineteen_Theme_Changelog#Version_1.1
+https://wordpress.org/documentation/article/twenty-nineteen-changelog/#Version_1.1
 
 = 1.0 =
 * Released: December 6, 2018

--- a/src/wp-content/themes/twentynineteen/readme.txt
+++ b/src/wp-content/themes/twentynineteen/readme.txt
@@ -41,7 +41,7 @@ GNU General Public License for more details.
 == Changelog ==
 
 = 2.8 =
-* Released: March 26, 2024
+* Released: April 2, 2024
 
 https://wordpress.org/documentation/article/twenty-nineteen-changelog/#Version_2.8
 

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -5,10 +5,10 @@ Theme URI: https://wordpress.org/themes/twentynineteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Our 2019 default theme is designed to show off the power of the block editor. It features custom styles for all the default blocks, and is built so that what you see in the editor looks like what you'll see on your website. Twenty Nineteen is designed to be adaptable to a wide range of websites, whether you’re running a photo blog, launching a new business, or supporting a non-profit. Featuring ample whitespace and modern sans-serif headlines paired with classic serif body text, it's built to be beautiful on all screen sizes.
-Tested up to: 6.4
+Tested up to: 6.5
 Requires at least: 4.7
 Requires PHP: 5.2.4
-Version: 2.7
+Version: 2.8
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentynineteen

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -5,10 +5,10 @@ Theme URI: https://wordpress.org/themes/twentynineteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Our 2019 default theme is designed to show off the power of the block editor. It features custom styles for all the default blocks, and is built so that what you see in the editor looks like what you'll see on your website. Twenty Nineteen is designed to be adaptable to a wide range of websites, whether you’re running a photo blog, launching a new business, or supporting a non-profit. Featuring ample whitespace and modern sans-serif headlines paired with classic serif body text, it's built to be beautiful on all screen sizes.
-Tested up to: 6.4
+Tested up to: 6.5
 Requires at least: 4.7
 Requires PHP: 5.2.4
-Version: 2.7
+Version: 2.8
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentynineteen

--- a/src/wp-content/themes/twentynineteen/style.scss
+++ b/src/wp-content/themes/twentynineteen/style.scss
@@ -4,10 +4,10 @@ Theme URI: https://wordpress.org/themes/twentynineteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Our 2019 default theme is designed to show off the power of the block editor. It features custom styles for all the default blocks, and is built so that what you see in the editor looks like what you'll see on your website. Twenty Nineteen is designed to be adaptable to a wide range of websites, whether you’re running a photo blog, launching a new business, or supporting a non-profit. Featuring ample whitespace and modern sans-serif headlines paired with classic serif body text, it's built to be beautiful on all screen sizes.
-Tested up to: 6.4
+Tested up to: 6.5
 Requires at least: 4.7
 Requires PHP: 5.2.4
-Version: 2.7
+Version: 2.8
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentynineteen

--- a/src/wp-content/themes/twentyseventeen/functions.php
+++ b/src/wp-content/themes/twentyseventeen/functions.php
@@ -452,7 +452,7 @@ function twentyseventeen_scripts() {
 	wp_enqueue_style( 'twentyseventeen-fonts', twentyseventeen_fonts_url(), array(), $font_version );
 
 	// Theme stylesheet.
-	wp_enqueue_style( 'twentyseventeen-style', get_stylesheet_uri(), array(), '20240326' );
+	wp_enqueue_style( 'twentyseventeen-style', get_stylesheet_uri(), array(), '20240402' );
 
 	// Theme block stylesheet.
 	wp_enqueue_style( 'twentyseventeen-block-style', get_theme_file_uri( '/assets/css/blocks.css' ), array( 'twentyseventeen-style' ), '20220912' );

--- a/src/wp-content/themes/twentyseventeen/functions.php
+++ b/src/wp-content/themes/twentyseventeen/functions.php
@@ -452,7 +452,7 @@ function twentyseventeen_scripts() {
 	wp_enqueue_style( 'twentyseventeen-fonts', twentyseventeen_fonts_url(), array(), $font_version );
 
 	// Theme stylesheet.
-	wp_enqueue_style( 'twentyseventeen-style', get_stylesheet_uri(), array(), '20240116' );
+	wp_enqueue_style( 'twentyseventeen-style', get_stylesheet_uri(), array(), '20240326' );
 
 	// Theme block stylesheet.
 	wp_enqueue_style( 'twentyseventeen-block-style', get_theme_file_uri( '/assets/css/blocks.css' ), array( 'twentyseventeen-style' ), '20220912' );

--- a/src/wp-content/themes/twentyseventeen/readme.txt
+++ b/src/wp-content/themes/twentyseventeen/readme.txt
@@ -76,7 +76,7 @@ Source: https://stocksnap.io/photo/striped-fabric-9CBVWF2CDU
 == Changelog ==
 
 = 3.6 =
-* Released: March 26, 2024
+* Released: April 2, 2024
 
 https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_3.6
 

--- a/src/wp-content/themes/twentyseventeen/readme.txt
+++ b/src/wp-content/themes/twentyseventeen/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Seventeen ===
 Contributors: wordpressdotorg
 Requires at least: 4.7
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.2.4
-Version: 3.5
+Version: 3.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: one-column, two-columns, right-sidebar, flexible-header, accessibility-ready, custom-colors, custom-header, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, post-formats, rtl-language-support, sticky-post, theme-options, threaded-comments, translation-ready, block-patterns
@@ -75,130 +75,135 @@ Source: https://stocksnap.io/photo/striped-fabric-9CBVWF2CDU
 
 == Changelog ==
 
+= 3.6 =
+* Released: March 26, 2024
+
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_3.6
+
 = 3.5 =
 * Released: January 16, 2024
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_3.5
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_3.5
 
 = 3.4 =
 * Released: November 7, 2023
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_3.4
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_3.4
 
 = 3.3 =
 * Released: August 8, 2023
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_3.3
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_3.3
 
 = 3.2 =
 * Released: March 28, 2023
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_3.2
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_3.2
 
 = 3.1 =
 * Released: November 1, 2022
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_3.1
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_3.1
 
 = 3.0 =
 * Released: May 24, 2022
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_3.0
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_3.0
 
 = 2.9 =
 * Released: January 25, 2022
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_2.9
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_2.9
 
 = 2.8 =
 * Released: July 20, 2021
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_2.8
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_2.8
 
 = 2.7 =
 * Released: April 14, 2021
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_2.7
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_2.7
 
 = 2.6 =
 * Released: March 9, 2021
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_2.6
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_2.6
 
 = 2.5 =
 * Released: December 8, 2020
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_2.5
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_2.5
 
 = 2.4 =
 * Released: August 11, 2020
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_2.4
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_2.4
 
 = 2.3 =
 * Released: March 31, 2020
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_2.3
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_2.3
 
 = 2.2 =
 * Released: May 7, 2019
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_2.2
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_2.2
 
 = 2.1 =
 * Released: February 21, 2019
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_2.1
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_2.1
 
 = 2.0 =
 * Released: January 9, 2019
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_2.0
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_2.0
 
 = 1.9 =
 * Released: December 19, 2018
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_1.9
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_1.9
 
 = 1.8 =
 * Released: December 6, 2018
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_1.8
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_1.8
 
 = 1.7 =
 * Released: August 2, 2018
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_1.7
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_1.7
 
 = 1.6 =
 * Released: May 17, 2018
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_1.6
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_1.6
 
 = 1.5 =
 * Released: April 4, 2018
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_1.5
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_1.5
 
 = 1.4 =
 * Released: November 14, 2017
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_1.4
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_1.4
 
 = 1.3 =
 * Released: June 8, 2017
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_1.3
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_1.3
 
 = 1.2 =
 * Released: April 18, 2017
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_1.2
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_1.2
 
 = 1.1 =
 * Released: January 6, 2017
 
-https://codex.wordpress.org/Twenty_Seventeen_Theme_Changelog#Version_1.1
+https://wordpress.org/documentation/article/twenty-seventeen-changelog/#Version_1.1
 
 = 1.0 =
 * Released: December 6, 2016

--- a/src/wp-content/themes/twentyseventeen/style.css
+++ b/src/wp-content/themes/twentyseventeen/style.css
@@ -4,8 +4,8 @@ Theme URI: https://wordpress.org/themes/twentyseventeen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Twenty Seventeen brings your site to life with header video and immersive featured images. With a focus on business sites, it features multiple sections on the front page as well as widgets, navigation and social menus, a logo, and more. Personalize its asymmetrical grid with a custom color scheme and showcase your multimedia content with post formats. Our default theme for 2017 works great in many languages, for any abilities, and on any device.
-Version: 3.5
-Tested up to: 6.4
+Version: 3.6
+Tested up to: 6.5
 Requires at least: 4.7
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later

--- a/src/wp-content/themes/twentysixteen/functions.php
+++ b/src/wp-content/themes/twentysixteen/functions.php
@@ -391,10 +391,10 @@ function twentysixteen_scripts() {
 	wp_enqueue_style( 'genericons', get_template_directory_uri() . '/genericons/genericons.css', array(), '20201208' );
 
 	// Theme stylesheet.
-	wp_enqueue_style( 'twentysixteen-style', get_stylesheet_uri(), array(), '20231107' );
+	wp_enqueue_style( 'twentysixteen-style', get_stylesheet_uri(), array(), '20240326' );
 
 	// Theme block stylesheet.
-	wp_enqueue_style( 'twentysixteen-block-style', get_template_directory_uri() . '/css/blocks.css', array( 'twentysixteen-style' ), '20231016' );
+	wp_enqueue_style( 'twentysixteen-block-style', get_template_directory_uri() . '/css/blocks.css', array( 'twentysixteen-style' ), '20240117' );
 
 	// Load the Internet Explorer specific stylesheet.
 	wp_enqueue_style( 'twentysixteen-ie', get_template_directory_uri() . '/css/ie.css', array( 'twentysixteen-style' ), '20170530' );
@@ -452,7 +452,7 @@ add_action( 'wp_enqueue_scripts', 'twentysixteen_scripts' );
  */
 function twentysixteen_block_editor_styles() {
 	// Block styles.
-	wp_enqueue_style( 'twentysixteen-block-editor-style', get_template_directory_uri() . '/css/editor-blocks.css', array(), '20230628' );
+	wp_enqueue_style( 'twentysixteen-block-editor-style', get_template_directory_uri() . '/css/editor-blocks.css', array(), '20240209' );
 	// Add custom fonts.
 	$font_version = ( 0 === strpos( (string) twentysixteen_fonts_url(), get_template_directory_uri() . '/' ) ) ? '20230328' : null;
 	wp_enqueue_style( 'twentysixteen-fonts', twentysixteen_fonts_url(), array(), $font_version );

--- a/src/wp-content/themes/twentysixteen/functions.php
+++ b/src/wp-content/themes/twentysixteen/functions.php
@@ -391,7 +391,7 @@ function twentysixteen_scripts() {
 	wp_enqueue_style( 'genericons', get_template_directory_uri() . '/genericons/genericons.css', array(), '20201208' );
 
 	// Theme stylesheet.
-	wp_enqueue_style( 'twentysixteen-style', get_stylesheet_uri(), array(), '20240326' );
+	wp_enqueue_style( 'twentysixteen-style', get_stylesheet_uri(), array(), '20240402' );
 
 	// Theme block stylesheet.
 	wp_enqueue_style( 'twentysixteen-block-style', get_template_directory_uri() . '/css/blocks.css', array( 'twentysixteen-style' ), '20240117' );

--- a/src/wp-content/themes/twentysixteen/readme.txt
+++ b/src/wp-content/themes/twentysixteen/readme.txt
@@ -73,7 +73,7 @@ Image used in screenshot.png: A photo by Austin Schmid (https://unsplash.com/sch
 == Changelog ==
 
 = 3.2 =
-* Released: March 26, 2024
+* Released: April 2, 2024
 
 https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_3.2
 

--- a/src/wp-content/themes/twentysixteen/readme.txt
+++ b/src/wp-content/themes/twentysixteen/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Sixteen ===
 Contributors: wordpressdotorg
 Requires at least: 4.4
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.2.4
-Version: 3.1
+Version: 3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: one-column, two-columns, right-sidebar, accessibility-ready, custom-background, custom-colors, custom-header, custom-menu, editor-style, featured-images, flexible-header, microformats, post-formats, rtl-language-support, sticky-post, threaded-comments, translation-ready, blog, block-patterns
@@ -72,110 +72,115 @@ Image used in screenshot.png: A photo by Austin Schmid (https://unsplash.com/sch
 
 == Changelog ==
 
+= 3.2 =
+* Released: March 26, 2024
+
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_3.2
+
 = 3.1 =
 * Released: November 7, 2023
 
-https://codex.wordpress.org/Twenty_Sixteen_Theme_Changelog#Version_3.1
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_3.1
 
 = 3.0 =
 * Released: August 8, 2023
 
-https://codex.wordpress.org/Twenty_Sixteen_Theme_Changelog#Version_3.0
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_3.0
 
 = 2.9 =
 * Released: March 28, 2023
 
-https://codex.wordpress.org/Twenty_Sixteen_Theme_Changelog#Version_2.9
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_2.9
 
 = 2.8 =
 * Released: November 1, 2022
 
-https://codex.wordpress.org/Twenty_Sixteen_Theme_Changelog#Version_2.8
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_2.8
 
 = 2.7 =
 * Released: May 24, 2022
 
-https://codex.wordpress.org/Twenty_Sixteen_Theme_Changelog#Version_2.7
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_2.7
 
 = 2.6 =
 * Released: January 25, 2022
 
-https://codex.wordpress.org/Twenty_Sixteen_Theme_Changelog#Version_2.6
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_2.6
 
 = 2.5 =
 * Released: July 20, 2021
 
-https://codex.wordpress.org/Twenty_Sixteen_Theme_Changelog#Version_2.5
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_2.5
 
 = 2.4 =
 * Released: March 9, 2021
 
-https://codex.wordpress.org/Twenty_Sixteen_Theme_Changelog#Version_2.4
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_2.4
 
 = 2.3 =
 * Released: December 8, 2020
 
-https://codex.wordpress.org/Twenty_Sixteen_Theme_Changelog#Version_2.3
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_2.3
 
 = 2.2 =
 * Released: August 11, 2020
 
-https://codex.wordpress.org/Twenty_Sixteen_Theme_Changelog#Version_2.2
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_2.2
 
 = 2.1 =
 * Released: March 31, 2020
 
-https://codex.wordpress.org/Twenty_Sixteen_Theme_Changelog#Version_2.1
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_2.1
 
 = 2.0 =
 * Released: May 7, 2019
 
-https://codex.wordpress.org/Twenty_Sixteen_Theme_Changelog#Version_2.0
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_2.0
 
 = 1.9 =
 * Released: February 21, 2019
 
-https://codex.wordpress.org/Twenty_Sixteen_Theme_Changelog#Version_1.9
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_1.9
 
 = 1.8 =
 * Released: January 9, 2019
 
-https://codex.wordpress.org/Twenty_Sixteen_Theme_Changelog#Version_1.8
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_1.8
 
 = 1.7 =
 * Released: December 19, 2018
 
-https://codex.wordpress.org/Twenty_Sixteen_Theme_Changelog#Version_1.7
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_1.7
 
 = 1.6 =
 * Released: December 6, 2018
 
-https://codex.wordpress.org/Twenty_Sixteen_Theme_Changelog#Version_1.6
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_1.6
 
 = 1.5 =
 * Released: May 17, 2018
 
-https://codex.wordpress.org/Twenty_Sixteen_Theme_Changelog#Version_1.5
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_1.5
 
 = 1.4 =
 * Released: November 14, 2017
 
-https://codex.wordpress.org/Twenty_Sixteen_Theme_Changelog#Version_1.4
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_1.4
 
 = 1.3 =
 * Released: August 16, 2016
 
-https://codex.wordpress.org/Twenty_Sixteen_Theme_Changelog#Version_1.3
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_1.3
 
 = 1.2 =
 * Released: April 12, 2016
 
-https://codex.wordpress.org/Twenty_Sixteen_Theme_Changelog#Version_1.2
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_1.2
 
 = 1.1 =
 * Released: January 6, 2016
 
-https://codex.wordpress.org/Twenty_Sixteen_Theme_Changelog#Version_1.1
+https://wordpress.org/documentation/article/twenty-sixteen-changelog/#Version_1.1
 
 = 1.0 =
 * Released: December 8, 2015

--- a/src/wp-content/themes/twentysixteen/style.css
+++ b/src/wp-content/themes/twentysixteen/style.css
@@ -4,8 +4,8 @@ Theme URI: https://wordpress.org/themes/twentysixteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Twenty Sixteen is a modernized take on an ever-popular WordPress layout — the horizontal masthead with an optional right sidebar that works perfectly for blogs and websites. It has custom color options with beautiful default color schemes, a harmonious fluid grid using a mobile-first approach, and impeccable polish in every detail. Twenty Sixteen will make your WordPress look beautiful everywhere.
-Version: 3.1
-Tested up to: 6.4
+Version: 3.2
+Tested up to: 6.5
 Requires at least: 4.4
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later

--- a/src/wp-content/themes/twentyten/header.php
+++ b/src/wp-content/themes/twentyten/header.php
@@ -39,7 +39,7 @@ if ( ( $paged >= 2 || $page >= 2 ) && ! is_404() ) {
 ?>
 	</title>
 <link rel="profile" href="https://gmpg.org/xfn/11" />
-<link rel="stylesheet" type="text/css" media="all" href="<?php echo esc_url( get_stylesheet_uri() ); ?>?ver=20240326" />
+<link rel="stylesheet" type="text/css" media="all" href="<?php echo esc_url( get_stylesheet_uri() ); ?>?ver=20240402" />
 <link rel="pingback" href="<?php echo esc_url( get_bloginfo( 'pingback_url' ) ); ?>">
 <?php
 	/*

--- a/src/wp-content/themes/twentyten/header.php
+++ b/src/wp-content/themes/twentyten/header.php
@@ -39,7 +39,7 @@ if ( ( $paged >= 2 || $page >= 2 ) && ! is_404() ) {
 ?>
 	</title>
 <link rel="profile" href="https://gmpg.org/xfn/11" />
-<link rel="stylesheet" type="text/css" media="all" href="<?php echo esc_url( get_stylesheet_uri() ); ?>?ver=20231107" />
+<link rel="stylesheet" type="text/css" media="all" href="<?php echo esc_url( get_stylesheet_uri() ); ?>?ver=20240326" />
 <link rel="pingback" href="<?php echo esc_url( get_bloginfo( 'pingback_url' ) ); ?>">
 <?php
 	/*

--- a/src/wp-content/themes/twentyten/readme.txt
+++ b/src/wp-content/themes/twentyten/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Ten ===
 Contributors: wordpressdotorg
 Requires at least: 3.0
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.2.4
-Stable tag: 4.0
+Stable tag: 4.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: blog, two-columns, custom-header, custom-background, threaded-comments, sticky-post, translation-ready, microformats, rtl-language-support, editor-style, custom-menu, flexible-header, featured-images, footer-widgets, featured-image-header, block-patterns
@@ -44,155 +44,160 @@ Images
 
 == Changelog ==
 
+= 4.1 =
+* Released: March 26, 2024
+
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_4.1
+
 = 4.0 =
 * Released: November 7, 2023
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_4.0
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_4.0
 
 = 3.9 =
 * Released: August 8, 2023
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_3.9
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_3.9
 
 = 3.8 =
 * Released: March 28, 2023
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_3.8
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_3.8
 
 = 3.7 =
 * Released: November 1, 2022
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_3.7
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_3.7
 
 = 3.6 =
 * Released: January 25, 2022
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_3.6
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_3.6
 
 = 3.5 =
 * Released: July 26, 2021
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_3.5
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_3.5
 
 = 3.4 =
 * Released: July 20, 2021
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_3.4
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_3.4
 
 = 3.3 =
 * Released: March 9, 2021
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_3.3
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_3.3
 
 = 3.2 =
 * Released: December 8, 2020
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_3.2
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_3.2
 
 = 3.1 =
 * Released: August 11, 2020
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_3.1
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_3.1
 
 = 3.0 =
 * Released: March 31, 2020
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_3.0
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_3.0
 
 = 2.9 =
 * Released: May 7, 2019
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_2.9
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_2.9
 
 = 2.8 =
 * Released: February 21, 2019
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_2.8
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_2.8
 
 = 2.7 =
 * Released: December 19, 2018
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_2.7
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_2.7
 
 = 2.6 =
 * Released: December 6, 2018
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_2.6
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_2.6
 
 = 2.5 =
 * Released: May 17, 2018
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_2.5
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_2.5
 
 = 2.4 =
 * Released: November 14, 2017
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_2.4
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_2.4
 
 = 2.3 =
 * Released: June 8, 2017
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_2.3
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_2.3
 
 = 2.2 =
 * Released: August 15, 2016
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_2.2
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_2.2
 
 = 2.1 =
 * Released: December 8, 2015
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_2.1
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_2.1
 
 = 2.0 =
 * Released: August 18, 2015
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_2.0
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_2.0
 
 = 1.9 =
 * Released: April 23, 2015
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_1.9
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_1.9
 
 = 1.8 =
 * Released: December 18, 2014
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_1.8
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_1.8
 
 = 1.7 =
 * Released: September 4, 2014
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_1.7
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_1.7
 
 = 1.6 =
 * Released: August 1, 2013
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_1.6
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_1.6
 
 = 1.5 =
 * Released: December 11, 2012
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_1.5
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_1.5
 
 = 1.4 =
 * Released: June 13, 2012
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_1.4
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_1.4
 
 = 1.3 =
 * Released: December 12, 2011
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_1.3
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_1.3
 
 = 1.2 =
 * Released: February 23, 2011
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_1.2
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_1.2
 
 = 1.1 =
 * Released: July 29, 2010
 
-https://codex.wordpress.org/Twenty_Ten_Theme_Changelog#Version_1.1
+https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_1.1
 
 = 1.0 =
 * Released: June 17, 2010

--- a/src/wp-content/themes/twentyten/readme.txt
+++ b/src/wp-content/themes/twentyten/readme.txt
@@ -45,7 +45,7 @@ Images
 == Changelog ==
 
 = 4.1 =
-* Released: March 26, 2024
+* Released: April 2, 2024
 
 https://wordpress.org/documentation/article/twenty-ten-changelog/#Version_4.1
 

--- a/src/wp-content/themes/twentyten/style.css
+++ b/src/wp-content/themes/twentyten/style.css
@@ -4,8 +4,8 @@ Theme URI: https://wordpress.org/themes/twentyten/
 Description: The 2010 theme for WordPress is stylish, customizable, simple, and readable -- make it yours with a custom menu, header image, and background. Twenty Ten supports six widgetized areas (two in the sidebar, four in the footer) and featured images (thumbnails for gallery posts and custom header images for posts and pages). It includes stylesheets for print and the admin Visual Editor, special styles for posts in the "Asides" and "Gallery" categories, and has an optional one-column page template that removes the sidebar.
 Author: the WordPress team
 Author URI: https://wordpress.org/
-Version: 4.0
-Tested up to: 6.4
+Version: 4.1
+Tested up to: 6.5
 Requires at least: 3.0
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later

--- a/src/wp-content/themes/twentythirteen/functions.php
+++ b/src/wp-content/themes/twentythirteen/functions.php
@@ -340,7 +340,7 @@ function twentythirteen_scripts_styles() {
 	wp_enqueue_style( 'genericons', get_template_directory_uri() . '/genericons/genericons.css', array(), '3.0.3' );
 
 	// Loads our main stylesheet.
-	wp_enqueue_style( 'twentythirteen-style', get_stylesheet_uri(), array(), '20231107' );
+	wp_enqueue_style( 'twentythirteen-style', get_stylesheet_uri(), array(), '20240326' );
 
 	// Theme block stylesheet.
 	wp_enqueue_style( 'twentythirteen-block-style', get_template_directory_uri() . '/css/blocks.css', array( 'twentythirteen-style' ), '20231016' );

--- a/src/wp-content/themes/twentythirteen/functions.php
+++ b/src/wp-content/themes/twentythirteen/functions.php
@@ -340,7 +340,7 @@ function twentythirteen_scripts_styles() {
 	wp_enqueue_style( 'genericons', get_template_directory_uri() . '/genericons/genericons.css', array(), '3.0.3' );
 
 	// Loads our main stylesheet.
-	wp_enqueue_style( 'twentythirteen-style', get_stylesheet_uri(), array(), '20240326' );
+	wp_enqueue_style( 'twentythirteen-style', get_stylesheet_uri(), array(), '20240402' );
 
 	// Theme block stylesheet.
 	wp_enqueue_style( 'twentythirteen-block-style', get_template_directory_uri() . '/css/blocks.css', array( 'twentythirteen-style' ), '20231016' );

--- a/src/wp-content/themes/twentythirteen/readme.txt
+++ b/src/wp-content/themes/twentythirteen/readme.txt
@@ -65,7 +65,7 @@ Toroidal Colony: https://www.flickr.com/photos/nasacommons/13889485757/in/album-
 == Changelog ==
 
 = 4.1 =
-* Released: March 26, 2024
+* Released: April 2, 2024
 
 https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_4.1
 

--- a/src/wp-content/themes/twentythirteen/readme.txt
+++ b/src/wp-content/themes/twentythirteen/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Thirteen ===
 Contributors: wordpressdotorg
 Requires at least: 3.6
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.2.4
-Stable tag: 4.0
+Stable tag: 4.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: blog, one-column, two-columns, right-sidebar, custom-header, custom-menu, editor-style, featured-images, footer-widgets, microformats, post-formats, rtl-language-support, sticky-post, translation-ready, accessibility-ready, block-patterns
@@ -64,155 +64,160 @@ Toroidal Colony: https://www.flickr.com/photos/nasacommons/13889485757/in/album-
 
 == Changelog ==
 
+= 4.1 =
+* Released: March 26, 2024
+
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_4.1
+
 = 4.0 =
 * Released: November 7, 2023
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_4.0
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_4.0
 
 = 3.9 =
 * Released: August 8, 2023
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_3.9
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_3.9
 
 = 3.8 =
 * Released: March 28, 2023
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_3.8
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_3.8
 
 = 3.7 =
 * Released: November 1, 2022
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_3.7
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_3.7
 
 = 3.6 =
 * Released: May 24, 2022
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_3.6
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_3.6
 
 = 3.5 =
 * Released: January 25, 2022
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_3.5
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_3.5
 
 = 3.4 =
 * Released: July 20, 2021
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_3.4
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_3.4
 
 = 3.3 =
 * Released: March 9, 2021
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_3.3
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_3.3
 
 = 3.2 =
 * Released: December 8, 2020
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_3.2
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_3.2
 
 = 3.1 =
 * Released: August 11, 2020
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_3.1
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_3.1
 
 = 3.0 =
 * Released: March 31, 2020
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_3.0
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_3.0
 
 = 2.9 =
 * Released: May 7, 2019
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_2.9
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_2.9
 
 = 2.8 =
 * Released: February 21, 2019
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_2.8
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_2.8
 
 = 2.7 =
 * Released: January 9, 2019
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_2.7
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_2.7
 
 = 2.6 =
 * Released: December 19, 2018
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_2.6
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_2.6
 
 = 2.5 =
 * Released: December 6, 2018
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_2.5
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_2.5
 
 = 2.4 =
 * Released: May 17, 2018
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_2.4
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_2.4
 
 = 2.3 =
 * Released: November 14, 2017
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_2.3
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_2.3
 
 = 2.2 =
 * Released: June 8, 2017
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_2.2
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_2.2
 
 = 2.1 =
 * Released: December 6, 2016
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_2.1
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_2.1
 
 = 2.0 =
 * Released: August 15, 2016
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_2.0
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_2.0
 
 = 1.9 =
 * Released: April 12, 2016
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_1.9
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_1.9
 
 = 1.8 =
 * Released: January 6, 2016
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_1.8
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_1.8
 
 = 1.7 =
 * Released: December 8, 2015
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_1.7
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_1.7
 
 = 1.6 =
 * Released: August 18, 2015
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_1.6
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_1.6
 
 = 1.5 =
 * Released: April 23, 2015
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_1.5
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_1.5
 
 = 1.4 =
 * Released: December 18, 2014
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_1.4
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_1.4
 
 = 1.3 =
 * Released: September 4, 2014
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_1.3
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_1.3
 
 = 1.2 =
 * Released: May 8, 2014
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_1.2
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_1.2
 
 = 1.1 =
 * Released: October 24, 2013
 
-https://codex.wordpress.org/Twenty_Thirteen_Theme_Changelog#Version_1.1
+https://wordpress.org/documentation/article/twenty-thirteen-changelog/#Version_1.1
 
 = 1.0 =
 * Released: August 1, 2013

--- a/src/wp-content/themes/twentythirteen/style.css
+++ b/src/wp-content/themes/twentythirteen/style.css
@@ -4,8 +4,8 @@ Theme URI: https://wordpress.org/themes/twentythirteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: The 2013 theme for WordPress takes us back to the blog, featuring a full range of post formats, each displayed beautifully in their own unique way. Design details abound, starting with a vibrant color scheme and matching header images, beautiful typography and icons, and a flexible layout that looks great on any device, big or small.
-Version: 4.0
-Tested up to: 6.4
+Version: 4.1
+Tested up to: 6.5
 Requires at least: 3.6
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later

--- a/src/wp-content/themes/twentytwelve/functions.php
+++ b/src/wp-content/themes/twentytwelve/functions.php
@@ -206,7 +206,7 @@ function twentytwelve_scripts_styles() {
 	}
 
 	// Loads our main stylesheet.
-	wp_enqueue_style( 'twentytwelve-style', get_stylesheet_uri(), array(), '20231107' );
+	wp_enqueue_style( 'twentytwelve-style', get_stylesheet_uri(), array(), '20240326' );
 
 	// Theme block stylesheet.
 	wp_enqueue_style( 'twentytwelve-block-style', get_template_directory_uri() . '/css/blocks.css', array( 'twentytwelve-style' ), '20230213' );

--- a/src/wp-content/themes/twentytwelve/functions.php
+++ b/src/wp-content/themes/twentytwelve/functions.php
@@ -206,7 +206,7 @@ function twentytwelve_scripts_styles() {
 	}
 
 	// Loads our main stylesheet.
-	wp_enqueue_style( 'twentytwelve-style', get_stylesheet_uri(), array(), '20240326' );
+	wp_enqueue_style( 'twentytwelve-style', get_stylesheet_uri(), array(), '20240402' );
 
 	// Theme block stylesheet.
 	wp_enqueue_style( 'twentytwelve-block-style', get_template_directory_uri() . '/css/blocks.css', array( 'twentytwelve-style' ), '20230213' );

--- a/src/wp-content/themes/twentytwelve/readme.txt
+++ b/src/wp-content/themes/twentytwelve/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Twelve ===
 Contributors: wordpressdotorg
 Requires at least: 3.5
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.2.4
-Stable tag: 4.1
+Stable tag: 4.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: blog, one-column, two-columns, right-sidebar, custom-background, custom-header, custom-menu, editor-style, featured-images, flexible-header, footer-widgets, full-width-template, microformats, post-formats, rtl-language-support, sticky-post, theme-options, translation-ready, block-patterns
@@ -53,155 +53,160 @@ Source: https://fontsource.org/fonts/open-sans
 
 == Changelog ==
 
+= 4.2 =
+* Released: March 26, 2024
+
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_4.2
+
 = 4.1 =
 * Released: November 7, 2023
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_4.1
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_4.1
 
 = 4.0 =
 * Released: August 8, 2023
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_4.0
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_4.0
 
 = 3.9 =
 * Released: March 28, 2023
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_3.9
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_3.9
 
 = 3.8 =
 * Released: November 1, 2022
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_3.8
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_3.8
 
 = 3.7 =
 * Released: May 24, 2022
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_3.7
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_3.7
 
 = 3.6 =
 * Released: January 25, 2022
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_3.6
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_3.6
 
 = 3.5 =
 * Released: July 26, 2021
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_3.5
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_3.5
 
 = 3.4 =
 * Released: July 20, 2021
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_3.4
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_3.4
 
 = 3.3 =
 * Released: December 8, 2020
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_3.3
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_3.3
 
 = 3.2 =
 * Released: August 11, 2020
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_3.2
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_3.2
 
 = 3.1 =
 * Released: March 31, 2020
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_3.1
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_3.1
 
 = 3.0 =
 * Released: May 7, 2019
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_3.0
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_3.0
 
 = 2.9 =
 * Released: February 21, 2019
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_2.9
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_2.9
 
 = 2.8 =
 * Released: January 9, 2019
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_2.8
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_2.8
 
 = 2.7 =
 * Released: December 19, 2018
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_2.7
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_2.7
 
 = 2.6 =
 * Released: December 6, 2018
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_2.6
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_2.6
 
 = 2.5 =
 * Released: May 17, 2018
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_2.5
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_2.5
 
 = 2.4 =
 * Released: November 14, 2017
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_2.4
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_2.4
 
 = 2.3 =
 * Released: June 8, 2017
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_2.3
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_2.3
 
 = 2.2 =
 * Released: December 6, 2016
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_2.2
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_2.2
 
 = 2.1 =
 * Released: August 15, 2016
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_2.1
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_2.1
 
 = 2.0 =
 * Released: April 12, 2016
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_2.0
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_2.0
 
 = 1.9 =
 * Released: December 8, 2015
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_1.9
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_1.9
 
 = 1.8 =
 * Released: August 18, 2015
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_1.8
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_1.8
 
 = 1.7 =
 * Released: April 23, 2015
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_1.7
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_1.7
 
 = 1.6 =
 * Released: December 18, 2014
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_1.6
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_1.6
 
 = 1.5 =
 * Released: September 4, 2014
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_1.5
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_1.5
 
 = 1.4 =
 * Released: May 8, 2014
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_1.4
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_1.4
 
 = 1.3 =
 * Released: October 24, 2013
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_1.3
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_1.3
 
 = 1.2 =
 * Released: August 1, 2013
 
-https://codex.wordpress.org/Twenty_Twelve_Theme_Changelog#Version_1.2
+https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_1.2
 
 = 1.1 =
 * Released: December 11, 2012

--- a/src/wp-content/themes/twentytwelve/readme.txt
+++ b/src/wp-content/themes/twentytwelve/readme.txt
@@ -54,7 +54,7 @@ Source: https://fontsource.org/fonts/open-sans
 == Changelog ==
 
 = 4.2 =
-* Released: March 26, 2024
+* Released: April 2, 2024
 
 https://wordpress.org/documentation/article/twenty-twelve-changelog/#Version_4.2
 

--- a/src/wp-content/themes/twentytwelve/style.css
+++ b/src/wp-content/themes/twentytwelve/style.css
@@ -4,8 +4,8 @@ Theme URI: https://wordpress.org/themes/twentytwelve/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: The 2012 theme for WordPress is a fully responsive theme that looks great on any device. Features include a front page template with its own widgets, an optional display font, styling for post formats on both index and single views, and an optional no-sidebar page template. Make it yours with a custom menu, header image, and background.
-Version: 4.1
-Tested up to: 6.4
+Version: 4.2
+Tested up to: 6.5
 Requires at least: 3.5
 Requires PHP: 5.2.4
 License: GNU General Public License v2 or later

--- a/src/wp-content/themes/twentytwenty/package-lock.json
+++ b/src/wp-content/themes/twentytwenty/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "twentytwenty",
-	"version": "2.5.0",
+	"version": "2.6.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "twentytwenty",
-			"version": "2.5.0",
+			"version": "2.6.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@wordpress/browserslist-config": "^5.31.0",

--- a/src/wp-content/themes/twentytwenty/package.json
+++ b/src/wp-content/themes/twentytwenty/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "twentytwenty",
-	"version": "2.5.0",
+	"version": "2.6.0",
 	"description": "Default WP Theme",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/src/wp-content/themes/twentytwenty/readme.txt
+++ b/src/wp-content/themes/twentytwenty/readme.txt
@@ -25,7 +25,7 @@ you pick, ensuring a high, accessible color contrast for your visitors.
 == Changelog ==
 
 = 2.6 =
-* Released: March 26, 2024
+* Released: April 2, 2024
 
 https://wordpress.org/documentation/article/twenty-twenty-changelog/#Version_2.6
 

--- a/src/wp-content/themes/twentytwenty/readme.txt
+++ b/src/wp-content/themes/twentytwenty/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Twenty ===
 Contributors: the WordPress team
 Requires at least: 4.7
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.2.4
-Stable tag: 2.5
+Stable tag: 2.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,11 @@ all elements on your site are automatically calculated based on the colors
 you pick, ensuring a high, accessible color contrast for your visitors.
 
 == Changelog ==
+
+= 2.6 =
+* Released: March 26, 2024
+
+https://wordpress.org/documentation/article/twenty-twenty-changelog/#Version_2.6
 
 = 2.5 =
 * Released: January 16, 2024

--- a/src/wp-content/themes/twentytwenty/style-rtl.css
+++ b/src/wp-content/themes/twentytwenty/style-rtl.css
@@ -1,8 +1,8 @@
 /*
 Theme Name: Twenty Twenty
 Text Domain: twentytwenty
-Version: 2.5
-Tested up to: 6.4
+Version: 2.6
+Tested up to: 6.5
 Requires at least: 4.7
 Requires PHP: 5.2.4
 Description: Our default theme for 2020 is designed to take full advantage of the flexibility of the block editor. Organizations and businesses have the ability to create dynamic landing pages with endless layouts using the group and column blocks. The centered content column and fine-tuned typography also makes it perfect for traditional blogs. Complete editor styles give you a good idea of what your content will look like, even before you publish. You can give your site a personal touch by changing the background colors and the accent color in the Customizer. The colors of all elements on your site are automatically calculated based on the colors you pick, ensuring a high, accessible color contrast for your visitors.

--- a/src/wp-content/themes/twentytwenty/style.css
+++ b/src/wp-content/themes/twentytwenty/style.css
@@ -1,8 +1,8 @@
 /*
 Theme Name: Twenty Twenty
 Text Domain: twentytwenty
-Version: 2.5
-Tested up to: 6.4
+Version: 2.6
+Tested up to: 6.5
 Requires at least: 4.7
 Requires PHP: 5.2.4
 Description: Our default theme for 2020 is designed to take full advantage of the flexibility of the block editor. Organizations and businesses have the ability to create dynamic landing pages with endless layouts using the group and column blocks. The centered content column and fine-tuned typography also makes it perfect for traditional blogs. Complete editor styles give you a good idea of what your content will look like, even before you publish. You can give your site a personal touch by changing the background colors and the accent color in the Customizer. The colors of all elements on your site are automatically calculated based on the colors you pick, ensuring a high, accessible color contrast for your visitors.

--- a/src/wp-content/themes/twentytwentyfour/readme.txt
+++ b/src/wp-content/themes/twentytwentyfour/readme.txt
@@ -14,7 +14,7 @@ Twenty Twenty-Four is designed to be flexible, versatile and applicable to any w
 == Changelog ==
 
 = 1.1 =
-* Released: March 26, 2024
+* Released: April 2, 2024
 
 https://wordpress.org/documentation/article/twenty-twenty-four-changelog/#Version_1.1
 

--- a/src/wp-content/themes/twentytwentyfour/readme.txt
+++ b/src/wp-content/themes/twentytwentyfour/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Twenty-Four ===
 Contributors: wordpressdotorg
 Requires at least: 6.4
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 7.0
-Stable tag: 1.0
+Stable tag: 1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -12,6 +12,11 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Twenty Twenty-Four is designed to be flexible, versatile and applicable to any website. Its collection of templates and patterns tailor to different needs, such as presenting a business, blogging and writing or showcasing work. A multitude of possibilities open up with just a few adjustments to color and typography. Twenty Twenty-Four comes with style variations and full page designs to help speed up the site building process, is fully compatible with the site editor, and takes advantage of new design tools introduced in WordPress 6.4.
 
 == Changelog ==
+
+= 1.1 =
+* Released: March 26, 2024
+
+https://wordpress.org/documentation/article/twenty-twenty-four-changelog/#Version_1.1
 
 = 1.0 =
 * Released: November 7, 2023

--- a/src/wp-content/themes/twentytwentyfour/style.css
+++ b/src/wp-content/themes/twentytwentyfour/style.css
@@ -5,9 +5,9 @@ Author: the WordPress team
 Author URI: https://wordpress.org
 Description: Twenty Twenty-Four is designed to be flexible, versatile and applicable to any website. Its collection of templates and patterns tailor to different needs, such as presenting a business, blogging and writing or showcasing work. A multitude of possibilities open up with just a few adjustments to color and typography. Twenty Twenty-Four comes with style variations and full page designs to help speed up the site building process, is fully compatible with the site editor, and takes advantage of new design tools introduced in WordPress 6.4.
 Requires at least: 6.4
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 7.0
-Version: 1.0
+Version: 1.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentyfour

--- a/src/wp-content/themes/twentytwentyone/assets/css/ie.css
+++ b/src/wp-content/themes/twentytwentyone/assets/css/ie.css
@@ -7,9 +7,9 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Twenty Twenty-One is a blank canvas for your ideas and it makes the block editor your best brush. With new block patterns, which allow you to create a beautiful layout in a matter of seconds, this theme’s soft colors and eye-catching — yet timeless — design will let your work shine. Take it for a spin! See how Twenty Twenty-One elevates your portfolio, business website, or personal blog.
 Requires at least: 5.3
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.6
-Version: 2.1
+Version: 2.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentyone

--- a/src/wp-content/themes/twentytwentyone/assets/sass/01-settings/file-header.scss
+++ b/src/wp-content/themes/twentytwentyone/assets/sass/01-settings/file-header.scss
@@ -5,9 +5,9 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Twenty Twenty-One is a blank canvas for your ideas and it makes the block editor your best brush. With new block patterns, which allow you to create a beautiful layout in a matter of seconds, this theme’s soft colors and eye-catching — yet timeless — design will let your work shine. Take it for a spin! See how Twenty Twenty-One elevates your portfolio, business website, or personal blog.
 Requires at least: 5.3
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.6
-Version: 2.1
+Version: 2.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentyone

--- a/src/wp-content/themes/twentytwentyone/package-lock.json
+++ b/src/wp-content/themes/twentytwentyone/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "twentytwentyone",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "twentytwentyone",
-			"version": "2.1.0",
+			"version": "2.2.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@wordpress/browserslist-config": "^5.30.0",

--- a/src/wp-content/themes/twentytwentyone/package.json
+++ b/src/wp-content/themes/twentytwentyone/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "twentytwentyone",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "Default WP Theme",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/src/wp-content/themes/twentytwentyone/readme.txt
+++ b/src/wp-content/themes/twentytwentyone/readme.txt
@@ -31,7 +31,7 @@ No data is saved in the database or transferred.
 == Changelog ==
 
 = 2.2 =
-* Released: March 26, 2024
+* Released: April 2, 2024
 
 https://wordpress.org/documentation/article/twenty-twenty-one-changelog/#Version_2.2
 

--- a/src/wp-content/themes/twentytwentyone/readme.txt
+++ b/src/wp-content/themes/twentytwentyone/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Twenty-One ===
 Contributors: wordpressdotorg
 Requires at least: 5.3
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.6
-Stable tag: 2.1
+Stable tag: 2.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,11 @@ LocalStorage is necessary for the setting to work and is only used when a user c
 No data is saved in the database or transferred.
 
 == Changelog ==
+
+= 2.2 =
+* Released: March 26, 2024
+
+https://wordpress.org/documentation/article/twenty-twenty-one-changelog/#Version_2.2
 
 = 2.1 =
 * Released: January 16, 2024

--- a/src/wp-content/themes/twentytwentyone/style-rtl.css
+++ b/src/wp-content/themes/twentytwentyone/style-rtl.css
@@ -7,9 +7,9 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Twenty Twenty-One is a blank canvas for your ideas and it makes the block editor your best brush. With new block patterns, which allow you to create a beautiful layout in a matter of seconds, this theme’s soft colors and eye-catching — yet timeless — design will let your work shine. Take it for a spin! See how Twenty Twenty-One elevates your portfolio, business website, or personal blog.
 Requires at least: 5.3
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.6
-Version: 2.1
+Version: 2.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentyone

--- a/src/wp-content/themes/twentytwentyone/style.css
+++ b/src/wp-content/themes/twentytwentyone/style.css
@@ -7,9 +7,9 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Twenty Twenty-One is a blank canvas for your ideas and it makes the block editor your best brush. With new block patterns, which allow you to create a beautiful layout in a matter of seconds, this theme’s soft colors and eye-catching — yet timeless — design will let your work shine. Take it for a spin! See how Twenty Twenty-One elevates your portfolio, business website, or personal blog.
 Requires at least: 5.3
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.6
-Version: 2.1
+Version: 2.2
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentyone

--- a/src/wp-content/themes/twentytwentythree/readme.txt
+++ b/src/wp-content/themes/twentytwentythree/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Twenty-Three ===
 Contributors: wordpressdotorg
 Requires at least: 6.1
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.6
-Stable tag: 1.3
+Stable tag: 1.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -14,6 +14,11 @@ Twenty Twenty-Three is designed to take advantage of the new design tools introd
 Whether you want to build a complex or incredibly simple website, you can do it quickly and intuitively through the bundled styles or dive into creation and full customization yourself.
 
 == Changelog ==
+
+= 1.4 =
+* Released: March 26, 2024
+
+https://wordpress.org/documentation/article/twenty-twenty-three-changelog/#Version_1.4
 
 = 1.3 =
 * Released: November 7, 2023

--- a/src/wp-content/themes/twentytwentythree/readme.txt
+++ b/src/wp-content/themes/twentytwentythree/readme.txt
@@ -16,7 +16,7 @@ Whether you want to build a complex or incredibly simple website, you can do it 
 == Changelog ==
 
 = 1.4 =
-* Released: March 26, 2024
+* Released: April 2, 2024
 
 https://wordpress.org/documentation/article/twenty-twenty-three-changelog/#Version_1.4
 

--- a/src/wp-content/themes/twentytwentythree/style.css
+++ b/src/wp-content/themes/twentytwentythree/style.css
@@ -5,9 +5,9 @@ Author: the WordPress team
 Author URI: https://wordpress.org
 Description: Twenty Twenty-Three is designed to take advantage of the new design tools introduced in WordPress 6.1. With a clean, blank base as a starting point, this default theme includes ten diverse style variations created by members of the WordPress community. Whether you want to build a complex or incredibly simple website, you can do it quickly and intuitively through the bundled styles or dive into creation and full customization yourself.
 Requires at least: 6.1
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.6
-Version: 1.3
+Version: 1.4
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 Text Domain: twentytwentythree

--- a/src/wp-content/themes/twentytwentytwo/readme.txt
+++ b/src/wp-content/themes/twentytwentytwo/readme.txt
@@ -18,7 +18,7 @@ Whether you’re building a single-page website, a blog, a business website, or 
 == Changelog ==
 
 = 1.7 =
-* Released: March 26, 2024
+* Released: April 2, 2024
 
 https://wordpress.org/documentation/article/twenty-twenty-two-changelog/#Version_1.7
 

--- a/src/wp-content/themes/twentytwentytwo/readme.txt
+++ b/src/wp-content/themes/twentytwentytwo/readme.txt
@@ -1,9 +1,9 @@
 === Twenty Twenty-Two ===
 Contributors: wordpressdotorg
 Requires at least: 5.9
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.6
-Stable tag: 1.6
+Stable tag: 1.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -16,6 +16,11 @@ The true richness of Twenty Twenty-Two lies in its opportunity for customization
 Whether you’re building a single-page website, a blog, a business website, or a portfolio, Twenty Twenty-Two will help you create a site that is uniquely yours.
 
 == Changelog ==
+
+= 1.7 =
+* Released: March 26, 2024
+
+https://wordpress.org/documentation/article/twenty-twenty-two-changelog/#Version_1.7
 
 = 1.6 =
 * Released: November 7, 2023

--- a/src/wp-content/themes/twentytwentytwo/style.css
+++ b/src/wp-content/themes/twentytwentytwo/style.css
@@ -5,9 +5,9 @@ Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Built on a solidly designed foundation, Twenty Twenty-Two embraces the idea that everyone deserves a truly unique website. The theme’s subtle styles are inspired by the diversity and versatility of birds: its typography is lightweight yet strong, its color palette is drawn from nature, and its layout elements sit gently on the page. The true richness of Twenty Twenty-Two lies in its opportunity for customization. The theme is built to take advantage of the Site Editor features introduced in WordPress 5.9, which means that colors, typography, and the layout of every single page on your site can be customized to suit your vision. It also includes dozens of block patterns, opening the door to a wide range of professionally designed layouts in just a few clicks. Whether you’re building a single-page website, a blog, a business website, or a portfolio, Twenty Twenty-Two will help you create a site that is uniquely yours.
 Requires at least: 5.9
-Tested up to: 6.4
+Tested up to: 6.5
 Requires PHP: 5.6
-Version: 1.6
+Version: 1.7
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentytwo


### PR DESCRIPTION
Twenty Ten: 4.1
Twenty Eleven: 4.6
Twenty Twelve: 4.2
Twenty Thirteen: 4.1
Twenty Fourteen: 3.9
Twenty Fifteen: 3.7
Twenty Sixteen: 3.2
Twenty Seventeen: 3.6
Twenty Nineteen: 2.8
Twenty Twenty: 2.6
Twenty Twenty-One: 2.2
Twenty Twenty-Two: 1.7
Twenty Twenty-Three: 1.4
Twenty Twenty-Four: 1.1

All of these changelog links point to HelpHub now.

Trac ticket: https://core.trac.wordpress.org/ticket/59816

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
