### PR TITLE
Add type checking to the filters system

### DIFF
--- a/src/wp-includes/class-wp-hook.php
+++ b/src/wp-includes/class-wp-hook.php
@@ -353,7 +353,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 				} else {
 					$next_value = call_user_func_array( $the_['function'], array_slice( $args, 0, (int) $the_['accepted_args'] ) );
                 }
-                if ( ! is_type( $type, $next_value ) ) {
+                if ( ! wp_is_type( $type, $next_value ) ) {
                         _doing_it_wrong(
                                 $the_['function'],
                                 sprintf(
@@ -361,7 +361,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
                                         $type,
                                         gettype( $next_value )
                                 ),
-                                '5.8'
+                                '6.x'
                         );
                 } else {
                 	$value = $next_value;

--- a/src/wp-includes/class-wp-hook.php
+++ b/src/wp-includes/class-wp-hook.php
@@ -297,6 +297,34 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 * @return mixed The filtered value after all hooked functions are applied to it.
 	 */
 	public function apply_filters( $value, $args ) {
+             return $this->apply_filters_typed( 'mixed', $value, $args );
+     }
+
+     /**
+      * Calls the callback functions that have been added to a filter hook in a typesafe manner.
+      *
+      * @since 6.x.0
+      *
+      * @param mixed $value The value to filter.
+      * @param array $args  Additional parameters to pass to the callback functions.
+      *                     This array is expected to include $value at index 0.
+      * @return mixed The filtered value after all hooked functions are applied to it.
+      */
+     public function apply_filters_typesafe( $value, $args ) {
+             return $this->apply_filters_typed( gettype( $value ), $value, $args );
+     }
+
+     /**
+      * Calls the callback functions that have been added to a filter hook in a typed manner.
+      *
+      * @since 6.x.0
+      *
+      * @param mixed $value The value to filter.
+      * @param array $args  Additional parameters to pass to the callback functions.
+      *                     This array is expected to include $value at index 0.
+      * @return mixed The filtered value after all hooked functions are applied to it.
+      */
+     public function apply_filters_typed( $type, $value, $args ) {
 		if ( ! $this->callbacks ) {
 			return $value;
 		}
@@ -319,11 +347,24 @@ final class WP_Hook implements Iterator, ArrayAccess {
 
 				// Avoid the array_slice() if possible.
 				if ( 0 === $the_['accepted_args'] ) {
-					$value = call_user_func( $the_['function'] );
+					$next_value = call_user_func( $the_['function'] );
 				} elseif ( $the_['accepted_args'] >= $num_args ) {
-					$value = call_user_func_array( $the_['function'], $args );
+					$next_value = call_user_func_array( $the_['function'], $args );
 				} else {
-					$value = call_user_func_array( $the_['function'], array_slice( $args, 0, $the_['accepted_args'] ) );
+					$next_value = call_user_func_array( $the_['function'], array_slice( $args, 0, (int) $the_['accepted_args'] ) );
+                }
+                if ( ! is_type( $type, $next_value ) ) {
+                        _doing_it_wrong(
+                                $the_['function'],
+                                sprintf(
+                                        __( 'Invalid type returned in filter. Expected %1$s but received %2$s' ),
+                                        $type,
+                                        gettype( $next_value )
+                                ),
+                                '5.8'
+                        );
+                } else {
+                	$value = $next_value;
 				}
 			}
 		} while ( false !== next( $this->iterations[ $nesting_level ] ) );

--- a/src/wp-includes/class-wp-hook.php
+++ b/src/wp-includes/class-wp-hook.php
@@ -298,33 +298,33 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 */
 	public function apply_filters( $value, $args ) {
 		return $this->apply_filters_typed( 'mixed', $value, $args );
-	 }
+	}
 
-	 /**
-	  * Calls the callback functions that have been added to a filter hook in a typesafe manner.
-	  *
-	  * @since 6.x.0
-	  *
-	  * @param mixed $value The value to filter.
-	  * @param array $args  Additional parameters to pass to the callback functions.
-	  *                     This array is expected to include $value at index 0.
-	  * @return mixed The filtered value after all hooked functions are applied to it.
-	  */
-	 public function apply_filters_typesafe( $value, $args ) {
+	/**
+	 * Calls the callback functions that have been added to a filter hook in a typesafe manner.
+	*
+	* @since 6.x.0
+	*
+	* @param mixed $value The value to filter.
+	* @param array $args  Additional parameters to pass to the callback functions.
+	*                     This array is expected to include $value at index 0.
+	* @return mixed The filtered value after all hooked functions are applied to it.
+	*/
+	public function apply_filters_typesafe( $value, $args ) {
 		return $this->apply_filters_typed( gettype( $value ), $value, $args );
 	 }
 
-	 /**
-	  * Calls the callback functions that have been added to a filter hook in a typed manner.
-	  *
-	  * @since 6.x.0
-	  *
-	  * @param mixed $value The value to filter.
-	  * @param array $args  Additional parameters to pass to the callback functions.
-	  *                     This array is expected to include $value at index 0.
-	  * @return mixed The filtered value after all hooked functions are applied to it.
-	  */
-	 public function apply_filters_typed( $type, $value, $args ) {
+	/**
+	 * Calls the callback functions that have been added to a filter hook in a typed manner.
+	*
+	* @since 6.x.0
+	*
+	* @param mixed $value The value to filter.
+	* @param array $args  Additional parameters to pass to the callback functions.
+	*                     This array is expected to include $value at index 0.
+	* @return mixed The filtered value after all hooked functions are applied to it.
+	*/
+	public function apply_filters_typed( $type, $value, $args ) {
 		if ( ! $this->callbacks ) {
 			return $value;
 		}
@@ -355,13 +355,13 @@ final class WP_Hook implements Iterator, ArrayAccess {
 				}
 				if ( ! wp_is_type( $type, $next_value ) ) {
 						_doing_it_wrong(
-								$the_['function'],
-								sprintf(
-										__( 'Invalid type returned in filter. Expected %1$s but received %2$s' ),
-										$type,
-										gettype( $next_value )
-								),
-								'6.x'
+							$the_['function'],
+							sprintf(
+								__( 'Invalid type returned in filter. Expected %1$s but received %2$s' ),
+								$type,
+								gettype( $next_value )
+							),
+							'6.x'
 						);
 				} else {
 					$value = $next_value;

--- a/src/wp-includes/class-wp-hook.php
+++ b/src/wp-includes/class-wp-hook.php
@@ -297,34 +297,34 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	 * @return mixed The filtered value after all hooked functions are applied to it.
 	 */
 	public function apply_filters( $value, $args ) {
-             return $this->apply_filters_typed( 'mixed', $value, $args );
-     }
+		return $this->apply_filters_typed( 'mixed', $value, $args );
+	 }
 
-     /**
-      * Calls the callback functions that have been added to a filter hook in a typesafe manner.
-      *
-      * @since 6.x.0
-      *
-      * @param mixed $value The value to filter.
-      * @param array $args  Additional parameters to pass to the callback functions.
-      *                     This array is expected to include $value at index 0.
-      * @return mixed The filtered value after all hooked functions are applied to it.
-      */
-     public function apply_filters_typesafe( $value, $args ) {
-             return $this->apply_filters_typed( gettype( $value ), $value, $args );
-     }
+	 /**
+	  * Calls the callback functions that have been added to a filter hook in a typesafe manner.
+	  *
+	  * @since 6.x.0
+	  *
+	  * @param mixed $value The value to filter.
+	  * @param array $args  Additional parameters to pass to the callback functions.
+	  *                     This array is expected to include $value at index 0.
+	  * @return mixed The filtered value after all hooked functions are applied to it.
+	  */
+	 public function apply_filters_typesafe( $value, $args ) {
+		return $this->apply_filters_typed( gettype( $value ), $value, $args );
+	 }
 
-     /**
-      * Calls the callback functions that have been added to a filter hook in a typed manner.
-      *
-      * @since 6.x.0
-      *
-      * @param mixed $value The value to filter.
-      * @param array $args  Additional parameters to pass to the callback functions.
-      *                     This array is expected to include $value at index 0.
-      * @return mixed The filtered value after all hooked functions are applied to it.
-      */
-     public function apply_filters_typed( $type, $value, $args ) {
+	 /**
+	  * Calls the callback functions that have been added to a filter hook in a typed manner.
+	  *
+	  * @since 6.x.0
+	  *
+	  * @param mixed $value The value to filter.
+	  * @param array $args  Additional parameters to pass to the callback functions.
+	  *                     This array is expected to include $value at index 0.
+	  * @return mixed The filtered value after all hooked functions are applied to it.
+	  */
+	 public function apply_filters_typed( $type, $value, $args ) {
 		if ( ! $this->callbacks ) {
 			return $value;
 		}
@@ -352,19 +352,19 @@ final class WP_Hook implements Iterator, ArrayAccess {
 					$next_value = call_user_func_array( $the_['function'], $args );
 				} else {
 					$next_value = call_user_func_array( $the_['function'], array_slice( $args, 0, (int) $the_['accepted_args'] ) );
-                }
-                if ( ! wp_is_type( $type, $next_value ) ) {
-                        _doing_it_wrong(
-                                $the_['function'],
-                                sprintf(
-                                        __( 'Invalid type returned in filter. Expected %1$s but received %2$s' ),
-                                        $type,
-                                        gettype( $next_value )
-                                ),
-                                '6.x'
-                        );
-                } else {
-                	$value = $next_value;
+				}
+				if ( ! wp_is_type( $type, $next_value ) ) {
+						_doing_it_wrong(
+								$the_['function'],
+								sprintf(
+										__( 'Invalid type returned in filter. Expected %1$s but received %2$s' ),
+										$type,
+										gettype( $next_value )
+								),
+								'6.x'
+						);
+				} else {
+					$value = $next_value;
 				}
 			}
 		} while ( false !== next( $this->iterations[ $nesting_level ] ) );

--- a/src/wp-includes/class-wp-hook.php
+++ b/src/wp-includes/class-wp-hook.php
@@ -312,7 +312,7 @@ final class WP_Hook implements Iterator, ArrayAccess {
 	*/
 	public function apply_filters_typesafe( $value, $args ) {
 		return $this->apply_filters_typed( gettype( $value ), $value, $args );
-	 }
+	}
 
 	/**
 	 * Calls the callback functions that have been added to a filter hook in a typed manner.

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -1789,7 +1789,7 @@ function is_wp_error( $thing ) {
  * @return bool Whether the variable is of the type.
  */
 function wp_is_type( $type, $value ) {
-	switch( $type ) {
+	switch ( $type ) {
 		case 'boolean':
 			return is_bool( $value );
 		case 'integer':

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -1809,6 +1809,8 @@ function wp_is_type( $type, $value ) {
 			return is_null( $value );
 		case 'unknown_type':
 			return false;
+		case 'mixed':
+			return true;
 		default:
 			/**
 			 * Filters whether the variable is of the type.

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -1782,38 +1782,45 @@ function is_wp_error( $thing ) {
  *
  * Returns whether `$value` is certain type.
  *
- * @since 6.x.0
+ * @since 6.x
  *
  * @param string $type  The type to check.
  * @param mixed  $value The variable to check.
  * @return bool Whether the variable is of the type.
  */
-function is_type( $type, $value ) {
-        switch( $type ) {
-                case 'boolean':
-                        return is_bool( $value );
-                case 'integer':
-                        return is_int( $value );
-                case 'double':
-                        return is_float( $value );
-                case 'string':
-                        return is_string( $value );
-                case 'array':
-                        return is_array( $value );
-                case 'object':
-                        return is_object( $value );
-                case 'resource':
-                case 'resource (closed)':
-                        return is_resource( $value );
-                case 'NULL':
-                        return is_null( $value );
-                case 'unknown_type':
-                        return false;
-                case 'mixed':
-                        return true;
-                default:
-                        return is_a( $value, $type ) || is_subclass_of( $value, $type );
-        }
+function wp_is_type( $type, $value ) {
+	switch( $type ) {
+		case 'boolean':
+			return is_bool( $value );
+		case 'integer':
+			return is_int( $value );
+		case 'double':
+			return is_float( $value );
+		case 'string':
+			return is_string( $value );
+		case 'array':
+			return is_array( $value );
+		case 'object':
+			return is_object( $value );
+		case 'resource':
+		case 'resource (closed)':
+			return is_resource( $value );
+		case 'NULL':
+			return is_null( $value );
+		case 'unknown_type':
+			return false;
+		default:
+			/**
+			 * Filters whether the variable is of the type.
+			 * The dynamic portion of the hook name, `$type`, refers to the type of the variable.
+			 *
+			 * @since 6.x
+			 *
+			 * @param bool  $is_type Is the variable of the type. Default false.
+			 * @param mixed $value The variable to check.
+			 */
+			return apply_filters( "wp_is_type_{$type}", false, $value );
+	}
 }
 
 

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -1778,6 +1778,47 @@ function is_wp_error( $thing ) {
 }
 
 /**
+ * Checks whether the given variable is a certain type.
+ *
+ * Returns whether `$value` is certain type.
+ *
+ * @since 6.x.0
+ *
+ * @param string $type  The type to check.
+ * @param mixed  $value The variable to check.
+ * @return bool Whether the variable is of the type.
+ */
+function is_type( $type, $value ) {
+        switch( $type ) {
+                case 'boolean':
+                        return is_bool( $value );
+                case 'integer':
+                        return is_int( $value );
+                case 'double':
+                        return is_float( $value );
+                case 'string':
+                        return is_string( $value );
+                case 'array':
+                        return is_array( $value );
+                case 'object':
+                        return is_object( $value );
+                case 'resource':
+                case 'resource (closed)':
+                        return is_resource( $value );
+                case 'NULL':
+                        return is_null( $value );
+                case 'unknown_type':
+                        return false;
+                case 'mixed':
+                        return true;
+                default:
+                        return is_a( $value, $type ) || is_subclass_of( $value, $type );
+        }
+}
+
+
+
+/**
  * Determines whether file modifications are allowed.
  *
  * @since 4.8.0

--- a/src/wp-includes/plugin.php
+++ b/src/wp-includes/plugin.php
@@ -171,7 +171,7 @@ function add_filter( $hook_name, $callback, $priority = 10, $accepted_args = 1 )
  * @return mixed The filtered value after all hooked functions are applied to it.
  */
 function apply_filters( $hook_name, $value, ...$args ) {
-        return apply_filters_typed( 'mixed', $hook_name, $value, ...$args );
+	return apply_filters_typed( 'mixed', $hook_name, $value, ...$args );
 }
 
 /**
@@ -183,7 +183,7 @@ function apply_filters( $hook_name, $value, ...$args ) {
  * @return mixed The filtered value after all hooked functions are applied to it.
  */
 function apply_filters_typesafe( $hook_name, $value, ...$args ) {
-        return apply_filters_typed( gettype( $value ), $hook_name, $value, ...$args );
+	return apply_filters_typed( gettype( $value ), $hook_name, $value, ...$args );
 }
 
 /**
@@ -210,7 +210,7 @@ function apply_filters_typed( $type, $hook_name, $value, ...$args ) {
 
 		$all_args = func_get_args(); // phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection
 		// Don't pass the type to the 'all' actions.
-        array_shift( $all_args );
+		array_shift( $all_args );
 		_wp_call_all_hook( $all_args );
 	}
 

--- a/src/wp-includes/plugin.php
+++ b/src/wp-includes/plugin.php
@@ -171,6 +171,31 @@ function add_filter( $hook_name, $callback, $priority = 10, $accepted_args = 1 )
  * @return mixed The filtered value after all hooked functions are applied to it.
  */
 function apply_filters( $hook_name, $value, ...$args ) {
+        return apply_filters_typed( 'mixed', $hook_name, $value, ...$args );
+}
+
+/**
+ * Calls the callback functions that have been added to a filter hook in a typesafe manner.
+ *
+ * @param string $tag     The name of the filter hook.
+ * @param mixed  $value   The value to filter.
+ * @param mixed  ...$args Additional parameters to pass to the callback functions.
+ * @return mixed The filtered value after all hooked functions are applied to it.
+ */
+function apply_filters_typesafe( $hook_name, $value, ...$args ) {
+        return apply_filters_typed( gettype( $value ), $hook_name, $value, ...$args );
+}
+
+/**
+ * Calls the callback functions that have been added to a filter hook in a typed manner.
+ *
+ * @param string $type    The type the return value should have.
+ * @param string $tag     The name of the filter hook.
+ * @param mixed  $value   The value to filter.
+ * @param mixed  ...$args Additional parameters to pass to the callback functions.
+ * @return mixed The filtered value after all hooked functions are applied to it.
+ */
+function apply_filters_typed( $type, $hook_name, $value, ...$args ) {
 	global $wp_filter, $wp_filters, $wp_current_filter;
 
 	if ( ! isset( $wp_filters[ $hook_name ] ) ) {
@@ -184,6 +209,8 @@ function apply_filters( $hook_name, $value, ...$args ) {
 		$wp_current_filter[] = $hook_name;
 
 		$all_args = func_get_args(); // phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue.NeedsInspection
+		// Don't pass the type to the 'all' actions.
+        array_shift( $all_args );
 		_wp_call_all_hook( $all_args );
 	}
 
@@ -202,7 +229,7 @@ function apply_filters( $hook_name, $value, ...$args ) {
 	// Pass the value to WP_Hook.
 	array_unshift( $args, $value );
 
-	$filtered = $wp_filter[ $hook_name ]->apply_filters( $value, $args );
+	$filtered = $wp_filter[ $hook_name ]->apply_filters_typed( $type, $value, $args );
 
 	array_pop( $wp_current_filter );
 

--- a/tests/phpunit/tests/filters.php
+++ b/tests/phpunit/tests/filters.php
@@ -539,4 +539,73 @@ class Tests_Filters extends WP_UnitTestCase {
 		global $wp_filter;
 		$this->current_priority = $wp_filter['the_content']->current_priority();
 	}
+
+	/**
+	 * @ticket 51525
+	 *
+	 * @dataProvider data_apply_filters_typed
+	 */
+	public function test_apply_filters_typed( $type, $value, $callbacks, $expected ) {
+		$hook_name = __FUNCTION__;
+
+		foreach ( $callbacks as $callback ) {
+			add_filter( $hook_name, $callback, 1, 1 );
+		}
+
+		$return = apply_filters_typed( $type, $value, array( $value ) );
+
+		foreach ( $callbacks as $callback ) {
+			remove_filter( $hook_name, $callback );
+		}
+
+		$this->assertSame( $expected, $return );
+	}
+
+	public function data_apply_filters_typed() {
+		return array(
+			'testShouldDiscardNotMatchingTypesCallbacks' => array(
+				'type' => 'boolean',
+				'value' => true,
+				'callbacks' => array(
+					'__return_false',
+					'__return_empty_string',
+				),
+				'expected' => false,
+			),
+		);
+	}
+
+	/**
+	 * @ticket 51525
+	 *
+	 * @dataProvider data_apply_filters_typesafe
+	 */
+	public function test_apply_filters_typesafe( $value, $callbacks, $expected ) {
+		$hook_name = __FUNCTION__;
+
+		foreach ( $callbacks as $callback ) {
+			add_filter( $hook_name, $callback, 1, 1 );
+		}
+
+		$return = apply_filters_typesafe( $value, array( $value ) );
+
+		foreach ( $callbacks as $callback ) {
+			remove_filter( $hook_name, $callback );
+		}
+
+		$this->assertSame( $expected, $return );
+	}
+
+	public function data_apply_filters_typesafe() {
+		return array(
+			'testShouldDiscardNotMatchingTypesCallbacks' => array(
+				'value' => true,
+				'callbacks' => array(
+					'__return_false',
+					'__return_zero',
+				),
+				'expected' => false,
+			),
+		);
+	}
 }

--- a/tests/phpunit/tests/filters.php
+++ b/tests/phpunit/tests/filters.php
@@ -564,13 +564,13 @@ class Tests_Filters extends WP_UnitTestCase {
 	public function data_apply_filters_typed() {
 		return array(
 			'testShouldDiscardNotMatchingTypesCallbacks' => array(
-				'type' => 'boolean',
-				'value' => true,
+				'type'      => 'boolean',
+				'value'     => true,
 				'callbacks' => array(
 					'__return_false',
 					'__return_empty_string',
 				),
-				'expected' => false,
+				'expected'  => false,
 			),
 		);
 	}
@@ -599,12 +599,12 @@ class Tests_Filters extends WP_UnitTestCase {
 	public function data_apply_filters_typesafe() {
 		return array(
 			'testShouldDiscardNotMatchingTypesCallbacks' => array(
-				'value' => true,
+				'value'     => true,
 				'callbacks' => array(
 					'__return_false',
 					'__return_zero',
 				),
-				'expected' => false,
+				'expected'  => false,
 			),
 		);
 	}

--- a/tests/phpunit/tests/filters.php
+++ b/tests/phpunit/tests/filters.php
@@ -552,7 +552,7 @@ class Tests_Filters extends WP_UnitTestCase {
 			add_filter( $hook_name, $callback, 1, 1 );
 		}
 
-		$return = apply_filters_typed( $type, $value, array( $value ) );
+		$return = apply_filters_typed( $type, $hook_name, $value );
 
 		foreach ( $callbacks as $callback ) {
 			remove_filter( $hook_name, $callback );
@@ -587,7 +587,7 @@ class Tests_Filters extends WP_UnitTestCase {
 			add_filter( $hook_name, $callback, 1, 1 );
 		}
 
-		$return = apply_filters_typesafe( $value, array( $value ) );
+		$return = apply_filters_typesafe( $hook_name, $value );
 
 		foreach ( $callbacks as $callback ) {
 			remove_filter( $hook_name, $callback );

--- a/tests/phpunit/tests/filters.php
+++ b/tests/phpunit/tests/filters.php
@@ -545,8 +545,10 @@ class Tests_Filters extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_apply_filters_typed
 	 */
-	public function test_apply_filters_typed( $type, $value, $callbacks, $expected ) {
+	public function test_apply_filters_typed( $type, $value, $callbacks, $doing_it_wrong, $expected ) {
 		$hook_name = __FUNCTION__;
+
+		$this->setExpectedIncorrectUsage( $doing_it_wrong );
 
 		foreach ( $callbacks as $callback ) {
 			add_filter( $hook_name, $callback, 1, 1 );
@@ -564,13 +566,14 @@ class Tests_Filters extends WP_UnitTestCase {
 	public function data_apply_filters_typed() {
 		return array(
 			'testShouldDiscardNotMatchingTypesCallbacks' => array(
-				'type'      => 'boolean',
-				'value'     => true,
-				'callbacks' => array(
+				'type'           => 'boolean',
+				'value'          => true,
+				'callbacks'      => array(
 					'__return_false',
 					'__return_empty_string',
 				),
-				'expected'  => false,
+				'doing_it_wrong' => '__return_empty_string',
+				'expected'       => false,
 			),
 		);
 	}
@@ -580,8 +583,10 @@ class Tests_Filters extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_apply_filters_typesafe
 	 */
-	public function test_apply_filters_typesafe( $value, $callbacks, $expected ) {
+	public function test_apply_filters_typesafe( $value, $callbacks, $doing_it_wrong, $expected ) {
 		$hook_name = __FUNCTION__;
+
+		$this->setExpectedIncorrectUsage( $doing_it_wrong );
 
 		foreach ( $callbacks as $callback ) {
 			add_filter( $hook_name, $callback, 1, 1 );
@@ -599,12 +604,13 @@ class Tests_Filters extends WP_UnitTestCase {
 	public function data_apply_filters_typesafe() {
 		return array(
 			'testShouldDiscardNotMatchingTypesCallbacks' => array(
-				'value'     => true,
-				'callbacks' => array(
+				'value'          => true,
+				'callbacks'      => array(
 					'__return_false',
 					'__return_zero',
 				),
-				'expected'  => false,
+				'doing_it_wrong' => '__return_zero',
+				'expected'       => false,
 			),
 		);
 	}

--- a/tests/phpunit/tests/hooks/applyFilters.php
+++ b/tests/phpunit/tests/hooks/applyFilters.php
@@ -79,6 +79,69 @@ class Tests_Hooks_ApplyFilters extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 51525
+	 *
+	 * @dataProvider data_apply_filters_typed
+	 */
+	public function test_apply_filters_typed( $type, $value, $callbacks, $expected ) {
+		$hook      = new WP_Hook();
+		$hook_name = __FUNCTION__;
+
+		foreach ( $callbacks as $callback ) {
+			$hook->add_filter( $hook_name, $callback, 1, 1 );
+		}
+
+		$return = $hook->apply_filters_typed( $type, $value, array( $value ) );
+
+		$this->assertSame( $expected, $return );
+	}
+
+	public function data_apply_filters_typed() {
+		return array(
+			'testShouldDiscardNotMatchingTypesCallbacks' => array(
+				'type' => 'boolean',
+				'value' => true,
+				'callbacks' => array(
+					'__return_false',
+					'__return_empty_string',
+				),
+				'expected' => false,
+			),
+		);
+	}
+
+	/**
+	 * @ticket 51525
+	 *
+	 * @dataProvider data_apply_filters_typesafe
+	 */
+	public function test_apply_filters_typesafe( $value, $callbacks, $expected ) {
+		$hook      = new WP_Hook();
+		$hook_name = __FUNCTION__;
+
+		foreach ( $callbacks as $callback ) {
+			$hook->add_filter( $hook_name, $callback, 1, 1 );
+		}
+
+		$return = $hook->apply_filters_typesafe( $value, array( $value ) );
+
+		$this->assertSame( $expected, $return );
+	}
+
+	public function data_apply_filters_typesafe() {
+		return array(
+			'testShouldDiscardNotMatchingTypesCallbacks' => array(
+				'value' => true,
+				'callbacks' => array(
+					'__return_false',
+					'__return_zero',
+				),
+				'expected' => false,
+			),
+		);
+	}
+
+	/**
 	 * Happy path data provider.
 	 *
 	 * @return array[]

--- a/tests/phpunit/tests/hooks/applyFilters.php
+++ b/tests/phpunit/tests/hooks/applyFilters.php
@@ -95,7 +95,6 @@ class Tests_Hooks_ApplyFilters extends WP_UnitTestCase {
 
 		$return = $hook->apply_filters_typed( $type, $value, array( $value ) );
 
-
 		$this->assertSame( $expected, $return );
 	}
 

--- a/tests/phpunit/tests/hooks/applyFilters.php
+++ b/tests/phpunit/tests/hooks/applyFilters.php
@@ -83,9 +83,11 @@ class Tests_Hooks_ApplyFilters extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_apply_filters_typed
 	 */
-	public function test_apply_filters_typed( $type, $value, $callbacks, $expected ) {
+	public function test_apply_filters_typed( $type, $value, $callbacks, $doing_it_wrong, $expected ) {
 		$hook      = new WP_Hook();
 		$hook_name = __FUNCTION__;
+
+		$this->setExpectedIncorrectUsage( $doing_it_wrong );
 
 		foreach ( $callbacks as $callback ) {
 			$hook->add_filter( $hook_name, $callback, 1, 1 );
@@ -93,19 +95,21 @@ class Tests_Hooks_ApplyFilters extends WP_UnitTestCase {
 
 		$return = $hook->apply_filters_typed( $type, $value, array( $value ) );
 
+
 		$this->assertSame( $expected, $return );
 	}
 
 	public function data_apply_filters_typed() {
 		return array(
 			'testShouldDiscardNotMatchingTypesCallbacks' => array(
-				'type'      => 'boolean',
-				'value'     => true,
-				'callbacks' => array(
+				'type'           => 'boolean',
+				'value'          => true,
+				'callbacks'      => array(
 					'__return_false',
 					'__return_empty_string',
 				),
-				'expected'  => false,
+				'doing_it_wrong' => '__return_empty_string',
+				'expected'       => false,
 			),
 		);
 	}
@@ -115,9 +119,11 @@ class Tests_Hooks_ApplyFilters extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_apply_filters_typesafe
 	 */
-	public function test_apply_filters_typesafe( $value, $callbacks, $expected ) {
+	public function test_apply_filters_typesafe( $value, $callbacks, $doing_it_wrong, $expected ) {
 		$hook      = new WP_Hook();
 		$hook_name = __FUNCTION__;
+
+		$this->setExpectedIncorrectUsage( $doing_it_wrong );
 
 		foreach ( $callbacks as $callback ) {
 			$hook->add_filter( $hook_name, $callback, 1, 1 );
@@ -131,12 +137,13 @@ class Tests_Hooks_ApplyFilters extends WP_UnitTestCase {
 	public function data_apply_filters_typesafe() {
 		return array(
 			'testShouldDiscardNotMatchingTypesCallbacks' => array(
-				'value'     => true,
-				'callbacks' => array(
+				'value'          => true,
+				'callbacks'      => array(
 					'__return_false',
 					'__return_zero',
 				),
-				'expected'  => false,
+				'doing_it_wrong' => '__return_zero',
+				'expected'       => false,
 			),
 		);
 	}

--- a/tests/phpunit/tests/hooks/applyFilters.php
+++ b/tests/phpunit/tests/hooks/applyFilters.php
@@ -99,13 +99,13 @@ class Tests_Hooks_ApplyFilters extends WP_UnitTestCase {
 	public function data_apply_filters_typed() {
 		return array(
 			'testShouldDiscardNotMatchingTypesCallbacks' => array(
-				'type' => 'boolean',
-				'value' => true,
+				'type'      => 'boolean',
+				'value'     => true,
 				'callbacks' => array(
 					'__return_false',
 					'__return_empty_string',
 				),
-				'expected' => false,
+				'expected'  => false,
 			),
 		);
 	}
@@ -131,12 +131,12 @@ class Tests_Hooks_ApplyFilters extends WP_UnitTestCase {
 	public function data_apply_filters_typesafe() {
 		return array(
 			'testShouldDiscardNotMatchingTypesCallbacks' => array(
-				'value' => true,
+				'value'     => true,
 				'callbacks' => array(
 					'__return_false',
 					'__return_zero',
 				),
-				'expected' => false,
+				'expected'  => false,
 			),
 		);
 	}

--- a/tests/phpunit/tests/load/wpIsType.php
+++ b/tests/phpunit/tests/load/wpIsType.php
@@ -61,7 +61,7 @@ class Tests_Load_WpIsType extends WP_UnitTestCase {
 			),
 			'testIsArray' => array(
 				'array',
-				[],
+				array(),
 				true,
 			),
 			'testIsNotArray' => array(
@@ -71,7 +71,7 @@ class Tests_Load_WpIsType extends WP_UnitTestCase {
 			),
 			'testIsObject' => array(
 				'object',
-				(object) [],
+				(object) array(),
 				true,
 			),
 			'testIsNotObject' => array(

--- a/tests/phpunit/tests/load/wpIsType.php
+++ b/tests/phpunit/tests/load/wpIsType.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Tests for is_type().
+ *
+ * @group load
+ *
+ * @covers ::is_login
+ */
+class Tests_Load_WpIsType extends WP_UnitTestCase {
+	/**
+	 * @ticket 51525
+	 *
+	 * @dataProvider data_wp_is_type
+	 */
+	public function test_wp_is_type( $type, $value, $expected ) {
+		$this->assertSame( $expected, wp_is_type( $type, $value ) );
+	}
+
+	public function data_wp_is_type() {
+		return array(
+			'testIsBool' => array(
+				'boolean',
+				true,
+				true,
+			),
+			'testIsNotBool' => array(
+				'boolean',
+				1,
+				false,
+			),
+			'testIsInt' => array(
+				'integer',
+				1,
+				true,
+			),
+			'testIsNotInt' => array(
+				'integer',
+				1.1,
+				false,
+			),
+			'testIsFloat' => array(
+				'double',
+				1.1,
+				true,
+			),
+			'testIsNotFloat' => array(
+				'double',
+				1,
+				false,
+			),
+			'testIsString' => array(
+				'string',
+				'1',
+				true,
+			),
+			'testIsNotString' => array(
+				'string',
+				1,
+				false,
+			),
+			'testIsArray' => array(
+				'array',
+				[],
+				true,
+			),
+			'testIsNotArray' => array(
+				'array',
+				1,
+				false,
+			),
+			'testIsObject' => array(
+				'object',
+				(object) [],
+				true,
+			),
+			'testIsNotObject' => array(
+				'object',
+				1,
+				false,
+			),
+			'testIsResource' => array(
+				'resource',
+				fopen( 'php://memory', 'r' ),
+				true,
+			),
+			'testIsNotResource' => array(
+				'resource',
+				1,
+				false,
+			),
+			'testIsNull' => array(
+				'NULL',
+				null,
+				true,
+			),
+			'testIsNotNull' => array(
+				'NULL',
+				1,
+				false,
+			),
+			'testIsUnknownType' => array(
+				'unknown_type',
+				1,
+				false,
+			),
+		);
+	}
+}

--- a/tests/phpunit/tests/load/wpIsType.php
+++ b/tests/phpunit/tests/load/wpIsType.php
@@ -19,67 +19,67 @@ class Tests_Load_WpIsType extends WP_UnitTestCase {
 
 	public function data_wp_is_type() {
 		return array(
-			'testIsBool' => array(
+			'testIsBool'        => array(
 				'boolean',
 				true,
 				true,
 			),
-			'testIsNotBool' => array(
+			'testIsNotBool'     => array(
 				'boolean',
 				1,
 				false,
 			),
-			'testIsInt' => array(
+			'testIsInt'         => array(
 				'integer',
 				1,
 				true,
 			),
-			'testIsNotInt' => array(
+			'testIsNotInt'      => array(
 				'integer',
 				1.1,
 				false,
 			),
-			'testIsFloat' => array(
+			'testIsFloat'       => array(
 				'double',
 				1.1,
 				true,
 			),
-			'testIsNotFloat' => array(
+			'testIsNotFloat'    => array(
 				'double',
 				1,
 				false,
 			),
-			'testIsString' => array(
+			'testIsString'      => array(
 				'string',
 				'1',
 				true,
 			),
-			'testIsNotString' => array(
+			'testIsNotString'   => array(
 				'string',
 				1,
 				false,
 			),
-			'testIsArray' => array(
+			'testIsArray'       => array(
 				'array',
 				array(),
 				true,
 			),
-			'testIsNotArray' => array(
+			'testIsNotArray'    => array(
 				'array',
 				1,
 				false,
 			),
-			'testIsObject' => array(
+			'testIsObject'      => array(
 				'object',
 				(object) array(),
 				true,
 			),
-			'testIsNotObject' => array(
+			'testIsNotObject'   => array(
 				'object',
 				1,
 				false,
 			),
-			'testIsResource' => array(
+			'testIsResource'    => array(
 				'resource',
 				fopen( 'php://memory', 'r' ),
 				true,
@@ -89,12 +89,12 @@ class Tests_Load_WpIsType extends WP_UnitTestCase {
 				1,
 				false,
 			),
-			'testIsNull' => array(
+			'testIsNull'        => array(
 				'NULL',
 				null,
 				true,
 			),
-			'testIsNotNull' => array(
+			'testIsNotNull'     => array(
 				'NULL',
 				1,
 				false,


### PR DESCRIPTION
Introduce type checking to the filters system by:
- Adding new methods to the hook class `apply_filters_typesafe()` and `apply_filters_typed()`
- Add new function `wp_is_type()` to check if a value is of the corresponding type
- Backward compatibility with apply_filters by passing a `mixed` type
- New functions `apply_filters_typesafe()` and `apply_filters_typed()`

New methods and functions have tests coming with them to validate their behaviour.

Trac ticket: https://core.trac.wordpress.org/ticket/51525

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
