### PR TITLE
[Proof of Concept] Optimize how shared block style variations are processed

### DIFF
--- a/src/wp-includes/block-supports/block-style-variations.php
+++ b/src/wp-includes/block-supports/block-style-variations.php
@@ -334,25 +334,6 @@ function wp_resolve_block_style_variations_from_theme_json_partials( $theme_json
 }
 
 /**
- * Merges shared block style variations registered within the
- * `styles.blocks.variations` property of the primary theme.json file.
- *
- * @since 6.6.0
- * @access private
- *
- * @param WP_Theme_JSON_Data $theme_json Current theme.json data.
- *
- * @return WP_Theme_JSON_Data
- */
-function wp_resolve_block_style_variations_from_primary_theme_json( $theme_json ) {
-	$theme_json_data        = $theme_json->get_data();
-	$block_style_variations = $theme_json_data['styles']['blocks']['variations'] ?? array();
-	$variations_data        = wp_resolve_block_style_variations( $block_style_variations );
-
-	return wp_merge_block_style_variations_data( $variations_data, $theme_json );
-}
-
-/**
  * Merges block style variations registered via the block styles registry with a
  * style object, under their appropriate block types within theme.json styles.
  * Any variation values defined within the theme.json specific to a block type
@@ -400,7 +381,6 @@ add_filter( 'render_block', 'wp_render_block_style_variation_class_name', 10, 2 
 add_action( 'wp_enqueue_scripts', 'wp_enqueue_block_style_variation_styles', 1 );
 
 // Resolve block style variations from all their potential sources. The order here is deliberate.
-add_filter( 'wp_theme_json_data_theme', 'wp_resolve_block_style_variations_from_primary_theme_json', 10, 1 );
 add_filter( 'wp_theme_json_data_theme', 'wp_resolve_block_style_variations_from_theme_json_partials', 10, 1 );
 add_filter( 'wp_theme_json_data_theme', 'wp_resolve_block_style_variations_from_styles_registry', 10, 1 );
 

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -14,6 +14,7 @@
  */
 class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 
+
 	/**
 	 * Administrator ID.
 	 *
@@ -3928,6 +3929,67 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			),
 		);
 		$this->assertSameSetsWithIndex( $expected, $sanitized_theme_json, 'Sanitized theme.json styles does not match' );
+	}
+
+	/**
+	 * @ticket 61451
+	 * @ticket 61312
+	 *
+	 */
+	public function test_unwraps_block_style_variations() {
+		register_block_style(
+			'core/paragraph',
+			array(
+				'name'  => 'myVariation',
+				'label' => 'My variation',
+			)
+		);
+		register_block_style(
+			'core/group',
+			array(
+				'name'  => 'myVariation',
+				'label' => 'My variation',
+			)
+		);
+
+		$input    = new WP_Theme_JSON(
+			array(
+				'version' => 3,
+				'styles'  => array(
+					'blocks' => array(
+						'variations' => array(
+							'myVariation' => array(
+								'title'      => 'My variation',
+								'blockTypes' => array( 'core/paragraph', 'core/group' ),
+								'color'      => array( 'background' => 'backgroundColor' ),
+							),
+						),
+					),
+				),
+			)
+		);
+		$expected = array(
+			'version' => WP_Theme_JSON::LATEST_SCHEMA,
+			'styles'  => array(
+				'blocks' => array(
+					'core/paragraph' => array(
+						'variations' => array(
+							'myVariation' => array(
+								'color' => array( 'background' => 'backgroundColor' ),
+							),
+						),
+					),
+					'core/group'     => array(
+						'variations' => array(
+							'myVariation' => array(
+								'color' => array( 'background' => 'backgroundColor' ),
+							),
+						),
+					),
+				),
+			),
+		);
+		$this->assertSameSetsWithIndex( $expected, $input->get_raw_data(), 'Unwrapped block style variations do not match' );
 	}
 
 	/**


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/61451
Follow-up work for https://core.trac.wordpress.org/ticket/61312

## What

This PR tries to optimize the data flow for operating with section styles.

## Why

It has proven less optimized than we wanted.

## How

At some point, the code transforms the following:

```json
{
  "styles": {
    "blocks": {
      "variations": {
        "myVariation": {
          "title": "My variation",
          "blockTypes": [ "core/paragraph", "core/group" ],
          "color": {
            "background": "yellow"
          }
        }
      }
    }
  }
}
```

into:

```json
{
  "styles": {
    "blocks": {
      "core/paragraph": {
        "color": {
          "background": "yellow"
        }
      },
      "core/group": {
        "color": {
          "background": "yellow"
        }
      }
    }
  }
}
```

The existing code executes that transformation using the `wp_theme_json_data_*` filters – having to recreate the `WP_Theme_JSON` structures a few times.

The optimization proposed in this PR explores moving that transform into the `WP_Theme_JSON` constructor directly, following what we do with `appearanceTools` settings.


## Test

TBD.