### PR TITLE
Global Styles: Update util for scoping CSS selectors

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1764,12 +1764,17 @@ class WP_Theme_JSON {
 	 * </code>
 	 *
 	 * @since 5.9.0
+	 * @since 6.6.0 Add early return if missing scope or selector.
 	 *
 	 * @param string $scope    Selector to scope to.
 	 * @param string $selector Original selector.
 	 * @return string Scoped selector.
 	 */
 	public static function scope_selector( $scope, $selector ) {
+		if ( ! $scope || ! $selector ) {
+			return $selector;
+		}
+
 		$scopes    = explode( ',', $scope );
 		$selectors = explode( ',', $selector );
 

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -1764,7 +1764,7 @@ class WP_Theme_JSON {
 	 * </code>
 	 *
 	 * @since 5.9.0
-	 * @since 6.6.0 Add early return if missing scope or selector.
+	 * @since 6.6.0 Added early return if missing scope or selector.
 	 *
 	 * @param string $scope    Selector to scope to.
 	 * @param string $selector Original selector.


### PR DESCRIPTION
Syncs the changes from:
- https://github.com/WordPress/gutenberg/pull/61026

Adds early return for existing scope_selector method making it more robust and ready for extending block style variations. See: https://github.com/WordPress/gutenberg/pull/57908

Unit tests: `npm run test:php -- --filter Tests_Theme_wpThemeJson`

Trac ticket: https://core.trac.wordpress.org/ticket/61120

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
