### PR TITLE
Block Hooks API: Harmonize ignoredHookedBlocks metadata injection logic

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -828,21 +828,20 @@ function _build_block_template_object_from_post_object( $post, $terms = array(),
  * @since 6.6.0
  * @access private
  *
- * @param stdClass        $changes    An object representing a template or template part
+ * @param stdClass        $obj        An object representing a template or template part
  *                                    prepared for inserting or updating the database.
- * @param WP_REST_Request $deprecated Deprecated. Not used.
  * @return WP_Block_Template|WP_Error Template or error object.
  */
-function _build_block_template_object_from_prepared_database_object( $changes ) {
-	$meta  = isset( $changes->meta_input ) ? $changes->meta_input : array();
-	$terms = isset( $changes->tax_input ) ? $changes->tax_input : array();
+function _build_block_template_object_from_prepared_database_object( $obj ) {
+	$meta  = isset( $obj->meta_input ) ? $obj->meta_input : array();
+	$terms = isset( $obj->tax_input ) ? $obj->tax_input : array();
 
-	if ( empty( $changes->ID ) ) {
+	if ( empty( $obj->ID ) ) {
 		// There's no post object for this template in the database for this template yet.
-		$post = $changes;
+		$post = $obj;
 	} else {
 		// Find the existing post object.
-		$post = get_post( $changes->ID );
+		$post = get_post( $obj->ID );
 
 		// If the post is a revision, use the parent post's post_name and post_type.
 		$post_id = wp_is_post_revision( $post );
@@ -853,9 +852,9 @@ function _build_block_template_object_from_prepared_database_object( $changes ) 
 		}
 
 		// Apply the changes to the existing post object.
-		$post = (object) array_merge( (array) $post, (array) $changes );
+		$post = (object) array_merge( (array) $post, (array) $obj );
 
-		$type_terms        = get_the_terms( $changes->ID, 'wp_theme' );
+		$type_terms        = get_the_terms( $obj->ID, 'wp_theme' );
 		$terms['wp_theme'] = ! is_wp_error( $type_terms ) && ! empty( $type_terms ) ? $type_terms[0]->name : null;
 	}
 
@@ -868,7 +867,7 @@ function _build_block_template_object_from_prepared_database_object( $changes ) 
 	}
 
 	if ( 'wp_template_part' === $post->post_type && ! isset( $terms['wp_template_part_area'] ) ) {
-		$area_terms                     = get_the_terms( $changes->ID, 'wp_template_part_area' );
+		$area_terms                     = get_the_terms( $obj->ID, 'wp_template_part_area' );
 		$terms['wp_template_part_area'] = ! is_wp_error( $area_terms ) && ! empty( $area_terms ) ? $area_terms[0]->name : null;
 	}
 

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -832,7 +832,7 @@ function _build_block_template_object_from_post_object( $post, $terms = array(),
  *                                    prepared for inserting or updating the database.
  * @return WP_Block_Template|WP_Error Template or error object.
  */
-function _build_block_template_object_from_prepared_database_object( $obj ) {
+function _build_block_template_object_from_database_object( $obj ) {
 	$meta  = isset( $obj->meta_input ) ? $obj->meta_input : array();
 	$terms = isset( $obj->tax_input ) ? $obj->tax_input : array();
 

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1580,4 +1580,3 @@ function get_template_hierarchy( $slug, $is_custom = false, $template_prefix = '
 	}
 	return $template_hierarchy;
 }
-

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1119,7 +1119,8 @@ function make_after_block_visitor( $hooked_blocks, $context, $callback = 'insert
  * hooked blocks, and inject a `metadata.ignoredHookedBlocks` attribute into the anchor
  * blocks to reflect the latter.
  *
- * @since 6.6.0
+ * @since 6.5.0
+ * @since 6.6.0 The function now also supports `wp_navigation` post objects.
  * @access private
  *
  * @param stdClass        $changes    An object representing a template or template part

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1150,7 +1150,7 @@ function inject_ignored_hooked_blocks_metadata_attributes( $changes, $deprecated
 
 	$blocks = parse_blocks( $changes->post_content );
 
-	if ( 'wp_navigation' === $changes->post_type ) {
+	if ( isset( $changes->post_type ) && 'wp_navigation' === $changes->post_type ) {
 		/*
 		* In this scenario the user has likely tried to create a navigation via the REST API.
 		* In which case we won't have a post ID to work with and store meta against.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1185,20 +1185,20 @@ function inject_ignored_hooked_blocks_metadata_attributes( $changes, $deprecated
 
 		return $changes;
 
-	} else {
-		$template = _build_block_template_object_from_database_object( $changes );
-
-		if ( is_wp_error( $template ) ) {
-			return $template;
-		}
-
-		$before_block_visitor = make_before_block_visitor( $hooked_blocks, $template, 'set_ignored_hooked_blocks_metadata' );
-		$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $template, 'set_ignored_hooked_blocks_metadata' );
-
-		$changes->post_content = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
-
-		return $changes;
 	}
+
+	$template = _build_block_template_object_from_database_object( $changes );
+
+	if ( is_wp_error( $template ) ) {
+		return $template;
+	}
+
+	$before_block_visitor = make_before_block_visitor( $hooked_blocks, $template, 'set_ignored_hooked_blocks_metadata' );
+	$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $template, 'set_ignored_hooked_blocks_metadata' );
+
+	$changes->post_content = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
+
+	return $changes;
 }
 
 /**

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1186,7 +1186,7 @@ function inject_ignored_hooked_blocks_metadata_attributes( $changes, $deprecated
 		return $changes;
 
 	} else {
-		$template = _build_block_template_object_from_prepared_database_object( $changes );
+		$template = _build_block_template_object_from_database_object( $changes );
 
 		if ( is_wp_error( $template ) ) {
 			return $template;

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1120,7 +1120,7 @@ function make_after_block_visitor( $hooked_blocks, $context, $callback = 'insert
  * blocks to reflect the latter.
  *
  * @since 6.5.0
- * @since 6.6.0 The function now also supports `wp_navigation` post objects.
+ * @since 6.6.0 The function now also supports `wp_navigation` post_type.
  * @access private
  *
  * @param stdClass        $changes    An object representing a template or template part

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -757,4 +757,9 @@ add_action( 'init', '_wp_register_default_font_collections' );
 add_filter( 'rest_pre_insert_wp_template', 'inject_ignored_hooked_blocks_metadata_attributes' );
 add_filter( 'rest_pre_insert_wp_template_part', 'inject_ignored_hooked_blocks_metadata_attributes' );
 
+// Note: When can we remove this conditional?
+if ( ! has_filter( 'rest_pre_insert_wp_navigation', 'block_core_navigation_update_ignore_hooked_blocks_meta' ) && ! has_filter( 'rest_pre_insert_wp_navigation', 'gutenberg_block_core_navigation_update_ignore_hooked_blocks_meta' ) ) {
+	add_filter( 'rest_pre_insert_wp_navigation', 'inject_ignored_hooked_blocks_metadata_attributes' );
+}
+
 unset( $filter, $action );

--- a/tests/phpunit/tests/block-templates/base.php
+++ b/tests/phpunit/tests/block-templates/base.php
@@ -9,6 +9,9 @@ abstract class WP_Block_Templates_UnitTestCase extends WP_UnitTestCase {
 
 	protected static $template_post;
 	protected static $template_part_post;
+	protected static $uncustomized_template_db_object;
+	protected static $customized_template_db_object;
+
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		/*
@@ -72,6 +75,31 @@ abstract class WP_Block_Templates_UnitTestCase extends WP_UnitTestCase {
 
 		wp_set_post_terms( self::$template_part_post->ID, WP_TEMPLATE_PART_AREA_HEADER, 'wp_template_part_area' );
 		wp_set_post_terms( self::$template_part_post->ID, self::TEST_THEME, 'wp_theme' );
+
+		// Setup uncustomized template db object.
+		self::$uncustomized_template_db_object = (object) array(
+			'post_type'    => 'wp_template',
+			'post_status'  => 'publish',
+			'tax_input'    => array(
+				'wp_theme' => self::TEST_THEME,
+			),
+			'meta_input'   => array(
+				'origin' => 'theme',
+			),
+			'post_content' => '<!-- wp:heading {"level":1,"metadata":{"ignoredHookedBlocks":["tests/ignored"]}} --><h1>Template</h1><!-- /wp:heading -->',
+			'post_type'    => 'wp_template',
+			'post_name'    => 'my_template',
+			'post_title'   => 'My Template',
+			'post_excerpt' => 'Description of my template',
+		);
+
+		// Setup customized template db object.
+		self::$customized_template_db_object = (object) array(
+			'post_name'    => 'my_template',
+			'post_title'   => 'My Customized Template',
+			'post_status'  => 'publish',
+			'post_content' => '<!-- wp:heading {"level":1,"metadata":{"ignoredHookedBlocks":["tests/ignored"]}} --><h1>Template</h1><!-- /wp:heading -->',
+		);
 	}
 
 	public static function wpTearDownAfterClass() {

--- a/tests/phpunit/tests/block-templates/base.php
+++ b/tests/phpunit/tests/block-templates/base.php
@@ -11,6 +11,8 @@ abstract class WP_Block_Templates_UnitTestCase extends WP_UnitTestCase {
 	protected static $template_part_post;
 	protected static $uncustomized_template_db_object;
 	protected static $customized_template_db_object;
+	protected static $uncustomized_template_part_db_object;
+	protected static $customized_template_part_db_object;
 
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
@@ -78,7 +80,6 @@ abstract class WP_Block_Templates_UnitTestCase extends WP_UnitTestCase {
 
 		// Setup uncustomized template db object.
 		self::$uncustomized_template_db_object = (object) array(
-			'post_type'    => 'wp_template',
 			'post_status'  => 'publish',
 			'tax_input'    => array(
 				'wp_theme' => self::TEST_THEME,
@@ -99,6 +100,31 @@ abstract class WP_Block_Templates_UnitTestCase extends WP_UnitTestCase {
 			'post_title'   => 'My Customized Template',
 			'post_status'  => 'publish',
 			'post_content' => '<!-- wp:heading {"level":1,"metadata":{"ignoredHookedBlocks":["tests/ignored"]}} --><h1>Template</h1><!-- /wp:heading -->',
+		);
+
+		// Setup uncustomized template part db object.
+		self::$uncustomized_template_part_db_object = (object) array(
+			'post_status'  => 'publish',
+			'tax_input'    => array(
+				'wp_theme'              => self::TEST_THEME,
+				'wp_template_part_area' => WP_TEMPLATE_PART_AREA_HEADER,
+			),
+			'meta_input'   => array(
+				'origin' => 'theme',
+			),
+			'post_content' => '<!-- wp:heading {"level":2,"metadata":{"ignoredHookedBlocks":["tests/ignored"]}} --><h2>Template Part</h2><!-- /wp:heading -->',
+			'post_type'    => 'wp_template_part',
+			'post_name'    => 'my_template_part',
+			'post_title'   => 'My Template Part',
+			'post_excerpt' => 'Description of my template part',
+		);
+
+		// Setup customised template part db object.
+		self::$customized_template_part_db_object = (object) array(
+			'post_name'    => 'my_template_part',
+			'post_title'   => 'My Customized Template Part',
+			'post_status'  => 'publish',
+			'post_content' => '<!-- wp:heading {"level":2,"metadata":{"ignoredHookedBlocks":["tests/ignored"]}} --><h2>Template Customized Part</h2><!-- /wp:heading -->',
 		);
 	}
 

--- a/tests/phpunit/tests/block-templates/buildBlockTemplateObjectFromDatabaseObject.php
+++ b/tests/phpunit/tests/block-templates/buildBlockTemplateObjectFromDatabaseObject.php
@@ -1,0 +1,64 @@
+<?php
+
+require_once __DIR__ . '/base.php';
+
+/**
+ * @group block-templates
+ * @covers ::_build_block_template_object_from_database_object
+ */
+class Tests_Block_Templates_BuildBlockTemplateFromDatabaseObject extends WP_Block_Templates_UnitTestCase {
+
+	/**
+	 * Tear down each test method.
+	 *
+	 * @since 6.6.0
+	 */
+	public function tear_down() {
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		if ( $registry->is_registered( 'tests/my-block' ) ) {
+			$registry->unregister( 'tests/my-block' );
+		}
+
+		if ( $registry->is_registered( 'tests/ignored' ) ) {
+			$registry->unregister( 'tests/ignored' );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @ticket 60759
+	 */
+	public function test_should_build_template_from_uncustomized_object() {
+		$template = _build_block_template_object_from_database_object( self::$uncustomized_template_db_object );
+
+		$this->assertNotWPError( $template );
+		$this->assertSame( get_stylesheet() . '//my_template', $template->id );
+		$this->assertSame( get_stylesheet(), $template->theme );
+		$this->assertSame( 'my_template', $template->slug );
+		$this->assertSame( 'publish', $template->status );
+		$this->assertSame( 'custom', $template->source );
+		$this->assertSame( 'My Template', $template->title );
+		$this->assertSame( 'Description of my template', $template->description );
+		$this->assertSame( 'wp_template', $template->type );
+	}
+
+	/**
+	 * @ticket 60759
+	 */
+	public function test_should_build_template_from_customized_object() {
+		self::$customized_template_db_object->ID = self::$template_post->ID;
+		$template                                = _build_block_template_object_from_database_object( self::$customized_template_db_object );
+
+		$this->assertNotWPError( $template );
+		$this->assertSame( get_stylesheet() . '//my_template', $template->id );
+		$this->assertSame( get_stylesheet(), $template->theme );
+		$this->assertSame( 'my_template', $template->slug );
+		$this->assertSame( 'publish', $template->status );
+		$this->assertSame( 'custom', $template->source );
+		$this->assertSame( 'My Customized Template', $template->title );
+		$this->assertSame( 'Description of my template', $template->description );
+		$this->assertSame( 'wp_template', $template->type );
+	}
+}

--- a/tests/phpunit/tests/block-templates/buildBlockTemplateObjectFromDatabaseObject.php
+++ b/tests/phpunit/tests/block-templates/buildBlockTemplateObjectFromDatabaseObject.php
@@ -61,4 +61,39 @@ class Tests_Block_Templates_BuildBlockTemplateFromDatabaseObject extends WP_Bloc
 		$this->assertSame( 'Description of my template', $template->description );
 		$this->assertSame( 'wp_template', $template->type );
 	}
+
+	/**
+	 * @ticket 60759
+	 */
+	public function test_should_build_template_part_from_uncustomized_object() {
+		$template = _build_block_template_object_from_database_object( self::$uncustomized_template_part_db_object );
+
+		$this->assertNotWPError( $template );
+		$this->assertSame( get_stylesheet() . '//my_template_part', $template->id );
+		$this->assertSame( get_stylesheet(), $template->theme );
+		$this->assertSame( 'my_template_part', $template->slug );
+		$this->assertSame( 'publish', $template->status );
+		$this->assertSame( 'custom', $template->source );
+		$this->assertSame( 'My Template Part', $template->title );
+		$this->assertSame( 'Description of my template part', $template->description );
+		$this->assertSame( 'wp_template_part', $template->type );
+	}
+
+	/**
+	 * @ticket 60759
+	 */
+	public function test_should_build_template_part_from_customized_object() {
+		self::$customized_template_part_db_object->ID = self::$template_part_post->ID;
+		$template                                     = _build_block_template_object_from_database_object( self::$customized_template_part_db_object );
+
+		$this->assertNotWPError( $template );
+		$this->assertSame( get_stylesheet() . '//my_template_part', $template->id );
+		$this->assertSame( get_stylesheet(), $template->theme );
+		$this->assertSame( 'my_template_part', $template->slug );
+		$this->assertSame( 'publish', $template->status );
+		$this->assertSame( 'custom', $template->source );
+		$this->assertSame( 'My Customized Template Part', $template->title );
+		$this->assertSame( 'Description of my template part', $template->description );
+		$this->assertSame( 'wp_template_part', $template->type );
+	}
 }


### PR DESCRIPTION
This PR aims to haromize the injection of the `ignoredHookedBlocks` data. We currently have two points of processing for this with the first being for `wp_template` & `wp_template_part` and the second being for `wp_navigation` which is stored separately in the `wp_postmeta` table. For us to combine these into a single approach this PR has a conditional statement to handle `wp_navigation` items separately.

I've also created (and tested) a new function to build template objects (`WP_Template`) from database objects (`stdClass`) which is where we intercept this data when the controller prepares it for the database.

Trac ticket: https://core.trac.wordpress.org/ticket/60759

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
