### PR TITLE
Update add new post type labels

### DIFF
--- a/src/wp-admin/edit-link-form.php
+++ b/src/wp-admin/edit-link-form.php
@@ -19,7 +19,7 @@ if ( ! empty( $link_id ) ) {
 	$nonce_action = 'update-bookmark_' . $link_id;
 } else {
 	/* translators: %s: URL to Links screen. */
-	$heading      = sprintf( __( '<a href="%s">Links</a> / Add New Link' ), 'link-manager.php' );
+	$heading      = sprintf( __( '<a href="%s">Links</a> / Add Link' ), 'link-manager.php' );
 	$submit_text  = __( 'Add Link' );
 	$form_name    = 'addlink';
 	$nonce_action = 'add-bookmark';
@@ -87,7 +87,7 @@ echo esc_html( $title );
 ?>
 </h1>
 
-<a href="link-add.php" class="page-title-action"><?php echo esc_html__( 'Add New Link' ); ?></a>
+<a href="link-add.php" class="page-title-action"><?php echo esc_html__( 'Add Link' ); ?></a>
 
 <hr class="wp-header-end">
 

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -1200,12 +1200,12 @@ function link_categories_meta_box( $link ) {
 	</div>
 
 	<div id="category-adder" class="wp-hidden-children">
-		<a id="category-add-toggle" href="#category-add" class="taxonomy-add-new"><?php _e( '+ Add New Category' ); ?></a>
+		<a id="category-add-toggle" href="#category-add" class="taxonomy-add-new"><?php _e( '+ Add Category' ); ?></a>
 		<p id="link-category-add" class="wp-hidden-child">
 			<label class="screen-reader-text" for="newcat">
 				<?php
 				/* translators: Hidden accessibility text. */
-				_e( '+ Add New Category' );
+				_e( '+ Add Category' );
 				?>
 			</label>
 			<input type="text" name="newcat" id="newcat" class="form-required form-input-tip" value="<?php esc_attr_e( 'New category name' ); ?>" aria-required="true" />

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -461,7 +461,7 @@ function wp_comment_reply( $position = 1, $checkbox = false, $mode = 'single', $
 	<legend>
 		<span class="hidden" id="editlegend"><?php _e( 'Edit Comment' ); ?></span>
 		<span class="hidden" id="replyhead"><?php _e( 'Reply to Comment' ); ?></span>
-		<span class="hidden" id="addhead"><?php _e( 'Add New Comment' ); ?></span>
+		<span class="hidden" id="addhead"><?php _e( 'Add Comment' ); ?></span>
 	</legend>
 
 	<div id="replycontainer">
@@ -735,7 +735,7 @@ function meta_form( $post = null ) {
 		natcasesort( $keys );
 	}
 	?>
-<p><strong><?php _e( 'Add New Custom Field:' ); ?></strong></p>
+<p><strong><?php _e( 'Add Custom Field:' ); ?></strong></p>
 <table id="newmeta">
 <thead>
 <tr>

--- a/src/wp-admin/link-add.php
+++ b/src/wp-admin/link-add.php
@@ -14,7 +14,7 @@ if ( ! current_user_can( 'manage_links' ) ) {
 }
 
 // Used in the HTML title tag.
-$title       = __( 'Add New Link' );
+$title       = __( 'Add Link' );
 $parent_file = 'link-manager.php';
 
 $action  = ! empty( $_REQUEST['action'] ) ? sanitize_text_field( $_REQUEST['action'] ) : '';

--- a/src/wp-admin/link-manager.php
+++ b/src/wp-admin/link-manager.php
@@ -101,7 +101,7 @@ echo esc_html( $title );
 ?>
 </h1>
 
-<a href="link-add.php" class="page-title-action"><?php echo esc_html__( 'Add New Link' ); ?></a>
+<a href="link-add.php" class="page-title-action"><?php echo esc_html__( 'Add Link' ); ?></a>
 
 <?php
 if ( isset( $_REQUEST['s'] ) && strlen( $_REQUEST['s'] ) ) {

--- a/src/wp-admin/menu.php
+++ b/src/wp-admin/menu.php
@@ -65,7 +65,7 @@ $menu[4] = array( '', 'read', 'separator1', '', 'wp-menu-separator' );
 
 $menu[10]                      = array( __( 'Media' ), 'upload_files', 'upload.php', '', 'menu-top menu-icon-media', 'menu-media', 'dashicons-admin-media' );
 	$submenu['upload.php'][5]  = array( __( 'Library' ), 'upload_files', 'upload.php' );
-	$submenu['upload.php'][10] = array( __( 'Add New Media File' ), 'upload_files', 'media-new.php' );
+	$submenu['upload.php'][10] = array( __( 'Add Media File' ), 'upload_files', 'media-new.php' );
 	$i                         = 15;
 foreach ( get_taxonomies_for_attachments( 'objects' ) as $tax ) {
 	if ( ! $tax->show_ui || ! $tax->show_in_menu ) {
@@ -78,7 +78,7 @@ foreach ( get_taxonomies_for_attachments( 'objects' ) as $tax ) {
 
 $menu[15]                            = array( __( 'Links' ), 'manage_links', 'link-manager.php', '', 'menu-top menu-icon-links', 'menu-links', 'dashicons-admin-links' );
 	$submenu['link-manager.php'][5]  = array( _x( 'All Links', 'admin menu' ), 'manage_links', 'link-manager.php' );
-	$submenu['link-manager.php'][10] = array( __( 'Add New Link' ), 'manage_links', 'link-add.php' );
+	$submenu['link-manager.php'][10] = array( __( 'Add Link' ), 'manage_links', 'link-add.php' );
 	$submenu['link-manager.php'][15] = array( __( 'Link Categories' ), 'manage_categories', 'edit-tags.php?taxonomy=link_category' );
 
 // $menu[20] = Pages.
@@ -307,7 +307,7 @@ $menu[65] = array( sprintf( __( 'Plugins %s' ), $count ), 'activate_plugins', 'p
 $submenu['plugins.php'][5] = array( __( 'Installed Plugins' ), 'activate_plugins', 'plugins.php' );
 
 if ( ! is_multisite() ) {
-	$submenu['plugins.php'][10] = array( __( 'Add New Plugin' ), 'install_plugins', 'plugin-install.php' );
+	$submenu['plugins.php'][10] = array( __( 'Add Plugin' ), 'install_plugins', 'plugin-install.php' );
 	if ( wp_is_block_theme() ) {
 		// Place the menu item below the Theme File Editor menu item.
 		add_action( 'admin_menu', '_add_plugin_file_editor_to_tools', 101 );
@@ -328,9 +328,9 @@ if ( current_user_can( 'list_users' ) ) {
 	$_wp_real_parent_file['profile.php'] = 'users.php'; // Back-compat for plugins adding submenus to profile.php.
 	$submenu['users.php'][5]             = array( __( 'All Users' ), 'list_users', 'users.php' );
 	if ( current_user_can( 'create_users' ) ) {
-		$submenu['users.php'][10] = array( __( 'Add New User' ), 'create_users', 'user-new.php' );
+		$submenu['users.php'][10] = array( __( 'Add User' ), 'create_users', 'user-new.php' );
 	} elseif ( is_multisite() ) {
-		$submenu['users.php'][10] = array( __( 'Add New User' ), 'promote_users', 'user-new.php' );
+		$submenu['users.php'][10] = array( __( 'Add User' ), 'promote_users', 'user-new.php' );
 	}
 
 	$submenu['users.php'][15] = array( __( 'Profile' ), 'read', 'profile.php' );
@@ -338,9 +338,9 @@ if ( current_user_can( 'list_users' ) ) {
 	$_wp_real_parent_file['users.php'] = 'profile.php';
 	$submenu['profile.php'][5]         = array( __( 'Profile' ), 'read', 'profile.php' );
 	if ( current_user_can( 'create_users' ) ) {
-		$submenu['profile.php'][10] = array( __( 'Add New User' ), 'create_users', 'user-new.php' );
+		$submenu['profile.php'][10] = array( __( 'Add User' ), 'create_users', 'user-new.php' );
 	} elseif ( is_multisite() ) {
-		$submenu['profile.php'][10] = array( __( 'Add New User' ), 'promote_users', 'user-new.php' );
+		$submenu['profile.php'][10] = array( __( 'Add User' ), 'promote_users', 'user-new.php' );
 	}
 }
 

--- a/src/wp-admin/my-sites.php
+++ b/src/wp-admin/my-sites.php
@@ -78,7 +78,7 @@ echo esc_html( $title );
 if ( in_array( get_site_option( 'registration' ), array( 'all', 'blog' ), true ) ) {
 	/** This filter is documented in wp-login.php */
 	$sign_up_url = apply_filters( 'wp_signup_location', network_site_url( 'wp-signup.php' ) );
-	printf( ' <a href="%s" class="page-title-action">%s</a>', esc_url( $sign_up_url ), esc_html__( 'Add New Site' ) );
+	printf( ' <a href="%s" class="page-title-action">%s</a>', esc_url( $sign_up_url ), esc_html__( 'Add Site' ) );
 }
 
 if ( empty( $blogs ) ) :

--- a/src/wp-admin/network/menu.php
+++ b/src/wp-admin/network/menu.php
@@ -50,11 +50,11 @@ $menu[4] = array( '', 'read', 'separator1', '', 'wp-menu-separator' );
 /* translators: Sites menu item. */
 $menu[5]                  = array( __( 'Sites' ), 'manage_sites', 'sites.php', '', 'menu-top menu-icon-site', 'menu-site', 'dashicons-admin-multisite' );
 $submenu['sites.php'][5]  = array( __( 'All Sites' ), 'manage_sites', 'sites.php' );
-$submenu['sites.php'][10] = array( __( 'Add New Site' ), 'create_sites', 'site-new.php' );
+$submenu['sites.php'][10] = array( __( 'Add Site' ), 'create_sites', 'site-new.php' );
 
 $menu[10]                 = array( __( 'Users' ), 'manage_network_users', 'users.php', '', 'menu-top menu-icon-users', 'menu-users', 'dashicons-admin-users' );
 $submenu['users.php'][5]  = array( __( 'All Users' ), 'manage_network_users', 'users.php' );
-$submenu['users.php'][10] = array( __( 'Add New User' ), 'create_users', 'user-new.php' );
+$submenu['users.php'][10] = array( __( 'Add User' ), 'create_users', 'user-new.php' );
 
 if ( current_user_can( 'update_themes' ) && $update_data['counts']['themes'] ) {
 	$menu[15] = array(
@@ -78,7 +78,7 @@ if ( current_user_can( 'update_themes' ) && $update_data['counts']['themes'] ) {
 	$menu[15] = array( __( 'Themes' ), 'manage_network_themes', 'themes.php', '', 'menu-top menu-icon-appearance', 'menu-appearance', 'dashicons-admin-appearance' );
 }
 $submenu['themes.php'][5]  = array( __( 'Installed Themes' ), 'manage_network_themes', 'themes.php' );
-$submenu['themes.php'][10] = array( __( 'Add New Theme' ), 'install_themes', 'theme-install.php' );
+$submenu['themes.php'][10] = array( __( 'Add Theme' ), 'install_themes', 'theme-install.php' );
 $submenu['themes.php'][15] = array( __( 'Theme File Editor' ), 'edit_themes', 'theme-editor.php' );
 
 if ( current_user_can( 'update_plugins' ) && $update_data['counts']['plugins'] ) {
@@ -103,7 +103,7 @@ if ( current_user_can( 'update_plugins' ) && $update_data['counts']['plugins'] )
 	$menu[20] = array( __( 'Plugins' ), 'manage_network_plugins', 'plugins.php', '', 'menu-top menu-icon-plugins', 'menu-plugins', 'dashicons-admin-plugins' );
 }
 $submenu['plugins.php'][5]  = array( __( 'Installed Plugins' ), 'manage_network_plugins', 'plugins.php' );
-$submenu['plugins.php'][10] = array( __( 'Add New Plugin' ), 'install_plugins', 'plugin-install.php' );
+$submenu['plugins.php'][10] = array( __( 'Add Plugin' ), 'install_plugins', 'plugin-install.php' );
 $submenu['plugins.php'][15] = array( __( 'Plugin File Editor' ), 'edit_plugins', 'plugin-editor.php' );
 
 $menu[25] = array( __( 'Settings' ), 'manage_network_options', 'settings.php', '', 'menu-top menu-icon-settings', 'menu-settings', 'dashicons-admin-settings' );

--- a/src/wp-admin/network/settings.php
+++ b/src/wp-admin/network/settings.php
@@ -248,9 +248,9 @@ if ( isset( $_GET['updated'] ) ) {
 			</tr>
 
 			<tr id="addnewusers">
-				<th scope="row"><?php _e( 'Add New Users' ); ?></th>
+				<th scope="row"><?php _e( 'Add Users' ); ?></th>
 				<td>
-					<label><input name="add_new_users" type="checkbox" id="add_new_users" value="1"<?php checked( get_site_option( 'add_new_users' ) ); ?> /> <?php _e( 'Allow site administrators to add new users to their site via the "Users &rarr; Add New" page' ); ?></label>
+					<label><input name="add_new_users" type="checkbox" id="add_new_users" value="1"<?php checked( get_site_option( 'add_new_users' ) ); ?> /> <?php _e( 'Allow site administrators to add new users to their site via the "Users &rarr; Add User" page' ); ?></label>
 				</td>
 			</tr>
 

--- a/src/wp-admin/network/site-new.php
+++ b/src/wp-admin/network/site-new.php
@@ -179,7 +179,7 @@ if ( isset( $_GET['update'] ) ) {
 }
 
 // Used in the HTML title tag.
-$title       = __( 'Add New Site' );
+$title       = __( 'Add Site' );
 $parent_file = 'sites.php';
 
 wp_enqueue_script( 'user-suggest' );
@@ -189,7 +189,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 ?>
 
 <div class="wrap">
-<h1 id="add-new-site"><?php _e( 'Add New Site' ); ?></h1>
+<h1 id="add-new-site"><?php _e( 'Add Site' ); ?></h1>
 <?php
 if ( ! empty( $messages ) ) {
 	$notice_args = array(

--- a/src/wp-admin/network/site-users.php
+++ b/src/wp-admin/network/site-users.php
@@ -339,15 +339,15 @@ if ( current_user_can( 'promote_users' ) && apply_filters( 'show_network_site_us
 
 <?php
 /**
- * Filters whether to show the Add New User form on the Multisite Users screen.
+ * Filters whether to show the Add User form on the Multisite Users screen.
  *
  * @since 3.1.0
  *
- * @param bool $bool Whether to show the Add New User form. Default true.
+ * @param bool $bool Whether to show the Add User form. Default true.
  */
 if ( current_user_can( 'create_users' ) && apply_filters( 'show_network_site_users_add_new_form', true ) ) :
 	?>
-<h2 id="add-new-user"><?php _e( 'Add New User' ); ?></h2>
+<h2 id="add-new-user"><?php _e( 'Add User' ); ?></h2>
 <form action="<?php echo esc_url( network_admin_url( 'site-users.php?action=newuser' ) ); ?>" id="newuser" method="post">
 	<input type="hidden" name="id" value="<?php echo esc_attr( $id ); ?>" />
 	<table class="form-table" role="presentation">
@@ -374,7 +374,7 @@ if ( current_user_can( 'create_users' ) && apply_filters( 'show_network_site_use
 		</tr>
 	</table>
 	<?php wp_nonce_field( 'add-user', '_wpnonce_add-new-user' ); ?>
-	<?php submit_button( __( 'Add New User' ), 'primary', 'add-user', true, array( 'id' => 'submit-add-user' ) ); ?>
+	<?php submit_button( __( 'Add User' ), 'primary', 'add-user', true, array( 'id' => 'submit-add-user' ) ); ?>
 </form>
 <?php endif; ?>
 </div>

--- a/src/wp-admin/network/sites.php
+++ b/src/wp-admin/network/sites.php
@@ -28,7 +28,7 @@ get_current_screen()->add_help_tab(
 		'id'      => 'overview',
 		'title'   => __( 'Overview' ),
 		'content' =>
-			'<p>' . __( 'Add New takes you to the Add New Site screen. You can search for a site by Name, ID number, or IP address. Screen Options allows you to choose how many sites to display on one page.' ) . '</p>' .
+			'<p>' . __( 'Add takes you to the Add Site screen. You can search for a site by Name, ID number, or IP address. Screen Options allows you to choose how many sites to display on one page.' ) . '</p>' .
 			'<p>' . __( 'This is the main table of all sites on this network. Switch between list and excerpt views by using the icons above the right side of the table.' ) . '</p>' .
 			'<p>' . __( 'Hovering over each site reveals seven options (three for the primary site):' ) . '</p>' .
 			'<ul><li>' . __( 'An Edit link to a separate Edit Site screen.' ) . '</li>' .
@@ -390,7 +390,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 <h1 class="wp-heading-inline"><?php _e( 'Sites' ); ?></h1>
 
 <?php if ( current_user_can( 'create_sites' ) ) : ?>
-	<a href="<?php echo esc_url( network_admin_url( 'site-new.php' ) ); ?>" class="page-title-action"><?php echo esc_html__( 'Add New Site' ); ?></a>
+	<a href="<?php echo esc_url( network_admin_url( 'site-new.php' ) ); ?>" class="page-title-action"><?php echo esc_html__( 'Add Site' ); ?></a>
 <?php endif; ?>
 
 <?php

--- a/src/wp-admin/network/themes.php
+++ b/src/wp-admin/network/themes.php
@@ -363,7 +363,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 <h1 class="wp-heading-inline"><?php echo esc_html( $title ); ?></h1>
 
 <?php if ( current_user_can( 'install_themes' ) ) : ?>
-	<a href="theme-install.php" class="page-title-action"><?php echo esc_html__( 'Add New Theme' ); ?></a>
+	<a href="theme-install.php" class="page-title-action"><?php echo esc_html__( 'Add Theme' ); ?></a>
 <?php endif; ?>
 
 <?php

--- a/src/wp-admin/network/user-new.php
+++ b/src/wp-admin/network/user-new.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Add New User network administration panel.
+ * Add User network administration panel.
  *
  * @package WordPress
  * @subpackage Multisite
@@ -97,14 +97,14 @@ if ( isset( $_GET['update'] ) ) {
 }
 
 // Used in the HTML title tag.
-$title       = __( 'Add New User' );
+$title       = __( 'Add User' );
 $parent_file = 'users.php';
 
 require_once ABSPATH . 'wp-admin/admin-header.php';
 ?>
 
 <div class="wrap">
-<h1 id="add-new-user"><?php _e( 'Add New User' ); ?></h1>
+<h1 id="add-new-user"><?php _e( 'Add User' ); ?></h1>
 <?php
 if ( '' !== $message ) {
 	wp_admin_notice(

--- a/src/wp-admin/network/users.php
+++ b/src/wp-admin/network/users.php
@@ -289,7 +289,7 @@ if ( isset( $_REQUEST['updated'] ) && 'true' === $_REQUEST['updated'] && ! empty
 	<?php
 	if ( current_user_can( 'create_users' ) ) :
 		?>
-		<a href="<?php echo esc_url( network_admin_url( 'user-new.php' ) ); ?>" class="page-title-action"><?php echo esc_html__( 'Add New User' ); ?></a>
+		<a href="<?php echo esc_url( network_admin_url( 'user-new.php' ) ); ?>" class="page-title-action"><?php echo esc_html__( 'Add User' ); ?></a>
 		<?php
 	endif;
 

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -566,7 +566,7 @@ get_current_screen()->add_help_tab(
 				'<p>' . __( 'The search for installed plugins will search for terms in their name, description, or author.' ) . ' <span id="live-search-desc" class="hide-if-no-js">' . __( 'The search results will be updated as you type.' ) . '</span></p>' .
 				'<p>' . sprintf(
 					/* translators: %s: WordPress Plugin Directory URL. */
-					__( 'If you would like to see more plugins to choose from, click on the &#8220;Add New Plugin&#8221; button and you will be able to browse or search for additional plugins from the <a href="%s">WordPress Plugin Directory</a>. Plugins in the WordPress Plugin Directory are designed and developed by third parties, and are compatible with the license WordPress uses. Oh, and they&#8217;re free!' ),
+					__( 'If you would like to see more plugins to choose from, click on the &#8220;Add Plugin&#8221; button and you will be able to browse or search for additional plugins from the <a href="%s">WordPress Plugin Directory</a>. Plugins in the WordPress Plugin Directory are designed and developed by third parties, and are compatible with the license WordPress uses. Oh, and they&#8217;re free!' ),
 					__( 'https://wordpress.org/plugins/' )
 				) . '</p>',
 	)
@@ -754,7 +754,7 @@ echo esc_html( $title );
 <?php
 if ( ( ! is_multisite() || is_network_admin() ) && current_user_can( 'install_plugins' ) ) {
 	?>
-	<a href="<?php echo esc_url( self_admin_url( 'plugin-install.php' ) ); ?>" class="page-title-action"><?php echo esc_html__( 'Add New Plugin' ); ?></a>
+	<a href="<?php echo esc_url( self_admin_url( 'plugin-install.php' ) ); ?>" class="page-title-action"><?php echo esc_html__( 'Add Plugin' ); ?></a>
 	<?php
 }
 

--- a/src/wp-admin/theme-install.php
+++ b/src/wp-admin/theme-install.php
@@ -54,7 +54,7 @@ wp_localize_script(
 			'adminUrl'   => parse_url( self_admin_url(), PHP_URL_PATH ),
 		),
 		'l10n'            => array(
-			'addNew'              => __( 'Add New Theme' ),
+			'addNew'              => __( 'Add Theme' ),
 			'search'              => __( 'Search Themes' ),
 			'searchPlaceholder'   => __( 'Search themes...' ), // Placeholder (no ellipsis).
 			'upload'              => __( 'Upload Theme' ),

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -153,7 +153,7 @@ if ( current_user_can( 'install_themes' ) ) {
 	} else {
 		$help_install = '<p>' . sprintf(
 			/* translators: %s: https://wordpress.org/themes/ */
-			__( 'If you would like to see more themes to choose from, click on the &#8220;Add New Theme&#8221; button and you will be able to browse or search for additional themes from the <a href="%s">WordPress Theme Directory</a>. Themes in the WordPress Theme Directory are designed and developed by third parties, and are compatible with the license WordPress uses. Oh, and they&#8217;re free!' ),
+			__( 'If you would like to see more themes to choose from, click on the &#8220;Add Theme&#8221; button and you will be able to browse or search for additional themes from the <a href="%s">WordPress Theme Directory</a>. Themes in the WordPress Theme Directory are designed and developed by third parties, and are compatible with the license WordPress uses. Oh, and they&#8217;re free!' ),
 			__( 'https://wordpress.org/themes/' )
 		) . '</p>';
 	}
@@ -231,7 +231,7 @@ wp_localize_script(
 			'adminUrl'      => parse_url( admin_url(), PHP_URL_PATH ),
 		),
 		'l10n'     => array(
-			'addNew'            => __( 'Add New Theme' ),
+			'addNew'            => __( 'Add Theme' ),
 			'search'            => __( 'Search Installed Themes' ),
 			'searchPlaceholder' => __( 'Search installed themes...' ), // Placeholder (no ellipsis).
 			/* translators: %d: Number of themes. */
@@ -254,7 +254,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 	</h1>
 
 	<?php if ( ! is_multisite() && current_user_can( 'install_themes' ) ) : ?>
-		<a href="<?php echo esc_url( admin_url( 'theme-install.php' ) ); ?>" class="hide-if-no-js page-title-action"><?php echo esc_html__( 'Add New Theme' ); ?></a>
+		<a href="<?php echo esc_url( admin_url( 'theme-install.php' ) ); ?>" class="hide-if-no-js page-title-action"><?php echo esc_html__( 'Add Theme' ); ?></a>
 	<?php endif; ?>
 
 	<form class="search-form"></form>

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -212,7 +212,7 @@ if ( 'grid' === $mode ) {
 		<?php
 		if ( current_user_can( 'upload_files' ) ) {
 			?>
-			<a href="<?php echo esc_url( admin_url( 'media-new.php' ) ); ?>" class="page-title-action aria-button-if-js"><?php echo esc_html__( 'Add New Media File' ); ?></a>
+			<a href="<?php echo esc_url( admin_url( 'media-new.php' ) ); ?>" class="page-title-action aria-button-if-js"><?php echo esc_html__( 'Add Media File' ); ?></a>
 			<?php
 		}
 		?>
@@ -419,7 +419,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 <?php
 if ( current_user_can( 'upload_files' ) ) {
 	?>
-	<a href="<?php echo esc_url( admin_url( 'media-new.php' ) ); ?>" class="page-title-action"><?php echo esc_html__( 'Add New Media File' ); ?></a>
+	<a href="<?php echo esc_url( admin_url( 'media-new.php' ) ); ?>" class="page-title-action"><?php echo esc_html__( 'Add Media File' ); ?></a>
 						<?php
 }
 

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -261,7 +261,7 @@ switch ( $action ) {
 
 			<?php if ( ! IS_PROFILE_PAGE ) : ?>
 				<?php if ( current_user_can( 'create_users' ) ) : ?>
-					<a href="user-new.php" class="page-title-action"><?php echo esc_html__( 'Add New User' ); ?></a>
+					<a href="user-new.php" class="page-title-action"><?php echo esc_html__( 'Add User' ); ?></a>
 				<?php elseif ( is_multisite() && current_user_can( 'promote_users' ) ) : ?>
 					<a href="user-new.php" class="page-title-action"><?php echo esc_html__( 'Add Existing User' ); ?></a>
 				<?php endif; ?>

--- a/src/wp-admin/user-new.php
+++ b/src/wp-admin/user-new.php
@@ -252,7 +252,7 @@ Please click the following link to confirm the invite:
 }
 
 // Used in the HTML title tag.
-$title       = __( 'Add New User' );
+$title       = __( 'Add User' );
 $parent_file = 'users.php';
 
 $do_both = false;
@@ -260,7 +260,7 @@ if ( is_multisite() && current_user_can( 'promote_users' ) && current_user_can( 
 	$do_both = true;
 }
 
-$help = '<p>' . __( 'To add a new user to your site, fill in the form on this screen and click the Add New User button at the bottom.' ) . '</p>';
+$help = '<p>' . __( 'To add a new user to your site, fill in the form on this screen and click the Add User button at the bottom.' ) . '</p>';
 
 if ( is_multisite() ) {
 	$help .= '<p>' . __( 'Because this is a multisite installation, you may add accounts that already exist on the Network by specifying a username or email, and defining a role. For more options, such as specifying a password, you have to be a Network Administrator and use the hover link under an existing user&#8217;s name to Edit the user profile under Network Admin > All Users.' ) . '</p>' .
@@ -271,7 +271,7 @@ if ( is_multisite() ) {
 	'<p>' . __( 'By default, new users will receive an email letting them know they&#8217;ve been added as a user for your site. This email will also contain a password reset link. Uncheck the box if you do not want to send the new user a welcome email.' ) . '</p>';
 }
 
-$help .= '<p>' . __( 'Remember to click the Add New User button at the bottom of this screen when you are finished.' ) . '</p>';
+$help .= '<p>' . __( 'Remember to click the Add User button at the bottom of this screen when you are finished.' ) . '</p>';
 
 get_current_screen()->add_help_tab(
 	array(
@@ -374,7 +374,7 @@ if ( isset( $_GET['update'] ) ) {
 <h1 id="add-new-user">
 <?php
 if ( current_user_can( 'create_users' ) ) {
-	_e( 'Add New User' );
+	_e( 'Add User' );
 } elseif ( current_user_can( 'promote_users' ) ) {
 	_e( 'Add Existing User' );
 }
@@ -498,7 +498,7 @@ if ( is_multisite() && current_user_can( 'promote_users' ) ) {
 
 if ( current_user_can( 'create_users' ) ) {
 	if ( $do_both ) {
-		echo '<h2 id="create-new-user">' . __( 'Add New User' ) . '</h2>';
+		echo '<h2 id="create-new-user">' . __( 'Add User' ) . '</h2>';
 	}
 	?>
 <p><?php _e( 'Create a brand new user and add them to this site.' ); ?></p>
@@ -650,7 +650,7 @@ if ( current_user_can( 'create_users' ) ) {
 	do_action( 'user_new_form', 'add-new-user' );
 	?>
 
-	<?php submit_button( __( 'Add New User' ), 'primary', 'createuser', true, array( 'id' => 'createusersub' ) ); ?>
+	<?php submit_button( __( 'Add User' ), 'primary', 'createuser', true, array( 'id' => 'createusersub' ) ); ?>
 
 </form>
 <?php } // End if current_user_can( 'create_users' ). ?>

--- a/src/wp-admin/users.php
+++ b/src/wp-admin/users.php
@@ -33,7 +33,7 @@ get_current_screen()->add_help_tab(
 		'id'      => 'overview',
 		'title'   => __( 'Overview' ),
 		'content' => '<p>' . __( 'This screen lists all the existing users for your site. Each user has one of five defined roles as set by the site admin: Site Administrator, Editor, Author, Contributor, or Subscriber. Users with roles other than Administrator will see fewer options in the dashboard navigation when they are logged in, based on their role.' ) . '</p>' .
-						'<p>' . __( 'To add a new user for your site, click the Add New button at the top of the screen or Add New in the Users menu section.' ) . '</p>',
+						'<p>' . __( 'To add a new user for your site, click the Add User button at the top of the screen or Add User in the Users menu section.' ) . '</p>',
 	)
 );
 
@@ -778,7 +778,7 @@ switch ( $wp_list_table->current_action() ) {
 			printf(
 				'<a href="%1$s" class="page-title-action">%2$s</a>',
 				esc_url( admin_url( 'user-new.php' ) ),
-				esc_html__( 'Add New User' )
+				esc_html__( 'Add User' )
 			);
 		} elseif ( is_multisite() && current_user_can( 'promote_users' ) ) {
 			printf(

--- a/src/wp-content/themes/twentyeleven/readme.txt
+++ b/src/wp-content/themes/twentyeleven/readme.txt
@@ -15,7 +15,7 @@ For more information about Twenty Eleven please go to https://codex.wordpress.or
 
 == Installation ==
 
-1. In your admin panel, go to Appearance -> Themes and click the 'Add New' button.
+1. In your admin panel, go to Appearance -> Themes and click the 'Add' button.
 2. Type in Twenty Eleven in the search form and press the 'Enter' key in your keyboard.
 3. Click on the 'Activate' button to use your new theme right away.
 4. Go to https://codex.wordpress.org/Twenty_Eleven for a guide to customize this theme.

--- a/src/wp-content/themes/twentyfifteen/readme.txt
+++ b/src/wp-content/themes/twentyfifteen/readme.txt
@@ -23,7 +23,7 @@ For more information about Twenty Fifteen please go to https://wordpress.org/doc
 
 == Installation ==
 
-1. In your admin panel, go to Appearance -> Themes and click the 'Add New' button.
+1. In your admin panel, go to Appearance -> Themes and click the 'Add' button.
 2. Type in Twenty Fifteen in the search form and press the 'Enter' key on your keyboard.
 3. Click on the 'Activate' button to use your new theme right away.
 4. Go to https://wordpress.org/documentation/article/twenty-fifteen/ for a guide on how to customize this theme.

--- a/src/wp-content/themes/twentyfourteen/readme.txt
+++ b/src/wp-content/themes/twentyfourteen/readme.txt
@@ -15,7 +15,7 @@ For more information about Twenty Fourteen please go to https://codex.wordpress.
 
 == Installation ==
 
-1. In your admin panel, go to Appearance -> Themes and click the 'Add New' button.
+1. In your admin panel, go to Appearance -> Themes and click the 'Add' button.
 2. Type in Twenty Fourteen in the search form and press the 'Enter' key in your keyboard.
 3. Click on the 'Activate' button to use your new theme right away.
 4. Go to https://codex.wordpress.org/Twenty_Fourteen for a guide to customize this theme.

--- a/src/wp-content/themes/twentynineteen/readme.txt
+++ b/src/wp-content/themes/twentynineteen/readme.txt
@@ -17,7 +17,7 @@ For more information about Twenty Nineteen please go to https://wordpress.org/do
 
 == Installation ==
 
-1. In your admin panel, go to Appearance -> Themes and click the 'Add New' button.
+1. In your admin panel, go to Appearance -> Themes and click the 'Add' button.
 2. Type in Twenty Nineteen in the search form and press the 'Enter' key on your keyboard.
 3. Click on the 'Activate' button to use your new theme right away.
 4. Go to https://wordpress.org/documentation/article/twenty-nineteen/ for a guide on how to customize this theme.

--- a/src/wp-content/themes/twentyseventeen/readme.txt
+++ b/src/wp-content/themes/twentyseventeen/readme.txt
@@ -16,7 +16,7 @@ For more information about Twenty Seventeen please go to https://wordpress.org/d
 
 == Installation ==
 
-1. In your admin panel, go to Appearance -> Themes and click the 'Add New' button.
+1. In your admin panel, go to Appearance -> Themes and click the 'Add' button.
 2. Type in Twenty Seventeen in the search form and press the 'Enter' key on your keyboard.
 3. Click on the 'Activate' button to use your new theme right away.
 4. Go to https://wordpress.org/documentation/article/twenty-seventeen/ for a guide on how to customize this theme.

--- a/src/wp-content/themes/twentysixteen/readme.txt
+++ b/src/wp-content/themes/twentysixteen/readme.txt
@@ -22,7 +22,7 @@ For more information about Twenty Sixteen please go to https://wordpress.org/doc
 
 == Installation ==
 
-1. In your admin panel, go to Appearance -> Themes and click the 'Add New' button.
+1. In your admin panel, go to Appearance -> Themes and click the 'Add' button.
 2. Type in Twenty Sixteen in the search form and press the 'Enter' key on your keyboard.
 3. Click on the 'Activate' button to use your new theme right away.
 4. Go to https://wordpress.org/documentation/article/twenty-sixteen/ for a guide on how to customize this theme.

--- a/src/wp-content/themes/twentyten/readme.txt
+++ b/src/wp-content/themes/twentyten/readme.txt
@@ -15,7 +15,7 @@ For more information about Twenty Ten theme please go to https://codex.wordpress
 
 == Installation ==
 
-1. In your admin panel, go to Appearance -> Themes and click the 'Add New' button.
+1. In your admin panel, go to Appearance -> Themes and click the 'Add' button.
 2. Type in Twenty Ten in the search form and press the 'Enter' key in your keyboard.
 3. Click on the 'Activate' button to use your new theme right away.
 4. Go to https://codex.wordpress.org/Twenty_Ten for a guide to customize this theme.

--- a/src/wp-content/themes/twentythirteen/readme.txt
+++ b/src/wp-content/themes/twentythirteen/readme.txt
@@ -15,7 +15,7 @@ For more information about Twenty Thirteen please go to https://codex.wordpress.
 
 == Installation ==
 
-1. In your admin panel, go to Appearance -> Themes and click the 'Add New' button.
+1. In your admin panel, go to Appearance -> Themes and click the 'Add' button.
 2. Type in Twenty Thirteen in the search form and press the 'Enter' key in your keyboard.
 3. Click on the 'Activate' button to use your new theme right away.
 4. Go to https://codex.wordpress.org/Twenty_Thirteen for a guide to customize this theme.

--- a/src/wp-content/themes/twentytwelve/readme.txt
+++ b/src/wp-content/themes/twentytwelve/readme.txt
@@ -15,7 +15,7 @@ For more information about Twenty Twelve please go to https://codex.wordpress.or
 
 == Installation ==
 
-1. In your admin panel, go to Appearance -> Themes and click the 'Add New' button.
+1. In your admin panel, go to Appearance -> Themes and click the 'Add' button.
 2. Type in Twenty Twelve in the search form and press the 'Enter' key in your keyboard.
 3. Click on the 'Activate' button to use your new theme right away.
 4. Go to https://codex.wordpress.org/Twenty_Twelve for a guide to customize this theme.

--- a/src/wp-content/themes/twentytwentyone/readme.txt
+++ b/src/wp-content/themes/twentytwentyone/readme.txt
@@ -17,7 +17,7 @@ Take it for a spin! See how Twenty Twenty-One elevates your portfolio, business 
 
 == Installation ==
 
-1. In your admin panel, go to Appearance -> Themes and click the 'Add New' button.
+1. In your admin panel, go to Appearance -> Themes and click the 'Add' button.
 2. Type in Twenty Twenty-One in the search form and press the 'Enter' key on your keyboard.
 3. Click on the 'Activate' button to use your new theme right away.
 4. Go to INSERT ABOUT PAGE for a guide on how to customize this theme.

--- a/src/wp-includes/class-wp-customize-control.php
+++ b/src/wp-includes/class-wp-customize-control.php
@@ -631,7 +631,7 @@ class WP_Customize_Control {
 				<?php if ( $this->allow_addition && current_user_can( 'publish_pages' ) && current_user_can( 'edit_theme_options' ) ) : // Currently tied to menus functionality. ?>
 					<button type="button" class="button-link add-new-toggle">
 						<?php
-						/* translators: %s: Add New Page label. */
+						/* translators: %s: Add Page label. */
 						printf( __( '+ %s' ), get_post_type_object( 'page' )->labels->add_new_item );
 						?>
 					</button>

--- a/src/wp-includes/class-wp-post-type.php
+++ b/src/wp-includes/class-wp-post-type.php
@@ -962,8 +962,8 @@ final class WP_Post_Type {
 		self::$default_labels = array(
 			'name'                     => array( _x( 'Posts', 'post type general name' ), _x( 'Pages', 'post type general name' ) ),
 			'singular_name'            => array( _x( 'Post', 'post type singular name' ), _x( 'Page', 'post type singular name' ) ),
-			'add_new'                  => array( __( 'Add New Post' ), __( 'Add New Page' ) ),
-			'add_new_item'             => array( __( 'Add New Post' ), __( 'Add New Page' ) ),
+			'add_new'                  => array( __( 'Add Post' ), __( 'Add Page' ) ),
+			'add_new_item'             => array( __( 'Add Post' ), __( 'Add Page' ) ),
 			'edit_item'                => array( __( 'Edit Post' ), __( 'Edit Page' ) ),
 			'new_item'                 => array( __( 'New Post' ), __( 'New Page' ) ),
 			'view_item'                => array( __( 'View Post' ), __( 'View Page' ) ),

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -624,7 +624,7 @@ final class WP_Taxonomy {
 			'edit_item'                  => array( __( 'Edit Tag' ), __( 'Edit Category' ) ),
 			'view_item'                  => array( __( 'View Tag' ), __( 'View Category' ) ),
 			'update_item'                => array( __( 'Update Tag' ), __( 'Update Category' ) ),
-			'add_new_item'               => array( __( 'Add New Tag' ), __( 'Add New Category' ) ),
+			'add_new_item'               => array( __( 'Add Tag' ), __( 'Add Category' ) ),
 			'new_item_name'              => array( __( 'New Tag Name' ), __( 'New Category Name' ) ),
 			'separate_items_with_commas' => array( __( 'Separate tags with commas' ), null ),
 			'add_or_remove_items'        => array( __( 'Add or remove tags' ), null ),

--- a/src/wp-includes/customize/class-wp-customize-header-image-control.php
+++ b/src/wp-includes/customize/class-wp-customize-header-image-control.php
@@ -212,23 +212,23 @@ class WP_Customize_Header_Image_Control extends WP_Customize_Image_Control {
 			<p class="customizer-section-intro customize-control-description">
 				<?php
 				if ( current_theme_supports( 'custom-header', 'video' ) ) {
-					_e( 'Click &#8220;Add New Image&#8221; to upload an image file from your computer. Your theme works best with an image that matches the size of your video &#8212; you&#8217;ll be able to crop your image once you upload it for a perfect fit.' );
+					_e( 'Click &#8220;Add Image&#8221; to upload an image file from your computer. Your theme works best with an image that matches the size of your video &#8212; you&#8217;ll be able to crop your image once you upload it for a perfect fit.' );
 				} elseif ( $width && $height ) {
 					printf(
 						/* translators: %s: Header size in pixels. */
-						__( 'Click &#8220;Add New Image&#8221; to upload an image file from your computer. Your theme works best with an image with a header size of %s pixels &#8212; you&#8217;ll be able to crop your image once you upload it for a perfect fit.' ),
+						__( 'Click &#8220;Add Image&#8221; to upload an image file from your computer. Your theme works best with an image with a header size of %s pixels &#8212; you&#8217;ll be able to crop your image once you upload it for a perfect fit.' ),
 						sprintf( '<strong>%s &times; %s</strong>', $width, $height )
 					);
 				} elseif ( $width ) {
 					printf(
 						/* translators: %s: Header width in pixels. */
-						__( 'Click &#8220;Add New Image&#8221; to upload an image file from your computer. Your theme works best with an image with a header width of %s pixels &#8212; you&#8217;ll be able to crop your image once you upload it for a perfect fit.' ),
+						__( 'Click &#8220;Add Image&#8221; to upload an image file from your computer. Your theme works best with an image with a header width of %s pixels &#8212; you&#8217;ll be able to crop your image once you upload it for a perfect fit.' ),
 						sprintf( '<strong>%s</strong>', $width )
 					);
 				} else {
 					printf(
 						/* translators: %s: Header height in pixels. */
-						__( 'Click &#8220;Add New Image&#8221; to upload an image file from your computer. Your theme works best with an image with a header height of %s pixels &#8212; you&#8217;ll be able to crop your image once you upload it for a perfect fit.' ),
+						__( 'Click &#8220;Add Image&#8221; to upload an image file from your computer. Your theme works best with an image with a header height of %s pixels &#8212; you&#8217;ll be able to crop your image once you upload it for a perfect fit.' ),
 						sprintf( '<strong>%s</strong>', $height )
 					);
 				}
@@ -246,7 +246,7 @@ class WP_Customize_Header_Image_Control extends WP_Customize_Image_Control {
 			<div class="actions">
 				<?php if ( current_user_can( 'upload_files' ) ) : ?>
 				<button type="button"<?php echo $visibility; ?> class="button remove" aria-label="<?php esc_attr_e( 'Hide header image' ); ?>"><?php _e( 'Hide image' ); ?></button>
-				<button type="button" class="button new" id="header_image-button" aria-label="<?php esc_attr_e( 'Add New Header Image' ); ?>"><?php _e( 'Add New Image' ); ?></button>
+				<button type="button" class="button new" id="header_image-button" aria-label="<?php esc_attr_e( 'Add Header Image' ); ?>"><?php _e( 'Add Image' ); ?></button>
 				<?php endif; ?>
 			</div>
 			<div class="choices">

--- a/src/wp-includes/media-template.php
+++ b/src/wp-includes/media-template.php
@@ -222,7 +222,7 @@ function wp_print_media_templates() {
 		</div>
 	</script>
 
-	<?php // Template for the inline uploader, used for example in the Media Library admin page - Add New. ?>
+	<?php // Template for the inline uploader, used for example in the Media Library admin page - Add. ?>
 	<script type="text/html" id="tmpl-uploader-inline">
 		<# var messageClass = data.message ? 'has-upload-message' : 'no-upload-message'; #>
 		<# if ( data.canClose ) { #>

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -75,7 +75,7 @@ function create_initial_post_types() {
 			'labels'                => array(
 				'name'           => _x( 'Media', 'post type general name' ),
 				'name_admin_bar' => _x( 'Media', 'add new from admin bar' ),
-				'add_new'        => __( 'Add New Media File' ),
+				'add_new'        => __( 'Add Media File' ),
 				'edit_item'      => __( 'Edit Media' ),
 				'view_item'      => ( '1' === get_option( 'wp_attachment_pages_enabled' ) ) ? __( 'View Attachment Page' ) : __( 'View Media File' ),
 				'attributes'     => __( 'Attachment Attributes' ),
@@ -202,8 +202,8 @@ function create_initial_post_types() {
 			'labels'           => array(
 				'name'               => _x( 'Changesets', 'post type general name' ),
 				'singular_name'      => _x( 'Changeset', 'post type singular name' ),
-				'add_new'            => __( 'Add New Changeset' ),
-				'add_new_item'       => __( 'Add New Changeset' ),
+				'add_new'            => __( 'Add Changeset' ),
+				'add_new_item'       => __( 'Add Changeset' ),
 				'new_item'           => __( 'New Changeset' ),
 				'edit_item'          => __( 'Edit Changeset' ),
 				'view_item'          => __( 'View Changeset' ),
@@ -284,8 +284,8 @@ function create_initial_post_types() {
 			'labels'                => array(
 				'name'                     => _x( 'Patterns', 'post type general name' ),
 				'singular_name'            => _x( 'Pattern', 'post type singular name' ),
-				'add_new'                  => __( 'Add New Pattern' ),
-				'add_new_item'             => __( 'Add New Pattern' ),
+				'add_new'                  => __( 'Add Pattern' ),
+				'add_new_item'             => __( 'Add Pattern' ),
 				'new_item'                 => __( 'New Pattern' ),
 				'edit_item'                => __( 'Edit Block Pattern' ),
 				'view_item'                => __( 'View Pattern' ),
@@ -349,8 +349,8 @@ function create_initial_post_types() {
 			'labels'                          => array(
 				'name'                  => _x( 'Templates', 'post type general name' ),
 				'singular_name'         => _x( 'Template', 'post type singular name' ),
-				'add_new'               => __( 'Add New Template' ),
-				'add_new_item'          => __( 'Add New Template' ),
+				'add_new'               => __( 'Add Template' ),
+				'add_new_item'          => __( 'Add Template' ),
 				'new_item'              => __( 'New Template' ),
 				'edit_item'             => __( 'Edit Template' ),
 				'view_item'             => __( 'View Template' ),
@@ -414,8 +414,8 @@ function create_initial_post_types() {
 			'labels'                          => array(
 				'name'                  => _x( 'Template Parts', 'post type general name' ),
 				'singular_name'         => _x( 'Template Part', 'post type singular name' ),
-				'add_new'               => __( 'Add New Template Part' ),
-				'add_new_item'          => __( 'Add New Template Part' ),
+				'add_new'               => __( 'Add Template Part' ),
+				'add_new_item'          => __( 'Add Template Part' ),
 				'new_item'              => __( 'New Template Part' ),
 				'edit_item'             => __( 'Edit Template Part' ),
 				'view_item'             => __( 'View Template Part' ),
@@ -515,8 +515,8 @@ function create_initial_post_types() {
 			'labels'                => array(
 				'name'                  => _x( 'Navigation Menus', 'post type general name' ),
 				'singular_name'         => _x( 'Navigation Menu', 'post type singular name' ),
-				'add_new'               => __( 'Add New Navigation Menu' ),
-				'add_new_item'          => __( 'Add New Navigation Menu' ),
+				'add_new'               => __( 'Add Navigation Menu' ),
+				'add_new_item'          => __( 'Add Navigation Menu' ),
 				'new_item'              => __( 'New Navigation Menu' ),
 				'edit_item'             => __( 'Edit Navigation Menu' ),
 				'view_item'             => __( 'View Navigation Menu' ),
@@ -2016,7 +2016,7 @@ function _post_type_meta_capabilities( $capabilities = null ) {
  * - `name` - General name for the post type, usually plural. The same and overridden
  *          by `$post_type_object->label`. Default is 'Posts' / 'Pages'.
  * - `singular_name` - Name for one object of this post type. Default is 'Post' / 'Page'.
- * - `add_new` - Label for adding a new item. Default is 'Add New Post' / 'Add New Page'.
+ * - `add_new` - Label for adding a new item. Default is 'Add Post' / 'Add Page'.
  * - `add_new_item` - Label for adding a new singular item. Default is 'Add New Post' / 'Add New Page'.
  * - `edit_item` - Label for editing a singular item. Default is 'Edit Post' / 'Edit Page'.
  * - `new_item` - Label for the new item page title. Default is 'New Post' / 'New Page'.

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2017,7 +2017,7 @@ function _post_type_meta_capabilities( $capabilities = null ) {
  *          by `$post_type_object->label`. Default is 'Posts' / 'Pages'.
  * - `singular_name` - Name for one object of this post type. Default is 'Post' / 'Page'.
  * - `add_new` - Label for adding a new item. Default is 'Add Post' / 'Add Page'.
- * - `add_new_item` - Label for adding a new singular item. Default is 'Add New Post' / 'Add New Page'.
+ * - `add_new_item` - Label for adding a new singular item. Default is 'Add Post' / 'Add Page'.
  * - `edit_item` - Label for editing a singular item. Default is 'Edit Post' / 'Edit Page'.
  * - `new_item` - Label for the new item page title. Default is 'New Post' / 'New Page'.
  * - `view_item` - Label for viewing a singular item. Default is 'View Post' / 'View Page'.

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -146,7 +146,7 @@ function create_initial_taxonomies() {
 				'all_items'                  => __( 'All Link Categories' ),
 				'edit_item'                  => __( 'Edit Link Category' ),
 				'update_item'                => __( 'Update Link Category' ),
-				'add_new_item'               => __( 'Add New Link Category' ),
+				'add_new_item'               => __( 'Add Link Category' ),
 				'new_item_name'              => __( 'New Link Category Name' ),
 				'separate_items_with_commas' => null,
 				'add_or_remove_items'        => null,
@@ -233,7 +233,7 @@ function create_initial_taxonomies() {
 			'labels'             => array(
 				'name'                       => _x( 'Pattern Categories', 'taxonomy general name' ),
 				'singular_name'              => _x( 'Pattern Category', 'taxonomy singular name' ),
-				'add_new_item'               => __( 'Add New Category' ),
+				'add_new_item'               => __( 'Add Category' ),
 				'add_or_remove_items'        => __( 'Add or remove pattern categories' ),
 				'back_to_items'              => __( '&larr; Go to Pattern Categories' ),
 				'choose_from_most_used'      => __( 'Choose from the most used pattern categories' ),
@@ -677,7 +677,7 @@ function unregister_taxonomy( $taxonomy ) {
  *     @type string $edit_item                  Default 'Edit Tag'/'Edit Category'.
  *     @type string $view_item                  Default 'View Tag'/'View Category'.
  *     @type string $update_item                Default 'Update Tag'/'Update Category'.
- *     @type string $add_new_item               Default 'Add New Tag'/'Add New Category'.
+ *     @type string $add_new_item               Default 'Add Tag'/'Add Category'.
  *     @type string $new_item_name              Default 'New Tag Name'/'New Category Name'.
  *     @type string $separate_items_with_commas This label is only used for non-hierarchical taxonomies. Default
  *                                              'Separate tags with commas', used in the meta box.

--- a/tests/phpunit/tests/formatting/wpAutop.php
+++ b/tests/phpunit/tests/formatting/wpAutop.php
@@ -22,9 +22,9 @@ Upgrading is a couple of clicks!</p>
 <p>Then you can start enjoying the WordPress experience:</p>
 <ul>
 <li>Edit your personal information at <a href="%3$s" title="Edit settings like your password, your display name and your contact information">Users &#8250; Profile</a></li>
-<li>Start publishing at <a href="%4$s" title="Create a new post">Posts &#8250; Add New</a> and at <a href="%5$s" title="Create a new page">Pages &#8250; Add New</a></li>
-<li>Browse and install plugins at <a href="%6$s" title="Browse and install plugins at the official WordPress repository directly from your Dashboard">Plugins &#8250; Add New</a></li>
-<li>Browse and install themes at <a href="%7$s" title="Browse and install themes at the official WordPress repository directly from your Dashboard">Appearance &#8250; Add New Themes</a></li>
+<li>Start publishing at <a href="%4$s" title="Create a new post">Posts &#8250; Add</a> and at <a href="%5$s" title="Create a new page">Pages &#8250; Add</a></li>
+<li>Browse and install plugins at <a href="%6$s" title="Browse and install plugins at the official WordPress repository directly from your Dashboard">Plugins &#8250; Add</a></li>
+<li>Browse and install themes at <a href="%7$s" title="Browse and install themes at the official WordPress repository directly from your Dashboard">Appearance &#8250; Add Themes</a></li>
 <li>Modify and prettify your website&#8217;s links at <a href="%8$s" title="For example, select a link structure like: http://example.com/1999/12/post-name">Settings &#8250; Permalinks</a></li>
 <li>Import content from another system or WordPress site at <a href="%9$s" title="WordPress comes with importers for the most common publishing systems">Tools &#8250; Import</a></li>
 <li>Find answers to your questions at the <a href="%10$s" title="The official WordPress documentation, maintained by the WordPress community">WordPress Codex</a></li>
@@ -47,9 +47,9 @@ Upgrading is a couple of clicks!
 Then you can start enjoying the WordPress experience:
 <ul>
 <li>Edit your personal information at <a href="%3$s" title="Edit settings like your password, your display name and your contact information">Users &#8250; Profile</a></li>
-<li>Start publishing at <a href="%4$s" title="Create a new post">Posts &#8250; Add New</a> and at <a href="%5$s" title="Create a new page">Pages &#8250; Add New</a></li>
-<li>Browse and install plugins at <a href="%6$s" title="Browse and install plugins at the official WordPress repository directly from your Dashboard">Plugins &#8250; Add New</a></li>
-<li>Browse and install themes at <a href="%7$s" title="Browse and install themes at the official WordPress repository directly from your Dashboard">Appearance &#8250; Add New Themes</a></li>
+<li>Start publishing at <a href="%4$s" title="Create a new post">Posts &#8250; Add</a> and at <a href="%5$s" title="Create a new page">Pages &#8250; Add</a></li>
+<li>Browse and install plugins at <a href="%6$s" title="Browse and install plugins at the official WordPress repository directly from your Dashboard">Plugins &#8250; Add</a></li>
+<li>Browse and install themes at <a href="%7$s" title="Browse and install themes at the official WordPress repository directly from your Dashboard">Appearance &#8250; Add Themes</a></li>
 <li>Modify and prettify your website&#8217;s links at <a href="%8$s" title="For example, select a link structure like: http://example.com/1999/12/post-name">Settings &#8250; Permalinks</a></li>
 <li>Import content from another system or WordPress site at <a href="%9$s" title="WordPress comes with importers for the most common publishing systems">Tools &#8250; Import</a></li>
 <li>Find answers to your questions at the <a href="%10$s" title="The official WordPress documentation, maintained by the WordPress community">WordPress Codex</a></li>

--- a/tests/phpunit/tests/l10n/wpTranslationsConvert.php
+++ b/tests/phpunit/tests/l10n/wpTranslationsConvert.php
@@ -398,7 +398,7 @@ class WP_Translation_Controller_Convert_Tests extends WP_UnitTestCase {
 		$this->assertFalse( $controller->translate( "string that doesn't exist", '', 'unittest' ) );
 
 		$this->assertSame( 'رونوشت‌ها فعال نشدند.', $controller->translate( 'Revisions not enabled.', '', 'unittest' ) );
-		$this->assertSame( 'افزودن جدید', $controller->translate( 'Add New', 'file', 'unittest' ) );
+		$this->assertSame( 'افزودن جدید', $controller->translate( 'Add', 'file', 'unittest' ) );
 
 		$this->assertSame( '%s دیدگاه', $controller->translate_plural( array( '%s comment', '%s comments' ), 0, '', 'unittest' ) );
 		$this->assertSame( '%s دیدگاه', $controller->translate_plural( array( '%s comment', '%s comments' ), 1, '', 'unittest' ) );

--- a/tests/visual-regression/specs/visual-snapshots.test.js
+++ b/tests/visual-regression/specs/visual-snapshots.test.js
@@ -35,9 +35,9 @@ test.describe( 'Admin Visual Snapshots', () => {
 		});
 	} );
 
-	test( 'Add New Media', async ({ admin, page }) => {
+	test( 'Add Media', async ({ admin, page }) => {
 		await admin.visitAdminPage( '/media-new.php' );
-		await expect( page ).toHaveScreenshot( 'Add New Media.png', {
+		await expect( page ).toHaveScreenshot( 'Add Media.png', {
 			mask: elementsToHide.map( ( selector ) => page.locator( selector ) ),
 		});
 	} );
@@ -84,9 +84,9 @@ test.describe( 'Admin Visual Snapshots', () => {
 		});
 	} );
 
-	test( 'Add New User', async ({ admin, page }) => {
+	test( 'Add User', async ({ admin, page }) => {
 		await admin.visitAdminPage( '/user-new.php' );
-		await expect( page ).toHaveScreenshot( 'Add New User.png', {
+		await expect( page ).toHaveScreenshot( 'Add User.png', {
 			mask: [
 					...elementsToHide,
 					'.password-input-wrapper'


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/61219

If "new" is removed from the add_new_item string for core post types then button labels can be shortened, and title case (which is inconsistent with Gutenberg buttons) sidestepped.

"Add New Post" → "Add Post"
"Add New Page" → "Add Page"
"Add New User" → "Add User"
"Add New Theme" → "Add Theme"
And so on.

It's most problematic in the Site Editor where labels like "Add New Template Part" feel unnecessarily verbose.

Description is from the ticket.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
