### PR TITLE
Format: improve param indentation

### DIFF
--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -967,7 +967,7 @@ class WP_Theme_JSON_Resolver {
 	 *
 	 * @since 6.6.0
 	 *
-	 * @param array $data       Array following the theme.json specification.
+	 * @param array $data Array following the theme.json specification.
 	 * @return array Theme json data including shared block style variation definitions.
 	 */
 	private static function inject_variations_from_block_styles_registry( $data ) {

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -925,7 +925,7 @@ class WP_Theme_JSON_Resolver {
 	 *
 	 * @since 6.6.0
 	 *
-	 * @param array $data   Array following the theme.json specification.
+	 * @param array $data       Array following the theme.json specification.
 	 * @param array $variations Shared block style variations.
 	 * @return array Theme json data including shared block style variation definitions.
 	 */


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/61451
Follow-up to https://github.com/WordPress/wordpress-develop/pull/6873

Formats missing spaces around `@param` docblock.

Props @mukeshpanchal27 