### PR TITLE
Autosaves controller: return a WP_Error if the post object is invalid

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -247,7 +247,7 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 			return $autosave_id;
 		}
 
-		$autosave = get_post( $autosave_id );
+		$autosave = $this->get_post( $autosave_id );
 		$request->set_param( 'context', 'edit' );
 
 		$response = $this->prepare_item_for_response( $autosave, $request );
@@ -362,7 +362,7 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 	public function create_post_autosave( $post_data, array $meta = array() ) {
 
 		$post_id = (int) $post_data['ID'];
-		$post    = get_post( $post_id );
+		$post    = $this->get_post( $post_id );
 
 		if ( is_wp_error( $post ) ) {
 			return $post;
@@ -493,5 +493,32 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 		return array(
 			'context' => $this->get_context_param( array( 'default' => 'view' ) ),
 		);
+	}
+
+	/**
+	 * Gets the post, if the ID is valid.
+	 *
+	 * @since 6.7.0
+	 *
+	 * @param int $id Supplied ID.
+	 * @return WP_Post|WP_Error Post object if ID is valid, WP_Error otherwise.
+	 */
+	protected function get_post( $id ) {
+		$error = new WP_Error(
+			'rest_post_invalid_id',
+			__( 'Invalid post ID.' ),
+			array( 'status' => 404 )
+		);
+
+		if ( (int) $id <= 0 ) {
+			return $error;
+		}
+
+		$post = get_post( (int) $id );
+		if ( empty( $post ) || empty( $post->ID ) || $this->parent_post_type !== $post->post_type ) {
+			return $error;
+		}
+
+		return $post;
 	}
 }

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -248,6 +248,10 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 		}
 
 		$autosave = $this->get_post( $autosave_id );
+		if ( is_wp_error( $autosave ) ) {
+			return $autosave;
+		}
+
 		$request->set_param( 'context', 'edit' );
 
 		$response = $this->prepare_item_for_response( $autosave, $request );
@@ -515,7 +519,7 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 		}
 
 		$post = get_post( (int) $id );
-		if ( empty( $post ) || empty( $post->ID ) || $this->parent_post_type !== $post->post_type ) {
+		if ( empty( $post ) || empty( $post->ID ) ) {
 			return $error;
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php
@@ -514,11 +514,12 @@ class WP_REST_Autosaves_Controller extends WP_REST_Revisions_Controller {
 			array( 'status' => 404 )
 		);
 
-		if ( (int) $id <= 0 ) {
+		$id = (int) $id;
+		if ( $id <= 0 ) {
 			return $error;
 		}
 
-		$post = get_post( (int) $id );
+		$post = get_post( $id );
 		if ( empty( $post ) || empty( $post->ID ) ) {
 			return $error;
 		}

--- a/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
@@ -784,4 +784,56 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( $autosave['id'], $data['id'], 'Original autosave was not returned' );
 	}
+
+	/**
+	 * @ticket 52925
+	 *
+	 * @covers WP_REST_Autosaves_Controller::create_item
+	 * @covers WP_REST_Autosaves_Controller::get_post
+	 */
+	public function test_create_item_invalid_integration() {
+		$request = new WP_REST_Request( 'POST', '/wp/v2/posts/' . self::$post_id . '/autosaves' );
+		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
+		$params = $this->set_post_data(
+			array(
+				'id' => REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
+			)
+		);
+		$request->set_body_params( $params );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
+	}
+
+	/**
+	 * @ticket 52925
+	 *
+	 * @covers WP_REST_Autosaves_Controller::create_item
+	 * @covers WP_REST_Autosaves_Controller::get_post
+	 */
+	public function test_create_item_invalid_unit() {
+		$autosaves_controller = new WP_REST_Autosaves_Controller( 'post' );
+		$response             = $autosaves_controller->create_item(
+			array(
+				'id' => REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
+			)
+		);
+		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
+	}
+
+	/**
+	 * @ticket 52925
+	 *
+	 * @covers WP_REST_Autosaves_Controller::create_post_autosave
+	 * @covers WP_REST_Autosaves_Controller::get_post
+	 */
+	public function test_create_post_autosave_invalid() {
+		$autosaves_controller = new WP_REST_Autosaves_Controller( 'post' );
+		$response             = $autosaves_controller->create_post_autosave(
+			array(
+				'ID' => REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
+			)
+		);
+		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );
+	}
 }

--- a/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
@@ -828,7 +828,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 		$autosaves_controller = new WP_REST_Autosaves_Controller( 'post' );
 		$response             = $autosaves_controller->create_post_autosave(
 			array(
-				'ID' => REST_TESTS_IMPOSSIBLY_HIGH_NUMBER,
+				'ID' => $autosave_post_id,
 			)
 		);
 		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );

--- a/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
@@ -792,6 +792,8 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	 *
 	 * @covers WP_REST_Autosaves_Controller::create_item
 	 * @covers WP_REST_Autosaves_Controller::get_post
+	 *
+	 * @param int $autosave_revision_id The autosave revision ID.
 	 */
 	public function test_invalid_autosave_revision_id_should_trigger_error_response( $autosave_revision_id ) {
 		wp_set_current_user( self::$editor_id );
@@ -823,12 +825,14 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	 *
 	 * @covers WP_REST_Autosaves_Controller::create_post_autosave
 	 * @covers WP_REST_Autosaves_Controller::get_post
+	 *
+	 * @param int $parent_post_id Parent post ID.
 	 */
-	public function test_invalid_revision_id_should_trigger_error_response( $autosave_post_id ) {
+	public function test_invalid_parent_post_id_should_trigger_error_response( $parent_post_id ) {
 		$autosaves_controller = new WP_REST_Autosaves_Controller( 'post' );
 		$response             = $autosaves_controller->create_post_autosave(
 			array(
-				'ID' => $autosave_post_id,
+				'ID' => $parent_post_id,
 			)
 		);
 		$this->assertErrorResponse( 'rest_post_invalid_id', $response, 404 );

--- a/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
@@ -847,7 +847,7 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 	 *
 	 * @return array
 	 */
-	public function data_invalid_post_id() {
+	public static function data_invalid_post_id() {
 		return array(
 			'impossibly high post ID' => array( REST_TESTS_IMPOSSIBLY_HIGH_NUMBER ),
 			'negative post ID'        => array( -1 ),

--- a/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-autosaves-controller.php
@@ -807,6 +807,10 @@ class WP_Test_REST_Autosaves_Controller extends WP_Test_REST_Post_Type_Controlle
 		);
 		$request->set_body_params( $body_parameters );
 
+		/**
+		 * It's hard to programmatically create an invalid $autosave_id,
+		 * so mocking the ::create_post_autosave() method seems like a more reasonable solution.
+		 */
 		$autosaves_controller = $this->getMockBuilder( WP_REST_Autosaves_Controller::class )
 									->setConstructorArgs( array( 'post' ) )
 									->onlyMethods( array( 'create_post_autosave' ) )


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/52925

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
