### PR TITLE
Fix autoprefixer warning in media.css for ticket 60876

### DIFF
--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -1124,7 +1124,7 @@ border color while dragging a file over the uploader drop area */
 .imgedit-panel-tools > .imgedit-menu {
 	display: flex;
 	column-gap: 4px;
-	align-items: start;
+	align-items: flex-start;
 	flex-wrap: wrap;
 }
 


### PR DESCRIPTION
Fix Autoprefixer warning in `src/wp-admin/css/media.css` when running `precommit:css` Grunt task issue.

Trac ticket: [#60876](https://core.trac.wordpress.org/ticket/60876)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
