### PR TITLE
Twenty Nineteen: Allow centering text in Latest Posts block

### DIFF
--- a/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
+++ b/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
@@ -253,10 +253,6 @@
 			line-height: $font__line-height-heading;
 			text-decoration: none;
 		}
-	}
-
-	.wp-block-archives,
-	.wp-block-categories {
 
 		&.aligncenter {
 			text-align: center;

--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -1357,6 +1357,12 @@ ul.wp-block-archives li ul,
   padding-left: 1rem;
 }
 
+[data-align="center"] ul.wp-block-archives, [data-align="center"]
+.wp-block-categories, [data-align="center"]
+.wp-block-latest-posts {
+  text-align: center;
+}
+
 .wp-block-categories ul {
   padding-top: 0.75rem;
 }

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -734,6 +734,10 @@ ul.wp-block-archives,
 			padding-left: $size__spacing-unit;
 		}
 	}
+
+	[data-align="center"] & {
+		text-align: center;
+	}
 }
 
 .wp-block-categories {

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -5581,7 +5581,8 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-archives.aligncenter,
-.entry .entry-content .wp-block-categories.aligncenter {
+.entry .entry-content .wp-block-categories.aligncenter,
+.entry .entry-content .wp-block-latest-posts.aligncenter {
   text-align: center;
 }
 

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -5593,7 +5593,8 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-archives.aligncenter,
-.entry .entry-content .wp-block-categories.aligncenter {
+.entry .entry-content .wp-block-categories.aligncenter,
+.entry .entry-content .wp-block-latest-posts.aligncenter {
   text-align: center;
 }
 


### PR DESCRIPTION
This centers the text of the Latest Posts block, if a user selects center alignment, grouping it in the same `.aligncenter` rule written for Archives and Categories List blocks. This also updates styles for all three blocks in the editor.

[Trac 56537](https://core.trac.wordpress.org/ticket/56537)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
