### PR TITLE
Interactivity: Prevent empty state or config from being printed as []

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -140,20 +140,36 @@ final class WP_Interactivity_API {
 	 * @since 6.5.0
 	 */
 	public function print_client_interactivity_data() {
-		$store      = array();
-		$has_state  = ! empty( $this->state_data );
-		$has_config = ! empty( $this->config_data );
+		if ( empty( $this->state_data ) && empty( $this->config_data ) ) {
+			return;
+		}
 
-		if ( $has_state || $has_config ) {
-			if ( $has_config ) {
-				$store['config'] = $this->config_data;
+		$interactivity_data = array();
+
+		$config = array();
+		foreach ( $this->config_data as $key => $value ) {
+			if ( ! empty( $value ) ) {
+				$config[ $key ] = $value;
 			}
-			if ( $has_state ) {
-				$store['state'] = $this->state_data;
+		}
+		if ( ! empty( $config ) ) {
+			$interactivity_data['config'] = $config;
+		}
+
+		$state = array();
+		foreach ( $this->state_data as $key => $value ) {
+			if ( ! empty( $value ) ) {
+				$state[ $key ] = $value;
 			}
+		}
+		if ( ! empty( $state ) ) {
+			$interactivity_data['state'] = $state;
+		}
+
+		if ( ! empty( $interactivity_data ) ) {
 			wp_print_inline_script_tag(
 				wp_json_encode(
-					$store,
+					$interactivity_data,
 					JSON_HEX_TAG | JSON_HEX_AMP
 				),
 				array(

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -239,7 +239,7 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 	/**
 	 * Tests that empty state objects are pruned from printed state.
 	 *
-	 * @ticket X
+	 * @ticket 60761
 	 *
 	 * @covers ::print_client_interactivity_data
 	 */
@@ -260,7 +260,7 @@ SCRIPT_TAG;
 	/**
 	 * Tests that state consisting of only empty state objects is not printed.
 	 *
-	 * @ticket X
+	 * @ticket 60761
 	 *
 	 * @covers ::print_client_interactivity_data
 	 */
@@ -273,7 +273,7 @@ SCRIPT_TAG;
 	/**
 	 * Tests that nested empty state objects are serialized correctly.
 	 *
-	 * @ticket X
+	 * @ticket 60761
 	 *
 	 * @covers ::print_client_interactivity_data
 	 */

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -237,7 +237,7 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that empty state objects are pruned from printed state.
+	 * Tests that empty state objects are pruned from printed data.
 	 *
 	 * @ticket 60761
 	 *
@@ -258,7 +258,7 @@ SCRIPT_TAG;
 	}
 
 	/**
-	 * Tests that state consisting of only empty state objects is not printed.
+	 * Tests that data consisting of only empty state objects is not printed.
 	 *
 	 * @ticket 60761
 	 *
@@ -271,7 +271,7 @@ SCRIPT_TAG;
 	}
 
 	/**
-	 * Tests that nested empty state objects are serialized correctly.
+	 * Tests that nested empty state objects are printed correctly.
 	 *
 	 * @ticket 60761
 	 *
@@ -283,6 +283,60 @@ SCRIPT_TAG;
 		$expected       = <<<'SCRIPT_TAG'
 <script type="application/json" id="wp-interactivity-data">
 {"state":{"myPlugin":{"emptyArray":[]}}}
+</script>
+
+SCRIPT_TAG;
+
+		$this->assertEquals( $expected, $printed_script );
+	}
+
+	/**
+	 * Tests that empty config objects are pruned from printed data.
+	 *
+	 * @ticket 60761
+	 *
+	 * @covers ::print_client_interactivity_data
+	 */
+	public function test_config_not_printed_when_empty_array() {
+		$this->interactivity->config( 'pluginWithEmptyConfig_prune', array() );
+		$this->interactivity->config( 'pluginWithConfig_include', array( 'value' => 'excellent' ) );
+		$printed_script = get_echo( array( $this->interactivity, 'print_client_interactivity_data' ) );
+		$expected       = <<<'SCRIPT_TAG'
+<script type="application/json" id="wp-interactivity-data">
+{"config":{"pluginWithConfig_include":{"value":"excellent"}}}
+</script>
+
+SCRIPT_TAG;
+
+		$this->assertEquals( $expected, $printed_script );
+	}
+
+	/**
+	 * Tests that data consisting of only empty config objects is not printed.
+	 *
+	 * @ticket 60761
+	 *
+	 * @covers ::print_client_interactivity_data
+	 */
+	public function test_config_not_printed_when_only_empty_arrays() {
+		$this->interactivity->config( 'pluginWithEmptyConfig_prune', array() );
+		$printed_script = get_echo( array( $this->interactivity, 'print_client_interactivity_data' ) );
+		$this->assertSame( '', $printed_script );
+	}
+
+	/**
+	 * Tests that nested empty config objects are printed correctly.
+	 *
+	 * @ticket 60761
+	 *
+	 * @covers ::print_client_interactivity_data
+	 */
+	public function test_config_printed_correctly_with_nested_empty_array() {
+		$this->interactivity->config( 'myPlugin', array( 'emptyArray' => array() ) );
+		$printed_script = get_echo( array( $this->interactivity, 'print_client_interactivity_data' ) );
+		$expected       = <<<'SCRIPT_TAG'
+<script type="application/json" id="wp-interactivity-data">
+{"config":{"myPlugin":{"emptyArray":[]}}}
 </script>
 
 SCRIPT_TAG;

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -254,7 +254,7 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 
 SCRIPT_TAG;
 
-		$this->assertEquals( $expected, $printed_script );
+		$this->assertSame( $expected, $printed_script );
 	}
 
 	/**
@@ -287,7 +287,7 @@ SCRIPT_TAG;
 
 SCRIPT_TAG;
 
-		$this->assertEquals( $expected, $printed_script );
+		$this->assertSame( $expected, $printed_script );
 	}
 
 	/**
@@ -308,7 +308,7 @@ SCRIPT_TAG;
 
 SCRIPT_TAG;
 
-		$this->assertEquals( $expected, $printed_script );
+		$this->assertSame( $expected, $printed_script );
 	}
 
 	/**
@@ -341,7 +341,7 @@ SCRIPT_TAG;
 
 SCRIPT_TAG;
 
-		$this->assertEquals( $expected, $printed_script );
+		$this->assertSame( $expected, $printed_script );
 	}
 
 	/**

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -236,7 +236,59 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 		$this->assertEquals( array( 'config' => array( 'myPlugin' => array( 'a' => 1 ) ) ), $result );
 	}
 
+	/**
+	 * Tests that empty state objects are pruned from printed state.
+	 *
+	 * @ticket X
+	 *
+	 * @covers ::print_client_interactivity_data
+	 */
+	public function test_state_not_printed_when_empty_array() {
+		$this->interactivity->state( 'pluginWithEmptyState_prune', array() );
+		$this->interactivity->state( 'pluginWithState_include', array( 'value' => 'excellent' ) );
+		$printed_script = get_echo( array( $this->interactivity, 'print_client_interactivity_data' ) );
+		$expected       = <<<'SCRIPT_TAG'
+<script type="application/json" id="wp-interactivity-data">
+{"state":{"pluginWithState_include":{"value":"excellent"}}}
+</script>
 
+SCRIPT_TAG;
+
+		$this->assertEquals( $expected, $printed_script );
+	}
+
+	/**
+	 * Tests that state consisting of only empty state objects is not printed.
+	 *
+	 * @ticket X
+	 *
+	 * @covers ::print_client_interactivity_data
+	 */
+	public function test_state_not_printed_when_only_empty_arrays() {
+		$this->interactivity->state( 'pluginWithEmptyState_prune', array() );
+		$printed_script = get_echo( array( $this->interactivity, 'print_client_interactivity_data' ) );
+		$this->assertSame( '', $printed_script );
+	}
+
+	/**
+	 * Tests that nested empty state objects are serialized correctly.
+	 *
+	 * @ticket X
+	 *
+	 * @covers ::print_client_interactivity_data
+	 */
+	public function test_state_printed_correctly_with_nested_empty_array() {
+		$this->interactivity->state( 'myPlugin', array('emptyArray' => array()) );
+		$printed_script = get_echo( array( $this->interactivity, 'print_client_interactivity_data' ) );
+		$expected       = <<<'SCRIPT_TAG'
+<script type="application/json" id="wp-interactivity-data">
+{"state":{"myPlugin":{"emptyArray":[]}}}
+</script>
+
+SCRIPT_TAG;
+
+		$this->assertEquals( $expected, $printed_script );
+	}
 
 	/**
 	 * Tests that special characters in the initial state and configuration are

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -278,7 +278,7 @@ SCRIPT_TAG;
 	 * @covers ::print_client_interactivity_data
 	 */
 	public function test_state_printed_correctly_with_nested_empty_array() {
-		$this->interactivity->state( 'myPlugin', array('emptyArray' => array()) );
+		$this->interactivity->state( 'myPlugin', array( 'emptyArray' => array() ) );
 		$printed_script = get_echo( array( $this->interactivity, 'print_client_interactivity_data' ) );
 		$expected       = <<<'SCRIPT_TAG'
 <script type="application/json" id="wp-interactivity-data">


### PR DESCRIPTION
Prevent an empty Interactivity store from being serialized as `[]`. Stores are expected to be JSON objects (`{}`), but PHP will `json_encode` empty arrays as `[]`.

An option would be to force PHP to use empty objects with `JSON_FORCE_OBJECT`, but that is deep, so if we wanted e.g. `array( 'myStore' => array( 'ids' => array() ) )` the inner `array()` would also become `{}`, which we probably don't want.

Instead, this PR prunes stores and configurations that are empty arrays. This results in less redundant data being serialized into the HTML and fixes the issue of store objects being serialized as JavaScript arrays.

Trac ticket: https://core.trac.wordpress.org/ticket/60761

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
