### PR TITLE
Build: Add globalThis DefinePlugin config to webpack

### DIFF
--- a/tools/webpack/shared.js
+++ b/tools/webpack/shared.js
@@ -41,6 +41,26 @@ const getBaseConfig = ( env ) => {
 		watch: env.watch,
 		plugins: [
 			new DefinePlugin( {
+				/*
+				 * These variables are part of https://github.com/WordPress/gutenberg/pull/61486
+				 * They're expected to be released in an upcoming version of Gutenberg.
+				 *
+				 * Defining this before the packages are released is harmless.
+				 *
+				 * @todo Remove the non-globalThis defines here when packages have been upgraded to the globalThis versions.
+				 */
+
+				// Inject the `IS_GUTENBERG_PLUGIN` global, used for feature flagging.
+				'globalThis.IS_GUTENBERG_PLUGIN': JSON.stringify(
+					Boolean( process.env.npm_package_config_IS_GUTENBERG_PLUGIN )
+				),
+				// Inject the `IS_WORDPRESS_CORE` global, used for feature flagging.
+				'globalThis.IS_WORDPRESS_CORE': JSON.stringify(
+					Boolean( process.env.npm_package_config_IS_WORDPRESS_CORE )
+				),
+				// Inject the `SCRIPT_DEBUG` global, used for dev versions of JavaScript.
+				'globalThis.SCRIPT_DEBUG': JSON.stringify( mode === 'development' ),
+
 				// Inject the `IS_GUTENBERG_PLUGIN` global, used for feature flagging.
 				'process.env.IS_GUTENBERG_PLUGIN': false,
 				// Inject the `IS_WORDPRESS_CORE` global, used for feature flagging.

--- a/tools/webpack/shared.js
+++ b/tools/webpack/shared.js
@@ -51,22 +51,20 @@ const getBaseConfig = ( env ) => {
 				 */
 
 				// Inject the `IS_GUTENBERG_PLUGIN` global, used for feature flagging.
-				'globalThis.IS_GUTENBERG_PLUGIN': JSON.stringify(
-					Boolean( process.env.npm_package_config_IS_GUTENBERG_PLUGIN )
-				),
+				'globalThis.IS_GUTENBERG_PLUGIN': JSON.stringify( false ),
 				// Inject the `IS_WORDPRESS_CORE` global, used for feature flagging.
-				'globalThis.IS_WORDPRESS_CORE': JSON.stringify(
-					Boolean( process.env.npm_package_config_IS_WORDPRESS_CORE )
-				),
+				'globalThis.IS_WORDPRESS_CORE': JSON.stringify( true ),
 				// Inject the `SCRIPT_DEBUG` global, used for dev versions of JavaScript.
-				'globalThis.SCRIPT_DEBUG': JSON.stringify( mode === 'development' ),
+				'globalThis.SCRIPT_DEBUG': JSON.stringify(
+					mode === 'development'
+				),
 
 				// Inject the `IS_GUTENBERG_PLUGIN` global, used for feature flagging.
-				'process.env.IS_GUTENBERG_PLUGIN': false,
+				'process.env.IS_GUTENBERG_PLUGIN': JSON.stringify( false ),
 				// Inject the `IS_WORDPRESS_CORE` global, used for feature flagging.
-				'process.env.IS_WORDPRESS_CORE': true,
+				'process.env.IS_WORDPRESS_CORE': JSON.stringify( true ),
 				// Inject the `SCRIPT_DEBUG` global, used for dev versions of JavaScript.
-				SCRIPT_DEBUG: mode === 'development',
+				SCRIPT_DEBUG: JSON.stringify( mode === 'development' ),
 			} ),
 		],
 	};


### PR DESCRIPTION
This updates the build to account for the following PR:

https://github.com/WordPress/gutenberg/pull/61486

This affects the build of JavaScript packages to ensure dead-code elimination works correctly.

It should be harmless to land this PR before packages are updated. The older configuration can be removed after the packages are updated.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/61262

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
