### PR TITLE
Tests/InteractivityAPI: stabilize and improve maintainability

### DIFF
--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPIFunctions.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPIFunctions.php
@@ -332,16 +332,18 @@ class Tests_Interactivity_API_wpInteractivityAPIFunctions extends WP_UnitTestCas
 				),
 			)
 		);
-		function test_render_block_data( $parsed_block ) {
+
+		$test_render_block_data = static function ( $parsed_block ) {
 			$parsed_block['testKey'] = true;
 			return $parsed_block;
-		}
-		add_filter( 'render_block_data', 'test_render_block_data' );
+		};
+
+		add_filter( 'render_block_data', $test_render_block_data );
 		$post_content      = '<!-- wp:test/custom-directive-block /-->';
 		$processed_content = do_blocks( $post_content );
 		$processor         = new WP_HTML_Tag_Processor( $processed_content );
 		$processor->next_tag( array( 'data-wp-interactive' => 'nameSpace' ) );
-		remove_filter( 'render_block_data', 'test_render_block_data' );
+		remove_filter( 'render_block_data', $test_render_block_data );
 		unregister_block_type( 'test/custom-directive-block' );
 		$this->assertSame( 'test', $processor->get_attribute( 'value' ) );
 	}

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPIFunctions.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPIFunctions.php
@@ -354,27 +354,43 @@ class Tests_Interactivity_API_wpInteractivityAPIFunctions extends WP_UnitTestCas
 	 *
 	 * @ticket 60356
 	 *
-	 * @covers wp_interactivity_data_wp_context
+	 * @covers       wp_interactivity_data_wp_context
+	 * @dataProvider data_wp_interactivity_data_wp_context_with_different_arrays
+	 *
+	 * @param array  $context  Context to encode.
+	 * @param string $expected Expected function output.
 	 */
