### PR TITLE
Fix block library and global styles stylesheet ordering when a block variation is active

### DIFF
--- a/src/wp-includes/block-supports/block-style-variations.php
+++ b/src/wp-includes/block-supports/block-style-variations.php
@@ -87,6 +87,7 @@ function wp_resolve_block_style_variation_ref_values( &$variation_data, $theme_j
  * different filter.
  *
  * @since 6.6.0
+ * @since 6.6.2 Reorder the dependencies for 'block-style-variation-styles' styles.
  * @access private
  *
  * @param array $parsed_block The parsed block.
@@ -196,7 +197,7 @@ function wp_render_block_style_variation_support_styles( $parsed_block ) {
 		return $parsed_block;
 	}
 
-	wp_register_style( 'block-style-variation-styles', false, array( 'global-styles', 'wp-block-library' ) );
+	wp_register_style( 'block-style-variation-styles', false, array( 'wp-block-library', 'global-styles' ) );
 	wp_add_inline_style( 'block-style-variation-styles', $variation_styles );
 
 	/*


### PR DESCRIPTION
Supeceded by https://github.com/WordPress/wordpress-develop/pull/7088

Trac ticket: https://core.trac.wordpress.org/ticket/61748
Gutenberg issue: https://github.com/WordPress/gutenberg/issues/63912
Gutenberg PR: https://github.com/WordPress/gutenberg/pull/63918

## What?
Reorders the dependencies for `block-style-variations-styles`

## Why?
The order of the dependencies here was causing different ordering of stylesheets on the page

When a theme is using theme.json presets that match the naming used by core, this can suddenly cause those core styles to override those from the theme.json (the css variables from core take precedence over those generated from the theme.json.

_Props to @aaronrobertshaw for spotting the problematic line of code_

## Testing Instructions
- Alter the Twenty Twenty Four `theme.json` file to include a font size with the slug `normal` that is something fairly large, like `2rem`
- Make a page with some text using that font size and preview it - note that the text is correctly sized to `2rem`
- Add a button with the Outline style on the same page and preview it again 

Expected: the text is still `2rem`
Before: the text was incorrectly `16px`

## Screenshots or screencast <!-- if applicable -->
#### Before
| Regular button | Outline button |
|--------|--------|
| ![Screenshot 2024-07-25 at 10 33 43 AM](https://github.com/user-attachments/assets/fd5b3da9-1e8f-4593-9b2b-a87de3b7fcc3) | ![Screenshot 2024-07-25 at 10 33 32 AM](https://github.com/user-attachments/assets/99a91b0e-ef42-4860-871d-b3daaf749b32) |

#### After
| Regular button | Outline button |
|--------|--------|
| ![Screenshot 2024-07-25 at 10 33 57 AM](https://github.com/user-attachments/assets/5ca03e21-0678-4953-ae2b-b32757f58b0b) | ![Screenshot 2024-07-25 at 10 34 08 AM](https://github.com/user-attachments/assets/d5134413-e192-4297-8022-b9539612c203) |





---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
