### PR TITLE
Replace `$stati` and `$post_stati` variables

### DIFF
--- a/src/wp-admin/export.php
+++ b/src/wp-admin/export.php
@@ -238,8 +238,8 @@ function export_date_options( $post_type = 'post' ) {
 		<select name="post_status" id="post-status">
 			<option value="0"><?php _e( 'All' ); ?></option>
 			<?php
-			$post_stati = get_post_stati( array( 'internal' => false ), 'objects' );
-			foreach ( $post_stati as $status ) :
+			$post_statuses = get_post_stati( array( 'internal' => false ), 'objects' );
+			foreach ( $post_statuses as $status ) :
 				?>
 			<option value="<?php echo esc_attr( $status->name ); ?>"><?php echo esc_html( $status->label ); ?></option>
 			<?php endforeach; ?>
@@ -289,7 +289,7 @@ function export_date_options( $post_type = 'post' ) {
 		<label for="page-status" class="label-responsive"><?php _e( 'Status:' ); ?></label>
 		<select name="page_status" id="page-status">
 			<option value="0"><?php _e( 'All' ); ?></option>
-			<?php foreach ( $post_stati as $status ) : ?>
+			<?php foreach ( $post_statuses as $status ) : ?>
 			<option value="<?php echo esc_attr( $status->name ); ?>"><?php echo esc_html( $status->label ); ?></option>
 			<?php endforeach; ?>
 		</select>

--- a/src/wp-admin/includes/class-wp-comments-list-table.php
+++ b/src/wp-admin/includes/class-wp-comments-list-table.php
@@ -237,7 +237,7 @@ class WP_Comments_List_Table extends WP_List_Table {
 		$status_links = array();
 		$num_comments = ( $post_id ) ? wp_count_comments( $post_id ) : wp_count_comments();
 
-		$stati = array(
+		$statuses = array(
 			/* translators: %s: Number of comments. */
 			'all'       => _nx_noop(
 				'All <span class="count">(%s)</span>',
@@ -282,7 +282,7 @@ class WP_Comments_List_Table extends WP_List_Table {
 		);
 
 		if ( ! EMPTY_TRASH_DAYS ) {
-			unset( $stati['trash'] );
+			unset( $statuses['trash'] );
 		}
 
 		$link = admin_url( 'edit-comments.php' );
@@ -291,7 +291,7 @@ class WP_Comments_List_Table extends WP_List_Table {
 			$link = add_query_arg( 'comment_type', $comment_type, $link );
 		}
 
-		foreach ( $stati as $status => $label ) {
+		foreach ( $statuses as $status => $label ) {
 			if ( 'mine' === $status ) {
 				$current_user_id    = get_current_user_id();
 				$num_comments->mine = get_comments(

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -1679,13 +1679,13 @@ function register_and_do_post_meta_boxes( $post ) {
 		add_meta_box( 'commentstatusdiv', __( 'Discussion' ), 'post_comment_status_meta_box', null, 'normal', 'core', array( '__back_compat_meta_box' => true ) );
 	}
 
-	$stati = get_post_stati( array( 'public' => true ) );
-	if ( empty( $stati ) ) {
-		$stati = array( 'publish' );
+	$statuses = get_post_stati( array( 'public' => true ) );
+	if ( empty( $statuses ) ) {
+		$statuses = array( 'publish' );
 	}
-	$stati[] = 'private';
+	$statuses[] = 'private';
 
-	if ( in_array( get_post_status( $post ), $stati, true ) ) {
+	if ( in_array( get_post_status( $post ), $statuses, true ) ) {
 		/*
 		 * If the post type support comments, or the post has comments,
 		 * allow the Comments meta box.

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -1199,9 +1199,9 @@ function _fix_attachment_links( $post ) {
  * @return string[] An array of all the statuses for the supplied post type.
  */
 function get_available_post_statuses( $type = 'post' ) {
-	$stati = wp_count_posts( $type );
+	$statuses = wp_count_posts( $type );
 
-	return array_keys( get_object_vars( $stati ) );
+	return array_keys( get_object_vars( $statuses ) );
 }
 
 /**
@@ -1217,9 +1217,9 @@ function wp_edit_posts_query( $q = false ) {
 	if ( false === $q ) {
 		$q = $_GET;
 	}
-	$q['m']     = isset( $q['m'] ) ? (int) $q['m'] : 0;
-	$q['cat']   = isset( $q['cat'] ) ? (int) $q['cat'] : 0;
-	$post_stati = get_post_stati();
+	$q['m']        = isset( $q['m'] ) ? (int) $q['m'] : 0;
+	$q['cat']      = isset( $q['cat'] ) ? (int) $q['cat'] : 0;
+	$post_statuses = get_post_stati();
 
 	if ( isset( $q['post_type'] ) && in_array( $q['post_type'], get_post_types(), true ) ) {
 		$post_type = $q['post_type'];
@@ -1231,7 +1231,7 @@ function wp_edit_posts_query( $q = false ) {
 	$post_status      = '';
 	$perm             = '';
 
-	if ( isset( $q['post_status'] ) && in_array( $q['post_status'], $post_stati, true ) ) {
+	if ( isset( $q['post_status'] ) && in_array( $q['post_status'], $post_statuses, true ) ) {
 		$post_status = $q['post_status'];
 		$perm        = 'readable';
 	}

--- a/tests/phpunit/tests/includes/helpers.php
+++ b/tests/phpunit/tests/includes/helpers.php
@@ -225,9 +225,9 @@ class Tests_TestHelpers extends WP_UnitTestCase {
 		register_post_status( 'foo' );
 		_unregister_post_status( 'foo' );
 
-		$stati = get_post_stati();
+		$statuses = get_post_stati();
 
-		$this->assertArrayNotHasKey( 'foo', $stati );
+		$this->assertArrayNotHasKey( 'foo', $statuses );
 	}
 
 	/**


### PR DESCRIPTION
- Replaces `$stati` with `$statuses`
- Replaces `$post_stati` with `$post_statuses`

[Trac 58134](https://core.trac.wordpress.org/ticket/58134)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
