### PR TITLE
Pages: cast $max_depth and $depth to int on class Walker

### DIFF
--- a/src/wp-includes/class-wp-walker.php
+++ b/src/wp-includes/class-wp-walker.php
@@ -290,11 +290,11 @@ class Walker {
 	 * @return string XHTML of the specified page of elements.
 	 */
 	public function paged_walk( $elements, $max_depth, $page_num, $per_page, ...$args ) {
+		$max_depth = (int) $max_depth;
+
 		if ( empty( $elements ) || $max_depth < -1 ) {
 			return '';
 		}
-
-		$max_depth = (int) $max_depth;
 
 		$output = '';
 

--- a/src/wp-includes/class-wp-walker.php
+++ b/src/wp-includes/class-wp-walker.php
@@ -135,6 +135,9 @@ class Walker {
 			return;
 		}
 
+		$max_depth = (int) $max_depth;
+		$depth     = (int) $depth;
+
 		$id_field = $this->db_fields['id'];
 		$id       = $element->$id_field;
 
@@ -190,6 +193,8 @@ class Walker {
 	 */
 	public function walk( $elements, $max_depth, ...$args ) {
 		$output = '';
+
+		$max_depth = (int) $max_depth;
 
 		// Invalid parameter or nothing to walk.
 		if ( $max_depth < -1 || empty( $elements ) ) {
@@ -288,6 +293,8 @@ class Walker {
 		if ( empty( $elements ) || $max_depth < -1 ) {
 			return '';
 		}
+
+		$max_depth = (int) $max_depth;
 
 		$output = '';
 

--- a/tests/phpunit/tests/post/wpListPages.php
+++ b/tests/phpunit/tests/post/wpListPages.php
@@ -160,6 +160,39 @@ class Tests_Post_wpListPages extends WP_UnitTestCase {
 		$this->assertSameIgnoreEOL( $expected, wp_list_pages( $args ) );
 	}
 
+	public function test_wp_list_pages_depth_equals_zero() {
+		$expected = '<li class="pagenav">Pages<ul><li class="page_item page-item-' . self::$parent_1 . ' page_item_has_children"><a href="' . get_permalink( self::$parent_1 ) . '">Parent 1</a>
+<ul class=\'children\'>
+	<li class="page_item page-item-' . self::$children[ self::$parent_1 ][0] . '"><a href="' . get_permalink( self::$children[ self::$parent_1 ][0] ) . '">Child 1</a></li>
+	<li class="page_item page-item-' . self::$children[ self::$parent_1 ][1] . '"><a href="' . get_permalink( self::$children[ self::$parent_1 ][1] ) . '">Child 2</a></li>
+	<li class="page_item page-item-' . self::$children[ self::$parent_1 ][2] . '"><a href="' . get_permalink( self::$children[ self::$parent_1 ][2] ) . '">Child 3</a></li>
+</ul>
+</li>
+<li class="page_item page-item-' . self::$parent_2 . ' page_item_has_children"><a href="' . get_permalink( self::$parent_2 ) . '">Parent 2</a>
+<ul class=\'children\'>
+	<li class="page_item page-item-' . self::$children[ self::$parent_2 ][0] . '"><a href="' . get_permalink( self::$children[ self::$parent_2 ][0] ) . '">Child 1</a></li>
+	<li class="page_item page-item-' . self::$children[ self::$parent_2 ][1] . '"><a href="' . get_permalink( self::$children[ self::$parent_2 ][1] ) . '">Child 2</a></li>
+	<li class="page_item page-item-' . self::$children[ self::$parent_2 ][2] . '"><a href="' . get_permalink( self::$children[ self::$parent_2 ][2] ) . '">Child 3</a></li>
+</ul>
+</li>
+<li class="page_item page-item-' . self::$parent_3 . ' page_item_has_children"><a href="' . get_permalink( self::$parent_3 ) . '">Parent 3</a>
+<ul class=\'children\'>
+	<li class="page_item page-item-' . self::$children[ self::$parent_3 ][0] . '"><a href="' . get_permalink( self::$children[ self::$parent_3 ][0] ) . '">Child 1</a></li>
+	<li class="page_item page-item-' . self::$children[ self::$parent_3 ][1] . '"><a href="' . get_permalink( self::$children[ self::$parent_3 ][1] ) . '">Child 2</a></li>
+	<li class="page_item page-item-' . self::$children[ self::$parent_3 ][2] . '"><a href="' . get_permalink( self::$children[ self::$parent_3 ][2] ) . '">Child 3</a></li>
+</ul>
+</li>
+</ul></li>';
+
+		// We need to execute wp_list_pages with a string to force calling wp_parse_args.
+		ob_start();
+		wp_list_pages( 'depth=0' );
+		$pages = ob_get_clean();
+
+		// if depth is equal 0 we expected to show all levels of children
+		$this->assertSameIgnoreEOL( $expected, $pages );
+	}
+
 	public function test_wp_list_pages_show_date() {
 		$args = array(
 			'echo'      => false,


### PR DESCRIPTION
Cast $max_depth and $depth to integer on class Walker (class-wp-walker), so it's compliant with strict comparisons.

Trac ticket: https://core.trac.wordpress.org/ticket/61749

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
