### PR TITLE
Improve security key handling in pluggable.php

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2448,15 +2448,22 @@ if ( ! function_exists( 'wp_salt' ) ) :
 			 * https://i18n.svn.wordpress.org/<locale code>/branches/<wp version>/dist/wp-config-sample.php
 			 */
 			$duplicated_keys[ __( 'put your unique phrase here' ) ] = true;
+			$option_prime = array();
 
 			foreach ( array( 'AUTH', 'SECURE_AUTH', 'LOGGED_IN', 'NONCE', 'SECRET' ) as $first ) {
 				foreach ( array( 'KEY', 'SALT' ) as $second ) {
 					if ( ! defined( "{$first}_{$second}" ) ) {
+						if ( 'SECRET' !== $first ) {
+							$option_prime[] = strtolower( "{$first}_{$second}" );
+						}
 						continue;
 					}
 					$value                     = constant( "{$first}_{$second}" );
 					$duplicated_keys[ $value ] = isset( $duplicated_keys[ $value ] );
 				}
+			}
+			if ( $option_prime ) {
+				wp_prime_site_option_caches( $option_prime );
 			}
 		}
 


### PR DESCRIPTION
Requires [#61053](https://core.trac.wordpress.org/ticket/61053). 

Use `wp_prime_site_option_caches` to prime option / network option caches if not defined as const. 

Trac ticket: https://core.trac.wordpress.org/ticket/59871

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
