### PR TITLE
Interactivity API: Fix directives in tags whose closing tag is not visited not working

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -283,9 +283,9 @@ final class WP_Interactivity_API {
 					}
 
 					/*
-					* If this tag will visit its closer tag, it adds it to the tag stack
-					* so it can process its closing tag and check for unbalanced tags.
-					*/
+					 * If this tag will visit its closer tag, it adds it to the tag stack
+					 * so it can process its closing tag and check for unbalanced tags.
+					 */
 					if ( $p->has_and_visits_its_closer_tag() ) {
 						$tag_stack[] = array( $tag_name, $directives_prefixes );
 					}

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -246,22 +246,20 @@ final class WP_Interactivity_API {
 			}
 
 			if ( $p->is_tag_closer() ) {
-				if ( $p->has_and_visits_its_closer_tag() ) {
-					list( $opening_tag_name, $directives_prefixes ) = end( $tag_stack );
+				list( $opening_tag_name, $directives_prefixes ) = end( $tag_stack );
 
-					if ( 0 === count( $tag_stack ) || $opening_tag_name !== $tag_name ) {
+				if ( 0 === count( $tag_stack ) || $opening_tag_name !== $tag_name ) {
 
-						/*
-						 * If the tag stack is empty or the matching opening tag is not the
-						 * same than the closing tag, it means the HTML is unbalanced and it
-						 * stops processing it.
-						 */
-						$unbalanced = true;
-						break;
-					} else {
-						// Remove the last tag from the stack.
-						array_pop( $tag_stack );
-					}
+					/*
+					 * If the tag stack is empty or the matching opening tag is not the
+					 * same than the closing tag, it means the HTML is unbalanced and it
+					 * stops processing it.
+					 */
+					$unbalanced = true;
+					break;
+				} else {
+					// Remove the last tag from the stack.
+					array_pop( $tag_stack );
 				}
 			} else {
 				if ( 0 !== count( $p->get_attribute_names_with_prefix( 'data-wp-each-child' ) ) ) {

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -246,20 +246,22 @@ final class WP_Interactivity_API {
 			}
 
 			if ( $p->is_tag_closer() ) {
-				list( $opening_tag_name, $directives_prefixes ) = end( $tag_stack );
+				if ( $p->has_and_visits_its_closer_tag() ) {
+					list( $opening_tag_name, $directives_prefixes ) = end( $tag_stack );
 
-				if ( 0 === count( $tag_stack ) || $opening_tag_name !== $tag_name ) {
+					if ( 0 === count( $tag_stack ) || $opening_tag_name !== $tag_name ) {
 
-					/*
-					 * If the tag stack is empty or the matching opening tag is not the
-					 * same than the closing tag, it means the HTML is unbalanced and it
-					 * stops processing it.
-					 */
-					$unbalanced = true;
-					break;
-				} else {
-					// Remove the last tag from the stack.
-					array_pop( $tag_stack );
+						/*
+						 * If the tag stack is empty or the matching opening tag is not the
+						 * same than the closing tag, it means the HTML is unbalanced and it
+						 * stops processing it.
+						 */
+						$unbalanced = true;
+						break;
+					} else {
+						// Remove the last tag from the stack.
+						array_pop( $tag_stack );
+					}
 				}
 			} else {
 				if ( 0 !== count( $p->get_attribute_names_with_prefix( 'data-wp-each-child' ) ) ) {
@@ -281,9 +283,9 @@ final class WP_Interactivity_API {
 					}
 
 					/*
-					 * If this tag will visit its closer tag, it adds it to the tag stack
-					 * so it can process its closing tag and check for unbalanced tags.
-					 */
+					* If this tag will visit its closer tag, it adds it to the tag stack
+					* so it can process its closing tag and check for unbalanced tags.
+					*/
 					if ( $p->has_and_visits_its_closer_tag() ) {
 						$tag_stack[] = array( $tag_name, $directives_prefixes );
 					}

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPIFunctions.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPIFunctions.php
@@ -10,7 +10,7 @@
  *
  * @group interactivity-api
  */
-class Tests_Interactivity_API_Functions extends WP_UnitTestCase {
+class Tests_Interactivity_API_wpInteractivityAPIFunctions extends WP_UnitTestCase {
 	/**
 	 * Set up.
 	 */
@@ -389,5 +389,32 @@ class Tests_Interactivity_API_Functions extends WP_UnitTestCase {
 		$this->assertEquals( 'data-wp-context=\'{"apos":"\u0027bar\u0027"}\'', wp_interactivity_data_wp_context( array( 'apos' => "'bar'" ) ) );
 		$this->assertEquals( 'data-wp-context=\'{"quot":"\u0022baz\u0022"}\'', wp_interactivity_data_wp_context( array( 'quot' => '"baz"' ) ) );
 		$this->assertEquals( 'data-wp-context=\'{"amp":"T\u0026T"}\'', wp_interactivity_data_wp_context( array( 'amp' => 'T&T' ) ) );
+	}
+
+	/**
+	 * Tests that directives processing of tags that don't visit closer tag work.
+	 *
+	 * @ticket 60746
+	 *
+	 * @covers ::wp_interactivity_process_directives_of_interactive_blocks
+	 */
+	public function test_process_directives_in_tags_that_dont_visit_closer_tag() {
+		register_block_type(
+			'test/custom-directive-block',
+			array(
+				'render_callback' => function () {
+					return '<iframe data-wp-interactive="nameSpace" ' . wp_interactivity_data_wp_context( array( 'text' => 'test' ) ) . ' data-wp-class--test="context.text" src="1"></iframe>';
+				},
+				'supports'        => array(
+					'interactivity' => true,
+				),
+			)
+		);
+		$post_content      = '<!-- wp:test/custom-directive-block /-->';
+		$processed_content = do_blocks( $post_content );
+		$processor         = new WP_HTML_Tag_Processor( $processed_content );
+		$processor->next_tag( array( 'class_name' => 'test' ) );
+		unregister_block_type( 'test/custom-directive-block' );
+		$this->assertEquals( '1', $processor->get_attribute( 'src' ) );
 	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/60746

Right now, if I add directives to tags with closing tag that is not visited by the tag processor, it breaks the whole server-side rendering processing.

This is the list of those tags: https://github.com/WordPress/wordpress-develop/blob/186eeafb6888431fdf445b2abf2036f0606edcd5/src/wp-includes/interactivity-api/class-wp-interactivity-api-directives-processor.php#L25-L34

For example, if I try to add a directive to an iframe, it breaks the processing.

Co-authored by [@cbravobernal](https://profiles.wordpress.org/cbravobernal)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
