### PR TITLE
Themes REST API endpoint: Add stylesheet_uri and template_uri fields to the response

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -224,6 +224,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 	 *
 	 * @since 5.0.0
 	 * @since 5.9.0 Renamed `$theme` to `$item` to match parent class for PHP 8 named parameter support.
+	 * @since 6.6.0 Added `stylesheet_uri` and `template_uri` fields.
 	 *
 	 * @param WP_Theme        $item    Theme object.
 	 * @param WP_REST_Request $request Request object.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -331,6 +331,14 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 			$data['is_block_theme'] = $theme->is_block_theme();
 		}
 
+		if ( rest_is_field_included( 'stylesheet_uri', $fields ) ) {
+			$data['stylesheet_uri'] = get_stylesheet_directory_uri();
+		}
+
+		if ( rest_is_field_included( 'template_uri', $fields ) ) {
+			$data['template_uri'] = get_template_directory_uri();
+		}
+
 		$data = $this->add_additional_fields_to_object( $data, $request );
 
 		// Wrap the data in a response object.
@@ -447,8 +455,18 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 					'type'        => 'string',
 					'readonly'    => true,
 				),
+				'stylesheet_uri' => array(
+					'description' => __( 'The uri for the theme\'s stylesheet directory.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+				),
 				'template'       => array(
 					'description' => __( 'The theme\'s template. If this is a child theme, this refers to the parent theme, otherwise this is the same as the theme\'s stylesheet.' ),
+					'type'        => 'string',
+					'readonly'    => true,
+				),
+				'template_uri'       => array(
+					'description' => __( 'The uri for the theme\'s template directory. If this is a child theme, this refers to the parent theme, otherwise this is the same as the theme\'s stylesheet directory.' ),
 					'type'        => 'string',
 					'readonly'    => true,
 				),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -333,11 +333,19 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 		}
 
 		if ( rest_is_field_included( 'stylesheet_uri', $fields ) ) {
-			$data['stylesheet_uri'] = $theme->get_stylesheet_directory_uri();
+			if ( $this->is_same_theme( $theme, $current_theme ) ) {
+				$data['stylesheet_uri'] = get_stylesheet_directory_uri();
+			} else {
+				$data['stylesheet_uri'] = $theme->get_stylesheet_directory_uri();
+			}
 		}
 
 		if ( rest_is_field_included( 'template_uri', $fields ) ) {
-			$data['template_uri'] = $theme->get_template_directory_uri();
+			if ( $this->is_same_theme( $theme, $current_theme ) ) {
+				$data['template_uri'] = get_template_directory_uri();
+			} else {
+				$data['template_uri'] = $theme->get_template_directory_uri();
+			}
 		}
 
 		$data = $this->add_additional_fields_to_object( $data, $request );
@@ -459,6 +467,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 				'stylesheet_uri' => array(
 					'description' => __( 'The uri for the theme\'s stylesheet directory.' ),
 					'type'        => 'string',
+					'format'      => 'uri',
 					'readonly'    => true,
 				),
 				'template'       => array(
@@ -469,6 +478,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 				'template_uri'       => array(
 					'description' => __( 'The uri for the theme\'s template directory. If this is a child theme, this refers to the parent theme, otherwise this is the same as the theme\'s stylesheet directory.' ),
 					'type'        => 'string',
+					'format'      => 'uri',
 					'readonly'    => true,
 				),
 				'author'         => array(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -333,11 +333,11 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 		}
 
 		if ( rest_is_field_included( 'stylesheet_uri', $fields ) ) {
-			$data['stylesheet_uri'] = get_stylesheet_directory_uri();
+			$data['stylesheet_uri'] = $theme->get_stylesheet_directory_uri();
 		}
 
 		if ( rest_is_field_included( 'template_uri', $fields ) ) {
-			$data['template_uri'] = get_template_directory_uri();
+			$data['template_uri'] = $theme->get_template_directory_uri();
 		}
 
 		$data = $this->add_additional_fields_to_object( $data, $request );

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -547,11 +547,23 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 	 * @ticket 61021
 	 */
 	public function test_theme_stylesheet_uri() {
-		$response      = self::perform_active_theme_request();
+		wp_set_current_user( self::$admin_id );
+		$request = new WP_REST_Request( 'GET', self::$themes_route );
+		$request->set_param( 'status', array( 'active', 'inactive' ) );
+
+		$response      = rest_get_server()->dispatch( $request );
 		$result        = $response->get_data();
 		$current_theme = wp_get_theme();
-		$this->assertArrayHasKey( 'stylesheet_uri', $result[0] );
-		$this->assertSame( $current_theme->get_stylesheet_directory_uri(), $result[0]['stylesheet_uri'] );
+
+		foreach ( $result as $theme_result ) {
+			$this->assertArrayHasKey( 'stylesheet_uri', $theme_result );
+			if ( 'active' === $theme_result['status'] ) {
+				$this->assertSame( get_stylesheet_directory_uri(), $theme_result['stylesheet_uri'] );
+			} else {
+				$theme = wp_get_theme( $theme_result['stylesheet'] );
+				$this->assertSame( $theme->get_stylesheet_directory_uri(), $theme_result['stylesheet_uri'] );
+			}
+		}
 	}
 
 	/**
@@ -579,11 +591,23 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 	 * @ticket 61021
 	 */
 	public function test_theme_template_uri() {
-		$response      = self::perform_active_theme_request();
+		wp_set_current_user( self::$admin_id );
+		$request = new WP_REST_Request( 'GET', self::$themes_route );
+		$request->set_param( 'status', array( 'active', 'inactive' ) );
+
+		$response      = rest_get_server()->dispatch( $request );
 		$result        = $response->get_data();
 		$current_theme = wp_get_theme();
-		$this->assertArrayHasKey( 'template_uri', $result[0] );
-		$this->assertSame( $current_theme->get_template_directory_uri(), $result[0]['template_uri'] );
+
+		foreach ( $result as $theme_result ) {
+			$this->assertArrayHasKey( 'template_uri', $theme_result );
+			if ( 'active' === $theme_result['status'] ) {
+				$this->assertSame( get_template_directory_uri(), $theme_result['template_uri'] );
+			} else {
+				$theme = wp_get_theme( $theme_result['stylesheet'] );
+				$this->assertSame( $theme->get_template_directory_uri(), $theme_result['template_uri'] );
+			}
+		}
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -558,10 +558,18 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		foreach ( $result as $theme_result ) {
 			$this->assertArrayHasKey( 'stylesheet_uri', $theme_result );
 			if ( 'active' === $theme_result['status'] ) {
-				$this->assertSame( get_stylesheet_directory_uri(), $theme_result['stylesheet_uri'] );
+				$this->assertSame(
+					get_stylesheet_directory_uri(),
+					$theme_result['stylesheet_uri'],
+					'stylesheet_uri for an active theme should be the same as the global get_stylesheet_directory_uri()'
+				);
 			} else {
 				$theme = wp_get_theme( $theme_result['stylesheet'] );
-				$this->assertSame( $theme->get_stylesheet_directory_uri(), $theme_result['stylesheet_uri'] );
+				$this->assertSame(
+					$theme->get_stylesheet_directory_uri(),
+					$theme_result['stylesheet_uri'],
+					"stylesheet_uri for an inactive theme should be the same as the theme's get_stylesheet_directory_uri() method"
+				);
 			}
 		}
 	}
@@ -602,10 +610,18 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		foreach ( $result as $theme_result ) {
 			$this->assertArrayHasKey( 'template_uri', $theme_result );
 			if ( 'active' === $theme_result['status'] ) {
-				$this->assertSame( get_template_directory_uri(), $theme_result['template_uri'] );
+				$this->assertSame(
+					get_template_directory_uri(),
+					$theme_result['template_uri'],
+					'template_uri for an active theme should be the same as the global get_template_directory_uri()'
+				);
 			} else {
 				$theme = wp_get_theme( $theme_result['stylesheet'] );
-				$this->assertSame( $theme->get_template_directory_uri(), $theme_result['template_uri'] );
+				$this->assertSame(
+					$theme->get_template_directory_uri(),
+					$theme_result['template_uri'],
+					"template_uri for an inactive theme should be the same as the theme's get_template_directory_uri() method"
+				);
 			}
 		}
 	}

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -162,6 +162,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 	 * Test retrieving a collection of themes.
 	 *
 	 * @ticket 45016
+	 * @ticket 61021
 	 */
 	public function test_get_items() {
 		$response = self::perform_active_theme_request();
@@ -182,8 +183,10 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 			'screenshot',
 			'status',
 			'stylesheet',
+			'stylesheet_uri',
 			'tags',
 			'template',
+			'template_uri',
 			'textdomain',
 			'theme_supports',
 			'theme_uri',
@@ -198,6 +201,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 	 * Test retrieving a collection of inactive themes.
 	 *
 	 * @ticket 50152
+	 * @ticket 61021
 	 */
 	public function test_get_items_inactive() {
 		wp_set_current_user( self::$admin_id );
@@ -221,8 +225,10 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 			'screenshot',
 			'status',
 			'stylesheet',
+			'stylesheet_uri',
 			'tags',
 			'template',
+			'template_uri',
 			'textdomain',
 			'theme_uri',
 			'version',
@@ -347,12 +353,13 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 	 * Verify the theme schema.
 	 *
 	 * @ticket 45016
+	 * @ticket 61021
 	 */
 	public function test_get_item_schema() {
 		$response   = self::perform_active_theme_request( 'OPTIONS' );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertCount( 16, $properties );
+		$this->assertCount( 18, $properties );
 
 		$this->assertArrayHasKey( 'author', $properties );
 		$this->assertArrayHasKey( 'raw', $properties['author']['properties'] );
@@ -377,6 +384,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'screenshot', $properties );
 		$this->assertArrayHasKey( 'status', $properties );
 		$this->assertArrayHasKey( 'stylesheet', $properties );
+		$this->assertArrayHasKey( 'stylesheet_uri', $properties );
 
 		$this->assertArrayHasKey( 'tags', $properties );
 		$this->assertArrayHasKey( 'raw', $properties['tags']['properties'] );
@@ -384,6 +392,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'rendered', $properties['tags']['properties'] );
 
 		$this->assertArrayHasKey( 'template', $properties );
+		$this->assertArrayHasKey( 'template_uri', $properties );
 		$this->assertArrayHasKey( 'textdomain', $properties );
 		$this->assertArrayHasKey( 'theme_supports', $properties );
 
@@ -535,6 +544,17 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 	}
 
 	/**
+	 * @ticket 61021
+	 */
+	public function test_theme_stylesheet_uri() {
+		$response      = self::perform_active_theme_request();
+		$result        = $response->get_data();
+		$current_theme = wp_get_theme();
+		$this->assertArrayHasKey( 'stylesheet_uri', $result[0] );
+		$this->assertSame( $current_theme->get_stylesheet_directory_uri(), $result[0]['stylesheet_uri'] );
+	}
+
+	/**
 	 * @ticket 49906
 	 */
 	public function test_theme_tags() {
@@ -553,6 +573,17 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'template', $result[0] );
 		$this->assertSame( 'default', $result[0]['template'] );
+	}
+
+	/**
+	 * @ticket 61021
+	 */
+	public function test_theme_template_uri() {
+		$response      = self::perform_active_theme_request();
+		$result        = $response->get_data();
+		$current_theme = wp_get_theme();
+		$this->assertArrayHasKey( 'template_uri', $result[0] );
+		$this->assertSame( $current_theme->get_template_directory_uri(), $result[0]['template_uri'] );
 	}
 
 	/**
@@ -1273,8 +1304,10 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 			'screenshot',
 			'status',
 			'stylesheet',
+			'stylesheet_uri',
 			'tags',
 			'template',
+			'template_uri',
 			'textdomain',
 			'theme_uri',
 			'version',


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Based on an idea from @ramonjd and @noisysocks in https://github.com/WordPress/gutenberg/pull/60578/, this PR explores adding `stylesheet_uri` and `template_uri` fields to the API response for the `themes` endpoint. The goal being to expose the URI of the directory for a theme (or its parent theme when dealing with child themes) so that theme relative URIs can be constructed by consumers of this endpoint. An example use case is in https://github.com/WordPress/gutenberg/pull/60578/

A quick way to test this is to apply the PR and then open up the post editor and run the following from the console:

```
wp.apiFetch( { path: '/wp/v2/themes/twentytwentyfour' } );
```

In the API response, you should see stylesheet and template uris in the response:

<img width="843" alt="image" src="https://github.com/WordPress/wordpress-develop/assets/14988353/fe845714-0d9c-42de-aa4c-0b9e2c117f21">

Trac ticket: https://core.trac.wordpress.org/ticket/61021

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
