### PR TITLE
fix: styles from Twenty Seventeen To  Twenty  Ten  within iframe editor

### DIFF
--- a/src/wp-content/themes/twentyeleven/functions.php
+++ b/src/wp-content/themes/twentyeleven/functions.php
@@ -317,7 +317,11 @@ function twentyeleven_block_editor_styles() {
 	// Block styles.
 	wp_enqueue_style( 'twentyeleven-block-editor-style', get_template_directory_uri() . '/editor-blocks.css', array(), '20220927' );
 }
-add_action( 'enqueue_block_editor_assets', 'twentyeleven_block_editor_styles' );
+if ( is_admin() && version_compare( $GLOBALS['wp_version'], '6.3', '>=' ) ) {
+	add_action( 'enqueue_block_assets', 'twentyeleven_block_editor_styles', 1, 1 );
+} else {
+	add_action( 'enqueue_block_editor_assets', 'twentyeleven_block_editor_styles', 1, 1 );
+}
 
 if ( ! function_exists( 'twentyeleven_header_style' ) ) :
 	/**

--- a/src/wp-content/themes/twentyfifteen/functions.php
+++ b/src/wp-content/themes/twentyfifteen/functions.php
@@ -489,7 +489,11 @@ function twentyfifteen_block_editor_styles() {
 	$font_version = ( 0 === strpos( (string) twentyfifteen_fonts_url(), get_template_directory_uri() . '/' ) ) ? '20230328' : null;
 	wp_enqueue_style( 'twentyfifteen-fonts', twentyfifteen_fonts_url(), array(), $font_version );
 }
-add_action( 'enqueue_block_editor_assets', 'twentyfifteen_block_editor_styles' );
+if ( is_admin() && version_compare( $GLOBALS['wp_version'], '6.3', '>=' ) ) {
+	add_action( 'enqueue_block_assets', 'twentyfifteen_block_editor_styles', 1, 1 );
+} else {
+	add_action( 'enqueue_block_editor_assets', 'twentyfifteen_block_editor_styles', 1, 1 );
+}
 
 
 /**

--- a/src/wp-content/themes/twentyfourteen/functions.php
+++ b/src/wp-content/themes/twentyfourteen/functions.php
@@ -449,7 +449,11 @@ function twentyfourteen_block_editor_styles() {
 	$font_version = ( 0 === strpos( (string) twentyfourteen_font_url(), get_template_directory_uri() . '/' ) ) ? '20230328' : null;
 	wp_enqueue_style( 'twentyfourteen-fonts', twentyfourteen_font_url(), array(), $font_version );
 }
-add_action( 'enqueue_block_editor_assets', 'twentyfourteen_block_editor_styles' );
+if ( is_admin() && version_compare( $GLOBALS['wp_version'], '6.3', '>=' ) ) {
+	add_action( 'enqueue_block_assets', 'twentyfourteen_block_editor_styles', 1, 1 );
+} else {
+	add_action( 'enqueue_block_editor_assets', 'twentyfourteen_block_editor_styles', 1, 1 );
+}
 
 if ( ! function_exists( 'twentyfourteen_the_attached_image' ) ) :
 	/**

--- a/src/wp-content/themes/twentynineteen/functions.php
+++ b/src/wp-content/themes/twentynineteen/functions.php
@@ -321,7 +321,11 @@ function twentynineteen_editor_customizer_styles() {
 		wp_add_inline_style( 'twentynineteen-editor-customizer-styles', twentynineteen_custom_colors_css() );
 	}
 }
-add_action( 'enqueue_block_editor_assets', 'twentynineteen_editor_customizer_styles' );
+if ( is_admin() && version_compare( $GLOBALS['wp_version'], '6.3', '>=' ) ) {
+	add_action( 'enqueue_block_assets', 'twentynineteen_editor_customizer_styles', 1, 1 );
+} else {
+	add_action( 'enqueue_block_editor_assets', 'twentynineteen_editor_customizer_styles', 1, 1 );
+}
 
 /**
  * Display custom color CSS in customizer and on frontend.

--- a/src/wp-content/themes/twentyseventeen/functions.php
+++ b/src/wp-content/themes/twentyseventeen/functions.php
@@ -546,7 +546,11 @@ function twentyseventeen_block_editor_styles() {
 	$font_version = ( 0 === strpos( (string) twentyseventeen_fonts_url(), get_template_directory_uri() . '/' ) ) ? '20230328' : null;
 	wp_enqueue_style( 'twentyseventeen-fonts', twentyseventeen_fonts_url(), array(), $font_version );
 }
-add_action( 'enqueue_block_editor_assets', 'twentyseventeen_block_editor_styles' );
+if ( is_admin() && version_compare( $GLOBALS['wp_version'], '6.3', '>=' ) ) {
+	add_action( 'enqueue_block_assets', 'twentyseventeen_block_editor_styles', 1, 1 );
+} else {
+	add_action( 'enqueue_block_editor_assets', 'twentyseventeen_block_editor_styles', 1, 1 );
+}
 
 /**
  * Add custom image sizes attribute to enhance responsive image functionality

--- a/src/wp-content/themes/twentysixteen/functions.php
+++ b/src/wp-content/themes/twentysixteen/functions.php
@@ -457,7 +457,11 @@ function twentysixteen_block_editor_styles() {
 	$font_version = ( 0 === strpos( (string) twentysixteen_fonts_url(), get_template_directory_uri() . '/' ) ) ? '20230328' : null;
 	wp_enqueue_style( 'twentysixteen-fonts', twentysixteen_fonts_url(), array(), $font_version );
 }
-add_action( 'enqueue_block_editor_assets', 'twentysixteen_block_editor_styles' );
+if ( is_admin() && version_compare( $GLOBALS['wp_version'], '6.3', '>=' ) ) {
+	add_action( 'enqueue_block_assets', 'twentysixteen_block_editor_styles', 1, 1 );
+} else {
+	add_action( 'enqueue_block_editor_assets', 'twentysixteen_block_editor_styles', 1, 1 );
+}
 
 /**
  * Adds custom classes to the array of body classes.

--- a/src/wp-content/themes/twentyten/functions.php
+++ b/src/wp-content/themes/twentyten/functions.php
@@ -777,7 +777,11 @@ function twentyten_block_editor_styles() {
 	// Block styles.
 	wp_enqueue_style( 'twentyten-block-editor-style', get_template_directory_uri() . '/editor-blocks.css', array(), '20230627' );
 }
-add_action( 'enqueue_block_editor_assets', 'twentyten_block_editor_styles' );
+if ( is_admin() && version_compare( $GLOBALS['wp_version'], '6.3', '>=' ) ) {
+	add_action( 'enqueue_block_assets', 'twentyten_block_editor_styles', 1, 1 );
+} else {
+	add_action( 'enqueue_block_editor_assets', 'twentyten_block_editor_styles', 1, 1 );
+}
 
 // Block Patterns.
 require get_template_directory() . '/block-patterns.php';

--- a/src/wp-content/themes/twentythirteen/functions.php
+++ b/src/wp-content/themes/twentythirteen/functions.php
@@ -389,7 +389,11 @@ function twentythirteen_block_editor_styles() {
 	$font_version = ( 0 === strpos( (string) twentythirteen_fonts_url(), get_template_directory_uri() . '/' ) ) ? '20230328' : null;
 	wp_enqueue_style( 'twentythirteen-fonts', twentythirteen_fonts_url(), array(), $font_version );
 }
-add_action( 'enqueue_block_editor_assets', 'twentythirteen_block_editor_styles' );
+if ( is_admin() && version_compare( $GLOBALS['wp_version'], '6.3', '>=' ) ) {
+	add_action( 'enqueue_block_assets', 'twentythirteen_block_editor_styles', 1, 1 );
+} else {
+	add_action( 'enqueue_block_editor_assets', 'twentythirteen_block_editor_styles', 1, 1 );
+}
 
 /**
  * Filter the page title.

--- a/src/wp-content/themes/twentytwelve/functions.php
+++ b/src/wp-content/themes/twentytwelve/functions.php
@@ -229,7 +229,11 @@ function twentytwelve_block_editor_styles() {
 	$font_version = ( 0 === strpos( (string) twentytwelve_get_font_url(), get_template_directory_uri() . '/' ) ) ? '20230328' : null;
 	wp_enqueue_style( 'twentytwelve-fonts', twentytwelve_get_font_url(), array(), $font_version );
 }
-add_action( 'enqueue_block_editor_assets', 'twentytwelve_block_editor_styles' );
+if ( is_admin() && version_compare( $GLOBALS['wp_version'], '6.3', '>=' ) ) {
+	add_action( 'enqueue_block_assets', 'twentytwelve_block_editor_styles', 1, 1 );
+} else {
+	add_action( 'enqueue_block_editor_assets', 'twentytwelve_block_editor_styles', 1, 1 );
+}
 
 /**
  * Add preconnect for Google Fonts.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/61591

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
