### PR TITLE
Improve theme file caching in class-wp-theme-json.php

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2225,7 +2225,13 @@ class WP_Theme_JSON {
 			 * Skip protected properties that are explicitly set to `null`.
 			 */
 			if ( is_array( $value_path ) ) {
-				$path_string = implode( '.', $value_path );
+				$path_string = '';
+				for ( $i = 0; $i < count( $value_path ); $i++ ) {
+					if ( $i > 0 ) {
+						$path_string .= '.';
+					}
+					$path_string .= $value_path[ $i ];
+				}
 				if (
 					isset( static::PROTECTED_PROPERTIES[ $path_string ] ) &&
 					_wp_array_get( $settings, static::PROTECTED_PROPERTIES[ $path_string ], null ) === null


### PR DESCRIPTION
Minor changes have been made to class-wp-theme-json.php to better cache the theme files. This includes adding an 'update_cache' functionality that sets 'str_start_with' and 'str_start_with_cache', and removing redundant checks for empty or non-numerical values. These improvements aim to optimize performance by updating cache when necessary.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket:  https://core.trac.wordpress.org/ticket/59595

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
