### PR TITLE
Add filter wp_list_table_classes to add classes to table in Admin

### DIFF
--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -1656,7 +1656,15 @@ class WP_List_Table {
 
 		$mode_class = esc_attr( 'table-view-' . $mode );
 
-		return array( 'widefat', 'fixed', 'striped', $mode_class, $this->_args['plural'] );
+		$classes = array( 'widefat', 'fixed', 'striped', $mode_class, $this->_args['plural'] );
+
+		// Apply the filter
+		$classes = apply_filters( 'wp_list_table_classes', $classes, $this );
+
+		// Sanitize each class
+		$classes = array_map( 'sanitize_html_class', $classes );
+
+		return $classes;
 	}
 
 	/**


### PR DESCRIPTION
Trac Ticket - https://core.trac.wordpress.org/ticket/58824

This PR addresses the issue where there is no way to change the classes in the posts list table.
Currently, the posts list table template is hardcoded, preventing the addition of any specific classes.

Added new filter `wp_list_table_classes` to do the same. 
Can use like this - 
```php

function add_custom_clases( $classes, $table ) {
	$classes[] = 'custom-class';
	return $classes;
}
add_filter( 'wp_list_table_classes', 'add_custom_clases', 10, 2 );
```