### PR TITLE
Simplify the block bindings HTML replacement logic until the HTML API is ready

### DIFF
--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -306,68 +306,27 @@ class WP_Block {
 		switch ( $block_type->attributes[ $attribute_name ]['source'] ) {
 			case 'html':
 			case 'rich-text':
-				$block_reader = new WP_HTML_Tag_Processor( $block_content );
-
-				// TODO: Support for CSS selectors whenever they are ready in the HTML API.
-				// In the meantime, support comma-separated selectors by exploding them into an array.
-				$selectors = explode( ',', $block_type->attributes[ $attribute_name ]['selector'] );
-				// Add a bookmark to the first tag to be able to iterate over the selectors.
-				$block_reader->next_tag();
-				$block_reader->set_bookmark( 'iterate-selectors' );
-
-				// TODO: This shouldn't be needed when the `set_inner_html` function is ready.
-				// Store the parent tag and its attributes to be able to restore them later in the button.
-				// The button block has a wrapper while the paragraph and heading blocks don't.
-				if ( 'core/button' === $this->name ) {
-					$button_wrapper                 = $block_reader->get_tag();
-					$button_wrapper_attribute_names = $block_reader->get_attribute_names_with_prefix( '' );
-					$button_wrapper_attrs           = array();
-					foreach ( $button_wrapper_attribute_names as $name ) {
-						$button_wrapper_attrs[ $name ] = $block_reader->get_attribute( $name );
-					}
+				// Hardcode the selectors and processing until the HTML API is able to read CSS selectors and replace inner HTML.
+				// TODO: Use the HTML API instead.
+				if ( 'core/paragraph' === $this->name && 'content' === $attribute_name ) {
+					$selector = 'p';
 				}
-
-				foreach ( $selectors as $selector ) {
-					// If the parent tag, or any of its children, matches the selector, replace the HTML.
-					if ( strcasecmp( $block_reader->get_tag( $selector ), $selector ) === 0 || $block_reader->next_tag(
-						array(
-							'tag_name' => $selector,
-						)
-					) ) {
-						$block_reader->release_bookmark( 'iterate-selectors' );
-
-						// TODO: Use `set_inner_html` method whenever it's ready in the HTML API.
-						// Until then, it is hardcoded for the paragraph, heading, and button blocks.
-						// Store the tag and its attributes to be able to restore them later.
-						$selector_attribute_names = $block_reader->get_attribute_names_with_prefix( '' );
-						$selector_attrs           = array();
-						foreach ( $selector_attribute_names as $name ) {
-							$selector_attrs[ $name ] = $block_reader->get_attribute( $name );
-						}
-						$selector_markup = "<$selector>" . wp_kses_post( $source_value ) . "</$selector>";
-						$amended_content = new WP_HTML_Tag_Processor( $selector_markup );
-						$amended_content->next_tag();
-						foreach ( $selector_attrs as $attribute_key => $attribute_value ) {
-							$amended_content->set_attribute( $attribute_key, $attribute_value );
-						}
-						if ( 'core/paragraph' === $this->name || 'core/heading' === $this->name ) {
-							return $amended_content->get_updated_html();
-						}
-						if ( 'core/button' === $this->name ) {
-							$button_markup  = "<$button_wrapper>{$amended_content->get_updated_html()}</$button_wrapper>";
-							$amended_button = new WP_HTML_Tag_Processor( $button_markup );
-							$amended_button->next_tag();
-							foreach ( $button_wrapper_attrs as $attribute_key => $attribute_value ) {
-								$amended_button->set_attribute( $attribute_key, $attribute_value );
-							}
-							return $amended_button->get_updated_html();
-						}
+				if ( 'core/heading' === $this->name && 'content' === $attribute_name ) {
+					$selector = 'h[1-6]';
+				}
+				if ( 'core/button' === $this->name && 'text' === $attribute_name ) {
+					// Check if it is a <button> or <a> tag.
+					if ( preg_match( '/<button[^>]*>.*?<\/button>/', $block_content ) ) {
+						$selector = 'button';
 					} else {
-						$block_reader->seek( 'iterate-selectors' );
+						$selector = 'a';
 					}
 				}
-				$block_reader->release_bookmark( 'iterate-selectors' );
-				return $block_content;
+				if ( empty( $selector ) ) {
+					return $block_content;
+				}
+				$pattern = '/(<' . $selector . '[^>]*>).*?(<\/' . $selector . '>)/i';
+				return preg_replace( $pattern, '$1' . wp_kses_post( $source_value ) . '$2', $block_content );
 
 			case 'attribute':
 				$amended_content = new WP_HTML_Tag_Processor( $block_content );
@@ -413,7 +372,7 @@ class WP_Block {
 		 * There can be only one root interactive block at a time because the rendered HTML of that block contains
 		 * the rendered HTML of all its inner blocks, including any interactive block.
 		 */
-		static $root_interactive_block  = null;
+		static $root_interactive_block = null;
 		/**
 		 * Filters whether Interactivity API should process directives.
 		 *

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -340,13 +340,10 @@ class WP_Block {
 				}
 				$amended_content->set_attribute( $block_type->attributes[ $attribute_name ]['attribute'], $source_value );
 				return $amended_content->get_updated_html();
-				break;
 
 			default:
 				return $block_content;
-				break;
 		}
-		return;
 	}
 
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61351

Backport of the following PRs: [#61236](https://github.com/WordPress/gutenberg/pull/61236) and [#61660](https://github.com/WordPress/gutenberg/pull/61660)

## What?
Change the block bindings HTML replacement logic to use a hardcoded list of selectors based on the block and a regex to substitute the inner content.

Apart from that, it removes some extra breaks that are not needed.

## Why?
The existing logic is too complex because the HTML API doesn't support CSS selectors yet and it doesn't have an official way to modify the inner HTML. This makes it difficult to understand, iterate on it and add new functionalities.

As it will be solved in the future once the HTML API is ready, I believe it is better to keep a simple hardcoded version that is easier to understand and iterate on.

## How?
* Change the selector based on the supported blocks.
* Using a regex, replace the inner content.

## Testing Instructions

0. Register a custom field in your site to test it. You can use a code snippet like this:
```
register_meta(
	'post',
	'text_custom_field',
	array(
		'show_in_rest' => true,
		'single'       => true,
		'type'         => 'string',
		'default'	   => 'default value',
	)
);
```

1. Go to a page and insert a paragraph block.
2. Go to the Code editor and connect the paragraph to the custom field by adding the metadata bindings property. It should look something like this:
```
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"text_custom_field"}}}}} -->
<p>Original content</p>
<!-- /wp:paragraph -->
```
3. Save the page and check that in the frontend, the text defined in the custom field is used.
4. Repeat the process for heading, and button blocks.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
