### PR TITLE
[PHP] Replace `substr(PHP_OS)` calls with `PHP_OS_FAMILY` in PHP 7.2

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -2257,11 +2257,11 @@ function get_temp_dir() {
  * @return bool Whether the path is writable.
  */
 function wp_is_writable( $path ) {
-	if ( 'WIN' === strtoupper( substr( PHP_OS, 0, 3 ) ) ) {
+	if ( PHP_OS_FAMILY === 'Windows' ) {
 		return win_is_writable( $path );
-	} else {
-		return @is_writable( $path );
 	}
+
+	return @is_writable( $path );
 }
 
 /**

--- a/tests/phpunit/tests/filesystem/wpFilesystemDirect/base.php
+++ b/tests/phpunit/tests/filesystem/wpFilesystemDirect/base.php
@@ -160,7 +160,7 @@ abstract class WP_Filesystem_Direct_UnitTestCase extends WP_UnitTestCase {
 	 * @return bool Whether the operating system is Windows.
 	 */
 	public static function is_windows() {
-		return 'WIN' === substr( PHP_OS, 0, 3 );
+		return 'Windows' === PHP_OS_FAMILY;
 	}
 
 	/**


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61574
Follow-up to #6969, and responding to a comment in @jrfnl's #6975

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
