### PR TITLE
Adds the missing files to the $_old_files array for 6.6

### DIFF
--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -765,6 +765,11 @@ $_old_files = array(
 	'wp-admin/images/about-header-freedoms.svg',
 	'wp-admin/images/about-header-contribute.svg',
 	'wp-admin/images/about-header-background.svg',
+	// 6.6
+	'wp-includes/blocks/block/editor.css',
+	'wp-includes/blocks/block/editor.min.css',
+	'wp-includes/blocks/block/editor-rtl.css',
+	'wp-includes/blocks/block/editor-rtl.min.css',
 );
 
 /**


### PR DESCRIPTION
Adds the following files to the `$_old_files` array for 6.6:

```
$ svn diff --summarize https://core.svn.wordpress.org/tags/6.5 https://core.svn.wordpress.org/tags/6.6 | grep '^D'
D       https://core.svn.wordpress.org/tags/6.5/wp-includes/blocks/block/editor.css
D       https://core.svn.wordpress.org/tags/6.5/wp-includes/blocks/block/editor.min.css
D       https://core.svn.wordpress.org/tags/6.5/wp-includes/blocks/block/editor-rtl.css
D       https://core.svn.wordpress.org/tags/6.5/wp-includes/blocks/block/editor-rtl.min.css
```

Originally flagged as false positives, these specific files did exist in 6.4.5 and 6.5.5, but no longer exist in 6.6.

Trac ticket: https://core.trac.wordpress.org/ticket/61665

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
