### PR TITLE
Add a databse persisted fallback for the default font folder path

### DIFF
--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -161,8 +161,7 @@ function wp_get_font_dir() {
 	 *
 	 * @param array $defaults The original fonts directory data.
 	 */
-	$defaults = apply_filters( 'font_dir', $defaults );
-	return $defaults;
+	return apply_filters( 'font_dir', $defaults );
 }
 
 /**

--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -95,14 +95,14 @@ function wp_unregister_font_collection( string $slug ) {
  * Returns the default font directory path and URL.
  *
  * @since 6.5.0
- * 
+ *
  * @param bool $refresh_cache Optional. Whether to refresh the cache and generate a new default font directory path and URL. Default is false.
  * @return array Default font directory path and URL.
  */
-function wp_default_font_dir (  $refresh_cache = false  ) {
+function wp_default_font_dir( $refresh_cache = false ) {
 	$defaults = get_option( 'font_dir' );
 
-	if ( !empty ( $defaults ) &&  ! $refresh_cache ) {
+	if ( ! empty( $defaults ) && ! $refresh_cache ) {
 		return $defaults;
 	}
 
@@ -123,9 +123,9 @@ function wp_default_font_dir (  $refresh_cache = false  ) {
 	@wp_mkdir_p( $defaults['path'] );
 
 	if ( ! wp_is_writable( $defaults['path'] ) ) {
-		$defaults = wp_upload_dir();
-		$defaults['path'] = path_join( $defaults['basedir'], 'fonts' );
-		$defaults['url'] = $defaults['baseurl'] . '/fonts';
+		$defaults           = wp_upload_dir();
+		$defaults['path']   = path_join( $defaults['basedir'], 'fonts' );
+		$defaults['url']    = $defaults['baseurl'] . '/fonts';
 		$defaults['subdir'] = '/fonts';
 	}
 

--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -120,7 +120,9 @@ function wp_default_font_dir (  $refresh_cache = false  ) {
 		'error'   => false,
 	);
 
-	if ( ! wp_mkdir_p( $defaults['path'] ) ) {
+	@wp_mkdir_p( $defaults['path'] );
+
+	if ( ! wp_is_writable( $defaults['path'] ) ) {
 		$defaults = wp_upload_dir();
 		$defaults['path'] = path_join( $defaults['basedir'], 'fonts' );
 		$defaults['url'] = $defaults['baseurl'] . '/fonts';

--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -150,10 +150,6 @@ function wp_default_font_dir( $refresh_cache = false ) {
  * }
  */
 function wp_get_font_dir() {
-	if ( doing_filter( 'font_dir' ) ) {
-		return;
-	}
-
 	$defaults = wp_default_font_dir( true );
 
 	/**

--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -120,7 +120,7 @@ function wp_default_font_dir( $refresh_cache = false ) {
 		'error'   => false,
 	);
 
-	@wp_mkdir_p( $defaults['path'] );
+	wp_mkdir_p( $defaults['path'] );
 
 	if ( ! wp_is_writable( $defaults['path'] ) ) {
 		$defaults           = wp_upload_dir();

--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -123,10 +123,12 @@ function wp_default_font_dir( $refresh_cache = false ) {
 	wp_mkdir_p( $defaults['path'] );
 
 	if ( ! wp_is_writable( $defaults['path'] ) ) {
-		$defaults           = wp_upload_dir();
-		$defaults['path']   = path_join( $defaults['basedir'], 'fonts' );
-		$defaults['url']    = $defaults['baseurl'] . '/fonts';
-		$defaults['subdir'] = '/fonts';
+		$defaults            = wp_upload_dir();
+		$defaults['path']    = path_join( $defaults['basedir'], 'fonts' );
+		$defaults['url']     = $defaults['baseurl'] . '/fonts';
+		$defaults['subdir']  = '';
+		$defaults['basedir'] = path_join( $defaults['basedir'], 'fonts' );
+		$defaults['baseurl'] = $defaults['baseurl'] . '/fonts';
 	}
 
 	update_option( 'font_dir', $defaults );

--- a/tests/phpunit/tests/fonts/wpDefaultFontDir.php
+++ b/tests/phpunit/tests/fonts/wpDefaultFontDir.php
@@ -12,32 +12,40 @@
  */
 class Tests_Fonts_WpDefaultFontDir extends WP_UnitTestCase {
 
-    public function test_default_font_dir() {
-        $font_dir = wp_default_font_dir();
+	public function test_default_font_dir() {
+		$font_dir = wp_default_font_dir();
 
-        $this->assertSame( $font_dir, array(
-            'path'    => WP_CONTENT_DIR . '/fonts',
-            'url'     => content_url( 'fonts' ),
-            'subdir'  => '',
-            'basedir' => WP_CONTENT_DIR . '/fonts',
-            'baseurl' => content_url( 'fonts' ),
-            'error'   => false,
-        ), 'The font directory should be a dir inside wp-content' );
-    }
+		$this->assertSame(
+			$font_dir,
+			array(
+				'path'    => WP_CONTENT_DIR . '/fonts',
+				'url'     => content_url( 'fonts' ),
+				'subdir'  => '',
+				'basedir' => WP_CONTENT_DIR . '/fonts',
+				'baseurl' => content_url( 'fonts' ),
+				'error'   => false,
+			),
+			'The font directory should be a dir inside wp-content'
+		);
+	}
 
-    public function test_uploads_font_dir() {
-        $font_dir = wp_default_font_dir( true );
-        chmod( $font_dir['path'], 0000 );
-        
-        $upload_dir = wp_upload_dir();
+	public function test_uploads_font_dir() {
+		$font_dir = wp_default_font_dir( true );
+		chmod( $font_dir['path'], 0000 );
 
-        $this->assertSame( $font_dir, array(
-            'path'    => path_join( $upload_dir['basedir'], 'fonts' ),
-            'url'     => $upload_dir['baseurl'] . '/fonts',
-            'subdir'  => '/fonts',
-            'basedir' => $upload_dir['basedir'],
-            'baseurl' => $upload_dir['baseurl'],
-            'error'   => false,
-        ), 'The font directory should be a subdir in the uploads directory.' );
-    }
+		$upload_dir = wp_upload_dir();
+
+		$this->assertSame(
+			$font_dir,
+			array(
+				'path'    => path_join( $upload_dir['basedir'], 'fonts' ),
+				'url'     => $upload_dir['baseurl'] . '/fonts',
+				'subdir'  => '/fonts',
+				'basedir' => $upload_dir['basedir'],
+				'baseurl' => $upload_dir['baseurl'],
+				'error'   => false,
+			),
+			'The font directory should be a subdir in the uploads directory.'
+		);
+	}
 }

--- a/tests/phpunit/tests/fonts/wpDefaultFontDir.php
+++ b/tests/phpunit/tests/fonts/wpDefaultFontDir.php
@@ -16,7 +16,6 @@ class Tests_Fonts_WpDefaultFontDir extends WP_UnitTestCase {
 		$font_dir = wp_default_font_dir();
 
 		$this->assertSame(
-			$font_dir,
 			array(
 				'path'    => WP_CONTENT_DIR . '/fonts',
 				'url'     => content_url( 'fonts' ),
@@ -25,6 +24,7 @@ class Tests_Fonts_WpDefaultFontDir extends WP_UnitTestCase {
 				'baseurl' => content_url( 'fonts' ),
 				'error'   => false,
 			),
+            $font_dir,
 			'The font directory should be a dir inside wp-content'
 		);
 	}
@@ -36,7 +36,6 @@ class Tests_Fonts_WpDefaultFontDir extends WP_UnitTestCase {
 		$upload_dir = wp_upload_dir();
 
 		$this->assertSame(
-			$font_dir,
 			array(
 				'path'    => path_join( $upload_dir['basedir'], 'fonts' ),
 				'url'     => $upload_dir['baseurl'] . '/fonts',
@@ -45,6 +44,7 @@ class Tests_Fonts_WpDefaultFontDir extends WP_UnitTestCase {
 				'baseurl' => $upload_dir['baseurl'],
 				'error'   => false,
 			),
+            $font_dir,
 			'The font directory should be a subdir in the uploads directory.'
 		);
 	}

--- a/tests/phpunit/tests/fonts/wpDefaultFontDir.php
+++ b/tests/phpunit/tests/fonts/wpDefaultFontDir.php
@@ -39,9 +39,9 @@ class Tests_Fonts_WpDefaultFontDir extends WP_UnitTestCase {
 			array(
 				'path'    => path_join( $upload_dir['basedir'], 'fonts' ),
 				'url'     => $upload_dir['baseurl'] . '/fonts',
-				'subdir'  => '/fonts',
-				'basedir' => $upload_dir['basedir'],
-				'baseurl' => $upload_dir['baseurl'],
+				'subdir'  => '',
+				'basedir' => path_join( $upload_dir['basedir'], 'fonts' ),
+				'baseurl' => $upload_dir['baseurl'] . '/fonts',
 				'error'   => false,
 			),
 			$font_dir,

--- a/tests/phpunit/tests/fonts/wpDefaultFontDir.php
+++ b/tests/phpunit/tests/fonts/wpDefaultFontDir.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Test wp_default_font_dir().
+ *
+ * @package WordPress
+ * @subpackage Font Library
+ *
+ * @group fonts
+ * @group font-library
+ *
+ * @covers ::wp_default_font_dir
+ */
+class Tests_Fonts_WpDefaultFontDir extends WP_UnitTestCase {
+
+    public function test_default_font_dir() {
+        $font_dir = wp_default_font_dir();
+
+        $this->assertSame( $font_dir, array(
+            'path'    => WP_CONTENT_DIR . '/fonts',
+            'url'     => content_url( 'fonts' ),
+            'subdir'  => '',
+            'basedir' => WP_CONTENT_DIR . '/fonts',
+            'baseurl' => content_url( 'fonts' ),
+            'error'   => false,
+        ), 'The font directory should be a dir inside wp-content' );
+    }
+
+    public function test_uploads_font_dir() {
+        $font_dir = wp_default_font_dir( true );
+        chmod( $font_dir['path'], 0000 );
+        
+        $upload_dir = wp_upload_dir();
+
+        $this->assertSame( $font_dir, array(
+            'path'    => path_join( $upload_dir['basedir'], 'fonts' ),
+            'url'     => $upload_dir['baseurl'] . '/fonts',
+            'subdir'  => '/fonts',
+            'basedir' => $upload_dir['basedir'],
+            'baseurl' => $upload_dir['baseurl'],
+            'error'   => false,
+        ), 'The font directory should be a subdir in the uploads directory.' );
+    }
+}

--- a/tests/phpunit/tests/fonts/wpDefaultFontDir.php
+++ b/tests/phpunit/tests/fonts/wpDefaultFontDir.php
@@ -24,7 +24,7 @@ class Tests_Fonts_WpDefaultFontDir extends WP_UnitTestCase {
 				'baseurl' => content_url( 'fonts' ),
 				'error'   => false,
 			),
-            $font_dir,
+			$font_dir,
 			'The font directory should be a dir inside wp-content'
 		);
 	}
@@ -44,7 +44,7 @@ class Tests_Fonts_WpDefaultFontDir extends WP_UnitTestCase {
 				'baseurl' => $upload_dir['baseurl'],
 				'error'   => false,
 			),
-            $font_dir,
+			$font_dir,
 			'The font directory should be a subdir in the uploads directory.'
 		);
 	}


### PR DESCRIPTION
## What?

Add a fallback for the default font directory persisted in the database as a site option.
There's an alternative PR without database persistence:  https://github.com/WordPress/wordpress-develop/pull/6259


## Why?
> For installations that don’t support modification of the wp-content directory, the Font Library will use wp-content/uploads/fonts as a fallback location, ensuring we stay true to our project philosophy of designing for the majority while still making the feature available to anyone out of the box without extra steps from the user. 

Decision from https://make.wordpress.org/core/2024/03/07/unblocking-wp6-5-font-library-and-synced-pattern-overrides/
Discussion: https://github.com/WordPress/gutenberg/issues/59699

## How?
Add the `wp_default_font_dir` function.
If `/wp-content/fonts` is writable this function should return:
```php
array(
    'path' => '/var/www/src/wp-content/fonts',
    'url' => 'http://localhost:8889/wp-content/fonts',
    'subdir' => ''
    'basedir' => '/var/www/src/wp-content/fonts',
    'baseurl' => 'http://localhost:8889/wp-content/fonts'
    'error' => false
)
```
If `/wp-content/fonts` is not writable this function should return:
```php
array(
    'path' => '/var/www/src/wp-content/uploads/fonts',
    'url' => 'http://localhost:8889/wp-content/uploads/fonts',
    'subdir' => ''
    'basedir' => '/var/www/src/wp-content/uploads/fonts',
    'baseurl' => 'http://localhost:8889/wp-content/uploads/fonts'
    'error' => false
)
```
The output of this function is persisted in the database as a site_option. To refresh the value persisted the `wp_default_font_dir` function should be called like this `wp_default_font_dir( true )`.

---

Trac ticket: https://core.trac.wordpress.org/ticket/60751#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
