### PR TITLE
Add role attribute to improve accessibility

### DIFF
--- a/src/js/_enqueues/admin/privacy-tools.js
+++ b/src/js/_enqueues/admin/privacy-tools.js
@@ -47,7 +47,7 @@ jQuery( function( $ ) {
 
 		$requestRow.after( function() {
 			return '<tr class="' + resultRowClasses + '"><th colspan="5">' +
-				'<div class="notice inline notice-alt ' + classes + '">' +
+				'<div class="notice inline notice-alt ' + classes + '" role="alert">' +
 				'<p>' + summaryMessage + '</p>' +
 				itemList +
 				'</div>' +

--- a/src/js/_enqueues/admin/user-profile.js
+++ b/src/js/_enqueues/admin/user-profile.js
@@ -151,7 +151,9 @@
 	 * @param {string}        message The message to insert.
 	 */
 	function addInlineNotice( $this, success, message ) {
-		var resultDiv = $( '<div />' );
+		var resultDiv = $( '<div />', {
+			role: 'alert'
+		} );
 
 		// Set up the notice div.
 		resultDiv.addClass( 'notice inline' );
@@ -474,10 +476,10 @@
 		}).done( function( response ) {
 			$this.prop( 'disabled', true );
 			$this.siblings( '.notice' ).remove();
-			$this.before( '<div class="notice notice-success inline"><p>' + response.message + '</p></div>' );
+			$this.before( '<div class="notice notice-success inline" role="alert"><p>' + response.message + '</p></div>' );
 		}).fail( function( response ) {
 			$this.siblings( '.notice' ).remove();
-			$this.before( '<div class="notice notice-error inline"><p>' + response.message + '</p></div>' );
+			$this.before( '<div class="notice notice-error inline" role="alert"><p>' + response.message + '</p></div>' );
 		});
 
 		e.preventDefault();

--- a/src/js/_enqueues/lib/ajax-response.js
+++ b/src/js/_enqueues/lib/ajax-response.js
@@ -53,10 +53,10 @@ window.wpAjax = jQuery.extend( {
 				parsed.responses.push( response );
 			} );
 			if ( err.length ) {
-				re.html( '<div class="notice notice-error">' + err + '</div>' );
+				re.html( '<div class="notice notice-error" role="alert">' + err + '</div>' );
 				wp.a11y.speak( err );
 			} else if ( noticeMessage.length ) {
-				re.html( '<div class="notice notice-success is-dismissible"><p>' + noticeMessage + '</p></div>');
+				re.html( '<div class="notice notice-success is-dismissible" role="alert"><p>' + noticeMessage + '</p></div>');
 				jQuery(document).trigger( 'wp-updates-notice-added' );
 				wp.a11y.speak( noticeMessage );
 			}
@@ -64,15 +64,15 @@ window.wpAjax = jQuery.extend( {
 		}
 		if ( isNaN( x ) ) {
 			wp.a11y.speak( x );
-			return ! re.html( '<div class="notice notice-error"><p>' + x + '</p></div>' );
+			return ! re.html( '<div class="notice notice-error" role="alert"><p>' + x + '</p></div>' );
 		}
 		x = parseInt( x, 10 );
 		if ( -1 === x ) {
 			wp.a11y.speak( wpAjax.noPerm );
-			return ! re.html( '<div class="notice notice-error"><p>' + wpAjax.noPerm + '</p></div>' );
+			return ! re.html( '<div class="notice notice-error" role="alert"><p>' + wpAjax.noPerm + '</p></div>' );
 		} else if ( 0 === x ) {
 			wp.a11y.speak( wpAjax.broken );
-			return ! re.html( '<div class="notice notice-error"><p>' + wpAjax.broken  + '</p></div>' );
+			return ! re.html( '<div class="notice notice-error" role="alert"><p>' + wpAjax.broken  + '</p></div>' );
 		}
 		return true;
 	},

--- a/src/js/_enqueues/wp/customize/widgets.js
+++ b/src/js/_enqueues/wp/customize/widgets.js
@@ -1623,7 +1623,8 @@
 
 				// @todo This should use the Notifications API introduced to panels. See <https://core.trac.wordpress.org/ticket/38794>.
 				noticeContainer = $( '<div></div>', {
-					'class': 'no-widget-areas-rendered-notice'
+					'class': 'no-widget-areas-rendered-notice',
+					'role': 'alert'
 				});
 				panelMetaContainer.append( noticeContainer );
 

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -875,7 +875,7 @@
 
 		$card
 			.addClass( 'plugin-card-update-failed' )
-			.append( '<div class="notice notice-error notice-alt is-dismissible"><p>' + errorMessage + '</p></div>' );
+			.append( '<div class="notice notice-error notice-alt is-dismissible" role="alert"><p>' + errorMessage + '</p></div>' );
 
 		$card.on( 'click', '.notice.is-dismissible .notice-dismiss', function() {
 

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -2287,7 +2287,7 @@
 
 		// Remove any existing error.
 		$filesystemForm.find( '.notice' ).remove();
-		$filesystemForm.find( '#request-filesystem-credentials-title' ).after( '<div class="notice notice-alt notice-error"><p>' + message + '</p></div>' );
+		$filesystemForm.find( '#request-filesystem-credentials-title' ).after( '<div class="notice notice-alt notice-error" role="alert"><p>' + message + '</p></div>' );
 	};
 
 	/**

--- a/src/js/_enqueues/wp/widgets/custom-html.js
+++ b/src/js/_enqueues/wp/widgets/custom-html.js
@@ -148,7 +148,7 @@ wp.customHtmlWidgets = ( function( $ ) {
 					} ) );
 				}
 			} else if ( 0 !== errorAnnotations.length ) {
-				errorNotice = $( '<div class="inline notice notice-error notice-alt"></div>' );
+				errorNotice = $( '<div class="inline notice notice-error notice-alt" role="alert"></div>' );
 				errorNotice.append( $( '<p></p>', {
 					text: message
 				} ) );

--- a/src/js/_enqueues/wp/widgets/media.js
+++ b/src/js/_enqueues/wp/widgets/media.js
@@ -158,7 +158,7 @@ wp.mediaWidgets = ( function( $ ) {
 							}
 						} else {
 							if ( ! noticeContainer.length ) {
-								noticeContainer = $( '<div class="media-widget-embed-notice notice notice-error notice-alt"></div>' );
+								noticeContainer = $( '<div class="media-widget-embed-notice notice notice-error notice-alt" role="alert"></div>' );
 								noticeContainer.hide();
 								embedLinkView.views.parent.$el.prepend( noticeContainer );
 							}


### PR DESCRIPTION
Fixes : [ticket/47111](https://core.trac.wordpress.org/ticket/47111)

## Summary

Add role as alert on containers showing any type of dynamically added notifications error/success/informational notice (specifically on javascript files).

---

## Testing Instructions

1. To test `src/js/_enqueues/admin/privacy-tools.js`: 
- Go to Tools > Erase Personal Data or Tools > Export Personal Data. Performing a data export or erase data request. Verify that before the patch, the notice is not read out immediately by the screen reader and that after the patch, it is.

2. To test `src/js/_enqueues/admin/user-profile.js`: 
- Go to Users > Profile. Request a password reset. Verify that before the patch, the notice is not read out immediately by the screen reader and that after the patch, it is.

3. To test `src/js/_enqueues/lib/ajax-response.js`: 
- Go to Comments page on dashboard. And if any sort of error occurs then before the patch, the notice is not read out immediately by the screen reader and that after the patch, it is.

4. To test `src/js/_enqueues/wp/customize/widgets.js`: 
- Go to Appearance > Customize > Widgets customizer . And if any sort of notice is displayed then before the patch, the notice is not read out immediately by the screen reader and that after the patch, it is.

5. To test `src/js/_enqueues/wp/updates.js`: 
- Go to Plugins >Add New Plugin. And install any plugin. If the plugin triggers some error during installation then a card will be displayed. Before the patch, the card is not read out immediately by the screen reader and that after the patch, it is.

6. To test `src/js/_enqueues/wp/widgets/custom-html.js`: 
- Go to Appearance > Widgets. If any html lint error occurs. Then an error notice will be displayed. Before the patch, the card is not read out immediately by the screen reader and that after the patch, it is.

7. To test `src/js/_enqueues/wp/widgets/media.js`: 
- Go to Post > Add New Post. If any media embed error occurs. Then an error notice will be displayed. Before the patch, the card is not read out immediately by the screen reader and that after the patch, it is.
