### PR TITLE
Script Modules: Add server to client data passing

### DIFF
--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -372,7 +372,7 @@ class WP_Script_Modules {
 	 *
 	 * The data will be embedded in the page HTML and can be read by Script Modules on page load.
 	 *
-	 * @since 6.6.0
+	 * @since 6.7.0
 	 *
 	 * Data can be associated with a Script Module via the
 	 * {@see "script_module_data_{$module_id}"} filter.
@@ -430,7 +430,7 @@ class WP_Script_Modules {
 			 *   }
 			 *   initMyScriptModuleWithData( data );
 			 *
-			 * @since 6.6.0
+			 * @since 6.7.0
 			 *
 			 * @param array $data The data associated with the Script Module.
 			 */

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -378,7 +378,7 @@ class WP_Script_Modules {
 	 * {@see "script_module_data_{$module_id}"} filter.
 	 *
 	 * The data for a Script Module will be serialized as JSON in a script tag with an ID of the
-	 * form `wp-scriptmodule-data_{$module_id}`.
+	 * form `wp-script-module-data-{$module_id}`.
 	 */
 	public function print_script_module_data(): void {
 		$modules = array();
@@ -416,12 +416,12 @@ class WP_Script_Modules {
 			 * If the filter returns no data (an empty array), nothing will be embedded in the page.
 			 *
 			 * The data for a given Script Module, if provided, will be JSON serialized in a script
-			 * tag with an ID of the form `wp-scriptmodule-data_{$module_id}`.
+			 * tag with an ID of the form `wp-script-module-data-{$module_id}`.
 			 *
 			 * The data can be read on the client with a pattern like this:
 			 *
 			 * @example
-			 *   const dataContainer = document.getElementById( 'wp-scriptmodule-data_MyScriptModuleID' );
+			 *   const dataContainer = document.getElementById( 'wp-script-module-data-MyScriptModuleID' );
 			 *   let data = {};
 			 *   if ( dataContainer ) {
 			 *     try {
@@ -475,7 +475,7 @@ class WP_Script_Modules {
 					),
 					array(
 						'type' => 'application/json',
-						'id'   => "wp-scriptmodule-data_{$module_id}",
+						'id'   => "wp-script-module-data-{$module_id}",
 					)
 				);
 			}

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -432,7 +432,7 @@ class WP_Script_Modules {
 			 *
 			 * @since 6.6.0
 			 *
-			 * @param array $data The data that should be associated with the array.
+			 * @param array $data The data associated with the Script Module.
 			 */
 			$data = apply_filters( "scriptmoduledata_{$module_id}", array() );
 

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -436,7 +436,7 @@ class WP_Script_Modules {
 			 */
 			$data = apply_filters( "scriptmoduledata_{$module_id}", array() );
 
-			if ( is_array( $data ) && ! empty( $data ) ) {
+			if ( is_array( $data ) && array() !== $data ) {
 				/*
 				 * This data will be printed as JSON inside a script tag like this:
 				 *   <script type="application/json"></script>

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -375,7 +375,7 @@ class WP_Script_Modules {
 	 * @since 6.6.0
 	 *
 	 * Data can be associated with a Script Module via the
-	 * {@see "scriptmoduledata_{$module_id}"} filter.
+	 * {@see "script_module_data_{$module_id}"} filter.
 	 *
 	 * The data for a Script Module will be serialized as JSON in a script tag with an ID of the
 	 * form `wp-scriptmodule-data_{$module_id}`.
@@ -406,7 +406,7 @@ class WP_Script_Modules {
 			 *
 			 * @example
 			 *   add_filter(
-			 *     'scriptmoduledata_MyScriptModuleID',
+			 *     'script_module_data_MyScriptModuleID',
 			 *     function ( array $data ): array {
 			 *       $data['script-needs-this-data'] = 'ok';
 			 *       return $data;
@@ -434,7 +434,7 @@ class WP_Script_Modules {
 			 *
 			 * @param array $data The data associated with the Script Module.
 			 */
-			$data = apply_filters( "scriptmoduledata_{$module_id}", array() );
+			$data = apply_filters( "script_module_data_{$module_id}", array() );
 
 			if ( is_array( $data ) && array() !== $data ) {
 				/*

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -182,6 +182,9 @@ class WP_Script_Modules {
 		add_action( 'admin_print_footer_scripts', array( $this, 'print_import_map' ) );
 		add_action( 'admin_print_footer_scripts', array( $this, 'print_enqueued_script_modules' ) );
 		add_action( 'admin_print_footer_scripts', array( $this, 'print_script_module_preloads' ) );
+
+		add_action( 'wp_footer', array( $this, 'print_script_module_data' ) );
+		add_action( 'admin_print_footer_scripts', array( $this, 'print_script_module_data' ) );
 	}
 
 	/**
@@ -362,5 +365,120 @@ class WP_Script_Modules {
 		$src = apply_filters( 'script_module_loader_src', $src, $id );
 
 		return $src;
+	}
+
+	/**
+	 * Print data associated with Script Modules.
+	 *
+	 * The data will be embedded in the page HTML and can be read by Script Modules on page load.
+	 *
+	 * @since 6.6.0
+	 *
+	 * Data can be associated with a Script Module via the
+	 * {@see "scriptmoduledata_{$module_id}"} filter.
+	 *
+	 * The data for a Script Module will be serialized as JSON in a script tag with an ID of the
+	 * form `wp-scriptmodule-data_{$module_id}`.
+	 */
+	public function print_script_module_data(): void {
+		$modules = array();
+		foreach ( array_keys( $this->get_marked_for_enqueue() ) as $id ) {
+			$modules[ $id ] = true;
+		}
+		foreach ( array_keys( $this->get_import_map()['imports'] ) as $id ) {
+			$modules[ $id ] = true;
+		}
+
+		foreach ( array_keys( $modules ) as $module_id ) {
+			/**
+			 * Filters data associated with a given Script Module.
+			 *
+			 * Script Modules may require data that is required for initialization or is essential
+			 * to have immediately available on page load. These are suitable use cases for
+			 * this data.
+			 *
+			 * The dynamic portion of the hook name, `$module_id`, refers to the Script Module ID
+			 * that the data is associated with.
+			 *
+			 * This is best suited to pass essential data that must be available to the module for
+			 * initialization or immediately on page load. It does not replace the REST API or
+			 * fetching data from the client.
+			 *
+			 * @example
+			 *   add_filter(
+			 *     'scriptmoduledata_MyScriptModuleID',
+			 *     function ( array $data ): array {
+			 *       $data['script-needs-this-data'] = 'ok';
+			 *       return $data;
+			 *     }
+			 *   );
+			 *
+			 * If the filter returns no data (an empty array), nothing will be embedded in the page.
+			 *
+			 * The data for a given Script Module, if provided, will be JSON serialized in a script
+			 * tag with an ID of the form `wp-scriptmodule-data_{$module_id}`.
+			 *
+			 * The data can be read on the client with a pattern like this:
+			 *
+			 * @example
+			 *   const dataContainer = document.getElementById( 'wp-scriptmodule-data_MyScriptModuleID' );
+			 *   let data = {};
+			 *   if ( dataContainer ) {
+			 *     try {
+			 *       data = JSON.parse( dataContainer.textContent );
+			 *     } catch {}
+			 *   }
+			 *   initMyScriptModuleWithData( data );
+			 *
+			 * @since 6.6.0
+			 *
+			 * @param array $data The data that should be associated with the array.
+			 */
+			$data = apply_filters( "scriptmoduledata_{$module_id}", array() );
+
+			if ( is_array( $data ) && ! empty( $data ) ) {
+				/*
+				 * This data will be printed as JSON inside a script tag like this:
+				 *   <script type="application/json"></script>
+				 *
+				 * A script tag must be closed by a sequence beginning with `</`. It's impossible to
+				 * close a script tag without using `<`. We ensure that `<` is escaped and `/` can
+				 * remain unescaped, so `</script>` will be printed as `\u003C/script\u00E3`.
+				 *
+				 *   - JSON_HEX_TAG: All < and > are converted to \u003C and \u003E.
+				 *   - JSON_UNESCAPED_SLASHES: Don't escape /.
+				 *
+				 * If the page will use UTF-8 encoding, it's safe to print unescaped unicode:
+				 *
+				 *   - JSON_UNESCAPED_UNICODE: Encode multibyte Unicode characters literally (instead of as `\uXXXX`).
+				 *   - JSON_UNESCAPED_LINE_TERMINATORS: The line terminators are kept unescaped when
+				 *     JSON_UNESCAPED_UNICODE is supplied. It uses the same behaviour as it was
+				 *     before PHP 7.1 without this constant. Available as of PHP 7.1.0.
+				 *
+				 * The JSON specification requires encoding in UTF-8, so if the generated HTML page
+				 * is not encoded in UTF-8 then it's not safe to include those literals. They must
+				 * be escaped to avoid encoding issues.
+				 *
+				 * @see https://www.rfc-editor.org/rfc/rfc8259.html for details on encoding requirements.
+				 * @see https://www.php.net/manual/en/json.constants.php for details on these constants.
+				 * @see https://html.spec.whatwg.org/#script-data-state for details on script tag parsing.
+				 */
+				$json_encode_flags = JSON_HEX_TAG | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS;
+				if ( ! is_utf8_charset() ) {
+					$json_encode_flags = JSON_HEX_TAG | JSON_UNESCAPED_SLASHES;
+				}
+
+				wp_print_inline_script_tag(
+					wp_json_encode(
+						$data,
+						$json_encode_flags
+					),
+					array(
+						'type' => 'application/json',
+						'id'   => "wp-scriptmodule-data_{$module_id}",
+					)
+				);
+			}
+		}
 	}
 }

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -912,7 +912,7 @@ HTML;
 	 * @dataProvider data_invalid_script_module_data
 	 * @param mixed $data Data to return in filter.
 	 */
-	public function test_print_script_module_data_does_not_print_bad_data( $data ) {
+	public function test_print_script_module_data_does_not_print_invalid_data( $data ) {
 		$this->script_modules->enqueue( '@test/module', '/example.js' );
 		add_action(
 			'scriptmoduledata_@test/module',

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -732,4 +732,211 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 
 		$this->assertSame( 'wp-load-polyfill-importmap', $id );
 	}
+
+	/**
+	 * @ticket 60647
+	 */
+	public function test_print_script_module_data_prints_enqueued_module_data() {
+		$this->script_modules->enqueue( '@test/module', '/example.js' );
+		add_action(
+			'scriptmoduledata_@test/module',
+			function ( $data ) {
+				$data['foo'] = 'bar';
+				return $data;
+			}
+		);
+
+		$actual = get_echo( array( $this->script_modules, 'print_script_module_data' ) );
+
+		$expected = <<<HTML
+<script type="application/json" id="wp-scriptmodule-data_@test/module">
+{"foo":"bar"}
+</script>
+
+HTML;
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * @ticket 60647
+	 */
+	public function test_print_script_module_data_prints_dependency_module_data() {
+		$this->script_modules->register( '@test/dependency', '/dependency.js' );
+		$this->script_modules->enqueue( '@test/module', '/example.js', array( '@test/dependency' ) );
+		add_action(
+			'scriptmoduledata_@test/dependency',
+			function ( $data ) {
+				$data['foo'] = 'bar';
+				return $data;
+			}
+		);
+
+		$actual = get_echo( array( $this->script_modules, 'print_script_module_data' ) );
+
+		$expected = <<<HTML
+<script type="application/json" id="wp-scriptmodule-data_@test/dependency">
+{"foo":"bar"}
+</script>
+
+HTML;
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * @ticket 60647
+	 */
+	public function test_print_script_module_data_does_not_print_nondependency_module_data() {
+		$this->script_modules->register( '@test/other', '/dependency.js' );
+		$this->script_modules->enqueue( '@test/module', '/example.js' );
+		add_action(
+			'scriptmoduledata_@test/other',
+			function ( $data ) {
+				$data['foo'] = 'bar';
+				return $data;
+			}
+		);
+
+		$actual = get_echo( array( $this->script_modules, 'print_script_module_data' ) );
+
+		$this->assertSame( '', $actual );
+	}
+
+	/**
+	 * @ticket 60647
+	 */
+	public function test_print_script_module_data_does_not_print_empty_data() {
+		$this->script_modules->enqueue( '@test/module', '/example.js' );
+		add_action(
+			'scriptmoduledata_@test/module',
+			function ( $data ) {
+				return $data;
+			}
+		);
+
+		$actual = get_echo( array( $this->script_modules, 'print_script_module_data' ) );
+
+		$this->assertSame( '', $actual );
+	}
+
+	/**
+	 * @ticket 60647
+	 *
+	 * @dataProvider data_special_chars_script_encoding
+	 * @param string $input    Raw input string.
+	 * @param string $expected Expected output string.
+	 * @param string $charset  Blog charset option.
+	 */
+	public function test_print_script_module_data_encoding( $input, $expected, $charset ) {
+		add_filter(
+			'pre_option_blog_charset',
+			function () use ( $charset ) {
+				return $charset;
+			}
+		);
+
+		$this->script_modules->enqueue( '@test/module', '/example.js' );
+		add_action(
+			'scriptmoduledata_@test/module',
+			function ( $data ) use ( $input ) {
+				$data[''] = $input;
+				return $data;
+			}
+		);
+
+		$actual = get_echo( array( $this->script_modules, 'print_script_module_data' ) );
+
+		$expected = <<<HTML
+<script type="application/json" id="wp-scriptmodule-data_@test/module">
+{"":"{$expected}"}
+</script>
+
+HTML;
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public static function data_special_chars_script_encoding(): array {
+		return array(
+			// UTF-8
+			'Solidus'                                => array( '/', '/', 'UTF-8' ),
+			'Double quote'                           => array( '"', '\\"', 'UTF-8' ),
+			'Single quote'                           => array( '\'', '\'', 'UTF-8' ),
+			'Less than'                              => array( '<', '\u003C', 'UTF-8' ),
+			'Greater than'                           => array( '>', '\u003E', 'UTF-8' ),
+			'Ampersand'                              => array( '&', '&', 'UTF-8' ),
+			'Newline'                                => array( "\n", "\\n", 'UTF-8' ),
+			'Tab'                                    => array( "\t", "\\t", 'UTF-8' ),
+			'Form feed'                              => array( "\f", "\\f", 'UTF-8' ),
+			'Carriage return'                        => array( "\r", "\\r", 'UTF-8' ),
+			'Line separator'                         => array( "\u{2028}", "\u{2028}", 'UTF-8' ),
+			'Paragraph separator'                    => array( "\u{2029}", "\u{2029}", 'UTF-8' ),
+
+			/*
+			 * The following is the Flag of England emoji
+			 * PHP: "\u{1F3F4}\u{E0067}\u{E0062}\u{E0065}\u{E006E}\u{E0067}\u{E007F}"
+			 */
+			'Flag of england'                        => array( '🏴󠁧󠁢󠁥󠁮󠁧󠁿', '🏴󠁧󠁢󠁥󠁮󠁧󠁿', 'UTF-8' ),
+			'Malicious script closer'                => array( '</script>', '\u003C/script\u003E', 'UTF-8' ),
+			'Entity-encoded malicious script closer' => array( '&lt;/script&gt;', '&lt;/script&gt;', 'UTF-8' ),
+
+			// Non UTF-8
+			'Solidus'                                => array( '/', '/', 'iso-8859-1' ),
+			'Less than'                              => array( '<', '\u003C', 'iso-8859-1' ),
+			'Greater than'                           => array( '>', '\u003E', 'iso-8859-1' ),
+			'Ampersand'                              => array( '&', '&', 'iso-8859-1' ),
+			'Newline'                                => array( "\n", "\\n", 'iso-8859-1' ),
+			'Tab'                                    => array( "\t", "\\t", 'iso-8859-1' ),
+			'Form feed'                              => array( "\f", "\\f", 'iso-8859-1' ),
+			'Carriage return'                        => array( "\r", "\\r", 'iso-8859-1' ),
+			'Line separator'                         => array( "\u{2028}", "\u2028", 'iso-8859-1' ),
+			'Paragraph separator'                    => array( "\u{2029}", "\u2029", 'iso-8859-1' ),
+			/*
+			 * The following is the Flag of England emoji
+			 * PHP: "\u{1F3F4}\u{E0067}\u{E0062}\u{E0065}\u{E006E}\u{E0067}\u{E007F}"
+			 */
+			'Flag of england'                        => array( '🏴󠁧󠁢󠁥󠁮󠁧󠁿', "\ud83c\udff4\udb40\udc67\udb40\udc62\udb40\udc65\udb40\udc6e\udb40\udc67\udb40\udc7f", 'iso-8859-1' ),
+			'Malicious script closer'                => array( '</script>', '\u003C/script\u003E', 'iso-8859-1' ),
+			'Entity-encoded malicious script closer' => array( '&lt;/script&gt;', '&lt;/script&gt;', 'iso-8859-1' ),
+
+		);
+	}
+
+	/**
+	 * @ticket 60647
+	 *
+	 * @dataProvider data_invalid_script_module_data
+	 * @param mixed $data Data to return in filter.
+	 */
+	public function test_print_script_module_data_does_not_print_bad_data( $data ) {
+		$this->script_modules->enqueue( '@test/module', '/example.js' );
+		add_action(
+			'scriptmoduledata_@test/module',
+			function ( $_ ) use ( $data ) {
+				return $data;
+			}
+		);
+
+		$actual = get_echo( array( $this->script_modules, 'print_script_module_data' ) );
+
+		$this->assertSame( '', $actual );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public static function data_invalid_script_module_data(): array {
+		return array(
+			'null'     => array( null ),
+			'stdClass' => array( new stdClass() ),
+			'number 1' => array( 1 ),
+			'string'   => array( 'string' ),
+		);
+	}
 }

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -734,7 +734,7 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 60647
+	 * @ticket 61510
 	 */
 	public function test_print_script_module_data_prints_enqueued_module_data() {
 		$this->script_modules->enqueue( '@test/module', '/example.js' );
@@ -758,7 +758,7 @@ HTML;
 	}
 
 	/**
-	 * @ticket 60647
+	 * @ticket 61510
 	 */
 	public function test_print_script_module_data_prints_dependency_module_data() {
 		$this->script_modules->register( '@test/dependency', '/dependency.js' );
@@ -783,7 +783,7 @@ HTML;
 	}
 
 	/**
-	 * @ticket 60647
+	 * @ticket 61510
 	 */
 	public function test_print_script_module_data_does_not_print_nondependency_module_data() {
 		$this->script_modules->register( '@test/other', '/dependency.js' );
@@ -802,7 +802,7 @@ HTML;
 	}
 
 	/**
-	 * @ticket 60647
+	 * @ticket 61510
 	 */
 	public function test_print_script_module_data_does_not_print_empty_data() {
 		$this->script_modules->enqueue( '@test/module', '/example.js' );
@@ -819,7 +819,7 @@ HTML;
 	}
 
 	/**
-	 * @ticket 60647
+	 * @ticket 61510
 	 *
 	 * @dataProvider data_special_chars_script_encoding
 	 * @param string $input    Raw input string.
@@ -907,7 +907,7 @@ HTML;
 	}
 
 	/**
-	 * @ticket 60647
+	 * @ticket 61510
 	 *
 	 * @dataProvider data_invalid_script_module_data
 	 * @param mixed $data Data to return in filter.

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -739,7 +739,7 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 	public function test_print_script_module_data_prints_enqueued_module_data() {
 		$this->script_modules->enqueue( '@test/module', '/example.js' );
 		add_action(
-			'scriptmoduledata_@test/module',
+			'script_module_data_@test/module',
 			function ( $data ) {
 				$data['foo'] = 'bar';
 				return $data;
@@ -764,7 +764,7 @@ HTML;
 		$this->script_modules->register( '@test/dependency', '/dependency.js' );
 		$this->script_modules->enqueue( '@test/module', '/example.js', array( '@test/dependency' ) );
 		add_action(
-			'scriptmoduledata_@test/dependency',
+			'script_module_data_@test/dependency',
 			function ( $data ) {
 				$data['foo'] = 'bar';
 				return $data;
@@ -789,7 +789,7 @@ HTML;
 		$this->script_modules->register( '@test/other', '/dependency.js' );
 		$this->script_modules->enqueue( '@test/module', '/example.js' );
 		add_action(
-			'scriptmoduledata_@test/other',
+			'script_module_data_@test/other',
 			function ( $data ) {
 				$data['foo'] = 'bar';
 				return $data;
@@ -807,7 +807,7 @@ HTML;
 	public function test_print_script_module_data_does_not_print_empty_data() {
 		$this->script_modules->enqueue( '@test/module', '/example.js' );
 		add_action(
-			'scriptmoduledata_@test/module',
+			'script_module_data_@test/module',
 			function ( $data ) {
 				return $data;
 			}
@@ -836,7 +836,7 @@ HTML;
 
 		$this->script_modules->enqueue( '@test/module', '/example.js' );
 		add_action(
-			'scriptmoduledata_@test/module',
+			'script_module_data_@test/module',
 			function ( $data ) use ( $input ) {
 				$data[''] = $input;
 				return $data;
@@ -915,7 +915,7 @@ HTML;
 	public function test_print_script_module_data_does_not_print_invalid_data( $data ) {
 		$this->script_modules->enqueue( '@test/module', '/example.js' );
 		add_action(
-			'scriptmoduledata_@test/module',
+			'script_module_data_@test/module',
 			function ( $_ ) use ( $data ) {
 				return $data;
 			}

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -749,7 +749,7 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 		$actual = get_echo( array( $this->script_modules, 'print_script_module_data' ) );
 
 		$expected = <<<HTML
-<script type="application/json" id="wp-scriptmodule-data_@test/module">
+<script type="application/json" id="wp-script-module-data-@test/module">
 {"foo":"bar"}
 </script>
 
@@ -774,7 +774,7 @@ HTML;
 		$actual = get_echo( array( $this->script_modules, 'print_script_module_data' ) );
 
 		$expected = <<<HTML
-<script type="application/json" id="wp-scriptmodule-data_@test/dependency">
+<script type="application/json" id="wp-script-module-data-@test/dependency">
 {"foo":"bar"}
 </script>
 
@@ -846,7 +846,7 @@ HTML;
 		$actual = get_echo( array( $this->script_modules, 'print_script_module_data' ) );
 
 		$expected = <<<HTML
-<script type="application/json" id="wp-scriptmodule-data_@test/module">
+<script type="application/json" id="wp-script-module-data-@test/module">
 {"":"{$expected}"}
 </script>
 


### PR DESCRIPTION
Add the `print_script_module_data` function to the `WP_Script_Modules` class.

Register hooks to call this function on `wp_footer` and `admin_print_footer_scripts`.

[See the Make/Core Proposal](https://make.wordpress.org/core/2024/05/06/proposal-server-to-client-data-sharing-for-script-modules/) and the [PR in Gutenberg](https://github.com/WordPress/gutenberg/pull/61658). In summary (from the proposal):

> - A new filter runs for each Script Module that is enqueued or in the dependency graph. This filter allows arbitrary data to be associated with a given Script Module and added to the rendered page.
> - Script Module data is embedded in the page as JSON in a <script type="application/json"> tag.
> - Script Modules are responsible for reading the data and performing their own initialization.

The new filter is `"script_module_data_{$module_id}"`. It should accept and return an array that will be serialized in page HTML (if it is not empty):

```php
add_filter(
	'script_module_data_myModuleID',
	function ( array $data ): array {
		$data['some-data-here'] = 'the client can read this on page load';
		return $data;
	}
);
```

#6683 includes an example of usage in for Core Script Modules.

Closes #6433 (superseded).

Trac ticket: https://core.trac.wordpress.org/ticket/61510

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
