### PR TITLE
60895 Add batch support to users REST API WP_REST_Users_Controller

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -25,6 +25,14 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	protected $meta;
 
 	/**
+	 * Whether the controller supports batching.
+	 *
+	 * @since 6.5.1
+	 * @var array
+	 */
+	protected $allow_batch = array( 'v1' => true );
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 4.7.0
@@ -61,6 +69,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 					'permission_callback' => array( $this, 'create_item_permissions_check' ),
 					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
 				),
+				'allow_batch' => $this->allow_batch,
 				'schema' => array( $this, 'get_public_item_schema' ),
 			)
 		);

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -70,7 +70,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
 				),
 				'allow_batch' => $this->allow_batch,
-				'schema' => array( $this, 'get_public_item_schema' ),
+				'schema'      => array( $this, 'get_public_item_schema' ),
 			)
 		);
 
@@ -116,7 +116,8 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 						),
 					),
 				),
-				'schema' => array( $this, 'get_public_item_schema' ),
+				'allow_batch' => $this->allow_batch,
+				'schema'      => array( $this, 'get_public_item_schema' ),
 			)
 		);
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -27,7 +27,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	/**
 	 * Whether the controller supports batching.
 	 *
-	 * @since 6.5.1
+	 * @since 6.6.0
 	 * @var array
 	 */
 	protected $allow_batch = array( 'v1' => true );

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -180,12 +180,14 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/users' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
+		$this->assertSame( array( 'v1' => true ), $data['endpoints'][0]['allow_batch'] );
 		$this->assertSame( 'view', $data['endpoints'][0]['args']['context']['default'] );
 		$this->assertSame( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 		// Single.
 		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/users/' . self::$user );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
+		$this->assertSame( array( 'v1' => true ), $data['endpoints'][0]['allow_batch'] );
 		$this->assertSame( 'view', $data['endpoints'][0]['args']['context']['default'] );
 		$this->assertSame( array( 'view', 'embed', 'edit' ), $data['endpoints'][0]['args']['context']['enum'] );
 	}


### PR DESCRIPTION
Following the development discussions in [#53063](https://core.trac.wordpress.org/ticket/53063) and [#50244](https://core.trac.wordpress.org/ticket/50244) for some reason batch support was not added to users.

We were working on importing a large number of users as part of a migration project to WordPress / WooCommerce to discover that WP REST API does not support batching for Users in `WP_REST_Users_Controller` since `allow_batch` is not explicitly set to `true` in `register_rest_route`.

This PR adds batch support for users in `WP_REST_Users_Controller`.

Example batch create users request:
```shell
curl --location 'http://localhost:8080/wp-json/batch/v1' \
--header 'Content-Type: application/json' \
--header 'Authorization: Basic ##REDACTED##' \
--data-raw '{
    "requests": [
        {
            "method": "POST",
            "path": "/wp/v2/users",
            "body": {
                "username": "testuser1",
                "email": "testuser1@localhost.local",
                "password": "##REDACTED##"
            }
        },
        {
            "method": "POST",
            "path": "/wp/v2/users",
            "body": {
                "username": "testuser2",
                "email": "testuser2@localhost.local",
                "password": "##REDACTED##"
            }
        }
    ]
}'
```


Trac ticket: https://core.trac.wordpress.org/ticket/60895
Reference: https://core.trac.wordpress.org/ticket/53063

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
