### PR TITLE
HTML API: Consistent case sensitive handling of class names

### DIFF
--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2899,7 +2899,7 @@ HTML
 	 * @covers ::remove_class
 	 */
 	public function test_remove_class_removes_case_insensitive_matches() {
-		$processor = new WP_HTML_Tag_Processor( '<div class="REMOVE-a remove-A REMOVE-b remove-B Keep">' );
+		$processor = new WP_HTML_Tag_Processor( '<div class="Keep REMOVE-a remove-A REMOVE-b remove-B">' );
 		$processor->next_tag();
 		$processor->remove_class( 'remove-a' );
 		$processor->remove_class( 'REMOVE-B' );

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2896,6 +2896,22 @@ HTML
 	/**
 	 * @ticket 61531
 	 *
+	 * @covers ::add_class
+	 */
+	public function test_add_class_respects_provided_casing() {
+		$processor = new WP_HTML_Tag_Processor( '<div>' );
+		$processor->next_tag();
+		$processor->add_class( 'mIxEd-CaSiNg' );
+		$this->assertSame(
+			'<div class="mIxEd-CaSiNg">',
+			$processor->get_updated_html(),
+			'::add_class did not respect the provided class name casing.'
+		);
+	}
+
+	/**
+	 * @ticket 61531
+	 *
 	 * @covers ::remove_class
 	 */
 	public function test_remove_class_removes_case_insensitive_matches() {

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2559,6 +2559,7 @@ HTML;
 
 	/**
 	 * @ticket 56299
+	 * @ticket TBD
 	 *
 	 * @covers WP_HTML_Tag_Processor::add_class
 	 * @covers WP_HTML_Tag_Processor::set_attribute
@@ -2617,6 +2618,14 @@ HTML;
 			'tag inside of CDATA'      => array(
 				'input'    => '<![CDATA[This <is> a <strong id="yes">HTML Tag</strong>]]><span>test</span>',
 				'expected' => '<![CDATA[This <is> a <strong class="firstTag" foo="bar" id="yes">HTML Tag</strong>]]><span class="secondTag">test</span>',
+			),
+			'tags already with added class names' => array(
+				'input'    => '<div class="firstTag"><div class="secondTag">',
+				'expected' => '<div foo="bar" class="firstTag"><div class="secondTag">',
+			),
+			'tags already with added class names mixed casing' => array(
+				'input'    => '<div class="FIRSTTAG"><div class="secondtag">',
+				'expected' => '<div foo="bar" class="FIRSTTAG"><div class="secondtag">',
 			),
 		);
 	}

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2877,7 +2877,7 @@ HTML
 	}
 
 	/**
-	 * @ticket TBD
+	 * @ticket 61531
 	 *
 	 * @covers ::add_class
 	 */
@@ -2894,7 +2894,7 @@ HTML
 	}
 
 	/**
-	 * @ticket TBD
+	 * @ticket 61531
 	 *
 	 * @covers ::remove_class
 	 */

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2559,7 +2559,6 @@ HTML;
 
 	/**
 	 * @ticket 56299
-	 * @ticket TBD
 	 *
 	 * @covers WP_HTML_Tag_Processor::add_class
 	 * @covers WP_HTML_Tag_Processor::set_attribute
@@ -2618,14 +2617,6 @@ HTML;
 			'tag inside of CDATA'      => array(
 				'input'    => '<![CDATA[This <is> a <strong id="yes">HTML Tag</strong>]]><span>test</span>',
 				'expected' => '<![CDATA[This <is> a <strong class="firstTag" foo="bar" id="yes">HTML Tag</strong>]]><span class="secondTag">test</span>',
-			),
-			'tags already with added class names' => array(
-				'input'    => '<div class="firstTag"><div class="secondTag">',
-				'expected' => '<div foo="bar" class="firstTag"><div class="secondTag">',
-			),
-			'tags already with added class names mixed casing' => array(
-				'input'    => '<div class="FIRSTTAG"><div class="secondtag">',
-				'expected' => '<div foo="bar" class="FIRSTTAG"><div class="secondtag">',
 			),
 		);
 	}

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2875,4 +2875,38 @@ HTML
 			'Should have properly applied the update from in front of the cursor.'
 		);
 	}
+
+	/**
+	 * @ticket TBD
+	 *
+	 * @covers ::add_class
+	 */
+	public function test_add_class_does_not_duplicate_case_insensitive_classes() {
+		$processor = new WP_HTML_Tag_Processor( '<div class="UPPER lower">' );
+		$processor->next_tag();
+		$processor->add_class( 'upper' );
+		$processor->add_class( 'LOWER' );
+		$this->assertSame(
+			'<div class="UPPER lower">',
+			$processor->get_updated_html(),
+			'::add_class added case-insensitive duplicate class names.'
+		);
+	}
+
+	/**
+	 * @ticket TBD
+	 *
+	 * @covers ::remove_class
+	 */
+	public function test_remove_class_removes_case_insensitive_matches() {
+		$processor = new WP_HTML_Tag_Processor( '<div class="REMOVE-a remove-A REMOVE-b remove-B Keep">' );
+		$processor->next_tag();
+		$processor->remove_class( 'remove-a' );
+		$processor->remove_class( 'REMOVE-B' );
+		$this->assertSame(
+			'<div class="Keep">',
+			$processor->get_updated_html(),
+			'::remove_class did not remove case-insensitive class name matches.'
+		);
+	}
 }


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/61531

> The Tag Processor CSS class name methods `class_list`, `add_class`, and `remove_class` should be consistent regarding case sensitivity.
>
> These methods are intended to align with CSS class names, meaning that matching should be done ASCII case-insensitive. `class_list` already yields lower case unique class names, but `remove_class` and `add_class` do not have similar behavior of treating case-insensitive matching classes as equal.
>
> - `add_class` should only add classes that are not already present (compared ASCII case-insensitive).
> - `remove_class` should remove all matching classes (compared ASCII case-insensitive).
>
> This was discussed with [@dmsnell](https://profiles.wordpress.org/dmsnell) on Slack here: https://wordpress.slack.com/archives/C05NFB818PQ/p1719403633636769
Related to [#61520](https://core.trac.wordpress.org/ticket/61520) which documents the lower-casing behavior of `class_list`.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
