### PR TITLE
TT3 theme [Whisper variation] - unnecessary image border and background (:hover)

### DIFF
--- a/src/wp-content/themes/twentytwentythree/styles/whisper.json
+++ b/src/wp-content/themes/twentytwentythree/styles/whisper.json
@@ -183,6 +183,20 @@
 					}
 				}
 			},
+			"core/post-featured-image": {
+				"elements": {
+					"link": {
+						"border": {
+							"width": "0"
+						},
+						":hover": {
+							"color": {
+								"background": "transparent"
+							}
+						}
+					}
+				}
+			},
 			"core/post-title": {
 				"elements": {
 					"link": {

--- a/src/wp-content/themes/twentytwentythree/styles/whisper.json
+++ b/src/wp-content/themes/twentytwentythree/styles/whisper.json
@@ -83,6 +83,20 @@
 	},
 	"styles": {
 		"blocks": {
+			"core/image": {
+				"elements": {
+					"link": {
+						"border": {
+							"width": "0"
+						},
+						":hover": {
+							"color": {
+								"background": "transparent"
+							}
+						}
+					}
+				}
+			},
 			"core/navigation": {
 				"color": {
 					"text": "var(--wp--preset--color--contrast)"

--- a/src/wp-content/themes/twentytwentythree/styles/whisper.json
+++ b/src/wp-content/themes/twentytwentythree/styles/whisper.json
@@ -279,6 +279,15 @@
 					"width": "6px 0 0 0"
 				}
 			},
+			"core/site-logo": {
+				"elements": {
+					"link": {
+						"border": {
+							"width": "0"
+						}
+					}
+				}
+			},
 			"core/site-title": {
 				"elements": {
 					"link": {


### PR DESCRIPTION
[Trac #57638](https://core.trac.wordpress.org/ticket/57368)

The Whisper style variation relies heavily on utilizing the `border-bottom` to give links their underlined appearance. As opposed to the usual `text-decoration: underline`. This starts to surface in unexpected visual results when an Image, Site Logo, or Post Featured Image block is wrapped in a link and has border radius applied.

Steps to create issue with latest WP trunk (or prior versions) with Twenty Twenty-Three theme activated:

1. Go to Global Styles and choose Whisper style variation
2. Add a Site Logo block a transparent image (.png), or an Image block in a post with a link attached to it and border radius set, or a Post Featured Image that has the 'Link to Post' option enabled and a border radius.

(Note: in order to see style variation changes you oftentimes have to switch away from the variation that has the changes, 'Save' changes, and then switch back to it in the Global Styles area. This busts the cache.

Screenshots of the current issue with the border on the Site Logo and Image in Twenty Twenty-Three (v1.0)

![Screen Shot 2022-12-21 at 1 10 19 PM](https://user-images.githubusercontent.com/405912/208984063-fb71e646-6e28-474a-a5e4-2b64f19e3791.png)

![Screen Shot 2022-12-21 at 1 12 12 PM](https://user-images.githubusercontent.com/405912/208984071-d5539066-1c76-489d-ba63-67f4721eadf1.png)
