### PR TITLE
Fix regression with theme.json `settings.shadow.defaultPresets`

### DIFF
--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -846,7 +846,7 @@ function get_classic_theme_supports_block_editor_settings() {
 
 	$shadow_presets = current( (array) get_theme_support( 'editor-shadow-presets' ) );
 	if ( false !== $shadow_presets ) {
-		$theme_settings['shadow'] = $shadow_presets;
+		$theme_settings['shadow_presets'] = $shadow_presets;
 	}
 
 	return $theme_settings;

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -844,5 +844,10 @@ function get_classic_theme_supports_block_editor_settings() {
 		$theme_settings['gradients'] = $gradient_presets;
 	}
 
+	$shadow_presets = current( (array) get_theme_support( 'editor-shadow-presets' ) );
+	if ( false !== $shadow_presets ) {
+		$theme_settings['shadow'] = $shadow_presets;
+	}
+
 	return $theme_settings;
 }

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -312,6 +312,19 @@ class WP_Theme_JSON_Resolver {
 			}
 			$theme_support_data['settings']['color']['defaultGradients'] = $default_gradients;
 
+			if ( ! isset( $theme_support_data['settings']['shadow'] ) ) {
+				$theme_support_data['settings']['shadow'] = array();
+			}
+			$default_shadows = false;
+			if ( current_theme_supports( 'default-shadow-presets' ) ) {
+				$default_shadows = true;
+			}
+			if ( ! isset( $theme_support_data['settings']['shadow']['presets'] ) ) {
+				// If the theme does not have any shadows, we still want to show the core ones.
+				$default_shadows = true;
+			}
+			$theme_support_data['settings']['shadow']['defaultPresets'] = $default_shadows;
+
 			// Allow themes to enable link color setting via theme_support.
 			if ( current_theme_supports( 'link-color' ) ) {
 				$theme_support_data['settings']['color']['link'] = true;

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -679,7 +679,6 @@ class WP_Theme_JSON {
 		array( 'spacing', 'margin' ),
 		array( 'spacing', 'padding' ),
 		array( 'typography', 'lineHeight' ),
-		array( 'shadow', 'defaultPresets' ),
 	);
 
 	/**

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -3294,6 +3294,13 @@ class WP_Theme_JSON {
 			$theme_settings['settings']['color']['gradients'] = $settings['gradients'];
 		}
 
+		if ( isset( $settings['shadow'] ) ) {
+			if ( ! isset( $theme_settings['settings']['shadow'] ) ) {
+				$theme_settings['settings']['shadow'] = array();
+			}
+			$theme_settings['settings']['shadow']['presets'] = $settings['shadow'];
+		}
+
 		if ( isset( $settings['fontSizes'] ) ) {
 			$font_sizes = $settings['fontSizes'];
 			// Back-compatibility for presets without units.

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -3294,11 +3294,11 @@ class WP_Theme_JSON {
 			$theme_settings['settings']['color']['gradients'] = $settings['gradients'];
 		}
 
-		if ( isset( $settings['shadow'] ) ) {
+		if ( isset( $settings['shadow_presets'] ) ) {
 			if ( ! isset( $theme_settings['settings']['shadow'] ) ) {
 				$theme_settings['settings']['shadow'] = array();
 			}
-			$theme_settings['settings']['shadow']['presets'] = $settings['shadow'];
+			$theme_settings['settings']['shadow']['presets'] = $settings['shadow_presets'];
 		}
 
 		if ( isset( $settings['fontSizes'] ) ) {

--- a/src/wp-includes/theme.json
+++ b/src/wp-includes/theme.json
@@ -191,7 +191,7 @@
 			"text": true
 		},
 		"shadow": {
-			"defaultPresets": false,
+			"defaultPresets": true,
 			"presets": [
 				{
 					"name": "Natural",

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -4233,7 +4233,7 @@ function create_initial_theme_features() {
 							'name'     => array(
 								'type' => 'string',
 							),
-							'shadow' => array(
+							'shadow'   => array(
 								'type' => 'string',
 							),
 							'slug'     => array(

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -2642,6 +2642,7 @@ function get_theme_starter_content() {
  * @since 6.3.0 The `border` feature allows themes without theme.json to add border styles to blocks.
  * @since 6.5.0 The `appearance-tools` feature enables a few design tools for blocks,
  *              see `WP_Theme_JSON::APPEARANCE_TOOLS_OPT_INS` for a complete list.
+ * @since 6.5.0 The `editor-shadow-presets` feature is added for adding custom shadow presets to the editor.
  *
  * @global array $_wp_theme_features
  *
@@ -2668,6 +2669,7 @@ function get_theme_starter_content() {
  *                          - 'disable-layout-styles'
  *                          - 'editor-color-palette'
  *                          - 'editor-gradient-presets'
+ *                          - 'editor-shadow-presets'
  *                          - 'editor-font-sizes'
  *                          - 'editor-styles'
  *                          - 'featured-content'

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -4221,6 +4221,31 @@ function create_initial_theme_features() {
 		)
 	);
 	register_theme_feature(
+		'editor-shadow-presets',
+		array(
+			'type'         => 'array',
+			'description'  => __( 'Custom shadow presets if defined by the theme.' ),
+			'show_in_rest' => array(
+				'schema' => array(
+					'items' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'name'     => array(
+								'type' => 'string',
+							),
+							'shadow' => array(
+								'type' => 'string',
+							),
+							'slug'     => array(
+								'type' => 'string',
+							),
+						),
+					),
+				),
+			),
+		)
+	);
+	register_theme_feature(
 		'editor-styles',
 		array(
 			'description'  => __( 'Whether theme opts in to the editor styles CSS wrapper.' ),

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -4230,13 +4230,13 @@ function create_initial_theme_features() {
 					'items' => array(
 						'type'       => 'object',
 						'properties' => array(
-							'name'     => array(
+							'name'   => array(
 								'type' => 'string',
 							),
-							'shadow'   => array(
+							'shadow' => array(
 								'type' => 'string',
 							),
-							'slug'     => array(
+							'slug'   => array(
 								'type' => 'string',
 							),
 						),

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -410,6 +410,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'editor-color-palette', $theme_supports );
 		$this->assertArrayHasKey( 'editor-font-sizes', $theme_supports );
 		$this->assertArrayHasKey( 'editor-gradient-presets', $theme_supports );
+		$this->assertArrayHasKey( 'editor-shadow-presets', $theme_supports );
 		$this->assertArrayHasKey( 'editor-styles', $theme_supports );
 		$this->assertArrayHasKey( 'formats', $theme_supports );
 		$this->assertArrayHasKey( 'html5', $theme_supports );
@@ -417,7 +418,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'responsive-embeds', $theme_supports );
 		$this->assertArrayHasKey( 'title-tag', $theme_supports );
 		$this->assertArrayHasKey( 'wp-block-styles', $theme_supports );
-		$this->assertCount( 23, $theme_supports, 'There should be 23 theme supports' );
+		$this->assertCount( 24, $theme_supports, 'There should be 24 theme supports' );
 	}
 
 	/**

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -293,9 +293,6 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			'typography' => array(
 				'lineHeight' => true,
 			),
-			'shadow'     => array(
-				'defaultPresets' => true,
-			),
 			'blocks'     => array(
 				'core/paragraph' => array(
 					'typography' => array(
@@ -333,9 +330,6 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 					),
 					'typography' => array(
 						'lineHeight' => false,
-					),
-					'shadow'     => array(
-						'defaultPresets' => true,
 					),
 				),
 			),


### PR DESCRIPTION
All discussion for this issue should be done in https://github.com/WordPress/gutenberg/issues/59989

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

## Description

- Reverts core theme.json `settings.shadow.defaultPresets` to `true` to fix the regression. (Back to working the same as color/gradient preset configuration for block themes.)
- Adds `editor-shadow-presets` and `default-shadow-presets` for classic themes to configure shadows. (Works the same way as color/gradient preset configuration in classic themes.)

Backport to Gutenberg: https://github.com/WordPress/gutenberg/pull/60000
Gutenberg issue: https://github.com/WordPress/gutenberg/issues/59989
Trac ticket: https://core.trac.wordpress.org/ticket/60815

## Testing

Here is an example theme.json for testing that would override the default `natural` shadow with a red shadow to make the difference obvious.

```jsonc
// theme.json
{
	"$schema": "https://schemas.wp.org/wp/6.4/theme.json",
	"version": 2,
	"settings": {
		"shadow": {
			"presets": [
				{
					"name": "Natural",
					"slug": "natural",
					"shadow": "6px 6px 9px #F00"
				}
			]
		},
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		}
	},
	"styles": {
		"blocks": {
			"core/button": {
				"shadow": "var(--wp--preset--shadow--natural)"
			}
		}
	}
}
```

1. Use the above theme.json as an example theme.
2. Insert a button in a post.
3. Preview the post in `wp/6.4`
4. Preview the post in `trunk`
5. Preview the post in this PR
6. See that `wp/6.4` and this PR match.

### Regression screenshots

| WP 6.4 | Current 6.5 | This PR |
| --- | --- | --- |
| ![Screen Shot 2024-03-19 at 12 56 11](https://github.com/WordPress/gutenberg/assets/5129775/7c4250f0-65e5-40b9-a064-3be87e2fea81) | ![Screen Shot 2024-03-19 at 12 55 36](https://github.com/WordPress/gutenberg/assets/5129775/061263ba-53aa-4812-85ab-0e48ebde35fd) | ![Screen Shot 2024-03-19 at 12 55 24](https://github.com/WordPress/gutenberg/assets/5129775/a85552b2-5b65-401b-8284-7e4f9bb06a4c) |

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
