### PR TITLE
Test/Admin/wpPrivacyRequestsTable: Split the test class and create a new TestCase

### DIFF
--- a/tests/phpunit/tests/admin/Admin_WpPrivacyRequestsTable_GetViews_Test.php
+++ b/tests/phpunit/tests/admin/Admin_WpPrivacyRequestsTable_GetViews_Test.php
@@ -1,0 +1,28 @@
+<?php
+
+require_once __DIR__ . '/Admin_WpPrivacyRequestsTable_TestCase.php';
+
+/**
+ * Test `WP_Privacy_Requests_Table::get_views`.
+ *
+ * @package WordPress\UnitTests
+ *
+ * @since 5.1.0
+ *
+ * @group admin
+ * @group privacy
+ * @covers WP_Privacy_Requests_Table::get_views
+ */
+class Admin_WpPrivacyRequestsTable_GetViews_Test extends Admin_WpPrivacyRequestsTable_TestCase {
+
+	/**
+	 * @ticket 42066
+	 */
+	public function test_get_views_should_return_views_by_default() {
+		$expected = array(
+			'all' => '<a href="http://example.org/wp-admin/export-personal-data.php" class="current" aria-current="page">All <span class="count">(0)</span></a>',
+		);
+
+		$this->assertSame( $expected, $this->get_mocked_class_instance()->get_views() );
+	}
+}

--- a/tests/phpunit/tests/admin/Admin_WpPrivacyRequestsTable_PrepareItems_Test.php
+++ b/tests/phpunit/tests/admin/Admin_WpPrivacyRequestsTable_PrepareItems_Test.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . '/Admin_WpPrivacyRequestsTable_TestCase.php';
 
 /**
- * Test the `WP_Privacy_Requests_Table` class.
+ * Test `WP_Privacy_Requests_Table::prepare_items`
  *
  * @package WordPress\UnitTests
  *
@@ -11,8 +11,9 @@ require_once __DIR__ . '/Admin_WpPrivacyRequestsTable_TestCase.php';
  *
  * @group admin
  * @group privacy
+ * @covers WP_Privacy_Requests_Table::prepare_items
  */
-class Tests_Admin_wpPrivacyRequestsTable extends Admin_WpPrivacyRequestsTable_TestCase {
+class Admin_WpPrivacyRequestsTable_PrepareItems_Test extends Admin_WpPrivacyRequestsTable_TestCase {
 
 	/**
 	 * Test columns should be sortable.
@@ -23,9 +24,8 @@ class Tests_Admin_wpPrivacyRequestsTable extends Admin_WpPrivacyRequestsTable_Te
 	 * @param string|null $orderby  Order by.
 	 * @param string|null $search   Search term.
 	 * @param string      $expected Expected in SQL query.
-
+	 *
 	 * @dataProvider data_columns_should_be_sortable
-	 * @covers WP_Privacy_Requests_Table::prepare_items
 	 * @ticket 43960
 	 */
 	public function test_columns_should_be_sortable( $order, $orderby, $search, $expected ) {
@@ -129,18 +129,5 @@ class Tests_Admin_wpPrivacyRequestsTable extends Admin_WpPrivacyRequestsTable_Te
 				'expected' => 'post_date ASC',
 			),
 		);
-	}
-
-	/**
-	 * @ticket 42066
-	 *
-	 * @covers WP_Privacy_Requests_List_Table::get_views
-	 */
-	public function test_get_views_should_return_views_by_default() {
-		$expected = array(
-			'all' => '<a href="http://example.org/wp-admin/export-personal-data.php" class="current" aria-current="page">All <span class="count">(0)</span></a>',
-		);
-
-		$this->assertSame( $expected, $this->get_mocked_class_instance()->get_views() );
 	}
 }

--- a/tests/phpunit/tests/admin/Admin_WpPrivacyRequestsTable_TestCase.php
+++ b/tests/phpunit/tests/admin/Admin_WpPrivacyRequestsTable_TestCase.php
@@ -9,7 +9,7 @@ abstract class Admin_WpPrivacyRequestsTable_TestCase extends WP_UnitTestCase {
 	 *
 	 * @var string
 	 */
-	private $sql;
+	protected $sql;
 
 	/**
 	 * Clean up after each test.

--- a/tests/phpunit/tests/admin/Admin_WpPrivacyRequestsTable_TestCase.php
+++ b/tests/phpunit/tests/admin/Admin_WpPrivacyRequestsTable_TestCase.php
@@ -1,0 +1,69 @@
+<?php
+
+abstract class Admin_WpPrivacyRequestsTable_TestCase extends WP_UnitTestCase {
+
+	/**
+	 * Temporary storage for SQL to allow a filter to access it.
+	 *
+	 * Used in the `test_columns_should_be_sortable()` test method.
+	 *
+	 * @var string
+	 */
+	private $sql;
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		unset( $this->sql );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Get instance for mocked class.
+	 *
+	 * @since 5.1.0
+	 *
+	 * @return PHPUnit_Framework_MockObject_MockObject|WP_Privacy_Requests_Table Mocked class instance.
+	 */
+	public function get_mocked_class_instance() {
+		$args = array(
+			'plural'   => 'privacy_requests',
+			'singular' => 'privacy_request',
+			'screen'   => 'export_personal_data',
+		);
+
+		$instance = $this
+			->getMockBuilder( 'WP_Privacy_Requests_Table' )
+			->setConstructorArgs( array( $args ) )
+			->getMockForAbstractClass();
+
+		$reflection = new ReflectionClass( $instance );
+
+		// Set the request type as 'export_personal_data'.
+		$reflection_property = $reflection->getProperty( 'request_type' );
+		$reflection_property->setAccessible( true );
+		$reflection_property->setValue( $instance, 'export_personal_data' );
+
+		// Set the post type as 'user_request'.
+		$reflection_property = $reflection->getProperty( 'post_type' );
+		$reflection_property->setAccessible( true );
+		$reflection_property->setValue( $instance, 'user_request' );
+
+		return $instance;
+	}
+
+	/**
+	 * Filter to grab the complete SQL query.
+	 *
+	 * @since 5.1.0
+	 *
+	 * @param string $request The complete SQL query.
+	 * @return string The complete SQL query.
+	 */
+	public function filter_posts_request( $request ) {
+		$this->sql = $request;
+		return $request;
+	}
+}

