### PR TITLE
Update WordPress blog version and database upgrade routine

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -115,7 +115,7 @@ CREATE TABLE $wpdb->comments (
 	comment_parent bigint(20) unsigned NOT NULL default '0',
 	user_id bigint(20) unsigned NOT NULL default '0',
 	PRIMARY KEY  (comment_ID),
-	KEY comment_post_ID (comment_post_ID),
+	KEY comment_post_ID (comment_post_ID,comment_content($max_index_length)),
 	KEY comment_approved_date_gmt (comment_approved,comment_date_gmt),
 	KEY comment_date_gmt (comment_date_gmt),
 	KEY comment_parent (comment_parent),

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2386,10 +2386,10 @@ function upgrade_650() {
 }
 
 /**
- * Executes changes made in WordPress 6.5.0.
+ * Executes changes made in WordPress 6.6.0.
  *
  * @ignore
- * @since 6.5.0
+ * @since 6.6.0
  *
  * @global int  $wp_current_db_version The old (current) database version.
  * @global wpdb $wpdb                  WordPress database abstraction object.

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -847,6 +847,9 @@ function upgrade_all() {
 		upgrade_650();
 	}
 
+	if ( $wp_current_db_version < 57778 ) {
+		upgrade_660();
+	}
 	maybe_disable_link_manager();
 
 	maybe_disable_automattic_widgets();
@@ -2379,6 +2382,23 @@ function upgrade_650() {
 
 		$autoload = array_fill_keys( $theme_mods_options, 'no' );
 		wp_set_option_autoload_values( $autoload );
+	}
+}
+
+/**
+ * Executes changes made in WordPress 6.5.0.
+ *
+ * @ignore
+ * @since 6.5.0
+ *
+ * @global int  $wp_current_db_version The old (current) database version.
+ * @global wpdb $wpdb                  WordPress database abstraction object.
+ */
+function upgrade_660() {
+	global $wp_current_db_version, $wpdb;
+
+	if ( $wp_current_db_version < 57778 ) {
+		drop_index( $wpdb->comments, 'comment_post_ID' );
 	}
 }
 

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -23,7 +23,7 @@ $wp_version = '6.6-alpha-57778-src';
  *
  * @global int $wp_db_version
  */
-$wp_db_version = 57155;
+$wp_db_version = 57778;
 
 /**
  * Holds the TinyMCE version.


### PR DESCRIPTION
The database version for WordPress has been updated. As a result, a new database upgrade routine "upgrade_660" has been introduced. Also, an adjustment has been made to refine the structure of the 'comment_post_ID' index in the comments table, enhancing database performance.

Trac ticket: 26858