### PR TITLE
Fixed Warnings when use remove_menu_page() with a non exist page

### DIFF
--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1849,11 +1849,13 @@ function add_comments_page( $page_title, $menu_title, $capability, $menu_slug, $
  */
 function remove_menu_page( $menu_slug ) {
 	global $menu;
-
-	foreach ( $menu as $i => $item ) {
-		if ( $menu_slug === $item[2] ) {
-			unset( $menu[ $i ] );
-			return $item;
+	
+	if ( ! empty ( $menu ) && is_array( $menu ) ) {
+		foreach ( $menu as $i => $item ) {
+			if ( $menu_slug === $item[2] ) {
+				unset( $menu[ $i ] );
+				return $item;
+			}
 		}
 	}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61479

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
