### PR TITLE
Media library: fix CSS typo

### DIFF
--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -2834,7 +2834,7 @@
 		background: #ffffff;
 		width: 100%;
 		height: 100%;
-		visibility: hidden;
+		display: none;
 		position: absolute;
 		left: 0;
 		right: 0;

--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -2818,7 +2818,7 @@
 	.media-frame .wp-filter .media-toolbar-secondary {
 		position: unset;
 	}
-	
+
 	.media-frame .media-toolbar-secondary .spinner {
 		position: absolute;
 		top: 0;
@@ -2828,13 +2828,13 @@
 		right: 0;
 		z-index: 9;
 	}
-	
+
 	.media-bg-overlay {
 		content: '';
 		background: #ffffff;
 		width: 100%;
 		height: 100%;
-		display: hidden;
+		visibility: hidden;
 		position: absolute;
 		left: 0;
 		right: 0;


### PR DESCRIPTION
`display: hidden` is invalid CSS

It's causing the following bug:

https://github.com/WordPress/gutenberg/issues/60152


### Step-by-step test instructions 

1. Insert an Image block
2. Click on "Media library" to insert an image
3. Narrow the viewport width to < 782px
4. Observe that the "Select" button is active


### Before


<img width="704" alt="Screenshot 2024-03-25 at 3 21 28 pm" src="https://github.com/WordPress/wordpress-develop/assets/6458278/fbe5ede7-d0ef-4028-8c81-71195c93e190">



### After

<img width="700" alt="Screenshot 2024-03-25 at 3 21 22 pm" src="https://github.com/WordPress/wordpress-develop/assets/6458278/5be1a7df-7634-482c-bb54-2c4133dff8c9">

Trac ticket: https://core.trac.wordpress.org/ticket/33049

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
