### PR TITLE
Add input for saving the build as an artifact.

### DIFF
--- a/.github/workflows/reusable-test-core-build-process.yml
+++ b/.github/workflows/reusable-test-core-build-process.yml
@@ -21,6 +21,11 @@ on:
         required: false
         type: 'boolean'
         default: true
+      save-build:
+        description: 'Whether to save a ZIP of built WordPress as an artifact.'
+        required: false
+        type: 'boolean'
+        default: false
       prepare-playground:
         description: 'Whether to prepare the artifacts needed for Playground testing.'
         required: false
@@ -97,14 +102,14 @@ jobs:
 
       - name: Upload ZIP as a GitHub Actions artifact
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
-        if: ${{ inputs.prepare-playground }}
+        if: ${{ inputs.save-build || inputs.prepare-playground }}
         with:
           name: wordpress-build-${{ github.event_name == 'pull_request' && github.event.number || github.sha }}
           path: wordpress.zip
           if-no-files-found: error
 
       - name: Save PR number
-        if: ${{ inputs.prepare-playground && github.repository == 'WordPress/wordpress-develop' && github.event_name == 'pull_request' }}
+        if: ${{ inputs.prepare-playground }}
         run: |
           mkdir -p ./pr-number
           echo ${{ github.event.number }} > ./pr-number/NR

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -31,7 +31,7 @@ jobs:
   # Tests the WordPress Core build process on multiple operating systems.
   test-core-build-process:
     name: Core running from ${{ matrix.directory }}
-    uses: desrosj/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@add-input-for-saving-build
+    uses: desrosj/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@add/input-for-saving-build
     permissions:
       contents: read
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -44,10 +44,13 @@ jobs:
           # Only prepare artifacts for Playground once.
           - os: ubuntu-latest
             directory: 'build'
-            prepare-playground: true
+            save-build: true
+            prepare-playground: ${{ github.event_name == 'pull_request' && true || false }}
+
     with:
       os: ${{ matrix.os }}
       directory: ${{ matrix.directory }}
+      save-build: ${{ matrix.save-build }}
       prepare-playground: ${{ matrix.prepare-playground && matrix.prepare-playground || false }}
 
   # Tests the WordPress Core build process on MacOS.

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -31,7 +31,7 @@ jobs:
   # Tests the WordPress Core build process on multiple operating systems.
   test-core-build-process:
     name: Core running from ${{ matrix.directory }}
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
+    uses: desrosj/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@add-input-for-saving-build
     permissions:
       contents: read
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -45,12 +45,12 @@ jobs:
           - os: ubuntu-latest
             directory: 'build'
             save-build: true
-            prepare-playground: ${{ github.event_name == 'pull_request' && true || false }}
+            prepare-playground: ${{ github.event_name == 'pull_request' && true || '' }}
 
     with:
       os: ${{ matrix.os }}
       directory: ${{ matrix.directory }}
-      save-build: ${{ matrix.save-build }}
+      save-build: ${{ matrix.save-build && matrix.save-build || false }}
       prepare-playground: ${{ matrix.prepare-playground && matrix.prepare-playground || false }}
 
   # Tests the WordPress Core build process on MacOS.


### PR DESCRIPTION
There are times where the ZIP file of the build should be stored as an artifact but the PR number is not required.

For example, Playground testing information is not required for push events, only PRs. But the build ZIP is required for all events where the performance testing workflow runs (a comparison is made between the previous commit and the current one).

Trac ticket: https://core.trac.wordpress.org/ticket/59416

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
