### PR TITLE
Fix: wp_audio_shortcode, handle boolean attribute correctly in foreach

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -3358,7 +3358,11 @@ function wp_audio_shortcode( $attr, $content = '' ) {
 	$attr_strings = array();
 
 	foreach ( $html_atts as $k => $v ) {
-		$attr_strings[] = $k . '="' . esc_attr( $v ) . '"';
+		if ( in_array( $k, array( 'loop', 'autoplay', 'muted' ), true ) && true === $v ) {
+			$attr_strings[] = esc_attr( $k );
+		} else {
+			$attr_strings[] = $k . '="' . esc_attr( $v ) . '"';
+		}
 	}
 
 	$html = '';


### PR DESCRIPTION
wp_audio_shortcode() was chaging boolean attributes to 1, as of true === 1, in debug i notice it was directly happening after foreach, not by eascaping, so I have add a if statement to handle boolean attributes and directly pass our key, as Key can be directly work for boolean attributes in HTML.

Trac Ticket: https://core.trac.wordpress.org/ticket/61515