### PR TITLE
Build/Test Tools: Add a workflow for the HTML API's html5lib tests.

### DIFF
--- a/.github/workflows/html5lib-tests.yml
+++ b/.github/workflows/html5lib-tests.yml
@@ -52,7 +52,7 @@ jobs:
   # - Checks out the WordPress Test reporter repository.
   # - Submit the test results to the WordPress.org host test results.
   run-html-api-html5lib-tests:
-    name: PHP ${{ matrix.php }}${{ matrix.multisite && ' multisite' || '' }}
+    name: PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -61,7 +61,6 @@ jobs:
       fail-fast: false
       matrix:
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
-        multisite: [ false, true ]
 
     steps:
       - name: Configure environment variables
@@ -135,7 +134,7 @@ jobs:
         run: npm run env:install
 
       - name: Run HTML API html5lib PHPUnit tests
-        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ matrix.multisite && 'tests/phpunit/multisite.xml' || 'phpunit.xml.dist' }} --group html-api-html5lib-tests
+        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c phpunit.xml.dist --group html-api-html5lib-tests
 
       - name: Ensure version-controlled files are not modified or deleted
         run: git diff --exit-code

--- a/.github/workflows/html5lib-tests.yml
+++ b/.github/workflows/html5lib-tests.yml
@@ -5,14 +5,22 @@ on:
     branches:
       - trunk
       # The html5lib tests were introduced in WordPress 6.6.
-      - '[6-9].[6-9]'
+      - '6.[6-9]'
+      - '[7-9].[0-9]'
+      - '[1-9][0-9]+.[0-9]'
     tags:
-      - '[6-9]+.[6-9]'
-      - '[6-9]+.[6-9].[0-9]+'
+      - '6.[6-9]'
+      - '6.[6-9].[0-9]+'
+      - '[7-9].[0-9]'
+      - '[7-9].[0-9].[0-9]+'
+      - '[1-9][0-9]+.[0-9]'
+      - '[1-9][0-9]+.[0-9].[0-9]+'
   pull_request:
     branches:
       - trunk
-      - '[6-9].[6-9]'
+      - '6.[6-9]'
+      - '[7-9].[0-9]'
+      - '[1-9][0-9]+.[0-9]'
     paths:
       # Any change to a PHP file in the HTML API should run checks.
       - 'src/wp-includes/html-api/**.php'

