### PR TITLE
Reduce font size of credit page h1 for ticket 61030

### DIFF
--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -585,7 +585,7 @@
 .privacy-php .about__header-title h1,
 .contribute-php .about__header-title h1 {
 	/* Fluid font size scales on browser size 960px - 1200px. */
-	font-size: clamp(2rem, 10vw - 3rem, 4rem);
+	font-size: clamp(2rem, 20vw - 9rem, 4rem);
 }
 
 .about__header-text {
@@ -655,7 +655,7 @@
 	.privacy-php .about__header-title h1,
 	.contribute-php .about__header-title h1 {
 		/* Fluid font size scales on browser size 600px - 960px. */
-		font-size: clamp(3rem, 6.67vw - 0.5rem, 4.5rem);
+		font-size: clamp(2rem, 20vw - 9rem, 4rem);
 	}
 
 	.about__header-navigation .nav-tab {


### PR DESCRIPTION
Reduced the heading size for credits page for smaller viewport.

Trac ticket: [#61030](https://core.trac.wordpress.org/ticket/61030)


