### PR TITLE
Fix wp_template renaming when `hooked_block_types` filter exists

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1603,7 +1603,7 @@ function inject_ignored_hooked_blocks_metadata_attributes( $changes, $deprecated
 	}
 
 	$hooked_blocks = get_hooked_blocks();
-	if ( empty( $hooked_blocks ) && ! has_filter( 'hooked_block_types' ) ) {
+	if ( empty ( $changes->post_content ) || ( empty( $hooked_blocks ) && ! has_filter( 'hooked_block_types' ) ) ) {
 		return $changes;
 	}
 

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1602,8 +1602,12 @@ function inject_ignored_hooked_blocks_metadata_attributes( $changes, $deprecated
 		_deprecated_argument( __FUNCTION__, '6.5.3' );
 	}
 
+	if ( ! isset( $changes->post_content ) ) {
+		return $changes;
+	}
+
 	$hooked_blocks = get_hooked_blocks();
-	if ( ! isset( $changes->post_content ) || ( empty( $hooked_blocks ) && ! has_filter( 'hooked_block_types' ) ) ) {
+	if ( ( empty( $hooked_blocks ) && ! has_filter( 'hooked_block_types' ) ) ) {
 		return $changes;
 	}
 

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1603,7 +1603,7 @@ function inject_ignored_hooked_blocks_metadata_attributes( $changes, $deprecated
 	}
 
 	$hooked_blocks = get_hooked_blocks();
-	if ( empty ( $changes->post_content ) || ( empty( $hooked_blocks ) && ! has_filter( 'hooked_block_types' ) ) ) {
+	if ( empty( $changes->post_content ) || ( empty( $hooked_blocks ) && ! has_filter( 'hooked_block_types' ) ) ) {
 		return $changes;
 	}
 

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1603,7 +1603,7 @@ function inject_ignored_hooked_blocks_metadata_attributes( $changes, $deprecated
 	}
 
 	$hooked_blocks = get_hooked_blocks();
-	if ( empty( $changes->post_content ) || ( empty( $hooked_blocks ) && ! has_filter( 'hooked_block_types' ) ) ) {
+	if ( ! isset( $changes->post_content ) || ( empty( $hooked_blocks ) && ! has_filter( 'hooked_block_types' ) ) ) {
 		return $changes;
 	}
 

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1607,7 +1607,7 @@ function inject_ignored_hooked_blocks_metadata_attributes( $changes, $deprecated
 	}
 
 	$hooked_blocks = get_hooked_blocks();
-	if ( ( empty( $hooked_blocks ) && ! has_filter( 'hooked_block_types' ) ) ) {
+	if ( empty( $hooked_blocks ) && ! has_filter( 'hooked_block_types' ) ) {
 		return $changes;
 	}
 

--- a/tests/phpunit/tests/block-templates/injectIgnoredHookedBlocksMetadataAttributes.php
+++ b/tests/phpunit/tests/block-templates/injectIgnoredHookedBlocksMetadataAttributes.php
@@ -621,4 +621,59 @@ class Tests_Block_Templates_InjectIgnoredHookedBlocksMetadataAttributes extends 
 			'The template part\'s post content was modified.'
 		);
 	}
+
+	/**
+	 * @ticket 61550
+	 */
+	public function test_inject_ignored_hooked_blocks_metadata_attributes_into_template_with_no_changes_to_post_content() {
+		register_block_type(
+			'tests/hooked-block',
+			array(
+				'block_hooks' => array(
+					'core/heading' => 'after',
+				),
+			)
+		);
+
+		$id       = self::TEST_THEME . '//' . 'my_template';
+		$template = get_block_template( $id, 'wp_template' );
+
+		$changes     = new stdClass();
+		$changes->ID = $template->wp_id;
+
+		// Note that we're not setting `$changes->post_content`!
+
+		$post = inject_ignored_hooked_blocks_metadata_attributes( $changes );
+		$this->assertFalse(
+			isset( $post->post_content ),
+			"post_content shouldn't have been set."
+		);
+	}
+
+	/**
+	 * @ticket 61550
+	 */
+	public function test_inject_ignored_hooked_blocks_metadata_attributes_into_template_part_with_no_changes_to_post_content() {
+		register_block_type(
+			'tests/hooked-block',
+			array(
+				'block_hooks' => array(
+					'core/heading' => 'after',
+				),
+			)
+		);
+
+		$id       = self::TEST_THEME . '//' . 'my_template_part';
+		$template = get_block_template( $id, 'wp_template_part' );
+
+		$changes     = new stdClass();
+		$changes->ID = $template->wp_id;
+		// Note that we're not setting `$changes->post_content`!
+
+		$post = inject_ignored_hooked_blocks_metadata_attributes( $changes );
+		$this->assertFalse(
+			isset( $post->post_content ),
+			"post_content shouldn't have been set."
+		);
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

The ticket explains the problem.

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/61550

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
