### PR TITLE
Enhancement: Add alias s for search in WP_Term_Query class

### DIFF
--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -161,6 +161,7 @@ class WP_Term_Query {
 	 *     @type string          $search                 Search criteria to match terms. Will be SQL-formatted with
 	 *                                                   wildcards before and after. Default empty.
 	 *     @type string          $s                      Alias of `$search`. Default empty.
+	 *                                                   @since 6.7.0
 	 *     @type string          $name__like             Retrieve terms with criteria by which a term is LIKE
 	 *                                                   `$name__like`. Default empty.
 	 *     @type string          $description__like      Retrieve terms where the description is LIKE

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -92,6 +92,7 @@ class WP_Term_Query {
 	 * @since 5.1.0 Introduced the 'meta_compare_key' parameter.
 	 * @since 5.3.0 Introduced the 'meta_type_key' parameter.
 	 * @since 6.4.0 Introduced the 'cache_results' parameter.
+	 * @since 6.7.0 Introduced the 's' parameter.
 	 *
 	 * @param string|array $query {
 	 *     Optional. Array or query string of term query parameters. Default empty.
@@ -161,7 +162,6 @@ class WP_Term_Query {
 	 *     @type string          $search                 Search criteria to match terms. Will be SQL-formatted with
 	 *                                                   wildcards before and after. Default empty.
 	 *     @type string          $s                      Alias of `$search`. Default empty.
-	 *                                                   @since 6.7.0
 	 *     @type string          $name__like             Retrieve terms with criteria by which a term is LIKE
 	 *                                                   `$name__like`. Default empty.
 	 *     @type string          $description__like      Retrieve terms where the description is LIKE

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -160,6 +160,7 @@ class WP_Term_Query {
 	 *                                                   (even if `$hide_empty` is set to true). Default true.
 	 *     @type string          $search                 Search criteria to match terms. Will be SQL-formatted with
 	 *                                                   wildcards before and after. Default empty.
+	 *     @type string          $s                      Alias of `$search`. Default empty.
 	 *     @type string          $name__like             Retrieve terms with criteria by which a term is LIKE
 	 *                                                   `$name__like`. Default empty.
 	 *     @type string          $description__like      Retrieve terms where the description is LIKE
@@ -214,6 +215,7 @@ class WP_Term_Query {
 			'term_taxonomy_id'       => '',
 			'hierarchical'           => true,
 			'search'                 => '',
+			's'                      => '',
 			'name__like'             => '',
 			'description__like'      => '',
 			'pad_counts'             => false,
@@ -643,6 +645,9 @@ class WP_Term_Query {
 			$limits = '';
 		}
 
+		if ( ! empty( $args['s'] ) ) {
+			$args['search'] = $args['s'];
+		}
 		if ( ! empty( $args['search'] ) ) {
 			$this->sql_clauses['where']['search'] = $this->get_search_sql( $args['search'] );
 		}

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -645,6 +645,7 @@ class WP_Term_Query {
 			$limits = '';
 		}
 
+		// Adding alias for the s for the search.
 		if ( ! empty( $args['s'] ) ) {
 			$args['search'] = $args['s'];
 		}


### PR DESCRIPTION
Fixes [Ticket #51811](https://core.trac.wordpress.org/ticket/51811)

For searching, in addition to search, now just like in WP_Query class we can pass 's' as a parameter. This aims in keeping the code consistent.