### PR TITLE
Fix allowed HTML tags declaration in `wp_trigger_error()`

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6068,7 +6068,7 @@ function wp_trigger_error( $function_name, $message, $error_level = E_USER_NOTIC
 	$message = wp_kses(
 		$message,
 		array(
-			'a'      => array( 'href' ),
+			'a'      => array( 'href' => true ),
 			'br'     => array(),
 			'code'   => array(),
 			'em'     => array(),

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6068,11 +6068,11 @@ function wp_trigger_error( $function_name, $message, $error_level = E_USER_NOTIC
 	$message = wp_kses(
 		$message,
 		array(
-			'a' => array( 'href' ),
-			'br',
-			'code',
-			'em',
-			'strong',
+			'a'      => array( 'href' ),
+			'br'     => array(),
+			'code'   => array(),
+			'em'     => array(),
+			'strong' => array(),
 		),
 		array( 'http', 'https' )
 	);

--- a/tests/phpunit/tests/functions/wpTriggerError.php
+++ b/tests/phpunit/tests/functions/wpTriggerError.php
@@ -102,6 +102,11 @@ class Tests_Functions_WpTriggerError extends WP_UnitTestCase {
 				'message'          => '<strong>expected</strong> the function name and message',
 				'expected_message' => 'some_function(): <strong>expected</strong> the function name and message',
 			),
+			'HTML links are present in message'            => array(
+				'function_name'    => 'some_function',
+				'message'          => '<a href="https://example.com">expected the function name and message</a>',
+				'expected_message' => 'some_function(): <a href="https://example.com">expected the function name and message</a>',
+			),
 			'disallowed HTML elements are present in message' => array(
 				'function_name'    => 'some_function',
 				'message'          => '<script>alert("expected the function name and message")</script>',

--- a/tests/phpunit/tests/functions/wpTriggerError.php
+++ b/tests/phpunit/tests/functions/wpTriggerError.php
@@ -82,20 +82,30 @@ class Tests_Functions_WpTriggerError extends WP_UnitTestCase {
 	 */
 	public function data_should_trigger_error() {
 		return array(
-			'function name and message are given' => array(
+			'function name and message are given'          => array(
 				'function_name'    => 'some_function',
 				'message'          => 'expected the function name and message',
 				'expected_message' => 'some_function(): expected the function name and message',
 			),
-			'message is given'                    => array(
+			'message is given'                             => array(
 				'function_name'    => '',
 				'message'          => 'expect only the message',
 				'expected_message' => 'expect only the message',
 			),
-			'function name is given'              => array(
+			'function name is given'                       => array(
 				'function_name'    => 'some_function',
 				'message'          => '',
 				'expected_message' => 'some_function(): ',
+			),
+			'allowed HTML elements are present in message' => array(
+				'function_name'    => 'some_function',
+				'message'          => '<strong>expected</strong> the function name and message',
+				'expected_message' => 'some_function(): <strong>expected</strong> the function name and message',
+			),
+			'disallowed HTML elements are present in message' => array(
+				'function_name'    => 'some_function',
+				'message'          => '<script>alert("expected the function name and message")</script>',
+				'expected_message' => 'some_function(): alert("expected the function name and message")',
 			),
 		);
 	}


### PR DESCRIPTION
Update allowed HTML tags declaration in `wp_trigger_error()`.

Trac ticket: https://core.trac.wordpress.org/ticket/61318

# Commit Message

General: Fix array format for allowed HTML passed into wp_kses() for wp_trigger_error().

Kses requires an associative array of allowed HTML.

See #57686. Follow-up to [56707].

Props thelovekesh, westonruter.
Fixes #61318.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
