### PR TITLE
Make theme.json related caches persistent

### DIFF
--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -808,8 +808,8 @@ final class WP_Theme implements ArrayAccess {
 	 * @param array|string $data Data to store
 	 * @return bool Return value from wp_cache_add()
 	 */
-	private function cache_add( $key, $data ) {
-		return wp_cache_add( $key . '-' . $this->cache_hash, $data, 'themes', self::$cache_expiration );
+	public function cache_add( $key, $data, $group = 'themes' ) {
+		return wp_cache_add( $key . '-' . $this->cache_hash, $data, $group, self::$cache_expiration );
 	}
 
 	/**
@@ -822,8 +822,8 @@ final class WP_Theme implements ArrayAccess {
 	 * @param string $key Type of data to retrieve (theme, screenshot, headers, post_templates)
 	 * @return mixed Retrieved data
 	 */
-	private function cache_get( $key ) {
-		return wp_cache_get( $key . '-' . $this->cache_hash, 'themes' );
+	public function cache_get( $key, $group = 'themes' ) {
+		return wp_cache_get( $key . '-' . $this->cache_hash, $group );
 	}
 
 	/**
@@ -835,6 +835,8 @@ final class WP_Theme implements ArrayAccess {
 		foreach ( array( 'theme', 'screenshot', 'headers', 'post_templates' ) as $key ) {
 			wp_cache_delete( $key . '-' . $this->cache_hash, 'themes' );
 		}
+		$this->delete_theme_json_cache();
+
 		$this->template               = null;
 		$this->textdomain_loaded      = null;
 		$this->theme_root_uri         = null;
@@ -847,6 +849,27 @@ final class WP_Theme implements ArrayAccess {
 		$this->headers                = array();
 		$this->__construct( $this->stylesheet, $this->theme_root );
 		$this->delete_pattern_cache();
+	}
+
+	/**
+	 * This method is used to delete the cached theme JSON data for certain keys
+	 * that are stored in the 'theme_json' cache group.
+	 *
+	 * @since x.x.x
+	 */
+	public function delete_theme_json_cache() {
+		$keys = array(
+			'wp_get_global_stylesheet',
+			'wp_get_global_styles_svg_filters',
+			'wp_get_global_settings_custom',
+			'wp_get_global_settings_theme',
+			'wp_get_global_styles_custom_css',
+			'wp_get_theme_data_template_parts',
+		);
+
+		foreach ( $keys as $key ) {
+			wp_cache_delete( $key . '-' . $this->cache_hash, 'theme_json' );
+		}
 	}
 
 	/**

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -356,6 +356,7 @@ add_action( 'init', 'check_theme_switched', 99 );
 add_action( 'init', array( 'WP_Block_Supports', 'init' ), 22 );
 add_action( 'switch_theme', 'wp_clean_theme_json_cache' );
 add_action( 'start_previewing_theme', 'wp_clean_theme_json_cache' );
+add_action( 'save_post_wp_global_styles', 'wp_clean_theme_json_cache' );
 add_action( 'after_switch_theme', '_wp_menus_changed' );
 add_action( 'after_switch_theme', '_wp_sidebars_changed' );
 add_action( 'wp_enqueue_scripts', 'wp_enqueue_emoji_styles' );

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -5252,9 +5252,10 @@ function wp_get_global_styles_svg_filters() {
 	 */
 	$can_use_cached = ! wp_is_development_mode( 'theme' );
 	$cache_group    = 'theme_json';
+	$theme          = wp_get_theme();
 	$cache_key      = 'wp_get_global_styles_svg_filters';
 	if ( $can_use_cached ) {
-		$cached = wp_cache_get( $cache_key, $cache_group );
+		$cached = $theme->cache_get( $cache_key, $cache_group );
 		if ( $cached ) {
 			return $cached;
 		}
@@ -5271,7 +5272,7 @@ function wp_get_global_styles_svg_filters() {
 	$svgs = $tree->get_svg_filters( $origins );
 
 	if ( $can_use_cached ) {
-		wp_cache_set( $cache_key, $svgs, $cache_group );
+		$theme->cache_add( $cache_key, $svgs, $cache_group );
 	}
 
 	return $svgs;

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -46,6 +46,7 @@ function wp_get_global_settings( $path = array(), $context = array() ) {
 		$origin = 'theme';
 	}
 
+	$theme = wp_get_theme();
 	/*
 	 * By using the 'theme_json' group, this data is marked to be non-persistent across requests.
 	 * See `wp_cache_add_non_persistent_groups` in src/wp-includes/load.php and other places.
@@ -73,13 +74,13 @@ function wp_get_global_settings( $path = array(), $context = array() ) {
 
 	$settings = false;
 	if ( $can_use_cached ) {
-		$settings = wp_cache_get( $cache_key, $cache_group );
+		$settings = $theme->cache_get( $cache_key, $cache_group );
 	}
 
 	if ( false === $settings ) {
 		$settings = WP_Theme_JSON_Resolver::get_merged_data( $origin )->get_settings();
 		if ( $can_use_cached ) {
-			wp_cache_set( $cache_key, $settings, $cache_group );
+			$theme->cache_add( $cache_key, $settings, $cache_group );
 		}
 	}
 
@@ -153,6 +154,7 @@ function wp_get_global_stylesheet( $types = array() ) {
 	 * developer's workflow.
 	 */
 	$can_use_cached = empty( $types ) && ! wp_is_development_mode( 'theme' );
+	$theme = wp_get_theme();
 
 	/*
 	 * By using the 'theme_json' group, this data is marked to be non-persistent across requests.
@@ -173,7 +175,7 @@ function wp_get_global_stylesheet( $types = array() ) {
 	$cache_group = 'theme_json';
 	$cache_key   = 'wp_get_global_stylesheet';
 	if ( $can_use_cached ) {
-		$cached = wp_cache_get( $cache_key, $cache_group );
+		$cached = $theme->cache_get( $cache_key, $cache_group );
 		if ( $cached ) {
 			return $cached;
 		}
@@ -236,7 +238,7 @@ function wp_get_global_stylesheet( $types = array() ) {
 
 	$stylesheet = $styles_variables . $styles_rest;
 	if ( $can_use_cached ) {
-		wp_cache_set( $cache_key, $stylesheet, $cache_group );
+		$theme->cache_add( $cache_key, $stylesheet, $cache_group );
 	}
 
 	return $stylesheet;
@@ -258,7 +260,7 @@ function wp_get_global_styles_custom_css() {
 	 * developer's workflow.
 	 */
 	$can_use_cached = ! wp_is_development_mode( 'theme' );
-
+	$theme = wp_get_theme();
 	/*
 	 * By using the 'theme_json' group, this data is marked to be non-persistent across requests.
 	 * @see `wp_cache_add_non_persistent_groups()`.
@@ -278,7 +280,7 @@ function wp_get_global_styles_custom_css() {
 	$cache_key   = 'wp_get_global_styles_custom_css';
 	$cache_group = 'theme_json';
 	if ( $can_use_cached ) {
-		$cached = wp_cache_get( $cache_key, $cache_group );
+		$cached = $theme->cache_get( $cache_key, $cache_group );
 		if ( $cached ) {
 			return $cached;
 		}
@@ -288,7 +290,7 @@ function wp_get_global_styles_custom_css() {
 	$stylesheet = $tree->get_custom_css();
 
 	if ( $can_use_cached ) {
-		wp_cache_set( $cache_key, $stylesheet, $cache_group );
+		$theme->cache_add( $cache_key, $stylesheet, $cache_group );
 	}
 
 	return $stylesheet;
@@ -442,13 +444,9 @@ function wp_theme_has_theme_json() {
  *
  * @since 6.2.0
  */
-function wp_clean_theme_json_cache() {
-	wp_cache_delete( 'wp_get_global_stylesheet', 'theme_json' );
-	wp_cache_delete( 'wp_get_global_styles_svg_filters', 'theme_json' );
-	wp_cache_delete( 'wp_get_global_settings_custom', 'theme_json' );
-	wp_cache_delete( 'wp_get_global_settings_theme', 'theme_json' );
-	wp_cache_delete( 'wp_get_global_styles_custom_css', 'theme_json' );
-	wp_cache_delete( 'wp_get_theme_data_template_parts', 'theme_json' );
+function wp_clean_theme_json_cache( $stylesheet = '' ) {
+	$theme = wp_get_theme( $stylesheet );
+	$theme->delete_theme_json_cache();
 	WP_Theme_JSON_Resolver::clean_cached_data();
 }
 
@@ -489,9 +487,10 @@ function wp_get_theme_data_template_parts() {
 	$cache_key      = 'wp_get_theme_data_template_parts';
 	$can_use_cached = ! wp_is_development_mode( 'theme' );
 
+	$theme    = wp_get_theme();
 	$metadata = false;
 	if ( $can_use_cached ) {
-		$metadata = wp_cache_get( $cache_key, $cache_group );
+		$metadata = $theme->cache_get( $cache_key, $cache_group );
 		if ( false !== $metadata ) {
 			return $metadata;
 		}
@@ -500,7 +499,7 @@ function wp_get_theme_data_template_parts() {
 	if ( false === $metadata ) {
 		$metadata = WP_Theme_JSON_Resolver::get_theme_data( array(), array( 'with_supports' => false ) )->get_template_parts();
 		if ( $can_use_cached ) {
-			wp_cache_set( $cache_key, $metadata, $cache_group );
+			$theme->cache_add( $cache_key, $metadata, $cache_group );
 		}
 	}
 

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -887,7 +887,7 @@ function wp_start_object_cache() {
 			)
 		);
 
-		wp_cache_add_non_persistent_groups( array( 'counts', 'plugins', 'theme_json' ) );
+		wp_cache_add_non_persistent_groups( array( 'counts', 'plugins' ) );
 	}
 
 	$first_init = false;

--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -577,7 +577,7 @@ function switch_to_blog( $new_blog_id, $deprecated = null ) {
 				);
 			}
 
-			wp_cache_add_non_persistent_groups( array( 'counts', 'plugins', 'theme_json' ) );
+			wp_cache_add_non_persistent_groups( array( 'counts', 'plugins' ) );
 		}
 	}
 
@@ -671,7 +671,7 @@ function restore_current_blog() {
 				);
 			}
 
-			wp_cache_add_non_persistent_groups( array( 'counts', 'plugins', 'theme_json' ) );
+			wp_cache_add_non_persistent_groups( array( 'counts', 'plugins' ) );
 		}
 	}
 


### PR DESCRIPTION
Make theme.json related caches persistent by reusing `cache_get` and `cache_add` methods in WP_Theme. This means that caches are only saved for 1800 seconds. Caches for theme json are invalidated for the following reason. 

- WP_Theme::cache_delete is called. Which is called when themes are updated, files edited or theme is deleted. 
- Global style post is updated. 
- Theme is switched or previewed. 
- Invalidated after 1800 seconds like other theme caches. 

Trac ticket: https://core.trac.wordpress.org/ticket/57789

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
