### PR TITLE
Add: question mark tooltip for remember me

### DIFF
--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -196,6 +196,34 @@ p {
 	margin-bottom: 0;
 }
 
+p.forgetmenot .tooltip {
+    position: relative;
+    display: inline-block;
+    cursor: help;
+}
+
+p.forgetmenot .tooltip .tooltiptext {
+    visibility: hidden;
+    width: 160px;
+    background-color: #333;
+    color: #fff;
+    text-align: center;
+    border-radius: 6px;
+    padding: 5px 0;
+    position: absolute;
+    z-index: 1;
+    bottom: 125%;
+    left: 50%;
+    margin-left: -80px;
+    opacity: 0;
+    transition: opacity 0.3s;
+}
+
+p.forgetmenot .tooltip:hover .tooltiptext {
+    visibility: visible;
+    opacity: 1;
+}
+
 .login .button-primary {
 	float: right;
 }

--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -196,13 +196,13 @@ p {
 	margin-bottom: 0;
 }
 
-p.forgetmenot .tooltip {
+.login form .forgetmenot .tooltip {
     position: relative;
     display: inline-block;
     cursor: help;
 }
 
-p.forgetmenot .tooltip .tooltiptext {
+.login form .forgetmenot .tooltip .tooltiptext {
     visibility: hidden;
     width: 160px;
     background-color: #333;
@@ -219,7 +219,7 @@ p.forgetmenot .tooltip .tooltiptext {
     transition: opacity 0.3s;
 }
 
-p.forgetmenot .tooltip:hover .tooltiptext {
+.login form .forgetmenot .tooltip:hover .tooltiptext {
     visibility: visible;
     opacity: 1;
 }

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -1526,7 +1526,7 @@ switch ( $action ) {
 			do_action( 'login_form' );
 
 			?>
-			<p class="forgetmenot"><input name="rememberme" type="checkbox" id="rememberme" value="forever" <?php checked( $rememberme ); ?> /> <label for="rememberme"><?php esc_html_e( 'Remember Me' ); ?></label></p>
+			<p class="forgetmenot"><input name="rememberme" type="checkbox" id="rememberme" value="forever" <?php checked( $rememberme ); ?> /> <label for="rememberme"><?php esc_html_e( 'Remember Me' ); ?></label> <span class="tooltip">?<span class="tooltiptext">Stay Login, even brower closes.</span></span> </p>
 			<p class="submit">
 				<input type="submit" name="wp-submit" id="wp-submit" class="button button-primary button-large" value="<?php esc_attr_e( 'Log In' ); ?>" />
 				<?php


### PR DESCRIPTION
- Add tooltip on side of Login page remember me button.
- Can edit message of Tooltip.
- Follow design same from ticket 51006.
- Can be used to resolve 51006 if we make `tooltip` and `tooltiptext` by removing front selector.

Trac Ticket: https://core.trac.wordpress.org/ticket/55343