### PR TITLE
Add valid preferred_ext check in wp_mime_type_icon and unit testcase …

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6862,7 +6862,7 @@ function wp_mime_type_icon( $mime = 0, $preferred_ext = '.png' ) {
 		$icon = wp_cache_get( "mime_type_icon_$mime" );
 	}
 
-	// Check preferred file format is available and if it is begins with a period or not.
+	// Check if preferred file format variable is present and is a validly formatted file extension.
 	if ( ! empty( $preferred_ext ) && is_string( $preferred_ext ) && ! str_starts_with( $preferred_ext, '.' ) ) {
 		$preferred_ext = '.' . strtolower( $preferred_ext );
 	}

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6862,6 +6862,11 @@ function wp_mime_type_icon( $mime = 0, $preferred_ext = '.png' ) {
 		$icon = wp_cache_get( "mime_type_icon_$mime" );
 	}
 
+	// Check preferred file format is available and if it is begins with a period or not.
+	if ( ! empty( $preferred_ext ) && is_string( $preferred_ext ) && ! str_starts_with( $preferred_ext, '.' ) ) {
+		$preferred_ext = '.' . strtolower( $preferred_ext );
+	}
+
 	$post_id = 0;
 	if ( empty( $icon ) ) {
 		$post_mimes = array();

--- a/tests/phpunit/tests/post/attachments.php
+++ b/tests/phpunit/tests/post/attachments.php
@@ -527,7 +527,7 @@ class Tests_Post_Attachments extends WP_UnitTestCase {
 		$icon1 = wp_mime_type_icon( 'video/mp4', '.png' ); // Added `$preferred_ext` parameter.
 		$icon2 = wp_mime_type_icon( 'video/mp4', 'png' ); // Added `$preferred_ext` parameter without period.
 
-		$this->assertStringContainsString( 'images/media/video.png', $icon1 );
-		$this->assertStringContainsString( 'images/media/video.png', $icon2 );
+		$this->assertStringContainsString( 'images/media/video.png', $icon1, 'Mime type icon should be correctly returned with ".png" argument.' );
+		$this->assertStringContainsString( 'images/media/video.png', $icon2, 'Mime type icon should be correctly returned with ".png" argument.' );
 	}
 }

--- a/tests/phpunit/tests/post/attachments.php
+++ b/tests/phpunit/tests/post/attachments.php
@@ -519,4 +519,15 @@ class Tests_Post_Attachments extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'images/media/video.png', $icon );
 	}
+
+	/**
+	 * @ticket 60610
+	 */
+	public function test_wp_mime_type_icon_video_with_preferred_ext() {
+		$icon1 = wp_mime_type_icon( 'video/mp4', '.png' ); // Added `$preferred_ext` parameter.
+		$icon2 = wp_mime_type_icon( 'video/mp4', 'png' ); // Added `$preferred_ext` parameter without period.
+
+		$this->assertStringContainsString( 'images/media/video.png', $icon1 );
+		$this->assertStringContainsString( 'images/media/video.png', $icon2 );
+	}
 }


### PR DESCRIPTION
…for it

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Add `$preferred_ext` check in function `wp_mime_type_icon` with proper unit test cases.

Trac ticket: [#60610](https://core.trac.wordpress.org/ticket/60610)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
