### PR TITLE
Interactivity API: Include `preact/debug` when `SCRIPT_DEBUG` is enabled

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -219,12 +219,9 @@ final class WP_Interactivity_API {
 	public function register_script_modules() {
 		$suffix = wp_scripts_get_suffix();
 
-		// Use a debug version of the runtime when SCRIPT_DEBUG is enabled.
-		$runtime_module = SCRIPT_DEBUG ? 'interactivity-debug' : 'interactivity';
-
 		wp_register_script_module(
 			'@wordpress/interactivity',
-			includes_url( "js/dist/$runtime_module$suffix.js" )
+			includes_url( "js/dist/interactivity$suffix.js" )
 		);
 
 		wp_register_script_module(

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -219,9 +219,12 @@ final class WP_Interactivity_API {
 	public function register_script_modules() {
 		$suffix = wp_scripts_get_suffix();
 
+		// Use a debug version of the runtime when SCRIPT_DEBUG is enabled.
+		$runtime_module = SCRIPT_DEBUG ? 'interactivity-debug' : 'interactivity';
+
 		wp_register_script_module(
 			'@wordpress/interactivity',
-			includes_url( "js/dist/interactivity$suffix.js" )
+			includes_url( "js/dist/$runtime_module$suffix.js" )
 		);
 
 		wp_register_script_module(

--- a/tools/webpack/modules.js
+++ b/tools/webpack/modules.js
@@ -14,6 +14,10 @@ const {
 	WORDPRESS_NAMESPACE,
 } = require( './shared' );
 
+const SUBMODULES = [
+	{ name: 'interactivity-debug', path: 'interactivity/build-module/debug' },
+];
+
 module.exports = function (
 	env = { environment: 'production', watch: false, buildTarget: false }
 ) {
@@ -29,18 +33,30 @@ module.exports = function (
 	const baseConfig = getBaseConfig( env );
 	const config = {
 		...baseConfig,
-		entry: MODULES.map( ( packageName ) =>
-			packageName.replace( WORDPRESS_NAMESPACE, '' )
-		).reduce( ( memo, packageName ) => {
-			memo[ packageName ] = {
-				import: normalizeJoin(
-					baseDir,
-					`node_modules/@wordpress/${ packageName }`
-				),
-			};
+		entry: {
+			...MODULES.map( ( packageName ) =>
+				packageName.replace( WORDPRESS_NAMESPACE, '' )
+			).reduce( ( memo, packageName ) => {
+				memo[ packageName ] = {
+					import: normalizeJoin(
+						baseDir,
+						`node_modules/@wordpress/${ packageName }`
+					),
+				};
 
-			return memo;
-		}, {} ),
+				return memo;
+			}, {} ),
+			...SUBMODULES.reduce( ( memo, { name, path } ) => {
+				memo[ name ] = {
+					import: normalizeJoin(
+						baseDir,
+						`node_modules/@wordpress/${ path }`
+					),
+				};
+
+				return memo;
+			}, {} ),
+		},
 		experiments: {
 			outputModule: true,
 		},

--- a/tools/webpack/modules.js
+++ b/tools/webpack/modules.js
@@ -14,10 +14,6 @@ const {
 	WORDPRESS_NAMESPACE,
 } = require( './shared' );
 
-const SUBMODULES = [
-	{ name: 'interactivity-debug', path: 'interactivity/build-module/debug' },
-];
-
 module.exports = function (
 	env = { environment: 'production', watch: false, buildTarget: false }
 ) {
@@ -33,30 +29,22 @@ module.exports = function (
 	const baseConfig = getBaseConfig( env );
 	const config = {
 		...baseConfig,
-		entry: {
-			...MODULES.map( ( packageName ) =>
-				packageName.replace( WORDPRESS_NAMESPACE, '' )
-			).reduce( ( memo, packageName ) => {
-				memo[ packageName ] = {
-					import: normalizeJoin(
-						baseDir,
-						`node_modules/@wordpress/${ packageName }`
-					),
-				};
+		entry: MODULES.map( ( packageName ) =>
+			packageName.replace( WORDPRESS_NAMESPACE, '' )
+		).reduce( ( memo, packageName ) => {
+			const path =
+				'development' === mode && 'interactivity' === packageName
+					? 'interactivity/build-module/debug'
+					: packageName;
+			memo[ packageName ] = {
+				import: normalizeJoin(
+					baseDir,
+					`node_modules/@wordpress/${ path }`
+				),
+			};
 
-				return memo;
-			}, {} ),
-			...SUBMODULES.reduce( ( memo, { name, path } ) => {
-				memo[ name ] = {
-					import: normalizeJoin(
-						baseDir,
-						`node_modules/@wordpress/${ path }`
-					),
-				};
-
-				return memo;
-			}, {} ),
-		},
+			return memo;
+		}, {} ),
 		experiments: {
 			outputModule: true,
 		},


### PR DESCRIPTION
Syncs the changes from the following PR:

- https://github.com/WordPress/gutenberg/pull/60514

Enqueues a different Interactivity API runtime version with `preact/debug` when `SCRIPT_DEBUG` is enabled.

Trac ticket: https://core.trac.wordpress.org/ticket/61171

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
