### PR TITLE
Font Library: update the google fonts JSON data url to the latest version of the file

### DIFF
--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -194,7 +194,7 @@ function _wp_register_default_font_collections() {
 		array(
 			'name'          => _x( 'Google Fonts', 'font collection name' ),
 			'description'   => __( 'Install from Google Fonts. Fonts are copied to and served from your site.' ),
-			'font_families' => 'https://s.w.org/images/fonts/17.7/collections/google-fonts-with-preview.json',
+			'font_families' => 'https://s.w.org/images/fonts/wp-6.5/collections/google-fonts-with-preview.json',
 			'categories'    => array(
 				array(
 					'name' => _x( 'Sans Serif', 'font category' ),


### PR DESCRIPTION
## What ?

 Update the Google Fonts JSON data URL to the latest deployed version in the WordPress.org CDN.

Reference:
https://meta.trac.wordpress.org/ticket/7522
https://github.com/WordPress/google-fonts-to-wordpress-collection/pull/21

--- 

Trac ticket: https://core.trac.wordpress.org/ticket/60819

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
