### PR TITLE
Restore React and ReactDOM umd builds

### DIFF
--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -96,6 +96,8 @@ module.exports = function (
 		'wp-polyfill-importmap.js': 'es-module-shims/dist/es-module-shims.wasm.js',
 		'moment.js': 'moment/moment.js',
 		'regenerator-runtime.js': 'regenerator-runtime/runtime.js',
+		'react.js': 'react/umd/react.development.js',
+		'react-dom.js': 'react-dom/umd/react-dom.development.js',
 	};
 
 	const minifiedVendors = {
@@ -109,6 +111,8 @@ module.exports = function (
 			'objectFitPolyfill/dist/objectFitPolyfill.min.js',
 		'wp-polyfill-inert.min.js': 'wicg-inert/dist/inert.min.js',
 		'moment.min.js': 'moment/min/moment.min.js',
+		'react.min.js': 'react/umd/react.production.min.js',
+		'react-dom.min.js': 'react-dom/umd/react-dom.production.min.js',
 	};
 
 	const minifyVendors = {

--- a/tools/webpack/vendors.js
+++ b/tools/webpack/vendors.js
@@ -4,8 +4,6 @@
 const { join } = require( 'path' );
 
 const importedVendors = {
-	react: { import: 'react', global: 'React' },
-	'react-dom': { import: 'react-dom', global: 'ReactDOM' },
 	'react-jsx-runtime': {
 		import: 'react/jsx-runtime',
 		global: 'ReactJSXRuntime',
@@ -21,7 +19,7 @@ module.exports = function (
 		: mode === 'production'
 		? 'build'
 		: 'src';
-    buildTarget = buildTarget + '/wp-includes/js/dist/vendor/';
+	buildTarget = buildTarget + '/wp-includes/js/dist/vendor/';
 	return [
 		...Object.entries( importedVendors ).flatMap( ( [ name, config ] ) => {
 			return [ 'production', 'development' ].map( ( currentMode ) => {
@@ -45,12 +43,9 @@ module.exports = function (
 						},
 					},
 
-					externals:
-						name === 'react'
-							? {}
-							: {
-									react: 'React',
-							  },
+					externals: {
+						react: 'React',
+					},
 				};
 			} );
 		} ),


### PR DESCRIPTION
In 6.6 we tried moving away from the deprecated React UMD builds, the issue we faced is that there's a warning that is triggered on the console because we're not using a separate impact for `createRoot`. (SCRIPT_DEBUG true and `npm run build`)

`Warning: You are importing createRoot from "react-dom" which is not supported. You should instead import it from "react-dom/client".`

This warning has been removed in React 19 though along with the removal of the UMD builds, so we should be able to revert this PR when we upgrade to React 19.

Trac ticket: https://core.trac.wordpress.org/ticket/61324

