### PR TITLE
Plugins: Refresh plugin-install.php instead of redirect on activation. (v2)

### DIFF
--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -950,8 +950,13 @@
 		// Transform the 'Install' button into an 'Activate' button.
 		$message
 			.removeClass( 'install-now installed button-disabled updated-message' )
-			.addClass( 'activate-now button-primary' )
-			.attr( 'href', response.activateUrl );
+			.addClass( 'activate-now button-primary' );
+
+			if ( 'plugin-information-footer' === $message.parent().attr( 'id' ) ) {
+				$message.attr( 'href', response.activateUrl + '&redirect_to=' + encodeURIComponent( window.parent.location.href ) );
+			} else {
+				$message.attr( 'href', response.activateUrl );
+			}
 
 		wp.a11y.speak( __( 'Plugin dependencies check completed successfully.' ) );
 		$document.trigger( 'wp-check-plugin-dependencies-success', response );

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -1020,7 +1020,7 @@ function wp_get_plugin_action_button( $name, $data, $compatible_php, $compatible
 						);
 
 						if ( 'plugin-information-modal' === $context ) {
-							$query_args['redirect_to'] = urlencode( wp_get_referer() );
+							$query_args['redirect_to'] = wp_get_referer();
 						}
 						$activate_url = add_query_arg( $query_args, network_admin_url( 'plugins.php' ) );
 

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -913,7 +913,8 @@ function install_plugin_information() {
  * }
  * @param bool         $compatible_php   The result of a PHP compatibility check.
  * @param bool         $compatible_wp    The result of a WP compatibility check.
