### PR TITLE
Default fonts directory to wp-content/uploads/fonts

### DIFF
--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -167,19 +167,14 @@ function _wp_filter_font_directory( $font_dir ) {
 		return $font_dir;
 	}
 
-	$site_path = '';
-	if ( is_multisite() && ! ( is_main_network() && is_main_site() ) ) {
-		$site_path = '/sites/' . get_current_blog_id();
-	}
-
 	$font_dir = array(
-		'path'    => path_join( WP_CONTENT_DIR, 'fonts' ) . $site_path,
-		'url'     => untrailingslashit( content_url( 'fonts' ) ) . $site_path,
-		'subdir'  => '',
-		'basedir' => path_join( WP_CONTENT_DIR, 'fonts' ) . $site_path,
-		'baseurl' => untrailingslashit( content_url( 'fonts' ) ) . $site_path,
-		'error'   => false,
-	);
+        'path'    => untrailingslashit( $font_dir['basedir'] ) . '/fonts',
+        'url'     => untrailingslashit( $font_dir['baseurl'] ) . '/fonts',
+        'subdir'  => '',
+        'basedir' => untrailingslashit( $font_dir['basedir'] ) . '/fonts',
+        'baseurl' => untrailingslashit( $font_dir['baseurl'] ) . '/fonts',
+        'error'   => false,
+    );
 
 	/**
 	 * Filters the fonts directory data.

--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -168,13 +168,13 @@ function _wp_filter_font_directory( $font_dir ) {
 	}
 
 	$font_dir = array(
-        'path'    => untrailingslashit( $font_dir['basedir'] ) . '/fonts',
-        'url'     => untrailingslashit( $font_dir['baseurl'] ) . '/fonts',
-        'subdir'  => '',
-        'basedir' => untrailingslashit( $font_dir['basedir'] ) . '/fonts',
-        'baseurl' => untrailingslashit( $font_dir['baseurl'] ) . '/fonts',
-        'error'   => false,
-    );
+		'path'    => untrailingslashit( $font_dir['basedir'] ) . '/fonts',
+		'url'     => untrailingslashit( $font_dir['baseurl'] ) . '/fonts',
+		'subdir'  => '',
+		'basedir' => untrailingslashit( $font_dir['basedir'] ) . '/fonts',
+		'baseurl' => untrailingslashit( $font_dir['baseurl'] ) . '/fonts',
+		'error'   => false,
+	);
 
 	/**
 	 * Filters the fonts directory data.

--- a/tests/phpunit/tests/fonts/font-library/wpFontsDir.php
+++ b/tests/phpunit/tests/fonts/font-library/wpFontsDir.php
@@ -1,8 +1,4 @@
 <?php
-
-use SebastianBergmann\RecursionContext\InvalidArgumentException;
-use PHPUnit\Framework\ExpectationFailedException;
-
 /**
  * Test wp_get_font_dir().
  *

--- a/tests/phpunit/tests/fonts/font-library/wpFontsDir.php
+++ b/tests/phpunit/tests/fonts/font-library/wpFontsDir.php
@@ -15,13 +15,15 @@ class Tests_Fonts_WpFontDir extends WP_UnitTestCase {
 
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
+		
+		$upload_dir = wp_get_upload_dir();
 
 		static::$dir_defaults = array(
-			'path'    => path_join( WP_CONTENT_DIR, 'fonts' ),
-			'url'     => content_url( 'fonts' ),
+			'path'    => untrailingslashit( $upload_dir['basedir'] ) . '/fonts',
+			'url'     => untrailingslashit( $upload_dir['baseurl'] ) . '/fonts',
 			'subdir'  => '',
-			'basedir' => path_join( WP_CONTENT_DIR, 'fonts' ),
-			'baseurl' => content_url( 'fonts' ),
+			'basedir' => untrailingslashit( $upload_dir['basedir'] ) . '/fonts',
+			'baseurl' => untrailingslashit( $upload_dir['baseurl'] ) . '/fonts',
 			'error'   => false,
 		);
 	}

--- a/tests/phpunit/tests/fonts/font-library/wpFontsDir.php
+++ b/tests/phpunit/tests/fonts/font-library/wpFontsDir.php
@@ -39,6 +39,8 @@ class Tests_Fonts_WpFontDir extends WP_UnitTestCase {
 	/**
 	 * Ensure that the fonts directory is correct for a multisite installation.
 	 *
+	 * The main site will use the default location and others will follow a pattern of  `/sites/{$blog_id}/fonts`
+	 *
 	 * @group multisite
 	 * @group ms-required
 	 */

--- a/tests/phpunit/tests/fonts/font-library/wpFontsDir.php
+++ b/tests/phpunit/tests/fonts/font-library/wpFontsDir.php
@@ -15,7 +15,6 @@ class Tests_Fonts_WpFontDir extends WP_UnitTestCase {
 
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
-		
 		$upload_dir = wp_get_upload_dir();
 
 		static::$dir_defaults = array(


### PR DESCRIPTION
## What?
Default fonts directory to `wp-content/uploads/fonts` instead of `wp-content/fonts`.

## Context links:
- https://github.com/WordPress/gutenberg/issues/53965
- https://github.com/WordPress/gutenberg/issues/59417
- https://make.wordpress.org/core/2024/03/07/unblocking-wp6-5-font-library-and-synced-pattern-overrides/
- https://make.wordpress.org/core/2024/03/21/font-library-update-storage-of-font-files/
- https://make.wordpress.org/core/2024/03/25/wordpress-6-5-release-delayed-1-week/

---
Trac ticket: https://core.trac.wordpress.org/ticket/60845

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

_Edit: Add third context link and trac ticket -- @peterwilsoncc_