### PR TITLE
Plugins: Only use AJAX for activation via modal.

### DIFF
--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -2643,7 +2643,7 @@
 		 *
 		 * @param {Event} event Event interface.
 		 */
-		$pluginFilter.on( 'click', '.activate-now', function( event ) {
+		$( '#plugin-information-footer' ).on( 'click', '.activate-now', function( event ) {
 			var $activateButton = $( event.target );
 
 			event.preventDefault();


### PR DESCRIPTION
Previously, plugin activation on the `Plugins > Add New` screen was performed using AJAX, no longer performing redirects. This meant that users would not see a newly activated plugin's menu items, admin notices, or other UI elements until the user refreshed or navigated to another screen.

This isolates AJAX activation to the "View details" / "More details" modals so that when activating a single plugin by clicking `Activate` in its plugin card on the `Plugins > Add New` screen, a redirect will be performed.

Trac ticket: https://core.trac.wordpress.org/ticket/60992