-	public function test_wp_interactivity_data_wp_context_with_different_arrays() {
-		$this->assertSame( 'data-wp-context=\'{}\'', wp_interactivity_data_wp_context( array() ) );
-		$this->assertSame(
-			'data-wp-context=\'{"a":1,"b":"2","c":true}\'',
-			wp_interactivity_data_wp_context(
-				array(
+	public function test_wp_interactivity_data_wp_context_with_different_arrays( $context, $expected ) {
+		$this->assertSame( $expected, wp_interactivity_data_wp_context( $context ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_wp_interactivity_data_wp_context_with_different_arrays() {
+		return array(
+			'empty array'                                  => array(
+				'context'  => array(),
+				'expected' => 'data-wp-context=\'{}\'',
+			),
+			'associative array with mixed values'          => array(
+				'context'  => array(
 					'a' => 1,
 					'b' => '2',
 					'c' => true,
-				)
-			)
-		);
-		$this->assertSame(
-			'data-wp-context=\'{"a":[1,2]}\'',
-			wp_interactivity_data_wp_context( array( 'a' => array( 1, 2 ) ) )
-		);
-		$this->assertSame(
-			'data-wp-context=\'[1,2]\'',
-			wp_interactivity_data_wp_context( array( 1, 2 ) )
+				),
+				'expected' => 'data-wp-context=\'{"a":1,"b":"2","c":true}\'',
+			),
+			'associative array with nested array as value' => array(
+				'context'  => array( 'a' => array( 1, 2 ) ),
+				'expected' => 'data-wp-context=\'{"a":[1,2]}\'',
+			),
+			'array without keys, integer values'           => array(
+				'context'  => array( 1, 2 ),
+				'expected' => 'data-wp-context=\'[1,2]\'',
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPIFunctions.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPIFunctions.php
@@ -400,28 +400,48 @@ class Tests_Interactivity_API_wpInteractivityAPIFunctions extends WP_UnitTestCas
 	 *
 	 * @ticket 60356
 	 *
-	 * @covers wp_interactivity_data_wp_context
+	 * @covers       wp_interactivity_data_wp_context
+	 * @dataProvider data_wp_interactivity_data_wp_context_with_different_arrays_and_a_namespace
+	 *
+	 * @param array  $context  Context to encode.
+	 * @param string $store    Store namespace.
+	 * @param string $expected Expected function output.
 	 */
-	public function test_wp_interactivity_data_wp_context_with_different_arrays_and_a_namespace() {
-		$this->assertSame( 'data-wp-context=\'myPlugin::{}\'', wp_interactivity_data_wp_context( array(), 'myPlugin' ) );
-		$this->assertSame(
-			'data-wp-context=\'myPlugin::{"a":1,"b":"2","c":true}\'',
-			wp_interactivity_data_wp_context(
-				array(
+	public function test_wp_interactivity_data_wp_context_with_different_arrays_and_a_namespace( $context, $store, $expected ) {
+		$this->assertSame( $expected, wp_interactivity_data_wp_context( $context, $store ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_wp_interactivity_data_wp_context_with_different_arrays_and_a_namespace() {
+		return array(
+			'empty array'                                  => array(
+				'context'  => array(),
+				'store'    => 'myPlugin',
+				'expected' => 'data-wp-context=\'myPlugin::{}\'',
+			),
+			'associative array with mixed values'          => array(
+				'context'  => array(
 					'a' => 1,
 					'b' => '2',
 					'c' => true,
 				),
-				'myPlugin'
-			)
-		);
-		$this->assertSame(
-			'data-wp-context=\'myPlugin::{"a":[1,2]}\'',
-			wp_interactivity_data_wp_context( array( 'a' => array( 1, 2 ) ), 'myPlugin' )
-		);
-		$this->assertSame(
-			'data-wp-context=\'myPlugin::[1,2]\'',
-			wp_interactivity_data_wp_context( array( 1, 2 ), 'myPlugin' )
+				'store'    => 'myPlugin',
+				'expected' => 'data-wp-context=\'myPlugin::{"a":1,"b":"2","c":true}\'',
+			),
+			'associative array with nested array as value' => array(
+				'context'  => array( 'a' => array( 1, 2 ) ),
+				'store'    => 'myPlugin',
+				'expected' => 'data-wp-context=\'myPlugin::{"a":[1,2]}\'',
+			),
+			'array without keys, integer values'           => array(
+				'context'  => array( 1, 2 ),
+				'store'    => 'myPlugin',
+				'expected' => 'data-wp-context=\'myPlugin::[1,2]\'',
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPIFunctions.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPIFunctions.php
@@ -453,13 +453,40 @@ class Tests_Interactivity_API_wpInteractivityAPIFunctions extends WP_UnitTestCas
 	 *
 	 * @ticket 60356
 	 *
-	 * @covers wp_interactivity_data_wp_context
+	 * @covers       wp_interactivity_data_wp_context
+	 * @dataProvider data_wp_interactivity_data_wp_context_with_json_flags
+	 *
+	 * @param array  $context  Context to encode.
+	 * @param string $expected Expected function output.
 	 */
-	public function test_wp_interactivity_data_wp_context_with_json_flags() {
-		$this->assertSame( 'data-wp-context=\'{"tag":"\u003Cfoo\u003E"}\'', wp_interactivity_data_wp_context( array( 'tag' => '<foo>' ) ) );
-		$this->assertSame( 'data-wp-context=\'{"apos":"\u0027bar\u0027"}\'', wp_interactivity_data_wp_context( array( 'apos' => "'bar'" ) ) );
-		$this->assertSame( 'data-wp-context=\'{"quot":"\u0022baz\u0022"}\'', wp_interactivity_data_wp_context( array( 'quot' => '"baz"' ) ) );
-		$this->assertSame( 'data-wp-context=\'{"amp":"T\u0026T"}\'', wp_interactivity_data_wp_context( array( 'amp' => 'T&T' ) ) );
+	public function test_wp_interactivity_data_wp_context_with_json_flags( $context, $expected ) {
+		$this->assertSame( $expected, wp_interactivity_data_wp_context( $context ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_wp_interactivity_data_wp_context_with_json_flags() {
+		return array(
+			'value contains <> brackets'        => array(
+				'context'  => array( 'tag' => '<foo>' ),
+				'expected' => 'data-wp-context=\'{"tag":"\u003Cfoo\u003E"}\'',
+			),
+			'value contains single quote chars' => array(
+				'context'  => array( 'apos' => "'bar'" ),
+				'expected' => 'data-wp-context=\'{"apos":"\u0027bar\u0027"}\'',
+			),
+			'value contains double quote chars' => array(
+				'context'  => array( 'quot' => '"baz"' ),
+				'expected' => 'data-wp-context=\'{"quot":"\u0022baz\u0022"}\'',
+			),
+			'value contains & ampersand'        => array(
+				'context'  => array( 'amp' => 'T&T' ),
+				'expected' => 'data-wp-context=\'{"amp":"T\u0026T"}\'',
+			),
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Tests/wpInteractivityAPIFunctions: don't declare nested named function

Once the `test_process_directives_when_block_is_filtered()` method has run, the named `test_render_block_data()` function declared nested within becomes part of the global namespace, which could cause problems for other tests.

Quite apart from the fact that the name starting with `test_`  is confusing (as methods prefixed with `test_` are supposed to be test methods to be run by PHPUnit).

Using a closure for this callback fixes the issue.

### Tests/test_wp_interactivity_data_wp_context_with_different_arrays(): use data provider

Refactor the test to use a data provider with named test cases.

This is better as:
1. One failing test will not block the other tests from running.
2. Each test is now referenced by name in any error message, making it more straight forward to see which test failed.
3. The test no longer contains multiple assertions.
3. It makes it more straight forward to add additional tests.

### Tests/test_wp_interactivity_data_wp_context_with_different_arrays_and_a_namespace(): use data provider

Refactor the test to use a data provider with named test cases.

This is better as:
1. One failing test will not block the other tests from running.
2. Each test is now referenced by name in any error message, making it more straight forward to see which test failed.
3. The test no longer contains multiple assertions.
3. It makes it more straight forward to add additional tests.

### Tests/test_wp_interactivity_data_wp_context_with_json_flags(): use data provider

Refactor the test to use a data provider with named test cases.

This is better as:
1. One failing test will not block the other tests from running.
2. Each test is now referenced by name in any error message, making it more straight forward to see which test failed.
3. The test no longer contains multiple assertions.
3. It makes it more straight forward to add additional tests.

Trac ticket: https://core.trac.wordpress.org/ticket/61530

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
