### PR TITLE
KSES: Allow Custom Data Attributes having dashes in their dataset name.

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -1529,24 +1529,27 @@ function wp_kses_attr_check( &$name, &$value, &$whole, $vless, $element, $allowe
 
 	$allowed_attr = $allowed_html[ $element_low ];
 
+	/*
+	 * Allow Custom Data Attributes (`data-*`).
+	 *
+	 * When specifying `$allowed_html`, the attribute name should be set as
+	 * `data-*` (not to be mixed with the HTML 4.0 `data` attribute, see
+	 * https://www.w3.org/TR/html40/struct/objects.html#adef-data).
+	 *
+	 * Custom data attributes appear on an HTML element in the `dataset`
+	 * property and are available from JavaScript with a transformed name.
+	 *
+	 * @see https://html.spec.whatwg.org/#custom-data-attribute
+	 */
 	if ( ! isset( $allowed_attr[ $name_low ] ) || '' === $allowed_attr[ $name_low ] ) {
-		/*
-		 * Allow `data-*` attributes.
-		 *
-		 * When specifying `$allowed_html`, the attribute name should be set as
-		 * `data-*` (not to be mixed with the HTML 4.0 `data` attribute, see
-		 * https://www.w3.org/TR/html40/struct/objects.html#adef-data).
-		 *
-		 * Note: the attribute name should only contain `A-Za-z0-9_-` chars.
-		 */
-		if ( str_starts_with( $name_low, 'data-' ) && ! empty( $allowed_attr['data-*'] )
-			&& preg_match( '/^data-[a-z0-9_-]+$/', $name_low, $match )
-		) {
+		$dataset_name = wp_js_dataset_name( $name );
+		if ( isset( $dataset_name ) && ! empty( $allowed_attr['data-*'] ) ) {
 			/*
-			 * Add the whole attribute name to the allowed attributes and set any restrictions
-			 * for the `data-*` attribute values for the current element.
+			 * The attribute name passed in here is the `data-*` name, or the name in
+			 * the raw HTML. Add it to the set of allowed attributes and adopt the
+			 * restrictions applied to all custom data attributes for the element.
 			 */
-			$allowed_attr[ $match[0] ] = $allowed_attr['data-*'];
+			$allowed_attr[ $name_low ] = $allowed_attr['data-*'];
 		} else {
 			$name  = '';
 			$value = '';

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1441,25 +1441,114 @@ EOF;
 	/**
 	 * Data attributes are globally accepted.
 	 *
-	 * @ticket 33121
+	 * @ticket 61501
+	 *
+	 * @dataProvider data_data_attributes_and_whether_they_are_allowed
+	 *
+	 * @param string $attribute_name Custom data attribute, e.g. "data-wp-bind--enabled".
+	 * @param bool   $is_allowed     Whether the given attribute should be allowed.
 	 */
-	public function test_wp_kses_attr_data_attribute_is_allowed() {
-		$test     = '<div data-foo="foo" data-bar="bar" datainvalid="gone" data-two-hyphens="remains">Pens and pencils</div>';
-		$expected = '<div data-foo="foo" data-bar="bar" data-two-hyphens="remains">Pens and pencils</div>';
+	public function test_wp_kses_attr_boolean_data_attribute_is_allowed( string $attribute_name, bool $is_allowed ) {
+		$element = "<div {$attribute_name}>Pens and pencils.</div>";
 
-		$this->assertEqualHTML( $expected, wp_kses_post( $test ) );
+		$processor = new WP_HTML_Tag_Processor( $element );
+		$processor->next_tag();
+
+		$this->assertTrue(
+			$processor->get_attribute( $attribute_name ),
+			"Failed to find expected attribute '{$attribute_name}' before filtering: check test."
+		);
+
+		$processor = new WP_HTML_Tag_Processor( wp_kses_post( $element ) );
+		$this->assertTrue(
+			$processor->next_tag(),
+			'Failed to find containing tag after filtering: check test.'
+		);
+
+		if ( $is_allowed ) {
+			$this->assertTrue(
+				$processor->get_attribute( $attribute_name ),
+				"Allowed custom data attribute '{$attribute_name}' should not have been removed."
+			);
+		} else {
+			$this->assertNull(
+				$processor->get_attribute( $attribute_name ),
+				"Should have removed un-allowed custom data attribute '{$attribute_name}'."
+			);
+		}
 	}
 
 	/**
-	 * Data attributes with leading, trailing, and double "-" are globally accepted.
+	 * Ensures that only allowable custom data attributes with values are retained.
 	 *
-	 * @ticket 61052
+	 * @ticket 33121
+	 *
+	 * @dataProvider data_data_attributes_and_whether_they_are_allowed
+	 *
+	 * @param string $attribute_name Custom data attribute, e.g. "dat-wp-bind--enabled".
+	 * @param bool   $is_allowed     Whether the given attribute should be allowed.
 	 */
-	public function test_wp_kses_attr_data_attribute_hypens_allowed() {
-		$test     = '<div data--leading="remains" data-trailing-="remains" data-middle--double="remains">Pens and pencils</div>';
-		$expected = '<div data--leading="remains" data-trailing-="remains" data-middle--double="remains">Pens and pencils</div>';
+	public function test_wp_kses_attr_data_attribute_is_allowed( string $attribute_name, bool $is_allowed ) {
+		$element = "<div {$attribute_name}='shadows and dust'>Pens and pencils.</div>";
 
-		$this->assertEqualHTML( $expected, wp_kses_post( $test ) );
+		$processor = new WP_HTML_Tag_Processor( $element );
+		$processor->next_tag();
+
+		$this->assertIsString(
+			$processor->get_attribute( $attribute_name ),
+			"Failed to find expected attribute '{$attribute_name}' before filtering: check test."
+		);
+
+		$processor = new WP_HTML_Tag_Processor( wp_kses_post( $element ) );
+		$this->assertTrue(
+			$processor->next_tag(),
+			'Failed to find containing tag after filtering: check test.'
+		);
+
+		if ( $is_allowed ) {
+			$this->assertIsString(
+				$processor->get_attribute( $attribute_name ),
+				"Allowed custom data attribute '{$attribute_name}' should not have been removed."
+			);
+		} else {
+			$this->assertNull(
+				$processor->get_attribute( $attribute_name ),
+				"Should have removed un-allowed custom data attribute '{$attribute_name}'."
+			);
+		}
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[].
+	 */
+	public static function data_data_attributes_and_whether_they_are_allowed() {
+		return array(
+			// Allowable custom data attributes.
+			'Normative attribute'      => array( 'data-foo', true ),
+			'Non-consecutive dashes'   => array( 'data-two-hyphens', true ),
+			'Double-dashes'            => array( 'data--double-dash', true ),
+			'Trailing dash'            => array( 'data-trailing-dash-', true ),
+			'Uppercase alphas'         => array( 'data-Post-ID', true ),
+			'Bind Directive'           => array( 'data-wp-bind--enabled', true ),
+			'Single-dash suffix'       => array( 'data-after-', true ),
+			'Double-dash prefix'       => array( 'data--before', true ),
+			'Double-dash suffix'       => array( 'data-after--', true ),
+			'Double-dashes everywhere' => array( 'data--one--two--', true ),
+			'Underscore'               => array( 'data-over_under', true ),
+
+			// Not custom data attributes.
+			'No data- prefix'          => array( 'post-id', false ),
+			'No dash after prefix'     => array( 'datainvalid', false ),
+
+			// Un-allowable custom data attributes.
+			'Nothing after prefix'     => array( 'data-', false ),
+			'Whitespace after prefix'  => array( "data-\u{2003}", false ),
+			'Emoji in name'            => array( 'data-🐄', false ),
+			'Brackets'                 => array( 'data-[enabled]', false ),
+			'Colon'                    => array( 'data-wp:bind', false ),
+		);
 	}
 
 	/**


### PR DESCRIPTION
Trac ticket: Core-61501.
_(was Core-61052)_
Alternative in #6598 

Allow for additional custom data attributes in `wp_kses_attr_check()`.

In this patch the set of allowable custom data attribute names is expanded to permit those including dashes in the `dataset` name. The term `dataset` name here means the name appearing to JavaScript in a browser. This is found by stripping away the `data-` prefix, lowercasing, and then turning every dash-letter combination into a capital letter.

The Interactivity API relies on data attributes of the form `data-wp-bind--enabled`. The corresponding dataset name here is `wpBind-Enabled`, and is currently blocked by `wp_kses_attr_check()`. This patch allows that and any other data attribute through which would include those dashes in the translated name.

This patch is structured in two parts:

 1. Ensure that Core can recognize whether a given attribute represents a custom data attribute.
 2. Once recognizing the custom data attributes, apply a WordPress-specific set of constraints to determine whether to allow it.

The effect of this change is allowing a double-dash when previously only a single dash after the initial `data-` prefix was allowed. It's more complicated than this, because, as evidenced in the test suite, double dashes translate into different names based on where they appear and what follows them in the attribute name.

<details><summary>Code used to produce this table</summary>

```php
<style>
td, th {
	margin-right: 1em;
}
</style>
<?php

require_once __PATH_TO_REPO__ . '/wordpress-develop/src/wp-load.php';

$variations = [
	'data-',
	'post-id',
	'data-post-id',
	'data-Post-ID',
	'data-uPPer-cAsE',
	"data-\u{2003}",
	'data-🐄-pasture',
	'data-wp-bind--enabled',
	'data-over_under',
	'data--before',
	'data-after-',
	'data-after-after--',
	'data--one--two--',
	'data---one---two---',
	'data-[wish:granted]',
];

echo '<table><tr><th>Attribute Name<th>Dataset Name<th>Before<th>After</tr>';
foreach ( $variations as $name ) {
	$_name    = $name;
	$_value   = 'some-value';
	$_whole   = "{$_name}=\"{$_value}\"";
	$_vless   = 'n';
	$_element = 'div';
	$_allowed_html = [ 'div' => [ 'data-*' => true ] ];

	$was_allowed = wp_old_kses_check( $_name, $_value, $_whole, $_vless, $_element, $_allowed_html );
	$was_allowed = $was_allowed ? '✅' : '🚫';

	$_name    = $name;
	$_value   = 'some-value';
	$_whole   = "{$_name}=\"{$_value}\"";
	$_vless   = 'n';
	$_element = 'div';
	$_allowed_html = [ 'div' => [ 'data-*' => true ] ];

	$is_allowed = wp_kses_attr_check( $_name, $_value, $_whole, $_vless, $_element, $_allowed_html );
	$is_allowed = $is_allowed ? '✅' : '🚫';

	echo <<<HTML
	<tr>
	<th><code>{$name}</code>
	<td style="font-family: monospace;" is-data {$name}>{$name}
	<td>{$was_allowed}
	<td>{$is_allowed}
	HTML;
}
echo '</table>';

?>
<script>
document.querySelectorAll( '[is-data]' ).forEach( node => {
	node.innerText = Object.keys( node.dataset ).join( ', ' );
} );
</script>
<?php

function wp_old_kses_check( &$name, &$value, &$whole, $vless, $element, $allowed_html ) {
	$name_low    = strtolower( $name );
	$element_low = strtolower( $element );

	if ( ! isset( $allowed_html[ $element_low ] ) ) {
		$name  = '';
		$value = '';
		$whole = '';
		return false;
	}

	$allowed_attr = $allowed_html[ $element_low ];

	if ( ! isset( $allowed_attr[ $name_low ] ) || '' === $allowed_attr[ $name_low ] ) {
		/*
		 * Allow `data-*` attributes.
		 *
		 * When specifying `$allowed_html`, the attribute name should be set as
		 * `data-*` (not to be mixed with the HTML 4.0 `data` attribute, see
		 * https://www.w3.org/TR/html40/struct/objects.html#adef-data).
		 *
		 * Note: the attribute name should only contain `A-Za-z0-9_-` chars,
		 * double hyphens `--` are not accepted by WordPress.
		 */
		if ( str_starts_with( $name_low, 'data-' ) && ! empty( $allowed_attr['data-*'] )
			&& preg_match( '/^data(?:-[a-z0-9_]+)+$/', $name_low, $match )
		) {
			/*
			 * Add the whole attribute name to the allowed attributes and set any restrictions
			 * for the `data-*` attribute values for the current element.
			 */
			$allowed_attr[ $match[0] ] = $allowed_attr['data-*'];
		} else {
			$name  = '';
			$value = '';
			$whole = '';
			return false;
		}
	}

	if ( 'style' === $name_low ) {
		$new_value = safecss_filter_attr( $value );

		if ( empty( $new_value ) ) {
			$name  = '';
			$value = '';
			$whole = '';
			return false;
		}

		$whole = str_replace( $value, $new_value, $whole );
		$value = $new_value;
	}

	if ( is_array( $allowed_attr[ $name_low ] ) ) {
		// There are some checks.
		foreach ( $allowed_attr[ $name_low ] as $currkey => $currval ) {
			if ( ! wp_kses_check_attr_val( $value, $vless, $currkey, $currval ) ) {
				$name  = '';
				$value = '';
				$whole = '';
				return false;
			}
		}
	}

	return true;
}
```

</details>

<img width="395" alt="Screenshot 2024-05-22 at 10 58 02 AM" src="https://github.com/WordPress/wordpress-develop/assets/5431237/15caab7f-1c69-4fe4-9094-f497cfcaf5e9">

> These are recommendations. If these naming recommendations are not followed, no errors will occur. The attributes will still be matched using CSS [attribute selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors), with the attribute being case insensitive and any attribute value being case-sensitive. Attributes not conforming to these three recommendations will also still be recognized by the JavaScript [HTMLElement.dataset](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/dataset) property and user-agents will include the attribute in the [DOMStringMap](https://developer.mozilla.org/en-US/docs/Web/API/DOMStringMap) containing all the custom data attributes for an [HTMLElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement).

https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/data-*