### PR TITLE
Block Hooks: Pass correct context to filters

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1469,6 +1469,7 @@ function inject_ignored_hooked_blocks_metadata_attributes( $post, $request ) {
 	remove_filter( 'hooked_block_types', '__return_empty_array', 99999 );
 
 	$post_to_template_key_map = array(
+		'post_author'  => 'author',
 		'post_content' => 'content',
 		'post_title'   => 'title',
 		'post_excerpt' => 'description',

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1465,6 +1465,15 @@ function inject_ignored_hooked_blocks_metadata_attributes( $changes, $request ) 
 	// To that end, we need to suppress hooked blocks from getting inserted into the template.
 	add_filter( 'hooked_block_types', '__return_empty_array', 99999, 0 );
 
+	if ( isset( $changes->ID ) ) {
+		$post = get_post( $changes->ID );
+	} else {
+		// This means that there's not post for this template in the DB yet.
+		$post = new stdClass; // Is this correct? Might instead want to init a WP_Post with some fields set.
+	}
+
+	$post_with_changes_applied = (object) array_merge( (array) $post, (array) $changes );
+
 	// We also need to mimic terms and meta for the post based on the corresponding
 	// `terms_input` and `meta_input` properties in the changes object.
 
@@ -1496,7 +1505,7 @@ function inject_ignored_hooked_blocks_metadata_attributes( $changes, $request ) 
 
 	add_filter( 'get_the_terms', $terms_filter, 10, 3 );
 	add_filter( 'get_post_metadata', $meta_filter, 10, 4 );
-	$template = _build_block_template_result_from_post( $changes );
+	$template = _build_block_template_result_from_post( $post_with_changes_applied );
 	remove_filter( 'get_post_metadata', $meta_filter );
 	remove_filter( 'get_the_terms', $terms_filter );
 

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1488,11 +1488,11 @@ function inject_ignored_hooked_blocks_metadata_attributes( $post, $request ) {
 			}
 		}
 
-		if ( isset( $post->meta_input['origin'] )  ) {
+		if ( isset( $post->meta_input['origin'] ) ) {
 			$template->origin = $post->meta_input['origin'];
 		}
 
-		if ( isset( $post->tax_input['wp_theme'] )  ) {
+		if ( isset( $post->tax_input['wp_theme'] ) ) {
 			$template->theme = $post->tax_input['wp_theme'];
 		}
 

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1472,6 +1472,7 @@ function inject_ignored_hooked_blocks_metadata_attributes( $post, $request ) {
 		// TODO: Should maybe make this static. E.g. in the Templates Controller?
 		$post_to_template_key_map = array(
 			'post_author'  => 'author',
+			'post_name'    => 'slug',
 			'post_content' => 'content',
 			'post_title'   => 'title',
 			'post_excerpt' => 'description',

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1491,6 +1491,12 @@ function inject_ignored_hooked_blocks_metadata_attributes( $post, $request ) {
 		if ( isset( $post->meta_input['origin'] )  ) {
 			$template->origin = $post->meta_input['origin'];
 		}
+
+		if ( isset( $post->tax_input['wp_theme'] )  ) {
+			$template->theme = $post->tax_input['wp_theme'];
+		}
+
+		$template->id = $template->theme . '//' . $template->slug;
 	}
 
 	$before_block_visitor = make_before_block_visitor( $hooked_blocks, $template, 'set_ignored_hooked_blocks_metadata' );

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1505,9 +1505,8 @@ function inject_ignored_hooked_blocks_metadata_attributes( $changes, $request ) 
 	$before_block_visitor = make_before_block_visitor( $hooked_blocks, $template, 'set_ignored_hooked_blocks_metadata' );
 	$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $template, 'set_ignored_hooked_blocks_metadata' );
 
-	$blocks  = parse_blocks( $changes->post_content );
-	$content = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
+	$blocks                = parse_blocks( $changes->post_content );
+	$changes->post_content = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
 
-	$changes->post_content = $content;
 	return $changes;
 }

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1486,6 +1486,10 @@ function inject_ignored_hooked_blocks_metadata_attributes( $post, $request ) {
 				$template->{$template_key} = $post->$post_key;
 			}
 		}
+
+		if ( isset( $post->meta_input['origin'] )  ) {
+			$template->origin = $post->meta_input['origin'];
+		}
 	}
 
 	$before_block_visitor = make_before_block_visitor( $hooked_blocks, $template, 'set_ignored_hooked_blocks_metadata' );

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1468,21 +1468,23 @@ function inject_ignored_hooked_blocks_metadata_attributes( $post, $request ) {
 	$template = $request['id'] ? get_block_template( $request['id'], $post_type ) : null;
 	remove_filter( 'hooked_block_types', '__return_empty_array', 99999 );
 
-	// TODO: Should maybe make this static. E.g. in the Templates Controller?
-	$post_to_template_key_map = array(
-		'post_author'  => 'author',
-		'post_content' => 'content',
-		'post_title'   => 'title',
-		'post_excerpt' => 'description',
-		'post_type'    => 'type',
-		'post_status'  => 'status',
-	);
+	if ( $template ) {
+		// TODO: Should maybe make this static. E.g. in the Templates Controller?
+		$post_to_template_key_map = array(
+			'post_author'  => 'author',
+			'post_content' => 'content',
+			'post_title'   => 'title',
+			'post_excerpt' => 'description',
+			'post_type'    => 'type',
+			'post_status'  => 'status',
+		);
 
-	// We need to overwrite the built template object with the incoming one from the request.
-	// This is so we can provide the correct context to the Block Hooks API which expects the `WP_Block_Template` object.
-	foreach ( $post_to_template_key_map as $post_key => $template_key ) {
-		if ( isset( $post->$post_key ) ) {
-			$template->{$template_key} = $post->$post_key;
+		// We need to overwrite the built template object with the incoming one from the request.
+		// This is so we can provide the correct context to the Block Hooks API which expects the `WP_Block_Template` object.
+		foreach ( $post_to_template_key_map as $post_key => $template_key ) {
+			if ( isset( $post->$post_key ) ) {
+				$template->{$template_key} = $post->$post_key;
+			}
 		}
 	}
 

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1469,7 +1469,9 @@ function inject_ignored_hooked_blocks_metadata_attributes( $post, $request ) {
 	remove_filter( 'hooked_block_types', '__return_empty_array', 99999 );
 
 	if ( $template ) {
-		// TODO: Should maybe make this static. E.g. in the Templates Controller?
+		// TODO: We might want to extract the mapping logic below into a separate function
+		// and reuse it in unit tests, and in `_build_block_template_result_from_post`.
+
 		$post_to_template_key_map = array(
 			'post_author'  => 'author',
 			'post_name'    => 'slug',

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1469,7 +1469,7 @@ function inject_ignored_hooked_blocks_metadata_attributes( $changes, $request ) 
 		$post = get_post( $changes->ID );
 	} else {
 		// This means that there's not post for this template in the DB yet.
-		$post = new stdClass; // Is this correct? Might instead want to init a WP_Post with some fields set.
+		$post = new stdClass(); // Is this correct? Might instead want to init a WP_Post with some fields set.
 	}
 
 	$post_with_changes_applied = (object) array_merge( (array) $post, (array) $changes );
@@ -1477,21 +1477,21 @@ function inject_ignored_hooked_blocks_metadata_attributes( $changes, $request ) 
 	// We also need to mimic terms and meta for the post based on the corresponding
 	// `terms_input` and `meta_input` properties in the changes object.
 
-	$terms_filter = function( $terms, $post_id, $taxonomy ) use ( $changes ) {
+	$terms_filter = function ( $terms, $post_id, $taxonomy ) use ( $changes ) {
 		if ( 'wp_theme' !== $taxonomy || ! isset( $changes->tax_input['wp_theme'] ) ) {
 			return $terms;
 		}
 
 		// TODO: Verify it's not an error object.
 		// TODO: Verify that $post_id matches (or isn't set).
-		$term       = new stdClass;
+		$term       = new stdClass();
 		$term->name = $changes->tax_input['wp_theme'];
 
 		$term = new WP_Term( $term );
 		return array( $term );
 	};
 
-	$meta_filter = function( $value, $post_id, $meta_key, $single ) use ( $changes ) {
+	$meta_filter = function ( $value, $post_id, $meta_key, $single ) use ( $changes ) {
 		if ( 'origin' === $meta_key && isset( $changes->meta_input['origin'] ) ) {
 			return $single ? $changes->meta_input['origin'] : array( $changes->meta_input['origin'] );
 		}

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1468,6 +1468,22 @@ function inject_ignored_hooked_blocks_metadata_attributes( $post, $request ) {
 	$template = $request['id'] ? get_block_template( $request['id'], $post_type ) : null;
 	remove_filter( 'hooked_block_types', '__return_empty_array', 99999 );
 
+	$post_to_template_key_map = array(
+		'post_content' => 'content',
+		'post_title'   => 'title',
+		'post_excerpt' => 'description',
+		'post_type'    => 'type',
+		'post_status'  => 'status',
+	);
+
+	// We need to overwrite the built template object with the incoming one from the request.
+	// This is so we can provide the correct context to the Block Hooks API which expects the `WP_Block_Template` object.
+	foreach ( $post_to_template_key_map as $post_key => $template_key ) {
+		if ( isset( $post->$post_key ) ) {
+			$template->{$template_key} = $post->$post_key;
+		}
+	}
+
 	$before_block_visitor = make_before_block_visitor( $hooked_blocks, $template, 'set_ignored_hooked_blocks_metadata' );
 	$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $template, 'set_ignored_hooked_blocks_metadata' );
 

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1469,16 +1469,17 @@ function inject_ignored_hooked_blocks_metadata_attributes( $post, $request ) {
 	// `terms_input` and `meta_input` properties in the changes object.
 
 	$terms_filter = function( $terms, $post_id, $taxonomy ) use ( $post ) {
-		if ( 'wp_theme' === $taxonomy && isset( $post->tax_input['wp_theme'] ) ) {
-			// TODO: Verify it's not an error object.
-			// TODO: Verify that $post_id matches (or isn't set).
-			$term       = new stdClass;
-			$term->name = $post->tax_input['wp_theme'];
-
-			$term = new WP_Term( $term );
-			return array( $term );
+		if ( 'wp_theme' !== $taxonomy || ! isset( $post->tax_input['wp_theme'] ) ) {
+			return $terms;
 		}
-		return $terms;
+
+		// TODO: Verify it's not an error object.
+		// TODO: Verify that $post_id matches (or isn't set).
+		$term       = new stdClass;
+		$term->name = $post->tax_input['wp_theme'];
+
+		$term = new WP_Term( $term );
+		return array( $term );
 	};
 
 	$meta_filter = function( $value, $post_id, $meta_key, $single ) use ( $post ) {

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1468,6 +1468,7 @@ function inject_ignored_hooked_blocks_metadata_attributes( $post, $request ) {
 	$template = $request['id'] ? get_block_template( $request['id'], $post_type ) : null;
 	remove_filter( 'hooked_block_types', '__return_empty_array', 99999 );
 
+	// TODO: Should maybe make this static. E.g. in the Templates Controller?
 	$post_to_template_key_map = array(
 		'post_author'  => 'author',
 		'post_content' => 'content',

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -555,7 +555,6 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			);
 		} else {
 			$changes->post_name   = $template->slug;
-			$changes->post_type   = $this->post_type;
 			$changes->ID          = $template->wp_id;
 			$changes->post_status = 'publish';
 		}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -555,6 +555,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			);
 		} else {
 			$changes->post_name   = $template->slug;
+			$changes->post_type   = $this->post_type;
 			$changes->ID          = $template->wp_id;
 			$changes->post_status = 'publish';
 		}

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -493,6 +493,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$changes               = new stdClass();
 		$changes->post_type   = 'wp_template';
 		$changes->post_author  = 123;
+		$changes->post_name    = 'my-updated-template';
 		$changes->post_title   = 'My updated Template';
 		$changes->post_content = '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->';
 		$changes->post_excerpt = 'Displays a single post on your website unless a custom template...';
@@ -511,6 +512,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 
 		$post_to_template_key_map = array(
 			'post_author'  => 'author',
+			'post_name'    => 'slug',
 			'post_content' => 'content',
 			'post_title'   => 'title',
 			'post_excerpt' => 'description',

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -429,7 +429,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$request->set_param( 'id', $id );
 
 		$changes               = new stdClass();
-		$changes->post_content = 'Content';
+		$changes->post_content = '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->';
 
 		$post = inject_ignored_hooked_blocks_metadata_attributes( $changes, $request );
 		$this->assertSame(

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -24,7 +24,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 				'post_type'    => 'wp_template',
 				'post_name'    => 'my_template',
 				'post_title'   => 'My Template',
-				'post_content' => '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->',
+				'post_content' => 'Content',
 				'post_excerpt' => 'Description of my template',
 				'tax_input'    => array(
 					'wp_theme' => array(
@@ -42,7 +42,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 				'post_type'    => 'wp_template',
 				'post_name'    => 'my_template',
 				'post_title'   => 'My Template',
-				'post_content' => '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->',
+				'post_content' => 'Content',
 				'post_excerpt' => 'Description of my template',
 				'tax_input'    => array(
 					'wp_theme' => array(
@@ -60,7 +60,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 				'post_type'    => 'wp_template_part',
 				'post_name'    => 'my_template_part',
 				'post_title'   => 'My Template Part',
-				'post_content' => '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->',
+				'post_content' => 'Content',
 				'post_excerpt' => 'Description of my template part',
 				'tax_input'    => array(
 					'wp_theme'              => array(
@@ -429,7 +429,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$request->set_param( 'id', $id );
 
 		$changes               = new stdClass();
-		$changes->post_content = '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->';
+		$changes->post_content = 'Content';
 
 		$post = inject_ignored_hooked_blocks_metadata_attributes( $changes, $request );
 		$this->assertSame(
@@ -498,8 +498,8 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		inject_ignored_hooked_blocks_metadata_attributes( $changes, $request );
 
 		$args              = $action->get_args();
-		$anchor_block_type = $args[0][2];
-		$context           = $args[0][3];
+		$anchor_block_type = end($args)[2];
+		$context           = end($args)[3];
 
 		$this->assertSame( 'tests/anchor-block', $anchor_block_type );
 		$this->assertInstanceOf( 'WP_Block_Template', $context );

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -492,7 +492,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 
 		//$this->assertSame( 'rest_pre_insert_wp_template', current_filter() );
 
-		$post    = inject_ignored_hooked_blocks_metadata_attributes( $changes, $request );
+		inject_ignored_hooked_blocks_metadata_attributes( $changes, $request );
 
 		$args              = $action->get_args();
 		$anchor_block_type = $args[0][2];

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -478,13 +478,13 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	 * @covers inject_ignored_hooked_blocks_metadata_attributes
 	 */
 	public function test_inject_ignored_hooked_blocks_metadata_attributes_applies_filter_correctly() {
-		$action = new MockAction();
-		add_filter( 'hooked_block_types', array( $action, 'filter' ), 10, 4 );
-
 		global $wp_current_filter;
 		// Mock currently set filter. The $wp_current_filter global is reset during teardown by
 		// the unit test base class.
 		$wp_current_filter[] = 'rest_pre_insert_wp_template';
+
+		$action = new MockAction();
+		add_filter( 'hooked_block_types', array( $action, 'filter' ), 10, 4 );
 
 		$id      = self::TEST_THEME . '//' . 'my_template';
 		$request = new WP_REST_Request( 'POST', '/wp/v2/templates/' . $id );

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -504,20 +504,23 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 
 		$this->assertSame( 'tests/anchor-block', $anchor_block_type );
 		$this->assertInstanceOf( 'WP_Block_Template', $context );
-		$this->assertSame(
-			$changes->post_title,
-			$context->title,
-			'The title field of the context passed to the hooked_block_types filter doesn\'t match the template changes.'
+
+		$post_to_template_key_map = array(
+			'post_author'  => 'author',
+			'post_content' => 'content',
+			'post_title'   => 'title',
+			'post_excerpt' => 'description',
+			'post_type'    => 'type',
+			'post_status'  => 'status',
 		);
-		$this->assertSame(
-			$changes->post_content,
-			$context->content,
-			'The content field of the context passed to the hooked_block_types filter doesn\'t match the template changes.'
-		);
-		$this->assertSame(
-			$changes->post_excerpt,
-			$context->description,
-			'The description field of the context passed to the hooked_block_types filter doesn\'t match the template changes.'
-		);
+
+		$expected = array();
+		foreach ( $post_to_template_key_map as $post_key => $template_key ) {
+			if ( isset( $changes->$post_key ) ) {
+				$expected[ $template_key ] = $changes->$post_key;
+			}
+		}
+
+		$this->assertEquals( $expected, (array) $context );
 	}
 }

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -495,8 +495,6 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$changes->post_content = '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->';
 		$changes->post_excerpt = 'Displays a single post on your website unless a custom template...';
 
-		//$this->assertSame( 'rest_pre_insert_wp_template', current_filter() );
-
 		inject_ignored_hooked_blocks_metadata_attributes( $changes, $request );
 
 		$args              = $action->get_args();

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -495,6 +495,9 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$changes->post_title   = 'My updated Template';
 		$changes->post_content = '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->';
 		$changes->post_excerpt = 'Displays a single post on your website unless a custom template...';
+		$changes->meta_input   = array(
+			'origin' => 'custom',
+		);
 
 		inject_ignored_hooked_blocks_metadata_attributes( $changes, $request );
 
@@ -520,6 +523,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 				$expected[ $template_key ] = $changes->$post_key;
 			}
 		}
+		$expected['origin'] = 'custom';
 
 		$this->assertEquals( $expected, (array) $context );
 	}

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -479,8 +479,8 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	 */
 	public function test_inject_ignored_hooked_blocks_metadata_attributes_applies_filter_correctly() {
 		global $wp_current_filter;
-		// Mock currently set filter. The $wp_current_filter global is reset during teardown by
-		// the unit test base class.
+		// Mock currently set filter.
+		// The $wp_current_filter global is reset during teardown by the unit test base class.
 		$wp_current_filter[] = 'rest_pre_insert_wp_template';
 
 		$action = new MockAction();

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -490,17 +490,21 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$request = new WP_REST_Request( 'POST', '/wp/v2/templates/' . $id );
 		$request->set_param( 'id', $id );
 
-		$changes               = new stdClass();
-		$changes->post_type    = 'wp_template';
-		$changes->post_author  = 123;
-		$changes->post_name    = 'my-updated-template';
-		$changes->post_title   = 'My updated Template';
-		$changes->post_content = '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->';
-		$changes->post_excerpt = 'Displays a single post on your website unless a custom template...';
-		$changes->meta_input   = array(
-			'origin' => 'custom',
+		$changes                = new stdClass();
+		$changes->ID            = self::$template_post->ID;
+		$changes->post_type     = 'wp_template';
+		$changes->post_author   = 123;
+		$changes->post_name     = 'my-updated-template';
+		$changes->post_title    = 'My updated Template';
+		$changes->post_content  = '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->';
+		$changes->post_excerpt  = 'Displays a single post on your website unless a custom template...';
+		$changes->post_status   = 'publish';
+		$changes->post_modified = '2021-07-01 12:00:00'; // FIXME
+		$changes->meta_input    = array(
+			'origin'           => 'custom',
+			'is_wp_suggestion' => true,
 		);
-		$changes->tax_input    = array(
+		$changes->tax_input     = array(
 			'wp_theme' => self::TEST_THEME,
 		);
 
@@ -514,13 +518,15 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'WP_Block_Template', $context );
 
 		$post_to_template_key_map = array(
-			'post_author'  => 'author',
-			'post_name'    => 'slug',
-			'post_content' => 'content',
-			'post_title'   => 'title',
-			'post_excerpt' => 'description',
-			'post_type'    => 'type',
-			'post_status'  => 'status',
+			'ID'            => 'wp_id',
+			'post_author'   => 'author',
+			'post_name'     => 'slug',
+			'post_content'  => 'content',
+			'post_title'    => 'title',
+			'post_excerpt'  => 'description',
+			'post_type'     => 'type',
+			'post_status'   => 'status',
+			'post_modified' => 'modified',
 		);
 
 		$expected = array();
@@ -529,9 +535,11 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 				$expected[ $template_key ] = $changes->$post_key;
 			}
 		}
-		$expected['id']     = self::TEST_THEME . '//' . 'my-updated-template';
-		$expected['origin'] = 'custom';
-		$expected['theme']  = self::TEST_THEME;
+		$expected['id']        = self::TEST_THEME . '//' . 'my-updated-template';
+		$expected['origin']    = 'custom';
+		$expected['source']    = 'custom';
+		$expected['theme']     = self::TEST_THEME;
+		$expected['is_custom'] = false;
 
 		$this->assertEquals( $expected, (array) $context );
 	}

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -491,6 +491,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$request->set_param( 'id', $id );
 
 		$changes               = new stdClass();
+		$changes->post_author  = 123;
 		$changes->post_title   = 'My updated Template';
 		$changes->post_content = '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->';
 		$changes->post_excerpt = 'Displays a single post on your website unless a custom template...';

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -475,6 +475,8 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 60754
+	 *
 	 * @covers inject_ignored_hooked_blocks_metadata_attributes
 	 */
 	public function test_inject_ignored_hooked_blocks_metadata_attributes_applies_filter_correctly() {

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -491,7 +491,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$request->set_param( 'id', $id );
 
 		$changes               = new stdClass();
-		$changes->post_type   = 'wp_template';
+		$changes->post_type    = 'wp_template';
 		$changes->post_author  = 123;
 		$changes->post_name    = 'my-updated-template';
 		$changes->post_title   = 'My updated Template';
@@ -500,7 +500,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$changes->meta_input   = array(
 			'origin' => 'custom',
 		);
-		$changes->tax_input   = array(
+		$changes->tax_input    = array(
 			'wp_theme' => self::TEST_THEME,
 		);
 

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -24,7 +24,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 				'post_type'    => 'wp_template',
 				'post_name'    => 'my_template',
 				'post_title'   => 'My Template',
-				'post_content' => 'Content',
+				'post_content' => '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->',
 				'post_excerpt' => 'Description of my template',
 				'tax_input'    => array(
 					'wp_theme' => array(
@@ -42,7 +42,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 				'post_type'    => 'wp_template',
 				'post_name'    => 'my_template',
 				'post_title'   => 'My Template',
-				'post_content' => 'Content',
+				'post_content' => '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->',
 				'post_excerpt' => 'Description of my template',
 				'tax_input'    => array(
 					'wp_theme' => array(
@@ -60,7 +60,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 				'post_type'    => 'wp_template_part',
 				'post_name'    => 'my_template_part',
 				'post_title'   => 'My Template Part',
-				'post_content' => 'Content',
+				'post_content' => '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->',
 				'post_excerpt' => 'Description of my template part',
 				'tax_input'    => array(
 					'wp_theme'              => array(
@@ -426,6 +426,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 
 		$id      = self::TEST_THEME . '//' . 'my_template';
 		$request = new WP_REST_Request( 'POST', '/wp/v2/templates/' . $id );
+		$request->set_param( 'id', $id );
 
 		$changes               = new stdClass();
 		$changes->post_content = '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->';
@@ -460,6 +461,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 
 		$id      = self::TEST_THEME . '//' . 'my_template_part';
 		$request = new WP_REST_Request( 'POST', '/wp/v2/template-parts/' . $id );
+		$request->set_param( 'id', $id );
 
 		$changes               = new stdClass();
 		$changes->post_content = '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->';
@@ -486,6 +488,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 
 		$id      = self::TEST_THEME . '//' . 'my_template';
 		$request = new WP_REST_Request( 'POST', '/wp/v2/templates/' . $id );
+		$request->set_param( 'id', $id );
 
 		$changes               = new stdClass();
 		$changes->post_content = '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->';
@@ -499,10 +502,10 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$context           = $args[0][3];
 
 		$this->assertSame( 'tests/anchor-block', $anchor_block_type );
-		$this->assertInstanceOf( 'WP_Block_Template', $context ); // FIXME: Currently failing :/
+		$this->assertInstanceOf( 'WP_Block_Template', $context );
 		$this->assertSame(
 			$changes->post_content,
-			$context->post_content,
+			$context->content,
 			'The context passed to the hooked_block_types filter doesn\'t match the template changes.'
 		);
 	}

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -412,7 +412,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	public function test_inject_ignored_hooked_blocks_metadata_attributes_into_template() {
 		global $wp_current_filter;
 		// Mock currently set filter. The $wp_current_filter global is reset during teardown by
-		// WP_UnitTestCase_Base::_restore_hooks() in tests/phpunit/includes/abstract-testcase.php.
+		// the unit test base class.
 		$wp_current_filter[] = 'rest_pre_insert_wp_template';
 
 		register_block_type(
@@ -446,7 +446,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	public function test_inject_ignored_hooked_blocks_metadata_attributes_into_template_part() {
 		global $wp_current_filter;
 		// Mock currently set filter. The $wp_current_filter global is reset during teardown by
-		// WP_UnitTestCase_Base::_restore_hooks() in tests/phpunit/includes/abstract-testcase.php.
+		// the unit test base class.
 		$wp_current_filter[] = 'rest_pre_insert_wp_template_part';
 
 		register_block_type(

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -491,7 +491,9 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$request->set_param( 'id', $id );
 
 		$changes               = new stdClass();
+		$changes->post_title   = 'My updated Template';
 		$changes->post_content = '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->';
+		$changes->post_excerpt = 'Displays a single post on your website unless a custom template...';
 
 		//$this->assertSame( 'rest_pre_insert_wp_template', current_filter() );
 
@@ -504,9 +506,19 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$this->assertSame( 'tests/anchor-block', $anchor_block_type );
 		$this->assertInstanceOf( 'WP_Block_Template', $context );
 		$this->assertSame(
+			$changes->post_title,
+			$context->title,
+			'The title field of the context passed to the hooked_block_types filter doesn\'t match the template changes.'
+		);
+		$this->assertSame(
 			$changes->post_content,
 			$context->content,
-			'The context passed to the hooked_block_types filter doesn\'t match the template changes.'
+			'The content field of the context passed to the hooked_block_types filter doesn\'t match the template changes.'
+		);
+		$this->assertSame(
+			$changes->post_excerpt,
+			$context->description,
+			'The description field of the context passed to the hooked_block_types filter doesn\'t match the template changes.'
 		);
 	}
 }

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -500,6 +500,9 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$changes->meta_input   = array(
 			'origin' => 'custom',
 		);
+		$changes->tax_input   = array(
+			'wp_theme' => self::TEST_THEME,
+		);
 
 		inject_ignored_hooked_blocks_metadata_attributes( $changes, $request );
 
@@ -526,7 +529,9 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 				$expected[ $template_key ] = $changes->$post_key;
 			}
 		}
+		$expected['id']     = self::TEST_THEME . '//' . 'my-updated-template';
 		$expected['origin'] = 'custom';
+		$expected['theme']  = self::TEST_THEME;
 
 		$this->assertEquals( $expected, (array) $context );
 	}

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -498,8 +498,8 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		inject_ignored_hooked_blocks_metadata_attributes( $changes, $request );
 
 		$args              = $action->get_args();
-		$anchor_block_type = end($args)[2];
-		$context           = end($args)[3];
+		$anchor_block_type = end( $args )[2];
+		$context           = end( $args )[3];
 
 		$this->assertSame( 'tests/anchor-block', $anchor_block_type );
 		$this->assertInstanceOf( 'WP_Block_Template', $context );

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -491,6 +491,7 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 		$request->set_param( 'id', $id );
 
 		$changes               = new stdClass();
+		$changes->post_type   = 'wp_template';
 		$changes->post_author  = 123;
 		$changes->post_title   = 'My updated Template';
 		$changes->post_content = '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->';

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -537,11 +537,14 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 				$expected[ $template_key ] = $changes->$post_key;
 			}
 		}
-		$expected['id']        = self::TEST_THEME . '//' . 'my-updated-template';
-		$expected['origin']    = 'custom';
-		$expected['source']    = 'custom';
-		$expected['theme']     = self::TEST_THEME;
-		$expected['is_custom'] = false;
+		$expected['id']             = self::TEST_THEME . '//' . 'my-updated-template';
+		$expected['origin']         = 'custom';
+		$expected['source']         = 'custom';
+		$expected['theme']          = self::TEST_THEME;
+		$expected['is_custom']      = false;
+		$expected['has_theme_file'] = false;
+		$expected['post_types']     = null;
+		$expected['area']           = null;
 
 		$this->assertEquals( $expected, (array) $context );
 	}

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -14,7 +14,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 	 * @var int
 	 */
 	protected static $admin_id;
-	private static $post;
+	private static $template_post;
 
 	/**
 	 * Create fake data before our tests run.
@@ -29,7 +29,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		);
 
 		// Set up template post.
-		$args       = array(
+		$args                = array(
 			'post_type'    => 'wp_template',
 			'post_name'    => 'my_template',
 			'post_title'   => 'My Template',
@@ -41,12 +41,12 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 				),
 			),
 		);
-		self::$post = self::factory()->post->create_and_get( $args );
-		wp_set_post_terms( self::$post->ID, get_stylesheet(), 'wp_theme' );
+		self::$template_post = self::factory()->post->create_and_get( $args );
+		wp_set_post_terms( self::$template_post->ID, get_stylesheet(), 'wp_theme' );
 	}
 
 	public static function wpTearDownAfterClass() {
-		wp_delete_post( self::$post->ID );
+		wp_delete_post( self::$template_post->ID );
 	}
 
 	/**
@@ -130,11 +130,11 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 					'rendered' => 'My Template',
 				),
 				'status'          => 'publish',
-				'wp_id'           => self::$post->ID,
+				'wp_id'           => self::$template_post->ID,
 				'has_theme_file'  => false,
 				'is_custom'       => true,
 				'author'          => 0,
-				'modified'        => mysql_to_rfc3339( self::$post->post_modified ),
+				'modified'        => mysql_to_rfc3339( self::$template_post->post_modified ),
 				'author_text'     => 'Test Blog',
 				'original_source' => 'site',
 			),
@@ -177,11 +177,11 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 					'rendered' => 'My Template',
 				),
 				'status'          => 'publish',
-				'wp_id'           => self::$post->ID,
+				'wp_id'           => self::$template_post->ID,
 				'has_theme_file'  => false,
 				'is_custom'       => true,
 				'author'          => 0,
-				'modified'        => mysql_to_rfc3339( self::$post->post_modified ),
+				'modified'        => mysql_to_rfc3339( self::$template_post->post_modified ),
 				'author_text'     => 'Test Blog',
 				'original_source' => 'site',
 			),
@@ -216,11 +216,11 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 					'rendered' => 'My Template',
 				),
 				'status'          => 'publish',
-				'wp_id'           => self::$post->ID,
+				'wp_id'           => self::$template_post->ID,
 				'has_theme_file'  => false,
 				'is_custom'       => true,
 				'author'          => 0,
-				'modified'        => mysql_to_rfc3339( self::$post->post_modified ),
+				'modified'        => mysql_to_rfc3339( self::$template_post->post_modified ),
 				'author_text'     => 'Test Blog',
 				'original_source' => 'site',
 			),

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -974,12 +974,9 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 
 		$id          = get_stylesheet() . '//' . 'my_template_part';
 		$body_params = array(
-			'id'          => $id,
-			'title'       => 'Untitled Template Part',
-			'slug'        => 'my_template_part',
-			'description' => 'Description of my template part.',
-			'author'      => 1,
-			'content'     => '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->',
+			'id'      => $id,
+			'slug'    => 'my_template_part',
+			'content' => '<!-- wp:tests/anchor-block -->Hello<!-- /wp:tests/anchor-block -->',
 		);
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/template-parts/' . $id );


### PR DESCRIPTION
- [x] Add unit test coverage to demonstrate/cover issue.
- [x] Fix (probably by ~casting `$changes` to `WP_Block_Template`~ building. `WP_Block_Template` object from `$changes`).
- [x] Transform object comparison in unit test to individual assertions! One for each field. (Like we had before ce3c67bcaa31ae0c7288f235a24e55b782ed1ac4. Will require adding a lot of individual assertions.)
- [x] Add unit test to the controller. This will allow us to provide a sparse `$request` (whose missing fields will be set by the controller), rather than a "full" `$changes` object, as we have to do in the `block-template-utils.php` unit test.
  - [x] To allow for missing fields and emulate the template that will result from the database write, we should ideally "merge" the data from `$changes` into the existing `$template`. (Done in https://github.com/WordPress/wordpress-develop/pull/6254/commits/ac59c76d539c51dec2c2d87971e0690a40ac15aa.)
- [ ] Add unit tests for newly created template (that doesn't exist in the DB yet). Both for controller, and for the isolated filter.
- [x] Add unit test for template _parts_ to `block-template-utils.php`. (Cover setting of `area`!)

Trac ticket: https://core.trac.wordpress.org/ticket/60754

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
