### PR TITLE
Theme JSON: Add missing i18n for variations

### DIFF
--- a/src/wp-includes/theme-i18n.json
+++ b/src/wp-includes/theme-i18n.json
@@ -80,6 +80,15 @@
 			}
 		}
 	},
+	"styles": {
+		"blocks": {
+			"variations": {
+				"*": {
+					"title": "Style variation name"
+				}
+			}
+		}
+	},
 	"customTemplates": [
 		{
 			"title": "Custom template name"


### PR DESCRIPTION
This PR backports https://github.com/WordPress/gutenberg/pull/62552

The changes included add support for internationalizing the block style variations labels defined from a theme.json or theme style variation file.

### Test Instructions

In the `theme.json` of the theme, paste the following contents under `styles.blocks.variations`:

```json
"myvariation": {
    "title": "My Variation",
    "blockTypes": ["core/group"],
    "color": {
        "background": "var(--wp--preset--color--base-2)"
    }
}
```

| Without the `title` | With the `title` |
| --- | --- |
| <img width="278" alt="Captura de ecrã 2024-06-13, às 21 51 45" src="https://github.com/WordPress/gutenberg/assets/583546/88aa296e-8dba-4b36-bfd2-f56ef9006576"> | <img width="278" alt="Captura de ecrã 2024-06-13, às 21 52 04" src="https://github.com/WordPress/gutenberg/assets/583546/9c78d6a9-01c0-4870-82a5-322c12282b85"> |

Trac ticket: https://core.trac.wordpress.org/ticket/61442

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
