### PR TITLE
Use an image on WordPress.org CDN in external HTTP tests

### DIFF
--- a/tests/phpunit/tests/functions/wpRemoteFopen.php
+++ b/tests/phpunit/tests/functions/wpRemoteFopen.php
@@ -27,10 +27,10 @@ class Tests_Functions_wpRemoteFopen extends WP_UnitTestCase {
 	 */
 	public function test_wp_remote_fopen() {
 		// This URL gives a direct 200 response.
-		$url      = 'https://asdftestblog1.wordpress.com/wp-content/uploads/2007/09/2007-06-30-dsc_4700-1.jpg';
+		$url      = 'https://s.w.org/screenshots/3.9/dashboard.png';
 		$response = wp_remote_fopen( $url );
 
 		$this->assertIsString( $response );
-		$this->assertSame( 40148, strlen( $response ) );
+		$this->assertSame( 153204, strlen( $response ) );
 	}
 }

--- a/tests/phpunit/tests/http/functions.php
+++ b/tests/phpunit/tests/http/functions.php
@@ -11,7 +11,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	 */
 	public function test_head_request() {
 		// This URL gives a direct 200 response.
-		$url      = 'https://asdftestblog1.wordpress.com/wp-content/uploads/2007/09/2007-06-30-dsc_4700-1.jpg';
+		$url      = 'https://s.w.org/screenshots/3.9/dashboard.png';
 		$response = wp_remote_head( $url );
 
 		$this->skipTestOnTimeout( $response );
@@ -20,8 +20,8 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 
 		$this->assertIsArray( $response );
 
-		$this->assertSame( 'image/jpeg', $headers['Content-Type'] );
-		$this->assertSame( '40148', $headers['Content-Length'] );
+		$this->assertSame( 'image/png', $headers['Content-Type'] );
+		$this->assertSame( '153204', $headers['Content-Length'] );
 		$this->assertSame( 200, wp_remote_retrieve_response_code( $response ) );
 	}
 
@@ -30,7 +30,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	 */
 	public function test_head_redirect() {
 		// This URL will 301 redirect.
-		$url      = 'https://asdftestblog1.wordpress.com/files/2007/09/2007-06-30-dsc_4700-1.jpg';
+		$url      = 'https://wp.org/screenshots/3.9/dashboard.png';
 		$response = wp_remote_head( $url );
 
 		$this->skipTestOnTimeout( $response );
@@ -41,7 +41,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	 * @covers ::wp_remote_head
 	 */
 	public function test_head_404() {
-		$url      = 'https://asdftestblog1.wordpress.com/wp-content/uploads/2007/09/awefasdfawef.jpg';
+		$url      = 'https://wordpress.org/screenshots/3.9/awefasdfawef.jpg';
 		$response = wp_remote_head( $url );
 
 		$this->skipTestOnTimeout( $response );
@@ -54,7 +54,7 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	 * @covers ::wp_remote_retrieve_response_code
 	 */
 	public function test_get_request() {
-		$url = 'https://asdftestblog1.files.wordpress.com/2007/09/2007-06-30-dsc_4700-1.jpg';
+		$url = 'https://s.w.org/screenshots/3.9/dashboard.png';
 
 		$response = wp_remote_get( $url );
 
@@ -65,8 +65,8 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 		$this->assertIsArray( $response );
 
 		// Should return the same headers as a HEAD request.
-		$this->assertSame( 'image/jpeg', $headers['Content-Type'] );
-		$this->assertSame( '40148', $headers['Content-Length'] );
+		$this->assertSame( 'image/png', $headers['Content-Type'] );
+		$this->assertSame( '153204', $headers['Content-Length'] );
 		$this->assertSame( 200, wp_remote_retrieve_response_code( $response ) );
 	}
 
@@ -76,8 +76,8 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	 * @covers ::wp_remote_retrieve_response_code
 	 */
 	public function test_get_redirect() {
-		// This will redirect to asdftestblog1.files.wordpress.com.
-		$url = 'https://asdftestblog1.wordpress.com/files/2007/09/2007-06-30-dsc_4700-1.jpg';
+		// This will redirect to wordpress.org.
+		$url = 'https://wp.org/screenshots/3.9/dashboard.png';
 
 		$response = wp_remote_get( $url );
 
@@ -86,8 +86,8 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 		$headers = wp_remote_retrieve_headers( $response );
 
 		// Should return the same headers as a HEAD request.
-		$this->assertSame( 'image/jpeg', $headers['Content-Type'] );
-		$this->assertSame( '40148', $headers['Content-Length'] );
+		$this->assertSame( 'image/png', $headers['Content-Type'] );
+		$this->assertSame( '153204', $headers['Content-Length'] );
 		$this->assertSame( 200, wp_remote_retrieve_response_code( $response ) );
 	}
 
@@ -95,8 +95,8 @@ class Tests_HTTP_Functions extends WP_UnitTestCase {
 	 * @covers ::wp_remote_get
 	 */
 	public function test_get_redirect_limit_exceeded() {
-		// This will redirect to asdftestblog1.files.wordpress.com.
-		$url = 'https://asdftestblog1.wordpress.com/files/2007/09/2007-06-30-dsc_4700-1.jpg';
+		// This will redirect to wordpress.org.
+		$url = 'https://wp.org/screenshots/3.9/dashboard.png';
 
 		// Pretend we've already redirected 5 times.
 		$response = wp_remote_get( $url, array( 'redirection' => -1 ) );

--- a/tests/phpunit/tests/image/functions.php
+++ b/tests/phpunit/tests/image/functions.php
@@ -638,7 +638,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 	 */
 	public function test_wp_crop_image_with_url() {
 		$file = wp_crop_image(
-			'https://asdftestblog1.files.wordpress.com/2008/04/canola.jpg',
+			'https://s.w.org/screenshots/3.9/dashboard.png',
 			0,
 			0,
 			100,
@@ -646,7 +646,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 			100,
 			100,
 			false,
-			DIR_TESTDATA . '/images/' . __FUNCTION__ . '.jpg'
+			DIR_TESTDATA . '/images/' . __FUNCTION__ . '.png'
 		);
 
 		if ( is_wp_error( $file ) && $file->get_error_code() === 'invalid_image' ) {
@@ -687,7 +687,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 	 */
 	public function test_wp_crop_image_should_fail_with_wp_error_object_if_url_does_not_exist() {
 		$file = wp_crop_image(
-			'https://asdftestblog1.files.wordpress.com/2008/04/canoladoesnotexist.jpg',
+			'https://wordpress.org/screenshots/3.9/canoladoesnotexist.jpg',
 			0,
 			0,
 			100,


### PR DESCRIPTION
Due to some changes on the WP.com side to compress the requested images on the fly, the exact image size in the response could be different between platforms.

This commit aims to make the affected tests more reliable.

Trac ticket: https://core.trac.wordpress.org/ticket/60865

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
