### PR TITLE
Experiment: Doodlings on how a Core URL parser could look.

### DIFF
--- a/src/wp-includes/html-api/class-wp-url.php
+++ b/src/wp-includes/html-api/class-wp-url.php
@@ -1,0 +1,131 @@
+<?php
+
+class WP_URL {
+	/**
+	 * Contains the original URL string.
+	 *
+	 * Example:
+	 *
+	 *     - http://wordpress.org
+	 *     - https://wordpress.org/absolute/path
+	 *     - javascript:alert(1);
+	 *     - /relative/path
+	 *     - /?with=query&string
+	 *     - /#with-fragment
+	 *
+	 * @since 6.6.0
+	 *
+	 * @var string
+	 */
+	private $raw_url;
+
+	/**
+	 * For relative URLs, this provides the base.
+	 *
+	 * @var string|null
+	 */
+	private $base_url;
+
+	/**
+	 * Indicates if the URL is an absolute or relative reference.
+	 *
+	 * @var bool
+	 */
+	private $is_relative;
+
+	private $parser_state = self::STATE_READY;
+
+	private $scheme;
+
+	private $username;
+
+	private $password;
+
+	private $host;
+
+	private $port;
+
+	private $path;
+
+	private $query_params;
+
+	private $fragment;
+
+	/**
+	 * Creates a new instance from a potential string URL.
+	 *
+	 * @since 6.6.0
+	 *
+	 * @param string $raw_url Possibly represents a URL.
+	 * @return WP_URL Newly-created URL.
+	 */
+	public static function parse( $raw_url, $base_url = null ) {
+		if ( ! is_string( $raw_url ) || strlen( $raw_url ) <= 0 ) {
+			return null;
+		}
+
+		$url          = new WP_URL( $base_url );
+		$url->raw_url = $raw_url;
+		$at           = 0;
+
+		$first_char  = $raw_url[0];
+		$is_relative = '/' === $first_char || '?' === $first_char || '#' === $first_char;
+
+		$url->is_relative = $is_relative;
+		if ( ! $is_relative ) {
+			$scheme_length = strpos( $raw_url, ':' );
+			if ( false === $scheme_length ) {
+				return null;
+			}
+
+			$scheme = strtolower( substr( $raw_url, 0, $scheme_length ) );
+			if ( 'ftp' !== $scheme && 'http' !== $scheme && 'https' !== $scheme && 'javascript' !== $scheme ) {
+				return null;
+			}
+
+			$url->scheme = $scheme;
+
+			// Validate that `://` follows the scheme.
+			$at = $scheme_length + 1;
+			if ( '/' !== $raw_url[ $at ] && '/' !== $raw_url[ $at + 1 ] ) {
+				return null;
+			}
+			$at += 2;
+
+			// @todo Detect username and password authentication.
+
+			// @todo Validate domain characters.
+			$domain_length = strspn( $raw_url, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-.', $at );
+			if ( 0 === $domain_length ) {
+				return null;
+			}
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Constructor function.
+	 *
+	 * @param ?string $base_url Base URL for completing relative URLs.
+	 */
+	public function __construct( $base_url = null ) {
+		$this->base_url = $base_url;
+	}
+
+	public function is_valid() {
+
+	}
+
+	// Constants that would pollute the top of the class.
+
+	const STATE_READY = 0;
+	const STATE_SCHEMA = 1;
+	const STATE_USERNAME = 2;
+	const STATE_PASSWORD = 3;
+	const STATE_HOST = 4;
+	const STATE_PORT = 5;
+	const STATE_PATH = 6;
+	const STATE_QUERY = 7;
+	const STATE_FRAGMENT = 8;
+}

--- a/tests/phpunit/tests/html-api/wpUrl.php
+++ b/tests/phpunit/tests/html-api/wpUrl.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Unit tests covering WP_URL functionality.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ *
+ * @since 6.6.0
+ *
+ * @group html-api
+ *
+ * @coversDefaultClass WP_URL
+ */
+class Tests_HtmlApi_WpUrl extends WP_UnitTestCase {
+	/**
+	 * Ensures that invalid URLs are invalidated.
+	 *
+	 * @ticket {TICKET_NUMBER}
+	 *
+	 * @dataProvider data_invalid_urls
+	 *
+	 * @param string $raw_url Contains something that isn't a valid URL.
+	 */
+	public function test_invalidates_non_urls( $raw_url ) {
+		$this->assertNull(
+			WP_URL::parse( $raw_url ),
+			"Should have rejected invalid URL: {$raw_url}"
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[].
+	 */
+	public static function data_invalid_urls() {
+		return array(
+			'Invalid scheme'        => array( 'sip://123.456.789.0' ),
+			'Missing scheme-suffix' => array( 'http:path' ),
+			'Broken scheme-suffix'  => array( 'http:/path' ),
+		);
+	}
+}

--- a/tests/phpunit/tests/html-api/wpUrl.php
+++ b/tests/phpunit/tests/html-api/wpUrl.php
@@ -38,6 +38,9 @@ class Tests_HtmlApi_WpUrl extends WP_UnitTestCase {
 			'Invalid scheme'        => array( 'sip://123.456.789.0' ),
 			'Missing scheme-suffix' => array( 'http:path' ),
 			'Broken scheme-suffix'  => array( 'http:/path' ),
+			'Non-ASCII hostname'    => array( 'https://going-to-🌕.com' ),
+			'Missing port number'   => array( 'http://domain:' ),
+			'Too-high port number'  => array( 'http://domain:135481' ),
 		);
 	}
 }


### PR DESCRIPTION
Please ignore this PR; it's meant to serve as a place for exploring some design ideas for a URL parser in Core.

## Summary

There are issues with PHP's URL parsing, and correspondingly with WordPress'. Here are some issues that would be good to eventually address:

 - Domains can have non-ASCII characters and these are ultimately encoded via punycode. We need to know that `xn--i28h` and `😄` represent the same text.
 - Percent-encoding should be uniform and applied everywhere it's necessary, but we often get partially-encoded inputs.
 - URLs should only be encoded once, and the query string gets encoded differently than the path, so it's not workable to encode an entire URL as a string. It needs to be broken apart and reassembled. If we do encode it multiple times it's essential to avoid double-encoding things like `&` and `%` otherwise the URL will be broken.

See also:
 - [Parsing Millions of URLs per Second](https://lemire.me/en/publication/arxiv231110533/): this normalizes URLs in a way that I think would benefit Core. All variations of a URL should collapse into _a_ canonical representation, simplifying all processing code analyzing them. Also, this library is fast and may have many insights for PHP. Better IMO would be to get this into PHP itself.