### PR TITLE
Passing int term in term_exists then parent param not respected

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -1609,7 +1609,10 @@ function term_exists( $term, $taxonomy = '', $parent_term = null ) {
 		if ( 0 === $term ) {
 			return 0;
 		}
-		$args  = wp_parse_args( array( 'include' => array( $term ) ), $defaults );
+		$args = wp_parse_args( array( 'include' => array( $term ) ), $defaults );
+		if ( ! empty( $taxonomy ) && is_numeric( $parent_term ) ) {
+			$args['parent'] = (int) $parent_term;
+		}
 		$terms = get_terms( $args );
 	} else {
 		$term = trim( wp_unslash( $term ) );


### PR DESCRIPTION
Fixes [Ticket #55358](https://core.trac.wordpress.org/ticket/55358)

This PR addresses an issue in the term_exists function where the parent_term was not being respected when a term with an integer ID was passed along with a parent term ID. The function would only check if the term with the specified ID existed, ignoring the parent-child relationship.

Changes Made:

- Updated the term_exists function to include the parent parameter in the query arguments when the term is an integer and a parent term ID is specified.
- Added a condition to check for the presence of a parent term ID and include it in the query arguments.