### PR TITLE
Twenty Nineteen: honor Button block's `font-weight` and `text-decoration` settings

### DIFF
--- a/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
+++ b/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
@@ -245,6 +245,14 @@
 		&.has-custom-font-size .wp-block-button__link {
 			font-size: 1em;
 		}
+
+		&[style*="font-weight"] .wp-block-button__link {
+			font-weight: inherit;
+		}
+
+		&[style*="text-decoration"] .wp-block-button__link {
+			text-decoration: inherit;
+		}
 	}
 
 	//! Latest posts, categories, archives

--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -1026,6 +1026,11 @@ figcaption,
   color: #0073aa;
 }
 
+.wp-block-buttons[style*="font-weight"] .wp-block-button__link,
+.wp-block-button[style*="font-weight"] .wp-block-button__link {
+  font-weight: inherit;
+}
+
 .wp-block-search .wp-block-search__button {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 0.88889em;

--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -1031,6 +1031,11 @@ figcaption,
   font-weight: inherit;
 }
 
+.wp-block-buttons[style*="text-decoration"] .wp-block-button__link,
+.wp-block-button[style*="text-decoration"] .wp-block-button__link {
+  text-decoration: inherit;
+}
+
 .wp-block-search .wp-block-search__button {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   font-size: 0.88889em;

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -424,6 +424,14 @@ figcaption,
 	}
 }
 
+.wp-block-buttons,
+.wp-block-button {
+
+	&[style*="font-weight"] .wp-block-button__link {
+		font-weight: inherit;
+	}
+}
+
 .wp-block-search {
 	.wp-block-search__button {
 		@include font-family( $font__heading );

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -430,6 +430,10 @@ figcaption,
 	&[style*="font-weight"] .wp-block-button__link {
 		font-weight: inherit;
 	}
+
+	&[style*="text-decoration"] .wp-block-button__link {
+		text-decoration: inherit;
+	}
 }
 
 .wp-block-search {

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -5565,6 +5565,16 @@ body.page .main-navigation {
   font-size: 1em;
 }
 
+.entry .entry-content .wp-block-buttons[style*="font-weight"] .wp-block-button__link,
+.entry .entry-content .wp-block-button[style*="font-weight"] .wp-block-button__link {
+  font-weight: inherit;
+}
+
+.entry .entry-content .wp-block-buttons[style*="text-decoration"] .wp-block-button__link,
+.entry .entry-content .wp-block-button[style*="text-decoration"] .wp-block-button__link {
+  text-decoration: inherit;
+}
+
 .entry .entry-content .wp-block-archives,
 .entry .entry-content .wp-block-categories,
 .entry .entry-content .wp-block-latest-posts {

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -5577,6 +5577,16 @@ body.page .main-navigation {
   font-size: 1em;
 }
 
+.entry .entry-content .wp-block-buttons[style*="font-weight"] .wp-block-button__link,
+.entry .entry-content .wp-block-button[style*="font-weight"] .wp-block-button__link {
+  font-weight: inherit;
+}
+
+.entry .entry-content .wp-block-buttons[style*="text-decoration"] .wp-block-button__link,
+.entry .entry-content .wp-block-button[style*="text-decoration"] .wp-block-button__link {
+  text-decoration: inherit;
+}
+
 .entry .entry-content .wp-block-archives,
 .entry .entry-content .wp-block-categories,
 .entry .entry-content .wp-block-latest-posts {


### PR DESCRIPTION
Inherits custom font weight and text decoration settings, both on the front end and within the editor.

[Trac 61437](https://core.trac.wordpress.org/ticket/61437)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
