### PR TITLE
Consider editing strings for 6.5 About page

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -200,7 +200,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 					</svg>
 				</div>
 				<h3 style="margin-top:calc(var(--gap) * 0.75);margin-bottom:calc(var(--gap) * 0.5)"><?php _e( 'Performance updates' ); ?></h3>
-				<p><?php _e( 'This release includes 110+ performance updates, with an impressive increase in speed and efficiency across the Post Editor and Site Editor. Loading, input processing, and Site Editor navigation each see an increase in speed between two to six times faster than before. Translated sites see up to 25% improvement in load time for this release.' ); ?></p>
+				<p><?php _e( 'This release includes 110+ performance updates, with an impressive increase in speed and efficiency across the Post Editor and Site Editor. Loading is over two times faster than in 6.4, with input processing speed up to five times faster than the previous release. Translated sites see up to 25% improvement in load time for this release.' ); ?></p>
 			</div>
 			<div class="column">
 				<div class="about__image">

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -112,7 +112,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 					<img src="https://s.w.org/images/core/6.5/7-data-views.webp" alt="" height="270" width="270" />
 				</div>
 				<h3 class="is-smaller-heading" style="margin-bottom:calc(var(--gap) / 4);"><?php _e( 'Discover new Data Views' ); ?></h3>
-				<p><?php _e( 'Make fast, informed changes with data views for pages, templates, patterns, and template parts. Arrange data in a table or grid view and enjoy a new UI for toggling fields and making bulk changes.' ); ?></p>
+				<p><?php _e( 'Find and organize your data however you like with data views for pages, templates, patterns, and template parts. Arrange it in a table or grid view with the option to toggle fields and make bulk changes.' ); ?></p>
 			</div>
 			<div class="column">
 				<div class="about__image">

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -66,7 +66,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 			</div>
 			<div class="column is-vertically-aligned-center">
 				<h3><?php _e( 'Add and manage fonts across your site' ); ?></h3>
-				<p><?php _e( 'The new Font Library puts you in control of an essential piece of your site&#8217;s design—typography—without coding or extra steps. Effortlessly install, remove, and activate local and Google Fonts across your site regardless of your active theme. The ability to include custom typography collections gives site creators and publishers even more choice.' ); ?></p>
+				<p><?php _e( 'The new Font Library puts you in control of an essential piece of your site&#8217;s design—typography—without coding or extra steps. Effortlessly install, remove, and activate local and Google Fonts across your site for any block theme. The ability to include custom typography collections gives site creators and publishers even more choice.' ); ?></p>
 			</div>
 		</div>
 

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -180,7 +180,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 					printf(
 						/* translators: %s: Requires Plugins */
 						__( 'There&#8217;s now an easier way to manage plugin dependencies. Plugin authors can supply a new %s header with a comma-separated list of required plugin slugs, presenting users with links to install and activate those plugins first.' ),
-						'<code>Requires Plugins</code>'
+						'<code lang="en">Requires Plugins</code>'
 					);
 					?>
 				</p>

--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -513,6 +513,10 @@
 	display: none !important;
 }
 
+.about__container code {
+	font-size: inherit;
+}
+
 .about__section {
 	font-size: 1.125rem;
 	line-height: 1.55;


### PR DESCRIPTION
- Correct performance metrics, according to https://github.com/WordPress/gutenberg/issues/58028#issuecomment-2007633881
- Clarify that the Font Library is for block themes
- Edit the paragraph about Data Views

I also added a `lang` attribute and set the `code` element to inherit `font-size` because `13px` bothered me.

[Trac 60303](https://core.trac.wordpress.org/ticket/60303)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
