### PR TITLE
Revert changes to block bindings replacement logic and stop using regex

### DIFF
--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -333,28 +333,68 @@ class WP_Block {
 		switch ( $block_type->attributes[ $attribute_name ]['source'] ) {
 			case 'html':
 			case 'rich-text':
-				// Hardcode the selectors and processing until the HTML API is able to read CSS selectors and replace inner HTML.
-				// TODO: Use the HTML API instead.
-				if ( 'core/paragraph' === $this->name && 'content' === $attribute_name ) {
-					$selector = 'p';
-				}
-				if ( 'core/heading' === $this->name && 'content' === $attribute_name ) {
-					$selector = 'h[1-6]';
-				}
-				if ( 'core/button' === $this->name && 'text' === $attribute_name ) {
-					// Check if it is a <button> or <a> tag.
-					if ( preg_match( '/<button[^>]*>.*?<\/button>/', $block_content ) ) {
-						$selector = 'button';
-					} else {
-						$selector = 'a';
+				$block_reader = new WP_HTML_Tag_Processor( $block_content );
+
+				// TODO: Support for CSS selectors whenever they are ready in the HTML API.
+				// In the meantime, support comma-separated selectors by exploding them into an array.
+				$selectors = explode( ',', $block_type->attributes[ $attribute_name ]['selector'] );
+				// Add a bookmark to the first tag to be able to iterate over the selectors.
+				$block_reader->next_tag();
+				$block_reader->set_bookmark( 'iterate-selectors' );
+
+				// TODO: This shouldn't be needed when the `set_inner_html` function is ready.
+				// Store the parent tag and its attributes to be able to restore them later in the button.
+				// The button block has a wrapper while the paragraph and heading blocks don't.
+				if ( 'core/button' === $this->name ) {
+					$button_wrapper                 = $block_reader->get_tag();
+					$button_wrapper_attribute_names = $block_reader->get_attribute_names_with_prefix( '' );
+					$button_wrapper_attrs           = array();
+					foreach ( $button_wrapper_attribute_names as $name ) {
+						$button_wrapper_attrs[ $name ] = $block_reader->get_attribute( $name );
 					}
 				}
-				if ( empty( $selector ) ) {
-					return $block_content;
-				}
-				$pattern = '/(<' . $selector . '[^>]*>).*?(<\/' . $selector . '>)/i';
-				return preg_replace( $pattern, '$1' . wp_kses_post( $source_value ) . '$2', $block_content );
 
+				foreach ( $selectors as $selector ) {
+					// If the parent tag, or any of its children, matches the selector, replace the HTML.
+					if ( strcasecmp( $block_reader->get_tag( $selector ), $selector ) === 0 || $block_reader->next_tag(
+						array(
+							'tag_name' => $selector,
+						)
+					) ) {
+						$block_reader->release_bookmark( 'iterate-selectors' );
+
+						// TODO: Use `set_inner_html` method whenever it's ready in the HTML API.
+						// Until then, it is hardcoded for the paragraph, heading, and button blocks.
+						// Store the tag and its attributes to be able to restore them later.
+						$selector_attribute_names = $block_reader->get_attribute_names_with_prefix( '' );
+						$selector_attrs           = array();
+						foreach ( $selector_attribute_names as $name ) {
+							$selector_attrs[ $name ] = $block_reader->get_attribute( $name );
+						}
+						$selector_markup = "<$selector>" . wp_kses_post( $source_value ) . "</$selector>";
+						$amended_content = new WP_HTML_Tag_Processor( $selector_markup );
+						$amended_content->next_tag();
+						foreach ( $selector_attrs as $attribute_key => $attribute_value ) {
+							$amended_content->set_attribute( $attribute_key, $attribute_value );
+						}
+						if ( 'core/paragraph' === $this->name || 'core/heading' === $this->name ) {
+							return $amended_content->get_updated_html();
+						}
+						if ( 'core/button' === $this->name ) {
+							$button_markup  = "<$button_wrapper>{$amended_content->get_updated_html()}</$button_wrapper>";
+							$amended_button = new WP_HTML_Tag_Processor( $button_markup );
+							$amended_button->next_tag();
+							foreach ( $button_wrapper_attrs as $attribute_key => $attribute_value ) {
+								$amended_button->set_attribute( $attribute_key, $attribute_value );
+							}
+							return $amended_button->get_updated_html();
+						}
+					} else {
+						$block_reader->seek( 'iterate-selectors' );
+					}
+				}
+				$block_reader->release_bookmark( 'iterate-selectors' );
+				return $block_content;
 			case 'attribute':
 				$amended_content = new WP_HTML_Tag_Processor( $block_content );
 				if ( ! $amended_content->next_tag(

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -395,6 +395,7 @@ class WP_Block {
 				}
 				$block_reader->release_bookmark( 'iterate-selectors' );
 				return $block_content;
+
 			case 'attribute':
 				$amended_content = new WP_HTML_Tag_Processor( $block_content );
 				if ( ! $amended_content->next_tag(

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -236,6 +236,42 @@ HTML;
 	}
 
 	/**
+	 * Tests that including symbols and numbers works well with bound attributes.
+	 *
+	 * @ticket 61385
+	 *
+	 * @covers WP_Block::process_block_bindings
+	 */
+	public function test_using_symbols_in_block_bindings_value() {
+		$get_value_callback = function () {
+			return '$12.50';
+		};
+
+		register_block_bindings_source(
+			self::SOURCE_NAME,
+			array(
+				'label'              => self::SOURCE_LABEL,
+				'get_value_callback' => $get_value_callback,
+			)
+		);
+
+		$block_content = <<<HTML
+<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"test/source"}}}} -->
+<p>Default content</p>
+<!-- /wp:paragraph -->
+HTML;
+		$parsed_blocks = parse_blocks( $block_content );
+		$block         = new WP_Block( $parsed_blocks[0] );
+		$result        = $block->render();
+
+		$this->assertSame(
+			'<p>$12.50</p>',
+			trim( $result ),
+			'The block content should properly show the symbol and numbers.'
+		);
+	}
+
+	/**
 	 * Tests if the `__default` attribute is replaced with real attribues for
 	 * pattern overrides.
 	 *


### PR DESCRIPTION
## What?
Revert part of the changes made in [this pull request](https://github.com/WordPress/wordpress-develop/pull/6712/) to avoid using regex that can cause potential bugs like [this one](https://github.com/WordPress/gutenberg/issues/62347#top).

## Why?
The idea of that pull request was to simplify the logic and potentially support more attributes in bindings, but it is causing other problems like the mentioned issue. I believe it is safer to revert these changes and do the refactoring once the HTML API supports CSS selectors and provides a way to set inner content.

## How?
Just reverting the changes made to the previous implementation, which seemed to be working fine.

## Testing Instructions
Follow the testing instructions of https://github.com/WordPress/gutenberg/issues/62347#top and check that the issue is solved.

I also added a unit test to cover the issue.

Trac ticket: https://core.trac.wordpress.org/ticket/61385

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
