### PR TITLE
Make sure `WP_Block_Supports::$block_to_render['attrs']` exists and is an array

### DIFF
--- a/src/wp-includes/class-wp-block-supports.php
+++ b/src/wp-includes/class-wp-block-supports.php
@@ -103,7 +103,7 @@ class WP_Block_Supports {
 			return array();
 		}
 
-		$block_attributes = array_key_exists( 'attrs', self::$block_to_render )
+		$block_attributes = array_key_exists( 'attrs', self::$block_to_render ) && is_array( self::$block_to_render['attrs'] )
 			? self::$block_to_render['attrs']
 			: array();
 


### PR DESCRIPTION
Add an additional check to `WP_Block_Supports::apply_block_supports()` to make sure `WP_Block_Supports::$block_to_render['attrs']` is present and is an array. This prevents a Fatal error when a block contains an invalid JSON attributes.

Trac ticket: https://core.trac.wordpress.org/ticket/61151

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
