### PR TITLE
Enhancement: Changing Site Admin Email Assumes Username and Who Took the Action

### DIFF
--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1483,9 +1483,9 @@ function update_option_new_admin_email( $old_value, $value ) {
 
 	/* translators: Do not translate USERNAME, ADMIN_URL, EMAIL, SITENAME, SITEURL: those are placeholders. */
 	$email_text = __(
-		'Howdy ###USERNAME###,
+		'Howdy,
 
-Someone with administrator capabilities recently requested to have the
+User ###USERNAME### with administrator capabilities recently requested to have the
 administration email address changed on this site:
 ###SITEURL###
 


### PR DESCRIPTION
Trac Ticket : [Ticket #48879](https://core.trac.wordpress.org/ticket/48879)

This PR addresses and resolves the confusion caused by the current email notification sent when the site admin email address is updated.
Issues Fixed:
1. Incorrect Addressing: The email was previously addressed to the current user's username, causing confusion for the recipient.
2. Misleading Language: The email stated “Howdy, ###USERNAME### ” which was misleading for recipients who did not perform the action.
Changes Made:
* The email is now addressed generically without using the current user's username. i.e “Howdy,”
* The language has been updated to indicate that someone (specified by the username of the requester) has requested the email change, rather than implying the recipient performed the action.
These changes aim to reduce confusion and prevent users from thinking the email is a phishing attempt.
