### PR TITLE
Fixed Error appearing in `add_feed()` function when `$feedname` parameter start with `_`

### DIFF
--- a/src/wp-includes/rewrite.php
+++ b/src/wp-includes/rewrite.php
@@ -244,7 +244,7 @@ function remove_permastruct( $name ) {
  *
  * @global WP_Rewrite $wp_rewrite WordPress rewrite component.
  *
- * @param string   $feedname Feed name.
+ * @param string   $feedname Feed name (It should not start with '_').
  * @param callable $callback Callback to run on feed display.
  * @return string Feed action name.
  */

--- a/src/wp-includes/rewrite.php
+++ b/src/wp-includes/rewrite.php
@@ -244,7 +244,7 @@ function remove_permastruct( $name ) {
  *
  * @global WP_Rewrite $wp_rewrite WordPress rewrite component.
  *
- * @param string   $feedname Feed name (It should not start with '_').
+ * @param string   $feedname Feed name (it should not start with '_').
  * @param callable $callback Callback to run on feed display.
  * @return string Feed action name.
  */


### PR DESCRIPTION
Trac ticket:  https://core.trac.wordpress.org/ticket/59945

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
