### PR TITLE
Update post.php to allow post_name pre-populating on new post page.

### DIFF
--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -835,8 +835,8 @@ function get_default_post_to_edit( $post_type = 'post', $create_in_db = false ) 
 	/**
 	 * Filters the default post name initially used in the "Write Post" form.
 	 *
-  	 * @since 6.5.0
-    	 *
+	 * @since 6.5.0
+	 *
 	 * @param string  $post_name Default post name.
 	 * @param WP_Post $post      Post object.
 	 */

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -755,6 +755,11 @@ function get_default_post_to_edit( $post_type = 'post', $create_in_db = false ) 
 		$post_excerpt = esc_html( wp_unslash( $_REQUEST['excerpt'] ) );
 	}
 
+	$post_name = '';
+	if ( ! empty( $_REQUEST['post_name'] ) ) {
+		$post_name = esc_html( wp_unslash( $_REQUEST['post_name'] ) );
+	}
+
 	if ( $create_in_db ) {
 		$post_id = wp_insert_post(
 			array(
@@ -826,6 +831,14 @@ function get_default_post_to_edit( $post_type = 'post', $create_in_db = false ) 
 	 * @param WP_Post $post         Post object.
 	 */
 	$post->post_excerpt = (string) apply_filters( 'default_excerpt', $post_excerpt, $post );
+
+	/**
+	 * Filters the default post name initially used in the "Write Post" form.
+	 *
+	 * @param string  $post_name Default post name.
+	 * @param WP_Post $post      Post object.
+	 */
+	$post->post_name = (string) apply_filters( 'default_name', $post_name, $post );
 
 	return $post;
 }

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -835,6 +835,8 @@ function get_default_post_to_edit( $post_type = 'post', $create_in_db = false ) 
 	/**
 	 * Filters the default post name initially used in the "Write Post" form.
 	 *
+  	 * @since 6.5.0
+    	 *
 	 * @param string  $post_name Default post name.
 	 * @param WP_Post $post      Post object.
 	 */


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Add `post_name` to the fields that can be pre-populated through URL parameters in `get_default_post_to_edit()`.

Trac ticket: https://core.trac.wordpress.org/ticket/60791#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
