### PR TITLE
Honor 'template_hierarchy' filters when creating a template in the Site Editor

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1358,13 +1358,16 @@ function wp_generate_block_templates_export_file() {
  */
 function get_template_hierarchy( $slug, $is_custom = false, $template_prefix = '' ) {
 	if ( 'index' === $slug ) {
-		return array( 'index' );
+		/** This filter is documented in wp-includes/template.php */
+		return apply_filters( 'index_template_hierarchy', array( 'index' ) );
 	}
 	if ( $is_custom ) {
-		return array( 'page', 'singular', 'index' );
+		/** This filter is documented in wp-includes/template.php */
+		return apply_filters( 'page_template_hierarchy', array( 'page', 'singular', 'index' ) );
 	}
 	if ( 'front-page' === $slug ) {
-		return array( 'front-page', 'home', 'index' );
+		/** This filter is documented in wp-includes/template.php */
+		return apply_filters( 'frontpage_template_hierarchy', array( 'front-page', 'home', 'index' ) );
 	}
 
 	$matches = array();

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1439,6 +1439,7 @@ function get_template_hierarchy( $slug, $is_custom = false, $template_prefix = '
 	}
 	$valid_template_types = array( '404', 'archive', 'attachment', 'author', 'category', 'date', 'embed', 'frontpage', 'home', 'index', 'page', 'paged', 'privacypolicy', 'search', 'single', 'singular', 'tag', 'taxonomy' );
 	if ( in_array( $template_type, $valid_template_types ) ) {
+		/** This filter is documented in wp-includes/template.php */
 		return apply_filters( "{$template_type}_template_hierarchy", $template_hierarchy );
 	}
 	return $template_hierarchy;

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1430,6 +1430,17 @@ function get_template_hierarchy( $slug, $is_custom = false, $template_prefix = '
 		$template_hierarchy[] = 'singular';
 	}
 	$template_hierarchy[] = 'index';
+
+	$template_type = '';
+	if ( ! empty( $template_prefix ) ) {
+		list( $template_type ) = explode( '-', $template_prefix );
+	} else {
+		list( $template_type ) = explode( '-', $slug );
+	}
+	$valid_template_types = array( '404', 'archive', 'attachment', 'author', 'category', 'date', 'embed', 'frontpage', 'home', 'index', 'page', 'paged', 'privacypolicy', 'search', 'single', 'singular', 'tag', 'taxonomy' );
+	if ( in_array( $template_type, $valid_template_types ) ) {
+		return apply_filters( "{$template_type}_template_hierarchy", $template_hierarchy );
+	}
 	return $template_hierarchy;
 }
 

--- a/tests/phpunit/tests/block-templates/getTemplateHierarchy.php
+++ b/tests/phpunit/tests/block-templates/getTemplateHierarchy.php
@@ -41,6 +41,20 @@ class Tests_Block_Templates_GetTemplate_Hierarchy extends WP_Block_Templates_Uni
 	}
 
 	/**
+	 * @ticket 60846
+	 */
+	public function test_get_template_hierarchy_with_hooks() {
+		add_filter(
+			'date_template_hierarchy',
+			function ( $templates ) {
+				return array_merge( array( 'date-custom' ), $templates );
+			}
+		);
+		$expected = array( 'date-custom', 'date', 'archive', 'index' );
+		$this->assertSame( $expected, get_template_hierarchy( 'date' ) );
+	}
+
+	/**
 	 * Data provider.
 	 *
 	 * @return array


### PR DESCRIPTION
## Testing steps

1. Add this code snippet to your site. You can use the [Code Snippets plugin](https://wordpress.org/plugins/code-snippets/): 
```PHP
add_filter( 'page_template_hierarchy', function ( $templates ) {
        return ['single'];
} );
```
2. Visit any page in the frontend. You will notice the Single template is used, instead of the Page template.
3. Now, go to Appearance > Editor > Templates > Add New Template > Pages and select any page.
4. Verify the suggested content to start with in the Choose a pattern screen is from the Single template, instead of the Page template.

Before | After
--- | ---
![](https://github.com/WordPress/gutenberg/assets/3616980/7598c990-1a64-4df3-b509-47d83fc59239) | ![](https://github.com/WordPress/gutenberg/assets/3616980/fff09fd9-5600-4969-89f6-dab6523f50de)

Trac ticket: https://core.trac.wordpress.org/ticket/60846

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
