### PR TITLE
Add plugin dependencies help tab on plugins pages

### DIFF
--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -609,7 +609,7 @@ if ( current_user_can( 'install_plugins' ) ) {
 			'title'   => __( 'Dependencies' ),
 			'content' =>
 				'<p>' . __( 'Plugin Dependencies aims to make the process of installing and activating addons (dependents) and the plugins they rely on (dependencies) consistent and easy.' ) . '</p>' .
-				'<p>' . __( 'If a dependency plugin is deleted via FTP or deployment, a notice will be displayed on the Plugin administration screens, informing the user that there are missing dependencies to install and/or activate. Additionally, each dependent whose dependencies are no longer met will have an error notice in their plugin row.' ) . '</p>' .
+				'<p>' . __( 'If a required plugin is deleted, a notice will be displayed on the Plugin administration screen informing the user that there is a missing dependency(s) to install and/or activate. Additionally, each plugin whose dependencies are not met will have an error notice on their plugin row.' ) . '</p>' .
 				'<p>' . __( 'If a dependent plugin is missing some dependencies, its activation button is disabled until the related dependencies are activated.' ) . '</p>',
 		)
 	);

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -608,9 +608,9 @@ if ( current_user_can( 'install_plugins' ) ) {
 			'id'      => 'plugins-dependencies',
 			'title'   => __( 'Dependencies' ),
 			'content' =>
-				'<p>' . __( 'Plugin Dependencies aims to make the process of installing and activating addons (dependents) and the plugins they rely on (dependencies) consistent and easy.' ) . '</p>' .
-				'<p>' . __( 'If a required plugin is deleted, a notice will be displayed on the Plugin administration screen informing the user that there is a missing dependency(s) to install and/or activate. Additionally, each plugin whose dependencies are not met will have an error notice on their plugin row.' ) . '</p>' .
-				'<p>' . __( 'If a parent plugin is missing a dependency(s), its activation button will be disabled until the required dependency(s) are activated.' ) . '</p>',
+				'<p>' . __( 'Plugin Dependencies aims to make the process of installing and activating add-ons (dependents) and the plugins they rely on (dependencies) consistent and easy.' ) . '</p>' .
+				'<p>' . __( 'If a required plugin is deleted, a notice will be displayed on the Plugin administration screen informing the user that there is some missing dependencies to install and/or activate. Additionally, each plugin whose dependencies are not met will have an error notice on their plugin row.' ) . '</p>' .
+				'<p>' . __( 'If a dependent plugin is missing some dependencies, its activation button will be disabled until the required dependencies are activated.' ) . '</p>',
 		)
 	);
 }

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -610,7 +610,7 @@ if ( current_user_can( 'install_plugins' ) ) {
 			'content' =>
 				'<p>' . __( 'Plugin Dependencies aims to make the process of installing and activating addons (dependents) and the plugins they rely on (dependencies) consistent and easy.' ) . '</p>' .
 				'<p>' . __( 'If a required plugin is deleted, a notice will be displayed on the Plugin administration screen informing the user that there is a missing dependency(s) to install and/or activate. Additionally, each plugin whose dependencies are not met will have an error notice on their plugin row.' ) . '</p>' .
-				'<p>' . __( 'If a dependent plugin is missing some dependencies, its activation button is disabled until the related dependencies are activated.' ) . '</p>',
+				'<p>' . __( 'If a parent plugin is missing a dependency(s), its activation button will be disabled until the required dependency(s) are activated.' ) . '</p>',
 		)
 	);
 }

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -610,7 +610,7 @@ if ( current_user_can( 'install_plugins' ) ) {
 			'content' =>
 				'<p>' . __( 'Plugin Dependencies aims to make the process of installing and activating addons (dependents) and the plugins they rely on (dependencies) consistent and easy.' ) . '</p>' .
 				'<p>' . __( 'If a dependency plugin is deleted via FTP or deployment, a notice will be displayed on the administration’s plugin screens, informing the user that there are missing dependencies to install and/or activate. Additionally, each dependent whose dependencies are no longer met will have an error notice in their plugin row.' ) . '</p>' .
-				'<p>' . __( 'In case plugin activation link is disabled, this is due to missing required dependencies for the said plugin.' ) . '</p>'
+				'<p>' . __( 'In case plugin activation link is disabled, this is due to missing required dependencies for the said plugin.' ) . '</p>',
 		)
 	);
 }

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -609,8 +609,8 @@ if ( current_user_can( 'install_plugins' ) ) {
 			'title'   => __( 'Dependencies' ),
 			'content' =>
 				'<p>' . __( 'Plugin Dependencies aims to make the process of installing and activating addons (dependents) and the plugins they rely on (dependencies) consistent and easy.' ) . '</p>' .
-				'<p>' . __( 'If a dependency plugin is deleted via FTP or deployment, a notice will be displayed on the administration’s plugin screens, informing the user that there are missing dependencies to install and/or activate. Additionally, each dependent whose dependencies are no longer met will have an error notice in their plugin row.' ) . '</p>' .
-				'<p>' . __( 'In case plugin activation link is disabled, this is due to missing required dependencies for the said plugin.' ) . '</p>',
+				'<p>' . __( 'If a dependency plugin is deleted via FTP or deployment, a notice will be displayed on the Plugin administration screens, informing the user that there are missing dependencies to install and/or activate. Additionally, each dependent whose dependencies are no longer met will have an error notice in their plugin row.' ) . '</p>' .
+				'<p>' . __( 'If a dependent plugin is missing some dependencies, its activation button is disabled until the related dependencies are activated.' ) . '</p>',
 		)
 	);
 }

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -602,6 +602,19 @@ if ( current_user_can( 'update_plugins' ) && wp_is_auto_update_enabled_for_type(
 	$help_sidebar_autoupdates = '<p>' . __( '<a href="https://wordpress.org/documentation/article/plugins-themes-auto-updates/">Documentation on Auto-updates</a>' ) . '</p>';
 }
 
+if ( current_user_can( 'install_plugins' ) ) {
+	get_current_screen()->add_help_tab(
+		array(
+			'id'      => 'plugins-dependencies',
+			'title'   => __( 'Dependencies' ),
+			'content' =>
+				'<p>' . __( 'Plugin Dependencies aims to make the process of installing and activating addons (dependents) and the plugins they rely on (dependencies) consistent and easy.' ) . '</p>' .
+				'<p>' . __( 'If a dependency plugin is deleted via FTP or deployment, a notice will be displayed on the administration’s plugin screens, informing the user that there are missing dependencies to install and/or activate. Additionally, each dependent whose dependencies are no longer met will have an error notice in their plugin row.' ) . '</p>' .
+				'<p>' . __( 'In case plugin activation link is disabled, this is due to missing required dependencies for the said plugin.' ) . '</p>'
+		)
+	);
+}
+
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 	'<p>' . __( '<a href="https://wordpress.org/documentation/article/manage-plugins/">Documentation on Managing Plugins</a>' ) . '</p>' .


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60466

**Preview:**
<img width="1322" alt="image" src="https://github.com/WordPress/wordpress-develop/assets/3604454/2b631f60-a8f3-4a27-aea6-0e02172c498c">

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
