### PR TITLE
Twenty Nineteen: remove extra space beneath Audio block

### DIFF
--- a/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
+++ b/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
@@ -137,6 +137,7 @@
 		width: 100%;
 
 		audio {
+			display: block;
 			width: 100%;
 		}
 

--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -1003,6 +1003,11 @@ figcaption,
   line-height: 1.6;
 }
 
+/** === Audio === */
+.wp-block-audio audio {
+  display: block;
+}
+
 /** === Button === */
 .wp-block-buttons {
   line-height: 1.2;

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -377,6 +377,15 @@ figcaption,
 	}
 }
 
+/** === Audio === */
+
+.wp-block-audio {
+
+	audio {
+		display: block;
+	}
+}
+
 /** === Button === */
 
 .wp-block-buttons {

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -5458,6 +5458,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-audio audio {
+  display: block;
   width: 100%;
 }
 

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -5470,6 +5470,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-audio audio {
+  display: block;
   width: 100%;
 }
 


### PR DESCRIPTION
Sets `audio` element to `display: block` in the Audio block, for both the front end and the editor.

[Trac 53681](https://core.trac.wordpress.org/ticket/53681)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
