### PR TITLE
REST API: Prevent error when passing invalid `type` parameter

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-search-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-search-controller.php
@@ -395,7 +395,7 @@ class WP_REST_Search_Controller extends WP_REST_Controller {
 	protected function get_search_handler( $request ) {
 		$type = $request->get_param( self::PROP_TYPE );
 
-		if ( ! $type || ! isset( $this->search_handlers[ $type ] ) ) {
+		if ( ! $type || ! is_string( $type ) || ! isset( $this->search_handlers[ $type ] ) ) {
 			return new WP_Error(
 				'rest_search_invalid_type',
 				__( 'Invalid type parameter.' ),

--- a/tests/phpunit/tests/rest-api/rest-search-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-search-controller.php
@@ -888,4 +888,18 @@ class WP_Test_REST_Search_Controller extends WP_Test_REST_Controller_Testcase {
 			wp_list_pluck( $response->get_data(), 'id' )
 		);
 	}
+
+	/**
+	 * @ticket 60771
+	 */
+	public function test_sanitize_subtypes_validates_type() {
+		$response = $this->do_request_with_params(
+			array(
+				'subtype' => 'page',
+				'type'    => array( 'invalid' ),
+			)
+		);
+
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );
+	}
 }


### PR DESCRIPTION
In `WP_REST_Search_Controller`, avoid a PHP error when the `type` parameter is not a string as expected.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60771

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
