### PR TITLE
get_comment_author(): fix fatal error when the incoming object does not have an ID.

### DIFF
--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -24,7 +24,13 @@
 function get_comment_author( $comment_id = 0 ) {
 	$comment = get_comment( $comment_id );
 
-	$comment_id = ! empty( $comment->comment_ID ) ? $comment->comment_ID : (string) $comment_id;
+	if ( ! empty( $comment->comment_ID ) ) {
+		$comment_id = $comment->comment_ID;
+	} elseif ( is_scalar( $comment_id ) ) {
+		$comment_id = (string) $comment_id;
+	} else {
+		$comment_id = '';
+	}
 
 	if ( empty( $comment->comment_author ) ) {
 		$user = ! empty( $comment->user_id ) ? get_userdata( $comment->user_id ) : false;

--- a/tests/phpunit/tests/comment/getCommentAuthor.php
+++ b/tests/phpunit/tests/comment/getCommentAuthor.php
@@ -56,4 +56,58 @@ class Tests_Comment_GetCommentAuthor extends WP_UnitTestCase {
 
 		get_comment_author( self::$non_existent_comment_id ); // Non-existent comment ID.
 	}
+
+	/**
+	 * @ticket 61681
+	 *
+	 * @dataProvider data_should_return_author_when_given_object_without_comment_id
+	 *
+	 * @param stdClass $comment_props Comment properties test data.
+	 * @param string   $expected      The expected result.
+	 * @param array    $user_data     Optional. User data for creating an author. Default empty array.
+	 */
+	public function test_should_return_author_when_given_object_without_comment_id( $comment_props, $expected, $user_data = array() ) {
+		if ( ! empty( $comment_props->user_id ) ) {
+			$user                   = self::factory()->user->create_and_get( $user_data );
+			$comment_props->user_id = $user->ID;
+		}
+		$comment = new WP_Comment( $comment_props );
+		$this->assertSame( $expected, get_comment_author( $comment ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_should_return_author_when_given_object_without_comment_id() {
+		return array(
+			'with no author'             => array(
+				'comment_props' => new stdClass(),
+				'expected'      => 'Anonymous',
+			),
+			'with author name'           => array(
+				'comment_props' => (object) array(
+					'comment_author' => 'tester1',
+				),
+				'expected'      => 'tester1',
+			),
+			'with author name, empty ID' => array(
+				'comment_props' => (object) array(
+					'comment_author' => 'tester2',
+					'comment_ID'     => '',
+				),
+				'expected'      => 'tester2',
+			),
+			'with author ID'             => array(
+				'comment_props' => (object) array(
+					'user_id' => 1, // populates in the test with an actual user ID.
+				),
+				'expected'      => 'Tester3',
+				'user_data'     => array(
+					'display_name' => 'Tester3',
+				),
+			),
+		);
+	}
 }


### PR DESCRIPTION
If an instance of `WP_Comment` is passed to `get_comment_author()`  without an ID (either before the comment is saved in the database or somehow the ID is reset), a fatal error can happen.

See the fatal error in action when attempting to type cast an object into a string https://3v4l.org/iKkEd.

### First commit: Tests
The first commit adds tests for the cases where the `comment_ID` is empty. When running only this commit without the fix, all PHPUnit tests fail for the reported fatal error:

```
Object of class WP_Comment could not be converted to string
```

For example:
```
There were 4 errors:

1) Tests_Comment_GetCommentAuthor::test_should_return_author_when_given_object_without_comment_id with data set "with no author" (stdClass Object (), 'Anonymous')
Object of class WP_Comment could not be converted to string

/var/www/src/wp-includes/comment-template.php:27
/var/www/tests/phpunit/tests/comment/getCommentAuthor.php:75
phpvfscomposer:///var/www/vendor/phpunit/phpunit/phpunit:106
/var/www/vendor/bin/phpunit:118

2) Tests_Comment_GetCommentAuthor::test_should_return_author_when_given_object_without_comment_id with data set "with author name" (stdClass Object (...), 'tester1')
Object of class WP_Comment could not be converted to string

/var/www/src/wp-includes/comment-template.php:27
/var/www/tests/phpunit/tests/comment/getCommentAuthor.php:75
phpvfscomposer:///var/www/vendor/phpunit/phpunit/phpunit:106
/var/www/vendor/bin/phpunit:118

3) Tests_Comment_GetCommentAuthor::test_should_return_author_when_given_object_without_comment_id with data set "with author name, empty ID" (stdClass Object (...), 'tester2')
Object of class WP_Comment could not be converted to string

/var/www/src/wp-includes/comment-template.php:27
/var/www/tests/phpunit/tests/comment/getCommentAuthor.php:75
phpvfscomposer:///var/www/vendor/phpunit/phpunit/phpunit:106
/var/www/vendor/bin/phpunit:118

4) Tests_Comment_GetCommentAuthor::test_should_return_author_when_given_object_without_comment_id with data set "with author ID" (stdClass Object (...), 'Tester3', array('Tester3'))
Object of class WP_Comment could not be converted to string

/var/www/src/wp-includes/comment-template.php:27
/var/www/tests/phpunit/tests/comment/getCommentAuthor.php:75
phpvfscomposer:///var/www/vendor/phpunit/phpunit/phpunit:106
/var/www/vendor/bin/phpunit:118
```

### Second commit: Fix
The second commit refactors/restructures [r58335](https://core.trac.wordpress.org/changeset/r58335) code and adds defensive guarding.

Restructures from a ternary to an if/elseif/else structure for the 3 paths:

- When `$comment->comment_ID` is not empty, then it uses the property.
- When `$comment_id` is scalar, then it type casts it to a `string`.
- Else, the default is an empty `string`.

Trac ticket: https://core.trac.wordpress.org/ticket/61681

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
