### PR TITLE
Block Hooks API: Move ignoredHookedBlocks metadata injection logic

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1599,11 +1599,7 @@ function inject_ignored_hooked_blocks_metadata_attributes( $changes, $deprecated
 		return $template;
 	}
 
-	$before_block_visitor = make_before_block_visitor( $hooked_blocks, $template, 'set_ignored_hooked_blocks_metadata' );
-	$after_block_visitor  = make_after_block_visitor( $hooked_blocks, $template, 'set_ignored_hooked_blocks_metadata' );
-
-	$blocks                = parse_blocks( $changes->post_content );
-	$changes->post_content = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
+	$changes->post_content = apply_block_hooks_to_content( $changes->post_content, $template, 'set_ignored_hooked_blocks_metadata' );
 
 	return $changes;
 }

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -757,4 +757,7 @@ add_action( 'init', '_wp_register_default_font_collections' );
 add_filter( 'rest_pre_insert_wp_template', 'inject_ignored_hooked_blocks_metadata_attributes' );
 add_filter( 'rest_pre_insert_wp_template_part', 'inject_ignored_hooked_blocks_metadata_attributes' );
 
+// Update ignoredHookedBlocks postmeta for wp_navigation post type.
+add_filter( 'rest_pre_insert_wp_navigation', 'update_ignored_hooked_blocks_postmeta' );
+
 unset( $filter, $action );

