### PR TITLE
Fix for failing PHPUnit tests cases

### DIFF
--- a/tests/phpunit/tests/http/functions.php
+++ b/tests/phpunit/tests/http/functions.php
@@ -11,7 +11,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	 */
 	public function test_head_request() {
 		// This URL gives a direct 200 response.
-		$url      = 'https://asdftestblog1.files.wordpress.com/2007/09/2007-06-30-dsc_4700-1.jpg';
+		$url      = 'https://asdftestblog1.wordpress.com/wp-content/uploads/2008/04/canola.jpg';
 		$response = wp_remote_head( $url );
 
 		$this->skipTestOnTimeout( $response );
@@ -21,7 +21,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 		$this->assertIsArray( $response );
 
 		$this->assertSame( 'image/jpeg', $headers['Content-Type'] );
-		$this->assertSame( '40148', $headers['Content-Length'] );
+		$this->assertSame( '98333', $headers['Content-Length'] );
 		$this->assertSame( 200, wp_remote_retrieve_response_code( $response ) );
 	}
 
@@ -41,7 +41,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	 * @covers ::wp_remote_head
 	 */
 	public function test_head_404() {
-		$url      = 'https://asdftestblog1.files.wordpress.com/2007/09/awefasdfawef.jpg';
+		$url      = 'https://asdftestblog1.wordpress.com/wp-content/uploads/2008/04/dsc20040724_152504.jpg';
 		$response = wp_remote_head( $url );
 
 		$this->skipTestOnTimeout( $response );

--- a/tests/phpunit/tests/http/functions.php
+++ b/tests/phpunit/tests/http/functions.php
@@ -41,7 +41,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	 * @covers ::wp_remote_head
 	 */
 	public function test_head_404() {
-		$url      = 'https://asdftestblog1.wordpress.com/wp-content/uploads/2008/04/dsc20040724_152504.jpg';
+		$url      = 'https://asdftestblog1.wordpress.com/wp-content/uploads/2008/04/dsc20040724_1525042.jpg';
 		$response = wp_remote_head( $url );
 
 		$this->skipTestOnTimeout( $response );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Some PHPUnit Tests are failing in wordpress-develop repo due to dummy images are not returning expected results.

**Steps to reproduce:**
- Raise a new PR in wordpress-develop repo against trunk
- Automatic tests start run
- Some tests will get fail

**Screenshot of issue:**
![Screenshot 2024-03-30 at 7 08 45 PM](https://github.com/WordPress/wordpress-develop/assets/29377089/3599c4e5-5248-4c46-9cab-883e83e8bfa4)

**Fixes:**
I have replaced the dummy images which were causing the issue with other dummy.

Trac ticket: https://core.trac.wordpress.org/ticket/60865

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
