### PR TITLE
Fix cropping tools in the block editor

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -626,7 +626,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 					$width  = (int) round( ( $size['width'] * $args['width'] ) / 100.0 );
 					$height = (int) round( ( $size['height'] * $args['height'] ) / 100.0 );
 
-					if ( $size['width'] !== $width && $size['height'] !== $height ) {
+					if ( $size['width'] !== $width || $size['height'] !== $height ) {
 						$result = $image_editor->crop( $crop_x, $crop_y, $width, $height );
 
 						if ( is_wp_error( $result ) ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

## What

Fixes cropping tools in the block editor. Related Gutenberg issue: https://github.com/WordPress/gutenberg/issues/62855.

## Why

Currently, the cropping tool in the block editor doesn't apply the selected crop.

As of https://github.com/WordPress/wordpress-develop/commit/4f175e167ebd33d68ebe347fcc376f1342d9e873 / https://github.com/WordPress/wordpress-develop/pull/6876, the width and height cropping values are rounded and cast to an `int` before the comparison to see if the target width and height differ from the original width and height.

Since they are now `int`s, it exposes a bug where the `&&` of the `if` conditional meant that if you were only cropping in one dimension, the check wouldn't pass, and cropping would not occur.

In the block editor, the cropping tools are aspect ratio based, so one of the dimensions will always match that of the source image. Therefore, now that the values are cast as `int`s, we need to update the condition that allows a cropping to occur. In this case, I believe it should be `||` instead of `&&`. If either width or height is different from the source image, then we should allow a crop.

## How to test

1. Add an image block to a post in the block editor
2. Click on the Crop tool in the block toolbar
3. Select a Crop from the aspect ratio dropdown
4. Click Apply
5. The aspect ratio should be applied in the final image
6. Save and load the post on the site frontend and double check that the crop is correct

Trac ticket: https://core.trac.wordpress.org/ticket/61514

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
