### PR TITLE
HTML API: Add tests for comments

### DIFF
--- a/tests/phpunit/tests/html-api/wpHtmlProcessorComments.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorComments.php
@@ -23,29 +23,10 @@ class Tests_HtmlApi_WpHtmlProcessorComments extends WP_UnitTestCase {
 		$processor = WP_HTML_Processor::create_fragment( $html );
 		$processor->next_token();
 
-		$this->assertSame(
-			$expected_token_name,
-			$processor->get_token_name(),
-			"Found incorrect token name {$processor->get_token_name()}."
-		);
-
-		$this->assertSame(
-			$expected_comment_type,
-			$processor->get_comment_type(),
-			"Found incorrect comment type {$processor->get_comment_type()}."
-		);
-
-		$this->assertSame(
-			$expected_modifiable_text,
-			$processor->get_modifiable_text(),
-			'Found incorrect modifiable text.'
-		);
-
-		$this->assertSame(
-			$expected_tag,
-			$processor->get_tag(),
-			"Found incorrect comment \"tag\" {$processor->get_tag()}."
-		);
+		$this->assertSame( $expected_token_name, $processor->get_token_name() );
+		$this->assertSame( $expected_comment_type, $processor->get_comment_type() );
+		$this->assertSame( $expected_modifiable_text, $processor->get_modifiable_text() );
+		$this->assertSame( $expected_tag, $processor->get_tag() );
 	}
 
 	/**

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorComments.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorComments.php
@@ -19,11 +19,11 @@ class Tests_HtmlApi_WpHtmlProcessorComments extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_comments
 	 */
