### PR TITLE
wp_video_shortcode() outputs invalid HTML

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -3631,7 +3631,11 @@ function wp_video_shortcode( $attr, $content = '' ) {
 
 	$attr_strings = array();
 	foreach ( $html_atts as $k => $v ) {
-		$attr_strings[] = $k . '="' . esc_attr( $v ) . '"';
+		if ( in_array( $k, array( 'loop', 'autoplay', 'muted' ), true ) ) {
+			$attr_strings[] = $k . '="' . esc_attr( true === $v ? 'true' : 'false' ) . '"';
+		} else {
+			$attr_strings[] = $k . '="' . esc_attr( $v ) . '"';
+		}
 	}
 
 	$html = '';


### PR DESCRIPTION
wp_video_shortcode() was chaging boolean attributes to 1, as of true === 1, in debug i notice it was directly happening after foreach, not by eascaping, so I have add a if statement to handle boolean attributes and make ternary opretion for them, so we can still escape value as WP standards and our problem solves too.

Before changes:
<img width="1158" alt="wp-sbc" src="https://github.com/WordPress/wordpress-develop/assets/55100775/e844342f-f391-4e2e-a158-c99ca3c9390a">

After Changes:
<img width="1296" alt="wp_sac" src="https://github.com/WordPress/wordpress-develop/assets/55100775/9f897c0a-aed2-4be3-b5ae-388ab264f83c">

Trac Ticket: https://core.trac.wordpress.org/ticket/60178