### PR TITLE
Block API: Add support for block aliases (PoC)

### DIFF
--- a/src/wp-includes/class-wp-block-type-registry.php
+++ b/src/wp-includes/class-wp-block-type-registry.php
@@ -107,10 +107,10 @@ final class WP_Block_Type_Registry {
 		$aliases = $block_type->get_aliases();
 		if ( ! empty( $aliases ) ) {
 			foreach ( $aliases as $alias_name => $alias_args ) {
-				if ( ! $this->is_registered( $alias_name ) ) {
+				if ( ! isset( $this->$registered_block_type_aliases[ $alias_name ] ) ) {
 					$new_args                             = array_merge( $args, $alias_args );
 					$new_args['alias_of']                 = $name;
-					$alias_args['attributes']['metadata'] = array( 'canonicalBlock' => $name );
+					$alias_args['attributes']['metadata'] = array( 'alias' => $name );
 
 					// Register the alias block.
 					$this->registered_block_type_aliases[ $alias_name ] = new WP_Block_Type( $alias_name, array_merge( $args, $alias_args ) );
@@ -166,10 +166,6 @@ final class WP_Block_Type_Registry {
 			return null;
 		}
 
-		if ( isset( $this->registered_block_type_aliases[ $name ] ) ) {
-			return $this->registered_block_type_aliases[ $name ];
-		}
-
 		return $this->registered_block_types[ $name ];
 	}
 
@@ -181,7 +177,7 @@ final class WP_Block_Type_Registry {
 	 * @return WP_Block_Type[] Associative array of `$block_type_name => $block_type` pairs.
 	 */
 	public function get_all_registered() {
-		return array_merge( $this->registered_block_types, $this->registered_block_type_aliases );
+		return $this->registered_block_types;
 	}
 
 	/**
@@ -193,7 +189,7 @@ final class WP_Block_Type_Registry {
 	 * @return bool True if the block type is registered, false otherwise.
 	 */
 	public function is_registered( $name ) {
-		return isset( $this->registered_block_types[ $name ] ) || isset( $this->registered_block_type_aliases[ $name ] );
+		return isset( $this->registered_block_types[ $name ] );
 	}
 
 	public function __wakeup() {

--- a/src/wp-includes/class-wp-block-type-registry.php
+++ b/src/wp-includes/class-wp-block-type-registry.php
@@ -108,8 +108,8 @@ final class WP_Block_Type_Registry {
 		if ( ! empty( $aliases ) ) {
 			foreach ( $aliases as $alias_name => $alias_args ) {
 				if ( ! isset( $this->$registered_block_type_aliases[ $alias_name ] ) ) {
-					$new_args                             = array_merge( $args, $alias_args );
-					$new_args['alias_of']                 = $name;
+					$new_args                           = array_merge( $args, $alias_args );
+					$new_args['alias_of']               = $name;
 					$new_args['attributes']['metadata'] = array( 'alias' => $name );
 
 					// Register the alias block.

--- a/src/wp-includes/class-wp-block-type-registry.php
+++ b/src/wp-includes/class-wp-block-type-registry.php
@@ -109,10 +109,9 @@ final class WP_Block_Type_Registry {
 			foreach ( $aliases as $alias_name => $alias_args ) {
 				if ( ! isset( $this->registered_block_type_aliases[ $alias_name ] ) ) {
 					$new_args                           = array_merge( $args, $alias_args );
-					$new_args['alias_of']               = $name;
 					$new_args['attributes']['metadata'] = array( 'alias' => $name );
 
-					// Register the alias block.
+					// Add the alias to the alias registry.
 					$this->registered_block_type_aliases[ $alias_name ] = new WP_Block_Type( $alias_name, array_merge( $args, $alias_args ) );
 				}
 			}

--- a/src/wp-includes/class-wp-block-type-registry.php
+++ b/src/wp-includes/class-wp-block-type-registry.php
@@ -107,7 +107,7 @@ final class WP_Block_Type_Registry {
 		$aliases = $block_type->get_aliases();
 		if ( ! empty( $aliases ) ) {
 			foreach ( $aliases as $alias_name => $alias_args ) {
-				if ( ! isset( $this->$registered_block_type_aliases[ $alias_name ] ) ) {
+				if ( ! isset( $this->registered_block_type_aliases[ $alias_name ] ) ) {
 					$new_args                           = array_merge( $args, $alias_args );
 					$new_args['alias_of']               = $name;
 					$new_args['attributes']['metadata'] = array( 'alias' => $name );

--- a/src/wp-includes/class-wp-block-type-registry.php
+++ b/src/wp-includes/class-wp-block-type-registry.php
@@ -110,7 +110,7 @@ final class WP_Block_Type_Registry {
 				if ( ! isset( $this->$registered_block_type_aliases[ $alias_name ] ) ) {
 					$new_args                             = array_merge( $args, $alias_args );
 					$new_args['alias_of']                 = $name;
-					$alias_args['attributes']['metadata'] = array( 'alias' => $name );
+					$new_args['attributes']['metadata'] = array( 'alias' => $name );
 
 					// Register the alias block.
 					$this->registered_block_type_aliases[ $alias_name ] = new WP_Block_Type( $alias_name, array_merge( $args, $alias_args ) );

--- a/src/wp-includes/class-wp-block-type-registry.php
+++ b/src/wp-includes/class-wp-block-type-registry.php
@@ -109,7 +109,9 @@ final class WP_Block_Type_Registry {
 			foreach ( $aliases as $alias_name => $alias_args ) {
 				if ( ! isset( $this->registered_block_type_aliases[ $alias_name ] ) ) {
 					// Add the alias to the alias registry.
-					$this->registered_block_type_aliases[ $alias_name ] = new WP_Block_Type( $alias_name, array_merge( $args, $alias_args ) );
+					$alias_block_type                                   = new WP_Block_Type( $alias_name, array_merge( $args, $alias_args ) );
+					$alias_block_type->alias_of                         = $name;
+					$this->registered_block_type_aliases[ $alias_name ] = $alias_block_type;
 				}
 			}
 		}

--- a/src/wp-includes/class-wp-block-type-registry.php
+++ b/src/wp-includes/class-wp-block-type-registry.php
@@ -108,9 +108,6 @@ final class WP_Block_Type_Registry {
 		if ( ! empty( $aliases ) ) {
 			foreach ( $aliases as $alias_name => $alias_args ) {
 				if ( ! isset( $this->registered_block_type_aliases[ $alias_name ] ) ) {
-					$new_args                           = array_merge( $args, $alias_args );
-					$new_args['attributes']['metadata'] = array( 'alias' => $name );
-
 					// Add the alias to the alias registry.
 					$this->registered_block_type_aliases[ $alias_name ] = new WP_Block_Type( $alias_name, array_merge( $args, $alias_args ) );
 				}

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -135,6 +135,22 @@ class WP_Block_Type {
 	public $variation_callback = null;
 
 	/**
+	 * List of aliases for this block type. Only accessible through magic getter. null by default.
+	 *
+	 * @since 6.6.0
+	 * @var array[]|null
+	 */
+	private $aliases = null;
+
+	/**
+	 * If this is an alias block type, this property will contain the name of the block type it is an alias of.
+	 *
+	 * @since 6.6.0
+	 * @var string
+	 */
+	public $alias_of = null;
+
+	/**
 	 * Custom CSS selectors for theme.json style generation.
 	 *
 	 * @since 6.3.0
@@ -364,6 +380,10 @@ class WP_Block_Type {
 	public function __get( $name ) {
 		if ( 'variations' === $name ) {
 			return $this->get_variations();
+		}
+
+		if ( 'aliases' === $name ) {
+			return $this->get_aliases();
 		}
 
 		if ( 'uses_context' === $name ) {
@@ -614,6 +634,40 @@ class WP_Block_Type {
 		 * @param WP_Block_Type $block_type The full block type object.
 		 */
 		return apply_filters( 'get_block_type_variations', $this->variations, $this );
+	}
+
+	/**
+	 * Get block aliases.
+	 *
+	 * @since 6.6.0
+	 *
+	 * @return array[]
+	 */
+	public function get_aliases() {
+		if ( ! isset( $this->aliases ) ) {
+			$this->aliases = array();
+			$variations    = array();
+			if ( is_callable( $this->variation_callback ) ) {
+				$variations = call_user_func( $this->variation_callback );
+			}
+
+			foreach ( $variations as $variation ) {
+				if ( ! empty( $variation['alias'] ) && true === $variation['alias'] ) {
+					unset( $variation['alias'] );
+					$this->aliases[][ $variation['name'] ] = $variation;
+				}
+			}
+		}
+
+		/**
+		 * Filters the registered aliases for a block type.
+		 *
+		 * @since 6.6.0
+		 *
+		 * @param array         $aliases    Array of registered aliases for a block type.
+		 * @param WP_Block_Type $block_type The full block type object.
+		 */
+		return apply_filters( 'get_block_type_aliases', $this->aliases, $this );
 	}
 
 	/**

--- a/src/wp-includes/class-wp-block-type.php
+++ b/src/wp-includes/class-wp-block-type.php
@@ -621,7 +621,13 @@ class WP_Block_Type {
 		if ( ! isset( $this->variations ) ) {
 			$this->variations = array();
 			if ( is_callable( $this->variation_callback ) ) {
-				$this->variations = call_user_func( $this->variation_callback );
+				$variations = call_user_func( $this->variation_callback );
+				foreach ( $variations as $variation ) {
+					if ( ! empty( $variation['supports']['alias'] ) && true === $variation['supports']['alias'] ) {
+						$this->aliases[ $variation['name'] ] = $variation;
+					}
+				}
+				$this->variations = $variations;
 			}
 		}
 
@@ -633,7 +639,14 @@ class WP_Block_Type {
 		 * @param array         $variations Array of registered variations for a block type.
 		 * @param WP_Block_Type $block_type The full block type object.
 		 */
-		return apply_filters( 'get_block_type_variations', $this->variations, $this );
+		$variations = apply_filters( 'get_block_type_variations', $this->variations, $this );
+
+		foreach ( $variations as $variation ) {
+			if ( ! empty( $variation['supports']['alias'] ) && true === $variation['supports']['alias'] ) {
+				$this->aliases[ $variation['name'] ] = $variation;
+			}
+		}
+		return $variations;
 	}
 
 	/**
@@ -645,17 +658,10 @@ class WP_Block_Type {
 	 */
 	public function get_aliases() {
 		if ( ! isset( $this->aliases ) ) {
-			$this->aliases = array();
-			$variations    = array();
-			if ( is_callable( $this->variation_callback ) ) {
-				$variations = call_user_func( $this->variation_callback );
-			}
+			$this->get_variations();
 
-			foreach ( $variations as $variation ) {
-				if ( ! empty( $variation['alias'] ) && true === $variation['alias'] ) {
-					unset( $variation['alias'] );
-					$this->aliases[][ $variation['name'] ] = $variation;
-				}
+			if ( ! isset( $this->aliases ) ) {
+				$this->aliases = array();
 			}
 		}
 


### PR DESCRIPTION
Gutenberg counterpart: https://github.com/WordPress/gutenberg/pull/61481

This PR is a little more exploratory/hacky, I'm not sure quite yet how the end result will look but my thinking is that when we come across aliased blocks on the server I want them to also be treated like `WP_Block_Type`'s and be aware of its canonical block, but also for the canonical block to know about all of its aliases.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->
Related to: https://github.com/WordPress/gutenberg/issues/43743

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
