### PR TITLE
Plugins: Move misplaced `return` statement in `wp_get_plugin_action_button()`.

### DIFF
--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -1048,7 +1048,7 @@ function wp_get_plugin_action_button( $name, $data, $compatible_php, $compatible
 				}
 				break;
 		}
-
-		return $button;
 	}
+
+	return $button;
 }

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -912,7 +912,7 @@ function install_plugin_information() {
  * }
  * @param bool         $compatible_php   The result of a PHP compatibility check.
  * @param bool         $compatible_wp    The result of a WP compatibility check.
- * @return string The markup for the dependency row button.
+ * @return string The markup for the dependency row button. An empty string if the user does not have capabilities.
  */
 function wp_get_plugin_action_button( $name, $data, $compatible_php, $compatible_wp ) {
 	$button           = '';

--- a/tests/phpunit/tests/admin/includes/wpGetPluginActionButton.php
+++ b/tests/phpunit/tests/admin/includes/wpGetPluginActionButton.php
@@ -94,6 +94,8 @@ class Tests_Admin_Includes_WpGetPluginActionButton extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_capabilities
 	 *
+	 * @group ms-excluded
+	 *
 	 * @param string $capability The name of the capability.
 	 */
 	public function test_should_not_return_empty_string_with_proper_capabilities( $capability ) {

--- a/tests/phpunit/tests/admin/includes/wpGetPluginActionButton.php
+++ b/tests/phpunit/tests/admin/includes/wpGetPluginActionButton.php
@@ -123,4 +123,28 @@ class Tests_Admin_Includes_WpGetPluginActionButton extends WP_UnitTestCase {
 	public function data_capabilities() {
 		return self::text_array_to_dataprovider( array( 'install_plugins', 'update_plugins' ) );
 	}
+
+	/**
+	 * Tests that an empty string is not returned when the user has the correct capabilities.
+	 *
+	 * @ticket
+	 *
+	 * @group ms-required
+	 */
+	public function test_should_not_return_empty_string_with_proper_capabilities_multisite() {
+		wp_set_current_user( self::$user_id );
+
+		grant_super_admin( self::$user_id );
+
+		$actual = wp_get_plugin_action_button(
+			self::$test_plugin->name,
+			self::$test_plugin,
+			true,
+			true
+		);
+
+		revoke_super_admin( self::$user_id );
+
+		$this->assertNotSame( '', $actual, 'Button markup should be returned.' );
+	}
 }

--- a/tests/phpunit/tests/admin/includes/wpGetPluginActionButton.php
+++ b/tests/phpunit/tests/admin/includes/wpGetPluginActionButton.php
@@ -84,7 +84,8 @@ class Tests_Admin_Includes_WpGetPluginActionButton extends WP_UnitTestCase {
 			true
 		);
 
-		$this->assertSame( '', $actual, 'No button markup should be returned.' );
+		$this->assertIsString( $actual, 'A string should be returned.' );
+		$this->assertEmpty( $actual, 'An empty string should be returned.' );
 	}
 
 	/**
@@ -113,7 +114,8 @@ class Tests_Admin_Includes_WpGetPluginActionButton extends WP_UnitTestCase {
 
 		self::$role->remove_cap( $capability );
 
-		$this->assertNotSame( '', $actual, 'Button markup should be returned.' );
+		$this->assertIsString( $actual, 'A string should be returned.' );
+		$this->assertNotEmpty( $actual, 'An empty string should not be returned.' );
 	}
 
 	/**
@@ -147,6 +149,7 @@ class Tests_Admin_Includes_WpGetPluginActionButton extends WP_UnitTestCase {
 
 		revoke_super_admin( self::$user_id );
 
-		$this->assertNotSame( '', $actual, 'Button markup should be returned.' );
+		$this->assertIsString( $actual, 'A string should be returned.' );
+		$this->assertNotEmpty( $actual, 'An empty string should not be returned.' );
 	}
 }

--- a/tests/phpunit/tests/admin/includes/wpGetPluginActionButton.php
+++ b/tests/phpunit/tests/admin/includes/wpGetPluginActionButton.php
@@ -72,7 +72,7 @@ class Tests_Admin_Includes_WpGetPluginActionButton extends WP_UnitTestCase {
 	/**
 	 * Tests that an empty string is returned when the user does not have the correct capabilities.
 	 *
-	 * @ticket
+	 * @ticket 61400
 	 */
 	public function test_should_return_empty_string_without_proper_capabilities() {
 		wp_set_current_user( self::$user_id );
@@ -90,7 +90,7 @@ class Tests_Admin_Includes_WpGetPluginActionButton extends WP_UnitTestCase {
 	/**
 	 * Tests that an empty string is not returned when the user has the correct capabilities.
 	 *
-	 * @ticket
+	 * @ticket 61400
 	 *
 	 * @dataProvider data_capabilities
 	 *
@@ -127,7 +127,7 @@ class Tests_Admin_Includes_WpGetPluginActionButton extends WP_UnitTestCase {
 	/**
 	 * Tests that an empty string is not returned when the user has the correct capabilities.
 	 *
-	 * @ticket
+	 * @ticket 61400
 	 *
 	 * @group ms-required
 	 */

--- a/tests/phpunit/tests/admin/includes/wpGetPluginActionButton.php
+++ b/tests/phpunit/tests/admin/includes/wpGetPluginActionButton.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * Tests for wp_get_plugin_action_button().
+ *
+ * @group plugins
+ * @group admin
+ *
+ * @covers ::wp_get_plugin_action_button
+ */
+class Tests_Admin_Includes_WpGetPluginActionButton extends WP_UnitTestCase {
+
+	/**
+	 * User role.
+	 *
+	 * @var WP_Role
+	 */
+	private static $role;
+
+	/**
+	 * User ID.
+	 *
+	 * @var int
+	 */
+	private static $user_id;
+
+	/**
+	 * Test plugin data.
+	 *
+	 * @var stdClass
+	 */
+	private static $test_plugin;
+
+	/**
+	 * Sets up properties and adds a test plugin before any tests run.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+
+		$role_name = 'wp_get_plugin_action_button-test-role';
+		add_role( $role_name, 'Test Role' );
+
+		self::$role        = get_role( $role_name );
+		self::$user_id     = self::factory()->user->create( array( 'role' => $role_name ) );
+		self::$test_plugin = (object) array(
+			'name'    => 'My Plugin',
+			'slug'    => 'my-plugin',
+			'version' => '1.0.0',
+		);
+
+		mkdir( WP_PLUGIN_DIR . '/' . self::$test_plugin->slug );
+		file_put_contents(
+			WP_PLUGIN_DIR . '/' . self::$test_plugin->slug . '/my_plugin.php',
+			"<?php\n/**\n* Plugin Name: " . self::$test_plugin->name . "\n* Version: " . self::$test_plugin->version . "\n*/"
+		);
+	}
+
+	/**
+	 * Removes the test plugin and its directory after all tests run.
+	 */
+	public static function tear_down_after_class() {
+		parent::tear_down_after_class();
+
+		remove_role( self::$role->name );
+
+		unlink( WP_PLUGIN_DIR . '/' . self::$test_plugin->slug . '/my_plugin.php' );
+		rmdir( WP_PLUGIN_DIR . '/' . self::$test_plugin->slug );
+	}
+
+	/**
+	 * Tests that an empty string is returned when the user does not have the correct capabilities.
+	 *
+	 * @ticket
+	 */
+	public function test_should_return_empty_string_without_proper_capabilities() {
+		wp_set_current_user( self::$user_id );
+
+		$actual = wp_get_plugin_action_button(
+			self::$test_plugin->name,
+			self::$test_plugin,
+			true,
+			true
+		);
+
+		$this->assertSame( '', $actual, 'No button markup should be returned.' );
+	}
+
+	/**
+	 * Tests that an empty string is not returned when the user has the correct capabilities.
+	 *
+	 * @ticket
+	 *
+	 * @dataProvider data_capabilities
+	 *
+	 * @param string $capability The name of the capability.
+	 */
+	public function test_should_not_return_empty_string_with_proper_capabilities( $capability ) {
+		self::$role->add_cap( $capability );
+
+		wp_set_current_user( self::$user_id );
+
+		$actual = wp_get_plugin_action_button(
+			self::$test_plugin->name,
+			self::$test_plugin,
+			true,
+			true
+		);
+
+		self::$role->remove_cap( $capability );
+
+		$this->assertNotSame( '', $actual, 'Button markup should be returned.' );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_capabilities() {
+		return self::text_array_to_dataprovider( array( 'install_plugins', 'update_plugins' ) );
+	}
+}

--- a/tests/phpunit/tests/admin/includes/wpGetPluginActionButton.php
+++ b/tests/phpunit/tests/admin/includes/wpGetPluginActionButton.php
@@ -92,9 +92,9 @@ class Tests_Admin_Includes_WpGetPluginActionButton extends WP_UnitTestCase {
 	 *
 	 * @ticket 61400
 	 *
-	 * @dataProvider data_capabilities
-	 *
 	 * @group ms-excluded
+	 *
+	 * @dataProvider data_capabilities
 	 *
 	 * @param string $capability The name of the capability.
 	 */

--- a/tests/phpunit/tests/admin/includes/wpGetPluginActionButton.php
+++ b/tests/phpunit/tests/admin/includes/wpGetPluginActionButton.php
@@ -88,7 +88,8 @@ class Tests_Admin_Includes_WpGetPluginActionButton extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that an empty string is not returned when the user has the correct capabilities.
+	 * Tests that an empty string is not returned when the user
+	 * has the correct capabilities on single site.
 	 *
 	 * @ticket 61400
 	 *
@@ -98,7 +99,7 @@ class Tests_Admin_Includes_WpGetPluginActionButton extends WP_UnitTestCase {
 	 *
 	 * @param string $capability The name of the capability.
 	 */
-	public function test_should_not_return_empty_string_with_proper_capabilities( $capability ) {
+	public function test_should_not_return_empty_string_with_proper_capabilities_single_site( $capability ) {
 		self::$role->add_cap( $capability );
 
 		wp_set_current_user( self::$user_id );
@@ -125,7 +126,8 @@ class Tests_Admin_Includes_WpGetPluginActionButton extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that an empty string is not returned when the user has the correct capabilities.
+	 * Tests that an empty string is not returned when the user
+	 * has the correct capabilities on multisite.
 	 *
 	 * @ticket 61400
 	 *


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61400
