### PR TITLE
HTML API: Add tests for virtual node breadcrumbs and depth

### DIFF
--- a/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
@@ -573,4 +573,52 @@ HTML
 			'Should have retained breadcrumbs from bookmarked location after seeking backwards to it.'
 		);
 	}
+
+	/**
+	 * Ensures that breadcrumbs are properly reported on virtual nodes.
+	 *
+	 * @dataProvider data_virtual_nodes_breadcrumbs_depth
+	 *
+	 * @ticket 61348
+	 */
+	public function test_breadcrumbs_on_virtual_nodes( $html, $token_position, $expected_breadcrumbs ) {
+		$processor = WP_HTML_Processor::create_fragment( $html );
+
+		for ( $i = 0; $i < $token_position; $i++ ) {
+			$processor->next_token();
+		}
+
+		$this->assertEquals( $expected_breadcrumbs, $processor->get_breadcrumbs(), "Found incorrect breadcrumbs in {$html}." );
+	}
+
+	/**
+	 * Ensures that get_current_depth reports the correct depth on virtual nodes.
+	 *
+	 * @dataProvider data_virtual_nodes_breadcrumbs_depth
+	 *
+	 * @ticket 61348
+	 */
+	public function test_depth_on_virtual_nodes( $html, $token_position, $expected_breadcrumbs ) {
+		$processor = WP_HTML_Processor::create_fragment( $html );
+
+		for ( $i = 0; $i < $token_position; $i++ ) {
+			$processor->next_token();
+		}
+
+		$this->assertSame( count( $expected_breadcrumbs ), $processor->get_current_depth(), "Found incorrect depth in {$html}." );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_virtual_nodes_breadcrumbs_depth() {
+		return array(
+			'Implied P tag opener on unmatched closer'    => array( '</p>', 1, array( 'HTML', 'BODY', 'P' ) ),
+			'Implied heading tag closer on heading child' => array( '<h1><h2>', 2, array( 'HTML', 'BODY' ) ),
+			'Implied A tag closer on A tag child'         => array( '<a><a>', 2, array( 'HTML', 'BODY' ) ),
+			'Implied A tag closer on A tag descendent'    => array( '<a><span><a>', 4, array( 'HTML', 'BODY' ) ),
+		);
+	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
@@ -581,11 +581,18 @@ HTML
 	 *
 	 * @ticket 61348
 	 */
-	public function test_breadcrumbs_on_virtual_nodes( $html, $token_position, $expected_breadcrumbs ) {
+	public function test_breadcrumbs_on_virtual_nodes( string $html, int $token_position, string $expected_tag_name, string $expect_open_close, array $expected_breadcrumbs ) {
 		$processor = WP_HTML_Processor::create_fragment( $html );
 
 		for ( $i = 0; $i < $token_position; $i++ ) {
 			$processor->next_token();
+		}
+
+		$this->assertSame( $expected_tag_name, $processor->get_tag(), "Found incorrect tag name {$processor->get_tag()}." );
+		if ( 'open' === $expect_open_close ) {
+			$this->assertFalse( $processor->is_tag_closer(), "Found closer when opener expected at {$processor->get_tag()}." );
+		} else {
+			$this->assertTrue( $processor->is_tag_closer(), "Found opener when closer expected at {$processor->get_tag()}." );
 		}
 
 		$this->assertEquals( $expected_breadcrumbs, $processor->get_breadcrumbs(), "Found incorrect breadcrumbs in {$html}." );
@@ -598,7 +605,7 @@ HTML
 	 *
 	 * @ticket 61348
 	 */
-	public function test_depth_on_virtual_nodes( $html, $token_position, $expected_breadcrumbs ) {
+	public function test_depth_on_virtual_nodes( string $html, int $token_position, string $expected_tag_name, string $expect_open_close, array $expected_breadcrumbs ) {
 		$processor = WP_HTML_Processor::create_fragment( $html );
 
 		for ( $i = 0; $i < $token_position; $i++ ) {
@@ -611,14 +618,21 @@ HTML
 	/**
 	 * Data provider.
 	 *
+	 * Data arrays will have the following shape:
+	 *     0: string        Input html.
+	 *     1: int           Token index to seek.
+	 *     2: string        Expected tag name.
+	 *     3: string        'open' or 'close' indicating an opener or closer is expected.
+	 *     4: array<string> Expected breadcrumbs.
+	 *
 	 * @return array[]
 	 */
 	public static function data_virtual_nodes_breadcrumbs() {
 		return array(
-			'Implied P tag opener on unmatched closer'    => array( '</p>', 1, array( 'HTML', 'BODY', 'P' ) ),
-			'Implied heading tag closer on heading child' => array( '<h1><h2>', 2, array( 'HTML', 'BODY' ) ),
-			'Implied A tag closer on A tag child'         => array( '<a><a>', 2, array( 'HTML', 'BODY' ) ),
-			'Implied A tag closer on A tag descendent'    => array( '<a><span><a>', 4, array( 'HTML', 'BODY' ) ),
+			'Implied P tag opener on unmatched closer'    => array( '</p>', 1, 'P', 'open', array( 'HTML', 'BODY', 'P' ) ),
+			'Implied heading tag closer on heading child' => array( '<h1><h2>', 2, 'H1', 'close', array( 'HTML', 'BODY' ) ),
+			'Implied A tag closer on A tag child'         => array( '<a><a>', 2, 'A', 'close', array( 'HTML', 'BODY' ) ),
+			'Implied A tag closer on A tag descendent'    => array( '<a><span><a>', 4, 'A', 'close', array( 'HTML', 'BODY' ) ),
 		);
 	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorBreadcrumbs.php
@@ -577,7 +577,7 @@ HTML
 	/**
 	 * Ensures that breadcrumbs are properly reported on virtual nodes.
 	 *
-	 * @dataProvider data_virtual_nodes_breadcrumbs_depth
+	 * @dataProvider data_virtual_nodes_breadcrumbs
 	 *
 	 * @ticket 61348
 	 */
@@ -594,7 +594,7 @@ HTML
 	/**
 	 * Ensures that get_current_depth reports the correct depth on virtual nodes.
 	 *
-	 * @dataProvider data_virtual_nodes_breadcrumbs_depth
+	 * @dataProvider data_virtual_nodes_breadcrumbs
 	 *
 	 * @ticket 61348
 	 */
@@ -613,7 +613,7 @@ HTML
 	 *
 	 * @return array[]
 	 */
-	public static function data_virtual_nodes_breadcrumbs_depth() {
+	public static function data_virtual_nodes_breadcrumbs() {
 		return array(
 			'Implied P tag opener on unmatched closer'    => array( '</p>', 1, array( 'HTML', 'BODY', 'P' ) ),
 			'Implied heading tag closer on heading child' => array( '<h1><h2>', 2, array( 'HTML', 'BODY' ) ),


### PR DESCRIPTION
Add unit tests for virtual node breadcrumbs and depth. This includes tests for behaviors that were fixed in https://github.com/WordPress/wordpress-develop/pull/6914 / https://core.trac.wordpress.org/changeset/58590.
Trac ticket: https://core.trac.wordpress.org/ticket/61348

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
