### PR TITLE
Add unified AJAX action hook handling for both logged-in and non-logged in users

### DIFF
--- a/src/wp-admin/admin-ajax.php
+++ b/src/wp-admin/admin-ajax.php
@@ -182,8 +182,6 @@ if ( has_action( "wp_ajax_all_{$action}" ) ) {
 	 *
 	 * The dynamic portion of the hook name, `$action`, refers
 	 * to the name of the Ajax action callback being fired.
-	 *
-	 * @since 6.6.0
 	 */
 	do_action( "wp_ajax_all_{$action}" );
 	wp_die();

--- a/src/wp-admin/admin-ajax.php
+++ b/src/wp-admin/admin-ajax.php
@@ -184,7 +184,7 @@ if ( has_action( "wp_ajax_all_{$action}" ) ) {
 	 * to the name of the Ajax action callback being fired.
 	 */
 	do_action( "wp_ajax_all_{$action}" );
-	wp_die();
+	wp_die( '0' );
 }
 
 if ( is_user_logged_in() ) {

--- a/src/wp-admin/admin-ajax.php
+++ b/src/wp-admin/admin-ajax.php
@@ -175,6 +175,20 @@ add_action( 'wp_ajax_check_plugin_dependencies', array( 'WP_Plugin_Dependencies'
 
 $action = $_REQUEST['action'];
 
+if ( has_action( "wp_ajax_all_{$action}" ) ) {
+	/**
+	 * Fires both authenticated as well as non-authenticated
+	 * Ajax actions for all users.
+	 *
+	 * The dynamic portion of the hook name, `$action`, refers
+	 * to the name of the Ajax action callback being fired.
+	 *
+	 * @since 6.6.0
+	 */
+	do_action( "wp_ajax_all_{$action}" );
+	wp_die();
+}
+
 if ( is_user_logged_in() ) {
 	// If no action is registered, return a Bad Request response.
 	if ( ! has_action( "wp_ajax_{$action}" ) ) {


### PR DESCRIPTION
## Description

This PR introduces a unified approach to handling AJAX actions in WordPress for both logged-in and non-logged-in users. 

## Changes Made

- Introduced the `wp_ajax_all_{$action}` hook to allow for a single AJAX action handler that works regardless of user authentication status.

## Why the New Hook?

- Simplifies the code for handling AJAX requests.
- Reduces redundancy and potential errors in defining multiple hooks.
- Improves developer experience and code maintainability.

## Trac ticket: https://core.trac.wordpress.org/ticket/61710
