### PR TITLE
Removing the wp_filter_kses filter when inserting user

### DIFF
--- a/src/wp-admin/includes/user.php
+++ b/src/wp-admin/includes/user.php
@@ -78,7 +78,7 @@ function edit_user( $user_id = 0 ) {
 	}
 
 	if ( isset( $_POST['email'] ) ) {
-		$user->user_email = sanitize_text_field( wp_unslash( $_POST['email'] ) );
+		$user->user_email = sanitize_email( wp_unslash( $_POST['email'] ) );
 	}
 	if ( isset( $_POST['url'] ) ) {
 		if ( empty( $_POST['url'] ) || 'http://' === $_POST['url'] ) {

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -51,7 +51,6 @@ if ( is_admin() ) {
 foreach ( array( 'pre_comment_author_email', 'pre_user_email' ) as $filter ) {
 	add_filter( $filter, 'trim' );
 	add_filter( $filter, 'sanitize_email' );
-	add_filter( $filter, 'wp_filter_kses' );
 }
 
 // Email admin display.

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -2185,4 +2185,57 @@ class Tests_User extends WP_UnitTestCase {
 
 		return $additional_profile_data;
 	}
+
+	/**
+	 * Checks that edit_user() correctly sanitizes the supplied email address.
+	 *
+	 * @ticket 45714
+	 */
+	public function test_edit_user_sanitizes_email_address() {
+		$_POST    = array();
+		$_GET     = array();
+		$_REQUEST = array();
+
+		$user = $this->factory()->user->create_and_get(
+			array(
+				'email' => 'eusp1@example.com',
+			)
+		);
+
+		$_POST['nickname']   = 'eusp1';
+		$_POST['user_login'] = $user->user_login;
+
+		// Success cases.
+		foreach ( array(
+			'eusp2@example.com'       => 'eusp2@example.com',
+			'eusp3%4@example.com'     => 'eusp3%4@example.com',
+			'eusp4@example.com!'      => 'eusp4@example.com',
+			'  eusp6@example.com%aa ' => 'eusp6@example.comaa',
+			'eu\'sp@example.com'      => 'eu\'sp@example.com',
+		) as $em_pre => $em_post ) {
+			$_POST['email'] = $em_pre;
+
+			$user_id = edit_user( $user->ID );
+
+			$this->assertIsInt( $user_id );
+
+			$user = get_user_by( 'ID', $user_id );
+
+			$this->assertInstanceOf( 'WP_User', $user );
+			$this->assertEquals( $em_post, $user->user_email );
+		}
+
+		// Failure cases (resulting in an invalid email address).
+		foreach ( array(
+			''      => '',
+			'eusp5' => 'eusp5',
+		) as $em_pre => $em_post ) {
+			$_POST['email'] = $em_pre;
+			$user_id        = edit_user( $user->ID );
+
+			$this->assertInstanceOf( 'WP_Error', $user_id );
+			$this->assertEquals( 'empty_email', $user_id->get_error_code() );
+		}
+	}
+
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Removing the wp_filter_kses filter when inserting user.

Trac ticket: https://core.trac.wordpress.org/ticket/45714

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
