### PR TITLE
Interactivity: Fix string index warning

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -577,8 +577,8 @@ final class WP_Interactivity_API {
 				$result          = $this->evaluate( $attribute_value, end( $namespace_stack ), end( $context_stack ) );
 
 				if ( null !== $result && (
-						false !== $result ||
-						( strlen( $bound_attribute ) > 5 && '-' === $bound_attribute[4] )
+					false !== $result ||
+					( strlen( $bound_attribute ) > 5 && '-' === $bound_attribute[4] )
 				) ) {
 					/*
 					 * If the result of the evaluation is a boolean and the attribute is

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -587,7 +587,10 @@ final class WP_Interactivity_API {
 					 * replicate what Preact will later do in the client:
 					 * https://github.com/preactjs/preact/blob/ea49f7a0f9d1ff2c98c0bdd66aa0cbc583055246/src/diff/props.js#L131C24-L136
 					 */
-					if ( is_bool( $result ) && '-' === $bound_attribute[4] ) {
+					if (
+						is_bool( $result ) &&
+						( strlen( $bound_attribute ) > 5 && '-' === $bound_attribute[4] )
+					) {
 						$result = $result ? 'true' : 'false';
 					}
 					$p->set_attribute( $bound_attribute, $result );

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -576,7 +576,10 @@ final class WP_Interactivity_API {
 				$attribute_value = $p->get_attribute( $attribute_name );
 				$result          = $this->evaluate( $attribute_value, end( $namespace_stack ), end( $context_stack ) );
 
-				if ( null !== $result && ( false !== $result || '-' === $bound_attribute[4] ) ) {
+				if ( null !== $result && (
+						false !== $result ||
+						( strlen( $bound_attribute ) > 5 && '-' === $bound_attribute[4] )
+				) ) {
 					/*
 					 * If the result of the evaluation is a boolean and the attribute is
 					 * `aria-` or `data-, convert it to a string "true" or "false". It

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-bind.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-bind.php
@@ -62,7 +62,7 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	public function test_wp_bind_sets_attribute() {
 		$html    = '<div data-wp-bind--id="myPlugin::state.id">Text</div>';
 		list($p) = $this->process_directives( $html );
-		$this->assertEquals( 'some-id', $p->get_attribute( 'id' ) );
+		$this->assertSame( 'some-id', $p->get_attribute( 'id' ) );
 	}
 
 	/**
@@ -75,7 +75,7 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	public function test_wp_bind_replaces_attribute() {
 		$html    = '<div id="other-id" data-wp-bind--id="myPlugin::state.id">Text</div>';
 		list($p) = $this->process_directives( $html );
-		$this->assertEquals( 'some-id', $p->get_attribute( 'id' ) );
+		$this->assertSame( 'some-id', $p->get_attribute( 'id' ) );
 	}
 
 	/**
@@ -88,7 +88,7 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	public function test_wp_bind_sets_number_value() {
 		$html    = '<img data-wp-bind--width="myPlugin::state.width">';
 		list($p) = $this->process_directives( $html );
-		$this->assertEquals( '100', $p->get_attribute( 'width' ) );
+		$this->assertSame( '100', $p->get_attribute( 'width' ) );
 	}
 
 	/**
@@ -101,8 +101,8 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	public function test_wp_bind_sets_true_string() {
 		$html               = '<div data-wp-bind--id="myPlugin::state.trueString">Text</div>';
 		list($p, $new_html) = $this->process_directives( $html );
-		$this->assertEquals( 'true', $p->get_attribute( 'id' ) );
-		$this->assertEquals( '<div id="true" data-wp-bind--id="myPlugin::state.trueString">Text</div>', $new_html );
+		$this->assertSame( 'true', $p->get_attribute( 'id' ) );
+		$this->assertSame( '<div id="true" data-wp-bind--id="myPlugin::state.trueString">Text</div>', $new_html );
 	}
 
 	/**
@@ -115,8 +115,8 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	public function test_wp_bind_sets_false_string() {
 		$html               = '<div data-wp-bind--id="myPlugin::state.falseString">Text</div>';
 		list($p, $new_html) = $this->process_directives( $html );
-		$this->assertEquals( 'false', $p->get_attribute( 'id' ) );
-		$this->assertEquals( '<div id="false" data-wp-bind--id="myPlugin::state.falseString">Text</div>', $new_html );
+		$this->assertSame( 'false', $p->get_attribute( 'id' ) );
+		$this->assertSame( '<div id="false" data-wp-bind--id="myPlugin::state.falseString">Text</div>', $new_html );
 	}
 
 	/**
@@ -129,7 +129,7 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	public function test_wp_bind_ignores_empty_bound_attribute() {
 		$html     = '<div data-wp-bind="myPlugin::state.id">Text</div>';
 		$new_html = $this->interactivity->process_directives( $html );
-		$this->assertEquals( $html, $new_html );
+		$this->assertSame( $html, $new_html );
 	}
 
 	/**
@@ -143,7 +143,7 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	public function test_wp_bind_doesnt_do_anything_on_non_existent_references() {
 		$html     = '<div data-wp-bind--id="myPlugin::state.nonExistengKey">Text</div>';
 		$new_html = $this->interactivity->process_directives( $html );
-		$this->assertEquals( $html, $new_html );
+		$this->assertSame( $html, $new_html );
 	}
 
 	/**
@@ -156,7 +156,7 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	public function test_wp_bind_ignores_empty_value() {
 		$html     = '<div data-wp-bind--id="">Text</div>';
 		$new_html = $this->interactivity->process_directives( $html );
-		$this->assertEquals( $html, $new_html );
+		$this->assertSame( $html, $new_html );
 	}
 
 	/**
@@ -169,7 +169,7 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	public function test_wp_bind_ignores_without_value() {
 		$html     = '<div data-wp-bind--id>Text</div>';
 		$new_html = $this->interactivity->process_directives( $html );
-		$this->assertEquals( $html, $new_html );
+		$this->assertSame( $html, $new_html );
 	}
 
 	/**
@@ -183,7 +183,7 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	public function test_wp_bind_works_with_multiple_same_directives() {
 		$html    = '<div data-wp-bind--id="myPlugin::state.id" data-wp-bind--id="myPlugin::state.id">Text</div>';
 		list($p) = $this->process_directives( $html );
-		$this->assertEquals( 'some-id', $p->get_attribute( 'id' ) );
+		$this->assertSame( 'some-id', $p->get_attribute( 'id' ) );
 	}
 
 	/**
@@ -197,8 +197,8 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	public function test_wp_bind_works_with_multiple_different_directives() {
 		$html    = '<img data-wp-bind--id="myPlugin::state.id" data-wp-bind--width="myPlugin::state.width">';
 		list($p) = $this->process_directives( $html );
-		$this->assertEquals( 'some-id', $p->get_attribute( 'id' ) );
-		$this->assertEquals( '100', $p->get_attribute( 'width' ) );
+		$this->assertSame( 'some-id', $p->get_attribute( 'id' ) );
+		$this->assertSame( '100', $p->get_attribute( 'width' ) );
 	}
 
 	/**
@@ -212,7 +212,7 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 		$html               = '<div data-wp-bind--hidden="myPlugin::!state.isOpen">Text</div>';
 		list($p, $new_html) = $this->process_directives( $html );
 		$this->assertTrue( $p->get_attribute( 'hidden' ) );
-		$this->assertEquals( '<div hidden data-wp-bind--hidden="myPlugin::!state.isOpen">Text</div>', $new_html );
+		$this->assertSame( '<div hidden data-wp-bind--hidden="myPlugin::!state.isOpen">Text</div>', $new_html );
 	}
 
 	/**
@@ -227,7 +227,7 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 		$html               = '<div hidden="true" data-wp-bind--hidden="myPlugin::!state.isOpen">Text</div>';
 		list($p, $new_html) = $this->process_directives( $html );
 		$this->assertTrue( $p->get_attribute( 'hidden' ) );
-		$this->assertEquals( '<div hidden data-wp-bind--hidden="myPlugin::!state.isOpen">Text</div>', $new_html );
+		$this->assertSame( '<div hidden data-wp-bind--hidden="myPlugin::!state.isOpen">Text</div>', $new_html );
 	}
 
 	/**
@@ -242,12 +242,12 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 		$html               = '<div data-wp-bind--hidden="myPlugin::state.isOpen">Text</div>';
 		list($p, $new_html) = $this->process_directives( $html );
 		$this->assertNull( $p->get_attribute( 'hidden' ) );
-		$this->assertEquals( $html, $new_html );
+		$this->assertSame( $html, $new_html );
 
 		$html               = '<div data-wp-bind--hidden="myPlugin::state.null">Text</div>';
 		list($p, $new_html) = $this->process_directives( $html );
 		$this->assertNull( $p->get_attribute( 'hidden' ) );
-		$this->assertEquals( $html, $new_html );
+		$this->assertSame( $html, $new_html );
 	}
 
 	/**
@@ -279,13 +279,13 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	public function test_wp_bind_adds_value_if_true_in_aria_or_data_attributes() {
 		$html               = '<div data-wp-bind--aria-hidden="myPlugin::!state.isOpen">Text</div>';
 		list($p, $new_html) = $this->process_directives( $html );
-		$this->assertEquals( 'true', $p->get_attribute( 'aria-hidden' ) );
-		$this->assertEquals( '<div aria-hidden="true" data-wp-bind--aria-hidden="myPlugin::!state.isOpen">Text</div>', $new_html );
+		$this->assertSame( 'true', $p->get_attribute( 'aria-hidden' ) );
+		$this->assertSame( '<div aria-hidden="true" data-wp-bind--aria-hidden="myPlugin::!state.isOpen">Text</div>', $new_html );
 
 		$html               = '<div data-wp-bind--data-is-closed="myPlugin::!state.isOpen">Text</div>';
 		list($p, $new_html) = $this->process_directives( $html );
-		$this->assertEquals( 'true', $p->get_attribute( 'data-is-closed' ) );
-		$this->assertEquals( '<div data-is-closed="true" data-wp-bind--data-is-closed="myPlugin::!state.isOpen">Text</div>', $new_html );
+		$this->assertSame( 'true', $p->get_attribute( 'data-is-closed' ) );
+		$this->assertSame( '<div data-is-closed="true" data-wp-bind--data-is-closed="myPlugin::!state.isOpen">Text</div>', $new_html );
 	}
 
 	/**
@@ -299,15 +299,15 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	public function test_wp_bind_replaces_value_if_true_in_aria_or_data_attributes() {
 		$html               = '<div aria-hidden="false" data-wp-bind--aria-hidden="myPlugin::!state.isOpen">Text</div>';
 		list($p, $new_html) = $this->process_directives( $html );
-		$this->assertEquals( 'true', $p->get_attribute( 'aria-hidden' ) );
-		$this->assertEquals( '<div aria-hidden="true" data-wp-bind--aria-hidden="myPlugin::!state.isOpen">Text</div>', $new_html );
+		$this->assertSame( 'true', $p->get_attribute( 'aria-hidden' ) );
+		$this->assertSame( '<div aria-hidden="true" data-wp-bind--aria-hidden="myPlugin::!state.isOpen">Text</div>', $new_html );
 
 		$html     = '<div data-is-closed="false" data-wp-bind--data-is-closed="myPlugin::!state.isOpen">Text</div>';
 		$new_html = $this->interactivity->process_directives( $html );
 		$p        = new WP_HTML_Tag_Processor( $new_html );
 		$p->next_tag();
-		$this->assertEquals( 'true', $p->get_attribute( 'data-is-closed' ) );
-		$this->assertEquals( '<div data-is-closed="true" data-wp-bind--data-is-closed="myPlugin::!state.isOpen">Text</div>', $new_html );
+		$this->assertSame( 'true', $p->get_attribute( 'data-is-closed' ) );
+		$this->assertSame( '<div data-is-closed="true" data-wp-bind--data-is-closed="myPlugin::!state.isOpen">Text</div>', $new_html );
 	}
 
 	/**
@@ -321,13 +321,13 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	public function test_wp_bind_adds_value_if_false_in_aria_or_data_attributes() {
 		$html               = '<div data-wp-bind--aria-hidden="myPlugin::state.isOpen">Text</div>';
 		list($p, $new_html) = $this->process_directives( $html );
-		$this->assertEquals( 'false', $p->get_attribute( 'aria-hidden' ) );
-		$this->assertEquals( '<div aria-hidden="false" data-wp-bind--aria-hidden="myPlugin::state.isOpen">Text</div>', $new_html );
+		$this->assertSame( 'false', $p->get_attribute( 'aria-hidden' ) );
+		$this->assertSame( '<div aria-hidden="false" data-wp-bind--aria-hidden="myPlugin::state.isOpen">Text</div>', $new_html );
 
 		$html               = '<div data-wp-bind--data-is-closed="myPlugin::state.isOpen">Text</div>';
 		list($p, $new_html) = $this->process_directives( $html );
-		$this->assertEquals( 'false', $p->get_attribute( 'data-is-closed' ) );
-		$this->assertEquals( '<div data-is-closed="false" data-wp-bind--data-is-closed="myPlugin::state.isOpen">Text</div>', $new_html );
+		$this->assertSame( 'false', $p->get_attribute( 'data-is-closed' ) );
+		$this->assertSame( '<div data-is-closed="false" data-wp-bind--data-is-closed="myPlugin::state.isOpen">Text</div>', $new_html );
 	}
 
 	/**
@@ -341,13 +341,13 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	public function test_wp_bind_replaces_value_if_false_in_aria_or_data_attributes() {
 		$html               = '<div aria-hidden="true" data-wp-bind--aria-hidden="myPlugin::state.isOpen">Text</div>';
 		list($p, $new_html) = $this->process_directives( $html );
-		$this->assertEquals( 'false', $p->get_attribute( 'aria-hidden' ) );
-		$this->assertEquals( '<div aria-hidden="false" data-wp-bind--aria-hidden="myPlugin::state.isOpen">Text</div>', $new_html );
+		$this->assertSame( 'false', $p->get_attribute( 'aria-hidden' ) );
+		$this->assertSame( '<div aria-hidden="false" data-wp-bind--aria-hidden="myPlugin::state.isOpen">Text</div>', $new_html );
 
 		$html               = '<div data-is-closed="true" data-wp-bind--data-is-closed="myPlugin::state.isOpen">Text</div>';
 		list($p, $new_html) = $this->process_directives( $html );
-		$this->assertEquals( 'false', $p->get_attribute( 'data-is-closed' ) );
-		$this->assertEquals( '<div data-is-closed="false" data-wp-bind--data-is-closed="myPlugin::state.isOpen">Text</div>', $new_html );
+		$this->assertSame( 'false', $p->get_attribute( 'data-is-closed' ) );
+		$this->assertSame( '<div data-is-closed="false" data-wp-bind--data-is-closed="myPlugin::state.isOpen">Text</div>', $new_html );
 	}
 
 	/**
@@ -377,9 +377,9 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	public function test_wp_bind_handles_nested_bindings() {
 		$html    = '<div data-wp-bind--id="myPlugin::state.id"><img data-wp-bind--width="myPlugin::state.width"></div>';
 		list($p) = $this->process_directives( $html );
-		$this->assertEquals( 'some-id', $p->get_attribute( 'id' ) );
+		$this->assertSame( 'some-id', $p->get_attribute( 'id' ) );
 		$p->next_tag();
-		$this->assertEquals( '100', $p->get_attribute( 'width' ) );
+		$this->assertSame( '100', $p->get_attribute( 'width' ) );
 	}
 
 	/**
@@ -392,6 +392,6 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	public function test_wp_bind_handles_true_value() {
 		$html    = '<div data-wp-bind--id="myPlugin::state.trueValue"></div>';
 		list($p) = $this->process_directives( $html );
-		$this->assertEquals( 'true', $p->get_attribute( 'id' ) );
+		$this->assertSame( 'true', $p->get_attribute( 'id' ) );
 	}
 }

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-bind.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-bind.php
@@ -392,6 +392,6 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	public function test_wp_bind_handles_true_value() {
 		$html    = '<div data-wp-bind--id="myPlugin::state.trueValue"></div>';
 		list($p) = $this->process_directives( $html );
-		$this->assertSame( 'true', $p->get_attribute( 'id' ) );
+		$this->assertSame( true, $p->get_attribute( 'id' ) );
 	}
 }

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-bind.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-bind.php
@@ -33,6 +33,8 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 				'null'        => null,
 				'trueString'  => 'true',
 				'falseString' => 'false',
+				'trueValue'   => true,
+				'falseValue'  => false,
 			)
 		);
 	}
@@ -378,5 +380,18 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 		$this->assertEquals( 'some-id', $p->get_attribute( 'id' ) );
 		$p->next_tag();
 		$this->assertEquals( '100', $p->get_attribute( 'width' ) );
+	}
+
+	/**
+	 * Tests handling of bindings within nested tags.
+	 *
+	 * @ticket 60758
+	 *
+	 * @covers ::process_directives
+	 */
+	public function test_wp_bind_handles_true_value() {
+		$html    = '<div data-wp-bind--id="myPlugin::state.trueValue"></div>';
+		list($p) = $this->process_directives( $html );
+		$this->assertEquals( 'true', $p->get_attribute( 'id' ) );
 	}
 }

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-bind.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-bind.php
@@ -383,7 +383,7 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests handling of bindings within nested tags.
+	 * Tests handling bindings to boolean values.
 	 *
 	 * @ticket 60758
 	 *


### PR DESCRIPTION
Fix the following warning when using an interactivity bind directive with a short attribute name, e.g. `wp-data-bind--id`.

> Warning: Uninitialized string offset 4 in /var/www/html/wp-includes/interactivity-api/class-wp-interactivity-api.php on line 579


Trac ticket: https://core.trac.wordpress.org/ticket/60758

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
