### PR TITLE
Add PHP Version as an input for performance workflow

### DIFF
--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -17,7 +17,7 @@ on:
         type: 'string'
         default: '6.1.1'
       php-version:
-        description: 'The PHP version to us.'
+        description: 'The PHP version to use.'
         required: false
         type: 'string'
         default: '8.3'

--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -20,7 +20,7 @@ on:
         description: 'The PHP version to use.'
         required: false
         type: 'string'
-        default: '8.3'
+        default: 'latest'
       memcached:
         description: 'Whether to enable memcached.'
         required: false
@@ -48,7 +48,7 @@ env:
   TARGET_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
 
   LOCAL_PHP_MEMCACHED: ${{ inputs.memcached }}
-  LOCAL_PHP: ${{ inputs.php-version }}-fpm
+  LOCAL_PHP: ${{ inputs.php-version }}${{ 'latest' != inputs.php-version && '-fpm' }}
 
 jobs:
   # Performs the following steps:

--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -17,7 +17,7 @@ on:
         type: 'string'
         default: '6.1.1'
       php-version:
-        description: 'The PHP version to use for running the tests.'
+        description: 'The PHP version to us.'
         required: false
         type: 'string'
         default: '8.3'
@@ -48,7 +48,7 @@ env:
   TARGET_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
 
   LOCAL_PHP_MEMCACHED: ${{ inputs.memcached }}
-  LOCAL_PHP: '${{ inputs.php-version }}-fpm'
+  LOCAL_PHP: ${{ inputs.php-version }}-fpm
 
 jobs:
   # Performs the following steps:

--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -16,6 +16,11 @@ on:
         required: false
         type: 'string'
         default: '6.1.1'
+      php-version:
+        description: 'The PHP version to use for running the tests.'
+        required: false
+        type: 'string'
+        default: '8.3'
       memcached:
         description: 'Whether to enable memcached.'
         required: false
@@ -43,6 +48,7 @@ env:
   TARGET_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
 
   LOCAL_PHP_MEMCACHED: ${{ inputs.memcached }}
+  LOCAL_PHP: '${{ inputs.php-version }}-fpm'
 
 jobs:
   # Performs the following steps:

--- a/.github/workflows/reusable-test-core-build-process.yml
+++ b/.github/workflows/reusable-test-core-build-process.yml
@@ -92,6 +92,6 @@ jobs:
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         if: ${{ inputs.directory == 'build' && 'ubuntu-latest' == inputs.os }}
         with:
-          name: wordpress-build-db589b327cf551071cfee14a6be36e8552321db9
+          name: wordpress-build-${{ github.event_name == 'pull_request' && github.event.number || github.sha }}
           path: wordpress.zip
           if-no-files-found: error

--- a/.github/workflows/reusable-test-core-build-process.yml
+++ b/.github/workflows/reusable-test-core-build-process.yml
@@ -92,6 +92,6 @@ jobs:
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         if: ${{ inputs.directory == 'build' && 'ubuntu-latest' == inputs.os }}
         with:
-          name: wordpress-build-${{ github.event_name == 'pull_request' && github.event.number || github.sha }}
+          name: wordpress-build-db589b327cf551071cfee14a6be36e8552321db9
           path: wordpress.zip
           if-no-files-found: error


### PR DESCRIPTION
This adds a `php-version` input to the reusable performance testing workflow. This is to accommodate the changes to fix the workflow in the 6.4 branch once that branch is updated to make use of the new reusable workflows.

Trac ticket: https://core.trac.wordpress.org/ticket/60127

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
