### PR TITLE
Assert files exist/do not exist directly.

### DIFF
--- a/tests/phpunit/tests/fonts/font-library/fontLibraryHooks.php
+++ b/tests/phpunit/tests/fonts/font-library/fontLibraryHooks.php
@@ -46,8 +46,8 @@ class Tests_Fonts_FontLibraryHooks extends WP_UnitTestCase {
 
 		wp_delete_post( $font_face_id, true );
 
-		$this->assertFalse( file_exists( $font_path ), 'The font file should have been deleted when the post was deleted.' );
-		$this->assertTrue( file_exists( $other_font_path ), 'The other font file should exist.' );
+		$this->assertFileDoesNotExist( $font_path, 'The font file should have been deleted when the post was deleted.' );
+		$this->assertFileExists( $other_font_path, 'The other font file should exist.' );
 	}
 
 	protected function create_font_face_with_file( $filename ) {

--- a/tests/phpunit/tests/privacy/wpPrivacyDeleteOldExportFiles.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyDeleteOldExportFiles.php
@@ -113,7 +113,7 @@ class Tests_Privacy_wpPrivacyDeleteOldExportFiles extends WP_UnitTestCase {
 	public function test_expired_files_should_be_deleted() {
 		wp_privacy_delete_old_export_files();
 
-		$this->assertFalse( file_exists( self::$expired_export_file ) );
+		$this->assertFileDoesNotExist( self::$expired_export_file );
 	}
 
 	/**
@@ -124,7 +124,7 @@ class Tests_Privacy_wpPrivacyDeleteOldExportFiles extends WP_UnitTestCase {
 	public function test_unexpired_files_should_not_be_deleted() {
 		wp_privacy_delete_old_export_files();
 
-		$this->assertTrue( file_exists( self::$active_export_file ) );
+		$this->assertFileExists( self::$active_export_file );
 	}
 
 	/**
@@ -135,7 +135,7 @@ class Tests_Privacy_wpPrivacyDeleteOldExportFiles extends WP_UnitTestCase {
 	public function test_index_file_should_never_be_deleted() {
 		wp_privacy_delete_old_export_files();
 
-		$this->assertTrue( file_exists( self::$index_path ) );
+		$this->assertFileExists( self::$index_path );
 	}
 
 	/**
@@ -147,8 +147,8 @@ class Tests_Privacy_wpPrivacyDeleteOldExportFiles extends WP_UnitTestCase {
 		add_filter( 'wp_privacy_export_expiration', array( $this, 'filter_export_file_expiration_time' ) );
 
 		wp_privacy_delete_old_export_files();
-		$this->assertTrue( file_exists( self::$active_export_file ) );
-		$this->assertTrue( file_exists( self::$expired_export_file ) );
+		$this->assertFileExists( self::$active_export_file );
+		$this->assertFileExists( self::$expired_export_file );
 
 		remove_filter( 'wp_privacy_export_expiration', array( $this, 'filter_export_file_expiration_time' ) );
 	}

--- a/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
@@ -289,7 +289,7 @@ class Tests_Privacy_wpPrivacyGeneratePersonalDataExportFile extends WP_UnitTestC
 		$this->expectOutputString( '' );
 		wp_privacy_generate_personal_data_export_file( self::$export_request_id );
 
-		$this->assertTrue( file_exists( self::$exports_dir . 'index.php' ) );
+		$this->assertFileExists( self::$exports_dir . 'index.php' );
 	}
 
 	/**
@@ -300,7 +300,7 @@ class Tests_Privacy_wpPrivacyGeneratePersonalDataExportFile extends WP_UnitTestC
 	public function test_can_succeed() {
 		wp_privacy_generate_personal_data_export_file( self::$export_request_id );
 
-		$this->assertTrue( file_exists( $this->export_file_name ) );
+		$this->assertFileExists( $this->export_file_name );
 	}
 
 	/**
@@ -408,7 +408,7 @@ class Tests_Privacy_wpPrivacyGeneratePersonalDataExportFile extends WP_UnitTestC
 		$this->expectOutputString( '' );
 
 		wp_privacy_generate_personal_data_export_file( self::$export_request_id );
-		$this->assertTrue( file_exists( $this->export_file_name ) );
+		$this->assertFileExists( $this->export_file_name );
 
 		// Create a temporary export directory for the test's export files.
 		$report_dir = trailingslashit( self::$exports_dir . 'test_contents' );


### PR DESCRIPTION
Avoid the `assertTrue|False( file_exists() )` pattern and use file assertions directly.

Trac ticket: https://core.trac.wordpress.org/ticket/60705

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
