### PR TITLE
Trac 61269: Add new filter and control for auto-redirect in 6.5.4

### DIFF
--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -2456,7 +2456,7 @@
 	};
 
 	$( function() {
-		var $pluginFilter        = $( '.plugin-title .row-actions, #plugin-filter, #plugin-information-footer' ),
+		var $pluginFilter        = $( '#plugin-filter, #plugin-information-footer' ),
 			$bulkActionForm      = $( '#bulk-action-form' ),
 			$filesystemForm      = $( '#request-filesystem-credentials-form' ),
 			$filesystemModal     = $( '#request-filesystem-credentials-dialog' ),

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -1153,19 +1153,21 @@
 				}
 			);
 
-			// Add a notice to the modal's footer.
-			$message.replaceWith( wp.updates.adminNotice( noticeData ) );
+			if ( 'undefined' === typeof response.configurationData.url ) {
+				// Add a notice to the modal's footer.
+				$message.replaceWith( wp.updates.adminNotice( noticeData ) );
 
-			// Send notice information back to the parent screen.
-			noticeTarget = window.parent === window ? null : window.parent;
-			$.support.postMessage = !! window.postMessage;
-			if ( false !== $.support.postMessage && null !== noticeTarget && -1 === window.parent.location.pathname.indexOf( 'index.php' ) ) {
-				noticeTarget.postMessage(
-					JSON.stringify( noticeData ),
-					window.location.origin
-				);
+				// Send notice information back to the parent screen.
+				noticeTarget = window.parent === window ? null : window.parent;
+				$.support.postMessage = !! window.postMessage;
+				if ( false !== $.support.postMessage && null !== noticeTarget && -1 === window.parent.location.pathname.indexOf( 'index.php' ) ) {
+					noticeTarget.postMessage(
+						JSON.stringify( noticeData ),
+						window.location.origin
+					);
+				}
 			}
-		} else {
+		} else if ( 'undefined' === typeof response.configurationData.url ) {
 			// Add a notice to the top of the screen.
 			wp.updates.addAdminNotice( noticeData );
 		}

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -1105,10 +1105,11 @@
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param {Object} response            Response from the server.
-	 * @param {string} response.slug       Slug of the activated plugin.
-	 * @param {string} response.pluginName Name of the activated plugin.
-	 * @param {string} response.plugin     The plugin file, relative to the plugins directory.
+	 * @param {Object} response                   Response from the server.
+	 * @param {string} response.slug              Slug of the activated plugin.
+	 * @param {string} response.pluginName        Name of the activated plugin.
+	 * @param {string} response.plugin            The plugin file, relative to the plugins directory.
+	 * @param {Array}  response.configurationData An array of plugin configuration data.
 	 */
 	wp.updates.activatePluginSuccess = function( response ) {
 		var $message = $( '.plugin-card-' + response.slug + ', #plugin-information-footer' ).find( '.activating-message' ),
@@ -1184,8 +1185,16 @@
 						)
 					}
 				);
+
+				if ( 'undefined' !== typeof response.configurationData.url ) {
+					window.parent.location.href = response.configurationData.url;
+				}
 			} else {
 				$message.removeClass( 'activated-message' ).text( _x( 'Active', 'plugin' ) );
+
+				if ( 'undefined' !== typeof response.configurationData.url ) {
+					window.location.href = response.configurationData.url;
+				}
 			}
 		}, 1000 );
 	};
