### PR TITLE
Remove Slideshare from oembed allow list.

### DIFF
--- a/src/wp-includes/class-wp-oembed.php
+++ b/src/wp-includes/class-wp-oembed.php
@@ -75,7 +75,6 @@ class WP_oEmbed {
 			'#https?://(www\.)?twitter\.com/\w{1,15}/timelines/.*#i' => array( 'https://publish.twitter.com/oembed', true ),
 			'#https?://(www\.)?twitter\.com/i/moments/.*#i' => array( 'https://publish.twitter.com/oembed', true ),
 			'#https?://(www\.)?soundcloud\.com/.*#i'       => array( 'https://soundcloud.com/oembed', true ),
-			'#https?://(.+?\.)?slideshare\.net/.*#i'       => array( 'https://www.slideshare.net/api/oembed/2', true ),
 			'#https?://(open|play)\.spotify\.com/.*#i'     => array( 'https://embed.spotify.com/oembed/', true ),
 			'#https?://(.+\.)?imgur\.com/.*#i'             => array( 'https://api.imgur.com/oembed', true ),
 			'#https?://(www\.)?issuu\.com/.+/docs/.+#i'    => array( 'https://issuu.com/oembed_wp', true ),
@@ -148,7 +147,6 @@ class WP_oEmbed {
 		 * | SmugMug      | smugmug.com                               | 3.0.0   |
 		 * | YouTube      | youtu.be                                  | 3.0.0   |
 		 * | Twitter      | twitter.com                               | 3.4.0   |
-		 * | Slideshare   | slideshare.net                            | 3.5.0   |
 		 * | SoundCloud   | soundcloud.com                            | 3.5.0   |
 		 * | Dailymotion  | dai.ly                                    | 3.6.0   |
 		 * | Flickr       | flic.kr                                   | 3.6.0   |
@@ -215,6 +213,7 @@ class WP_oEmbed {
 		 * | Facebook     | facebook.com         | 4.7.0     | 5.5.2     |
 		 * | Meetup.com   | meetup.com           | 3.9.0     | 6.0.1     |
 		 * | Meetup.com   | meetu.ps             | 3.9.0     | 6.0.1     |
+		 * | Slideshare   | slideshare.net       | 3.5.0     | 6.6.0     |
 		 *
 		 * @see wp_oembed_add_provider()
 		 *

--- a/src/wp-includes/class-wp-oembed.php
+++ b/src/wp-includes/class-wp-oembed.php
@@ -213,7 +213,7 @@ class WP_oEmbed {
 		 * | Facebook     | facebook.com         | 4.7.0     | 5.5.2     |
 		 * | Meetup.com   | meetup.com           | 3.9.0     | 6.0.1     |
 		 * | Meetup.com   | meetu.ps             | 3.9.0     | 6.0.1     |
-		 * | Slideshare   | slideshare.net       | 3.5.0     | 6.6.0     |
+		 * | SlideShare   | slideshare.net       | 3.5.0     | 6.6.0     |
 		 *
 		 * @see wp_oembed_add_provider()
 		 *


### PR DESCRIPTION
The Slideshare oembed endpoint has been effectively deprecated so should no longer be included in the allow list.

Trac ticket: https://core.trac.wordpress.org/ticket/61349#comment:4

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
