### PR TITLE
Blocks: Add utilities to help find next block comment delimiter in a document.

### DIFF
--- a/src/wp-includes/block-parser/class-wp-parsed-block-delimiter-info.php
+++ b/src/wp-includes/block-parser/class-wp-parsed-block-delimiter-info.php
@@ -1,0 +1,694 @@
+<?php
+/**
+ * WP_Parsed_Block_Delimiter_Info class.
+ *
+ * Stores information about a parsed block delimiter, such
+ * as where it is found, the block type it represents, and
+ * the textual range in which the attributes are found.
+ *
+ * @package WordPress
+ * @subpackage Block-API
+ * @since {WP_VERSION}
+ */
+
+/**
+ * Stores information about a parsed block delimiter.
+ *
+ * This class is a low-level class meant to serve as a record
+ * when parsing blocks. It stores byte offsets into a document
+ * where a given block delimiter is found and includes helper
+ * methods for efficiently extracting information.
+ *
+ * @access private
+ *
+ * @since {WP_VERSION}
+ */
+class WP_Parsed_Block_Delimiter_Info {
+	/**
+	 * Indicates if the last operation failed, otherwise
+	 * will be `null` for success.
+	 *
+	 * @var string|null
+	 */
+	private static $last_error = self::UNINITIALIZED;
+
+	/**
+	 * Holds a reference to the original source text from which to
+	 * extract the parsed spans of the delimiter.
+	 *
+	 * @since {WP_VERSION}
+	 *
+	 * @var string
+	 */
+	private $source_text;
+
+	/**
+	 * Byte offset into source text where entire delimiter begins.
+	 *
+	 * @since {WP_VERSION}
+	 *
+	 * @var int
+	 */
+	private $delimiter_at;
+
+	/**
+	 * Byte length of full span of delimiter.
+	 *
+	 * @since {WP_VERSION}
+	 *
+	 * @var int
+	 */
+	private $delimiter_length;
+
+	/**
+	 * Byte offset where namespace span begins.
+	 *
+	 * @since {WP_VERSION}
+	 *
+	 * @var int
+	 */
+	private $namespace_at;
+
+	/**
+	 * Byte length of namespace span, or `0` if implicitly in the "core" namespace.
+	 *
+	 * @since {WP_VERSION}
+	 *
+	 * @var int
+	 */
+	private $namespace_length;
+
+	/**
+	 * Byte offset where block name span begins.
+	 *
+	 * @since {WP_VERSION}
+	 *
+	 * @var int
+	 */
+	private $name_at;
+
+	/**
+	 * Byte length of block name span.
+	 *
+	 * @since {WP_VERSION}
+	 *
+	 * @var int
+	 */
+	private $name_length;
+
+	/**
+	 * Byte offset where JSON attributes span begins.
+	 *
+	 * @since {WP_VERSION}
+	 *
+	 * @var int
+	 */
+	private $json_at;
+
+	/**
+	 * Byte length of JSON attributes span, or `0` if none are present.
+	 *
+	 * @since {WP_VERSION}
+	 *
+	 * @var int
+	 */
+	private $json_length;
+
+	/**
+	 * Indicates what kind of block comment delimiter this represents.
+	 *
+	 * One of:
+	 *
+	 *  - `static::OPENER` If the delimiter is opening a block.
+	 *  - `static::CLOSER` If the delimiter is closing an open block.
+	 *  - `static::VOID`   If the delimiter represents a void block with no inner content.
+	 *
+	 * If a parsed comment delimiter contains both the closing and the void
+	 * flags then it will be interpreted as a block closer, and the void flag
+	 * will be considered a mistake.
+	 *
+	 * @since {WP_VERSION}
+	 *
+	 * @var string
+	 */
+	private $type;
+
+	/**
+	 * Finds the next block delimiter in a text document and returns a parsed
+	 * block delimiter info record if it parses, otherwise returns `null`.
+	 *
+	 * Block comment delimiters must be valid HTML comments and may contain JSON.
+	 * This search does not determine, however, if the JSON is valid.
+	 *
+	 * Example delimiters:
+	 *
+	 *     `<!-- wp:paragraph {"dropCap": true} -->`
+	 *     `<!-- wp:separator /-->`
+	 *     `<!-- /wp:paragraph -->`
+	 *
+	 * In the case that a block comment delimiter contains both the void indicator and
+	 * also the closing indicator, it will be treated as a block closing delimiter.
+	 *
+	 * Example:
+	 *
+	 *     // Find all image block opening delimiters.
+	 *     $at     = 0;
+	 *     $end    = strlen( $html );
+	 *     $images = array();
+	 *     while ( $at < $end ) {
+	 *         $delimiter = WP_Parsed_Block_Delimiter_Info::next_delimiter( $html, $at, $next_at, $next_length );
+	 *         if ( ! isset( $delimiter ) ) {
+	 *             break;
+	 *         }
+	 *
+	 *         if (
+	 *             WP_Parsed_Block_Delimiter_Info::OPENER === $delimiter->get_delimiter_type() &&
+	 *             $delimiter->is_block_type( 'core/image' )
+	 *         ) {
+	 *             $images[] = $delimiter;
+	 *         }
+	 *
+	 *         $at = $next_at + $next_length;
+	 *     }
+	 *
+	 * @param string   $text                 Input document possibly containing block comment delimiters.
+	 * @param int      $starting_byte_offset Where in the input document to begin searching.
+	 * @param int|null $match_byte_offset    Optional. When provided, will be set to the byte offset in
+	 *                                       the input document where the delimiter was found, if one
+	 *                                       is found, otherwise not set.
+	 * @param int|null $match_byte_length    Optional. When provided, will be set to the byte length of
+	 *                                       the matched delimiter if one is found, otherwise not set.
+	 * @return WP_Parsed_Block_Delimiter_Info|null Parsed block delimiter info record if found, otherwise `null`.
+	 */
+	public static function next_delimiter( string $text, int $starting_byte_offset, int &$match_byte_offset = null, int &$match_byte_length = null ): ?WP_Parsed_Block_Delimiter_Info {
+		$end                = strlen( $text );
+		$at                 = $starting_byte_offset;
+		$delimiter          = null;
+		static::$last_error = null;
+
+		while ( $at < $end ) {
+			// Find the next possible opening.
+			$comment_opening_at = strpos( $text, '<!--', $at );
+			if ( false === $comment_opening_at ) {
+				++$at;
+				continue;
+			}
+
+			$opening_whitespace_at     = $comment_opening_at + 4;
+			$opening_whitespace_length = strspn( $text, " \t\f\r\n", $opening_whitespace_at );
+			if ( 0 === $opening_whitespace_length ) {
+				++$at;
+				continue;
+			}
+
+			$wp_prefix_at = $opening_whitespace_at + $opening_whitespace_length;
+			if ( $wp_prefix_at >= $end ) {
+				static::$last_error = self::INCOMPLETE_INPUT;
+				return null;
+			}
+
+			$has_closer = false;
+			if ( '/' === $text[ $wp_prefix_at ] ) {
+				$has_closer = true;
+				++$wp_prefix_at;
+			}
+
+			if ( 0 !== substr_compare( $text, 'wp:', $wp_prefix_at, 3 ) ) {
+				++$at;
+				continue;
+			}
+
+			$namespace_at = $wp_prefix_at + 3;
+			if ( $namespace_at >= $end ) {
+				static::$last_error = self::INCOMPLETE_INPUT;
+				return null;
+			}
+
+			$start_of_namespace = $text[ $namespace_at ];
+
+			// The namespace must start with a-z.
+			if ( 'a' > $start_of_namespace || 'z' < $start_of_namespace ) {
+				++$at;
+				continue;
+			}
+
+			$namespace_length = 1 + strspn( $text, 'abcdefghijklmnopqrstuvwxyz0123456789-_', $namespace_at + 1 );
+			$separator_at     = $namespace_at + $namespace_length;
+			if ( $separator_at >= $end ) {
+				static::$last_error = self::INCOMPLETE_INPUT;
+				return null;
+			}
+
+			$has_separator = '/' === $text[ $separator_at ];
+			if ( $has_separator ) {
+				$name_at       = $separator_at + 1;
+				$start_of_name = $text[ $name_at ];
+				if ( 'a' > $start_of_name || 'z' < $start_of_name ) {
+					++$at;
+					continue;
+				}
+
+				$name_length = 1 + strspn( $text, 'abcdefghijklmnopqrstuvwxyz0123456789-_', $name_at + 1 );
+			} else {
+				$name_at          = $namespace_at;
+				$name_length      = $namespace_length;
+				$namespace_length = 0;
+			}
+
+			$after_name_whitespace_at     = $name_at + $name_length;
+			$after_name_whitespace_length = strspn( $text, " \t\f\r\n", $after_name_whitespace_at );
+			if ( 0 === $after_name_whitespace_length ) {
+				++$at;
+				continue;
+			}
+
+			$json_at = $after_name_whitespace_at + $after_name_whitespace_length;
+			if ( $json_at >= $end ) {
+				static::$last_error = self::INCOMPLETE_INPUT;
+				return null;
+			}
+			$has_json    = '{' === $text[ $json_at ];
+			$json_length = 0;
+
+			/*
+			 * For the final span of the delimiter it's most efficient to find the end
+			 * of the HTML comment and work backwards. This prevents complicated parsing
+			 * inside the JSON span, which cannot contain the HTML comment terminator.
+			 */
+			$comment_closing_at = strpos( $text, '-->', $json_at );
+			if ( false === $comment_closing_at ) {
+				static::$last_error = self::INCOMPLETE_INPUT;
+				return null;
+			}
+
+			/*
+			 * It looks like this logic leaves an error in here, when the position
+			 * overlaps the JSON or block name. However, for neither of those is it
+			 * possible to parse a valid block if that last overlapping character
+			 * is the void flag. This, therefore, will be valid regardless of how
+			 * the rest of the comment delimiter is written.
+			 */
+			if ( '/' === $text[ $comment_closing_at - 1 ] ) {
+				$has_void_flag    = true;
+				$void_flag_length = 1;
+			} else {
+				$has_void_flag    = false;
+				$void_flag_length = 0;
+			}
+
+			/*
+			 * If there's no JSON, then the span of text after the name
+			 * until the comment closing must be completely whitespace.
+			 */
+			if ( ! $has_json ) {
+				$max_whitespace_length = $comment_closing_at - $json_at - $void_flag_length;
+
+				// This shouldn't be possible, but it can't be allowed regardless.
+				if ( $max_whitespace_length < 0 ) {
+					++$at;
+					continue;
+				}
+
+				$closing_whitespace_length = strspn( $text, " \t\f\r\n", $json_at, $comment_closing_at - $json_at - $void_flag_length );
+				if ( 0 === $after_name_whitespace_length + $closing_whitespace_length ) {
+					++$at;
+					continue;
+				}
+
+				// This must be a block delimiter!
+				$delimiter = new static();
+				break;
+			}
+
+			// There's no JSON, so attempt to find its boundary.
+			$after_json_whitespace_length = 0;
+			for ( $char_at = $comment_closing_at - $void_flag_length - 1; $char_at > $json_at; $char_at-- ) {
+				$char = $text[ $char_at ];
+
+				switch ( $char ) {
+					case ' ':
+					case "\t":
+					case "\f":
+					case "\r":
+					case "\n":
+						++$after_json_whitespace_length;
+						continue 2;
+
+					case '}':
+						$json_length = $char_at - $json_at + 1;
+						break 2;
+
+					default:
+						++$at;
+						continue 3;
+				}
+			}
+
+			if ( 0 === $json_length || 0 === $after_json_whitespace_length ) {
+				++$at;
+				continue;
+			}
+
+			// This must be a block delimiter!
+			$delimiter = new static();
+			break;
+		}
+
+		if ( null === $delimiter ) {
+			return null;
+		}
+
+		$delimiter->source_text = $text;
+
+		$delimiter->delimiter_at     = $comment_opening_at;
+		$delimiter->delimiter_length = $comment_closing_at + 3 - $comment_opening_at;
+
+		$delimiter->namespace_at     = $namespace_at;
+		$delimiter->namespace_length = $namespace_length;
+
+		$delimiter->name_at     = $name_at;
+		$delimiter->name_length = $name_length;
+
+		$delimiter->json_at     = $json_at;
+		$delimiter->json_length = $json_length;
+
+		$delimiter->type = $has_closer ? static::CLOSER : ( $has_void_flag ? static::VOID : static::OPENER );
+
+		$match_byte_offset = $delimiter->delimiter_at;
+		$match_byte_length = $delimiter->delimiter_length;
+
+		return $delimiter;
+	}
+
+	/**
+	 * Constructor function.
+	 */
+	private function __construct() {
+		// This is not to be called from the outside.
+	}
+
+	/**
+	 * Indicates if the last attempt to parse a block comment delimiter
+	 * failed, if set, otherwise `null` if the last attempt succeeded.
+	 *
+	 * @return string|null
+	 */
+	public static function get_last_error() {
+		return static::$last_error;
+	}
+
+	/**
+	 * Allocates a substring from the source text containing the delimiter
+	 * and releases the reference to the source text.
+	 *
+	 * Use this function when the delimiter is holding on to the source
+	 * text and preventing it from being freed by PHP. This function incurs
+	 * a string allocation, however, so if the source text will be retained
+	 * anyway there's no need to detach, as that memory cannot be freed.
+	 *
+	 * This is a low-level function available for controlling the performance
+	 * of sensitive hot-paths. You probably don't need this.
+	 *
+	 * Example:
+	 *
+	 *     function first_block( $html ) {
+	 *         return WP_Parsed_Block_Delimiter_Info::next_delimiter( $really_long_html, 0 );
+	 *     }
+	 *
+	 *     $delimiter = first_block( $really_long_html_document );
+	 *     // `$really_long_html_document` is still retained inside `$delimiter`, which could lead to a memory leak.
+	 *
+	 *     $delimiter->allocate_and_detach_from_source_text();
+	 *     // `$really_long_html_document` is no longer referenced, and its memory may be freed or used for something else.
+	 *
+	 * @since {WP_VERSION}
+	 *
+	 * @return void
+	 */
+	public function allocate_and_detach_from_source_text(): void {
+		$this->source_text = substr( $this->source_text, $this->delimiter_at, $this->delimiter_length );
+
+		$byte_delta = $this->delimiter_at;
+
+		$this->delimiter_at -= $byte_delta;
+		$this->namespace_at -= $byte_delta;
+		$this->name_at      -= $byte_delta;
+		$this->json_at      -= $byte_delta;
+	}
+
+	/**
+	 * Returns the type of the block comment delimiter.
+	 *
+	 * One of:
+	 *
+	 *  - `static::OPENER`
+	 *  - `static::CLOSER`
+	 *  - `static::VOID`
+	 *
+	 * @since {WP_VERSION}
+	 *
+	 * @return string type of the block comment delimiter.
+	 */
+	public function get_delimiter_type(): string {
+		return $this->type;
+	}
+
+	/**
+	 * Indicates if the block delimiter represents a block of the given type.
+	 *
+	 * Since the "core" namespace may be implicit, it's allowable to pass
+	 * either the fully-qualified block type with namespace and block name
+	 * as well as the shorthand version only containing the block name, if
+	 * the desired block is in the "core" namespace.
+	 *
+	 * Example:
+	 *
+	 *     $is_core_paragraph = $delimiter->is_block_type( 'paragraph' );
+	 *     $is_core_paragraph = $delimiter->is_block_type( 'core/paragraph' );
+	 *     $is_formula        = $delimiter->is_block_type( 'math-block/formula' );
+	 *
+	 * @since {WP_VERSION}
+	 *
+	 * @param string $block_type Block type name for the desired block.
+	 *                           E.g. "paragraph", "core/paragraph", "math-blocks/formula".
+	 * @return bool Whether this delimiter represents a block of the given type.
+	 */
+	public function is_block_type( string $block_type ): bool {
+		$slash_at = strpos( $block_type, '/' );
+		if ( false === $slash_at ) {
+			$namespace  = 'core';
+			$block_name = $block_type;
+		} else {
+			$namespace  = substr( $block_type, 0, $slash_at );
+			$block_name = substr( $block_type, $slash_at + 1 );
+		}
+
+		// Only the 'core' namespace is allowed to be omitted.
+		if ( 0 === $this->name_length && 'core' !== $namespace ) {
+			return false;
+		}
+
+		// If given an explicit namespace, they must match.
+		if (
+			strlen( $namespace ) !== $this->namespace_length ||
+			0 !== substr_compare( $this->source_text, $namespace, $this->namespace_at, $this->namespace_length )
+		) {
+			return false;
+		}
+
+		// The block name must match.
+		return (
+			strlen( $block_name ) === $this->name_length &&
+			0 === substr_compare( $this->source_text, $block_name, $this->name_at, $this->name_length )
+		);
+	}
+
+	/**
+	 * Allocates a substring for the block type and returns the
+	 * fully-qualified name, including the namespace.
+	 *
+	 * This function allocates a substring for the given block type. This
+	 * allocation will be small and likely fine in most cases, but it's
+	 * preferable to call {@link static::is_block_type} if only needing
+	 * to know whether the delimiter is for a given block type, as that
+	 * function is more efficient for this purpose and avoids the allocation.
+	 *
+	 * Example:
+	 *
+	 *     'core/paragraph' = $delimiter->allocate_and_return_block_type();
+	 *
+	 * @since {WP_VERSION}
+	 *
+	 * @return string Fully-qualified block namespace and type, e.g. "core/paragraph".
+	 */
+	public function allocate_and_return_block_type(): string {
+		// This is implicitly in the "core" namespace.
+		if ( 0 === $this->namespace_length ) {
+			$block_name = substr( $this->source_text, $this->name_at, $this->name_length );
+			return "core/{$block_name}";
+		}
+
+		return substr( $this->source_text, $this->namespace_at, $this->namespace_length + $this->name_length + 1 );
+	}
+
+	/**
+	 * Returns a lazy wrapper around the block attributes, which can be used
+	 * for efficiently interacting with the JSON attributes.
+	 *
+	 * @throws Exception This function is not yet implement.
+	 *
+	 * @since {WP_VERSION}
+	 *
+	 * @return void
+	 */
+	public function get_attributes(): void {
+		throw new Exception( 'Lazy attribute parsing not yet supported' );
+	}
+
+	/**
+	 * Attempts to parse and return the entire JSON attributes from the delimiter,
+	 * allocating memory and processing the JSON span in the process.
+	 *
+	 * This does not return any parsed attributes for a closing block delimiter
+	 * even if there is a span of JSON content; this JSON is a parsing error.
+	 *
+	 * Consider calling {@link static::get_attributes} instead if it's not
+	 * necessary to read all the attributes at the same time, as that provides
+	 * a more efficient mechanism for typical use cases.
+	 *
+	 * Since the JSON span inside the comment delimiter may not be valid JSON,
+	 * this function will return `null` if it cannot parse the span.
+	 *
+	 * If the delimiter contains no JSON span, it will also return `null`.
+	 * Calling code will need to differentiate the lack of attributes from
+	 * an empty array containing no attributes.
+	 *
+	 * Example:
+	 *
+	 *     $delimiter = WP_Parsed_Block_Delimiter_Info::next_delimiter( '<!-- wp:image {"url": "https://wordpress.org/favicon.ico"} -->', 0 );
+	 *     $memory_hungry_and_slow_attributes = $delimiter->allocate_and_return_parsed_attributes();
+	 *     $memory_hungry_and_slow_attributes === array( 'url' => 'https://wordpress.org/favicon.ico' );
+	 *
+	 *     $delimiter = WP_Parsed_Block_Delimiter_Info::next_delimiter( '<!-- /wp:image {"url": "https://wordpress.org/favicon.ico"} -->', 0 );
+	 *     null       = $delimiter->allocate_and_return_parsed_attributes();
+	 *
+	 *     $delimiter = WP_Parsed_Block_Delimiter_Info::next_delimiter( '<!-- wp:separator {} /-->', 0 );
+	 *     array()    === $delimiter->allocate_and_return_parsed_attributes();
+	 *
+	 *     $delimiter = WP_Parsed_Block_Delimiter_Info::next_delimiter( '<!-- wp:separator /-->', 0 );
+	 *     null       = $delimiter->allocate_and_return_parsed_attributes();
+	 *
+	 * @since {WP_VERSION}
+	 *
+	 * @return array|null Parsed JSON attributes, if present and valid, otherwise `null`.
+	 */
+	public function allocate_and_return_parsed_attributes(): ?array {
+		if ( static::CLOSER === $this->type ) {
+			return null;
+		}
+
+		if ( 0 === $this->json_length ) {
+			return null;
+		}
+
+		$json_span = substr( $this->source_text, $this->json_at, $this->json_length );
+		$parsed    = json_decode( $json_span, null, 512, JSON_OBJECT_AS_ARRAY | JSON_INVALID_UTF8_SUBSTITUTE );
+
+		return ( JSON_ERROR_NONE === json_last_error() && is_array( $parsed ) ) ? $parsed : null;
+	}
+
+	// Debugging methods not meant for production use.
+
+	/**
+	 * Prints a debugging message showing the structure of the parsed delimiter.
+	 *
+	 * This is not meant to be used in production!
+	 *
+	 * @access private
+	 *
+	 * @since {WP_VERSION}
+	 *
+	 * @return void
+	 */
+	public function debug_print_structure(): void {
+		$c = ( ! defined( 'STDOUT' ) || posix_isatty( STDOUT ) )
+			? function ( $color = null ) { return $color; } // phpcs:ignore
+			: function ( $color ) { return ''; }; // phpcs:ignore
+
+		$namespace  = substr( $this->source_text, $this->namespace_at, $this->namespace_length );
+		$slash      = 0 === $this->namespace_length ? '' : '/';
+		$block_name = substr( $this->source_text, $this->name_at, $this->name_length );
+		$closer     = static::CLOSER === $this->type ? '/' : '';
+		$json       = substr( $this->source_text, $this->json_at, $this->json_length );
+
+		$opener_whitespace_at     = $this->delimiter_at + 4;
+		$opener_whitespace_length = $this->namespace_at - 3 - $opener_whitespace_at - ( static::CLOSER === $this->type ? 1 : 0 );
+
+		$after_name_whitespace_at     = $this->name_at + $this->name_length;
+		$after_name_whitespace_length = $this->json_at - $after_name_whitespace_at;
+
+		$closing_whitespace_at     = $this->json_at + $this->json_length;
+		$closing_whitespace_length = $this->delimiter_at + $this->delimiter_length - 3 - $closing_whitespace_at;
+
+		if ( '/' === $this->source_text[ $this->delimiter_at + $this->delimiter_length - 4 ] ) {
+			$void_flag = '/';
+			--$closing_whitespace_length;
+		} else {
+			$void_flag = '';
+		}
+
+		$w = function ( $whitespace ) use ( $c ) {
+			return $c( "\e[2;90m" ) . str_replace( array( ' ', "\t", "\f", "\r", "\n" ), array( '␣', '␉', '␌', '␍', '␤' ), $whitespace );
+		};
+
+		echo "{$c( "\e[90m" )}<!--"; // phpcs:ignore
+		echo $w( substr( $this->source_text, $opener_whitespace_at, $opener_whitespace_length ) ); // phpcs:ignore
+		echo "{$c( "\e[0;31m" )}{$closer}"; // phpcs:ignore
+		echo "{$c("\e[90m" )}wp:{$c( "\e[2;34m" )}{$namespace}"; // phpcs:ignore
+		echo "{$c( "\e[2;90m" )}{$slash}"; // phpcs:ignore
+		echo "{$c( "\e[0;34m" )}{$block_name}"; // phpcs:ignore
+		echo $w( substr( $this->source_text, $after_name_whitespace_at, $after_name_whitespace_length ) ); // phpcs:ignore
+		echo "{$c("\e[0;2;32m" )}{$json}"; // phpcs:ignore
+		echo $w( substr( $this->source_text, $closing_whitespace_at, $closing_whitespace_length ) ); // phpcs:ignore
+		echo "{$c( "\e[0;36m" )}{$void_flag}{$c("\e[90m")}-->\n"; // phpcs:ignore
+	}
+
+	// Constant declarations that would otherwise pollute the top of the class.
+
+	/**
+	 * Indicates that the block comment delimiter closes an open block.
+	 *
+	 * @since {WP_VERSION}
+	 */
+	const CLOSER = 'closer';
+
+	/**
+	 * Indicates that the parser started parsing a block comment delimiter, but
+	 * the input document ended before it could finish. The document was likely truncated.
+	 *
+	 * @since {WP_VERSION}
+	 */
+	const INCOMPLETE_INPUT = 'incomplete-input';
+
+	/**
+	 * Indicates that the block comment delimiter opens a block.
+	 *
+	 * @since {WP_VERSION}
+	 */
+	const OPENER = 'opener';
+
+	/**
+	 * Indicates that the parser has not yet attempted to parse a block comment delimiter.
+	 *
+	 * @since {WP_VERSION}
+	 */
+	const UNINITIALIZED = 'uninitialized';
+
+	/**
+	 * Indicates that the block comment delimiter represents a void block
+	 * with no inner content of any kind.
+	 *
+	 * @since {WP_VERSION}
+	 */
+	const VOID = 'void';
+}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1289,6 +1289,123 @@ function make_after_block_visitor( $hooked_blocks, $context, $callback = 'insert
 }
 
 /**
+ * Returns a regular expression which can be used to find
+ * block comment delimiters in a given HTML document.
+ *
+ * Returned matches contain named capture groups:
+ *  - 'closer' is '/' if the delimiter is a block closer.
+ *  - 'namespace' is non-empty if a block namespace was provided,
+ *    otherwise the block name is assumed to be in the "core/" namespace.
+ *  - 'name' is the block name, always non-empty.
+ *  - 'attrs' contains the content which may be JSON, if non-empty.
+ *  - 'void' is '/' if the delimiter indicates a void block.
+ *
+ * Example:
+ *
+ *     if ( 1 === preg_match( get_block_delimiter_regex(), $block_content, $delimiter_match ) ) {
+ *         $is_closer  = '/' === $delimiter_match['closer'];
+ *         $is_void    = '/' === $delimiter_match['void'];
+ *         $block_name = ( $delimiter_match['namespace'] ?? 'core/' ) . $delimiter_match['name'];
+ *         $attrs      = array();
+ *         if ( ! $is_closer ) {
+ *             $json = json_decode( $delimiter_match['attrs'] );
+ *             if ( JSON_ERROR_NONE === json_last_error() ) {
+ *                 $attrs = $json;
+ *             }
+ *         }
+ *     }
+ *
+ * @since {WP_VERSION}
+ *
+ * @return string PCRE pattern which can be used to find and parse block delimiter HTML comments.
+ */
+function get_block_delimiter_regex(): string {
+	return <<<'REGEXP'
+~
+<!--
+	\s+
+	(?P<closer>/)?                                                 # This pattern also detects closing block delimiters.
+	wp:(?P<namespace>[a-z][a-z0-9_-]*/)?(?P<name>[a-z][a-z0-9_-]*) # e.g. "core/paragraph", "paragraph", or "math-blocks/formula".
+	\s+
+	(?P<attrs>{(?:(?:[^}]+|}+(?=})|(?!}\s+/?-->).)*+)?}\s+)?       # It's required to parse the JSON separately, if it exists.
+	(?P<void>/)?                                                   # Void blocks have no content and no closer.
+-->
+~sx
+REGEXP;
+}
+
+/**
+ * Returns a regular expression which can be used to find block comment
+ * delimiters for a given block type in a given HTML document.
+ *
+ * Returned matches contain named capture groups:
+ *  - 'closer' is '/' if the delimiter is a block closer.
+ *  - 'namespace' is non-empty if a block namespace was provided,
+ *    otherwise the block name is assumed to be in the "core/" namespace.
+ *  - 'name' is the block name, always non-empty.
+ *  - 'attrs' contains the content which may be JSON, if non-empty.
+ *  - 'void' is '/' if the delimiter indicates a void block.
+ *
+ * Example:
+ *
+ *     if ( 1 === preg_match( get_named_block_delimiter_regex( 'core/image' ), $block_content, $delimiter_match ) ) {
+ *         $is_closer  = '/' === $delimiter_match['closer'];
+ *         $is_void    = '/' === $delimiter_match['void'];
+ *         $block_name = ( $delimiter_match['namespace'] ?? 'core/' ) . $delimiter_match['name'];
+ *         $attrs      = array();
+ *         if ( ! $is_closer ) {
+ *             $json = json_decode( $delimiter_match['attrs'] );
+ *             if ( JSON_ERROR_NONE === json_last_error() ) {
+ *                 $attrs = $json;
+ *             }
+ *         }
+ *     }
+ *
+ * @since {WP_VERSION}
+ *
+ * @param string $block_name Namespace and name of block, e.g. "math-blocks/formula".
+ *                           Defaults to "core" namespace if none is provided.
+ * @return string PCRE pattern which can be used to find and parse block delimiter HTML comments.
+ */
+function get_named_block_delimiter_regex( string $block_name ): string {
+	$slash_at  = strpos( $block_name, '/' );
+	$namespace = false === $slash_at ? 'core' : substr( $block_name, 0, $slash_at );
+	$name      = false === $slash_at ? substr( $block_name, $slash_at + 1 ) : $block_name;
+	$is_core   = 'core' === $namespace;
+
+	$namespace = preg_quote( $namespace, '~' );
+	$name      = preg_quote( $name, '~' );
+
+	if ( $is_core ) {
+		return <<<REGEXP
+~
+<!--
+	\s+
+	(?P<closer>/)?                                           # This pattern also detects closing block delimiters.
+	wp:(?P<namespace>core/)?(?P<name>{$name})                # e.g. "core/paragraph", "paragraph".
+	\s+
+	(?P<attrs>{(?:(?:[^}]+|}+(?=})|(?!}\s+/?-->).)*+)?}\s+)? # It's required to parse the JSON separately, if it exists.
+	(?P<void>/)?                                             # Void blocks have no content and no closer.
+-->
+~sx
+REGEXP;
+	}
+
+	return <<<REGEXP
+~
+<!--
+	\s+
+	(?P<closer>/)?                                           # This pattern also detects closing block delimiters.
+	wp:(?P<namespace>{$namespace}/)(?P<name>{$name})         # e.g. "math-blocks/formula".
+	\s+
+	(?P<attrs>{(?:(?:[^}]+|}+(?=})|(?!}\s+/?-->).)*+)?}\s+)? # It's required to parse the JSON separately, if it exists.
+	(?P<void>/)?                                             # Void blocks have no content and no closer.
+-->
+~sx
+REGEXP;
+}
+
+/**
  * Given an array of attributes, returns a string in the serialized attributes
  * format prepared for post content.
  *

--- a/src/wp-includes/class-wp-block-parser.php
+++ b/src/wp-includes/class-wp-block-parser.php
@@ -244,13 +244,7 @@ class WP_Block_Parser {
 		 * a closer has no attributes). we can trap them both and process the
 		 * match back in PHP to see which one it was.
 		 */
