### PR TITLE
WP_Query::parse_query: Handle invalid query arg types

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -814,18 +814,36 @@ class WP_Query {
 			$qv['p'] = (int) $qv['p'];
 		}
 
-		$qv['page_id']  = is_scalar( $qv['page_id'] ) ? absint( $qv['page_id'] ) : 0;
-		$qv['year']     = is_scalar( $qv['year'] ) ? absint( $qv['year'] ) : 0;
-		$qv['monthnum'] = is_scalar( $qv['monthnum'] ) ? absint( $qv['monthnum'] ) : 0;
-		$qv['day']      = is_scalar( $qv['day'] ) ? absint( $qv['day'] ) : 0;
-		$qv['w']        = is_scalar( $qv['w'] ) ? absint( $qv['w'] ) : 0;
-		$qv['m']        = is_scalar( $qv['m'] ) ? preg_replace( '|[^0-9]|', '', $qv['m'] ) : '';
-		$qv['paged']    = is_scalar( $qv['paged'] ) ? absint( $qv['paged'] ) : 0;
-		$qv['cat']      = preg_replace( '|[^0-9,-]|', '', $qv['cat'] ); // Array or comma-separated list of positive or negative integers.
-		$qv['author']   = is_scalar( $qv['author'] ) ? preg_replace( '|[^0-9,-]|', '', $qv['author'] ) : ''; // Comma-separated list of positive or negative integers.
-		$qv['pagename'] = is_scalar( $qv['pagename'] ) ? trim( $qv['pagename'] ) : '';
-		$qv['name']     = is_scalar( $qv['name'] ) ? trim( $qv['name'] ) : '';
-		$qv['title']    = is_scalar( $qv['title'] ) ? trim( $qv['title'] ) : '';
+		$qv['page_id']             = is_scalar( $qv['page_id'] ) ? absint( $qv['page_id'] ) : 0;
+		$qv['year']                = is_scalar( $qv['year'] ) ? absint( $qv['year'] ) : 0;
+		$qv['monthnum']            = is_scalar( $qv['monthnum'] ) ? absint( $qv['monthnum'] ) : 0;
+		$qv['day']                 = is_scalar( $qv['day'] ) ? absint( $qv['day'] ) : 0;
+		$qv['w']                   = is_scalar( $qv['w'] ) ? absint( $qv['w'] ) : 0;
+		$qv['m']                   = is_scalar( $qv['m'] ) ? preg_replace( '|[^0-9]|', '', $qv['m'] ) : '';
+		$qv['paged']               = is_scalar( $qv['paged'] ) ? absint( $qv['paged'] ) : 0;
+		$qv['cat']                 = preg_replace( '|[^0-9,-]|', '', $qv['cat'] ); // Array or comma-separated list of positive or negative integers.
+		$qv['author']              = is_scalar( $qv['author'] ) ? preg_replace( '|[^0-9,-]|', '', $qv['author'] ) : ''; // Comma-separated list of positive or negative integers.
+		$qv['pagename']            = is_scalar( $qv['pagename'] ) ? trim( $qv['pagename'] ) : '';
+		$qv['name']                = is_scalar( $qv['name'] ) ? trim( $qv['name'] ) : '';
+		$qv['title']               = is_scalar( $qv['title'] ) ? trim( $qv['title'] ) : '';
+		$qv['feed']                = is_scalar( $qv['feed'] ) ? trim( $qv['feed'] ) : '';
+		$qv['attachment']          = is_scalar( $qv['attachment'] ) ? $qv['attachment'] : '';
+		$qv['author_name']         = is_scalar( $qv['author_name'] ) ? $qv['author_name'] : '';
+		$qv['author__in']          = is_array( $qv['author__in'] ) ? $qv['author__in'] : array();
+		$qv['author__not_in']      = is_array( $qv['author__not_in'] ) ? $qv['author__not_in'] : array();
+		$qv['category__and']       = is_array( $qv['category__and'] ) ? $qv['category__and'] : array();
+		$qv['category__in']        = is_array( $qv['category__in'] ) ? $qv['category__in'] : array();
+		$qv['category__not_in']    = is_array( $qv['category__not_in'] ) ? $qv['category__not_in'] : array();
+		$qv['post__in']            = is_array( $qv['post__in'] ) ? $qv['post__in'] : array();
+		$qv['post__not_in']        = is_array( $qv['post__not_in'] ) ? $qv['post__not_in'] : array();
+		$qv['post_name__in']       = is_array( $qv['post_name__in'] ) ? $qv['post_name__in'] : array();
+		$qv['post_parent__in']     = is_array( $qv['post_parent__in'] ) ? $qv['post_parent__in'] : array();
+		$qv['post_parent__not_in'] = is_array( $qv['post_parent__not_in'] ) ? $qv['post_parent__not_in'] : array();
+		$qv['tag__and']            = is_array( $qv['tag__and'] ) ? $qv['tag__and'] : array();
+		$qv['tag__in']             = is_array( $qv['tag__in'] ) ? $qv['tag__in'] : array();
+		$qv['tag__not_in']         = is_array( $qv['tag__not_in'] ) ? $qv['tag__not_in'] : array();
+		$qv['tag_slug__and']       = is_array( $qv['tag_slug__and'] ) ? $qv['tag_slug__and'] : array();
+		$qv['tag_slug__in']        = is_array( $qv['tag_slug__in'] ) ? $qv['tag_slug__in'] : array();
 
 		if ( is_scalar( $qv['hour'] ) && '' !== $qv['hour'] ) {
 			$qv['hour'] = absint( $qv['hour'] );

--- a/tests/phpunit/tests/query/php8xCompat.php
+++ b/tests/phpunit/tests/query/php8xCompat.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @group query
+ */
+class Tests_Query_Args_Php_8x_Compat extends WP_UnitTestCase {
+	/**
+	 * @ticket 60745
+	 * @dataProvider invalid_query_arg_data_provider
+	 */
+	public function test_feed_query_arg_with_array_value( $query_args ) {
+		$post  = self::factory()->post->create_and_get();
+		$query = new WP_Query( $query_args );
+		$posts = $query->get_posts();
+		$this->assertSame( 1, count( $posts ) );
+	}
+
+	public function invalid_query_arg_data_provider() {
+		return array(
+			'scalar_query_arg_is_array' => array(
+				array(
+					'attachment'      => array(),
+					'attachment_id'   => array(),
+					'author'          => array(),
+					'author_name'     => array(),
+					'cat'             => array(),
+					'day'             => array(),
+					'embed'           => array(),
+					'error'           => array(),
+					'favicon'         => array(),
+					'feed'            => array(),
+					'hour'            => array(),
+					'm'               => array(),
+					'menu_order'      => array(),
+					'minute'          => array(),
+					'monthnum'        => array(),
+					'name'            => array(),
+					'p'               => array(),
+					'page'            => array(),
+					'page_id'         => array(),
+					'paged'           => array(),
+					'pagename'        => array(),
+					'post_status'     => array(),
+					'post_type'       => array(),
+					'preview'         => array(),
+					'robots'          => array(),
+					's'               => array(),
+					'second'          => array(),
+					'subpost'         => array(),
+					'subpost_id'      => array(),
+					'tb'              => array(),
+					'title'           => array(),
+					'w'               => array(),
+					'withcomments'    => array(),
+					'withoutcomments' => array(),
+					'year'            => array(),
+				),
+			),
+			'query_array_arg_is_string' => array(
+				array(
+					'author__in'          => 'string',
+					'author__not_in'      => 'string',
+					'category__and'       => 'string',
+					'category__in'        => 'string',
+					'category__not_in'    => 'string',
+					'post__in'            => 'string',
+					'post__not_in'        => 'string',
+					'post_name__in'       => 'string',
+					'post_parent__in'     => 'string',
+					'post_parent__not_in' => 'string',
+					'tag__and'            => 'string',
+					'tag__in'             => 'string',
+					'tag__not_in'         => 'string',
+					'tag_slug__and'       => 'string',
+					'tag_slug__in'        => 'string',
+				),
+			),
+		);
+	}
+}


### PR DESCRIPTION
Add `is_scalar`/`is_array` checks.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60745

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
