### PR TITLE
Fixed - Twenty Nineteen : `Pullquote Block` Text Decoration is not reflecting in frontend for citation

### DIFF
--- a/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
+++ b/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
@@ -396,7 +396,7 @@
 		}
 
 		cite {
-			display: inline-block;
+			display: block;
 			@include font-family( $font__heading );
 			line-height: 1.6;
 			text-transform: none;


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61507

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
