### PR TITLE
Add handling for __default attribute to block bindings for pattern overrides

### DIFF
--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -271,7 +271,7 @@ class WP_Block {
 			// Build an binding array of all supported attributes.
 			// Note that this also omits the `__default` attribute from the
 			// resulting array.
-			foreach ( $supported_block_attrs[ $parsed_block['blockName'] ] as $attribute_name ) {
+			foreach ( $supported_block_attributes[ $parsed_block['blockName'] ] as $attribute_name ) {
 				$updated_bindings = array();
 				// Retain any non-pattern override bindings that might be present.
 				$updated_bindings[ $attribute_name ] = isset( $bindings[ $attribute_name ] )

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -236,6 +236,7 @@ class WP_Block {
 	 * block with the values of the `text_custom_field` and `url_custom_field` post meta.
 	 *
 	 * @since 6.5.0
+	 * @since 6.6.0 Handle the `__default` attribute for pattern overrides.
 	 *
 	 * @return array The computed block attributes for the provided block bindings.
 	 */
@@ -259,7 +260,28 @@ class WP_Block {
 			return $computed_attributes;
 		}
 
-		foreach ( $parsed_block['attrs']['metadata']['bindings'] as $attribute_name => $block_binding ) {
+		$bindings = $parsed_block['attrs']['metadata']['bindings'];
+
+		// If the default binding is set for pattern overrides, replace it
+		// with a pattern override binding for all supported attributes.
+		if (
+			isset( $bindings['__default']['source'] ) &&
+			'core/pattern-overrides' === $bindings['__default']['source']
+		) {
+			// Build an binding array of all supported attributes.
+			// Note that this also omits the `__default` attribute from the
+			// resulting array.
+			foreach ( $supported_block_attrs[ $parsed_block['blockName'] ] as $attribute_name ) {
+				$updated_bindings = array();
+				// Retain any non-pattern override bindings that might be present.
+				$updated_bindings[ $attribute_name ] = isset( $bindings[ $attribute_name ] )
+					? $bindings[ $attribute_name ]
+					: array( 'source' => 'core/pattern-overrides' );
+			}
+			$bindings = $updated_bindings;
+		}
+
+		foreach ( $bindings as $attribute_name => $block_binding ) {
 			// If the attribute is not in the supported list, process next attribute.
 			if ( ! in_array( $attribute_name, $supported_block_attributes[ $this->name ], true ) ) {
 				continue;
@@ -413,7 +435,7 @@ class WP_Block {
 		 * There can be only one root interactive block at a time because the rendered HTML of that block contains
 		 * the rendered HTML of all its inner blocks, including any interactive block.
 		 */
-		static $root_interactive_block  = null;
+		static $root_interactive_block = null;
 		/**
 		 * Filters whether Interactivity API should process directives.
 		 *

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -262,17 +262,21 @@ class WP_Block {
 
 		$bindings = $parsed_block['attrs']['metadata']['bindings'];
 
-		// If the default binding is set for pattern overrides, replace it
-		// with a pattern override binding for all supported attributes.
+		/*
+		 * If the default binding is set for pattern overrides, replace it
+		 * with a pattern override binding for all supported attributes.
+		 */
 		if (
 			isset( $bindings['__default']['source'] ) &&
 			'core/pattern-overrides' === $bindings['__default']['source']
 		) {
 			$updated_bindings = array();
 
-			// Build an binding array of all supported attributes.
-			// Note that this also omits the `__default` attribute from the
-			// resulting array.
+			/*
+			 * Build an binding array of all supported attributes.
+			 * Note that this also omits the `__default` attribute from the
+			 * resulting array.
+			 */
 			foreach ( $supported_block_attributes[ $parsed_block['blockName'] ] as $attribute_name ) {
 				// Retain any non-pattern override bindings that might be present.
 				$updated_bindings[ $attribute_name ] = isset( $bindings[ $attribute_name ] )

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -273,7 +273,7 @@ class WP_Block {
 			$updated_bindings = array();
 
 			/*
-			 * Build an binding array of all supported attributes.
+			 * Build a binding array of all supported attributes.
 			 * Note that this also omits the `__default` attribute from the
 			 * resulting array.
 			 */

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -268,11 +268,12 @@ class WP_Block {
 			isset( $bindings['__default']['source'] ) &&
 			'core/pattern-overrides' === $bindings['__default']['source']
 		) {
+			$updated_bindings = array();
+
 			// Build an binding array of all supported attributes.
 			// Note that this also omits the `__default` attribute from the
 			// resulting array.
 			foreach ( $supported_block_attributes[ $parsed_block['blockName'] ] as $attribute_name ) {
-				$updated_bindings = array();
 				// Retain any non-pattern override bindings that might be present.
 				$updated_bindings[ $attribute_name ] = isset( $bindings[ $attribute_name ] )
 					? $bindings[ $attribute_name ]

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -243,29 +243,20 @@ HTML;
 	 * @covers ::register_block_bindings_source
 	 */
 	public function test_default_binding_for_pattern_overrides() {
-		$get_value_callback = function ( $source_args, $block_instance, $attribute_name ) {
-			return "The attribute name is '$attribute_name'";
-		};
-
-		register_block_bindings_source(
-			'core/pattern-overrides',
-			array(
-				'label'              => self::SOURCE_LABEL,
-				'get_value_callback' => $get_value_callback,
-			)
-		);
+		$expected_content = 'This is the content value';
 
 		$block_content = <<<HTML
-<!-- wp:paragraph {"metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
+<!-- wp:paragraph {"metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}}, "name":"Test"}} -->
 <p>This should not appear</p>
 <!-- /wp:paragraph -->
 HTML;
+
 		$parsed_blocks = parse_blocks( $block_content );
-		$block         = new WP_Block( $parsed_blocks[0] );
+		$block         = new WP_Block( $parsed_blocks[0], array( 'pattern/overrides' => array( 'Test' => array( 'content' => $expected_content ) ) ) );
 		$result        = $block->render();
 
 		$this->assertSame(
-			"<p>The attribute name is 'content'</p>",
+			"<p>$expected_content</p>",
 			trim( $result ),
 			'The `__default` attribute should be replaced with the real attribute prior to the callback.'
 		);

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -236,17 +236,18 @@ HTML;
 	}
 
 	/**
-	 * Tests if the block content is sanitized when unsafe HTML is passed.
+	 * Tests if the `__default` attribute is replaced with real attribues for
+	 * pattern overrides.
 	 *
 	 * @ticket 61333
 	 *
-	 * @covers ::register_block_bindings_source
+	 * @covers WP_Block::process_block_bindings
 	 */
 	public function test_default_binding_for_pattern_overrides() {
 		$expected_content = 'This is the content value';
 
 		$block_content = <<<HTML
-<!-- wp:paragraph {"metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}}, "name":"Test"}} -->
+<!-- wp:paragraph {"metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"Test"}} -->
 <p>This should not appear</p>
 <!-- /wp:paragraph -->
 HTML;

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -244,14 +244,13 @@ HTML;
 	 */
 	public function test_default_binding_for_pattern_overrides() {
 		$get_value_callback = function ( $source_args, $block_instance, $attribute_name ) {
-			$value = $source_args['key'];
 			return "The attribute name is '$attribute_name'";
 		};
 
 		register_block_bindings_source(
 			'core/pattern-overrides',
 			array(
-				'label'              => 'Pattern overrides',
+				'label'              => self::SOURCE_LABEL,
 				'get_value_callback' => $get_value_callback,
 			)
 		);


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61333

This is the PHP backport for the gutenberg PR https://github.com/WordPress/gutenberg/pull/60694.

It adds handling for a `__default` block binding attribute for pattern overrides. When this binding attribute is encountered by the block binding code it dynamically adds support for all supported block binding attributes. 

## Testing instructions
This has been rebased with the latest package updates, so is now fully testable.

1. Add a heading, paragragph, image and button to a post (or use a pattern that contains those blocks)
2. Select them and choose 'Create pattern' from the block options menu
3. Name the pattern, keep the Synced toggled enabled, and create the pattern
4. Select 'Edit original' from the toolbar of the pattern that was inserted into the post
5. For the heading, paragraph, image and button block, select each one individually, and in the advanced inspector tools choose 'Enable Overrides'. Give the blocks a name in the resulting dialog.
6. Save the pattern and go back to the post
7. Enter some content into the heading, paragraph, image and button with the pattern instance int he post
8. Preview the post and ensure the content is correct on the frontend

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
