### PR TITLE
Create action `edit_form_before_title`

### DIFF
--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -529,6 +529,16 @@ do_action( 'edit_form_top', $post );
 <div id="poststuff">
 <div id="post-body" class="metabox-holder columns-<?php echo ( 1 === get_current_screen()->get_columns() ) ? '1' : '2'; ?>">
 <div id="post-body-content">
+<?php
+/**
+ * Fires before the title field.
+ *
+ * @since 6.5.1
+ *
+ * @param WP_Post $post Post object.
+ */
+do_action( 'edit_form_before_title', $post );
+?>
 
 <?php if ( post_type_supports( $post_type, 'title' ) ) { ?>
 <div id="titlediv">


### PR DESCRIPTION
 Triggered on the "classic" add/edit post pages before the title field is displayed. Will be the pair of already existing edit_form_after_title.

Helps hooking in before the title input field being displayed, so it would make it possible for plugins like ACF (or plugins extending ACF) to show custom fields even before the title input.

Trac ticket: https://core.trac.wordpress.org/ticket/60968

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
