### PR TITLE
Fix: Condition is not strictly checked on options-general.php file

### DIFF
--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -354,12 +354,14 @@ if ( str_contains( $tzstring, 'Etc/GMT' ) ) {
 
 if ( empty( $tzstring ) ) { // Create a UTC+- zone if no timezone string exists.
 	$check_zone_info = false;
-	if ( 0 === (int) $current_offset ) {
+	if ( 0 === $current_offset || '0' === $current_offset ) {
 		$tzstring = 'UTC+0';
-	} elseif ( $current_offset < 0 ) {
+	} elseif ( ( is_numeric( $current_offset ) && (float) $current_offset < 0 ) ) {
 		$tzstring = 'UTC' . $current_offset;
-	} else {
+	} elseif ( is_numeric( $current_offset ) ) {
 		$tzstring = 'UTC+' . $current_offset;
+	} else {
+		$tzstring = 'UTC+0';
 	}
 }
 

--- a/tests/phpunit/tests/option/gmtOffset.php
+++ b/tests/phpunit/tests/option/gmtOffset.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Unit tests for gmt_offset handling.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ */
+
+/**
+ * Test cases for the gmt_offset option.
+ */
+class Tests_Option_GMT_Offset extends WP_UnitTestCase {
+
+	/**
+	 * Test gmt_offset comparison with integer 0.
+	 *
+	 * @ticket  57030
+	 */
+	public function test_gmt_offset_with_integer_zero() {
+		update_option( 'gmt_offset', 0 );
+		$current_offset = get_option( 'gmt_offset' );
+		$this->assertSame( 0, $current_offset );
+
+		// Simulate the code logic
+		if ( 0 === $current_offset ) {
+			$tzstring = 'UTC+0';
+		}
+
+		$this->assertEquals( 'UTC+0', $tzstring );
+	}
+
+	/**
+	 * Test gmt_offset comparison with string '0'.
+	 *
+	 * @ticket  57030
+	 */
+	public function test_gmt_offset_with_string_zero() {
+		update_option( 'gmt_offset', '0' );
+		$current_offset = get_option( 'gmt_offset' );
+		$this->assertSame( '0', $current_offset );
+
+		// Simulate the code logic
+		if ( '0' === $current_offset ) {
+			$tzstring = 'UTC+0';
+		}
+
+		$this->assertEquals( 'UTC+0', $tzstring );
+	}
+
+	/**
+	 * Test gmt_offset comparison with negative float.
+	 *
+	 * @ticket  57030
+	 */
+	public function test_gmt_offset_with_negative_float() {
+		update_option( 'gmt_offset', -5.5 );
+		$current_offset = get_option( 'gmt_offset' );
+		$this->assertSame( -5.5, (float) $current_offset );
+
+		// Simulate the code logic
+		if ( $current_offset < 0 ) {
+			$tzstring = 'UTC' . $current_offset;
+		}
+
+		$this->assertEquals( 'UTC-5.5', $tzstring );
+	}
+
+	/**
+	 * Test gmt_offset comparison with invalid value.
+	 *
+	 * @ticket  57030
+	 */
+	public function test_gmt_offset_with_invalid_value() {
+		update_option( 'gmt_offset', 'invalid' );
+		$current_offset = get_option( 'gmt_offset' );
+
+		// Simulate the code logic
+		if ( 0 === (int) $current_offset ) {
+			$tzstring = 'UTC+0';
+		} elseif ( is_numeric( $current_offset ) && (float) $current_offset < 0 ) {
+			$tzstring = 'UTC' . $current_offset;
+		} elseif ( is_numeric( $current_offset ) ) {
+			$tzstring = 'UTC+' . $current_offset;
+		} else {
+			// Handle unexpected types gracefully.
+			$tzstring = 'UTC+0';
+		}
+
+		$this->assertEquals( 'UTC+0', $tzstring );
+	}
+}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/57030

## Description

- Fixes a strict comparison issue in `options-general.php` where the `$current_offset` variable was not being strictly compared as an integer. 
- This issue could lead to unexpected behavior when comparing the `gmt_offset` option, especially when it could be interpreted as different types such as string or float.

### Changes Made

- Adjusted the comparison of `$current_offset` to ensure it is strictly compared as an integer `0`.
- Updated logic to handle cases where `gmt_offset` may vary in type (integer, string, or float).
- Introduced unit tests to validate the behavior across different `gmt_offset` scenarios.

### Added Unit Tests

- Created `gmtOffset.php` file to house unit tests specifically targeting the `gmt_offset` behavior.
- Covered scenarios such as integer `0`, string `'0'`, negative float values, and invalid string inputs for `gmt_offset`.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
