### PR TITLE
Trac #61574  - remove some more redundant code/docs

### DIFF
--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -1270,7 +1270,7 @@ function xfn_check( $xfn_relationship, $xfn_value = '', $deprecated = '' ) {
 		_deprecated_argument( __FUNCTION__, '2.5.0' ); // Never implemented.
 	}
 
-	$link_rel  = isset( $link->link_rel ) ? $link->link_rel : ''; // In PHP 5.3: $link_rel = $link->link_rel ?: '';
+	$link_rel  = isset( $link->link_rel ) ? $link->link_rel : '';
 	$link_rels = preg_split( '/\s+/', $link_rel );
 
 	// Mark the specified value as checked if it matches the current link's relationship.

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -6141,8 +6141,7 @@ final class WP_Customize_Manager {
 	 * This method exists because the partial object and context data are passed
 	 * into a partial's render_callback so we cannot use get_custom_logo() as
 	 * the render_callback directly since it expects a blog ID as the first
-	 * argument. When WP no longer supports PHP 5.3, this method can be removed
-	 * in favor of an anonymous function.
+	 * argument.
 	 *
 	 * @see WP_Customize_Manager::register_controls()
 	 *

--- a/src/wp-includes/class-wp-object-cache.php
+++ b/src/wp-includes/class-wp-object-cache.php
@@ -73,7 +73,7 @@ class WP_Object_Cache {
 	private $multisite;
 
 	/**
-	 * Sets up object properties; PHP 5 style constructor.
+	 * Sets up object properties.
 	 *
 	 * @since 2.0.8
 	 */

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -699,12 +699,8 @@ function ms_allowed_http_request_hosts( $is_external, $host ) {
  * A wrapper for PHP's parse_url() function that handles consistency in the return values
  * across PHP versions.
  *
- * PHP 5.4.7 expanded parse_url()'s ability to handle non-absolute URLs, including
- * schemeless and relative URLs with "://" in the path. This function works around
- * those limitations providing a standard output on PHP 5.2~5.4+.
- *
- * Secondly, across various PHP versions, schemeless URLs containing a ":" in the query
- * are being handled inconsistently. This function works around those differences as well.
+ * Across various PHP versions, schemeless URLs containing a ":" in the query
+ * are being handled inconsistently. This function works around those differences.
  *
  * @since 4.4.0
  * @since 4.7.0 The `$component` parameter was added for parity with PHP's `parse_url()`.

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -453,8 +453,6 @@ function wp_is_maintenance_mode() {
 /**
  * Gets the time elapsed so far during this PHP script.
  *
- * Uses REQUEST_TIME_FLOAT that appeared in PHP 5.4.0.
- *
  * @since 5.8.0
  *
  * @return float Seconds since the PHP script started.

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -1679,10 +1679,7 @@ function wp_is_ini_value_changeable( $setting ) {
 		}
 	}
 
-	// Bit operator to workaround https://bugs.php.net/bug.php?id=44936 which changes access level to 63 in PHP 5.2.6 - 5.2.17.
-	if ( isset( $ini_all[ $setting ]['access'] )
-		&& ( INI_ALL === ( $ini_all[ $setting ]['access'] & 7 ) || INI_USER === ( $ini_all[ $setting ]['access'] & 7 ) )
-	) {
+	if ( isset( $ini_all[ $setting ]['access'] ) && ( INI_ALL === $ini_all[ $setting ]['access'] || INI_USER === $ini_all[ $setting ]['access'] ) ) {
 		return true;
 	}
 

--- a/src/wp-includes/rest-api/class-wp-rest-request.php
+++ b/src/wp-includes/rest-api/class-wp-rest-request.php
@@ -709,7 +709,7 @@ class WP_REST_Request implements ArrayAccess {
 	 * Parses the request body parameters.
 	 *
 	 * Parses out URL-encoded bodies for request methods that aren't supported
-	 * natively by PHP. In PHP 5.x, only POST has these parsed automatically.
+	 * natively by PHP.
 	 *
 	 * @since 4.4.0
 	 */

--- a/tests/phpunit/tests/formatting/escTextarea.php
+++ b/tests/phpunit/tests/formatting/escTextarea.php
@@ -12,7 +12,6 @@ class Tests_Formatting_EscTextarea extends WP_UnitTestCase {
 	}
 
 	/*
-	 * Only fails in PHP 5.4 onwards
 	 * @ticket 23688
 	 */
 	public function test_esc_textarea_charset_iso_8859_1() {

--- a/tests/phpunit/tests/formatting/wpHtmleditPre.php
+++ b/tests/phpunit/tests/formatting/wpHtmleditPre.php
@@ -13,7 +13,6 @@ class Tests_Formatting_wpHtmleditPre extends WP_UnitTestCase {
 	}
 
 	/*
-	 * Only fails in PHP 5.4 onwards
 	 * @ticket 23688
 	 */
 	public function test_wp_htmledit_pre_charset_iso_8859_1() {

--- a/tests/phpunit/tests/formatting/wpRicheditPre.php
+++ b/tests/phpunit/tests/formatting/wpRicheditPre.php
@@ -13,7 +13,6 @@ class Tests_Formatting_wpRicheditPre extends WP_UnitTestCase {
 	}
 
 	/*
-	 * Only fails in PHP 5.4 onwards
 	 * @ticket 23688
 	 */
 	public function test_wp_richedit_pre_charset_iso_8859_1() {

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -114,7 +114,7 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 				),
 			),
 
-			// < PHP 5.4.7: Schemeless URL.
+			// Schemeless URL.
 			array(
 				'//example.com/path/',
 				array(
@@ -138,7 +138,7 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 				),
 			),
 
-			// < PHP 5.4.7: Scheme separator in the URL.
+			// Scheme separator in the URL.
 			array(
 				'http://example.com/http://example.net/',
 				array(
@@ -149,7 +149,7 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 			),
 			array( '/path/http://example.net/', array( 'path' => '/path/http://example.net/' ) ),
 
-			// < PHP 5.4.7: IPv6 literals in schemeless URLs are handled incorrectly.
+			// IPv6 literals in schemeless URLs.
 			array(
 				'//[::FFFF::127.0.0.1]/',
 				array(

--- a/tests/phpunit/tests/load/wpIsIniValueChangeable.php
+++ b/tests/phpunit/tests/load/wpIsIniValueChangeable.php
@@ -41,7 +41,7 @@ class Tests_Load_wpIsIniValueChangeable extends WP_UnitTestCase {
 			array( 'upload_tmp_dir', false ), // PHP_INI_SYSTEM.
 		);
 
-		if ( PHP_VERSION_ID > 70000 && extension_loaded( 'Tidy' ) ) {
+		if ( extension_loaded( 'Tidy' ) ) {
 			$array[] = array( 'tidy.clean_output', true ); // PHP_INI_USER.
 		}
 


### PR DESCRIPTION
### Remove redundant PHP version check

What with the minimum supported PHP version currently being PHP 7.2.x, this check has become redundant.

### Docs: remove redundant comments [1]

This commit removes various comments containing "hints" of things to do after a particular PHP version drop. These hints are incorrect/not actionable for various reasons (see below), so have no value.

Some typical reasons:
* Even though a function could be turned into a closure, removing the function would be a BC-break which is not acceptable, so this suggestion is not actionable.
* Short ternaries are forbidden by the coding standard exactly to prevent the faulty code suggested in the comment from getting into the codebase.

### Docs: remove redundant comments [2]

This commit removes various comments referencing PHP versions which are no longer supported. These PHP version references have no value anymore now support for those PHP versions has been dropped.

### wp_is_ini_value_changeable(): minor simplification

This commit reverts the code to the code from before the bug fix related to PHP 5.2.6-5.2.17.
As support for PHP 5.2 has been dropped, the work-around for the PHP 5.2 bug is no longer needed.

Refs:
* 78789beda9d71bb7fcf725839ad72f17ce9ff115
* SVN commit 38017


Trac ticket: https://core.trac.wordpress.org/ticket/61574

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
