### PR TITLE
Tests/admin/wpPluginInstallListTable: rename the original test class

### DIFF
--- a/tests/phpunit/tests/admin/Admin_WpPluginInstallListTable_GetViews_Test.php
+++ b/tests/phpunit/tests/admin/Admin_WpPluginInstallListTable_GetViews_Test.php
@@ -3,9 +3,9 @@
 /**
  * @group admin
  *
- * @covers WP_Plugin_Install_List_Table
+ * @covers WP_Plugin_Install_List_Table::get_views
  */
-class Tests_Admin_wpPluginInstallListTable extends WP_UnitTestCase {
+class Admin_WpPluginInstallListTable_GetViews_Test extends WP_UnitTestCase {
 	/**
 	 * @var WP_Plugin_Install_List_Table
 	 */
@@ -18,8 +18,6 @@ class Tests_Admin_wpPluginInstallListTable extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 42066
-	 *
-	 * @covers WP_Plugin_Install_List_Table::get_views
 	 */
 	public function test_get_views_should_return_no_views_by_default() {
 		$this->assertSame( array(), $this->table->get_views() );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
## Tests/admin/wpPluginInstallListTable: rename the original test class to be more descriptive and adjust covers notaiton.

This will allow the test class to be compatible with PHPUnit 11.

Includes removing method level @covers tags in favour of class level @covers tags to allow for supporting PHPUnit 11 attributes instead of annotations.

Trac ticket: https://core.trac.wordpress.org/ticket/65208

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
