### PR TITLE
Tests: Fix npm tests on macOS

### DIFF
--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -82,7 +82,6 @@ jobs:
           node --version
           curl --version
           git --version
-          svn --version
 
       - name: Install npm Dependencies
         run: npm ci

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -127,7 +127,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   test-npm-macos:
     name: Test npm on MacOS
-    runs-on: macos-latest
+    runs-on: macos-13 # Later GHA macOS runners are arm64-only, for which node 14 isn't available.
     permissions:
       contents: read
     timeout-minutes: 30

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -147,7 +147,6 @@ jobs:
           node --version
           curl --version
           git --version
-          svn --version
 
       - name: Install npm Dependencies
         run: npm ci


### PR DESCRIPTION
The npm tests GHA workflow has recently been [failing](https://github.com/WordPress/wordpress-develop/actions/runs/8848719739/attempts/2) for the macOS environment on the 6.3 branch:

> Not found in manifest. Falling back to download directly from Node
> [...]
> Unable to find Node version '14' for platform darwin and architecture arm64.

The reason is that [GHA's `macos-latest` test runner has recently been updated to macOS 14 "Sonoma"](https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/) _on Intel Silicone (arm64)_; OTOH, `.nvmrc` is pinned to node `14`, which isn't available for Apple Silicone (arm64).

If we want to avoid upgrading our entire build chain from node 14 to 16 for a legacy WP branch, then our best course of action is to pin the macOS runner to an Intel-based architecture (amd64).

Per this [overview](https://docs.github.com/de/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories), the best candidate is probably `macos-13`, as it's apparently the latest Intel-based macOS version runner available to public repositories.

Some prior Slack discussion here: https://wordpress.slack.com/archives/C02RQBWTW/p1714137046024979

Props @swissspidy for helping with this investigation.

Trac ticket: TBD

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
