### PR TITLE
Read only once the theme.json files from the `styles/` folder.

### DIFF
--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -751,7 +751,7 @@ class WP_Theme_JSON_Resolver {
 		}
 		ksort( $variation_files );
 		foreach ( $variation_files as $path => $file ) {
-			$decoded_file = wp_json_file_decode( $path, array( 'associative' => true ) );
+			$decoded_file = self::read_json_file( $path );
 			if ( is_array( $decoded_file ) && static::style_variation_has_scope( $decoded_file, $scope ) ) {
 				$translated = static::translate( $decoded_file, wp_get_theme()->get( 'TextDomain' ) );
 				$variation  = ( new WP_Theme_JSON( $translated ) )->get_raw_data();

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -725,6 +725,7 @@ class WP_Theme_JSON_Resolver {
 	 * @since 6.6.0 Added configurable scope parameter to allow filtering
 	 *              theme.json partial files by the scope to which they
 	 *              can be applied e.g. theme vs block etc.
+	 *              Added basic caching for read theme.json partial files.
 	 *
 	 * @param string $scope The scope or type of style variation to retrieve e.g. theme, block etc.
 	 * @return array


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/61451

## What

Read only once the theme.json files stored in the `styles/` folder.

## Why

I've realized that, unlike the `theme.json` files defined by core & theme, we don't cache these — hence we end up reading them a few times from the filesystem.

## How

By using the existing `read_json_file` function instead of using `wp_json_file_decode` directly.

## How to test

1. Verify the theme style variations are working as expected.

Go to "Site Editor > Styles" and apply one of them. Verify the changes are reflected in the front end. Do the same from the global styles sidebar in the site editor.

2. Verify the block style variations defined via theme.json are working as expected.

Create a `partial.json` file within the `styles/` folder with the following contents:

```json
{
        "$schema": "https://schemas.wp.org/trunk/theme.json",
        "version": 2,
        "title": "Partial",
        "blockTypes": [ "core/group" ],
        "styles": {
                "color": {
                        "background": "aliceblue"
                }
        }
}
```

Go to any editor, add a group block, and verify there is a "Partial" style variation (Block Settings > Styles). Apply the variation and save the changes. Verify the contents are the expected (background color is aliceblue) — also in the front-end.

## Commit

Commit message, to make it easy for committers:

```txt
Read only once the theme.json files stored in the `styles/` folder.

Props oandregal, aaronrobertshaw, joemcgill, ramonopoly, isabel_brison.
See #61451.
```
