### PR TITLE
Fix broken plugin block when WP version is incompatible

### DIFF
--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -626,7 +626,7 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 				} elseif ( ! $compatible_wp ) {
 					$incompatible_notice_message .= __( 'This plugin does not work with your version of WordPress.' );
 					if ( current_user_can( 'update_core' ) ) {
-						$incompatible_notice_message .= printf(
+						$incompatible_notice_message .= sprintf(
 							/* translators: %s: URL to WordPress Updates screen. */
 							' ' . __( '<a href="%s">Please update WordPress</a>.' ),
 							self_admin_url( 'update-core.php' )


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

I propose to fix broken layout of pugins list that occurs when the plugin is not compatible with current WP version. 

Steps to reproduce:

1. Install WordPress 6.4.3
2. Navigate to Plugins -> Add New Plugin
3. Search for Create Block Theme

|Before|After|
|---|---|
|<img width="537" alt="Screenshot 2024-06-19 at 11 33 34" src="https://github.com/WordPress/wordpress-develop/assets/727413/e98bdc27-bafc-4c6c-9c74-a28228671c89"> | <img width="533" alt="Screenshot 2024-06-19 at 11 33 43" src="https://github.com/WordPress/wordpress-develop/assets/727413/537605f1-0bd8-455a-864a-81ab1b87ad21">|


Trac ticket: https://core.trac.wordpress.org/ticket/61465

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
