### PR TITLE
Update class-wp-widget-factory.php

### DIFF
--- a/src/wp-includes/class-wp-widget-factory.php
+++ b/src/wp-includes/class-wp-widget-factory.php
@@ -59,7 +59,7 @@ class WP_Widget_Factory {
 		if ( $widget instanceof WP_Widget ) {
 			$this->widgets[ spl_object_hash( $widget ) ] = $widget;
 		} else {
-			$this->widgets[ $widget ] = new $widget();
+			$this->widgets[ $widget ] = new $widget( $widget, $widget );
 		}
 	}
 


### PR DESCRIPTION
Fixing a persistent Error that occurs when upgrading to PHP 8.X from a PHP 7.X version. If this fix is not deployed, the error message "Fatal error: Uncaught ArgumentCountError: Too few arguments to function WP_Widget::__construct()" will appear and the entire WordPress site, including the admin area, is not accessible.

Trac ticket: https://core.trac.wordpress.org/ticket/61415
