### PR TITLE
Prepopulate Username for login after password reset to meet WCAG 2.2

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -3183,7 +3183,7 @@ function retrieve_password( $user_login = null ) {
 	$message .= sprintf( __( 'Username: %s' ), $user_login ) . "\r\n\r\n";
 	$message .= __( 'If this was a mistake, ignore this email and nothing will happen.' ) . "\r\n\r\n";
 	$message .= __( 'To reset your password, visit the following address:' ) . "\r\n\r\n";
-	$message .= network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user_login ), 'login' ) . '&wp_lang=' . $locale . "\r\n\r\n";
+	$message .= network_site_url( "wp-login.php?action=rp&key=$key&login=" . rawurlencode( $user_login ), 'login' ) . '&wp_lang=' . $locale . '&user=' . $user_login .  "\r\n\r\n";
 
 	if ( ! is_user_logged_in() ) {
 		$requester_ip = $_SERVER['REMOTE_ADDR'];

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -364,7 +364,7 @@ function login_footer( $input_id = '' ) {
 		if ( ! empty( $languages ) ) {
 			?>
 			<div class="language-switcher">
-				<form id="language-switcher" method="get">
+				<form id="language-switcher" action="" method="get">
 
 					<label for="language-switcher-locales">
 						<span class="dashicons dashicons-translation" aria-hidden="true"></span>
@@ -986,13 +986,16 @@ switch ( $action ) {
 		 */
 		do_action( 'validate_password_reset', $errors, $user );
 
+		if( isset( $_GET['user'] ) )
+			$username = wp_unslash( $_GET['user'] );
+
 		if ( ( ! $errors->has_errors() ) && isset( $_POST['pass1'] ) && ! empty( $_POST['pass1'] ) ) {
 			reset_password( $user, $_POST['pass1'] );
 			setcookie( $rp_cookie, ' ', time() - YEAR_IN_SECONDS, $rp_path, COOKIE_DOMAIN, is_ssl(), true );
 			login_header(
 				__( 'Password Reset' ),
 				wp_get_admin_notice(
-					__( 'Your password has been reset.' ) . ' <a href="' . esc_url( wp_login_url() ) . '">' . __( 'Log in' ) . '</a>',
+					__( 'Your password has been reset.' ) . ' <a href="' . esc_url( wp_login_url() ) . "?" . 'user=' . $username . '">' . __( 'Log in' ) . '</a>',
 					array(
 						'type'               => 'info',
 						'additional_classes' => array( 'message', 'reset-pass' ),
@@ -1018,8 +1021,10 @@ switch ( $action ) {
 			$errors
 		);
 
+		if( isset( $_GET['user'] ) )
+			$username = wp_unslash( $_GET['user'] );
 		?>
-		<form name="resetpassform" id="resetpassform" action="<?php echo esc_url( network_site_url( 'wp-login.php?action=resetpass', 'login_post' ) ); ?>" method="post" autocomplete="off">
+		<form name="resetpassform" id="resetpassform" action="<?php echo esc_url( network_site_url( 'wp-login.php?action=resetpass&user=' . $username, 'login_post' ) ); ?>" method="post" autocomplete="off">
 			<input type="hidden" id="user_login" value="<?php echo esc_attr( $rp_login ); ?>" autocomplete="off" />
 
 			<div class="user-pass1-wrap">
@@ -1492,6 +1497,9 @@ switch ( $action ) {
 		}
 
 		wp_enqueue_script( 'user-profile' );
+		if( isset( $_GET['user'] ) ) {
+			$user_login = wp_unslash( $_GET['user'] );
+		}
 		?>
 
 		<form name="loginform" id="loginform" action="<?php echo esc_url( site_url( 'wp-login.php', 'login_post' ) ); ?>" method="post">


### PR DESCRIPTION
<!-- Insert a description of your changes here -->
This PR mainly focuses upon the new feature of pre-populating the username field in the login form after password reset to meet WCAG 2.2 for accessibility.
For this feature, a new query parameter has been added to the password reset link that is sent to the email , so that after password reset the username field can be pre-field on the basis of the query parameter value `user=`
Screen-recording for demo

https://github.com/WordPress/wordpress-develop/assets/96969845/ed068467-12b0-4a3a-a042-aedc45dc5f77


Trac ticket: <!-- insert a link to the WordPress Trac ticket here --> https://core.trac.wordpress.org/ticket/60726

Contributor name - Rishav Dutta 

---

