### PR TITLE
Recommend MariaDB 10.5 or greater.

### DIFF
--- a/src/readme.html
+++ b/src/readme.html
@@ -58,7 +58,7 @@
 <h3>Recommendations</h3>
 <ul>
 	<li><a href="https://www.php.net/">PHP</a> version <strong>7.4</strong> or greater.</li>
-	<li><a href="https://www.mysql.com/">MySQL</a> version <strong>8.0</strong> or greater OR <a href="https://mariadb.org/">MariaDB</a> version <strong>10.4</strong> or greater.</li>
+	<li><a href="https://www.mysql.com/">MySQL</a> version <strong>8.0</strong> or greater OR <a href="https://mariadb.org/">MariaDB</a> version <strong>10.5</strong> or greater.</li>
 	<li>The <a href="https://httpd.apache.org/docs/2.2/mod/mod_rewrite.html">mod_rewrite</a> Apache module.</li>
 	<li><a href="https://wordpress.org/news/2016/12/moving-toward-ssl/">HTTPS</a> support.</li>
 	<li>A link to <a href="https://wordpress.org/">wordpress.org</a> on your site.</li>

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -18,7 +18,7 @@ class WP_Site_Health {
 	private $mysql_server_version        = '';
 	private $mysql_required_version      = '5.5';
 	private $mysql_recommended_version   = '8.0';
-	private $mariadb_recommended_version = '10.4';
+	private $mariadb_recommended_version = '10.5';
 
 	public $php_memory_limit;
 

--- a/tests/phpunit/tests/admin/wpSiteHealth.php
+++ b/tests/phpunit/tests/admin/wpSiteHealth.php
@@ -38,9 +38,6 @@ class Tests_Admin_wpSiteHealth extends WP_UnitTestCase {
 	 * @covers ::__construct()
 	 */
 	public function test_mysql_recommended_version_matches_readme_html() {
-		// This test is designed to only run on trunk.
-		$this->skipOnAutomatedBranches();
-
 		$reflection          = new ReflectionClass( $this->instance );
 		$reflection_property = $reflection->getProperty( 'mysql_recommended_version' );
 		$reflection_property->setAccessible( true );
@@ -57,9 +54,6 @@ class Tests_Admin_wpSiteHealth extends WP_UnitTestCase {
 	 * @covers ::__construct()
 	 */
 	public function test_mariadb_recommended_version_matches_readme_html() {
-		// This test is designed to only run on trunk.
-		$this->skipOnAutomatedBranches();
-
 		$reflection          = new ReflectionClass( $this->instance );
 		$reflection_property = $reflection->getProperty( 'mariadb_recommended_version' );
 		$reflection_property->setAccessible( true );


### PR DESCRIPTION
 MariaDB 10.4 has reached the end of life with 10.4.34 being the final release.

To ensure WordPress is recommending a supported version of the software, the recommended version should be updated to 10.5 or greater.

https://core.trac.wordpress.org/ticket/61458