### PR TITLE
Add test coverage for register_block_type_from_metadata args

### DIFF
--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -992,15 +992,18 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 * Tests that the function returns the registered block when the `block.json`
 	 * is found in the fixtures directory.
 	 *
+	 * @dataProvider data_block_registers_with_metadata_fixture
+	 *
 	 * @ticket 50263
 	 * @ticket 50328
 	 * @ticket 57585
 	 * @ticket 59797
 	 * @ticket 60233
 	 */
-	public function test_block_registers_with_metadata_fixture() {
+	public function test_block_registers_with_metadata_fixture( $folder, $args ) {
 		$result = register_block_type_from_metadata(
-			DIR_TESTDATA . '/blocks/notice'
+			$folder,
+			$args
 		);
 
 		$this->assertInstanceOf( 'WP_Block_Type', $result );
@@ -1133,6 +1136,21 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 
 		// @ticket 53148
 		$this->assertIsCallable( $result->render_callback );
+	}
+
+	public function data_block_registers_with_metadata_fixture() {
+		$folder = DIR_TESTDATA . '/blocks/notice';
+		return array(
+			'block.json with no extra arguments' => array(
+				$folder,
+				array(),
+			),
+			'arguments' => array(
+				'',
+				wp_json_file_decode( $folder . '/block.json', array( 'associative' => true ) )
+			),
+
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -1200,7 +1200,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 			),
 			'arguments' => array(
 				'',
-				$args
+				$args,
 			),
 
 		);

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -1140,6 +1140,59 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 
 	public function data_block_registers_with_metadata_fixture() {
 		$folder = DIR_TESTDATA . '/blocks/notice';
+		$json = wp_json_file_decode( $folder . '/block.json', array( 'associative' => true ) ); // We need the mappings!
+
+		$property_mappings = array(
+			'apiVersion'      => 'api_version',
+			'name'            => 'name',
+			'title'           => 'title',
+			'category'        => 'category',
+			'parent'          => 'parent',
+			'ancestor'        => 'ancestor',
+			'icon'            => 'icon',
+			'description'     => 'description',
+			'keywords'        => 'keywords',
+			'attributes'      => 'attributes',
+			'providesContext' => 'provides_context',
+			'usesContext'     => 'uses_context',
+			'selectors'       => 'selectors',
+			'supports'        => 'supports',
+			'styles'          => 'styles',
+			'variations'      => 'variations',
+			'example'         => 'example',
+			'allowedBlocks'   => 'allowed_blocks',
+		);
+
+		$script_fields = array(
+			'editorScript' => 'editor_script_handles',
+			'script'       => 'script_handles',
+			'viewScript'   => 'view_script_handles',
+		);
+
+		$module_fields = array(
+			'viewScriptModule' => 'view_script_module_ids',
+		);
+
+		$style_fields = array(
+			'editorStyle' => 'editor_style_handles',
+			'style'       => 'style_handles',
+			'viewStyle'   => 'view_style_handles',
+		);
+
+		$all_mappings = array_merge(
+			$property_mappings,
+			$script_fields,
+			$module_fields,
+			$style_fields
+		);
+
+		$args = array();
+		foreach ( $all_mappings as $json_key => $arg_key ) {
+			if ( isset( $json[ $json_key ] ) ) {
+				$args[ $arg_key ] = $json[ $json_key ];
+			}
+		}
+
 		return array(
 			'block.json with no extra arguments' => array(
 				$folder,
@@ -1147,7 +1200,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 			),
 			'arguments' => array(
 				'',
-				wp_json_file_decode( $folder . '/block.json', array( 'associative' => true ) )
+				$args
 			),
 
 		);


### PR DESCRIPTION
WIP.

Add test coverage to verify that providing `$args` rather than a `block.json` file to [`register_block_type_from_metadata`](https://developer.wordpress.org/reference/functions/register_block_type_from_metadata/) results in the same block being created.

Trac ticket: TBD

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
