### PR TITLE
Global styles: block background UI controls

### DIFF
--- a/src/wp-includes/block-supports/background.php
+++ b/src/wp-includes/block-supports/background.php
@@ -62,13 +62,14 @@ function wp_render_background_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$background_styles                    = array();
-	$background_styles['backgroundImage'] = isset( $block_attributes['style']['background']['backgroundImage'] ) ? $block_attributes['style']['background']['backgroundImage'] : array();
+	$background_styles                       = array();
+	$background_styles['backgroundImage']    = $block_attributes['style']['background']['backgroundImage'] ?? null;
+	$background_styles['backgroundSize']     = $block_attributes['style']['background']['backgroundSize'] ?? null;
+	$background_styles['backgroundPosition'] = $block_attributes['style']['background']['backgroundPosition'] ?? null;
+	$background_styles['backgroundRepeat']   = $block_attributes['style']['background']['backgroundRepeat'] ?? null;
 
 	if ( ! empty( $background_styles['backgroundImage'] ) ) {
-		$background_styles['backgroundSize']     = isset( $block_attributes['style']['background']['backgroundSize'] ) ? $block_attributes['style']['background']['backgroundSize'] : 'cover';
-		$background_styles['backgroundPosition'] = isset( $block_attributes['style']['background']['backgroundPosition'] ) ? $block_attributes['style']['background']['backgroundPosition'] : null;
-		$background_styles['backgroundRepeat']   = isset( $block_attributes['style']['background']['backgroundRepeat'] ) ? $block_attributes['style']['background']['backgroundRepeat'] : null;
+		$background_styles['backgroundSize'] = $background_styles['backgroundSize'] ?? 'cover';
 
 		// If the background size is set to `contain` and no position is set, set the position to `center`.
 		if ( 'contain' === $background_styles['backgroundSize'] && ! $background_styles['backgroundPosition'] ) {

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -873,7 +873,8 @@ class WP_Theme_JSON_Resolver {
 			isset( $background_image_url ) &&
 			is_string( $background_image_url ) &&
 			// Skip if the src doesn't start with the placeholder, as there's nothing to replace.
-			str_starts_with( $background_image_url, $placeholder ) ) {
+			str_starts_with( $background_image_url, $placeholder )
+		) {
 			$file_type          = wp_check_filetype( $background_image_url );
 			$src_url            = str_replace( $placeholder, '', $background_image_url );
 			$resolved_theme_uri = array(
@@ -893,12 +894,12 @@ class WP_Theme_JSON_Resolver {
 				if ( ! isset( $block_styles['background']['backgroundImage']['url'] ) ) {
 					continue;
 				}
-				$background_image_url = $block_styles['background']['backgroundImage']['url'] ?? null;
+				$background_image_url = $block_styles['background']['backgroundImage']['url'];
 				if (
-					isset( $background_image_url ) &&
 					is_string( $background_image_url ) &&
 					// Skip if the src doesn't start with the placeholder, as there's nothing to replace.
-					str_starts_with( $background_image_url, $placeholder ) ) {
+					str_starts_with( $background_image_url, $placeholder )
+				) {
 					$file_type          = wp_check_filetype( $background_image_url );
 					$src_url            = str_replace( $placeholder, '', $background_image_url );
 					$resolved_theme_uri = array(

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -848,6 +848,7 @@ class WP_Theme_JSON_Resolver {
 	 * as the value of `_link` object in REST API responses.
 	 *
 	 * @since 6.6.0
+	 * @since 6.7.0 Resolve relative paths in block styles.
 	 *
 	 * @param WP_Theme_JSON $theme_json A theme json instance.
 	 * @return array An array of resolved paths.
@@ -860,21 +861,19 @@ class WP_Theme_JSON_Resolver {
 		}
 
 		$theme_json_data = $theme_json->get_raw_data();
-
-		// Top level styles.
-		$background_image_url = isset( $theme_json_data['styles']['background']['backgroundImage']['url'] ) ? $theme_json_data['styles']['background']['backgroundImage']['url'] : null;
-
 		/*
 		 * The same file convention when registering web fonts.
 		 * See: WP_Font_Face_Resolver::to_theme_file_uri.
 		 */
 		$placeholder = 'file:./';
+
+		// Top level styles.
+		$background_image_url = $theme_json_data['styles']['background']['backgroundImage']['url'] ?? null;
 		if (
 			isset( $background_image_url ) &&
 			is_string( $background_image_url ) &&
 			// Skip if the src doesn't start with the placeholder, as there's nothing to replace.
-			str_starts_with( $background_image_url, $placeholder )
-		) {
+			str_starts_with( $background_image_url, $placeholder ) ) {
 			$file_type          = wp_check_filetype( $background_image_url );
 			$src_url            = str_replace( $placeholder, '', $background_image_url );
 			$resolved_theme_uri = array(
@@ -886,6 +885,33 @@ class WP_Theme_JSON_Resolver {
 				$resolved_theme_uri['type'] = $file_type['type'];
 			}
 			$resolved_theme_uris[] = $resolved_theme_uri;
+		}
+
+		// Block styles.
+		if ( ! empty( $theme_json_data['styles']['blocks'] ) ) {
+			foreach ( $theme_json_data['styles']['blocks'] as $block_name => $block_styles ) {
+				if ( ! isset( $block_styles['background']['backgroundImage']['url'] ) ) {
+					continue;
+				}
+				$background_image_url = $block_styles['background']['backgroundImage']['url'] ?? null;
+				if (
+					isset( $background_image_url ) &&
+					is_string( $background_image_url ) &&
+					// Skip if the src doesn't start with the placeholder, as there's nothing to replace.
+					str_starts_with( $background_image_url, $placeholder ) ) {
+					$file_type          = wp_check_filetype( $background_image_url );
+					$src_url            = str_replace( $placeholder, '', $background_image_url );
+					$resolved_theme_uri = array(
+						'name'   => $background_image_url,
+						'href'   => sanitize_url( get_theme_file_uri( $src_url ) ),
+						'target' => "styles.blocks.{$block_name}.background.backgroundImage.url",
+					);
+					if ( isset( $file_type['type'] ) ) {
+						$resolved_theme_uri['type'] = $file_type['type'];
+					}
+					$resolved_theme_uris[] = $resolved_theme_uri;
+				}
+			}
 		}
 
 		return $resolved_theme_uris;

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -520,10 +520,10 @@ class WP_Theme_JSON {
 	 */
 	const VALID_STYLES = array(
 		'background' => array(
-			'backgroundImage'    => 'top',
-			'backgroundPosition' => 'top',
-			'backgroundRepeat'   => 'top',
-			'backgroundSize'     => 'top',
+			'backgroundImage'    => null,
+			'backgroundPosition' => null,
+			'backgroundRepeat'   => null,
+			'backgroundSize'     => null,
 		),
 		'border'     => array(
 			'color'  => null,

--- a/src/wp-includes/global-styles-and-settings.php
+++ b/src/wp-includes/global-styles-and-settings.php
@@ -299,6 +299,7 @@ function wp_get_global_styles_custom_css() {
  * Adds global style rules to the inline style for each block.
  *
  * @since 6.1.0
+ * @since 6.7.0 Resolve relative paths in block styles.
  *
  * @global WP_Styles $wp_styles
  */
@@ -306,6 +307,7 @@ function wp_add_global_styles_for_blocks() {
 	global $wp_styles;
 
 	$tree        = WP_Theme_JSON_Resolver::get_merged_data();
+	$tree        = WP_Theme_JSON_Resolver::resolve_theme_file_uris( $tree );
 	$block_nodes = $tree->get_styles_block_nodes();
 
 	$can_use_cached = ! wp_is_development_mode( 'theme' );

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -5014,7 +5014,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		);
 
 		$expected_styles = "html{min-height: calc(100% - var(--wp-admin--admin-bar--height, 0px));}:root :where(body){background-image: url('http://example.org/image.png');background-position: center center;background-repeat: no-repeat;background-size: contain;}";
-		$this->assertSame( $expected_styles, $theme_json->get_styles_for_block( $body_node ), 'Styles returned from "::get_stylesheet()" with top-level background styles type does not match expectations' );
+		$this->assertSame( $expected_styles, $theme_json->get_styles_for_block( $body_node ), 'Styles returned from "::get_stylesheet()" with top-level background styles type do not match expectations' );
 
 		$theme_json = new WP_Theme_JSON(
 			array(
@@ -5031,8 +5031,65 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		);
 
 		$expected_styles = "html{min-height: calc(100% - var(--wp-admin--admin-bar--height, 0px));}:root :where(body){background-image: url('http://example.org/image.png');background-position: center center;background-repeat: no-repeat;background-size: contain;}";
-		$this->assertSame( $expected_styles, $theme_json->get_styles_for_block( $body_node ), 'Styles returned from "::get_stylesheet()" with top-level background image as string type does not match expectations' );
+		$this->assertSame( $expected_styles, $theme_json->get_styles_for_block( $body_node ), 'Styles returned from "::get_stylesheet()" with top-level background image as string type do not match expectations' );
 	}
+
+    /**
+     * @ticket 61588
+     */
+    public function test_get_block_background_image_styles() {
+        $theme_json = new WP_Theme_JSON(
+            array(
+                'version' => WP_Theme_JSON::LATEST_SCHEMA,
+                'styles'  => array(
+                    'blocks' => array(
+                        'core/group' => array(
+                            'background' => array(
+                                'backgroundImage'    => "url('http://example.org/group.png')",
+                                'backgroundSize'     => 'cover',
+                                'backgroundRepeat'   => 'no-repeat',
+                                'backgroundPosition' => 'center center',
+                            ),
+                        ),
+                        'core/quote' => array(
+                            'background' => array(
+                                'backgroundImage'    => array(
+                                    'url' => 'http://example.org/quote.png',
+                                ),
+                                'backgroundSize'     => 'cover',
+                                'backgroundRepeat'   => 'no-repeat',
+                                'backgroundPosition' => 'center center',
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        );
+
+        $quote_node = array(
+            'name'      => 'core/quote',
+            'path'      => array( 'styles', 'blocks', 'core/quote' ),
+            'selector'  => '.wp-block-quote',
+            'selectors' => array(
+                'root' => '.wp-block-quote',
+            ),
+        );
+
+        $quote_styles = ":root :where(.wp-block-quote){background-image: url('http://example.org/quote.png');background-position: center center;background-repeat: no-repeat;background-size: cover;}";
+        $this->assertSame( $quote_styles, $theme_json->get_styles_for_block( $quote_node ), 'Styles returned from "::get_styles_for_block()" with block-level background styles do not match expectations' );
+
+        $group_node = array(
+            'name'      => 'core/group',
+            'path'      => array( 'styles', 'blocks', 'core/group' ),
+            'selector'  => '.wp-block-group',
+            'selectors' => array(
+                'root' => '.wp-block-group',
+            ),
+        );
+
+        $group_styles = ":root :where(.wp-block-group){background-image: url('http://example.org/group.png');background-position: center center;background-repeat: no-repeat;background-size: cover;}";
+        $this->assertSame( $group_styles, $theme_json->get_styles_for_block( $group_node ), 'Styles returned from "::get_styles_for_block()" with block-level background styles as string type do not match expectations' );
+    }
 
 	/**
 	 * @ticket 57536

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -5034,62 +5034,62 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		$this->assertSame( $expected_styles, $theme_json->get_styles_for_block( $body_node ), 'Styles returned from "::get_stylesheet()" with top-level background image as string type do not match expectations' );
 	}
 
-    /**
-     * @ticket 61588
-     */
-    public function test_get_block_background_image_styles() {
-        $theme_json = new WP_Theme_JSON(
-            array(
-                'version' => WP_Theme_JSON::LATEST_SCHEMA,
-                'styles'  => array(
-                    'blocks' => array(
-                        'core/group' => array(
-                            'background' => array(
-                                'backgroundImage'    => "url('http://example.org/group.png')",
-                                'backgroundSize'     => 'cover',
-                                'backgroundRepeat'   => 'no-repeat',
-                                'backgroundPosition' => 'center center',
-                            ),
-                        ),
-                        'core/quote' => array(
-                            'background' => array(
-                                'backgroundImage'    => array(
-                                    'url' => 'http://example.org/quote.png',
-                                ),
-                                'backgroundSize'     => 'cover',
-                                'backgroundRepeat'   => 'no-repeat',
-                                'backgroundPosition' => 'center center',
-                            ),
-                        ),
-                    ),
-                ),
-            )
-        );
+	/**
+	 * @ticket 61588
+	 */
+	public function test_get_block_background_image_styles() {
+		$theme_json = new WP_Theme_JSON(
+			array(
+				'version' => WP_Theme_JSON::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'core/group' => array(
+							'background' => array(
+								'backgroundImage'    => "url('http://example.org/group.png')",
+								'backgroundSize'     => 'cover',
+								'backgroundRepeat'   => 'no-repeat',
+								'backgroundPosition' => 'center center',
+							),
+						),
+						'core/quote' => array(
+							'background' => array(
+								'backgroundImage'    => array(
+									'url' => 'http://example.org/quote.png',
+								),
+								'backgroundSize'     => 'cover',
+								'backgroundRepeat'   => 'no-repeat',
+								'backgroundPosition' => 'center center',
+							),
+						),
+					),
+				),
+			)
+		);
 
-        $quote_node = array(
-            'name'      => 'core/quote',
-            'path'      => array( 'styles', 'blocks', 'core/quote' ),
-            'selector'  => '.wp-block-quote',
-            'selectors' => array(
-                'root' => '.wp-block-quote',
-            ),
-        );
+		$quote_node = array(
+			'name'      => 'core/quote',
+			'path'      => array( 'styles', 'blocks', 'core/quote' ),
+			'selector'  => '.wp-block-quote',
+			'selectors' => array(
+				'root' => '.wp-block-quote',
+			),
+		);
 
-        $quote_styles = ":root :where(.wp-block-quote){background-image: url('http://example.org/quote.png');background-position: center center;background-repeat: no-repeat;background-size: cover;}";
-        $this->assertSame( $quote_styles, $theme_json->get_styles_for_block( $quote_node ), 'Styles returned from "::get_styles_for_block()" with block-level background styles do not match expectations' );
+		$quote_styles = ":root :where(.wp-block-quote){background-image: url('http://example.org/quote.png');background-position: center center;background-repeat: no-repeat;background-size: cover;}";
+		$this->assertSame( $quote_styles, $theme_json->get_styles_for_block( $quote_node ), 'Styles returned from "::get_styles_for_block()" with block-level background styles do not match expectations' );
 
-        $group_node = array(
-            'name'      => 'core/group',
-            'path'      => array( 'styles', 'blocks', 'core/group' ),
-            'selector'  => '.wp-block-group',
-            'selectors' => array(
-                'root' => '.wp-block-group',
-            ),
-        );
+		$group_node = array(
+			'name'      => 'core/group',
+			'path'      => array( 'styles', 'blocks', 'core/group' ),
+			'selector'  => '.wp-block-group',
+			'selectors' => array(
+				'root' => '.wp-block-group',
+			),
+		);
 
-        $group_styles = ":root :where(.wp-block-group){background-image: url('http://example.org/group.png');background-position: center center;background-repeat: no-repeat;background-size: cover;}";
-        $this->assertSame( $group_styles, $theme_json->get_styles_for_block( $group_node ), 'Styles returned from "::get_styles_for_block()" with block-level background styles as string type do not match expectations' );
-    }
+		$group_styles = ":root :where(.wp-block-group){background-image: url('http://example.org/group.png');background-position: center center;background-repeat: no-repeat;background-size: cover;}";
+		$this->assertSame( $group_styles, $theme_json->get_styles_for_block( $group_node ), 'Styles returned from "::get_styles_for_block()" with block-level background styles as string type do not match expectations' );
+	}
 
 	/**
 	 * @ticket 57536

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -1340,14 +1340,14 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 						'core/quote' => array(
 							'background' => array(
 								'backgroundImage' => array(
-									'url' => 'file:./example/img/quote.jpg',
+									'url' => 'file:./assets/quote.jpg',
 								),
 							),
 						),
 						'core/verse' => array(
 							'background' => array(
 								'backgroundImage' => array(
-									'url' => 'file:./example/img/verse.gif',
+									'url' => 'file:./assets/verse.gif',
 								),
 							),
 						),

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -1268,6 +1268,22 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 							'url' => 'file:./assets/image.png',
 						),
 					),
+					'blocks'     => array(
+						'core/quote' => array(
+							'background' => array(
+								'backgroundImage' => array(
+									'url' => 'file:./assets/quote.png',
+								),
+							),
+						),
+						'core/verse' => array(
+							'background' => array(
+								'backgroundImage' => array(
+									'url' => 'file:./assets/verse.png',
+								),
+							),
+						),
+					),
 				),
 			)
 		);
@@ -1278,6 +1294,22 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 				'background' => array(
 					'backgroundImage' => array(
 						'url' => 'https://example.org/wp-content/themes/example-theme/assets/image.png',
+					),
+				),
+				'blocks'     => array(
+					'core/quote' => array(
+						'background' => array(
+							'backgroundImage' => array(
+								'url' => 'https://example.org/wp-content/themes/example-theme/assets/quote.png',
+							),
+						),
+					),
+					'core/verse' => array(
+						'background' => array(
+							'backgroundImage' => array(
+								'url' => 'https://example.org/wp-content/themes/example-theme/assets/verse.png',
+							),
+						),
 					),
 				),
 			),
@@ -1304,6 +1336,22 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 							'url' => 'file:./assets/image.png',
 						),
 					),
+					'blocks'     => array(
+						'core/quote' => array(
+							'background' => array(
+								'backgroundImage' => array(
+									'url' => 'file:./example/img/quote.jpg',
+								),
+							),
+						),
+						'core/verse' => array(
+							'background' => array(
+								'backgroundImage' => array(
+									'url' => 'file:./example/img/verse.gif',
+								),
+							),
+						),
+					),
 				),
 			)
 		);
@@ -1314,6 +1362,18 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 				'href'   => 'https://example.org/wp-content/themes/example-theme/assets/image.png',
 				'target' => 'styles.background.backgroundImage.url',
 				'type'   => 'image/png',
+			),
+			array(
+				'name'   => 'file:./assets/quote.jpg',
+				'href'   => 'https://example.org/wp-content/themes/example-theme/assets/quote.jpg',
+				'target' => 'styles.blocks.core/quote.background.backgroundImage.url',
+				'type'   => 'image/jpeg',
+			),
+			array(
+				'name'   => 'file:./assets/verse.gif',
+				'href'   => 'https://example.org/wp-content/themes/example-theme/assets/verse.gif',
+				'target' => 'styles.blocks.core/verse.background.backgroundImage.url',
+				'type'   => 'image/gif',
 			),
 		);
 

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -1257,6 +1257,7 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 	 *
 	 * @covers WP_Theme_JSON_Resolver::resolve_theme_file_uris
 	 * @ticket 61273
+	 * @ticket 61588
 	 */
 	public function test_resolve_theme_file_uris() {
 		$theme_json = new WP_Theme_JSON(
@@ -1325,6 +1326,7 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 	 *
 	 * @covers WP_Theme_JSON_Resolver::get_resolved_theme_uris
 	 * @ticket 61273
+	 * @ticket 61588
 	 */
 	public function test_get_resolved_theme_uris() {
 		$theme_json = new WP_Theme_JSON(


### PR DESCRIPTION
Syncing source code changes from WordPress/gutenberg#60100

Enables background images for supported blocks in global styles.


## Testing

This PR adds the backend functionality only, which means the editor UI isn't yet available.

To test, define some background images for blocks. Here's an example using some of the images in `src/wp-content/themes/twentytwentyfour/`

```json
{
	"$schema": "../../schemas/json/theme.json",
	"version": 3,
	"settings": {
		"appearanceTools": true
	},
	"styles": {
		"blocks": {
			"core/verse": {
				"background": {
					"backgroundImage": {
						"url": "file:./assets/images/art-gallery.webp"
					}
				}
			},
			"core/quote": {
				"background": {
					"backgroundImage": {
						"url": "file:./assets/images/building-exterior.webp"
					}
				}
			},
			"core/pullquote": {
				"background": {
					"backgroundImage": {
						"url": "file:./assets/images/hotel-facade.webp"
					}
				}
			},
			"core/post-content": {
				"background": {
					"backgroundImage": {
						"url": "file:./assets/images/windows.webp"
					}
				}
			}
		}
	}
}
```

Here is some test HTML to create a test post:

```html
<!-- wp:verse {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base-2"}}},"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60","right":"var:preset|spacing|60"}}},"textColor":"base-2","fontSize":"x-large"} -->
<pre class="wp-block-verse has-base-2-color has-text-color has-link-color has-x-large-font-size" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">Verse</pre>
<!-- /wp:verse -->

<!-- wp:pullquote {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base-2"}}}},"textColor":"base-2","fontSize":"x-large"} -->
<figure class="wp-block-pullquote has-base-2-color has-text-color has-link-color has-x-large-font-size"><blockquote><p>Pullquote</p></blockquote></figure>
<!-- /wp:pullquote -->

<!-- wp:quote -->
<blockquote class="wp-block-quote"><!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60","right":"var:preset|spacing|60"}},"elements":{"link":{"color":{"text":"var:preset|color|base-2"}}}},"textColor":"base-2","fontSize":"x-large"} -->
<p class="has-base-2-color has-text-color has-link-color has-x-large-font-size" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">Quote</p>
<!-- /wp:paragraph --></blockquote>
<!-- /wp:quote -->
```

The editor and frontend should display the background images:

<img width="836" alt="Screenshot 2024-07-08 at 12 54 27 PM" src="https://github.com/WordPress/wordpress-develop/assets/6458278/90e60152-9ee8-499a-99ba-63796f5ecc84">





Trac ticket: https://core.trac.wordpress.org/ticket/61588

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
