### PR TITLE
43251 add a check for editable roles 

### DIFF
--- a/src/wp-admin/includes/ms.php
+++ b/src/wp-admin/includes/ms.php
@@ -1172,3 +1172,24 @@ function get_site_screen_help_sidebar_content() {
 		'<p>' . __( '<a href="https://developer.wordpress.org/advanced-administration/multisite/admin/#network-admin-sites-screen">Documentation on Site Management</a>' ) . '</p>' .
 		'<p>' . __( '<a href="https://wordpress.org/support/forum/multisite/">Support forums</a>' ) . '</p>';
 }
+
+
+/**
+ * Makes sure the passed $role is part of editable_roles
+ *
+ * @since 6.7.0
+ *
+ * @param string $role - name of the role
+ * @return void
+ */
+
+function ensure_editable_role( $role ) {
+	$roles = get_editable_roles();
+	if ( ! isset( $roles[ $role ] ) ) {
+		wp_die(
+			'<h1>' . __( 'You need a higher level of permission.' ) . '</h1>' .
+			'<p>' . __( 'Sorry, you are not allowed to assign users to this role.' ) . '</p>',
+			403
+		);
+	}
+}

--- a/src/wp-admin/user-new.php
+++ b/src/wp-admin/user-new.php
@@ -67,6 +67,16 @@ if ( isset( $_REQUEST['action'] ) && 'adduser' === $_REQUEST['action'] ) {
 		$redirect = add_query_arg( array( 'update' => 'addexisting' ), 'user-new.php' );
 	} else {
 		if ( isset( $_POST['noconfirmation'] ) && current_user_can( 'manage_network_users' ) ) {
+
+			$roles = get_editable_roles();
+			if ( ! isset( $roles[ $_REQUEST['role'] ] ) ) {
+				wp_die(
+					'<h1>' . __( 'You need a higher level of permission.' ) . '</h1>' .
+					'<p>' . __( 'Sorry, you are not allowed to assign users to this role.' ) . '</p>',
+					403
+				);
+			}
+
 			$result = add_existing_user_to_blog(
 				array(
 					'user_id' => $user_id,
@@ -218,6 +228,16 @@ Please click the following link to confirm the invite:
 				add_filter( 'wpmu_signup_user_notification', '__return_false' );  // Disable confirmation email.
 				add_filter( 'wpmu_welcome_user_notification', '__return_false' ); // Disable welcome email.
 			}
+
+			$roles = get_editable_roles();
+			if ( ! isset( $roles[ $_REQUEST['role'] ] ) ) {
+				wp_die(
+					'<h1>' . __( 'You need a higher level of permission.' ) . '</h1>' .
+					'<p>' . __( 'Sorry, you are not allowed to assign users to this role.' ) . '</p>',
+					403
+				);
+			}
+
 			wpmu_signup_user(
 				$new_user_login,
 				$new_user_email,

--- a/src/wp-admin/user-new.php
+++ b/src/wp-admin/user-new.php
@@ -68,14 +68,7 @@ if ( isset( $_REQUEST['action'] ) && 'adduser' === $_REQUEST['action'] ) {
 	} else {
 		if ( isset( $_POST['noconfirmation'] ) && current_user_can( 'manage_network_users' ) ) {
 
-			$roles = get_editable_roles();
-			if ( ! isset( $roles[ $_REQUEST['role'] ] ) ) {
-				wp_die(
-					'<h1>' . __( 'You need a higher level of permission.' ) . '</h1>' .
-					'<p>' . __( 'Sorry, you are not allowed to assign users to this role.' ) . '</p>',
-					403
-				);
-			}
+			ensure_editable_role( $_REQUEST['role'] );
 
 			$result = add_existing_user_to_blog(
 				array(
@@ -229,14 +222,7 @@ Please click the following link to confirm the invite:
 				add_filter( 'wpmu_welcome_user_notification', '__return_false' ); // Disable welcome email.
 			}
 
-			$roles = get_editable_roles();
-			if ( ! isset( $roles[ $_REQUEST['role'] ] ) ) {
-				wp_die(
-					'<h1>' . __( 'You need a higher level of permission.' ) . '</h1>' .
-					'<p>' . __( 'Sorry, you are not allowed to assign users to this role.' ) . '</p>',
-					403
-				);
-			}
+			ensure_editable_role( $_REQUEST['role'] );
 
 			wpmu_signup_user(
 				$new_user_login,

--- a/tests/phpunit/tests/multisite/wpmuValidateUserSignup.php
+++ b/tests/phpunit/tests/multisite/wpmuValidateUserSignup.php
@@ -222,7 +222,7 @@ if ( is_multisite() ) :
 		}
 
 		public function test_ensure_editable_role() {
-			$exception    = null;
+			$exception = null;
 			try {
 				ensure_editable_role( 'editor' );
 			} catch ( WPDieException $e ) {
@@ -230,7 +230,7 @@ if ( is_multisite() ) :
 			}
 			$this->assertNull( $exception );
 
-			$exception    = null;
+			$exception = null;
 			try {
 				ensure_editable_role( 'non-existant' );
 			} catch ( WPDieException $e ) {
@@ -239,19 +239,25 @@ if ( is_multisite() ) :
 			$this->assertNotNull( $exception );
 			$this->assertStringContainsString( 'Sorry, you are not allowed to assign users to this role.', $exception->getMessage() );
 
-			$exception    = null;
+			$exception = null;
 			try {
-				add_filter( 'editable_roles', function ( $roles ) {
-					unset( $roles['administrator'] );
-					return $roles;
-				} );
+				add_filter(
+					'editable_roles',
+					function ( $roles ) {
+						unset( $roles['administrator'] );
+						return $roles;
+					}
+				);
 
 				ensure_editable_role( 'administrator' );
 
-				remove_filter( 'editable_roles', function ( $roles ) {
-					unset( $roles['administrator'] );
-					return $roles;
-				} );
+				remove_filter(
+					'editable_roles',
+					function ( $roles ) {
+						unset( $roles['administrator'] );
+						return $roles;
+					}
+				);
 			} catch ( WPDieException $e ) {
 				$exception = $e;
 			}

--- a/tests/phpunit/tests/multisite/wpmuValidateUserSignup.php
+++ b/tests/phpunit/tests/multisite/wpmuValidateUserSignup.php
@@ -241,9 +241,17 @@ if ( is_multisite() ) :
 
 			$exception    = null;
 			try {
-				add_filter( 'editable_roles', function( $roles ) { unset( $roles['administrator'] ); return $roles; } );
+				add_filter( 'editable_roles', function ( $roles ) {
+					unset( $roles['administrator'] );
+					return $roles;
+				} );
+
 				ensure_editable_role( 'administrator' );
-				remove_filter( 'editable_roles', function( $roles ) { unset( $roles['administrator'] ); return $roles; } );
+
+				remove_filter( 'editable_roles', function ( $roles ) {
+					unset( $roles['administrator'] );
+					return $roles;
+				} );
 			} catch ( WPDieException $e ) {
 				$exception = $e;
 			}

--- a/tests/phpunit/tests/multisite/wpmuValidateUserSignup.php
+++ b/tests/phpunit/tests/multisite/wpmuValidateUserSignup.php
@@ -220,6 +220,36 @@ if ( is_multisite() ) :
 
 			$this->assertContains( 'invalid_nonce', $valid['errors']->get_error_codes() );
 		}
+
+		public function test_ensure_editable_role() {
+			$exception    = null;
+			try {
+				ensure_editable_role( 'editor' );
+			} catch ( WPDieException $e ) {
+				$exception = $e;
+			}
+			$this->assertNull( $exception );
+
+			$exception    = null;
+			try {
+				ensure_editable_role( 'non-existant' );
+			} catch ( WPDieException $e ) {
+				$exception = $e;
+			}
+			$this->assertNotNull( $exception );
+			$this->assertStringContainsString( 'Sorry, you are not allowed to assign users to this role.', $exception->getMessage() );
+
+			$exception    = null;
+			try {
+				add_filter( 'editable_roles', function( $roles ) { unset( $roles['administrator'] ); return $roles; } );
+				ensure_editable_role( 'administrator' );
+				remove_filter( 'editable_roles', function( $roles ) { unset( $roles['administrator'] ); return $roles; } );
+			} catch ( WPDieException $e ) {
+				$exception = $e;
+			}
+			$this->assertNotNull( $exception );
+			$this->assertStringContainsString( 'Sorry, you are not allowed to assign users to this role.', $exception->getMessage() );
+		}
 	}
 
 endif;


### PR DESCRIPTION
This adds a check to the create/add user to blog screen to match and allow only the roles that are displayed in the UI.

Trac ticket: https://core.trac.wordpress.org/ticket/43251
