### PR TITLE
Administration: Add a `primary` class to the FTP Credentials Modal submit button.

### DIFF
--- a/src/wp-admin/includes/file.php
+++ b/src/wp-admin/includes/file.php
@@ -2664,7 +2664,7 @@ function request_filesystem_credentials( $form_post, $type = '', $error = false,
 	<p class="request-filesystem-credentials-action-buttons">
 		<?php wp_nonce_field( 'filesystem-credentials', '_fs_nonce', false, true ); ?>
 		<button class="button cancel-button" data-js-action="close" type="button"><?php _e( 'Cancel' ); ?></button>
-		<?php submit_button( __( 'Proceed' ), '', 'upgrade', false ); ?>
+		<?php submit_button( __( 'Proceed' ), 'primary', 'upgrade', false ); ?>
 	</p>
 </div>
 </form>


### PR DESCRIPTION
Testing steps: 

1) Add this to your wp-config.php: `define( 'FS_METHOD', 'ftpext' );`
2) Install an old version of a plugin
3) Browse to wp-admin/plugins.php
4) Click on the update now link in the plugin’s table row

https://core.trac.wordpress.org/ticket/37647