### PR TITLE
Try: Render variation alias blocks (set canonical name early)

### DIFF
--- a/src/wp-includes/block-supports/generated-classname.php
+++ b/src/wp-includes/block-supports/generated-classname.php
@@ -60,7 +60,7 @@ function wp_apply_generated_classname_support( $block_type, $block_attributes ) 
 
 		$variation = infer_block_variation( $block_type, $block_attributes );
 		if ( $variation ) {
-			$attributes['class'] .= ' ' . $block_classname . '-' . $variation;
+			$attributes['class'] .= ' ' . wp_get_block_default_classname( $block_type->name . '/' . $variation );
 		}
 	}
 

--- a/src/wp-includes/block-supports/generated-classname.php
+++ b/src/wp-includes/block-supports/generated-classname.php
@@ -48,7 +48,7 @@ function wp_get_block_default_classname( $block_name ) {
  * @param WP_Block_Type $block_type Block Type.
  * @return array Block CSS classes and inline styles.
  */
-function wp_apply_generated_classname_support( $block_type ) {
+function wp_apply_generated_classname_support( $block_type, $block_attributes ) {
 	$attributes                      = array();
 	$has_generated_classname_support = block_has_support( $block_type, 'className', true );
 	if ( $has_generated_classname_support ) {
@@ -56,6 +56,11 @@ function wp_apply_generated_classname_support( $block_type ) {
 
 		if ( $block_classname ) {
 			$attributes['class'] = $block_classname;
+		}
+
+		$variation = infer_block_variation( $block_type, $block_attributes );
+		if ( $variation ) {
+			$attributes['class'] .= ' ' . $block_classname . '-' . $variation;
 		}
 	}
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2356,3 +2356,36 @@ function _wp_footnotes_force_filtered_html_on_import_filter( $arg ) {
 	}
 	return $arg;
 }
+
+/**
+ * Checks if the block name is a variation of a block. Variations follow a specific format
+ * of `namespace/block-name/variation-name`.
+ *
+ * @access private
+ * @since 6.6.0
+ *
+ * @param string $block_name
+ * @return boolean
+ */
+function block_is_variation( $block_name ) {
+	return substr_count( $block_name, '/' ) === 2;
+}
+
+/**
+ * Returns the canonical block name for a block. If the block is a variation, it will return
+ * the block name without the variation name.
+ *
+ * @access private
+ * @since 6.6.0
+ *
+ * @param string $block_name
+ * @return string
+ */
+function get_canonical_block_name( $block_name ) {
+	if ( block_is_variation( $block_name ) ) {
+		$parts = explode( '/', $block_name );
+		return $parts[0] . '/' . $parts[1];
+	}
+
+	return $block_name;
+}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2390,11 +2390,11 @@ function get_canonical_block_name( $block_name ) {
 	return $block_name;
 }
 
-function infer_block_variation( $block_type, $attributes ) {
+function infer_block_variation( $block_type, $block_attributes ) {
 	$variations = $block_type->get_variations();
 	foreach ( $variations as $variation ) {
 		foreach ( $variation['attributes'] as $attribute => $value ) {
-			if ( ! isset( $attributes[ $attribute ] ) || $attributes[ $attribute ] !== $value ) {
+			if ( ! isset( $block_attributes[ $attribute ] ) || $block_attributes[ $attribute ] !== $value ) {
 				continue 2;
 			}
 		}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2389,3 +2389,15 @@ function get_canonical_block_name( $block_name ) {
 
 	return $block_name;
 }
+
+function infer_block_variation( $block_type, $attributes ) {
+	$variations = $block_type->get_variations();
+	foreach ( $variations as $variation ) {
+		foreach ( $variation['attributes'] as $attribute => $value ) {
+			if ( ! isset( $attributes[ $attribute ] ) || $attributes[ $attribute ] !== $value ) {
+				continue 2;
+			}
+		}
+		return $variation['name'];
+	}
+}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2393,7 +2393,11 @@ function get_canonical_block_name( $block_name ) {
 function infer_block_variation( $block_type, $block_attributes ) {
 	$variations = $block_type->get_variations();
 	foreach ( $variations as $variation ) {
-		foreach ( $variation['attributes'] as $attribute => $value ) {
+		$attributes = $variation['attributes'];
+		if ( isset( $variation['isActive'] ) && is_array( $variation['isActive'] ) ) {
+			$attributes = array_intersect_key( $attributes, array_flip( $variation['isActive'] ) );
+		}
+		foreach ( $attributes as $attribute => $value ) {
 			if ( ! isset( $block_attributes[ $attribute ] ) || $block_attributes[ $attribute ] !== $value ) {
 				continue 2;
 			}

--- a/src/wp-includes/class-wp-block-parser.php
+++ b/src/wp-includes/class-wp-block-parser.php
@@ -245,7 +245,7 @@ class WP_Block_Parser {
 		 * match back in PHP to see which one it was.
 		 */
 		$has_match = preg_match(
-			'/<!--\s+(?P<closer>\/)?wp:(?P<namespace>[a-z][a-z0-9_-]*\/)?(?P<name>[a-z][a-z0-9_-]*)\s+(?P<attrs>{(?:(?:[^}]+|}+(?=})|(?!}\s+\/?-->).)*+)?}\s+)?(?P<void>\/)?-->/s',
+			'/<!--\s+(?P<closer>\/)?wp:(?P<namespace>[a-z][a-z0-9_-]*\/)?(?P<name>[a-z][a-z0-9_-]*)(?:\/(?P<variation>[a-z][a-z0-9_-]*))?\s+(?P<attrs>{(?:(?:[^}]+|}+(?=})|(?!}\s+\/?-->).)*+)?}\s+)?(?P<void>\/)?-->/s',
 			$this->document,
 			$matches,
 			PREG_OFFSET_CAPTURE,
@@ -264,13 +264,14 @@ class WP_Block_Parser {
 
 		list( $match, $started_at ) = $matches[0];
 
-		$length    = strlen( $match );
-		$is_closer = isset( $matches['closer'] ) && -1 !== $matches['closer'][1];
-		$is_void   = isset( $matches['void'] ) && -1 !== $matches['void'][1];
-		$namespace = $matches['namespace'];
-		$namespace = ( isset( $namespace ) && -1 !== $namespace[1] ) ? $namespace[0] : 'core/';
-		$name      = $namespace . $matches['name'][0];
-		$has_attrs = isset( $matches['attrs'] ) && -1 !== $matches['attrs'][1];
+		$length       = strlen( $match );
+		$is_closer    = isset( $matches['closer'] ) && -1 !== $matches['closer'][1];
+		$is_void      = isset( $matches['void'] ) && -1 !== $matches['void'][1];
+		$is_variation = isset( $matches['variation'] ) && -1 !== $matches['variation'][1];
+		$namespace    = $matches['namespace'];
+		$namespace    = ( isset( $namespace ) && -1 !== $namespace[1] ) ? $namespace[0] : 'core/';
+		$name         = $is_variation ? $namespace . $matches['name'][0] . '/' . $matches['variation'][0] : $namespace . $matches['name'][0];
+		$has_attrs    = isset( $matches['attrs'] ) && -1 !== $matches['attrs'][1];
 
 		/*
 		 * Fun fact! It's not trivial in PHP to create "an empty associative array" since all arrays

--- a/src/wp-includes/class-wp-block-supports.php
+++ b/src/wp-includes/class-wp-block-supports.php
@@ -95,7 +95,7 @@ class WP_Block_Supports {
 	 */
 	public function apply_block_supports() {
 		$block_type = WP_Block_Type_Registry::get_instance()->get_registered(
-			self::$block_to_render['blockName']
+			get_canonical_block_name( self::$block_to_render['blockName'] )
 		);
 
 		// If no render_callback, assume styles have been previously handled.

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -136,7 +136,8 @@ class WP_Block {
 
 		$this->registry = $registry;
 
-		$this->block_type = $registry->get_registered( $this->name );
+		$block_name       = $this->get_canonical_block_name( $this->name );
+		$this->block_type = $registry->get_registered( $block_name );
 
 		$this->available_context = $available_context;
 
@@ -169,6 +170,19 @@ class WP_Block {
 		if ( ! empty( $block['innerContent'] ) ) {
 			$this->inner_content = $block['innerContent'];
 		}
+	}
+
+	public function is_variant( $name ) {
+		return substr_count( $this->name, '/' ) === 2;
+	}
+
+	public function get_canonical_block_name( $name ) {
+		if ( $this->is_variant( $name ) ) {
+			$parts = explode( '/', $name );
+			return $parts[0] . '/' . $parts[1];
+		}
+
+		return $name;
 	}
 
 	/**

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -173,7 +173,7 @@ class WP_Block {
 	}
 
 	public function is_variant( $name ) {
-		return substr_count( $this->name, '/' ) === 2;
+		return substr_count( $name, '/' ) === 2;
 	}
 
 	public function get_canonical_block_name( $name ) {

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -128,7 +128,7 @@ class WP_Block {
 	 */
 	public function __construct( $block, $available_context = array(), $registry = null ) {
 		$this->parsed_block = $block;
-		$this->name         = $block['blockName'];
+		$this->name         = get_canonical_block_name( $block['blockName'] );
 
 		if ( is_null( $registry ) ) {
 			$registry = WP_Block_Type_Registry::get_instance();
@@ -136,8 +136,7 @@ class WP_Block {
 
 		$this->registry = $registry;
 
-		$block_name       = $this->get_canonical_block_name( $this->name );
-		$this->block_type = $registry->get_registered( $block_name );
+		$this->block_type = $registry->get_registered( $this->name );
 
 		$this->available_context = $available_context;
 
@@ -170,19 +169,6 @@ class WP_Block {
 		if ( ! empty( $block['innerContent'] ) ) {
 			$this->inner_content = $block['innerContent'];
 		}
-	}
-
-	public function is_variant( $name ) {
-		return substr_count( $name, '/' ) === 2;
-	}
-
-	public function get_canonical_block_name( $name ) {
-		if ( $this->is_variant( $name ) ) {
-			$parts = explode( '/', $name );
-			return $parts[0] . '/' . $parts[1];
-		}
-
-		return $name;
 	}
 
 	/**


### PR DESCRIPTION
This is a variation (no pun intended) of @tjcafferkey's #6555. It's the same commits, but cut off after 52d6b3d926ed8fc2af6eba4c79a4fecd6aa32767 -- i.e. with no changes to the `WP_Block_Type` and `WP_Block_Type_Registry` classes. Instead, the canonical block name is extracted early on during instantiation of the `WP_Block` instance, and used to interact with those other classes.

This seems to be working for me:

<img width="334" alt="image" src="https://github.com/WordPress/wordpress-develop/assets/96308/097474cd-c7bb-46ea-aff4-b38b2252925a">

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
