### PR TITLE
Add opacity as an allowed attribute to safecss_filter_attr()

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2539,6 +2539,7 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 			'box-shadow',
 			'aspect-ratio',
 			'container-type',
+			'opacity',
 
 			// Custom CSS properties.
 			'--*',

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1353,6 +1353,11 @@ EOF;
 				'css'      => 'background-repeat: no-repeat',
 				'expected' => 'background-repeat: no-repeat',
 			),
+			// `background-repeat` introduced in 6.7.
+			array(
+				'css'      => 'opacity: 10',
+				'expected' => 'opacity: 10',
+			),
 		);
 	}
 


### PR DESCRIPTION
Backport of the following Gutenberg PR

https://github.com/WordPress/gutenberg/pull/59891

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/61536#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
