### PR TITLE
Added cache to translations to prevent re-translating the strings over and over

### DIFF
--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -192,9 +192,10 @@ function determine_locale() {
  */
 function translate( $text, $domain = 'default' ) {
 	static $translated = array();
+	$current_locale = determine_locale();
 
-	if ( isset( $translated[ $text . $domain ] ) ) {
-		return $translated[ $text . $domain ];
+	if ( isset( $translated[ $text . $domain . $current_locale ] ) ) {
+		return $translated[ $text . $domain . $current_locale ];
 	}
 
 	$translations = get_translations_for_domain( $domain );
@@ -224,7 +225,7 @@ function translate( $text, $domain = 'default' ) {
 	 */
 	$translation = apply_filters( "gettext_{$domain}", $translation, $text, $domain );
 
-	$translated[ $text . $domain ] = $translation;
+	$translated[ $text . $domain . $current_locale ] = $translation;
 
 	return $translation;
 }

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -193,8 +193,8 @@ function determine_locale() {
 function translate( $text, $domain = 'default' ) {
 	static $translated = array();
 
-	if ( isset( $translated[ $text.$domain ] ) ) {
-		return $translated[ $text.$domain ];
+	if ( isset( $translated[ $text . $domain ] ) ) {
+		return $translated[ $text . $domain ];
 	}
 
 	$translations = get_translations_for_domain( $domain );
@@ -224,7 +224,7 @@ function translate( $text, $domain = 'default' ) {
 	 */
 	$translation = apply_filters( "gettext_{$domain}", $translation, $text, $domain );
 
-	$translated[ $text.$domain ] = $translation;
+	$translated[ $text . $domain ] = $translation;
 
 	return $translation;
 }

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -191,7 +191,7 @@ function determine_locale() {
  * @return string Translated text.
  */
 function translate( $text, $domain = 'default' ) {
-	static $translated = [];
+	static $translated = array();
 
 	if ( isset( $translated[ $text.$domain ] ) ) {
 		return $translated[ $text.$domain ];

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -191,6 +191,12 @@ function determine_locale() {
  * @return string Translated text.
  */
 function translate( $text, $domain = 'default' ) {
+	static $translated = [];
+
+	if ( isset( $translated[ $text.$domain ] ) ) {
+		return $translated[ $text.$domain ];
+	}
+
 	$translations = get_translations_for_domain( $domain );
 	$translation  = $translations->translate( $text );
 
@@ -217,6 +223,8 @@ function translate( $text, $domain = 'default' ) {
 	 * @param string $domain      Text domain. Unique identifier for retrieving translated strings.
 	 */
 	$translation = apply_filters( "gettext_{$domain}", $translation, $text, $domain );
+
+	$translated[ $text.$domain ] = $translation;
 
 	return $translation;
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61624

This PR adds a cache to the `translate` function to prevent `gettext` filters from running when the same string is being translated over and over by a plugin.

Another option would be to add a hook to allow other plugins to take control of when to preemptively return a cached translation or how to cache them.