--- a/tests/phpunit/tests/admin/wpPrivacyRequestsTable.php
+++ b/tests/phpunit/tests/admin/wpPrivacyRequestsTable.php
@@ -1,4 +1,7 @@
 <?php
+
+require_once __DIR__ . '/Admin_WpPrivacyRequestsTable_TestCase.php';
+
 /**
  * Test the `WP_Privacy_Requests_Table` class.
  *

--- a/tests/phpunit/tests/admin/wpPrivacyRequestsTable.php
+++ b/tests/phpunit/tests/admin/wpPrivacyRequestsTable.php
@@ -12,59 +12,7 @@ require_once __DIR__ . '/Admin_WpPrivacyRequestsTable_TestCase.php';
  * @group admin
  * @group privacy
  */
-class Tests_Admin_wpPrivacyRequestsTable extends WP_UnitTestCase {
-
-	/**
-	 * Temporary storage for SQL to allow a filter to access it.
-	 *
-	 * Used in the `test_columns_should_be_sortable()` test method.
-	 *
-	 * @var string
-	 */
-	private $sql;
-
-	/**
-	 * Clean up after each test.
-	 */
-	public function tear_down() {
-		unset( $this->sql );
-
-		parent::tear_down();
-	}
-
-	/**
-	 * Get instance for mocked class.
-	 *
-	 * @since 5.1.0
-	 *
-	 * @return PHPUnit_Framework_MockObject_MockObject|WP_Privacy_Requests_Table Mocked class instance.
-	 */
-	public function get_mocked_class_instance() {
-		$args = array(
-			'plural'   => 'privacy_requests',
-			'singular' => 'privacy_request',
-			'screen'   => 'export_personal_data',
-		);
-
-		$instance = $this
-			->getMockBuilder( 'WP_Privacy_Requests_Table' )
-			->setConstructorArgs( array( $args ) )
-			->getMockForAbstractClass();
-
-		$reflection = new ReflectionClass( $instance );
-
-		// Set the request type as 'export_personal_data'.
-		$reflection_property = $reflection->getProperty( 'request_type' );
-		$reflection_property->setAccessible( true );
-		$reflection_property->setValue( $instance, 'export_personal_data' );
-
-		// Set the post type as 'user_request'.
-		$reflection_property = $reflection->getProperty( 'post_type' );
-		$reflection_property->setAccessible( true );
-		$reflection_property->setValue( $instance, 'user_request' );
-
-		return $instance;
-	}
+class Tests_Admin_wpPrivacyRequestsTable extends Admin_WpPrivacyRequestsTable_TestCase {
 
 	/**
 	 * Test columns should be sortable.
@@ -99,19 +47,6 @@ class Tests_Admin_wpPrivacyRequestsTable extends WP_UnitTestCase {
 		unset( $_REQUEST['s'] );
 
 		$this->assertStringContainsString( "ORDER BY {$wpdb->posts}.{$expected}", $this->sql );
-	}
-
-	/**
-	 * Filter to grab the complete SQL query.
-	 *
-	 * @since 5.1.0
-	 *
-	 * @param string $request The complete SQL query.
-	 * @return string The complete SQL query.
-	 */
-	public function filter_posts_request( $request ) {
-		$this->sql = $request;
-		return $request;
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This PR splits the existing test class `wpPrivacyRequestsTable` into two, and creates a new TestCase.
The purpose is to make the test classes compatible with PHPUnit 11.

Move tear down and helper functions from `wpPrivacyRequestsTable` to a new abstract TestCase so that they can be reused in multiple tests.

Split off the test for `WP_Privacy_Requests_Table::get_views` into a separate test class,
`Admin_WpPrivacyRequestsTable_GetViews_Test`.

Correct the `covers` for `WP_Privacy_Requests_Table::get_views:

- Previously `@covers WP_Privacy_Requests_List_Table::get_views`.
- Updated `@covers WP_Privacy_Requests_Table::get_views`.

The previous was possibly a typo.

Rename the remaining test `Tests_Admin_wpPrivacyRequestsTable` and test file to `Admin_WpPrivacyRequestsTable_PrepareItems_Test`, to clarify which method that is being tested. Move the covers to the class level.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here --> https://core.trac.wordpress.org/ticket/65208

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
