### PR TITLE
Block Hooks API: Insert metadata at the same time as hooked blocks

### DIFF
--- a/src/wp-content/themes/twentytwentyfour/functions.php
+++ b/src/wp-content/themes/twentytwentyfour/functions.php
@@ -204,3 +204,23 @@ if ( ! function_exists( 'twentytwentyfour_pattern_categories' ) ) :
 endif;
 
 add_action( 'init', 'twentytwentyfour_pattern_categories' );
+
+function register_hooked_block( $hooked_blocks, $position, $anchor_block, $context ) {
+	if ( $anchor_block === 'core/post-content' && $position === 'after' ) {
+		$hooked_blocks[] = 'core/loginout';
+	}
+
+	return $hooked_blocks;
+}
+
+add_filter( 'hooked_block_types', 'register_hooked_block', 10, 4 );
+
+function register_hooked_block_one( $hooked_blocks, $position, $anchor_block, $context ) {
+	if ( $anchor_block === 'core/post-content' && $position === 'before' ) {
+		$hooked_blocks[] = 'core/page-list';
+	}
+
+	return $hooked_blocks;
+}
+
+add_filter( 'hooked_block_types', 'register_hooked_block_one', 10, 4 );

--- a/src/wp-content/themes/twentytwentyfour/functions.php
+++ b/src/wp-content/themes/twentytwentyfour/functions.php
@@ -204,23 +204,3 @@ if ( ! function_exists( 'twentytwentyfour_pattern_categories' ) ) :
 endif;
 
 add_action( 'init', 'twentytwentyfour_pattern_categories' );
-
-function register_hooked_block( $hooked_blocks, $position, $anchor_block, $context ) {
-	if ( $anchor_block === 'core/post-content' && $position === 'after' ) {
-		$hooked_blocks[] = 'core/loginout';
-	}
-
-	return $hooked_blocks;
-}
-
-add_filter( 'hooked_block_types', 'register_hooked_block', 10, 4 );
-
-function register_hooked_block_one( $hooked_blocks, $position, $anchor_block, $context ) {
-	if ( $anchor_block === 'core/post-content' && $position === 'before' ) {
-		$hooked_blocks[] = 'core/page-list';
-	}
-
-	return $hooked_blocks;
-}
-
-add_filter( 'hooked_block_types', 'register_hooked_block_one', 10, 4 );

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -558,8 +558,8 @@ function _build_block_template_result_from_file( $template_file, $template_type 
 	$after_block_visitor  = null;
 	$hooked_blocks        = get_hooked_blocks();
 	if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
-		$before_block_visitor = make_before_block_visitor( $hooked_blocks, $template );
-		$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $template );
+		$before_block_visitor = make_before_block_visitor( $hooked_blocks, $template, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );
+		$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $template, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );
 	}
 	$blocks            = parse_blocks( $template->content );
 	$template->content = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
