### PR TITLE
Fix docblock for filter pre_get_language_files_from_path

### DIFF
--- a/src/wp-includes/class-wp-textdomain-registry.php
+++ b/src/wp-includes/class-wp-textdomain-registry.php
@@ -182,8 +182,8 @@ class WP_Textdomain_Registry {
 		 * @since 6.5.0
 		 *
 		 * @param null|array $files List of translation files. Default null.
-		 * @param string $path The path from which translation files are being fetched.
-		 **/
+		 * @param string     $path  The path from which translation files are being fetched.
+		 */
 		$files = apply_filters( 'pre_get_language_files_from_path', null, $path );
 
 		if ( null !== $files ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

In changeset https://core.trac.wordpress.org/changeset/57287 for new filter named pre_get_language_files_from_path in WP_Textdomain_Registry hook docblock has misalignment `@params` and ended with `**/`.

Trac ticket: [#61416](https://core.trac.wordpress.org/ticket/61416)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