-	public function test_comment_processing( string $html, string $expected_token_name, string $expected_modifiable_text = '', string $expected_comment_type = null, string $expected_tag = null ) {
+	public function test_comment_processing( string $html, string $expected_comment_type, string $expected_modifiable_text, string $expected_tag = null ) {
 		$processor = WP_HTML_Processor::create_fragment( $html );
 		$processor->next_token();
 
-		$this->assertSame( $expected_token_name, $processor->get_token_name() );
+		$this->assertSame( '#comment', $processor->get_token_name() );
 		$this->assertSame( $expected_comment_type, $processor->get_comment_type() );
 		$this->assertSame( $expected_modifiable_text, $processor->get_modifiable_text() );
 		$this->assertSame( $expected_tag, $processor->get_tag() );
@@ -36,16 +36,42 @@ class Tests_HtmlApi_WpHtmlProcessorComments extends WP_UnitTestCase {
 	 */
 	public static function data_comments() {
 		return array(
-			'Normative comment'              => array( '<!-- A comment. -->', '#comment', ' A comment. ', WP_HTML_Processor::COMMENT_AS_HTML_COMMENT ),
-			'Abruptly closed comment'        => array( '<!-->', '#comment', '', WP_HTML_Processor::COMMENT_AS_ABRUPTLY_CLOSED_COMMENT ),
-			'Invalid HTML comment !'         => array( '<! Bang opener >', '#comment', ' Bang opener ', WP_HTML_Processor::COMMENT_AS_INVALID_HTML ),
-			'Invalid HTML comment ?'         => array( '<? Question opener >', '#comment', ' Question opener ', WP_HTML_Processor::COMMENT_AS_INVALID_HTML ),
-			'Funky comment # (empty)'        => array( '</#>', '#funky-comment', '#' ),
-			'Funky comment #'                => array( '</# foo>', '#funky-comment', '# foo' ),
-			'Funky comment •'                => array( '</• bar>', '#funky-comment', '• bar' ),
-			'Processing instriction comment' => array( '<?pi-target Instruction body. ?>', '#comment', ' Instruction body. ', WP_HTML_Processor::COMMENT_AS_PI_NODE_LOOKALIKE, 'pi-target' ),
-			'Processing instriction php'     => array( '<?php const HTML_COMMENT = true; ?>', '#comment', ' const HTML_COMMENT = true; ', WP_HTML_Processor::COMMENT_AS_PI_NODE_LOOKALIKE, 'php' ),
-			'CDATA comment'                  => array( '<![CDATA[ cdata body ]]>', '#comment', ' cdata body ', WP_HTML_Processor::COMMENT_AS_CDATA_LOOKALIKE ),
+			'Normative comment'              => array( '<!-- A comment. -->', WP_HTML_Processor::COMMENT_AS_HTML_COMMENT, ' A comment. ' ),
+			'Abruptly closed comment'        => array( '<!-->', WP_HTML_Processor::COMMENT_AS_ABRUPTLY_CLOSED_COMMENT, '' ),
+			'Invalid HTML comment !'         => array( '<! Bang opener >', WP_HTML_Processor::COMMENT_AS_INVALID_HTML, ' Bang opener ' ),
+			'Invalid HTML comment ?'         => array( '<? Question opener >', WP_HTML_Processor::COMMENT_AS_INVALID_HTML, ' Question opener ' ),
+			'CDATA comment'                  => array( '<![CDATA[ cdata body ]]>', WP_HTML_Processor::COMMENT_AS_CDATA_LOOKALIKE, ' cdata body ' ),
+			'Processing instriction comment' => array( '<?pi-target Instruction body. ?>', WP_HTML_Processor::COMMENT_AS_PI_NODE_LOOKALIKE, ' Instruction body. ', 'pi-target' ),
+			'Processing instriction php'     => array( '<?php const HTML_COMMENT = true; ?>', WP_HTML_Processor::COMMENT_AS_PI_NODE_LOOKALIKE, ' const HTML_COMMENT = true; ', 'php' ),
+		);
+	}
+
+	/**
+	 * Ensures that different types of comments are processed correctly.
+	 *
+	 * @ticket 61530
+	 *
+	 * @dataProvider data_funky_comments
+	 */
+	public function test_funky_comment( string $html, string $expected_modifiable_text ) {
+		$processor = WP_HTML_Processor::create_fragment( $html );
+		$processor->next_token();
+
+		$this->assertSame( '#funky-comment', $processor->get_token_name() );
+		$this->assertSame( $expected_modifiable_text, $processor->get_modifiable_text() );
+		$this->assertSame( $expected_tag, $processor->get_tag() );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_funky_comments() {
+		return array(
+			'Funky comment # (empty)' => array( '</#>', '#' ),
+			'Funky comment #'         => array( '</# foo>', '# foo' ),
+			'Funky comment •'         => array( '</• bar>', '• bar' ),
 		);
 	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorComments.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorComments.php
@@ -19,7 +19,7 @@ class Tests_HtmlApi_WpHtmlProcessorComments extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_comments
 	 */
-	public function test_comment_processing( string $html, int $token_position, string $expected_token_name, ?string $expected_comment_type, string $expected_modifiable_text = '', string $expected_tag = null ) {
+	public function test_comment_processing( string $html, int $token_position, string $expected_token_name, string $expected_modifiable_text = '', string $expected_comment_type = null, string $expected_tag = null ) {
 		$processor = WP_HTML_Processor::create_fragment( $html );
 
 		for ( $i = 0; $i < $token_position; $i++ ) {
@@ -58,15 +58,15 @@ class Tests_HtmlApi_WpHtmlProcessorComments extends WP_UnitTestCase {
 	 */
 	public static function data_comments() {
 		return array(
-			'Normative comment'              => array( '<!-- A comment. -->', 1, '#comment', WP_HTML_Processor::COMMENT_AS_HTML_COMMENT, ' A comment. ' ),
-			'Abruptly closed comment'        => array( '<!-->', 1, '#comment', WP_HTML_Processor::COMMENT_AS_ABRUPTLY_CLOSED_COMMENT ),
-			'Invalid HTML comment !'         => array( '<! Bang opener >', 1, '#comment', WP_HTML_Processor::COMMENT_AS_INVALID_HTML, ' Bang opener ' ),
-			'Invalid HTML comment ?'         => array( '<? Question opener >', 1, '#comment', WP_HTML_Processor::COMMENT_AS_INVALID_HTML, ' Question opener ' ),
-			'Funky comment # (empty)'        => array( '</#>', 1, '#funky-comment', null, '#' ),
-			'Funky comment #'                => array( '</# foo>', 1, '#funky-comment', null, '# foo' ),
-			'Funky comment •'                => array( '</• bar>', 1, '#funky-comment', null, '• bar' ),
-			'Processing instriction comment' => array( '<?pi-target Instruction body. ?>', 1, '#comment', WP_HTML_Processor::COMMENT_AS_PI_NODE_LOOKALIKE, ' Instruction body. ', 'pi-target' ),
-			'CDATA comment'                  => array( '<![CDATA[ cdata body ]]>', 1, '#comment', WP_HTML_Processor::COMMENT_AS_CDATA_LOOKALIKE, ' cdata body ' ),
+			'Normative comment'              => array( '<!-- A comment. -->', 1, '#comment', ' A comment. ', WP_HTML_Processor::COMMENT_AS_HTML_COMMENT ),
+			'Abruptly closed comment'        => array( '<!-->', 1, '#comment', '', WP_HTML_Processor::COMMENT_AS_ABRUPTLY_CLOSED_COMMENT ),
+			'Invalid HTML comment !'         => array( '<! Bang opener >', 1, '#comment', ' Bang opener ', WP_HTML_Processor::COMMENT_AS_INVALID_HTML ),
+			'Invalid HTML comment ?'         => array( '<? Question opener >', 1, '#comment', ' Question opener ', WP_HTML_Processor::COMMENT_AS_INVALID_HTML ),
+			'Funky comment # (empty)'        => array( '</#>', 1, '#funky-comment', '#' ),
+			'Funky comment #'                => array( '</# foo>', 1, '#funky-comment', '# foo' ),
+			'Funky comment •'                => array( '</• bar>', 1, '#funky-comment', '• bar' ),
+			'Processing instriction comment' => array( '<?pi-target Instruction body. ?>', 1, '#comment', ' Instruction body. ', WP_HTML_Processor::COMMENT_AS_PI_NODE_LOOKALIKE, 'pi-target' ),
+			'CDATA comment'                  => array( '<![CDATA[ cdata body ]]>', 1, '#comment', ' cdata body ', WP_HTML_Processor::COMMENT_AS_CDATA_LOOKALIKE ),
 		);
 	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorComments.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorComments.php
@@ -66,6 +66,7 @@ class Tests_HtmlApi_WpHtmlProcessorComments extends WP_UnitTestCase {
 			'Funky comment #'                => array( '</# foo>', 1, '#funky-comment', '# foo' ),
 			'Funky comment •'                => array( '</• bar>', 1, '#funky-comment', '• bar' ),
 			'Processing instriction comment' => array( '<?pi-target Instruction body. ?>', 1, '#comment', ' Instruction body. ', WP_HTML_Processor::COMMENT_AS_PI_NODE_LOOKALIKE, 'pi-target' ),
+			'Processing instriction php'     => array( '<?php const HTML_COMMENT = true; ?>', 1, '#comment', ' const HTML_COMMENT = true; ', WP_HTML_Processor::COMMENT_AS_PI_NODE_LOOKALIKE, 'php' ),
 			'CDATA comment'                  => array( '<![CDATA[ cdata body ]]>', 1, '#comment', ' cdata body ', WP_HTML_Processor::COMMENT_AS_CDATA_LOOKALIKE ),
 		);
 	}

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorComments.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorComments.php
@@ -59,7 +59,6 @@ class Tests_HtmlApi_WpHtmlProcessorComments extends WP_UnitTestCase {
 
 		$this->assertSame( '#funky-comment', $processor->get_token_name() );
 		$this->assertSame( $expected_modifiable_text, $processor->get_modifiable_text() );
-		$this->assertSame( $expected_tag, $processor->get_tag() );
 	}
 
 	/**

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorComments.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorComments.php
@@ -19,12 +19,9 @@ class Tests_HtmlApi_WpHtmlProcessorComments extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_comments
 	 */
-	public function test_comment_processing( string $html, int $token_position, string $expected_token_name, string $expected_modifiable_text = '', string $expected_comment_type = null, string $expected_tag = null ) {
+	public function test_comment_processing( string $html, string $expected_token_name, string $expected_modifiable_text = '', string $expected_comment_type = null, string $expected_tag = null ) {
 		$processor = WP_HTML_Processor::create_fragment( $html );
-
-		for ( $i = 0; $i < $token_position; $i++ ) {
-			$processor->next_token();
-		}
+		$processor->next_token();
 
 		$this->assertSame(
 			$expected_token_name,
@@ -58,16 +55,16 @@ class Tests_HtmlApi_WpHtmlProcessorComments extends WP_UnitTestCase {
 	 */
 	public static function data_comments() {
 		return array(
-			'Normative comment'              => array( '<!-- A comment. -->', 1, '#comment', ' A comment. ', WP_HTML_Processor::COMMENT_AS_HTML_COMMENT ),
-			'Abruptly closed comment'        => array( '<!-->', 1, '#comment', '', WP_HTML_Processor::COMMENT_AS_ABRUPTLY_CLOSED_COMMENT ),
-			'Invalid HTML comment !'         => array( '<! Bang opener >', 1, '#comment', ' Bang opener ', WP_HTML_Processor::COMMENT_AS_INVALID_HTML ),
-			'Invalid HTML comment ?'         => array( '<? Question opener >', 1, '#comment', ' Question opener ', WP_HTML_Processor::COMMENT_AS_INVALID_HTML ),
-			'Funky comment # (empty)'        => array( '</#>', 1, '#funky-comment', '#' ),
-			'Funky comment #'                => array( '</# foo>', 1, '#funky-comment', '# foo' ),
-			'Funky comment •'                => array( '</• bar>', 1, '#funky-comment', '• bar' ),
-			'Processing instriction comment' => array( '<?pi-target Instruction body. ?>', 1, '#comment', ' Instruction body. ', WP_HTML_Processor::COMMENT_AS_PI_NODE_LOOKALIKE, 'pi-target' ),
-			'Processing instriction php'     => array( '<?php const HTML_COMMENT = true; ?>', 1, '#comment', ' const HTML_COMMENT = true; ', WP_HTML_Processor::COMMENT_AS_PI_NODE_LOOKALIKE, 'php' ),
-			'CDATA comment'                  => array( '<![CDATA[ cdata body ]]>', 1, '#comment', ' cdata body ', WP_HTML_Processor::COMMENT_AS_CDATA_LOOKALIKE ),
+			'Normative comment'              => array( '<!-- A comment. -->', '#comment', ' A comment. ', WP_HTML_Processor::COMMENT_AS_HTML_COMMENT ),
+			'Abruptly closed comment'        => array( '<!-->', '#comment', '', WP_HTML_Processor::COMMENT_AS_ABRUPTLY_CLOSED_COMMENT ),
+			'Invalid HTML comment !'         => array( '<! Bang opener >', '#comment', ' Bang opener ', WP_HTML_Processor::COMMENT_AS_INVALID_HTML ),
+			'Invalid HTML comment ?'         => array( '<? Question opener >', '#comment', ' Question opener ', WP_HTML_Processor::COMMENT_AS_INVALID_HTML ),
+			'Funky comment # (empty)'        => array( '</#>', '#funky-comment', '#' ),
+			'Funky comment #'                => array( '</# foo>', '#funky-comment', '# foo' ),
+			'Funky comment •'                => array( '</• bar>', '#funky-comment', '• bar' ),
+			'Processing instriction comment' => array( '<?pi-target Instruction body. ?>', '#comment', ' Instruction body. ', WP_HTML_Processor::COMMENT_AS_PI_NODE_LOOKALIKE, 'pi-target' ),
+			'Processing instriction php'     => array( '<?php const HTML_COMMENT = true; ?>', '#comment', ' const HTML_COMMENT = true; ', WP_HTML_Processor::COMMENT_AS_PI_NODE_LOOKALIKE, 'php' ),
+			'CDATA comment'                  => array( '<![CDATA[ cdata body ]]>', '#comment', ' cdata body ', WP_HTML_Processor::COMMENT_AS_CDATA_LOOKALIKE ),
 		);
 	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorComments.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorComments.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Unit tests covering WP_HTML_Processor functionality.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ *
+ * @since 6.4.0
+ *
+ * @group html-api
+ *
+ * @coversDefaultClass WP_HTML_Processor
+ */
+class Tests_HtmlApi_WpHtmlProcessorComments extends WP_UnitTestCase {
+	/**
+	 * Ensures that normative Processing Instruction nodes are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_basic_assertion_processing_instruction() {
+		$processor = WP_HTML_Processor::create_fragment( '<?wp-bit{"just": "kidding"}?>' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#comment',
+			$processor->get_token_name(),
+			"Should have found comment token but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertSame(
+			WP_HTML_Processor::COMMENT_AS_PI_NODE_LOOKALIKE,
+			$processor->get_comment_type(),
+			'Should have detected a Processing Instruction-like invalid comment.'
+		);
+
+		$this->assertSame(
+			'wp-bit',
+			$processor->get_tag(),
+			"Should have found PI target as tag name but found {$processor->get_tag()} instead."
+		);
+
+		$this->assertNull(
+			$processor->get_attribute( 'type' ),
+			'Should not have been able to query attributes on non-element token.'
+		);
+
+		$this->assertSame(
+			'{"just": "kidding"}',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+
+	/**
+	 * Ensures that normative Processing Instruction nodes are properly parsed.
+	 *
+	 * @ticket 60170
+	 *
+	 * @since 6.5.0
+	 *
+	 * @covers WP_HTML_Tag_Processor::next_token
+	 */
+	public function test_assertion_processing_instruction_descendant() {
+		$processor = WP_HTML_Processor::create_fragment( '<div><?wp-bit{"just": "kidding"}?></div>' );
+		$processor->next_token();
+		$processor->next_token();
+
+		$this->assertSame(
+			'#comment',
+			$processor->get_token_name(),
+			"Should have found comment token but found {$processor->get_token_name()} instead."
+		);
+
+		$this->assertSame(
+			WP_HTML_Processor::COMMENT_AS_PI_NODE_LOOKALIKE,
+			$processor->get_comment_type(),
+			'Should have detected a Processing Instruction-like invalid comment.'
+		);
+
+		$this->assertSame(
+			'wp-bit',
+			$processor->get_tag(),
+			"Should have found PI target as tag name but found {$processor->get_tag()} instead."
+		);
+
+		$this->assertNull(
+			$processor->get_attribute( 'type' ),
+			'Should not have been able to query attributes on non-element token.'
+		);
+
+		$this->assertSame(
+			'{"just": "kidding"}',
+			$processor->get_modifiable_text(),
+			'Found incorrect modifiable text.'
+		);
+	}
+}

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorComments.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorComments.php
@@ -15,7 +15,7 @@ class Tests_HtmlApi_WpHtmlProcessorComments extends WP_UnitTestCase {
 	/**
 	 * Ensures that different types of comments are processed correctly.
 	 *
-	 * @ticket TBD
+	 * @ticket 61530
 	 *
 	 * @dataProvider data_comments
 	 */


### PR DESCRIPTION
Trac ticket: Core-61530

Add tests for comment handling.

These tests caught a regression during the 6.6 development cycle (with processing instruction comment tag name) that was fixed, but the tests were not merged.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
