### PR TITLE
Add fonts dir to Filesystem Permissions section in Site Health

### DIFF
--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -347,6 +347,7 @@ class WP_Debug_Data {
 		$is_writable_upload_dir         = wp_is_writable( $upload_dir['basedir'] );
 		$is_writable_wp_plugin_dir      = wp_is_writable( WP_PLUGIN_DIR );
 		$is_writable_template_directory = wp_is_writable( get_theme_root( get_template() ) );
+		$is_writable_fonts_dir          = wp_is_writable( wp_get_font_dir()['basedir'] );
 
 		$info['wp-filesystem'] = array(
 			'label'       => __( 'Filesystem Permissions' ),
@@ -376,6 +377,11 @@ class WP_Debug_Data {
 					'label' => __( 'The themes directory' ),
 					'value' => ( $is_writable_template_directory ? __( 'Writable' ) : __( 'Not writable' ) ),
 					'debug' => ( $is_writable_template_directory ? 'writable' : 'not writable' ),
+				),
+				'fonts'      => array(
+					'label' => __( 'The fonts directory' ),
+					'value' => ( $is_writable_fonts_dir ? __( 'Writable' ) : __( 'Not writable' ) ),
+					'debug' => ( $is_writable_fonts_dir ? 'writable' : 'not writable' ),
 				),
 			),
 		);


### PR DESCRIPTION
Follow-up to [#6260](https://github.com/WordPress/wordpress-develop/pull/6260#issuecomment-2052593365).

Trac ticket: https://core.trac.wordpress.org/ticket/60719

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