- * @param string       $context          Optional. The context the button will appear in. Default empty string.
+ * @param string       $context          Optional. The context the button will appear in.
+ *                                       Accepts 'plugin-information-modal'. Default empty string.
  * @return string The markup for the dependency row button.
  */
 function wp_get_plugin_action_button( $name, $data, $compatible_php, $compatible_wp, $context = '' ) {

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -1011,14 +1011,17 @@ function wp_get_plugin_action_button( $name, $data, $compatible_php, $compatible
 						$button_text = _x( 'Activate', 'plugin' );
 						/* translators: %s: Plugin name. */
 						$button_label = _x( 'Activate %s', 'plugin' );
-						$activate_url = add_query_arg(
-							array(
-								'_wpnonce' => wp_create_nonce( 'activate-plugin_' . $status['file'] ),
-								'action'   => 'activate',
-								'plugin'   => $status['file'],
-							),
-							network_admin_url( 'plugins.php' )
+
+						$query_args = array(
+							'_wpnonce' => wp_create_nonce( 'activate-plugin_' . $status['file'] ),
+							'action'   => 'activate',
+							'plugin'   => $status['file'],
 						);
+
+						if ( 'plugin-information-modal' === $context ) {
+							$query_args['redirect_to'] = urlencode( wp_get_referer() );
+						}
+						$activate_url = add_query_arg( $query_args, network_admin_url( 'plugins.php' ) );
 
 						if ( is_network_admin() ) {
 							$button_text = _x( 'Network Activate', 'plugin' );

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -879,7 +879,7 @@ function install_plugin_information() {
 	echo "</div>\n"; // #plugin-information-scrollable
 	echo "<div id='$tab-footer'>\n";
 	if ( ! empty( $api->download_link ) && ( current_user_can( 'install_plugins' ) || current_user_can( 'update_plugins' ) ) ) {
-		$button = wp_get_plugin_action_button( $api->name, $api, $compatible_php, $compatible_wp );
+		$button = wp_get_plugin_action_button( $api->name, $api, $compatible_php, $compatible_wp, 'plugin-information-modal' );
 		$button = str_replace( 'class="', 'class="right ', $button );
 
 		if ( ! str_contains( $button, _x( 'Activate', 'plugin' ) ) ) {

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -901,6 +901,7 @@ function install_plugin_information() {
  * Gets the markup for the plugin install action button.
  *
  * @since 6.5.0
+ * @since 6.6.0 Added the `$context` parameter.
  *
  * @param string       $name           Plugin name.
  * @param array|object $data           {
@@ -912,9 +913,10 @@ function install_plugin_information() {
  * }
  * @param bool         $compatible_php   The result of a PHP compatibility check.
  * @param bool         $compatible_wp    The result of a WP compatibility check.
+ * @param string       $context          Optional. The context the button will appear in. Default empty string.
  * @return string The markup for the dependency row button.
  */
-function wp_get_plugin_action_button( $name, $data, $compatible_php, $compatible_wp ) {
+function wp_get_plugin_action_button( $name, $data, $compatible_php, $compatible_wp, $context = '' ) {
 	$button           = '';
 	$data             = (object) $data;
 	$status           = install_plugin_install_status( $data );

--- a/src/wp-admin/plugin-install.php
+++ b/src/wp-admin/plugin-install.php
@@ -24,6 +24,17 @@ if ( is_multisite() && ! is_network_admin() ) {
 	exit;
 }
 
+if ( isset( $_GET['activate'] ) ) {
+	wp_admin_notice(
+		__( 'Plugin activated.' ),
+		array(
+			'id'                 => 'message',
+			'additional_classes' => array( 'updated' ),
+			'dismissible'        => true,
+		)
+	);
+}
+
 $wp_list_table = _get_list_table( 'WP_Plugin_Install_List_Table' );
 $pagenum       = $wp_list_table->get_pagenum();
 

--- a/src/wp-admin/plugin-install.php
+++ b/src/wp-admin/plugin-install.php
@@ -24,17 +24,6 @@ if ( is_multisite() && ! is_network_admin() ) {
 	exit;
 }
 
-if ( isset( $_GET['activate'] ) ) {
-	wp_admin_notice(
-		__( 'Plugin activated.' ),
-		array(
-			'id'                 => 'message',
-			'additional_classes' => array( 'updated' ),
-			'dismissible'        => true,
-		)
-	);
-}
-
 $wp_list_table = _get_list_table( 'WP_Plugin_Install_List_Table' );
 $pagenum       = $wp_list_table->get_pagenum();
 
@@ -145,6 +134,17 @@ get_current_screen()->set_screen_reader_content(
  * WordPress Administration Template Header.
  */
 require_once ABSPATH . 'wp-admin/admin-header.php';
+
+if ( isset( $_GET['activate'] ) ) {
+	wp_admin_notice(
+		__( 'Plugin activated.' ),
+		array(
+			'id'                 => 'message',
+			'additional_classes' => array( 'updated' ),
+			'dismissible'        => true,
+		)
+	);
+}
 
 WP_Plugin_Dependencies::initialize();
 WP_Plugin_Dependencies::display_admin_notice_for_unmet_dependencies();

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -87,7 +87,7 @@ if ( $action ) {
 
 				if ( isset( $_GET['redirect_to'] ) ) {
 					// This will occur when a plugin is activated from within a modal.
-					$url = add_query_arg( 'redirect_to', $_GET['redirect_to'], $url );
+					$url = add_query_arg( 'redirect_to', wp_unslash( $_GET['redirect_to'] ), $url );
 				} else {
 					// This will occur when a plugin is activated from its plugin card.
 					$url = add_query_arg( 'redirect_to', wp_get_referer(), $url );
@@ -106,7 +106,7 @@ if ( $action ) {
 			exit;
 		case 'finish-activation':
 			if ( isset( $_GET['redirect_to'] ) ) {
-				$url = urldecode( $_GET['redirect_to'] );
+				$url = urldecode( wp_unslash( $_GET['redirect_to'] ) );
 
 				if ( isset( $_GET['activate'] ) ) {
 					$url = add_query_arg( 'activate', 'true', $url );

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -83,6 +83,12 @@ if ( $action ) {
 				wp_redirect( self_admin_url( 'import.php?import=' . str_replace( '-importer', '', dirname( $plugin ) ) ) );
 			} elseif ( isset( $_GET['from'] ) && 'press-this' === $_GET['from'] ) {
 				wp_redirect( self_admin_url( 'press-this.php' ) );
+			} elseif ( str_contains( wp_get_referer(), 'wp-admin/plugin-install.php' ) ) {
+				if ( isset( $_GET['redirect_to'] ) ) {
+					wp_redirect( urldecode( $_GET['redirect_to'] ) );
+				} else {
+					wp_redirect( wp_get_referer() );
+				}
 			} else {
 				// Overrides the ?error=true one above.
 				wp_redirect( self_admin_url( "plugins.php?activate=true&plugin_status=$status&paged=$page&s=$s" ) );

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -84,11 +84,16 @@ if ( $action ) {
 			} elseif ( isset( $_GET['from'] ) && 'press-this' === $_GET['from'] ) {
 				wp_redirect( self_admin_url( 'press-this.php' ) );
 			} elseif ( str_contains( wp_get_referer(), 'wp-admin/plugin-install.php' ) ) {
+				$url = wp_get_referer();
 				if ( isset( $_GET['redirect_to'] ) ) {
-					wp_redirect( urldecode( $_GET['redirect_to'] ) );
-				} else {
-					wp_redirect( wp_get_referer() );
+					$url = urldecode( $_GET['redirect_to'] );
 				}
+
+				if ( ! is_wp_error( $result ) ) {
+					$url = add_query_arg( 'activate', 'true', $url );
+				}
+
+				wp_redirect( $url );
 			} else {
 				// Overrides the ?error=true one above.
 				wp_redirect( self_admin_url( "plugins.php?activate=true&plugin_status=$status&paged=$page&s=$s" ) );

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -113,8 +113,9 @@ if ( $action ) {
 				}
 
 				wp_redirect( $url );
+				exit;
 			}
-			exit;
+			break;
 		case 'activate-selected':
 			if ( ! current_user_can( 'activate_plugins' ) ) {
 				wp_die( __( 'Sorry, you are not allowed to activate plugins for this site.' ) );

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -87,10 +87,10 @@ if ( $action ) {
 
 				if ( isset( $_GET['redirect_to'] ) ) {
 					// This will occur when a plugin is activated from within a modal.
-					$url = add_query_arg( 'redirect_to', urldecode( $_GET['redirect_to'] ), $url );
+					$url = add_query_arg( 'redirect_to', $_GET['redirect_to'], $url );
 				} else {
 					// This will occur when a plugin is activated from its plugin card.
-					$url = add_query_arg( 'redirect_to', urlencode( wp_get_referer() ), $url );
+					$url = add_query_arg( 'redirect_to', wp_get_referer(), $url );
 				}
 				$url = add_query_arg( 'action', 'finish-activation', $url );
 

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -83,6 +83,15 @@ if ( $action ) {
 			} elseif ( isset( $_GET['from'] ) && 'press-this' === $_GET['from'] ) {
 				wp_redirect( self_admin_url( 'press-this.php' ) );
 			} elseif ( str_contains( wp_get_referer(), self_admin_url( 'plugin-install.php' ) ) ) {
+				/*
+				 * After activating from 'plugin-install.php', the user will be returned to the previous page.
+				 *
+				 * For backward compatibility, since 'load-plugins.php' callbacks and any other code
+				 * before now have already run, the user must first be redirected to 'plugins.php' again.
+				 *
+				 * This ensures that plugin functionality dependent on earlier code in this file still runs
+				 * after the plugin has been activated.
+				 */
 				$url = self_admin_url( 'plugins.php' );
 
 				if ( isset( $_GET['redirect_to'] ) ) {
@@ -92,6 +101,11 @@ if ( $action ) {
 					// This will occur when a plugin is activated from its plugin card.
 					$url = add_query_arg( 'redirect_to', wp_get_referer(), $url );
 				}
+
+				/*
+				 * On the re-loading of this file, the 'finish-activation' action will perform
+				 * the redirect to the previous page from which the plugin was activated.
+				 */
 				$url = add_query_arg( 'action', 'finish-activation', $url );
 
 				if ( ! is_wp_error( $result ) ) {

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -99,7 +99,7 @@ if ( $action ) {
 					$url = add_query_arg( 'redirect_to', wp_unslash( $_GET['redirect_to'] ), $url );
 				} else {
 					// This will occur when a plugin is activated from its plugin card.
-					$url = add_query_arg( 'redirect_to', wp_get_referer(), $url );
+					$url = add_query_arg( 'redirect_to', urlencode( wp_get_referer() ), $url );
 				}
 
 				/*
@@ -120,7 +120,7 @@ if ( $action ) {
 			}
 			exit;
 		case 'finish-activation':
-			if ( ! did_filter( 'wp_redirect' ) && isset( $_GET['redirect_to'] ) ) {
+			if ( isset( $_GET['redirect_to'] ) ) {
 				$url = urldecode( wp_unslash( $_GET['redirect_to'] ) );
 
 				if ( isset( $_GET['activate'] ) ) {

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -83,7 +83,7 @@ if ( $action ) {
 				wp_redirect( self_admin_url( 'import.php?import=' . str_replace( '-importer', '', dirname( $plugin ) ) ) );
 			} elseif ( isset( $_GET['from'] ) && 'press-this' === $_GET['from'] ) {
 				wp_redirect( self_admin_url( 'press-this.php' ) );
-			} elseif ( str_contains( wp_get_referer(), 'wp-admin/plugin-install.php' ) ) {
+			} elseif ( str_contains( wp_get_referer(), network_admin_url( 'plugin-install.php' ) ) ) {
 				$url = wp_get_referer();
 				if ( isset( $_GET['redirect_to'] ) ) {
 					$url = urldecode( $_GET['redirect_to'] );

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -120,7 +120,7 @@ if ( $action ) {
 			}
 			exit;
 		case 'finish-activation':
-			if ( isset( $_GET['redirect_to'] ) ) {
+			if ( ! did_filter( 'wp_redirect' ) && isset( $_GET['redirect_to'] ) ) {
 				$url = urldecode( wp_unslash( $_GET['redirect_to'] ) );
 
 				if ( isset( $_GET['activate'] ) ) {

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -109,6 +109,7 @@ if ( $action ) {
 				$url = add_query_arg( 'action', 'finish-activation', $url );
 
 				if ( ! is_wp_error( $result ) ) {
+					// This ensures the user gets feedback the plugin was successfully activated.
 					$url = add_query_arg( 'activate', 'true', $url );
 				}
 
@@ -123,6 +124,7 @@ if ( $action ) {
 				$url = urldecode( wp_unslash( $_GET['redirect_to'] ) );
 
 				if ( isset( $_GET['activate'] ) ) {
+					// This ensures the user gets feedback the plugin was successfully activated.
 					$url = add_query_arg( 'activate', 'true', $url );
 				}
 


### PR DESCRIPTION
This PR implements an alternative approach to #6717.

- Adds a `$context` parameter to `wp_get_plugin_action_button()` to conditionally modify the button's markup.
- When generating the `Activate` button, adds a `redirect_to` query arg with the URL-encoded referer as the value.
- Passes `'plugin-information-modal'` as the context when generating the button inside the modal.
- When the referer is `plugin-install.php`, redirects to the `redirect_to` query arg's value, if present, or to the referrer.
  - `redirect_to` covers modal-based activation.
  - referer covers card-based activation.
- Ensures the JS-generated `Activate` button contains the `redirect_to` query arg, only if in the modal.
- Ensures the user receives feedback both on `plugins.php` and `plugin-install.php`.

**Note: Remember to build the PR branch and perform a hard refresh on `plugins.php` or `plugin-install.php` before testing.**

Trac ticket: https://core.trac.wordpress.org/ticket/61330