### PR TITLE
Interactivity API: Add server derived state getter handling

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -116,8 +116,24 @@ final class WP_Interactivity_API {
 	 * @return array The current state for the specified store namespace. This will be the updated state if a $state
 	 *               argument was provided.
 	 */
-	public function state( string $store_namespace = '', array $state = array() ): array {
+	public function state( ?string $store_namespace = null, ?array $state = null ): array {
 		if ( ! $store_namespace ) {
+			if ( $state ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'The namespace is required when state data is passed.' ),
+					'6.6.0'
+				);
+				return array();
+			}
+			if ( null !== $store_namespace ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'The namespace should be a non-empty string.' ),
+					'6.6.0'
+				);
+				return array();
+			}
 			$store_namespace = end( $this->namespace_stack );
 		}
 		if ( ! isset( $this->state_data[ $store_namespace ] ) ) {

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -447,7 +447,7 @@ final class WP_Interactivity_API {
 		}
 
 		if ( $unbalanced ) {
-			// Restet the namespace and context stacks to their previous values.
+			// Reset the namespace and context stacks to their previous values.
 			array_splice( $this->namespace_stack, $namespace_stack_size );
 			array_splice( $this->context_stack, $context_stack_size );
 		}

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -78,7 +78,7 @@ final class WP_Interactivity_API {
 	 * the order they are processed.
 	 *
 	 * This list is populated only during directive processing, and it should
-	 * remain empty afterwards.
+	 * become `null` afterwards.
 	 *
 	 * @since 6.6.0
 	 * @var array<string>|null
@@ -90,7 +90,7 @@ final class WP_Interactivity_API {
 	 * the order they are processed.
 	 *
 	 * This list is populated only during directive processing, and it should
-	 * remain empty afterwards.
+	 * become `null` afterwards.
 	 *
 	 * @since 6.6.0
 	 * @var array<array<mixed>>|null

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -320,10 +320,10 @@ final class WP_Interactivity_API {
 	 * Processes the interactivity directives contained within the HTML content
 	 * and updates the markup accordingly.
 	 *
-	 * It uses the instance's context and namespace stacks, which is shared between
-	 * all calls, and it returns null if the HTML contains unbalanced tags.
+	 * It uses the WP_Interactivity_API instance's context and namespace stacks,
+	 * which are shared between all calls.
 	 *
-	 * TODO: Revisit this method's name.
+	 * This method returns null if the HTML contains unbalanced tags.
 	 *
 	 * @since 6.5.0
 	 * @since 6.6.0 The function displays a warning message when the HTML contains unbalanced tags or a directive appears in a MATH or SVG tag.

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -450,6 +450,10 @@ final class WP_Interactivity_API {
 			}
 		}
 
+		if ( $current instanceof Closure ) {
+			$current = $current( $store );
+		}
+
 		// Returns the opposite if it contains a negation operator (!).
 		return $should_negate_value ? ! $current : $current;
 	}

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -77,8 +77,7 @@ final class WP_Interactivity_API {
 	 * Stack of namespaces defined by `data-wp-interactive` directives, in
 	 * the order they are processed.
 	 *
-	 * This list is populated only during directive processing, and it should
-	 * become `null` afterwards.
+	 * This is only available during directive processing, otherwise it is `null`.
 	 *
 	 * @since 6.6.0
 	 * @var array<string>|null

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -538,6 +538,13 @@ final class WP_Interactivity_API {
 		}
 
 		if ( $current instanceof Closure ) {
+			/*
+			 * This is a derived state getter. This property's namespace needs
+			 * to be added onto the namespace stack to get the right one when
+			 * `wp_interactivity_state` or `wp_interactivity_get_config` are
+			 * called inside the getter without specifying the namespace.
+			 */
+			array_push( $this->namespace_stack, $ns );
 			try {
 				$current = $current();
 			} catch ( Throwable $e ) {
@@ -552,6 +559,9 @@ final class WP_Interactivity_API {
 					'6.6.0'
 				);
 				return null;
+			} finally {
+				// Remove the property's namespace from the stack.
+				array_pop( $this->namespace_stack );
 			}
 		}
 

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -540,7 +540,21 @@ final class WP_Interactivity_API {
 		}
 
 		if ( $current instanceof Closure ) {
-			$current = $current();
+			try {
+				$current = $current();
+			} catch ( Throwable $e ) {
+				_doing_it_wrong(
+					__METHOD__,
+					sprintf(
+						/* translators: 1: Path pointing to an Interactivity API state property, 2: Namespace for an Interactivity API store. */
+						__( 'Uncaught error executing a derived state callback with path "%1$s" and namespace "%2$s".' ),
+						$path,
+						$ns
+					),
+					'6.6.0'
+				);
+				return null;
+			}
 		}
 
 		// Returns the opposite if it contains a negation operator (!).

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -486,7 +486,7 @@ final class WP_Interactivity_API {
 		}
 
 		if ( $current instanceof Closure ) {
-			$current = $current();
+			$current = $current( $store );
 		}
 
 		// Returns the opposite if it contains a negation operator (!).

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -563,10 +563,9 @@ final class WP_Interactivity_API {
 
 		if ( $current instanceof Closure ) {
 			/*
-			 * This is a derived state getter. This property's namespace needs
-			 * to be added onto the namespace stack to get the right one when
-			 * `wp_interactivity_state` or `wp_interactivity_get_config` are
-			 * called inside the getter without specifying the namespace.
+			 * This state getter's namespace is added to the stack so that
+			 * `state()` or `get_config()` read that namespace when called
+			 * without specifying one.
 			 */
 			array_push( $this->namespace_stack, $ns );
 			try {

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -336,7 +336,7 @@ final class WP_Interactivity_API {
 			return $html;
 		}
 
-		$result = $this->process_directives_args( $html );
+		$result = $this->_process_directives( $html );
 
 		return null === $result ? $html : $result;
 	}
@@ -350,14 +350,12 @@ final class WP_Interactivity_API {
 	 *
 	 * This method returns null if the HTML contains unbalanced tags.
 	 *
-	 * @since 6.5.0
-	 * @since 6.6.0 The function displays a warning message when the HTML contains unbalanced tags or a directive appears in a MATH or SVG tag.
-	 * @since 6.6.0 Removed `namespace_stack` and `context_stack` arguments.
+	 * @since 6.6.0
 	 *
 	 * @param string $html The HTML content to process.
 	 * @return string|null The processed HTML content. It returns null when the HTML contains unbalanced tags.
 	 */
-	private function process_directives_args( string $html ) {
+	private function _process_directives( string $html ) {
 		$p          = new WP_Interactivity_API_Directives_Processor( $html );
 		$tag_stack  = array();
 		$unbalanced = false;
@@ -1117,7 +1115,7 @@ HTML;
 				);
 
 				// Processes the inner content with the new context.
-				$processed_item = $this->process_directives_args( $inner_content );
+				$processed_item = $this->_process_directives( $inner_content );
 
 				if ( null === $processed_item ) {
 					// If the HTML is unbalanced, stop processing it.

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -680,10 +680,8 @@ final class WP_Interactivity_API {
 	 *
 	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
 	 * @param string                                    $mode            Whether the processing is entering or exiting the tag.
-	 * @param array                                     $context_stack   The reference to the context stack.
-	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
-	private function data_wp_bind_processor( WP_Interactivity_API_Directives_Processor $p, string $mode, array &$context_stack, array &$namespace_stack ) {
+	private function data_wp_bind_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
 		if ( 'enter' === $mode ) {
 			$all_bind_directives = $p->get_attribute_names_with_prefix( 'data-wp-bind--' );
 
@@ -694,7 +692,7 @@ final class WP_Interactivity_API {
 				}
 
 				$attribute_value = $p->get_attribute( $attribute_name );
-				$result          = $this->evaluate( $attribute_value, end( $namespace_stack ), end( $context_stack ) );
+				$result          = $this->evaluate( $attribute_value );
 
 				if (
 					null !== $result &&
@@ -734,10 +732,8 @@ final class WP_Interactivity_API {
 	 *
 	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
 	 * @param string                                    $mode            Whether the processing is entering or exiting the tag.
-	 * @param array                                     $context_stack   The reference to the context stack.
-	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
-	private function data_wp_class_processor( WP_Interactivity_API_Directives_Processor $p, string $mode, array &$context_stack, array &$namespace_stack ) {
+	private function data_wp_class_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
 		if ( 'enter' === $mode ) {
 			$all_class_directives = $p->get_attribute_names_with_prefix( 'data-wp-class--' );
 
@@ -748,7 +744,7 @@ final class WP_Interactivity_API {
 				}
 
 				$attribute_value = $p->get_attribute( $attribute_name );
-				$result          = $this->evaluate( $attribute_value, end( $namespace_stack ), end( $context_stack ) );
+				$result          = $this->evaluate( $attribute_value );
 
 				if ( $result ) {
 					$p->add_class( $class_name );
@@ -769,10 +765,8 @@ final class WP_Interactivity_API {
 	 *
 	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
 	 * @param string                                    $mode            Whether the processing is entering or exiting the tag.
-	 * @param array                                     $context_stack   The reference to the context stack.
-	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
-	private function data_wp_style_processor( WP_Interactivity_API_Directives_Processor $p, string $mode, array &$context_stack, array &$namespace_stack ) {
+	private function data_wp_style_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
 		if ( 'enter' === $mode ) {
 			$all_style_attributes = $p->get_attribute_names_with_prefix( 'data-wp-style--' );
 
@@ -783,7 +777,7 @@ final class WP_Interactivity_API {
 				}
 
 				$directive_attribute_value = $p->get_attribute( $attribute_name );
-				$style_property_value      = $this->evaluate( $directive_attribute_value, end( $namespace_stack ), end( $context_stack ) );
+				$style_property_value      = $this->evaluate( $directive_attribute_value );
 				$style_attribute_value     = $p->get_attribute( 'style' );
 				$style_attribute_value     = ( $style_attribute_value && ! is_bool( $style_attribute_value ) ) ? $style_attribute_value : '';
 
@@ -862,13 +856,11 @@ final class WP_Interactivity_API {
 	 *
 	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
 	 * @param string                                    $mode            Whether the processing is entering or exiting the tag.
-	 * @param array                                     $context_stack   The reference to the context stack.
-	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
-	private function data_wp_text_processor( WP_Interactivity_API_Directives_Processor $p, string $mode, array &$context_stack, array &$namespace_stack ) {
+	private function data_wp_text_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
 		if ( 'enter' === $mode ) {
 			$attribute_value = $p->get_attribute( 'data-wp-text' );
-			$result          = $this->evaluate( $attribute_value, end( $namespace_stack ), end( $context_stack ) );
+			$result          = $this->evaluate( $attribute_value );
 
 			/*
 			 * Follows the same logic as Preact in the client and only changes the
@@ -1000,17 +992,15 @@ HTML;
 	 *
 	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
 	 * @param string                                    $mode            Whether the processing is entering or exiting the tag.
-	 * @param array                                     $context_stack   The reference to the context stack.
-	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 * @param array                                     $tag_stack       The reference to the tag stack.
 	 */
-	private function data_wp_each_processor( WP_Interactivity_API_Directives_Processor $p, string $mode, array &$context_stack, array &$namespace_stack, array &$tag_stack ) {
+	private function data_wp_each_processor( WP_Interactivity_API_Directives_Processor $p, string $mode, array &$tag_stack ) {
 		if ( 'enter' === $mode && 'TEMPLATE' === $p->get_tag() ) {
 			$attribute_name   = $p->get_attribute_names_with_prefix( 'data-wp-each' )[0];
 			$extracted_suffix = $this->extract_prefix_and_suffix( $attribute_name );
 			$item_name        = isset( $extracted_suffix[1] ) ? $this->kebab_to_camel_case( $extracted_suffix[1] ) : 'item';
 			$attribute_value  = $p->get_attribute( $attribute_name );
-			$result           = $this->evaluate( $attribute_value, end( $namespace_stack ), end( $context_stack ) );
+			$result           = $this->evaluate( $attribute_value );
 
 			// Gets the content between the template tags and leaves the cursor in the closer tag.
 			$inner_content = $p->get_content_between_balanced_template_tags();
@@ -1044,7 +1034,7 @@ HTML;
 			}
 
 			// Extracts the namespace from the directive attribute value.
-			$namespace_value         = end( $namespace_stack );
+			$namespace_value         = end( $this->namespace_stack );
 			list( $namespace_value ) = is_string( $attribute_value ) && ! empty( $attribute_value )
 				? $this->extract_directive_value( $attribute_value, $namespace_value )
 				: array( $namespace_value, null );
@@ -1053,17 +1043,17 @@ HTML;
 			$processed_content = '';
 			foreach ( $result as $item ) {
 				// Creates a new context that includes the current item of the array.
-				$context_stack[] = array_replace_recursive(
-					end( $context_stack ) !== false ? end( $context_stack ) : array(),
+				$this->context_stack[] = array_replace_recursive(
+					end( $this->context_stack ) !== false ? end( $this->context_stack ) : array(),
 					array( $namespace_value => array( $item_name => $item ) )
 				);
 
 				// Processes the inner content with the new context.
-				$processed_item = $this->process_directives_args( $inner_content, $context_stack, $namespace_stack );
+				$processed_item = $this->process_directives_args( $inner_content );
 
 				if ( null === $processed_item ) {
 					// If the HTML is unbalanced, stop processing it.
-					array_pop( $context_stack );
+					array_pop( $this->context_stack );
 					return;
 				}
 
@@ -1076,7 +1066,7 @@ HTML;
 				$processed_content .= $i->get_updated_html();
 
 				// Removes the current context from the stack.
-				array_pop( $context_stack );
+				array_pop( $this->context_stack );
 			}
 
 			// Appends the processed content after the tag closer of the template.

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -635,18 +635,16 @@ final class WP_Interactivity_API {
 	 *
 	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
 	 * @param string                                    $mode            Whether the processing is entering or exiting the tag.
-	 * @param array                                     $context_stack   The reference to the context stack.
-	 * @param array                                     $namespace_stack The reference to the store namespace stack.
 	 */
-	private function data_wp_context_processor( WP_Interactivity_API_Directives_Processor $p, string $mode, array &$context_stack, array &$namespace_stack ) {
+	private function data_wp_context_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
 		// When exiting tags, it removes the last context from the stack.
 		if ( 'exit' === $mode ) {
-			array_pop( $context_stack );
+			array_pop( $this->context_stack );
 			return;
 		}
 
 		$attribute_value = $p->get_attribute( 'data-wp-context' );
-		$namespace_value = end( $namespace_stack );
+		$namespace_value = end( $this->namespace_stack );
 
 		// Separates the namespace from the context JSON object.
 		list( $namespace_value, $decoded_json ) = is_string( $attribute_value ) && ! empty( $attribute_value )
@@ -658,8 +656,8 @@ final class WP_Interactivity_API {
 		 * previous context with the new one.
 		 */
 		if ( is_string( $namespace_value ) ) {
-			$context_stack[] = array_replace_recursive(
-				end( $context_stack ) !== false ? end( $context_stack ) : array(),
+			$this->context_stack[] = array_replace_recursive(
+				end( $this->context_stack ) !== false ? end( $this->context_stack ) : array(),
 				array( $namespace_value => is_array( $decoded_json ) ? $decoded_json : array() )
 			);
 		} else {
@@ -668,7 +666,7 @@ final class WP_Interactivity_API {
 			 * It needs to do so because the function pops out the current context
 			 * from the stack whenever it finds a `data-wp-context`'s closing tag.
 			 */
-			$context_stack[] = end( $context_stack );
+			$this->context_stack[] = end( $this->context_stack );
 		}
 	}
 

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -93,7 +93,7 @@ final class WP_Interactivity_API {
 	 * remain empty afterwards.
 	 *
 	 * @since 6.6.0
-	 * @var array
+	 * @var array<array<mixed>>
 	 */
 	private $context_stack = array();
 

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -101,18 +101,22 @@ final class WP_Interactivity_API {
 	 * Gets and/or sets the initial state of an Interactivity API store for a
 	 * given namespace.
 	 *
-	 * If state for that store namespace already exists, it merges the new
-	 * provided state with the existing one.
+	 * When no namespace is specified, it returns the state defined for the
+	 * current value in the internal namespace stack.
 	 *
 	 * @since 6.5.0
+	 * @since 6.6.0 The `$store_namespace` param is optional.
 	 *
-	 * @param string $store_namespace The unique store namespace identifier.
+	 * @param string $store_namespace Optional. The unique store namespace identifier.
 	 * @param array  $state           Optional. The array that will be merged with the existing state for the specified
 	 *                                store namespace.
 	 * @return array The current state for the specified store namespace. This will be the updated state if a $state
 	 *               argument was provided.
 	 */
-	public function state( string $store_namespace, array $state = array() ): array {
+	public function state( string $store_namespace = '', array $state = array() ): array {
+		if ( ! $store_namespace ) {
+			$store_namespace = end( $this->namespace_stack );
+		}
 		if ( ! isset( $this->state_data[ $store_namespace ] ) ) {
 			$this->state_data[ $store_namespace ] = array();
 		}

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -81,9 +81,9 @@ final class WP_Interactivity_API {
 	 * remain empty afterwards.
 	 *
 	 * @since 6.6.0
-	 * @var array<string>
+	 * @var array<string>|null
 	 */
-	private $namespace_stack = array();
+	private $namespace_stack = null;
 
 	/**
 	 * Stack of contexts defined by `data-wp-context` directives, in
@@ -93,9 +93,9 @@ final class WP_Interactivity_API {
 	 * remain empty afterwards.
 	 *
 	 * @since 6.6.0
-	 * @var array<array<mixed>>
+	 * @var array<array<mixed>>|null
 	 */
-	private $context_stack = array();
+	private $context_stack = null;
 
 	/**
 	 * Gets and/or sets the initial state of an Interactivity API store for a
@@ -134,6 +134,15 @@ final class WP_Interactivity_API {
 				);
 				return array();
 			}
+			if ( null === $this->namespace_stack ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'The namespace can only be omitted during directive processing.' ),
+					'6.6.0'
+				);
+				return array();
+			}
+
 			$store_namespace = end( $this->namespace_stack );
 		}
 		if ( ! isset( $this->state_data[ $store_namespace ] ) ) {
@@ -269,6 +278,15 @@ final class WP_Interactivity_API {
 	 * @param string $store_namespace Optional. The unique store namespace identifier.
 	 */
 	public function get_context( ?string $store_namespace = null ): array {
+		if ( null === $this->context_stack ) {
+			_doing_it_wrong(
+				__METHOD__,
+				__( 'The context can only be read during directive processing.' ),
+				'6.6.0'
+			);
+			return array();
+		}
+
 		if ( ! $store_namespace ) {
 			if ( null !== $store_namespace ) {
 				_doing_it_wrong(
@@ -336,7 +354,13 @@ final class WP_Interactivity_API {
 			return $html;
 		}
 
+		$this->namespace_stack = array();
+		$this->context_stack   = array();
+
 		$result = $this->_process_directives( $html );
+
+		$this->namespace_stack = null;
+		$this->context_stack   = null;
 
 		return null === $result ? $html : $result;
 	}

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -240,6 +240,28 @@ final class WP_Interactivity_API {
 	}
 
 	/**
+	 * Returns the latest value on the context stack with the passed namespace.
+	 *
+	 * When the namespace is omitted, it uses the current namespace on the
+	 * namespace stack.
+	 *
+	 * @since 6.6.0
+	 *
+	 * @param string $store_namespace Optional. The unique store namespace identifier.
+	 */
+	public function get_context( string $store_namespace = '' ): array {
+		if ( ! $store_namespace ) {
+			$store_namespace = end( $this->namespace_stack );
+		}
+
+		$context = end( $this->context_stack );
+
+		return ( $store_namespace && $context && isset( $context[ $store_namespace ] ) )
+			? $context[ $store_namespace ]
+			: array();
+	}
+
+	/**
 	 * Registers the `@wordpress/interactivity` script modules.
 	 *
 	 * @since 6.5.0

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -412,10 +412,7 @@ final class WP_Interactivity_API {
 						? self::$directive_processors[ $directive_prefix ]
 						: array( $this, self::$directive_processors[ $directive_prefix ] );
 
-					call_user_func_array(
-						$func,
-						array( $p, $mode, &$context_stack, &$namespace_stack, &$tag_stack )
-					);
+					call_user_func_array( $func, array( $p, $mode, &$tag_stack ) );
 				}
 			}
 		}
@@ -593,15 +590,13 @@ final class WP_Interactivity_API {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
-	 * @param string                                    $mode            Whether the processing is entering or exiting the tag.
-	 * @param array                                     $context_stack   The reference to the context stack.
-	 * @param array                                     $namespace_stack The reference to the store namespace stack.
+	 * @param WP_Interactivity_API_Directives_Processor $p    The directives processor instance.
+	 * @param string                                    $mode Whether the processing is entering or exiting the tag.
 	 */
-	private function data_wp_interactive_processor( WP_Interactivity_API_Directives_Processor $p, string $mode, array &$context_stack, array &$namespace_stack ) {
+	private function data_wp_interactive_processor( WP_Interactivity_API_Directives_Processor $p, string $mode ) {
 		// When exiting tags, it removes the last namespace from the stack.
 		if ( 'exit' === $mode ) {
-			array_pop( $namespace_stack );
+			array_pop( $this->namespace_stack );
 			return;
 		}
 
@@ -625,9 +620,9 @@ final class WP_Interactivity_API {
 				$new_namespace = $attribute_value;
 			}
 		}
-		$namespace_stack[] = ( $new_namespace && 1 === preg_match( '/^([\w\-_\/]+)/', $new_namespace ) )
+		$this->namespace_stack[] = ( $new_namespace && 1 === preg_match( '/^([\w\-_\/]+)/', $new_namespace ) )
 			? $new_namespace
-			: end( $namespace_stack );
+			: end( $this->namespace_stack );
 	}
 
 	/**

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -88,8 +88,7 @@ final class WP_Interactivity_API {
 	 * Stack of contexts defined by `data-wp-context` directives, in
 	 * the order they are processed.
 	 *
-	 * This list is populated only during directive processing, and it should
-	 * become `null` afterwards.
+	 * This is only available during directive processing, otherwise it is `null`.
 	 *
 	 * @since 6.6.0
 	 * @var array<array<mixed>>|null

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -512,7 +512,7 @@ final class WP_Interactivity_API {
 		}
 
 		if ( $current instanceof Closure ) {
-			$current = $current( $store );
+			$current = $current();
 		}
 
 		// Returns the opposite if it contains a negation operator (!).

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -403,7 +403,7 @@ final class WP_Interactivity_API {
 			if ( 'SVG' === $tag_name || 'MATH' === $tag_name ) {
 				if ( $p->get_attribute_names_with_prefix( 'data-wp-' ) ) {
 					/* translators: 1: SVG or MATH HTML tag, 2: Namespace of the interactive block. */
-					$message = sprintf( __( 'Interactivity directives were detected on an incompatible %1$s tag when processing "%2$s". These directives will be ignored in the server side render.' ), $tag_name, end( $namespace_stack ) );
+					$message = sprintf( __( 'Interactivity directives were detected on an incompatible %1$s tag when processing "%2$s". These directives will be ignored in the server side render.' ), $tag_name, end( $this->namespace_stack ) );
 					_doing_it_wrong( __METHOD__, $message, '6.6.0' );
 				}
 				$p->skip_to_tag_closer();
@@ -506,7 +506,7 @@ final class WP_Interactivity_API {
 		if ( $unbalanced || 0 < count( $tag_stack ) ) {
 			$tag_errored = 0 < count( $tag_stack ) ? end( $tag_stack )[0] : $tag_name;
 			/* translators: %1s: Namespace processed, %2s: The tag that caused the error; could be any HTML tag.  */
-			$message = sprintf( __( 'Interactivity directives failed to process in "%1$s" due to a missing "%2$s" end tag.' ), end( $namespace_stack ), $tag_errored );
+			$message = sprintf( __( 'Interactivity directives failed to process in "%1$s" due to a missing "%2$s" end tag.' ), end( $this->namespace_stack ), $tag_errored );
 			_doing_it_wrong( __METHOD__, $message, '6.6.0' );
 			return null;
 		}

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -268,8 +268,17 @@ final class WP_Interactivity_API {
 	 *
 	 * @param string $store_namespace Optional. The unique store namespace identifier.
 	 */
-	public function get_context( string $store_namespace = '' ): array {
+	public function get_context( ?string $store_namespace = null ): array {
 		if ( ! $store_namespace ) {
+			if ( null !== $store_namespace ) {
+				_doing_it_wrong(
+					__METHOD__,
+					__( 'The namespace should be a non-empty string.' ),
+					'6.6.0'
+				);
+				return array();
+			}
+
 			$store_namespace = end( $this->namespace_stack );
 		}
 

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -105,7 +105,7 @@ final class WP_Interactivity_API {
 	 * provided state with the existing one.
 	 *
 	 * When no namespace is specified, it returns the state defined for the
-	 * current value in the internal namespace stack.
+	 * current value in the internal namespace stack during a `process_directives` call.
 	 *
 	 * @since 6.5.0
 	 * @since 6.6.0 The `$store_namespace` param is optional.
@@ -271,7 +271,7 @@ final class WP_Interactivity_API {
 	 * Returns the latest value on the context stack with the passed namespace.
 	 *
 	 * When the namespace is omitted, it uses the current namespace on the
-	 * namespace stack.
+	 * namespace stack during a `process_directives` call.
 	 *
 	 * @since 6.6.0
 	 *

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -81,7 +81,7 @@ final class WP_Interactivity_API {
 	 * remain empty afterwards.
 	 *
 	 * @since 6.6.0
-	 * @var array
+	 * @var array<string>
 	 */
 	private $namespace_stack = array();
 

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -101,6 +101,9 @@ final class WP_Interactivity_API {
 	 * Gets and/or sets the initial state of an Interactivity API store for a
 	 * given namespace.
 	 *
+	 * If state for that store namespace already exists, it merges the new
+	 * provided state with the existing one.
+	 *
 	 * When no namespace is specified, it returns the state defined for the
 	 * current value in the internal namespace stack.
 	 *

--- a/src/wp-includes/interactivity-api/interactivity-api.php
+++ b/src/wp-includes/interactivity-api/interactivity-api.php
@@ -47,7 +47,11 @@ function wp_interactivity_process_directives( string $html ): string {
  * If state for that store namespace already exists, it merges the new
  * provided state with the existing one.
  *
+ * The namespace can be omitted inside derived state getters, using the
+ * namespace where the getter is defined.
+ *
  * @since 6.5.0
+ * @since 6.6.0 The namespace can be omitted when called inside derived state getters.
  *
  * @param string $store_namespace The unique store namespace identifier.
  * @param array  $state           Optional. The array that will be merged with the existing state for the specified

--- a/src/wp-includes/interactivity-api/interactivity-api.php
+++ b/src/wp-includes/interactivity-api/interactivity-api.php
@@ -103,3 +103,21 @@ function wp_interactivity_data_wp_context( array $context, string $store_namespa
 		( empty( $context ) ? '{}' : wp_json_encode( $context, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP ) ) .
 		'\'';
 }
+
+/**
+ * Gets the current Interactivity API context for a given namespace.
+ *
+ * The function should be used only during directive processing. If the
+ * `$store_namespace` parameter is omitted, it uses the current namespace value
+ * on the internal namespace stack.
+ *
+ * It returns an empty array when the specified namespace is not defined.
+ *
+ * @since 6.6.0
+ *
+ * @param string $store_namespace Optional. The unique store namespace identifier.
+ * @return array The context for the specified store namespace.
+ */
+function wp_interactivity_get_context( string $store_namespace = '' ): array {
+	return wp_interactivity()->get_context( $store_namespace );
+}

--- a/src/wp-includes/interactivity-api/interactivity-api.php
+++ b/src/wp-includes/interactivity-api/interactivity-api.php
@@ -55,7 +55,7 @@ function wp_interactivity_process_directives( string $html ): string {
  * @return array The state for the specified store namespace. This will be the updated state if a $state argument was
  *               provided.
  */
-function wp_interactivity_state( string $store_namespace, array $state = array() ): array {
+function wp_interactivity_state( ?string $store_namespace = null, array $state = array() ): array {
 	return wp_interactivity()->state( $store_namespace, $state );
 }
 

--- a/src/wp-includes/interactivity-api/interactivity-api.php
+++ b/src/wp-includes/interactivity-api/interactivity-api.php
@@ -118,6 +118,6 @@ function wp_interactivity_data_wp_context( array $context, string $store_namespa
  * @param string $store_namespace Optional. The unique store namespace identifier.
  * @return array The context for the specified store namespace.
  */
-function wp_interactivity_get_context( string $store_namespace = '' ): array {
+function wp_interactivity_get_context( ?string $store_namespace = null ): array {
 	return wp_interactivity()->get_context( $store_namespace );
 }

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-each.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-each.php
@@ -581,7 +581,7 @@ class Tests_WP_Interactivity_API_WP_Each extends WP_UnitTestCase {
 	 *
 	 * @covers ::process_directives
 	 *
-	 * @expectedIncorrectUsage WP_Interactivity_API::process_directives_args
+	 * @expectedIncorrectUsage WP_Interactivity_API::_process_directives
 	 */
 	public function test_wp_each_unbalanced_tags() {
 		$original = '' .
@@ -601,7 +601,7 @@ class Tests_WP_Interactivity_API_WP_Each extends WP_UnitTestCase {
 	 *
 	 * @covers ::process_directives
 	 *
-	 * @expectedIncorrectUsage WP_Interactivity_API::process_directives_args
+	 * @expectedIncorrectUsage WP_Interactivity_API::_process_directives
 	 */
 	public function test_wp_each_unbalanced_tags_in_nested_template_tags() {
 		$this->interactivity->state( 'myPlugin', array( 'list2' => array( 3, 4 ) ) );

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-text.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-text.php
@@ -132,7 +132,7 @@ class Tests_Interactivity_API_WpInteractivityAPIWPText extends WP_UnitTestCase {
 	 *
 	 * @covers ::process_directives
 	 *
-	 * @expectedIncorrectUsage WP_Interactivity_API::process_directives_args
+	 * @expectedIncorrectUsage WP_Interactivity_API::_process_directives
 	 */
 	public function test_wp_text_fails_with_unbalanced_and_same_tags_inside_content() {
 		$html     = '<div data-wp-text="myPlugin::state.text">Text<div></div>';

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -426,6 +426,30 @@ JSON;
 	}
 
 	/**
+	 * Test that calling state without a namespace arg returns the state data
+	 * for the current namespace in the internal namespace stack.
+	 *
+	 * @ticket 61037
+	 *
+	 * @covers ::state
+	 */
+	public function test_state_without_namespace() {
+		$interactivity = new ReflectionClass( $this->interactivity );
+
+		$namespace_stack = $interactivity->getProperty( 'namespace_stack' );
+		$namespace_stack->setAccessible( true );
+		$namespace_stack->setValue( $this->interactivity, array( 'myPlugin' ) );
+
+		$this->interactivity->state( 'myPlugin', array( 'a' => 1 ) );
+		$this->interactivity->state( 'otherPlugin', array( 'b' => 2 ) );
+
+		$this->assertEquals(
+			array( 'a' => 1 ),
+			$this->interactivity->state()
+		);
+	}
+
+	/**
 	 * Tests extracting directive values from different string formats.
 	 *
 	 * @ticket 60356

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -450,6 +450,141 @@ JSON;
 	}
 
 	/**
+	 * Test that `get_context` returns the latest context value for the given
+	 * namespace.
+	 *
+	 * @ticket 61037
+	 *
+	 * @covers ::get_context
+	 */
+	public function test_get_context_with_namespace() {
+		$interactivity = new ReflectionClass( $this->interactivity );
+
+		$namespace_stack = $interactivity->getProperty( 'namespace_stack' );
+		$namespace_stack->setAccessible( true );
+		$namespace_stack->setValue( $this->interactivity, array( 'myPlugin' ) );
+
+		$ctx_stack = array(
+			array(
+				'myPlugin' => array( 'a' => 0 ),
+			),
+			array(
+				'myPlugin'    => array( 'a' => 1 ),
+				'otherPlugin' => array( 'b' => 2 ),
+			),
+		);
+
+		$ctx_stack_prop = $interactivity->getProperty( 'context_stack' );
+		$ctx_stack_prop->setAccessible( true );
+		$ctx_stack_prop->setValue( $this->interactivity, $ctx_stack );
+
+		$this->assertEquals(
+			array( 'a' => 1 ),
+			$this->interactivity->get_context( 'myPlugin' )
+		);
+		$this->assertEquals(
+			array( 'b' => 2 ),
+			$this->interactivity->get_context( 'otherPlugin' )
+		);
+	}
+
+	/**
+	 * Test that `get_context` uses the current namespace in the internal
+	 * namespace stack when the parameter is omitted.
+	 *
+	 * @ticket 61037
+	 *
+	 * @covers ::get_context
+	 */
+	public function test_get_context_without_namespace() {
+		$interactivity = new ReflectionClass( $this->interactivity );
+
+		$namespace_stack = $interactivity->getProperty( 'namespace_stack' );
+		$namespace_stack->setAccessible( true );
+		$namespace_stack->setValue( $this->interactivity, array( 'myPlugin' ) );
+
+		$ctx_stack = array(
+			array(
+				'myPlugin' => array( 'a' => 0 ),
+			),
+			array(
+				'myPlugin'    => array( 'a' => 1 ),
+				'otherPlugin' => array( 'b' => 2 ),
+			),
+		);
+
+		$ctx_stack_prop = $interactivity->getProperty( 'context_stack' );
+		$ctx_stack_prop->setAccessible( true );
+		$ctx_stack_prop->setValue( $this->interactivity, $ctx_stack );
+
+		$this->assertEquals(
+			array( 'a' => 1 ),
+			$this->interactivity->get_context()
+		);
+	}
+
+	/**
+	 * Test that `get_context` returns an empty array when the context stack is
+	 * empty.
+	 *
+	 * @ticket 61037
+	 *
+	 * @covers ::get_context
+	 */
+	public function test_get_context_with_empty_context_stack() {
+		$interactivity = new ReflectionClass( $this->interactivity );
+
+		$namespace_stack = $interactivity->getProperty( 'namespace_stack' );
+		$namespace_stack->setAccessible( true );
+		$namespace_stack->setValue( $this->interactivity, array( 'myPlugin' ) );
+
+		$ctx_stack = array();
+
+		$ctx_stack_prop = $interactivity->getProperty( 'context_stack' );
+		$ctx_stack_prop->setAccessible( true );
+		$ctx_stack_prop->setValue( $this->interactivity, $ctx_stack );
+
+		$this->assertEquals(
+			array(),
+			$this->interactivity->get_context( 'myPlugin' )
+		);
+	}
+
+	/**
+	 * Test that `get_context` returns an empty array if the given namespace is
+	 * not defined.
+	 *
+	 * @ticket 61037
+	 *
+	 * @covers ::get_context
+	 */
+	public function test_get_context_with_undefined_namespace() {
+		$interactivity = new ReflectionClass( $this->interactivity );
+
+		$namespace_stack = $interactivity->getProperty( 'namespace_stack' );
+		$namespace_stack->setAccessible( true );
+		$namespace_stack->setValue( $this->interactivity, array( 'myPlugin' ) );
+
+		$ctx_stack = array(
+			array(
+				'myPlugin' => array( 'a' => 0 ),
+			),
+			array(
+				'myPlugin' => array( 'a' => 1 ),
+			),
+		);
+
+		$ctx_stack_prop = $interactivity->getProperty( 'context_stack' );
+		$ctx_stack_prop->setAccessible( true );
+		$ctx_stack_prop->setValue( $this->interactivity, $ctx_stack );
+
+		$this->assertEquals(
+			array(),
+			$this->interactivity->get_context( 'otherPlugin' )
+		);
+	}
+
+	/**
 	 * Tests extracting directive values from different string formats.
 	 *
 	 * @ticket 60356

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -856,7 +856,18 @@ JSON;
 		);
 		$evaluate = new ReflectionMethod( $this->interactivity, 'evaluate' );
 		$evaluate->setAccessible( true );
-		return $evaluate->invokeArgs( $this->interactivity, array( $directive_value, $default_namespace, $context ) );
+
+		$interactivity = new ReflectionClass( $this->interactivity );
+
+		$namespace_stack = $interactivity->getProperty( 'namespace_stack' );
+		$namespace_stack->setAccessible( true );
+		$namespace_stack->setValue( $this->interactivity, array( $default_namespace ) );
+
+		$context_stack = $interactivity->getProperty( 'context_stack' );
+		$context_stack->setAccessible( true );
+		$context_stack->setValue( $this->interactivity, array( $default_namespace => $context ) );
+
+		return $evaluate->invokeArgs( $this->interactivity, array( $directive_value ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -1419,6 +1419,7 @@ JSON;
 				},
 			)
 		);
+		$this->set_internal_context_stack();
 		$this->set_internal_namespace_stack( 'myPlugin' );
 
 		$result = $this->evaluate( 'state.derivedThatThrows' );

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -450,6 +450,55 @@ JSON;
 	}
 
 	/**
+	 * Test that passing state data without a valid namespace does nothing and
+	 * just returns an empty array.
+	 *
+	 * @ticket 61037
+	 *
+	 * @covers ::state
+	 * @expectedIncorrectUsage WP_Interactivity_API::state
+	 */
+	public function test_state_with_data_and_invalid_namespace() {
+		$interactivity = new ReflectionClass( $this->interactivity );
+
+		$namespace_stack = $interactivity->getProperty( 'namespace_stack' );
+		$namespace_stack->setAccessible( true );
+		$namespace_stack->setValue( $this->interactivity, array( 'myPlugin' ) );
+
+		$this->interactivity->state( 'myPlugin', array( 'a' => 1 ) );
+		$this->interactivity->state( 'otherPlugin', array( 'b' => 2 ) );
+
+		$this->assertEquals(
+			array(),
+			$this->interactivity->state( null, array( 'newProp' => 'value' ) )
+		);
+	}
+
+	/**
+	 * Test that calling state with an empty string as namespace is not allowed.
+	 *
+	 * @ticket 61037
+	 *
+	 * @covers ::state
+	 * @expectedIncorrectUsage WP_Interactivity_API::state
+	 */
+	public function test_state_without_namespace_and_with_data() {
+		$interactivity = new ReflectionClass( $this->interactivity );
+
+		$namespace_stack = $interactivity->getProperty( 'namespace_stack' );
+		$namespace_stack->setAccessible( true );
+		$namespace_stack->setValue( $this->interactivity, array( 'myPlugin' ) );
+
+		$this->interactivity->state( 'myPlugin', array( 'a' => 1 ) );
+		$this->interactivity->state( 'otherPlugin', array( 'b' => 2 ) );
+
+		$this->assertEquals(
+			array(),
+			$this->interactivity->state( '' )
+		);
+	}
+
+	/**
 	 * Test that `get_context` returns the latest context value for the given
 	 * namespace.
 	 *

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -997,12 +997,14 @@ JSON;
 
 					public function offsetUnset( $offset ): void {}
 				},
-				'derived'   => function ( $store ) {
+				'derived'   => function () {
+					$state   = $this->interactivity->state();
+					$context = $this->interactivity->get_context();
 					return 'Derived state: ' .
-						$store['state']['key'] .
+						$state['key'] .
 						"\n" .
 						'Derived context: ' .
-						$store['context']['key'];
+						$context['key'];
 				},
 			);
 		};

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -634,6 +634,41 @@ JSON;
 	}
 
 	/**
+	 * Test that `get_context` should not be called with an empty string.
+	 *
+	 * @ticket 61037
+	 *
+	 * @covers ::get_context
+	 * @expectedIncorrectUsage WP_Interactivity_API::get_context
+	 */
+	public function test_get_context_with_empty_namespace() {
+		$interactivity = new ReflectionClass( $this->interactivity );
+
+		$namespace_stack = $interactivity->getProperty( 'namespace_stack' );
+		$namespace_stack->setAccessible( true );
+		$namespace_stack->setValue( $this->interactivity, array( 'myPlugin' ) );
+
+		$ctx_stack = array(
+			array(
+				'myPlugin' => array( 'a' => 0 ),
+			),
+			array(
+				'myPlugin' => array( 'a' => 1 ),
+			),
+		);
+
+		$ctx_stack_prop = $interactivity->getProperty( 'context_stack' );
+		$ctx_stack_prop->setAccessible( true );
+		$ctx_stack_prop->setValue( $this->interactivity, $ctx_stack );
+
+		$this->assertEquals(
+			array(),
+			$this->interactivity->get_context( '' )
+		);
+	}
+
+
+	/**
 	 * Tests extracting directive values from different string formats.
 	 *
 	 * @ticket 60356

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -1250,7 +1250,7 @@ JSON;
 	 */
 	public function test_evaluate_derived_state() {
 		$result = $this->evaluate( 'state.derived' );
-		$this->assertEquals( "Derived state: myPlugin-state\nDerived context: myPlugin-context", $result );
+		$this->assertSame( "Derived state: myPlugin-state\nDerived context: myPlugin-context", $result );
 	}
 
 
@@ -1264,7 +1264,7 @@ JSON;
 	 */
 	public function test_evaluate_derived_state_that_throws() {
 		$result = $this->evaluate( 'state.derivedThatThrows' );
-		$this->assertEquals( null, $result );
+		$this->assertNull( $result );
 	}
 
 	/**

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -1064,24 +1064,21 @@ JSON;
 			$obj       = new stdClass();
 			$obj->prop = $name;
 			return array(
-				'key'       => $name,
-				'nested'    => array( 'key' => $name . '-nested' ),
-				'obj'       => $obj,
-				'arrAccess' => new class() implements ArrayAccess {
+				'key'               => $name,
+				'nested'            => array( 'key' => $name . '-nested' ),
+				'obj'               => $obj,
+				'arrAccess'         => new class() implements ArrayAccess {
 					#[\ReturnTypeWillChange]
 					public function offsetExists( $offset ) {
 						return true;
 					}
-
 					public function offsetGet( $offset ): string {
 						return $offset;
 					}
-
 					public function offsetSet( $offset, $value ): void {}
-
 					public function offsetUnset( $offset ): void {}
 				},
-				'derived'   => function () {
+				'derived'           => function () {
 					$state   = wp_interactivity_state();
 					$context = wp_interactivity_get_context();
 					return 'Derived state: ' .
@@ -1089,6 +1086,9 @@ JSON;
 						"\n" .
 						'Derived context: ' .
 						$context['key'];
+				},
+				'derivedThatThrows' => function () {
+					throw new Error( 'Something bad happened.' );
 				},
 			);
 		};
@@ -1251,6 +1251,20 @@ JSON;
 	public function test_evaluate_derived_state() {
 		$result = $this->evaluate( 'state.derived' );
 		$this->assertEquals( "Derived state: myPlugin-state\nDerived context: myPlugin-context", $result );
+	}
+
+
+	/**
+	 * Tests the `evaluate` method for derived state functions.
+	 *
+	 * @ticket 61037
+	 *
+	 * @covers ::evaluate
+	 * @expectedIncorrectUsage WP_Interactivity_API::evaluate
+	 */
+	public function test_evaluate_derived_state_that_throws() {
+		$result = $this->evaluate( 'state.derivedThatThrows' );
+		$this->assertEquals( null, $result );
 	}
 
 	/**

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -838,6 +838,13 @@ JSON;
 
 					public function offsetUnset( $offset ): void {}
 				},
+				'derived'   => function ( $store ) {
+					return 'Derived state: ' .
+						$store['state']['key'] .
+						"\n" .
+						'Derived context: ' .
+						$store['context']['key'];
+				},
 			);
 		};
 		$this->interactivity->state( 'myPlugin', $generate_state( 'myPlugin-state' ) );
@@ -966,6 +973,18 @@ JSON;
 
 		$result = $this->evaluate( 'path', '{}' );
 		$this->assertNull( $result );
+	}
+
+	/**
+	 * Tests the `evaluate` method for derived state functions.
+	 *
+	 * @ticket 61037
+	 *
+	 * @covers ::evaluate
+	 */
+	public function test_evaluate_derived_state() {
+		$result = $this->evaluate( 'state.derived' );
+		$this->assertEquals( "Derived state: myPlugin-state\nDerived context: myPlugin-context", $result );
 	}
 
 	/**

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -1082,8 +1082,8 @@ JSON;
 					public function offsetUnset( $offset ): void {}
 				},
 				'derived'   => function () {
-					$state   = $this->interactivity->state();
-					$context = $this->interactivity->get_context();
+					$state   = wp_interactivity_state();
+					$context = wp_interactivity_get_context();
 					return 'Derived state: ' .
 						$state['key'] .
 						"\n" .
@@ -1112,7 +1112,15 @@ JSON;
 		$context_stack->setAccessible( true );
 		$context_stack->setValue( $this->interactivity, array( $default_namespace => $context ) );
 
-		return $evaluate->invokeArgs( $this->interactivity, array( $directive_value ) );
+		global $wp_interactivity;
+		$wp_interactivity_prev = $wp_interactivity;
+		$wp_interactivity      = $this->interactivity;
+
+		$result = $evaluate->invokeArgs( $this->interactivity, array( $directive_value ) );
+
+		$wp_interactivity = $wp_interactivity_prev;
+
+		return $result;
 	}
 
 	/**
@@ -1237,6 +1245,8 @@ JSON;
 	 * @ticket 61037
 	 *
 	 * @covers ::evaluate
+	 * @covers wp_interactivity_state
+	 * @covers wp_interactivity_get_context
 	 */
 	public function test_evaluate_derived_state() {
 		$result = $this->evaluate( 'state.derived' );

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -545,7 +545,7 @@ JSON;
 			array(
 				'myPlugin'    => array( 'a' => 1 ),
 				'otherPlugin' => array( 'b' => 2 ),
-			),
+			)
 		);
 
 		$this->assertEquals(
@@ -575,7 +575,7 @@ JSON;
 			array(
 				'myPlugin'    => array( 'a' => 1 ),
 				'otherPlugin' => array( 'b' => 2 ),
-			),
+			)
 		);
 
 		$this->assertEquals(
@@ -618,7 +618,7 @@ JSON;
 			),
 			array(
 				'myPlugin' => array( 'a' => 1 ),
-			),
+			)
 		);
 
 		$this->assertEquals(
@@ -643,7 +643,7 @@ JSON;
 			),
 			array(
 				'myPlugin' => array( 'a' => 1 ),
-			),
+			)
 		);
 
 		$this->assertEquals(

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -1071,7 +1071,7 @@ JSON;
 	 * instance were find `data-wp-context` directives during
 	 * `process_directives` execution.
 	 *
-	 * @param array<string> $stack Values for the internal context stack.
+	 * @param array<array<mixed>> $stack Values for the internal context stack.
 	 */
 	private function set_internal_context_stack( ...$stack ) {
 		$interactivity = new ReflectionClass( $this->interactivity );

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -502,7 +502,7 @@ JSON;
 	 * @covers ::state
 	 * @expectedIncorrectUsage WP_Interactivity_API::state
 	 */
-	public function test_state_without_namespace_and_with_data() {
+	public function test_state_with_empty_string_as_namespace() {
 		$this->set_internal_namespace_stack( 'myPlugin' );
 
 		$this->interactivity->state( 'myPlugin', array( 'a' => 1 ) );
@@ -523,9 +523,11 @@ JSON;
 	 * @covers ::state
 	 * @expectedIncorrectUsage WP_Interactivity_API::state
 	 */
-	public function test_wp_interactivity_state_without_namespace() {
-		$state = $this->interactivity->state();
-		$this->assertEquals( array(), $state );
+	public function test_state_without_namespace_outside_directive_processing() {
+		$this->assertEquals(
+			array(),
+			$this->interactivity->state()
+		);
 	}
 
 	/**


### PR DESCRIPTION
Implement derived state callback handling in server directive processing.

The implementation expects a `Closure` type. `call_user_func` was avoided because it would be difficult to differentiate the string paths in the directive from a callable function name.

Trac ticket: https://core.trac.wordpress.org/ticket/61037

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
