### PR TITLE
HTML API: Implement step_in_caption

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -3049,7 +3049,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * This internal function performs the 'in caption' insertion mode
 	 * logic for the generalized WP_HTML_Processor::step() function.
 	 *
-	 * @since 6.7.0 Stub implementation.
+	 * @since 6.7.0
 	 *
 	 * @throws WP_HTML_Unsupported_Exception When encountering unsupported HTML input.
 	 *
@@ -3059,7 +3059,70 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @return bool Whether an element was found.
 	 */
 	private function step_in_caption(): bool {
-		$this->bail( 'No support for parsing in the ' . WP_HTML_Processor_State::INSERTION_MODE_IN_CAPTION . ' state.' );
+		$tag_name = $this->get_tag();
+		$op_sigil = $this->is_tag_closer() ? '-' : '+';
+		$op       = "{$op_sigil}{$tag_name}";
+
+		switch ( $op ) {
+			/*
+			 * > An end tag whose tag name is "caption"
+			 * > A start tag whose tag name is one of: "caption", "col", "colgroup", "tbody", "td", "tfoot", "th", "thead", "tr"
+			 * > An end tag whose tag name is "table"
+			 *
+			 * These tag handling rules are identical except for the final instruction.
+			 * Handle them in a single block.
+			 */
+			case '-CAPTION':
+			case '+CAPTION':
+			case '+COL':
+			case '+COLGROUP':
+			case '+TBODY':
+			case '+TD':
+			case '+TFOOT':
+			case '+TH':
+			case '+THEAD':
+			case '+TR':
+			case '-TABLE':
+				if ( ! $this->state->stack_of_open_elements->has_element_in_table_scope( 'CAPTION' ) ) {
+					// @todo Indicate a parse error once it's possible.
+					return $this->step();
+				}
+				$this->generate_implied_end_tags();
+				if ( ! $this->state->stack_of_open_elements->current_node_is( 'CAPTION' ) ) {
+					// @todo Indicate a parse error once it's possible.
+				}
+				$this->state->stack_of_open_elements->pop_until( 'CAPTION' );
+				$this->state->active_formatting_elements->clear_up_to_last_marker();
+				$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_TABLE;
+
+				// If this is not a CAPTION end tag, the token should be reprocessed.
+				if ( '-CAPTION' === $op ) {
+					return true;
+				}
+				return $this->step( self::REPROCESS_CURRENT_NODE );
+
+			/**
+			 * > An end tag whose tag name is one of: "body", "col", "colgroup", "html", "tbody", "td", "tfoot", "th", "thead", "tr"
+			 */
+			case '-BODY':
+			case '-COL':
+			case '-COLGROUP':
+			case '-HTML':
+			case '-TBODY':
+			case '-TD':
+			case '-TFOOT':
+			case '-TH':
+			case '-THEAD':
+			case '-TR':
+				// @todo Indicate a parse error once it's possible.
+				return $this->step();
+		}
+
+		/**
+		 * > Anything else
+		 * >   Process the token using the rules for the "in body" insertion mode.
+		 */
+		return $this->step_in_body();
 	}
 
 	/**

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -3084,13 +3084,15 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '+TR':
 			case '-TABLE':
 				if ( ! $this->state->stack_of_open_elements->has_element_in_table_scope( 'CAPTION' ) ) {
-					// @todo Indicate a parse error once it's possible.
+					// Parse error: ignore the token.
 					return $this->step();
 				}
+
 				$this->generate_implied_end_tags();
 				if ( ! $this->state->stack_of_open_elements->current_node_is( 'CAPTION' ) ) {
 					// @todo Indicate a parse error once it's possible.
 				}
+
 				$this->state->stack_of_open_elements->pop_until( 'CAPTION' );
 				$this->state->active_formatting_elements->clear_up_to_last_marker();
 				$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_IN_TABLE;
@@ -3114,7 +3116,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '-TH':
 			case '-THEAD':
 			case '-TR':
-				// @todo Indicate a parse error once it's possible.
+				// Parse error: ignore the token.
 				return $this->step();
 		}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61576

This builds on TABLE support from https://github.com/WordPress/wordpress-develop/pull/6040 (merged here).

HTML5-lib test change (`./vendor/bin/phpunit --group html-api-html5lib-tests`, (compared with https://github.com/WordPress/wordpress-develop/pull/6040):

```diff
-Tests: 609, Assertions: 377, Skipped: 232.
+Tests: 609, Assertions: 384, Skipped: 225.
```


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
