### PR TITLE
Block variations: Add class name

### DIFF
--- a/src/wp-includes/block-supports/generated-classname.php
+++ b/src/wp-includes/block-supports/generated-classname.php
@@ -60,7 +60,7 @@ function wp_apply_generated_classname_support( $block_type, $block_attributes ) 
 
 		$variation = infer_block_variation( $block_type, $block_attributes );
 		if ( $variation ) {
-			$attributes['class'] .= ' ' . $block_classname . '-' . $variation;
+			$attributes['class'] .= ' ' . wp_get_block_default_classname( $block_type->name . '/' . $variation );
 		}
 	}
 

--- a/src/wp-includes/block-supports/generated-classname.php
+++ b/src/wp-includes/block-supports/generated-classname.php
@@ -58,7 +58,7 @@ function wp_apply_generated_classname_support( $block_type, $block_attributes ) 
 			$attributes['class'] = $block_classname;
 		}
 
-		$variation = infer_block_variation( $block_type, $block_attributes );
+		$variation = get_active_block_variation( $block_type, $block_attributes );
 		if ( $variation ) {
 			$attributes['class'] .= ' ' . wp_get_block_default_classname( $block_type->name . '/' . $variation );
 		}

--- a/src/wp-includes/block-supports/generated-classname.php
+++ b/src/wp-includes/block-supports/generated-classname.php
@@ -60,7 +60,9 @@ function wp_apply_generated_classname_support( $block_type, $block_attributes ) 
 
 		$variation = get_active_block_variation( $block_type, $block_attributes );
 		if ( $variation ) {
-			$attributes['class'] .= ' ' . wp_get_block_default_classname( $block_type->name . '/' . $variation['name'] );
+			$attributes['class'] .= ' ' . wp_get_block_default_classname(
+				$block_type->name . '/' . $variation['name']
+			);
 		}
 	}
 

