### PR TITLE
Add an input to allow test errors

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -108,7 +108,7 @@ jobs:
   #
   test-with-mariadb:
     name: PHP ${{ matrix.php }}
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-phpunit-tests.yml@trunk
+    uses: desrosj/wordpress-develop/.github/workflows/reusable-phpunit-tests.yml@add/continue-on-error-input-phpunit
     permissions:
       contents: read
     secrets: inherit

--- a/.github/workflows/reusable-phpunit-tests.yml
+++ b/.github/workflows/reusable-phpunit-tests.yml
@@ -50,6 +50,11 @@ on:
         required: false
         type: 'boolean'
         default: false
+      allow-errors:
+        description: 'Whether to continue when test errors occur.'
+        required: false
+        type: boolean
+        default: false
 env:
   LOCAL_PHP: ${{ inputs.php }}-fpm
   LOCAL_DB_TYPE: ${{ inputs.db-type }}
@@ -156,22 +161,27 @@ jobs:
         run: npm run env:install
 
       - name: Run PHPUnit tests
+        continue-on-error: ${{ inputs.allow-errors }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }}
 
       - name: Run AJAX tests
+        continue-on-error: ${{ inputs.allow-errors }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }} --group ajax
 
       - name: Run ms-files tests as a multisite install
         if: ${{ inputs.multisite }}
+        continue-on-error: ${{ inputs.allow-errors }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }} --group ms-files
 
       - name: Run external HTTP tests
         if: ${{ ! inputs.multisite }}
+        continue-on-error: ${{ inputs.allow-errors }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }} --group external-http
 
       # __fakegroup__ is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.
       - name: Run (Xdebug) tests
         if: ${{ inputs.php != '8.3' }}
+        continue-on-error: ${{ inputs.allow-errors }}
         run: LOCAL_PHP_XDEBUG=true node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit -v --group xdebug --exclude-group __fakegroup__
 
       - name: Ensure version-controlled files are not modified or deleted


### PR DESCRIPTION
This adds an input to prevent test errors from failing the workflow. This is useful for older branches where support for a specific version of PHP was not 100%.

Trac ticket: https://core.trac.wordpress.org/ticket/61213

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
