### PR TITLE
Themes: add "description" key to i18n schema

### DIFF
--- a/src/wp-includes/theme-i18n.json
+++ b/src/wp-includes/theme-i18n.json
@@ -1,5 +1,6 @@
 {
 	"title": "Style variation name",
+	"description": "Style variation description",
 	"settings": {
 		"typography": {
 				"fontSizes": [


### PR DESCRIPTION
A "description" key was added to theme.json in https://github.com/WordPress/gutenberg/pull/45242

It was synced to Core in https://github.com/WordPress/wordpress-develop/pull/4687

A corresponding entry to the theme.json i18n schema was not part of the change. This PR does that.

Here's the corresponding update to the wp-cli repo: https://github.com/wp-cli/i18n-command/pull/408

See discussion: https://github.com/WordPress/gutenberg/pull/45242#issuecomment-2196574068

Trac ticket: https://core.trac.wordpress.org/ticket/61543

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
