### PR TITLE
Replace em-based line-heigh with unitless values

### DIFF
--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -1416,7 +1416,7 @@ p.description code {
 
 p.popular-tags {
 	border: none;
-	line-height: 2em;
+	line-height: 2;
 	padding: 8px 12px 12px;
 	text-align: justify;
 }

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -2341,7 +2341,7 @@ div.action-links,
 
 	table.plugin-install td.column-name strong {
 		font-size: 1.4em;
-		line-height: 1.6em;
+		line-height: 1.6;
 	}
 
 	table.plugin-install #the-list td {

--- a/src/wp-admin/css/nav-menus.css
+++ b/src/wp-admin/css/nav-menus.css
@@ -178,7 +178,7 @@ input.bulk-select-switcher:focus + .bulk-select-button-label {
 	appearance: none;
 	font-size: inherit;
 	border: 0;
-	line-height: 2.1em;
+	line-height: 2.1;
 	background: none;
 	cursor: pointer;
 	text-decoration: underline;


### PR DESCRIPTION
no I was found some line height em values in
replace line height value from em to unitless

Files updated:
- edit.css
- nav-menus.css
- list-tables.css

Trac ticket: https://core.trac.wordpress.org/ticket/59960
