### PR TITLE
Backport: Block Styles: Allow registration of block styles across block types and include style data

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1879,6 +1879,7 @@ function block_version( $content ) {
  * Registers a new block style.
  *
  * @since 5.3.0
+ * @since 6.6.0 Updated types as registry now allows registering styles for multiple block types at once.
  *
  * @link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-styles/
  *

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1886,7 +1886,8 @@ function block_version( $content ) {
  * @param string|array $block_name       Block type name including namespace or array of namespaced block type names.
  * @param array        $style_properties Array containing the properties of the style name, label,
  *                                       style_handle (name of the stylesheet to be enqueued),
- *                                       inline_style (string containing the CSS to be added).
+ *                                       inline_style (string containing the CSS to be added),
+ *                                       style_data (theme.json-like array to generate CSS from).
  *                                       See WP_Block_Styles_Registry::register().
  * @return bool True if the block style was registered with success and false otherwise.
  */

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1882,11 +1882,11 @@ function block_version( $content ) {
  *
  * @link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-styles/
  *
- * @param string $block_name       Block type name including namespace.
- * @param array  $style_properties Array containing the properties of the style name, label,
- *                                 style_handle (name of the stylesheet to be enqueued),
- *                                 inline_style (string containing the CSS to be added).
- *                                 See WP_Block_Styles_Registry::register().
+ * @param string|array $block_name       Block type name including namespace or array of namespaced block type names.
+ * @param array        $style_properties Array containing the properties of the style name, label,
+ *                                       style_handle (name of the stylesheet to be enqueued),
+ *                                       inline_style (string containing the CSS to be added).
+ *                                       See WP_Block_Styles_Registry::register().
  * @return bool True if the block style was registered with success and false otherwise.
  */
 function register_block_style( $block_name, $style_properties ) {

--- a/src/wp-includes/class-wp-block-styles-registry.php
+++ b/src/wp-includes/class-wp-block-styles-registry.php
@@ -42,11 +42,12 @@ final class WP_Block_Styles_Registry {
 	 * or with an inline tag.
 	 *
 	 * @since 5.3.0
+	 * @since 6.6.0 Added ability to register style across multiple block types along with theme.json-like style data.
 	 *
 	 * @link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-styles/
 	 *
-	 * @param string $block_name       Block type name including namespace.
-	 * @param array  $style_properties {
+	 * @param string|array $block_name       Block type name including namespace or array of namespaced block type names.
+	 * @param array        $style_properties {
 	 *     Array containing the properties of the style.
 	 *
 	 *     @type string $name         The identifier of the style used to compute a CSS class.
@@ -56,16 +57,17 @@ final class WP_Block_Styles_Registry {
 	 *     @type string $style_handle The handle to an already registered style that should be
 	 *                                enqueued in places where block styles are needed.
 	 *     @type bool   $is_default   Whether this is the default style for the block type.
+	 *     @type array  $style_data   Theme.json-like object to generate CSS from.
 	 * }
 	 * @return bool True if the block style was registered with success and false otherwise.
 	 */
 	public function register( $block_name, $style_properties ) {
 
-		if ( ! isset( $block_name ) || ! is_string( $block_name ) ) {
+		if ( ! is_string( $block_name ) && ! is_array( $block_name ) ) {
 			_doing_it_wrong(
 				__METHOD__,
-				__( 'Block name must be a string.' ),
-				'5.3.0'
+				__( 'Block name must be a string or array.' ),
+				'6.6.0'
 			);
 			return false;
 		}
@@ -89,11 +91,14 @@ final class WP_Block_Styles_Registry {
 		}
 
 		$block_style_name = $style_properties['name'];
+		$block_names      = is_string( $block_name ) ? array( $block_name ) : $block_name;
 
-		if ( ! isset( $this->registered_block_styles[ $block_name ] ) ) {
-			$this->registered_block_styles[ $block_name ] = array();
+		foreach ( $block_names as $name ) {
+			if ( ! isset( $this->registered_block_styles[ $name ] ) ) {
+				$this->registered_block_styles[ $name ] = array();
+			}
+			$this->registered_block_styles[ $name ][ $block_style_name ] = $style_properties;
 		}
-		$this->registered_block_styles[ $block_name ][ $block_style_name ] = $style_properties;
 
 		return true;
 	}

--- a/tests/phpunit/tests/blocks/wpBlockStylesRegistry.php
+++ b/tests/phpunit/tests/blocks/wpBlockStylesRegistry.php
@@ -43,7 +43,7 @@ class Tests_Blocks_wpBlockStylesRegistry extends WP_UnitTestCase {
 	/**
 	 * Should accept valid string block type name.
 	 *
-	 * @ticket
+	 * @ticket 61274
 	 */
 	public function test_register_block_style_with_string_block_name() {
 		$name             = 'core/paragraph';
@@ -56,7 +56,7 @@ class Tests_Blocks_wpBlockStylesRegistry extends WP_UnitTestCase {
 	/**
 	 * Should accept valid array of block type names.
 	 *
-	 * @ticket
+	 * @ticket 61274
 	 */
 	public function test_register_block_style_with_array_of_block_names() {
 		$names            = array( 'core/paragraph', 'core/group' );

--- a/tests/phpunit/tests/blocks/wpBlockStylesRegistry.php
+++ b/tests/phpunit/tests/blocks/wpBlockStylesRegistry.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Tests for WP_Block_Styles_Registry.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ * @since 6.6.0
+ *
+ * @group blocks
+ */
+class Tests_Blocks_wpBlockStylesRegistry extends WP_UnitTestCase {
+
+	/**
+	 * Fake block styles registry.
+	 *
+	 * @since 6.6.0
+	 * @var WP_Block_Styles_Registry
+	 */
+	private $registry = null;
+
+	/**
+	 * Set up each test method.
+	 *
+	 * @since 6.6.0
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->registry = new WP_Block_Styles_Registry();
+	}
+
+	/**
+	 * Tear down each test method.
+	 *
+	 * @since 6.6.0
+	 */
+	public function tear_down() {
+		$this->registry = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Should accept valid string block type name.
+	 *
+	 * @ticket
+	 */
+	public function test_register_block_style_with_string_block_name() {
+		$name             = 'core/paragraph';
+		$style_properties = array( 'name' => 'fancy' );
+		$result           = $this->registry->register( $name, $style_properties );
+		$this->assertTrue( $result );
+		$this->assertTrue( $this->registry->is_registered( 'core/paragraph', 'fancy' ) );
+	}
+
+	/**
+	 * Should accept valid array of block type names.
+	 *
+	 * @ticket
+	 */
+	public function test_register_block_style_with_array_of_block_names() {
+		$names            = array( 'core/paragraph', 'core/group' );
+		$style_properties = array( 'name' => 'plain' );
+		$result           = $this->registry->register( $names, $style_properties );
+		$this->assertTrue( $result );
+		$this->assertTrue( $this->registry->is_registered( 'core/paragraph', 'plain' ) );
+		$this->assertTrue( $this->registry->is_registered( 'core/group', 'plain' ) );
+	}
+}


### PR DESCRIPTION
Adds to core the functionality from: 

- https://github.com/WordPress/gutenberg/pull/61029

The Gutenberg PR linked above was forced to add a new global function because the core `WP_Block_Styles_Registry` class was marked as `final`. This backport involves updating the `WP_Block_Styles_Registry` class directly with matching functionality.

Included is the addition of `style_data` within the supported style properties. The `style_data` property is a theme.json shaped array that will be used by the new [section styling feature](https://github.com/WordPress/gutenberg/issues/57537) to generate a dynamic stylesheet for the block style.

Trac ticket: https://core.trac.wordpress.org/ticket/61274

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
