### PR TITLE
Clear theme json data between theme unit tests

### DIFF
--- a/tests/phpunit/tests/theme/base.php
+++ b/tests/phpunit/tests/theme/base.php
@@ -44,6 +44,7 @@ abstract class WP_Theme_UnitTestCase extends WP_UnitTestCase {
 		remove_filter( 'template_root', array( $this, 'filter_set_theme_root' ) );
 
 		wp_clean_themes_cache();
+		wp_clean_theme_json_cache();
 		unset( $GLOBALS['wp_themes'] );
 
 		parent::tear_down();

--- a/tests/phpunit/tests/theme/wpAddGlobalStylesForBlocks.php
+++ b/tests/phpunit/tests/theme/wpAddGlobalStylesForBlocks.php
@@ -131,6 +131,7 @@ class Tests_Theme_WpAddGlobalStylesForBlocks extends WP_Theme_UnitTestCase {
 	 * @ticket 61165
 	 */
 	public function test_blocks_inline_styles_get_rendered() {
+		$this->set_up_third_party_block();
 		wp_register_style( 'global-styles', false, array(), true, true );
 		wp_enqueue_style( 'global-styles' );
 		wp_add_global_styles_for_blocks();
@@ -174,6 +175,7 @@ class Tests_Theme_WpAddGlobalStylesForBlocks extends WP_Theme_UnitTestCase {
 	 * @ticket 61165
 	 */
 	public function test_third_party_blocks_inline_styles_for_elements_get_rendered() {
+		$this->set_up_third_party_block();
 		wp_register_style( 'global-styles', false, array(), true, true );
 		wp_enqueue_style( 'global-styles' );
 		wp_add_global_styles_for_blocks();


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This clears the theme json related caches in the `WP_Theme_UnitTestCase:::tear_down()` method to avoid cross pollution between tests when a theme is changed during a test run and fixes a few tests that were only passing by relying on this cross pollution.

Trac ticket: https://core.trac.wordpress.org/ticket/61337

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
