### PR TITLE
Fix the issue where the "is_ssl()" function fails to get the correct protocol when WordPress is deployed on an upstream server.

### DIFF
--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -1627,6 +1627,8 @@ function is_ssl() {
 		}
 	} elseif ( isset( $_SERVER['SERVER_PORT'] ) && ( '443' === (string) $_SERVER['SERVER_PORT'] ) ) {
 		return true;
+	} elseif ( isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) && ( 'https' === (string) $_SERVER['HTTP_X_FORWARDED_PROTO'] ) ) {
+		return true;
 	}
 
 	return false;


### PR DESCRIPTION
When WordPress is deployed on an upstream server with its port set to 80, and the upstream server (such as Nginx) handles HTTPS requests on port 443, the is_ssl() function in WordPress may malfunction, leading to UI issues where some resources stop to load.

Trac ticket: [https://core.trac.wordpress.org/ticket/61463](https://core.trac.wordpress.org/ticket/61463)