@@ -944,8 +944,8 @@ function _build_block_template_result_from_post( $post ) {
 
 	$hooked_blocks = get_hooked_blocks();
 	if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
-		$before_block_visitor = make_before_block_visitor( $hooked_blocks, $template );
-		$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $template );
+		$before_block_visitor = make_before_block_visitor( $hooked_blocks, $template, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );
+		$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $template, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );
 		$blocks               = parse_blocks( $template->content );
 		$template->content    = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
 	}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -954,7 +954,7 @@ function insert_hooked_blocks( &$parsed_anchor_block, $relative_position, $hooke
  *                                                             Can be one of 'before', 'after', 'first_child', or 'last_child'.
  * @param array                           $hooked_blocks       An array of hooked block types, grouped by anchor block and relative position.
  * @param WP_Block_Template|WP_Post|array $context             The block template, template part, or pattern that the anchor block belongs to.
- * @return string
+ * @return string Empty string.
  */
 function set_ignored_hooked_blocks_metadata( &$parsed_anchor_block, $relative_position, $hooked_blocks, $context ) {
 	$anchor_block_type  = $parsed_anchor_block['blockName'];

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1008,7 +1008,7 @@ function set_ignored_hooked_blocks_metadata( &$parsed_anchor_block, $relative_po
  *
  * This function is meant for internal use only.
  *
- * @since 6.5.0
+ * @since 6.5.1
  * @access private
  *
  * @param array                           $parsed_anchor_block The anchor block, in parsed block array format.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -858,11 +858,11 @@ function get_hooked_blocks() {
  * @since 6.5.0
  * @access private
  *
- * @param array                   $parsed_anchor_block The anchor block, in parsed block array format.
- * @param string                  $relative_position   The relative position of the hooked blocks.
- *                                                     Can be one of 'before', 'after', 'first_child', or 'last_child'.
- * @param array                   $hooked_blocks       An array of hooked block types, grouped by anchor block and relative position.
- * @param WP_Block_Template|array $context             The block template, template part, or pattern that the anchor block belongs to.
+ * @param array                           $parsed_anchor_block The anchor block, in parsed block array format.
+ * @param string                          $relative_position   The relative position of the hooked blocks.
+ *                                                             Can be one of 'before', 'after', 'first_child', or 'last_child'.
+ * @param array                           $hooked_blocks       An array of hooked block types, grouped by anchor block and relative position.
+ * @param WP_Block_Template|WP_Post|array $context             The block template, template part, or pattern that the anchor block belongs to.
  * @return string
  */
 function insert_hooked_blocks( &$parsed_anchor_block, $relative_position, $hooked_blocks, $context ) {
@@ -949,12 +949,12 @@ function insert_hooked_blocks( &$parsed_anchor_block, $relative_position, $hooke
  * @since 6.5.0
  * @access private
  *
- * @param array                   $parsed_anchor_block The anchor block, in parsed block array format.
- * @param string                  $relative_position   The relative position of the hooked blocks.
- *                                                     Can be one of 'before', 'after', 'first_child', or 'last_child'.
- * @param array                   $hooked_blocks       An array of hooked block types, grouped by anchor block and relative position.
- * @param WP_Block_Template|array $context             The block template, template part, or pattern that the anchor block belongs to.
- * @return string An empty string.
+ * @param array                           $parsed_anchor_block The anchor block, in parsed block array format.
+ * @param string                          $relative_position   The relative position of the hooked blocks.
+ *                                                             Can be one of 'before', 'after', 'first_child', or 'last_child'.
+ * @param array                           $hooked_blocks       An array of hooked block types, grouped by anchor block and relative position.
+ * @param WP_Block_Template|WP_Post|array $context             The block template, template part, or pattern that the anchor block belongs to.
+ * @return string
  */
 function set_ignored_hooked_blocks_metadata( &$parsed_anchor_block, $relative_position, $hooked_blocks, $context ) {
 	$anchor_block_type  = $parsed_anchor_block['blockName'];
@@ -1003,6 +1003,29 @@ function set_ignored_hooked_blocks_metadata( &$parsed_anchor_block, $relative_po
 }
 
 /**
+ * Returns the markup for blocks hooked to the given anchor block in a specific relative position and then
+ * adds a list of hooked block types to an anchor block's ignored hooked block types.
+ *
+ * This function is meant for internal use only.
+ *
+ * @since 6.5.0
+ * @access private
+ *
+ * @param array                           $parsed_anchor_block The anchor block, in parsed block array format.
+ * @param string                          $relative_position   The relative position of the hooked blocks.
+ *                                                             Can be one of 'before', 'after', 'first_child', or 'last_child'.
+ * @param array                           $hooked_blocks       An array of hooked block types, grouped by anchor block and relative position.
+ * @param WP_Block_Template|WP_Post|array $context             The block template, template part, or pattern that the anchor block belongs to.
+ * @return string
+ */
+function insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( &$parsed_anchor_block, $relative_position, $hooked_blocks, $context ) {
+	$markup = insert_hooked_blocks( $parsed_anchor_block, $relative_position, $hooked_blocks, $context );
+	$markup .= set_ignored_hooked_blocks_metadata( $parsed_anchor_block, $relative_position, $hooked_blocks, $context );
+
+	return $markup;
+}
+
+/**
  * Returns a function that injects the theme attribute into, and hooked blocks before, a given block.
  *
  * The returned function can be used as `$pre_callback` argument to `traverse_and_serialize_block(s)`,
@@ -1020,11 +1043,11 @@ function set_ignored_hooked_blocks_metadata( &$parsed_anchor_block, $relative_po
  *                                                       or pattern that the blocks belong to.
  * @param callable                        $callback      A function that will be called for each block to generate
  *                                                       the markup for a given list of blocks that are hooked to it.
- *                                                       Default: 'insert_hooked_blocks'.
+ *                                                       Default: 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata'.
  * @return callable A function that returns the serialized markup for the given block,
  *                  including the markup for any hooked blocks before it.
  */
-function make_before_block_visitor( $hooked_blocks, $context, $callback = 'insert_hooked_blocks' ) {
+function make_before_block_visitor( $hooked_blocks, $context, $callback = 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' ) {
 	/**
 	 * Injects hooked blocks before the given block, injects the `theme` attribute into Template Part blocks, and returns the serialized markup.
 	 *
@@ -1077,11 +1100,11 @@ function make_before_block_visitor( $hooked_blocks, $context, $callback = 'inser
  *                                                       or pattern that the blocks belong to.
  * @param callable                        $callback      A function that will be called for each block to generate
  *                                                       the markup for a given list of blocks that are hooked to it.
- *                                                       Default: 'insert_hooked_blocks'.
+ *                                                       Default: 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata'.
  * @return callable A function that returns the serialized markup for the given block,
  *                  including the markup for any hooked blocks after it.
  */
-function make_after_block_visitor( $hooked_blocks, $context, $callback = 'insert_hooked_blocks' ) {
+function make_after_block_visitor( $hooked_blocks, $context, $callback = 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' ) {
 	/**
 	 * Injects hooked blocks after the given block, and returns the serialized markup.
 	 *

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1008,7 +1008,7 @@ function set_ignored_hooked_blocks_metadata( &$parsed_anchor_block, $relative_po
  *
  * This function is meant for internal use only.
  *
- * @since 6.5.1
+ * @since 6.6.0
  * @access private
  *
  * @param array                           $parsed_anchor_block The anchor block, in parsed block array format.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1043,11 +1043,11 @@ function insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( &$parsed_a
  *                                                       or pattern that the blocks belong to.
  * @param callable                        $callback      A function that will be called for each block to generate
  *                                                       the markup for a given list of blocks that are hooked to it.
- *                                                       Default: 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata'.
+ *                                                       Default: 'insert_hooked_blocks'.
  * @return callable A function that returns the serialized markup for the given block,
  *                  including the markup for any hooked blocks before it.
  */
-function make_before_block_visitor( $hooked_blocks, $context, $callback = 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' ) {
+function make_before_block_visitor( $hooked_blocks, $context, $callback = 'insert_hooked_blocks' ) {
 	/**
 	 * Injects hooked blocks before the given block, injects the `theme` attribute into Template Part blocks, and returns the serialized markup.
 	 *
@@ -1100,11 +1100,11 @@ function make_before_block_visitor( $hooked_blocks, $context, $callback = 'inser
  *                                                       or pattern that the blocks belong to.
  * @param callable                        $callback      A function that will be called for each block to generate
  *                                                       the markup for a given list of blocks that are hooked to it.
- *                                                       Default: 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata'.
+ *                                                       Default: 'insert_hooked_blocks'.
  * @return callable A function that returns the serialized markup for the given block,
  *                  including the markup for any hooked blocks after it.
  */
-function make_after_block_visitor( $hooked_blocks, $context, $callback = 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' ) {
+function make_after_block_visitor( $hooked_blocks, $context, $callback = 'insert_hooked_blocks' ) {
 	/**
 	 * Injects hooked blocks after the given block, and returns the serialized markup.
 	 *

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -174,8 +174,8 @@ final class WP_Block_Patterns_Registry {
 		$before_block_visitor = '_inject_theme_attribute_in_template_part_block';
 		$after_block_visitor  = null;
 		if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
-			$before_block_visitor = make_before_block_visitor( $hooked_blocks, $pattern );
-			$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $pattern );
+			$before_block_visitor = make_before_block_visitor( $hooked_blocks, $pattern, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );
+			$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $pattern, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );
 		}
 		$blocks  = parse_blocks( $content );
 		$content = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );

--- a/tests/phpunit/tests/blocks/getHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/getHookedBlocks.php
@@ -151,7 +151,7 @@ class Tests_Blocks_GetHookedBlocks extends WP_UnitTestCase {
 			$template->content
 		);
 		$this->assertStringContainsString(
-			'<!-- wp:post-content {"layout":{"type":"constrained"}} /-->'
+			'<!-- wp:post-content {"layout":{"type":"constrained"},"metadata":{"ignoredHookedBlocks":["tests/hooked-after"]}} /-->'
 			. '<!-- wp:tests/hooked-after /-->',
 			$template->content
 		);
@@ -180,7 +180,7 @@ class Tests_Blocks_GetHookedBlocks extends WP_UnitTestCase {
 
 		$this->assertStringContainsString(
 			'<!-- wp:tests/hooked-before /-->'
-			. '<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} /-->',
+			. '<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"},"metadata":{"ignoredHookedBlocks":["tests/hooked-before"]}} /-->',
 			$template->content
 		);
 		$this->assertStringNotContainsString(
@@ -221,7 +221,7 @@ class Tests_Blocks_GetHookedBlocks extends WP_UnitTestCase {
 			$pattern['content']
 		);
 		$this->assertStringContainsString(
-			'<!-- wp:comments -->'
+			'<!-- wp:comments {"metadata":{"ignoredHookedBlocks":["tests/hooked-first-child"]}} -->'
 			. '<div class="wp-block-comments">'
 			. '<!-- wp:tests/hooked-first-child /-->',
 			str_replace( array( "\n", "\t" ), '', $pattern['content'] )

--- a/tests/phpunit/tests/blocks/insertHookedBlocksAndSetIgnoredHookedBlocksMetadata.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocksAndSetIgnoredHookedBlocksMetadata.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Tests for the insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata function.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @since 6.6.0
+ *
+ * @group blocks
+ * @group block-hooks
+ */
+class Tests_Blocks_InsertHookedBlocksAndSetIgnoredHookedBlocksMetadata extends WP_UnitTestCase {
+    const ANCHOR_BLOCK_TYPE       = 'tests/anchor-block';
+	const HOOKED_BLOCK_TYPE       = 'tests/hooked-block';
+	const OTHER_HOOKED_BLOCK_TYPE = 'tests/other-hooked-block';
+
+	const HOOKED_BLOCKS = array(
+		self::ANCHOR_BLOCK_TYPE => array(
+			'after'  => array( self::HOOKED_BLOCK_TYPE ),
+			'before' => array( self::OTHER_HOOKED_BLOCK_TYPE ),
+		),
+	);
+
+	/**
+	 * @ticket 60506
+	 */
+	private static function create_block_template_object() {
+		$template              = new WP_Block_Template();
+		$template->type        = 'wp_template';
+		$template->theme       = 'test-theme';
+		$template->slug        = 'single';
+		$template->id          = $template->theme . '//' . $template->slug;
+		$template->title       = 'Single';
+		$template->content     = '<!-- wp:tests/anchor-block /-->';
+		$template->description = 'Description of my template';
+
+		return $template;
+	}
+
+    /**
+	 * @covers ::insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata
+	 */
+	public function test_insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata_returns_correct_markup() {
+		$anchor_block = array(
+			'blockName' => self::ANCHOR_BLOCK_TYPE,
+		);
+
+		$actual = insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		$this->assertSame(
+			'<!-- wp:' . self::HOOKED_BLOCK_TYPE . ' /-->',
+			$actual,
+			"Markup for hooked block wasn't generated correctly."
+		);
+	}
+
+	/**
+	 * @covers ::insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata
+	 */
+	public function test_insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata_if_block_is_ignored() {
+		$anchor_block = array(
+			'blockName' => 'tests/anchor-block',
+			'attrs'     => array(
+				'metadata' => array(
+					'ignoredHookedBlocks' => array( self::HOOKED_BLOCK_TYPE ),
+				),
+			),
+		);
+
+		$actual = insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		$this->assertSame(
+			'',
+			$actual,
+			"No markup should've been generated for ignored hooked block."
+		);
+	}
+
+	/**
+	 * @covers ::insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata
+	 */
+	public function test_insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata_filter_can_suppress_hooked_block() {
+		$anchor_block = array(
+			'blockName'    => self::ANCHOR_BLOCK_TYPE,
+			'attrs'        => array(
+				'layout' => array(
+					'type' => 'flex',
+				),
+			),
+			'innerContent' => array(),
+		);
+
+		$filter = function ( $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block ) {
+			// Is the hooked block adjacent to the anchor block?
+			if ( 'before' !== $relative_position && 'after' !== $relative_position ) {
+				return $parsed_hooked_block;
+			}
+
+			if (
+				isset( $parsed_anchor_block['attrs']['layout']['type'] ) &&
+				'flex' === $parsed_anchor_block['attrs']['layout']['type']
+			) {
+				return null;
+			}
+
+			return $parsed_hooked_block;
+		};
+		add_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 4 );
+		$actual = insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		remove_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter );
+
+		$this->assertSame( '', $actual, "No markup should've been generated for hooked block suppressed by filter." );
+	}
+
+	/**
+	 * @covers ::insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata
+	 */
+	public function test_insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata_sets_metadata() {
+		$anchor_block = array(
+			'blockName' => 'tests/anchor-block',
+		);
+
+		$hooked_blocks = array(
+			'tests/anchor-block' => array(
+				'after' => array( 'tests/hooked-block' ),
+			),
+		);
+
+		insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( $anchor_block, 'after', $hooked_blocks, null );
+		$this->assertSame( array( 'tests/hooked-block' ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
+	}
+
+	/**
+	 * @covers ::insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata
+	 */
+	public function test_insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata_added_by_context_aware_filter() {
+		$anchor_block = array(
+			'blockName' => 'tests/anchor-block',
+			'attrs'     => array(),
+		);
+
+		$filter = function ( $hooked_block_types, $relative_position, $anchor_block_type, $context ) {
+			if (
+				! $context instanceof WP_Block_Template ||
+				! property_exists( $context, 'slug' ) ||
+				'single' !== $context->slug
+			) {
+				return $hooked_block_types;
+			}
+
+			if ( 'tests/anchor-block' === $anchor_block_type && 'after' === $relative_position ) {
+				$hooked_block_types[] = 'tests/hooked-block-added-by-filter';
+			}
+
+			return $hooked_block_types;
+		};
+
+		$template = self::create_block_template_object();
+
+		add_filter( 'hooked_block_types', $filter, 10, 4 );
+		insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( $anchor_block, 'after', array(), $template );
+		remove_filter( 'hooked_block_types', $filter, 10 );
+
+		$this->assertSame(
+			array( 'tests/hooked-block-added-by-filter' ),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks']
+		);
+	}
+
+	/**
+	 * @covers ::insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata
+	 */
+	public function test_insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata_for_block_suppressed_by_filter() {
+		$anchor_block = array(
+			'blockName' => 'tests/anchor-block',
+			'attrs'     => array(),
+		);
+
+		$hooked_blocks = array(
+			'tests/anchor-block' => array(
+				'after' => array( 'tests/hooked-block', 'tests/hooked-block-suppressed-by-filter' ),
+			),
+		);
+
+		$filter = function ( $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block ) {
+			if (
+				'tests/hooked-block-suppressed-by-filter' === $hooked_block_type &&
+				'after' === $relative_position &&
+				'tests/anchor-block' === $parsed_anchor_block['blockName']
+			) {
+				return null;
+			}
+
+			return $parsed_hooked_block;
+		};
+
+		add_filter( 'hooked_block', $filter, 10, 4 );
+		insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( $anchor_block, 'after', $hooked_blocks, null );
+		remove_filter( 'hooked_block', $filter );
+
+		$this->assertSame( array( 'tests/hooked-block' ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
+	}
+}

--- a/tests/phpunit/tests/blocks/insertHookedBlocksAndSetIgnoredHookedBlocksMetadata.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocksAndSetIgnoredHookedBlocksMetadata.php
@@ -57,6 +57,23 @@ class Tests_Blocks_InsertHookedBlocksAndSetIgnoredHookedBlocksMetadata extends W
 	/**
 	 * @covers ::insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata
 	 */
+	public function test_insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata_no_duplicate_hooked_block() {
+		$anchor_block = array(
+			'blockName' => self::ANCHOR_BLOCK_TYPE,
+		);
+
+		$actual  = insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		$actual .= insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		$this->assertSame(
+			'<!-- wp:' . self::HOOKED_BLOCK_TYPE . ' /-->',
+			$actual,
+			"Markup for hooked block wasn't generated correctly."
+		);
+	}
+
+	/**
+	 * @covers ::insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata
+	 */
 	public function test_insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata_if_block_is_ignored() {
 		$anchor_block = array(
 			'blockName' => 'tests/anchor-block',

--- a/tests/phpunit/tests/blocks/insertHookedBlocksAndSetIgnoredHookedBlocksMetadata.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocksAndSetIgnoredHookedBlocksMetadata.php
@@ -9,6 +9,7 @@
  *
  * @group blocks
  * @group block-hooks
+ * @covers ::insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata
  */
 class Tests_Blocks_InsertHookedBlocksAndSetIgnoredHookedBlocksMetadata extends WP_UnitTestCase {
 	const ANCHOR_BLOCK_TYPE       = 'tests/anchor-block';
@@ -39,7 +40,7 @@ class Tests_Blocks_InsertHookedBlocksAndSetIgnoredHookedBlocksMetadata extends W
 	}
 
 	/**
-	 * @covers ::insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata
+	 * @ticket 59574
 	 */
 	public function test_insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata_returns_correct_markup_and_sets_metadata() {
 		$anchor_block = array(
@@ -60,7 +61,7 @@ class Tests_Blocks_InsertHookedBlocksAndSetIgnoredHookedBlocksMetadata extends W
 	}
 
 	/**
-	 * @covers ::insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata
+	 * @ticket 59574
 	 */
 	public function test_insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata_if_block_is_ignored() {
 		$anchor_block = array(
@@ -86,7 +87,7 @@ class Tests_Blocks_InsertHookedBlocksAndSetIgnoredHookedBlocksMetadata extends W
 	}
 
 	/**
-	 * @covers ::insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata
+	 * @ticket 59574
 	 */
 	public function test_insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata_if_other_block_is_ignored() {
 		$anchor_block = array(
@@ -117,7 +118,7 @@ class Tests_Blocks_InsertHookedBlocksAndSetIgnoredHookedBlocksMetadata extends W
 	}
 
 	/**
-	 * @covers ::insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata
+	 * @ticket 59574
 	 */
 	public function test_insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata_filter_can_suppress_hooked_block() {
 		$anchor_block = array(
@@ -158,7 +159,7 @@ class Tests_Blocks_InsertHookedBlocksAndSetIgnoredHookedBlocksMetadata extends W
 	}
 
 	/**
-	 * @covers ::insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata
+	 * @ticket 59574
 	 */
 	public function test_insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata_added_by_context_aware_filter() {
 		$anchor_block = array(
@@ -201,7 +202,7 @@ class Tests_Blocks_InsertHookedBlocksAndSetIgnoredHookedBlocksMetadata extends W
 	}
 
 	/**
-	 * @covers ::insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata
+	 * @ticket 59574
 	 */
 	public function test_insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata_for_block_suppressed_by_filter() {
 		$anchor_block = array(

--- a/tests/phpunit/tests/blocks/insertHookedBlocksAndSetIgnoredHookedBlocksMetadata.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocksAndSetIgnoredHookedBlocksMetadata.php
@@ -41,7 +41,7 @@ class Tests_Blocks_InsertHookedBlocksAndSetIgnoredHookedBlocksMetadata extends W
 	/**
 	 * @covers ::insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata
 	 */
-	public function test_insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata_returns_correct_markup() {
+	public function test_insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata_returns_correct_markup_and_sets_metadata() {
 		$anchor_block = array(
 			'blockName' => self::ANCHOR_BLOCK_TYPE,
 		);
@@ -52,22 +52,10 @@ class Tests_Blocks_InsertHookedBlocksAndSetIgnoredHookedBlocksMetadata extends W
 			$actual,
 			"Markup for hooked block wasn't generated correctly."
 		);
-	}
-
-	/**
-	 * @covers ::insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata
-	 */
-	public function test_insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata_no_duplicate_hooked_block() {
-		$anchor_block = array(
-			'blockName' => self::ANCHOR_BLOCK_TYPE,
-		);
-
-		$actual  = insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
-		$actual .= insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
 		$this->assertSame(
-			'<!-- wp:' . self::HOOKED_BLOCK_TYPE . ' /-->',
-			$actual,
-			"Markup for hooked block wasn't generated correctly."
+			array( 'tests/hooked-block' ),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'],
+			"Block wasn't added to ignoredHookedBlocks metadata."
 		);
 	}
 
@@ -89,6 +77,11 @@ class Tests_Blocks_InsertHookedBlocksAndSetIgnoredHookedBlocksMetadata extends W
 			'',
 			$actual,
 			"No markup should've been generated for ignored hooked block."
+		);
+		$this->assertSame(
+			array( 'tests/hooked-block' ),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'],
+			"ignoredHookedBlocks metadata shouldn't have been modified."
 		);
 	}
 
@@ -126,24 +119,6 @@ class Tests_Blocks_InsertHookedBlocksAndSetIgnoredHookedBlocksMetadata extends W
 		remove_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter );
 
 		$this->assertSame( '', $actual, "No markup should've been generated for hooked block suppressed by filter." );
-	}
-
-	/**
-	 * @covers ::insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata
-	 */
-	public function test_insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata_sets_metadata() {
-		$anchor_block = array(
-			'blockName' => 'tests/anchor-block',
-		);
-
-		$hooked_blocks = array(
-			'tests/anchor-block' => array(
-				'after' => array( 'tests/hooked-block' ),
-			),
-		);
-
-		insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( $anchor_block, 'after', $hooked_blocks, null );
-		$this->assertSame( array( 'tests/hooked-block' ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/blocks/insertHookedBlocksAndSetIgnoredHookedBlocksMetadata.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocksAndSetIgnoredHookedBlocksMetadata.php
@@ -88,6 +88,37 @@ class Tests_Blocks_InsertHookedBlocksAndSetIgnoredHookedBlocksMetadata extends W
 	/**
 	 * @covers ::insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata
 	 */
+	public function test_insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata_if_other_block_is_ignored() {
+		$anchor_block = array(
+			'blockName' => 'tests/anchor-block',
+			'attrs'     => array(
+				'metadata' => array(
+					'ignoredHookedBlocks' => array( 'tests/other-ignored-block' ),
+				),
+			),
+		);
+
+		$hooked_blocks = array(
+			'tests/anchor-block' => array(
+				'after' => array( 'tests/hooked-block' ),
+			),
+		);
+
+		$actual = insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( $anchor_block, 'after', $hooked_blocks, array() );
+		$this->assertSame(
+			'<!-- wp:' . self::HOOKED_BLOCK_TYPE . ' /-->',
+			$actual,
+			"Markup for newly hooked block should've been generated."
+		);
+		$this->assertSame(
+			array( 'tests/other-ignored-block', 'tests/hooked-block' ),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks']
+		);
+	}
+
+	/**
+	 * @covers ::insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata
+	 */
 	public function test_insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata_filter_can_suppress_hooked_block() {
 		$anchor_block = array(
 			'blockName'    => self::ANCHOR_BLOCK_TYPE,

--- a/tests/phpunit/tests/blocks/insertHookedBlocksAndSetIgnoredHookedBlocksMetadata.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocksAndSetIgnoredHookedBlocksMetadata.php
@@ -11,7 +11,7 @@
  * @group block-hooks
  */
 class Tests_Blocks_InsertHookedBlocksAndSetIgnoredHookedBlocksMetadata extends WP_UnitTestCase {
-    const ANCHOR_BLOCK_TYPE       = 'tests/anchor-block';
+	const ANCHOR_BLOCK_TYPE       = 'tests/anchor-block';
 	const HOOKED_BLOCK_TYPE       = 'tests/hooked-block';
 	const OTHER_HOOKED_BLOCK_TYPE = 'tests/other-hooked-block';
 
@@ -38,7 +38,7 @@ class Tests_Blocks_InsertHookedBlocksAndSetIgnoredHookedBlocksMetadata extends W
 		return $template;
 	}
 
-    /**
+	/**
 	 * @covers ::insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata
 	 */
 	public function test_insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata_returns_correct_markup() {

--- a/tests/phpunit/tests/blocks/insertHookedBlocksAndSetIgnoredHookedBlocksMetadata.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocksAndSetIgnoredHookedBlocksMetadata.php
@@ -23,7 +23,7 @@ class Tests_Blocks_InsertHookedBlocksAndSetIgnoredHookedBlocksMetadata extends W
 	);
 
 	/**
-	 * @ticket 60506
+	 * @ticket 59574
 	 */
 	private static function create_block_template_object() {
 		$template              = new WP_Block_Template();

--- a/tests/phpunit/tests/blocks/insertHookedBlocksAndSetIgnoredHookedBlocksMetadata.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocksAndSetIgnoredHookedBlocksMetadata.php
@@ -228,9 +228,18 @@ class Tests_Blocks_InsertHookedBlocksAndSetIgnoredHookedBlocksMetadata extends W
 		};
 
 		add_filter( 'hooked_block', $filter, 10, 4 );
-		insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( $anchor_block, 'after', $hooked_blocks, null );
+		$actual = insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( $anchor_block, 'after', $hooked_blocks, null );
 		remove_filter( 'hooked_block', $filter );
 
-		$this->assertSame( array( 'tests/hooked-block' ), $anchor_block['attrs']['metadata']['ignoredHookedBlocks'] );
+		$this->assertSame(
+			'<!-- wp:tests/hooked-block /-->',
+			$actual,
+			"Markup for hooked block wasn't generated correctly."
+		);
+		$this->assertSame(
+			array( 'tests/hooked-block' ),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'],
+			"ignoredHookedBlocks metadata wasn't set correctly."
+		);
 	}
 }

--- a/tests/phpunit/tests/blocks/insertHookedBlocksAndSetIgnoredHookedBlocksMetadata.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocksAndSetIgnoredHookedBlocksMetadata.php
@@ -150,6 +150,11 @@ class Tests_Blocks_InsertHookedBlocksAndSetIgnoredHookedBlocksMetadata extends W
 		remove_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter );
 
 		$this->assertSame( '', $actual, "No markup should've been generated for hooked block suppressed by filter." );
+		$this->assertSame(
+			array(),
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'],
+			"No block should've been added to ignoredHookedBlocks metadata."
+		);
 	}
 
 	/**
@@ -180,12 +185,18 @@ class Tests_Blocks_InsertHookedBlocksAndSetIgnoredHookedBlocksMetadata extends W
 		$template = self::create_block_template_object();
 
 		add_filter( 'hooked_block_types', $filter, 10, 4 );
-		insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( $anchor_block, 'after', array(), $template );
+		$actual = insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( $anchor_block, 'after', array(), $template );
 		remove_filter( 'hooked_block_types', $filter, 10 );
 
 		$this->assertSame(
+			'<!-- wp:tests/hooked-block-added-by-filter /-->',
+			$actual,
+			"Markup for hooked block added by filter wasn't generated correctly."
+		);
+		$this->assertSame(
 			array( 'tests/hooked-block-added-by-filter' ),
-			$anchor_block['attrs']['metadata']['ignoredHookedBlocks']
+			$anchor_block['attrs']['metadata']['ignoredHookedBlocks'],
+			"Block added by filter wasn't added to ignoredHookedBlocks metadata."
 		);
 	}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/59574

The block hooks UI toggle relies on the `ignoredHookedBlocks` when determining whether to show the toggle in the Site Editor UI. The current problem is that for uncustomized templates we don't add this meta data. Currently the visitor functions have a default callback of `insert_hooked_blocks` and we only add the meta data when we're writing to the database via an available filter in the template controller.

This PR creates a new default callback which both inserts the hooked blocks and adds the `ignoredHookedBlocks` meta data to the anchor block, and makes this the new default callback for the visitor functions. This means we will continue to add `ignoredHookedBlocks` meta when writing to the database meaning this operation happens twice. Although not ideal this is necessary to cover the following scenarios;

* When the user adds an anchor block within the editor we still need to add the `ignoredHookedBlocks` meta to it to prevent hooked blocks hooking on to it unexpectedly on the frontend, this means we keep parity between the frontend and editor.
* When a user writes template data to the database directly through the API (instead of the editor) we need to again ensure we're not inserting hooked blocks unexpectedly.

It is worth noting that with this change it means the first hooked block to insert relative to its anchor block will be accepted. Any additional blocks of the same type (ie a second `core/loginout` block) trying to hook onto the same anchor block will be ignored, irrespective of the position.

## Manual testing instructions:
1 . Clear template customizations
2. Add the first code block to your themes functions.php
3. Go to the Single Posts template and check the loginout block is inserted after the post content.
4. Click the post content to check the toggle exists to show/hide the hooked block.
5. Save the template
6. Add the second code block and reload the Single Posts template. Follow steps 1-4 again and check them against the Page List block.

```php
function register_loginout_hooked_block( $hooked_blocks, $position, $anchor_block, $context ) {
	if ( $anchor_block === 'core/post-content' && $position === 'after' ) {
		$hooked_blocks[] = 'core/loginout';
	}

	return $hooked_blocks;
}
add_filter( 'hooked_block_types', 'register_loginout_hooked_block', 10, 4 );
```

```php
function register_pagelist_hooked_block( $hooked_blocks, $position, $anchor_block, $context ) {
	if ( $anchor_block === 'core/post-content' && $position === 'before' ) {
		$hooked_blocks[] = 'core/page-list';
	}

	return $hooked_blocks;
}
add_filter( 'hooked_block_types', 'register_pagelist_hooked_block', 10, 4 );
```

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
