### PR TITLE
Added site logo theme support for `Twenty Ten, Twenty Eleven, Twenty Twelve, Twenty Thirteen, Twenty Fourteen` Themes

### DIFF
--- a/src/wp-content/themes/twentyeleven/functions.php
+++ b/src/wp-content/themes/twentyeleven/functions.php
@@ -213,6 +213,16 @@ if ( ! function_exists( 'twentyeleven_setup' ) ) :
 
 		add_theme_support( 'custom-header', $custom_header_support );
 
+		// Enable support for custom logo.
+		add_theme_support(
+			'custom-logo',
+			array(
+				'height'      => 240,
+				'width'       => 240,
+				'flex-height' => true,
+			)
+		);
+
 		if ( ! function_exists( 'get_custom_header' ) ) {
 			// This is all for compatibility with versions of WordPress prior to 3.4.
 			define( 'HEADER_TEXTCOLOR', $custom_header_support['default-text-color'] );

--- a/src/wp-content/themes/twentyfourteen/functions.php
+++ b/src/wp-content/themes/twentyfourteen/functions.php
@@ -218,6 +218,16 @@ if ( ! function_exists( 'twentyfourteen_setup' ) ) :
 
 		// Indicate widget sidebars can use selective refresh in the Customizer.
 		add_theme_support( 'customize-selective-refresh-widgets' );
+
+		// Enable support for custom logo.
+		add_theme_support(
+			'custom-logo',
+			array(
+				'height'      => 240,
+				'width'       => 240,
+				'flex-height' => true,
+			)
+		);
 	}
 endif; // twentyfourteen_setup()
 add_action( 'after_setup_theme', 'twentyfourteen_setup' );

--- a/src/wp-content/themes/twentyten/functions.php
+++ b/src/wp-content/themes/twentyten/functions.php
@@ -125,6 +125,16 @@ if ( ! function_exists( 'twentyten_setup' ) ) :
 		// Add default posts and comments RSS feed links to head.
 		add_theme_support( 'automatic-feed-links' );
 
+		// Enable support for custom logo.
+		add_theme_support(
+			'custom-logo',
+			array(
+				'height'      => 240,
+				'width'       => 240,
+				'flex-height' => true,
+			)
+		);
+
 		/*
 		 * Make theme available for translation.
 		 * Translations can be filed in the /languages/ directory.

--- a/src/wp-content/themes/twentythirteen/functions.php
+++ b/src/wp-content/themes/twentythirteen/functions.php
@@ -253,6 +253,16 @@ function twentythirteen_setup() {
 
 	// Indicate widget sidebars can use selective refresh in the Customizer.
 	add_theme_support( 'customize-selective-refresh-widgets' );
+
+	// Enable support for custom logo.
+	add_theme_support(
+		'custom-logo',
+		array(
+			'height'      => 240,
+			'width'       => 240,
+			'flex-height' => true,
+		)
+	);
 }
 add_action( 'after_setup_theme', 'twentythirteen_setup' );
 

--- a/src/wp-content/themes/twentytwelve/functions.php
+++ b/src/wp-content/themes/twentytwelve/functions.php
@@ -131,6 +131,16 @@ function twentytwelve_setup() {
 
 	// Indicate widget sidebars can use selective refresh in the Customizer.
 	add_theme_support( 'customize-selective-refresh-widgets' );
+
+	// Enable support for custom logo.
+	add_theme_support(
+		'custom-logo',
+		array(
+			'height'      => 240,
+			'width'       => 240,
+			'flex-height' => true,
+		)
+	);
 }
 add_action( 'after_setup_theme', 'twentytwelve_setup' );
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61766

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
