### PR TITLE
Twenty Nineteen: increase specificity for Read More block width

### DIFF
--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -1625,7 +1625,7 @@ ul.wp-block-archives li ul,
 }
 
 /** === Read More Block === */
-.wp-block-read-more.wp-block-read-more {
+.wp-block.wp-block-read-more {
   width: -moz-fit-content;
   width: fit-content;
 }

--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -1624,6 +1624,12 @@ ul.wp-block-archives li ul,
   width: 100%;
 }
 
+/** === Read More Block === */
+.wp-block-read-more.wp-block-read-more {
+  width: -moz-fit-content;
+  width: fit-content;
+}
+
 /** === Post Author Block === */
 .avatar,
 .wp-block-post-author__avatar img {

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -1045,7 +1045,7 @@ $group-block-background__padding: $font__size_base;
 
 /** === Read More Block === */
 
-.wp-block-read-more.wp-block-read-more {
+.wp-block.wp-block-read-more {
 	width: -moz-fit-content;
 	width: fit-content;
 }

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -1043,6 +1043,13 @@ $group-block-background__padding: $font__size_base;
 	}
 }
 
+/** === Read More Block === */
+
+.wp-block-read-more.wp-block-read-more {
+	width: -moz-fit-content;
+	width: fit-content;
+}
+
 /** === Post Author Block === */
 
 .avatar,


### PR DESCRIPTION
Applies the Read More block's width in the theme by adding more classes (total of three when combined with `.editor-styles-wrapper`):
```
.editor-styles-wrapper .wp-block-read-more.wp-block-read-more {
  width: -moz-fit-content;
  width: fit-content;
}
```
to override
```
.editor-styles-wrapper .wp-block .wp-block {
  width: initial;
}
```

[Trac 61126](https://core.trac.wordpress.org/ticket/61126)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
