### PR TITLE
Interactivity API: Fix SSR context included in void tags shouldn't propagate to following elements

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -482,7 +482,7 @@ final class WP_Interactivity_API {
 	 * @param array                                     $context_stack   The reference to the context stack.
 	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
-	private function data_wp_interactive_processor( WP_Interactivity_API_Directives_Processor $p, $mode, array &$context_stack, array &$namespace_stack ) {
+	private function data_wp_interactive_processor( WP_Interactivity_API_Directives_Processor $p, string $mode, array &$context_stack, array &$namespace_stack ) {
 		// In closing tags, it removes the last namespace from the stack.
 		if ( 'exit' === $mode ) {
 			array_pop( $namespace_stack );
@@ -527,7 +527,7 @@ final class WP_Interactivity_API {
 	 * @param array                                     $context_stack   The reference to the context stack.
 	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
-	private function data_wp_context_processor( WP_Interactivity_API_Directives_Processor $p, $mode, array &$context_stack, array &$namespace_stack ) {
+	private function data_wp_context_processor( WP_Interactivity_API_Directives_Processor $p, string $mode, array &$context_stack, array &$namespace_stack ) {
 		// When exiting tags, it removes the last context from the stack.
 		if ( 'exit' === $mode ) {
 			array_pop( $context_stack );
@@ -574,7 +574,7 @@ final class WP_Interactivity_API {
 	 * @param array                                     $context_stack   The reference to the context stack.
 	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
-	private function data_wp_bind_processor( WP_Interactivity_API_Directives_Processor $p, $mode, array &$context_stack, array &$namespace_stack ) {
+	private function data_wp_bind_processor( WP_Interactivity_API_Directives_Processor $p, string $mode, array &$context_stack, array &$namespace_stack ) {
 		if ( 'enter' === $mode ) {
 			$all_bind_directives = $p->get_attribute_names_with_prefix( 'data-wp-bind--' );
 
@@ -619,7 +619,7 @@ final class WP_Interactivity_API {
 	 * @param array                                     $context_stack   The reference to the context stack.
 	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
-	private function data_wp_class_processor( WP_Interactivity_API_Directives_Processor $p, $mode, array &$context_stack, array &$namespace_stack ) {
+	private function data_wp_class_processor( WP_Interactivity_API_Directives_Processor $p, string $mode, array &$context_stack, array &$namespace_stack ) {
 		if ( 'enter' === $mode ) {
 			$all_class_directives = $p->get_attribute_names_with_prefix( 'data-wp-class--' );
 
@@ -654,7 +654,7 @@ final class WP_Interactivity_API {
 	 * @param array                                     $context_stack   The reference to the context stack.
 	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
-	private function data_wp_style_processor( WP_Interactivity_API_Directives_Processor $p, $mode, array &$context_stack, array &$namespace_stack ) {
+	private function data_wp_style_processor( WP_Interactivity_API_Directives_Processor $p, string $mode, array &$context_stack, array &$namespace_stack ) {
 		if ( 'enter' === $mode ) {
 			$all_style_attributes = $p->get_attribute_names_with_prefix( 'data-wp-style--' );
 
@@ -747,7 +747,7 @@ final class WP_Interactivity_API {
 	 * @param array                                     $context_stack   The reference to the context stack.
 	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
-	private function data_wp_text_processor( WP_Interactivity_API_Directives_Processor $p, $mode, array &$context_stack, array &$namespace_stack ) {
+	private function data_wp_text_processor( WP_Interactivity_API_Directives_Processor $p, string $mode, array &$context_stack, array &$namespace_stack ) {
 		if ( 'enter' === $mode ) {
 			$attribute_value = $p->get_attribute( 'data-wp-text' );
 			$result          = $this->evaluate( $attribute_value, end( $namespace_stack ), end( $context_stack ) );
@@ -844,7 +844,7 @@ HTML;
 	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
 	 * @param string                                    $mode            Whether the processing is entering or exiting the tag.
 	 */
-	private function data_wp_router_region_processor( WP_Interactivity_API_Directives_Processor $p, $mode ) {
+	private function data_wp_router_region_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
 		if ( 'enter' === $mode && ! $this->has_processed_router_region ) {
 			$this->has_processed_router_region = true;
 
@@ -886,7 +886,7 @@ HTML;
 	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 * @param array                                     $tag_stack       The reference to the tag stack.
 	 */
-	private function data_wp_each_processor( WP_Interactivity_API_Directives_Processor $p, $mode, array &$context_stack, array &$namespace_stack, array &$tag_stack ) {
+	private function data_wp_each_processor( WP_Interactivity_API_Directives_Processor $p, string $mode, array &$context_stack, array &$namespace_stack, array &$tag_stack ) {
 		if ( 'enter' === $mode && 'TEMPLATE' === $p->get_tag() ) {
 			$attribute_name   = $p->get_attribute_names_with_prefix( 'data-wp-each' )[0];
 			$extracted_suffix = $this->extract_prefix_and_suffix( $attribute_name );

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -299,42 +299,33 @@ final class WP_Interactivity_API {
 
 			/*
 			 * Sorts the attributes by the order of the `directives_processor` array
-			 * and checks what directives are present in this element.
+			 * and checks what directives are present in this element. The processing
+			 * order is reversed for tag closers.
 			 */
-			$existing_directives_prefixes          = array_intersect(
-				$directive_processor_prefixes,
+			$directives_prefixes = array_intersect(
+				$p->is_tag_closer()
+					? $directive_processor_prefixes_reversed
+					: $directive_processor_prefixes,
 				$directives_prefixes
 			);
-			$existing_directives_prefixes_reversed = array_intersect(
-				$directive_processor_prefixes_reversed,
-				$directives_prefixes
-			);
-			// If it is not a tag closer, process directives in normal order.
-			if ( ! $p->is_tag_closer() ) {
-				foreach ( $existing_directives_prefixes as $directive_prefix ) {
-					$func = is_array( self::$directive_processors[ $directive_prefix ] )
-						? self::$directive_processors[ $directive_prefix ]
-						: array( $this, self::$directive_processors[ $directive_prefix ] );
 
-					call_user_func_array(
-						$func,
-						array( $p, false, &$context_stack, &$namespace_stack, &$tag_stack )
-					);
-				}
+			// Executes the directive processors present in this element.
+			foreach ( $directives_prefixes as $directive_prefix ) {
+				$func = is_array( self::$directive_processors[ $directive_prefix ] )
+					? self::$directive_processors[ $directive_prefix ]
+					: array( $this, self::$directive_processors[ $directive_prefix ] );
+				call_user_func_array(
+					$func,
+					array( $p, &$context_stack, &$namespace_stack, &$tag_stack )
+				);
 			}
 
-			// If it is a tag closer, or it doesn't visit the closer tag, process directives in reversed order.
-			// For cases where it doesn't visit closer tags, it needs to run in both orders.
-			if ( $p->is_tag_closer() || ! $p->has_and_visits_its_closer_tag() ) {
-				foreach ( $existing_directives_prefixes_reversed as $directive_prefix ) {
-					$func = is_array( self::$directive_processors[ $directive_prefix ] )
-						? self::$directive_processors[ $directive_prefix ]
-						: array( $this, self::$directive_processors[ $directive_prefix ] );
-
-					call_user_func_array(
-						$func,
-						array( $p, true, &$context_stack, &$namespace_stack, &$tag_stack )
-					);
+			// Remove context from stack if it is a void tag.
+			if ( WP_HTML_Processor::is_void( $tag_name ) ) {
+				foreach ( $directives_prefixes as $directive_prefix ) {
+					if ( 'data-wp-context' === $directive_prefix ) {
+						array_pop( $context_stack );
+					}
 				}
 			}
 		}
@@ -488,13 +479,12 @@ final class WP_Interactivity_API {
 	 * @since 6.5.0
 	 *
 	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
-	 * @param boolean                                   $is_exiting_tag  Whether the current tag is currently exiting or not.
 	 * @param array                                     $context_stack   The reference to the context stack.
 	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
-	private function data_wp_interactive_processor( WP_Interactivity_API_Directives_Processor $p, $is_exiting_tag, array &$context_stack, array &$namespace_stack ) {
+	private function data_wp_interactive_processor( WP_Interactivity_API_Directives_Processor $p, array &$context_stack, array &$namespace_stack ) {
 		// In closing tags, it removes the last namespace from the stack.
-		if ( $is_exiting_tag ) {
+		if ( $p->is_tag_closer() ) {
 			array_pop( $namespace_stack );
 			return;
 		}
@@ -533,13 +523,12 @@ final class WP_Interactivity_API {
 	 * @since 6.5.0
 	 *
 	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
-	 * @param boolean                                   $is_exiting_tag  Whether the current tag is currently exiting or not.
 	 * @param array                                     $context_stack   The reference to the context stack.
 	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
-	private function data_wp_context_processor( WP_Interactivity_API_Directives_Processor $p, $is_exiting_tag, array &$context_stack, array &$namespace_stack ) {
-		// When exiting tags, it removes the last context from the stack.
-		if ( $is_exiting_tag ) {
+	private function data_wp_context_processor( WP_Interactivity_API_Directives_Processor $p, array &$context_stack, array &$namespace_stack ) {
+		// In closing tags, it removes the last context from the stack.
+		if ( $p->is_tag_closer() ) {
 			array_pop( $context_stack );
 			return;
 		}
@@ -580,12 +569,11 @@ final class WP_Interactivity_API {
 	 * @since 6.5.0
 	 *
 	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
-	 * @param boolean                                   $is_exiting_tag  Whether the current tag is currently exiting or not.
 	 * @param array                                     $context_stack   The reference to the context stack.
 	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
-	private function data_wp_bind_processor( WP_Interactivity_API_Directives_Processor $p, $is_exiting_tag, array &$context_stack, array &$namespace_stack ) {
-		if ( ! $is_exiting_tag ) {
+	private function data_wp_bind_processor( WP_Interactivity_API_Directives_Processor $p, array &$context_stack, array &$namespace_stack ) {
+		if ( ! $p->is_tag_closer() ) {
 			$all_bind_directives = $p->get_attribute_names_with_prefix( 'data-wp-bind--' );
 
 			foreach ( $all_bind_directives as $attribute_name ) {
@@ -625,12 +613,11 @@ final class WP_Interactivity_API {
 	 * @since 6.5.0
 	 *
 	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
-	 * @param boolean                                   $is_exiting_tag  Whether the current tag is currently exiting or not.
 	 * @param array                                     $context_stack   The reference to the context stack.
 	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
-	private function data_wp_class_processor( WP_Interactivity_API_Directives_Processor $p, $is_exiting_tag, array &$context_stack, array &$namespace_stack ) {
-		if ( ! $is_exiting_tag ) {
+	private function data_wp_class_processor( WP_Interactivity_API_Directives_Processor $p, array &$context_stack, array &$namespace_stack ) {
+		if ( ! $p->is_tag_closer() ) {
 			$all_class_directives = $p->get_attribute_names_with_prefix( 'data-wp-class--' );
 
 			foreach ( $all_class_directives as $attribute_name ) {
@@ -660,12 +647,11 @@ final class WP_Interactivity_API {
 	 * @since 6.5.0
 	 *
 	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
-	 * @param boolean                                   $is_exiting_tag  Whether the current tag is currently exiting or not.
 	 * @param array                                     $context_stack   The reference to the context stack.
 	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
-	private function data_wp_style_processor( WP_Interactivity_API_Directives_Processor $p, $is_exiting_tag, array &$context_stack, array &$namespace_stack ) {
-		if ( ! $is_exiting_tag ) {
+	private function data_wp_style_processor( WP_Interactivity_API_Directives_Processor $p, array &$context_stack, array &$namespace_stack ) {
+		if ( ! $p->is_tag_closer() ) {
 			$all_style_attributes = $p->get_attribute_names_with_prefix( 'data-wp-style--' );
 
 			foreach ( $all_style_attributes as $attribute_name ) {
@@ -753,12 +739,11 @@ final class WP_Interactivity_API {
 	 * @since 6.5.0
 	 *
 	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
-	 * @param boolean                                   $is_exiting_tag  Whether the current tag is currently exiting or not.
 	 * @param array                                     $context_stack   The reference to the context stack.
 	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
-	private function data_wp_text_processor( WP_Interactivity_API_Directives_Processor $p, $is_exiting_tag, array &$context_stack, array &$namespace_stack ) {
-		if ( ! $is_exiting_tag ) {
+	private function data_wp_text_processor( WP_Interactivity_API_Directives_Processor $p, array &$context_stack, array &$namespace_stack ) {
+		if ( ! $p->is_tag_closer() ) {
 			$attribute_value = $p->get_attribute( 'data-wp-text' );
 			$result          = $this->evaluate( $attribute_value, end( $namespace_stack ), end( $context_stack ) );
 
@@ -851,11 +836,10 @@ HTML;
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
-	 * @param boolean                                   $is_exiting_tag  Whether the current tag is currently exiting or not.
+	 * @param WP_Interactivity_API_Directives_Processor $p The directives processor instance.
 	 */
-	private function data_wp_router_region_processor( WP_Interactivity_API_Directives_Processor $p, $is_exiting_tag ) {
-		if ( ! $is_exiting_tag && ! $this->has_processed_router_region ) {
+	private function data_wp_router_region_processor( WP_Interactivity_API_Directives_Processor $p ) {
+		if ( ! $p->is_tag_closer() && ! $this->has_processed_router_region ) {
 			$this->has_processed_router_region = true;
 
 			// Initialize the `core/router` store.
@@ -891,13 +875,12 @@ HTML;
 	 * @since 6.5.0
 	 *
 	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
-	 * @param boolean                                   $is_exiting_tag  Whether the current tag is currently exiting or not.
 	 * @param array                                     $context_stack   The reference to the context stack.
 	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 * @param array                                     $tag_stack       The reference to the tag stack.
 	 */
-	private function data_wp_each_processor( WP_Interactivity_API_Directives_Processor $p, $is_exiting_tag, array &$context_stack, array &$namespace_stack, array &$tag_stack ) {
-		if ( ! $is_exiting_tag && 'TEMPLATE' === $p->get_tag() ) {
+	private function data_wp_each_processor( WP_Interactivity_API_Directives_Processor $p, array &$context_stack, array &$namespace_stack, array &$tag_stack ) {
+		if ( ! $p->is_tag_closer() && 'TEMPLATE' === $p->get_tag() ) {
 			$attribute_name   = $p->get_attribute_names_with_prefix( 'data-wp-each' )[0];
 			$extracted_suffix = $this->extract_prefix_and_suffix( $attribute_name );
 			$item_name        = isset( $extracted_suffix[1] ) ? $this->kebab_to_camel_case( $extracted_suffix[1] ) : 'item';

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -229,8 +229,7 @@ final class WP_Interactivity_API {
 		$tag_stack  = array();
 		$unbalanced = false;
 
-		$directive_processor_prefixes          = array_keys( self::$directive_processors );
-		$directive_processor_prefixes_reversed = array_reverse( $directive_processor_prefixes );
+		$directive_processor_prefixes = array_keys( self::$directive_processors );
 
 		while ( $p->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
 			$tag_name = $p->get_tag();
@@ -297,34 +296,34 @@ final class WP_Interactivity_API {
 				continue;
 			}
 
-			/*
-			 * Sorts the attributes by the order of the `directives_processor` array
-			 * and checks what directives are present in this element. The processing
-			 * order is reversed for tag closers.
-			 */
-			$directives_prefixes = array_intersect(
-				$p->is_tag_closer()
-					? $directive_processor_prefixes_reversed
-					: $directive_processor_prefixes,
-				$directives_prefixes
-			);
-
 			// Executes the directive processors present in this element.
-			foreach ( $directives_prefixes as $directive_prefix ) {
-				$func = is_array( self::$directive_processors[ $directive_prefix ] )
-					? self::$directive_processors[ $directive_prefix ]
-					: array( $this, self::$directive_processors[ $directive_prefix ] );
-				call_user_func_array(
-					$func,
-					array( $p, &$context_stack, &$namespace_stack, &$tag_stack )
-				);
+			if ( ! $p->is_tag_closer() ) {
+				/*
+				 * Sorts the attributes by the order of the `directives_processor` array
+				 * and checks what directives are present in this element.
+				 */
+				$directives_prefixes = array_intersect( $directive_processor_prefixes, $directives_prefixes );
+				foreach ( $directives_prefixes as $directive_prefix ) {
+					$func = is_array( self::$directive_processors[ $directive_prefix ] )
+						? self::$directive_processors[ $directive_prefix ]
+						: array( $this, self::$directive_processors[ $directive_prefix ] );
+					call_user_func_array(
+						$func,
+						array( $p, &$context_stack, &$namespace_stack, &$tag_stack )
+					);
+				}
 			}
 
-			// Remove context from stack if it is a void tag.
-			if ( WP_HTML_Processor::is_void( $tag_name ) ) {
+			// Remove context and namespace from stack if needed at the end of processing of each element.
+			if ( $p->is_tag_closer() || ! $p->has_and_visits_its_closer_tag() ) {
 				foreach ( $directives_prefixes as $directive_prefix ) {
-					if ( 'data-wp-context' === $directive_prefix ) {
-						array_pop( $context_stack );
+					switch ( $directive_prefix ) {
+						case 'data-wp-interactive':
+							array_pop( $namespace_stack );
+							break;
+						case 'data-wp-context':
+							array_pop( $context_stack );
+							break;
 					}
 				}
 			}
@@ -483,12 +482,6 @@ final class WP_Interactivity_API {
 	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
 	private function data_wp_interactive_processor( WP_Interactivity_API_Directives_Processor $p, array &$context_stack, array &$namespace_stack ) {
-		// In closing tags, it removes the last namespace from the stack.
-		if ( $p->is_tag_closer() ) {
-			array_pop( $namespace_stack );
-			return;
-		}
-
 		// Tries to decode the `data-wp-interactive` attribute value.
 		$attribute_value = $p->get_attribute( 'data-wp-interactive' );
 
@@ -527,12 +520,6 @@ final class WP_Interactivity_API {
 	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
 	private function data_wp_context_processor( WP_Interactivity_API_Directives_Processor $p, array &$context_stack, array &$namespace_stack ) {
-		// In closing tags, it removes the last context from the stack.
-		if ( $p->is_tag_closer() ) {
-			array_pop( $context_stack );
-			return;
-		}
-
 		$attribute_value = $p->get_attribute( 'data-wp-context' );
 		$namespace_value = end( $namespace_stack );
 
@@ -573,33 +560,31 @@ final class WP_Interactivity_API {
 	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
 	private function data_wp_bind_processor( WP_Interactivity_API_Directives_Processor $p, array &$context_stack, array &$namespace_stack ) {
-		if ( ! $p->is_tag_closer() ) {
-			$all_bind_directives = $p->get_attribute_names_with_prefix( 'data-wp-bind--' );
+		$all_bind_directives = $p->get_attribute_names_with_prefix( 'data-wp-bind--' );
 
-			foreach ( $all_bind_directives as $attribute_name ) {
-				list( , $bound_attribute ) = $this->extract_prefix_and_suffix( $attribute_name );
-				if ( empty( $bound_attribute ) ) {
-					return;
+		foreach ( $all_bind_directives as $attribute_name ) {
+			list( , $bound_attribute ) = $this->extract_prefix_and_suffix( $attribute_name );
+			if ( empty( $bound_attribute ) ) {
+				return;
+			}
+
+			$attribute_value = $p->get_attribute( $attribute_name );
+			$result          = $this->evaluate( $attribute_value, end( $namespace_stack ), end( $context_stack ) );
+
+			if ( null !== $result && ( false !== $result || '-' === $bound_attribute[4] ) ) {
+				/*
+				 * If the result of the evaluation is a boolean and the attribute is
+				 * `aria-` or `data-, convert it to a string "true" or "false". It
+				 * follows the exact same logic as Preact because it needs to
+				 * replicate what Preact will later do in the client:
+				 * https://github.com/preactjs/preact/blob/ea49f7a0f9d1ff2c98c0bdd66aa0cbc583055246/src/diff/props.js#L131C24-L136
+				 */
+				if ( is_bool( $result ) && '-' === $bound_attribute[4] ) {
+					$result = $result ? 'true' : 'false';
 				}
-
-				$attribute_value = $p->get_attribute( $attribute_name );
-				$result          = $this->evaluate( $attribute_value, end( $namespace_stack ), end( $context_stack ) );
-
-				if ( null !== $result && ( false !== $result || '-' === $bound_attribute[4] ) ) {
-					/*
-					 * If the result of the evaluation is a boolean and the attribute is
-					 * `aria-` or `data-, convert it to a string "true" or "false". It
-					 * follows the exact same logic as Preact because it needs to
-					 * replicate what Preact will later do in the client:
-					 * https://github.com/preactjs/preact/blob/ea49f7a0f9d1ff2c98c0bdd66aa0cbc583055246/src/diff/props.js#L131C24-L136
-					 */
-					if ( is_bool( $result ) && '-' === $bound_attribute[4] ) {
-						$result = $result ? 'true' : 'false';
-					}
-					$p->set_attribute( $bound_attribute, $result );
-				} else {
-					$p->remove_attribute( $bound_attribute );
-				}
+				$p->set_attribute( $bound_attribute, $result );
+			} else {
+				$p->remove_attribute( $bound_attribute );
 			}
 		}
 	}
@@ -617,23 +602,21 @@ final class WP_Interactivity_API {
 	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
 	private function data_wp_class_processor( WP_Interactivity_API_Directives_Processor $p, array &$context_stack, array &$namespace_stack ) {
-		if ( ! $p->is_tag_closer() ) {
-			$all_class_directives = $p->get_attribute_names_with_prefix( 'data-wp-class--' );
+		$all_class_directives = $p->get_attribute_names_with_prefix( 'data-wp-class--' );
 
-			foreach ( $all_class_directives as $attribute_name ) {
-				list( , $class_name ) = $this->extract_prefix_and_suffix( $attribute_name );
-				if ( empty( $class_name ) ) {
-					return;
-				}
+		foreach ( $all_class_directives as $attribute_name ) {
+			list( , $class_name ) = $this->extract_prefix_and_suffix( $attribute_name );
+			if ( empty( $class_name ) ) {
+				return;
+			}
 
-				$attribute_value = $p->get_attribute( $attribute_name );
-				$result          = $this->evaluate( $attribute_value, end( $namespace_stack ), end( $context_stack ) );
+			$attribute_value = $p->get_attribute( $attribute_name );
+			$result          = $this->evaluate( $attribute_value, end( $namespace_stack ), end( $context_stack ) );
 
-				if ( $result ) {
-					$p->add_class( $class_name );
-				} else {
-					$p->remove_class( $class_name );
-				}
+			if ( $result ) {
+				$p->add_class( $class_name );
+			} else {
+				$p->remove_class( $class_name );
 			}
 		}
 	}
@@ -651,36 +634,34 @@ final class WP_Interactivity_API {
 	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
 	private function data_wp_style_processor( WP_Interactivity_API_Directives_Processor $p, array &$context_stack, array &$namespace_stack ) {
-		if ( ! $p->is_tag_closer() ) {
-			$all_style_attributes = $p->get_attribute_names_with_prefix( 'data-wp-style--' );
+		$all_style_attributes = $p->get_attribute_names_with_prefix( 'data-wp-style--' );
 
-			foreach ( $all_style_attributes as $attribute_name ) {
-				list( , $style_property ) = $this->extract_prefix_and_suffix( $attribute_name );
-				if ( empty( $style_property ) ) {
-					continue;
-				}
+		foreach ( $all_style_attributes as $attribute_name ) {
+			list( , $style_property ) = $this->extract_prefix_and_suffix( $attribute_name );
+			if ( empty( $style_property ) ) {
+				continue;
+			}
 
-				$directive_attribute_value = $p->get_attribute( $attribute_name );
-				$style_property_value      = $this->evaluate( $directive_attribute_value, end( $namespace_stack ), end( $context_stack ) );
-				$style_attribute_value     = $p->get_attribute( 'style' );
-				$style_attribute_value     = ( $style_attribute_value && ! is_bool( $style_attribute_value ) ) ? $style_attribute_value : '';
+			$directive_attribute_value = $p->get_attribute( $attribute_name );
+			$style_property_value      = $this->evaluate( $directive_attribute_value, end( $namespace_stack ), end( $context_stack ) );
+			$style_attribute_value     = $p->get_attribute( 'style' );
+			$style_attribute_value     = ( $style_attribute_value && ! is_bool( $style_attribute_value ) ) ? $style_attribute_value : '';
 
+			/*
+			 * Checks first if the style property is not falsy and the style
+			 * attribute value is not empty because if it is, it doesn't need to
+			 * update the attribute value.
+			 */
+			if ( $style_property_value || $style_attribute_value ) {
+				$style_attribute_value = $this->merge_style_property( $style_attribute_value, $style_property, $style_property_value );
 				/*
-				 * Checks first if the style property is not falsy and the style
-				 * attribute value is not empty because if it is, it doesn't need to
-				 * update the attribute value.
+				 * If the style attribute value is not empty, it sets it. Otherwise,
+				 * it removes it.
 				 */
-				if ( $style_property_value || $style_attribute_value ) {
-					$style_attribute_value = $this->merge_style_property( $style_attribute_value, $style_property, $style_property_value );
-					/*
-					 * If the style attribute value is not empty, it sets it. Otherwise,
-					 * it removes it.
-					 */
-					if ( ! empty( $style_attribute_value ) ) {
-						$p->set_attribute( 'style', $style_attribute_value );
-					} else {
-						$p->remove_attribute( 'style' );
-					}
+				if ( ! empty( $style_attribute_value ) ) {
+					$p->set_attribute( 'style', $style_attribute_value );
+				} else {
+					$p->remove_attribute( 'style' );
 				}
 			}
 		}
@@ -743,20 +724,18 @@ final class WP_Interactivity_API {
 	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
 	private function data_wp_text_processor( WP_Interactivity_API_Directives_Processor $p, array &$context_stack, array &$namespace_stack ) {
-		if ( ! $p->is_tag_closer() ) {
-			$attribute_value = $p->get_attribute( 'data-wp-text' );
-			$result          = $this->evaluate( $attribute_value, end( $namespace_stack ), end( $context_stack ) );
+		$attribute_value = $p->get_attribute( 'data-wp-text' );
+		$result          = $this->evaluate( $attribute_value, end( $namespace_stack ), end( $context_stack ) );
 
-			/*
-			 * Follows the same logic as Preact in the client and only changes the
-			 * content if the value is a string or a number. Otherwise, it removes the
-			 * content.
-			 */
-			if ( is_string( $result ) || is_numeric( $result ) ) {
-				$p->set_content_between_balanced_tags( esc_html( $result ) );
-			} else {
-				$p->set_content_between_balanced_tags( '' );
-			}
+		/*
+		 * Follows the same logic as Preact in the client and only changes the
+		 * content if the value is a string or a number. Otherwise, it removes the
+		 * content.
+		 */
+		if ( is_string( $result ) || is_numeric( $result ) ) {
+			$p->set_content_between_balanced_tags( esc_html( $result ) );
+		} else {
+			$p->set_content_between_balanced_tags( '' );
 		}
 	}
 
@@ -839,7 +818,7 @@ HTML;
 	 * @param WP_Interactivity_API_Directives_Processor $p The directives processor instance.
 	 */
 	private function data_wp_router_region_processor( WP_Interactivity_API_Directives_Processor $p ) {
-		if ( ! $p->is_tag_closer() && ! $this->has_processed_router_region ) {
+		if ( ! $this->has_processed_router_region ) {
 			$this->has_processed_router_region = true;
 
 			// Initialize the `core/router` store.
@@ -880,7 +859,7 @@ HTML;
 	 * @param array                                     $tag_stack       The reference to the tag stack.
 	 */
 	private function data_wp_each_processor( WP_Interactivity_API_Directives_Processor $p, array &$context_stack, array &$namespace_stack, array &$tag_stack ) {
-		if ( ! $p->is_tag_closer() && 'TEMPLATE' === $p->get_tag() ) {
+		if ( 'TEMPLATE' === $p->get_tag() ) {
 			$attribute_name   = $p->get_attribute_names_with_prefix( 'data-wp-each' )[0];
 			$extracted_suffix = $this->extract_prefix_and_suffix( $attribute_name );
 			$item_name        = isset( $extracted_suffix[1] ) ? $this->kebab_to_camel_case( $extracted_suffix[1] ) : 'item';

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -483,7 +483,7 @@ final class WP_Interactivity_API {
 	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
 	private function data_wp_interactive_processor( WP_Interactivity_API_Directives_Processor $p, string $mode, array &$context_stack, array &$namespace_stack ) {
-		// In closing tags, it removes the last namespace from the stack.
+		// When exiting tags, it removes the last namespace from the stack.
 		if ( 'exit' === $mode ) {
 			array_pop( $namespace_stack );
 			return;

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -319,6 +319,15 @@ final class WP_Interactivity_API {
 					array( $p, &$context_stack, &$namespace_stack, &$tag_stack )
 				);
 			}
+
+			// Remove context from stack if it is a void tag.
+			if ( WP_HTML_Processor::is_void( $tag_name ) ) {
+				foreach ( $directives_prefixes as $directive_prefix ) {
+					if ( 'data-wp-context' === $directive_prefix ) {
+						array_pop( $context_stack );
+					}
+				}
+			}
 		}
 
 		/*

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPIFunctions.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPIFunctions.php
@@ -417,4 +417,45 @@ class Tests_Interactivity_API_wpInteractivityAPIFunctions extends WP_UnitTestCas
 		unregister_block_type( 'test/custom-directive-block' );
 		$this->assertEquals( '1', $processor->get_attribute( 'src' ) );
 	}
+
+	/**
+	 * Tests that context from void tags is not propagated to next tags.
+	 *
+	 * @ticket 60768
+	 *
+	 * @covers ::wp_interactivity_process_directives_of_interactive_blocks
+	 */
+	public function test_process_context_directive_in_void_tags() {
+		register_block_type(
+			'test/custom-directive-block',
+			array(
+				'render_callback' => function () {
+					return '<div data-wp-interactive="nameSpace" data-wp-context=\'{"text": "outer"}\'><input id="first-input" data-wp-context=\'{"text": "inner"}\' data-wp-bind--value="context.text" /><input id="second-input" data-wp-bind--value="context.text" /></div>';
+				},
+				'supports'        => array(
+					'interactivity' => true,
+				),
+			)
+		);
+		$post_content      = '<!-- wp:test/custom-directive-block /-->';
+		$processed_content = do_blocks( $post_content );
+		$processor         = new WP_HTML_Tag_Processor( $processed_content );
+		$processor->next_tag(
+			array(
+				'tag_name' => 'input',
+				'id'       => 'first-input',
+			)
+		);
+		$first_input_value = $processor->get_attribute( 'value' );
+		$processor->next_tag(
+			array(
+				'tag_name' => 'input',
+				'id'       => 'second-input',
+			)
+		);
+		$second_input_value = $processor->get_attribute( 'value' );
+		unregister_block_type( 'test/custom-directive-block' );
+		$this->assertEquals( 'inner', $first_input_value );
+		$this->assertEquals( 'outer', $second_input_value );
+	}
 }

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPIFunctions.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPIFunctions.php
@@ -458,4 +458,38 @@ class Tests_Interactivity_API_wpInteractivityAPIFunctions extends WP_UnitTestCas
 		$this->assertEquals( 'inner', $first_input_value );
 		$this->assertEquals( 'outer', $second_input_value );
 	}
+
+	/**
+	 * Tests that namespace from void tags is not propagated to next tags.
+	 *
+	 * @ticket 60768
+	 *
+	 * @covers wp_interactivity_process_directives_of_interactive_blocks
+	 */
+	public function test_process_interactive_directive_in_void_tags() {
+		wp_interactivity_state(
+			'void',
+			array(
+				'text' => 'void',
+			)
+		);
+		register_block_type(
+			'test/custom-directive-block',
+			array(
+				'render_callback' => function () {
+					return '<div data-wp-interactive="parent"><img data-wp-interactive="void" /><input data-wp-bind--value="state.text" /></div>';
+				},
+				'supports'        => array(
+					'interactivity' => true,
+				),
+			)
+		);
+		$post_content      = '<!-- wp:test/custom-directive-block /-->';
+		$processed_content = do_blocks( $post_content );
+		$processor         = new WP_HTML_Tag_Processor( $processed_content );
+		$processor->next_tag( array( 'tag_name' => 'input' ) );
+		$input_value = $processor->get_attribute( 'value' );
+		unregister_block_type( 'test/custom-directive-block' );
+		$this->assertNull( $input_value );
+	}
 }

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPIFunctions.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPIFunctions.php
@@ -423,7 +423,7 @@ class Tests_Interactivity_API_wpInteractivityAPIFunctions extends WP_UnitTestCas
 	 *
 	 * @ticket 60768
 	 *
-	 * @covers ::wp_interactivity_process_directives_of_interactive_blocks
+	 * @covers wp_interactivity_process_directives_of_interactive_blocks
 	 */
 	public function test_process_context_directive_in_void_tags() {
 		register_block_type(


### PR DESCRIPTION
From my tests, when the same context is used in an inner void tag element and its parent, it is overwritten when it shouldn't. For example, in this use case:

```
<div data-wp-context='{"text": "outer"}'>
<img data-wp-context='{"text": "inner"}'>
<p data-wp-text="context.text"></p>
</div>
```

The last paragraph should receive the parent div context "outer" instead of the img "inner.

From what I've seen in the code, this specific case hasn't been considered while processing `data-wp-context`, and it just removes the context from the stack when it finds a closing tag: [link](https://github.com/SantosGuillamot/wordpress-develop/blob/cb5ba25f9c117ca7b2d550e0f10158e8cc35fb2d/src/wp-includes/interactivity-api/class-wp-interactivity-api.php#L531-L535).

In my tests, checking if it is a void tag in the directives processing and removing the context in that case, seems to solve the issue. Although I must say I am still unfamiliar with the SSR of the directives.

I've also added a test to cover this use case.

Trac ticket: https://core.trac.wordpress.org/ticket/60768

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
