### PR TITLE
Tests/admin/wpMediaListTable: split the test class

### DIFF
--- a/tests/phpunit/tests/admin/Admin_WpMediaListTable_GetRowActions_Test.php
+++ b/tests/phpunit/tests/admin/Admin_WpMediaListTable_GetRowActions_Test.php
@@ -4,16 +4,16 @@ require_once __DIR__ . '/Admin_WpMediaListTable_TestCase.php';
 
 /**
  * @group admin
+ * 
+ * @covers WP_Media_List_Table::_get_row_actions
  */
-class Tests_Admin_wpMediaListTable extends Admin_WpMediaListTable_TestCase {
+class Admin_WpMediaListTable_GetRowActions_Test extends Admin_WpMediaListTable_TestCase {
 
 	/**
 	 * Tests that `WP_Media_List_Table::_get_row_actions()` only includes an action
 	 * in certain scenarios.
 	 *
 	 * @ticket 57893
-	 *
-	 * @covers WP_Media_List_Table::_get_row_actions
 	 *
 	 * @dataProvider data_get_row_actions_should_include_action
 	 *
@@ -93,8 +93,6 @@ class Tests_Admin_wpMediaListTable extends Admin_WpMediaListTable_TestCase {
 	 * in certain scenarios.
 	 *
 	 * @ticket 57893
-	 *
-	 * @covers WP_Media_List_Table::_get_row_actions
 	 *
 	 * @dataProvider data_get_row_actions_should_not_include_action
 	 *
@@ -204,8 +202,6 @@ class Tests_Admin_wpMediaListTable extends Admin_WpMediaListTable_TestCase {
 	 * when a permalink is not available.
 	 *
 	 * @ticket 57893
-	 *
-	 * @covers WP_Media_List_Table::_get_row_actions
 	 */
 	public function test_get_row_actions_should_not_include_view_without_a_permalink() {
 		self::set_is_trash( false );
@@ -226,8 +222,6 @@ class Tests_Admin_wpMediaListTable extends Admin_WpMediaListTable_TestCase {
 	 * Tests that `WP_Media_List_Table::_get_row_actions()` includes the 'copy' action.
 	 *
 	 * @ticket 57893
-	 *
-	 * @covers WP_Media_List_Table::_get_row_actions
 	 */
 	public function test_get_row_actions_should_include_copy() {
 		self::set_is_trash( false );
@@ -246,8 +240,6 @@ class Tests_Admin_wpMediaListTable extends Admin_WpMediaListTable_TestCase {
 	 * when an attachment URL is not available.
 	 *
 	 * @ticket 57893
-	 *
-	 * @covers WP_Media_List_Table::_get_row_actions
 	 */
 	public function test_get_row_actions_should_not_include_copy_without_an_attachment_url() {
 		self::set_is_trash( false );
@@ -268,8 +260,6 @@ class Tests_Admin_wpMediaListTable extends Admin_WpMediaListTable_TestCase {
 	 * Tests that `WP_Media_List_Table::_get_row_actions()` includes the 'download' action.
 	 *
 	 * @ticket 57893
-	 *
-	 * @covers WP_Media_List_Table::_get_row_actions
 	 */
 	public function test_get_row_actions_should_include_download() {
 		$_get_row_actions = new ReflectionMethod( self::$list_table, '_get_row_actions' );
@@ -286,8 +276,6 @@ class Tests_Admin_wpMediaListTable extends Admin_WpMediaListTable_TestCase {
 	 * when an attachment URL is not available.
 	 *
 	 * @ticket 57893
-	 *
-	 * @covers WP_Media_List_Table::_get_row_actions
 	 */
 	public function test_get_row_actions_should_not_include_download_without_an_attachment_url() {
 		// Ensure the attachment URL is `false`.

--- a/tests/phpunit/tests/admin/Admin_WpMediaListTable_GetRowActions_Test.php
+++ b/tests/phpunit/tests/admin/Admin_WpMediaListTable_GetRowActions_Test.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/Admin_WpMediaListTable_TestCase.php';
 
 /**
  * @group admin
- * 
+ *
  * @covers WP_Media_List_Table::_get_row_actions
  */
 class Admin_WpMediaListTable_GetRowActions_Test extends Admin_WpMediaListTable_TestCase {

--- a/tests/phpunit/tests/admin/Admin_WpMediaListTable_PrepareItems_Test.php
+++ b/tests/phpunit/tests/admin/Admin_WpMediaListTable_PrepareItems_Test.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/Admin_WpMediaListTable_TestCase.php';
 
 /**
  * @group admin
- * 
+ *
  * @covers WP_Media_List_Table::prepare_items
  */
 class Admin_WpMediaListTable_PrepareItems_Test extends Admin_WpMediaListTable_TestCase {

--- a/tests/phpunit/tests/admin/Admin_WpMediaListTable_PrepareItems_Test.php
+++ b/tests/phpunit/tests/admin/Admin_WpMediaListTable_PrepareItems_Test.php
@@ -1,0 +1,49 @@
+<?php
+
+require_once __DIR__ . '/Admin_WpMediaListTable_TestCase.php';
+
+/**
+ * @group admin
+ * 
+ * @covers WP_Media_List_Table::prepare_items
+ */
+class Admin_WpMediaListTable_PrepareItems_Test extends Admin_WpMediaListTable_TestCase {
+
+	/**
+	 * Tests that a call to WP_Media_List_Table::prepare_items() on a site without any scheduled events
+	 * does not result in a PHP warning.
+	 *
+	 * The warning that we should not see:
+	 * PHP <= 7.4: `Invalid argument supplied for foreach()`.
+	 * PHP 8.0 and higher: `Warning: foreach() argument must be of type array|object, bool given`.
+	 *
+	 * Note: This does not test the actual functioning of the WP_Media_List_Table::prepare_items() method.
+	 * It just and only tests for/against the PHP warning.
+	 *
+	 * @ticket 53949
+	 * @group cron
+	 */
+	public function test_prepare_items_without_cron_option_does_not_throw_warning() {
+		global $wp_query;
+
+		// Note: setMethods() is deprecated in PHPUnit 9, but still supported.
+		$mock = $this->getMockBuilder( WP_Media_List_Table::class )
+			->disableOriginalConstructor()
+			->disallowMockingUnknownTypes()
+			->setMethods( array( 'set_pagination_args' ) )
+			->getMock();
+
+		$mock->expects( $this->once() )
+			->method( 'set_pagination_args' );
+
+		$wp_query->query_vars['posts_per_page'] = 10;
+		delete_option( 'cron' );
+
+		// Verify that the cause of the error is in place.
+		$this->assertIsArray( _get_cron_array(), '_get_cron_array() does not return an array.' );
+		$this->assertEmpty( _get_cron_array(), '_get_cron_array() does not return an empty array.' );
+
+		// If this test does not error out due to the PHP warning, we're good.
+		$mock->prepare_items();
+	}
+}

--- a/tests/phpunit/tests/admin/Admin_WpMediaListTable_TestCase.php
+++ b/tests/phpunit/tests/admin/Admin_WpMediaListTable_TestCase.php
@@ -1,0 +1,135 @@
+<?php
+
+abstract class Admin_WpMediaListTable_TestCase extends WP_UnitTestCase {
+
+	/**
+	 * A list table for testing.
+	 *
+	 * @var WP_Media_List_Table
+	 */
+	protected static $list_table;
+
+	/**
+	 * A reflection of the `$is_trash` property.
+	 *
+	 * @var ReflectionProperty
+	 */
+	protected static $is_trash;
+
+	/**
+	 * The original value of the `$is_trash` property.
+	 *
+	 * @var bool|null
+	 */
+	protected static $is_trash_original;
+
+	/**
+	 * A reflection of the `$detached` property.
+	 *
+	 * @var ReflectionProperty
+	 */
+	protected static $detached;
+
+	/**
+	 * The original value of the `$detached` property.
+	 *
+	 * @var bool|null
+	 */
+	protected static $detached_original;
+
+	/**
+	 * The ID of an 'administrator' user for testing.
+	 *
+	 * @var int
+	 */
+	protected static $admin;
+
+	/**
+	 * The ID of a 'subscriber' user for testing.
+	 *
+	 * @var int
+	 */
+	protected static $subscriber;
+
+	/**
+	 * A post for testing.
+	 *
+	 * @var WP_Post
+	 */
+	protected static $post;
+
+	/**
+	 * An attachment for testing.
+	 *
+	 * @var WP_Post
+	 */
+	protected static $attachment;
+
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		require_once ABSPATH . 'wp-admin/includes/class-wp-media-list-table.php';
+
+		self::$list_table = new WP_Media_List_Table();
+		self::$is_trash   = new ReflectionProperty( self::$list_table, 'is_trash' );
+		self::$detached   = new ReflectionProperty( self::$list_table, 'detached' );
+
+		self::$is_trash->setAccessible( true );
+		self::$is_trash_original = self::$is_trash->getValue( self::$list_table );
+		self::$is_trash->setAccessible( false );
+
+		self::$detached->setAccessible( true );
+		self::$detached_original = self::$detached->getValue( self::$list_table );
+		self::$detached->setAccessible( false );
+
+		// Create users.
+		self::$admin      = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		self::$subscriber = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		// Create posts.
+		self::$post       = self::factory()->post->create_and_get();
+		self::$attachment = self::factory()->attachment->create_and_get(
+			array(
+				'post_name'      => 'attachment-name',
+				'file'           => 'image.jpg',
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+	}
+
+	/**
+	 * Restores reflections to their original values.
+	 */
+	public function tear_down() {
+		self::set_is_trash( self::$is_trash_original );
+		self::set_detached( self::$detached_original );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Sets the `$is_trash` property.
+	 *
+	 * Helper method.
+	 *
+	 * @param bool $is_trash Whether the attachment filter is currently 'trash'.
+	 */
+	protected static function set_is_trash( $is_trash ) {
+		self::$is_trash->setAccessible( true );
+		self::$is_trash->setValue( self::$list_table, $is_trash );
+		self::$is_trash->setAccessible( false );
+	}
+
+	/**
+	 * Sets the `$detached` property.
+	 *
+	 * Helper method.
+	 *
+	 * @param bool $detached Whether the attachment filter is currently 'detached'.
+	 */
+	protected static function set_detached( $detached ) {
+		self::$detached->setAccessible( true );
+		self::$detached->setValue( self::$list_table, $detached );
+		self::$detached->setAccessible( false );
+	}
+}

--- a/tests/phpunit/tests/admin/wpMediaListTable.php
+++ b/tests/phpunit/tests/admin/wpMediaListTable.php
@@ -8,45 +8,6 @@ require_once __DIR__ . '/Admin_WpMediaListTable_TestCase.php';
 class Tests_Admin_wpMediaListTable extends Admin_WpMediaListTable_TestCase {
 
 	/**
-	 * Tests that a call to WP_Media_List_Table::prepare_items() on a site without any scheduled events
-	 * does not result in a PHP warning.
-	 *
-	 * The warning that we should not see:
-	 * PHP <= 7.4: `Invalid argument supplied for foreach()`.
-	 * PHP 8.0 and higher: `Warning: foreach() argument must be of type array|object, bool given`.
-	 *
-	 * Note: This does not test the actual functioning of the WP_Media_List_Table::prepare_items() method.
-	 * It just and only tests for/against the PHP warning.
-	 *
-	 * @ticket 53949
-	 * @covers WP_Media_List_Table::prepare_items
-	 * @group cron
-	 */
-	public function test_prepare_items_without_cron_option_does_not_throw_warning() {
-		global $wp_query;
-
-		// Note: setMethods() is deprecated in PHPUnit 9, but still supported.
-		$mock = $this->getMockBuilder( WP_Media_List_Table::class )
-			->disableOriginalConstructor()
-			->disallowMockingUnknownTypes()
-			->setMethods( array( 'set_pagination_args' ) )
-			->getMock();
-
-		$mock->expects( $this->once() )
-			->method( 'set_pagination_args' );
-
-		$wp_query->query_vars['posts_per_page'] = 10;
-		delete_option( 'cron' );
-
-		// Verify that the cause of the error is in place.
-		$this->assertIsArray( _get_cron_array(), '_get_cron_array() does not return an array.' );
-		$this->assertEmpty( _get_cron_array(), '_get_cron_array() does not return an empty array.' );
-
-		// If this test does not error out due to the PHP warning, we're good.
-		$mock->prepare_items();
-	}
-
-	/**
 	 * Tests that `WP_Media_List_Table::_get_row_actions()` only includes an action
 	 * in certain scenarios.
 	 *

--- a/tests/phpunit/tests/admin/wpMediaListTable.php
+++ b/tests/phpunit/tests/admin/wpMediaListTable.php
@@ -1,113 +1,11 @@
 <?php
 
+require_once __DIR__ . '/Admin_WpMediaListTable_TestCase.php';
+
 /**
  * @group admin
  */
-class Tests_Admin_wpMediaListTable extends WP_UnitTestCase {
-	/**
-	 * A list table for testing.
-	 *
-	 * @var WP_Media_List_Table
-	 */
-	protected static $list_table;
-
-	/**
-	 * A reflection of the `$is_trash` property.
-	 *
-	 * @var ReflectionProperty
-	 */
-	protected static $is_trash;
-
-	/**
-	 * The original value of the `$is_trash` property.
-	 *
-	 * @var bool|null
-	 */
-	protected static $is_trash_original;
-
-	/**
-	 * A reflection of the `$detached` property.
-	 *
-	 * @var ReflectionProperty
-	 */
-	protected static $detached;
-
-	/**
-	 * The original value of the `$detached` property.
-	 *
-	 * @var bool|null
-	 */
-	protected static $detached_original;
-
-	/**
-	 * The ID of an 'administrator' user for testing.
-	 *
-	 * @var int
-	 */
-	protected static $admin;
-
-	/**
-	 * The ID of a 'subscriber' user for testing.
-	 *
-	 * @var int
-	 */
-	protected static $subscriber;
-
-	/**
-	 * A post for testing.
-	 *
-	 * @var WP_Post
-	 */
-	protected static $post;
-
-	/**
-	 * An attachment for testing.
-	 *
-	 * @var WP_Post
-	 */
-	protected static $attachment;
-
-	public static function set_up_before_class() {
-		parent::set_up_before_class();
-
-		require_once ABSPATH . 'wp-admin/includes/class-wp-media-list-table.php';
-
-		self::$list_table = new WP_Media_List_Table();
-		self::$is_trash   = new ReflectionProperty( self::$list_table, 'is_trash' );
-		self::$detached   = new ReflectionProperty( self::$list_table, 'detached' );
-
-		self::$is_trash->setAccessible( true );
-		self::$is_trash_original = self::$is_trash->getValue( self::$list_table );
-		self::$is_trash->setAccessible( false );
-
-		self::$detached->setAccessible( true );
-		self::$detached_original = self::$detached->getValue( self::$list_table );
-		self::$detached->setAccessible( false );
-
-		// Create users.
-		self::$admin      = self::factory()->user->create( array( 'role' => 'administrator' ) );
-		self::$subscriber = self::factory()->user->create( array( 'role' => 'subscriber' ) );
-
-		// Create posts.
-		self::$post       = self::factory()->post->create_and_get();
-		self::$attachment = self::factory()->attachment->create_and_get(
-			array(
-				'post_name'      => 'attachment-name',
-				'file'           => 'image.jpg',
-				'post_mime_type' => 'image/jpeg',
-			)
-		);
-	}
-
-	/**
-	 * Restores reflections to their original values.
-	 */
-	public function tear_down() {
-		self::set_is_trash( self::$is_trash_original );
-		self::set_detached( self::$detached_original );
-
-		parent::tear_down();
-	}
+class Tests_Admin_wpMediaListTable extends Admin_WpMediaListTable_TestCase {
 
 	/**
 	 * Tests that a call to WP_Media_List_Table::prepare_items() on a site without any scheduled events
@@ -441,31 +339,5 @@ class Tests_Admin_wpMediaListTable extends WP_UnitTestCase {
 
 		$this->assertIsArray( $actions, 'An array was not returned.' );
 		$this->assertArrayNotHasKey( 'download', $actions, '"download" was included in the actions.' );
-	}
-
-	/**
-	 * Sets the `$is_trash` property.
-	 *
-	 * Helper method.
-	 *
-	 * @param bool $is_trash Whether the attachment filter is currently 'trash'.
-	 */
-	private static function set_is_trash( $is_trash ) {
-		self::$is_trash->setAccessible( true );
-		self::$is_trash->setValue( self::$list_table, $is_trash );
-		self::$is_trash->setAccessible( false );
-	}
-
-	/**
-	 * Sets the `$detached` property.
-	 *
-	 * Helper method.
-	 *
-	 * @param bool $detached Whether the attachment filter is currently 'detached'.
-	 */
-	private static function set_detached( $detached ) {
-		self::$detached->setAccessible( true );
-		self::$detached->setValue( self::$list_table, $detached );
-		self::$detached->setAccessible( false );
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
Tests/admin/wpMediaListTable:

The tests for `WP_Media_List_Table` use the same set up, tear down and helper methods. By moving them to a new abstract TestCase class, `Admin_WpMediaListTable_TestCase`, they can be reused by multiple tests.

The test for `prepare_items` is moved to a new test class; `Admin_WpMediaListTable_PrepareItems_Test` and the `@covers` is moved to the class level.
This will allow the test class to be compatible with PHPUnit 11 using the new `Admin_WpListMediaTable_TestCase` class.

`Tests_Admin_wpMediaListTable` is renamed to `Admin_WpMediaListTable_GetRowActions_Test` to reflect that the remaining test is for `_get_row_actions`. The `@covers` is moved to the class level.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->
https://core.trac.wordpress.org/ticket/65208

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
