### PR TITLE
fix: mark $deleted property as deprecated in WP_User class.

### DIFF
--- a/src/wp-includes/class-wp-user.php
+++ b/src/wp-includes/class-wp-user.php
@@ -30,7 +30,7 @@
  * @property int    $user_level
  * @property string $display_name
  * @property string $spam
- * @property string $deleted
+ * @property string $deleted Deprecated. Use {@see $spam} instead.
  * @property string $locale
  * @property string $rich_editing
  * @property string $syntax_highlighting


### PR DESCRIPTION
### Ticket: https://core.trac.wordpress.org/ticket/61149

## Description
Ensure consistent handling of 'checked' property in `wp_update_plugins()` function.

- This **PR** addresses ticket [#61149](https://core.trac.wordpress.org/ticket/61149) by marking the `$deleted` property in the `WP_User` class as deprecated. 
- After reviewing the WordPress core code, it was found that the `$deleted` column is only mentioned once in the function `wp_update_user_counts()`. 
- This reference appears to be irrelevant since the `$spam` property has replaced its functionality. To reflect this change, the documentation for the `WP_User` class is updated accordingly.

## Changes Made
- Updated the docblock for the `$deleted` property in the `WP_User` class to mark it as deprecated.
- Added a reference to use the `$spam` property instead.
