### PR TITLE
Plugins: Show an admin notice on successful activation.

### DIFF
--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -1165,11 +1165,7 @@
 			wp.updates.addAdminNotice( noticeData );
 		}
 
-		setTimeout( function() {
-			$message.removeClass( 'activated-message' )
-			.text( _x( 'Active', 'plugin' ) );
-
-			if ( 'plugin-information-footer' === $message.parent().attr( 'id' ) ) {
+			setTimeout( function() {
 				wp.updates.setCardButtonStatus(
 					{
 						status: 'plugin-active',

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -1123,7 +1123,7 @@
 				id: 'plugin-activated-successfully',
 				className: 'notice-success',
 				message: sprintf(
-					/* translators: %s: The refresh button's attributes. */
+					/* translators: %s: The refresh link's attributes. */
 					__( 'Plugin activated. Some changes may not occur until you refresh the page. <a %s>Refresh Now</a>' ),
 					'href="#" class="button button-secondary refresh-page"'
 				),

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -1151,7 +1151,8 @@
 				}
 			);
 
-			noticeTarget = window.parent === window ? null : window.parent;
+			// Add a notice to the modal's footer.
+			$message.replaceWith( wp.updates.adminNotice( noticeData ) );
 
 			$.support.postMessage = !! window.postMessage;
 			if ( false !== $.support.postMessage && null !== noticeTarget && -1 === window.parent.location.pathname.indexOf( 'index.php' ) ) {

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -1154,6 +1154,8 @@
 			// Add a notice to the modal's footer.
 			$message.replaceWith( wp.updates.adminNotice( noticeData ) );
 
+			// Send notice information back to the parent screen.
+			noticeTarget = window.parent === window ? null : window.parent;
 			$.support.postMessage = !! window.postMessage;
 			if ( false !== $.support.postMessage && null !== noticeTarget && -1 === window.parent.location.pathname.indexOf( 'index.php' ) ) {
 				noticeTarget.postMessage(
@@ -1161,9 +1163,6 @@
 					window.location.origin
 				);
 			}
-		} else {
-			wp.updates.addAdminNotice( noticeData );
-		}
 
 			setTimeout( function() {
 				wp.updates.setCardButtonStatus(
@@ -1179,8 +1178,11 @@
 						)
 					}
 				);
-			}
-		}, 1000 );
+			}, 1000 );
+		} else {
+			// Add a notice to the top of the screen.
+			wp.updates.addAdminNotice( noticeData );
+		}
 	};
 
 	/**

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -1130,7 +1130,7 @@
 			},
 			noticeTarget;
 
-		wp.a11y.speak( __( 'Activation completed successfully.' ) );
+		wp.a11y.speak( __( 'Activation completed successfully. Some changes may not occur until you refresh the page.' ) );
 		$document.trigger( 'wp-plugin-activate-success', response );
 
 		$message

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -3486,5 +3486,22 @@
 				} );
 			}
 		);
+
+		/**
+		 * Click handler for page refresh link.
+		 *
+		 * @since 6.5.3
+		 *
+		 * @param {Event} event Event interface.
+		 */
+		$document.on( 'click', '.refresh-page', function( e ) {
+			e.preventDefault();
+
+			if ( window.parent === window ) {
+				window.location.reload();
+			} else {
+				window.parent.location.reload();
+			}
+		});
 	} );
 })( jQuery, window.wp, window._wpUpdatesSettings );

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -1112,6 +1112,7 @@
 	 */
 	wp.updates.activatePluginSuccess = function( response ) {
 		var $message = $( '.plugin-card-' + response.slug + ', #plugin-information-footer' ).find( '.activating-message' ),
+			isInModal = 'plugin-information-footer' === $message.parent().attr( 'id' ),
 			buttonText = _x( 'Activated!', 'plugin' ),
 			ariaLabel = sprintf(
 				/* translators: %s: The plugin name. */
@@ -1139,7 +1140,7 @@
 			.attr( 'aria-label', ariaLabel )
 			.text( buttonText );
 
-		if ( 'plugin-information-footer' === $message.parent().attr( 'id' ) ) {
+		if ( isInModal ) {
 			wp.updates.setCardButtonStatus(
 				{
 					status: 'activated-plugin',
@@ -1163,8 +1164,13 @@
 					window.location.origin
 				);
 			}
+		} else {
+			// Add a notice to the top of the screen.
+			wp.updates.addAdminNotice( noticeData );
+		}
 
-			setTimeout( function() {
+		setTimeout( function() {
+			if ( isInModal ) {
 				wp.updates.setCardButtonStatus(
 					{
 						status: 'plugin-active',
@@ -1178,11 +1184,10 @@
 						)
 					}
 				);
-			}, 1000 );
-		} else {
-			// Add a notice to the top of the screen.
-			wp.updates.addAdminNotice( noticeData );
-		}
+			} else {
+				$message.removeClass( 'activated-message' ).text( _x( 'Active', 'plugin' ) );
+			}
+		}, 1000 );
 	};
 
 	/**

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -1120,7 +1120,7 @@
 			),
 			noticeData = {
 				id: 'plugin-activated-successfully',
-				className: 'notice notice-success',
+				className: 'notice-success',
 				message: sprintf(
 					/* translators: %s: The plugin's name. */
 					__( '%s was activated successfully. Some changes may not occur until you refresh the page.' ),

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -3493,14 +3493,14 @@
 		 *
 		 * @param {Event} event Event interface.
 		 */
