### PR TITLE
Fix font size and citation display for Pullquote block in Twenty Nineteen

### DIFF
--- a/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
+++ b/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
@@ -370,6 +370,7 @@
 		border-color: transparent;
 		border-width: 2px;
 		padding: $size__spacing-unit;
+		font-size: 1em;
 
 		blockquote {
 			border: none;

--- a/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
+++ b/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
@@ -396,7 +396,7 @@
 		}
 
 		cite {
-			display: inline-block;
+			display: block;
 			@include font-family( $font__heading );
 			line-height: 1.6;
 			text-transform: none;

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -5681,6 +5681,7 @@ body.page .main-navigation {
   border-color: transparent;
   border-width: 2px;
   padding: 1rem;
+  font-size: 1em;
 }
 
 .entry .entry-content .wp-block-pullquote blockquote {
@@ -5710,7 +5711,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-pullquote cite {
-  display: inline-block;
+  display: block;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
   text-transform: none;

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -5693,6 +5693,7 @@ body.page .main-navigation {
   border-color: transparent;
   border-width: 2px;
   padding: 1rem;
+  font-size: 1em;
 }
 
 .entry .entry-content .wp-block-pullquote blockquote {
@@ -5722,7 +5723,7 @@ body.page .main-navigation {
 }
 
 .entry .entry-content .wp-block-pullquote cite {
-  display: inline-block;
+  display: block;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   line-height: 1.6;
   text-transform: none;


### PR DESCRIPTION
- Restores the default Pullquote paragraph font size to 49.5 (2.25em * 22px), which has been multiplied by 1.5 since WordPress 6.1.
- Sets the `cite` element to `display: block` for consistent spacing and `text-decoration`.

[Trac 61507](https://core.trac.wordpress.org/ticket/61507)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
