### PR TITLE
Tests: Remove trailing characters from ticket annotations

### DIFF
--- a/tests/phpunit/tests/cron.php
+++ b/tests/phpunit/tests/cron.php
@@ -598,7 +598,7 @@ class Tests_Cron extends WP_UnitTestCase {
 	 * When no timestamp is specified, the next event should be returned.
 	 * When a timestamp is specified, a particular event should be returned.
 	 *
-	 * @ticket 45976.
+	 * @ticket 45976
 	 *
 	 * @covers ::wp_get_scheduled_event
 	 */
@@ -643,7 +643,7 @@ class Tests_Cron extends WP_UnitTestCase {
 	 * When no timestamp is specified, the next event should be returned.
 	 * When a timestamp is specified, a particular event should be returned.
 	 *
-	 * @ticket 45976.
+	 * @ticket 45976
 	 *
 	 * @covers ::wp_get_scheduled_event
 	 */
@@ -689,7 +689,7 @@ class Tests_Cron extends WP_UnitTestCase {
 	/**
 	 * Ensure wp_get_scheduled_event() returns false when expected.
 	 *
-	 * @ticket 45976.
+	 * @ticket 45976
 	 *
 	 * @covers ::wp_get_scheduled_event
 	 */

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -1685,7 +1685,7 @@ class Tests_DB extends WP_UnitTestCase {
 			),
 
 			/*
-			 * @ticket 56933.
+			 * @ticket 56933
 			 * When preparing a '%%%s%%', test that the inserted value
 			 * is not wrapped in single quotes between the 2 "%".
 			 */
@@ -1838,7 +1838,7 @@ class Tests_DB extends WP_UnitTestCase {
 			),
 
 			/*
-			 * @ticket 52506.
+			 * @ticket 52506
 			 * Adding an escape method for Identifiers (e.g. table/field names).
 			 */
 			array(

--- a/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportGroupHtml.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportGroupHtml.php
@@ -43,8 +43,10 @@ class Tests_Privacy_wpPrivacyGeneratePersonalDataExportGroupHtml extends WP_Unit
 	/**
 	 * Test when a multiple data items are passed.
 	 *
+	 * Updated to remove </h2> from test to avoid Count introducing failure (ticket 46895).
+	 *
 	 * @ticket 44044
-	 * @ticket 46895 Updated to remove </h2> from test to avoid Count introducing failure.
+	 * @ticket 46895
 	 */
 	public function test_group_html_generation_multiple_data_items() {
 		$data = array(


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/61238

Test this with:

```sh
phpunit --group 45976
```

On this branch, 3 tests are run. On trunk, no tests run.

>PHPUnit tests use the @ticket 1234 annotation to reference tickets, but are also used as a PHPUnit group so that tests can be filtered like this:
> `phpunit --group 1234`
> Where only tests with the @ticket 1234 will run (or a 1234 group).
> Some annotations include additional characters, such as a full stop "." or other details on the ticket line. This breaks the group-based ticket filtering.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
