### PR TITLE
Tests/kses: remove unnecessary use of utf8_encode()

### DIFF
--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -2140,7 +2140,7 @@ HTML;
 			// $allowedentitynames values testing.
 			'nbsp'               => array(
 				'input'    => array( '', 'nbsp' ),
-				'expected' => utf8_encode( chr( 160 ) ),
+				'expected' => "\u{00A0}",
 			),
 			'iexcl'              => array(
 				'input'    => array( '', 'iexcl' ),


### PR DESCRIPTION
One of the tests for the `wp_kses_xml_named_entities()` function used `utf8_encode( chr( 160 ) )` to set an expectation of a Unicode character for a non breaking space.

It is understandable that this expectation was previously set this way, as it is not possible for a developer to distinguish between a _breaking_ space and a _non-breaking_ space visually, so the chances of the test accidentally breaking on an incorrect safe when the plain Unicode character would be used, was high.

However, the `utf8_encode()` function is deprecated as of PHP 8.2 and we need to remove its use from the WP codebase.

Now, PHP 7.0 happens to have introduced [Unicode escape sequences](https://wiki.php.net/rfc/unicode_escape), which allows to create a text string using unicode characters referenced by their codepoint and luckily WP has a minimum supported PHP version of PHP 7.0 nowadays.

By switching the test case to provide the test expectation using a Unicode escape sequence, we remove the use of the deprecated PHP function and still preserve the safeguard against the test accidentally breaking.

Trac ticket: https://core.trac.wordpress.org/ticket/55603
Trac ticket: https://core.trac.wordpress.org/ticket/60705

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
