### PR TITLE
Add an is_dir check to prevent a notice from a missing directory with RecursiveDirectoryIterator

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "workbench.colorCustomizations": {
-    "activityBar.background": "#4C0C61",
-    "titleBar.activeBackground": "#6A1188",
-    "titleBar.activeForeground": "#FDFAFE"
-  }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "workbench.colorCustomizations": {
+    "activityBar.background": "#4C0C61",
+    "titleBar.activeBackground": "#6A1188",
+    "titleBar.activeForeground": "#FDFAFE"
+  }
+}

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -228,17 +228,21 @@ function _get_block_templates_paths( $base_directory ) {
 	if ( isset( $template_path_list[ $base_directory ] ) ) {
 		return $template_path_list[ $base_directory ];
 	}
-	$path_list = array();
-	try {
-		$nested_files      = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $base_directory ) );
-		$nested_html_files = new RegexIterator( $nested_files, '/^.+\.html$/i', RecursiveRegexIterator::GET_MATCH );
-		foreach ( $nested_html_files as $path => $file ) {
-			$path_list[] = $path;
+	if ( is_dir( $base_directory ) ) {
+		$path_list = array();
+		try {
+			$nested_files      = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $base_directory ) );
+			$nested_html_files = new RegexIterator( $nested_files, '/^.+\.html$/i', RecursiveRegexIterator::GET_MATCH );
+			foreach ( $nested_html_files as $path => $file ) {
+				$path_list[] = $path;
+			}
+		} catch ( Exception $e ) {
+			// Do nothing.
 		}
-	} catch ( Exception $e ) {
-		// Do nothing.
+		$template_path_list[ $base_directory ] = $path_list;
+	} else {
+		$template_path_list[ $base_directory ] = array();
 	}
-	$template_path_list[ $base_directory ] = $path_list;
 	return $path_list;
 }
 

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -243,7 +243,7 @@ function _get_block_templates_paths( $base_directory ) {
 	} else {
 		$template_path_list[ $base_directory ] = array();
 	}
-	return $path_list;
+	return $template_path_list[ $base_directory ];
 }
 
 /**

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -228,22 +228,16 @@ function _get_block_templates_paths( $base_directory ) {
 	if ( isset( $template_path_list[ $base_directory ] ) ) {
 		return $template_path_list[ $base_directory ];
 	}
+	$path_list = array();
 	if ( is_dir( $base_directory ) ) {
-		$path_list = array();
-		try {
-			$nested_files      = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $base_directory ) );
-			$nested_html_files = new RegexIterator( $nested_files, '/^.+\.html$/i', RecursiveRegexIterator::GET_MATCH );
-			foreach ( $nested_html_files as $path => $file ) {
-				$path_list[] = $path;
-			}
-		} catch ( Exception $e ) {
-			// Do nothing.
+		$nested_files      = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $base_directory ) );
+		$nested_html_files = new RegexIterator( $nested_files, '/^.+\.html$/i', RecursiveRegexIterator::GET_MATCH );
+		foreach ( $nested_html_files as $path => $file ) {
+			$path_list[] = $path;
 		}
-		$template_path_list[ $base_directory ] = $path_list;
-	} else {
-		$template_path_list[ $base_directory ] = array();
 	}
-	return $template_path_list[ $base_directory ];
+	$template_path_list[ $base_directory ] = $path_list;
+	return $path_list;
 }
 
 /**


### PR DESCRIPTION
Though https://core.trac.wordpress.org/ticket/58196 improved the performance of `_get_block_templates_paths()` in 77dcb1771ae14e655edaf514f0f55c28212d9bb2, this does throw a notice:

> RecursiveDirectoryIterator::__construct(/var/www/wp-content/themes/:theme/templates): Failed to open directory: No such file or directory

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60915

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
