### PR TITLE
Auto convert HEIC images to JPEG on upload

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -639,6 +639,7 @@ add_action( 'wp_playlist_scripts', 'wp_playlist_scripts' );
 add_action( 'customize_controls_enqueue_scripts', 'wp_plupload_default_settings' );
 add_action( 'plugins_loaded', '_wp_add_additional_image_sizes', 0 );
 add_filter( 'plupload_default_settings', 'wp_show_heic_upload_error' );
+add_filter( 'wp_handle_upload_prefilter', 'wp_auto_convert_heic_images' );
 
 // Nav menu.
 add_filter( 'nav_menu_item_id', '_nav_menu_item_id_use_once', 10, 2 );


### PR DESCRIPTION
Automatically converts HEIC images to JPEG on upload. See ticket for details and motivation.

Implementation is based on the GPL2 [HEIC Support](https://wordpress.org/plugins/heic-support/) plugin written by @csalzano. Attribution is included in the doc comment.

Unlike the HEIC Support plugin, HEIC images are _always_ converted to JPEG and the original file is deleted. This is what the majority of users will want and aligns with what Apple does in its apps that support HEIC. Website admins can customise the behaviour by installing a plugin (e.g. HEIC Support) or by removing the hook:

```php
remove_filter( 'wp_handle_upload_prefilter', 'wp_auto_convert_heic_images' );
```

The [existing error message](https://github.com/WordPress/wordpress-develop/blob/5b0006ca9b5408aa73b6dc71fb5b3ebf85f497ec/src/wp-includes/script-loader.php#L1006) that appears when you upload a HEIC image that encourages the user to convert the image and try again is suppressed when auto-conversion is enabled.

Here's a video showing how this looks:

https://github.com/user-attachments/assets/b59e9765-6bda-4887-b41f-9eea9d147297

You'll note in the video that the Image block doesn't look great while the HEIC is uploading. This is because I'm using a browser that doesn't support HEIC and so the Image block isn't able to show a preview. We'll need to improve this in Gutenberg as a separate PR by e.g. showing a nicer placeholder when there is no image available.

Trac ticket: https://core.trac.wordpress.org/ticket/53645