### PR TITLE
Fixed : Coding Standards - An extra line in between functions in `wp-includes/blocks.php`

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1774,7 +1774,6 @@ function filter_block_kses_value( $value, $allowed_html, $allowed_protocols = ar
 	return $value;
 }
 
-
 /**
  * Sanitizes the value of the Template Part block's `tagName` attribute.
  *


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61493

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
