### PR TITLE
Fix performance workflow artifacts in old branches on `workflow_dispatch`.

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -33,7 +33,7 @@ jobs:
   # Runs the performance test suite.
   performance:
     name: Performance tests ${{ matrix.memcached && '(with memcached)' || '' }}
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-performance.yml@trunk
+    uses: desrosj/wordpress-develop/.github/workflows/reusable-performance.yml@fix/reusable-performance-workflow-target-sha
     permissions:
       contents: read
     if: ${{ ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) && ! contains( github.event.before, '00000000' ) }}

--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -45,7 +45,7 @@ env:
   BASE_TAG: ${{ inputs.BASE_TAG }}
   LOCAL_DIR: ${{ inputs.LOCAL_DIR }}
   TARGET_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || '' }}
-  TARGET_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+  TARGET_SHA: ''
 
   LOCAL_PHP_MEMCACHED: ${{ inputs.memcached }}
   LOCAL_PHP: ${{ inputs.php-version }}${{ 'latest' != inputs.php-version && '-fpm' || '' }}
@@ -54,6 +54,7 @@ jobs:
   # Performs the following steps:
   # - Configure environment variables.
   # - Checkout repository.
+  # - Determine the target SHA value.
   # - Set up Node.js.
   # - Log debug information.
   # - Install npm dependencies.
@@ -109,6 +110,9 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+
+      - name: Retrieve previous commit SHA
+        run: echo "TARGET_SHA=$(git rev-parse HEAD^1)" >> $GITHUB_ENV
 
       - name: Set up Node.js
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2

--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -112,6 +112,7 @@ jobs:
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
           fetch-depth: ${{ github.event_name == 'workflow_dispatch' && '2' || '1' }}
 
+      # The `workflow_dispatch` event is the only one missing the needed SHA to target.
       - name: Retrieve previous commit SHA (if necessary)
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: echo "TARGET_SHA=$(git rev-parse HEAD^1)" >> $GITHUB_ENV

--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -110,6 +110,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+          fetch-depth: 2
 
       - name: Retrieve previous commit SHA
         run: echo "TARGET_SHA=$(git rev-parse HEAD^1)" >> $GITHUB_ENV

--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -45,7 +45,7 @@ env:
   BASE_TAG: ${{ inputs.BASE_TAG }}
   LOCAL_DIR: ${{ inputs.LOCAL_DIR }}
   TARGET_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || '' }}
-  TARGET_SHA: ''
+  TARGET_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
 
   LOCAL_PHP_MEMCACHED: ${{ inputs.memcached }}
   LOCAL_PHP: ${{ inputs.php-version }}${{ 'latest' != inputs.php-version && '-fpm' || '' }}
@@ -54,7 +54,7 @@ jobs:
   # Performs the following steps:
   # - Configure environment variables.
   # - Checkout repository.
-  # - Determine the target SHA value.
+  # - Determine the target SHA value (on `workflow_dispatch` only).
   # - Set up Node.js.
   # - Log debug information.
   # - Install npm dependencies.
@@ -110,9 +110,10 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
-          fetch-depth: 2
+          fetch-depth: ${{ github.event_name == 'workflow_dispatch' && '2' || '1' }}
 
-      - name: Retrieve previous commit SHA
+      - name: Retrieve previous commit SHA (if necessary)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         run: echo "TARGET_SHA=$(git rev-parse HEAD^1)" >> $GITHUB_ENV
 
       - name: Set up Node.js


### PR DESCRIPTION
This attempts to use native `git` commands to find the preceding commit SHA when one is not provided through GitHub Actions contexts.

Trac ticket: https://core.trac.wordpress.org/ticket/61699

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
