### PR TITLE
Resolves JQMIGRATE warnings for bulk edit

### DIFF
--- a/src/js/_enqueues/admin/inline-edit-post.js
+++ b/src/js/_enqueues/admin/inline-edit-post.js
@@ -262,7 +262,7 @@ window.wp = window.wp || {};
 		 *
 		 * @listens click
 		 */
-		$( '#bulk-titles .ntdelbutton' ).click( function() {
+		$( '#bulk-titles .ntdelbutton' ).on( 'click', function() {
 			var $this = $( this ),
 				id = $this.attr( 'id' ).substr( 1 ),
 				$prev = $this.parent().prev().children( '.ntdelbutton' ),
@@ -275,9 +275,9 @@ window.wp = window.wp || {};
 
 			// Move focus to a proper place when items are removed.
 			if ( $next.length ) {
-				$next.focus();
+				$prev.trigger( 'focus' );
 			} else if ( $prev.length ) {
-				$prev.focus();
+				$prev.trigger( 'focus' );
 			} else {
 				$( '#bulk-titles-list' ).remove();
 				inlineEditPost.revert();
@@ -302,7 +302,7 @@ window.wp = window.wp || {};
 		}
 
 		// Set initial focus on the Bulk Edit region.
-		$( '#bulk-edit .inline-edit-wrapper' ).attr( 'tabindex', '-1' ).focus();
+		$( '#bulk-edit .inline-edit-wrapper' ).attr( 'tabindex', '-1' ).trigger( 'focus' );
 		// Scrolls to the top of the table where the editor is rendered.
 		$('html, body').animate( { scrollTop: 0 }, 'fast' );
 	},

--- a/src/js/_enqueues/admin/inline-edit-post.js
+++ b/src/js/_enqueues/admin/inline-edit-post.js
@@ -275,7 +275,7 @@ window.wp = window.wp || {};
 
 			// Move focus to a proper place when items are removed.
 			if ( $next.length ) {
-				$prev.trigger( 'focus' );
+				$next.trigger( 'focus' );
 			} else if ( $prev.length ) {
 				$prev.trigger( 'focus' );
 			} else {


### PR DESCRIPTION
---
## PR Description 
This PR is to resolve warnings a user will get on their browsers console for deprecated use of click and focus functions in jQuery when bulk editing.

### Steps to reproduce these warnings
Step 1: Add in wp-config.php file `define( 'SCRIPT_DEBUG', true );` 
Step 2: Go to WP admin dashboard
Step 3: Click pages
Step 4: Select multiple elements and choose "Edit" from bulk actions and then click on "Apply"
Step 5: In the browser console you will be able to see the warnings:

### Warnings on Console

<img width="665" alt="Screenshot 2024-06-18 at 4 40 59 PM" src="https://github.com/WordPress/wordpress-develop/assets/80690679/b963bd50-535f-40c9-9b89-c8eb5603b6cf">

- Trac ticket: https://core.trac.wordpress.org/ticket/61409
---