### PR TITLE
improve regex to not break HTML comments

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -294,7 +294,6 @@ add_filter( 'option_home', '_config_wp_home' );
 add_filter( 'option_siteurl', '_config_wp_siteurl' );
 add_filter( 'tiny_mce_before_init', '_mce_set_direction' );
 add_filter( 'teeny_mce_before_init', '_mce_set_direction' );
-add_filter( 'pre_kses', 'wp_pre_kses_less_than' );
 add_filter( 'pre_kses', 'wp_pre_kses_block_attributes', 10, 3 );
 add_filter( 'sanitize_title', 'sanitize_title_with_dashes', 10, 3 );
 add_action( 'check_comment_flood', 'check_comment_flood_db', 10, 4 );

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -981,7 +981,7 @@ function wp_kses_split( $content, $allowed_html, $allowed_protocols ) {
 	$pass_allowed_html      = $allowed_html;
 	$pass_allowed_protocols = $allowed_protocols;
 
-	return preg_replace_callback( '%(<!--.*?(-->|$))|(<[^>]*(>|$)|>)%', '_wp_kses_split_callback', $content );
+	return preg_replace_callback( '%<!--(?!#exec\s).*?(?:-->|$)|(<(?:[^<>]*|(?1))*+(?<!--)>)|[<>]%s', '_wp_kses_split_callback', $content );
 }
 
 /**
@@ -1081,8 +1081,12 @@ function wp_kses_split2( $content, $allowed_html, $allowed_protocols ) {
 	$content = wp_kses_stripslashes( $content );
 
 	// It matched a ">" character.
-	if ( ! str_starts_with( $content, '<' ) ) {
+	if ( '>' === $content ) {
 		return '&gt;';
+	}
+
+	if ( '<' === $content ) {
+		return '&lt;';
 	}
 
 	// Allow HTML comments.


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61246

I also added tests for the original ticket that introduced the deprecated function https://core.trac.wordpress.org/ticket/4409, since there were none.

Additionally, the fix also improves the existing logic by combining the escaping logic for <> into a single regex (ensuring it cannot be partially broken by removing of a filter and can be relied upon in 100% of cases).

Furthermore, a side effect is that it fixes broken behavior that kses would leave the last single or double quote unescaped, while escaping everything else unnecessarily.
see xssAttacks.xml "Remote Stylesheet 3" it will unnecessarily escape the " but will leave the last " unescaped
This seems to be a general issue that the last ' or " won't be escaped, e.g. also in 
`jQuery('#abc').append('<iframe src="xyz.com"></iframe>');` 
you'll end up with 
`jQuery(&#039;#abc&#039;).append(&#039;');`

which itself was unsafe as the '); delimits the string now and can probably somehow abused (not too familiar with that tbf, so feedback welcome)

