### PR TITLE
Update: register block style variations defined by the theme using the `init` action

### DIFF
--- a/src/wp-includes/block-supports/block-style-variations.php
+++ b/src/wp-includes/block-supports/block-style-variations.php
@@ -249,7 +249,7 @@ function wp_resolve_block_style_variations( $variations ) {
 		 * Block style variations read in via standalone theme.json partials
 		 * need to have their name set to the kebab case version of their title.
 		 */
-		$variation_name  = $have_named_variations ? $key : _wp_to_kebab_case( $variation['title'] );
+		$variation_name = $have_named_variations ? $key : _wp_to_kebab_case( $variation['title'] );
 
 		foreach ( $supported_blocks as $block_type ) {
 			// Add block style variation data under current block type.
@@ -409,6 +409,7 @@ add_filter( 'wp_theme_json_data_user', 'wp_resolve_block_style_variations_from_t
  * Registers any block style variations contained within the provided
  * theme.json data.
  *
+ * @since 6.6.0
  * @access private
  *
  * @param array $variations Shared block style variations.
@@ -468,6 +469,7 @@ function wp_register_block_style_variations_from_theme_json_data( $variations ) 
  * - the theme's partials (standalone files in `/styles` that only define block style variations)
  * - the user's theme.json (for example, theme style variations the user selected)
  *
+ * @since 6.6.0
  * @access private
  */
 function wp_register_block_style_variations_from_theme() {

--- a/src/wp-includes/block-supports/block-style-variations.php
+++ b/src/wp-includes/block-supports/block-style-variations.php
@@ -406,13 +406,16 @@ add_filter( 'wp_theme_json_data_theme', 'wp_resolve_block_style_variations_from_
 add_filter( 'wp_theme_json_data_user', 'wp_resolve_block_style_variations_from_theme_style_variation', 10, 1 );
 
 /**
+ * Registers any block style variations contained within the provided
+ * theme.json data.
+ *
  * @access private
+ *
+ * @param array $variations Shared block style variations.
  */
 function wp_register_block_style_variations_from_theme_json_data( $variations ) {
-	$variations_data = array();
-
 	if ( empty( $variations ) ) {
-		return $variations_data;
+		return $variations;
 	}
 
 	$registry              = WP_Block_Styles_Registry::get_instance();

--- a/src/wp-includes/block-supports/block-style-variations.php
+++ b/src/wp-includes/block-supports/block-style-variations.php
@@ -231,7 +231,6 @@ function wp_resolve_and_register_block_style_variations( $variations ) {
 		return $variations_data;
 	}
 
-	$registry              = WP_Block_Styles_Registry::get_instance();
 	$have_named_variations = ! wp_is_numeric_array( $variations );
 
 	foreach ( $variations as $key => $variation ) {
@@ -254,22 +253,8 @@ function wp_resolve_and_register_block_style_variations( $variations ) {
 		 * need to have their name set to the kebab case version of their title.
 		 */
 		$variation_name  = $have_named_variations ? $key : _wp_to_kebab_case( $variation['title'] );
-		$variation_label = $variation['title'] ?? $variation_name;
 
 		foreach ( $supported_blocks as $block_type ) {
-			$registered_styles = $registry->get_registered_styles_for_block( $block_type );
-
-			// Register block style variation if it hasn't already been registered.
-			if ( ! array_key_exists( $variation_name, $registered_styles ) ) {
-				register_block_style(
-					$block_type,
-					array(
-						'name'  => $variation_name,
-						'label' => $variation_label,
-					)
-				);
-			}
-
 			// Add block style variation data under current block type.
 			$path = array( $block_type, 'variations', $variation_name );
 			_wp_array_set( $variations_data, $path, $variation_data );

--- a/src/wp-includes/block-supports/block-style-variations.php
+++ b/src/wp-includes/block-supports/block-style-variations.php
@@ -461,18 +461,17 @@ function wp_register_block_style_variations_from_theme_json_data( $variations ) 
 }
 
 /**
- * @access private
+ * Register shared block style variations defined by the theme.
  *
- * Register the block style variations defined by the theme.
  * These can come in three forms:
- *
  * - the theme's theme.json
- * - the theme's partials (standalone files in styles that only define block style variations)
+ * - the theme's partials (standalone files in `/styles` that only define block style variations)
  * - the user's theme.json (for example, theme style variations the user selected)
  *
+ * @access private
  */
 function wp_register_block_style_variations_from_theme() {
-	// Partials.
+	// Partials from `/styles`.
 	$variations_partials = WP_Theme_JSON_Resolver::get_style_variations( 'block' );
 	wp_register_block_style_variations_from_theme_json_data( $variations_partials );
 
@@ -496,4 +495,4 @@ function wp_register_block_style_variations_from_theme() {
 	$variations_user = $theme_json_user->get_data()['styles']['blocks']['variations'] ?? array();
 	wp_register_block_style_variations_from_theme_json_data( $variations_user );
 }
-add_filter( 'init', 'wp_register_block_style_variations_from_theme' );
+add_action( 'init', 'wp_register_block_style_variations_from_theme' );

--- a/src/wp-includes/block-supports/block-style-variations.php
+++ b/src/wp-includes/block-supports/block-style-variations.php
@@ -422,3 +422,83 @@ add_filter( 'wp_theme_json_data_theme', 'wp_resolve_block_style_variations_from_
 add_filter( 'wp_theme_json_data_theme', 'wp_resolve_block_style_variations_from_styles_registry', 10, 1 );
 
 add_filter( 'wp_theme_json_data_user', 'wp_resolve_block_style_variations_from_theme_style_variation', 10, 1 );
+
+/**
+ * @access private
+ */
+function wp_register_block_style_variations_from_theme_json_data( $variations ) {
+	$variations_data = array();
+
+	if ( empty( $variations ) ) {
+		return $variations_data;
+	}
+
+	$registry              = WP_Block_Styles_Registry::get_instance();
+	$have_named_variations = ! wp_is_numeric_array( $variations );
+
+	foreach ( $variations as $key => $variation ) {
+		$supported_blocks = $variation['blockTypes'] ?? array();
+
+		/*
+		 * Standalone theme.json partial files for block style variations
+		 * will have their styles under a top-level property by the same name.
+		 * Variations defined within an existing theme.json or theme style
+		 * variation will themselves already be the required styles data.
+		 */
+		$variation_data = $variation['styles'] ?? $variation;
+
+		if ( empty( $variation_data ) ) {
+			continue;
+		}
+
+		/*
+		 * Block style variations read in via standalone theme.json partials
+		 * need to have their name set to the kebab case version of their title.
+		 */
+		$variation_name  = $have_named_variations ? $key : _wp_to_kebab_case( $variation['title'] );
+		$variation_label = $variation['title'] ?? $variation_name;
+
+		foreach ( $supported_blocks as $block_type ) {
+			$registered_styles = $registry->get_registered_styles_for_block( $block_type );
+
+			// Register block style variation if it hasn't already been registered.
+			if ( ! array_key_exists( $variation_name, $registered_styles ) ) {
+				register_block_style(
+					$block_type,
+					array(
+						'name'  => $variation_name,
+						'label' => $variation_label,
+					)
+				);
+			}
+		}
+	}
+}
+
+/**
+ * @access private
+ *
+ * Register the block style variations defined by the theme.
+ * These can come in three forms:
+ *
+ * - the theme's theme.json
+ * - the theme's partials (standalone files in styles that only define block style variations)
+ * - the user's theme.json (for example, theme style variations the user selected)
+ *
+ */
+function wp_register_block_style_variations_from_theme() {
+	// Partials.
+	$variations_partials = WP_Theme_JSON_Resolver::get_style_variations( 'block' );
+	wp_register_block_style_variations_from_theme_json_data( $variations_partials );
+
+	// theme.json of the theme.
+	$theme_json_theme = WP_Theme_JSON_Resolver::get_theme_data();
+	$variations_theme = $theme_json_theme->get_data()['styles']['blocks']['variations'] ?? array();
+	wp_register_block_style_variations_from_theme_json_data( $variations_theme );
+
+	// User data linked for this theme.
+	$theme_json_user = WP_Theme_JSON_Resolver::get_user_data();
+	$variations_user = $theme_json_user->get_data()['styles']['blocks']['variations'] ?? array();
+	wp_register_block_style_variations_from_theme_json_data( $variations_user );
+}
+add_filter( 'init', 'wp_register_block_style_variations_from_theme' );

--- a/src/wp-includes/block-supports/block-style-variations.php
+++ b/src/wp-includes/block-supports/block-style-variations.php
@@ -224,7 +224,7 @@ function wp_render_block_style_variation_class_name( $block_content, $block ) {
  *
  * @return array Block variations data to be merged under `styles.blocks`.
  */
-function wp_resolve_and_register_block_style_variations( $variations ) {
+function wp_resolve_block_style_variations( $variations ) {
 	$variations_data = array();
 
 	if ( empty( $variations ) ) {
@@ -312,7 +312,7 @@ function wp_merge_block_style_variations_data( $variations_data, $theme_json, $o
 function wp_resolve_block_style_variations_from_theme_style_variation( $theme_json ) {
 	$theme_json_data   = $theme_json->get_data();
 	$shared_variations = $theme_json_data['styles']['blocks']['variations'] ?? array();
-	$variations_data   = wp_resolve_and_register_block_style_variations( $shared_variations );
+	$variations_data   = wp_resolve_block_style_variations( $shared_variations );
 
 	return wp_merge_block_style_variations_data( $variations_data, $theme_json, 'user' );
 }
@@ -330,7 +330,7 @@ function wp_resolve_block_style_variations_from_theme_style_variation( $theme_js
  */
 function wp_resolve_block_style_variations_from_theme_json_partials( $theme_json ) {
 	$block_style_variations = WP_Theme_JSON_Resolver::get_style_variations( 'block' );
-	$variations_data        = wp_resolve_and_register_block_style_variations( $block_style_variations );
+	$variations_data        = wp_resolve_block_style_variations( $block_style_variations );
 
 	return wp_merge_block_style_variations_data( $variations_data, $theme_json );
 }
@@ -349,7 +349,7 @@ function wp_resolve_block_style_variations_from_theme_json_partials( $theme_json
 function wp_resolve_block_style_variations_from_primary_theme_json( $theme_json ) {
 	$theme_json_data        = $theme_json->get_data();
 	$block_style_variations = $theme_json_data['styles']['blocks']['variations'] ?? array();
-	$variations_data        = wp_resolve_and_register_block_style_variations( $block_style_variations );
+	$variations_data        = wp_resolve_block_style_variations( $block_style_variations );
 
 	return wp_merge_block_style_variations_data( $variations_data, $theme_json );
 }

--- a/src/wp-includes/block-supports/block-style-variations.php
+++ b/src/wp-includes/block-supports/block-style-variations.php
@@ -476,6 +476,16 @@ function wp_register_block_style_variations_from_theme() {
 	$variations_partials = WP_Theme_JSON_Resolver::get_style_variations( 'block' );
 	wp_register_block_style_variations_from_theme_json_data( $variations_partials );
 
+	/*
+	 * Pull the data from the specific origin instead of the merged data.
+	 * This is because, for 6.6, we only support registering block style variations
+	 * for the 'theme' and 'custom' origins but not for 'default' (core theme.json)
+	 * or 'custom' (theme.json in a block).
+	 *
+	 * When/If we add support for every origin, we should switch to using the public API
+	 * instead, e.g.: wp_get_global_styles( array( 'blocks', 'variations' ) ).
+	 */
+
 	// theme.json of the theme.
 	$theme_json_theme = WP_Theme_JSON_Resolver::get_theme_data();
 	$variations_theme = $theme_json_theme->get_data()['styles']['blocks']['variations'] ?? array();

--- a/src/wp-includes/block-supports/block-style-variations.php
+++ b/src/wp-includes/block-supports/block-style-variations.php
@@ -213,9 +213,6 @@ function wp_render_block_style_variation_class_name( $block_content, $block ) {
 
 /**
  * Collects block style variation data for merging with theme.json data.
- * As each block style variation is processed it is registered if it hasn't
- * been already. This registration is required for later sanitization of
- * theme.json data.
  *
  * @since 6.6.0
  * @access private

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
@@ -263,6 +263,23 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Posts_Controller {
 			} elseif ( isset( $existing_config['styles'] ) ) {
 				$config['styles'] = $existing_config['styles'];
 			}
+
+			// If the incoming request is going to create a new variation
+			// that is not yet registered, we register it here.
+			// This is because the variations are registered on init,
+			// but we want this endpoint to return the new variation immediately:
+			// if we don't register it, it'll be stripped out of the response
+			// just in this request (subsequent ones will be ok).
+			// Take the variations defined in styles.blocks.variations from the incoming request
+			// that are not part of the $exsting_config.
+			if ( isset( $request['styles']['blocks']['variations'] ) ) {
+				$existing_variations = isset( $existing_config['styles']['blocks']['variations'] ) ? $existing_config['styles']['blocks']['variations'] : array();
+				$new_variations      = array_diff_key( $request['styles']['blocks']['variations'], $existing_variations );
+				if ( ! empty( $new_variations ) ) {
+					wp_register_block_style_variations_from_theme_json_data( $new_variations );
+				}
+			}
+
 			if ( isset( $request['settings'] ) ) {
 				$config['settings'] = $request['settings'];
 			} elseif ( isset( $existing_config['settings'] ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
@@ -231,6 +231,7 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Posts_Controller {
 	 *
 	 * @since 5.9.0
 	 * @since 6.2.0 Added validation of styles.css property.
+	 * @since 6.6.0 Added registration of newly created style variations provided by the user.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return stdClass|WP_Error Prepared item on success. WP_Error on when the custom CSS is not valid.
@@ -264,14 +265,16 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Posts_Controller {
 				$config['styles'] = $existing_config['styles'];
 			}
 
-			// If the incoming request is going to create a new variation
-			// that is not yet registered, we register it here.
-			// This is because the variations are registered on init,
-			// but we want this endpoint to return the new variation immediately:
-			// if we don't register it, it'll be stripped out of the response
-			// just in this request (subsequent ones will be ok).
-			// Take the variations defined in styles.blocks.variations from the incoming request
-			// that are not part of the $exsting_config.
+			/*
+			 * If the incoming request is going to create a new variation
+			 * that is not yet registered, we register it here.
+			 * This is because the variations are registered on init,
+			 * but we want this endpoint to return the new variation immediately:
+			 * if we don't register it, it'll be stripped out of the response
+			 * just in this request (subsequent ones will be ok).
+			 * Take the variations defined in styles.blocks.variations from the incoming request
+			 * that are not part of the $exsting_config.
+			 */
 			if ( isset( $request['styles']['blocks']['variations'] ) ) {
 				$existing_variations = isset( $existing_config['styles']['blocks']['variations'] ) ? $existing_config['styles']['blocks']['variations'] : array();
 				$new_variations      = array_diff_key( $request['styles']['blocks']['variations'], $existing_variations );

--- a/tests/phpunit/tests/block-supports/block-style-variations.php
+++ b/tests/phpunit/tests/block-supports/block-style-variations.php
@@ -65,6 +65,11 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 	public function test_add_registered_block_styles_to_theme_data() {
 		switch_theme( 'block-theme' );
 
+		// Trigger block style registration that occurs on `init` action.
+		// do_action( 'init' ) could be used here however this direct call
+		// means only the updates being tested are performed.
+		wp_register_block_style_variations_from_theme();
+
 		$variation_styles_data = array(
 			'color'    => array(
 				'background' => 'darkslateblue',

--- a/tests/phpunit/tests/block-supports/block-style-variations.php
+++ b/tests/phpunit/tests/block-supports/block-style-variations.php
@@ -65,9 +65,11 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 	public function test_add_registered_block_styles_to_theme_data() {
 		switch_theme( 'block-theme' );
 
-		// Trigger block style registration that occurs on `init` action.
-		// do_action( 'init' ) could be used here however this direct call
-		// means only the updates being tested are performed.
+		/*
+		 * Trigger block style registration that occurs on `init` action.
+		 * do_action( 'init' ) could be used here however this direct call
+		 * means only the updates being tested are performed.
+		 */
 		wp_register_block_style_variations_from_theme();
 
 		$variation_styles_data = array(

--- a/tests/phpunit/tests/rest-api/rest-global-styles-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-global-styles-controller.php
@@ -603,6 +603,55 @@ class WP_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controller_Test
 	}
 
 	/**
+	 * Tests the submission of a custom block style variation that was defined
+	 * within a theme style variation and wouldn't be registered at the time
+	 * of saving via the API.
+	 *
+	 * @covers WP_REST_Global_Styles_Controller_Gutenberg::update_item
+	 * @ticket 61312
+	 */
+	public function test_update_item_with_custom_block_style_variations() {
+		wp_set_current_user( self::$admin_id );
+		if ( is_multisite() ) {
+			grant_super_admin( self::$admin_id );
+		}
+
+		$group_variations = array(
+			'fromThemeStyleVariation' => array(
+				'color' => array(
+					'background' => '#ffffff',
+					'text'       => '#000000',
+				),
+			),
+		);
+
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/global-styles/' . self::$global_styles_id );
+		$request->set_body_params(
+			array(
+				'styles' => array(
+					'blocks' => array(
+						'variations' => array(
+							'fromThemeStyleVariation' => array(
+								'blockTypes' => array( 'core/group', 'core/columns' ),
+								'color'      => array(
+									'background' => '#000000',
+									'text'       => '#ffffff',
+								),
+							),
+						),
+						'core/group' => array(
+							'variations' => $group_variations,
+						),
+					),
+				),
+			)
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertSame( $group_variations, $data['styles']['blocks']['core/group']['variations'] );
+	}
+
+	/**
 	 * @doesNotPerformAssertions
 	 */
 	public function test_delete_item() {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61312

Backports https://github.com/WordPress/gutenberg/pull/62461 and https://github.com/WordPress/gutenberg/pull/62495
Fixes: https://github.com/WordPress/gutenberg/issues/62303
Alternative to https://github.com/WordPress/gutenberg/pull/62405#issuecomment-2155131064

## What?

This PR changes how the block style variations defined by the theme are registered: from using the `wp_theme_json_data_*` filters to use the `init` filter.

## Why?

Using the `wp_theme_json_data_*` filters is problematic: in some scenarios (e.g.: ) variations end up not being registered because those filters were not dispatched, hence their styles are not generated. Using `init` is in line with what themes have been doing until now in their `functions.php` and makes sure the style variations are registered in all the places.

## How?

- b5e5f4d853cc640d78ccbdafe866c3302bb6edf4 Hook into the `init` hook and register the block style variations from the 3 places where they can come from:
  - theme.json "partials": json files stored in `styles/` that are not theme style variations
  - theme's theme.json
  - user's theme.json (this would come from the theme style variations defined by the theme)
- 85e3c2f2e95f570a33dad0f950b2b451f8022f66 Remove the code that registers them upon dispatching the `wp_theme_json_data_*` filters.

## Testing Instructions

1. Register style variations in all the places the theme is allowed to (use TT4).

In the `theme.json` file of the theme, paste the following under `styles.blocks.variations`:

```json
"ThemeDark": {
    "blockTypes": [
        "core/group",
        "core/columns"
    ],
    "color": {
            "background": "blue"
    }
}
```

In the `styles/ember.json` (theme style variation) file, paste the following under `styles.blocks.variations`:

```json
"VariationDark": {
    "blockTypes": [
        "core/group",
        "core/columns"
    ],
    "color": {
            "background": "yellow"
    }
}
```

Create a new file called `styles/partial.json` (partial theme.json), and paste the following:

```json
{
        "$schema": "https://schemas.wp.org/trunk/theme.json",
        "version": 2,
        "title": "PartialDark",
        "blockTypes": [ "core/group", "core/columns", "core/media-text" ],
        "styles": {
                "color": {
                        "background": "green"
                }
        }
}
```

2. Open the site editor, go to Styles, apply the "Ember" theme style variation and save.
3. Go to the site editor, select a group block, and verify the three new style variations are available:

<img width="277" alt="Captura de ecrã 2024-06-07, às 17 41 03" src="https://github.com/WordPress/gutenberg/assets/583546/fafdc159-71c5-47e3-b776-78f0bc7c6b10">

4. Edit the styles of one of them, for example, PartialDark. Go to "Global Styles > Blocks > Group > PartialDark". Modify the background color to something else.
5. Save the post. The expected result is that it stays as it is (it's not reset to the default).

https://github.com/WordPress/wordpress-develop/assets/583546/14bf5644-4203-4921-87c3-10a282632a5a



