### PR TITLE
Improve resizing for indexed PNG images in WP Image Editor Imagick

### DIFF
--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -612,7 +612,7 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 				}
 				if ( $this->indexed_color_encoded && $this->image->getImageAlphaChannel() && defined( 'Imagick::IMGTYPE_PALETTEMATTE' ) ) {
 					$this->image->setImageType( Imagick::IMGTYPE_PALETTEMATTE );
-				} elseif ( defined( 'Imagick::IMGTYPE_PALETTEMATTE' ) ) {
+				} elseif ( $this->indexed_color_encoded && defined( 'Imagick::IMGTYPE_PALETTE' ) ) {
 					$this->image->setImageType( Imagick::IMGTYPE_PALETTE );
 				}
 			}

--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -594,7 +594,7 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 						$max_colors = 0;
 				}
 				if ( ! empty( $max_colors ) ) {
-					$max_colors = min( $max_colors, $current_colors + 8 );
+					$max_colors = min( $max_colors, $current_colors );
 					$this->image->quantizeImage( $max_colors, $this->image->getColorspace(), 0, false, false );
                 	/**
                 	 * ImageMagick likes to convert gray indexed images to grayscale.

--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -566,22 +566,10 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 				$this->image->setOption( 'png:compression-filter', '5' );
 				$this->image->setOption( 'png:compression-level', '9' );
 				$this->image->setOption( 'png:compression-strategy', '1' );
-				$this->image->setOption( 'png:exclude-chunk', 'all' );
-			}
-
-			/*
-			 * If alpha channel is not defined, set it opaque.
-			 *
-			 * Note that Imagick::getImageAlphaChannel() is only available if Imagick
-			 * has been compiled against ImageMagick version 6.4.0 or newer.
-			 */
-			if ( is_callable( array( $this->image, 'getImageAlphaChannel' ) )
-				&& is_callable( array( $this->image, 'setImageAlphaChannel' ) )
-				&& defined( 'Imagick::ALPHACHANNEL_UNDEFINED' )
-				&& defined( 'Imagick::ALPHACHANNEL_OPAQUE' )
-			) {
-				if ( $this->image->getImageAlphaChannel() === Imagick::ALPHACHANNEL_UNDEFINED ) {
-					$this->image->setImageAlphaChannel( Imagick::ALPHACHANNEL_OPAQUE );
+				if ( $this->indexed_color_encoded ) {
+					$this->image->setOption( 'png:include-chunk', 'tRNS' );
+				} else {
+					$this->image->setOption( 'png:exclude-chunk', 'all' );
 				}
 			}
 
@@ -605,6 +593,27 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 				if ( ! empty( $max_colors ) ) {
 					$max_colors = min( $max_colors, $current_colors + 8 );
 					$this->image->quantizeImage( $max_colors, $this->image->getColorspace(), 0, false, false );
+				}
+			}
+
+			/*
+			 * If alpha channel is not defined, set it opaque.
+			 *
+			 * Note that Imagick::getImageAlphaChannel() is only available if Imagick
+			 * has been compiled against ImageMagick version 6.4.0 or newer.
+			 */
+			if ( is_callable( array( $this->image, 'getImageAlphaChannel' ) )
+				&& is_callable( array( $this->image, 'setImageAlphaChannel' ) )
+				&& defined( 'Imagick::ALPHACHANNEL_UNDEFINED' )
+				&& defined( 'Imagick::ALPHACHANNEL_OPAQUE' )
+			) {
+				if ( $this->image->getImageAlphaChannel() === Imagick::ALPHACHANNEL_UNDEFINED ) {
+					$this->image->setImageAlphaChannel( Imagick::ALPHACHANNEL_OPAQUE );
+				}
+				if ( $this->indexed_color_encoded && $this->image->getImageAlphaChannel() && defined( 'Imagick::IMGTYPE_PALETTEMATTE' ) ) {
+					$this->image->setImageType( Imagick::IMGTYPE_PALETTEMATTE );
+				} elseif ( defined( 'Imagick::IMGTYPE_PALETTEMATTE' ) ) {
+					$this->image->setImageType( Imagick::IMGTYPE_PALETTE );
 				}
 			}
 

--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -21,6 +21,24 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 	 */
 	protected $image;
 
+	/**
+	 * Stores the information whether the image is indexed-color encoded.
+	 *
+	 * @since 6.6
+	 * @access protected
+	 * @var bool
+	 */
+	protected $indexed_color_encoded = false;
+
+	/**
+	 * Stores the information whether the image is indexed-color encoded.
+	 *
+	 * @since 6.6
+	 * @access protected
+	 * @var int
+	 */
+	protected $indexed_pixel_depth = false;
+
 	public function __destruct() {
 		if ( $this->image instanceof Imagick ) {
 			// We don't need the original in memory anymore.
@@ -321,6 +339,76 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 	}
 
 	/**
+	 * Gets the bit depth for PNG images and checks for indexed-color mode.
+	 *
+	 * Access the file directly, as we cannot currently rely on Imagick to identify
+	 * palette images with alpha support.
+	 *
+	 * @since 6.6.0
+	 */
+	protected function get_png_color_depth() {
+		if ( 'image/png' !== $this->mime_type ) {
+			return;
+		}
+		if ( wp_is_stream( $this->file ) ) {
+			return;
+		}
+		if ( ! is_file( $this->file ) ) {
+			return;
+		}
+		if ( filesize( $this->file ) < 24 ) {
+			return;
+		}
+
+		$file_handle = fopen( $this->file, 'rb' );
+
+		if ( ! $file_handle ) {
+			return;
+		}
+
+		$png_header = fread( $file_handle, 4 );
+		if ( chr( 0x89 ) . 'PNG' !== $png_header ) {
+			return;
+		}
+
+		// Move forward 8 bytes.
+		fread( $file_handle, 8 );
+		$png_ihdr = fread( $file_handle, 4 );
+
+		// Make sure we have an IHDR.
+		if ( 'IHDR' !== $png_ihdr ) {
+			return;
+		}
+
+		// Skip past the dimensions.
+		$dimensions = fread( $file_handle, 8 );
+
+		// Bit depth: 1 byte
+		// Bit depth is a single-byte integer giving the number of bits per sample or
+		// per palette index (not per pixel).
+		//
+		// Valid values are 1, 2, 4, 8, and 16, although not all values are allowed for all color types.
+		$this->indexed_pixel_depth = ord( (string) fread( $file_handle, 1 ) );
+
+		// Color type is a single-byte integer that describes the interpretation of the image data.
+		// Color type codes represent sums of the following values:
+		// 1 (palette used), 2 (color used), and 4 (alpha channel used).
+		// The valid color types are:
+		// 0 => Grayscale
+		// 2 => Truecolor
+		// 3 => Indexed
+		// 4 => Greyscale with alpha
+		// 6 => Truecolour with alpha
+		$color_type = ord( (string) fread( $file_handle, 1 ) );
+
+		if ( 3 === (int) $color_type ) {
+			$this->indexed_color_encoded = true;
+		}
+
+		fclose( $file_handle );
+	}
+
+	/**
 	 * Resizes current image.
 	 *
 	 * At minimum, either a height or width must be provided.
@@ -409,6 +497,20 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 			$filter = defined( 'Imagick::FILTER_TRIANGLE' ) ? Imagick::FILTER_TRIANGLE : false;
 		}
 
+		if ( 'image/png' === $this->mime_type ) {
+			// Check to see if a PNG is indexed, and find the pixel depth.
+			$this->get_png_color_depth();
+
+			/**
+			 * If the PNG image is indexed, also check to see how many colors it currently has. For instance,
+			 * an 8-bit image can have up to 256 colors, but it may only have 20, which will make a
+			 * significant difference in the quantization.
+			 */
+			if ( $this->indexed_color_encoded && is_callable( array( $this->image, 'getImageColors' ) ) ) {
+				$current_colors = $this->image->getImageColors();
+			}
+		}
+
 		/**
 		 * Filters whether to strip metadata from images when they're resized.
 		 *
@@ -480,6 +582,29 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 			) {
 				if ( $this->image->getImageAlphaChannel() === Imagick::ALPHACHANNEL_UNDEFINED ) {
 					$this->image->setImageAlphaChannel( Imagick::ALPHACHANNEL_OPAQUE );
+				}
+			}
+
+			if ( $this->indexed_color_encoded ) {
+				switch ( $this->indexed_pixel_depth ) {
+					case 8:
+						$max_colors = 255;
+						break;
+					case 4:
+						$max_colors = 16;
+						break;
+					case 2:
+						$max_colors = 4;
+						break;
+					case 1:
+						$max_colors = 2;
+						break;
+					default:
+						$max_colors = 0;
+				}
+				if ( ! empty( $max_colors ) ) {
+					$max_colors = min( $max_colors, $current_colors + 8 );
+					$this->image->quantizeImage( $max_colors, $this->image->getColorspace(), 0, false, false );
 				}
 			}
 


### PR DESCRIPTION
This does the following to improve resizing of indexed PNG images:
1. Added a method to get the PNG color type and pixel depth directly from the original image.
2. Get the original number of colors in an indexed PNG prior to scaling the image.
3. Preserve the tRNS chunk if an indexed PNG also has transparency.
4. Use quantizeImage() to reduce the number of colors in the image after scaling.
5. In cases where quantizeImage() converts the colorspace to grayscale, set png:format=png8 to force ImageMagick to output an indexed PNG.

Trac ticket: https://core.trac.wordpress.org/ticket/36477

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
