### PR TITLE
Block bindings: Expose sources in the editor settings to consume them in the client

### DIFF
--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -648,6 +648,23 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 		$editor_settings['postContentAttributes'] = $post_content_block_attributes;
 	}
 
+	// Expose block bindings sources in the editor settings.
+	$registered_block_bindings_sources = get_all_registered_block_bindings_sources();
+	if ( ! empty( $registered_block_bindings_sources ) ) {
+		// Initialize array.
+		$editor_settings['blockBindings'] = array();
+		foreach ( $registered_block_bindings_sources as $source_name => $source_properties ) {
+			// Add source with the label to editor settings.
+			$editor_settings['blockBindings'][ $source_name ] = array(
+				'label' => $source_properties->label,
+			);
+			// Add `usesContext` property if exists.
+			if ( ! empty( $source_properties->uses_context ) ) {
+				$editor_settings['blockBindings'][ $source_name ]['usesContext'] = $source_properties->uses_context;
+			}
+		}
+	}
+
 	/**
 	 * Filters the settings to pass to the block editor for all editor type.
 	 *

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -652,15 +652,15 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 	$registered_block_bindings_sources = get_all_registered_block_bindings_sources();
 	if ( ! empty( $registered_block_bindings_sources ) ) {
 		// Initialize array.
-		$editor_settings['blockBindings'] = array();
+		$editor_settings['blockBindingsSources'] = array();
 		foreach ( $registered_block_bindings_sources as $source_name => $source_properties ) {
 			// Add source with the label to editor settings.
-			$editor_settings['blockBindings'][ $source_name ] = array(
+			$editor_settings['blockBindingsSources'][ $source_name ] = array(
 				'label' => $source_properties->label,
 			);
 			// Add `usesContext` property if exists.
 			if ( ! empty( $source_properties->uses_context ) ) {
-				$editor_settings['blockBindings'][ $source_name ]['usesContext'] = $source_properties->uses_context;
+				$editor_settings['blockBindingsSources'][ $source_name ]['usesContext'] = $source_properties->uses_context;
 			}
 		}
 	}

--- a/tests/phpunit/tests/block-bindings/register.php
+++ b/tests/phpunit/tests/block-bindings/register.php
@@ -77,6 +77,9 @@ class Tests_Block_Bindings_Register extends WP_UnitTestCase {
 		);
 
 		$registered = get_all_registered_block_bindings_sources();
+		unregister_block_bindings_source( 'test/source-one' );
+		unregister_block_bindings_source( 'test/source-two' );
+		unregister_block_bindings_source( 'test/source-three' );
 		$this->assertEquals( $expected, $registered );
 	}
 

--- a/tests/phpunit/tests/block-bindings/register.php
+++ b/tests/phpunit/tests/block-bindings/register.php
@@ -77,9 +77,6 @@ class Tests_Block_Bindings_Register extends WP_UnitTestCase {
 		);
 
 		$registered = get_all_registered_block_bindings_sources();
-		unregister_block_bindings_source( 'test/source-one' );
-		unregister_block_bindings_source( 'test/source-two' );
-		unregister_block_bindings_source( 'test/source-three' );
 		$this->assertEquals( $expected, $registered );
 	}
 

--- a/tests/phpunit/tests/block-bindings/wpBlockBindingsRegistry.php
+++ b/tests/phpunit/tests/block-bindings/wpBlockBindingsRegistry.php
@@ -269,6 +269,9 @@ class Tests_Blocks_wpBlockBindingsRegistry extends WP_UnitTestCase {
 		);
 
 		$registered = $this->registry->get_all_registered();
+		$this->registry->unregister( 'test/source-one' );
+		$this->registry->unregister( 'test/source-two' );
+		$this->registry->unregister( 'test/source-three' );
 		$this->assertEquals( $expected, $registered );
 	}
 
@@ -311,6 +314,9 @@ class Tests_Blocks_wpBlockBindingsRegistry extends WP_UnitTestCase {
 
 		$expected = new WP_Block_Bindings_Source( $source_two_name, $source_two_properties );
 		$result   = $this->registry->get_registered( 'test/source-two' );
+		$this->registry->unregister( 'test/source-one' );
+		$this->registry->unregister( 'test/source-two' );
+		$this->registry->unregister( 'test/source-three' );
 
 		$this->assertEquals(
 			$expected,
@@ -380,6 +386,8 @@ class Tests_Blocks_wpBlockBindingsRegistry extends WP_UnitTestCase {
 		);
 
 		$new_uses_context = $block_registry->get_registered( 'core/paragraph' )->uses_context;
+		unregister_block_bindings_source( 'test/source-one' );
+		unregister_block_bindings_source( 'test/source-two' );
 		// Checks that the resulting `uses_context` contains the values from both sources.
 		$this->assertContains( 'commonContext', $new_uses_context );
 		$this->assertContains( 'sourceOneContext', $new_uses_context );

--- a/tests/phpunit/tests/block-bindings/wpBlockBindingsRegistry.php
+++ b/tests/phpunit/tests/block-bindings/wpBlockBindingsRegistry.php
@@ -269,9 +269,6 @@ class Tests_Blocks_wpBlockBindingsRegistry extends WP_UnitTestCase {
 		);
 
 		$registered = $this->registry->get_all_registered();
-		$this->registry->unregister( 'test/source-one' );
-		$this->registry->unregister( 'test/source-two' );
-		$this->registry->unregister( 'test/source-three' );
 		$this->assertEquals( $expected, $registered );
 	}
 

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -730,11 +730,22 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 		$registered_block_bindings_sources = get_all_registered_block_bindings_sources();
 
 		foreach ( $registered_block_bindings_sources as $name => $properties ) {
-			$registered_properties = get_object_vars( $properties );
-			// Remove name property as it is not part of the settings.
-			unset( $registered_properties['name'] );
-			$settings_properties = $settings['blockBindingsSources'][ $name ];
-			$this->assertSameSets( $registered_properties, $settings_properties );
+			// Check all the registered sources are exposed.
+			$this->assertArrayHasKey( $name, $settings['blockBindingsSources'] );
+
+			// Check only the expected properties are included, and they have the proper value.
+			$expected_properties = array(
+				'label' => $properties->label,
+			);
+			// Add optional properties if they are defined.
+			if ( ! empty( $properties->uses_context ) ) {
+				$expected_properties['usesContext'] = $properties->uses_context;
+			}
+
+			$this->assertSameSets(
+				$expected_properties,
+				$settings['blockBindingsSources'][ $name ]
+			);
 		}
 	}
 }

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -720,4 +720,21 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * @ticket 61641
+	 */
+	public function test_get_block_editor_settings_block_bindings_sources() {
+		$block_editor_context              = new WP_Block_Editor_Context();
+		$settings                          = get_block_editor_settings( array(), $block_editor_context );
+		$registered_block_bindings_sources = get_all_registered_block_bindings_sources();
+
+		foreach ( $registered_block_bindings_sources as $name => $properties ) {
+			$registered_properties = get_object_vars( $properties );
+			// Remove name property as it is not part of the settings.
+			unset( $registered_properties['name'] );
+			$settings_properties = $settings['blockBindingsSources'][ $name ];
+			$this->assertSameSets( $registered_properties, $settings_properties );
+		}
+	}
 }

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -743,6 +743,8 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 		);
 		$settings        = get_block_editor_settings( array(), $block_editor_context );
 		$exposed_sources = $settings['blockBindingsSources'];
+		unregister_block_bindings_source( 'test/source-one' );
+		unregister_block_bindings_source( 'test/source-two' );
 		// It is expected to have 4 sources: the 2 registered sources in the test, and the 2 core sources.
 		$this->assertCount( 4, $exposed_sources );
 		$source_one = $exposed_sources['test/source-one'];


### PR DESCRIPTION
Originally explored in this other pull request: https://github.com/WordPress/wordpress-develop/pull/6456

## What?

It adds a new property to the editor settings to expose the block bindings sources registered in the server. This allows to reuse some of its properties like `label` and `uses_context` without having to replicate that in JavaScript.

There is a [related pull request in Gutenberg](https://github.com/WordPress/gutenberg/pull/63470), where these settings are being consumed.

## Why?

It makes some block bindings editor functionalities work by default, improving the user experience, and it simplifies how sources are registered in the client.

## How?

Add a new property including all the registered sources while the editor settings are being initialized.

Trac ticket: https://core.trac.wordpress.org/ticket/61641

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