@@ -2447,7 +2456,7 @@
 	};
 
 	$( function() {
-		var $pluginFilter        = $( '#plugin-filter, #plugin-information-footer' ),
+		var $pluginFilter        = $( '.plugin-title .row-actions, #plugin-filter, #plugin-information-footer' ),
 			$bulkActionForm      = $( '#bulk-action-form' ),
 			$filesystemForm      = $( '#request-filesystem-credentials-form' ),
 			$filesystemModal     = $( '#request-filesystem-credentials-dialog' ),

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -4604,7 +4604,7 @@ function wp_ajax_activate_plugin() {
 	 *                        Default empty string for no configuration URL.
 	 * }
 	 */
-	$configuration_data = apply_filters( 'plugin_configuration_data_' . $status['slug'], array( 'url' => '' ) );
+	$configuration_data = apply_filters( "wp_plugin_configuration_data_{$status['slug']}", array( 'url' => '' ) );
 	if ( is_array( $configuration_data ) ) {
 		$status['configurationData'] = array();
 

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -4591,6 +4591,9 @@ function wp_ajax_activate_plugin() {
 	/**
 	 * Filters the data for the plugin's configuration workflow.
 	 *
+	 * The dynamic portion of the hook refers to the plugin's slug provided by the
+	 * AJAX activation request. For the Hello Dolly plugin, this would be `hello-dolly`.
+	 *
 	 * @since 6.5.4
 	 *
 	 * @param array {

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -4589,14 +4589,7 @@ function wp_ajax_activate_plugin() {
 	}
 
 	/**
-	 * Filters the configuration data for the plugin.
-	 *
-	 * The dynamic portion of the hook name refers to the plugin slug.
-	 *
-	 * How WordPress uses this data may change in the future.
-	 *
-	 * Currently, the user will be redirected to the configuration URL
-	 * after activating the plugin.
+	 * Filters the data for the plugin's configuration workflow.
 	 *
 	 * @since 6.5.4
 	 *

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -4613,9 +4613,9 @@ function wp_ajax_activate_plugin() {
 		$status['configurationData'] = array();
 
 		if ( isset( $configuration_data['url'] ) ) {
-			$configuration_url = trim( $configuration_data['url'] );
+			$configuration_url = sanitize_url( $configuration_data['url'] );
 
-			if ( str_starts_with( $configuration_url, admin_url() ) ) {
+			if ( $configuration_url ) {
 				$status['configurationData']['url'] = $configuration_url;
 			}
 		}

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -4612,7 +4612,7 @@ function wp_ajax_activate_plugin() {
 	if ( is_array( $configuration_data ) ) {
 		$status['configurationData'] = array();
 
-		if ( isset( $configuration_data['url'] ) ) {
+		if ( isset( $configuration_data['url'] ) && is_string( $configuration_data['url'] ) ) {
 			$configuration_url = sanitize_url( $configuration_data['url'] );
 
 			if ( $configuration_url ) {

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -4612,7 +4612,7 @@ function wp_ajax_activate_plugin() {
 	if ( is_array( $configuration_data ) ) {
 		$status['configurationData'] = array();
 
-		if ( isset( $configuration_data['url'] ) && is_string( $configuration_data['url'] ) ) {
+		if ( ! empty( $configuration_data['url'] ) && is_string( $configuration_data['url'] ) ) {
 			$configuration_url = sanitize_url( $configuration_data['url'] );
 
 			if ( $configuration_url ) {

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -4588,6 +4588,39 @@ function wp_ajax_activate_plugin() {
 		wp_send_json_error( $status );
 	}
 
+	/**
+	 * Filters the configuration data for the plugin.
+	 *
+	 * The dynamic portion of the hook name refers to the plugin slug.
+	 *
+	 * How WordPress uses this data may change in the future.
+	 *
+	 * Currently, the user will be redirected to the configuration URL
+	 * after activating the plugin.
+	 *
+	 * @since 6.5.4
+	 *
+	 * @param array {
+	 *      An array of configuration data for the plugin.
+	 *
+	 *      @type string $url The URL to configure the plugin.
+	 *                        Must be an absolute URL beginning with the administration URL.
+	 *                        Default empty string for no configuration URL.
+	 * }
+	 */
+	$configuration_data = apply_filters( 'plugin_configuration_data_' . $status['slug'], array( 'url' => '' ) );
+	if ( is_array( $configuration_data ) ) {
+		$status['configurationData'] = array();
+
+		if ( isset( $configuration_data['url'] ) ) {
+			$configuration_url = trim( $configuration_data['url'] );
+
+			if ( str_starts_with( $configuration_url, admin_url() ) ) {
+				$status['configurationData']['url'] = $configuration_url;
+			}
+		}
+	}
+
 	wp_send_json_success( $status );
 }
 


### PR DESCRIPTION
* Adds a new `plugin_configuration_data_{$slug}` filter for plugins to register their URL.
* Adds redirect control. For 6.5.4, redirect will happen after plugin activation.

## Testing

[Instructions are found here in the Trac ticket](https://core.trac.wordpress.org/ticket/61269#comment:13).

## Sample code for plugins:

Plugins will need to add code to hook into / register their URL. Here's an example with WooCommerce where the `url` is the an absolute to its wizard:

```php
add_filter( 'plugin_configuration_data_woocommerce', static function() {
	return array(
		'url' => admin_url( 'admin.php?page=wc-admin' ),
	);
} );
``` 

Props @costdev @aaronjorbin 

Trac ticket: https://core.trac.wordpress.org/ticket/61269

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
