### PR TITLE
Show post meta fields in revisions panel

### DIFF
--- a/src/wp-includes/revision.php
+++ b/src/wp-includes/revision.php
@@ -1132,18 +1132,3 @@ function _wp_preview_meta_filter( $value, $object_id, $meta_key, $single ) {
 
 	return get_post_meta( $preview->ID, $meta_key, $single );
 }
-
-/**
- * Add any revisioned meta fields to the revisions screen.
- *
- * @since 6.7.0
- *
- * @param string $revision_field The field value, but $revision->$field
- *                               (footnotes) does not exist.
- * @param string $field          The field name, in this case "footnotes".
- * @param object $revision       The revision object to compare against.
- * @return string The field value.
- */
-function wp_add_revisioned_meta_to_revision_ui( $revision_field, $field, $revision ) {
-	return get_metadata( 'post', $revision->ID );
-}

--- a/src/wp-includes/revision.php
+++ b/src/wp-includes/revision.php
@@ -32,6 +32,7 @@ function _wp_post_revision_fields( $post = array(), $deprecated = false ) {
 			'post_title'   => __( 'Title' ),
 			'post_content' => __( 'Content' ),
 			'post_excerpt' => __( 'Excerpt' ),
+			'post_meta'    => __( 'Post Meta' ),
 		);
 	}
 
@@ -1130,4 +1131,19 @@ function _wp_preview_meta_filter( $value, $object_id, $meta_key, $single ) {
 	}
 
 	return get_post_meta( $preview->ID, $meta_key, $single );
+}
+
+/**
+ * Add any revisioned meta fields to the revisions screen.
+ *
+ * @since 6.7.0
+ *
+ * @param string $revision_field The field value, but $revision->$field
+ *                               (footnotes) does not exist.
+ * @param string $field          The field name, in this case "footnotes".
+ * @param object $revision       The revision object to compare against.
+ * @return string The field value.
+ */
+function wp_add_revisioned_meta_to_revision_ui( $revision_field, $field, $revision ) {
+	return get_metadata( 'post', $revision->ID );
 }


### PR DESCRIPTION
Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

I can see that there was a similar [closed ticket](https://core.trac.wordpress.org/ticket/59636) for this and a [related pull request](https://github.com/WordPress/wordpress-develop/pull/5364/).

I just left a [comment in the trac ticket](https://core.trac.wordpress.org/ticket/59636#comment:11) to discuss how to proceed here.

@adamsilverstein @Mamaduka As you discussed this in the past, it would be great to hear your opinion on the best path forward.

## What?
Basically, this pull request shows the changes made to the post meta fields that have revisions enabled in the revisions UI.

## Why?
For 6.6, it is planned to [allow the editing of custom fields when a block is connected to them](https://github.com/WordPress/gutenberg/issues/60956#issuecomment-2144790954). With that, I believe it is important to show the relevant changes in the revisions.

## How?
It iterates through the `wp_post_revision_meta_keys`, and it creates a new row in the diff for each of the meta fields that have changed.

I excluded the `footnotes` because it has its own section right now, but I am not sure if it should be unified in the proposed "Post Meta".

## Demo
This is a quick demo of how it works after the changes in this pull request:

https://github.com/WordPress/wordpress-develop/assets/34552881/7b41894d-8235-4943-98dd-6536eb3ead4a


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
