### PR TITLE
Section Styles: Add slug to solve inconsistency in variation names

### DIFF
--- a/src/wp-includes/block-supports/block-style-variations.php
+++ b/src/wp-includes/block-supports/block-style-variations.php
@@ -249,7 +249,7 @@ function wp_resolve_block_style_variations( $variations ) {
 		 * Block style variations read in via standalone theme.json partials
 		 * need to have their name set to the kebab case version of their title.
 		 */
-		$variation_name = $have_named_variations ? $key : _wp_to_kebab_case( $variation['title'] );
+		$variation_name = $have_named_variations ? $key : ( $variation['slug'] ?? _wp_to_kebab_case( $variation['title'] ) );
 
 		foreach ( $supported_blocks as $block_type ) {
 			// Add block style variation data under current block type.
@@ -441,7 +441,7 @@ function wp_register_block_style_variations_from_theme_json_data( $variations ) 
 		 * Block style variations read in via standalone theme.json partials
 		 * need to have their name set to the kebab case version of their title.
 		 */
-		$variation_name  = $have_named_variations ? $key : _wp_to_kebab_case( $variation['title'] );
+		$variation_name  = $have_named_variations ? $key : ( $variation['slug'] ?? _wp_to_kebab_case( $variation['title'] ) );
 		$variation_label = $variation['title'] ?? $variation_name;
 
 		foreach ( $supported_blocks as $block_type ) {

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -358,6 +358,7 @@ class WP_Theme_JSON {
 		'description',
 		'patterns',
 		'settings',
+		'slug',
 		'styles',
 		'templateParts',
 		'title',
@@ -3244,7 +3245,7 @@ class WP_Theme_JSON {
 	 * @since 6.3.2 Preserves global styles block variations when securing styles.
 	 * @since 6.6.0 Updated to allow variation element styles and $origin parameter.
 	 *
-	 * @param array $theme_json Structure to sanitize.
+	 * @param array  $theme_json Structure to sanitize.
 	 * @param string $origin    Optional. What source of data this object represents.
 	 *                          One of 'blocks', 'default', 'theme', or 'custom'. Default 'theme'.
 	 * @return array Sanitized structure.

--- a/tests/phpunit/data/themedir1/block-theme/styles/block-style-variation-with-slug.json
+++ b/tests/phpunit/data/themedir1/block-theme/styles/block-style-variation-with-slug.json
@@ -1,0 +1,12 @@
+{
+	"version": 3,
+	"blockTypes": [ "core/group", "core/columns" ],
+	"slug": "WithSlug",
+	"title": "With Slug",
+	"styles": {
+		"color": {
+			"background": "aliceblue",
+			"text": "midnightblue"
+		}
+	}
+}

--- a/tests/phpunit/tests/block-supports/block-style-variations.php
+++ b/tests/phpunit/tests/block-supports/block-style-variations.php
@@ -61,6 +61,7 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 	 * variation file within `/styles`, are added to the theme data.
 	 *
 	 * @ticket 61312
+	 * @ticket 61440
 	 */
 	public function test_add_registered_block_styles_to_theme_data() {
 		switch_theme( 'block-theme' );
@@ -98,6 +99,22 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 			),
 		);
 
+		/*
+		 * This style is to be deliberately overwritten by the theme.json partial
+		 * See `tests/phpunit/data/themedir1/block-theme/styles/block-style-variation-with-slug.json`.
+		 */
+		register_block_style(
+			'core/group',
+			array(
+				'name'       => 'WithSlug',
+				'style_data' => array(
+					'color' => array(
+						'background' => 'whitesmoke',
+						'text'       => 'black',
+					),
+				),
+			)
+		);
 		register_block_style(
 			'core/group',
 			array(
@@ -110,6 +127,13 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 		$group_styles = $theme_json['styles']['blocks']['core/group'] ?? array();
 		$expected     = array(
 			'variations' => array(
+				// @ticket 61440
+				'WithSlug'                => array(
+					'color' => array(
+						'background' => 'aliceblue',
+						'text'       => 'midnightblue',
+					),
+				),
 				'my-variation'            => $variation_styles_data,
 
 				/*
@@ -134,6 +158,6 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 
 		unregister_block_style( 'core/group', 'my-variation' );
 
-		$this->assertSameSetsWithIndex( $group_styles, $expected );
+		$this->assertSameSetsWithIndex( $expected, $group_styles );
 	}
 }

--- a/tests/phpunit/tests/block-supports/block-style-variations.php
+++ b/tests/phpunit/tests/block-supports/block-style-variations.php
@@ -157,6 +157,7 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 		);
 
 		unregister_block_style( 'core/group', 'my-variation' );
+		unregister_block_style( 'core/group', 'WithSlug' );
 
 		$this->assertSameSetsWithIndex( $expected, $group_styles );
 	}

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -1160,6 +1160,19 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 							),
 						),
 					),
+					// @ticket 61440
+					array(
+						'blockTypes' => array( 'core/group', 'core/columns' ),
+						'version'    => 3,
+						'slug'       => 'WithSlug',
+						'title'      => 'With Slug',
+						'styles'     => array(
+							'color' => array(
+								'background' => 'aliceblue',
+								'text'       => 'midnightblue',
+							),
+						),
+					),
 				),
 			),
 		);


### PR DESCRIPTION
Backports the PHP changes from https://github.com/WordPress/gutenberg/pull/62550 fixing an issue with duplicate block style options appearing and variation definitions from different sources not merging correctly.

Test Instructions:

1. Register a block style variation via `register_block_style` snippet below
```php
		register_block_style(
			'core/group',
			array(
				'name'         => 'MyVariation',
				'label'        => __( 'My variation', 'twentytwentyfour' ),
				'inline_style' => '
				.is-style-MyVariation {
					background-color: red;
				}',
			)
		);
```
2. Create theme.json partial file within `/styles/partial.json` using the following snippet
```json
{
    "$schema": "https://schemas.wp.org/trunk/theme.json",
    "version": 2,
    "title": "My variation",
    "slug": "MyVariation",
    "blockTypes": [ "core/group" ],
    "styles": {
            "color": {
                    "background": "blue",
                    "text": "white"
            }
    }
}
```
3. Open the site editor, select a group block and confirm only a single block style option other than default
4. Select that block style and confirm that the partial theme.json files' style applies correctly

Unit Tests:
```
npm run test:php -- --filter WP_Block_Supports_Block_Style_Variations_Test
```
```
npm run test:php -- --filter Tests_Theme_wpThemeJsonResolver
```


Trac ticket: https://core.trac.wordpress.org/ticket/61440

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
