### PR TITLE
Add `nicename_exists` function and associated tests

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -1990,6 +1990,7 @@ function username_exists( $username ) {
 
 /**
  * Determines whether the given user_nicename exists.
+ *
  * For more information on this and similar theme functions, check out
  * the {@link https://developer.wordpress.org/themes/basics/conditional-tags/
  * Conditional Tags} article in the Theme Developer Handbook.

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -1998,9 +1998,8 @@ function username_exists( $username ) {
  * @since 6.7.0
  *
  * @param string $nicename Nicename.
- * @param string $login (Optional) User login to compare against.
- *
- * @return int|false The user's ID on success, and false on failure.
+ * @param string $login    Optional. User login to compare against.
+ * @return int|false The user ID on success, false on failure.
  */
 function nicename_exists( $nicename, $login = false ) {
 	$user_id = false;

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2011,7 +2011,6 @@ function nicename_exists( $nicename, $login = false ) {
 	return $user_id;
 }
 
-
 /**
  * Determines whether the given email exists.
  *

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -1989,6 +1989,32 @@ function username_exists( $username ) {
 }
 
 /**
+ * Determines whether the given user_nicename exists.
+ * For more information on this and similar theme functions, check out
+ * the {@link https://developer.wordpress.org/themes/basics/conditional-tags/
+ * Conditional Tags} article in the Theme Developer Handbook.
+ *
+ * @since 6.6.0
+ *
+ * @param string $nicename Nicename.
+ * @param string $login (Optional) User login to compare against.
+ *
+ * @return int|false The user's ID on success, and false on failure.
+ */
+function nicename_exists( $nicename, $login = false ) {
+	$user_id = false;
+	$user = get_user_by( 'slug', $nicename );
+	if ( $user ) {
+		if ( $login !== $user->user_login ) {
+			$user_id = $user->ID;
+		}
+	}
+
+	return $user_id;
+}
+
+
+/**
  * Determines whether the given email exists.
  *
  * For more information on this and similar theme functions, check out
@@ -2206,7 +2232,7 @@ function wp_insert_user( $userdata ) {
 		return new WP_Error( 'user_nicename_too_long', __( 'Nicename may not be longer than 50 characters.' ) );
 	}
 
-	$user_nicename_check = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->users WHERE user_nicename = %s AND user_login != %s LIMIT 1", $user_nicename, $user_login ) );
+	$user_nicename_check = nicename_exists( $user_nicename, $user_login );
 
 	if ( $user_nicename_check ) {
 		$suffix = 2;
@@ -2214,7 +2240,7 @@ function wp_insert_user( $userdata ) {
 			// user_nicename allows 50 chars. Subtract one for a hyphen, plus the length of the suffix.
 			$base_length         = 49 - mb_strlen( $suffix );
 			$alt_user_nicename   = mb_substr( $user_nicename, 0, $base_length ) . "-$suffix";
-			$user_nicename_check = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->users WHERE user_nicename = %s AND user_login != %s LIMIT 1", $alt_user_nicename, $user_login ) );
+			$user_nicename_check = nicename_exists( $alt_user_nicename, $user_login );
 			++$suffix;
 		}
 		$user_nicename = $alt_user_nicename;

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2003,7 +2003,7 @@ function username_exists( $username ) {
  */
 function user_nicename_exists( $nicename, $login = false ) {
 	$user_id = false;
-	$user = get_user_by( 'slug', $nicename );
+	$user    = get_user_by( 'slug', $nicename );
 	if ( $user && $login !== $user->user_login ) {
 		$user_id = $user->ID;
 	}

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -1989,7 +1989,7 @@ function username_exists( $username ) {
 }
 
 /**
- * Determines whether the given user_nicename exists.
+ * Determines whether the given user nicename exists.
  *
  * For more information on this and similar theme functions, check out
  * the {@link https://developer.wordpress.org/themes/basics/conditional-tags/
@@ -2001,7 +2001,7 @@ function username_exists( $username ) {
  * @param string $login    Optional. User login to compare against.
  * @return int|false The user ID on success, false on failure.
  */
-function nicename_exists( $nicename, $login = false ) {
+function user_nicename_exists($nicename, $login = false ) {
 	$user_id = false;
 	$user = get_user_by( 'slug', $nicename );
 	if ( $user && $login !== $user->user_login ) {
@@ -2229,7 +2229,7 @@ function wp_insert_user( $userdata ) {
 		return new WP_Error( 'user_nicename_too_long', __( 'Nicename may not be longer than 50 characters.' ) );
 	}
 
-	$user_nicename_check = nicename_exists( $user_nicename, $user_login );
+	$user_nicename_check = user_nicename_exists( $user_nicename, $user_login );
 
 	if ( $user_nicename_check ) {
 		$suffix = 2;
@@ -2237,7 +2237,7 @@ function wp_insert_user( $userdata ) {
 			// user_nicename allows 50 chars. Subtract one for a hyphen, plus the length of the suffix.
 			$base_length         = 49 - mb_strlen( $suffix );
 			$alt_user_nicename   = mb_substr( $user_nicename, 0, $base_length ) . "-$suffix";
-			$user_nicename_check = nicename_exists( $alt_user_nicename, $user_login );
+			$user_nicename_check = user_nicename_exists( $alt_user_nicename, $user_login );
 			++$suffix;
 		}
 		$user_nicename = $alt_user_nicename;

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2001,7 +2001,7 @@ function username_exists( $username ) {
  * @param string $login    Optional. User login to compare against.
  * @return int|false The user ID on success, false on failure.
  */
-function user_nicename_exists($nicename, $login = false ) {
+function user_nicename_exists( $nicename, $login = false ) {
 	$user_id = false;
 	$user = get_user_by( 'slug', $nicename );
 	if ( $user && $login !== $user->user_login ) {

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -1995,7 +1995,7 @@ function username_exists( $username ) {
  * the {@link https://developer.wordpress.org/themes/basics/conditional-tags/
  * Conditional Tags} article in the Theme Developer Handbook.
  *
- * @since 6.6.0
+ * @since 6.7.0
  *
  * @param string $nicename Nicename.
  * @param string $login (Optional) User login to compare against.

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2004,10 +2004,8 @@ function username_exists( $username ) {
 function nicename_exists( $nicename, $login = false ) {
 	$user_id = false;
 	$user = get_user_by( 'slug', $nicename );
-	if ( $user ) {
-		if ( $login !== $user->user_login ) {
-			$user_id = $user->ID;
-		}
+	if ( $user && $login !== $user->user_login ) {
+		$user_id = $user->ID;
 	}
 
 	return $user_id;

--- a/tests/phpunit/tests/user/nicenameExisits.php
+++ b/tests/phpunit/tests/user/nicenameExisits.php
@@ -34,7 +34,7 @@ class Tests_User_Nicename_Exists extends WP_UnitTestCase {
 	 *
 	 * @ticket 44921
 	 */
-	public function test_nicename_exists_with_different_user_login() {
+	public function test_user_nicename_exists_with_different_user_login() {
 		$user_id_1 = $this->factory()->user->create( array( 'user_nicename' => 'test-nicename' ) );
 		$user_id_2 = $this->factory()->user->create();
 		$user_2    = get_user_by( 'id', $user_id_2 );

--- a/tests/phpunit/tests/user/nicenameExisits.php
+++ b/tests/phpunit/tests/user/nicenameExisits.php
@@ -43,7 +43,7 @@ class Tests_User_Nicename_Exists extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that `nicename_exists` returns false when the nicename exists but belongs to a different user.
+	 * Tests that `user_nicename_exists` returns false when the nicename exists but belongs to a different user.
 	 *
 	 * @ticket 44921
 	 */

--- a/tests/phpunit/tests/user/nicenameExisits.php
+++ b/tests/phpunit/tests/user/nicenameExisits.php
@@ -47,7 +47,7 @@ class Tests_User_Nicename_Exists extends WP_UnitTestCase {
 	 *
 	 * @ticket 44921
 	 */
-	public function test_nicename_exists_with_same_user_login() {
+	public function test_user_nicename_exists_with_same_user_login() {
 		$user_id_1 = $this->factory()->user->create( array( 'user_nicename' => 'test-nicename' ) );
 		$user_1    = get_user_by( 'id', $user_id_1 );
 

--- a/tests/phpunit/tests/user/nicenameExisits.php
+++ b/tests/phpunit/tests/user/nicenameExisits.php
@@ -5,7 +5,7 @@
  *
  * @group user
  *
- * @covers ::nicename_exists
+ * @covers ::user_nicename_exists
  */
 class Tests_User_Nicename_Exists extends WP_UnitTestCase {
 
@@ -17,7 +17,7 @@ class Tests_User_Nicename_Exists extends WP_UnitTestCase {
 	public function test_nicename_exists_with_existing_nicename() {
 		$user_id = $this->factory()->user->create( array( 'user_nicename' => 'test-nicename' ) );
 
-		$this->assertSame( $user_id, nicename_exists( 'test-nicename' ) );
+		$this->assertSame( $user_id, user_nicename_exists( 'test-nicename' ) );
 	}
 
 	/**
@@ -26,7 +26,7 @@ class Tests_User_Nicename_Exists extends WP_UnitTestCase {
 	 * @ticket 44921
 	 */
 	public function test_nicename_exists_with_nonexistent_nicename() {
-		$this->assertFalse( nicename_exists( 'nonexistent-nicename' ) );
+		$this->assertFalse( user_nicename_exists( 'nonexistent-nicename' ) );
 	}
 
 	/**
@@ -39,7 +39,7 @@ class Tests_User_Nicename_Exists extends WP_UnitTestCase {
 		$user_id_2 = $this->factory()->user->create();
 		$user_2    = get_user_by( 'id', $user_id_2 );
 
-		$this->assertSame( $user_id_1, nicename_exists( 'test-nicename', $user_2->user_login ) );
+		$this->assertSame( $user_id_1, user_nicename_exists( 'test-nicename', $user_2->user_login ) );
 	}
 
 	/**
@@ -51,6 +51,6 @@ class Tests_User_Nicename_Exists extends WP_UnitTestCase {
 		$user_id_1 = $this->factory()->user->create( array( 'user_nicename' => 'test-nicename' ) );
 		$user_1    = get_user_by( 'id', $user_id_1 );
 
-		$this->assertFalse( nicename_exists( 'test-nicename', $user_1->user_login ) );
+		$this->assertFalse( user_nicename_exists( 'test-nicename', $user_1->user_login ) );
 	}
 }

--- a/tests/phpunit/tests/user/nicenameExisits.php
+++ b/tests/phpunit/tests/user/nicenameExisits.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Tests the `nicename_exists` function.
+ * Tests the `user_nicename_exists` function.
  *
  * @group user
  *

--- a/tests/phpunit/tests/user/nicenameExisits.php
+++ b/tests/phpunit/tests/user/nicenameExisits.php
@@ -10,7 +10,7 @@
 class Tests_User_Nicename_Exists extends WP_UnitTestCase {
 
 	/**
-	 * Tests that `nicename_exists` returns the user ID when the nicename exists.
+	 * Tests that `user_nicename_exists` returns the user ID when the nicename exists.
 	 *
 	 * @ticket 44921
 	 */

--- a/tests/phpunit/tests/user/nicenameExisits.php
+++ b/tests/phpunit/tests/user/nicenameExisits.php
@@ -7,7 +7,7 @@
  *
  * @covers ::nicename_exists
  */
-class Tests_User_NicenameExists extends WP_UnitTestCase {
+class Tests_User_Nicename_Exists extends WP_UnitTestCase {
 
 	/**
 	 * Tests that `nicename_exists` returns the user ID when the nicename exists.

--- a/tests/phpunit/tests/user/nicenameExisits.php
+++ b/tests/phpunit/tests/user/nicenameExisits.php
@@ -25,7 +25,7 @@ class Tests_User_Nicename_Exists extends WP_UnitTestCase {
 	 *
 	 * @ticket 44921
 	 */
-	public function test_nicename_exists_with_nonexistent_nicename() {
+	public function test_user_nicename_exists_with_nonexistent_nicename() {
 		$this->assertFalse( user_nicename_exists( 'nonexistent-nicename' ) );
 	}
 

--- a/tests/phpunit/tests/user/nicenameExisits.php
+++ b/tests/phpunit/tests/user/nicenameExisits.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Tests the `nicename_exists` function.
+ *
+ * @group user
+ *
+ * @covers ::nicename_exists
+ */
+class Tests_User_NicenameExists extends WP_UnitTestCase {
+
+	/**
+	 * Tests that `nicename_exists` returns the user ID when the nicename exists.
+	 *
+	 * @ticket 44921
+	 */
+	public function test_nicename_exists_with_existing_nicename() {
+		$user_id = $this->factory()->user->create( array( 'user_nicename' => 'test-nicename' ) );
+
+		$this->assertSame( $user_id, nicename_exists( 'test-nicename' ) );
+	}
+
+	/**
+	 * Tests that `nicename_exists` returns false when the nicename does not exist.
+	 *
+	 * @ticket 44921
+	 */
+	public function test_nicename_exists_with_nonexistent_nicename() {
+		$this->assertFalse( nicename_exists( 'nonexistent-nicename' ) );
+	}
+
+	/**
+	 * Tests that `nicename_exists` returns false when the nicename exists but belongs to a different user.
+	 *
+	 * @ticket 44921
+	 */
+	public function test_nicename_exists_with_different_user_login() {
+		$user_id_1 = $this->factory()->user->create( array( 'user_nicename' => 'test-nicename' ) );
+		$user_id_2 = $this->factory()->user->create();
+		$user_2 = get_user_by('id', $user_id_2 );
+
+		$this->assertSame( $user_id_1, nicename_exists( 'test-nicename', $user_2->user_login ) );
+	}
+
+	/**
+	 * Tests that `nicename_exists` returns false when the nicename exists but belongs to a different user.
+	 *
+	 * @ticket 44921
+	 */
+	public function test_nicename_exists_with_same_user_login() {
+		$user_id_1 = $this->factory()->user->create( array( 'user_nicename' => 'test-nicename' ) );
+		$user_1 = get_user_by('id', $user_id_1 );
+
+		$this->assertFalse( nicename_exists( 'test-nicename', $user_1->user_login ) );
+	}
+}

--- a/tests/phpunit/tests/user/nicenameExisits.php
+++ b/tests/phpunit/tests/user/nicenameExisits.php
@@ -37,7 +37,7 @@ class Tests_User_NicenameExists extends WP_UnitTestCase {
 	public function test_nicename_exists_with_different_user_login() {
 		$user_id_1 = $this->factory()->user->create( array( 'user_nicename' => 'test-nicename' ) );
 		$user_id_2 = $this->factory()->user->create();
-		$user_2 = get_user_by('id', $user_id_2 );
+		$user_2    = get_user_by( 'id', $user_id_2 );
 
 		$this->assertSame( $user_id_1, nicename_exists( 'test-nicename', $user_2->user_login ) );
 	}
@@ -49,7 +49,7 @@ class Tests_User_NicenameExists extends WP_UnitTestCase {
 	 */
 	public function test_nicename_exists_with_same_user_login() {
 		$user_id_1 = $this->factory()->user->create( array( 'user_nicename' => 'test-nicename' ) );
-		$user_1 = get_user_by('id', $user_id_1 );
+		$user_1    = get_user_by( 'id', $user_id_1 );
 
 		$this->assertFalse( nicename_exists( 'test-nicename', $user_1->user_login ) );
 	}

--- a/tests/phpunit/tests/user/nicenameExisits.php
+++ b/tests/phpunit/tests/user/nicenameExisits.php
@@ -30,7 +30,7 @@ class Tests_User_Nicename_Exists extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that `nicename_exists` returns false when the nicename exists but belongs to a different user.
+	 * Tests that `user_nicename_exists` returns false when the nicename exists but belongs to a different user.
 	 *
 	 * @ticket 44921
 	 */

--- a/tests/phpunit/tests/user/nicenameExisits.php
+++ b/tests/phpunit/tests/user/nicenameExisits.php
@@ -21,7 +21,7 @@ class Tests_User_Nicename_Exists extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that `nicename_exists` returns false when the nicename does not exist.
+	 * Tests that `user_nicename_exists` returns false when the nicename does not exist.
 	 *
 	 * @ticket 44921
 	 */

--- a/tests/phpunit/tests/user/nicenameExisits.php
+++ b/tests/phpunit/tests/user/nicenameExisits.php
@@ -14,7 +14,7 @@ class Tests_User_Nicename_Exists extends WP_UnitTestCase {
 	 *
 	 * @ticket 44921
 	 */
-	public function test_nicename_exists_with_existing_nicename() {
+	public function test_user_nicename_exists_with_existing_nicename() {
 		$user_id = $this->factory()->user->create( array( 'user_nicename' => 'test-nicename' ) );
 
 		$this->assertSame( $user_id, user_nicename_exists( 'test-nicename' ) );


### PR DESCRIPTION
The `nicename_exists` function is implemented to determine if a given user_nicename exists. The function is also integrated into the user nickname checking mechanism within the user class. Additionally, various test cases for the new function have been added, which cover scenarios with existing, non-existing, and nicknames associated with different user logins.

Trac ticket: https://core.trac.wordpress.org/ticket/44921