### PR TITLE
add support for __experimentalSkiSerialization to the shadow attribute

### DIFF
--- a/src/wp-includes/block-supports/shadow.php
+++ b/src/wp-includes/block-supports/shadow.php
@@ -52,7 +52,10 @@ function wp_register_shadow_support( $block_type ) {
 function wp_apply_shadow_support( $block_type, $block_attributes ) {
 	$has_shadow_support = block_has_support( $block_type, 'shadow', false );
 
-	if ( ! $has_shadow_support ) {
+	if (
+		! $has_shadow_support ||
+		wp_should_skip_block_supports_serialization( $block_type, 'shadow' )
+	) {
 		return array();
 	}
 

--- a/src/wp-includes/block-supports/shadow.php
+++ b/src/wp-includes/block-supports/shadow.php
@@ -43,6 +43,7 @@ function wp_register_shadow_support( $block_type ) {
  * This will be applied to the block markup in the front-end.
  *
  * @since 6.3.0
+ * @since 6.6.0 Return early if __experimentalSkipSerialization is true.
  * @access private
  *
  * @param  WP_Block_Type $block_type       Block type.

--- a/tests/phpunit/tests/block-supports/shadow.php
+++ b/tests/phpunit/tests/block-supports/shadow.php
@@ -22,10 +22,15 @@ class Test_Block_Supports_Shadow extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 58590
+	 * Registers a new block for testing shadow support.
+	 *
+	 * @param string $block_name Name for the test block.
+	 * @param array  $supports   Array defining block support configuration.
+	 *
+	 * @return WP_Block_Type The block type for the newly registered test block.
 	 */
-	public function test_shadow_style_is_applied() {
-		$this->test_block_name = 'test/shadow-style-is-applied';
+	private function register_shadow_block_with_support( $block_name, $supports = array() ) {
+		$this->test_block_name = $block_name;
 		register_block_type(
 			$this->test_block_name,
 			array(
@@ -35,55 +40,71 @@ class Test_Block_Supports_Shadow extends WP_UnitTestCase {
 						'type' => 'object',
 					),
 				),
-				'supports'    => array(
-					'shadow' => true,
-				),
+				'supports'    => $supports,
 			)
 		);
-		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $this->test_block_name );
-		$block_atts = array(
-			'style' => array(
-				'shadow' => '60px -16px teal',
-			),
-		);
+		$registry = WP_Block_Type_Registry::get_instance();
 
-		$actual   = wp_apply_shadow_support( $block_type, $block_atts );
-		$expected = array(
-			'style' => 'box-shadow:60px -16px teal;',
+		return $registry->get_registered( $this->test_block_name );
+	}
+
+	/**
+	 * Tests the generation of shadow block support styles.
+	 *
+	 * @dataProvider data_generate_shadow_fixtures
+	 *
+	 * @param boolean|array $support Shadow block support configuration.
+	 * @param string        $value   Shadow style value for style attribute object.
+	 * @param array         $expected       Expected shadow block support styles.
+	 */
+	public function test_gutenberg_apply_shadow_support( $support, $value, $expected ) {
+		$block_type  = self::register_shadow_block_with_support(
+			'test/shadow-block',
+			array( 'shadow' => $support )
 		);
+		$block_attrs = array( 'style' => array( 'shadow' => $value ) );
+		$actual      = gutenberg_apply_shadow_support( $block_type, $block_attrs );
 
 		$this->assertSame( $expected, $actual );
 	}
 
 	/**
-	 * @ticket 58590
+	 * Data provider.
+	 *
+	 * @return array
 	 */
-	public function test_shadow_without_block_supports() {
-		$this->test_block_name = 'test/shadow-with-skipped-serialization-block-supports';
-		register_block_type(
-			$this->test_block_name,
-			array(
-				'api_version' => 2,
-				'attributes'  => array(
-					'style' => array(
-						'type' => 'object',
-					),
-				),
-				'supports'    => array(),
-			)
-		);
-		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $this->test_block_name );
-		$block_atts = array(
-			'style' => array(
-				'shadow' => '60px -16px teal',
+	public function data_generate_shadow_fixtures() {
+		return array(
+			'with no styles'               => array(
+				'support'  => true,
+				'value'    => '',
+				'expected' => array(),
+			),
+			'without support'              => array(
+				'support'  => false,
+				'value'    => '1px 1px 1px #000',
+				'expected' => array(),
+			),
+			'with single shadow'           => array(
+				'support'  => true,
+				'value'    => '1px 1px 1px #000',
+				'expected' => array( 'style' => 'box-shadow:1px 1px 1px #000;' ),
+			),
+			'with comma separated shadows' => array(
+				'support'  => true,
+				'value'    => '1px 1px 1px #000, 2px 2px 2px #fff',
+				'expected' => array( 'style' => 'box-shadow:1px 1px 1px #000, 2px 2px 2px #fff;' ),
+			),
+			'with preset shadow'           => array(
+				'support'  => true,
+				'value'    => 'var:preset|shadow|natural',
+				'expected' => array( 'style' => 'box-shadow:var(--wp--preset--shadow--natural);' ),
+			),
+			'with serialization skipped'   => array(
+				'support'  => array( '__experimentalSkipSerialization' => true ),
+				'value'    => '1px 1px 1px #000',
+				'expected' => array(),
 			),
 		);
-
-		$actual   = wp_apply_spacing_support( $block_type, $block_atts );
-		$expected = array();
-
-		$this->assertSame( $expected, $actual );
 	}
 }

--- a/tests/phpunit/tests/block-supports/shadow.php
+++ b/tests/phpunit/tests/block-supports/shadow.php
@@ -57,13 +57,13 @@ class Test_Block_Supports_Shadow extends WP_UnitTestCase {
 	 * @param string        $value   Shadow style value for style attribute object.
 	 * @param array         $expected       Expected shadow block support styles.
 	 */
-	public function test_gutenberg_apply_shadow_support( $support, $value, $expected ) {
+	public function test_wp_apply_shadow_support( $support, $value, $expected ) {
 		$block_type  = self::register_shadow_block_with_support(
 			'test/shadow-block',
 			array( 'shadow' => $support )
 		);
 		$block_attrs = array( 'style' => array( 'shadow' => $value ) );
-		$actual      = gutenberg_apply_shadow_support( $block_type, $block_attrs );
+		$actual      = wp_apply_shadow_support( $block_type, $block_attrs );
 
 		$this->assertSame( $expected, $actual );
 	}


### PR DESCRIPTION
**What?**
This is a backport of the merged Gutenberg PR https://github.com/WordPress/gutenberg/pull/59887
When a dynamic block defines __experimentalSkipSerialization in its block.supports.shadow the styles continue to be printed to the block wrapper element. This PR corrects that behavior so that shadow behaves like border, color, and others.
**Why?**
This provides the expected behavior for dynamic blocks that need to opt out of having the shadow styles printed to the block wrapper.
**How?**
Added a check at the start of the render function to return an empty array if the block has set __experimentalSkipSerialization

(This is my first attempt at submitting a Gutenberg PR to be included back into WP Core so welcome any advice if I'm doing this wrong)

Trac ticket: https://core.trac.wordpress.org/ticket/60784#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
