### PR TITLE
Fixed : `$user_login` double escaped with incorrect/empty password in `wp-login.php`

### DIFF
--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -1482,7 +1482,7 @@ switch ( $action ) {
 		login_header( __( 'Log In' ), '', $errors );
 
 		if ( isset( $_POST['log'] ) ) {
-			$user_login = ( 'incorrect_password' === $errors->get_error_code() || 'empty_password' === $errors->get_error_code() ) ? esc_attr( wp_unslash( $_POST['log'] ) ) : '';
+			$user_login = ( 'incorrect_password' === $errors->get_error_code() || 'empty_password' === $errors->get_error_code() ) ? wp_unslash( $_POST['log'] ) : '';
 		}
 
 		$rememberme = ! empty( $_POST['rememberme'] );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/55335

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
