### PR TITLE
Add: Template and template_lock to post types endpoint.

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-post-types-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-post-types-controller.php
@@ -246,6 +246,14 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 			$data['rest_namespace'] = $namespace;
 		}
 
+		if ( rest_is_field_included( 'template', $fields ) && ! empty( $post_type->template ) ) {
+			$data['template'] = $post_type->template;
+		}
+
+		if ( rest_is_field_included( 'template_lock', $fields ) && ! empty( $post_type->template_lock ) && false !== $post_type->template_lock ) {
+			$data['template_lock'] = $post_type->template_lock;
+		}
+
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data    = $this->add_additional_fields_to_object( $data, $request );
 		$data    = $this->filter_response_by_context( $data, $context );
@@ -406,6 +414,19 @@ class WP_REST_Post_Types_Controller extends WP_REST_Controller {
 					'type'        => array( 'string', 'null' ),
 					'context'     => array( 'view', 'edit', 'embed' ),
 					'readonly'    => true,
+				),
+				'template'       => array(
+					'type'        => 'array',
+					'description' => __( 'The block template associated with the post type, if it exists.', 'gutenberg' ),
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'template_lock'  => array(
+					'type'        => 'string',
+					'enum'        => array( 'all', 'insert', 'contentOnly' ),
+					'description' => __( 'The template_lock associated with the post type, if any.', 'gutenberg' ),
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
 				),
 			),
 		);


### PR DESCRIPTION
Trac: https://core.trac.wordpress.org/ticket/61477

Backports https://github.com/WordPress/gutenberg/pull/62488 into the core.
Adds template and template_lock property of the post type to post types REST API endpoint.

This change allows to fix a bug where the template of a page is not respected when creating a new page on the site editor.

The update on the unit test is in progress and is still missing.


## Testing
With the Gutenberg plugin disabled.
I added the following test code to a PHP file:

```
function myplugin_register_template() {
    $post_type_object = get_post_type_object( 'page' );
    $post_type_object->template = array(
        array( 'core/image' ),
    );
	$post_type_object->template_lock = 'all';
}
add_action( 'init', 'myplugin_register_template' );
```

I opened the site editor and pasted:
wp.data.select('core').getPostType( 'page' );

I verified the template and template_lock information was included.
I repeated the test with the Gutenberg plugin enabled to make sure things worked well together.