### PR TITLE
Bundled themes: Remove `px` unit from zero values, use CSS shorthand, remove empty space at the ends of lines

### DIFF
--- a/src/wp-content/themes/twentyeleven/blocks.css
+++ b/src/wp-content/themes/twentyeleven/blocks.css
@@ -155,9 +155,9 @@ p.has-drop-cap:not(:focus)::first-letter {
 	border: none;
 	-moz-border-radius: 3px;
 	border-radius: 3px;
-	-webkit-box-shadow: 0px 1px 2px rgba(0,0,0,0.3);
-	-moz-box-shadow: 0px 1px 2px rgba(0,0,0,0.3);
-	box-shadow: 0px 1px 2px rgba(0,0,0,0.3);
+	-webkit-box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+	-moz-box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+	box-shadow: 0 1px 2px rgba(0,0,0,0.3);
 	color: #eee;
 	cursor: pointer;
 	font-size: 15px;
@@ -240,9 +240,9 @@ p.has-drop-cap:not(:focus)::first-letter {
 /* Buttons */
 
 .wp-block-button .wp-block-button__link {
-	-webkit-box-shadow: 0px 1px 2px rgba(0,0,0,0.3);
-	-moz-box-shadow: 0px 1px 2px rgba(0,0,0,0.3);
-	box-shadow: 0px 1px 2px rgba(0,0,0,0.3);
+	-webkit-box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+	-moz-box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+	box-shadow: 0 1px 2px rgba(0,0,0,0.3);
 	cursor: pointer;
 	font-size: 15px;
 	margin: 20px 0;

--- a/src/wp-content/themes/twentyeleven/colors/dark.css
+++ b/src/wp-content/themes/twentyeleven/colors/dark.css
@@ -409,15 +409,15 @@ section.recent-posts .other-recent-posts .comments-link a:hover {
 .widget_search #searchsubmit {
 	background: #222;
 	border-color: #333;
-	-webkit-box-shadow: inset 0px -1px 1px rgba(0, 0, 0, 0.09);
-	-moz-box-shadow: inset 0px -1px 1px rgba(0, 0, 0, 0.09);
-	box-shadow: inset 0px -1px 1px rgba(0, 0, 0, 0.09);
+	-webkit-box-shadow: inset 0 -1px 1px rgba(0, 0, 0, 0.09);
+	-moz-box-shadow: inset 0 -1px 1px rgba(0, 0, 0, 0.09);
+	box-shadow: inset 0 -1px 1px rgba(0, 0, 0, 0.09);
 	color: #777;
 }
 .widget_search #searchsubmit:active {
-	-webkit-box-shadow: inset 0px 1px 1px rgba(0, 0, 0, 0.1);
-	-moz-box-shadow: inset 0px 1px 1px rgba(0, 0, 0, 0.1);
-	box-shadow: inset 0px 1px 1px rgba(0, 0, 0, 0.1);
+	-webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.1);
+	-moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.1);
+	box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.1);
 	color: #40220c;
 }
 
@@ -545,9 +545,9 @@ li.bypostauthor a.comment-reply-link:active {
 }
 #respond input#submit {
 	background: #ddd;
-	-webkit-box-shadow: 0px 1px 2px rgba(0,0,0,0.3);
-	-moz-box-shadow: 0px 1px 2px rgba(0,0,0,0.3);
-	box-shadow: 0px 1px 2px rgba(0,0,0,0.3);
+	-webkit-box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+	-moz-box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+	box-shadow: 0 1px 2px rgba(0,0,0,0.3);
 	color: #111;
 	text-shadow: 0 -1px 0 rgba(0,0,0,0.3);
 }

