### PR TITLE
Block Hooks API: Consolidate approach to get all hooked blocks

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -606,17 +606,14 @@ function _build_block_template_result_from_file( $template_file, $template_type 
 		$template->area = $template_file['area'];
 	}
 
-	$hooked_blocks        = get_hooked_blocks();
-	$has_hooked_blocks    = ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' );
 	$before_block_visitor = '_inject_theme_attribute_in_template_part_block';
 	$after_block_visitor  = null;
-
-	if ( $has_hooked_blocks ) {
-		$before_block_visitor = make_before_block_visitor( $hooked_blocks, $template, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );
-		$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $template, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );
+	if ( maybe_has_hooked_blocks() ) {
+		$before_block_visitor = make_before_block_visitor( null, $template, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );
+		$after_block_visitor  = make_after_block_visitor( null, $template, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );
 	}
 
-	if ( 'wp_template_part' === $template->type && $has_hooked_blocks ) {
+	if ( 'wp_template_part' === $template->type && maybe_has_hooked_blocks() ) {
 		/*
 		 * In order for hooked blocks to be inserted at positions first_child and last_child in a template part,
 		 * we need to wrap its content a mock template part block and traverse it.
@@ -1014,10 +1011,9 @@ function _build_block_template_result_from_post( $post ) {
 		}
 	}
 
-	$hooked_blocks = get_hooked_blocks();
-	if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
-		$before_block_visitor = make_before_block_visitor( $hooked_blocks, $template, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );
-		$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $template, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );
+	if ( maybe_has_hooked_blocks() ) {
+		$before_block_visitor = make_before_block_visitor( null, $template, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );
+		$after_block_visitor  = make_after_block_visitor( null, $template, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );
 		if ( 'wp_template_part' === $template->type ) {
 			$existing_ignored_hooked_blocks = get_post_meta( $post->ID, '_wp_ignored_hooked_blocks', true );
 			$attributes                     = ! empty( $existing_ignored_hooked_blocks ) ? array( 'metadata' => array( 'ignoredHookedBlocks' => json_decode( $existing_ignored_hooked_blocks, true ) ) ) : array();
@@ -1602,8 +1598,7 @@ function inject_ignored_hooked_blocks_metadata_attributes( $changes, $deprecated
 		_deprecated_argument( __FUNCTION__, '6.5.3' );
 	}
 
-	$hooked_blocks = get_hooked_blocks();
-	if ( empty( $hooked_blocks ) && ! has_filter( 'hooked_block_types' ) ) {
+	if ( ! maybe_has_hooked_blocks() ) {
 		return $changes;
 	}
 

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -165,17 +165,16 @@ final class WP_Block_Patterns_Registry {
 	 * @since 6.4.0
 	 *
 	 * @param array $pattern       Registered pattern properties.
-	 * @param array $hooked_blocks The list of hooked blocks.
 	 * @return string The content of the block pattern.
 	 */
-	private function prepare_content( $pattern, $hooked_blocks ) {
+	private function prepare_content( $pattern ) {
 		$content = $pattern['content'];
 
 		$before_block_visitor = '_inject_theme_attribute_in_template_part_block';
 		$after_block_visitor  = null;
-		if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
-			$before_block_visitor = make_before_block_visitor( $hooked_blocks, $pattern, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );
-			$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $pattern, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );
+		if ( maybe_has_hooked_blocks() ) {
+			$before_block_visitor = make_before_block_visitor( null, $pattern, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );
+			$after_block_visitor  = make_after_block_visitor( null, $pattern, 'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata' );
 		}
 		$blocks  = parse_blocks( $content );
 		$content = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
@@ -222,7 +221,7 @@ final class WP_Block_Patterns_Registry {
 
 		$pattern            = $this->registered_patterns[ $pattern_name ];
 		$pattern['content'] = $this->get_content( $pattern_name );
-		$pattern['content'] = $this->prepare_content( $pattern, get_hooked_blocks() );
+		$pattern['content'] = $this->prepare_content( $pattern );
 
 		return $pattern;
 	}
@@ -237,14 +236,13 @@ final class WP_Block_Patterns_Registry {
 	 *                 and per style.
 	 */
 	public function get_all_registered( $outside_init_only = false ) {
-		$patterns      = $outside_init_only
+		$patterns = $outside_init_only
 				? $this->registered_patterns_outside_init
 				: $this->registered_patterns;
-		$hooked_blocks = get_hooked_blocks();
 
 		foreach ( $patterns as $index => $pattern ) {
 			$pattern['content']            = $this->get_content( $pattern['name'], $outside_init_only );
-			$patterns[ $index ]['content'] = $this->prepare_content( $pattern, $hooked_blocks );
+			$patterns[ $index ]['content'] = $this->prepare_content( $pattern );
 		}
 
 		return array_values( $patterns );

--- a/tests/phpunit/tests/blocks/getHookedBlocksByAnchorBlock.php
+++ b/tests/phpunit/tests/blocks/getHookedBlocksByAnchorBlock.php
@@ -1,0 +1,329 @@
+<?php
+/**
+ * Tests for the features using get_hooked_blocks_by_anchor_block function.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @since 6.7.0
+ *
+ * @group blocks
+ * @group block-hooks
+ */
+class Tests_Blocks_GetHookedBlocksByAnchorBlock extends WP_UnitTestCase {
+
+	const TEST_THEME_NAME = 'block-theme-with-hooked-blocks';
+
+	/**
+	 * Tear down after each test.
+	 *
+	 * @since 6.7.0
+	 */
+	public function tear_down() {
+		// Removes test block types registered by test cases.
+		$block_types = WP_Block_Type_Registry::get_instance()->get_all_registered();
+		foreach ( $block_types as $block_type ) {
+			$block_name = $block_type->name;
+			if ( str_starts_with( $block_name, 'tests/' ) ) {
+				unregister_block_type( $block_name );
+			}
+		}
+
+		// Removes test block patterns registered with the test theme.
+		$patterns = WP_Block_Patterns_Registry::get_instance()->get_all_registered();
+		foreach ( $patterns as $pattern ) {
+			if ( empty( $pattern['slug'] ) ) {
+				continue;
+			}
+			$pattern_name = $pattern['slug'];
+			if ( str_starts_with( $pattern_name, self::TEST_THEME_NAME ) ) {
+				unregister_block_pattern( $pattern_name );
+			}
+		}
+
+		parent::tear_down();
+	}
+
+	private function switch_to_block_theme_hooked_blocks() {
+		switch_theme( self::TEST_THEME_NAME );
+
+		_register_theme_block_patterns();
+
+		$theme_blocks_dir = wp_normalize_path( realpath( get_theme_file_path( 'blocks' ) ) );
+		register_block_type( $theme_blocks_dir . '/hooked-before' );
+		register_block_type( $theme_blocks_dir . '/hooked-after' );
+		register_block_type( $theme_blocks_dir . '/hooked-first-child' );
+		register_block_type( $theme_blocks_dir . '/hooked-last-child' );
+	}
+
+	private static function create_block_template_object() {
+		$template              = new WP_Block_Template();
+		$template->type        = 'wp_template';
+		$template->theme       = 'test-theme';
+		$template->slug        = 'single';
+		$template->id          = $template->theme . '//' . $template->slug;
+		$template->title       = 'Single';
+		$template->content     = '<!-- wp:tests/anchor-block /-->';
+		$template->description = 'Description of my template';
+
+		return $template;
+	}
+
+	/**
+	 * @ticket 60769
+	 *
+	 * @covers ::get_hooked_blocks_by_anchor_block
+	 */
+	public function test_get_hooked_blocks_by_anchor_block_no_match_found() {
+		$result = get_hooked_blocks_by_anchor_block( 'core/test-block', 'before', array() );
+
+		$this->assertSame( array(), $result );
+	}
+
+	/**
+	 * @ticket 60769
+	 *
+	 * @covers ::get_hooked_blocks_by_anchor_block
+	 */
+	public function test_get_hooked_blocks_by_anchor_block_matches_found_block_json() {
+		register_block_type(
+			'tests/injected-one',
+			array(
+				'block_hooks' => array(
+					'tests/hooked-at-before'           => 'before',
+					'tests/hooked-at-after'            => 'after',
+					'tests/hooked-at-before-and-after' => 'before',
+				),
+			)
+		);
+		register_block_type(
+			'tests/injected-two',
+			array(
+				'block_hooks' => array(
+					'tests/hooked-at-before'           => 'before',
+					'tests/hooked-at-after'            => 'after',
+					'tests/hooked-at-before-and-after' => 'after',
+					'tests/hooked-at-first-child'      => 'first_child',
+					'tests/hooked-at-last-child'       => 'last_child',
+				),
+			)
+		);
+
+		$this->assertSame(
+			array( 'tests/injected-one', 'tests/injected-two' ),
+			get_hooked_blocks_by_anchor_block( 'tests/hooked-at-before', 'before', array() )
+		);
+
+		$this->assertSame(
+			array( 'tests/injected-two' ),
+			get_hooked_blocks_by_anchor_block( 'tests/hooked-at-first-child', 'first_child', array() )
+		);
+
+		$this->assertSame(
+			array( 'tests/injected-two' ),
+			get_hooked_blocks_by_anchor_block( 'tests/hooked-at-last-child', 'last_child', array() )
+		);
+
+		$this->assertSame(
+			array( 'tests/injected-two' ),
+			get_hooked_blocks_by_anchor_block( 'tests/hooked-at-before-and-after', 'after', array() )
+		);
+	}
+
+	/**
+	 * @ticket 60769
+	 *
+	 * @covers ::get_hooked_blocks_by_anchor_block
+	 */
+	public function test_get_hooked_blocks_by_anchor_block_matches_found_filter() {
+		$filter = function ( $hooked_block_types, $relative_position, $anchor_block_type, $context ) {
+			if (
+				! $context instanceof WP_Block_Template ||
+				! property_exists( $context, 'slug' ) ||
+				'single' !== $context->slug
+			) {
+				return $hooked_block_types;
+			}
+
+			if ( 'tests/anchor-block' === $anchor_block_type && 'after' === $relative_position ) {
+				$hooked_block_types[] = 'tests/hooked-block-added-by-filter';
+			}
+
+			return $hooked_block_types;
+		};
+
+		$template = self::create_block_template_object();
+
+		add_filter( 'hooked_block_types', $filter, 10, 4 );
+		$hooked_blocks = get_hooked_blocks_by_anchor_block( 'tests/anchor-block', 'after', $template );
+		remove_filter( 'hooked_block_types', $filter, 10 );
+
+		$this->assertSame( array( 'tests/hooked-block-added-by-filter' ), $hooked_blocks );
+	}
+
+	/**
+	 * @ticket 60769
+	 *
+	 * @covers ::get_hooked_blocks_by_anchor_block
+	 */
+	public function test_get_hooked_blocks_by_anchor_block_corrupt_filter() {
+		$filter = function ( $hooked_block_types, $relative_position, $anchor_block_type, $context ) {
+			$hooked_block_types = 'corrupt';
+			return $hooked_block_types;
+		};
+
+		$template = self::create_block_template_object();
+
+		add_filter( 'hooked_block_types', $filter, 10, 4 );
+		$hooked_blocks = get_hooked_blocks_by_anchor_block( 'tests/anchor-block', 'after', $template );
+		remove_filter( 'hooked_block_types', $filter, 10 );
+
+		$this->assertSame( array(), $hooked_blocks );
+	}
+
+	/**
+	 * @ticket 60769
+	 *
+	 * @covers ::get_hooked_blocks_by_anchor_block
+	 */
+	public function test_get_hooked_blocks_by_anchor_block_matches_found_filter_and_block_json() {
+		register_block_type(
+			'tests/block-json-block',
+			array(
+				'block_hooks' => array(
+					'tests/anchor-block' => 'after',
+				),
+			)
+		);
+
+		$filter = function ( $hooked_block_types, $relative_position, $anchor_block_type, $context ) {
+			if (
+				! $context instanceof WP_Block_Template ||
+				! property_exists( $context, 'slug' ) ||
+				'single' !== $context->slug
+			) {
+				return $hooked_block_types;
+			}
+
+			if ( 'tests/anchor-block' === $anchor_block_type && 'after' === $relative_position ) {
+				$hooked_block_types[] = 'tests/hooked-block-added-by-filter';
+			}
+
+			return $hooked_block_types;
+		};
+
+		$template = self::create_block_template_object();
+
+		add_filter( 'hooked_block_types', $filter, 10, 4 );
+		$hooked_blocks = get_hooked_blocks_by_anchor_block( 'tests/anchor-block', 'after', $template );
+		remove_filter( 'hooked_block_types', $filter, 10 );
+
+		$this->assertSame( array( 'tests/block-json-block', 'tests/hooked-block-added-by-filter' ), $hooked_blocks );
+	}
+
+	/**
+	 * @ticket 60769
+	 * @ticket 59313
+	 * @ticket 60008
+	 * @ticket 60506
+	 *
+	 * @covers ::get_hooked_blocks_by_anchor_block
+	 * @covers ::get_hooked_blocks
+	 * @covers ::get_block_file_template
+	 */
+	public function test_loading_template_with_hooked_blocks() {
+		$this->switch_to_block_theme_hooked_blocks();
+
+		$template = get_block_file_template( get_stylesheet() . '//single' );
+
+		$this->assertStringNotContainsString(
+			'<!-- wp:tests/hooked-before /-->',
+			$template->content
+		);
+		$this->assertStringContainsString(
+			'<!-- wp:post-content {"layout":{"type":"constrained"},"metadata":{"ignoredHookedBlocks":["tests/hooked-after"]}} /-->'
+			. '<!-- wp:tests/hooked-after /-->',
+			$template->content
+		);
+		$this->assertStringNotContainsString(
+			'<!-- wp:tests/hooked-first-child /-->',
+			$template->content
+		);
+		$this->assertStringNotContainsString(
+			'<!-- wp:tests/hooked-last-child /-->',
+			$template->content
+		);
+	}
+
+	/**
+	 * @ticket 60769
+	 * @ticket 59313
+	 * @ticket 60008
+	 * @ticket 60506
+	 *
+	 * @covers ::get_hooked_blocks_by_anchor_block
+	 * @covers ::get_hooked_blocks
+	 * @covers ::get_block_file_template
+	 */
+	public function test_loading_template_part_with_hooked_blocks() {
+		$this->switch_to_block_theme_hooked_blocks();
+
+		$template = get_block_file_template( get_stylesheet() . '//header', 'wp_template_part' );
+
+		$this->assertStringContainsString(
+			'<!-- wp:tests/hooked-before /-->'
+			. '<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"},"metadata":{"ignoredHookedBlocks":["tests/hooked-before"]}} /-->',
+			$template->content
+		);
+		$this->assertStringNotContainsString(
+			'<!-- wp:tests/hooked-after /-->',
+			$template->content
+		);
+		$this->assertStringNotContainsString(
+			'<!-- wp:tests/hooked-first-child /-->',
+			$template->content
+		);
+		$this->assertStringNotContainsString(
+			'<!-- wp:tests/hooked-last-child /-->',
+			$template->content
+		);
+	}
+
+	/**
+	 * @ticket 60769
+	 * @ticket 59313
+	 * @ticket 60008
+	 * @ticket 60506
+	 *
+	 * @covers ::get_hooked_blocks_by_anchor_block
+	 * @covers ::get_hooked_blocks
+	 * @covers ::get_block_file_template
+	 */
+	public function test_loading_pattern_with_hooked_blocks() {
+		$this->switch_to_block_theme_hooked_blocks();
+
+		$pattern = WP_Block_Patterns_Registry::get_instance()->get_registered(
+			get_stylesheet() . '/hidden-comments'
+		);
+
+		$this->assertStringNotContainsString(
+			'<!-- wp:tests/hooked-before /-->',
+			$pattern['content']
+		);
+		$this->assertStringNotContainsString(
+			'<!-- wp:tests/hooked-after /-->',
+			$pattern['content']
+		);
+		$this->assertStringContainsString(
+			'<!-- wp:comments {"metadata":{"ignoredHookedBlocks":["tests/hooked-first-child"]}} -->'
+			. '<div class="wp-block-comments">'
+			. '<!-- wp:tests/hooked-first-child /-->',
+			str_replace( array( "\n", "\t" ), '', $pattern['content'] )
+		);
+		$this->assertStringContainsString(
+			'<!-- wp:tests/hooked-last-child /-->'
+			. '<!-- /wp:comment-template -->',
+			str_replace( array( "\n", "\t" ), '', $pattern['content'] )
+		);
+	}
+}

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -15,12 +15,46 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 	const HOOKED_BLOCK_TYPE       = 'tests/hooked-block';
 	const OTHER_HOOKED_BLOCK_TYPE = 'tests/other-hooked-block';
 
-	const HOOKED_BLOCKS = array(
-		self::ANCHOR_BLOCK_TYPE => array(
-			'after'  => array( self::HOOKED_BLOCK_TYPE ),
-			'before' => array( self::OTHER_HOOKED_BLOCK_TYPE ),
-		),
-	);
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		// Removes test block types registered by test cases.
+		$block_types = WP_Block_Type_Registry::get_instance()->get_all_registered();
+		foreach ( $block_types as $block_type ) {
+			$block_name = $block_type->name;
+			if ( str_starts_with( $block_name, 'tests/' ) ) {
+				unregister_block_type( $block_name );
+			}
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		register_block_type(
+			self::HOOKED_BLOCK_TYPE,
+			array(
+				'block_hooks' => array(
+					self::ANCHOR_BLOCK_TYPE => 'after',
+				),
+			)
+		);
+
+		register_block_type(
+			self::OTHER_HOOKED_BLOCK_TYPE,
+			array(
+				'block_hooks' => array(
+					self::ANCHOR_BLOCK_TYPE => 'before',
+				),
+			)
+		);
+	}
 
 	/**
 	 * @ticket 59572
@@ -34,7 +68,7 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 			'blockName' => self::ANCHOR_BLOCK_TYPE,
 		);
 
-		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		$actual = insert_hooked_blocks( $anchor_block, 'after', null, array() );
 		$this->assertSame(
 			'<!-- wp:' . self::HOOKED_BLOCK_TYPE . ' /-->',
 			$actual,
@@ -59,7 +93,7 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 			),
 		);
 
-		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		$actual = insert_hooked_blocks( $anchor_block, 'after', null, array() );
 		$this->assertSame(
 			'',
 			$actual,
@@ -84,7 +118,7 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 			),
 		);
 
-		$actual = insert_hooked_blocks( $anchor_block, 'before', self::HOOKED_BLOCKS, array() );
+		$actual = insert_hooked_blocks( $anchor_block, 'before', null, array() );
 		$this->assertSame(
 			'<!-- wp:' . self::OTHER_HOOKED_BLOCK_TYPE . ' /-->',
 			$actual,
@@ -125,7 +159,7 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 			return $parsed_hooked_block;
 		};
 		add_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 4 );
-		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		$actual = insert_hooked_blocks( $anchor_block, 'after', null, array() );
 		remove_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter );
 
 		$this->assertSame(
@@ -171,7 +205,7 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 			);
 		};
 		add_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
-		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		$actual = insert_hooked_blocks( $anchor_block, 'after', null, array() );
 		remove_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter );
 
 		$this->assertSame(
@@ -213,7 +247,7 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 			return $parsed_hooked_block;
 		};
 		add_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 4 );
-		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		$actual = insert_hooked_blocks( $anchor_block, 'after', null, array() );
 		remove_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter );
 
 		$this->assertSame( '', $actual, "No markup should've been generated for hooked block suppressed by filter." );


### PR DESCRIPTION
Our current approach to getting hooked blocks has two parts to it:

We use `get_hooked_blocks()` to get all of the hooked blocks which are hooked from the `block.json` file.
In function `insert_hooked_blocks` we apply the filter callbacks (passing a derived value from step 1 as the default value) to get hooked blocks that are applied by the `hooked_block_types` filter.

Currently it's a bit confusing and without knowledge you'd assume `get_hooked_blocks()` would retrieve all of the hooked blocks. Additionally it feels like you have to run a few different pieces of code separately and combine their resulting values to get a complete picture which could result in some bugs or unnecessary complexities.

This PR aims to fix that by creating a single function to get hooked blocks based on anchor block and position.

**Note**: As a result of this refactor it has meant executing `get_hooked_blocks()` multiple times in the lifecycle of a request, to prevent any performance degradation I've memoized the result of the function but would appreciate a second opinion on this.

Trac ticket: https://core.trac.wordpress.org/ticket/60769

Related https://github.com/WordPress/gutenberg/pull/62658

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
