### PR TITLE
handled Exif array values returned from wp_read_image_metadata()

### DIFF
--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -990,7 +990,7 @@ function wp_read_image_metadata( $file ) {
 			$meta['created_timestamp'] = wp_exif_date2ts( $exif['DateTimeDigitized'] );
 		}
 		if ( ! empty( $exif['FocalLength'] ) ) {
-			$meta['focal_length'] = (string) $exif['FocalLength'];
+			$meta['focal_length'] = is_array( $exif['FocalLength'] ) ? implode( ',', $exif['FocalLength'] ) : (string) $exif['FocalLength'];
 			if ( is_scalar( $exif['FocalLength'] ) ) {
 				$meta['focal_length'] = (string) wp_exif_frac2dec( $exif['FocalLength'] );
 			}
@@ -1000,7 +1000,7 @@ function wp_read_image_metadata( $file ) {
 			$meta['iso'] = trim( $meta['iso'] );
 		}
 		if ( ! empty( $exif['ExposureTime'] ) ) {
-			$meta['shutter_speed'] = (string) $exif['ExposureTime'];
+			$meta['shutter_speed'] = is_array( $exif['ExposureTime'] ) ? implode( ',', $exif['ExposureTime'] ) : (string) $exif['ExposureTime'];
 			if ( is_scalar( $exif['ExposureTime'] ) ) {
 				$meta['shutter_speed'] = (string) wp_exif_frac2dec( $exif['ExposureTime'] );
 			}


### PR DESCRIPTION
This PR change handles array values returned from the `exif_read_data()` function which is mainly used at `wp_read_image_metadata()`. It converts array values to comma separated values.

Trac ticket: https://core.trac.wordpress.org/ticket/58240