### PR TITLE
KSES: Add test cases for "bogus comment" syntax not currently detected.

### DIFF
--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1936,11 +1936,13 @@ HTML;
 	 *
 	 * @ticket 61009
 	 *
+	 * @dataProvider data_html_containing_various_kinds_of_html_comments
+	 *
 	 * @param string $html_comment    HTML containing a comment; must not be a valid comment
 	 *                                but must be syntax which a browser interprets as a comment.
 	 * @param string $expected_output How `wp_kses()` ought to transform the comment.
 	 */
-	public function wp_kses_preserves_html_comments( $html_comment, $expected_output ) {
+	public function test_wp_kses_preserves_html_comments( $html_comment, $expected_output ) {
 		$this->assertSame(
 			$expected_output,
 			wp_kses( $html_comment, array() ),
@@ -1957,6 +1959,7 @@ HTML;
 		return array(
 			'Normative HTML comment'            => array( 'before<!-- this is a comment -->after', 'before<!-- this is a comment -->after' ),
 			'Closing tag with invalid tag name' => array( 'before<//not a tag>after', 'before<//not a tag>after' ),
+			'Incorrectly opened comment (Markup declaration)' => array( 'before<!also not a tag>after', 'before<!also not a tag>after' ),
 		);
 	}
 


### PR DESCRIPTION
In [[58418]](https://core.trac.wordpress.org/changeset/58418) a test was added without the `test_` prefix in its function
name, and because of that, it wasn't run in the test suite.
The prefix has been added to ensure that it runs.

In the original patch, due to a logical bug, a recursive loop to
transform the inside contents of the bogus comments was never run
more than once. This has been fixed.

This patch also includes one more case where `kses` wasn't
properly detecting the bogus comment state, and adds a test case
to cover this. It limits itself to some but not all constructions
of invalid markup declaration so that it doesn't conflict with
existing behaviors around those and other kinds of invalid comments.

See also #6840