### PR TITLE
Fix return type in @phpdocs for `rest_parse_data`

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1277,7 +1277,7 @@ function rest_get_avatar_sizes() {
  * @param string $date      RFC3339 timestamp.
  * @param bool   $force_utc Optional. Whether to force UTC timezone instead of using
  *                          the timestamp's timezone. Default false.
- * @return int Unix timestamp.
+ * @return int|false Unix timestamp or false if invalid date.
  */
 function rest_parse_date( $date, $force_utc = false ) {
 	if ( $force_utc ) {


### PR DESCRIPTION
The return type was `int` but it would return `false` if the date format passed is invalid.

Trac ticket: https://core.trac.wordpress.org/ticket/60699