### PR TITLE
Global Styles: Add missing block style variation defaults

### DIFF
--- a/src/wp-includes/theme.json
+++ b/src/wp-includes/theme.json
@@ -332,6 +332,40 @@
 		}
 	},
 	"styles": {
+		"blocks": {
+			"core/button": {
+				"variations": {
+					"outline": {
+						"border": {
+							"width": "2px",
+							"style": "solid",
+							"color": "currentColor"
+						},
+						"color": {
+							"text": "currentColor",
+							"gradient": "transparent none"
+						},
+						"spacing": {
+							"padding": {
+								"top": "0.667em",
+								"right": "1.33em",
+								"bottom": "0.667em",
+								"left": "1.33em"
+							}
+						}
+					}
+				}
+			},
+			"core/site-logo": {
+				"variations": {
+					"rounded": {
+						"border": {
+							"radius": "9999px"
+						}
+					}
+				}
+			}
+		},
 		"elements": {
 			"button": {
 				"color": {


### PR DESCRIPTION
Backports the default block style variation styles to the core theme.json file after the general specificity reduction of global styles in https://github.com/WordPress/gutenberg/pull/61638.

To test:
1. Prior to checking out this branch, visit the site editor and edit the home page with TT4 active
2. Select the button and switch its block style to Outline. Note the appearance doesn't change.
3. Checkout this branch and repeat the steps. The Outline style should take effect.

Trac ticket: https://core.trac.wordpress.org/ticket/61165

| Before | After |
|---|---|
| <img width="628" alt="Screenshot 2024-06-12 at 3 18 21 PM" src="https://github.com/WordPress/wordpress-develop/assets/60436221/4e4894f9-b006-4d9d-b3cb-19fe748334de"> | <img width="633" alt="Screenshot 2024-06-12 at 3 18 56 PM" src="https://github.com/WordPress/wordpress-develop/assets/60436221/fda8af69-cc64-476d-85f6-9b2662d5289f"> |


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
