### PR TITLE
Test/Admin/IncludesUser: Rename the test file to be more descriptive

### DIFF
--- a/tests/phpunit/tests/admin/Admin_Includes_User_WpIsAuthorizeApplicationPasswordRequestValid_Test.php
+++ b/tests/phpunit/tests/admin/Admin_Includes_User_WpIsAuthorizeApplicationPasswordRequestValid_Test.php
@@ -3,16 +3,16 @@
 /**
  * @group admin
  * @group user
+ *
+ * @covers ::wp_is_authorize_application_password_request_valid
  */
-class Tests_Admin_IncludesUser extends WP_UnitTestCase {
+class Admin_Includes_User_WpIsAuthorizeApplicationPasswordRequestValid_Test extends WP_UnitTestCase {
 
 	/**
 	 * Test redirect URLs for application password authorization requests.
 	 *
 	 * @ticket 42790
 	 * @ticket 52617
-	 *
-	 * @covers ::wp_is_authorize_application_password_request_valid
 	 *
 	 * @dataProvider data_is_authorize_application_password_request_valid
 	 *


### PR DESCRIPTION

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Renames `IncludesUser` to include the path, file name, and function name, to better indicate which function the test tests: `Admin_Includes_User_WpIsAuthorizeApplicationPasswordRequestValid_Test`

Moves `@covers` to the test class level.

Trac ticket: https://core.trac.wordpress.org/ticket/53010

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
