### PR TITLE
Add default return value to the WP_REST_Templates_Controller::get_wp_templates_author_text_field() method

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -872,7 +872,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 				return $author->get( 'display_name' );
 		}
 
-		// / Ensure that the method always returns a string.
+		// Ensure that the method always returns a string.
 		return '';
 	}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -872,7 +872,10 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 				return $author->get( 'display_name' );
 		}
 
-		// Ensure that the method always returns a string.
+		/*
+		 * Ensure a string data type is always returned as the default and
+		 * a fail-safe in case `$original_source` is not one of the cases.
+		 */
 		return '';
 	}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -865,6 +865,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			case 'site':
 				return get_bloginfo( 'name' );
 			case 'user':
+			default:
 				$author = get_user_by( 'id', $template_object->author );
 				if ( ! $author ) {
 					return __( 'Unknown author' );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -865,13 +865,15 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			case 'site':
 				return get_bloginfo( 'name' );
 			case 'user':
-			default:
 				$author = get_user_by( 'id', $template_object->author );
 				if ( ! $author ) {
 					return __( 'Unknown author' );
 				}
 				return $author->get( 'display_name' );
 		}
+
+		// / Ensure that the method always returns a string.
+		return '';
 	}
 
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Trac ticket: https://core.trac.wordpress.org/ticket/61580

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
