### PR TITLE
Validate the parent_post_id before calling get_block_template

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-template-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-template-revisions-controller.php
@@ -160,7 +160,7 @@ class WP_REST_Template_Revisions_Controller extends WP_REST_Revisions_Controller
 	 *
 	 * @since 6.4.0
 	 *
-	 * @param int $parent_post_id Supplied ID.
+	 * @param string $parent_post_id Supplied ID.
 	 * @return WP_Post|WP_Error Post object if ID is valid, WP_Error otherwise.
 	 */
 	protected function get_parent( $parent_post_id ) {
@@ -170,7 +170,7 @@ class WP_REST_Template_Revisions_Controller extends WP_REST_Revisions_Controller
 			array( 'status' => 404 )
 		);
 
-		if ( is_null( $parent_post_id ) ) {
+		if ( null === $parent_post_id ) {
 			return $error;
 		}
 		$template = get_block_template( $parent_post_id, $this->parent_post_type );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-template-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-template-revisions-controller.php
@@ -170,7 +170,7 @@ class WP_REST_Template_Revisions_Controller extends WP_REST_Revisions_Controller
 			array( 'status' => 404 )
 		);
 
-		if ( (int) $parent_post_id <= 0 ) {
+		if ( is_null( $parent_post_id ) ) {
 			return $error;
 		}
 		$template = get_block_template( $parent_post_id, $this->parent_post_type );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-template-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-template-revisions-controller.php
@@ -164,14 +164,19 @@ class WP_REST_Template_Revisions_Controller extends WP_REST_Revisions_Controller
 	 * @return WP_Post|WP_Error Post object if ID is valid, WP_Error otherwise.
 	 */
 	protected function get_parent( $parent_post_id ) {
+		$error = new WP_Error(
+			'rest_post_invalid_parent',
+			__( 'Invalid template parent ID.' ),
+			array( 'status' => 404 )
+		);
+
+		if ( (int) $parent_post_id <= 0 ) {
+			return $error;
+		}
 		$template = get_block_template( $parent_post_id, $this->parent_post_type );
 
 		if ( ! $template ) {
-			return new WP_Error(
-				'rest_post_invalid_parent',
-				__( 'Invalid template parent ID.' ),
-				array( 'status' => 404 )
-			);
+			return $error;
 		}
 
 		return get_post( $template->wp_id );

--- a/tests/phpunit/tests/rest-api/wpRestTemplateRevisionsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplateRevisionsController.php
@@ -564,9 +564,9 @@ class Tests_REST_wpRestTemplateRevisionsController extends WP_Test_REST_Controll
 	 * @ticket 61113
 	 */
 	public function test_get_item_permissions_check_without_parent() {
-		$request = new WP_REST_Request( 'GET' );
+		$request    = new WP_REST_Request( 'GET' );
 		$controller = new WP_REST_Template_Revisions_Controller( self::PARENT_POST_TYPE );
-		$result = $controller->get_item_permissions_check( $request );
+		$result     = $controller->get_item_permissions_check( $request );
 		$this->assertWPError( $result );
 		$this->assertSame( 'rest_post_invalid_parent', $result->get_error_code() );
 	}

--- a/tests/phpunit/tests/rest-api/wpRestTemplateRevisionsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplateRevisionsController.php
@@ -558,4 +558,16 @@ class Tests_REST_wpRestTemplateRevisionsController extends WP_Test_REST_Controll
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_post_invalid_parent', $response, WP_Http::NOT_FOUND );
 	}
+
+	/**
+	 * @covers WP_REST_Template_Revisions_Controller::get_items_permissions_check
+	 * @ticket 61113
+	 */
+	public function test_get_item_permissions_check_without_parent() {
+		$request = new WP_REST_Request( 'GET' );
+		$controller = new WP_REST_Template_Revisions_Controller( self::PARENT_POST_TYPE );
+		$result = $controller->get_item_permissions_check( $request );
+		$this->assertWPError( $result );
+		$this->assertSame( 'rest_post_invalid_parent', $result->get_error_code() );
+	}
 }


### PR DESCRIPTION
Prevent deprecation warning when calling `WP_REST_Templates_Revisions_Controller->get_items_permission_check()` with an empty WP_REST_Request

Trac ticket: https://core.trac.wordpress.org/ticket/61113