### PR TITLE
Docblocks edited to correspond to negative value of parameter $post_id and usage of absint() functions.

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2681,7 +2681,7 @@ function unregister_post_meta( $post_type, $meta_key ) {
  * @since 1.2.0
  *
  * @param int $post_id Optional. Post ID. Default is the ID of the global `$post`. If is 
- * 					   negative value, it will be converted to its absolute value.
+ * 					   negative value, it will be converted to its absolute value. Default '0'.
  * @return mixed An array of values.
  *               False for an invalid `$post_id` (non-numeric value or zero).
  *               An empty string if a valid but non-existing post ID is passed.

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2579,8 +2579,8 @@ function delete_post_meta( $post_id, $meta_key, $meta_value = '' ) {
  *
  * @since 1.5.0
  *
- * @param int    $post_id Post ID. If is negative value, it will be converted to its 
- * 					      absolute value.
+ * @param int    $post_id Post ID. If is negative value, it will be converted to its
+ *                        absolute value.
  * @param string $key     Optional. The meta key to retrieve. By default,
  *                        returns data for all keys. Default empty.
  * @param bool   $single  Optional. Whether to return a single value.
@@ -2680,8 +2680,8 @@ function unregister_post_meta( $post_type, $meta_key ) {
  *
  * @since 1.2.0
  *
- * @param int $post_id Optional. Post ID. Default is the ID of the global `$post`. If is 
- * 					   negative value, it will be converted to its absolute value. Default '0'.
+ * @param int $post_id Optional. Post ID. Default is the ID of the global `$post`. If is
+ *                     negative value, it will be converted to its absolute value. Default '0'.
  * @return mixed An array of values.
  *               False for an invalid `$post_id` (non-numeric value or zero).
  *               An empty string if a valid but non-existing post ID is passed.

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2579,7 +2579,8 @@ function delete_post_meta( $post_id, $meta_key, $meta_value = '' ) {
  *
  * @since 1.5.0
  *
- * @param int    $post_id Post ID.
+ * @param int    $post_id Post ID. If is negative value, it will be converted to its 
+ * 					      absolute value.
  * @param string $key     Optional. The meta key to retrieve. By default,
  *                        returns data for all keys. Default empty.
  * @param bool   $single  Optional. Whether to return a single value.
@@ -2587,7 +2588,7 @@ function delete_post_meta( $post_id, $meta_key, $meta_value = '' ) {
  *                        Default false.
  * @return mixed An array of values if `$single` is false.
  *               The value of the meta field if `$single` is true.
- *               False for an invalid `$post_id` (non-numeric, zero, or negative value).
+ *               False for an invalid `$post_id` (non-numeric value or zero).
  *               An empty string if a valid but non-existing post ID is passed.
  */
 function get_post_meta( $post_id, $key = '', $single = false ) {
@@ -2679,9 +2680,10 @@ function unregister_post_meta( $post_type, $meta_key ) {
  *
  * @since 1.2.0
  *
- * @param int $post_id Optional. Post ID. Default is the ID of the global `$post`.
+ * @param int $post_id Optional. Post ID. Default is the ID of the global `$post`. If is 
+ * 					   negative value, it will be converted to its absolute value.
  * @return mixed An array of values.
- *               False for an invalid `$post_id` (non-numeric, zero, or negative value).
+ *               False for an invalid `$post_id` (non-numeric value or zero).
  *               An empty string if a valid but non-existing post ID is passed.
  */
 function get_post_custom( $post_id = 0 ) {


### PR DESCRIPTION
Trac ticket: [https://core.trac.wordpress.org/ticket/60646](https://core.trac.wordpress.org/ticket/60646)

- Docblock of functions `get_post_meta()` and `get_post_custom()` edited to correspond to negative value of the parameter $post_id
- Default value added in docblock of `get_post_custom()`   for parameter $post_id
