### PR TITLE
Refactor transient API for non-hook version

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2608,7 +2608,7 @@ function set_site_transient( $transient, $value, $expiration = 0 ) {
 	 */
 	$expiration = apply_filters( "expiration_of_site_transient_{$transient}", $expiration, $value, $transient );
 
-	$result = set_site_transient_nohook($transient, $value, $expiration);
+	$result = set_site_transient_nohook( $transient, $value, $expiration );
 
 	if ( $result ) {
 
@@ -2647,8 +2647,7 @@ function set_site_transient( $transient, $value, $expiration = 0 ) {
  * @param $expiration
  * @return bool
  */
-function set_site_transient_nohook( $transient, $value, $expiration ): bool
-{
+function set_site_transient_nohook( $transient, $value, $expiration ) {
 	if ( wp_using_ext_object_cache() || wp_installing() ) {
 		$result = wp_cache_set( $transient, $value, 'site-transient', $expiration );
 	} else {

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2647,7 +2647,7 @@ function set_site_transient( $transient, $value, $expiration = 0 ) {
  * @param $expiration
  * @return bool
  */
-function set_site_transient_nohook( $transient, $value, $expiration ) {
+function set_site_transient_nohook( $transient, $value, $expiration = 0 ) {
 	if ( wp_using_ext_object_cache() || wp_installing() ) {
 		$result = wp_cache_set( $transient, $value, 'site-transient', $expiration );
 	} else {

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2608,25 +2608,7 @@ function set_site_transient( $transient, $value, $expiration = 0 ) {
 	 */
 	$expiration = apply_filters( "expiration_of_site_transient_{$transient}", $expiration, $value, $transient );
 
-	if ( wp_using_ext_object_cache() || wp_installing() ) {
-		$result = wp_cache_set( $transient, $value, 'site-transient', $expiration );
-	} else {
-		$transient_timeout = '_site_transient_timeout_' . $transient;
-		$option            = '_site_transient_' . $transient;
-		wp_prime_site_option_caches( array( $option, $transient_timeout ) );
-
-		if ( false === get_site_option( $option ) ) {
-			if ( $expiration ) {
-				add_site_option( $transient_timeout, time() + $expiration );
-			}
-			$result = add_site_option( $option, $value );
-		} else {
-			if ( $expiration ) {
-				update_site_option( $transient_timeout, time() + $expiration );
-			}
-			$result = update_site_option( $option, $value );
-		}
-	}
+	$result = set_site_transient_nohook($transient, $value, $expiration);
 
 	if ( $result ) {
 
@@ -2656,6 +2638,36 @@ function set_site_transient( $transient, $value, $expiration = 0 ) {
 		do_action( 'setted_site_transient', $transient, $value, $expiration );
 	}
 
+	return $result;
+}
+
+/**
+ * @param string $transient
+ * @param $value
+ * @param $expiration
+ * @return bool
+ */
+function set_site_transient_nohook( $transient, $value, $expiration ): bool
+{
+	if ( wp_using_ext_object_cache() || wp_installing() ) {
+		$result = wp_cache_set( $transient, $value, 'site-transient', $expiration );
+	} else {
+		$transient_timeout = '_site_transient_timeout_' . $transient;
+		$option            = '_site_transient_' . $transient;
+		wp_prime_site_option_caches( array( $option, $transient_timeout ) );
+
+		if ( false === get_site_option( $option ) ) {
+			if ( $expiration ) {
+				add_site_option( $transient_timeout, time() + $expiration );
+			}
+			$result = add_site_option( $option, $value );
+		} else {
+			if ( $expiration ) {
+				update_site_option( $transient_timeout, time() + $expiration );
+			}
+			$result = update_site_option( $option, $value );
+		}
+	}
 	return $result;
 }
 

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -72,7 +72,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 
 	// Update last_checked for current to prevent multiple blocking requests if request hangs.
 	$current->last_checked = time();
-	set_site_transient( 'update_core', $current );
+	set_site_transient_nohook( 'update_plugins', $current );
 
 	if ( method_exists( $wpdb, 'db_server_info' ) ) {
 		$mysql_version = $wpdb->db_server_info();


### PR DESCRIPTION
This commit refactors the transient API to include a non-hook version named, `set_site_transient_nohook`. This update reduces redundancy in setting transients and creates a more streamlined, efficient operation in `option.php`. Additionally, the update method has been changed in `update.php` to utilize this new non-hook version.

Trac ticket: https://core.trac.wordpress.org/ticket/43160