### PR TITLE
Test/Admin/WpAutomaticUpdater: Split the tests and add a new TestCase

### DIFF
--- a/tests/phpunit/tests/admin/Admin_WpAutomaticUpdater_IsAllowedDir_Test.php
+++ b/tests/phpunit/tests/admin/Admin_WpAutomaticUpdater_IsAllowedDir_Test.php
@@ -1,0 +1,139 @@
+<?php
+
+require_once __DIR__ . '/Admin_WpAutomaticUpdater_TestCase.php';
+
+/**
+ * @group admin
+ * @group upgrade
+ *
+ * @covers WP_Automatic_Updater::is_allowed_dir
+ */
+class Admin_WpAutomaticUpdater_IsAllowedDir_Test extends Admin_WpAutomaticUpdater_TestCase {
+
+	/**
+	 * Tests that `WP_Automatic_Updater::is_allowed_dir()` returns true
+	 * when the `open_basedir` directive is not set.
+	 *
+	 * @ticket 42619
+	 *
+	 */
+	public function test_is_allowed_dir_should_return_true_if_open_basedir_is_not_set() {
+		$this->assertTrue( self::$updater->is_allowed_dir( ABSPATH ) );
+	}
+
+	/**
+	 * Tests that `WP_Automatic_Updater::is_allowed_dir()` returns true
+	 * when the `open_basedir` directive is set and the path is allowed.
+	 *
+	 * Runs in a separate process to ensure that `open_basedir` changes
+	 * don't impact other tests should an error occur.
+	 *
+	 * This test does not preserve global state to prevent the exception
+	 * "Serialization of 'Closure' is not allowed" when running in
+	 * a separate process.
+	 *
+	 * @ticket 42619
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_is_allowed_dir_should_return_true_if_open_basedir_is_set_and_path_is_allowed() {
+		// The repository for PHPUnit and test suite resources.
+		$abspath_parent      = trailingslashit( dirname( ABSPATH ) );
+		$abspath_grandparent = trailingslashit( dirname( $abspath_parent ) );
+
+		$open_basedir_backup = ini_get( 'open_basedir' );
+		// Allow access to the directory one level above the repository.
+		ini_set( 'open_basedir', sys_get_temp_dir() . PATH_SEPARATOR . wp_normalize_path( $abspath_grandparent ) );
+
+		// Checking an allowed directory should succeed.
+		$actual = self::$updater->is_allowed_dir( wp_normalize_path( ABSPATH ) );
+
+		ini_set( 'open_basedir', $open_basedir_backup );
+
+		$this->assertTrue( $actual );
+	}
+
+	/**
+	 * Tests that `WP_Automatic_Updater::is_allowed_dir()` returns false
+	 * when the `open_basedir` directive is set and the path is not allowed.
+	 *
+	 * Runs in a separate process to ensure that `open_basedir` changes
+	 * don't impact other tests should an error occur.
+	 *
+	 * This test does not preserve global state to prevent the exception
+	 * "Serialization of 'Closure' is not allowed" when running in
+	 * a separate process.
+	 *
+	 * @ticket 42619
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_is_allowed_dir_should_return_false_if_open_basedir_is_set_and_path_is_not_allowed() {
+		// The repository for PHPUnit and test suite resources.
+		$abspath_parent      = trailingslashit( dirname( ABSPATH ) );
+		$abspath_grandparent = trailingslashit( dirname( $abspath_parent ) );
+
+		$open_basedir_backup = ini_get( 'open_basedir' );
+		// Allow access to the directory one level above the repository.
+		ini_set( 'open_basedir', sys_get_temp_dir() . PATH_SEPARATOR . wp_normalize_path( $abspath_grandparent ) );
+
+		// Checking a directory not within the allowed path should trigger an `open_basedir` warning.
+		$actual = self::$updater->is_allowed_dir( '/.git' );
+
+		ini_set( 'open_basedir', $open_basedir_backup );
+
+		$this->assertFalse( $actual );
+	}
+
+	/**
+	 * Tests that `WP_Automatic_Updater::is_allowed_dir()` throws `_doing_it_wrong()`
+	 * when an invalid `$dir` argument is provided.
+	 *
+	 * @ticket 42619
+	 *
+	 * @expectedIncorrectUsage WP_Automatic_Updater::is_allowed_dir
+	 *
+	 * @dataProvider data_is_allowed_dir_should_throw_doing_it_wrong_with_invalid_dir
+	 *
+	 * @param mixed $dir The directory to check.
+	 */
+	public function test_is_allowed_dir_should_throw_doing_it_wrong_with_invalid_dir( $dir ) {
+		$this->assertFalse( self::$updater->is_allowed_dir( $dir ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_is_allowed_dir_should_throw_doing_it_wrong_with_invalid_dir() {
+		return array(
+			// Type checks and boolean comparisons.
+			'null'                              => array( 'dir' => null ),
+			'(bool) false'                      => array( 'dir' => false ),
+			'(bool) true'                       => array( 'dir' => true ),
+			'(int) 0'                           => array( 'dir' => 0 ),
+			'(int) -0'                          => array( 'dir' => -0 ),
+			'(int) 1'                           => array( 'dir' => 1 ),
+			'(int) -1'                          => array( 'dir' => -1 ),
+			'(float) 0.0'                       => array( 'dir' => 0.0 ),
+			'(float) -0.0'                      => array( 'dir' => -0.0 ),
+			'(float) 1.0'                       => array( 'dir' => 1.0 ),
+			'empty string'                      => array( 'dir' => '' ),
+			'empty array'                       => array( 'dir' => array() ),
+			'populated array'                   => array( 'dir' => array( ABSPATH ) ),
+			'empty object'                      => array( 'dir' => new stdClass() ),
+			'populated object'                  => array( 'dir' => (object) array( ABSPATH ) ),
+			'INF'                               => array( 'dir' => INF ),
+			'NAN'                               => array( 'dir' => NAN ),
+
+			// Ensures that `trim()` has been called.
+			'string with only spaces'           => array( 'dir' => '   ' ),
+			'string with only tabs'             => array( 'dir' => "\t\t" ),
+			'string with only newlines'         => array( 'dir' => "\n\n" ),
+			'string with only carriage returns' => array( 'dir' => "\r\r" ),
+		);
+	}
+}

--- a/tests/phpunit/tests/admin/Admin_WpAutomaticUpdater_IsAllowedDir_Test.php
+++ b/tests/phpunit/tests/admin/Admin_WpAutomaticUpdater_IsAllowedDir_Test.php
@@ -15,7 +15,6 @@ class Admin_WpAutomaticUpdater_IsAllowedDir_Test extends Admin_WpAutomaticUpdate
 	 * when the `open_basedir` directive is not set.
 	 *
 	 * @ticket 42619
-	 *
 	 */
 	public function test_is_allowed_dir_should_return_true_if_open_basedir_is_not_set() {
 		$this->assertTrue( self::$updater->is_allowed_dir( ABSPATH ) );

--- a/tests/phpunit/tests/admin/Admin_WpAutomaticUpdater_IsVcsCheckout_Test.php
+++ b/tests/phpunit/tests/admin/Admin_WpAutomaticUpdater_IsVcsCheckout_Test.php
@@ -15,7 +15,6 @@ class Admin_WpAutomaticUpdater_IsVcsCheckout_Test extends Admin_WpAutomaticUpdat
 	 * when none of the checked directories are allowed.
 	 *
 	 * @ticket 58563
-	 *
 	 */
 	public function test_is_vcs_checkout_should_return_false_when_no_directories_are_allowed() {
 		$updater_mock = $this->getMockBuilder( 'WP_Automatic_Updater' )

--- a/tests/phpunit/tests/admin/Admin_WpAutomaticUpdater_IsVcsCheckout_Test.php
+++ b/tests/phpunit/tests/admin/Admin_WpAutomaticUpdater_IsVcsCheckout_Test.php
@@ -1,0 +1,35 @@
+<?php
+
+require_once __DIR__ . '/Admin_WpAutomaticUpdater_TestCase.php';
+
+/**
+ * @group admin
+ * @group upgrade
+ *
+ * @covers WP_Automatic_Updater::is_vcs_checkout
+ */
+class Admin_WpAutomaticUpdater_IsVcsCheckout_Test extends Admin_WpAutomaticUpdater_TestCase {
+
+	/**
+	 * Tests that `WP_Automatic_Updater::is_vcs_checkout()` returns `false`
+	 * when none of the checked directories are allowed.
+	 *
+	 * @ticket 58563
+	 *
+	 */
+	public function test_is_vcs_checkout_should_return_false_when_no_directories_are_allowed() {
+		$updater_mock = $this->getMockBuilder( 'WP_Automatic_Updater' )
+			// Note: setMethods() is deprecated in PHPUnit 9, but still supported.
+			->setMethods( array( 'is_allowed_dir' ) )
+			->getMock();
+
+		/*
+		 * As none of the directories should be allowed, simply mocking `WP_Automatic_Updater`
+		 * and forcing `::is_allowed_dir()` to return `false` removes the need to run the test
+		 * in a separate process due to setting the `open_basedir` PHP directive.
+		 */
+		$updater_mock->expects( $this->any() )->method( 'is_allowed_dir' )->willReturn( false );
+
+		$this->assertFalse( $updater_mock->is_vcs_checkout( get_temp_dir() ) );
+	}
+}

--- a/tests/phpunit/tests/admin/Admin_WpAutomaticUpdater_SendPluginThemeEmail_Test.php
+++ b/tests/phpunit/tests/admin/Admin_WpAutomaticUpdater_SendPluginThemeEmail_Test.php
@@ -6,17 +6,15 @@ require_once __DIR__ . '/Admin_WpAutomaticUpdater_TestCase.php';
  * @group admin
  * @group upgrade
  *
- * @covers WP_Automatic_Updater
+ * @covers WP_Automatic_Updater::send_plugin_theme_email
  */
-class Tests_Admin_WpAutomaticUpdater extends Admin_WpAutomaticUpdater_TestCase {
+class Admin_WpAutomaticUpdater_SendPluginThemeEmail_Test extends Admin_WpAutomaticUpdater_TestCase {
 
 	/**
 	 * Tests that `WP_Automatic_Updater::send_plugin_theme_email()` appends
 	 * plugin URLs.
 	 *
 	 * @ticket 53049
-	 *
-	 * @covers WP_Automatic_Updater::send_plugin_theme_email
 	 *
 	 * @dataProvider data_send_plugin_theme_email_should_append_plugin_urls
 	 *
@@ -284,8 +282,6 @@ class Tests_Admin_WpAutomaticUpdater extends Admin_WpAutomaticUpdater_TestCase {
 	 *
 	 * @ticket 53049
 	 *
-	 * @covers WP_Automatic_Updater::send_plugin_theme_email
-	 *
 	 * @dataProvider data_send_plugin_theme_email_should_not_append_plugin_urls
 	 *
 	 * @param string[] $urls       The URL(s) to search for. Must not be empty.
@@ -544,163 +540,5 @@ class Tests_Admin_WpAutomaticUpdater extends Admin_WpAutomaticUpdater_TestCase {
 				),
 			),
 		);
-	}
-
-	/**
-	 * Tests that `WP_Automatic_Updater::is_allowed_dir()` returns true
-	 * when the `open_basedir` directive is not set.
-	 *
-	 * @ticket 42619
-	 *
-	 * @covers WP_Automatic_Updater::is_allowed_dir
-	 */
-	public function test_is_allowed_dir_should_return_true_if_open_basedir_is_not_set() {
-		$this->assertTrue( self::$updater->is_allowed_dir( ABSPATH ) );
-	}
-
-	/**
-	 * Tests that `WP_Automatic_Updater::is_allowed_dir()` returns true
-	 * when the `open_basedir` directive is set and the path is allowed.
-	 *
-	 * Runs in a separate process to ensure that `open_basedir` changes
-	 * don't impact other tests should an error occur.
-	 *
-	 * This test does not preserve global state to prevent the exception
-	 * "Serialization of 'Closure' is not allowed" when running in
-	 * a separate process.
-	 *
-	 * @ticket 42619
-	 *
-	 * @covers WP_Automatic_Updater::is_allowed_dir
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test_is_allowed_dir_should_return_true_if_open_basedir_is_set_and_path_is_allowed() {
-		// The repository for PHPUnit and test suite resources.
-		$abspath_parent      = trailingslashit( dirname( ABSPATH ) );
-		$abspath_grandparent = trailingslashit( dirname( $abspath_parent ) );
-
-		$open_basedir_backup = ini_get( 'open_basedir' );
-		// Allow access to the directory one level above the repository.
-		ini_set( 'open_basedir', sys_get_temp_dir() . PATH_SEPARATOR . wp_normalize_path( $abspath_grandparent ) );
-
-		// Checking an allowed directory should succeed.
-		$actual = self::$updater->is_allowed_dir( wp_normalize_path( ABSPATH ) );
-
-		ini_set( 'open_basedir', $open_basedir_backup );
-
-		$this->assertTrue( $actual );
-	}
-
-	/**
-	 * Tests that `WP_Automatic_Updater::is_allowed_dir()` returns false
-	 * when the `open_basedir` directive is set and the path is not allowed.
-	 *
-	 * Runs in a separate process to ensure that `open_basedir` changes
-	 * don't impact other tests should an error occur.
-	 *
-	 * This test does not preserve global state to prevent the exception
-	 * "Serialization of 'Closure' is not allowed" when running in
-	 * a separate process.
-	 *
-	 * @ticket 42619
-	 *
-	 * @covers WP_Automatic_Updater::is_allowed_dir
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	public function test_is_allowed_dir_should_return_false_if_open_basedir_is_set_and_path_is_not_allowed() {
-		// The repository for PHPUnit and test suite resources.
-		$abspath_parent      = trailingslashit( dirname( ABSPATH ) );
-		$abspath_grandparent = trailingslashit( dirname( $abspath_parent ) );
-
-		$open_basedir_backup = ini_get( 'open_basedir' );
-		// Allow access to the directory one level above the repository.
-		ini_set( 'open_basedir', sys_get_temp_dir() . PATH_SEPARATOR . wp_normalize_path( $abspath_grandparent ) );
-
-		// Checking a directory not within the allowed path should trigger an `open_basedir` warning.
-		$actual = self::$updater->is_allowed_dir( '/.git' );
-
-		ini_set( 'open_basedir', $open_basedir_backup );
-
-		$this->assertFalse( $actual );
-	}
-
-	/**
-	 * Tests that `WP_Automatic_Updater::is_allowed_dir()` throws `_doing_it_wrong()`
-	 * when an invalid `$dir` argument is provided.
-	 *
-	 * @ticket 42619
-	 *
-	 * @covers WP_Automatic_Updater::is_allowed_dir
-	 *
-	 * @expectedIncorrectUsage WP_Automatic_Updater::is_allowed_dir
-	 *
-	 * @dataProvider data_is_allowed_dir_should_throw_doing_it_wrong_with_invalid_dir
-	 *
-	 * @param mixed $dir The directory to check.
-	 */
-	public function test_is_allowed_dir_should_throw_doing_it_wrong_with_invalid_dir( $dir ) {
-		$this->assertFalse( self::$updater->is_allowed_dir( $dir ) );
-	}
-
-	/**
-	 * Data provider.
-	 *
-	 * @return array[]
-	 */
-	public function data_is_allowed_dir_should_throw_doing_it_wrong_with_invalid_dir() {
-		return array(
-			// Type checks and boolean comparisons.
-			'null'                              => array( 'dir' => null ),
-			'(bool) false'                      => array( 'dir' => false ),
-			'(bool) true'                       => array( 'dir' => true ),
-			'(int) 0'                           => array( 'dir' => 0 ),
-			'(int) -0'                          => array( 'dir' => -0 ),
-			'(int) 1'                           => array( 'dir' => 1 ),
-			'(int) -1'                          => array( 'dir' => -1 ),
-			'(float) 0.0'                       => array( 'dir' => 0.0 ),
-			'(float) -0.0'                      => array( 'dir' => -0.0 ),
-			'(float) 1.0'                       => array( 'dir' => 1.0 ),
-			'empty string'                      => array( 'dir' => '' ),
-			'empty array'                       => array( 'dir' => array() ),
-			'populated array'                   => array( 'dir' => array( ABSPATH ) ),
-			'empty object'                      => array( 'dir' => new stdClass() ),
-			'populated object'                  => array( 'dir' => (object) array( ABSPATH ) ),
-			'INF'                               => array( 'dir' => INF ),
-			'NAN'                               => array( 'dir' => NAN ),
-
-			// Ensures that `trim()` has been called.
-			'string with only spaces'           => array( 'dir' => '   ' ),
-			'string with only tabs'             => array( 'dir' => "\t\t" ),
-			'string with only newlines'         => array( 'dir' => "\n\n" ),
-			'string with only carriage returns' => array( 'dir' => "\r\r" ),
-		);
-	}
-
-	/**
-	 * Tests that `WP_Automatic_Updater::is_vcs_checkout()` returns `false`
-	 * when none of the checked directories are allowed.
-	 *
-	 * @ticket 58563
-	 *
-	 * @covers WP_Automatic_Updater::is_vcs_checkout
-	 */
-	public function test_is_vcs_checkout_should_return_false_when_no_directories_are_allowed() {
-		$updater_mock = $this->getMockBuilder( 'WP_Automatic_Updater' )
-			// Note: setMethods() is deprecated in PHPUnit 9, but still supported.
-			->setMethods( array( 'is_allowed_dir' ) )
-			->getMock();
-
-		/*
-		 * As none of the directories should be allowed, simply mocking `WP_Automatic_Updater`
-		 * and forcing `::is_allowed_dir()` to return `false` removes the need to run the test
-		 * in a separate process due to setting the `open_basedir` PHP directive.
-		 */
-		$updater_mock->expects( $this->any() )->method( 'is_allowed_dir' )->willReturn( false );
-
-		$this->assertFalse( $updater_mock->is_vcs_checkout( get_temp_dir() ) );
 	}
 }

--- a/tests/phpunit/tests/admin/Admin_WpAutomaticUpdater_TestCase.php
+++ b/tests/phpunit/tests/admin/Admin_WpAutomaticUpdater_TestCase.php
@@ -1,0 +1,34 @@
+<?php
+
+abstract class Admin_WpAutomaticUpdater_TestCase extends WP_UnitTestCase {
+	/**
+	 * An instance of WP_Automatic_Updater.
+	 *
+	 * @var WP_Automatic_Updater
+	 */
+	protected static $updater;
+
+	/**
+	 * WP_Automatic_Updater::send_plugin_theme_email
+	 * made accessible.
+	 *
+	 * @var ReflectionMethod
+	 */
+	protected static $send_plugin_theme_email;
+
+	/**
+	 * Sets up shared fixtures.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		require_once ABSPATH . 'wp-admin/includes/class-wp-automatic-updater.php';
+		self::$updater = new WP_Automatic_Updater();
+
+		self::$send_plugin_theme_email = new ReflectionMethod( self::$updater, 'send_plugin_theme_email' );
+		self::$send_plugin_theme_email->setAccessible( true );
+	}
+
+	public function set_up() {
+		parent::set_up();
+		add_filter( 'pre_wp_mail', '__return_false' );
+	}
+}

--- a/tests/phpunit/tests/admin/wpAutomaticUpdater.php
+++ b/tests/phpunit/tests/admin/wpAutomaticUpdater.php
@@ -1,42 +1,14 @@
 <?php
 
+require_once __DIR__ . '/Admin_WpAutomaticUpdater_TestCase.php';
+
 /**
  * @group admin
  * @group upgrade
  *
  * @covers WP_Automatic_Updater
  */
-class Tests_Admin_WpAutomaticUpdater extends WP_UnitTestCase {
-	/**
-	 * An instance of WP_Automatic_Updater.
-	 *
-	 * @var WP_Automatic_Updater
-	 */
-	private static $updater;
-
-	/**
-	 * WP_Automatic_Updater::send_plugin_theme_email
-	 * made accessible.
-	 *
-	 * @var ReflectionMethod
-	 */
-	private static $send_plugin_theme_email;
-
-	/**
-	 * Sets up shared fixtures.
-	 */
-	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		require_once ABSPATH . 'wp-admin/includes/class-wp-automatic-updater.php';
-		self::$updater = new WP_Automatic_Updater();
-
-		self::$send_plugin_theme_email = new ReflectionMethod( self::$updater, 'send_plugin_theme_email' );
-		self::$send_plugin_theme_email->setAccessible( true );
-	}
-
-	public function set_up() {
-		parent::set_up();
-		add_filter( 'pre_wp_mail', '__return_false' );
-	}
+class Tests_Admin_WpAutomaticUpdater extends Admin_WpAutomaticUpdater_TestCase {
 
 	/**
 	 * Tests that `WP_Automatic_Updater::send_plugin_theme_email()` appends


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
Move the setup functions from `Tests_Admin_WpAutomaticUpdater` to a new abstract TestCase class, so that they can be used by multiple tests for the `WpAutomaticUpdater` class.

Splits the existing test class `Tests_Admin_WpAutomaticUpdater` into three classes. This will allow these test classes to be compatible with PHPUnit 11.

- `class Tests_Admin_WpAutomaticUpdater` is renamed to `Admin_WpAutomaticUpdater_SendPluginThemeEmail_Test` and covers `WP_Automatic_Updater::send_plugin_theme_email`

- Tests that covers `WP_Automatic_Updater::is_allowed_dir` are moved to a new test class: `Admin_WpAutomaticUpdater_IsAllowedDir_Test`

- The test that covers `WP_Automatic_Updater::is_vcs_checkout` is moved to a new test class: `Admin_WpAutomaticUpdater_IsVcsCheckout_Test`

- Duplicate `@covers` are removed, the remaining `@covers` are moved to the test class level.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here --> https://core.trac.wordpress.org/ticket/65208

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
