### PR TITLE
Fixed : Return value of `_wp_delete_all_temp_backups()` is not used

### DIFF
--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -1122,15 +1122,18 @@ function _wp_delete_all_temp_backups() {
 	ob_end_clean();
 
 	if ( false === $credentials || ! WP_Filesystem( $credentials ) ) {
-		return new WP_Error( 'fs_unavailable', __( 'Could not access filesystem.' ) );
+		wp_trigger_error( __FUNCTION__, __( 'Could not access filesystem.' ), E_USER_ERROR );
+		return;
 	}
 
 	if ( ! $wp_filesystem->wp_content_dir() ) {
-		return new WP_Error(
-			'fs_no_content_dir',
+		wp_trigger_error(
+			__FUNCTION__,
 			/* translators: %s: Directory name. */
-			sprintf( __( 'Unable to locate WordPress content directory (%s).' ), 'wp-content' )
+			sprintf( __( 'Unable to locate WordPress content directory (%s).' ), 'wp-content' ),
+			E_USER_ERROR
 		);
+		return;
 	}
 
 	$temp_backup_dir = $wp_filesystem->wp_content_dir() . 'upgrade-temp-backup/';


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61116

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
