### PR TITLE
Add location reset button, focus on city input after clicking change

### DIFF
--- a/src/wp-admin/admin-ajax.php
+++ b/src/wp-admin/admin-ajax.php
@@ -60,6 +60,7 @@ $core_actions_post = array(
 	'oembed-cache',
 	'image-editor',
 	'delete-comment',
+	'clear-community-events',
 	'delete-tag',
 	'delete-link',
 	'delete-meta',

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -469,6 +469,7 @@
 .community-events-errors [aria-hidden="true"],
 .community-events-loading[aria-hidden="true"],
 .community-events[aria-hidden="true"],
+.community-events-reset-location[aria-hidden="true"],
 .community-events form[aria-hidden="true"] {
 	display: none;
 }

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -360,6 +360,17 @@ function wp_ajax_autocomplete_user() {
 	wp_die( wp_json_encode( $return ) );
 }
 
+
+/**
+ * Handles Ajax requests for clearing community events
+ */
+function wp_ajax_clear_community_events() {
+	check_ajax_referer( 'community_events' );
+	$user_id        = get_current_user_id();
+	delete_user_option( $user_id, 'community-events-location', true );
+	wp_send_json_success();
+}
+
 /**
  * Handles Ajax requests for community events
  *

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1381,10 +1381,22 @@ function wp_print_community_events_markup() {
 			<p>
 				<span id="community-events-location-message"></span>
 
-				<button class="button-link community-events-toggle-location" aria-expanded="false">
-					<span class="dashicons dashicons-location" aria-hidden="true"></span>
-					<span class="community-events-location-edit"><?php _e( 'Select location' ); ?></span>
-				</button>
+				<span id="community-events-change-location" aria-hidden="true">
+					<button class="button-link community-events-toggle-location" aria-expanded="false">
+						<span class="dashicons dashicons-location" aria-hidden="true"></span>
+						<span class="community-events-location-edit"><?php _e( 'Select a location' ); ?></span>
+					</button>
+
+					<span class="community-events-reset-location" aria-hidden="true">
+						<?php _e( 'or' ); ?>
+
+						<button class="button-link community-events-location-clear">
+							<span><?php _e( 'reset to your location.' ); ?></span>
+						</button>
+					</span>
+
+					<span class="spinner community-events-reset-spinner"></span>
+				</span>
 			</p>
 
 			<form class="community-events-form" aria-hidden="true" action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ); ?>" method="post">


### PR DESCRIPTION
- Add a button to reset the selected location
- Focus user on the city input after clicking the select location button

Parts of the code are based on the PR of Yeora of the similar ticket ( https://github.com/WordPress/wordpress-develop/pull/844/files ), but the user experience is different.

Trac ticket: https://core.trac.wordpress.org/ticket/51884