### PR TITLE
TT2: Wrap Navigation block in Row within the header.html template part

### DIFF
--- a/src/wp-content/themes/twentytwentytwo/parts/header.html
+++ b/src/wp-content/themes/twentytwentytwo/parts/header.html
@@ -5,9 +5,12 @@
 
 <!-- wp:site-title /--></div>
 <!-- /wp:group -->
-
+<!-- wp:group {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"left"}} -->
+<div class="wp-block-group">
 <!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} -->
 <!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-<!-- /wp:navigation --></div>
+<!-- /wp:navigation -->
+</div>
+<!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/src/wp-content/themes/twentytwentytwo/parts/header.html
+++ b/src/wp-content/themes/twentytwentytwo/parts/header.html
@@ -9,8 +9,7 @@
 <div class="wp-block-group">
 <!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} -->
 <!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
-<!-- /wp:navigation -->
-</div>
+<!-- /wp:navigation --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->


### PR DESCRIPTION
Now that the Block Hooks API has been released as part of WordPress 6.4 3PDs may want to insert their own blocks into the header, specifically after the Navigation block. This currently causes problems because the Navigation block and it's siblings are treated as flex items due to its parent being a Row block.

This PR wraps the Navigation block within a Row block of its own. By default the behaviour of the header should remain the same and introduce no regressions but this now means plugins are able to use the Block Hooks API to automatically insert their own blocks using the Navigation as an anchor block without them being treated as flex items (e.g. Mini Cart or My Account blocks)

Trac ticket: https://core.trac.wordpress.org/ticket/60724

## Testing instructions

1. Ensure that the TT2 default header behaves the same on various viewport sizes and browsers, and no regressions have been introduced by this change.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
