### PR TITLE
HTML API: Simplify breadcrumb accounting.

### DIFF
--- a/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRules.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRules.php
@@ -387,7 +387,16 @@ class Tests_HtmlApi_WpHtmlProcessorSemanticRules extends WP_UnitTestCase {
 		$this->assertSame( 'CODE', $processor->get_tag(), "Expected to start test on CODE element but found {$processor->get_tag()} instead." );
 		$this->assertSame( array( 'HTML', 'BODY', 'DIV', 'SPAN', 'CODE' ), $processor->get_breadcrumbs(), 'Failed to produce expected DOM nesting.' );
 
-		$this->assertTrue( $processor->next_token(), 'Failed to advance past CODE tag to expected SPAN closer.' );
+		$this->assertTrue(
+			$processor->next_tag(
+				array(
+					'tag_name'    => 'SPAN',
+					'tag_closers' => 'visit',
+				)
+			),
+			'Failed to advance past CODE tag to expected SPAN closer.'
+		);
+		$this->assertSame( 'SPAN', $processor->get_tag() );
 		$this->assertTrue( $processor->is_tag_closer(), 'Expected to find closing SPAN, but found opener instead.' );
 		$this->assertSame( array( 'HTML', 'BODY', 'DIV' ), $processor->get_breadcrumbs(), 'Failed to advance past CODE tag to expected DIV opener.' );
 


### PR DESCRIPTION
Trac ticket: Core-61576

Since the HTML Processor started visiting all nodes in a document, both real and virtual, the breadcrumb accounting became a bit complicated and it's not entirely clear that it is fully reliable.

In this patch the breadcrumbs are rebuilt separately from the stack of open elements in order to eliminate the problem of the stateful stack interactions and the post-hoc event queue.

Breadcrumbs are greatly simplified as a result, and more verifiably correct, in this construction.