### PR TITLE
Backport: Add filter for duotone to account for gutenberg_restore_image_outer_container in classic themes

### DIFF
--- a/src/wp-includes/block-supports/duotone.php
+++ b/src/wp-includes/block-supports/duotone.php
@@ -57,3 +57,7 @@ add_filter( 'block_editor_settings_all', array( 'WP_Duotone', 'add_editor_settin
 
 // Migrate the old experimental duotone support flag.
 add_filter( 'block_type_metadata_settings', array( 'WP_Duotone', 'migrate_experimental_duotone_support_flag' ), 10, 2 );
+
+// Restore duotone classes to the image wrapper div.
+add_filter( 'render_block_core/image', array( 'WP_Duotone', 'restore_image_outer_container' ), 11, 2 );
+

--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -1025,50 +1025,33 @@ add_filter( 'render_block_core/group', 'wp_restore_group_inner_container', 10, 2
  * @return string Filtered block content.
  */
 function wp_restore_image_outer_container( $block_content, $block ) {
-	$image_with_align = "
-/# 1) everything up to the class attribute contents
-(
-	^\s*
-	<figure\b
-	[^>]*
-	\bclass=
-	[\"']
-)
-# 2) the class attribute contents
-(
-	[^\"']*
-	\bwp-block-image\b
-	[^\"']*
-	\b(?:alignleft|alignright|aligncenter)\b
-	[^\"']*
-)
-# 3) everything after the class attribute contents
-(
-	[\"']
-	[^>]*
-	>
-	.*
-	<\/figure>
-)/iUx";
-
-	if (
-		wp_theme_has_theme_json() ||
-		0 === preg_match( $image_with_align, $block_content, $matches )
-	) {
+	if ( wp_theme_has_theme_json() ) {
 		return $block_content;
 	}
 
-	$wrapper_classnames = array( 'wp-block-image' );
-
-	// If the block has a classNames attribute these classnames need to be removed from the content and added back
-	// to the new wrapper div also.
-	if ( ! empty( $block['attrs']['className'] ) ) {
-		$wrapper_classnames = array_merge( $wrapper_classnames, explode( ' ', $block['attrs']['className'] ) );
+	$tags          = new WP_HTML_Tag_Processor( $block_content );
+	$wrapper_query = array(
+		'tag_name'   => 'div',
+		'class_name' => 'wp-block-image',
+	);
+	if ( ! $tags->next_tag( $wrapper_query ) ) {
+		return $block_content;
 	}
-	$content_classnames          = explode( ' ', $matches[2] );
-	$filtered_content_classnames = array_diff( $content_classnames, $wrapper_classnames );
 
-	return '<div class="' . implode( ' ', $wrapper_classnames ) . '">' . $matches[1] . implode( ' ', $filtered_content_classnames ) . $matches[3] . '</div>';
+	$tags->set_bookmark( 'wrapper-div' );
+	$tags->next_tag();
+
+	$inner_classnames = explode( ' ', $tags->get_attribute( 'class' ) );
+	foreach ( $inner_classnames as $classname ) {
+		if ( 0 === strpos( $classname, 'wp-duotone' ) ) {
+			$tags->remove_class( $classname );
+			$tags->seek( 'wrapper-div' );
+			$tags->add_class( $classname );
+			break;
+		}
+	}
+
+	return $tags->get_updated_html();
 }
 
 add_filter( 'render_block_core/image', 'wp_restore_image_outer_container', 10, 2 );

--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -1300,4 +1300,45 @@ class WP_Duotone {
 
 		return 'url(#' . $filter_id . ')';
 	}
+
+	/**
+	 * Fixes the issue with our generated class name not being added to the block's outer container
+	 * in classic themes.
+	 *
+	 * @since 6.5.0
+	 *
+	 * @param  string $block_content Rendered block content.
+	 * @return string                Filtered block content.
+	 */
+	public static function restore_image_outer_container( $block_content ) {
+		if ( wp_theme_has_theme_json() ) {
+			return $block_content;
+		}
+
+		$tags          = new WP_HTML_Tag_Processor( $block_content );
+		$wrapper_query = array(
+			'tag_name'   => 'div',
+			'class_name' => 'wp-block-image',
+		);
+		if ( ! $tags->next_tag( $wrapper_query ) ) {
+			return $block_content;
+		}
+
+		$tags->set_bookmark( 'wrapper-div' );
+		$tags->next_tag();
+
+		$inner_classnames = explode( ' ', $tags->get_attribute( 'class' ) );
+		foreach ( $inner_classnames as $classname ) {
+			if ( 0 === strpos( $classname, 'wp-duotone' ) ) {
+				$tags->remove_class( $classname );
+				$tags->seek( 'wrapper-div' );
+				$tags->add_class( $classname );
+				break;
+			}
+		}
+
+		return $tags->get_updated_html();
+	}
+
+
 }


### PR DESCRIPTION
Backport for  https://github.com/WordPress/gutenberg/pull/59764

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/61271<!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
