### PR TITLE
Fixed the Add new theme search form alignment

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1090,6 +1090,7 @@ th.action-links {
 
 .wp-filter .search-form {
 	float: right;
+	margin: 10px 0px;
 	display: flex;
 	align-items: center;
 	column-gap: .5rem;


### PR DESCRIPTION

Fixed the Add new theme search form alignment by adding the `margin: 10px 0px;` at the `.wp-filter .search-form` class. 


Trac ticket: https://core.trac.wordpress.org/ticket/61389

