### PR TITLE
Post "Read" Capability for Rest API

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -161,12 +161,15 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		$post_type = get_post_type_object( $this->post_type );
 
-		if ( 'edit' === $request['context'] && ! current_user_can( $post_type->cap->edit_posts ) ) {
-			return new WP_Error(
-				'rest_forbidden_context',
-				__( 'Sorry, you are not allowed to edit posts in this post type.' ),
-				array( 'status' => rest_authorization_required_code() )
-			);
+		// Check if the post type is non-public.
+		if ( ! $post_type->public ) {
+			if ( 'edit' === $request['context'] && ! current_user_can( $post_type->cap->edit_posts ) ) {
+				return new WP_Error(
+					'rest_forbidden_context',
+					__( 'Sorry, you are not allowed to edit posts in this post type.' ),
+					array( 'status' => rest_authorization_required_code() )
+				);
+			}
 		}
 
 		return true;


### PR DESCRIPTION
### Ticket: https://core.trac.wordpress.org/ticket/57829

## Description

This **PR** aims to improve the REST API functionality in WordPress by modifying the permission checks for reading posts. Currently, non-public post types remain queryable through the REST API, which poses a challenge for developers seeking to restrict access to certain types of posts.

### Changes Made

1. **Enhanced Permission Check:** Modified the `get_items_permissions_check` method in the REST API controller responsible for handling post requests.
2. **Conditional Logic:** Implemented conditional logic to check if the post type is non-public. If so, the permission check now ensures that only users with the capability to edit posts can read posts via the REST API for non-public post types.

### Why This Change is Necessary

- The current behavior of the REST API allows non-public post types to be queried, regardless of their accessibility.
- This modification provides developers with more control over post access via the REST API, particularly for non-public post types, aligning better with their intended permissions and restrictions.
- Enhances security and privacy by ensuring that only authorized users can access non-public posts via the REST API.


