### PR TITLE
Preserve target="_blank" in Biographical Info and Taxonomy Description

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -735,6 +735,8 @@ if ( ! CUSTOM_TAGS ) {
  * @see wp_allowed_protocols() for the default allowed protocols in link URLs.
  *
  * @since 1.0.0
+ * 
+ * @global array[]       $allowedtags       Array of KSES allowed HTML elements.
  *
  * @param string         $content           Text content to filter.
  * @param array[]|string $allowed_html      An array of allowed HTML elements and attributes,
@@ -745,8 +747,16 @@ if ( ! CUSTOM_TAGS ) {
  * @return string Filtered content containing only the allowed HTML.
  */
 function wp_kses( $content, $allowed_html, $allowed_protocols = array() ) {
+	global $allowedtags;
+
 	if ( empty( $allowed_protocols ) ) {
 		$allowed_protocols = wp_allowed_protocols();
+	}
+
+	// Allow the 'target' attribute for anchor tags in term descriptions.
+	if ( 'pre_term_description' === $allowed_html ) {
+		$allowed_html                = $allowedtags;
+		$allowed_html['a']['target'] = true;
 	}
 
 	$content = wp_kses_no_null( $content, array( 'slash_zero' => 'keep' ) );

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -756,6 +756,7 @@ function wp_kses( $content, $allowed_html, $allowed_protocols = array() ) {
 	// Allow the 'target' attribute for anchor tags in term descriptions.
 	if ( 'pre_term_description' === $allowed_html ) {
 		$allowed_html                = $allowedtags;
+		$allowed_html['a']['rel']    = true;
 		$allowed_html['a']['target'] = true;
 	}
 

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -735,7 +735,7 @@ if ( ! CUSTOM_TAGS ) {
  * @see wp_allowed_protocols() for the default allowed protocols in link URLs.
  *
  * @since 1.0.0
- * 
+ *
  * @global array[]       $allowedtags       Array of KSES allowed HTML elements.
  *
  * @param string         $content           Text content to filter.

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -390,8 +390,9 @@ if ( ! CUSTOM_TAGS ) {
 	 */
 	$allowedtags = array(
 		'a'          => array(
-			'href'  => true,
-			'title' => true,
+			'href'   => true,
+			'title'  => true,
+			'target' => true,
 		),
 		'abbr'       => array(
 			'title' => true,

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -736,8 +736,6 @@ if ( ! CUSTOM_TAGS ) {
  *
  * @since 1.0.0
  *
- * @global array[]       $allowedtags       Array of KSES allowed HTML elements.
- *
  * @param string         $content           Text content to filter.
  * @param array[]|string $allowed_html      An array of allowed HTML elements and attributes,
  *                                          or a context name such as 'post'. See wp_kses_allowed_html()
@@ -747,17 +745,8 @@ if ( ! CUSTOM_TAGS ) {
  * @return string Filtered content containing only the allowed HTML.
  */
 function wp_kses( $content, $allowed_html, $allowed_protocols = array() ) {
-	global $allowedtags;
-
 	if ( empty( $allowed_protocols ) ) {
 		$allowed_protocols = wp_allowed_protocols();
-	}
-
-	// Allow the 'target' and 'rel' attribute for anchor tags in term descriptions.
-	if ( 'pre_term_description' === $allowed_html ) {
-		$allowed_html                = $allowedtags;
-		$allowed_html['a']['rel']    = true;
-		$allowed_html['a']['target'] = true;
 	}
 
 	$content = wp_kses_no_null( $content, array( 'slash_zero' => 'keep' ) );
@@ -906,12 +895,14 @@ function wp_kses_allowed_html( $context = '' ) {
 			return $tags;
 
 		case 'user_description':
+		case 'pre_term_description':
 		case 'pre_user_description':
 			$tags                = $allowedtags;
 			$tags['a']['rel']    = true;
 			$tags['a']['target'] = true;
 			/** This filter is documented in wp-includes/kses.php */
 			return apply_filters( 'wp_kses_allowed_html', $tags, $context );
+
 
 		case 'strip':
 			/** This filter is documented in wp-includes/kses.php */

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -390,9 +390,8 @@ if ( ! CUSTOM_TAGS ) {
 	 */
 	$allowedtags = array(
 		'a'          => array(
-			'href'   => true,
-			'title'  => true,
-			'target' => true,
+			'href'  => true,
+			'title' => true,
 		),
 		'abbr'       => array(
 			'title' => true,

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -896,8 +896,9 @@ function wp_kses_allowed_html( $context = '' ) {
 
 		case 'user_description':
 		case 'pre_user_description':
-			$tags             = $allowedtags;
-			$tags['a']['rel'] = true;
+			$tags                = $allowedtags;
+			$tags['a']['rel']    = true;
+			$tags['a']['target'] = true;
 			/** This filter is documented in wp-includes/kses.php */
 			return apply_filters( 'wp_kses_allowed_html', $tags, $context );
 

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -903,7 +903,6 @@ function wp_kses_allowed_html( $context = '' ) {
 			/** This filter is documented in wp-includes/kses.php */
 			return apply_filters( 'wp_kses_allowed_html', $tags, $context );
 
-
 		case 'strip':
 			/** This filter is documented in wp-includes/kses.php */
 			return apply_filters( 'wp_kses_allowed_html', array(), $context );

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -753,7 +753,7 @@ function wp_kses( $content, $allowed_html, $allowed_protocols = array() ) {
 		$allowed_protocols = wp_allowed_protocols();
 	}
 
-	// Allow the 'target' attribute for anchor tags in term descriptions.
+	// Allow the 'target' and 'rel' attribute for anchor tags in term descriptions.
 	if ( 'pre_term_description' === $allowed_html ) {
 		$allowed_html                = $allowedtags;
 		$allowed_html['a']['rel']    = true;


### PR DESCRIPTION
## Description

This PR ensures that `target="_blank"` is preserved in the Biographical Info and Taxonomy Description fields to maintain the intended link behavior.

## Testing Instructions

### Biographical Info

- Go to the profile page: `/wp-admin/profile.php`
- In the `About Yourself > Biographical Info` section add a link that includes `target` attribute and save it, for example:
```
I love <a href="https://wordpress.org/" target="_blank">WordPress</a>.
```
- Refresh the page and you'll see that the `target` attribute is preserved.
- Go to the page where the author biography is displayed.
- Inspect the link element, the `target` attribute will be present and work as expected.

<img width="1582" alt="add-biographical-info" src="https://github.com/user-attachments/assets/a30be19b-79ed-4d98-a9ba-516bd625ffc6">

<img width="1582" alt="view-biographical-info" src="https://github.com/user-attachments/assets/9222f174-89c1-4316-8ffa-1541bc8be986">

### Taxonomy Description

- Go to the category page: `/wp-admin/edit-tags.php?taxonomy=category` and select any category to edit.
- In the `Description` section add a link that includes `target` attribute and save it, for example:
```
Uncategorized is the defualt category in <a href="https://wordpress.org/" target="_blank">WordPress</a>.
```
- Refresh the page and you'll see that the `target` attribute is preserved.
- Go to the page where the category description is displayed.
- Inspect the link element, the `target` attribute will be present and work as expected.

<img width="1582" alt="add-term-description" src="https://github.com/user-attachments/assets/7038dc57-ba75-4a71-9681-2555b7394765">

<img width="1582" alt="view-term-description" src="https://github.com/user-attachments/assets/ffc5ae90-4eae-46a8-872e-cb84d796cfaa">

## Trac ticket: https://core.trac.wordpress.org/ticket/12056
