### PR TITLE
Toolbar: Update the site editor link in the Admin Bar

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -455,6 +455,7 @@ function wp_admin_bar_site_menu( $wp_admin_bar ) {
  *
  * @since 5.9.0
  * @since 6.3.0 Added `$_wp_current_template_id` global for editing of current template directly from the admin bar.
+ * @since 6.6.0 Added the `canvas` query arg to the Site Editor link.
  *
  * @global string $_wp_current_template_id
  *
@@ -481,6 +482,7 @@ function wp_admin_bar_edit_site_menu( $wp_admin_bar ) {
 				array(
 					'postType' => 'wp_template',
 					'postId'   => $_wp_current_template_id,
+					'canvas'   => 'edit',
 				),
 				admin_url( 'site-editor.php' )
 			),


### PR DESCRIPTION
## What?

The details page is being removed from the site editor in 6.6. we need to direct the admin bar menu item to the "edit" mode page directly. 

## Testing Instructions

1- Open the frontend of your website (block theme)
2- Click that the "site editor" link
3- The active template should be opened in the site editor in edit mode.

Trac ticket: https://core.trac.wordpress.org/ticket/61266

