### PR TITLE
Fixed:The `recovery_mode_clean_expired_keys` cron event is orphaned after converting to Multisite

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -1018,6 +1018,11 @@ function populate_network( $network_id = 1, $domain = '', $email = '', $site_nam
 		return $errors;
 	}
 
+	// Remove the cron event since Recovery Mode is not used in Multisite.
+	if ( wp_next_scheduled( 'recovery_mode_clean_expired_keys' ) ) {
+		wp_clear_scheduled_hook( 'recovery_mode_clean_expired_keys' );
+	}
+
 	if ( 1 === $network_id ) {
 		$wpdb->insert(
 			$wpdb->site,
@@ -1046,6 +1051,11 @@ function populate_network( $network_id = 1, $domain = '', $email = '', $site_nam
 			'subdomain_install' => $subdomain_install,
 		)
 	);
+
+	// Remove the cron event since Recovery Mode is not used in Multisite.
+	if ( wp_next_scheduled( 'recovery_mode_clean_expired_keys' ) ) {
+		wp_clear_scheduled_hook( 'recovery_mode_clean_expired_keys' );
+	}
 
 	/*
 	 * When upgrading from single to multisite, assume the current site will

--- a/src/wp-includes/class-wp-recovery-mode.php
+++ b/src/wp-includes/class-wp-recovery-mode.php
@@ -95,7 +95,6 @@ class WP_Recovery_Mode {
 		add_action( 'wp_logout', array( $this, 'exit_recovery_mode' ) );
 		add_action( 'login_form_' . self::EXIT_ACTION, array( $this, 'handle_exit_recovery_mode' ) );
 		add_action( 'recovery_mode_clean_expired_keys', array( $this, 'clean_expired_keys' ) );
-		add_action( 'wp_install', array( $this, 'remove_orphaned_recovery_mode_cron_event' ) );
 
 		if ( ! wp_next_scheduled( 'recovery_mode_clean_expired_keys' ) && ! wp_installing() ) {
 			wp_schedule_event( time(), 'daily', 'recovery_mode_clean_expired_keys' );
@@ -261,21 +260,6 @@ class WP_Recovery_Mode {
 	 */
 	public function clean_expired_keys() {
 		$this->key_service->clean_expired_keys( $this->get_link_ttl() );
-	}
-
-	/**
-	 * Unschedule the recovery_mode_clean_expired_keys Event.
-	 */
-	public function remove_orphaned_recovery_mode_cron_event() {
-		// Check if we are in a Multisite installation.
-		if ( is_multisite() ) {
-			// Check if the cron event is scheduled.
-			$timestamp = wp_next_scheduled( 'recovery_mode_clean_expired_keys' );
-			if ( $timestamp ) {
-				// Unschedule the event.
-				wp_unschedule_event( $timestamp, 'recovery_mode_clean_expired_keys' );
-			}
-		}
 	}
 
 	/**

--- a/src/wp-includes/class-wp-recovery-mode.php
+++ b/src/wp-includes/class-wp-recovery-mode.php
@@ -95,7 +95,7 @@ class WP_Recovery_Mode {
 		add_action( 'wp_logout', array( $this, 'exit_recovery_mode' ) );
 		add_action( 'login_form_' . self::EXIT_ACTION, array( $this, 'handle_exit_recovery_mode' ) );
 		add_action( 'recovery_mode_clean_expired_keys', array( $this, 'clean_expired_keys' ) );
-		add_action( 'wp_install', array( $this, 'remove_orphaned_recovery_mode_cron_event' ), 10, 1 );
+		add_action( 'wp_install', array( $this, 'remove_orphaned_recovery_mode_cron_event' ) );
 
 		if ( ! wp_next_scheduled( 'recovery_mode_clean_expired_keys' ) && ! wp_installing() ) {
 			wp_schedule_event( time(), 'daily', 'recovery_mode_clean_expired_keys' );

--- a/src/wp-includes/class-wp-recovery-mode.php
+++ b/src/wp-includes/class-wp-recovery-mode.php
@@ -95,6 +95,7 @@ class WP_Recovery_Mode {
 		add_action( 'wp_logout', array( $this, 'exit_recovery_mode' ) );
 		add_action( 'login_form_' . self::EXIT_ACTION, array( $this, 'handle_exit_recovery_mode' ) );
 		add_action( 'recovery_mode_clean_expired_keys', array( $this, 'clean_expired_keys' ) );
+		add_action( 'wp_install', array( $this, 'remove_orphaned_recovery_mode_cron_event' ), 10, 1 );
 
 		if ( ! wp_next_scheduled( 'recovery_mode_clean_expired_keys' ) && ! wp_installing() ) {
 			wp_schedule_event( time(), 'daily', 'recovery_mode_clean_expired_keys' );
@@ -260,6 +261,21 @@ class WP_Recovery_Mode {
 	 */
 	public function clean_expired_keys() {
 		$this->key_service->clean_expired_keys( $this->get_link_ttl() );
+	}
+
+	/**
+	 * Unschedule the recovery_mode_clean_expired_keys Event.
+	 */
+	public function remove_orphaned_recovery_mode_cron_event() {
+		// Check if we are in a Multisite installation.
+		if ( is_multisite() ) {
+			// Check if the cron event is scheduled.
+			$timestamp = wp_next_scheduled( 'recovery_mode_clean_expired_keys' );
+			if ( $timestamp ) {
+				// Unschedule the event.
+				wp_unschedule_event( $timestamp, 'recovery_mode_clean_expired_keys' );
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61450

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
