### PR TITLE
Twenty Nineteen: match Button link font size to the block's custom size when chosen

### DIFF
--- a/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
+++ b/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
@@ -239,6 +239,14 @@
 		}
 	}
 
+	.wp-block-buttons,
+	.wp-block-button {
+
+		&.has-custom-font-size .wp-block-button__link {
+			font-size: 1em;
+		}
+	}
+
 	//! Latest posts, categories, archives
 	.wp-block-archives,
 	.wp-block-categories,

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -5563,6 +5563,11 @@ body.page .main-navigation {
   color: #111;
 }
 
+.entry .entry-content .wp-block-buttons.has-custom-font-size .wp-block-button__link,
+.entry .entry-content .wp-block-button.has-custom-font-size .wp-block-button__link {
+  font-size: 1em;
+}
+
 .entry .entry-content .wp-block-archives,
 .entry .entry-content .wp-block-categories,
 .entry .entry-content .wp-block-latest-posts {

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -5575,6 +5575,11 @@ body.page .main-navigation {
   color: #111;
 }
 
+.entry .entry-content .wp-block-buttons.has-custom-font-size .wp-block-button__link,
+.entry .entry-content .wp-block-button.has-custom-font-size .wp-block-button__link {
+  font-size: 1em;
+}
+
 .entry .entry-content .wp-block-archives,
 .entry .entry-content .wp-block-categories,
 .entry .entry-content .wp-block-latest-posts {


### PR DESCRIPTION
Resets the relative measurement on `.wp-block-button__link` when either its Buttons or Button block has a custom size. Without this change, the value is 88.9% of the selected size.

[Trac 56443](https://core.trac.wordpress.org/ticket/56443)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