--- a/src/wp-content/themes/twentyeleven/editor-blocks.css
+++ b/src/wp-content/themes/twentyeleven/editor-blocks.css
@@ -321,9 +321,9 @@ p.has-drop-cap:not(:focus)::first-letter {
 	border: none;
 	-moz-border-radius: 3px;
 	border-radius: 3px;
-	-webkit-box-shadow: 0px 1px 2px rgba(0,0,0,0.3);
-	-moz-box-shadow: 0px 1px 2px rgba(0,0,0,0.3);
-	box-shadow: 0px 1px 2px rgba(0,0,0,0.3);
+	-webkit-box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+	-moz-box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+	box-shadow: 0 1px 2px rgba(0,0,0,0.3);
 	color: #eee;
 	cursor: pointer;
 	font-size: 15px;
@@ -399,9 +399,9 @@ p.has-drop-cap:not(:focus)::first-letter {
 /* Buttons */
 
 .wp-block-button .wp-block-button__link {
-	-webkit-box-shadow: 0px 1px 2px rgba(0,0,0,0.3);
-	-moz-box-shadow: 0px 1px 2px rgba(0,0,0,0.3);
-	box-shadow: 0px 1px 2px rgba(0,0,0,0.3);
+	-webkit-box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+	-moz-box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+	box-shadow: 0 1px 2px rgba(0,0,0,0.3);
 	cursor: pointer;
 	font-size: 15px;
 	line-height: 24px;

--- a/src/wp-content/themes/twentyeleven/rtl.css
+++ b/src/wp-content/themes/twentyeleven/rtl.css
@@ -43,7 +43,7 @@ body {
 
 /* Simplify the pullquotes and pull styles */
 .one-column.singular .entry-meta .edit-link a {
-	right: 0px;
+	right: 0;
 	left: auto;
 }
 /* Make sure we have room for our comment avatars */
@@ -188,7 +188,7 @@ a.assistive-text:focus {
 	font-family: Arial, sans-serif;
 }
 .wp-caption .wp-caption-text {
-	padding: 10px 40px 5px 0px;
+	padding: 10px 40px 5px 0;
 }
 .wp-caption .wp-caption-text:before {
 	margin-right: 0;
@@ -515,7 +515,7 @@ section.recent-posts .other-recent-posts .comments-link > span {
 	}
 	.singular .entry-meta .edit-link a {
 		left: auto;
-		right: 0px;
+		right: 0;
 	}
 	/* Make sure we have room for our comment avatars */
 	.commentlist > li.comment,

--- a/src/wp-content/themes/twentyeleven/style.css
+++ b/src/wp-content/themes/twentyeleven/style.css
@@ -575,9 +575,9 @@ a.assistive-text:focus,
 	background: -o-linear-gradient(#252525, #0a0a0a);
 	background: -webkit-gradient(linear, 0% 0%, 0% 100%, from(#252525), to(#0a0a0a)); /* older webkit syntax */
 	background: -webkit-linear-gradient(#252525, #0a0a0a);
-	-webkit-box-shadow: rgba(0, 0, 0, 0.4) 0px 1px 2px;
-	-moz-box-shadow: rgba(0, 0, 0, 0.4) 0px 1px 2px;
-	box-shadow: rgba(0, 0, 0, 0.4) 0px 1px 2px;
+	-webkit-box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+	-moz-box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
 	clear: both;
 	display: block;
 	float: left;
@@ -1868,9 +1868,9 @@ video {
 .widget_search #searchsubmit {
 	background: #ddd;
 	border: 1px solid #ccc;
-	-webkit-box-shadow: inset 0px -1px 1px rgba(0, 0, 0, 0.09);
-	-moz-box-shadow: inset 0px -1px 1px rgba(0, 0, 0, 0.09);
-	box-shadow: inset 0px -1px 1px rgba(0, 0, 0, 0.09);
+	-webkit-box-shadow: inset 0 -1px 1px rgba(0, 0, 0, 0.09);
+	-moz-box-shadow: inset 0 -1px 1px rgba(0, 0, 0, 0.09);
+	box-shadow: inset 0 -1px 1px rgba(0, 0, 0, 0.09);
 	color: #888;
 	font-size: 13px;
 	line-height: 25px;
@@ -1880,9 +1880,9 @@ video {
 .widget_search #searchsubmit:active {
 	background: #1982d1;
 	border-color: #0861a5;
-	-webkit-box-shadow: inset 0px 1px 1px rgba(0, 0, 0, 0.1);
-	-moz-box-shadow: inset 0px 1px 1px rgba(0, 0, 0, 0.1);
-	box-shadow: inset 0px 1px 1px rgba(0, 0, 0, 0.1);
+	-webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.1);
+	-moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.1);
+	box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.1);
 	color: #bfddf3;
 }
 
@@ -2273,9 +2273,9 @@ a.comment-reply-link > span {
 	border: none;
 	-moz-border-radius: 3px;
 	border-radius: 3px;
-	-webkit-box-shadow: 0px 1px 2px rgba(0,0,0,0.3);
-	-moz-box-shadow: 0px 1px 2px rgba(0,0,0,0.3);
-	box-shadow: 0px 1px 2px rgba(0,0,0,0.3);
+	-webkit-box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+	-moz-box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+	box-shadow: 0 1px 2px rgba(0,0,0,0.3);
 	color: #eee;
 	cursor: pointer;
 	font-size: 15px;

--- a/src/wp-content/themes/twentynineteen/print.scss
+++ b/src/wp-content/themes/twentynineteen/print.scss
@@ -47,10 +47,10 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
 	h2,
 	h3,
 	h4,
-	.has-regular-font-size, 
-	.has-large-font-size, 
-	h2.author-title, 
-	p.author-bio, 
+	.has-regular-font-size,
+	.has-large-font-size,
+	h2.author-title,
+	p.author-bio,
 	.comments-title, h3 {
 		font-size: 14pt;
 		margin-top: 25px;

--- a/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
+++ b/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
@@ -553,9 +553,9 @@
 			display: block;
 		}
 
-		// If an image does not have a left/center/right alignment, 
-		// it's a direct child of .wp-block-image.  If it has no other 
-		// alignment added, we want to make sure the image and its 
+		// If an image does not have a left/center/right alignment,
+		// it's a direct child of .wp-block-image.  If it has no other
+		// alignment added, we want to make sure the image and its
 		// caption do not extend beyond the width of the text column.
 		&:not(.alignwide):not(.alignfull) > img,
 		&:not(.alignwide):not(.alignfull) > a > img,
@@ -840,7 +840,7 @@
 	//! Group
 	.wp-block-group {
 
-		// When the Group block is standard/wide, we need to prevent full-aligned 
+		// When the Group block is standard/wide, we need to prevent full-aligned
 		// child blocks from expanding out of their container.
 		&:not(.alignfull) > .wp-block-group__inner-container > .alignfull,
 		&:not(.alignfull) > .wp-block-group__inner-container > .wp-block-image > img {
@@ -881,7 +881,7 @@
 				}
 			}
 
-			// If the Group block is full-width, it does not need this extra padding. 
+			// If the Group block is full-width, it does not need this extra padding.
 			&.alignfull {
 				padding-left: 0;
 				padding-right: 0;
@@ -896,7 +896,7 @@
 			&:not(.alignfull) > .wp-block-group__inner-container > .alignfull {
 				width: 100%;
 				max-width: 100%;
-				
+
 				@include media(tablet) {
 					width: calc( 100% + #{$size__spacing-unit * 2} );
 					max-width: calc( 100% + #{$size__spacing-unit * 2} );
@@ -904,7 +904,6 @@
 				}
 			}
 		}
-		
 	}
 
 	//! Latest Comments

--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -1458,8 +1458,8 @@ ul.wp-block-archives li ul,
   padding: 0.5rem;
   text-align: left;
   text-align: center;
-  -webkit-margin-start: 0px;
-  margin-inline-start: 0px;
+  -webkit-margin-start: 0;
+  margin-inline-start: 0;
 }
 
 .wp-block-freeform {

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -426,7 +426,7 @@ figcaption,
 		font-size: $font__size-sm;
 		font-weight: bold;
 		border-radius: 5px;
-	
+
 		&:not(.has-text-color) {
 			color: #fff;
 		}
@@ -841,8 +841,8 @@ ul.wp-block-archives,
  		padding: ( $size__spacing-unit * .5 );
  		text-align: left;
 		text-align: center;
-		-webkit-margin-start: 0px;
-		margin-inline-start: 0px;
+		-webkit-margin-start: 0;
+		margin-inline-start: 0;
 	}
 }
 
@@ -865,8 +865,8 @@ ul.wp-block-archives,
 /** === Group Block === */
 
 // This matches the 22px value for 1rem that used on the front end.
-// It must be specified in pixels for the editor, since the root font 
-// size is different here. 
+// It must be specified in pixels for the editor, since the root font
+// size is different here.
 $group-block-background__padding: $font__size_base;
 
 .wp-block-group {
@@ -916,7 +916,7 @@ $group-block-background__padding: $font__size_base;
 
 	// Group block with background color
 	&.has-background {
-		
+
 		// Child blocks: Default alignments
 		> .wp-block-group__inner-container > .wp-block:not([data-align="wide"]):not([data-align="full"]):not(.alignwide):not(.alignfull) {
 			@include media(tablet) {
@@ -933,19 +933,19 @@ $group-block-background__padding: $font__size_base;
 // Full alignment
 .wp-block[data-align="full"] > .wp-block-group {
 
-		// Margins & padding are added to this container to mimic 
-		// the style + spacing of the .editor-writing-flow global 
-		// container. This way, child items sync up with the placement 
-		// and size of other top-level blocks. 
+		// Margins & padding are added to this container to mimic
+		// the style + spacing of the .editor-writing-flow global
+		// container. This way, child items sync up with the placement
+		// and size of other top-level blocks.
 		> .wp-block-group__inner-container {
 
 			// 2px of extra padding are added to each side here
-			// To better match up with the spacing of the whole 
-			// document. 
+			// To better match up with the spacing of the whole
+			// document.
 			@include media(tablet) {
 				width: 80%;
 				margin-left: 10%;
-				margin-right: 10%; 
+				margin-right: 10%;
 				padding-left: 10px;
 				padding-right: 10px;
 			}

--- a/src/wp-content/themes/twentyten/style.css
+++ b/src/wp-content/themes/twentyten/style.css
@@ -323,9 +323,9 @@ input[type="number"],
 textarea {
 	background: #f9f9f9;
 	border: 1px solid #ccc;
-	box-shadow: inset 1px 1px 1px rgba(0,0,0,0.1);
-	-moz-box-shadow: inset 1px 1px 1px rgba(0,0,0,0.1);
 	-webkit-box-shadow: inset 1px 1px 1px rgba(0,0,0,0.1);
+	-moz-box-shadow: inset 1px 1px 1px rgba(0,0,0,0.1);
+	box-shadow: inset 1px 1px 1px rgba(0,0,0,0.1);
 	padding: 2px;
 }
 a:link {
@@ -418,9 +418,9 @@ div.menu li {
 	text-decoration: none;
 }
 #access ul ul {
-	box-shadow: 0px 3px 3px rgba(0,0,0,0.2);
-	-moz-box-shadow: 0px 3px 3px rgba(0,0,0,0.2);
-	-webkit-box-shadow: 0px 3px 3px rgba(0,0,0,0.2);
+	-webkit-box-shadow: 0 3px 3px rgba(0,0,0,0.2);
+	-moz-box-shadow: 0 3px 3px rgba(0,0,0,0.2);
+	box-shadow: 0 3px 3px rgba(0,0,0,0.2);
 	display: none;
 	position: absolute;
 	top: 38px;

--- a/src/wp-content/themes/twentythirteen/css/blocks.css
+++ b/src/wp-content/themes/twentythirteen/css/blocks.css
@@ -202,7 +202,7 @@ body:not(.sidebar) .wp-block-cover > .wp-block-cover__inner-container > * {
 }
 
 @media screen and (min-width: 665px) {
-	body:not(.sidebar) .wp-block-cover__inner-container > .wp-block-group.alignfull, 
+	body:not(.sidebar) .wp-block-cover__inner-container > .wp-block-group.alignfull,
 	body:not(.sidebar) .wp-block-cover__inner-container > .wp-block-group.has-background.alignfull {
 		padding: 20px;
 	}

--- a/src/wp-content/themes/twentytwenty/print.css
+++ b/src/wp-content/themes/twentytwenty/print.css
@@ -35,7 +35,7 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   .posts {
     padding: 0;
   }
-  
+ 
   /* Width */
 
   .entry-content,
@@ -111,7 +111,7 @@ Andreas Hecht in https://www.jotform.com/blog/css-perfect-print-stylesheet-98272
   }
 
   /* Links */
-  
+
   a:link,
   a:visited,
   a {

--- a/src/wp-content/themes/twentytwentyone/.stylelintrc-css.json
+++ b/src/wp-content/themes/twentytwentyone/.stylelintrc-css.json
@@ -19,6 +19,7 @@
 		"number-leading-zero": null,
 		"no-descending-specificity": null,
 		"length-zero-no-unit": [true, {"ignore": ["custom-properties"]}],
+		"shorthand-property-no-redundant-values": true,
 		"value-keyword-case": ["lower", {
 			"ignoreKeywords": ["currentColor"]
 		}]

--- a/src/wp-content/themes/twentytwentyone/assets/css/ie.css
+++ b/src/wp-content/themes/twentytwentyone/assets/css/ie.css
@@ -2924,7 +2924,7 @@ dd {
 	left: 25px;
 	border-style: solid;
 	border-color: #28303d transparent;
-	border-width: 0 7px 10px 7px;
+	border-width: 0 7px 10px;
 }
 
 .wp-block-navigation > .wp-block-navigation__container > .has-child > .wp-block-navigation__container:after {
@@ -4830,7 +4830,7 @@ h1.page-title {
 .comment-meta .comment-metadata {
 	color: #28303d;
 	font-size: 1rem;
-	padding: 8px 0 9px 0;
+	padding: 8px 0 9px;
 }
 
 .comment-meta .comment-metadata .edit-link {
@@ -5291,7 +5291,7 @@ h1.page-title {
 		left: 25px;
 		border-style: solid;
 		border-color: #28303d transparent;
-		border-width: 0 7px 10px 7px;
+		border-width: 0 7px 10px;
 	}
 
 	.primary-navigation > div > .menu-wrapper > li > .sub-menu:after {
@@ -5832,7 +5832,7 @@ h1.page-title {
 @media only screen and (min-width: 822px) {
 
 	.comments-pagination {
-		margin: 90px auto 120px auto;
+		margin: 90px auto 120px;
 	}
 }
 

--- a/src/wp-content/themes/twentytwentyone/style-rtl.css
+++ b/src/wp-content/themes/twentytwentyone/style-rtl.css
@@ -2757,7 +2757,7 @@ dd {
 	right: var(--global--spacing-horizontal);
 	border-style: solid;
 	border-color: var(--primary-nav--border-color) transparent;
-	border-width: 0 7px 10px 7px;
+	border-width: 0 7px 10px;
 }
 
 .wp-block-navigation > .wp-block-navigation__container > .has-child > .wp-block-navigation__container:after {
@@ -4338,7 +4338,7 @@ h1.page-title {
 .comment-meta .comment-metadata {
 	color: var(--global--color-primary);
 	font-size: var(--global--font-size-xs);
-	padding: 8px 0 9px 0;
+	padding: 8px 0 9px;
 }
 
 .comment-meta .comment-metadata .edit-link {
@@ -4798,7 +4798,7 @@ h1.page-title {
 		right: var(--global--spacing-horizontal);
 		border-style: solid;
 		border-color: var(--primary-nav--border-color) transparent;
-		border-width: 0 7px 10px 7px;
+		border-width: 0 7px 10px;
 	}
 
 	.primary-navigation > div > .menu-wrapper > li > .sub-menu:after {

--- a/src/wp-content/themes/twentytwentyone/style.css
+++ b/src/wp-content/themes/twentytwentyone/style.css
@@ -2767,7 +2767,7 @@ dd {
 	left: var(--global--spacing-horizontal);
 	border-style: solid;
 	border-color: var(--primary-nav--border-color) transparent;
-	border-width: 0 7px 10px 7px;
+	border-width: 0 7px 10px;
 }
 
 .wp-block-navigation > .wp-block-navigation__container > .has-child > .wp-block-navigation__container:after {
@@ -4358,7 +4358,7 @@ h1.page-title {
 .comment-meta .comment-metadata {
 	color: var(--global--color-primary);
 	font-size: var(--global--font-size-xs);
-	padding: 8px 0 9px 0;
+	padding: 8px 0 9px;
 }
 
 .comment-meta .comment-metadata .edit-link {
@@ -4818,7 +4818,7 @@ h1.page-title {
 		left: var(--global--spacing-horizontal);
 		border-style: solid;
 		border-color: var(--primary-nav--border-color) transparent;
-		border-width: 0 7px 10px 7px;
+		border-width: 0 7px 10px;
 	}
 
 	.primary-navigation > div > .menu-wrapper > li > .sub-menu:after {


### PR DESCRIPTION
- Adds `shorthand-property-no-redundant-values` to Twenty Twenty-One's stylelint rules, which updates some values in the theme's stylesheets with CSS shorthand.
- Removes `px` from zero values in Twenty Ten, Twenty Eleven and Twenty Nineteen.
- Moves `box-shadow` prefixed rules before the standard property in Twenty Ten.
- Removes empty spaces at the ends of lines in Twenty Thirteen, Twenty Nineteen and Twenty Twenty (`measure_px_is_unnecessary_theme_bundle_css_53874.patch` included some of those changes and I found others).

[Trac 53874](https://core.trac.wordpress.org/ticket/53874)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
