### PR TITLE
Replace em-based line-height with unitless values

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -508,14 +508,14 @@ code {
 .widefat td ol,
 .widefat td ul {
 	font-size: 13px;
-	line-height: 1.5em;
+	line-height: 1.5;
 }
 
 .widefat th,
 .widefat thead td,
 .widefat tfoot td {
 	text-align: left;
-	line-height: 1.3em;
+	line-height: 1.3;
 	font-size: 14px;
 }
 
@@ -777,7 +777,7 @@ img.emoji {
 .widefat thead td,
 .widefat tfoot th,
 .widefat tfoot td {
-	line-height: 1.4em;
+	line-height: 1.4;
 }
 
 .widget .widget-top,

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -1416,7 +1416,7 @@ p.description code {
 
 p.popular-tags {
 	border: none;
-	line-height: 2em;
+	line-height: 2;
 	padding: 8px 12px 12px;
 	text-align: justify;
 }

--- a/src/wp-admin/css/install.css
+++ b/src/wp-admin/css/install.css
@@ -86,7 +86,7 @@ fieldset {
 	color: #3c434a; /* same as login.css */
 	font-size: 20px;
 	font-weight: 400;
-	line-height: 1.3em;
+	line-height: 1.3;
 	text-decoration: none;
 	text-align: center;
 	text-indent: -9999px;

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -2341,7 +2341,7 @@ div.action-links,
 
 	table.plugin-install td.column-name strong {
 		font-size: 1.4em;
-		line-height: 1.6em;
+		line-height: 1.6;
 	}
 
 	table.plugin-install #the-list td {

--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -200,7 +200,7 @@
 	height: 22px;
 	margin: 7px 6px;
 	width: 200px;
-	line-height: 2em;
+	line-height: 2;
 	padding: 0;
 	overflow: hidden;
 	border-radius: 22px;


### PR DESCRIPTION
I found some em-based line-height values in the CSS files within the wp-admin directories.

Files updated:
----------------
common.css
install.css
edit.css
nav-menus.css
list-tables.css

Trac ticket: https://core.trac.wordpress.org/ticket/59960