### PR TITLE
Adding new filter for permission capability for Export button

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1357,7 +1357,7 @@ function wp_is_theme_directory_ignored( $path ) {
 	$directories_to_ignore = array( '.DS_Store', '.svn', '.git', '.hg', '.bzr', 'node_modules', 'vendor' );
 
 	foreach ( $directories_to_ignore as $directory ) {
-		if ( strpos( $path, '/' . $directory . '/' ) !== false || substr( $path, -strlen( '/' . $directory )) === '/' . $directory ) {
+		if ( strpos( $path, '/' . $directory . '/' ) !== false || substr( $path, -strlen( '/' . $directory ) ) === '/' . $directory ) {
 			return true;
 		}
 	}

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1357,7 +1357,7 @@ function wp_is_theme_directory_ignored( $path ) {
 	$directories_to_ignore = array( '.DS_Store', '.svn', '.git', '.hg', '.bzr', 'node_modules', 'vendor' );
 
 	foreach ( $directories_to_ignore as $directory ) {
-		if ( str_starts_with( $path, $directory ) ) {
+		if ( strpos( $path, '/' . $directory . '/' ) !== false || substr( $path, -strlen( '/' . $directory )) === '/' . $directory ) {
 			return true;
 		}
 	}

--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1357,7 +1357,7 @@ function wp_is_theme_directory_ignored( $path ) {
 	$directories_to_ignore = array( '.DS_Store', '.svn', '.git', '.hg', '.bzr', 'node_modules', 'vendor' );
 
 	foreach ( $directories_to_ignore as $directory ) {
-		if ( strpos( $path, '/' . $directory . '/' ) !== false || substr( $path, -strlen( '/' . $directory ) ) === '/' . $directory ) {
+		if ( str_starts_with( $path, $directory ) ) {
 			return true;
 		}
 	}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-edit-site-export-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-edit-site-export-controller.php
@@ -53,9 +53,7 @@ class WP_REST_Edit_Site_Export_Controller extends WP_REST_Controller {
 	 * @return WP_Error|true True if the request has access, or WP_Error object.
 	 */
 	public function permissions_check() {
-		$allowed_user_capability = apply_filters( 'allowed_user_role_to_export_theme', 'export' );
-
-		if ( current_user_can( $allowed_user_capability ) ) {
+		if ( current_user_can( 'export' ) ) {
 			return true;
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-edit-site-export-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-edit-site-export-controller.php
@@ -53,7 +53,6 @@ class WP_REST_Edit_Site_Export_Controller extends WP_REST_Controller {
 	 * @return WP_Error|true True if the request has access, or WP_Error object.
 	 */
 	public function permissions_check() {
-
 		$allowed_user_capability = apply_filters( 'allowed_user_role_to_export_theme', 'edit_theme_options' );
 
 		if ( current_user_can( $allowed_user_capability ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-edit-site-export-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-edit-site-export-controller.php
@@ -53,7 +53,10 @@ class WP_REST_Edit_Site_Export_Controller extends WP_REST_Controller {
 	 * @return WP_Error|true True if the request has access, or WP_Error object.
 	 */
 	public function permissions_check() {
-		if ( current_user_can( 'edit_theme_options' ) ) {
+
+		$allowed_user_capability = apply_filters( 'allowed_user_role_to_export_theme', 'edit_theme_options' );
+
+		if ( current_user_can( $allowed_user_capability ) ) {
 			return true;
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-edit-site-export-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-edit-site-export-controller.php
@@ -53,7 +53,7 @@ class WP_REST_Edit_Site_Export_Controller extends WP_REST_Controller {
 	 * @return WP_Error|true True if the request has access, or WP_Error object.
 	 */
 	public function permissions_check() {
-		$allowed_user_capability = apply_filters( 'allowed_user_role_to_export_theme', 'edit_theme_options' );
+		$allowed_user_capability = apply_filters( 'allowed_user_role_to_export_theme', 'export' );
 
 		if ( current_user_can( $allowed_user_capability ) ) {
 			return true;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

New filter "allowed_user_role_to_export_theme" added to add control over the permission callback of that Export Functionality.

![image](https://github.com/WordPress/wordpress-develop/assets/68213636/371cb20e-365c-4d2e-8e21-d71361dc0f00)

Trac ticket: https://core.trac.wordpress.org/ticket/57379

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