-		$has_match = preg_match(
-			'/<!--\s+(?P<closer>\/)?wp:(?P<namespace>[a-z][a-z0-9_-]*\/)?(?P<name>[a-z][a-z0-9_-]*)\s+(?P<attrs>{(?:(?:[^}]+|}+(?=})|(?!}\s+\/?-->).)*+)?}\s+)?(?P<void>\/)?-->/s',
-			$this->document,
-			$matches,
-			PREG_OFFSET_CAPTURE,
-			$this->offset
-		);
+		$has_match = preg_match( get_block_delimiter_regex(), $this->document, $matches, PREG_OFFSET_CAPTURE, $this->offset );
 
 		// if we get here we probably have catastrophic backtracking or out-of-memory in the PCRE.
 		if ( false === $has_match ) {

--- a/src/wp-includes/class-wp-block-parser.php
+++ b/src/wp-includes/class-wp-block-parser.php
@@ -88,47 +88,52 @@ class WP_Block_Parser {
 	 * @return bool
 	 */
 	public function proceed() {
-		$next_token = $this->next_token();
-		list( $token_type, $block_name, $attrs, $start_offset, $token_length ) = $next_token;
+		$delimiter   = WP_Parsed_Block_Delimiter_Info::next_delimiter( $this->document, $this->offset, $delimiter_at, $delimiter_length );
 		$stack_depth = count( $this->stack );
 
-		// we may have some HTML soup before the next block.
-		$leading_html_start = $start_offset > $this->offset ? $this->offset : null;
-
-		switch ( $token_type ) {
-			case 'no-more-tokens':
-				// if not in a block then flush output.
-				if ( 0 === $stack_depth ) {
-					$this->add_freeform();
-					return false;
-				}
-
-				/*
-				 * Otherwise we have a problem
-				 * This is an error
-				 *
-				 * we have options
-				 * - treat it all as freeform text
-				 * - assume an implicit closer (easiest when not nesting)
-				 */
-
-				// for the easy case we'll assume an implicit closer.
-				if ( 1 === $stack_depth ) {
-					$this->add_block_from_stack();
-					return false;
-				}
-
-				/*
-				 * for the nested case where it's more difficult we'll
-				 * have to assume that multiple closers are missing
-				 * and so we'll collapse the whole stack piecewise
-				 */
-				while ( 0 < count( $this->stack ) ) {
-					$this->add_block_from_stack();
-				}
+		if ( ! isset( $delimiter ) ) {
+			// if not in a block then flush output.
+			if ( 0 === $stack_depth ) {
+				$this->add_freeform();
 				return false;
+			}
 
-			case 'void-block':
+			/*
+			 * Otherwise we have a problem
+			 * This is an error
+			 *
+			 * we have options
+			 * - treat it all as freeform text
+			 * - assume an implicit closer (easiest when not nesting)
+			 */
+
+			// for the easy case we'll assume an implicit closer.
+			if ( 1 === $stack_depth ) {
+				$this->add_block_from_stack();
+				return false;
+			}
+
+			/*
+			 * For the nested case where it's more difficult we'll
+			 * have to assume that multiple closers are missing
+			 * and so we'll collapse the whole stack piecewise
+			 *
+			 * The count of the stack changes during each iteration of the loop.
+			 */
+			while ( 0 < count( $this->stack ) ) { // phpcs:ignore
+				$this->add_block_from_stack();
+			}
+			return false;
+		}
+
+		// we may have some HTML soup before the next block.
+		$leading_html_start = $delimiter_at > $this->offset ? $this->offset : null;
+
+		switch ( $delimiter->get_delimiter_type() ) {
+			case WP_Parsed_Block_Delimiter_Info::VOID:
+				$block_name = $delimiter->allocate_and_return_block_type();
+				$attrs      = $delimiter->allocate_and_return_parsed_attributes() ?? array();
+
 				/*
 				 * easy case is if we stumbled upon a void block
 				 * in the top-level of the document
@@ -139,41 +144,44 @@ class WP_Block_Parser {
 							substr(
 								$this->document,
 								$leading_html_start,
-								$start_offset - $leading_html_start
+								$delimiter_at - $leading_html_start
 							)
 						);
 					}
 
 					$this->output[] = (array) new WP_Block_Parser_Block( $block_name, $attrs, array(), '', array() );
-					$this->offset   = $start_offset + $token_length;
+					$this->offset   = $delimiter_at + $delimiter_length;
 					return true;
 				}
 
 				// otherwise we found an inner block.
 				$this->add_inner_block(
 					new WP_Block_Parser_Block( $block_name, $attrs, array(), '', array() ),
-					$start_offset,
-					$token_length
+					$delimiter_at,
+					$delimiter_length
 				);
-				$this->offset = $start_offset + $token_length;
+				$this->offset = $delimiter_at + $delimiter_length;
 				return true;
 
-			case 'block-opener':
+			case WP_Parsed_Block_Delimiter_Info::OPENER:
+				$block_name = $delimiter->allocate_and_return_block_type();
+				$attrs      = $delimiter->allocate_and_return_parsed_attributes() ?? array();
+
 				// track all newly-opened blocks on the stack.
 				array_push(
 					$this->stack,
 					new WP_Block_Parser_Frame(
 						new WP_Block_Parser_Block( $block_name, $attrs, array(), '', array() ),
-						$start_offset,
-						$token_length,
-						$start_offset + $token_length,
+						$delimiter_at,
+						$delimiter_length,
+						$delimiter_at + $delimiter_length,
 						$leading_html_start
 					)
 				);
-				$this->offset = $start_offset + $token_length;
+				$this->offset = $delimiter_at + $delimiter_length;
 				return true;
 
-			case 'block-closer':
+			case WP_Parsed_Block_Delimiter_Info::CLOSER:
 				/*
 				 * if we're missing an opener we're in trouble
 				 * This is an error
@@ -191,8 +199,8 @@ class WP_Block_Parser {
 
 				// if we're not nesting then this is easy - close the block.
 				if ( 1 === $stack_depth ) {
-					$this->add_block_from_stack( $start_offset );
-					$this->offset = $start_offset + $token_length;
+					$this->add_block_from_stack( $delimiter_at );
+					$this->offset = $delimiter_at + $delimiter_length;
 					return true;
 				}
 
@@ -201,18 +209,18 @@ class WP_Block_Parser {
 				 * block and add it as a new innerBlock to the parent
 				 */
 				$stack_top                        = array_pop( $this->stack );
-				$html                             = substr( $this->document, $stack_top->prev_offset, $start_offset - $stack_top->prev_offset );
+				$html                             = substr( $this->document, $stack_top->prev_offset, $delimiter_at - $stack_top->prev_offset );
 				$stack_top->block->innerHTML     .= $html;
 				$stack_top->block->innerContent[] = $html;
-				$stack_top->prev_offset           = $start_offset + $token_length;
+				$stack_top->prev_offset           = $delimiter_at + $delimiter_length;
 
 				$this->add_inner_block(
 					$stack_top->block,
 					$stack_top->token_start,
 					$stack_top->token_length,
-					$start_offset + $token_length
+					$delimiter_at + $delimiter_length
 				);
-				$this->offset = $start_offset + $token_length;
+				$this->offset = $delimiter_at + $delimiter_length;
 				return true;
 
 			default:
@@ -228,69 +236,34 @@ class WP_Block_Parser {
 	 *
 	 * Returns the type of the find: kind of find, block information, attributes
 	 *
+	 * @deprecated {WP_VERSION} Replaced by WP_Parsed_Block_Delimiter_Info.
+	 *
 	 * @internal
 	 * @since 5.0.0
 	 * @since 4.6.1 fixed a bug in attribute parsing which caused catastrophic backtracking on invalid block comments
+	 * @since {WP_VERSION} Relies on the WP_Parsed_Block_Delimiter_Info class for parsing.
+	 *
 	 * @return array
 	 */
 	public function next_token() {
-		$matches = null;
-
-		/*
-		 * aye the magic
-		 * we're using a single RegExp to tokenize the block comment delimiters
-		 * we're also using a trick here because the only difference between a
-		 * block opener and a block closer is the leading `/` before `wp:` (and
-		 * a closer has no attributes). we can trap them both and process the
-		 * match back in PHP to see which one it was.
-		 */
-		$has_match = preg_match( get_block_delimiter_regex(), $this->document, $matches, PREG_OFFSET_CAPTURE, $this->offset );
-
-		// if we get here we probably have catastrophic backtracking or out-of-memory in the PCRE.
-		if ( false === $has_match ) {
+		$delimiter = WP_Parsed_Block_Delimiter_Info::next_delimiter( $this->document, $this->offset, $delimiter_at, $delimiter_length );
+		if ( ! isset( $delimiter ) ) {
 			return array( 'no-more-tokens', null, null, null, null );
 		}
 
-		// we have no more tokens.
-		if ( 0 === $has_match ) {
-			return array( 'no-more-tokens', null, null, null, null );
+		$name  = $delimiter->allocate_and_return_block_type();
+		$attrs = $delimiter->allocate_and_return_parsed_attributes() ?? array();
+
+		switch ( $delimiter->get_delimiter_type() ) {
+			case WP_Parsed_Block_Delimiter_Info::VOID:
+				return array( 'void-block', $name, $attrs, $delimiter_at, $delimiter_length );
+
+			case WP_Parsed_Block_Delimiter_Info::CLOSER:
+				return array( 'block-closer', $name, null, $delimiter_at, $delimiter_length );
+
+			case WP_Parsed_Block_Delimiter_Info::OPENER:
+				return array( 'block-opener', $name, $attrs, $delimiter_at, $delimiter_length );
 		}
-
-		list( $match, $started_at ) = $matches[0];
-
-		$length    = strlen( $match );
-		$is_closer = isset( $matches['closer'] ) && -1 !== $matches['closer'][1];
-		$is_void   = isset( $matches['void'] ) && -1 !== $matches['void'][1];
-		$namespace = $matches['namespace'];
-		$namespace = ( isset( $namespace ) && -1 !== $namespace[1] ) ? $namespace[0] : 'core/';
-		$name      = $namespace . $matches['name'][0];
-		$has_attrs = isset( $matches['attrs'] ) && -1 !== $matches['attrs'][1];
-
-		/*
-		 * Fun fact! It's not trivial in PHP to create "an empty associative array" since all arrays
-		 * are associative arrays. If we use `array()` we get a JSON `[]`
-		 */
-		$attrs = $has_attrs
-			? json_decode( $matches['attrs'][0], /* as-associative */ true )
-			: array();
-
-		/*
-		 * This state isn't allowed
-		 * This is an error
-		 */
-		if ( $is_closer && ( $is_void || $has_attrs ) ) {
-			// we can ignore them since they don't hurt anything.
-		}
-
-		if ( $is_void ) {
-			return array( 'void-block', $name, $attrs, $started_at, $length );
-		}
-
-		if ( $is_closer ) {
-			return array( 'block-closer', $name, null, $started_at, $length );
-		}
-
-		return array( 'block-opener', $name, $attrs, $started_at, $length );
 	}
 
 	/**

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -352,6 +352,7 @@ require ABSPATH . WPINC . '/class-wp-block-styles-registry.php';
 require ABSPATH . WPINC . '/class-wp-block-type-registry.php';
 require ABSPATH . WPINC . '/class-wp-block.php';
 require ABSPATH . WPINC . '/class-wp-block-list.php';
+require ABSPATH . WPINC . '/block-parser/class-wp-parsed-block-delimiter-info.php';
 require ABSPATH . WPINC . '/class-wp-block-parser-block.php';
 require ABSPATH . WPINC . '/class-wp-block-parser-frame.php';
 require ABSPATH . WPINC . '/class-wp-block-parser.php';


### PR DESCRIPTION
Trac ticket: Core-61401.
Theme: _Everything could be streaming, single-pass, reentrant, and low-overhead._

## Todo

 - [ ] While this is developed here, any changes to the Block Parser need to coordinate with the package in the Gutenberg repository.

## Breaking changes

 - When encountering a block delimiter with a closing flag and also a void flag, the existing parser prefers returning as a void block, but this returns the block closer. This is an edge case when things are already erroneous, but it makes more sense to me when writing this that we should prefer closing to introducing a void, as the void flag is more likely to be a mistake, and because if we treat a closer as a void we could lead to deep chains of unclosed blocks. This is something I'd like to re-examine as a whole with the block parsing, taking lessons from HTML's stack machine, but not in this change (for example, treat it as a closer if there's an open block of the given name).

## Related

 - Core-45312 where whitespace-only blocks are surprising with `parse_blocks()`

## Summary

In this patch two new functions are introduced for the purpose of returning a PCRE pattern that can be used to quickly and efficiently find blocks within an HTML document without having to parse the entire document and without building a full block tree.

These new functions enable more efficient processing for work that only needs to examine document structure or know a few things about a document without knowing everything, including but not limited to:

 - Finding the URL of the first image block in a document.
 - Inserting hooked blocks.
 - Analyzing block counts.

Further, a new class is introduced to further manage the process of finding block comment delimiters, one based on a hand-crafted parser designed for high performance: `WP_Parsed_Block_Delimiter_Info`.

This class provides a number of conveniences:

 - It performs zero allocations beyond a static set of numeric indices.
 - It holds onto the reference of the text it scanned, but can be detached to release that text. When detaching, it creates a substring of the text containing the full delimiter match.
 - It can indicate if the delimiter is for a given block type without performing any allocations.
 - It returns a lazy JSON parser by default for the attributes (not implemented yet) for more efficient interaction with the block attributes.
 - Inasmuch as is possible, all costs are explicit and only paid when requested by the calling code.

<img width="1334" alt="Screenshot 2024-06-09 at 5 51 40 PM" src="https://github.com/WordPress/wordpress-develop/assets/5431237/aa7b122c-30ad-469e-83a1-c8b32a57bc1f">

## Example

```php
// Get the first image in a post with the PCRE pattern.
while ( 1 === preg_match( get_named_block_delimiter_regex( 'image' ), $post_content, $matches, null, $at ) ) {
	if ( '/' === $matches['closer'] ) {
		$at += strlen( $matches[0] );
		continue;
	}
	
	$attrs = json_parse( $matches['attrs'] );
	if ( isset( $attrs['url'] ) ) {
		return $attrs['url'];
	}
}

return null;
```

```php
// Get the first image in a post with the utility class.
$image = null;
$at    = 0;
while ( ! isset( $image ) ) {
	$image = WP_Parsed_Block_Delimiter_Info::next_delimiter( $post_content, $at, $next_delimiter_at, $next_delimiter_length );
	if (
		'opener' === $image->get_delimiter_type() &&
		$image->is_block_type( 'core/image' )
	) {
		break;
	}

	$image = null;
	$at    = $next_delimiter_at + $next_delimiter_length;
}
```