### PR TITLE
Add transient validation methods and corresponding tests

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1391,13 +1391,12 @@ function delete_transient( $transient ) {
  * If the transient does not exist, does not have a value, or has expired,
  * then the return value will be false.
  *
- * @param string $transient Transient name. Expected to not be SQL-escaped.
- *
- * @return bool
  * @since 4.7.0
  *
+ * @param string $transient Transient name. Expected to not be SQL-escaped.
+ * @return bool
  */
-function valid_transient( $transient ) {
+function is_valid_transient($transient ) {
 	$transient_option  = '_transient_' . $transient;
 	$transient_timeout = '_transient_timeout_' . $transient;
 
@@ -1462,7 +1461,7 @@ function get_transient( $transient ) {
 			// If option is not in alloptions, it is not autoloaded and thus has a timeout.
 			$alloptions = wp_load_alloptions();
 
-			if ( ! isset( $alloptions[ $transient_option ] ) && ! valid_transient( $transient ) ) {
+			if ( ! isset( $alloptions[ $transient_option ] ) && ! is_valid_transient( $transient ) ) {
 				$value = false;
 			}
 		}
@@ -2505,10 +2504,9 @@ function delete_site_transient( $transient ) {
 * @since 4.7.0
 *
 * @param string $transient Transient name. Expected to not be SQL-escaped.
-*
 * @return bool
 */
-function valid_site_transient( $transient ) {
+function is_valid_site_transient($transient ) {
 	$transient_option  = '_site_transient_' . $transient;
 	$transient_timeout = '_site_transient_timeout_' . $transient;
 
@@ -2571,7 +2569,7 @@ function get_site_transient( $transient ) {
 	} else {
 		// Core transients that do not have a timeout. Listed here so querying timeouts can be avoided.
 		$no_timeout       = array( 'update_core', 'update_plugins', 'update_themes' );
-		if ( ! in_array( $transient, $no_timeout, true ) && ! valid_site_transient( $transient ) ) {
+		if ( ! in_array( $transient, $no_timeout, true ) && ! is_valid_site_transient( $transient ) ) {
 				$value = false;
 		}
 

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1386,6 +1386,40 @@ function delete_transient( $transient ) {
 }
 
 /**
+ * Determines if a transient is valid.
+ *
+ * If the transient does not exist, does not have a value, or has expired,
+ * then the return value will be false.
+ *
+ * @param string $transient Transient name. Expected to not be SQL-escaped.
+ *
+ * @return bool
+ * @since 4.7.0
+ *
+ */
+function valid_transient( $transient ) {
+	$transient_option  = '_transient_' . $transient;
+	$transient_timeout = '_transient_timeout_' . $transient;
+
+	wp_prime_option_caches( array( $transient_option, $transient_timeout ) );
+	$timeout = get_option( $transient_timeout );
+
+	// No transient found.
+	if ( false === $timeout ) {
+
+		return (bool) get_option( $transient_option );
+	} elseif ( $timeout < time() ) { // Expired transient detected.
+		delete_option('_transient_' . $transient);
+		delete_option($transient_timeout);
+
+		return false;
+	}
+
+	// Transient is valid.
+	return true;
+}
+
+/**
  * Retrieves the value of a transient.
  *
  * If the transient does not exist, does not have a value, or has expired,
@@ -1428,15 +1462,8 @@ function get_transient( $transient ) {
 			// If option is not in alloptions, it is not autoloaded and thus has a timeout.
 			$alloptions = wp_load_alloptions();
 
-			if ( ! isset( $alloptions[ $transient_option ] ) ) {
-				$transient_timeout = '_transient_timeout_' . $transient;
-				wp_prime_option_caches( array( $transient_option, $transient_timeout ) );
-				$timeout = get_option( $transient_timeout );
-				if ( false !== $timeout && $timeout < time() ) {
-					delete_option( $transient_option );
-					delete_option( $transient_timeout );
-					$value = false;
-				}
+			if ( ! isset( $alloptions[ $transient_option ] ) && ! valid_transient( $transient )  ) {
+				$value = false;
 			}
 		}
 
@@ -2469,7 +2496,39 @@ function delete_site_transient( $transient ) {
 
 	return $result;
 }
+/**
+* Determines if a site transient is valid.
+*
+* If the transient does not exist, does not have a value, or has expired,
+* then the return value will be false.
+*
+* @since 4.7.0
+*
+* @param string $transient Transient name. Expected to not be SQL-escaped.
+*
+* @return bool
+*/
+function valid_site_transient( $transient ) {
+	$transient_option  = '_site_transient_' . $transient;
+	$transient_timeout = '_site_transient_timeout_' . $transient;
 
+	wp_prime_site_option_caches( array( $transient_option, $transient_timeout ) );
+	$timeout = get_site_option( $transient_timeout );
+
+	// No transient found.
+	if ( false === $timeout ) {
+
+		return (bool) get_option( $transient_option );
+	} elseif ( $timeout < time() ) { // Expired transient detected.
+		delete_site_option( '_site_transient_' . $transient );
+		delete_site_option( $transient_timeout );
+
+		return false;
+	}
+
+	// Transient is valid.
+	return true;
+}
 /**
  * Retrieves the value of a site transient.
  *
@@ -2512,21 +2571,12 @@ function get_site_transient( $transient ) {
 	} else {
 		// Core transients that do not have a timeout. Listed here so querying timeouts can be avoided.
 		$no_timeout       = array( 'update_core', 'update_plugins', 'update_themes' );
-		$transient_option = '_site_transient_' . $transient;
-		if ( ! in_array( $transient, $no_timeout, true ) ) {
-			$transient_timeout = '_site_transient_timeout_' . $transient;
-			wp_prime_site_option_caches( array( $transient_option, $transient_timeout ) );
-
-			$timeout = get_site_option( $transient_timeout );
-			if ( false !== $timeout && $timeout < time() ) {
-				delete_site_option( $transient_option );
-				delete_site_option( $transient_timeout );
+		if ( ! in_array( $transient, $no_timeout, true ) && ! valid_site_transient( $transient ) ) {
 				$value = false;
-			}
 		}
 
 		if ( ! isset( $value ) ) {
-			$value = get_site_option( $transient_option );
+			$value = get_site_option( '_site_transient_' . $transient );
 		}
 	}
 

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1391,7 +1391,7 @@ function delete_transient( $transient ) {
  * If the transient does not exist, does not have a value, or has expired,
  * then the return value will be false.
  *
- * @since 6.5.0
+ * @since 6.6.0
  *
  * @param string $transient Transient name. Expected to not be SQL-escaped.
  * @return bool
@@ -2501,7 +2501,7 @@ function delete_site_transient( $transient ) {
 * If the transient does not exist, does not have a value, or has expired,
 * then the return value will be false.
 *
-* @since 6.5.0
+* @since 6.6.0
 *
 * @param string $transient Transient name. Expected to not be SQL-escaped.
 * @return bool

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1409,8 +1409,8 @@ function valid_transient( $transient ) {
 
 		return (bool) get_option( $transient_option );
 	} elseif ( $timeout < time() ) { // Expired transient detected.
-		delete_option('_transient_' . $transient);
-		delete_option($transient_timeout);
+		delete_option( '_transient_' . $transient );
+		delete_option( $transient_timeout );
 
 		return false;
 	}
@@ -1462,7 +1462,7 @@ function get_transient( $transient ) {
 			// If option is not in alloptions, it is not autoloaded and thus has a timeout.
 			$alloptions = wp_load_alloptions();
 
-			if ( ! isset( $alloptions[ $transient_option ] ) && ! valid_transient( $transient )  ) {
+			if ( ! isset( $alloptions[ $transient_option ] ) && ! valid_transient( $transient ) ) {
 				$value = false;
 			}
 		}

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1391,7 +1391,7 @@ function delete_transient( $transient ) {
  * If the transient does not exist, does not have a value, or has expired,
  * then the return value will be false.
  *
- * @since 4.7.0
+ * @since 6.5.0
  *
  * @param string $transient Transient name. Expected to not be SQL-escaped.
  * @return bool
@@ -2501,7 +2501,7 @@ function delete_site_transient( $transient ) {
 * If the transient does not exist, does not have a value, or has expired,
 * then the return value will be false.
 *
-* @since 4.7.0
+* @since 6.5.0
 *
 * @param string $transient Transient name. Expected to not be SQL-escaped.
 * @return bool

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1396,7 +1396,7 @@ function delete_transient( $transient ) {
  * @param string $transient Transient name. Expected to not be SQL-escaped.
  * @return bool
  */
-function is_valid_transient($transient ) {
+function is_valid_transient( $transient ) {
 	$transient_option  = '_transient_' . $transient;
 	$transient_timeout = '_transient_timeout_' . $transient;
 
@@ -2506,7 +2506,7 @@ function delete_site_transient( $transient ) {
 * @param string $transient Transient name. Expected to not be SQL-escaped.
 * @return bool
 */
-function is_valid_site_transient($transient ) {
+function is_valid_site_transient( $transient ) {
 	$transient_option  = '_site_transient_' . $transient;
 	$transient_timeout = '_site_transient_timeout_' . $transient;
 

--- a/tests/phpunit/tests/option/ValidTransient.php
+++ b/tests/phpunit/tests/option/ValidTransient.php
@@ -4,7 +4,7 @@
  * @group option
  * @group transient
  *
- * @covers ::valid_transient
+ * @covers ::is_valid_transient
  */
 class Tests_Option_ValidTransient extends WP_UnitTestCase {
 
@@ -17,11 +17,11 @@ class Tests_Option_ValidTransient extends WP_UnitTestCase {
 
 		set_transient( $transient_name, $transient_value, 10 );
 
-		$this->assertTrue( valid_transient( $transient_name ) );
+		$this->assertTrue( is_valid_transient( $transient_name ) );
 
 		update_option( '_transient_timeout_' . $transient_name, time() - 10 );
 
-		$this->assertFalse( valid_transient( $transient_name ) );
+		$this->assertFalse( is_valid_transient( $transient_name ) );
 	}
 
 	/**
@@ -32,7 +32,7 @@ class Tests_Option_ValidTransient extends WP_UnitTestCase {
 		$transient_value = 'transient_value';
 
 		set_transient( $transient_name, $transient_value );
-		$this->assertTrue( valid_transient( $transient_name ) );
+		$this->assertTrue( is_valid_transient( $transient_name ) );
 	}
 
 	/**
@@ -41,6 +41,6 @@ class Tests_Option_ValidTransient extends WP_UnitTestCase {
 	public function test_valid_transient_with_no_transient() {
 		$transient_name = 'valid_transient_with_no_transient';
 
-		$this->assertFalse( valid_transient( $transient_name ) );
+		$this->assertFalse( is_valid_transient( $transient_name ) );
 	}
 }

--- a/tests/phpunit/tests/option/ValidTransient.php
+++ b/tests/phpunit/tests/option/ValidTransient.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @group option
+ * @group transient
+ *
+ * @covers ::valid_transient
+ */
+class Tests_Option_ValidTransient extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 37040
+	 */
+	public function test_valid_transient_with_expired_timeout() {
+		$transient_name = 'valid_transient_with_expired_timeout';
+		$transient_value = 'transient_value';
+
+		set_transient( $transient_name, $transient_value, 10 );
+
+		$this->assertTrue( valid_transient( $transient_name ) );
+
+		update_option( '_transient_timeout_' . $transient_name, time() - 10 );
+
+		$this->assertFalse( valid_transient( $transient_name ) );
+	}
+
+	/**
+	 * @ticket 37040
+	 */
+	public function test_valid_transient_with_no_timeout() {
+		$transient_name = 'valid_transient_with_no_timeout';
+		$transient_value = 'transient_value';
+
+		set_transient( $transient_name, $transient_value );
+		$this->assertTrue( valid_transient( $transient_name ) );
+	}
+
+	/**
+	 * @ticket 37040
+	 */
+	public function test_valid_transient_with_no_transient() {
+		$transient_name = 'valid_transient_with_no_transient';
+
+		$this->assertFalse( valid_transient( $transient_name ) );
+	}
+}

--- a/tests/phpunit/tests/option/ValidTransient.php
+++ b/tests/phpunit/tests/option/ValidTransient.php
@@ -12,7 +12,7 @@ class Tests_Option_ValidTransient extends WP_UnitTestCase {
 	 * @ticket 37040
 	 */
 	public function test_valid_transient_with_expired_timeout() {
-		$transient_name = 'valid_transient_with_expired_timeout';
+		$transient_name  = 'valid_transient_with_expired_timeout';
 		$transient_value = 'transient_value';
 
 		set_transient( $transient_name, $transient_value, 10 );
@@ -28,7 +28,7 @@ class Tests_Option_ValidTransient extends WP_UnitTestCase {
 	 * @ticket 37040
 	 */
 	public function test_valid_transient_with_no_timeout() {
-		$transient_name = 'valid_transient_with_no_timeout';
+		$transient_name  = 'valid_transient_with_no_timeout';
 		$transient_value = 'transient_value';
 
 		set_transient( $transient_name, $transient_value );

--- a/tests/phpunit/tests/option/validSiteTransient.php
+++ b/tests/phpunit/tests/option/validSiteTransient.php
@@ -12,7 +12,7 @@ class Tests_Option_ValidSiteTransient extends WP_UnitTestCase {
 	 * @ticket 37040
 	 */
 	public function test_valid_site_transient_with_expired_timeout() {
-		$transient_name = 'valid_site_transient_with_expired_timeout';
+		$transient_name  = 'valid_site_transient_with_expired_timeout';
 		$transient_value = 'transient_value';
 
 		set_site_transient( $transient_name, $transient_value, 10 );
@@ -28,7 +28,7 @@ class Tests_Option_ValidSiteTransient extends WP_UnitTestCase {
 	 * @ticket 37040
 	 */
 	public function test_valid_site_transient_with_no_timeout() {
-		$transient_name = 'valid_site_transient_with_no_timeout';
+		$transient_name  = 'valid_site_transient_with_no_timeout';
 		$transient_value = 'transient_value';
 
 		set_site_transient( $transient_name, $transient_value );
@@ -49,7 +49,7 @@ class Tests_Option_ValidSiteTransient extends WP_UnitTestCase {
 	 * @ticket 37040
 	 */
 	public function test_valid_site_transient_with_no_site_transient() {
-		$transient_name = 'valid_site_transient_with_no_site_transient';
+		$transient_name  = 'valid_site_transient_with_no_site_transient';
 		$transient_value = 'transient_value';
 
 		set_transient( $transient_name, $transient_value );

--- a/tests/phpunit/tests/option/validSiteTransient.php
+++ b/tests/phpunit/tests/option/validSiteTransient.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @group option
+ * @group transient
+ *
+ * @covers ::valid_site_transient
+ */
+class Tests_Option_ValidSiteTransient extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 37040
+	 */
+	public function test_valid_site_transient_with_expired_timeout() {
+		$transient_name = 'valid_site_transient_with_expired_timeout';
+		$transient_value = 'transient_value';
+
+		set_site_transient( $transient_name, $transient_value, 10 );
+
+		$this->assertTrue( valid_site_transient( $transient_name ) );
+
+		update_option( '_site_transient_timeout_' . $transient_name, time() - 10 );
+
+		$this->assertFalse( valid_site_transient( $transient_name ) );
+	}
+
+	/**
+	 * @ticket 37040
+	 */
+	public function test_valid_site_transient_with_no_timeout() {
+		$transient_name = 'valid_site_transient_with_no_timeout';
+		$transient_value = 'transient_value';
+
+		set_site_transient( $transient_name, $transient_value );
+
+		$this->assertTrue( valid_site_transient( $transient_name ) );
+	}
+
+	/**
+	 * @ticket 37040
+	 */
+	public function test_valid_site_transient_with_no_transient() {
+		$transient_name = 'valid_site_transient_with_no_transient';
+
+		$this->assertFalse( valid_site_transient( $transient_name ) );
+	}
+
+	/**
+	 * @ticket 37040
+	 */
+	public function test_valid_site_transient_with_no_site_transient() {
+		$transient_name = 'valid_site_transient_with_no_site_transient';
+		$transient_value = 'transient_value';
+
+		set_transient( $transient_name, $transient_value );
+
+		$this->assertFalse( valid_site_transient( $transient_name ) );
+	}
+}

--- a/tests/phpunit/tests/option/validSiteTransient.php
+++ b/tests/phpunit/tests/option/validSiteTransient.php
@@ -4,7 +4,7 @@
  * @group option
  * @group transient
  *
- * @covers ::valid_site_transient
+ * @covers ::is_valid_site_transient
  */
 class Tests_Option_ValidSiteTransient extends WP_UnitTestCase {
 
@@ -17,11 +17,11 @@ class Tests_Option_ValidSiteTransient extends WP_UnitTestCase {
 
 		set_site_transient( $transient_name, $transient_value, 10 );
 
-		$this->assertTrue( valid_site_transient( $transient_name ) );
+		$this->assertTrue( is_valid_site_transient( $transient_name ) );
 
 		update_option( '_site_transient_timeout_' . $transient_name, time() - 10 );
 
-		$this->assertFalse( valid_site_transient( $transient_name ) );
+		$this->assertFalse( is_valid_site_transient( $transient_name ) );
 	}
 
 	/**
@@ -33,7 +33,7 @@ class Tests_Option_ValidSiteTransient extends WP_UnitTestCase {
 
 		set_site_transient( $transient_name, $transient_value );
 
-		$this->assertTrue( valid_site_transient( $transient_name ) );
+		$this->assertTrue( is_valid_site_transient( $transient_name ) );
 	}
 
 	/**
@@ -42,7 +42,7 @@ class Tests_Option_ValidSiteTransient extends WP_UnitTestCase {
 	public function test_valid_site_transient_with_no_transient() {
 		$transient_name = 'valid_site_transient_with_no_transient';
 
-		$this->assertFalse( valid_site_transient( $transient_name ) );
+		$this->assertFalse( is_valid_site_transient( $transient_name ) );
 	}
 
 	/**
@@ -54,6 +54,6 @@ class Tests_Option_ValidSiteTransient extends WP_UnitTestCase {
 
 		set_transient( $transient_name, $transient_value );
 
-		$this->assertFalse( valid_site_transient( $transient_name ) );
+		$this->assertFalse( is_valid_site_transient( $transient_name ) );
 	}
 }


### PR DESCRIPTION
A new function named 'valid_transient' has been introduced to verify if a transient and its value are valid, also by checking if they have not expired. Sites with transient data can use the 'valid_site_transient' function to perform similar checks. Along with these functions, PHPUnit test cases have been added to ensure these functions perform as expected.


Trac ticket: https://core.trac.wordpress.org/ticket/37040