### PR TITLE
Issue with parent term selection on wp-admin/edit-tags.php screen

### DIFF
--- a/src/js/_enqueues/admin/tags.js
+++ b/src/js/_enqueues/admin/tags.js
@@ -159,6 +159,7 @@ jQuery( function($) {
 			}
 
 			$('input:not([type="checkbox"]):not([type="radio"]):not([type="button"]):not([type="submit"]):not([type="reset"]):visible, textarea:visible', form).val('');
+			$('select', form).prop('selectedIndex',0);
 		});
 
 		return false;

--- a/src/js/_enqueues/admin/tags.js
+++ b/src/js/_enqueues/admin/tags.js
@@ -159,7 +159,6 @@ jQuery( function($) {
 			}
 
 			$('input:not([type="checkbox"]):not([type="radio"]):not([type="button"]):not([type="submit"]):not([type="reset"]):visible, textarea:visible', form).val('');
-			$('select', form).prop('selectedIndex',0);
 		});
 
 		return false;

--- a/tests/phpunit/tests/http/functions.php
+++ b/tests/phpunit/tests/http/functions.php
@@ -21,7 +21,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 		$this->assertIsArray( $response );
 
 		$this->assertSame( 'image/jpeg', $headers['Content-Type'] );
-		$this->assertSame( '40148', $headers['Content-Length'] );
+		$this->assertSame( '98333', $headers['Content-Length'] );
 		$this->assertSame( 200, wp_remote_retrieve_response_code( $response ) );
 	}
 

--- a/tests/phpunit/tests/http/functions.php
+++ b/tests/phpunit/tests/http/functions.php
@@ -11,7 +11,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	 */
 	public function test_head_request() {
 		// This URL gives a direct 200 response.
-		$url      = 'https://asdftestblog1.files.wordpress.com/2007/09/2007-06-30-dsc_4700-1.jpg';
+		$url      = 'https://asdftestblog1.wordpress.com/wp-content/uploads/2008/04/canola.jpg';
 		$response = wp_remote_head( $url );
 
 		$this->skipTestOnTimeout( $response );

--- a/tests/phpunit/tests/http/functions.php
+++ b/tests/phpunit/tests/http/functions.php
@@ -11,7 +11,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	 */
 	public function test_head_request() {
 		// This URL gives a direct 200 response.
-		$url      = 'https://asdftestblog1.wordpress.com/wp-content/uploads/2008/04/canola.jpg';
+		$url      = 'https://asdftestblog1.files.wordpress.com/2007/09/2007-06-30-dsc_4700-1.jpg';
 		$response = wp_remote_head( $url );
 
 		$this->skipTestOnTimeout( $response );
@@ -21,7 +21,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 		$this->assertIsArray( $response );
 
 		$this->assertSame( 'image/jpeg', $headers['Content-Type'] );
-		$this->assertSame( '98333', $headers['Content-Length'] );
+		$this->assertSame( '40148', $headers['Content-Length'] );
 		$this->assertSame( 200, wp_remote_retrieve_response_code( $response ) );
 	}
 
@@ -41,7 +41,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	 * @covers ::wp_remote_head
 	 */
 	public function test_head_404() {
-		$url      = 'https://asdftestblog1.wordpress.com/wp-content/uploads/2008/04/dsc20040724_152504.jpg';
+		$url      = 'https://asdftestblog1.files.wordpress.com/2007/09/awefasdfawef.jpg';
 		$response = wp_remote_head( $url );
 
 		$this->skipTestOnTimeout( $response );

--- a/tests/phpunit/tests/http/functions.php
+++ b/tests/phpunit/tests/http/functions.php
@@ -41,7 +41,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	 * @covers ::wp_remote_head
 	 */
 	public function test_head_404() {
-		$url      = 'https://asdftestblog1.files.wordpress.com/2007/09/awefasdfawef.jpg';
+		$url      = 'https://asdftestblog1.wordpress.com/wp-content/uploads/2008/04/dsc20040724_152504.jpg';
 		$response = wp_remote_head( $url );
 
 		$this->skipTestOnTimeout( $response );


### PR DESCRIPTION
Currently, on the "wp-admin/edit-tags.php" screen, when we input a new term with a parent term using the select dropdown, upon submission, all fields are reset except for the parent term dropdown. This may lead to unintended assignment of the parent term and create potential issues when adding new terms.

**Steps to reproduce**
- Login to wordPress dashboard
- Go to Posts > Categories
- Enter term name, slug, description and select parent
- Click on "Add New Category"
- Upon successful submission, all the fields ( name, slug, and description ) are reset, except the "Parent Category" dropdown.

**Actual Result:**
<img width="1792" alt="parent-category-issue" src="https://github.com/WordPress/wordpress-develop/assets/29377089/8dc0dd62-7500-47ff-8bff-8ab23667d281">

**Expected Result:**
![expected-result](https://github.com/WordPress/wordpress-develop/assets/29377089/5058264e-6f0f-47f6-ad73-e5db64f0e427)

Trac ticket: [60861](https://core.trac.wordpress.org/ticket/60861)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
