### PR TITLE
Fix docblock for filter lang_dir_for_domain

### DIFF
--- a/src/wp-includes/class-wp-textdomain-registry.php
+++ b/src/wp-includes/class-wp-textdomain-registry.php
@@ -101,7 +101,7 @@ class WP_Textdomain_Registry {
 		 * @param string|false $path   Languages directory path for the given domain and locale.
 		 * @param string       $domain Text domain.
 		 * @param string       $locale Locale.
-		 **/
+		 */
 		return apply_filters( 'lang_dir_for_domain', $path, $domain, $locale );
 	}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

In changeset https://core.trac.wordpress.org/changeset/58236 for new filter named lang_dir_for_domain in WP_Textdomain_Registry hook docblock has ended with **/. Its should be ended with */.

Trac ticket: [#61413](https://core.trac.wordpress.org/ticket/61413)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
