### PR TITLE
HTML API: Fix minor issues detecting funky comments and token boundaries.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1891,7 +1891,7 @@ class WP_HTML_Tag_Processor {
 					return false;
 				}
 
-				$closer_at = strpos( $html, '>', $at + 3 );
+				$closer_at = strpos( $html, '>', $at + 2 );
 				if ( false === $closer_at ) {
 					$this->parser_state = self::STATE_INCOMPLETE_INPUT;
 

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1629,7 +1629,7 @@ class WP_HTML_Tag_Processor {
 			 * `<!` transitions to markup declaration open state
 			 * https://html.spec.whatwg.org/multipage/parsing.html#markup-declaration-open-state
 			 */
-			if ( '!' === $html[ $at + 1 ] ) {
+			if ( ! $this->is_closing_tag && '!' === $html[ $at + 1 ] ) {
 				/*
 				 * `<!--` transitions to a comment state – apply further comment rules.
 				 * https://html.spec.whatwg.org/multipage/parsing.html#tag-open-state

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1809,6 +1809,12 @@ class WP_HTML_Tag_Processor {
 			 * See https://html.spec.whatwg.org/#parse-error-missing-end-tag-name
 			 */
 			if ( '>' === $html[ $at + 1 ] ) {
+				// `<>` is interpreted as plaintext.
+				if ( ! $this->is_closing_tag ) {
+					++$at;
+					continue;
+				}
+
 				$this->parser_state         = self::STATE_PRESUMPTUOUS_TAG;
 				$this->token_length         = $at + 2 - $this->token_starts_at;
 				$this->bytes_already_parsed = $at + 2;
@@ -1819,7 +1825,7 @@ class WP_HTML_Tag_Processor {
 			 * `<?` transitions to a bogus comment state – skip to the nearest >
 			 * See https://html.spec.whatwg.org/multipage/parsing.html#tag-open-state
 			 */
-			if ( '?' === $html[ $at + 1 ] ) {
+			if ( ! $this->is_closing_tag && '?' === $html[ $at + 1 ] ) {
 				$closer_at = strpos( $html, '>', $at + 2 );
 				if ( false === $closer_at ) {
 					$this->parser_state = self::STATE_INCOMPLETE_INPUT;

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-token-scanning.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-token-scanning.php
@@ -776,12 +776,12 @@ HTML
 	 */
 	public function test_various_funky_comments( $funky_comment_html, $modifiable_text ) {
 		$processor = new WP_HTML_Tag_Processor( $funky_comment_html );
-		while ( '#comment' !== $processor->get_token_type() && $processor->next_token() ) {
+		while ( '#funky-comment' !== $processor->get_token_type() && $processor->next_token() ) {
 			continue;
 		}
 
 		$this->assertSame(
-			'#comment',
+			'#funky-comment',
 			$processor->get_token_type(),
 			'Failed to find the expected funky comment.'
 		);

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-token-scanning.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-token-scanning.php
@@ -761,6 +761,55 @@ HTML
 	}
 
 	/**
+	 * Ensures that various funky comments are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.6
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 *
+	 * @dataProvider data_various_funky_comments
+	 *
+	 * @param string $funky_comment_html HTML containing a funky comment.
+	 * @param string $modifiable_text    Expected modifiable text of first funky comment in HTML.
+	 */
+	public function test_various_funky_comments( $funky_comment_html, $modifiable_text ) {
+		$processor = new WP_HTML_Tag_Processor( $funky_comment_html );
+		while ( '#funky-comment' !== $processor->get_token_type() && $processor->next_token() ) {
+			continue;
+		}
+
+		$this->assertSame(
+			'#funky-comment',
+			$processor->get_token_type(),
+			'Failed to find the expected funky comment.'
+		);
+
+		$this->assertSame(
+			$modifiable_text,
+			$processor->get_modifiable_text(),
+			'Found the wrong modifiable text span inside a funky comment.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[].
+	 */
+	public static function data_various_funky_comments() {
+		return array(
+			array( '</!>', '!' ),
+			array( '<//>', '/' ),
+			array( '<//wp:post-meta>', '/wp:post-meta' ),
+			array( '</{json}>', '{json}' ),
+			array( '</1><p>', '1' ),
+			array( '<p></__("Read more")></p>', '__("Read more")' ),
+		);
+	}
+
+	/**
 	 * Test helper that wraps a string in double quotes.
 	 *
 	 * @param string $s The string to wrap in double-quotes.

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-token-scanning.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-token-scanning.php
@@ -776,12 +776,12 @@ HTML
 	 */
 	public function test_various_funky_comments( $funky_comment_html, $modifiable_text ) {
 		$processor = new WP_HTML_Tag_Processor( $funky_comment_html );
-		while ( '#funky-comment' !== $processor->get_token_type() && $processor->next_token() ) {
+		while ( '#comment' !== $processor->get_token_type() && $processor->next_token() ) {
 			continue;
 		}
 
 		$this->assertSame(
-			'#funky-comment',
+			'#comment',
 			$processor->get_token_type(),
 			'Failed to find the expected funky comment.'
 		);
@@ -800,12 +800,12 @@ HTML
 	 */
 	public static function data_various_funky_comments() {
 		return array(
-			array( '</!>', '!' ),
-			array( '<//>', '/' ),
-			array( '<//wp:post-meta>', '/wp:post-meta' ),
-			array( '</{json}>', '{json}' ),
-			array( '</1><p>', '1' ),
-			array( '<p></__("Read more")></p>', '__("Read more")' ),
+			'Short-bang'     => array( '</!>', '!' ),
+			'Short-slash'    => array( '<//>', '/' ),
+			'Bit (no attrs)' => array( '<//wp:post-meta>', '/wp:post-meta' ),
+			'Curly-wrapped'  => array( '</{json}>', '{json}' ),
+			'Before P'       => array( '</1><p>', '1' ),
+			'After P'        => array( '<p></__("Read more")></p>', '__("Read more")' ),
 		);
 	}
 

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-token-scanning.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-token-scanning.php
@@ -765,7 +765,7 @@ HTML
 	 *
 	 * @ticket 60170
 	 *
-	 * @since 6.6.6
+	 * @since 6.6.0
 	 *
 	 * @covers WP_HTML_Tag_Processor::next_token
 	 *
@@ -800,16 +800,16 @@ HTML
 	 */
 	public static function data_various_funky_comments() {
 		return array(
-			'Space'             => array( '</ >', ' ' ),
-			'Short-bang'        => array( '</!>', '!' ),
-			'Markup Decl. Like' => array( '</?>', '?' ),
-			'Short-slash'       => array( '<//>', '/' ),
-			'Bit (no attrs)'    => array( '<//wp:post-meta>', '/wp:post-meta' ),
-			'Bit (attrs)'       => array( '<//wp:post-meta key=isbn>', '/wp:post-meta key=isbn' ),
-			'Curly-wrapped'     => array( '</{json}>', '{json}' ),
-			'Before P'          => array( '</1><p>', '1' ),
-			'After P'           => array( '<p></__("Read more")></p>', '__("Read more")' ),
-			'References'        => array( '</&gt;>', '&gt;' ),
+			'Space'          => array( '</ >', ' ' ),
+			'Short-bang'     => array( '</!>', '!' ),
+			'Question mark'  => array( '</?>', '?' ),
+			'Short-slash'    => array( '<//>', '/' ),
+			'Bit (no attrs)' => array( '<//wp:post-meta>', '/wp:post-meta' ),
+			'Bit (attrs)'    => array( '<//wp:post-meta key=isbn>', '/wp:post-meta key=isbn' ),
+			'Curly-wrapped'  => array( '</{json}>', '{json}' ),
+			'Before P'       => array( '</1><p>', '1' ),
+			'After P'        => array( '<p></__("Read more")></p>', '__("Read more")' ),
+			'Reference'      => array( '</&gt;>', '&gt;' ),
 		);
 	}
 

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-token-scanning.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-token-scanning.php
@@ -765,7 +765,7 @@ HTML
 	 *
 	 * @ticket 60170
 	 *
-	 * @since 6.5.6
+	 * @since 6.6.6
 	 *
 	 * @covers WP_HTML_Tag_Processor::next_token
 	 *
@@ -802,12 +802,14 @@ HTML
 		return array(
 			'Space'             => array( '</ >', ' ' ),
 			'Short-bang'        => array( '</!>', '!' ),
+			'Markup Decl. Like' => array( '</?>', '?' ),
 			'Short-slash'       => array( '<//>', '/' ),
 			'Bit (no attrs)'    => array( '<//wp:post-meta>', '/wp:post-meta' ),
+			'Bit (attrs)'       => array( '<//wp:post-meta key=isbn>', '/wp:post-meta key=isbn' ),
 			'Curly-wrapped'     => array( '</{json}>', '{json}' ),
 			'Before P'          => array( '</1><p>', '1' ),
 			'After P'           => array( '<p></__("Read more")></p>', '__("Read more")' ),
-			'Markup Decl. Like' => array( '</?>', '?' ),
+			'References'        => array( '</&gt;>', '&gt;' ),
 		);
 	}
 

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor-token-scanning.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor-token-scanning.php
@@ -800,12 +800,14 @@ HTML
 	 */
 	public static function data_various_funky_comments() {
 		return array(
-			'Short-bang'     => array( '</!>', '!' ),
-			'Short-slash'    => array( '<//>', '/' ),
-			'Bit (no attrs)' => array( '<//wp:post-meta>', '/wp:post-meta' ),
-			'Curly-wrapped'  => array( '</{json}>', '{json}' ),
-			'Before P'       => array( '</1><p>', '1' ),
-			'After P'        => array( '<p></__("Read more")></p>', '__("Read more")' ),
+			'Space'             => array( '</ >', ' ' ),
+			'Short-bang'        => array( '</!>', '!' ),
+			'Short-slash'       => array( '<//>', '/' ),
+			'Bit (no attrs)'    => array( '<//wp:post-meta>', '/wp:post-meta' ),
+			'Curly-wrapped'     => array( '</{json}>', '{json}' ),
+			'Before P'          => array( '</1><p>', '1' ),
+			'After P'           => array( '<p></__("Read more")></p>', '__("Read more")' ),
+			'Markup Decl. Like' => array( '</?>', '?' ),
 		);
 	}
 

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -618,7 +618,6 @@ SCRIPT_TAG;
 			'SPAN opener inside'   => array( '<div data-wp-bind--id="myPlugin::state.id"><span>Inner content</div>' ),
 			'SPAN closer after'    => array( '<div data-wp-bind--id="myPlugin::state.id">Inner content</div></span>' ),
 			'SPAN overlapping'     => array( '<div data-wp-bind--id="myPlugin::state.id"><span>Inner content</div></span>' ),
-			'Funky comment inside' => array( '<div data-wp-bind--id="myPlugin::state.id">Inner conntent</ ></div>' ),
 		);
 	}
 

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -609,15 +609,15 @@ SCRIPT_TAG;
 	 */
 	public static function data_html_with_unbalanced_tags() {
 		return array(
-			'DIV closer after'     => array( '<div data-wp-bind--id="myPlugin::state.id">Inner content</div></div>' ),
-			'DIV opener after'     => array( '<div data-wp-bind--id="myPlugin::state.id">Inner content</div><div>' ),
-			'DIV opener before'    => array( '<div><div data-wp-bind--id="myPlugin::state.id">Inner content</div>' ),
-			'DIV closer before'    => array( '</div><div data-wp-bind--id="myPlugin::state.id">Inner content</div>' ),
-			'DIV opener inside'    => array( '<div data-wp-bind--id="myPlugin::state.id">Inner<div>content</div>' ),
-			'DIV closer inside'    => array( '<div data-wp-bind--id="myPlugin::state.id">Inner</div>content</div>' ),
-			'SPAN opener inside'   => array( '<div data-wp-bind--id="myPlugin::state.id"><span>Inner content</div>' ),
-			'SPAN closer after'    => array( '<div data-wp-bind--id="myPlugin::state.id">Inner content</div></span>' ),
-			'SPAN overlapping'     => array( '<div data-wp-bind--id="myPlugin::state.id"><span>Inner content</div></span>' ),
+			'DIV closer after'   => array( '<div data-wp-bind--id="myPlugin::state.id">Inner content</div></div>' ),
+			'DIV opener after'   => array( '<div data-wp-bind--id="myPlugin::state.id">Inner content</div><div>' ),
+			'DIV opener before'  => array( '<div><div data-wp-bind--id="myPlugin::state.id">Inner content</div>' ),
+			'DIV closer before'  => array( '</div><div data-wp-bind--id="myPlugin::state.id">Inner content</div>' ),
+			'DIV opener inside'  => array( '<div data-wp-bind--id="myPlugin::state.id">Inner<div>content</div>' ),
+			'DIV closer inside'  => array( '<div data-wp-bind--id="myPlugin::state.id">Inner</div>content</div>' ),
+			'SPAN opener inside' => array( '<div data-wp-bind--id="myPlugin::state.id"><span>Inner content</div>' ),
+			'SPAN closer after'  => array( '<div data-wp-bind--id="myPlugin::state.id">Inner content</div></span>' ),
+			'SPAN overlapping'   => array( '<div data-wp-bind--id="myPlugin::state.id"><span>Inner content</div></span>' ),
 		);
 	}
 

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -588,29 +588,38 @@ SCRIPT_TAG;
 	 * @ticket 60356
 	 *
 	 * @covers ::process_directives
+	 *
+	 * @dataProvider data_html_with_unbalanced_tags
+	 *
+	 * @param string $html HTML containing unbalanced tags and also a directive.
 	 */
-	public function test_process_directives_doesnt_change_html_if_contains_unbalanced_tags() {
+	public function test_process_directives_doesnt_change_html_if_contains_unbalanced_tags( $html ) {
 		$this->interactivity->state( 'myPlugin', array( 'id' => 'some-id' ) );
 
-		$html_samples = array(
-			'<div data-wp-bind--id="myPlugin::state.id">Inner content</div></div>',
-			'<div data-wp-bind--id="myPlugin::state.id">Inner content</div><div>',
-			'<div><div data-wp-bind--id="myPlugin::state.id">Inner content</div>',
-			'</div><div data-wp-bind--id="myPlugin::state.id">Inner content</div>',
-			'<div data-wp-bind--id="myPlugin::state.id">Inner<div>content</div>',
-			'<div data-wp-bind--id="myPlugin::state.id">Inner</div>content</div>',
-			'<div data-wp-bind--id="myPlugin::state.id"><span>Inner content</div>',
-			'<div data-wp-bind--id="myPlugin::state.id">Inner content</div></span>',
-			'<div data-wp-bind--id="myPlugin::state.id"><span>Inner content</div></span>',
-			'<div data-wp-bind--id="myPlugin::state.id">Inner conntent</ ></div>',
-		);
+		$processed_html = $this->interactivity->process_directives( $html );
+		$p              = new WP_HTML_Tag_Processor( $processed_html );
+		$p->next_tag();
+		$this->assertNull( $p->get_attribute( 'id' ) );
+	}
 
-		foreach ( $html_samples as $html ) {
-			$processed_html = $this->interactivity->process_directives( $html );
-			$p              = new WP_HTML_Tag_Processor( $processed_html );
-			$p->next_tag();
-			$this->assertNull( $p->get_attribute( 'id' ) );
-		}
+	/**
+	 * Data provider.
+	 *
+	 * @return array[].
+	 */
+	public static function data_html_with_unbalanced_tags() {
+		return array(
+			'DIV closer after'     => array( '<div data-wp-bind--id="myPlugin::state.id">Inner content</div></div>' ),
+			'DIV opener after'     => array( '<div data-wp-bind--id="myPlugin::state.id">Inner content</div><div>' ),
+			'DIV opener before'    => array( '<div><div data-wp-bind--id="myPlugin::state.id">Inner content</div>' ),
+			'DIV closer before'    => array( '</div><div data-wp-bind--id="myPlugin::state.id">Inner content</div>' ),
+			'DIV opener inside'    => array( '<div data-wp-bind--id="myPlugin::state.id">Inner<div>content</div>' ),
+			'DIV closer inside'    => array( '<div data-wp-bind--id="myPlugin::state.id">Inner</div>content</div>' ),
+			'SPAN opener inside'   => array( '<div data-wp-bind--id="myPlugin::state.id"><span>Inner content</div>' ),
+			'SPAN closer after'    => array( '<div data-wp-bind--id="myPlugin::state.id">Inner content</div></span>' ),
+			'SPAN overlapping'     => array( '<div data-wp-bind--id="myPlugin::state.id"><span>Inner content</div></span>' ),
+			'Funky comment inside' => array( '<div data-wp-bind--id="myPlugin::state.id">Inner conntent</ ></div>' ),
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes Core-60170

In an audit of funky comment syntax some issues were uncovered relating to misidentifying them as other comments. This patch attempts to fix the identified issues.

| HTML | Before | After |
|---|---|---|
| `</ ><img>` | Funky Comment: ` ><img` | Funky Comment: ` `, Tag: `IMG` |

It was also discovered that some of the token boundaries are not properly recorded. While this hasn't caused a problem with the public interface or calling code, it would start to pose problems when continuing the reliance on the bookmarks to perform inner and outer markup changes.

Follow-up to [60428].