### PR TITLE
Remove an unneeded blank line

### DIFF
--- a/src/wp-load.php
+++ b/src/wp-load.php
@@ -57,7 +57,6 @@ if ( file_exists( ABSPATH . 'wp-config.php' ) ) {
 } else {
 
 	// A config file doesn't exist.
-
 	define( 'WPINC', 'wp-includes' );
 	require_once ABSPATH . WPINC . '/version.php';
 	require_once ABSPATH . WPINC . '/compat.php';


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Like in the Trac ticket, usually there is code right after a comment but not here. So, let's remove that blank line that's doing nothing. So, we adhere to coding standards.

Trac ticket: https://core.trac.wordpress.org/ticket/61070#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
