### PR TITLE
Script translations: Always look in `WP_LANG_DIR . '/plugins’`

### DIFF
--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1189,7 +1189,7 @@ function load_script_textdomain( $handle, $domain = 'default', $path = '' ) {
 		$relative = trim( $relative, '/' );
 		$relative = explode( '/', $relative );
 
-		$languages_path = WP_LANG_DIR . '/' . $relative[0];
+		$languages_path = WP_LANG_DIR . '/plugins';
 
 		$relative = array_slice( $relative, 2 ); // Remove plugins/<plugin name> or themes/<theme name>.
 		$relative = implode( '/', $relative );

--- a/tests/phpunit/tests/l10n/loadScriptTextdomain.php
+++ b/tests/phpunit/tests/l10n/loadScriptTextdomain.php
@@ -13,6 +13,7 @@ class Tests_L10n_LoadScriptTextdomain extends WP_UnitTestCase {
 	 * @ticket 46336
 	 * @ticket 46387
 	 * @ticket 49145
+	 * @ticket 60891
 	 *
 	 * @dataProvider data_resolve_relative_path
 	 */
@@ -118,6 +119,19 @@ class Tests_L10n_LoadScriptTextdomain extends WP_UnitTestCase {
 					'site_url',
 					static function () {
 						return '/wp';
+					},
+				),
+			),
+			// @ticket 60891
+			array(
+				'/languages/plugins/internationalized-plugin-en_US-2f86cb96a0233e7cb3b6f03ad573be0b.json',
+				'plugin-in-custom-plugin-dir',
+				'/wp-content/mods/my-plugin/js/script.js',
+				'internationalized-plugin',
+				array(
+					'plugins_url',
+					static function () {
+						return 'https://example.com/wp-content/mods';
 					},
 				),
 			),


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Script translations are always in `wp-content/languages/plugins`, where `plugins` doesn't change even when `wp-content/plugins` is relocated.

Trac ticket: https://core.trac.wordpress.org/ticket/60891

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
