### PR TITLE
Tests/HTMLAPI: fix newly introduced PHP 8.2 deprecation notice

### DIFF
--- a/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
@@ -254,7 +254,7 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 		}
 
 		if ( '' !== $text_node ) {
-			$output .= "${text_node}\"\n";
+			$output .= "{$text_node}\"\n";
 		}
 
 		// Tests always end with a trailing newline.


### PR DESCRIPTION
The `${` syntax for string interpolation was deprecated in PHP 8.2 and should not be used anymore.

Ref: https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation


Trac ticket: https://core.trac.wordpress.org/ticket/61530
Trac ticket: https://core.trac.wordpress.org/ticket/59654

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
