### PR TITLE
Fix: `get_edit_term_link()` optional taxonomy parameter error

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1092,7 +1092,7 @@ function get_edit_term_link( $term, $taxonomy = '', $object_type = '' ) {
 	}
 
 	$args = array(
-		'taxonomy' => $taxonomy,
+		'taxonomy' => $tax->name,
 		'tag_ID'   => $term_id,
 	);
 

--- a/tests/phpunit/tests/link/getEditTermLink.php
+++ b/tests/phpunit/tests/link/getEditTermLink.php
@@ -196,10 +196,9 @@ class Tests_Link_GetEditTermLink extends WP_UnitTestCase {
 
 		get_edit_term_link( $term, $taxonomy );
 	}
-	
 	/**
 	 * This function checks if the return URL of `get_edit_term_link()` when called without taxonomy matches with the expected output or not.
-	 * 
+	 *
 	 * @ticket 61726
 	 *
 	 * @return void

--- a/tests/phpunit/tests/link/getEditTermLink.php
+++ b/tests/phpunit/tests/link/getEditTermLink.php
@@ -196,6 +196,26 @@ class Tests_Link_GetEditTermLink extends WP_UnitTestCase {
 
 		get_edit_term_link( $term, $taxonomy );
 	}
+	
+	/**
+	 * This function checks if the return URL of `get_edit_term_link()` when called without taxonomy matches with the expected output or not.
+	 * 
+	 * @ticket 61726
+	 *
+	 * @return void
+	 */
+	public function test_get_edit_term_link_without_taxonomy() {
+		$term1 = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax',
+				'name'     => 'bar',
+			)
+		);
+
+		$actual   = get_edit_term_link( $term1 );
+		$expected = 'http://' . WP_TESTS_DOMAIN . '/wp-admin/term.php?taxonomy=wptests_tax&tag_ID=' . $term1 . '&post_type=post';
+		$this->assertSame( $expected, $actual );
+	}
 
 	/**
 	 * Data provider.

--- a/tests/phpunit/tests/link/getEditTermLink.php
+++ b/tests/phpunit/tests/link/getEditTermLink.php
@@ -200,19 +200,12 @@ class Tests_Link_GetEditTermLink extends WP_UnitTestCase {
 	 * This function checks if the return URL of `get_edit_term_link()` when called without taxonomy matches with the expected output or not.
 	 *
 	 * @ticket 61726
-	 *
-	 * @return void
 	 */
 	public function test_get_edit_term_link_without_taxonomy() {
-		$term1 = self::factory()->term->create(
-			array(
-				'taxonomy' => 'wptests_tax',
-				'name'     => 'bar',
-			)
-		);
+		$term = $this->get_term( 'wptests_tax', true );
 
-		$actual   = get_edit_term_link( $term1 );
-		$expected = 'http://' . WP_TESTS_DOMAIN . '/wp-admin/term.php?taxonomy=wptests_tax&tag_ID=' . $term1 . '&post_type=post';
+		$actual   = get_edit_term_link( $term );
+		$expected = sprintf( admin_url( 'term.php?taxonomy=wptests_tax&tag_ID=%d&post_type=post' ), $term );
 		$this->assertSame( $expected, $actual );
 	}
 


### PR DESCRIPTION
Trac Ticket: [Core-61726](https://core.trac.wordpress.org/ticket/61726)

## Problem

- The `get_edit_term_link()` function currently generates an incorrect URL when the `$taxonomy` parameter is omitted. This issue arises because `$taxonomy` was made optional. However, the implementation overlooked consistently using `$tax->name` to populate the taxonomy query parameter in all scenarios.

## Solution

- To resolve this issue, we have updated `get_edit_term_link()` to consistently use `$tax->name` instead of `$taxonomy` when generating the URL. This ensures that the correct taxonomy name is always included in the URL structure, preventing errors and inconsistencies.

## Steps to Reproduce

- Call `get_edit_term_link( 42 )` where `42` is the `ID` of a term.
    - Without the fix, observe that the generated URL lacks the taxonomy parameter, leading to incorrect behavior.

## Changes Made

- Modified `get_edit_term_link()` to use `$tax->name` for populating the taxonomy query parameter.
- Added a test case to verify that the issue is resolved and the correct URL structure is maintained.


## Testing

- Tested the fix by invoking `get_edit_term_link()` with and without the $taxonomy parameter.
- Verified that the URL structure is correct in both cases and no errors occur.
- This enhancement ensures consistent behavior in `get_edit_term_link()` when determining the correct taxonomy for generating term edit URLs.