### PR TITLE
Twenty Nineteen: Match post title font size in editor, and combine `:before` styles

### DIFF
--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -685,34 +685,25 @@ h1 {
   font-size: 2.25em;
 }
 
-h1:before {
-  background: #767676;
-  content: "\020";
-  display: block;
-  height: 2px;
-  margin: 1rem 0;
-  width: 1em;
-}
-
-h1.has-text-align-center:before {
-  margin-left: auto;
-  margin-right: auto;
-}
-
-h1.has-text-align-right:before {
-  margin-left: auto;
-}
-
 @media only screen and (min-width: 768px) {
   h1 {
     font-size: 2.8125em;
   }
 }
 
+.wp-block-post-title,
 h2 {
   font-size: 1.6875em;
 }
 
+@media only screen and (min-width: 768px) {
+  .wp-block-post-title,
+  h2 {
+    font-size: 2.25em;
+  }
+}
+
+h1:before,
 h2:before {
   background: #767676;
   content: "\020";
@@ -722,19 +713,15 @@ h2:before {
   width: 1em;
 }
 
+h1.has-text-align-center:before,
 h2.has-text-align-center:before {
   margin-left: auto;
   margin-right: auto;
 }
 
+h1.has-text-align-right:before,
 h2.has-text-align-right:before {
   margin-left: auto;
-}
-
-@media only screen and (min-width: 768px) {
-  h2 {
-    font-size: 2.25em;
-  }
 }
 
 h3 {

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -119,20 +119,24 @@ h6 {
 
 h1 {
 	font-size: $font__size-xl;
-	@include post-section-dash;
 
 	@include media(tablet) {
 		font-size: $font__size-xxl;
 	}
 }
 
+.wp-block-post-title,
 h2 {
 	font-size: $font__size-lg;
-	@include post-section-dash;
 
 	@include media(tablet) {
 		font-size: $font__size-xl;
 	}
+}
+
+h1,
+h2 {
+	@include post-section-dash;
 }
 
 h3 {


### PR DESCRIPTION
- Sets the `.wp-block-post-title` font sizes together with `h2`.
- Combines the `post-section-dash` mixin for both `h1` and `h2` in the same rulesets.

[Trac 58440](https://core.trac.wordpress.org/ticket/58440)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
