### PR TITLE
Html5lib tests: Fix reset of context element

### DIFF
--- a/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
@@ -294,9 +294,10 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 					}
 
 					// Finish previous test.
-					$test_line_number = $line_number;
-					$test_html        = '';
-					$test_dom         = '';
+					$test_line_number     = $line_number;
+					$test_html            = '';
+					$test_dom             = '';
+					$test_context_element = 'body';
 				}
 
 				$state = trim( substr( $line, 1 ) );

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
@@ -60,6 +60,7 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 		'tests23/line0101'           => 'Unimplemented: Reconstruction of active formatting elements.',
 		'tests25/line0169'           => 'Bug.',
 		'tests26/line0263'           => 'Bug: An active formatting element should be created for a trailing text node.',
+		'tests7/line0354'            => 'Bug.',
 		'tests8/line0001'            => 'Bug.',
 		'tests8/line0020'            => 'Bug.',
 		'tests8/line0037'            => 'Bug.',

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
@@ -156,12 +156,14 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 	/**
 	 * Generates the tree-like structure represented in the Html5lib tests.
 	 *
-	 * @param string $fragment_context Context element in which to parse HTML, such as BODY or SVG.
+	 * @param string? $fragment_context Context element in which to parse HTML, such as BODY or SVG.
 	 * @param string $html             Given test HTML.
 	 * @return string|null Tree structure of parsed HTML, if supported, else null.
 	 */
-	private static function build_tree_representation( $fragment_context, $html ) {
-		$processor = WP_HTML_Processor::create_fragment( $html, "<{$fragment_context}>" );
+	private static function build_tree_representation( ?string $fragment_context, string $html ) {
+		$processor = $fragment_context
+			? WP_HTML_Processor::create_fragment( $html, "<{$fragment_context}>" )
+			: WP_HTML_Processor::create_fragment( $html );
 		if ( null === $processor ) {
 			return null;
 		}
@@ -274,7 +276,7 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 		$line_number          = 0;
 		$test_html            = '';
 		$test_dom             = '';
-		$test_context_element = 'body';
+		$test_context_element = null;
 		$test_line_number     = 0;
 
 		while ( false !== ( $line = fgets( $handle ) ) ) {
@@ -298,7 +300,7 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 					$test_line_number     = $line_number;
 					$test_html            = '';
 					$test_dom             = '';
-					$test_context_element = 'body';
+					$test_context_element = null;
 				}
 
 				$state = trim( substr( $line, 1 ) );

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
@@ -156,8 +156,8 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 	/**
 	 * Generates the tree-like structure represented in the Html5lib tests.
 	 *
-	 * @param string? $fragment_context Context element in which to parse HTML, such as BODY or SVG.
-	 * @param string $html             Given test HTML.
+	 * @param string|null $fragment_context Context element in which to parse HTML, such as BODY or SVG.
+	 * @param string      $html             Given test HTML.
 	 * @return string|null Tree structure of parsed HTML, if supported, else null.
 	 */
 	private static function build_tree_representation( ?string $fragment_context, string $html ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/61102

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
