### PR TITLE
Twenty Nineteen: Update editor styles for Archives and Categories List blocks

### DIFF
--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -1378,6 +1378,11 @@ ul.wp-block-archives li ul,
   margin-bottom: -0.75rem;
 }
 
+.wp-block[data-align="center"] > .wp-block-archives,
+.wp-block[data-align="center"] > .wp-block-categories {
+  text-align: center;
+}
+
 /** === Latest Posts === */
 .wp-block-latest-posts .wp-block-latest-posts__post-date {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -751,6 +751,11 @@ ul.wp-block-archives,
 
 }
 
+.wp-block[data-align="center"] > .wp-block-archives,
+.wp-block[data-align="center"] > .wp-block-categories {
+	text-align: center;
+}
+
 /** === Latest Posts === */
 .wp-block-latest-posts {
 


### PR DESCRIPTION
When users select center alignment for Archives or Categories List blocks, this would make the editor style match the text alignment used on the front end.

[Trac 61186](https://core.trac.wordpress.org/ticket/61186)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
