### PR TITLE
`delete_network_options` should only set network `notoptions` on multisites

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2264,6 +2264,17 @@ function delete_network_option( $network_id, $option ) {
 				'site_id'  => $network_id,
 			)
 		);
+
+		if ( $result ) {
+			$notoptions_key = "$network_id:notoptions";
+			$notoptions     = wp_cache_get( $notoptions_key, 'site-options' );
+
+			if ( ! is_array( $notoptions ) ) {
+				$notoptions = array();
+			}
+			$notoptions[ $option ] = true;
+			wp_cache_set( $notoptions_key, $notoptions, 'site-options' );
+		}
 	}
 
 	if ( $result ) {
@@ -2292,15 +2303,6 @@ function delete_network_option( $network_id, $option ) {
 		 * @param int    $network_id ID of the network.
 		 */
 		do_action( 'delete_site_option', $option, $network_id );
-
-		$notoptions_key = "$network_id:notoptions";
-		$notoptions     = wp_cache_get( $notoptions_key, 'site-options' );
-
-		if ( ! is_array( $notoptions ) ) {
-			$notoptions = array();
-		}
-		$notoptions[ $option ] = true;
-		wp_cache_set( $notoptions_key, $notoptions, 'site-options' );
 
 		return true;
 	}

--- a/tests/phpunit/tests/option/networkOption.php
+++ b/tests/phpunit/tests/option/networkOption.php
@@ -60,6 +60,7 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 	 * Tests that calling delete_network_option() updates nooptions when option deleted.
 	 *
 	 * @ticket 61484
+	 * @ticket 61730
 	 *
 	 * @covers ::delete_network_option
 	 */
@@ -306,5 +307,109 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 
 		$updated_notoptions = wp_cache_get( $cache_key, $cache_group );
 		$this->assertArrayNotHasKey( $option_name, $updated_notoptions, 'The "foobar" option should not be in the notoptions cache after updating it.' );
+	}
+
+	/**
+	 * Test adding a previously known notoption returns the correct value.
+	 *
+	 * @ticket 61730
+	 *
+	 * @covers ::add_network_option
+	 * @covers ::delete_network_option
+	 */
+	public function test_adding_previous_notoption_returns_correct_value() {
+		$option_name = 'ticket_61730_option_to_be_created';
+
+		add_network_option( 1, $option_name, 'baz' );
+		delete_network_option( 1, $option_name );
+
+		$this->assertFalse( get_network_option( 1, $option_name ), 'The option should not be found.' );
+
+		add_network_option( 1, $option_name, 'foo' );
+		$this->assertSame( 'foo', get_network_option( 1, $option_name ), 'The option should return the newly set value.' );
+	}
+
+	/**
+	 * Test `get_network_option()` does not use network notoptions cache for single sites.
+	 *
+	 * @ticket 61730
+	 *
+	 * @group ms-excluded
+	 *
+	 * @covers ::get_network_option
+	 */
+	public function test_get_network_option_does_not_use_network_notoptions_cache_for_single_sites() {
+		get_network_option( 1, 'ticket_61730_notoption' );
+
+		$network_notoptions_cache     = wp_cache_get( '1:notoptions', 'site-options' );
+		$single_site_notoptions_cache = wp_cache_get( 'notoptions', 'options' );
+
+		$this->assertEmpty( $network_notoptions_cache, 'Network notoptions cache should not be set for single site installs.' );
+		$this->assertIsArray( $single_site_notoptions_cache, 'Single site notoptions cache should be set.' );
+		$this->assertArrayHasKey( 'ticket_61730_notoption', $single_site_notoptions_cache, 'The option should be in the notoptions cache.' );
+	}
+
+	/**
+	 * Test `delete_network_option()` does not use network notoptions cache for single sites.
+	 *
+	 * @ticket 61730
+	 * @ticket 61484
+	 *
+	 * @group ms-excluded
+	 *
+	 * @covers ::delete_network_option
+	 */
+	public function test_delete_network_option_does_not_use_network_notoptions_cache_for_single_sites() {
+		add_network_option( 1, 'ticket_61730_notoption', 'value' );
+		delete_network_option( 1, 'ticket_61730_notoption' );
+
+		$network_notoptions_cache     = wp_cache_get( '1:notoptions', 'site-options' );
+		$single_site_notoptions_cache = wp_cache_get( 'notoptions', 'options' );
+
+		$this->assertEmpty( $network_notoptions_cache, 'Network notoptions cache should not be set for single site installs.' );
+		$this->assertIsArray( $single_site_notoptions_cache, 'Single site notoptions cache should be set.' );
+		$this->assertArrayHasKey( 'ticket_61730_notoption', $single_site_notoptions_cache, 'The option should be in the notoptions cache.' );
+	}
+
+	/**
+	 * Test `get_network_option()` does not use single site notoptions cache for networks.
+	 *
+	 * @ticket 61730
+	 *
+	 * @group ms-required
+	 *
+	 * @covers ::get_network_option
+	 */
+	public function test_get_network_option_does_not_use_single_site_notoptions_cache_for_networks() {
+		get_network_option( 1, 'ticket_61730_notoption' );
+
+		$network_notoptions_cache     = wp_cache_get( '1:notoptions', 'site-options' );
+		$single_site_notoptions_cache = wp_cache_get( 'notoptions', 'options' );
+
+		$this->assertEmpty( $single_site_notoptions_cache, 'Single site notoptions cache should not be set for multisite installs.' );
+		$this->assertIsArray( $network_notoptions_cache, 'Multisite notoptions cache should be set.' );
+		$this->assertArrayHasKey( 'ticket_61730_notoption', $network_notoptions_cache, 'The option should be in the notoptions cache.' );
+	}
+
+	/**
+	 * Test `delete_network_option()` does not use single site notoptions cache for networks.
+	 *
+	 * @ticket 61730
+	 * @ticket 61484
+	 *
+	 * @group ms-required
+	 *
+	 * @covers ::delete_network_option
+	 */
+	public function test_delete_network_option_does_not_use_single_site_notoptions_cache_for_networks() {
+		add_network_option( 1, 'ticket_61730_notoption', 'value' );
+		delete_network_option( 1, 'ticket_61730_notoption' );
+
+		$network_notoptions_cache     = wp_cache_get( '1:notoptions', 'site-options' );
+		$single_site_notoptions_cache = wp_cache_get( 'notoptions', 'options' );
+
+		$this->assertEmpty( $single_site_notoptions_cache, 'Single site notoptions cache should not be set for multisite installs.' );
+		$this->assertIsArray( $network_notoptions_cache, 'Multisite notoptions cache should be set.' );
+		$this->assertArrayHasKey( 'ticket_61730_notoption', $network_notoptions_cache, 'The option should be in the notoptions cache.' );
 	}
 }

