### PR TITLE
Return empty object when no fallback templates are found (wp/v2/templates/lookup)

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -153,6 +153,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 	 *
 	 * @since 6.1.0
 	 * @since 6.3.0 Ignore empty templates.
+	 * @since 6.5.3 Return a 404 error if no fallback templates are found.
 	 *
 	 * @param WP_REST_Request $request The request instance.
 	 * @return WP_REST_Response|WP_Error
@@ -164,6 +165,10 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			$fallback_template = resolve_block_template( $request['slug'], $hierarchy, '' );
 			array_shift( $hierarchy );
 		} while ( ! empty( $hierarchy ) && empty( $fallback_template->content ) );
+
+		if ( ! $fallback_template ) {
+			return new WP_Error( 'rest_template_not_found', __( 'No fallback templates exist for that slug.' ), array( 'status' => 404 ) );
+		}
 
 		$response = $this->prepare_item_for_response( $fallback_template, $request );
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -153,7 +153,6 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 	 *
 	 * @since 6.1.0
 	 * @since 6.3.0 Ignore empty templates.
-	 * @since 6.5.3 Return a 404 error if no fallback templates are found.
 	 *
 	 * @param WP_REST_Request $request The request instance.
 	 * @return WP_REST_Response|WP_Error
@@ -166,11 +165,8 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			array_shift( $hierarchy );
 		} while ( ! empty( $hierarchy ) && empty( $fallback_template->content ) );
 
-		if ( ! $fallback_template ) {
-			return new WP_Error( 'rest_template_not_found', __( 'No fallback templates exist for that slug.' ), array( 'status' => 404 ) );
-		}
-
-		$response = $this->prepare_item_for_response( $fallback_template, $request );
+		// To maintain original behavior, return an empty object rather than a 404 error when no template is found.
+		$response = $fallback_template ? $this->prepare_item_for_response( $fallback_template, $request ) : new stdClass();
 
 		return rest_ensure_response( $response );
 	}

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -910,6 +910,18 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 	}
 
 	/**
+	 * @ticket 60909
+	 * @covers WP_REST_Templates_Controller::get_template_fallback
+	 */
+	public function test_get_template_fallback_not_found() {
+		wp_set_current_user( self::$admin_id );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/templates/lookup' );
+		$request->set_param( 'slug', 'not-found' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_template_not_found', $response, 404 );
+	}
+
+	/**
 	 * @ticket 57851
 	 *
 	 * @covers WP_REST_Templates_Controller::prepare_item_for_database

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -918,7 +918,8 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		$request = new WP_REST_Request( 'GET', '/wp/v2/templates/lookup' );
 		$request->set_param( 'slug', 'not-found' );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_template_not_found', $response, 404 );
+		$data     = $response->get_data();
+		$this->assertEquals( new stdClass(), $data, 'Response should be an empty object when a fallback template is not found.' );
 	}
 
 	/**


### PR DESCRIPTION
Modifies the wp/v2/templates/fallback endpoint to return a 404 error when no templates are found.

### Testing Instructions

- Activate a classic theme, such as twentyeleven
- Add a theme.json file to the theme with minimal content (e.g. `{ "version": 2 }`)
- Load a page in the editor
- You should see a request to `/wp-json/wp/v2/templates/lookup` respond with an empty object in the browser network tab
- There should not be any PHP warnings in the error log

Trac ticket: https://core.trac.wordpress.org/ticket/60909
Gutenberg PR: https://github.com/WordPress/gutenberg/pull/60925

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
