### PR TITLE
Block Hooks API: Move hooked blocks injection logic

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -760,4 +760,7 @@ add_filter( 'rest_pre_insert_wp_template_part', 'inject_ignored_hooked_blocks_me
 // Update ignoredHookedBlocks postmeta for wp_navigation post type.
 add_filter( 'rest_pre_insert_wp_navigation', 'update_ignored_hooked_blocks_postmeta' );
 
+// Inject hooked blocks into the wp_navigation post type REST response.
+add_filter( 'rest_prepare_wp_navigation', 'insert_hooked_blocks_into_rest_response', 10, 2 );
+
 unset( $filter, $action );


### PR DESCRIPTION
In a similar vein as @tjcafferkey's https://github.com/WordPress/wordpress-develop/pull/6604, this introduces a new `insert_hooked_blocks_into_rest_response` filter and adds it to the `rest_prepare_wp_navigation` hook.

This is part of an effort to move code from the Navigation block into Core. Specifically, `insert_hooked_blocks_into_rest_response` is based on [`block_core_navigation_insert_hooked_blocks_into_rest_response`](https://github.com/WordPress/gutenberg/blob/f44dfae735398aa8e9de10b47b4d598a8ad18b90/packages/block-library/src/navigation/index.php#L1642-L1667).

**Testing instructions:**

Preparation: Make sure you're using a Block Theme to test, ideally TT4. Add the following code to your site (e.g. to your theme's `functions.php`).

```php
function register_logout_block_as_navigation_last_child( $hooked_blocks, $position, $anchor_block, $context ) {
	if ( $anchor_block === 'core/navigation' && $position === 'last_child' ) {
		$hooked_blocks[] = 'core/loginout';
	}

	return $hooked_blocks;
}

add_filter( 'hooked_block_types', 'register_logout_block_as_navigation_last_child', 10, 4 );
```

1. If there's an existing `wp_navigation` post object for you Navigation menu in your database, make sure that it doesn't have any `_wp_ignored_hooked_blocks ` post meta set. (You can check the latter via `npm run wp-env run cli wp post meta list <postId>.`) Otherwise, you'll need to delete said post meta.
2. Go to the site editor and verify that the Login/out button block is added to the Navigation menu. You will probably see _two_ copies. The reason is that the Navigation block code still keeps inserting hooked blocks on its own.
3. To avoid the latter, apply the following patch, and reload the editor. You should now see only one copy of the Login/out block added.

```diff
diff --git a/src/wp-includes/blocks/navigation.php b/src/wp-includes/blocks/navigation.php
index ba1644cf60..bbc924328b 100644
--- a/src/wp-includes/blocks/navigation.php
+++ b/src/wp-includes/blocks/navigation.php
@@ -1567,9 +1567,15 @@ function block_core_navigation_insert_hooked_blocks_into_rest_response( $respons
 $rest_prepare_wp_navigation_core_callback = 'block_core_navigation_' . 'insert_hooked_blocks_into_rest_response';
 
 /*
- * Injection of hooked blocks into the Navigation block relies on some functions present in WP >= 6.5
- * that are not present in Gutenberg's WP 6.5 compatibility layer.
+ * Do not add the `block_core_navigation_insert_hooked_blocks_into_rest_response` filter in the following cases:
+ * - If Core has added the `insert_hooked_blocks_into_rest_response` filter already (WP >= 6.6);
+ * - or if the `set_ignored_hooked_blocks_metadata` function is unavailable (which is required for the filter to work. It was introduced by WP 6.5 but is not present in Gutenberg's WP 6.5 compatibility layer);
+ * - or if the `$rest_prepare_wp_navigation_core_callback` filter has already been added.
  */
-if ( function_exists( 'set_ignored_hooked_blocks_metadata' ) && ! has_filter( 'rest_prepare_wp_navigation', $rest_prepare_wp_navigation_core_callback ) ) {
+if (
+       ! has_filter( 'rest_prepare_wp_navigation', 'insert_hooked_blocks_into_rest_response' ) &&
+       function_exists( 'set_ignored_hooked_blocks_metadata' ) &&
+       ! has_filter( 'rest_prepare_wp_navigation', $rest_prepare_wp_navigation_core_callback )
+) {
        add_filter( 'rest_prepare_wp_navigation', 'block_core_navigation_insert_hooked_blocks_into_rest_response', 10, 3 );
 }
```

Here's a Gutenberg PR for that diff: https://github.com/WordPress/gutenberg/pull/62134. That PR will have to get merged and sync'd to Core _before_ we can land this change.

Trac ticket: https://core.trac.wordpress.org/ticket/60759

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
