### PR TITLE
Interactivity API: Allow server derived state to appear in non-final position

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -530,32 +530,32 @@ final class WP_Interactivity_API {
 			} else {
 				return null;
 			}
-		}
 
-		if ( $current instanceof Closure ) {
-			/*
-			 * This state getter's namespace is added to the stack so that
-			 * `state()` or `get_config()` read that namespace when called
-			 * without specifying one.
-			 */
-			array_push( $this->namespace_stack, $ns );
-			try {
-				$current = $current();
-			} catch ( Throwable $e ) {
-				_doing_it_wrong(
-					__METHOD__,
-					sprintf(
-						/* translators: 1: Path pointing to an Interactivity API state property, 2: Namespace for an Interactivity API store. */
-						__( 'Uncaught error executing a derived state callback with path "%1$s" and namespace "%2$s".' ),
-						$path,
-						$ns
-					),
-					'6.6.0'
-				);
-				return null;
-			} finally {
-				// Remove the property's namespace from the stack.
-				array_pop( $this->namespace_stack );
+			if ( $current instanceof Closure ) {
+				/*
+				 * This state getter's namespace is added to the stack so that
+				 * `state()` or `get_config()` read that namespace when called
+				 * without specifying one.
+				 */
+				array_push( $this->namespace_stack, $ns );
+				try {
+					$current = $current();
+				} catch ( Throwable $e ) {
+					_doing_it_wrong(
+						__METHOD__,
+						sprintf(
+							/* translators: 1: Path pointing to an Interactivity API state property, 2: Namespace for an Interactivity API store. */
+							__( 'Uncaught error executing a derived state callback with path "%1$s" and namespace "%2$s".' ),
+							$path,
+							$ns
+						),
+						'6.6.0'
+					);
+					return null;
+				} finally {
+					// Remove the property's namespace from the stack.
+					array_pop( $this->namespace_stack );
+				}
 			}
 		}
 

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -494,6 +494,7 @@ final class WP_Interactivity_API {
 	 * @since 6.5.0
 	 * @since 6.6.0 The function now adds a warning when the namespace is null, falsy, or the directive value is empty.
 	 * @since 6.6.0 Removed `default_namespace` and `context` arguments.
+	 * @since 6.6.0 Add support for derived state.
 	 *
 	 * @param string|true $directive_value The directive attribute value string or `true` when it's a boolean attribute.
 	 * @return mixed|null The result of the evaluation. Null if the reference path doesn't exist or the namespace is falsy.

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -1297,7 +1297,6 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 		$this->assertSame( "Derived state: otherPlugin-state\nDerived context: otherPlugin-context", $result );
 	}
 
-
 	/**
 	 * Tests the `evaluate` method for derived state functions that throw.
 	 *
@@ -1320,6 +1319,29 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 
 		$result = $this->evaluate( 'state.derivedThatThrows' );
 		$this->assertNull( $result );
+	}
+
+	/**
+	 * Tests the `evaluate` method for derived state intermediate values.
+	 *
+	 * @ticket 61741
+	 *
+	 * @covers ::evaluate
+	 */
+	public function test_evaluate_derived_state_intermediate() {
+		$this->interactivity->state(
+			'myPlugin',
+			array(
+				'derivedState' => function () {
+					return array( 'property' => 'value' );
+				},
+			)
+		);
+		$this->set_internal_context_stack();
+		$this->set_internal_namespace_stack( 'myPlugin' );
+
+		$result = $this->evaluate( 'state.derivedState.property' );
+		$this->assertSame( 'value', $result );
 	}
 
 	/**


### PR DESCRIPTION
In some cases, derived state returns and object. Directives may wish to
continue to access properties of the object. Support this behavior.

On the client, derived state is implemented as JavaScript getters. This
transparently supports traversing a directive value like this:

```
state.derivedState.property
```

We can support this behavior on the server by handling derived state at
whatever the `current` value is for evaluation.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/61741

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
