### PR TITLE
Update WP_Test_REST_TestCase::assertErrorResponse() to allow custom failure messages

### DIFF
--- a/tests/phpunit/includes/testcase-rest-api.php
+++ b/tests/phpunit/includes/testcase-rest-api.php
@@ -1,19 +1,30 @@
 <?php
 
 abstract class WP_Test_REST_TestCase extends WP_UnitTestCase {
-	protected function assertErrorResponse( $code, $response, $status = null ) {
+	/**
+	 * Asserts that the REST API response has specified error.
+	 *
+	 * @since 6.6.0 Added the `$message` parameter.
+	 *
+	 * @param string|int  						$code 		Expected error code.
+	 * @param true|WP_Error|WP_REST_Response   	$response  	REST API response.
+	 * @param int  								$status 	Optional. status code.
+	 * @param string 							$message 	Optional. Message to display when the assertion fails.
+	 *
+	 */
+	protected function assertErrorResponse( $code, $response, $status = null, $message = '' ) {
 
 		if ( $response instanceof WP_REST_Response ) {
 			$response = $response->as_error();
 		}
 
-		$this->assertWPError( $response );
-		$this->assertSame( $code, $response->get_error_code() );
+		$this->assertWPError( $response, $message );
+		$this->assertSame( $code, $response->get_error_code(), $message );
 
 		if ( null !== $status ) {
 			$data = $response->get_error_data();
-			$this->assertArrayHasKey( 'status', $data );
-			$this->assertSame( $status, $data['status'] );
+			$this->assertArrayHasKey( 'status', $data, $message );
+			$this->assertSame( $status, $data['status'], $message );
 		}
 	}
 }

--- a/tests/phpunit/includes/testcase-rest-api.php
+++ b/tests/phpunit/includes/testcase-rest-api.php
@@ -6,10 +6,10 @@ abstract class WP_Test_REST_TestCase extends WP_UnitTestCase {
 	 *
 	 * @since 6.6.0 Added the `$message` parameter.
 	 *
-	 * @param string|int  						$code 		Expected error code.
-	 * @param true|WP_Error|WP_REST_Response   	$response  	REST API response.
-	 * @param int  								$status 	Optional. status code.
-	 * @param string 							$message 	Optional. Message to display when the assertion fails.
+	 * @param string|int                        $code       Expected error code.
+	 * @param true|WP_Error|WP_REST_Response    $response   REST API response.
+	 * @param int                               $status     Optional. status code.
+	 * @param string                            $message    Optional. Message to display when the assertion fails.
 	 *
 	 */
 	protected function assertErrorResponse( $code, $response, $status = null, $message = '' ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60426

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
