### PR TITLE
Remove legacy webpack DefinePlugin configuration

### DIFF
--- a/tools/webpack/shared.js
+++ b/tools/webpack/shared.js
@@ -41,15 +41,6 @@ const getBaseConfig = ( env ) => {
 		watch: env.watch,
 		plugins: [
 			new DefinePlugin( {
-				/*
-				 * These variables are part of https://github.com/WordPress/gutenberg/pull/61486
-				 * They're expected to be released in an upcoming version of Gutenberg.
-				 *
-				 * Defining this before the packages are released is harmless.
-				 *
-				 * @todo Remove the non-globalThis defines here when packages have been upgraded to the globalThis versions.
-				 */
-
 				// Inject the `IS_GUTENBERG_PLUGIN` global, used for feature flagging.
 				'globalThis.IS_GUTENBERG_PLUGIN': JSON.stringify( false ),
 				// Inject the `IS_WORDPRESS_CORE` global, used for feature flagging.
@@ -58,13 +49,6 @@ const getBaseConfig = ( env ) => {
 				'globalThis.SCRIPT_DEBUG': JSON.stringify(
 					mode === 'development'
 				),
-
-				// Inject the `IS_GUTENBERG_PLUGIN` global, used for feature flagging.
-				'process.env.IS_GUTENBERG_PLUGIN': JSON.stringify( false ),
-				// Inject the `IS_WORDPRESS_CORE` global, used for feature flagging.
-				'process.env.IS_WORDPRESS_CORE': JSON.stringify( true ),
-				// Inject the `SCRIPT_DEBUG` global, used for dev versions of JavaScript.
-				SCRIPT_DEBUG: JSON.stringify( mode === 'development' ),
 			} ),
 		],
 	};


### PR DESCRIPTION
https://github.com/WordPress/gutenberg/pull/61486 changed the variables
compiled into Gutenberg packages via the webpack DefinePlugin.

https://core.trac.wordpress.org/changeset/58193 added the new
DefinePlugin configuration, but did not remove the legacy configuration
in order to be compatible with new and old Gutenberg versions before the
packages were updated.

Now that packages have been update, the legacy configuration should be
removed.

Follow-up to https://core.trac.wordpress.org/changeset/58193.

Trac ticket: https://core.trac.wordpress.org/ticket/61262

## Testing

You can confirm that these variables have been replaced during build and do not appear in compiled source:

```sh
# Install and build
npm ci
npm run build
# Look for patterns that should not exist
# There will only be a couple of comments in non-minified code
grep -RE '(SCRIPT_DEBUG|IS_WORDPRESS_CORE|IS_GUTENBERG_PLUGIN)' build/wp-includes/js/dist/
```

You can see they are in the packages:

```sh
# Lots of results
grep -RE '(SCRIPT_DEBUG|IS_WORDPRESS_CORE|IS_GUTENBERG_PLUGIN)' build/wp-includes/js/dist/
```

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
