### PR TITLE
In REST APIs, only prime meta data if there are registered keys

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -262,7 +262,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			$prepared_args['offset'] = $prepared_args['number'] * ( absint( $request['page'] ) - 1 );
 		}
 
-		// Don't overwrite the "update_post_meta_cache" value if it is already defined.
+		// Don't overwrite the "update_comment_meta_cache" value if it is already defined.
 		if ( ! isset( $prepared_args['update_comment_meta_cache'] ) ) {
 			$object_subtype         = isset( $prepared_args['post_type'] ) ? $prepared_args['post_type'] : '';
 			$should_prime_meta_keys = ! empty( get_registered_meta_keys( 'comment', $object_subtype ) );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -262,6 +262,20 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			$prepared_args['offset'] = $prepared_args['number'] * ( absint( $request['page'] ) - 1 );
 		}
 
+		// Don't overwrite the "update_post_meta_cache" value if it is already defined.
+		if ( ! isset( $prepared_args['update_post_meta_cache'] ) ) {
+			$object_subtype         = isset( $prepared_args['post_type'] ) ? $prepared_args['post_type'] : '';
+			$should_prime_meta_keys = ! empty( get_registered_meta_keys( 'comment', $object_subtype ) );
+			/**
+			 * Performance optimization. If there are no registered meta keys,
+			 * set "update_post_meta_cache" to false to avoid unnecessary priming of meta data.
+			 */
+			if ( ! $should_prime_meta_keys ) {
+				$prepared_args['update_comment_meta_cache']    = false;
+				$prepared_args['update_comment_post_cache'] = false;
+			}
+		}
+
 		/**
 		 * Filters WP_Comment_Query arguments when querying comments via the REST API.
 		 *

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -263,16 +263,15 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		}
 
 		// Don't overwrite the "update_post_meta_cache" value if it is already defined.
-		if ( ! isset( $prepared_args['update_post_meta_cache'] ) ) {
+		if ( ! isset( $prepared_args['update_comment_meta_cache'] ) ) {
 			$object_subtype         = isset( $prepared_args['post_type'] ) ? $prepared_args['post_type'] : '';
 			$should_prime_meta_keys = ! empty( get_registered_meta_keys( 'comment', $object_subtype ) );
 			/**
 			 * Performance optimization. If there are no registered meta keys,
-			 * set "update_post_meta_cache" to false to avoid unnecessary priming of meta data.
+			 * set "update_comment_meta_cache" to false to avoid unnecessary priming of meta data.
 			 */
 			if ( ! $should_prime_meta_keys ) {
-				$prepared_args['update_comment_meta_cache']    = false;
-				$prepared_args['update_comment_post_cache'] = false;
+				$prepared_args['update_comment_meta_cache'] = false;
 			}
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -267,8 +267,8 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			$object_subtype         = isset( $prepared_args['post_type'] ) ? $prepared_args['post_type'] : '';
 			$should_prime_meta_keys = ! empty( get_registered_meta_keys( 'comment', $object_subtype ) );
 			/**
-			 * Performance optimization. If there are no registered meta keys,
-			 * set "update_comment_meta_cache" to false to avoid unnecessary priming of meta data.
+			 * Performance optimization: if there are no registered meta keys,
+			 * set "update_comment_meta_cache" to false to avoid unnecessary priming of metadata.
 			 */
 			if ( ! $should_prime_meta_keys ) {
 				$prepared_args['update_comment_meta_cache'] = false;

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1157,8 +1157,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$object_subtype         = isset( $query_args['post_type'] ) ? $query_args['post_type'] : '';
 			$should_prime_meta_keys = ! empty( get_registered_meta_keys( 'post', $object_subtype ) );
 			/**
-			 * Performance optimization. If there are no registered meta keys,
-			 * set "update_post_meta_cache" to false to avoid unnecessary priming of meta data.
+			 * Performance optimization: if there are no registered meta keys,
+			 * set "update_post_meta_cache" to false to avoid unnecessary priming of metadata.
 			 */
 			if ( ! $should_prime_meta_keys ) {
 				$query_args['update_post_meta_cache'] = false;

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1152,29 +1152,20 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			}
 		}
 
