### PR TITLE
Section Styles: Fix ref values within block style variations

### DIFF
--- a/src/wp-includes/block-supports/block-style-variations.php
+++ b/src/wp-includes/block-supports/block-style-variations.php
@@ -118,8 +118,10 @@ function wp_render_block_style_variation_support_styles( $parsed_block ) {
 		return $parsed_block;
 	}
 
-	// Recursively resolve any ref values with the appropriate value within the
-	// theme_json data.
+	/*
+	 * Recursively resolve any ref values with the appropriate value within the
+	 * theme_json data.
+	 */
 	wp_resolve_block_style_variation_ref_values( $variation_data, $theme_json );
 
 	$variation_instance = wp_create_block_style_variation_instance_name( $parsed_block, $variation );

--- a/src/wp-includes/block-supports/block-style-variations.php
+++ b/src/wp-includes/block-supports/block-style-variations.php
@@ -41,6 +41,42 @@ function wp_get_block_style_variation_name_from_class( $class_string ) {
 }
 
 /**
+ * Recursively resolves any `ref` values within a block style variation's data.
+ *
+ * @since 6.6.0
+ * @access private
+ *
+ * @param array $variation_data Reference to the variation data being processed.
+ * @param array $theme_json     Theme.json data to retrieve referenced values from.
+ */
+function wp_resolve_block_style_variation_ref_values( &$variation_data, $theme_json ) {
+	foreach ( $variation_data as $key => &$value ) {
+		// Only need to potentially process arrays.
+		if ( is_array( $value ) ) {
+			// If ref value is set, attempt to find its matching value and update it.
+			if ( array_key_exists( 'ref', $value ) ) {
+				// Clean up any invalid ref value.
+				if ( empty( $value['ref'] ) || ! is_string( $value['ref'] ) ) {
+					unset( $variation_data[ $key ] );
+				}
+
+				$value_path = explode( '.', $value['ref'] ?? '' );
+				$ref_value  = _wp_array_get( $theme_json, $value_path );
+
+				// Only update the current value if the referenced path matched a value.
+				if ( null === $ref_value ) {
+					unset( $variation_data[ $key ] );
+				} else {
+					$value = $ref_value;
+				}
+			} else {
+				// Recursively look for ref instances.
+				wp_resolve_block_style_variation_ref_values( $value, $theme_json );
+			}
+		}
+	}
+}
+/**
  * Render the block style variation's styles.
  *
  * In the case of nested blocks with variations applied, we want the parent
@@ -81,6 +117,10 @@ function wp_render_block_style_variation_support_styles( $parsed_block ) {
 	if ( empty( $variation_data ) ) {
 		return $parsed_block;
 	}
+
+	// Recursively resolve any ref values with the appropriate value within the
+	// theme_json data.
+	wp_resolve_block_style_variation_ref_values( $variation_data, $theme_json );
 
 	$variation_instance = wp_create_block_style_variation_instance_name( $parsed_block, $variation );
 	$class_name         = "is-style-$variation_instance";

--- a/tests/phpunit/tests/block-supports/block-style-variations.php
+++ b/tests/phpunit/tests/block-supports/block-style-variations.php
@@ -159,4 +159,78 @@ class WP_Block_Supports_Block_Style_Variations_Test extends WP_UnitTestCase {
 
 		$this->assertSameSetsWithIndex( $expected, $group_styles, 'Variation data does not match' );
 	}
+
+	/**
+	 * Tests that block style variations resolve any `ref` values when generating styles.
+	 *
+	 * @ticket 61589
+	 */
+	public function test_block_style_variation_ref_values() {
+		switch_theme( 'block-theme' );
+
+		$variation_data = array(
+			'color'    => array(
+				'text'       => array(
+					'ref' => 'styles.does-not-exist',
+				),
+				'background' => array(
+					'ref' => 'styles.blocks.core/group.variations.block-style-variation-a.color.text',
+				),
+			),
+			'blocks'   => array(
+				'core/heading' => array(
+					'color' => array(
+						'text'       => array(
+							'ref' => 'styles.blocks.core/group.variations.block-style-variation-a.color.background',
+						),
+						'background' => array(
+							'ref' => '',
+						),
+					),
+				),
+			),
+			'elements' => array(
+				'link' => array(
+					'color'  => array(
+						'text'       => array(
+							'ref' => 'styles.blocks.core/group.variations.block-style-variation-b.color.text',
+						),
+						'background' => array(
+							'ref' => null,
+						),
+					),
+					':hover' => array(
+						'color' => array(
+							'text' => array(
+								'ref' => 'styles.blocks.core/group.variations.block-style-variation-b.color.background',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$theme_json = WP_Theme_JSON_Resolver::get_theme_data()->get_raw_data();
+
+		wp_resolve_block_style_variation_ref_values( $variation_data, $theme_json );
+
+		$expected = array(
+			'color'    => array( 'background' => 'plum' ),
+			'blocks'   => array(
+				'core/heading' => array(
+					'color' => array( 'text' => 'indigo' ),
+				),
+			),
+			'elements' => array(
+				'link' => array(
+					'color'  => array( 'text' => 'lightblue' ),
+					':hover' => array(
+						'color' => array( 'text' => 'midnightblue' ),
+					),
+				),
+			),
+		);
+
+		$this->assertSameSetsWithIndex( $expected, $variation_data, 'Variation data with resolved ref values does not match' );
+	}
 }


### PR DESCRIPTION
This PR backports the fix from:
- https://github.com/WordPress/gutenberg/pull/63172

This restores the ability to reference style values from elsewhere within theme.json for block style variations.

Trac ticket: https://core.trac.wordpress.org/ticket/61589#ticket

#### Test Instructions

1. Add some ref values for block style variations to your theme.json e.g. update TT4 with the sections from the theme.json snippet below
2. Load the site editor and edit the default home page
3. Confirm that outline buttons are displayed and have the correct referenced style values
4. Save and ensure the same on the frontend


<details>
<summary>Example theme.json snippet</summary>

```json
{
    "styles": {
        "elements": {
            "button": {
                "border": {
                    "color": "transparent",
                    "radius": "0.25em",
                    "style": "solid",
                    "width": "1px"
                },
                "color": {
                    "background": "var(--wp--preset--color--accent)",
                    "text": "var(--wp--preset--color--base)"
                },
                "spacing": {
                    "padding": {
                        "bottom": "0.5em",
                        "left": "1.25em",
                        "right": "1.25em",
                        "top": "0.5em"
                    }
                }
            }
        },
        "blocks": {
            "core/button": {
                "border": {
                    "color": { "ref": "styles.elements.button.border.color" },
                    "radius": { "ref": "styles.elements.button.border.radius" },
                    "style": { "ref": "styles.elements.button.border.style" },
                    "width": { "ref": "styles.elements.button.border.width" }
                },
                "color": {
                    "background": { "ref": "styles.elements.button.color.background" },
                    "text": { "ref": "styles.elements.button.color.text" }
                },
                "spacing": {
                    "padding": {
                        "bottom": { "ref": "styles.elements.button.spacing.padding.bottom" },
                        "left": { "ref": "styles.elements.button.spacing.padding.left" },
                        "right": { "ref": "styles.elements.button.spacing.padding.right" },
                        "top": { "ref": "styles.elements.button.spacing.padding.top" }
                    }
                },
                "variations": {
                    "outline": {
                        "border": {
                            "color": "currentColor",
                            "width": { "ref": "styles.elements.button.border.width" }
                        },
                        "color": {
                            "text": { "ref": "styles.elements.button.color.background" }
                        },
                        "spacing": {
                            "padding": {
                                "bottom": { "ref": "styles.elements.button.spacing.padding.bottom" },
                                "left": { "ref": "styles.elements.button.spacing.padding.left" },
                                "right": { "ref": "styles.elements.button.spacing.padding.right" },
                                "top": { "ref": "styles.elements.button.spacing.padding.top" },
                            }
                        }
                    }
                }
            }
        }
    }
}
```

</details>

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="640" alt="Screenshot 2024-07-05 at 6 21 01 PM" src="https://github.com/WordPress/wordpress-develop/assets/60436221/7452177d-d238-4be7-adb1-29a5e43370a5"> | <img width="652" alt="Screenshot 2024-07-05 at 6 20 41 PM" src="https://github.com/WordPress/wordpress-develop/assets/60436221/04bd42db-5da5-4fa7-9c73-5e111b59191b"> |




---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