-		$document.on( 'click', '.refresh-page', function( e ) {
-			e.preventDefault();
+		$document.on( 'click', '.refresh-page', function( event ) {
+			event.preventDefault();
 
 			if ( window.parent === window ) {
 				window.location.reload();
 			} else {
 				window.parent.location.reload();
 			}
-		});
+		} );
 	} );
 })( jQuery, window.wp, window._wpUpdatesSettings );

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -1122,10 +1122,11 @@
 				id: 'plugin-activated-successfully',
 				className: 'notice-success',
 				message: sprintf(
-					/* translators: %s: The plugin's name. */
-					__( '%s was activated successfully. Some changes may not occur until you refresh the page.' ),
-					response.pluginName
-				)
+					/* translators: %s: The refresh button's attributes. */
+					__( 'Plugin activated. Some changes may not occur until you refresh the page. <a %s>Refresh Now</a>' ),
+					'href="#" class="button button-secondary refresh-page"'
+				),
+				slug: response.slug
 			},
 			noticeTarget;
 

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1513,6 +1513,20 @@ div.error {
     margin-top: -5px;
 }
 
+#plugin-information-footer #plugin-activated-successfully {
+	margin-bottom: 0;
+}
+
+#plugin-information-footer #plugin-activated-successfully p {
+	margin: 0;
+}
+
+#plugin-information-footer #plugin-activated-successfully .refresh-page {
+	line-height: 2.15384615;
+	min-height: 0;
+	margin-bottom: 0;
+}
+
 .update-message p:before,
 .updating-message p:before,
 .updated-message p:before,

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1518,10 +1518,15 @@ div.error {
 }
 
 #plugin-information-footer #plugin-activated-successfully p {
+	display: flex;
+	gap: 1em;
+	align-items: center;
+	justify-content: space-between;
 	margin: 0;
 }
 
 #plugin-information-footer #plugin-activated-successfully .refresh-page {
+	flex-grow: 0;
 	line-height: 2.15384615;
 	min-height: 0;
 	margin-bottom: 0;


### PR DESCRIPTION
Plugin activation on the `Plugins > Add New` screen is performed using AJAX, no longer performing redirects. This means that users will not see a newly activated plugin's menu items, admin notices, or other UI elements until the user refreshes or navigates to another screen. Without adequate messaging and direction, users may be unsure of what to do next.

This shows an admin notice when a plugin is activated from its plugin card or modal, informing the user that the plugin was activated, and that some changes may not occur until they refresh the page.

This also displays the admin notice on `Plugins > Installed plugins` when a dependency is installed by modal from its dependent's plugin row.

The benefits of this approach are:
- AJAX-based activation remains as was intended by the Plugin Dependencies feature, and originally intended by the Shiny Updates feature.
- The user is informed that changes may not occur until the page is refreshed.
- The user's flow isn't assumed, and the user retains the choice of whether to continue installing and activating plugins, or to refresh the page.

Trac ticket: https://core.trac.wordpress.org/ticket/60992