### PR TITLE
HTML API: Add docs and tests about lowercasing in class_list

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1694,9 +1694,10 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	}
 
 	/**
-	 * Generator that yields each class name for the matched tag.
+	 * Generator for a foreach loop to step through each class name for the matched tag.
 	 *
-	 * Class names will be lowercased and unique class names will be yielded once.
+	 * This generator function is designed to be used inside a "foreach" loop.
+	 * This yields an ASCII-lowercased version of each class name.
 	 *
 	 * Example:
 	 *

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1700,7 +1700,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * Example:
 	 *
-	 *     $p = new WP_HTML_Tag_Processor( "<div class='FREE &lt;egg&lt;\tlang-en'>" );
+	 *     $p = WP_HTML_Processor::create_fragment( "<div class='FREE &lt;egg&lt;\tlang-en'>" );
 	 *     $p->next_tag();
 	 *     foreach ( $p->class_list() as $class_name ) {
 	 *         echo "{$class_name} ";

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1694,13 +1694,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	}
 
 	/**
-	 * Generator for a foreach loop to step through each class name for the matched tag.
+	 * Generator that yields each class name for the matched tag.
 	 *
-	 * This generator function is designed to be used inside a "foreach" loop.
+	 * Class names will be lowercased and unique class names will be yielded once.
 	 *
 	 * Example:
 	 *
-	 *     $p = WP_HTML_Processor::create_fragment( "<div class='free &lt;egg&lt;\tlang-en'>" );
+	 *     $p = new WP_HTML_Tag_Processor( "<div class='FREE &lt;egg&lt;\tlang-en'>" );
 	 *     $p->next_tag();
 	 *     foreach ( $p->class_list() as $class_name ) {
 	 *         echo "{$class_name} ";

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1038,13 +1038,13 @@ class WP_HTML_Tag_Processor {
 	}
 
 	/**
-	 * Generator for a foreach loop to step through each class name for the matched tag.
+	 * Generator that yields each class name for the matched tag.
 	 *
-	 * This generator function is designed to be used inside a "foreach" loop.
+	 * Class names will be lowercased and unique class names will be yielded once.
 	 *
 	 * Example:
 	 *
-	 *     $p = new WP_HTML_Tag_Processor( "<div class='free &lt;egg&lt;\tlang-en'>" );
+	 *     $p = new WP_HTML_Tag_Processor( "<div class='FREE &lt;egg&lt;\tlang-en'>" );
 	 *     $p->next_tag();
 	 *     foreach ( $p->class_list() as $class_name ) {
 	 *         echo "{$class_name} ";

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1038,9 +1038,10 @@ class WP_HTML_Tag_Processor {
 	}
 
 	/**
-	 * Generator that yields each class name for the matched tag.
+	 * Generator for a foreach loop to step through each class name for the matched tag.
 	 *
-	 * Class names will be lowercased and unique class names will be yielded once.
+	 * This generator function is designed to be used inside a "foreach" loop.
+	 * This yields an ASCII-lowercased version of each class name.
 	 *
 	 * Example:
 	 *

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2212,6 +2212,20 @@ HTML;
 	}
 
 	/**
+	 * @ticket 61520
+	 *
+	 * @covers WP_HTML_Tag_Processor::class_list
+	 */
+	public function test_class_list_lowercases_class_names() {
+		$processor = new WP_HTML_Tag_Processor( '<div class="A a B b">' );
+		$processor->next_tag();
+
+		$found_classes = iterator_to_array( $processor->class_list() );
+
+		$this->assertSame( array( 'a', 'b' ), $found_classes, 'Found incorrect class_names with mixed casing attribute value.' );
+	}
+
+	/**
 	 * @ticket 59209
 	 *
 	 * @covers WP_HTML_Tag_Processor::has_class


### PR DESCRIPTION
The class_list method yields class name strings in lower case. This is
intended but undocumented. Document and add tests for this behavior.




Trac ticket: https://core.trac.wordpress.org/ticket/61520

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
