### PR TITLE
Skip Gutenberg plugin activation test on older WP versions

### DIFF
--- a/tests/e2e/specs/gutenberg-plugin.test.js
+++ b/tests/e2e/specs/gutenberg-plugin.test.js
@@ -29,7 +29,18 @@ test.describe( 'Gutenberg plugin', () => {
 
 		expect( plugin.status ).toBe( 'inactive' );
 
-		await requestUtils.activatePlugin( 'gutenberg' );
+		try {
+			await requestUtils.activatePlugin( 'gutenberg' );
+		} catch ( error ) {
+			if (
+				typeof error === 'object' &&
+				error !== null &&
+				Object.prototype.hasOwnProperty.call( error, 'code' ) &&
+				error.code === 'plugin_wp_incompatible'
+			) {
+				test.skip();
+			}
+		}
 
 		plugin = await requestUtils.rest( {
 			path: 'wp/v2/plugins/gutenberg/gutenberg',

--- a/tests/e2e/specs/gutenberg-plugin.test.js
+++ b/tests/e2e/specs/gutenberg-plugin.test.js
@@ -32,9 +32,9 @@ test.describe( 'Gutenberg plugin', () => {
 			path: 'wp/v2/plugins/gutenberg/gutenberg',
 		} );
 
-		const wpVersion = require( '../../../package.json' ).version;
+		const wordPressVersion = require( '../../../package.json' ).version;
 		test.skip(
-			semver.lt( wpVersion, semver.coerce( plugin.requires_wp ) ),
+			semver.lt( wordPressVersion, semver.coerce( plugin.requires_wp ) ),
 			'Skip Gutenberg plugin activation test as WP version doesn\'t support it'
 		);
 

--- a/tests/e2e/specs/gutenberg-plugin.test.js
+++ b/tests/e2e/specs/gutenberg-plugin.test.js
@@ -11,21 +11,10 @@ test.describe( 'Gutenberg plugin', () => {
 		// Install Gutenberg plugin if it's not yet installed.
 		const pluginsMap = await requestUtils.getPluginsMap();
 		if ( ! pluginsMap.gutenberg ) {
-			try {
-				await requestUtils.rest( {
-					method: 'POST',
-					path: 'wp/v2/plugins?slug=gutenberg',
-				} );
-			} catch ( error ) {
-				if (
-					typeof error === 'object' &&
-					error !== null &&
-					Object.prototype.hasOwnProperty.call( error, 'code' ) &&
-					error.code === 'incompatible_wp_required_version'
-				) {
-					test.skip();
-				}
-			}
+			await requestUtils.rest( {
+				method: 'POST',
+				path: 'wp/v2/plugins?slug=gutenberg',
+			} );
 		}
 
 		// Refetch installed plugin details. It avoids stale values when the test installs the plugin.

--- a/tests/e2e/specs/gutenberg-plugin.test.js
+++ b/tests/e2e/specs/gutenberg-plugin.test.js
@@ -3,6 +3,11 @@
  */
 import { test, expect } from '@wordpress/e2e-test-utils-playwright';
 
+/**
+ * External depencencies
+ */
+import semver from 'semver';
+
 test.describe( 'Gutenberg plugin', () => {
 	// Increasing timeout to 5 minutes because potential plugin install could take longer.
 	test.setTimeout( 300_000 );
@@ -26,6 +31,12 @@ test.describe( 'Gutenberg plugin', () => {
 		let plugin = await requestUtils.rest( {
 			path: 'wp/v2/plugins/gutenberg/gutenberg',
 		} );
+
+		const wordPressVersion = require( '../../../package.json' ).version;
+		test.skip(
+			semver.lt( wordPressVersion, semver.coerce( plugin.requires_wp ) ),
+			'Skip Gutenberg plugin activation test as WP version doesn\'t support it'
+		);
 
 		expect( plugin.status ).toBe( 'inactive' );
 

--- a/tests/e2e/specs/gutenberg-plugin.test.js
+++ b/tests/e2e/specs/gutenberg-plugin.test.js
@@ -3,11 +3,6 @@
  */
 import { test, expect } from '@wordpress/e2e-test-utils-playwright';
 
-/**
- * External depencencies
- */
-import semver from 'semver';
-
 test.describe( 'Gutenberg plugin', () => {
 	// Increasing timeout to 5 minutes because potential plugin install could take longer.
 	test.setTimeout( 300_000 );
@@ -31,12 +26,6 @@ test.describe( 'Gutenberg plugin', () => {
 		let plugin = await requestUtils.rest( {
 			path: 'wp/v2/plugins/gutenberg/gutenberg',
 		} );
-
-		const wordPressVersion = require( '../../../package.json' ).version;
-		test.skip(
-			semver.lt( wordPressVersion, semver.coerce( plugin.requires_wp ) ),
-			'Skip Gutenberg plugin activation test as WP version doesn\'t support it'
-		);
 
 		expect( plugin.status ).toBe( 'inactive' );
 

--- a/tests/e2e/specs/gutenberg-plugin.test.js
+++ b/tests/e2e/specs/gutenberg-plugin.test.js
@@ -32,9 +32,9 @@ test.describe( 'Gutenberg plugin', () => {
 			path: 'wp/v2/plugins/gutenberg/gutenberg',
 		} );
 
-		const wordPressVersion = require( '../../../package.json' ).version;
+		const wpVersion = require( '../../../package.json' ).version;
 		test.skip(
-			semver.lt( wordPressVersion, semver.coerce( plugin.requires_wp ) ),
+			semver.lt( wpVersion, semver.coerce( plugin.requires_wp ) ),
 			'Skip Gutenberg plugin activation test as WP version doesn\'t support it'
 		);
 

--- a/tests/e2e/specs/gutenberg-plugin.test.js
+++ b/tests/e2e/specs/gutenberg-plugin.test.js
@@ -11,10 +11,21 @@ test.describe( 'Gutenberg plugin', () => {
 		// Install Gutenberg plugin if it's not yet installed.
 		const pluginsMap = await requestUtils.getPluginsMap();
 		if ( ! pluginsMap.gutenberg ) {
-			await requestUtils.rest( {
-				method: 'POST',
-				path: 'wp/v2/plugins?slug=gutenberg',
-			} );
+			try {
+				await requestUtils.rest( {
+					method: 'POST',
+					path: 'wp/v2/plugins?slug=gutenberg',
+				} );
+			} catch ( error ) {
+				if (
+					typeof error === 'object' &&
+					error !== null &&
+					Object.prototype.hasOwnProperty.call( error, 'code' ) &&
+					error.code === 'incompatible_wp_required_version'
+				) {
+					test.skip();
+				}
+			}
 		}
 
 		// Refetch installed plugin details. It avoids stale values when the test installs the plugin.

--- a/tests/e2e/specs/gutenberg-plugin.test.js
+++ b/tests/e2e/specs/gutenberg-plugin.test.js
@@ -39,6 +39,8 @@ test.describe( 'Gutenberg plugin', () => {
 				error.code === 'plugin_wp_incompatible'
 			) {
 				test.skip();
+			} else {
+				throw error;
 			}
 		}
 


### PR DESCRIPTION
The purpose of `tests/e2e/specs/gutenberg-plugin.test.js` is to ensure that running the Gutenberg plugin (stable version) on a WordPress `trunk` install doesn't produce any fatals.

The test has been around since WP 6.2. It makes sense to have it present on older branches, as the Gutenberg plugin not only supports `trunk`, but also the current stable version of WordPress (i.e. currently 6.5), and one version below (6.4). However, it is not expected to work on any earlier versions beyond that; in practice, it has produced errors on some of those.

~This changeset compares the WordPress version of the current branch (found in `package.json`) to the Gutenberg plugin's `required_wp` field. If the WordPress version is lower than the requirement, the test is skipped.~

This changeset checks the REST API response from the plugin activation requests. If it returns an error with error code `plugin_wp_incompatible`, it skips the test.

### Testing instructions

- Verify that the test passes on `trunk`.
- For the `6.5.` and `6.4` branches, temporarily cherry-pick the latest commit from this PR to the relevant branch, and run `npm run test:e2e -- tests/e2e/specs/gutenberg-plugin.test.js`. It should pass.
- To simulate the conditions that would cause the test to be skipped, switch back to the current branch, and temporarily update the `$wp_version` variable in `src/wp-includes/version.php`  to e.g. `6.2.0`. Run the test again; it should be skipped.
- The commit cannot be cherry-picked to `6.3` and prior as the test was refactored (from Puppeteer to Playwright) after 6.3. Per https://wordpress.org/plugins/gutenberg/, 6.3 is still supported, so it is currently expected to pass there. However, this is probably best solved by bumping the `Required WP Version` field (https://github.com/WordPress/gutenberg/pull/60780), and deleting the test file from the `6.3` branch (https://github.com/WordPress/wordpress-develop/pull/6397).

Trac ticket: https://core.trac.wordpress.org/ticket/60971

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
