### PR TITLE
add margin without mediaquery and fix it

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1090,6 +1090,7 @@ th.action-links {
 
 .wp-filter .search-form {
 	float: right;
+	margin: 10px 0px;
 	display: flex;
 	align-items: center;
 	column-gap: .5rem;


### PR DESCRIPTION
I fix it and margin for the search box without media query and delete margin top 0 for plugin search.

Trac ticket: https://core.trac.wordpress.org/ticket/61389