### PR TITLE
Section Styles: improve performance and conceptual consistency

### DIFF
--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -231,7 +231,7 @@ class WP_Theme_JSON_Resolver {
 	 * @since 5.9.0 Theme supports have been inlined and the `$theme_support_data` argument removed.
 	 * @since 6.0.0 Added an `$options` parameter to allow the theme data to be returned without theme supports.
 	 * @since 6.6.0 Add support for 'default-font-sizes' and 'default-spacing-sizes' theme supports.
-	 *              Register the block style variations coming from the partials and the theme.json.
+	 *              Added registration and merging of block style variations from partial theme.json files and the block styles registry.
 	 *
 	 * @param array $deprecated Deprecated. Not used.
 	 * @param array $options {
@@ -258,7 +258,10 @@ class WP_Theme_JSON_Resolver {
 				$theme_json_data = array( 'version' => WP_Theme_JSON::LATEST_SCHEMA );
 			}
 
-			// Register variations defined by theme partials (theme.json files in the styles directory).
+			/*
+			 * Register variations defined by theme partials (theme.json files in the styles directory).
+			 * This is required so the variations pass sanitization of theme.json data.
+			 */
 			$variations = static::get_style_variations( 'block' );
 			wp_register_block_style_variations_from_theme_json_partials( $variations );
 
@@ -927,8 +930,6 @@ class WP_Theme_JSON_Resolver {
 	 * @return array Theme json data including shared block style variation definitions.
 	 */
 	private static function inject_variations_from_block_style_variation_files( $data, $variations ) {
-		$new_variations = array();
-
 		if ( empty( $variations ) ) {
 			return $data;
 		}
@@ -938,19 +939,25 @@ class WP_Theme_JSON_Resolver {
 				continue;
 			}
 
-			$variation_name                    = $variation['slug'] ?? _wp_to_kebab_case( $variation['title'] );
-			$new_variations[ $variation_name ] = $variation['styles'];
-		}
+			$variation_name = $variation['slug'] ?? _wp_to_kebab_case( $variation['title'] );
 
-		if ( empty( $new_variations ) ) {
-			return $data;
-		}
+			foreach ( $variation['blockTypes'] as $block_type ) {
+				// First, override partial styles with any top-level styles.
+				$top_level_data = $data['styles']['variations'][ $variation_name ] ?? array();
+				if ( ! empty( $top_level_data ) ) {
+					$variation['styles'] = array_replace_recursive( $variation['styles'], $top_level_data );
+				}
 
-		// Merge shared variation definitions with theme.json file taking precedence
-		// over those sourced from partial theme.json files.
-		$current_variations = $data['styles']['variations'] ?? array();
-		$merged_variations  = array_replace_recursive( $new_variations, $current_variations );
-		_wp_array_set( $data, array( 'styles', 'variations' ), $merged_variations );
+				// Then, override styles so far with any block-level styles.
+				$block_level_data = $data['styles']['blocks'][ $block_type ]['variations'][ $variation_name ] ?? array();
+				if ( ! empty( $block_level_data ) ) {
+					$variation['styles'] = array_replace_recursive( $variation['styles'], $block_level_data );
+				}
+
+				$path = array( 'styles', 'blocks', $block_type, 'variations', $variation_name );
+				_wp_array_set( $data, $path, $variation['styles'] );
+			}
+		}
 
 		return $data;
 	}
@@ -960,7 +967,7 @@ class WP_Theme_JSON_Resolver {
 	 *
 	 * @since 6.6.0
 	 *
-	 * @param array $data   Array following the theme.json specification.
+	 * @param array $data       Array following the theme.json specification.
 	 * @param array $variations Shared block style variations.
 	 * @return array Theme json data including shared block style variation definitions.
 	 */
@@ -975,13 +982,15 @@ class WP_Theme_JSON_Resolver {
 				}
 
 				// First, override registry styles with any top-level styles.
-				if ( ! empty( $data['styles']['variations'][ $variation_name ] ) ) {
-					$variation['style_data'] = array_replace_recursive( $variation['style_data'], $data['styles']['variations'][ $variation_name ] ?? array() );
+				$top_level_data = $data['styles']['variations'][ $variation_name ] ?? array();
+				if ( ! empty( $top_level_data ) ) {
+					$variation['style_data'] = array_replace_recursive( $variation['style_data'], $top_level_data );
 				}
 
-				// Then, override registry styles with any block-level styles.
-				if ( ! empty( $data['styles']['blocks'][ $block_type ]['variations'][ $variation_name ] ) ) {
-					$variation['style_data'] = array_replace_recursive( $variation['style_data'], $data['styles']['blocks'][ $block_type ]['variations'][ $variation_name ] );
+				// Then, override styles so far with any block-level styles.
+				$block_level_data = $data['styles']['blocks'][ $block_type ]['variations'][ $variation_name ] ?? array();
+				if ( ! empty( $block_level_data ) ) {
+					$variation['style_data'] = array_replace_recursive( $variation['style_data'], $block_level_data );
 				}
 
 				$path = array( 'styles', 'blocks', $block_type, 'variations', $variation_name );

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -968,7 +968,6 @@ class WP_Theme_JSON_Resolver {
 	 * @since 6.6.0
 	 *
 	 * @param array $data       Array following the theme.json specification.
-	 * @param array $variations Shared block style variations.
 	 * @return array Theme json data including shared block style variation definitions.
 	 */
 	private static function inject_variations_from_block_styles_registry( $data ) {

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -592,7 +592,6 @@ class WP_Theme_JSON_Resolver {
 				unset( $decoded_data['isGlobalStylesUserThemeJSON'] );
 				$config = $decoded_data;
 			}
-
 		}
 
 		/** This filter is documented in wp-includes/class-wp-theme-json-resolver.php */
@@ -895,7 +894,7 @@ class WP_Theme_JSON_Resolver {
 	 *
 	 * @since 6.6.0
 	 *
-	 * @param WP_Theme_JSON  $theme_json A theme json instance.
+	 * @param WP_Theme_JSON $theme_json A theme json instance.
 	 * @return WP_Theme_JSON Theme merged with resolved paths, if any found.
 	 */
 	public static function resolve_theme_file_uris( $theme_json ) {
@@ -992,5 +991,4 @@ class WP_Theme_JSON_Resolver {
 
 		return $data;
 	}
-
 }

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -743,8 +743,8 @@ class WP_Theme_JSON {
 	 * Constructor.
 	 *
 	 * @since 5.8.0
-	 * @since 6.6.0 Key spacingScale by origin, and Pre-generate the
-	 *              spacingSizes from spacingScale.
+	 * @since 6.6.0 Key spacingScale by origin, and Pre-generate the spacingSizes from spacingScale.
+	 *              Added unwrapping of shared block style variations into block type variations if registered.
 	 *
 	 * @param array  $theme_json A structure that follows the theme.json schema.
 	 * @param string $origin     Optional. What source of data this object represents.
@@ -756,10 +756,10 @@ class WP_Theme_JSON {
 		}
 
 		$this->theme_json    = WP_Theme_JSON_Schema::migrate( $theme_json, $origin );
-		$this->theme_json    = static::unwrap_shared_block_style_variations( $this->theme_json );
 		$valid_block_names   = array_keys( static::get_blocks_metadata() );
 		$valid_element_names = array_keys( static::ELEMENTS );
 		$valid_variations    = static::get_valid_block_style_variations();
+		$this->theme_json    = static::unwrap_shared_block_style_variations( $this->theme_json, $valid_variations );
 		$this->theme_json    = static::sanitize( $this->theme_json, $valid_block_names, $valid_element_names, $valid_variations );
 		$this->theme_json    = static::maybe_opt_in_into_settings( $this->theme_json );
 
@@ -806,13 +806,12 @@ class WP_Theme_JSON {
 	/**
 	 * Unwraps shared block style variations.
 	 *
-	 * It takes the shared variations (styles.variations.variationName)
-	 * and applies them to all the blocks that have the given variation registered
+	 * It takes the shared variations (styles.variations.variationName) and
+	 * applies them to all the blocks that have the given variation registered
 	 * (styles.blocks.blockType.variations.variationName).
 	 *
-	 * For example, given the core/paragraph and core/group blocks have register the section-a
-	 * style variation, and given the following input:
-	 *
+	 * For example, given the `core/paragraph` and `core/group` blocks have
+	 * registered the `section-a` style variation, and given the following input:
 	 *
 	 * {
 	 *   "styles": {
@@ -843,25 +842,20 @@ class WP_Theme_JSON {
 	 *
 	 * @since 6.6.0
 	 *
-	 * @param array $theme_json A structure that follows the theme.json schema.
+	 * @param array $theme_json       A structure that follows the theme.json schema.
+	 * @param array $valid_variations Valid block style variations.
 	 * @return array Theme json data with shared variation definitions unwrapped under appropriate block types.
 	 */
-	private static function unwrap_shared_block_style_variations( $theme_json ) {
-		if ( ! isset( $theme_json['styles']['variations'] ) ) {
-			return $theme_json;
-		}
-
-		$registered_styles = WP_Block_Styles_Registry::get_instance()->get_all_registered();
-
-		if ( empty( $registered_styles ) ) {
+	private static function unwrap_shared_block_style_variations( $theme_json, $valid_variations ) {
+		if ( empty( $theme_json['styles']['variations'] ) || empty( $valid_variations ) ) {
 			return $theme_json;
 		}
 
 		$new_theme_json = $theme_json;
 		$variations     = $new_theme_json['styles']['variations'];
 
-		foreach ( $registered_styles as $block_type => $registered_variations ) {
-			foreach ( $registered_variations as $variation_name => $variation_data ) {
+		foreach ( $valid_variations as $block_type => $registered_variations ) {
+			foreach ( $registered_variations as $variation_name ) {
 				$block_level_data = $new_theme_json['styles']['blocks'][ $block_type ]['variations'][ $variation_name ] ?? array();
 				$top_level_data   = $variations[ $variation_name ] ?? array();
 				$merged_data      = array_replace_recursive( $top_level_data, $block_level_data );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
@@ -631,8 +631,12 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Posts_Controller {
 		}
 
 		$response   = array();
-		$variations = WP_Theme_JSON_Resolver::get_style_variations();
 
+		// Register theme-defined variations e.g. from block style variation partials under `/styles`.
+		$partials = WP_Theme_JSON_Resolver::get_style_variations( 'block' );
+		wp_register_block_style_variations_from_theme_json_partials( $partials );
+
+		$variations = WP_Theme_JSON_Resolver::get_style_variations();
 		foreach ( $variations as $variation ) {
 			$variation_theme_json = new WP_Theme_JSON( $variation );
 			$resolved_theme_uris  = WP_Theme_JSON_Resolver::get_resolved_theme_uris( $variation_theme_json );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
@@ -265,13 +265,9 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Posts_Controller {
 				$config['styles'] = $existing_config['styles'];
 			}
 
-			// Register theme-defined variations.
-			WP_Theme_JSON_Resolver::get_theme_data();
-
-			// Register user-defined variations.
-			if ( ! empty( $config['styles']['blocks']['variations'] ) ) {
-				wp_register_block_style_variations_from_theme_json_data( $config['styles']['blocks']['variations'] );
-			}
+			// Register theme-defined variations e.g. from block style variation partials under `/styles`.
+			$variations = WP_Theme_JSON_Resolver::get_style_variations( 'block' );
+			wp_register_block_style_variations_from_theme_json_partials( $variations );
 
 			if ( isset( $request['settings'] ) ) {
 				$config['settings'] = $request['settings'];

--- a/src/wp-includes/theme-i18n.json
+++ b/src/wp-includes/theme-i18n.json
@@ -80,15 +80,6 @@
 			}
 		}
 	},
-	"styles": {
-		"blocks": {
-			"variations": {
-				"*": {
-					"title": "Style variation name"
-				}
-			}
-		}
-	},
 	"customTemplates": [
 		{
 			"title": "Custom template name"

--- a/tests/phpunit/data/themedir1/block-theme-child-with-block-style-variations/theme.json
+++ b/tests/phpunit/data/themedir1/block-theme-child-with-block-style-variations/theme.json
@@ -1,4 +1,55 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
-	"version": 3
+	"version": 3,
+	"styles": {
+		"variations": {
+			"outline": {
+				"color": {
+					"background": "green",
+					"text": "white"
+				}
+			},
+			"block-style-variation-a": {
+				"color": {
+					"background": "darkseagreen"
+				},
+				"typography": {
+					"fontSize": "2em",
+					"lineHeight": "1.4em"
+				}
+			}
+		},
+		"blocks": {
+			"core/button": {
+				"variations": {
+					"outline": {
+						"color": {
+							"background": "red"
+						}
+					}
+				}
+			},
+			"core/media-text": {
+				"variations": {
+					"block-style-variation-a": {
+						"color": {
+							"background": "blue"
+						},
+						"typography": {
+							"fontSize": "1.5em"
+						}
+					}
+				}
+			},
+			"core/heading": {
+				"variations": {
+					"block-style-variation-b": {
+						"typography": {
+							"fontSize": "3em"
+						}
+					}
+				}
+			}
+		}
+	}
 }

--- a/tests/phpunit/tests/block-supports/block-style-variations.php
+++ b/tests/phpunit/tests/block-supports/block-style-variations.php
@@ -62,6 +62,7 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 	 *
 	 * @ticket 61312
 	 * @ticket 61440
+	 * @ticket 61451
 	 */
 	public function test_add_registered_block_styles_to_theme_data() {
 		switch_theme( 'block-theme' );
@@ -120,14 +121,6 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 		$group_styles = $theme_json['styles']['blocks']['core/group'] ?? array();
 		$expected     = array(
 			'variations' => array(
-				// @ticket 61440
-				'WithSlug'                => array(
-					'color' => array(
-						'background' => 'aliceblue',
-						'text'       => 'midnightblue',
-					),
-				),
-				'my-variation'            => $variation_styles_data,
 
 				/*
 				 * The following block style variations are registered
@@ -146,6 +139,18 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 						'text'       => 'lightblue',
 					),
 				),
+
+				/*
+				 * Manually registered variations.
+				 * @ticket 61440
+				 */
+				'WithSlug'                => array(
+					'color' => array(
+						'background' => 'aliceblue',
+						'text'       => 'midnightblue',
+					),
+				),
+				'my-variation'            => $variation_styles_data,
 			),
 		);
 

--- a/tests/phpunit/tests/block-supports/block-style-variations.php
+++ b/tests/phpunit/tests/block-supports/block-style-variations.php
@@ -66,11 +66,6 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 	public function test_add_registered_block_styles_to_theme_data() {
 		switch_theme( 'block-theme' );
 
-		// Register theme-defined variations.
-		WP_Theme_JSON_Resolver::get_theme_data();
-		// Register user-defined variations.
-		WP_Theme_JSON_Resolver::get_user_data();
-
 		$variation_styles_data = array(
 			'color'    => array(
 				'background' => 'darkslateblue',
@@ -157,6 +152,6 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 		unregister_block_style( 'core/group', 'my-variation' );
 		unregister_block_style( 'core/group', 'WithSlug' );
 
-		$this->assertSameSetsWithIndex( $expected, $group_styles );
+		$this->assertSameSetsWithIndex( $expected, $group_styles, 'Variation data does not match' );
 	}
 }

--- a/tests/phpunit/tests/rest-api/rest-global-styles-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-global-styles-controller.php
@@ -609,12 +609,25 @@ class WP_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controller_Test
 	 *
 	 * @covers WP_REST_Global_Styles_Controller_Gutenberg::update_item
 	 * @ticket 61312
+	 * @ticket 61451
 	 */
 	public function test_update_item_with_custom_block_style_variations() {
 		wp_set_current_user( self::$admin_id );
 		if ( is_multisite() ) {
 			grant_super_admin( self::$admin_id );
 		}
+
+		/*
+		 * For variations to be resolved they have to have been registered
+		 * via either a theme.json partial or through the WP_Block_Styles_Registry.
+		 */
+		register_block_style(
+			'core/group',
+			array(
+				'name'  => 'fromThemeStyleVariation',
+				'label' => 'From Theme Style Variation',
+			)
+		);
 
 		$group_variations = array(
 			'fromThemeStyleVariation' => array(
@@ -629,16 +642,16 @@ class WP_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controller_Test
 		$request->set_body_params(
 			array(
 				'styles' => array(
-					'blocks' => array(
-						'variations' => array(
-							'fromThemeStyleVariation' => array(
-								'blockTypes' => array( 'core/group', 'core/columns' ),
-								'color'      => array(
-									'background' => '#000000',
-									'text'       => '#ffffff',
-								),
+					'variations' => array(
+						'fromThemeStyleVariation' => array(
+							'blockTypes' => array( 'core/group', 'core/columns' ),
+							'color'      => array(
+								'background' => '#000000',
+								'text'       => '#ffffff',
 							),
 						),
+					),
+					'blocks'     => array(
 						'core/group' => array(
 							'variations' => $group_variations,
 						),

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -3931,6 +3931,92 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 61451
+	 */
+	public function test_unwraps_block_style_variations() {
+		register_block_style(
+			array( 'core/paragraph', 'core/group' ),
+			array(
+				'name'  => 'myVariation',
+				'label' => 'My variation',
+			)
+		);
+
+		$input = new WP_Theme_JSON(
+			array(
+				'version' => WP_Theme_JSON::LATEST_SCHEMA,
+				'styles'  => array(
+					'variations' => array(
+						'myVariation' => array(
+							'color'      => array(
+								'background' => 'topLevel',
+								'gradient'   => 'topLevel',
+							),
+							'typography' => array(
+								'fontFamily' => 'topLevel',
+							),
+						),
+					),
+					'blocks'     => array(
+						'core/paragraph' => array(
+							'variations' => array(
+								'myVariation' => array(
+									'color'   => array(
+										'background' => 'blockLevel',
+										'text'       => 'blockLevel',
+									),
+									'outline' => array(
+										'offset' => 'blockLevel',
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$expected = array(
+			'version' => WP_Theme_JSON::LATEST_SCHEMA,
+			'styles'  => array(
+				'blocks' => array(
+					'core/paragraph' => array(
+						'variations' => array(
+							'myVariation' => array(
+								'color'      => array(
+									'background' => 'blockLevel',
+									'gradient'   => 'topLevel',
+									'text'       => 'blockLevel',
+								),
+								'typography' => array(
+									'fontFamily' => 'topLevel',
+								),
+								'outline'    => array(
+									'offset' => 'blockLevel',
+								),
+							),
+						),
+					),
+					'core/group'     => array(
+						'variations' => array(
+							'myVariation' => array(
+								'color'      => array(
+									'background' => 'topLevel',
+									'gradient'   => 'topLevel',
+								),
+								'typography' => array(
+									'fontFamily' => 'topLevel',
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+		$this->assertSameSetsWithIndex( $expected, $input->get_raw_data(), 'Unwrapped block style variations do not match' );
+	}
+
+	/**
 	 * @ticket 57583
 	 *
 	 * @dataProvider data_sanitize_for_block_with_style_variations

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -1321,4 +1321,95 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 
 		$this->assertSame( $expected_data, $actual );
 	}
+
+	/**
+	 * Tests that block style variations data gets merged in the following
+	 * priority order, from highest priority to lowest.
+	 *
+	 * - `styles.blocks.blockType.variations` from theme.json
+	 * - `styles.variations` from theme.json
+	 * - variations from block style variation files under `/styles`
+	 * - variations from `WP_Block_Styles_Registry`
+	 *
+	 * @ticket 61451
+	 */
+	public function test_block_style_variation_merge_order() {
+		switch_theme( 'block-theme-child-with-block-style-variations' );
+
+		/*
+		 * Register style for a block that isn't included in the block style variation's partial
+		 * theme.json's blockTypes. The name must match though so we can ensure the partial's
+		 * styles do not get applied to this block.
+		 */
+		register_block_style(
+			'core/heading',
+			array(
+				'name'  => 'block-style-variation-b',
+				'label' => 'Heading only variation',
+			)
+		);
+
+		// Register variation for a block that will be partially overridden at all levels.
+		register_block_style(
+			'core/media-text',
+			array(
+				'name'       => 'block-style-variation-a',
+				'label'      => 'Block Style Variation A',
+				'style_data' => array(
+					'color' => array(
+						'background' => 'pink',
+						'gradient'   => 'var(--custom)',
+					),
+				),
+			)
+		);
+
+		$data         = WP_Theme_JSON_Resolver::get_theme_data()->get_raw_data();
+		$block_styles = $data['styles']['blocks'] ?? array();
+		$actual       = array_intersect_key(
+			$block_styles,
+			array_flip( array( 'core/button', 'core/media-text', 'core/heading' ) )
+		);
+		$expected     = array(
+			'core/button'     => array(
+				'variations' => array(
+					'outline' => array(
+						'color' => array(
+							'background' => 'red',
+							'text'       => 'white',
+						),
+					),
+				),
+			),
+			'core/media-text' => array(
+				'variations' => array(
+					'block-style-variation-a' => array(
+						'color'      => array(
+							'background' => 'blue',
+							'gradient'   => 'var(--custom)',
+							'text'       => 'aliceblue',
+						),
+						'typography' => array(
+							'fontSize'   => '1.5em',
+							'lineHeight' => '1.4em',
+						),
+					),
+				),
+			),
+			'core/heading'    => array(
+				'variations' => array(
+					'block-style-variation-b' => array(
+						'typography' => array(
+							'fontSize' => '3em',
+						),
+					),
+				),
+			),
+		);
+
+		unregister_block_style( 'core/heading', 'block-style-variation-b' );
+		unregister_block_style( 'core/media-text', 'block-style-variation-a' );
+
+		$this->assertSameSetsWithIndex( $expected, $actual, 'Merged variation styles do not match.' );
+	}
 }


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/61451
Follow-up work for https://core.trac.wordpress.org/ticket/61312

Backports https://github.com/WordPress/gutenberg/pull/62712

The changes in https://github.com/WordPress/gutenberg/pull/62712 make optimizations around the processing and registration of shared block style variations in theme.json as well as simplify the mental model for the feature increasing conceptual consistency.

These changes involve:
- Moving shared variation definitions from `styles.blocks.variations` to `styles.variations`
- Removing `blockTypes` from `styles.variations`. 
- Not automatically registering shared variations from theme style variation or primary theme.json files.
- Moving the merging of theme.json data into the `WP_Theme_JSON_Resolver` and `WP_Theme_JSON` classes as per [#6868](https://github.com/WordPress/wordpress-develop/pull/6868)


## Testing Instructions

1. Defines block style variations via the different sources below:
   - `register_block_style`
   - Theme.json partial file under `/styles` directory including `blockTypes`
   - Within a theme style variation under `styles.variations` 
       - Define at least one that is registered via `register_block_style` or a theme.json partial as well
       - Define a variation that hasn't been registered
2. Confirm that only registered variations appear for selection (those defined via `register_block_style`, theme.json partials, or in core block types `styles` property such as Button's Outline style)
3. Try out all the variations and ensure they get applied correctly in the editor and frontend
4. Update the variation definitions to define inner element and block type styles as well
5. Check the inner element and block type styles are applied correctly for variations
4. Test applying variations on blocks in a nested fashion
5. Update variation styles via Styles > Blocks > Block Type > Variation and confirm they apply correctly everywhere

<details>
<summary><strong>`register_block_style` Example</strong></summary>

```php
gutenberg_register_block_style(
	array( 'core/group', 'core/columns' ),
	array(
		'name'       => 'section-b',
		'label'      => __( 'Section B' ),
		'style_data' => array(
			'color'    => array(
				'background' => '#4f6f52',
				'text'       => '#d2e3c8',
			),
			'blocks'   => array(
				'core/group' => array(
					'color' => array(
						'background' => '#739072',
						'text'       => '#e3eedd',
					),
				),
			),
			'elements' => array(
				'link' => array(
					'color'  => array(
						'text' => '#ead196',
					),
					':hover' => array(
						'color' => array(
							'text' => '#ebd9b4',
						),
					),
				),
			),
		),
	)
);

```
</details>

<details>
<summary><strong>Theme.json Partial Example</strong></summary>

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 3,
	"title": "Section A",
	"slug": "section-a",
	"blockTypes": [ "core/group" ],
	"styles": {
		"color": {
			"background": "slategrey",
			"text": "snow"
		},
		"blocks": {
			"core/group": {
				"color": {
					"background": "darkslategrey",
					"text": "whitesmoke"
				}
			}
		}
	}
}
```
</details>


<details>
<summary><strong>Theme Style Variation Example (`styles.variations`)</strong></summary>

```json
{

	"styles": {
		"variations": {
			"section-a": {
				"color": {
					"background": "var(--wp--preset--color--theme-2)",
					"text": "var(--wp--preset--color--theme-5)"
				},
				"blocks": {
					"core/group": {
						"color": {
							"background": "var(--wp--preset--color--theme-4)",
							"text": "var(--wp--preset--color--theme-2)"
						}
					}
				}
			}
		}
	}
}
```
</details>