-		$post_type = isset( $query_args['post_type'] ) ? $query_args['post_type'] : '';
-		// Conditionally prime meta data.
-		if ( ! $this->custom_should_prime_meta( 'post', $post_type ) ) {
-			$query_args['update_post_meta_cache'] = false;
-		}
-
-		return $query_args;
-	}
-
-	protected function custom_should_prime_meta( $object_type, $object_subtype ) {
-		global $wp_meta_keys;
-
-		if ( ! isset( $wp_meta_keys[ $object_type ] ) ) {
-			return false;
-		}
-
-		foreach ( $wp_meta_keys[ $object_type ] as $meta_key => $meta ) {
-			if ( empty( $object_subtype ) || $meta['object_subtype'] === $object_subtype ) {
-				return true;
+		// Don't overwrite the "update_post_meta_cache" value if it is already defined.
+		if ( ! isset( $query_args['update_post_meta_cache'] ) ) {
+			$object_subtype         = isset( $query_args['post_type'] ) ? $query_args['post_type'] : '';
+			$should_prime_meta_keys = ! empty( get_registered_meta_keys( 'post', $object_subtype ) );
+			/**
+			 * Performance optimization. If there are no registered meta keys,
+			 * set "update_post_meta_cache" to false to avoid unnecessary priming of meta data.
+			 */
+			if ( ! $should_prime_meta_keys ) {
+				$query_args['update_post_meta_cache'] = false;
 			}
 		}
 
-		return false;
+		return $query_args;
 	}
 
 	/**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1152,7 +1152,29 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			}
 		}
 
+		$post_type = isset( $query_args['post_type'] ) ? $query_args['post_type'] : '';
+		// Conditionally prime meta data.
+		if ( ! $this->custom_should_prime_meta( 'post', $post_type ) ) {
+			$query_args['update_post_meta_cache'] = false;
+		}
+
 		return $query_args;
+	}
+
+	protected function custom_should_prime_meta( $object_type, $object_subtype ) {
+		global $wp_meta_keys;
+
+		if ( ! isset( $wp_meta_keys[ $object_type ] ) ) {
+			return false;
+		}
+
+		foreach ( $wp_meta_keys[ $object_type ] as $meta_key => $meta ) {
+			if ( empty( $object_subtype ) || $meta['object_subtype'] === $object_subtype ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
@@ -295,6 +295,18 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			}
 		}
 
+		// Don't overwrite the "update_term_meta_cache" value if it is already defined.
+		if ( ! isset( $prepared_args['update_term_meta_cache'] ) ) {
+			$should_prime_meta_keys = ! empty( get_registered_meta_keys( 'term', $taxonomy_obj->name ) );
+			/**
+			 * Performance optimization: if there are no registered meta keys,
+			 * set "update_term_meta_cache" to false to avoid unnecessary priming of metadata.
+			 */
+			if ( ! $should_prime_meta_keys ) {
+				$prepared_args['update_term_meta_cache'] = false;
+			}
+		}
+
 		/**
 		 * Filters get_terms() arguments when querying terms via the REST API.
 		 *

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
@@ -297,7 +297,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 
 		// Don't overwrite the "update_term_meta_cache" value if it is already defined.
 		if ( ! isset( $prepared_args['update_term_meta_cache'] ) ) {
-			$should_prime_meta_keys = ! empty( get_registered_meta_keys( 'term', $taxonomy_obj->name ) );
+			$should_prime_meta_keys = ! empty( get_registered_meta_keys( 'term', $prepared_args['taxonomy'] ) );
 			/**
 			 * Performance optimization: if there are no registered meta keys,
 			 * set "update_term_meta_cache" to false to avoid unnecessary priming of metadata.

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -5457,8 +5457,6 @@ Shankle pork chop prosciutto ribeye ham hock pastrami. T-bone shank brisket baco
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		rest_get_server()->dispatch( $request );
 
-		unregister_post_meta( 'post', 'test_meta_key' );
-
 		if ( empty( $action->get_args()[0][0]->query_vars ) || ! is_array( $action->get_args()[0][0]->query_vars ) ) {
 			$this->fail( 'Query vars were not captured.' );
 		}

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -1655,6 +1655,15 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$filter = new MockAction();
 		add_filter( 'update_post_metadata_cache', array( $filter, 'filter' ), 10, 2 );
 
+		// Register a meta key to ensure the parent post cache is primed. See @ticket 57749.
+		register_post_meta(
+			'attachment',
+			'test_attachment_key',
+			array(
+				'show_in_rest' => true,
+			)
+		);
+
 		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
 		rest_get_server()->dispatch( $request );
 

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -1667,6 +1667,8 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$request = new WP_REST_Request( 'GET', '/wp/v2/media' );
 		rest_get_server()->dispatch( $request );
 
+		unregister_post_meta( 'attachment', 'test_attachment_key' );
+
 		$args = $filter->get_args();
 		$last = end( $args );
 		$this->assertIsArray( $last, 'The last value is not an array' );

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -5488,7 +5488,8 @@ Shankle pork chop prosciutto ribeye ham hock pastrami. T-bone shank brisket baco
 	}
 
 	public function capture_query_vars( WP_Query $query ) {
-		// Capture the query vars.
+		// Capture the query variables only if they haven't been captured already
+		// as only the first query is relevant.
 		if ( null !== $this->captured_query_vars ) {
 			return;
 		}

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -5435,7 +5435,7 @@ Shankle pork chop prosciutto ribeye ham hock pastrami. T-bone shank brisket baco
 		$query_vars           = $action->get_args()[0][0]->query_vars;
 		$meta_cache_is_primed = ! array_key_exists( 'update_post_meta_cache', $query_vars ) || true === $query_vars['update_post_meta_cache'];
 
-		// Check if the captured query vars have 'update_post_meta_cache' set to true
+		// Check if the captured query vars have 'update_post_meta_cache' set to true.
 		$this->assertTrue(
 			$meta_cache_is_primed,
 			'Meta cache is not primed as expected when a custom meta key is registered.'

--- a/tests/phpunit/tests/rest-api/rest-term-meta-fields.php
+++ b/tests/phpunit/tests/rest-api/rest-term-meta-fields.php
@@ -1338,8 +1338,8 @@ class WP_Test_REST_Term_Meta_Fields extends WP_Test_REST_TestCase {
 	 *
 	 * @dataProvider data_term_meta_cache_is_primed_when_there_are_registered_keys
 	 *
-	 * @param string $taxonomy Taxonomy being tested.
-	 * @param string $route    REST API route to query for the test.
+	 * @param string $taxonomy The taxonomy being tested.
+	 * @param string $route    The REST API route to query for the test.
 	 */
 	public function test_term_meta_cache_is_primed_when_there_are_registered_keys( $taxonomy, $route ) {
 		global $wp_meta_keys;
@@ -1382,8 +1382,8 @@ class WP_Test_REST_Term_Meta_Fields extends WP_Test_REST_TestCase {
 	 *
 	 * @covers WP_REST_Terms_Controller::get_items
 	 *
-	 * @param string $taxonomy Taxonomy being tested.
-	 * @param string $route    REST API route to query for the test.
+	 * @param string $taxonomy The taxonomy being tested.
+	 * @param string $route    The REST API route to query for the test.
 	*/
 	public function test_term_meta_cache_is_not_primed_when_there_are_no_registered_keys( $taxonomy, $route ) {
 		global $wp_meta_keys;

--- a/tests/phpunit/tests/rest-api/rest-term-meta-fields.php
+++ b/tests/phpunit/tests/rest-api/rest-term-meta-fields.php
@@ -1332,6 +1332,77 @@ class WP_Test_REST_Term_Meta_Fields extends WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * @ticket 57749
+	 *
+	 * @covers WP_REST_Terms_Controller::get_items
+	 */
+	public function test_term_meta_cache_is_primed_when_there_are_registered_keys() {
+		global $wp_meta_keys;
+		$wp_meta_keys = array();
+
+		register_term_meta(
+			'category',
+			'test_meta_key',
+			array(
+				'show_in_rest' => true,
+			)
+		);
+
+		$action = new MockAction();
+		add_filter( 'pre_get_posts', array( $action, 'action' ), 10, 2 );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
+		rest_get_server()->dispatch( $request );
+
+		unregister_post_meta( 'post', 'test_meta_key' );
+
+		if ( empty( $action->get_args()[0][0]->query_vars ) || ! is_array( $action->get_args()[0][0]->query_vars ) ) {
+			$this->fail( 'Query vars were not captured.' );
+		}
+
+		$query_vars           = $action->get_args()[0][0]->query_vars;
+		$meta_cache_is_primed = ! array_key_exists( 'update_post_meta_cache', $query_vars ) || true === $query_vars['update_post_meta_cache'];
+
+		// Check if the captured query vars have 'update_post_meta_cache' set to true
+		$this->assertTrue(
+			$meta_cache_is_primed,
+			'Meta cache is not primed as expected when a custom meta key is registered.'
+		);
+	}
+
+	/**
+	 * @ticket 57749
+	 *
+	 * @covers WP_REST_Terms_Controller::get_items
+	 */
+	public function test_term_meta_cache_is_not_primed_when_there_are_no_registered_keys() {
+		global $wp_meta_keys;
+		$wp_meta_keys = array();
+
+		$action = new MockAction();
+		add_filter( 'pre_get_posts', array( $action, 'action' ), 10, 2 );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		rest_get_server()->dispatch( $request );
+
+		if ( empty( $action->get_args()[0][0]->query_vars ) || ! is_array( $action->get_args()[0][0]->query_vars ) ) {
+			$this->fail( 'Query vars were not captured.' );
+		}
+
+		$query_vars = $action->get_args()[0][0]->query_vars;
+
+		$this->assertArrayHasKey(
+			'update_post_meta_cache',
+			$query_vars,
+			'Query vars should contain the key "update_post_meta_cache".'
+		);
+		$this->assertFalse(
+			$query_vars['update_post_meta_cache'],
+			'The "update_post_meta_cache" key should be false when no meta keys are registered.'
+		);
+	}
+
+	/**
 	 * Internal function used to disable an insert query which
 	 * will trigger a wpdb error for testing purposes.
 	 */


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/57749

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
