### PR TITLE
Exclude language files from phpcs linting

### DIFF
--- a/phpcompat.xml.dist
+++ b/phpcompat.xml.dist
@@ -49,6 +49,9 @@
 	<!-- Exclude themes except the twenty* themes. -->
 	<exclude-pattern>/src/wp-content/themes/(?!twenty)*</exclude-pattern>
 
+	<!-- Exclude translation files. -->
+	<exclude-pattern>/src/wp-content/languages/*</exclude-pattern>
+
 	<!--
 		PHPCompatibilityParagonieSodiumCompat prevents false positives in `sodium_compat`.
 		However, because these files are included in a non-standard path, false positives are triggered in WordPress Core.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -106,6 +106,9 @@
 	<!-- Themes except the twenty* themes. -->
 	<exclude-pattern>/src/wp-content/themes/(?!twenty)*</exclude-pattern>
 
+	<!-- Translation files. -->
+	<exclude-pattern>/src/wp-content/languages/*</exclude-pattern>
+
 
 	<!--
 	#############################################################################


### PR DESCRIPTION
I noticed when trying to run `composer lint:errors` on my local installation that the process would run out of memory:

```
..........E....
Fatal error: Allowed memory size of 536870912 bytes exhausted (tried to allocate 90366752 bytes) in vendor/squizlabs/php_codesniffer/src/Runner.php on line 547
```

This appears to be caused by phpcs trying to scan the `*.i18n.php` translation files in the `wp-content/languages` directory, of which I have quite a few due to testing this functionality.

These files shouldn't be scanned by phpcs so can be ignored.

Trac ticket: https://core.trac.wordpress.org/ticket/59647