### PR TITLE
HTML API: Rely on HTML API in wp_replace_in_html_tags().

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -886,6 +886,8 @@ function shortcode_unautop( $text ) {
  * @author bmorel at ssi dot fr (modified)
  * @since 1.2.1
  *
+ * @see https://bytes.com/topic/php/389730-checking-see-if-character-utf8
+ *
  * @param string $str The string to be checked
  * @return bool True if $str fits a UTF-8 model, false otherwise.
  */


### PR DESCRIPTION
WIP: Refactor `wp_replace_in_html_tags()` to rely on the HTML API for more reliability.

## Status

Both failing tests appear to be failures in Core that are fixed in this patch.

<img width="713" alt="Screenshot 2024-05-27 at 5 27 49 PM" src="https://github.com/WordPress/wordpress-develop/assets/5431237/473d1dbe-1aa6-4e84-81ff-799f5640c775">

In the first case (`CDATA`) WordPress thinks that there's a CDATA section and so it looks for the closing `]]>` to terminate it, but the HTML specification indicates that these are invalid comments, so the span ends at the first `>`, not at the expected `]]>`.

In the second case, WordPress' `wp_html_split()` thinks that `<` splits text nodes into syntax tokens, but in this case, because there's not a valid tag name following it, the HTML specification indicates that the `<` should be treated as plaintext. `autop` adds a superfluous newline.