--- a/tests/phpunit/tests/option/networkOption.php
+++ b/tests/phpunit/tests/option/networkOption.php
@@ -73,6 +73,11 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 		$this->assertIsArray( $notoptions, 'The notoptions cache is expected to be an array.' );
 		$this->assertTrue( $notoptions['foo'], 'The deleted options is expected to be in notoptions.' );
 
+		if ( ! is_multisite() ) {
+			$network_notoptions = wp_cache_get( '1:notoptions', 'site-options' );
+			$this->assertTrue( empty( $network_notoptions['foo'] ), 'The deleted option is not expected to be in network notoptions on a non-multisite.' );
+		}
+
 		$before = get_num_queries();
 		get_network_option( 1, 'foo' );
 		$queries = get_num_queries() - $before;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

On a non-multisite, `get_network_option()`, `add_network_option()`, and `update_network_option()` don't bother updating the network `notoptions` cache, instead reling on `get_option()`, `add_option()`, and `update_option()` to use the non-network `notoptions`.

`delete_options()` and `delete_network_options()` were recently updated to populate the `notoptions` caches. But, contrary to existing practice, `delete_network_options()` was made to update the network `notoptions` cache even on non-multisites.

This moves the updating of the network `notoptions` cache in `delete_network_options()` to the multisite code path, matching the behavior of the other functions, and adds a test to verify this.

Trac ticket: https://core.trac.wordpress.org/ticket/61730

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
