### PR TITLE
Added new do_action `wp_admin_after_add_new_button `

### DIFF
--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -435,6 +435,12 @@ echo esc_html( $title );
 <?php
 if ( isset( $post_new_file ) && current_user_can( $post_type_object->cap->create_posts ) ) {
 	echo ' <a href="' . esc_url( admin_url( $post_new_file ) ) . '" class="page-title-action">' . esc_html( $post_type_object->labels->add_new ) . '</a>';
+	/**
+	 * Fires after the "Add New" button in the admin post type list.
+	 *
+	 * @param WP_Post_Type $post_type_object The post type object.
+	 */
+	do_action( 'wp_admin_after_add_new_button', $post_type_object );
 }
 ?>
 

--- a/src/wp-admin/edit.php
+++ b/src/wp-admin/edit.php
@@ -420,6 +420,12 @@ echo esc_html( $post_type_object->labels->name );
 <?php
 if ( current_user_can( $post_type_object->cap->create_posts ) ) {
 	echo ' <a href="' . esc_url( admin_url( $post_new_file ) ) . '" class="page-title-action">' . esc_html( $post_type_object->labels->add_new ) . '</a>';
+	/**
+	 * Fires after the "Add New" button in the admin post type list.
+	 *
+	 * @param WP_Post_Type $post_type_object The post type object.
+	 */
+	do_action( 'wp_admin_after_add_new_button', $post_type_object );
 }
 
 if ( isset( $_REQUEST['s'] ) && strlen( $_REQUEST['s'] ) ) {

--- a/src/wp-includes/class-wp-post-type.php
+++ b/src/wp-includes/class-wp-post-type.php
@@ -749,7 +749,7 @@ final class WP_Post_Type {
 	 * @since 4.6.0
 	 */
 	public function register_taxonomies() {
-		foreach ( $this->taxonomies as $taxonomy ) {
+		foreach ( (array) $this->taxonomies as $taxonomy ) {
 			register_taxonomy_for_object_type( $taxonomy, $this->name );
 		}
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
I recently encountered an issue where adding a button such as "Import" was impossible without JS manipulation (which is hackish). Adding this do_action will allow me and other users to dynamically add a button on the screen for custom post types. 

Trac ticket: https://core.trac.wordpress.org/ticket/61225#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
