### PR TITLE
Upgrade Moment.js to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
 				"json2php": "^0.0.7",
 				"lodash": "4.17.21",
 				"masonry-layout": "4.2.2",
-				"moment": "2.29.4",
+				"moment": "2.30.1",
 				"objectFitPolyfill": "2.3.5",
 				"polyfill-library": "4.8.0",
 				"react": "18.3.1",
@@ -25143,9 +25143,9 @@
 			}
 		},
 		"node_modules/moment": {
-			"version": "2.29.4",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+			"version": "2.30.1",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+			"integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
 			"engines": {
 				"node": "*"
 			}
@@ -53049,9 +53049,9 @@
 			}
 		},
 		"moment": {
-			"version": "2.29.4",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
+			"version": "2.30.1",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+			"integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
 		},
 		"moment-timezone": {
 			"version": "0.5.40",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
 		"json2php": "^0.0.7",
 		"lodash": "4.17.21",
 		"masonry-layout": "4.2.2",
-		"moment": "2.29.4",
+		"moment": "2.30.1",
 		"objectFitPolyfill": "2.3.5",
 		"polyfill-library": "4.8.0",
 		"react": "18.3.1",

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -112,7 +112,7 @@ function wp_default_packages_vendor( $scripts ) {
 		'react-dom'                   => '18.3.1',
 		'react-jsx-runtime'           => '18.3.1',
 		'regenerator-runtime'         => '0.14.0',
-		'moment'                      => '2.29.4',
+		'moment'                      => '2.30.1',
 		'lodash'                      => '4.17.21',
 		'wp-polyfill-fetch'           => '3.6.17',
 		'wp-polyfill-formdata'        => '4.0.10',


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This Pull Request is intended to upgrade Moment JS Package to the latest version (2.30.1)

Trac ticket: https://core.trac.wordpress.org/ticket/60516

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
