### PR TITLE
Expose the Site Editor Patterns page for all classic themes

### DIFF
--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -206,15 +206,7 @@ if ( ! is_multisite() && current_user_can( 'update_themes' ) ) {
 if ( wp_is_block_theme() ) {
 	$submenu['themes.php'][6] = array( _x( 'Editor', 'site editor menu item' ), 'edit_theme_options', 'site-editor.php' );
 } else {
-	$submenu['themes.php'][6] = array( _x( 'Patterns', 'patterns menu item' ), 'edit_theme_options', 'edit.php?post_type=wp_block' );
-}
-
-if ( ! wp_is_block_theme() && current_theme_supports( 'block-template-parts' ) ) {
-	$submenu['themes.php'][7] = array(
-		__( 'Template Parts' ),
-		'edit_theme_options',
-		'site-editor.php?path=/wp_template_part/all',
-	);
+	$submenu['themes.php'][6] = array( _x( 'Patterns', 'patterns menu item' ), 'edit_theme_options', 'site-editor.php?path=/patterns' );
 }
 
 $customize_url = add_query_arg( 'return', urlencode( remove_query_arg( wp_removable_query_args(), wp_unslash( $_SERVER['REQUEST_URI'] ) ) ), 'customize.php' );
@@ -222,9 +214,7 @@ $customize_url = add_query_arg( 'return', urlencode( remove_query_arg( wp_remova
 // Hide Customize link on block themes unless a plugin or theme
 // is using 'customize_register' to add a setting.
 if ( ! wp_is_block_theme() || has_action( 'customize_register' ) ) {
-	$position = ! wp_is_block_theme() && current_theme_supports( 'block-template-parts' ) ? 8 : 7;
-
-	$submenu['themes.php'][ $position ] = array( __( 'Customize' ), 'customize', esc_url( $customize_url ), '', 'hide-if-no-customize' );
+	$submenu['themes.php'][7] = array( __( 'Customize' ), 'customize', esc_url( $customize_url ), '', 'hide-if-no-customize' );
 }
 
 if ( current_theme_supports( 'menus' ) || current_theme_supports( 'widgets' ) ) {

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -5400,7 +5400,7 @@ function wp_widgets_add_menu() {
 	}
 
 	$menu_name = __( 'Widgets' );
-	if ( wp_is_block_theme() || current_theme_supports( 'block-template-parts' ) ) {
+	if ( wp_is_block_theme() ) {
 		$submenu['themes.php'][] = array( $menu_name, 'edit_theme_options', 'widgets.php' );
 	} else {
 		$submenu['themes.php'][8] = array( $menu_name, 'edit_theme_options', 'widgets.php' );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/61109

### Summary

This PR makes the following changes in the classic theme.

- Link Appearance > Patterns submenu to the Site Editor Patterns page (`wp-admin/site-editor.php?path=/patterns`)
- Remove Template Parts submenu

### About Menu Structure

It's a little confusing what the index of the submenu that `$submenu['themes.php']` has, but for the submenu that this PR relates to, it should be as follows.

#### Block Theme

```
[5] => Themes
[6] => Editor
[7] => (Customize)
```

#### Classic Theme

```
[5] => Themes
[6] => Patterns
[7] => Customize
[8] => (Widgets)
```

### Screenshots

### Block Theme (Twenty Twenty-Four)

It's no different than before.

![image](https://github.com/WordPress/wordpress-develop/assets/54422211/1ef80c35-fb31-4f71-aaaa-029e47787919)

### Classic Theme (Twenty Twenty-One)

The menu structure remains the same, but the Patterns submenu now links to the Site Editor's Patterns page.

![image](https://github.com/WordPress/wordpress-develop/assets/54422211/e52292b9-8083-4346-90d6-69740b4ac8ec)

### Classic theme with `block-template-parts` support

The Template Part submenu has been removed and the Patterns submenu now links to the Site Editor's Patterns page.

![image](https://github.com/WordPress/wordpress-develop/assets/54422211/f3cdd62f-b88f-4ad5-a3c3-3a20139fd1ef)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