--- a/tests/phpunit/tests/blocks/updateIgnoredHookedBlocksPostMeta.php
+++ b/tests/phpunit/tests/blocks/updateIgnoredHookedBlocksPostMeta.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Tests for update_ignored_hooked_blocks_postmeta
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @since 6.6.0
+ *
+ * @group blocks
+ * @covers ::update_ignored_hooked_blocks_postmeta
+ */
+class Tests_Blocks_UpdateIgnoredHookedBlocksPostMeta extends WP_UnitTestCase {
+	/**
+	 * Post object.
+	 *
+	 * @var object
+	 */
+	protected static $navigation_post;
+
+	/**
+	 * Setup method.
+	 */
+	public static function wpSetUpBeforeClass() {
+		self::$navigation_post = self::factory()->post->create_and_get(
+			array(
+				'post_type'    => 'wp_navigation',
+				'post_title'   => 'Navigation Menu',
+				'post_content' => 'Original content',
+			)
+		);
+	}
+
+	/**
+	 * Tear down each test method.
+	 */
+	public function tear_down() {
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		if ( $registry->is_registered( 'tests/my-block' ) ) {
+			$registry->unregister( 'tests/my-block' );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * @ticket 60759
+	 */
+	public function test_update_ignored_hooked_blocks_postmeta_preserves_entities() {
+		register_block_type(
+			'tests/my-block',
+			array(
+				'block_hooks' => array(
+					'core/navigation' => 'last_child',
+				),
+			)
+		);
+
+		$original_markup    = '<!-- wp:navigation-link {"label":"News & About","type":"page","id":2,"url":"http://localhost:8888/?page_id=2","kind":"post-type"} /-->';
+		$post               = new stdClass();
+		$post->ID           = self::$navigation_post->ID;
+		$post->post_content = $original_markup;
+		$post->post_type    = 'wp_navigation';
+
+		$post = update_ignored_hooked_blocks_postmeta( $post );
+
+		// We expect the '&' character to be replaced with its unicode representation.
+		$expected_markup = str_replace( '&', '\u0026', $original_markup );
+
+		$this->assertSame(
+			$expected_markup,
+			$post->post_content,
+			'Post content did not match expected markup with entities escaped.'
+		);
+		$this->assertSame(
+			array( 'tests/my-block' ),
+			json_decode( get_post_meta( self::$navigation_post->ID, '_wp_ignored_hooked_blocks', true ), true ),
+			'Block was not added to ignored hooked blocks metadata.'
+		);
+	}
+
+	/**
+	 * @ticket 60759
+	 */
+	public function test_update_ignored_hooked_blocks_postmeta_dont_modify_no_post_id() {
+		register_block_type(
+			'tests/my-block',
+			array(
+				'block_hooks' => array(
+					'core/navigation' => 'last_child',
+				),
+			)
+		);
+
+		$original_markup    = '<!-- wp:navigation-link {"label":"News","type":"page","id":2,"url":"http://localhost:8888/?page_id=2","kind":"post-type"} /-->';
+		$post               = new stdClass();
+		$post->post_content = $original_markup;
+		$post->post_type    = 'wp_navigation';
+
+		$post = update_ignored_hooked_blocks_postmeta( $post );
+
+		$this->assertSame(
+			$original_markup,
+			$post->post_content,
+			'Post content did not match the original markup.'
+		);
+	}
+
+	/**
+	 * @ticket 60759
+	 */
+	public function test_update_ignored_hooked_blocks_postmeta_retains_content_if_not_set() {
+		register_block_type(
+			'tests/my-block',
+			array(
+				'block_hooks' => array(
+					'core/navigation' => 'last_child',
+				),
+			)
+		);
+
+		$post             = new stdClass();
+		$post->ID         = self::$navigation_post->ID;
+		$post->post_title = 'Navigation Menu with changes';
+		$post->post_type  = 'wp_navigation';
+
+		$post = update_ignored_hooked_blocks_postmeta( $post );
+
+		$this->assertSame(
+			'Navigation Menu with changes',
+			$post->post_title,
+			'Post title was changed.'
+		);
+
+		$this->assertFalse(
+			isset( $post->post_content ),
+			'Post content should not be set.'
+		);
+	}
+
+	/**
+	 * @ticket 60759
+	 */
+	public function test_update_ignored_hooked_blocks_postmeta_dont_modify_if_not_navigation() {
+		register_block_type(
+			'tests/my-block',
+			array(
+				'block_hooks' => array(
+					'core/navigation' => 'last_child',
+				),
+			)
+		);
+
+		$original_markup    = '<!-- wp:navigation-link {"label":"News","type":"page","id":2,"url":"http://localhost:8888/?page_id=2","kind":"post-type"} /-->';
+		$post               = new stdClass();
+		$post->ID           = self::$navigation_post->ID;
+		$post->post_content = $original_markup;
+		$post->post_type    = 'post';
+
+		$post = update_ignored_hooked_blocks_postmeta( $post );
+
+		$this->assertSame(
+			$original_markup,
+			$post->post_content,
+			'Post content did not match the original markup.'
+		);
+	}
+
+	/**
+	 * @ticket 60759
+	 */
+	public function test_update_ignored_hooked_blocks_postmeta_dont_modify_if_no_post_type() {
+		register_block_type(
+			'tests/my-block',
+			array(
+				'block_hooks' => array(
+					'core/navigation' => 'last_child',
+				),
+			)
+		);
+
+		$original_markup    = '<!-- wp:navigation-link {"label":"News","type":"page","id":2,"url":"http://localhost:8888/?page_id=2","kind":"post-type"} /-->';
+		$post               = new stdClass();
+		$post->ID           = self::$navigation_post->ID;
+		$post->post_content = $original_markup;
+
+		$post = update_ignored_hooked_blocks_postmeta( $post );
+
+		$this->assertSame(
+			$original_markup,
+			$post->post_content,
+			'Post content did not match the original markup.'
+		);
+	}
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60759

**Testing instructions:**

1. Add the below code to your site.
2. Load the navigation block and check it renders in the editor/frontend
3. In the editor, update the navigation by adding another page and saving
4. Check the `wp_postmeta` table to see if `core/loginout` has been added to a row with the `meta_key` => `_wp_ignored_hooked_blocks`

```php
function register_logout_block_as_navigation_last_child( $hooked_blocks, $position, $anchor_block, $context ) {
	if ( $anchor_block === 'core/navigation' && $position === 'last_child' ) {
		$hooked_blocks[] = 'core/loginout';
	}

	return $hooked_blocks;
}

add_filter( 'hooked_block_types', 'register_logout_block_as_navigation_last_child', 10, 4 );
```

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
