### PR TITLE
HTML API: Respect `tag_name` query arg in `HTML_Processor::next_tag()`

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -466,6 +466,10 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					continue;
 				}
 
+				if ( isset( $query['tag_name'] ) && $query['tag_name'] !== $this->get_token_name() ) {
+					continue;
+				}
+
 				if ( isset( $needs_class ) && ! $this->has_class( $needs_class ) ) {
 					continue;
 				}


### PR DESCRIPTION
Trac ticket: Core-61581

Previously the HTML Processor was ignoring the `tag_name` argument in the `next_tag()` query if it existed. This was wrong adn would lead to calling code finding the very next tag, regardless of tag name, instead of the requested taag.

This patch adds the tag name detection code into `next_tag()` to fix the bug and ensure that `next_tag()` always returns only when finding a tag of the given name.

Follow-up to [[56274]](https://core.trac.wordpress.org/changeset/56274).