### PR TITLE
Block bindings: Add support for image caption

### DIFF
--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -354,6 +354,9 @@ class WP_Block {
 								return false;
 							}
 
+							// Set position of the opener tag.
+							$this->set_bookmark( 'opening' );
+
 							// Once this element closes the depth will be one shallower than it is now.
 							$depth = $this->get_current_depth();
 							while ( $this->next_token() && $this->get_current_depth() >= $depth ) {
@@ -364,10 +367,11 @@ class WP_Block {
 								return false;
 							}
 
-							$this->set_bookmark( 'here' );
+							// Set position of the opener tag.
+							$this->set_bookmark( 'closing' );
 
-							$opening = $this->bookmarks[ $this->current_element->token->bookmark_name ];
-							$closing = $this->bookmarks['_here'];
+							$opening = $this->bookmarks['_opening'];
+							$closing = $this->bookmarks['_closing'];
 							$start   = $opening->start + $opening->length;
 
 							$this->lexical_updates[] = new WP_HTML_Text_Replacement(

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -333,45 +333,46 @@ class WP_Block {
 		switch ( $block_type->attributes[ $attribute_name ]['source'] ) {
 			case 'html':
 			case 'rich-text':
-				// Create private anonymous class until the HTML API provides `set_inner_html` method.
-				$bindings_processor = new class( $block_content, WP_HTML_Processor::CONSTRUCTOR_UNLOCK_CODE ) extends WP_HTML_Processor {
-					public function set_inner_text( $new_content ) {
-						$tag_name = $this->get_tag();
-						// Get position of the opener tag.
-						$this->set_bookmark( 'opener_tag' );
-						$opener_tag_bookmark = $this->bookmarks['_opener_tag'];
-
-						// Visit the closing tag.
-						if ( ! $this->next_tag(
-							array(
-								'tag_name'    => $tag_name,
-								'tag_closers' => 'visit',
-							)
-						) || ! $this->is_tag_closer() ) {
-							$this->release_bookmark( 'opener_tag' );
-							return null;
-						}
-
-						// Get position of the closer tag.
-						$this->set_bookmark( 'closer_tag' );
-						$closer_tag_bookmark = $this->bookmarks['_closer_tag'];
-
-						// Appends the new content.
-						$after_opener_tag        = $opener_tag_bookmark->start + $opener_tag_bookmark->length;
-						$inner_content_length    = $closer_tag_bookmark->start - $after_opener_tag;
-						$this->lexical_updates[] = new WP_HTML_Text_Replacement( $after_opener_tag, $inner_content_length, $new_content );
-						$this->release_bookmark( 'opener_tag' );
-						$this->release_bookmark( 'closer_tag' );
-					}
-				};
-				$block_reader       = $bindings_processor::create_fragment( $block_content );
-
 				if ( 'core/image' === $this->name && 'caption' === $attribute_name ) {
+					// Create private anonymous class until the HTML API provides `set_inner_html` method.
+					$bindings_processor = new class( $block_content, WP_HTML_Processor::CONSTRUCTOR_UNLOCK_CODE ) extends WP_HTML_Processor {
+						public function set_inner_text( $new_content ) {
+							$tag_name = $this->get_tag();
+							// Get position of the opener tag.
+							$this->set_bookmark( 'opener_tag' );
+							$opener_tag_bookmark = $this->bookmarks['_opener_tag'];
+
+							// Visit the closing tag.
+							if ( ! $this->next_tag(
+								array(
+									'tag_name'    => $tag_name,
+									'tag_closers' => 'visit',
+								)
+							) || ! $this->is_tag_closer() ) {
+								$this->release_bookmark( 'opener_tag' );
+								return null;
+							}
+
+							// Get position of the closer tag.
+							$this->set_bookmark( 'closer_tag' );
+							$closer_tag_bookmark = $this->bookmarks['_closer_tag'];
+
+							// Appends the new content.
+							$after_opener_tag        = $opener_tag_bookmark->start + $opener_tag_bookmark->length;
+							$inner_content_length    = $closer_tag_bookmark->start - $after_opener_tag;
+							$this->lexical_updates[] = new WP_HTML_Text_Replacement( $after_opener_tag, $inner_content_length, $new_content );
+							$this->release_bookmark( 'opener_tag' );
+							$this->release_bookmark( 'closer_tag' );
+						}
+					};
+					$block_reader       = $bindings_processor::create_fragment( $block_content );
 					if ( $block_reader->next_tag( 'figcaption' ) ) {
 						$block_reader->set_inner_text( wp_kses_post( $source_value ) );
 					}
 					return $block_reader->get_updated_html();
 				}
+
+				$block_reader = new WP_HTML_Tag_Processor( $block_content );
 
 				// TODO: Support for CSS selectors whenever they are ready in the HTML API.
 				// In the meantime, support comma-separated selectors by exploding them into an array.

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -354,7 +354,7 @@ class WP_Block {
 								return false;
 							}
 
-							// Set position of the opener tag.
+							// Set position of the opening tag.
 							$this->set_bookmark( 'opening' );
 
 							// Once this element closes the depth will be one shallower than it is now.
@@ -367,7 +367,7 @@ class WP_Block {
 								return false;
 							}
 
-							// Set position of the opener tag.
+							// Set position of the closing tag.
 							$this->set_bookmark( 'closing' );
 
 							$opening = $this->bookmarks['_opening'];

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -349,7 +349,6 @@ class WP_Block {
 									'tag_closers' => 'visit',
 								)
 							) || ! $this->is_tag_closer() ) {
-								$this->release_bookmark( 'opener_tag' );
 								return null;
 							}
 
@@ -361,8 +360,6 @@ class WP_Block {
 							$after_opener_tag        = $opener_tag_bookmark->start + $opener_tag_bookmark->length;
 							$inner_content_length    = $closer_tag_bookmark->start - $after_opener_tag;
 							$this->lexical_updates[] = new WP_HTML_Text_Replacement( $after_opener_tag, $inner_content_length, $new_content );
-							$this->release_bookmark( 'opener_tag' );
-							$this->release_bookmark( 'closer_tag' );
 						}
 					};
 					$block_reader       = $bindings_processor::create_fragment( $block_content );

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -337,7 +337,7 @@ class WP_Block {
 					// Create private anonymous class until the HTML API provides `set_inner_html` method.
 					$bindings_processor = new class( $block_content, WP_HTML_Processor::CONSTRUCTOR_UNLOCK_CODE ) extends WP_HTML_Processor {
 						/**
-						 * Replace the inner text of an HTML with the passed content.
+						 * Replace the inner content of a figcaption element with the passed content.
 						 *
 						 * THIS IS A TEMPORARY SOLUTION IN CORE NOT TO BE EMULATED.
 						 * IT IS A TEMPORARY SOLUTION THAT JUST WORKS FOR THIS SPECIFIC
@@ -345,10 +345,10 @@ class WP_Block {
 						 *
 						 * @since 6.6.0
 						 *
-						 * @param string $new_content New text to insert in the HTML element.
-						 * @return bool Whether the inner text was properly replaced.
+						 * @param string $new_content New content to insert in the figcaption element.
+						 * @return bool Whether the inner content was properly replaced.
 						 */
-						public function set_inner_text( $new_content ) {
+						public function set_content_between_figcaption_balanced_tags( $new_content ) {
 							/*
 							 * THIS IS A STOP-GAP MEASURE NOT TO BE EMULATED.
 							 *
@@ -357,6 +357,7 @@ class WP_Block {
 							 */
 							if (
 								WP_HTML_Processor::STATE_MATCHED_TAG !== $this->parser_state ||
+                'figcaption' !== $this->get_tag() ||
 								$this->is_tag_closer()
 							) {
 								return false;

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -357,7 +357,7 @@ class WP_Block {
 							 */
 							if (
 								WP_HTML_Processor::STATE_MATCHED_TAG !== $this->parser_state ||
-                'figcaption' !== $this->get_tag() ||
+								'figcaption' !== $this->get_tag() ||
 								$this->is_tag_closer()
 							) {
 								return false;
@@ -396,7 +396,7 @@ class WP_Block {
 					};
 					$block_reader       = $bindings_processor::create_fragment( $block_content );
 					if ( $block_reader->next_tag( 'figcaption' ) ) {
-						$block_reader->set_inner_text( wp_kses_post( $source_value ) );
+						$block_reader->set_content_between_figcaption_balanced_tags( wp_kses_post( $source_value ) );
 					}
 					return $block_reader->get_updated_html();
 				}

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -348,7 +348,7 @@ class WP_Block {
 						 * @param string $new_content New content to insert in the figcaption element.
 						 * @return bool Whether the inner content was properly replaced.
 						 */
-						public function set_figcaption_inner_text( $new_content ) {
+						public function set_figcaption_inner_html( $new_content ) {
 							// Check that the processor is paused on an opener tag.
 							if ( 'FIGCAPTION' !== $this->get_tag() || $this->is_tag_closer() ) {
 								return false;
@@ -386,7 +386,7 @@ class WP_Block {
 
 					$block_reader = $bindings_processor::create_fragment( $block_content );
 					if ( $block_reader->next_tag( 'figcaption' ) ) {
-						$block_reader->set_figcaption_inner_text( $source_value );
+						$block_reader->set_figcaption_inner_html( $source_value );
 					}
 					return $block_reader->get_updated_html();
 				}

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -339,7 +339,7 @@ class WP_Block {
 						/**
 						 * Replace the inner text of an HTML with the passed content.
 						 *
-						 * THIS IS A STOP-GAP MEASURE IN CORE NOT TO BE EMULATED.
+						 * THIS IS A TEMPORARY SOLUTION IN CORE NOT TO BE EMULATED.
 						 * IT IS A TEMPORARY SOLUTION THAT JUST WORKS FOR THIS SPECIFIC
 						 * USE CASE UNTIL THE HTML PROCESSOR PROVIDES ITS OWN METHOD.
 						 *
@@ -349,7 +349,12 @@ class WP_Block {
 						 * @return bool Whether the inner text was properly replaced.
 						 */
 						public function set_inner_text( $new_content ) {
-							// Check that the processor is paused on an opener tag.
+							/*
+							 * THIS IS A STOP-GAP MEASURE NOT TO BE EMULATED.
+							 *
+							 * Check that the processor is paused on an opener tag.
+							 *
+							 */
 							if (
 								WP_HTML_Processor::STATE_MATCHED_TAG !== $this->parser_state ||
 								$this->is_tag_closer()

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -334,12 +334,12 @@ class WP_Block {
 			case 'html':
 			case 'rich-text':
 				// Create private anonymous class until the HTML API provides `set_inner_html` method.
-				$block_reader = new class($block_content) extends WP_HTML_Tag_Processor{
+				$bindings_processor = new class( $block_content, WP_HTML_Processor::CONSTRUCTOR_UNLOCK_CODE ) extends WP_HTML_Processor {
 					public function set_inner_text( $new_content ) {
 						$tag_name = $this->get_tag();
 						// Get position of the opener tag.
 						$this->set_bookmark( 'opener_tag' );
-						$opener_tag_bookmark = $this->bookmarks['opener_tag'];
+						$opener_tag_bookmark = $this->bookmarks['_opener_tag'];
 
 						// Visit the closing tag.
 						if ( ! $this->next_tag(
@@ -354,7 +354,7 @@ class WP_Block {
 
 						// Get position of the closer tag.
 						$this->set_bookmark( 'closer_tag' );
-						$closer_tag_bookmark = $this->bookmarks['closer_tag'];
+						$closer_tag_bookmark = $this->bookmarks['_closer_tag'];
 
 						// Appends the new content.
 						$after_opener_tag        = $opener_tag_bookmark->start + $opener_tag_bookmark->length;
@@ -364,6 +364,7 @@ class WP_Block {
 						$this->release_bookmark( 'closer_tag' );
 					}
 				};
+				$block_reader       = $bindings_processor::create_fragment( $block_content );
 
 				if ( 'core/image' === $this->name && 'caption' === $attribute_name ) {
 					if ( $block_reader->next_tag( 'figcaption' ) ) {

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -338,9 +338,8 @@ class WP_Block {
 					$bindings_processor = new class( $block_content, WP_HTML_Processor::CONSTRUCTOR_UNLOCK_CODE ) extends WP_HTML_Processor {
 						public function set_inner_text( $new_content ) {
 							$tag_name = $this->get_tag();
-							// Get position of the opener tag.
+							// Set position of the opener tag.
 							$this->set_bookmark( 'opener_tag' );
-							$opener_tag_bookmark = $this->bookmarks['_opener_tag'];
 
 							// Visit the closing tag.
 							if ( ! $this->next_tag(
@@ -352,8 +351,11 @@ class WP_Block {
 								return null;
 							}
 
-							// Get position of the closer tag.
+							// Set position of the closer tag.
 							$this->set_bookmark( 'closer_tag' );
+
+							// Get opener and closer tag bookmarks.
+							$opener_tag_bookmark = $this->bookmarks['_opener_tag'];
 							$closer_tag_bookmark = $this->bookmarks['_closer_tag'];
 
 							// Appends the new content.

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -335,7 +335,10 @@ class WP_Block {
 			case 'rich-text':
 				if ( 'core/image' === $this->name && 'caption' === $attribute_name ) {
 					// Create private anonymous class until the HTML API provides `set_inner_html` method.
-					$bindings_processor = new class( $block_content, WP_HTML_Processor::CONSTRUCTOR_UNLOCK_CODE ) extends WP_HTML_Processor {
+					$bindings_processor_builder = new class(
+						'Do not use this, it will not work. It is only here to create a subclass and call the static creator method',
+						WP_HTML_Processor::CONSTRUCTOR_UNLOCK_CODE
+					) extends WP_HTML_Processor {
 						/**
 						 * Replace the inner content of a figcaption element with the passed content.
 						 *
@@ -384,7 +387,7 @@ class WP_Block {
 						}
 					};
 
-					$block_reader = $bindings_processor::create_fragment( $block_content );
+					$block_reader = $bindings_processor_builder::create_fragment( $block_content );
 					if ( $block_reader->next_tag( 'figcaption' ) ) {
 						$block_reader->set_figcaption_inner_html( $source_value );
 					}

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -339,11 +339,11 @@ class WP_Block {
 						/**
 						 * Replace the inner content of a figcaption element with the passed content.
 						 *
-						 * THIS IS A TEMPORARY SOLUTION IN CORE NOT TO BE EMULATED.
-						 * IT IS A TEMPORARY SOLUTION THAT JUST WORKS FOR THIS SPECIFIC
-						 * USE CASE UNTIL THE HTML PROCESSOR PROVIDES ITS OWN METHOD.
+						 * DO NOT COPY THIS METHOD.
+						 * THE HTML PROCESSOR WILL HAVE A PROPER METHOD.
+						 * USE IT INSTEAD.
 						 *
-						 * @since 6.6.0
+						 * @since 6.7.0
 						 *
 						 * @param string $new_content New content to insert in the figcaption element.
 						 * @return bool Whether the inner content was properly replaced.

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -357,7 +357,7 @@ class WP_Block {
 							 */
 							if (
 								WP_HTML_Processor::STATE_MATCHED_TAG !== $this->parser_state ||
-								'figcaption' !== $this->get_tag() ||
+								'FIGCAPTION' !== $this->get_tag() ||
 								$this->is_tag_closer()
 							) {
 								return false;

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -223,7 +223,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * @var ?WP_HTML_Stack_Event
 	 */
-	private $current_element = null;
+	public $current_element = null;
 
 	/**
 	 * Context node if created as a fragment parser.

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -223,7 +223,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * @var ?WP_HTML_Stack_Event
 	 */
-	public $current_element = null;
+	private $current_element = null;
 
 	/**
 	 * Context node if created as a fragment parser.

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -298,4 +298,41 @@ HTML;
 			'The `__default` attribute should be replaced with the real attribute prior to the callback.'
 		);
 	}
+
+	/**
+	 * Tests that replacing inner text for bound attributes works as expected.
+	 *
+	 * @ticket 61466
+	 *
+	 * @covers WP_Block::process_block_bindings
+	 */
+	public function test_replacing_inner_text_with_block_bindings_value() {
+		$get_value_callback = function () {
+			return '$12.50';
+		};
+
+		register_block_bindings_source(
+			self::SOURCE_NAME,
+			array(
+				'label'              => self::SOURCE_LABEL,
+				'get_value_callback' => $get_value_callback,
+			)
+		);
+
+		$block_content = <<<HTML
+<!-- wp:image {"metadata":{"bindings":{"caption":{"source":"test/source"}}}} -->
+<figure class="wp-block-image"><img src="https://example.com/image.jpg" /><figcaption class="wp-element-caption">Default value</figcaption></figure>
+<!-- /wp:image -->
+HTML;
+
+		$parsed_blocks = parse_blocks( $block_content );
+		$block         = new WP_Block( $parsed_blocks[0] );
+		$result        = $block->render();
+
+		$this->assertSame(
+			'<figure class="wp-block-image"><img src="https://example.com/image.jpg" /><figcaption class="wp-element-caption">$12.50</figcaption></figure>',
+			trim( $result ),
+			'The image caption should be updated with the value returned by the source.'
+		);
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61466

This pull request should be tested together with [this other one from Gutenberg](https://github.com/WordPress/gutenberg/pull/61255), because it needs changes in the image render file.

## What?

Add support for the image caption attribute in block bindings.


## Why?

There is an issue with pattern overrides caused by this: https://github.com/WordPress/gutenberg/issues/62287.

Additionally, it is a good enhancement.

## How?

I created an anonymous class to extend the tag processor and include `set_inner_text` until there is a similar method provided by default.

Additionally, in Gutenberg pull request, I'm modifying the render file of the image to:
* Remove the `figcaption` element when it exists, and the binding value is empty.
* Add the `figcaption` element when it doesn't exist, and the binding value is not empty.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
