### PR TITLE
Docs: Improve documentation for `wp_strip_all_tags()`

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5503,7 +5503,7 @@ function normalize_whitespace( $str ) {
  *
  * This differs from strip_tags() because it removes the contents of
  * the `<script>` and `<style>` tags. E.g. `strip_tags( '<script>something</script>' )`
- * will return 'something'. wp_strip_all_tags will return ''
+ * will return 'something'. wp_strip_all_tags will return an empty string.
  *
  * @since 2.9.0
  *


### PR DESCRIPTION
Explicitly express return value of the example is "an empty string" and add a period to indicate the end of the sentence.

Trac ticket: https://core.trac.wordpress.org/ticket/61759
