### PR TITLE
Add `wp-theme-<name>` and `wp-child-theme-<name>` classes to body tag

### DIFF
--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -210,7 +210,7 @@ if ( $current_screen->is_block_editor() ) {
 }
 
 // Append the active theme's name as a CSS class to the body class.
-$admin_body_class .= ' wp-theme-' . sanitize_html_class( get_option( 'template' ) );
+$admin_body_class .= ' wp-theme-' . sanitize_html_class( get_template() );
 
 // If a child theme is active, append the child theme's name as an additional CSS class.
 if ( is_child_theme() ) {

--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -214,7 +214,7 @@ $admin_body_class .= ' wp-theme-' . sanitize_html_class( get_template() );
 
 // If a child theme is active, append the child theme's name as an additional CSS class.
 if ( is_child_theme() ) {
-	$admin_body_class .= ' wp-child-theme-' . sanitize_html_class( get_option( 'stylesheet' ) );
+	$admin_body_class .= ' wp-child-theme-' . sanitize_html_class( get_stylesheet() );
 }
 
 $error_get_last = error_get_last();

--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -209,6 +209,14 @@ if ( $current_screen->is_block_editor() ) {
 	$admin_body_class .= ' block-editor-page wp-embed-responsive';
 }
 
+// Append the active theme's name as a CSS class to the body class.
+$admin_body_class .= ' wp-theme-' . sanitize_html_class( get_option( 'template' ) );
+
+// If a child theme is active, append the child theme's name as an additional CSS class.
+if ( is_child_theme() ) {
+	$admin_body_class .= ' wp-child-theme-' . sanitize_html_class( get_option( 'stylesheet' ) );
+}
+
 $error_get_last = error_get_last();
 
 // Print a CSS class to make PHP errors visible.

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -836,6 +836,14 @@ function get_body_class( $css_class = '' ) {
 		}
 	}
 
+	// Add 'wp-theme-<name>' to default body classes.
+	$classes[] = 'wp-theme-' . sanitize_html_class( get_option( 'template' ) );
+
+	if ( is_child_theme() ) {
+		// Add 'wp-child-theme-<name>' to the body classes
+		$classes[] = 'wp-child-theme-' . sanitize_html_class( get_option( 'stylesheet' ) );
+	}
+
 	if ( ! empty( $css_class ) ) {
 		if ( ! is_array( $css_class ) ) {
 			$css_class = preg_split( '#\s+#', $css_class );

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -836,11 +836,11 @@ function get_body_class( $css_class = '' ) {
 		}
 	}
 
-	// Add 'wp-theme-<name>' to default body classes.
+	// Add the active theme's name as a CSS class to the body classes array.
 	$classes[] = 'wp-theme-' . sanitize_html_class( get_option( 'template' ) );
 
+	// If a child theme is active, add the child theme's name as an additional CSS class to the body classes array.
 	if ( is_child_theme() ) {
-		// Add 'wp-child-theme-<name>' to the body classes
 		$classes[] = 'wp-child-theme-' . sanitize_html_class( get_option( 'stylesheet' ) );
 	}
 

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -841,7 +841,7 @@ function get_body_class( $css_class = '' ) {
 
 	// If a child theme is active, add the child theme's name as an additional CSS class to the body classes array.
 	if ( is_child_theme() ) {
-		$classes[] = 'wp-child-theme-' . sanitize_html_class( get_option( 'stylesheet' ) );
+		$classes[] = 'wp-child-theme-' . sanitize_html_class( get_stylesheet() );
 	}
 
 	if ( ! empty( $css_class ) ) {

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -837,7 +837,7 @@ function get_body_class( $css_class = '' ) {
 	}
 
 	// Add the active theme's name as a CSS class to the body classes array.
-	$classes[] = 'wp-theme-' . sanitize_html_class( get_option( 'template' ) );
+	$classes[] = 'wp-theme-' . sanitize_html_class( get_template() );
 
 	// If a child theme is active, add the child theme's name as an additional CSS class to the body classes array.
 	if ( is_child_theme() ) {


### PR DESCRIPTION
## Description

This PR introduces new classes to the body tag in WordPress themes. The classes `wp-theme-<name>` and `wp-child-theme-<name>` (if child theme) are added, where `<name>` represents the sanitized name of the active theme and child theme, respectively.

## Changes Made

- Added `wp-theme-<name>` class to the body tag for the current theme.
- Added `wp-child-theme-<name>` class to the body tag for the current theme (if child theme).

## Screenshots

- For `twentytwentyfour` theme

<img width="1470" alt="theme" src="https://github.com/user-attachments/assets/dffa6d5a-da71-4c3a-9391-72144d556271">

- For a child theme named `childtheme` having `twentytwentyfour` as parent theme

<img width="1470" alt="child-theme" src="https://github.com/user-attachments/assets/32b89d6d-fd6e-4ccf-b0c5-0a2e589aacd6">

## Trac ticket: https://core.trac.wordpress.org/ticket/19736
