### PR TITLE
refresh original changes from topdownjimmy with current WordPress source

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -3118,7 +3118,14 @@ function feed_links( $args = array() ) {
 		'comstitle' => __( '%1$s %2$s Comments Feed' ),
 	);
 
-	$args = wp_parse_args( $args, $defaults );
+	/**
+	 * Filters feed links arguments.
+	 *
+	 * @since NEXT
+	 *
+	 * @param array $defaults An array of default feed links arguments.
+	 */
+	$args = wp_parse_args( $args, apply_filters( 'feed_links', $defaults ) );
 
 	/**
 	 * Filters whether to display the posts feed link.
@@ -3180,7 +3187,14 @@ function feed_links_extra( $args = array() ) {
 		'posttypetitle' => __( '%1$s %2$s %3$s Feed' ),
 	);
 
-	$args = wp_parse_args( $args, $defaults );
+	/**
+	 * Filters extra feed links arguments.
+	 *
+	 * @since NEXT
+	 *
+	 * @param array $defaults An array of default extra feed links arguments.
+	 */
+	$args = wp_parse_args( $args, apply_filters( 'feed_links_extra', $defaults ) );
 
 	if ( is_singular() ) {
 		$id   = 0;


### PR DESCRIPTION
This code change updates original changes from the trac ticket below, to match the current code from WordPress Trunk. Everything should match what the original patch submitter added, with the exception of a touch of extra punctuation with the PHPDoc block and the version. Once the PR is ready to be accepted, I can update the `NEXT` value for the accepted release version.

Trac ticket: See https://core.trac.wordpress.org/ticket/43225
