### PR TITLE
HTML Processor: Ensure is_tag_closer is correctly called

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -428,7 +428,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					continue;
 				}
 
-				if ( ! $this::is_tag_closer() || $visit_closers ) {
+				if ( ! $this->is_tag_closer() || $visit_closers ) {
 					return true;
 				}
 			}

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -463,7 +463,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					continue;
 				}
 
-				if ( ! parent::is_tag_closer() || $visit_closers ) {
+				if ( ! $this->is_tag_closer() || $visit_closers ) {
 					return true;
 				}
 			}


### PR DESCRIPTION
Trac Ticket: Core-61348

This is a follow-up to 163c3fd11026e0a6f93a7f88ab32dd1679ad0f88 / #6348 with two small fixes:

- Fix non-static is_tag_closer method called statically
- Fix call to parent is_tag_closer() that should call instance method


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
