### PR TITLE
Layout: Fix invalid css for nested fullwidth layouts with zero padding applied

### DIFF
--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -322,14 +322,22 @@ function wp_get_layout_style( $selector, $layout, $has_block_gap_support = false
 			 * They're added separately because padding might only be set on one side.
 			 */
 			if ( isset( $block_spacing_values['declarations']['padding-right'] ) ) {
-				$padding_right   = $block_spacing_values['declarations']['padding-right'];
+				$padding_right = $block_spacing_values['declarations']['padding-right'];
+				// Add unit if 0.
+				if ( '0' === $padding_right ) {
+					$padding_right = '0px';
+				}
 				$layout_styles[] = array(
 					'selector'     => "$selector > .alignfull",
 					'declarations' => array( 'margin-right' => "calc($padding_right * -1)" ),
 				);
 			}
 			if ( isset( $block_spacing_values['declarations']['padding-left'] ) ) {
-				$padding_left    = $block_spacing_values['declarations']['padding-left'];
+				$padding_left = $block_spacing_values['declarations']['padding-left'];
+				// Add unit if 0.
+				if ( '0' === $padding_left ) {
+					$padding_left = '0px';
+				}
 				$layout_styles[] = array(
 					'selector'     => "$selector > .alignfull",
 					'declarations' => array( 'margin-left' => "calc($padding_left * -1)" ),


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Backport https://github.com/WordPress/gutenberg/pull/63436 to core.

In the Layout block support, handle `0` values for padding as `0px` in `calc()` rules. This resolves a bug for nested fullwidth layouts when zero padding is applied. Due to how `calc()` works, without supplying the unit, the rule will not work, resulting in a horizontal scrollbar. For more information see [the original issue](https://github.com/WordPress/gutenberg/issues/63432) in the Gutenberg repo, or [the fix](https://github.com/WordPress/gutenberg/pull/63436).

### Testing instructions

1. Open a post or page.
2. Open the code editor within the top editor options panel.
3. Copy and paste [this gist](https://gist.github.com/richtabor/8c9422e5ac760641b5a0a4874b8fd2c9), which configures the conditions properly (nested align full blocks, with padding zeroed out on the parent).
4. See no horizontal scroll in the site front end.

Note: the issue will still be present in the post editor until the JS packages that include the JS changes from https://github.com/WordPress/gutenberg/pull/63436 are included in core.

Trac ticket: https://core.trac.wordpress.org/ticket/61656

Props: @richtabor for the fix.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
