### PR TITLE
Block Hooks API: Add Templates Controller filter to avoid triggering wp_update_post

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1440,7 +1440,7 @@ function get_template_hierarchy( $slug, $is_custom = false, $template_prefix = '
  * prepared for inserting or updating the database, locate all blocks that have
  * hooked blocks, and inject a `metadata.ignoredHookedBlocks` attribute into the anchor
  * blocks to reflect the latter.
- * 
+ *
  * @since 6.5.0
  * @access private
  *

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1440,6 +1440,8 @@ function get_template_hierarchy( $slug, $is_custom = false, $template_prefix = '
  * prepared for inserting or updating the database, locate all blocks that have
  * hooked blocks, and inject a `metadata.ignoredHookedBlocks` attribute into the anchor
  * blocks to reflect the latter.
+ * 
+ * @since 6.5.0
  *
  * @param stdClass        $post    An object representing a template or template part
  *                                 prepared for inserting or updating the database.

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1442,10 +1442,15 @@ function get_template_hierarchy( $slug, $is_custom = false, $template_prefix = '
  *
  * @param stdClass $post A post object with post type set to `wp_template` or `wp_template_part`.
  * @param WP_REST_Request $request Request object.
- * @param string   $post_type The post type of the post object.
  * @return stdClass The updated post object.
  */
-function inject_ignored_hooked_blocks_metadata_attributes( $post, $request, $post_type ) {
+function inject_ignored_hooked_blocks_metadata_attributes( $post, $request ) {
+	$filter_name = current_filter();
+	if ( ! str_starts_with( $filter_name, 'rest_pre_insert_' ) ) {
+		return $post;
+	}
+	$post_type = str_replace( 'rest_pre_insert_', '', $filter_name );
+
 	$hooked_blocks = get_hooked_blocks();
 	if ( empty( $hooked_blocks ) && ! has_filter( 'hooked_block_types' ) ) {
 		return $post;
@@ -1466,34 +1471,4 @@ function inject_ignored_hooked_blocks_metadata_attributes( $post, $request, $pos
 
 	$post->post_content = $content;
 	return $post;
-}
-
-/**
- * Inject ignoredHookedBlocks metadata attributes into a wp_template_part.
- *
- * Given a `wp_template` or `wp_template_part` post object, locate all blocks that have
- * hooked blocks, and inject a `metadata.ignoredHookedBlocks` attribute into the anchor
- * blocks to reflect the latter.
- *
- * @param stdClass $post A post object with post type set to `wp_template` or `wp_template_part`.
- * @param WP_REST_Request $request Request object.
- * @return stdClass The updated post object.
- */
-function inject_ignored_hooked_blocks_metadata_attributes_into_template_part( $post, $request ) {
-	return inject_ignored_hooked_blocks_metadata_attributes( $post, $request, 'wp_template_part' );
-}
-
-/**
- * Inject ignoredHookedBlocks metadata attributes into a wp_template.
- *
- * Given a `wp_template` or `wp_template_part` post object, locate all blocks that have
- * hooked blocks, and inject a `metadata.ignoredHookedBlocks` attribute into the anchor
- * blocks to reflect the latter.
- *
- * @param stdClass $post A post object with post type set to `wp_template` or `wp_template_part`.
- * @param WP_REST_Request $request Request object.
- * @return stdClass The updated post object.
- */
-function inject_ignored_hooked_blocks_metadata_attributes_into_template( $post, $request ) {
-	return inject_ignored_hooked_blocks_metadata_attributes( $post, $request, 'wp_template' );
 }

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1436,13 +1436,15 @@ function get_template_hierarchy( $slug, $is_custom = false, $template_prefix = '
 /**
  * Inject ignoredHookedBlocks metadata attributes into a template or template part.
  *
- * Given a `wp_template` or `wp_template_part` post object, locate all blocks that have
+ * Given an object that represents a `wp_template` or `wp_template_part` post object
+ * prepared for inserting or updating the database, locate all blocks that have
  * hooked blocks, and inject a `metadata.ignoredHookedBlocks` attribute into the anchor
  * blocks to reflect the latter.
  *
- * @param stdClass $post A post object with post type set to `wp_template` or `wp_template_part`.
+ * @param stdClass        $post    An object representing a template or template part
+ *                                 prepared for inserting or updating the database.
  * @param WP_REST_Request $request Request object.
- * @return stdClass The updated post object.
+ * @return stdClass The updated object representing a template or template part.
  */
 function inject_ignored_hooked_blocks_metadata_attributes( $post, $request ) {
 	$filter_name = current_filter();

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1442,6 +1442,7 @@ function get_template_hierarchy( $slug, $is_custom = false, $template_prefix = '
  * blocks to reflect the latter.
  * 
  * @since 6.5.0
+ * @access private
  *
  * @param stdClass        $post    An object representing a template or template part
  *                                 prepared for inserting or updating the database.

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1448,7 +1448,7 @@ function get_template_hierarchy( $slug, $is_custom = false, $template_prefix = '
 function inject_ignored_hooked_blocks_metadata_attributes( $post, $request, $post_type ) {
 	$hooked_blocks = get_hooked_blocks();
 	if ( empty( $hooked_blocks ) && ! has_filter( 'hooked_block_types' ) ) {
-		return;
+		return $post;
 	}
 
 	// At this point, the post has already been created.

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -752,9 +752,8 @@ add_action( 'deleted_post', '_wp_after_delete_font_family', 10, 2 );
 add_action( 'before_delete_post', '_wp_before_delete_font_face', 10, 2 );
 add_action( 'init', '_wp_register_default_font_collections' );
 
-// It might be nice to use a filter instead of an action, but the `WP_REST_Templates_Controller` doesn't
-// provide one (unlike e.g. `WP_REST_Posts_Controller`, which has `rest_pre_insert_{$this->post_type}`).
-add_action( 'rest_after_insert_wp_template', 'inject_ignored_hooked_blocks_metadata_attributes', 10, 3 );
-add_action( 'rest_after_insert_wp_template_part', 'inject_ignored_hooked_blocks_metadata_attributes', 10, 3 );
+// Add ignoredHookedBlocks metadata attribute to the template and template part post types.
+add_filter( 'rest_pre_insert_wp_template', 'inject_ignored_hooked_blocks_metadata_attributes', 10, 2 );
+add_filter( 'rest_pre_insert_wp_template_part', 'inject_ignored_hooked_blocks_metadata_attributes', 10, 2 );
 
 unset( $filter, $action );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -753,7 +753,7 @@ add_action( 'before_delete_post', '_wp_before_delete_font_face', 10, 2 );
 add_action( 'init', '_wp_register_default_font_collections' );
 
 // Add ignoredHookedBlocks metadata attribute to the template and template part post types.
-add_filter( 'rest_pre_insert_wp_template', 'inject_ignored_hooked_blocks_metadata_attributes_into_template', 10, 2 );
-add_filter( 'rest_pre_insert_wp_template_part', 'inject_ignored_hooked_blocks_metadata_attributes_into_template_part', 10, 2 );
+add_filter( 'rest_pre_insert_wp_template', 'inject_ignored_hooked_blocks_metadata_attributes', 10, 2 );
+add_filter( 'rest_pre_insert_wp_template_part', 'inject_ignored_hooked_blocks_metadata_attributes', 10, 2 );
 
 unset( $filter, $action );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -753,7 +753,7 @@ add_action( 'before_delete_post', '_wp_before_delete_font_face', 10, 2 );
 add_action( 'init', '_wp_register_default_font_collections' );
 
 // Add ignoredHookedBlocks metadata attribute to the template and template part post types.
-add_filter( 'rest_pre_insert_wp_template', 'inject_ignored_hooked_blocks_metadata_attributes', 10, 2 );
-add_filter( 'rest_pre_insert_wp_template_part', 'inject_ignored_hooked_blocks_metadata_attributes', 10, 2 );
+add_filter( 'rest_pre_insert_wp_template', 'inject_ignored_hooked_blocks_metadata_attributes_into_template', 10, 2 );
+add_filter( 'rest_pre_insert_wp_template_part', 'inject_ignored_hooked_blocks_metadata_attributes_into_template_part', 10, 2 );
 
 unset( $filter, $action );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -631,9 +631,9 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 		 *
 		 * @since 6.5.0
 		 *
-		 * @param stdClass        $prepared_post An object representing a single post prepared
-		 *                                       for inserting or updating the database.
-		 * @param WP_REST_Request $request       Request object.
+		 * @param stdClass        $changes An object representing a single post prepared
+		 *                                 for inserting or updating the database.
+		 * @param WP_REST_Request $request Request object.
 		 */
 		return apply_filters( "rest_pre_insert_{$this->post_type}", $changes, $request );
 	}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -619,22 +619,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			$changes->post_author = $post_author;
 		}
 
-		/**
-		 * Filters a post before it is inserted via the REST API.
-		 *
-		 * The dynamic portion of the hook name, `$this->post_type`, refers to the post type slug.
-		 *
-		 * Possible hook names include:
-		 *
-		 *  - `rest_pre_insert_wp_template`
-		 *  - `rest_pre_insert_wp_template_part`
-		 *
-		 * @since 6.5.0
-		 *
-		 * @param stdClass        $changes An object representing a single post prepared
-		 *                                 for inserting or updating the database.
-		 * @param WP_REST_Request $request Request object.
-		 */
+		/** This filter is documented in wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php */
 		return apply_filters( "rest_pre_insert_{$this->post_type}", $changes, $request );
 	}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -619,7 +619,23 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			$changes->post_author = $post_author;
 		}
 
-		return $changes;
+		/**
+		 * Filters a post before it is inserted via the REST API.
+		 *
+		 * The dynamic portion of the hook name, `$this->post_type`, refers to the post type slug.
+		 *
+		 * Possible hook names include:
+		 *
+		 *  - `rest_pre_insert_wp_template`
+		 *  - `rest_pre_insert_wp_template_part`
+		 *
+		 * @since 6.5.0
+		 *
+		 * @param stdClass        $prepared_post An object representing a single post prepared
+		 *                                       for inserting or updating the database.
+		 * @param WP_REST_Request $request       Request object.
+		 */
+		return apply_filters( "rest_pre_insert_{$this->post_type}", $changes, $request );
 	}
 
 	/**

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -87,6 +87,28 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tear down after each test.
+	 *
+	 * @since 6.5.0
+	 */
+	public function tear_down() {
+		global $wp_current_filter;
+
+		if (
+			'rest_pre_insert_wp_template' === current_filter() ||
+			'rest_pre_insert_wp_template_part' === current_filter()
+		) {
+			array_pop( $wp_current_filter );
+		}
+
+		if ( WP_Block_Type_Registry::get_instance()->is_registered( 'tests/hooked-block' ) ) {
+			unregister_block_type( 'tests/hooked-block' );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
 	 * @ticket 59338
 	 *
 	 * @covers ::_inject_theme_attribute_in_template_part_block
@@ -389,5 +411,44 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 			}
 		}
 		$this->assertTrue( $has_html_files, 'contains at least one html file' );
+	}
+
+	/**
+	 * @ticket 60671
+	 *
+	 * @covers inject_ignored_hooked_blocks_metadata_attributes
+	 */
+	public function test_inject_ignored_hooked_blocks_metadata_attributes_into_template() {
+		global $wp_current_filter;
+		// Mock currently set filter.
+		$wp_current_filter[] = 'rest_pre_insert_wp_template';
+
+		register_block_type(
+			'tests/hooked-block',
+			array(
+				'block_hooks' => array(
+					'tests/anchor-block' => 'after',
+				),
+			)
+		);
+
+		$id      = self::TEST_THEME . '//' . 'my_template';
+		$request = new WP_REST_Request( 'POST', '/wp/v2/templates/' . $id );
+
+		$changes = new stdClass();
+		$changes->post_name    = 'my_template';
+		$changes->post_type    = 'wp_template';
+		$changes->post_status  = 'publish';
+		$changes->post_content = '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->';
+		$changes->tax_input    = array(
+			'wp_theme' => self::TEST_THEME,
+		);
+
+		$post = inject_ignored_hooked_blocks_metadata_attributes( $changes, $request );
+		$this->assertSame(
+			'<!-- wp:tests/anchor-block {"metadata":{"ignoredHookedBlocks":["tests/hooked-block"]}} -->Hello<!-- /wp:tests/anchor-block -->',
+			$post->post_content,
+			'The hooked block was not injected into the anchor block\'s ignoredHookedBlocks metadata.'
+		);
 	}
 }

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -436,13 +436,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$request = new WP_REST_Request( 'POST', '/wp/v2/templates/' . $id );
 
 		$changes               = new stdClass();
-		$changes->post_name    = 'my_template';
-		$changes->post_type    = 'wp_template';
-		$changes->post_status  = 'publish';
 		$changes->post_content = '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->';
-		$changes->tax_input    = array(
-			'wp_theme' => self::TEST_THEME,
-		);
 
 		$post = inject_ignored_hooked_blocks_metadata_attributes( $changes, $request );
 		$this->assertSame(
@@ -475,13 +469,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$request = new WP_REST_Request( 'POST', '/wp/v2/template-parts/' . $id );
 
 		$changes               = new stdClass();
-		$changes->post_name    = 'my_template_part';
-		$changes->post_type    = 'wp_template';
-		$changes->post_status  = 'publish';
 		$changes->post_content = '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->';
-		$changes->tax_input    = array(
-			'wp_theme' => self::TEST_THEME,
-		);
 
 		$post = inject_ignored_hooked_blocks_metadata_attributes( $changes, $request );
 		$this->assertSame(

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -435,7 +435,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$id      = self::TEST_THEME . '//' . 'my_template';
 		$request = new WP_REST_Request( 'POST', '/wp/v2/templates/' . $id );
 
-		$changes = new stdClass();
+		$changes               = new stdClass();
 		$changes->post_name    = 'my_template';
 		$changes->post_type    = 'wp_template';
 		$changes->post_status  = 'publish';

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -50,6 +50,22 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 	}
 
 	/**
+	 * Tear down after each test.
+	 *
+	 * @since 6.5.0
+	 */
+	public function tear_down() {
+		if ( has_filter( 'rest_pre_insert_wp_template_part', 'inject_ignored_hooked_blocks_metadata_attributes' ) ) {
+			remove_filter( 'rest_pre_insert_wp_template_part', 'inject_ignored_hooked_blocks_metadata_attributes', 10 );
+		}
+		if ( WP_Block_Type_Registry::get_instance()->is_registered( 'tests/block' ) ) {
+			unregister_block_type( 'tests/hooked-block' );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
 	 * @covers WP_REST_Templates_Controller::register_routes
 	 * @ticket 54596
 	 * @ticket 56467
@@ -950,9 +966,5 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 			$prepared->post_content,
 			'The hooked block was not injected into the anchor block\'s ignoredHookedBlocks metadata.'
 		);
-
-		remove_filter( 'rest_pre_insert_wp_template_part', 'inject_ignored_hooked_blocks_metadata_attributes', 10 );
-
-		unregister_block_type( 'tests/hooked-block' );
 	}
 }

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -912,6 +912,12 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		$this->assertEmpty( $prepared->post_content, 'The content was not correct in the prepared template part.' );
 	}
 
+	/**
+	 * @ticket 60671
+	 *
+	 * @covers WP_REST_Templates_Controller::prepare_item_for_database
+	 * @covers inject_ignored_hooked_blocks_metadata_attributes
+	 */
 	public function test_prepare_item_for_database_injects_hooked_block() {
 		register_block_type(
 			'tests/hooked-block',


### PR DESCRIPTION
This change is inspired by this PR https://github.com/WordPress/gutenberg/pull/59561 since they are suffering from the same problem.

By creating a [rest_pre_insert_{$this->post_type}](https://developer.wordpress.org/reference/hooks/rest_pre_insert_this-post_type/) filter in the`WP_REST_Templates_Controller` rather than using the `rest_insert_{$this->post_type}` action. This avoids calling `wp_update_post` twice, which was the original reason for the issue, as it removed the backslash from the already-encoded entity. I suspect `wp_update_post` was also creating additional revisions which was mentioned in the linked Trac ticket.

By creating this filter it also creates consistency with the `WP_REST_Posts_Controller` which has [the same filter](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php#L1382-L1399).

Trac ticket: https://core.trac.wordpress.org/ticket/60671

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
