### PR TITLE
Removing unnecessary writes to the DB for `use_ssl` user meta

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2320,7 +2320,7 @@ function wp_insert_user( $userdata ) {
 	$admin_color         = empty( $userdata['admin_color'] ) ? 'fresh' : $userdata['admin_color'];
 	$meta['admin_color'] = preg_replace( '|[^a-z0-9 _.\-@]|i', '', $admin_color );
 
-	$meta['use_ssl'] = empty( $userdata['use_ssl'] ) ? 0 : (bool) $userdata['use_ssl'];
+	$meta['use_ssl'] = empty( $userdata['use_ssl'] ) || ! $userdata['use_ssl'] ? '0' : '1';
 
 	$meta['show_admin_bar_front'] = empty( $userdata['show_admin_bar_front'] ) ? 'true' : $userdata['show_admin_bar_front'];
 

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -2209,7 +2209,7 @@ class Tests_User extends WP_UnitTestCase {
 		// Data type of the use_ssl saved in the DB.
 		$type_in_db = gettype( get_user_meta( $user_id, 'use_ssl', true ) );
 
-		add_filter( 'insert_user_meta', array( $this, 'save_use_ssl_meta_type' ), 10, 3 );
+		add_filter( 'insert_user_meta', array( $this, 'save_use_ssl_meta_data_type' ), 10, 3 );
 
 		$_POST                 = array();
 		$_GET                  = array();

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -2200,7 +2200,7 @@ class Tests_User extends WP_UnitTestCase {
 			'nickname'   => 'nickname1',
 			'user_pass'  => 'test_password',
 		);
-	
+
 		// Insert the user into the database
 		$user_id = wp_insert_user( $userdata );
 		// Add in DB to be able to use in another method.
@@ -2209,7 +2209,7 @@ class Tests_User extends WP_UnitTestCase {
 		// Data type of the use_ssl saved in the DB.
 		$type_in_db = gettype( get_user_meta( $user_id, 'use_ssl', true ) );
 
-		add_filter( 'insert_user_meta', array($this, 'save_use_ssl_meta_type'), 10, 3 );
+		add_filter( 'insert_user_meta', array( $this, 'save_use_ssl_meta_type' ), 10, 3 );
 
 		$_POST                 = array();
 		$_GET                  = array();

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -2187,22 +2187,12 @@ class Tests_User extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test if the use_ssl is not written unneccesarily.
+	 * Test if the use_ssl doesn't write to DB unneccesarily.
 	 *
 	 * @ticket 60299
 	 */
 	public function test_unnecessary_assignment_of_use_ssl_in_meta() {
-		// Create a new user with some default data
-		$userdata = array(
-			'role'       => 'subscriber',
-			'email'      => 'test1@example.com',
-			'user_login' => 'test_user',
-			'nickname'   => 'nickname1',
-			'user_pass'  => 'test_password',
-		);
-
-		// Insert the user into the database
-		$user_id = wp_insert_user( $userdata );
+		$user_id = self::$contrib_id;
 		// Add in DB to be able to use in another method.
 		add_option( 'test_user_id_meta_ssl_type', $user_id );
 
@@ -2212,18 +2202,9 @@ class Tests_User extends WP_UnitTestCase {
 		add_filter( 'insert_user_meta', array( $this, 'save_use_ssl_meta_data_type' ), 10, 3 );
 
 		$_POST                 = array();
-		$_GET                  = array();
-		$_REQUEST              = array();
-		$_POST['role']         = 'subscriber';
-		$_POST['email']        = 'test1@example.com';
-		$_POST['user_login']   = 'test_user';
-		$_POST['first_name']   = 'first_name1';
-		$_POST['last_name']    = 'last_name1';
-		$_POST['nickname']     = 'nickname1';
-		$_POST['display_name'] = 'display_name1';
+		$_POST['nickname']     = 'nickname_test_1';
+		$_POST['email']        = 'email_test_1@example.com';
 		$_POST['use_ssl']      = 0; // Set Use SSL to false.
-		$_POST['pass1']        = 'password';
-		$_POST['pass2']        = 'password';
 
 		$user_id = edit_user( $user_id );
 

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -2201,10 +2201,10 @@ class Tests_User extends WP_UnitTestCase {
 
 		add_filter( 'insert_user_meta', array( $this, 'save_use_ssl_meta_data_type' ), 10, 3 );
 
-		$_POST                 = array();
-		$_POST['nickname']     = 'nickname_test_1';
-		$_POST['email']        = 'email_test_1@example.com';
-		$_POST['use_ssl']      = 0; // Set Use SSL to false.
+		$_POST             = array();
+		$_POST['nickname'] = 'nickname_test_1';
+		$_POST['email']    = 'email_test_1@example.com';
+		$_POST['use_ssl']  = 0; // Set Use SSL to false.
 
 		$user_id = edit_user( $user_id );
 

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -2221,8 +2221,7 @@ class Tests_User extends WP_UnitTestCase {
 		$_POST['last_name']    = 'last_name1';
 		$_POST['nickname']     = 'nickname1';
 		$_POST['display_name'] = 'display_name1';
-		// Set Use SSL to false.
-		$_POST['use_ssl']      = 0;
+		$_POST['use_ssl']      = 0; // Set Use SSL to false.
 		$_POST['pass1']        = 'password';
 		$_POST['pass2']        = 'password';
 
@@ -2243,7 +2242,7 @@ class Tests_User extends WP_UnitTestCase {
 	public function save_use_ssl_meta_data_type( $meta, $user, $update ) {
 		$user_id = get_option( 'test_user_id_meta_ssl_type' );
 
-		if ( $user->ID == $user_id ) {
+		if ( $user->ID === $user_id ) {
 			add_option( 'test_user_meta_ssl_data_type', gettype( $meta['use_ssl'] ) );
 		}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Removing unnecessary writes to the DB for `use_ssl` user meta, with unit tests.

Trac ticket: https://core.trac.wordpress.org/ticket/60299

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
