### PR TITLE
Block Hooks: Remove filter global reset from test teardown

### DIFF
--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -92,15 +92,6 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	 * @since 6.5.0
 	 */
 	public function tear_down() {
-		global $wp_current_filter;
-
-		if (
-			'rest_pre_insert_wp_template' === current_filter() ||
-			'rest_pre_insert_wp_template_part' === current_filter()
-		) {
-			array_pop( $wp_current_filter );
-		}
-
 		if ( WP_Block_Type_Registry::get_instance()->is_registered( 'tests/hooked-block' ) ) {
 			unregister_block_type( 'tests/hooked-block' );
 		}
@@ -420,7 +411,8 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	 */
 	public function test_inject_ignored_hooked_blocks_metadata_attributes_into_template() {
 		global $wp_current_filter;
-		// Mock currently set filter.
+		// Mock currently set filter. The $wp_current_filter global is reset during teardown by
+		// WP_UnitTestCase_Base::_restore_hooks() in tests/phpunit/includes/abstract-testcase.php.
 		$wp_current_filter[] = 'rest_pre_insert_wp_template';
 
 		register_block_type(

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -445,7 +445,8 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	 */
 	public function test_inject_ignored_hooked_blocks_metadata_attributes_into_template_part() {
 		global $wp_current_filter;
-		// Mock currently set filter.
+		// Mock currently set filter. The $wp_current_filter global is reset during teardown by
+		// WP_UnitTestCase_Base::_restore_hooks() in tests/phpunit/includes/abstract-testcase.php.
 		$wp_current_filter[] = 'rest_pre_insert_wp_template_part';
 
 		register_block_type(


### PR DESCRIPTION
https://github.com/WordPress/wordpress-develop/pull/6225 included a test that involved setting the `$wp_current_filter` global, and then removing it during teardown.

It was [pointed](https://wordpress.slack.com/archives/C02RQBWTW/p1709834987090339?thread_ts=1709820648.654859&cid=C02RQBWTW) [out](https://wordpress.slack.com/archives/C02RQBWTW/p1709839010104639?thread_ts=1709820648.654859&cid=C02RQBWTW) to me in Slack by @TimothyBJacobs that this is unnecessary:

>>> Filters should get automatically reset by the parent `tearDown` implementation.
>>
>> It's not the filter function I'm mocking though but the filter hook name (i.e. via the `$wp_current_filter` global)
>
> I believe that should get reset as well. https://github.com/WordPress/wordpress-develop/blob/9a616a573434b432a5efd4de21039250658371fe/tests/phpunit/includes/abstract-testcase.php#L382

This PR removes the unnecessary reset accordingly.

Follow-up [[57790]](https://core.trac.wordpress.org/changeset/57790).

Trac ticket: https://core.trac.wordpress.org/ticket/60671

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
