### PR TITLE
Section Styles: Prevent flash of variation style updates

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -72,6 +72,9 @@ $preload_paths = array(
 	sprintf( '%s/autosaves?context=edit', $rest_path ),
 	'/wp/v2/settings',
 	array( '/wp/v2/settings', 'OPTIONS' ),
+	'/wp/v2/global-styles/themes/' . get_stylesheet(),
+	'/wp/v2/themes?context=edit&status=active',
+	'/wp/v2/global-styles/' . WP_Theme_JSON_Resolver::get_user_global_styles_post_id() . '?context=edit',
 );
 
 block_editor_rest_api_preload( $preload_paths, $block_editor_context );


### PR DESCRIPTION
This PR backports the changes from https://github.com/WordPress/gutenberg/pull/63071

These changes include preloading the global styles REST API paths required to collect the global styles data for use in the block editor. This has two benefits:
- Prevents a flash of style updates for block style variations in the post editor
- Brings the post editor's preloaded paths a little more in line with the site editors

#### Test Instructions

1. Active a theme that defines styles for the button outline block style variation e.g. TT4
2. In the post editor add a button, select the Outline style, and save.
3. Reload the post editor and ensure there is no flash of styling (i.e. from a solid color to the outline variant)
4. In the site editor navigate to Styles > Blocks > Button > Outline
5. Apply custom styles for the Outline block style variation e.g. change the border color, background etc.
6. Save the Global Styles changes
7. Switch back to the post editor, loading your earlier post with the button outline block
8. When the editor loads there should be no flash of styling from the default theme outline styles to the custom styles assigned via Global Styles


Trac ticket: https://core.trac.wordpress.org/ticket/61553

| Before | After |
|---|---|
| <video src="https://github.com/WordPress/wordpress-develop/assets/60436221/1e4d2603-9aea-4d15-927f-739f73e9a452" /> | <video src="https://github.com/WordPress/wordpress-develop/assets/60436221/fffb815e-c08b-4ae3-925c-6da3af74ab72" /> |







---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
