### PR TITLE
Style Engine: continue get_classnames loop after adding the default classname 

### DIFF
--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -467,6 +467,7 @@ final class WP_Style_Engine {
 			foreach ( $style_definition['classnames'] as $classname => $property_key ) {
 				if ( true === $property_key ) {
 					$classnames[] = $classname;
+					continue;
 				}
 
 				$slug = static::get_slug_from_preset_value( $style_value, $property_key );


### PR DESCRIPTION
Quick janitorial PR that continues the `get_classnames` loop after adding the default classname.

Syncs changes from:

- https://github.com/WordPress/gutenberg/pull/60153

## Why?

Because we've added the classname by virtue of testing for `true`, and besides the subsequent `get_slug_from_preset_value` only works on a string, not a boolean.

Trac ticket: https://core.trac.wordpress.org/ticket/60847
