### PR TITLE
Backport: Templates perf: resolve patterns server side

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1359,7 +1359,14 @@ function resolve_pattern_blocks( $blocks, &$inner_content = null ) {
 	$i                = 0;
 	while ( $i < count( $blocks ) ) {
 		if ( 'core/pattern' === $blocks[ $i ]['blockName'] ) {
-			$slug = $blocks[ $i ]['attrs']['slug'];
+			$attrs = $blocks[ $i ]['attrs'];
+
+			if ( empty( $attrs['slug'] ) ) {
+				++$i;
+				continue;
+			}
+
+			$slug = $attrs['slug'];
 
 			if ( isset( $seen_refs[ $slug ] ) ) {
 				// Skip recursive patterns.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1344,7 +1344,16 @@ function traverse_and_serialize_block( $block, $pre_callback = null, $post_callb
 	);
 }
 
-function replace_pattern_blocks( $blocks, &$inner_content = null ) {
+/**
+ * Replaces patterns in a block tree with their content.
+ *
+ * @since 6.6.0
+ *
+ * @param array $blocks An array blocks.
+ *
+ * @return array An array of blocks with patterns replaced by their content.
+ */
+function resolve_pattern_blocks( $blocks, &$inner_content = null ) {
 	// Keep track of seen references to avoid infinite loops.
 	static $seen_refs = array();
 	$i                = 0;
@@ -1369,7 +1378,7 @@ function replace_pattern_blocks( $blocks, &$inner_content = null ) {
 
 			$blocks_to_insert   = parse_blocks( $pattern['content'] );
 			$seen_refs[ $slug ] = true;
-			$blocks_to_insert   = replace_pattern_blocks( $blocks_to_insert );
+			$blocks_to_insert   = resolve_pattern_blocks( $blocks_to_insert );
 			unset( $seen_refs[ $slug ] );
 			array_splice( $blocks, $i, 1, $blocks_to_insert );
 
@@ -1387,7 +1396,7 @@ function replace_pattern_blocks( $blocks, &$inner_content = null ) {
 			$i += count( $blocks_to_insert );
 		} else {
 			if ( ! empty( $blocks[ $i ]['innerBlocks'] ) ) {
-				$blocks[ $i ]['innerBlocks'] = replace_pattern_blocks(
+				$blocks[ $i ]['innerBlocks'] = resolve_pattern_blocks(
 					$blocks[ $i ]['innerBlocks'],
 					$blocks[ $i ]['innerContent']
 				);
@@ -1436,8 +1445,6 @@ function replace_pattern_blocks( $blocks, &$inner_content = null ) {
 function traverse_and_serialize_blocks( $blocks, $pre_callback = null, $post_callback = null ) {
 	$result       = '';
 	$parent_block = null; // At the top level, there is no parent block to pass to the callbacks; yet the callbacks expect a reference.
-
-	$blocks = replace_pattern_blocks( $blocks );
 
 	foreach ( $blocks as $index => $block ) {
 		if ( is_callable( $pre_callback ) ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1344,6 +1344,60 @@ function traverse_and_serialize_block( $block, $pre_callback = null, $post_callb
 	);
 }
 
+function replace_pattern_blocks( $blocks, &$inner_content = null ) {
+	// Keep track of seen references to avoid infinite loops.
+	static $seen_refs = array();
+	$i                = 0;
+	while ( $i < count( $blocks ) ) {
+		if ( 'core/pattern' === $blocks[ $i ]['blockName'] ) {
+			$slug = $blocks[ $i ]['attrs']['slug'];
+
+			if ( isset( $seen_refs[ $slug ] ) ) {
+				// Skip recursive patterns.
+				array_splice( $blocks, $i, 1 );
+				continue;
+			}
+
+			$registry = WP_Block_Patterns_Registry::get_instance();
+			$pattern  = $registry->get_registered( $slug );
+
+			// Skip unknown patterns.
+			if ( ! $pattern ) {
+				++$i;
+				continue;
+			}
+
+			$blocks_to_insert   = parse_blocks( $pattern['content'] );
+			$seen_refs[ $slug ] = true;
+			$blocks_to_insert   = replace_pattern_blocks( $blocks_to_insert );
+			unset( $seen_refs[ $slug ] );
+			array_splice( $blocks, $i, 1, $blocks_to_insert );
+
+			// If we have inner content, we need to insert nulls in the
+			// inner content array, otherwise serialize_blocks will skip
+			// blocks.
+			if ( $inner_content ) {
+				$null_indices  = array_keys( $inner_content, null, true );
+				$content_index = $null_indices[ $i ];
+				$nulls         = array_fill( 0, count( $blocks_to_insert ), null );
+				array_splice( $inner_content, $content_index, 1, $nulls );
+			}
+
+			// Skip inserted blocks.
+			$i += count( $blocks_to_insert );
+		} else {
+			if ( ! empty( $blocks[ $i ]['innerBlocks'] ) ) {
+				$blocks[ $i ]['innerBlocks'] = replace_pattern_blocks(
+					$blocks[ $i ]['innerBlocks'],
+					$blocks[ $i ]['innerContent']
+				);
+			}
+			++$i;
+		}
+	}
+	return $blocks;
+}
+
 /**
  * Given an array of parsed block trees, applies callbacks before and after serializing them and
  * returns their concatenated output.
@@ -1382,6 +1436,8 @@ function traverse_and_serialize_block( $block, $pre_callback = null, $post_callb
 function traverse_and_serialize_blocks( $blocks, $pre_callback = null, $post_callback = null ) {
 	$result       = '';
 	$parent_block = null; // At the top level, there is no parent block to pass to the callbacks; yet the callbacks expect a reference.
+
+	$blocks = replace_pattern_blocks( $blocks );
 
 	foreach ( $blocks as $index => $block ) {
 		if ( is_callable( $pre_callback ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-block-patterns-controller.php
@@ -162,6 +162,12 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function prepare_item_for_response( $item, $request ) {
+		// Resolve pattern blocks so they don't need to be resolved client-side
+		// in the editor, improving performance.
+		$blocks        = parse_blocks( $item['content'] );
+		$blocks        = resolve_pattern_blocks( $blocks );
+		$item['content'] = serialize_blocks( $blocks );
+
 		$fields = $this->get_fields_for_response( $request );
 		$keys   = array(
 			'name'          => 'name',

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -636,6 +636,12 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response Response object.
 	 */
 	public function prepare_item_for_response( $item, $request ) {
+		// Resolve pattern blocks so they don't need to be resolved client-side
+		// in the editor, improving performance.
+		$blocks        = parse_blocks( $item->content );
+		$blocks        = resolve_pattern_blocks( $blocks );
+		$item->content = serialize_blocks( $blocks );
+
 		// Restores the more descriptive, specific name for use within this method.
 		$template = $item;
 

--- a/tests/phpunit/tests/blocks/resolve-pattern-blocks.php
+++ b/tests/phpunit/tests/blocks/resolve-pattern-blocks.php
@@ -10,6 +10,27 @@
  * @group blocks
  */
 class Tests_Blocks_Resolve_Pattern_Blocks extends WP_UnitTestCase {
+    public function set_up() {
+		parent::set_up();
+
+        register_block_pattern( 'core/test', array(
+            'title'       => 'Test',
+            'content'     => '<!-- wp:paragraph -->Hello<!-- /wp:paragraph --><!-- wp:paragraph -->World<!-- /wp:paragraph -->',
+            'description' => 'Test pattern.',
+        ) );
+        register_block_pattern( 'core/recursive', array(
+            'title'       => 'Recursive',
+            'content'     => '<!-- wp:paragraph -->Recursive<!-- /wp:paragraph --><!-- wp:pattern {"slug":"core/recursive"} /-->',
+            'description' => 'Recursive pattern.',
+        ) );
+	}
+
+    public function tear_down() {
+        parent::tear_down();
+
+        unregister_block_pattern( 'core/test' );
+        unregister_block_pattern( 'core/recursive' );
+    }
 
 	/**
 	 * @dataProvider data_all
@@ -26,6 +47,12 @@ class Tests_Blocks_Resolve_Pattern_Blocks extends WP_UnitTestCase {
 		return array(
 			// Works without attributes, leaves the block as is.
 			array( '<!-- wp:pattern /-->', '<!-- wp:pattern /-->' ),
+            // Resolves the pattern.
+            array( '<!-- wp:pattern {"slug":"core/test"} /-->', '<!-- wp:paragraph -->Hello<!-- /wp:paragraph --><!-- wp:paragraph -->World<!-- /wp:paragraph -->' ),
+            // Skip recursive patterns.
+            array( '<!-- wp:pattern {"slug":"core/recursive"} /-->', '<!-- wp:paragraph -->Recursive<!-- /wp:paragraph -->' ),
+            // Resolves the pattern within a block.
+            array( '<!-- wp:group --><!-- wp:paragraph -->Before<!-- /wp:paragraph --><!-- wp:pattern {"slug":"core/test"} /--><!-- wp:paragraph -->After<!-- /wp:paragraph --><!-- /wp:group -->', '<!-- wp:group --><!-- wp:paragraph -->Before<!-- /wp:paragraph --><!-- wp:paragraph -->Hello<!-- /wp:paragraph --><!-- wp:paragraph -->World<!-- /wp:paragraph --><!-- wp:paragraph -->After<!-- /wp:paragraph --><!-- /wp:group -->' ),
 		);
 	}
 }

--- a/tests/phpunit/tests/blocks/resolve-pattern-blocks.php
+++ b/tests/phpunit/tests/blocks/resolve-pattern-blocks.php
@@ -10,33 +10,39 @@
  * @group blocks
  */
 class Tests_Blocks_Resolve_Pattern_Blocks extends WP_UnitTestCase {
-    public function set_up() {
+	public function set_up() {
 		parent::set_up();
 
-        register_block_pattern( 'core/test', array(
-            'title'       => 'Test',
-            'content'     => '<!-- wp:paragraph -->Hello<!-- /wp:paragraph --><!-- wp:paragraph -->World<!-- /wp:paragraph -->',
-            'description' => 'Test pattern.',
-        ) );
-        register_block_pattern( 'core/recursive', array(
-            'title'       => 'Recursive',
-            'content'     => '<!-- wp:paragraph -->Recursive<!-- /wp:paragraph --><!-- wp:pattern {"slug":"core/recursive"} /-->',
-            'description' => 'Recursive pattern.',
-        ) );
+		register_block_pattern(
+			'core/test',
+			array(
+				'title'       => 'Test',
+				'content'     => '<!-- wp:paragraph -->Hello<!-- /wp:paragraph --><!-- wp:paragraph -->World<!-- /wp:paragraph -->',
+				'description' => 'Test pattern.',
+			) 
+		);
+		register_block_pattern(
+			'core/recursive',
+			array(
+				'title'       => 'Recursive',
+				'content'     => '<!-- wp:paragraph -->Recursive<!-- /wp:paragraph --><!-- wp:pattern {"slug":"core/recursive"} /-->',
+				'description' => 'Recursive pattern.',
+			)
+		);
 	}
 
-    public function tear_down() {
-        parent::tear_down();
+	public function tear_down() {
+		parent::tear_down();
 
-        unregister_block_pattern( 'core/test' );
-        unregister_block_pattern( 'core/recursive' );
-    }
+		unregister_block_pattern( 'core/test' );
+		unregister_block_pattern( 'core/recursive' );
+	}
 
 	/**
 	 * @dataProvider data_all
 	 *
 	 * @param string $input
-     * @param string $expected
+	 * @param string $expected
 	 */
 	public function test_all( $input, $expected ) {
 		$actual = resolve_pattern_blocks( parse_blocks( $input ) );
@@ -47,12 +53,12 @@ class Tests_Blocks_Resolve_Pattern_Blocks extends WP_UnitTestCase {
 		return array(
 			// Works without attributes, leaves the block as is.
 			array( '<!-- wp:pattern /-->', '<!-- wp:pattern /-->' ),
-            // Resolves the pattern.
-            array( '<!-- wp:pattern {"slug":"core/test"} /-->', '<!-- wp:paragraph -->Hello<!-- /wp:paragraph --><!-- wp:paragraph -->World<!-- /wp:paragraph -->' ),
-            // Skip recursive patterns.
-            array( '<!-- wp:pattern {"slug":"core/recursive"} /-->', '<!-- wp:paragraph -->Recursive<!-- /wp:paragraph -->' ),
-            // Resolves the pattern within a block.
-            array( '<!-- wp:group --><!-- wp:paragraph -->Before<!-- /wp:paragraph --><!-- wp:pattern {"slug":"core/test"} /--><!-- wp:paragraph -->After<!-- /wp:paragraph --><!-- /wp:group -->', '<!-- wp:group --><!-- wp:paragraph -->Before<!-- /wp:paragraph --><!-- wp:paragraph -->Hello<!-- /wp:paragraph --><!-- wp:paragraph -->World<!-- /wp:paragraph --><!-- wp:paragraph -->After<!-- /wp:paragraph --><!-- /wp:group -->' ),
+			// Resolves the pattern.
+			array( '<!-- wp:pattern {"slug":"core/test"} /-->', '<!-- wp:paragraph -->Hello<!-- /wp:paragraph --><!-- wp:paragraph -->World<!-- /wp:paragraph -->' ),
+			// Skip recursive patterns.
+			array( '<!-- wp:pattern {"slug":"core/recursive"} /-->', '<!-- wp:paragraph -->Recursive<!-- /wp:paragraph -->' ),
+			// Resolves the pattern within a block.
+			array( '<!-- wp:group --><!-- wp:paragraph -->Before<!-- /wp:paragraph --><!-- wp:pattern {"slug":"core/test"} /--><!-- wp:paragraph -->After<!-- /wp:paragraph --><!-- /wp:group -->', '<!-- wp:group --><!-- wp:paragraph -->Before<!-- /wp:paragraph --><!-- wp:paragraph -->Hello<!-- /wp:paragraph --><!-- wp:paragraph -->World<!-- /wp:paragraph --><!-- wp:paragraph -->After<!-- /wp:paragraph --><!-- /wp:group -->' ),
 		);
 	}
 }

--- a/tests/phpunit/tests/blocks/resolve-pattern-blocks.php
+++ b/tests/phpunit/tests/blocks/resolve-pattern-blocks.php
@@ -8,6 +8,7 @@
  * @since 6.6.0
  *
  * @group blocks
+ * @covers resolve_pattern_blocks
  */
 class Tests_Blocks_Resolve_Pattern_Blocks extends WP_UnitTestCase {
 	public function set_up() {

--- a/tests/phpunit/tests/blocks/resolve-pattern-blocks.php
+++ b/tests/phpunit/tests/blocks/resolve-pattern-blocks.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Tests for resolve_pattern_blocks.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @since 6.6.0
+ *
+ * @group blocks
+ */
+class Tests_Blocks_Resolve_Pattern_Blocks extends WP_UnitTestCase {
+
+	/**
+	 * @dataProvider data_all
+	 *
+	 * @param string $input
+     * @param string $expected
+	 */
+	public function test_all( $input, $expected ) {
+		$actual = resolve_pattern_blocks( parse_blocks( $input ) );
+		$this->assertSame( $expected, serialize_blocks( $actual ) );
+	}
+
+	public function data_all() {
+		return array(
+			// Works without attributes, leaves the block as is.
+			array( '<!-- wp:pattern /-->', '<!-- wp:pattern /-->' ),
+		);
+	}
+}

--- a/tests/phpunit/tests/blocks/resolve-pattern-blocks.php
+++ b/tests/phpunit/tests/blocks/resolve-pattern-blocks.php
@@ -19,7 +19,7 @@ class Tests_Blocks_Resolve_Pattern_Blocks extends WP_UnitTestCase {
 				'title'       => 'Test',
 				'content'     => '<!-- wp:paragraph -->Hello<!-- /wp:paragraph --><!-- wp:paragraph -->World<!-- /wp:paragraph -->',
 				'description' => 'Test pattern.',
-			) 
+			)
 		);
 		register_block_pattern(
 			'core/recursive',

--- a/tests/phpunit/tests/blocks/resolvePatternBlocks.php
+++ b/tests/phpunit/tests/blocks/resolvePatternBlocks.php
@@ -10,7 +10,7 @@
  * @group blocks
  * @covers resolve_pattern_blocks
  */
-class Tests_Blocks_Resolve_Pattern_Blocks extends WP_UnitTestCase {
+class Tests_Blocks_ResolvePatternBlocks extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 

--- a/tests/phpunit/tests/blocks/resolvePatternBlocks.php
+++ b/tests/phpunit/tests/blocks/resolvePatternBlocks.php
@@ -40,26 +40,33 @@ class Tests_Blocks_ResolvePatternBlocks extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @dataProvider data_all
+	 * @dataProvider data_should_resolve_pattern_blocks_as_expected
 	 *
-	 * @param string $input
-	 * @param string $expected
+	 * @ticket 61228
+	 *
+	 * @param string $blocks   A string representing blocks that need resolving.
+	 * @param string $expected Expected result.
 	 */
-	public function test_all( $input, $expected ) {
-		$actual = resolve_pattern_blocks( parse_blocks( $input ) );
+	public function test_should_resolve_pattern_blocks_as_expected( $blocks, $expected ) {
+		$actual = resolve_pattern_blocks( parse_blocks( $blocks ) );
 		$this->assertSame( $expected, serialize_blocks( $actual ) );
 	}
 
-	public function data_all() {
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_should_resolve_pattern_blocks_as_expected() {
 		return array(
 			// Works without attributes, leaves the block as is.
-			array( '<!-- wp:pattern /-->', '<!-- wp:pattern /-->' ),
+			'pattern with no slug attribute' => array( '<!-- wp:pattern /-->', '<!-- wp:pattern /-->' ),
 			// Resolves the pattern.
-			array( '<!-- wp:pattern {"slug":"core/test"} /-->', '<!-- wp:paragraph -->Hello<!-- /wp:paragraph --><!-- wp:paragraph -->World<!-- /wp:paragraph -->' ),
-			// Skip recursive patterns.
-			array( '<!-- wp:pattern {"slug":"core/recursive"} /-->', '<!-- wp:paragraph -->Recursive<!-- /wp:paragraph -->' ),
+			'test pattern'                   => array( '<!-- wp:pattern {"slug":"core/test"} /-->', '<!-- wp:paragraph -->Hello<!-- /wp:paragraph --><!-- wp:paragraph -->World<!-- /wp:paragraph -->' ),
+			// Skips recursive patterns.
+			'recursive pattern'              => array( '<!-- wp:pattern {"slug":"core/recursive"} /-->', '<!-- wp:paragraph -->Recursive<!-- /wp:paragraph -->' ),
 			// Resolves the pattern within a block.
-			array( '<!-- wp:group --><!-- wp:paragraph -->Before<!-- /wp:paragraph --><!-- wp:pattern {"slug":"core/test"} /--><!-- wp:paragraph -->After<!-- /wp:paragraph --><!-- /wp:group -->', '<!-- wp:group --><!-- wp:paragraph -->Before<!-- /wp:paragraph --><!-- wp:paragraph -->Hello<!-- /wp:paragraph --><!-- wp:paragraph -->World<!-- /wp:paragraph --><!-- wp:paragraph -->After<!-- /wp:paragraph --><!-- /wp:group -->' ),
+			'pattern within a block'         => array( '<!-- wp:group --><!-- wp:paragraph -->Before<!-- /wp:paragraph --><!-- wp:pattern {"slug":"core/test"} /--><!-- wp:paragraph -->After<!-- /wp:paragraph --><!-- /wp:group -->', '<!-- wp:group --><!-- wp:paragraph -->Before<!-- /wp:paragraph --><!-- wp:paragraph -->Hello<!-- /wp:paragraph --><!-- wp:paragraph -->World<!-- /wp:paragraph --><!-- wp:paragraph -->After<!-- /wp:paragraph --><!-- /wp:group -->' ),
 		);
 	}
 }

--- a/tests/phpunit/tests/blocks/resolvePatternBlocks.php
+++ b/tests/phpunit/tests/blocks/resolvePatternBlocks.php
@@ -33,10 +33,10 @@ class Tests_Blocks_ResolvePatternBlocks extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
-		parent::tear_down();
-
 		unregister_block_pattern( 'core/test' );
 		unregister_block_pattern( 'core/recursive' );
+
+		parent::tear_down();
 	}
 
 	/**


### PR DESCRIPTION
Note that this replaces #6559, which I hadn't created from my fork.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/61228

This is a single backport for the following PRs:
* https://github.com/WordPress/gutenberg/pull/60349
 * https://github.com/WordPress/gutenberg/pull/61757

To test: check the patterns endpoint and search for `wp:pattern`. There should be 0 results.

<img width="1352" alt="Screenshot 2024-05-16 at 11 23 14" src="https://github.com/WordPress/wordpress-develop/assets/4710635/63b268b2-d0e3-48ce-a52d-506a4de39e30">


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
