### PR TITLE
Make `WP_Filesystem_Direct` tests more robust

### DIFF
--- a/tests/phpunit/tests/filesystem/wpFilesystemDirect/mkdir.php
+++ b/tests/phpunit/tests/filesystem/wpFilesystemDirect/mkdir.php
@@ -159,16 +159,15 @@ class Tests_Filesystem_WpFilesystemDirect_Mkdir extends WP_Filesystem_Direct_Uni
 
 		rmdir( $path );
 
-		$expected_group = $this->is_windows() ? $original_owner : $original_owner + 1;
-		$created        = self::$filesystem->mkdir( $path, 0755, $expected_group );
-		$owner          = fileowner( $path );
+		$created = self::$filesystem->mkdir( $path, 0755, $original_owner );
+		$owner   = fileowner( $path );
 
 		if ( $path !== self::$file_structure['test_dir']['path'] && is_dir( $path ) ) {
 			rmdir( $path );
 		}
 
 		$this->assertTrue( $created, 'The directory was not created.' );
-		$this->assertSame( $expected_group, $owner, 'The owner is incorrect.' );
+		$this->assertSame( $original_owner, $owner, 'The owner is incorrect.' );
 	}
 
 	/**
@@ -197,15 +196,14 @@ class Tests_Filesystem_WpFilesystemDirect_Mkdir extends WP_Filesystem_Direct_Uni
 
 		rmdir( $path );
 
-		$expected_group = $this->is_windows() ? $original_group : $original_group + 1;
-		$created        = self::$filesystem->mkdir( $path, 0755, false, $expected_group );
-		$group          = filegroup( $path );
+		$created = self::$filesystem->mkdir( $path, 0755, false, $original_group );
+		$group   = filegroup( $path );
 
 		if ( $path !== self::$file_structure['test_dir']['path'] && is_dir( $path ) ) {
 			rmdir( $path );
 		}
 
 		$this->assertTrue( $created, 'The directory was not created.' );
-		$this->assertSame( $expected_group, $group, 'The group is incorrect.' );
+		$this->assertSame( $original_group, $group, 'The group is incorrect.' );
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/57774

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
