### PR TITLE
Tests/admin/wpPostCommentsListTable: Rename the test class to include the method name

### DIFF
--- a/tests/phpunit/tests/admin/Admin_WpPostCommentsListTable_GetViews_Test.php
+++ b/tests/phpunit/tests/admin/Admin_WpPostCommentsListTable_GetViews_Test.php
@@ -3,9 +3,9 @@
 /**
  * @group admin
  *
- * @covers WP_Post_Comments_List_Table
+ * @covers WP_Post_Comments_List_Table::get_views
  */
-class Tests_Admin_wpPostCommentsListTable extends WP_UnitTestCase {
+class Admin_WpPostCommentsListTable_GetViews_Test extends WP_UnitTestCase {
 
 	/**
 	 * @var WP_Post_Comments_List_Table
@@ -20,7 +20,6 @@ class Tests_Admin_wpPostCommentsListTable extends WP_UnitTestCase {
 	/**
 	 * @ticket 42066
 	 *
-	 * @covers WP_Post_Comments_List_Table::get_views
 	 */
 	public function test_get_views_should_return_views_by_default() {
 		$this->table->prepare_items();


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Rename the test class `Tests_Admin_wpPostCommentsListTable` to `Admin_WpPostCommentsListTable_GetViews_Test` so that the name includes both the class and the method that the test covers.

Moves `@covers` to the class level.

Trac ticket: https://core.trac.wordpress.org/ticket/65208

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
