### PR TITLE
Remove unnecessary code for ensuring interactivity dependency in block core functions

### DIFF
--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -6254,13 +6254,6 @@ function the_block_template_skip_link() {
  */
 function block_core_query_ensure_interactivity_dependency() {
 	_deprecated_function( __FUNCTION__, '6.5.0', 'wp_register_script_module' );
-	global $wp_scripts;
-	if (
-		isset( $wp_scripts->registered['wp-block-query-view'] ) &&
-		! in_array( 'wp-interactivity', $wp_scripts->registered['wp-block-query-view']->deps, true )
-	) {
-		$wp_scripts->registered['wp-block-query-view']->deps[] = 'wp-interactivity';
-	}
 }
 
 /**
@@ -6273,13 +6266,6 @@ function block_core_query_ensure_interactivity_dependency() {
  */
 function block_core_file_ensure_interactivity_dependency() {
 	_deprecated_function( __FUNCTION__, '6.5.0', 'wp_register_script_module' );
-	global $wp_scripts;
-	if (
-		isset( $wp_scripts->registered['wp-block-file-view'] ) &&
-		! in_array( 'wp-interactivity', $wp_scripts->registered['wp-block-file-view']->deps, true )
-	) {
-		$wp_scripts->registered['wp-block-file-view']->deps[] = 'wp-interactivity';
-	}
 }
 
 /**
@@ -6292,11 +6278,4 @@ function block_core_file_ensure_interactivity_dependency() {
  */
 function block_core_image_ensure_interactivity_dependency() {
 	_deprecated_function( __FUNCTION__, '6.5.0', 'wp_register_script_module' );
-	global $wp_scripts;
-	if (
-		isset( $wp_scripts->registered['wp-block-image-view'] ) &&
-		! in_array( 'wp-interactivity', $wp_scripts->registered['wp-block-image-view']->deps, true )
-	) {
-		$wp_scripts->registered['wp-block-image-view']->deps[] = 'wp-interactivity';
-	}
 }

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -6250,7 +6250,6 @@ function the_block_template_skip_link() {
  * @since 6.4.0
  * @deprecated 6.5.0
  *
- * @global WP_Scripts $wp_scripts
  */
 function block_core_query_ensure_interactivity_dependency() {
 	_deprecated_function( __FUNCTION__, '6.5.0', 'wp_register_script_module' );
@@ -6262,7 +6261,6 @@ function block_core_query_ensure_interactivity_dependency() {
  * @since 6.4.0
  * @deprecated 6.5.0
  *
- * @global WP_Scripts $wp_scripts
  */
 function block_core_file_ensure_interactivity_dependency() {
 	_deprecated_function( __FUNCTION__, '6.5.0', 'wp_register_script_module' );
@@ -6274,7 +6272,6 @@ function block_core_file_ensure_interactivity_dependency() {
  * @since 6.4.0
  * @deprecated 6.5.0
  *
- * @global WP_Scripts $wp_scripts
  */
 function block_core_image_ensure_interactivity_dependency() {
 	_deprecated_function( __FUNCTION__, '6.5.0', 'wp_register_script_module' );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -281,10 +281,6 @@ function wp_default_packages_scripts( $scripts ) {
 	 */
 	$assets = include ABSPATH . WPINC . "/assets/script-loader-packages{$suffix}.php";
 
-	// Add the private version of the Interactivity API manually.
-	$scripts->add( 'wp-interactivity', '/wp-includes/js/dist/interactivity.min.js' );
-	did_action( 'init' ) && $scripts->add_data( 'wp-interactivity', 'strategy', 'defer' );
-
 	foreach ( $assets as $file_name => $package_data ) {
 		$basename = str_replace( $suffix . '.js', '', basename( $file_name ) );
 		$handle   = 'wp-' . $basename;


### PR DESCRIPTION
I'm removing old code for registering the private version of the Interactivity API pre-6.5.

The Interactivity API is being loaded as a [script module](https://make.wordpress.org/core/2024/03/04/script-modules-in-6-5/) as of WordPress 6.5.

I've **removed** the bodies of the previously deprecated functions, now no-ops, since the scripts are being registered as modules [here](https://github.com/WordPress/wordpress-develop/blob/9433cc089ab1f5ec8fe0e9dd9a33b19c579f94f6/src/wp-includes/interactivity-api/class-wp-interactivity-api.php#L172). These functions remain because they were public, but their execution is unnecessary.


Trac ticket: https://core.trac.wordpress.org/ticket/60913#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