--- a/src/wp-includes/block-supports/generated-classname.php
+++ b/src/wp-includes/block-supports/generated-classname.php
@@ -42,10 +42,12 @@ function wp_get_block_default_classname( $block_name ) {
  * Adds the generated classnames to the output.
  *
  * @since 5.6.0
+ * @since 6.6.0 Add a class name for the active block variation, if any.
  *
  * @access private
  *
- * @param WP_Block_Type $block_type Block Type.
+ * @param WP_Block_Type  $block_type Block Type.
+ * @param  array         $block_attributes Block attributes.
  * @return array Block CSS classes and inline styles.
  */
 function wp_apply_generated_classname_support( $block_type, $block_attributes ) {

--- a/src/wp-includes/block-supports/generated-classname.php
+++ b/src/wp-includes/block-supports/generated-classname.php
@@ -48,7 +48,7 @@ function wp_get_block_default_classname( $block_name ) {
  * @param WP_Block_Type $block_type Block Type.
  * @return array Block CSS classes and inline styles.
  */
-function wp_apply_generated_classname_support( $block_type ) {
+function wp_apply_generated_classname_support( $block_type, $block_attributes ) {
 	$attributes                      = array();
 	$has_generated_classname_support = block_has_support( $block_type, 'className', true );
 	if ( $has_generated_classname_support ) {
@@ -56,6 +56,11 @@ function wp_apply_generated_classname_support( $block_type ) {
 
 		if ( $block_classname ) {
 			$attributes['class'] = $block_classname;
+		}
+
+		$variation = infer_block_variation( $block_type, $block_attributes );
+		if ( $variation ) {
+			$attributes['class'] .= ' ' . $block_classname . '-' . $variation;
 		}
 	}
 

--- a/src/wp-includes/block-supports/generated-classname.php
+++ b/src/wp-includes/block-supports/generated-classname.php
@@ -47,7 +47,7 @@ function wp_get_block_default_classname( $block_name ) {
  * @access private
  *
  * @param WP_Block_Type  $block_type Block Type.
- * @param  array         $block_attributes Block attributes.
+ * @param array          $block_attributes Block attributes.
  * @return array Block CSS classes and inline styles.
  */
 function wp_apply_generated_classname_support( $block_type, $block_attributes ) {

--- a/src/wp-includes/block-supports/generated-classname.php
+++ b/src/wp-includes/block-supports/generated-classname.php
@@ -60,7 +60,7 @@ function wp_apply_generated_classname_support( $block_type, $block_attributes ) 
 
 		$variation = get_active_block_variation( $block_type, $block_attributes );
 		if ( $variation ) {
-			$attributes['class'] .= ' ' . wp_get_block_default_classname( $block_type->name . '/' . $variation );
+			$attributes['class'] .= ' ' . wp_get_block_default_classname( $block_type->name . '/' . $variation['name'] );
 		}
 	}
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2681,7 +2681,11 @@ function _wp_footnotes_force_filtered_html_on_import_filter( $arg ) {
 function get_active_block_variation( $block_type, $block_attributes ) {
 	foreach ( $block_type->get_variations() as $variation ) {
 		$attributes = $variation['attributes'];
-		if ( isset( $variation['isActive'] ) && is_array( $variation['isActive'] ) ) {
+		if (
+			isset( $variation['isActive'] ) &&
+			is_array( $variation['isActive'] ) &&
+			! empty( $variation['isActive'] )
+		) {
 			$attributes = $variation['isActive'];
 		} else {
 			$attributes = array_keys( $variation['attributes'] );

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2667,7 +2667,11 @@ function _wp_footnotes_force_filtered_html_on_import_filter( $arg ) {
 function infer_block_variation( $block_type, $block_attributes ) {
 	$variations = $block_type->get_variations();
 	foreach ( $variations as $variation ) {
-		foreach ( $variation['attributes'] as $attribute => $value ) {
+		$attributes = $variation['attributes'];
+		if ( isset( $variation['isActive'] ) && is_array( $variation['isActive'] ) ) {
+			$attributes = array_intersect_key( $attributes, array_flip( $variation['isActive'] ) );
+		}
+		foreach ( $attributes as $attribute => $value ) {
 			if ( ! isset( $block_attributes[ $attribute ] ) || $block_attributes[ $attribute ] !== $value ) {
 				continue 2;
 			}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2664,11 +2664,11 @@ function _wp_footnotes_force_filtered_html_on_import_filter( $arg ) {
 	return $arg;
 }
 
-function infer_block_variation( $block_type, $attributes ) {
+function infer_block_variation( $block_type, $block_attributes ) {
 	$variations = $block_type->get_variations();
 	foreach ( $variations as $variation ) {
 		foreach ( $variation['attributes'] as $attribute => $value ) {
-			if ( ! isset( $attributes[ $attribute ] ) || $attributes[ $attribute ] !== $value ) {
+			if ( ! isset( $block_attributes[ $attribute ] ) || $block_attributes[ $attribute ] !== $value ) {
 				continue 2;
 			}
 		}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2678,4 +2678,5 @@ function get_active_block_variation( $block_type, $block_attributes ) {
 		}
 		return $variation;
 	}
+	return null;
 }

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2671,9 +2671,6 @@ function _wp_footnotes_force_filtered_html_on_import_filter( $arg ) {
  * block attribute keys that are compared to the given block's attributes using
  * a strict equality check.
  *
- * If no `isActive` property is defined, all `attributes` specified by a variation
- * are compared to the given block's to determine if the variation is active.
- *
  * @param WP_Block_Type $block_type       Block Type.
  * @param array         $block_attributes Block attributes.
  * @return array|null The active block variation, or null if no active variation is found.
@@ -2686,8 +2683,6 @@ function get_active_block_variation( $block_type, $block_attributes ) {
 			! empty( $variation['isActive'] )
 		) {
 			$attributes = $variation['isActive'];
-		} else if ( isset( $variation['attributes'] ) ) {
-			$attributes = array_keys( $variation['attributes'] );
 		} else {
 			// We have no way to determine if this is the active variation.
 			continue;

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2689,7 +2689,8 @@ function get_active_block_variation( $block_type, $block_attributes ) {
 		} else if ( isset( $variation['attributes'] ) ) {
 			$attributes = array_keys( $variation['attributes'] );
 		} else {
-			return null; // TODO: Compare innerBlocks.
+			// We have no way to determine if this is the active variation.
+			continue;
 		}
 
 		foreach ( $attributes as $attribute ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2663,3 +2663,15 @@ function _wp_footnotes_force_filtered_html_on_import_filter( $arg ) {
 	}
 	return $arg;
 }
+
+function infer_block_variation( $block_type, $attributes ) {
+	$variations = $block_type->get_variations();
+	foreach ( $variations as $variation ) {
+		foreach ( $variation['attributes'] as $attribute => $value ) {
+			if ( ! isset( $attributes[ $attribute ] ) || $attributes[ $attribute ] !== $value ) {
+				continue 2;
+			}
+		}
+		return $variation['name'];
+	}
+}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2680,15 +2680,16 @@ function _wp_footnotes_force_filtered_html_on_import_filter( $arg ) {
  */
 function get_active_block_variation( $block_type, $block_attributes ) {
 	foreach ( $block_type->get_variations() as $variation ) {
-		$attributes = $variation['attributes'];
 		if (
 			isset( $variation['isActive'] ) &&
 			is_array( $variation['isActive'] ) &&
 			! empty( $variation['isActive'] )
 		) {
 			$attributes = $variation['isActive'];
-		} else {
+		} else if ( isset( $variation['attributes'] ) ) {
 			$attributes = array_keys( $variation['attributes'] );
+		} else {
+			return null; // FIXME: Compare innerBlocks.
 		}
 
 		foreach ( $attributes as $attribute ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2683,10 +2683,17 @@ function get_active_block_variation( $block_type, $block_attributes ) {
 	foreach ( $variations as $variation ) {
 		$attributes = $variation['attributes'];
 		if ( isset( $variation['isActive'] ) && is_array( $variation['isActive'] ) ) {
-			$attributes = array_intersect_key( $attributes, array_flip( $variation['isActive'] ) );
+			$attributes = $variation['isActive'];
+		} else {
+			$attributes = array_keys( $variation['attributes'] );
 		}
-		foreach ( $attributes as $attribute => $value ) {
-			if ( ! isset( $block_attributes[ $attribute ] ) || $block_attributes[ $attribute ] !== $value ) {
+
+		foreach ( $attributes as $attribute ) {
+			if (
+				! isset( $block_attributes[ $attribute ] ) ||
+				! isset( $variation['attributes'][ $attribute ] ) ||
+				$block_attributes[ $attribute ] !== $variation['attributes'][ $attribute ]
+			) {
 				continue 2;
 			}
 		}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2679,8 +2679,7 @@ function _wp_footnotes_force_filtered_html_on_import_filter( $arg ) {
  * @return array|null The active block variation, or null if no active variation is found.
  */
 function get_active_block_variation( $block_type, $block_attributes ) {
-	$variations = $block_type->get_variations();
-	foreach ( $variations as $variation ) {
+	foreach ( $block_type->get_variations() as $variation ) {
 		$attributes = $variation['attributes'];
 		if ( isset( $variation['isActive'] ) && is_array( $variation['isActive'] ) ) {
 			$attributes = $variation['isActive'];

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2676,6 +2676,6 @@ function get_active_block_variation( $block_type, $block_attributes ) {
 				continue 2;
 			}
 		}
-		return $variation['name'];
+		return $variation;
 	}
 }

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2664,6 +2664,20 @@ function _wp_footnotes_force_filtered_html_on_import_filter( $arg ) {
 	return $arg;
 }
 
+/**
+ * Returns the active block variation for a given block based on its attributes.
+ *
+ * Variations are determined by their `isActive` property, which is an array of
+ * block attribute keys that are compared to the given block's attributes using
+ * a strict equality check.
+ *
+ * If no `isActive` property is defined, all `attributes` specified by a variation
+ * are compared to the given block's to determine if the variation is active.
+ *
+ * @param WP_Block_Type $block_type       Block Type.
+ * @param array         $block_attributes Block attributes.
+ * @return array|null The active block variation, or null if no active variation is found.
+ */
 function get_active_block_variation( $block_type, $block_attributes ) {
 	$variations = $block_type->get_variations();
 	foreach ( $variations as $variation ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2664,7 +2664,7 @@ function _wp_footnotes_force_filtered_html_on_import_filter( $arg ) {
 	return $arg;
 }
 
-function infer_block_variation( $block_type, $block_attributes ) {
+function get_active_block_variation( $block_type, $block_attributes ) {
 	$variations = $block_type->get_variations();
 	foreach ( $variations as $variation ) {
 		$attributes = $variation['attributes'];

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2689,7 +2689,7 @@ function get_active_block_variation( $block_type, $block_attributes ) {
 		} else if ( isset( $variation['attributes'] ) ) {
 			$attributes = array_keys( $variation['attributes'] );
 		} else {
-			return null; // FIXME: Compare innerBlocks.
+			return null; // TODO: Compare innerBlocks.
 		}
 
 		foreach ( $attributes as $attribute ) {

--- a/tests/phpunit/tests/blocks/getActiveBlockVariation.php
+++ b/tests/phpunit/tests/blocks/getActiveBlockVariation.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Tests for the get_active_block_variation function.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @since 6.6.0
+ *
+ * @group blocks
+ */
+class Tests_Blocks_GetActiveBlockVariation extends WP_UnitTestCase {
+
+	/**
+	 * Block type.
+	 *
+	 * @var WP_Block_Type
+	 */
+	protected static $block_type;
+
+	/**
+	 * Set up before class.
+	 */
+	public static function wpSetUpBeforeClass() {
+		self::$block_type = new WP_Block_Type( 'tests/block-type', array(
+			'attributes' => array(
+				'attribute1' => array(
+					'type' => 'string',
+				),
+				'attribute2' => array(
+					'type' => 'string',
+				),
+			),
+			'variations' => self::mock_variation_callback(),
+		) );
+	}
+
+	public function test_get_active_block_variation_no_match() {
+		$block_attributes = array(
+			'attribute1' => 'var1-attr1',
+			'attribute2' => 'var1-attr2',
+			'attribute3' => 'mismatch',
+		);
+
+		$active_variation = get_active_block_variation( self::$block_type, $block_attributes );
+		$this->assertNull( $active_variation );
+	}
+
+	public function test_get_active_block_variation_match_without_is_active() {
+		$block_attributes = array(
+			'attribute1' => 'var1-attr1',
+			'attribute2' => 'var1-attr2',
+			'attribute3' => 'var1-attr3',
+		);
+
+		$active_variation = get_active_block_variation( self::$block_type, $block_attributes );
+		$this->assertSame( 'variation_with_is_active', $active_variation['name'] );
+	}
+
+	public function test_get_active_block_variation_match_with_empty_is_active() {
+		$block_attributes = array(
+			'attribute1' => 'var2-attr1',
+			'attribute2' => 'var2-attr2',
+			'attribute3' => 'var2-attr3',
+		);
+
+		$active_variation = get_active_block_variation( self::$block_type, $block_attributes );
+		$this->assertSame( 'variation_with_empty_is_active', $active_variation['name'] );
+	}
+
+	public function test_get_active_block_variation_match_with_is_active() {
+		$block_attributes = array(
+			'attribute1' => 'var3-attr1',
+			'attribute2' => 'var3-attr2',
+			'attribute3' => 'var3-attr3',
+		);
+
+		$active_variation = get_active_block_variation( self::$block_type, $block_attributes );
+		$this->assertSame( 'variation_without_is_active', $active_variation['name'] );
+	}
+
+	/**
+	 * Mock variation callback.
+	 *
+	 * @return array
+	 */
+	public static function mock_variation_callback() {
+		return array(
+			array(
+				'name'       => 'variation_with_is_active',
+				'attributes' => array(
+					'attribute1' => 'var1-attr1',
+					'attribute2' => 'var1-attr2',
+					'attribute3' => 'var1-attr3',
+				),
+				'isActive' => array(
+					'attribute1',
+					'attribute3',
+				),
+			),
+			array(
+				'name'       => 'variation_with_empty_is_active',
+				'attributes' => array(
+					'attribute1' => 'var2-attr1',
+					'attribute2' => 'var2-attr2',
+					'attribute3' => 'var2-attr3',
+				),
+				'isActive' => array(),
+			),
+			array(
+				'name'       => 'variation_without_is_active',
+				'attributes' => array(
+					'attribute1' => 'var3-attr1',
+					'attribute2' => 'var3-attr2',
+					'attribute3' => 'var3-attr3',
+				),
+			),
+		);
+	}
+};

--- a/tests/phpunit/tests/blocks/getActiveBlockVariation.php
+++ b/tests/phpunit/tests/blocks/getActiveBlockVariation.php
@@ -24,14 +24,17 @@ class Tests_Blocks_GetActiveBlockVariation extends WP_UnitTestCase {
 	 */
 	public static function wpSetUpBeforeClass() {
 		self::$block_type = new WP_Block_Type(
-			'tests/block-type',
+			'block/name',
 			array(
 				'attributes' => array(
-					'attribute1' => array(
-						'type' => 'string',
+					'testAttribute'       => array(
+						'type' => 'number',
 					),
-					'attribute2' => array(
-						'type' => 'string',
+					'firstTestAttribute'  => array(
+						'type' => 'number',
+					),
+					'secondTestAttribute' => array(
+						'type' => 'number',
 					),
 				),
 				'variations' => self::mock_variation_callback(),
@@ -44,9 +47,7 @@ class Tests_Blocks_GetActiveBlockVariation extends WP_UnitTestCase {
 	 */
 	public function test_get_active_block_variation_no_match() {
 		$block_attributes = array(
-			'attribute1' => 'var1-attr1',
-			'attribute2' => 'var1-attr2',
-			'attribute3' => 'mismatch',
+			'testAttribute' => 5555,
 		);
 
 		$active_variation = get_active_block_variation( self::$block_type, $block_attributes );
@@ -57,14 +58,32 @@ class Tests_Blocks_GetActiveBlockVariation extends WP_UnitTestCase {
 	 * @ticket 61265
 	 */
 	public function test_get_active_block_variation_match_with_is_active() {
-		$block_attributes = array(
-			'attribute1' => 'var1-attr1',
-			'attribute2' => 'var1-attr2',
-			'attribute3' => 'var1-attr3',
+		$active_variation = get_active_block_variation(
+			self::$block_type,
+			array(
+				'firstTestAttribute'  => 1,
+				'secondTestAttribute' => 10,
+			),
 		);
+		$this->assertSame( 'variation-1', $active_variation['name'] );
 
-		$active_variation = get_active_block_variation( self::$block_type, $block_attributes );
-		$this->assertSame( 'variation_with_is_active', $active_variation['name'] );
+		$active_variation = get_active_block_variation(
+			self::$block_type,
+			array(
+				'firstTestAttribute'  => 2,
+				'secondTestAttribute' => 20,
+			),
+		);
+		$this->assertSame( 'variation-2', $active_variation['name'] );
+
+		$active_variation = get_active_block_variation(
+			self::$block_type,
+			array(
+				'firstTestAttribute'  => 1,
+				'secondTestAttribute' => 20,
+			),
+		);
+		$this->assertSame( 'variation-3', $active_variation['name'] );
 	}
 
 	/**
@@ -75,15 +94,36 @@ class Tests_Blocks_GetActiveBlockVariation extends WP_UnitTestCase {
 	public static function mock_variation_callback() {
 		return array(
 			array(
-				'name'       => 'variation_with_is_active',
+				'name'       => 'variation-1',
 				'attributes' => array(
-					'attribute1' => 'var1-attr1',
-					'attribute2' => 'var1-attr2',
-					'attribute3' => 'var1-attr3',
+					'firstTestAttribute'  => 1,
+					'secondTestAttribute' => 10,
 				),
 				'isActive'   => array(
-					'attribute1',
-					'attribute3',
+					'firstTestAttribute',
+					'secondTestAttribute',
+				),
+			),
+			array(
+				'name'       => 'variation-2',
+				'attributes' => array(
+					'firstTestAttribute'  => 2,
+					'secondTestAttribute' => 20,
+				),
+				'isActive'   => array(
+					'firstTestAttribute',
+					'secondTestAttribute',
+				),
+			),
+			array(
+				'name'       => 'variation-3',
+				'attributes' => array(
+					'firstTestAttribute'  => 1,
+					'secondTestAttribute' => 20,
+				),
+				'isActive'   => array(
+					'firstTestAttribute',
+					'secondTestAttribute',
 				),
 			),
 		);

--- a/tests/phpunit/tests/blocks/getActiveBlockVariation.php
+++ b/tests/phpunit/tests/blocks/getActiveBlockVariation.php
@@ -63,7 +63,7 @@ class Tests_Blocks_GetActiveBlockVariation extends WP_UnitTestCase {
 			array(
 				'firstTestAttribute'  => 1,
 				'secondTestAttribute' => 10,
-			),
+			)
 		);
 		$this->assertSame( 'variation-1', $active_variation['name'] );
 
@@ -72,7 +72,7 @@ class Tests_Blocks_GetActiveBlockVariation extends WP_UnitTestCase {
 			array(
 				'firstTestAttribute'  => 2,
 				'secondTestAttribute' => 20,
-			),
+			)
 		);
 		$this->assertSame( 'variation-2', $active_variation['name'] );
 
@@ -81,7 +81,7 @@ class Tests_Blocks_GetActiveBlockVariation extends WP_UnitTestCase {
 			array(
 				'firstTestAttribute'  => 1,
 				'secondTestAttribute' => 20,
-			),
+			)
 		);
 		$this->assertSame( 'variation-3', $active_variation['name'] );
 	}

--- a/tests/phpunit/tests/blocks/getActiveBlockVariation.php
+++ b/tests/phpunit/tests/blocks/getActiveBlockVariation.php
@@ -68,34 +68,6 @@ class Tests_Blocks_GetActiveBlockVariation extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 61265
-	 */
-	public function test_get_active_block_variation_match_with_empty_is_active() {
-		$block_attributes = array(
-			'attribute1' => 'var2-attr1',
-			'attribute2' => 'var2-attr2',
-			'attribute3' => 'var2-attr3',
-		);
-
-		$active_variation = get_active_block_variation( self::$block_type, $block_attributes );
-		$this->assertSame( 'variation_with_empty_is_active', $active_variation['name'] );
-	}
-
-	/**
-	 * @ticket 61265
-	 */
-	public function test_get_active_block_variation_match_without_is_active() {
-		$block_attributes = array(
-			'attribute1' => 'var3-attr1',
-			'attribute2' => 'var3-attr2',
-			'attribute3' => 'var3-attr3',
-		);
-
-		$active_variation = get_active_block_variation( self::$block_type, $block_attributes );
-		$this->assertSame( 'variation_without_is_active', $active_variation['name'] );
-	}
-
-	/**
 	 * Mock variation callback.
 	 *
 	 * @return array
@@ -112,23 +84,6 @@ class Tests_Blocks_GetActiveBlockVariation extends WP_UnitTestCase {
 				'isActive'   => array(
 					'attribute1',
 					'attribute3',
-				),
-			),
-			array(
-				'name'       => 'variation_with_empty_is_active',
-				'attributes' => array(
-					'attribute1' => 'var2-attr1',
-					'attribute2' => 'var2-attr2',
-					'attribute3' => 'var2-attr3',
-				),
-				'isActive'   => array(),
-			),
-			array(
-				'name'       => 'variation_without_is_active',
-				'attributes' => array(
-					'attribute1' => 'var3-attr1',
-					'attribute2' => 'var3-attr2',
-					'attribute3' => 'var3-attr3',
 				),
 			),
 		);

--- a/tests/phpunit/tests/blocks/getActiveBlockVariation.php
+++ b/tests/phpunit/tests/blocks/getActiveBlockVariation.php
@@ -8,6 +8,7 @@
  * @since 6.6.0
  *
  * @group blocks
+ * @covers ::get_active_block_variation
  */
 class Tests_Blocks_GetActiveBlockVariation extends WP_UnitTestCase {
 
@@ -38,6 +39,9 @@ class Tests_Blocks_GetActiveBlockVariation extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @ticket 61265
+	 */
 	public function test_get_active_block_variation_no_match() {
 		$block_attributes = array(
 			'attribute1' => 'var1-attr1',
@@ -49,6 +53,9 @@ class Tests_Blocks_GetActiveBlockVariation extends WP_UnitTestCase {
 		$this->assertNull( $active_variation );
 	}
 
+	/**
+	 * @ticket 61265
+	 */
 	public function test_get_active_block_variation_match_without_is_active() {
 		$block_attributes = array(
 			'attribute1' => 'var1-attr1',
@@ -60,6 +67,9 @@ class Tests_Blocks_GetActiveBlockVariation extends WP_UnitTestCase {
 		$this->assertSame( 'variation_with_is_active', $active_variation['name'] );
 	}
 
+	/**
+	 * @ticket 61265
+	 */
 	public function test_get_active_block_variation_match_with_empty_is_active() {
 		$block_attributes = array(
 			'attribute1' => 'var2-attr1',
@@ -71,6 +81,9 @@ class Tests_Blocks_GetActiveBlockVariation extends WP_UnitTestCase {
 		$this->assertSame( 'variation_with_empty_is_active', $active_variation['name'] );
 	}
 
+	/**
+	 * @ticket 61265
+	 */
 	public function test_get_active_block_variation_match_with_is_active() {
 		$block_attributes = array(
 			'attribute1' => 'var3-attr1',

--- a/tests/phpunit/tests/blocks/getActiveBlockVariation.php
+++ b/tests/phpunit/tests/blocks/getActiveBlockVariation.php
@@ -56,7 +56,7 @@ class Tests_Blocks_GetActiveBlockVariation extends WP_UnitTestCase {
 	/**
 	 * @ticket 61265
 	 */
-	public function test_get_active_block_variation_match_without_is_active() {
+	public function test_get_active_block_variation_match_with_is_active() {
 		$block_attributes = array(
 			'attribute1' => 'var1-attr1',
 			'attribute2' => 'var1-attr2',
@@ -84,7 +84,7 @@ class Tests_Blocks_GetActiveBlockVariation extends WP_UnitTestCase {
 	/**
 	 * @ticket 61265
 	 */
-	public function test_get_active_block_variation_match_with_is_active() {
+	public function test_get_active_block_variation_match_without_is_active() {
 		$block_attributes = array(
 			'attribute1' => 'var3-attr1',
 			'attribute2' => 'var3-attr2',

--- a/tests/phpunit/tests/blocks/getActiveBlockVariation.php
+++ b/tests/phpunit/tests/blocks/getActiveBlockVariation.php
@@ -109,7 +109,7 @@ class Tests_Blocks_GetActiveBlockVariation extends WP_UnitTestCase {
 					'attribute2' => 'var1-attr2',
 					'attribute3' => 'var1-attr3',
 				),
-				'isActive' => array(
+				'isActive'   => array(
 					'attribute1',
 					'attribute3',
 				),
@@ -121,7 +121,7 @@ class Tests_Blocks_GetActiveBlockVariation extends WP_UnitTestCase {
 					'attribute2' => 'var2-attr2',
 					'attribute3' => 'var2-attr3',
 				),
-				'isActive' => array(),
+				'isActive'   => array(),
 			),
 			array(
 				'name'       => 'variation_without_is_active',
@@ -133,4 +133,4 @@ class Tests_Blocks_GetActiveBlockVariation extends WP_UnitTestCase {
 			),
 		);
 	}
-};
+}

--- a/tests/phpunit/tests/blocks/getActiveBlockVariation.php
+++ b/tests/phpunit/tests/blocks/getActiveBlockVariation.php
@@ -22,17 +22,20 @@ class Tests_Blocks_GetActiveBlockVariation extends WP_UnitTestCase {
 	 * Set up before class.
 	 */
 	public static function wpSetUpBeforeClass() {
-		self::$block_type = new WP_Block_Type( 'tests/block-type', array(
-			'attributes' => array(
-				'attribute1' => array(
-					'type' => 'string',
+		self::$block_type = new WP_Block_Type(
+			'tests/block-type',
+			array(
+				'attributes' => array(
+					'attribute1' => array(
+						'type' => 'string',
+					),
+					'attribute2' => array(
+						'type' => 'string',
+					),
 				),
-				'attribute2' => array(
-					'type' => 'string',
-				),
-			),
-			'variations' => self::mock_variation_callback(),
-		) );
+				'variations' => self::mock_variation_callback(),
+			)
+		);
 	}
 
 	public function test_get_active_block_variation_no_match() {


### PR DESCRIPTION
For a given block `my/block` with a variation `myvariation` that's registered on the server side (via [`variation_callback`](https://make.wordpress.org/core/2024/02/29/performance-improvements-for-registering-block-variations-with-callbacks/) or [`get_block_type_variations`](https://developer.wordpress.org/reference/hooks/get_block_type_variations/)), add a class `wp-block-my-block-myvariation` to the block wrapper.

### Design choices

This PR introduces a new function called `get_active_block_variation()`, which is modelled after its client-side counterpart, [`getActiveBlockVariation()`](https://developer.wordpress.org/block-editor/reference-guides/data/data-core-blocks/#getactiveblockvariation). The signatures are _almost_ identical, the major differences being:
-  The client-side version accepts a block type _name_, whereas the server side one expects a `WP_Block_Type` object. Some discussion on that [here](https://github.com/WordPress/wordpress-develop/pull/6602/files#r1609566865).
- The client-side version accepts an additional `scope` argument, which is forwarded to [`getBlockVariations()`](https://developer.wordpress.org/block-editor/reference-guides/data/data-core-blocks/#getblockvariations). It is used to specify if a variation should show up in the `inserter`, in `transforms`, or if it should only be used internally by the `block`. Since the server-side's counterpart `WP_Block_Type::get_variations()` doesn't support a `scope` argument, it is also not implemented in `get_active_block_variation()`. (It should be possible to add it later on to both functions if we so wish.)

**No separate block-supports.** This doesn't introduce a separate block-supports field to control the addition of a generated variation class name; instead, it relies on the existing `className` block-supports, as does the block's generated class name (i.e. the `wp-block-my-block` thing). The reason for this is that the addition of an extra class name was considered innocuous and similar enough to the generated block class name that it didn't merit introducing a separate block-supports, which would otherwise increase the API surface.

~**Inference.** Note that while `get_active_block_variation` respects the `isActive` field to determine the variation of a block given its attributes, it also has a fallback mechanism, which is to compare the variation's set of defining `attributes` to the block's.~

~I believe that this is a reasonable technique to determine a block variation, especially in the absence of an `isActive` field (which on the server side is furthermore limited to an array of attributes that need to be considered in determining a variation, as opposed to the client side, where arbitrary callbacks are allowed for `isActive`).~

~If we agree with this fallback mechanism, I'm inclined to add it to the client side's `getActiveBlockVariation` as well.~

_**Edit:** Removed the fallback mechanism, see https://github.com/WordPress/wordpress-develop/pull/6602/files#r1616104632._

### TODO

- [ ] Carry over refinements to how the active block is determined if `isActive` is an array of attribute names. See 
  - [ ] https://github.com/WordPress/gutenberg/pull/62088
  - [ ] https://github.com/WordPress/gutenberg/pull/62031
  - [ ] https://github.com/WordPress/gutenberg/pull/62272
  - [ ] https://github.com/WordPress/gutenberg/pull/62325
- [ ] Add unit test coverage for the above. Ideally, find a way to reuse test data from client-side `getActiveBlockVariation` unit tests.

### Testing Instructions

Test with a Block Theme (such as TT4) that uses Template Part block (and ideally also Navigation Link blocks), as those are among the few blocks with server-side registered variations. Inspect the page source and verify that the aforementioned blocks have indeed a variation-specific classname added, e.g. `wp-block-template-part-area_footer` or `wp-block-navigation-link-page`.

### Screenshots

<img width="783" alt="image" src="https://github.com/WordPress/wordpress-develop/assets/96308/d49678b8-2a94-4a2c-95aa-424fc742b4c0">

---

<img width="783" alt="image" src="https://github.com/WordPress/wordpress-develop/assets/96308/11b0a1e4-16ee-4b28-be25-f535aba262a7">

Trac ticket: https://core.trac.wordpress.org/ticket/61265

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
