### PR TITLE
Script Loader: Fix missing block style loaded with `style_handle`

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -572,6 +572,7 @@ add_action( 'admin_enqueue_scripts', 'wp_localize_jquery_ui_datepicker', 1000 );
 add_action( 'admin_enqueue_scripts', 'wp_common_block_scripts_and_styles' );
 add_action( 'enqueue_block_assets', 'wp_enqueue_registered_block_scripts_and_styles' );
 add_action( 'enqueue_block_assets', 'enqueue_block_styles_assets', 30 );
+add_action( 'wp_loaded', 'enqueue_block_styles_handle_assets' );
 /*
  * `wp_enqueue_registered_block_scripts_and_styles` is bound to both
  * `enqueue_block_editor_assets` and `enqueue_block_assets` hooks

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2700,6 +2700,20 @@ function enqueue_block_styles_handle_assets() {
 				continue;
 			}
 
+			/**
+			 * Add the path to the CSS file in the style extra data if missing.
+			 *
+			 * This allow WordPress to inline the CSS instead of loading it like an external  resource if the file
+			 * is bellow the size threshold.
+			 */
+			$style = $wp_styles->registered[ $style_properties['style_handle'] ];
+			if ( $style && ! empty( $style->src ) && empty( $style->extra['path'] ) ) {
+				$style_path = wp_normalize_path( str_replace( WP_CONTENT_URL, WP_CONTENT_DIR, $style->src ) );
+				if ( is_readable( $style_path ) ) {
+					$style->add_data( 'path', $style_path );
+				}
+			}
+
 			$handle           = $style_properties['style_handle'];
 			$enqueue_callback = function () use ( $handle ) {
 				wp_enqueue_style( $handle );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2700,7 +2700,7 @@ function enqueue_block_styles_handle_assets() {
 				continue;
 			}
 
-			/**
+			/*
 			 * Add the path to the CSS file in the style extra data if missing.
 			 *
 			 * This allow WordPress to inline the CSS instead of loading it like an external  resource if the file

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2684,7 +2684,7 @@ function enqueue_block_styles_assets() {
 }
 
 /**
- * Function responsible for enqueuing the CSS files required for block styles functionality on the editor and on the frontend.
+ * Function responsible for enqueuing the CSS files required for block styles functionality on the editor and frontend.
  *
  * @since 6.6.0
  *

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2662,25 +2662,6 @@ function enqueue_block_styles_assets() {
 
 	foreach ( $block_styles as $block_name => $styles ) {
 		foreach ( $styles as $style_properties ) {
-			if ( isset( $style_properties['style_handle'] ) ) {
-
-				// If the site loads separate styles per-block, enqueue the stylesheet on render.
-				if ( wp_should_load_separate_core_block_assets() ) {
-					add_filter(
-						'render_block',
-						static function ( $html, $block ) use ( $block_name, $style_properties ) {
-							if ( $block['blockName'] === $block_name ) {
-								wp_enqueue_style( $style_properties['style_handle'] );
-							}
-							return $html;
-						},
-						10,
-						2
-					);
-				} else {
-					wp_enqueue_style( $style_properties['style_handle'] );
-				}
-			}
 			if ( isset( $style_properties['inline_style'] ) ) {
 
 				// Default to "wp-block-library".
@@ -2698,6 +2679,49 @@ function enqueue_block_styles_assets() {
 				// Add inline styles to the calculated handle.
 				wp_add_inline_style( $handle, $style_properties['inline_style'] );
 			}
+		}
+	}
+}
+
+/**
+ * Function responsible for enqueuing the CSS files required for block styles functionality on the editor and on the frontend.
+ *
+ * @since 6.6.0
+ *
+ * @global WP_Styles $wp_styles
+ */
+function enqueue_block_styles_handle_assets() {
+	global $wp_styles;
+
+	$block_styles = WP_Block_Styles_Registry::get_instance()->get_all_registered();
+	foreach ( $block_styles as $block_name => $styles ) {
+		foreach ( $styles as $style_properties ) {
+			if ( ! isset( $style_properties['style_handle'] ) || ! isset( $wp_styles->registered[ $style_properties['style_handle'] ] ) ) {
+				continue;
+			}
+
+			$handle           = $style_properties['style_handle'];
+			$enqueue_callback = function () use ( $handle ) {
+				wp_enqueue_style( $handle );
+			};
+
+			if ( wp_should_load_separate_core_block_assets() ) {
+				add_filter(
+					'render_block',
+					static function ( $html, $block ) use ( $block_name, $enqueue_callback ) {
+						if ( $block['blockName'] === $block_name ) {
+							$enqueue_callback();
+						}
+
+						return $html;
+					},
+					10,
+					2
+				);
+				continue;
+			}
+
+			add_action( 'enqueue_block_assets', $enqueue_callback );
 		}
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Fix missing block style loaded with `style_handle`.

It's possible to register a block style with a handle instead of an inline style. In that case and when `wp_should_load_separate_core_block_assets()` is `true`, the current code will rely on the `render_block` filter to detect if the block is used on the page and the block style need to be enqueued.

This doesn't work as expected, since the function is called in `enqueue_block_assets` after the `render_block` filter has run.

This PR add a new function hooked to `wp_loaded` to fix the issue.

Trac ticket: https://core.trac.wordpress.org/ticket/55184

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
