### PR TITLE
Upgrade/Install: Disable maintenance mode when a core auto-update is skipped.

### DIFF
--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -511,6 +511,9 @@ class WP_Automatic_Updater {
 				&& ( 'up_to_date' === $upgrade_result->get_error_code()
 					|| 'locked' === $upgrade_result->get_error_code() )
 			) {
+				// Allow visitors to browse the site again.
+				$upgrader->maintenance_mode( false );
+
 				/*
 				 * These aren't actual errors, treat it as a skipped-update instead
 				 * to avoid triggering the post-core update failure routines.


### PR DESCRIPTION
Additional maintenance mode calls were added to the automatic updates process. However, there is an early return if a 'core' automatic update fails.

Maintenance mode isn't disabled until later in the `WP_Automatic_Updater::update()` method. This means that maintenance mode may continue to be enabled despite the core update being treated as a skipped update.

This disables maintenance mode before the early return.

Trac ticket: https://core.trac.wordpress.org/ticket/61459
