### PR TITLE
Add `(required)` Indication Next to Confirm Password on User Screens

### DIFF
--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -696,7 +696,7 @@ switch ( $action ) {
 								</td>
 							</tr>
 							<tr class="pw-weak">
-								<th><?php _e( 'Confirm Password' ); ?></th>
+								<th><?php _e( 'Confirm Password' ); ?> <span class="description"><?php _e('(required)'); ?></span></th>
 								<td>
 									<label>
 										<input type="checkbox" name="pw_weak" class="pw-checkbox" />

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -696,7 +696,7 @@ switch ( $action ) {
 								</td>
 							</tr>
 							<tr class="pw-weak">
-								<th><?php _e( 'Confirm Password' ); ?> <span class="description"><?php _e('(required)'); ?></span></th>
+								<th><?php _e( 'Confirm Password' ); ?> <span class="description"><?php _e( '(required)' ); ?></span></th>
 								<td>
 									<label>
 										<input type="checkbox" name="pw_weak" class="pw-checkbox" />

--- a/src/wp-admin/user-new.php
+++ b/src/wp-admin/user-new.php
@@ -604,7 +604,7 @@ if ( current_user_can( 'create_users' ) ) {
 		</td>
 	</tr>
 	<tr class="pw-weak">
-		<th><?php _e( 'Confirm Password' ); ?> <span class="description"><?php _e('(required)'); ?></span></th>
+		<th><?php _e( 'Confirm Password' ); ?> <span class="description"><?php _e( '(required)' ); ?></span></th>
 		<td>
 			<label>
 				<input type="checkbox" name="pw_weak" class="pw-checkbox" />

--- a/src/wp-admin/user-new.php
+++ b/src/wp-admin/user-new.php
@@ -604,7 +604,7 @@ if ( current_user_can( 'create_users' ) ) {
 		</td>
 	</tr>
 	<tr class="pw-weak">
-		<th><?php _e( 'Confirm Password' ); ?></th>
+		<th><?php _e( 'Confirm Password' ); ?> <span class="description"><?php _e('(required)'); ?></span></th>
 		<td>
 			<label>
 				<input type="checkbox" name="pw_weak" class="pw-checkbox" />


### PR DESCRIPTION
## Description

This PR adds a `(required)` indication next to the 'Confirm Password' on the new user and edit user screens. This helps users understand that they need to check this checkbox to enable the 'Add New User' or 'Update Profile' button when the manually added password is not strong enough. The update improves clarity and user experience by clearly indicating the required action.

## Screenshots

- Add User

<img width="1470" alt="add-user" src="https://github.com/WordPress/wordpress-develop/assets/51747980/d889ebd8-18d2-44c5-ba02-f7bbb8c21abc">

- Edit User

<img width="1470" alt="edit-user" src="https://github.com/WordPress/wordpress-develop/assets/51747980/d65f33a3-13ae-424e-b5ef-4d6f9b7a5897">

## Trac ticket: https://core.trac.wordpress.org/ticket/37284