--- a/.github/workflows/html5lib-tests.yml
+++ b/.github/workflows/html5lib-tests.yml
@@ -1,0 +1,190 @@
+name: HTML API html5lib Tests
+
+on:
+  push:
+    branches:
+      - trunk
+      # The html5lib tests were introduced in WordPress 6.6.
+      - '[6-9].[6-9]'
+    tags:
+      - '[6-9]+.[6-9]'
+      - '[6-9]+.[6-9].[0-9]+'
+  pull_request:
+    branches:
+      - trunk
+      - '[6-9].[6-9]'
+    paths:
+      # Any change to a PHP file in the HTML API should run checks.
+      - 'src/wp-includes/html-api/**.php'
+      - 'tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php'
+      - 'tests/phpunit/data/html5lib-tests/**.dat'
+  workflow_dispatch:
+
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
+jobs:
+  # Runs the HTML API html5lib PHPUnit tests for WordPress.
+  #
+  # Performs the following steps:
+  # - Sets environment variables.
+  # - Checks out the repository.
+  # - Sets up Node.js.
+  # - Sets up PHP.
+  # - Installs Composer dependencies.
+  # - Installs npm dependencies
+  # - Logs general debug information about the runner.
+  # - Logs Docker debug information (about the Docker installation within the runner).
+  # - Starts the WordPress Docker container.
+  # - Logs the running Docker containers.
+  # - Logs debug information about what's installed within the WordPress Docker containers.
+  # - Install WordPress within the Docker container.
+  # - Run the HTML API html5lib PHPUnit tests.
+  # - Ensures version-controlled files are not modified or deleted.
+  # - Checks out the WordPress Test reporter repository.
+  # - Submit the test results to the WordPress.org host test results.
+  run-html-api-html5lib-tests:
+    name: PHP ${{ matrix.php }}${{ matrix.multisite && ' multisite' || '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        multisite: [ false, true ]
+
+    steps:
+      - name: Configure environment variables
+        run: |
+          echo "PHP_FPM_UID=$(id -u)" >> $GITHUB_ENV
+          echo "PHP_FPM_GID=$(id -g)" >> $GITHUB_ENV
+
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      ##
+      # This allows Composer dependencies to be installed using a single step.
+      #
+      # Since the tests are currently run within the Docker containers where the PHP version varies,
+      # the same PHP version needs to be configured for the action runner machine so that the correct
+      # dependency versions are installed and cached.
+      ##
+      - name: Set up PHP
+        uses: shivammathur/setup-php@a4e22b60bbb9c1021113f2860347b0759f66fe5d # v2.30.0
+        with:
+          php-version: '${{ matrix.php }}'
+          coverage: none
+
+      # Since Composer dependencies are installed using `composer update` and no lock file is in version control,
+      # passing a custom cache suffix ensures that the cache is flushed at least once per week.
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@57532f8be5bda426838819c5ee9afb8af389d51a # v3.0.0
+        with:
+          custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: General debug information
+        run: |
+          npm --version
+          node --version
+          curl --version
+          git --version
+          composer --version
+          locale -a
+
+      - name: Docker debug information
+        run: |
+          docker -v
+
+      - name: Start Docker environment
+        run: |
+          npm run env:start
+
+      - name: Log running Docker containers
+        run: docker ps -a
+
+      - name: WordPress Docker container debug information
+        run: |
+          docker compose run --rm mysql ${{ env.LOCAL_DB_TYPE }} --version
+          docker compose run --rm php php --version
+          docker compose run --rm php php -m
+          docker compose run --rm php php -i
+          docker compose run --rm php locale -a
+
+      - name: Install WordPress
+        run: npm run env:install
+
+      - name: Run HTML API html5lib PHPUnit tests
+        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ matrix.multisite && 'tests/phpunit/multisite.xml' || 'phpunit.xml.dist' }} --group html-api-html5lib-tests
+
+      - name: Ensure version-controlled files are not modified or deleted
+        run: git diff --exit-code
+
+  slack-notifications:
+    name: Slack Notifications
+    uses: WordPress/wordpress-develop/.github/workflows/slack-notifications.yml@trunk
+    permissions:
+      actions: read
+      contents: read
+    needs: [ run-html-api-html5lib-tests ]
+    if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name != 'pull_request' && always() }}
+    with:
+      calling_status: ${{ contains( needs.*.result, 'cancelled' ) && 'cancelled' || contains( needs.*.result, 'failure' ) && 'failure' || 'success' }}
+    secrets:
+      SLACK_GHA_SUCCESS_WEBHOOK: ${{ secrets.SLACK_GHA_SUCCESS_WEBHOOK }}
+      SLACK_GHA_CANCELLED_WEBHOOK: ${{ secrets.SLACK_GHA_CANCELLED_WEBHOOK }}
+      SLACK_GHA_FIXED_WEBHOOK: ${{ secrets.SLACK_GHA_FIXED_WEBHOOK }}
+      SLACK_GHA_FAILURE_WEBHOOK: ${{ secrets.SLACK_GHA_FAILURE_WEBHOOK }}
+
+  failed-workflow:
+    name: Failed workflow tasks
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    needs: [ slack-notifications ]
+    if: |
+      always() &&
+      github.repository == 'WordPress/wordpress-develop' &&
+      github.event_name != 'pull_request' &&
+      github.run_attempt < 2 &&
+      (
+        contains( needs.*.result, 'cancelled' ) ||
+        contains( needs.*.result, 'failure' )
+      )
+
+    steps:
+      - name: Dispatch workflow run
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          retries: 2
+          retry-exempt-status-codes: 418
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'failed-workflow.yml',
+              ref: 'trunk',
+              inputs: {
+                run_id: '${{ github.run_id }}'
+              }
+            });

--- a/.github/workflows/html5lib-tests.yml
+++ b/.github/workflows/html5lib-tests.yml
@@ -37,20 +37,10 @@ jobs:
   # Performs the following steps:
   # - Sets environment variables.
   # - Checks out the repository.
-  # - Sets up Node.js.
-  # - Sets up PHP.
   # - Installs Composer dependencies.
-  # - Installs npm dependencies
   # - Logs general debug information about the runner.
-  # - Logs Docker debug information (about the Docker installation within the runner).
-  # - Starts the WordPress Docker container.
-  # - Logs the running Docker containers.
-  # - Logs debug information about what's installed within the WordPress Docker containers.
-  # - Install WordPress within the Docker container.
   # - Run the HTML API html5lib PHPUnit tests.
   # - Ensures version-controlled files are not modified or deleted.
-  # - Checks out the WordPress Test reporter repository.
-  # - Submit the test results to the WordPress.org host test results.
   run-html-api-html5lib-tests:
     name: PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
@@ -67,24 +57,15 @@ jobs:
         run: |
           echo "PHP_FPM_UID=$(id -u)" >> $GITHUB_ENV
           echo "PHP_FPM_GID=$(id -g)" >> $GITHUB_ENV
+          echo "WP_TESTS_SKIP_INSTALL=1" >> $GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
-      - name: Set up Node.js
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
-        with:
-          node-version-file: '.nvmrc'
-          cache: npm
-
       ##
       # This allows Composer dependencies to be installed using a single step.
-      #
-      # Since the tests are currently run within the Docker containers where the PHP version varies,
-      # the same PHP version needs to be configured for the action runner machine so that the correct
-      # dependency versions are installed and cached.
       ##
       - name: Set up PHP
         uses: shivammathur/setup-php@a4e22b60bbb9c1021113f2860347b0759f66fe5d # v2.30.0
@@ -99,42 +80,15 @@ jobs:
         with:
           custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
 
-      - name: Install npm dependencies
-        run: npm ci
-
       - name: General debug information
         run: |
