### PR TITLE
31354 restructure compound checkboxes disable

### DIFF
--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -898,6 +898,10 @@ ul#add-to-blog-users {
 	display: inline-block;
 }
 
+.form-table td fieldset label.indent-child {
+	margin-left: 1.5em !important;
+}
+
 .form-table td fieldset p label {
 	margin-top: 0 !important;
 }

--- a/src/wp-admin/includes/options.php
+++ b/src/wp-admin/includes/options.php
@@ -21,13 +21,46 @@ function options_discussion_add_js() {
 				childrenInputs = $(childInputElement );
 				ariaLiveRegion = $('#aria-live-region');
 
-			// Set editable/disabled state based on checkbox default state.
-			childrenInputs.toggleClass( 'disabled', ! parentCheckbox.prop( 'checked' ) );
-			parentCheckbox.attr( 'aria-expanded', parentCheckbox.prop( 'checked' ) );
-			// Disable the children if the parent is unchecked.
-			parentCheckbox.on( 'change', function(){
-				childrenInputs.toggleClass( 'disabled', ! this.checked );
-				$(this).attr( 'aria-expanded', this.checked);
+
+			function applyDisabledStyle(element, isDisabled) {
+				element.prop('disabled', isDisabled);
+				if (isDisabled) {
+					element.css({
+						'color': 'gray',
+						'opacity': '0.85',
+						'cursor': 'not-allowed'
+					});
+					element.closest('label').css({
+						'color': 'gray',
+						'opacity': '0.85',
+						'cursor': 'not-allowed',
+					});
+				} else {
+					element.css({
+						'color': '',
+						'opacity': '',
+						'cursor': ''
+					});
+					element.closest('label').css({
+						'color': '',
+						'opacity': '',
+						'cursor': '',
+					});
+				}
+			}
+
+			// Set the initial state based on the checkbox state
+			childrenInputs.find('input, select, textarea').each(function() {
+				applyDisabledStyle($(this), !parentCheckbox.prop('checked'));
+			});
+			parentCheckbox.attr('aria-expanded', parentCheckbox.prop('checked'));
+			// Update the disabled state of children on parent checkbox change
+			parentCheckbox.on('change', function() {
+				var isChecked = this.checked;
+				childrenInputs.find('input, select, textarea').each(function() {
+					applyDisabledStyle($(this), !isChecked);
+				});
+				$(this).attr('aria-expanded', isChecked);
 
 				// Announce the change to screen readers.
 				var message = this.checked ? 'Checked Checkbox, Dependent fields are now editable.' : 'Unchecked Checkbox, Dependent fields are now disabled.';

--- a/src/wp-admin/includes/options.php
+++ b/src/wp-admin/includes/options.php
@@ -16,30 +16,30 @@ function options_discussion_add_js() {
 	?>
 	<script>
 	(function($){
-		function toggleVisibility(parentCheckboxId, childInputElement){
+		function toggleEditableState(parentCheckboxId, childInputElement){
 			var parentCheckbox = $(parentCheckboxId ),
 				childrenInputs = $(childInputElement );
 				ariaLiveRegion = $('#aria-live-region');
 
-			// Set visibility based on checkbox default state.
-			childrenInputs.toggleClass( 'hide-if-js', ! parentCheckbox.prop( 'checked' ) );
+			// Set editable/disabled state based on checkbox default state.
+			childrenInputs.toggleClass( 'disabled', ! parentCheckbox.prop( 'checked' ) );
 			parentCheckbox.attr( 'aria-expanded', parentCheckbox.prop( 'checked' ) );
-			// Hide the children if the parent is unchecked.
+			// Disable the children if the parent is unchecked.
 			parentCheckbox.on( 'change', function(){
-				childrenInputs.toggleClass( 'hide-if-js', ! this.checked );
+				childrenInputs.toggleClass( 'disabled', ! this.checked );
 				$(this).attr( 'aria-expanded', this.checked);
 
 				// Announce the change to screen readers.
-				var message = this.checked ? 'Checked Checkbox, Dependent fields are now available below.' : 'Unchecked Checkbox, Dependent fields are now hidden.';
+				var message = this.checked ? 'Checked Checkbox, Dependent fields are now editable.' : 'Unchecked Checkbox, Dependent fields are now disabled.';
 				ariaLiveRegion.text( message );
 			});
 		}
 
 		// Call function for each expandable section of discussion settings.
-		toggleVisibility('#close_comments_for_old_posts', '.close-comments-setting' );
-		toggleVisibility('#thread_comments', '.thread-comments-setting' );
-		toggleVisibility('#page_comments', '.pagination-setting' );
-		toggleVisibility( '#show_avatars', '.avatar-settings' );
+		toggleEditableState('#close_comments_for_old_posts', '.close-comments-setting' );
+		toggleEditableState('#thread_comments', '.thread-comments-setting' );
+		toggleEditableState('#page_comments', '.pagination-setting' );
+		toggleEditableState( '#show_avatars', '.avatar-settings' );
 	})(jQuery);
 	</script>
 	<?php

--- a/src/wp-admin/includes/options.php
+++ b/src/wp-admin/includes/options.php
@@ -16,11 +16,30 @@ function options_discussion_add_js() {
 	?>
 	<script>
 	(function($){
-		var parent = $( '#show_avatars' ),
-			children = $( '.avatar-settings' );
-		parent.on( 'change', function(){
-			children.toggleClass( 'hide-if-js', ! this.checked );
-		});
+		function toggleVisibility(parentCheckboxId, childInputElement){
+			var parentCheckbox = $(parentCheckboxId ),
+				childrenInputs = $(childInputElement );
+				ariaLiveRegion = $('#aria-live-region');
+
+			// Set visibility based on checkbox default state.
+			childrenInputs.toggleClass( 'hide-if-js', ! parentCheckbox.prop( 'checked' ) );
+			parentCheckbox.attr( 'aria-expanded', parentCheckbox.prop( 'checked' ) );
+			// Hide the children if the parent is unchecked.
+			parentCheckbox.on( 'change', function(){
+				childrenInputs.toggleClass( 'hide-if-js', ! this.checked );
+				$(this).attr( 'aria-expanded', this.checked);
+
+				// Announce the change to screen readers.
+				var message = this.checked ? 'Dependent fields are now available below.' : 'Dependent fields are now hidden.';
+				ariaLiveRegion.text( message );
+			});
+		}
+
+		// Call function for each expandable section of discussion settings.
+		toggleVisibility('#close_comments_for_old_posts', '.close-comments-setting' );
+		toggleVisibility('#thread_comments', '.thread-comments-setting' );
+		toggleVisibility('#page_comments', '.pagination-setting' );
+		toggleVisibility( '#show_avatars', '.avatar-settings' );
 	})(jQuery);
 	</script>
 	<?php

--- a/src/wp-admin/includes/options.php
+++ b/src/wp-admin/includes/options.php
@@ -30,7 +30,7 @@ function options_discussion_add_js() {
 				$(this).attr( 'aria-expanded', this.checked);
 
 				// Announce the change to screen readers.
-				var message = this.checked ? 'Dependent fields are now available below.' : 'Dependent fields are now hidden.';
+				var message = this.checked ? 'Checked Checkbox, Dependent fields are now available below.' : 'Unchecked Checkbox, Dependent fields are now hidden.';
 				ariaLiveRegion.text( message );
 			});
 		}

--- a/src/wp-admin/options-discussion.php
+++ b/src/wp-admin/options-discussion.php
@@ -98,7 +98,7 @@ if ( ! get_option( 'users_can_register' ) && is_multisite() ) {
 <br />
 
 <label for="close_comments_days_old" class="close-comments-setting indent-child" >
-<?php _e( 'Number of days to keep old comments: '); ?>
+<?php _e( 'Number of days to keep old comments: ' ); ?>
 <input name="close_comments_days_old" type="number" step="1" min="0" id="close_comments_days_old" value="<?php echo esc_attr( get_option( 'close_comments_days_old' ) ); ?>" class="small-text" />
 </label>
 <br />
@@ -174,7 +174,7 @@ printf( __( 'Number of levels for threaded (nested) comments: %s' ), $thread_com
 <br />
 
 <label for="comment_order" class="pagination-setting indent-child">
-<?php _e( 'Comments to display at the top of each page: ' );?>
+<?php _e( 'Comments to display at the top of each page: ' ); ?>
 <select name="comment_order" id="comment_order">
 	<option value="asc" <?php selected( 'asc', get_option( 'comment_order' ) ); ?>><?php _e( 'older' ); ?></option>
 	<option value="desc" <?php selected( 'desc', get_option( 'comment_order' ) ); ?>><?php _e( 'newer' ); ?></option>

--- a/src/wp-admin/options-discussion.php
+++ b/src/wp-admin/options-discussion.php
@@ -39,8 +39,8 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 <div class="wrap">
 <h1><?php echo esc_html( $title ); ?></h1>
 
-    <!-- ARIA live region for screen readers -->
-    <div id="aria-live-region" aria-live="polite" class="screen-reader-text"></div>
+<!-- ARIA live region for screen readers -->
+<div id="aria-live-region" aria-live="polite" class="screen-reader-text"></div>
 
 
 <form method="post" action="options.php">
@@ -93,12 +93,12 @@ if ( ! get_option( 'users_can_register' ) && is_multisite() ) {
 
 <label for="close_comments_for_old_posts">
 <input name="close_comments_for_old_posts" type="checkbox" id="close_comments_for_old_posts" value="1" <?php checked( '1', get_option( 'close_comments_for_old_posts' ) ); ?> />
-<?php _e("Automatically close comments for old posts" )?>
+<?php _e( 'Automatically close comments for old posts' ); ?>
 </label>
 <br />
 
 <label for="close_comments_days_old" class="close-comments-setting indent-child" >
-<?php _e('Number of days to keep old comments: ')?>
+<?php _e( 'Number of days to keep old comments: '); ?>
 <input name="close_comments_days_old" type="number" step="1" min="0" id="close_comments_days_old" value="<?php echo esc_attr( get_option( 'close_comments_days_old' ) ); ?>" class="small-text" />
 </label>
 <br />
@@ -155,29 +155,29 @@ printf( __( 'Number of levels for threaded (nested) comments: %s' ), $thread_com
 </span></legend>
 <label for="page_comments">
 <input name="page_comments" type="checkbox" id="page_comments" value="1" <?php checked( '1', get_option( 'page_comments' ) ); ?> />
-<?php _e("Break comments into pages" )?>
+<?php _e( 'Break comments into pages' ); ?>
 </label>
 <br />
 
 <label for="comments_per_page" class="pagination-setting indent-child">
-<?php _e('Top level comments per page: ')?>
+<?php _e( 'Top level comments per page: ' ); ?>
 <input name="comments_per_page" type="number" step="1" min="0" id="comments_per_page" value="<?php echo esc_attr( get_option( 'comments_per_page' ) ); ?>" class="small-text" />
 </label>
 <br />
 
-<label for="default_comments_page" class="pagination-setting indent-child"><?php _e('Comments page to display by default: '); ?>
+<label for="default_comments_page" class="pagination-setting indent-child"><?php _e( 'Comments page to display by default: ' ); ?>
 <select name="default_comments_page" id="default_comments_page">
-	<option value="newest" <?php selected( 'newest', get_option( 'default_comments_page' ) ); ?>><?php _e('last page'); ?></option>
-	<option value="oldest" <?php selected( 'oldest', get_option( 'default_comments_page' ) ); ?>><?php _e('first page'); ?></option>
+	<option value="newest" <?php selected( 'newest', get_option( 'default_comments_page' ) ); ?>><?php _e( 'last page' ); ?></option>
+	<option value="oldest" <?php selected( 'oldest', get_option( 'default_comments_page' ) ); ?>><?php _e( 'first page' ); ?></option>
 </select>
 </label>
 <br />
 
 <label for="comment_order" class="pagination-setting indent-child">
-<?php _e('Comments to display at the top of each page: ')?>
+<?php _e( 'Comments to display at the top of each page: ' );?>
 <select name="comment_order" id="comment_order">
-	<option value="asc" <?php selected( 'asc', get_option( 'comment_order' ) ); ?>><?php _e('older'); ?></option>
-	<option value="desc" <?php selected( 'desc', get_option( 'comment_order' ) ); ?>><?php _e('newer'); ?></option>
+	<option value="asc" <?php selected( 'asc', get_option( 'comment_order' ) ); ?>><?php _e( 'older' ); ?></option>
+	<option value="desc" <?php selected( 'desc', get_option( 'comment_order' ) ); ?>><?php _e( 'newer' ); ?></option>
 </select>
 </label>
 <br />

--- a/src/wp-admin/options-discussion.php
+++ b/src/wp-admin/options-discussion.php
@@ -97,7 +97,7 @@ if ( ! get_option( 'users_can_register' ) && is_multisite() ) {
 </label>
 <br />
 
-<label for="close_comments_days_old" class="close-comments-setting" >
+<label for="close_comments_days_old" class="close-comments-setting indent-child" >
 <?php _e('Number of days to keep old comments: ')?>
 <input name="close_comments_days_old" type="number" step="1" min="0" id="close_comments_days_old" value="<?php echo esc_attr( get_option( 'close_comments_days_old' ) ); ?>" class="small-text" />
 </label>
@@ -115,7 +115,7 @@ if ( ! get_option( 'users_can_register' ) && is_multisite() ) {
 </label>
 <br />
 
-<label for="thread_comments_depth" class="thread-comments-setting">
+<label for="thread_comments_depth" class="thread-comments-setting indent-child">
 <?php
 /**
  * Filters the maximum depth of threaded/nested comments.
@@ -159,13 +159,13 @@ printf( __( 'Number of levels for threaded (nested) comments: %s' ), $thread_com
 </label>
 <br />
 
-<label for="comments_per_page" class="pagination-setting">
+<label for="comments_per_page" class="pagination-setting indent-child">
 <?php _e('Top level comments per page: ')?>
 <input name="comments_per_page" type="number" step="1" min="0" id="comments_per_page" value="<?php echo esc_attr( get_option( 'comments_per_page' ) ); ?>" class="small-text" />
 </label>
 <br />
 
-<label for="default_comments_page" class="pagination-setting"><?php _e('Comments page to display by default: '); ?>
+<label for="default_comments_page" class="pagination-setting indent-child"><?php _e('Comments page to display by default: '); ?>
 <select name="default_comments_page" id="default_comments_page">
 	<option value="newest" <?php selected( 'newest', get_option( 'default_comments_page' ) ); ?>><?php _e('last page'); ?></option>
 	<option value="oldest" <?php selected( 'oldest', get_option( 'default_comments_page' ) ); ?>><?php _e('first page'); ?></option>
@@ -173,7 +173,7 @@ printf( __( 'Number of levels for threaded (nested) comments: %s' ), $thread_com
 </label>
 <br />
 
-<label for="comment_order" class="pagination-setting">
+<label for="comment_order" class="pagination-setting indent-child">
 <?php _e('Comments to display at the top of each page: ')?>
 <select name="comment_order" id="comment_order">
 	<option value="asc" <?php selected( 'asc', get_option( 'comment_order' ) ); ?>><?php _e('older'); ?></option>

--- a/src/wp-admin/options-discussion.php
+++ b/src/wp-admin/options-discussion.php
@@ -89,13 +89,13 @@ if ( ! get_option( 'users_can_register' ) && is_multisite() ) {
 
 <label for="close_comments_for_old_posts">
 <input name="close_comments_for_old_posts" type="checkbox" id="close_comments_for_old_posts" value="1" <?php checked( '1', get_option( 'close_comments_for_old_posts' ) ); ?> />
-<?php
-printf(
-	/* translators: %s: Number of days. */
-	__( 'Automatically close comments on posts older than %s days' ),
-	'</label> <label for="close_comments_days_old"><input name="close_comments_days_old" type="number" min="0" step="1" id="close_comments_days_old" value="' . esc_attr( get_option( 'close_comments_days_old' ) ) . '" class="small-text" />'
-);
-?>
+<?php _e("Automatically close comments for old posts" )?>
+</label>
+<br />
+
+<label for="close_comments_days_old">
+<?php _e('Number of days to keep old comments: ')?>
+<input name="close_comments_days_old" type="number" step="1" min="0" id="close_comments_days_old" value="<?php echo esc_attr( get_option( 'close_comments_days_old' ) ); ?>" class="small-text" />
 </label>
 <br />
 
@@ -107,6 +107,11 @@ printf(
 
 <label for="thread_comments">
 <input name="thread_comments" type="checkbox" id="thread_comments" value="1" <?php checked( '1', get_option( 'thread_comments' ) ); ?> />
+<?php _e( 'Enable threaded (nested) comments' ); ?>
+</label>
+<br />
+
+<label for="thread_comments_depth">
 <?php
 /**
  * Filters the maximum depth of threaded/nested comments.
@@ -117,7 +122,7 @@ printf(
  */
 $maxdeep = (int) apply_filters( 'thread_comments_depth_max', 10 );
 
-$thread_comments_depth = '</label> <label for="thread_comments_depth"><select name="thread_comments_depth" id="thread_comments_depth">';
+$thread_comments_depth = '<select name="thread_comments_depth" id="thread_comments_depth">';
 for ( $i = 2; $i <= $maxdeep; $i++ ) {
 	$thread_comments_depth .= "<option value='" . esc_attr( $i ) . "'";
 	if ( (int) get_option( 'thread_comments_depth' ) === $i ) {
@@ -128,52 +133,53 @@ for ( $i = 2; $i <= $maxdeep; $i++ ) {
 $thread_comments_depth .= '</select>';
 
 /* translators: %s: Number of levels. */
-printf( __( 'Enable threaded (nested) comments %s levels deep' ), $thread_comments_depth );
+printf( __( 'Number of levels for threaded (nested) comments: %s' ), $thread_comments_depth );
 
 ?>
 </label>
 <br />
-<label for="page_comments">
-<input name="page_comments" type="checkbox" id="page_comments" value="1" <?php checked( '1', get_option( 'page_comments' ) ); ?> />
-<?php
-$default_comments_page = '</label> <label for="default_comments_page"><select name="default_comments_page" id="default_comments_page"><option value="newest"';
-if ( 'newest' === get_option( 'default_comments_page' ) ) {
-	$default_comments_page .= ' selected="selected"';
-}
-$default_comments_page .= '>' . __( 'last' ) . '</option><option value="oldest"';
-if ( 'oldest' === get_option( 'default_comments_page' ) ) {
-	$default_comments_page .= ' selected="selected"';
-}
-$default_comments_page .= '>' . __( 'first' ) . '</option></select>';
-printf(
-	/* translators: 1: Form field control for number of top level comments per page, 2: Form field control for the 'first' or 'last' page. */
-	__( 'Break comments into pages with %1$s top level comments per page and the %2$s page displayed by default' ),
-	'</label> <label for="comments_per_page"><input name="comments_per_page" type="number" step="1" min="0" id="comments_per_page" value="' . esc_attr( get_option( 'comments_per_page' ) ) . '" class="small-text" />',
-	$default_comments_page
-);
-?>
-</label>
-<br />
-<label for="comment_order">
-<?php
-
-$comment_order = '<select name="comment_order" id="comment_order"><option value="asc"';
-if ( 'asc' === get_option( 'comment_order' ) ) {
-	$comment_order .= ' selected="selected"';
-}
-$comment_order .= '>' . __( 'older' ) . '</option><option value="desc"';
-if ( 'desc' === get_option( 'comment_order' ) ) {
-	$comment_order .= ' selected="selected"';
-}
-$comment_order .= '>' . __( 'newer' ) . '</option></select>';
-
-/* translators: %s: Form field control for 'older' or 'newer' comments. */
-printf( __( 'Comments should be displayed with the %s comments at the top of each page' ), $comment_order );
-
-?>
-</label>
 </fieldset></td>
 </tr>
+
+<tr>
+<th scope="row"><?php _e( 'Comment Pagination' ); ?></th>
+<td><fieldset><legend class="screen-reader-text"><span>
+	<?php
+	/* translators: Hidden accessibility text. */
+	_e( 'Comment Pagination' );
+	?>
+</span></legend>
+<label for="page_comments">
+<input name="page_comments" type="checkbox" id="page_comments" value="1" <?php checked( '1', get_option( 'page_comments' ) ); ?> />
+<?php _e("Break comments into pages" )?>
+</label>
+<br />
+
+<label for="comments_per_page">
+<?php _e('Top level comments per page: ')?>
+<input name="comments_per_page" type="number" step="1" min="0" id="comments_per_page" value="<?php echo esc_attr( get_option( 'comments_per_page' ) ); ?>" class="small-text" />
+</label>
+<br />
+
+<label for="default_comments_page"><?php _e('Comments page to display by default: '); ?>
+<select name="default_comments_page" id="default_comments_page">
+	<option value="newest" <?php selected( 'newest', get_option( 'default_comments_page' ) ); ?>><?php _e('last page'); ?></option>
+	<option value="oldest" <?php selected( 'oldest', get_option( 'default_comments_page' ) ); ?>><?php _e('first page'); ?></option>
+</select>
+</label>
+<br />
+
+<label for="comment_order">
+<?php _e('Comments to display at the top of each page: ')?>
+<select name="comment_order" id="comment_order">
+	<option value="asc" <?php selected( 'asc', get_option( 'comment_order' ) ); ?>><?php _e('older'); ?></option>
+	<option value="desc" <?php selected( 'desc', get_option( 'comment_order' ) ); ?>><?php _e('newer'); ?></option>		
+</select>
+</label>
+<br />
+</fieldset></td>
+</tr>
+
 <tr>
 <th scope="row"><?php _e( 'Email me whenever' ); ?></th>
 <td><fieldset><legend class="screen-reader-text"><span>

--- a/src/wp-admin/options-discussion.php
+++ b/src/wp-admin/options-discussion.php
@@ -39,6 +39,10 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 <div class="wrap">
 <h1><?php echo esc_html( $title ); ?></h1>
 
+    <!-- ARIA live region for screen readers -->
+    <div id="aria-live-region" aria-live="polite" class="screen-reader-text"></div>
+
+
 <form method="post" action="options.php">
 <?php settings_fields( 'discussion' ); ?>
 
@@ -93,7 +97,7 @@ if ( ! get_option( 'users_can_register' ) && is_multisite() ) {
 </label>
 <br />
 
-<label for="close_comments_days_old">
+<label for="close_comments_days_old" class="close-comments-setting" >
 <?php _e('Number of days to keep old comments: ')?>
 <input name="close_comments_days_old" type="number" step="1" min="0" id="close_comments_days_old" value="<?php echo esc_attr( get_option( 'close_comments_days_old' ) ); ?>" class="small-text" />
 </label>
@@ -111,7 +115,7 @@ if ( ! get_option( 'users_can_register' ) && is_multisite() ) {
 </label>
 <br />
 
-<label for="thread_comments_depth">
+<label for="thread_comments_depth" class="thread-comments-setting">
 <?php
 /**
  * Filters the maximum depth of threaded/nested comments.
@@ -155,13 +159,13 @@ printf( __( 'Number of levels for threaded (nested) comments: %s' ), $thread_com
 </label>
 <br />
 
-<label for="comments_per_page">
+<label for="comments_per_page" class="pagination-setting">
 <?php _e('Top level comments per page: ')?>
 <input name="comments_per_page" type="number" step="1" min="0" id="comments_per_page" value="<?php echo esc_attr( get_option( 'comments_per_page' ) ); ?>" class="small-text" />
 </label>
 <br />
 
-<label for="default_comments_page"><?php _e('Comments page to display by default: '); ?>
+<label for="default_comments_page" class="pagination-setting"><?php _e('Comments page to display by default: '); ?>
 <select name="default_comments_page" id="default_comments_page">
 	<option value="newest" <?php selected( 'newest', get_option( 'default_comments_page' ) ); ?>><?php _e('last page'); ?></option>
 	<option value="oldest" <?php selected( 'oldest', get_option( 'default_comments_page' ) ); ?>><?php _e('first page'); ?></option>
@@ -169,11 +173,11 @@ printf( __( 'Number of levels for threaded (nested) comments: %s' ), $thread_com
 </label>
 <br />
 
-<label for="comment_order">
+<label for="comment_order" class="pagination-setting">
 <?php _e('Comments to display at the top of each page: ')?>
 <select name="comment_order" id="comment_order">
 	<option value="asc" <?php selected( 'asc', get_option( 'comment_order' ) ); ?>><?php _e('older'); ?></option>
-	<option value="desc" <?php selected( 'desc', get_option( 'comment_order' ) ); ?>><?php _e('newer'); ?></option>		
+	<option value="desc" <?php selected( 'desc', get_option( 'comment_order' ) ); ?>><?php _e('newer'); ?></option>
 </select>
 </label>
 <br />
@@ -192,6 +196,7 @@ printf( __( 'Number of levels for threaded (nested) comments: %s' ), $thread_com
 <input name="comments_notify" type="checkbox" id="comments_notify" value="1" <?php checked( '1', get_option( 'comments_notify' ) ); ?> />
 <?php _e( 'Anyone posts a comment' ); ?> </label>
 <br />
+
 <label for="moderation_notify">
 <input name="moderation_notify" type="checkbox" id="moderation_notify" value="1" <?php checked( '1', get_option( 'moderation_notify' ) ); ?> />
 <?php _e( 'A comment is held for moderation' ); ?> </label>
@@ -209,6 +214,7 @@ printf( __( 'Number of levels for threaded (nested) comments: %s' ), $thread_com
 <input name="comment_moderation" type="checkbox" id="comment_moderation" value="1" <?php checked( '1', get_option( 'comment_moderation' ) ); ?> />
 <?php _e( 'Comment must be manually approved' ); ?> </label>
 <br />
+
 <label for="comment_previously_approved"><input type="checkbox" name="comment_previously_approved" id="comment_previously_approved" value="1" <?php checked( '1', get_option( 'comment_previously_approved' ) ); ?> /> <?php _e( 'Comment author must have a previously approved comment' ); ?></label>
 </fieldset></td>
 </tr>


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here --> Added style to indent dependent input fields in discussions page. Added function to toggle disabled fields from parent. Need accessibility and structural feedback. Currently applying and removing styles/functionality, as need to disable input fields as well as gray out text to convey relation. 

Trac ticket:[ <!-- insert a link to the WordPress Trac ticket here -->](https://core.trac.wordpress.org/ticket/31354)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
