### PR TITLE
Twenty Sixteen: Pullquote block border, margin and padding

### DIFF
--- a/src/wp-content/themes/twentysixteen/css/blocks.css
+++ b/src/wp-content/themes/twentysixteen/css/blocks.css
@@ -394,12 +394,20 @@ hr.wp-block-separator {
 	background-color: #1a1a1a;
 }
 
+.has-dark-gray-border-color {
+	border-color: #1a1a1a;
+}
+
 .has-medium-gray-color {
 	color: #686868;
 }
 
 .has-medium-gray-background-color {
 	background-color: #686868;
+}
+
+.has-medium-gray-border-color {
+	border-color: #686868;
 }
 
 .has-light-gray-color {
@@ -410,12 +418,20 @@ hr.wp-block-separator {
 	background-color: #e5e5e5;
 }
 
+.has-light-gray-border-color {
+	border-color: #e5e5e5;
+}
+
 .has-white-color {
 	color: #fff;
 }
 
 .has-white-background-color {
 	background-color: #fff;
+}
+
+.has-white-border-color {
+	border-color: #fff;
 }
 
 .has-blue-gray-color {
@@ -426,12 +442,20 @@ hr.wp-block-separator {
 	background-color: #4d545c;
 }
 
+.has-blue-gray-border-color {
+	border-color: #4d545c;
+}
+
 .has-bright-blue-color {
 	color: #007acc;
 }
 
 .has-bright-blue-background-color {
 	background-color: #007acc;
+}
+
+.has-bright-blue-border-color {
+	border-color: #007acc;
 }
 
 .has-light-blue-color {
@@ -442,12 +466,20 @@ hr.wp-block-separator {
 	background-color: #9adffd;
 }
 
+.has-light-blue-border-color {
+	border-color: #9adffd;
+}
+
 .has-dark-brown-color {
 	color: #402b30;
 }
 
 .has-dark-brown-background-color {
 	background-color: #402b30;
+}
+
+.has-dark-brown-border-color {
+	border-color: #402b30;
 }
 
 .has-medium-brown-color {
@@ -458,12 +490,20 @@ hr.wp-block-separator {
 	background-color: #774e24;
 }
 
+.has-medium-brown-border-color {
+	border-color: #774e24;
+}
+
 .has-dark-red-color {
 	color: #640c1f;
 }
 
 .has-dark-red-background-color {
 	background-color: #640c1f;
+}
+
+.has-dark-red-border-color {
+	border-color: #640c1f;
 }
 
 .has-bright-red-color {
@@ -474,10 +514,18 @@ hr.wp-block-separator {
 	background-color: #ff675f;
 }
 
+.has-bright-red-border-color {
+	border-color: #ff675f;
+}
+
 .has-yellow-color {
 	color: #ffef8e;
 }
 
 .has-yellow-background-color {
 	background-color: #ffef8e;
+}
+
+.has-yellow-border-color {
+	border-color: #ffef8e;
 }

--- a/src/wp-content/themes/twentysixteen/css/blocks.css
+++ b/src/wp-content/themes/twentysixteen/css/blocks.css
@@ -176,6 +176,11 @@ p.has-drop-cap:not(:focus)::first-letter {
 	padding: 0;
 }
 
+.entry-content .wp-block-pullquote blockquote:not(.alignleft):not(.alignright) {
+	margin-left: 0;
+	margin-right: 0;
+}
+
 .wp-block-pullquote.has-text-color blockquote,
 .wp-block-pullquote.has-background blockquote,
 .has-background .wp-block-pullquote blockquote,

--- a/src/wp-content/themes/twentysixteen/css/blocks.css
+++ b/src/wp-content/themes/twentysixteen/css/blocks.css
@@ -181,6 +181,11 @@ p.has-drop-cap:not(:focus)::first-letter {
 	margin-right: 0;
 }
 
+.wp-block-pullquote:where([style*="border-width"]) blockquote {
+	padding-left: 1rem;
+	padding-right: 1rem;
+}
+
 .wp-block-pullquote.has-text-color blockquote,
 .wp-block-pullquote.has-background blockquote,
 .has-background .wp-block-pullquote blockquote,

--- a/src/wp-content/themes/twentysixteen/css/blocks.css
+++ b/src/wp-content/themes/twentysixteen/css/blocks.css
@@ -171,15 +171,9 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 .wp-block-pullquote blockquote {
 	color: #686868;
-	border-left: 4px solid #1a1a1a;
+	border: 0;
 	margin: 0;
-	padding: 0 0 0 24px;
-}
-
-.rtl .wp-block-pullquote blockquote {
-	border-left: none;
-	border-right: 4px solid #1a1a1a;
-	padding: 0 24px 0 0;
+	padding: 0;
 }
 
 .wp-block-pullquote.has-text-color blockquote,

--- a/src/wp-content/themes/twentysixteen/css/editor-blocks.css
+++ b/src/wp-content/themes/twentysixteen/css/editor-blocks.css
@@ -499,7 +499,7 @@ Description: Used to style blocks in the editor.
 
 /* Pullquote */
 
-.editor-block-list__block .wp-block-pullquote blockquote {
+.editor-styles-wrapper .wp-block-pullquote blockquote {
 	border: 0;
 	margin: 0;
 	padding: 0;

--- a/src/wp-content/themes/twentysixteen/css/editor-blocks.css
+++ b/src/wp-content/themes/twentysixteen/css/editor-blocks.css
@@ -505,6 +505,11 @@ Description: Used to style blocks in the editor.
 	padding: 0;
 }
 
+.editor-styles-wrapper .wp-block-pullquote:where([style*="border-width"]) blockquote {
+	padding-left: 1rem;
+	padding-right: 1rem;
+}
+
 .wp-block-pullquote blockquote > .editor-rich-text p {
 	font-size: 19px;
 	font-size: 1.1875rem;


### PR DESCRIPTION
- Removes the extra border and padding on the front end to restore the style that the block had before WordPress 5.4.
- Replaces the obsolete `.editor-block-list__block` class to set the `blockquote` element's border, margin and padding to zero again.
- Overrides negative left or right margin on the `blockquote` within a Pullquote block, for either LTR or RTL text direction.
- Adds `1rem` padding on the left and right when someone adds a border on all four sides of the block.

[Trac 59754](https://core.trac.wordpress.org/ticket/59754)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