-          npm --version
-          node --version
           curl --version
           git --version
           composer --version
           locale -a
 
-      - name: Docker debug information
-        run: |
-          docker -v
-
-      - name: Start Docker environment
-        run: |
-          npm run env:start
-
-      - name: Log running Docker containers
-        run: docker ps -a
-
-      - name: WordPress Docker container debug information
-        run: |
-          docker compose run --rm mysql ${{ env.LOCAL_DB_TYPE }} --version
-          docker compose run --rm php php --version
-          docker compose run --rm php php -m
-          docker compose run --rm php php -i
-          docker compose run --rm php locale -a
-
-      - name: Install WordPress
-        run: npm run env:install
-
       - name: Run HTML API html5lib PHPUnit tests
-        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c phpunit.xml.dist --group html-api-html5lib-tests
+        run: ./vendor/bin/phpunit --verbose -c phpunit.xml.dist --group html-api-html5lib-tests
 
       - name: Ensure version-controlled files are not modified or deleted
         run: git diff --exit-code

--- a/.github/workflows/html5lib-tests.yml
+++ b/.github/workflows/html5lib-tests.yml
@@ -49,8 +49,6 @@ jobs:
   # - Install WordPress within the Docker container.
   # - Run the HTML API html5lib PHPUnit tests.
   # - Ensures version-controlled files are not modified or deleted.
-  # - Checks out the WordPress Test reporter repository.
-  # - Submit the test results to the WordPress.org host test results.
   run-html-api-html5lib-tests:
     name: PHP ${{ matrix.php }}
     runs-on: ubuntu-latest

--- a/.github/workflows/html5lib-tests.yml
+++ b/.github/workflows/html5lib-tests.yml
@@ -37,10 +37,20 @@ jobs:
   # Performs the following steps:
   # - Sets environment variables.
   # - Checks out the repository.
+  # - Sets up Node.js.
+  # - Sets up PHP.
   # - Installs Composer dependencies.
+  # - Installs npm dependencies
   # - Logs general debug information about the runner.
+  # - Logs Docker debug information (about the Docker installation within the runner).
+  # - Starts the WordPress Docker container.
+  # - Logs the running Docker containers.
+  # - Logs debug information about what's installed within the WordPress Docker containers.
+  # - Install WordPress within the Docker container.
   # - Run the HTML API html5lib PHPUnit tests.
   # - Ensures version-controlled files are not modified or deleted.
+  # - Checks out the WordPress Test reporter repository.
+  # - Submit the test results to the WordPress.org host test results.
   run-html-api-html5lib-tests:
     name: PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
@@ -57,15 +67,24 @@ jobs:
         run: |
           echo "PHP_FPM_UID=$(id -u)" >> $GITHUB_ENV
           echo "PHP_FPM_GID=$(id -g)" >> $GITHUB_ENV
-          echo "WP_TESTS_SKIP_INSTALL=1" >> $GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
+      - name: Set up Node.js
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
       ##
       # This allows Composer dependencies to be installed using a single step.
+      #
+      # Since the tests are currently run within the Docker containers where the PHP version varies,
+      # the same PHP version needs to be configured for the action runner machine so that the correct
+      # dependency versions are installed and cached.
       ##
       - name: Set up PHP
         uses: shivammathur/setup-php@a4e22b60bbb9c1021113f2860347b0759f66fe5d # v2.30.0
@@ -80,15 +99,42 @@ jobs:
         with:
           custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
 
+      - name: Install npm dependencies
+        run: npm ci
+
       - name: General debug information
         run: |
+          npm --version
+          node --version
           curl --version
           git --version
           composer --version
           locale -a
 
+      - name: Docker debug information
+        run: |
+          docker -v
+
+      - name: Start Docker environment
+        run: |
+          npm run env:start
+
+      - name: Log running Docker containers
+        run: docker ps -a
+
+      - name: WordPress Docker container debug information
+        run: |
+          docker compose run --rm mysql ${{ env.LOCAL_DB_TYPE }} --version
+          docker compose run --rm php php --version
+          docker compose run --rm php php -m
+          docker compose run --rm php php -i
+          docker compose run --rm php locale -a
+
+      - name: Install WordPress
+        run: npm run env:install
+
       - name: Run HTML API html5lib PHPUnit tests
-        run: ./vendor/bin/phpunit --verbose -c phpunit.xml.dist --group html-api-html5lib-tests
+        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c phpunit.xml.dist --group html-api-html5lib-tests
 
       - name: Ensure version-controlled files are not modified or deleted
         run: git diff --exit-code

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
@@ -12,6 +12,8 @@
  *
  * See the README file at DIR_TESTDATA / html5lib-tests for details on the third-party suite.
  *
+ * A change to test that the workflow triggers.
+ *
  * @package WordPress
  * @subpackage HTML-API
  *


### PR DESCRIPTION
This adds a GitHub workflow to run the HTML API's html5lib tests when any changes are made to the HTML API, the html5lib tests, or the html5lib data files. Runs on multiple versions of PHP.

Trac ticket: https://core.trac.wordpress.org/ticket/61209