### PR TITLE
feat: add add_sites_page() function.

### DIFF
--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -121,6 +121,27 @@ function get_plugin_data( $plugin_file, $markup = true, $translate = true ) {
 }
 
 /**
+ * Adds a submenu page to the Multisite Sites main menu.
+ *
+ * This function takes a capability which will be used to determine whether
+ * or not a page is included in the menu.
+ *
+ * The function which is hooked in to handle the output of the page must check
+ * that the user has the required capability as well.
+ *
+ * @param string   $page_title The text to be displayed in the title tags of the page when the menu is selected.
+ * @param string   $menu_title The text to be used for the menu.
+ * @param string   $capability The capability required for this menu to be displayed to the user.
+ * @param string   $menu_slug  The slug name to refer to this menu by (should be unique for this menu).
+ * @param callable $callback   Optional. The function to be called to output the content for this page.
+ * @param int      $position   Optional. The position in the menu order this item should appear.
+ * @return string|false The resulting page's hook_suffix, or false if the user does not have the capability required.
+ */
+function add_sites_page( $page_title, $menu_title, $capability, $menu_slug, $callback = '', $position = null ) {
+	return add_submenu_page( 'sites.php', $page_title, $menu_title, $capability, $menu_slug, $callback, $position );
+}
+
+/**
  * Sanitizes plugin data, optionally adds markup, optionally translates.
  *
  * @since 2.7.0


### PR DESCRIPTION
### Ticket: https://core.trac.wordpress.org/ticket/61141

## Description

- This **PR** introduces a new function `add_sites_page()` to the WordPress core, addressing the ticket mentioned above.
- This function allows developers to add submenu items to the 'Sites' menu in the Network Admin area of a multisite installation. 
- Currently, similar functionality exists for other top-level admin menus, such as `add_dashboard_page()` and `add_users_page()`, but not for the 'Sites' menu.

### Changes Made

- Added the `add_sites_page()` function.

## Testing Instructions

1. Set up a local WordPress multisite installation.
2. Apply the changes from this PR.
3. Use the `add_sites_page()` function to add a submenu item under the 'Sites' menu in the Network Admin area.
4. Verify that the new submenu item appears and functions as expected.

### Example Usage

A sample usage of the `add_sites_page()` function:

```php
add_action( 'network_admin_menu', function() {
    add_sites_page(
        'Custom Sites Page',
        'Custom Sites',
        'manage_network',
        'custom-sites-page',
        'custom_sites_page_callback'
    );
});

function custom_sites_page_callback() {
    // Callback function for custom sites page.
}
