### PR TITLE
Remove any `wp_reset_vars()` usage in core

### DIFF
--- a/src/wp-admin/admin-post.php
+++ b/src/wp-admin/admin-post.php
@@ -29,7 +29,7 @@ nocache_headers();
 /** This action is documented in wp-admin/admin.php */
 do_action( 'admin_init' );
 
-$action = ! empty( $_REQUEST['action'] ) ? $_REQUEST['action'] : '';
+$action = ! empty( $_REQUEST['action'] ) ? sanitize_text_field( $_REQUEST['action'] ) : '';
 
 // Reject invalid parameters.
 if ( ! is_scalar( $action ) ) {

--- a/src/wp-admin/comment.php
+++ b/src/wp-admin/comment.php
@@ -16,7 +16,8 @@ $submenu_file = 'edit-comments.php';
  * @global string $action
  */
 global $action;
-wp_reset_vars( array( 'action' ) );
+
+$action = ! empty( $_REQUEST['action'] ) ? sanitize_text_field( $_REQUEST['action'] ) : '';
 
 if ( isset( $_POST['deletecomment'] ) ) {
 	$action = 'deletecomment';

--- a/src/wp-admin/customize.php
+++ b/src/wp-admin/customize.php
@@ -84,8 +84,10 @@ if ( $wp_customize->changeset_post_id() ) {
 	}
 }
 
+$url       = ! empty( $_REQUEST['url'] ) ? sanitize_text_field( $_REQUEST['url'] ) : '';
+$return    = ! empty( $_REQUEST['return'] ) ? sanitize_text_field( $_REQUEST['return'] ) : '';
+$autofocus = ! empty( $_REQUEST['autofocus'] ) ? sanitize_text_field( $_REQUEST['autofocus'] ) : '';
 
-wp_reset_vars( array( 'url', 'return', 'autofocus' ) );
 if ( ! empty( $url ) ) {
 	$wp_customize->set_preview_url( wp_unslash( $url ) );
 }

--- a/src/wp-admin/edit-tag-form.php
+++ b/src/wp-admin/edit-tag-form.php
@@ -44,11 +44,7 @@ if ( 'category' === $taxonomy ) {
 	do_action_deprecated( 'edit_tag_form_pre', array( $tag ), '3.0.0', '{$taxonomy}_pre_edit_form' );
 }
 
-/**
- * Use with caution, see https://developer.wordpress.org/reference/functions/wp_reset_vars/
- */
-wp_reset_vars( array( 'wp_http_referer' ) );
-
+$wp_http_referer = ! empty( $_REQUEST['wp_http_referer'] ) ? sanitize_text_field( $_REQUEST['wp_http_referer'] ) : '';
 $wp_http_referer = remove_query_arg( array( 'action', 'message', 'tag_ID' ), $wp_http_referer );
 
 // Also used by Edit Tags.

--- a/src/wp-admin/includes/class-wp-links-list-table.php
+++ b/src/wp-admin/includes/class-wp-links-list-table.php
@@ -50,7 +50,10 @@ class WP_Links_List_Table extends WP_List_Table {
 	public function prepare_items() {
 		global $cat_id, $s, $orderby, $order;
 
-		wp_reset_vars( array( 'action', 'cat_id', 'link_id', 'orderby', 'order', 's' ) );
+		$cat_id  = ! empty( $_REQUEST['cat_id'] ) ? absint( $_REQUEST['cat_id'] ) : 0;
+		$orderby = ! empty( $_REQUEST['orderby'] ) ? sanitize_text_field( $_REQUEST['orderby'] ) : '';
+		$order   = ! empty( $_REQUEST['order'] ) ? sanitize_text_field( $_REQUEST['order'] ) : '';
+		$s       = ! empty( $_REQUEST['s'] ) ? sanitize_text_field( $_REQUEST['s'] ) : '';
 
 		$args = array(
 			'hide_invisible' => 0,

--- a/src/wp-admin/includes/class-wp-ms-themes-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-themes-list-table.php
@@ -99,7 +99,9 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 	public function prepare_items() {
 		global $status, $totals, $page, $orderby, $order, $s;
 
-		wp_reset_vars( array( 'orderby', 'order', 's' ) );
+		$orderby = ! empty( $_REQUEST['orderby'] ) ? sanitize_text_field( $_REQUEST['orderby'] ) : '';
+		$order   = ! empty( $_REQUEST['order'] ) ? sanitize_text_field( $_REQUEST['order'] ) : '';
+		$s       = ! empty( $_REQUEST['s'] ) ? sanitize_text_field( $_REQUEST['s'] ) : '';
 
 		$themes = array(
 			/**

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -92,7 +92,7 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 
 		global $tabs, $tab, $paged, $type, $term;
 
-		wp_reset_vars( array( 'tab' ) );
+		$tab = ! empty( $_REQUEST['tab'] ) ? sanitize_text_field( $_REQUEST['tab'] ) : '';
 
 		$paged = $this->get_pagenum();
 

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -90,7 +90,8 @@ class WP_Plugins_List_Table extends WP_List_Table {
 	public function prepare_items() {
 		global $status, $plugins, $totals, $page, $orderby, $order, $s;
 
-		wp_reset_vars( array( 'orderby', 'order' ) );
+		$orderby = ! empty( $_REQUEST['orderby'] ) ? sanitize_text_field( $_REQUEST['orderby'] ) : '';
+		$order   = ! empty( $_REQUEST['order'] ) ? sanitize_text_field( $_REQUEST['order'] ) : '';
 
 		/**
 		 * Filters the full array of plugins to list in the Plugins list table.

--- a/src/wp-admin/includes/class-wp-theme-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-theme-install-list-table.php
@@ -36,7 +36,8 @@ class WP_Theme_Install_List_Table extends WP_Themes_List_Table {
 		require ABSPATH . 'wp-admin/includes/theme-install.php';
 
 		global $tabs, $tab, $paged, $type, $theme_field_defaults;
-		wp_reset_vars( array( 'tab' ) );
+
+		$tab = ! empty( $_REQUEST['tab'] ) ? sanitize_text_field( $_REQUEST['tab'] ) : '';
 
 		$search_terms  = array();
 		$search_string = '';

--- a/src/wp-admin/includes/deprecated.php
+++ b/src/wp-admin/includes/deprecated.php
@@ -1589,31 +1589,3 @@ function image_attachment_fields_to_save( $post, $attachment ) {
 
 	return $post;
 }
-
-/**
- * Resets global variables based on $_GET and $_POST.
- *
- * This function resets global variables based on the names passed
- * in the $vars array to the value of $_POST[$var] or $_GET[$var] or ''
- * if neither is defined.
- *
- * @since 2.0.0
- * @deprecated 6.6.0
- *
- * @param array $vars An array of globals to reset.
- */
-function wp_reset_vars( $vars ) {
-	_deprecated_function( __FUNCTION__, '6.6.0' );
-
-	foreach ( $vars as $var ) {
-		if ( empty( $_POST[ $var ] ) ) {
-			if ( empty( $_GET[ $var ] ) ) {
-				$GLOBALS[ $var ] = '';
-			} else {
-				$GLOBALS[ $var ] = $_GET[ $var ];
-			}
-		} else {
-			$GLOBALS[ $var ] = $_POST[ $var ];
-		}
-	}
-}

--- a/src/wp-admin/includes/deprecated.php
+++ b/src/wp-admin/includes/deprecated.php
@@ -1589,3 +1589,31 @@ function image_attachment_fields_to_save( $post, $attachment ) {
 
 	return $post;
 }
+
+/**
+ * Resets global variables based on $_GET and $_POST.
+ *
+ * This function resets global variables based on the names passed
+ * in the $vars array to the value of $_POST[$var] or $_GET[$var] or ''
+ * if neither is defined.
+ *
+ * @since 2.0.0
+ * @deprecated 6.6.0
+ *
+ * @param array $vars An array of globals to reset.
+ */
+function wp_reset_vars( $vars ) {
+	_deprecated_function( __FUNCTION__, '6.6.0' );
+
+	foreach ( $vars as $var ) {
+		if ( empty( $_POST[ $var ] ) ) {
+			if ( empty( $_GET[ $var ] ) ) {
+				$GLOBALS[ $var ] = '';
+			} else {
+				$GLOBALS[ $var ] = $_GET[ $var ];
+			}
+		} else {
+			$GLOBALS[ $var ] = $_POST[ $var ];
+		}
+	}
+}

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -576,6 +576,31 @@ function update_home_siteurl( $old_value, $value ) {
 }
 
 /**
+ * Resets global variables based on $_GET and $_POST.
+ *
+ * This function resets global variables based on the names passed
+ * in the $vars array to the value of $_POST[$var] or $_GET[$var] or ''
+ * if neither is defined.
+ *
+ * @since 2.0.0
+ *
+ * @param array $vars An array of globals to reset.
+ */
+function wp_reset_vars( $vars ) {
+	foreach ( $vars as $var ) {
+		if ( empty( $_POST[ $var ] ) ) {
+			if ( empty( $_GET[ $var ] ) ) {
+				$GLOBALS[ $var ] = '';
+			} else {
+				$GLOBALS[ $var ] = $_GET[ $var ];
+			}
+		} else {
+			$GLOBALS[ $var ] = $_POST[ $var ];
+		}
+	}
+}
+
+/**
  * Displays the given administration message.
  *
  * @since 2.1.0

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -575,32 +575,6 @@ function update_home_siteurl( $old_value, $value ) {
 	}
 }
 
-
-/**
- * Resets global variables based on $_GET and $_POST.
- *
- * This function resets global variables based on the names passed
- * in the $vars array to the value of $_POST[$var] or $_GET[$var] or ''
- * if neither is defined.
- *
- * @since 2.0.0
- *
- * @param array $vars An array of globals to reset.
- */
-function wp_reset_vars( $vars ) {
-	foreach ( $vars as $var ) {
-		if ( empty( $_POST[ $var ] ) ) {
-			if ( empty( $_GET[ $var ] ) ) {
-				$GLOBALS[ $var ] = '';
-			} else {
-				$GLOBALS[ $var ] = $_GET[ $var ];
-			}
-		} else {
-			$GLOBALS[ $var ] = $_POST[ $var ];
-		}
-	}
-}
-
 /**
  * Displays the given administration message.
  *

--- a/src/wp-admin/link-add.php
+++ b/src/wp-admin/link-add.php
@@ -17,7 +17,9 @@ if ( ! current_user_can( 'manage_links' ) ) {
 $title       = __( 'Add New Link' );
 $parent_file = 'link-manager.php';
 
-wp_reset_vars( array( 'action', 'cat_id', 'link_id' ) );
+$action  = ! empty( $_REQUEST['action'] ) ? sanitize_text_field( $_REQUEST['action'] ) : '';
+$cat_id  = ! empty( $_REQUEST['cat_id'] ) ? absint( $_REQUEST['cat_id'] ) : 0;
+$link_id = ! empty( $_REQUEST['link_id'] ) ? absint( $_REQUEST['link_id'] ) : 0;
 
 wp_enqueue_script( 'link' );
 wp_enqueue_script( 'xfn' );

--- a/src/wp-admin/link.php
+++ b/src/wp-admin/link.php
@@ -12,7 +12,9 @@
 /** Load WordPress Administration Bootstrap */
 require_once __DIR__ . '/admin.php';
 
-wp_reset_vars( array( 'action', 'cat_id', 'link_id' ) );
+$action  = ! empty( $_REQUEST['action'] ) ? sanitize_text_field( $_REQUEST['action'] ) : '';
+$cat_id  = ! empty( $_REQUEST['cat_id'] ) ? absint( $_REQUEST['cat_id'] ) : 0;
+$link_id = ! empty( $_REQUEST['link_id'] ) ? absint( $_REQUEST['link_id'] ) : 0;
 
 if ( ! current_user_can( 'manage_links' ) ) {
 	wp_link_manager_disabled_message();

--- a/src/wp-admin/media.php
+++ b/src/wp-admin/media.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/admin.php';
 $parent_file  = 'upload.php';
 $submenu_file = 'upload.php';
 
-wp_reset_vars( array( 'action' ) );
+$action = ! empty( $_REQUEST['action'] ) ? sanitize_text_field( $_REQUEST['action'] ) : '';
 
 switch ( $action ) {
 	case 'editattachment':

--- a/src/wp-admin/options-head.php
+++ b/src/wp-admin/options-head.php
@@ -8,7 +8,7 @@
  * @subpackage Administration
  */
 
-wp_reset_vars( array( 'action' ) );
+$action = ! empty( $_REQUEST['action'] ) ? sanitize_text_field( $_REQUEST['action'] ) : '';
 
 if ( isset( $_GET['updated'] ) && isset( $_GET['page'] ) ) {
 	// For back-compat with plugins that don't use the Settings API and just set updated=1 in the redirect.

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -23,7 +23,8 @@ $title       = __( 'Settings' );
 $this_file   = 'options.php';
 $parent_file = 'options-general.php';
 
-wp_reset_vars( array( 'action', 'option_page' ) );
+$action      = ! empty( $_REQUEST['action'] ) ? sanitize_text_field( $_REQUEST['action'] ) : '';
+$option_page = ! empty( $_REQUEST['option_page'] ) ? sanitize_text_field( $_REQUEST['option_page'] ) : '';
 
 $capability = 'manage_options';
 

--- a/src/wp-admin/post.php
+++ b/src/wp-admin/post.php
@@ -14,7 +14,7 @@ require_once __DIR__ . '/admin.php';
 $parent_file  = 'edit.php';
 $submenu_file = 'edit.php';
 
-wp_reset_vars( array( 'action' ) );
+$action = ! empty( $_REQUEST['action'] ) ? sanitize_text_field( $_REQUEST['action'] ) : '';
 
 if ( isset( $_GET['post'] ) && isset( $_POST['post_ID'] ) && (int) $_GET['post'] !== (int) $_POST['post_ID'] ) {
 	wp_die( __( 'A post ID mismatch has been detected.' ), __( 'Sorry, you are not allowed to edit this item.' ), 400 );

--- a/src/wp-admin/revision.php
+++ b/src/wp-admin/revision.php
@@ -21,14 +21,15 @@ require ABSPATH . 'wp-admin/includes/revision.php';
  * @global int    $from     The revision to compare from.
  * @global int    $to       Optional, required if revision missing. The revision to compare to.
  */
-wp_reset_vars( array( 'revision', 'action', 'from', 'to' ) );
 
-$revision_id = absint( $revision );
+$revision_id = ! empty( $_REQUEST['revision'] ) ? absint( $_REQUEST['revision'] ) : 0;
+$action      = ! empty( $_REQUEST['action'] ) ? sanitize_text_field( $_REQUEST['action'] ) : '';
+$from        = ! empty( $_REQUEST['from'] ) && is_numeric( $_REQUEST['from'] ) ? absint( $_REQUEST['from'] ) : null;
 
-$from = is_numeric( $from ) ? absint( $from ) : null;
-if ( ! $revision_id ) {
-	$revision_id = absint( $to );
+if ( ! empty( $_REQUEST['to'] ) && ! $revision_id ) {
+	$revision_id = absint( $_REQUEST['to'] );
 }
+
 $redirect = 'edit.php';
 
 switch ( $action ) {

--- a/src/wp-admin/revision.php
+++ b/src/wp-admin/revision.php
@@ -25,9 +25,10 @@ require ABSPATH . 'wp-admin/includes/revision.php';
 $revision_id = ! empty( $_REQUEST['revision'] ) ? absint( $_REQUEST['revision'] ) : 0;
 $action      = ! empty( $_REQUEST['action'] ) ? sanitize_text_field( $_REQUEST['action'] ) : '';
 $from        = ! empty( $_REQUEST['from'] ) && is_numeric( $_REQUEST['from'] ) ? absint( $_REQUEST['from'] ) : null;
+$to          = ! empty( $_REQUEST['to'] ) && is_numeric( $_REQUEST['to'] ) ? absint( $_REQUEST['to'] ) : null;
 
-if ( ! empty( $_REQUEST['to'] ) && ! $revision_id ) {
-	$revision_id = absint( $_REQUEST['to'] );
+if ( ! $revision_id ) {
+	$revision_id = $to;
 }
 
 $redirect = 'edit.php';

--- a/src/wp-admin/site-health.php
+++ b/src/wp-admin/site-health.php
@@ -9,7 +9,7 @@
 /** WordPress Administration Bootstrap */
 require_once __DIR__ . '/admin.php';
 
-wp_reset_vars( array( 'action' ) );
+$action = ! empty( $_REQUEST['action'] ) ? sanitize_text_field( $_REQUEST['action'] ) : '';
 
 $tabs = array(
 	/* translators: Tab heading for Site Health Status page. */

--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -56,7 +56,10 @@ get_current_screen()->set_help_sidebar(
 	'<p>' . __( '<a href="https://wordpress.org/support/forums/">Support forums</a>' ) . '</p>'
 );
 
-wp_reset_vars( array( 'action', 'error', 'file', 'theme' ) );
+$action = ! empty( $_REQUEST['action'] ) ? sanitize_text_field( $_REQUEST['action'] ) : '';
+$theme  = ! empty( $_REQUEST['theme'] ) ? sanitize_text_field( $_REQUEST['theme'] ) : '';
+$file   = ! empty( $_REQUEST['file'] ) ? sanitize_text_field( $_REQUEST['file'] ) : '';
+$error  = ! empty( $_REQUEST['error'] );
 
 if ( $theme ) {
 	$stylesheet = $theme;

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -10,7 +10,7 @@
 require_once __DIR__ . '/admin.php';
 require ABSPATH . 'wp-admin/includes/theme-install.php';
 
-wp_reset_vars( array( 'tab' ) );
+$tab = ! empty( $_REQUEST['tab'] ) ? sanitize_text_field( $_REQUEST['tab'] ) : '';
 
 if ( ! current_user_can( 'install_themes' ) ) {
 	wp_die( __( 'Sorry, you are not allowed to install themes on this site.' ) );

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -215,7 +215,9 @@ if ( current_user_can( 'switch_themes' ) ) {
 } else {
 	$themes = wp_prepare_themes_for_js( array( wp_get_theme() ) );
 }
-wp_reset_vars( array( 'theme', 'search' ) );
+
+$theme  = ! empty( $_REQUEST['theme'] ) ? sanitize_text_field( $_REQUEST['theme'] ) : '';
+$search = ! empty( $_REQUEST['search'] ) ? sanitize_text_field( $_REQUEST['search'] ) : '';
 
 wp_localize_script(
 	'theme',

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -12,9 +12,10 @@ require_once __DIR__ . '/admin.php';
 /** WordPress Translation Installation API */
 require_once ABSPATH . 'wp-admin/includes/translation-install.php';
 
-wp_reset_vars( array( 'action', 'user_id', 'wp_http_referer' ) );
+$action          = ! empty( $_REQUEST['action'] ) ? sanitize_text_field( $_REQUEST['action'] ) : '';
+$user_id         = ! empty( $_REQUEST['user_id'] ) ? absint( $_REQUEST['user_id'] ) : 0;
+$wp_http_referer = ! empty( $_REQUEST['wp_http_referer'] ) ? sanitize_text_field( $_REQUEST['wp_http_referer'] ) : '';
 
-$user_id      = (int) $user_id;
 $current_user = wp_get_current_user();
 
 if ( ! defined( 'IS_PROFILE_PAGE' ) ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/38073

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
