### PR TITLE
Block API: Render alias block with canonical block class name

### DIFF
--- a/src/wp-includes/block-supports/generated-classname.php
+++ b/src/wp-includes/block-supports/generated-classname.php
@@ -54,6 +54,11 @@ function wp_apply_generated_classname_support( $block_type ) {
 	if ( $has_generated_classname_support ) {
 		$block_classname = wp_get_block_default_classname( $block_type->name );
 
+		// If the block is a variation and thus has an alias, generate a classname based on the canonical block name.
+		if ( block_is_variation( $block_type->name ) ) {
+			$block_classname .= ' ' . get_canonical_block_name( $block_type->name );
+		}
+
 		if ( $block_classname ) {
 			$attributes['class'] = $block_classname;
 		}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2356,3 +2356,36 @@ function _wp_footnotes_force_filtered_html_on_import_filter( $arg ) {
 	}
 	return $arg;
 }
+
+/**
+ * Checks if the block name is a variation of a block. Variations follow a specific format
+ * of `namespace/block-name/variation-name`.
+ *
+ * @access private
+ * @since 6.6.0
+ *
+ * @param string $block_name
+ * @return boolean
+ */
+function block_is_variation( $block_name ) {
+	return substr_count( $block_name, '/' ) === 2;
+}
+
+/**
+ * Returns the canonical block name for a block. If the block is a variation, it will return
+ * the block name without the variation name.
+ *
+ * @access private
+ * @since 6.6.0
+ *
+ * @param string $block_name
+ * @return string
+ */
+function get_canonical_block_name( $block_name ) {
+	if ( block_is_variation( $block_name ) ) {
+		$parts = explode( '/', $block_name );
+		return $parts[0] . '/' . $parts[1];
+	}
+
+	return $block_name;
+}

--- a/src/wp-includes/class-wp-block-parser.php
+++ b/src/wp-includes/class-wp-block-parser.php
@@ -245,7 +245,7 @@ class WP_Block_Parser {
 		 * match back in PHP to see which one it was.
 		 */
 		$has_match = preg_match(
-			'/<!--\s+(?P<closer>\/)?wp:(?P<namespace>[a-z][a-z0-9_-]*\/)?(?P<name>[a-z][a-z0-9_-]*)\s+(?P<attrs>{(?:(?:[^}]+|}+(?=})|(?!}\s+\/?-->).)*+)?}\s+)?(?P<void>\/)?-->/s',
+			'/<!--\s+(?P<closer>\/)?wp:(?P<namespace>[a-z][a-z0-9_-]*\/)?(?P<name>[a-z][a-z0-9_-]*)(?:\/(?P<variation>[a-z][a-z0-9_-]*))?\s+(?P<attrs>{(?:(?:[^}]+|}+(?=})|(?!}\s+\/?-->).)*+)?}\s+)?(?P<void>\/)?-->/s',
 			$this->document,
 			$matches,
 			PREG_OFFSET_CAPTURE,
@@ -264,13 +264,14 @@ class WP_Block_Parser {
 
 		list( $match, $started_at ) = $matches[0];
 
-		$length    = strlen( $match );
-		$is_closer = isset( $matches['closer'] ) && -1 !== $matches['closer'][1];
-		$is_void   = isset( $matches['void'] ) && -1 !== $matches['void'][1];
-		$namespace = $matches['namespace'];
-		$namespace = ( isset( $namespace ) && -1 !== $namespace[1] ) ? $namespace[0] : 'core/';
-		$name      = $namespace . $matches['name'][0];
-		$has_attrs = isset( $matches['attrs'] ) && -1 !== $matches['attrs'][1];
+		$length       = strlen( $match );
+		$is_closer    = isset( $matches['closer'] ) && -1 !== $matches['closer'][1];
+		$is_void      = isset( $matches['void'] ) && -1 !== $matches['void'][1];
+		$is_variation = isset( $matches['variation'] ) && -1 !== $matches['variation'][1];
+		$namespace    = $matches['namespace'];
+		$namespace    = ( isset( $namespace ) && -1 !== $namespace[1] ) ? $namespace[0] : 'core/';
+		$name         = $is_variation ? $namespace . $matches['name'][0] . '/' . $matches['variation'][0] : $namespace . $matches['name'][0];
+		$has_attrs    = isset( $matches['attrs'] ) && -1 !== $matches['attrs'][1];
 
 		/*
 		 * Fun fact! It's not trivial in PHP to create "an empty associative array" since all arrays

--- a/src/wp-includes/class-wp-block-type-registry.php
+++ b/src/wp-includes/class-wp-block-type-registry.php
@@ -138,11 +138,14 @@ final class WP_Block_Type_Registry {
 	 * @return WP_Block_Type|null The registered block type, or null if it is not registered.
 	 */
 	public function get_registered( $name ) {
-		if ( ! $this->is_registered( $name ) ) {
+		$is_variation = block_is_variation( $name );
+		$block_name   = $is_variation ? get_canonical_block_name( $name ) : $name;
+
+		if ( ! $this->is_registered( $block_name ) ) {
 			return null;
 		}
 
-		return $this->registered_block_types[ $name ];
+		return $this->registered_block_types[ $block_name ];
 	}
 
 	/**

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -127,8 +127,10 @@ class WP_Block {
 	 * @param WP_Block_Type_Registry $registry          Optional block type registry.
 	 */
 	public function __construct( $block, $available_context = array(), $registry = null ) {
+		$is_variation       = block_is_variation( $block['blockName'] );
+		$block_name         = $is_variation ? get_canonical_block_name( $block['blockName'] ) : $block['blockName'];
 		$this->parsed_block = $block;
-		$this->name         = $block['blockName'];
+		$this->name         = $block_name;
 
 		if ( is_null( $registry ) ) {
 			$registry = WP_Block_Type_Registry::get_instance();


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

Consider the following markup:

```html
<!-- wp:social-links -->
<ul class="wp-block-social-links">
	<!-- wp:social-link {"url":"Tumblr.com","service":"tumblr"} /-->
	<!-- wp:core/social-link/wordpress {"url":"wordpress.com","service":"wordpress"} /-->
</ul>
<!-- /wp:social-links -->
```

The second social link has an alias `core/social-link/wordpress` which we need to render correctly on the frontend with the correct CSS class names.

All `WP_Block_Type`'s are registered under their canonical form, meaning aliases are not in the registry. So when we are rendering an alias block type we need to know what the alias is so we can generate the appropriate class names for it, for the above mark up this would be: `wp-social-link wp-social-link-wordpress wp-block-social-link`.

This PR uses a new utility function to check if the block name we are generating a class name for is a variation (e.g. has an alias) or not and if so we generate an additional CSS class for the canonical block name.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
