### PR TITLE
Interactivity API: Fix invalid test @covers annotations

### DIFF
--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-bind.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-bind.php
@@ -6,6 +6,8 @@
  * @package WordPress
  * @subpackage Interactivity API
  *
+ * @coversDefaultClass WP_Interactivity_API
+ *
  * @since 6.5.0
  *
  * @group interactivity-api

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-class.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-class.php
@@ -8,6 +8,8 @@
  *
  * @since 6.5.0
  *
+ * @coversDefaultClass WP_Interactivity_API
+ *
  * @group interactivity-api
  */
 class Tests_WP_Interactivity_API_WP_Class extends WP_UnitTestCase {

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-context.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-context.php
@@ -8,6 +8,8 @@
  *
  * @since 6.5.0
  *
+ * @coversDefaultClass WP_Interactivity_API
+ *
  * @group interactivity-api
  */
 class Tests_WP_Interactivity_API_WP_Context extends WP_UnitTestCase {

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-each.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-each.php
@@ -6,6 +6,8 @@
  * @package WordPress
  * @subpackage Interactivity API
  *
+ * @coversDefaultClass WP_Interactivity_API
+ *
  * @group interactivity-api
  */
 class Tests_WP_Interactivity_API_WP_Each extends WP_UnitTestCase {

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-interactive.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-interactive.php
@@ -8,6 +8,8 @@
  *
  * @since 6.5.0
  *
+ * @coversDefaultClass WP_Interactivity_API
+ *
  * @group interactivity-api
  */
 class Tests_WP_Interactivity_API_WP_Interactive extends WP_UnitTestCase {

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-router-region.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-router-region.php
@@ -6,6 +6,8 @@
  * @package WordPress
  * @subpackage Interactivity API
  *
+ * @coversDefaultClass WP_Interactivity_API
+ *
  * @group interactivity-api
  */
 class Tests_WP_Interactivity_API_WP_Router_Region extends WP_UnitTestCase {

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-style.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-style.php
@@ -8,6 +8,8 @@
  *
  * @since 6.5.0
  *
+ * @coversDefaultClass WP_Interactivity_API
+ *
  * @group interactivity-api
  */
 class Tests_WP_Interactivity_API_WP_Style extends WP_UnitTestCase {

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-text.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-text.php
@@ -8,6 +8,8 @@
  *
  * @since 6.5.0
  *
+ * @coversDefaultClass WP_Interactivity_API
+ *
  * @group interactivity-api
  */
 class Tests_WP_Interactivity_API_WP_Text extends WP_UnitTestCase {

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPIFunctions.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPIFunctions.php
@@ -69,7 +69,7 @@ class Tests_Interactivity_API_wpInteractivityAPIFunctions extends WP_UnitTestCas
 	 *
 	 * @ticket 60356
 	 *
-	 * @covers ::wp_interactivity_process_directives_of_interactive_blocks
+	 * @covers wp_interactivity_process_directives_of_interactive_blocks
 	 */
 	public function test_processs_directives_of_single_interactive_block() {
 		$post_content    = '<!-- wp:test/interactive-block { "block": 1 } /-->';
@@ -85,7 +85,7 @@ class Tests_Interactivity_API_wpInteractivityAPIFunctions extends WP_UnitTestCas
 	 *
 	 * @ticket 60356
 	 *
-	 * @covers ::wp_interactivity_process_directives_of_interactive_blocks
+	 * @covers wp_interactivity_process_directives_of_interactive_blocks
 	 */
 	public function test_processs_directives_of_multiple_interactive_blocks_in_paralell() {
 		$post_content    = '
@@ -111,7 +111,7 @@ class Tests_Interactivity_API_wpInteractivityAPIFunctions extends WP_UnitTestCas
 	 *
 	 * @ticket 60356
 	 *
-	 * @covers ::wp_interactivity_process_directives_of_interactive_blocks
+	 * @covers wp_interactivity_process_directives_of_interactive_blocks
 	 */
 	public function test_processs_directives_of_interactive_block_inside_non_interactive_block() {
 		$post_content    = '
@@ -131,7 +131,7 @@ class Tests_Interactivity_API_wpInteractivityAPIFunctions extends WP_UnitTestCas
 	 *
 	 * @ticket 60356
 	 *
-	 * @covers ::wp_interactivity_process_directives_of_interactive_blocks
+	 * @covers wp_interactivity_process_directives_of_interactive_blocks
 	 */
 	public function test_processs_directives_of_multple_interactive_blocks_inside_non_interactive_block() {
 		$post_content    = '
@@ -154,7 +154,7 @@ class Tests_Interactivity_API_wpInteractivityAPIFunctions extends WP_UnitTestCas
 	 *
 	 * @ticket 60356
 	 *
-	 * @covers ::wp_interactivity_process_directives_of_interactive_blocks
+	 * @covers wp_interactivity_process_directives_of_interactive_blocks
 	 */
 	public function test_processs_directives_of_interactive_block_inside_multple_non_interactive_block() {
 		$post_content    = '
@@ -179,7 +179,7 @@ class Tests_Interactivity_API_wpInteractivityAPIFunctions extends WP_UnitTestCas
 	 *
 	 * @ticket 60356
 	 *
-	 * @covers ::wp_interactivity_process_directives_of_interactive_blocks
+	 * @covers wp_interactivity_process_directives_of_interactive_blocks
 	 */
 	public function test_processs_directives_of_interactive_block_containing_non_interactive_block_without_directives() {
 		$post_content    = '
@@ -201,7 +201,7 @@ class Tests_Interactivity_API_wpInteractivityAPIFunctions extends WP_UnitTestCas
 	 *
 	 * @ticket 60356
 	 *
-	 * @covers ::wp_interactivity_process_directives_of_interactive_blocks
+	 * @covers wp_interactivity_process_directives_of_interactive_blocks
 	 */
 	public function test_processs_directives_of_interactive_block_containing_non_interactive_block_with_directives() {
 		$post_content    = '
@@ -224,7 +224,7 @@ class Tests_Interactivity_API_wpInteractivityAPIFunctions extends WP_UnitTestCas
 	 *
 	 * @ticket 60356
 	 *
-	 * @covers ::wp_interactivity_process_directives_of_interactive_blocks
+	 * @covers wp_interactivity_process_directives_of_interactive_blocks
 	 */
 	public function test_processs_directives_of_interactive_block_containing_nested_interactive_and_non_interactive_blocks() {
 		$post_content    = '
@@ -277,7 +277,7 @@ class Tests_Interactivity_API_wpInteractivityAPIFunctions extends WP_UnitTestCas
 	 *
 	 * @ticket 60356
 	 *
-	 * @covers ::wp_interactivity_process_directives_of_interactive_blocks
+	 * @covers wp_interactivity_process_directives_of_interactive_blocks
 	 */
 	public function test_process_directives_only_process_the_root_interactive_blocks() {
 		$class                = new ReflectionClass( 'WP_Interactivity_API' );
@@ -352,7 +352,7 @@ class Tests_Interactivity_API_wpInteractivityAPIFunctions extends WP_UnitTestCas
 	 *
 	 * @ticket 60356
 	 *
-	 * @covers ::wp_interactivity_data_wp_context
+	 * @covers wp_interactivity_data_wp_context
 	 */
 	public function test_wp_interactivity_data_wp_context_with_different_arrays() {
 		$this->assertEquals( 'data-wp-context=\'{}\'', wp_interactivity_data_wp_context( array() ) );
@@ -382,7 +382,7 @@ class Tests_Interactivity_API_wpInteractivityAPIFunctions extends WP_UnitTestCas
 	 *
 	 * @ticket 60356
 	 *
-	 * @covers ::wp_interactivity_data_wp_context
+	 * @covers wp_interactivity_data_wp_context
 	 */
 	public function test_wp_interactivity_data_wp_context_with_different_arrays_and_a_namespace() {
 		$this->assertEquals( 'data-wp-context=\'myPlugin::{}\'', wp_interactivity_data_wp_context( array(), 'myPlugin' ) );
@@ -415,7 +415,7 @@ class Tests_Interactivity_API_wpInteractivityAPIFunctions extends WP_UnitTestCas
 	 *
 	 * @ticket 60356
 	 *
-	 * @covers ::wp_interactivity_data_wp_context
+	 * @covers wp_interactivity_data_wp_context
 	 */
 	public function test_wp_interactivity_data_wp_context_with_json_flags() {
 		$this->assertEquals( 'data-wp-context=\'{"tag":"\u003Cfoo\u003E"}\'', wp_interactivity_data_wp_context( array( 'tag' => '<foo>' ) ) );


### PR DESCRIPTION
Fix invalid test `@covers` annotations.

You can confirm this produces no warnings when running:

```sh
XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-html ./artifacts/coverage/ --group interactivity-api --stop-on-warning
```

Trac ticket: https://core.trac.wordpress.org/ticket/60757

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
