### PR TITLE
[PHP 8.4] Fixes for implicit nullability deprecation

### DIFF
--- a/src/wp-admin/includes/export.php
+++ b/src/wp-admin/includes/export.php
@@ -401,7 +401,7 @@ function export_wp( $args = array() ) {
 	 *
 	 * @param int[] $post_ids Optional. Array of post IDs to filter the query by.
 	 */
-	function wxr_authors_list( array $post_ids = null ) {
+	function wxr_authors_list( ?array $post_ids = null ) {
 		global $wpdb;
 
 		if ( ! empty( $post_ids ) ) {

--- a/src/wp-includes/l10n/class-wp-translation-controller.php
+++ b/src/wp-includes/l10n/class-wp-translation-controller.php
@@ -98,7 +98,7 @@ final class WP_Translation_Controller {
 	 * @param string $locale           Optional. Locale. Default current locale.
 	 * @return bool True on success, false otherwise.
 	 */
-	public function load_file( string $translation_file, string $textdomain = 'default', string $locale = null ): bool {
+	public function load_file( string $translation_file, string $textdomain = 'default', ?string $locale = null ): bool {
 		if ( null === $locale ) {
 			$locale = $this->current_locale;
 		}
@@ -153,7 +153,7 @@ final class WP_Translation_Controller {
 	 * @param string                     $locale     Optional. Locale. Defaults to all locales.
 	 * @return bool True on success, false otherwise.
 	 */
-	public function unload_file( $file, string $textdomain = 'default', string $locale = null ): bool {
+	public function unload_file( $file, string $textdomain = 'default', ?string $locale = null ): bool {
 		if ( is_string( $file ) ) {
 			$file = realpath( $file );
 		}
@@ -198,7 +198,7 @@ final class WP_Translation_Controller {
 	 * @param string $locale     Optional. Locale. Defaults to all locales.
 	 * @return bool True on success, false otherwise.
 	 */
-	public function unload_textdomain( string $textdomain = 'default', string $locale = null ): bool {
+	public function unload_textdomain( string $textdomain = 'default', ?string $locale = null ): bool {
 		$unloaded = false;
 
 		if ( null !== $locale ) {
@@ -240,7 +240,7 @@ final class WP_Translation_Controller {
 	 * @param string $locale     Optional. Locale. Default current locale.
 	 * @return bool True if there are any loaded translations, false otherwise.
 	 */
-	public function is_textdomain_loaded( string $textdomain = 'default', string $locale = null ): bool {
+	public function is_textdomain_loaded( string $textdomain = 'default', ?string $locale = null ): bool {
 		if ( null === $locale ) {
 			$locale = $this->current_locale;
 		}
@@ -260,7 +260,7 @@ final class WP_Translation_Controller {
 	 * @param string $locale     Optional. Locale. Default current locale.
 	 * @return string|false Translation on success, false otherwise.
 	 */
-	public function translate( string $text, string $context = '', string $textdomain = 'default', string $locale = null ) {
+	public function translate( string $text, string $context = '', string $textdomain = 'default', ?string $locale = null ) {
 		if ( '' !== $context ) {
 			$context .= "\4";
 		}
@@ -294,7 +294,7 @@ final class WP_Translation_Controller {
 	 * @param string                      $locale     Optional. Locale. Default current locale.
 	 * @return string|false Translation on success, false otherwise.
 	 */
-	public function translate_plural( array $plurals, int $number, string $context = '', string $textdomain = 'default', string $locale = null ) {
+	public function translate_plural( array $plurals, int $number, string $context = '', string $textdomain = 'default', ?string $locale = null ) {
 		if ( '' !== $context ) {
 			$context .= "\4";
 		}
@@ -394,7 +394,7 @@ final class WP_Translation_Controller {
 	 *     @type string[]            $entries Array of translation entries.
 	 * }
 	 */
-	protected function locate_translation( string $singular, string $textdomain = 'default', string $locale = null ) {
+	protected function locate_translation( string $singular, string $textdomain = 'default', ?string $locale = null ) {
 		if ( array() === $this->loaded_translations ) {
 			return false;
 		}
@@ -427,7 +427,7 @@ final class WP_Translation_Controller {
 	 * @param string $locale     Optional. Locale. Default current locale.
 	 * @return WP_Translation_File[] List of translation files.
 	 */
-	protected function get_files( string $textdomain = 'default', string $locale = null ): array {
+	protected function get_files( string $textdomain = 'default', ?string $locale = null ): array {
 		if ( null === $locale ) {
 			$locale = $this->current_locale;
 		}

--- a/src/wp-includes/l10n/class-wp-translation-file.php
+++ b/src/wp-includes/l10n/class-wp-translation-file.php
@@ -81,7 +81,7 @@ abstract class WP_Translation_File {
 	 * @param string|null $filetype Optional. File type. Default inferred from file name.
 	 * @return false|WP_Translation_File
 	 */
-	public static function create( string $file, string $filetype = null ) {
+	public static function create( string $file, ?string $filetype = null ) {
 		if ( ! is_readable( $file ) ) {
 			return false;
 		}

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5499,7 +5499,7 @@ function wp_show_heic_upload_error( $plupload_settings ) {
  * @param array  $image_info Optional. Extended image information (passed by reference).
  * @return array|false Array of image information or false on failure.
  */
-function wp_getimagesize( $filename, array &$image_info = null ) {
+function wp_getimagesize( $filename, ?array &$image_info = null ) {
 	// Don't silence errors when in debug mode, unless running unit tests.
 	if ( defined( 'WP_DEBUG' ) && WP_DEBUG
 		&& ! defined( 'WP_RUN_CORE_TESTS' )


### PR DESCRIPTION
Fixes all issues that emit deprecation notices on PHP 8.4 for implicit nullable parameter type declarations.

See:
 - [RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)
 - [PHP 8.4: Implicitly nullable parameter declarations deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)

Exclude potential changes in the Requests library and `sodium_compat`.

Trac ticket: https://core.trac.wordpress.org/ticket/60786

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
