### PR TITLE
Twenty Twenty-Three: Extract pagination into pattern

### DIFF
--- a/src/wp-content/themes/twentytwentythree/patterns/pagination.php
+++ b/src/wp-content/themes/twentytwentythree/patterns/pagination.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Title: Pagination
+ * Slug: twentytwentythree/pagination
+ * Categories: featured
+ * Keywords: Pagination
+ */
+?>
+<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
+	<!-- wp:query-pagination-previous {"label":"<?php esc_html_e( 'Newer posts', 'twentytwentythree' ); ?>"} /-->
+	<!-- wp:query-pagination-next {"label":"<?php esc_html_e( 'Older posts', 'twentytwentythree' ); ?>"} /-->
+<!-- /wp:query-pagination -->

--- a/src/wp-content/themes/twentytwentythree/templates/archive.html
+++ b/src/wp-content/themes/twentytwentythree/templates/archive.html
@@ -17,10 +17,7 @@
 			<!-- /wp:spacer -->
 		<!-- /wp:post-template -->
 
-		<!-- wp:query-pagination {"paginationArrow":"arrow","layout":{"type":"flex","justifyContent":"space-between"}} -->
-			<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
-			<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
-		<!-- /wp:query-pagination -->
+		<!-- wp:pattern {"slug":"twentytwentythree/pagination"} /-->
 	</div>
 	<!-- /wp:query -->
 </main>

--- a/src/wp-content/themes/twentytwentythree/templates/home.html
+++ b/src/wp-content/themes/twentytwentythree/templates/home.html
@@ -19,10 +19,7 @@
 			<!-- /wp:spacer -->
 		<!-- /wp:post-template -->
 
-		<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
-			<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
-			<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
-		<!-- /wp:query-pagination -->
+		<!-- wp:pattern {"slug":"twentytwentythree/pagination"} /-->
 	</div>
 	<!-- /wp:query -->
 

--- a/src/wp-content/themes/twentytwentythree/templates/search.html
+++ b/src/wp-content/themes/twentytwentythree/templates/search.html
@@ -17,10 +17,7 @@
 			<!-- /wp:spacer -->
 		<!-- /wp:post-template -->
 
-		<!-- wp:query-pagination {"paginationArrow":"arrow","layout":{"type":"flex","justifyContent":"space-between"}} -->
-			<!-- wp:query-pagination-previous {"label":"Newer Posts"} /-->
-			<!-- wp:query-pagination-next {"label":"Older Posts"} /-->
-		<!-- /wp:query-pagination -->
+		<!-- wp:pattern {"slug":"twentytwentythree/pagination"} /-->
 
 		<!-- wp:query-no-results -->
 			<!-- wp:pattern {"slug":"twentytwentythree/hidden-no-results-content"} /-->


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This extracts the pagination into a pattern, which adds translation support to the pagination-previous and pagination-next labels.


Trac ticket: https://core.trac.wordpress.org/ticket/60298


# Testing Instructions

On your WordPress installation, make sure that you have enough posts to enable pagination on archives.

Download and install Twenty Twenty-Three.

> [!Note]
> At the time of writing, this only seems to work with the current Gutenberg plugin active.

> [!Note]
> The labels currently aren't translated in the `twentytwentythree` domain. I removed the domain in the `esc_html_e` calls in the pagination pattern to utilize the translations from the root domain that have been translated for the [`link_template.php`](https://github.com/WordPress/wordpress-develop/blob/30420b642d27c8ca23dd72e6ee5a91cafabf514b/src/wp-includes/link-template.php#L2868-L2869) file.

View the front of the site, confirm that the pagination blocks are visible on your homepage, an archive page, and the search page. Navigate to the next page. Verify you're on the right url. Verify the labels are showing correct and the previous and next navigation points again to the right pages.

Go to settings > general and change your site language.

Once more, view the front of the site and confirm that the pagination blocks are visible on your homepage, an archive page, and the search page. The labels should be translated. Navigate to the next page. Verify you're on the right url. Verify the labels are showing correct and are translated, and the previous and next navigation points again to the right pages.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
