### PR TITLE
Font Library: `mb_strtolower()` throws fatal without the optional `mbstring` PHP extension installed. 

### DIFF
--- a/src/wp-includes/fonts/class-wp-font-utils.php
+++ b/src/wp-includes/fonts/class-wp-font-utils.php
@@ -110,8 +110,12 @@ class WP_Font_Utils {
 			'unicodeRange' => 'U+0-10FFFF',
 		);
 		$settings = wp_parse_args( $settings, $defaults );
-
-		$font_family   = mb_strtolower( $settings['fontFamily'] );
+		if ( function_exists( 'mb_strtolower' ) ) {
+			$font_family   = mb_strtolower( $settings['fontFamily'] );
+		} else {
+			$font_family   = strtolower( $settings['fontFamily'] );
+		}
+			
 		$font_style    = strtolower( $settings['fontStyle'] );
 		$font_weight   = strtolower( $settings['fontWeight'] );
 		$font_stretch  = strtolower( $settings['fontStretch'] );

--- a/src/wp-includes/fonts/class-wp-font-utils.php
+++ b/src/wp-includes/fonts/class-wp-font-utils.php
@@ -115,7 +115,6 @@ class WP_Font_Utils {
 		} else {
 			$font_family   = strtolower( $settings['fontFamily'] );
 		}
-			
 		$font_style    = strtolower( $settings['fontStyle'] );
 		$font_weight   = strtolower( $settings['fontWeight'] );
 		$font_stretch  = strtolower( $settings['fontStretch'] );

--- a/src/wp-includes/fonts/class-wp-font-utils.php
+++ b/src/wp-includes/fonts/class-wp-font-utils.php
@@ -111,9 +111,9 @@ class WP_Font_Utils {
 		);
 		$settings = wp_parse_args( $settings, $defaults );
 		if ( function_exists( 'mb_strtolower' ) ) {
-			$font_family   = mb_strtolower( $settings['fontFamily'] );
+			$font_family = mb_strtolower( $settings['fontFamily'] );
 		} else {
-			$font_family   = strtolower( $settings['fontFamily'] );
+			$font_family = strtolower( $settings['fontFamily'] );
 		}
 		$font_style    = strtolower( $settings['fontStyle'] );
 		$font_weight   = strtolower( $settings['fontWeight'] );


### PR DESCRIPTION

Font Library: `mb_strtolower()` throws fatal without the optional `mbstring` PHP extension installed.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60823

Reported by @peterwilsoncc

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
