### PR TITLE
Fixed : Unused `$tag_name variable` in `WP_HTML_Tag_Processor::set_attribute`

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2972,7 +2972,6 @@ class WP_HTML_Tag_Processor {
 		if ( true === $value ) {
 			$updated_attribute = $name;
 		} else {
-			$tag_name        = $this->get_tag();
 			$comparable_name = strtolower( $name );
 
 			/*


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61494

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
