### PR TITLE
Trac 61420: Removes unused and unassigned sprintf in `wp_get_plugin_action_button()`

### DIFF
--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -942,16 +942,6 @@ function wp_get_plugin_action_button( $name, $data, $compatible_php, $compatible
 	$all_plugin_dependencies_installed = $installed_plugin_dependencies_count === $plugin_dependencies_count;
 	$all_plugin_dependencies_active    = $active_plugin_dependencies_count === $plugin_dependencies_count;
 
-	sprintf(
-		'<a class="install-now button" data-slug="%s" href="%s" aria-label="%s" data-name="%s" role="button">%s</a>',
-		esc_attr( $data->slug ),
-		esc_url( $status['url'] ),
-		/* translators: %s: Plugin name and version. */
-		esc_attr( sprintf( _x( 'Install %s now', 'plugin' ), $name ) ),
-		esc_attr( $name ),
-		_x( 'Install Now', 'plugin' )
-	);
-
 	if ( current_user_can( 'install_plugins' ) || current_user_can( 'update_plugins' ) ) {
 		switch ( $status['status'] ) {
 			case 'install':


### PR DESCRIPTION
Removes the unused / unassigned `sprintf` code from `wp_get_plugin_action_button()`.

Trac ticket: https://core.trac.wordpress.org/ticket/61420

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
