### PR TITLE
HTML API: Respect `class_name` query arg in `HTML_Processor::next_tag()`

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -386,9 +386,17 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			return false;
 		}
 
+		$needs_class = ( isset( $query['class_name'] ) && is_string( $query['class_name'] ) )
+			? $query['class_name']
+			: null;
+
 		if ( ! ( array_key_exists( 'breadcrumbs', $query ) && is_array( $query['breadcrumbs'] ) ) ) {
 			while ( $this->step() ) {
 				if ( '#tag' !== $this->get_token_type() ) {
+					continue;
+				}
+
+				if ( isset( $needs_class ) && ! $this->has_class( $needs_class ) ) {
 					continue;
 				}
 
@@ -414,6 +422,10 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 
 		while ( $match_offset > 0 && $this->step() ) {
 			if ( '#tag' !== $this->get_token_type() ) {
+				continue;
+			}
+
+			if ( isset( $needs_class ) && ! $this->has_class( $needs_class ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
Trac ticket: Core-58517

Previously the HTML Process was ignoring the `class_name` argument in the `next_tag()` query if it existed. This was wrong and would lead to calling code finding the wrong tag if provided.

This patch adds the class detection code back into `next_tag()` to fix the bug.

Follow-up to [[56274]](https://core.trac.wordpress.org/changeset/56274).