### PR TITLE
Update memory limit settings in default-constants.php

### DIFF
--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -57,7 +57,9 @@ function wp_initial_constants() {
 		if ( false === wp_is_ini_value_changeable( 'memory_limit' ) ) {
 			define( 'WP_MAX_MEMORY_LIMIT', $current_limit );
 		} elseif ( -1 === $current_limit_int || $current_limit_int > 268435456 /* = 256M */ ) {
-			define( 'WP_MAX_MEMORY_LIMIT', $current_limit );
+			define('WP_MAX_MEMORY_LIMIT', $current_limit);
+		} elseif ( wp_convert_hr_to_bytes( WP_MEMORY_LIMIT ) > 268435456 /* = 256M */ ) {
+			define( 'WP_MAX_MEMORY_LIMIT', WP_MEMORY_LIMIT );
 		} else {
 			define( 'WP_MAX_MEMORY_LIMIT', '256M' );
 		}

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -57,7 +57,7 @@ function wp_initial_constants() {
 		if ( false === wp_is_ini_value_changeable( 'memory_limit' ) ) {
 			define( 'WP_MAX_MEMORY_LIMIT', $current_limit );
 		} elseif ( -1 === $current_limit_int || $current_limit_int > 268435456 /* = 256M */ ) {
-			define('WP_MAX_MEMORY_LIMIT', $current_limit);
+			define( 'WP_MAX_MEMORY_LIMIT', $current_limit );
 		} elseif ( wp_convert_hr_to_bytes( WP_MEMORY_LIMIT ) > 268435456 /* = 256M */ ) {
 			define( 'WP_MAX_MEMORY_LIMIT', WP_MEMORY_LIMIT );
 		} else {


### PR DESCRIPTION
The code for setting the `WP_MAX_MEMORY_LIMIT` has been tweaked. If the defined `WP_MEMORY_LIMIT` in bytes is greater than 256M, `WP_MAX_MEMORY_LIMIT` will now be set to the value of `WP_MEMORY_LIMIT` instead of the current memory limit. This adjustment provides a more precise control of the memory limit.


Trac ticket: https://core.trac.wordpress.org/ticket/36426