### PR TITLE
Set mimimum comments per page to 1 (was 0)

### DIFF
--- a/src/wp-admin/options-discussion.php
+++ b/src/wp-admin/options-discussion.php
@@ -148,7 +148,7 @@ $default_comments_page .= '>' . __( 'first' ) . '</option></select>';
 printf(
 	/* translators: 1: Form field control for number of top level comments per page, 2: Form field control for the 'first' or 'last' page. */
 	__( 'Break comments into pages with %1$s top level comments per page and the %2$s page displayed by default' ),
-	'</label> <label for="comments_per_page"><input name="comments_per_page" type="number" step="1" min="0" id="comments_per_page" value="' . esc_attr( get_option( 'comments_per_page' ) ) . '" class="small-text" />',
+	'</label> <label for="comments_per_page"><input name="comments_per_page" type="number" step="1" min="1" id="comments_per_page" value="' . esc_attr( get_option( 'comments_per_page' ) ) . '" class="small-text" />',
 	$default_comments_page
 );
 ?>


### PR DESCRIPTION
In my opinion it makes to sense to be able to set the minimum comments per page to zero, while having the pagination option enabled.

Trac ticket: [#61468](https://core.trac.wordpress.org/ticket/61468)

