### PR TITLE
Try normalizing allowed_files

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6201,6 +6201,7 @@ function validate_file( $file, $allowed_files = array() ) {
 
 	// Normalize path for Windows servers
 	$file = wp_normalize_path( $file );
+	// Normalize path for $allowed_files as well so it's an apples to apples comparison
 	$allowed_files = array_map( 'wp_normalize_path', $allowed_files );
 
 	// `../` on its own is not allowed:

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6199,9 +6199,9 @@ function validate_file( $file, $allowed_files = array() ) {
 		return 0;
 	}
 
-	// Normalize path for Windows servers
+	// Normalize path for Windows servers.
 	$file = wp_normalize_path( $file );
-	// Normalize path for $allowed_files as well so it's an apples to apples comparison
+	// Normalize path for $allowed_files as well so it's an apples to apples comparison.
 	$allowed_files = array_map( 'wp_normalize_path', $allowed_files );
 
 	// `../` on its own is not allowed:

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6201,6 +6201,7 @@ function validate_file( $file, $allowed_files = array() ) {
 
 	// Normalize path for Windows servers
 	$file = wp_normalize_path( $file );
+	$allowed_files = array_map( 'wp_normalize_path', $allowed_files );
 
 	// `../` on its own is not allowed:
 	if ( '../' === $file ) {

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -1793,6 +1793,7 @@ class Tests_Functions extends WP_UnitTestCase {
 	 * Test file path validation
 	 *
 	 * @ticket 42016
+	 * @ticket 61488
 	 * @dataProvider data_validate_file
 	 *
 	 * @param string $file          File path.
@@ -1911,6 +1912,13 @@ class Tests_Functions extends WP_UnitTestCase {
 				'C:/WINDOWS/system32',
 				array( 'C:/WINDOWS/system32' ),
 				2,
+			),
+
+			// Windows Path with allowed file
+			array(
+				'Apache24\htdocs\wordpress/wp-content/themes/twentyten/style.css',
+				array( 'Apache24\htdocs\wordpress/wp-content/themes/twentyten/style.css' ),
+				0,
 			),
 
 			// Disallowed files:


### PR DESCRIPTION
Allowed files also needs to be normalized in order to ensure that valid paths are checked against each other

Trac ticket: https://core.trac.wordpress.org/ticket/61488
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
