### PR TITLE
Update help text in the admin area

### DIFF
--- a/src/wp-admin/network/sites.php
+++ b/src/wp-admin/network/sites.php
@@ -28,16 +28,14 @@ get_current_screen()->add_help_tab(
 		'id'      => 'overview',
 		'title'   => __( 'Overview' ),
 		'content' =>
-			'<p>' . __( 'Add New takes you to the Add New Site screen. You can search for a site by Name, ID number, or IP address. Screen Options allows you to choose how many sites to display on one page.' ) . '</p>' .
+			'<p>' . __( 'Add New Site takes you to the screen for adding a new site to the network. You can search for a site by Name, ID number, or IP address. Screen Options allows you to choose how many sites to display on one page.' ) . '</p>' .
 			'<p>' . __( 'This is the main table of all sites on this network. Switch between list and excerpt views by using the icons above the right side of the table.' ) . '</p>' .
 			'<p>' . __( 'Hovering over each site reveals seven options (three for the primary site):' ) . '</p>' .
 			'<ul><li>' . __( 'An Edit link to a separate Edit Site screen.' ) . '</li>' .
 			'<li>' . __( 'Dashboard leads to the Dashboard for that site.' ) . '</li>' .
 			'<li>' . __( 'Deactivate, Archive, and Spam which lead to confirmation screens. These actions can be reversed later.' ) . '</li>' .
-			'<li>' . __( 'Delete which is a permanent action after the confirmation screens.' ) . '</li>' .
-			'<li>' . __( 'Visit to go to the front-end site live.' ) . '</li></ul>' .
-			'<p>' . __( 'The site ID is used internally, and is not shown on the front end of the site or to users/viewers.' ) . '</p>' .
-			'<p>' . __( 'Clicking on bold headings can re-sort this table.' ) . '</p>',
+			'<li>' . __( 'Delete which is a permanent action after the confirmation screen.' ) . '</li>' .
+			'<li>' . __( 'Visit to go to the front-end of the live site.' ) . '</li></ul>',
 	)
 );
 

--- a/src/wp-admin/users.php
+++ b/src/wp-admin/users.php
@@ -33,7 +33,7 @@ get_current_screen()->add_help_tab(
 		'id'      => 'overview',
 		'title'   => __( 'Overview' ),
 		'content' => '<p>' . __( 'This screen lists all the existing users for your site. Each user has one of five defined roles as set by the site admin: Site Administrator, Editor, Author, Contributor, or Subscriber. Users with roles other than Administrator will see fewer options in the dashboard navigation when they are logged in, based on their role.' ) . '</p>' .
-						'<p>' . __( 'To add a new user for your site, click the Add New button at the top of the screen or Add New in the Users menu section.' ) . '</p>',
+						'<p>' . __( 'To add a new user for your site, click the Add New User button at the top of the screen or Add New User in the Users menu section.' ) . '</p>',
 	)
 );
 


### PR DESCRIPTION
This updates the "Add New" references in the help text, and removes and corrects some outdated info on the Network Admin -> Sites screen.

Trac ticket: https://core.trac.wordpress.org/ticket/61153