### PR TITLE
Add has_translation function to WP_Translation_Controller

### DIFF
--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1988,3 +1988,15 @@ function wp_get_word_count_type() {
 
 	return $wp_locale->get_word_count_type();
 }
+
+/**
+ * Returns a boolean to indicate whether a translation exists for a given string with optional text domain and locale.
+ *
+ * @param string $singular  Singular translation to check.
+ * @param string $textdomain  Optional. Text domain. Default 'default'.
+ * @param ?string $locale  Optional. Locale. Default current locale.
+ * @return bool  True if the translation exists, false otherwise.
+ */
+function has_translation( string $singular, string $textdomain = 'default', ?string $locale = null ): bool {
+	return WP_Translation_Controller::get_instance()->has_translation( $singular, $textdomain, $locale );
+}

--- a/src/wp-includes/l10n/class-wp-translation-controller.php
+++ b/src/wp-includes/l10n/class-wp-translation-controller.php
@@ -434,4 +434,20 @@ final class WP_Translation_Controller {
 
 		return $this->loaded_translations[ $locale ][ $textdomain ] ?? array();
 	}
+
+	/**
+	 * Returns a boolean to indicate whether a translation exists for a given string with optional text domain and locale.
+	 *
+	 * @param string $singular  Singular translation to check.
+	 * @param string $textdomain  Optional. Text domain. Default 'default'.
+	 * @param ?string $locale  Optional. Locale. Default current locale.
+	 * @return bool  True if the translation exists, false otherwise.
+	 */
+	public function has_translation( string $singular, string $textdomain = 'default', ?string $locale = null ): bool {
+		if ( null === $locale ) {
+			$locale = $this->current_locale;
+		}
+
+		return false !== $this->locate_translation( $singular, $textdomain, $locale );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Added a new `has_translation` public method to the `WP_Translation_Controller` which calls the protected `locate_translation` method to determine if a translation is available for the given string (with optional textdomain and locale).
Also, exposed this in `l10n.php`.

Trac ticket: [https://core.trac.wordpress.org/ticket/52696#comment:17](https://core.trac.wordpress.org/ticket/52696#comment:17)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
