### PR TITLE
Add unit test for external GD AVIF support

### DIFF
--- a/tests/phpunit/tests/image/functions.php
+++ b/tests/phpunit/tests/image/functions.php
@@ -1152,4 +1152,32 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Test that PHP and underlying external GD library actually supports AVIF.
+	 *
+	 * @link https://github.com/php/php-src/issues/12019
+	 *
+	 * @ticket 60628
+	 */
+	public function test_php_avif_support() {
+		if ( imagetypes() & IMG_AVIF ) {
+			$test_file = get_temp_dir() . 'php-gd.avif';
+
+			$result = @imageavif( imagecreatetruecolor( 16, 16 ), $test_file );
+
+			$this->assertTrue(
+				$result,
+				"imageavif() should return true."
+			);
+
+			$this->assertGreaterThan(
+				0,
+				filesize( $test_file ),
+				"filesize( '$test_file' ) should be greater than 0 bytes."
+			);
+
+			unlink( $test_file );
+		}
+	}
 }

--- a/tests/phpunit/tests/image/functions.php
+++ b/tests/phpunit/tests/image/functions.php
@@ -1168,7 +1168,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 
 			$this->assertTrue(
 				$result,
-				"imageavif() should return true."
+				'imageavif() should return true.'
 			);
 
 			$this->assertGreaterThan(


### PR DESCRIPTION
Add unit test for PHP AVIF support. PHP GD library might not have actual AVIF support, even though it reports to have such.

Trac ticket: https://core.trac.wordpress.org/ticket/60628

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
