### PR TITLE
Fix Unsupported operand types in class-wp-site-health.php

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2872,7 +2872,7 @@ class WP_Site_Health {
 		}
 
 		foreach ( $this->crons as $id => $cron ) {
-			if ( ( $cron->time - time() ) < $this->timeout_missed_cron ) {
+			if ( ( (int)$cron->time - time() ) < $this->timeout_missed_cron ) {
 				$this->last_missed_cron = $cron->hook;
 				return true;
 			}


### PR DESCRIPTION
Fixes the error `PHP Fatal error:  Uncaught TypeError: Unsupported operand types: string - int in /path/to/wp-admin/includes/class-wp-site-health.php`

Trac ticket: https://core.trac.wordpress.org/ticket/60388

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
