### PR TITLE
Prime transient and transient timeout options in `get_transient`

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1411,6 +1411,7 @@ function set_transient( $transient, $value, $expiration = 0 ) {
 	} else {
 		$transient_timeout = '_transient_timeout_' . $transient;
 		$transient_option  = '_transient_' . $transient;
+		wp_prime_option_caches( array( $transient_option, $transient_timeout ) );
 
 		if ( false === get_option( $transient_option ) ) {
 			$autoload = 'on';

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1331,7 +1331,7 @@ function get_transient( $transient ) {
 			if ( ! isset( $alloptions[ $transient_option ] ) ) {
 				$transient_timeout = '_transient_timeout_' . $transient;
 				wp_prime_option_caches( array( $transient_option, $transient_timeout ) );
-				$timeout           = get_option( $transient_timeout );
+				$timeout = get_option( $transient_timeout );
 				if ( false !== $timeout && $timeout < time() ) {
 					delete_option( $transient_option );
 					delete_option( $transient_timeout );

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1330,6 +1330,7 @@ function get_transient( $transient ) {
 
 			if ( ! isset( $alloptions[ $transient_option ] ) ) {
 				$transient_timeout = '_transient_timeout_' . $transient;
+				wp_prime_option_caches( array( $transient_option, $transient_timeout ) );
 				$timeout           = get_option( $transient_timeout );
 				if ( false !== $timeout && $timeout < time() ) {
 					delete_option( $transient_option );

--- a/tests/phpunit/tests/option/transient.php
+++ b/tests/phpunit/tests/option/transient.php
@@ -110,6 +110,24 @@ class Tests_Option_Transient extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure set_transient() primes the option cache checking for an existing transient.
+	 *
+	 * @ticket 61193
+	 *
+	 * @covers ::set_transient
+	 */
+	public function test_set_transient_primes_option_cache() {
+		$key     = rand_str();
+		$value   = rand_str();
+		$timeout = 100;
+
+		$before_queries = get_num_queries();
+		$this->assertTrue( set_transient( $key, $value, $timeout ) );
+		$transient_queries = get_num_queries() - $before_queries;
+		$this->assertSame( 3, $transient_queries, 'Expected three database queries setting the transient.' );
+	}
+
+	/**
 	 * @ticket 22807
 	 *
 	 * @covers ::set_transient

--- a/tests/phpunit/tests/option/transient.php
+++ b/tests/phpunit/tests/option/transient.php
@@ -88,9 +88,14 @@ class Tests_Option_Transient extends WP_UnitTestCase {
 	 * @covers ::get_transient
 	 */
 	public function test_get_transient_with_timeout_makes_a_single_database_call() {
-		$key     = rand_str();
-		$value   = rand_str();
-		$timeout = 100;
+		global $wpdb;
+		$key                        = 'test_transient';
+		$value                      = 'test_value';
+		$timeout                    = 100;
+		$expected_query             = "SELECT option_name, option_value FROM $wpdb->options WHERE option_name IN ('_transient_{$key}','_transient_timeout_{$key}')";
+		$unexpected_query_transient = "SELECT option_value FROM $wpdb->options WHERE option_name = '_transient_{$key}' LIMIT 1";
+		$unexpected_query_timeout   = "SELECT option_value FROM $wpdb->options WHERE option_name = '_transient_timeout_{$key}' LIMIT 1";
+		$queries                    = array();
 
 		set_transient( $key, $value, $timeout );
 
@@ -103,10 +108,22 @@ class Tests_Option_Transient extends WP_UnitTestCase {
 			wp_cache_delete( $option_name, 'options' );
 		}
 
+		add_filter(
+			'query',
+			function ( $query ) use ( &$queries ) {
+				$queries[] = $query;
+				return $query;
+			}
+		);
+
 		$before_queries = get_num_queries();
 		$this->assertSame( $value, get_transient( $key ) );
 		$transient_queries = get_num_queries() - $before_queries;
 		$this->assertSame( 1, $transient_queries, 'Expected a single database query to retrieve the transient.' );
+		$this->assertContains( $expected_query, $queries, 'Expected query to prime both transient options in a single call.' );
+		// Note: Some versions of PHPUnit and/or the test suite may report failures as asserting to contain rather than not to contain.
+		$this->assertNotContains( $unexpected_query_transient, $queries, 'Unexpected query of transient option individually.' );
+		$this->assertNotContains( $unexpected_query_timeout, $queries, 'Unexpected query of transient timeout option individually.' );
 	}
 
 	/**
@@ -117,14 +134,31 @@ class Tests_Option_Transient extends WP_UnitTestCase {
 	 * @covers ::set_transient
 	 */
 	public function test_set_transient_primes_option_cache() {
-		$key     = rand_str();
-		$value   = rand_str();
-		$timeout = 100;
+		global $wpdb;
+		$key                        = 'test_transient';
+		$value                      = 'test_value';
+		$timeout                    = 100;
+		$expected_query             = "SELECT option_name, option_value FROM $wpdb->options WHERE option_name IN ('_transient_{$key}','_transient_timeout_{$key}')";
+		$unexpected_query_transient = "SELECT option_value FROM $wpdb->options WHERE option_name = '_transient_{$key}' LIMIT 1";
+		$unexpected_query_timeout   = "SELECT option_value FROM $wpdb->options WHERE option_name = '_transient_timeout_{$key}' LIMIT 1";
+		$queries                    = array();
+
+		add_filter(
+			'query',
+			function ( $query ) use ( &$queries ) {
+				$queries[] = $query;
+				return $query;
+			}
+		);
 
 		$before_queries = get_num_queries();
 		$this->assertTrue( set_transient( $key, $value, $timeout ) );
 		$transient_queries = get_num_queries() - $before_queries;
 		$this->assertSame( 3, $transient_queries, 'Expected three database queries setting the transient.' );
+		$this->assertContains( $expected_query, $queries, 'Expected query to prime both transient options in a single call.' );
+		// Note: Some versions of PHPUnit and/or the test suite may report failures as asserting to contain rather than not to contain.
+		$this->assertNotContains( $unexpected_query_transient, $queries, 'Unexpected query of transient option individually.' );
+		$this->assertNotContains( $unexpected_query_timeout, $queries, 'Unexpected query of transient timeout option individually.' );
 	}
 
 	/**


### PR DESCRIPTION
**What**

Makes use of `wp_prime_option_caches()` within `get_transient()` to prime the transient and transient timeout options in a single database call.

For expiring transients, this reduces the number of database queries getting a transient from two to one.

**Why**

This has minimal impact on sites using a small number of transients. On sites running a plugin that makes heavy use of transients it may have a more significant impact.

Trac ticket: https://core.trac.wordpress.org/ticket/61193
