### PR TITLE
wp_kses & block parser being used on pre_term_name hook

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1682,6 +1682,11 @@ function traverse_and_serialize_blocks( $blocks, $pre_callback = null, $post_cal
  * @return string The filtered and sanitized content result.
  */
 function filter_block_content( $text, $allowed_html = 'post', $allowed_protocols = array() ) {
+
+	if ( current_filter() === 'pre_term_name' ) {
+        return $text;
+    }
+	
 	$result = '';
 
 	if ( str_contains( $text, '<!--' ) && str_contains( $text, '--->' ) ) {

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5206,6 +5206,11 @@ function wp_pre_kses_less_than_callback( $matches ) {
  * @return string Filtered text to run through KSES.
  */
 function wp_pre_kses_block_attributes( $content, $allowed_html, $allowed_protocols ) {
+
+	if ( current_filter() === 'pre_term_name' ) {
+        return $content;
+    }
+	
 	/*
 	 * `filter_block_content` is expected to call `wp_kses`. Temporarily remove
 	 * the filter to avoid recursion.

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -932,6 +932,11 @@ function wp_kses_allowed_html( $context = '' ) {
  * @return string Filtered content through {@see 'pre_kses'} hook.
  */
 function wp_kses_hook( $content, $allowed_html, $allowed_protocols ) {
+
+	if ( current_filter() === 'pre_term_name' ) {
+        return $content; // Bypass KSES for term names
+    }
+	
 	/**
 	 * Filters content to be run through KSES.
 	 *

--- a/tests/phpunit/tests/kses/test-term-name-parsing.php
+++ b/tests/phpunit/tests/kses/test-term-name-parsing.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Class Tests_Term_Name_Parsing
+ *
+ * @group kses
+ */
+class Tests_Term_Name_Parsing extends WP_UnitTestCase {
+
+	public function setUp() {
+		parent::setUp();
+		$this->kses_filters = array(
+			'pre_term_name' => 'wp_filter_kses',
+		);
+
+		foreach ( $this->kses_filters as $filter => $function ) {
+			add_filter( $filter, $function );
+		}
+	}
+
+	public function tearDown() {
+		foreach ( $this->kses_filters as $filter => $function ) {
+			remove_filter( $filter, $function );
+		}
+		parent::tearDown();
+	}
+
+	public function test_term_name_not_parsed_as_block_content() {
+		$term_name      = 'Term Name <script>alert("xss")</script>';
+		$sanitized_name = wp_kses( $term_name, array() );
+		$this->assertSame( 'Term Name alert("xss")', $sanitized_name );
+	}
+
+	public function test_post_content_parsed_as_block_content() {
+		$post_content      = '<!-- wp:paragraph --><p>Some <strong>content</strong></p><!-- /wp:paragraph -->';
+		$sanitized_content = wp_kses( $post_content, 'post' );
+		$this->assertSame( '<!-- wp:paragraph --><p>Some <strong>content</strong></p><!-- /wp:paragraph -->', $sanitized_content );
+	}
+}


### PR DESCRIPTION


### Changes Made
This **PR** enhances the KSES filtering mechanism in WordPress to improve handling of term names within content parsing. Specifically:

- **Code Changes:** Updated `wp_kses_hook` and `filter_block_content` functions to include a context check (`if ( current_filter() === 'pre_term_name' )`) to bypass block content parsing for term names. This prevents term names from being mistakenly treated as block content during sanitization processes.

### Purpose

- The purpose of these changes is to enhance the accuracy and efficiency of content filtering in WordPress, specifically when dealing with term names. By ensuring that term names are not parsed as block content, we improve security and performance while maintaining robust sanitization practices across different content types.
