### PR TITLE
Test/Admin/IncludesFile: Split the test class

### DIFF
--- a/tests/phpunit/tests/admin/Admin_Includes_File_DownloadUrl_Test.php
+++ b/tests/phpunit/tests/admin/Admin_Includes_File_DownloadUrl_Test.php
@@ -3,13 +3,13 @@
 /**
  * @group file
  * @group admin
+ *
+ * @covers ::download_url
  */
-class Tests_Admin_IncludesFile extends WP_UnitTestCase {
+class Admin_Includes_File_DownloadUrl_Test extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 43329
-	 *
-	 * @covers ::download_url
 	 */
 	public function test_download_url_non_200_response_code() {
 		add_filter( 'pre_http_request', array( $this, '_fake_download_url_non_200_response_code' ), 10, 3 );
@@ -58,8 +58,6 @@ class Tests_Admin_IncludesFile extends WP_UnitTestCase {
 	 * @ticket 38231
 	 * @dataProvider data_download_url_should_respect_filename_from_content_disposition_header
 	 *
-	 * @covers ::download_url
-	 *
 	 * @param $filter A callback containing a fake Content-Disposition header.
 	 */
 	public function test_download_url_should_respect_filename_from_content_disposition_header( $filter ) {
@@ -89,8 +87,6 @@ class Tests_Admin_IncludesFile extends WP_UnitTestCase {
 	/**
 	 * @ticket 55109
 	 * @dataProvider data_save_to_temp_directory_when_getting_filename_from_content_disposition_header
-	 *
-	 * @covers ::download_url
 	 *
 	 * @param $filter A callback containing a fake Content-Disposition header.
 	 */
@@ -172,8 +168,6 @@ class Tests_Admin_IncludesFile extends WP_UnitTestCase {
 	/**
 	 * @ticket 38231
 	 * @dataProvider data_download_url_should_reject_filename_from_invalid_content_disposition_header
-	 *
-	 * @covers ::download_url
 	 *
 	 * @param $filter A callback containing a fake Content-Disposition header.
 	 */
@@ -257,7 +251,6 @@ class Tests_Admin_IncludesFile extends WP_UnitTestCase {
 	/**
 	 * Verify that a WP_Error object is returned when invalid input is passed as the `$url` parameter.
 	 *
-	 * @covers ::download_url
 	 * @dataProvider data_download_url_empty_url
 	 *
 	 * @param mixed $url Input URL.
@@ -289,7 +282,6 @@ class Tests_Admin_IncludesFile extends WP_UnitTestCase {
 	 * is not thrown when the `$url` does not have a path component.
 	 *
 	 * @ticket 53635
-	 * @covers ::download_url
 	 */
 	public function test_download_url_no_warning_for_url_without_path() {
 		// Hook a mocked HTTP request response.
@@ -307,7 +299,6 @@ class Tests_Admin_IncludesFile extends WP_UnitTestCase {
 	 * and signature verification via a local file is requested.
 	 *
 	 * @ticket 53635
-	 * @covers ::download_url
 	 */
 	public function test_download_url_no_warning_for_url_without_path_with_signature_verification() {
 		// Hook a mocked HTTP request response.

--- a/tests/phpunit/tests/admin/Admin_Includes_File_GetHomePath_Test.php
+++ b/tests/phpunit/tests/admin/Admin_Includes_File_GetHomePath_Test.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @group file
+ * @group admin
+ *
+ * @covers ::get_home_path
+ */
+class Admin_Includes_File_GetHomePath_Test extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 20449
+	 */
+	public function test_get_home_path() {
+		$home    = get_option( 'home' );
+		$siteurl = get_option( 'siteurl' );
+		$sfn     = $_SERVER['SCRIPT_FILENAME'];
+		$this->assertSame( str_replace( '\\', '/', ABSPATH ), get_home_path() );
+
+		update_option( 'home', 'http://localhost' );
+		update_option( 'siteurl', 'http://localhost/wp' );
+
+		$_SERVER['SCRIPT_FILENAME'] = 'D:\root\vhosts\site\httpdocs\wp\wp-admin\options-permalink.php';
+		$this->assertSame( 'D:/root/vhosts/site/httpdocs/', get_home_path() );
+
+		$_SERVER['SCRIPT_FILENAME'] = '/Users/foo/public_html/trunk/wp/wp-admin/options-permalink.php';
+		$this->assertSame( '/Users/foo/public_html/trunk/', get_home_path() );
+
+		$_SERVER['SCRIPT_FILENAME'] = 'S:/home/wordpress/trunk/wp/wp-admin/options-permalink.php';
+		$this->assertSame( 'S:/home/wordpress/trunk/', get_home_path() );
+
+		update_option( 'home', $home );
+		update_option( 'siteurl', $siteurl );
+		$_SERVER['SCRIPT_FILENAME'] = $sfn;
+	}
+}

--- a/tests/phpunit/tests/admin/includesFile.php
+++ b/tests/phpunit/tests/admin/includesFile.php
@@ -7,34 +7,6 @@
 class Tests_Admin_IncludesFile extends WP_UnitTestCase {
 
 	/**
-	 * @ticket 20449
-	 *
-	 * @covers ::get_home_path
-	 */
-	public function test_get_home_path() {
-		$home    = get_option( 'home' );
-		$siteurl = get_option( 'siteurl' );
-		$sfn     = $_SERVER['SCRIPT_FILENAME'];
-		$this->assertSame( str_replace( '\\', '/', ABSPATH ), get_home_path() );
-
-		update_option( 'home', 'http://localhost' );
-		update_option( 'siteurl', 'http://localhost/wp' );
-
-		$_SERVER['SCRIPT_FILENAME'] = 'D:\root\vhosts\site\httpdocs\wp\wp-admin\options-permalink.php';
-		$this->assertSame( 'D:/root/vhosts/site/httpdocs/', get_home_path() );
-
-		$_SERVER['SCRIPT_FILENAME'] = '/Users/foo/public_html/trunk/wp/wp-admin/options-permalink.php';
-		$this->assertSame( '/Users/foo/public_html/trunk/', get_home_path() );
-
-		$_SERVER['SCRIPT_FILENAME'] = 'S:/home/wordpress/trunk/wp/wp-admin/options-permalink.php';
-		$this->assertSame( 'S:/home/wordpress/trunk/', get_home_path() );
-
-		update_option( 'home', $home );
-		update_option( 'siteurl', $siteurl );
-		$_SERVER['SCRIPT_FILENAME'] = $sfn;
-	}
-
-	/**
 	 * @ticket 43329
 	 *
 	 * @covers ::download_url


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Test/Admin/IncludesFile: Split the test class into one file and test class for `get_home_path` and one for `download_url`.
The test for `get_home_path` is moved to `Admin_Includes_File_GetHomePath_Test`.
The file- and class name for the tests for `download_url` is renamed from `IncludesFile` to `Admin_Includes_File_DownloadUrl_Test`.

Duplicate the `@covers` tags are removed.

Trac ticket: https://core.trac.wordpress.org/ticket/65208


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
