### PR TITLE
Twenty Sixteen: edit Navigation block submenu and responsive container styles

### DIFF
--- a/src/wp-content/themes/twentysixteen/css/blocks.css
+++ b/src/wp-content/themes/twentysixteen/css/blocks.css
@@ -332,7 +332,9 @@ hr.wp-block-separator {
 	margin-right: 0;
 }
 
-.wp-block-navigation .wp-block-navigation-submenu__toggle {
+.wp-block-navigation .wp-block-navigation-submenu__toggle,
+.wp-block-navigation .wp-block-navigation__responsive-container-open,
+.wp-block-navigation .wp-block-navigation__responsive-container-close {
 	background: transparent;
 	padding-top: 0;
 	padding-bottom: 0;

--- a/src/wp-content/themes/twentysixteen/css/blocks.css
+++ b/src/wp-content/themes/twentysixteen/css/blocks.css
@@ -336,11 +336,11 @@ hr.wp-block-separator {
 .wp-block-navigation .wp-block-navigation__responsive-container-open,
 .wp-block-navigation .wp-block-navigation__responsive-container-close {
 	background: transparent;
+	border-radius: 0;
+	letter-spacing: normal;
+	outline-offset: 0;
 	padding-top: 0;
 	padding-bottom: 0;
-	outline-offset: 0;
-	letter-spacing: normal;
-	border-radius: 0;
 }
 
 .entry-content :where(.wp-block-navigation .open-on-click .wp-block-navigation-submenu__toggle:not(:hover):not(:focus)) {

--- a/src/wp-content/themes/twentysixteen/css/blocks.css
+++ b/src/wp-content/themes/twentysixteen/css/blocks.css
@@ -325,6 +325,25 @@ hr.wp-block-separator {
 	display: list-item;
 }
 
+/* Navigation */
+
+.wp-block-navigation-item .wp-block-navigation-submenu {
+	margin-left: 0;
+	margin-right: 0;
+}
+
+.wp-block-navigation button {
+	background: transparent;
+	padding-top: 0;
+	padding-bottom: 0;
+	outline-offset: 0;
+	letter-spacing: normal;
+}
+
+.wp-block-navigation__responsive-container.is-menu-open {
+	padding: 0 1rem;
+}
+
 /*--------------------------------------------------------------
 5.0 Blocks - Widget Blocks
 --------------------------------------------------------------*/

--- a/src/wp-content/themes/twentysixteen/css/blocks.css
+++ b/src/wp-content/themes/twentysixteen/css/blocks.css
@@ -332,7 +332,7 @@ hr.wp-block-separator {
 	margin-right: 0;
 }
 
-.wp-block-navigation button {
+.wp-block-navigation .wp-block-navigation-submenu__toggle {
 	background: transparent;
 	padding-top: 0;
 	padding-bottom: 0;

--- a/src/wp-content/themes/twentysixteen/css/blocks.css
+++ b/src/wp-content/themes/twentysixteen/css/blocks.css
@@ -338,6 +338,7 @@ hr.wp-block-separator {
 	padding-bottom: 0;
 	outline-offset: 0;
 	letter-spacing: normal;
+	border-radius: 0;
 }
 
 .entry-content :where(.wp-block-navigation .open-on-click .wp-block-navigation-submenu__toggle:not(:hover):not(:focus)) {

--- a/src/wp-content/themes/twentysixteen/css/blocks.css
+++ b/src/wp-content/themes/twentysixteen/css/blocks.css
@@ -340,6 +340,10 @@ hr.wp-block-separator {
 	letter-spacing: normal;
 }
 
+.entry-content :where(.wp-block-navigation .open-on-click .wp-block-navigation-submenu__toggle:not(:hover):not(:focus)) {
+	box-shadow: 0 1px 0 0 currentColor;
+}
+
 .wp-block-navigation__responsive-container.is-menu-open {
 	padding: 0 1rem;
 }


### PR DESCRIPTION
- Removes left and right margins from the opened submenu at larger screen sizes.
- Resets styles for the submenu toggle (when it opens on click) plus the open and close buttons for the responsive container: `background`, `border-radius`, `letter-spacing`, `outline-offset`, and top and bottom padding.
- Adds a `box-shadow` to match the link styles if: the Navigation block is within `.entry-content`, the submenu is set to open on click, and the toggle button is not in `hover` or `focus` state.
- Adds a small amount of padding to the left and right sides of the responsive container when that is opened.

[Trac 60374](https://core.trac.wordpress.org/ticket/60374)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
