### PR TITLE
Language support for "An alt Decision Tree" W3C WAI document

### DIFF
--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -3237,10 +3237,16 @@ function edit_form_image_editor( $post ) {
 		<p class="attachment-alt-text-description" id="alt-text-description">
 		<?php
 
+		$url          = 'https://www.w3.org/WAI/tutorials/images/decision-tree';
+		$wai_language = get_w3_wai_language_code( get_locale() );
+		if ( '' !== $wai_language ) {
+			$url .= '/' . $wai_language;
+		}
+
 		printf(
 			/* translators: 1: Link to tutorial, 2: Additional link attributes, 3: Accessibility text. */
 			__( '<a href="%1$s" %2$s>Learn how to describe the purpose of the image%3$s</a>. Leave empty if the image is purely decorative.' ),
-			esc_url( 'https://www.w3.org/WAI/tutorials/images/decision-tree' ),
+			esc_url( $url ),
 			'target="_blank" rel="noopener"',
 			sprintf(
 				'<span class="screen-reader-text"> %s</span>',

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1942,3 +1942,39 @@ function wp_get_word_count_type() {
 
 	return $wp_locale->get_word_count_type();
 }
+
+/**
+ * Retrieves the W3C Web Accessibility Initiative (WAI) language code for a
+ * specified locale.
+ *
+ * @since 6.6.0
+ *
+ * @param string $locale The locale code from which to extract the language
+ * code, like 'de_DE' or 'ko_KR'.
+ *
+ * @return string Returns a two-letter WAI language code if the input locale
+ * matches one of the supported languages. If the locale doesn't match, is too
+ * short or empty, it returns an empty string.
+ */
+function get_w3_wai_language_code( $locale ) {
+	$locale = strtolower( $locale );
+
+	if ( strlen( $locale ) < 2 ) {
+		return '';
+	}
+
+	$lang_code     = substr( $locale, 0, 2 );
+	$wai_languages = array(
+		'de', // German
+		'fr', // French
+		'id', // Indonesian
+		'ja', // Japanese
+		'ko', // Korean
+	);
+
+	if ( in_array( $lang_code, $wai_languages, true ) ) {
+		return $lang_code;
+	}
+
+	return '';
+}

--- a/src/wp-includes/media-template.php
+++ b/src/wp-includes/media-template.php
@@ -156,10 +156,16 @@ function wp_underscore_video_template() {
 function wp_print_media_templates() {
 	$class = 'media-modal wp-core-ui';
 
+	$url          = 'https://www.w3.org/WAI/tutorials/images/decision-tree';
+	$wai_language = get_w3_wai_language_code( get_locale() );
+	if ( '' !== $wai_language ) {
+		$url .= '/' . $wai_language;
+	}
+
 	$alt_text_description = sprintf(
 		/* translators: 1: Link to tutorial, 2: Additional link attributes, 3: Accessibility text. */
 		__( '<a href="%1$s" %2$s>Learn how to describe the purpose of the image%3$s</a>. Leave empty if the image is purely decorative.' ),
-		esc_url( 'https://www.w3.org/WAI/tutorials/images/decision-tree' ),
+		esc_url( $url ),
 		'target="_blank" rel="noopener"',
 		sprintf(
 			'<span class="screen-reader-text"> %s</span>',

--- a/tests/phpunit/tests/l10n/getW3WAILanguageCode.php
+++ b/tests/phpunit/tests/l10n/getW3WAILanguageCode.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @group l10n
+ * @group i18n
+ * @ticket 60975
+ *
+ * @covers ::get_w3_wai_language_code
+ */
+class Tests_L10n_getW3WAILanguageCode extends WP_UnitTestCase {
+
+	public function test_empty_locale_should_return_empty_string() {
+		$this->assertSame( '', get_w3_wai_language_code( '' ) );
+	}
+
+	public function test_not_supported_locale_should_return_empty_string() {
+		$this->assertSame( '', get_w3_wai_language_code( 'es_ES' ) );
+		$this->assertSame( '', get_w3_wai_language_code( 'pt_BR' ) );
+	}
+
+	public function test_supported_locale_should_return_language_code() {
+		$this->assertSame( 'de', get_w3_wai_language_code( 'de_DE' ) );
+		$this->assertSame( 'fr', get_w3_wai_language_code( 'fr_FR' ) );
+		$this->assertSame( 'id', get_w3_wai_language_code( 'id_ID' ) );
+		$this->assertSame( 'ja', get_w3_wai_language_code( 'ja' ) );
+		$this->assertSame( 'ko', get_w3_wai_language_code( 'ko_KR' ) );
+	}
+}


### PR DESCRIPTION
Retrieves the W3C Web Accessibility Initiative (WAI) language code for a specified locale, allowing the external URL to be built with in the user language parameter when supported. Based on @joedolson's [suggestion of keeping a map][1] between WordPress locales and WAI language codes.

The function was added to `/wp-includes/l10n.php`, so it can be used from both `/wp-admin/includes/media.php` and `/wp-includes/media-template.php`. Unit tests were added as well.

It can be accessed in the WordPress Admin at:

- Media Library, list mode: `/wp-admin/post.php?post=[ID]&action=edit`
- Media Library, grid mode -> Image details modal: `/wp-admin/upload.php?item=[ID]`

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60975

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

[1]: https://core.trac.wordpress.org/ticket/60975#comment:2