### PR TITLE
Caching `get_core_data()` persistently 

### DIFF
--- a/src/wp-includes/class-wp-theme-json-data.php
+++ b/src/wp-includes/class-wp-theme-json-data.php
@@ -69,4 +69,15 @@ class WP_Theme_JSON_Data {
 	public function get_data() {
 		return $this->theme_json->get_raw_data();
 	}
+
+	/**
+	 * Return theme JSON object.
+	 *
+	 * @since 6.6.0
+	 *
+	 * @return WP_Theme_JSON
+	 */
+	public function get_theme_json() {
+		return $this->theme_json;
+	}
 }

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -162,14 +162,13 @@ class WP_Theme_JSON_Resolver {
 			return static::$core;
 		}
 
-		$cached_core = wp_cache_get( 'get_core_data', 'core_json' );
-
+		$cached_core = wp_cache_get( 'get_core_data', 'theme_files' );
 		if ( $cached_core ) {
 			$config = $cached_core;
 		} else {
 			$config = static::read_json_file( __DIR__ . '/theme.json' );
 			$config = static::translate( $config );
-			wp_cache_set( 'get_core_data', $config, 'core_json' );
+			wp_cache_set( 'get_core_data', $config, 'theme_files' );
 		}
 
 		/**
@@ -180,8 +179,7 @@ class WP_Theme_JSON_Resolver {
 		 * @param WP_Theme_JSON_Data $theme_json Class to access and update the underlying data.
 		 */
 		$theme_json   = apply_filters( 'wp_theme_json_data_default', new WP_Theme_JSON_Data( $config, 'default' ) );
-		$config       = $theme_json->get_data();
-		static::$core = new WP_Theme_JSON( $config, 'default' );
+		static::$core = $theme_json->get_theme_json();
 
 		return static::$core;
 	}

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -162,8 +162,15 @@ class WP_Theme_JSON_Resolver {
 			return static::$core;
 		}
 
-		$config = static::read_json_file( __DIR__ . '/theme.json' );
-		$config = static::translate( $config );
+		$cached_core = wp_cache_get( 'get_core_data', 'core_json' );
+
+		if ( $cached_core ) {
+			$config = $cached_core;
+		} else {
+			$config = static::read_json_file( __DIR__ . '/theme.json' );
+			$config = static::translate( $config );
+			wp_cache_set( 'get_core_data', $config, 'core_json' );
+		}
 
 		/**
 		 * Filters the default data provided by WordPress for global styles & settings.


### PR DESCRIPTION
Trac ticket: [#57789 ](https://core.trac.wordpress.org/ticket/57789)

Part 1 of 57789 is to see if we could improve performance by caching `get_core_data`.

Caching JSON before filter only gave a benefit for 0.01% 

The major regression at the moment is from `WP_Theme_JSON_Data::__construct` and `WP_Theme_JSON::__construct`

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
