### PR TITLE
Fix documentation of a _wp_preview_meta_filter() parameter

### DIFF
--- a/src/wp-includes/revision.php
+++ b/src/wp-includes/revision.php
@@ -1107,7 +1107,7 @@ function _wp_upgrade_revisions_of_post( $post, $revisions ) {
  * @param mixed  $value     Meta value to filter.
  * @param int    $object_id Object ID.
  * @param string $meta_key  Meta key to filter a value for.
- * @param bool   $single    Whether to return a single value. Default false.
+ * @param bool   $single    Whether to return a single value.
  * @return mixed Original meta value if the meta key isn't revisioned, the object doesn't exist,
  *               the post type is a revision or the post ID doesn't match the object ID.
  *               Otherwise, the revisioned meta value is returned for the preview.


### PR DESCRIPTION
Contrary to what was mentioned in the docblock, the `$single` parameter has no default value.

Trac ticket: https://core.trac.wordpress.org/ticket/61645

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
