### PR TITLE
Update class-phpass.php to use crypt_blowfish '$2y$' prefix

### DIFF
--- a/src/wp-includes/class-phpass.php
+++ b/src/wp-includes/class-phpass.php
@@ -3,14 +3,14 @@
  * Portable PHP password hashing framework.
  * @package phpass
  * @since 2.5.0
- * @version 0.5 / WordPress
+ * @version 0.5.1 / WordPress
  * @link https://www.openwall.com/phpass/
  */
 
 #
 # Portable PHP password hashing framework.
 #
-# Version 0.5 / WordPress.
+# Version 0.5.1 / WordPress.
 #
 # Written by Solar Designer <solar at openwall.com> in 2004-2006 and placed in
 # the public domain.  Revised in subsequent years, still public domain.
@@ -33,14 +33,6 @@
 # requirements (there can be none), but merely suggestions.
 #
 
-/**
- * Portable PHP password hashing framework.
- *
- * @package phpass
- * @version 0.5 / WordPress
- * @link https://www.openwall.com/phpass/
- * @since 2.5.0
- */
 class PasswordHash {
 	var $itoa64;
 	var $iteration_count_log2;
@@ -172,7 +164,9 @@ class PasswordHash {
 		# of entropy.
 		$itoa64 = './ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
-		$output = '$2a$';
+		# Use prefix '2y' for new hashes for PHP versions 5.2.7 and later
+		# Use BSD '2a' for PHP versions prior to 5.2.7
+		$output = PHP_VERSION_ID < 50307 ? '$2a$' : '$2y$';
 		$output .= chr((int)(ord('0') + $this->iteration_count_log2 / 10));
 		$output .= chr((ord('0') + $this->iteration_count_log2 % 10));
 		$output .= '$';
@@ -247,4 +241,10 @@ class PasswordHash {
 		# cases (that is, when we use /dev/urandom and bcrypt).
 		return $hash === $stored_hash;
 	}
+}
+
+# Define PHP_VERSION_ID for PHP versions prior to 5.2.7
+if (!defined('PHP_VERSION_ID')) {
+	$version = explode('.', PHP_VERSION);
+	define('PHP_VERSION_ID', ($version[0] * 10000 + $version[1] * 100 + $version[2]));
 }


### PR DESCRIPTION
Updated gensalt_blowfish() to use the prefix '$2y' for PHP versions 5.2.7 and later Added backwards compatible define for PHP_VERSION_ID Removed duplicate PHPDOC comment

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/61258

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
