### PR TITLE
Trac #31711 - refresh "is_front_page flag affected by frontpage ID and page Title strange conflict"

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4375,7 +4375,7 @@ class WP_Query {
 		if ( 'posts' === get_option( 'show_on_front' ) && $this->is_home() ) {
 			return true;
 		} elseif ( 'page' === get_option( 'show_on_front' ) && get_option( 'page_on_front' )
-			&& $this->is_page() && $this->get_queried_object_id() === get_option( 'page_on_front' )
+			&& $this->is_page() && $this->get_queried_object_id() === absint( get_option( 'page_on_front' ) )
 		) {
 			return true;
 		} else {

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4375,7 +4375,7 @@ class WP_Query {
 		if ( 'posts' === get_option( 'show_on_front' ) && $this->is_home() ) {
 			return true;
 		} elseif ( 'page' === get_option( 'show_on_front' ) && get_option( 'page_on_front' )
-			&& $this->is_page( get_option( 'page_on_front' ) )
+			&& $this->is_page() && $this->get_queried_object_id() === get_option( 'page_on_front' )
 		) {
 			return true;
 		} else {

--- a/tests/phpunit/tests/query/conditionals.php
+++ b/tests/phpunit/tests/query/conditionals.php
@@ -1309,7 +1309,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 		);
 		$post_2 = $this->factory->post->create(
 			array(
-				'post_type' => 'page',
+				'post_type'  => 'page',
 				'post_title' => $post_1,
 			)
 		);

--- a/tests/phpunit/tests/query/conditionals.php
+++ b/tests/phpunit/tests/query/conditionals.php
@@ -1301,12 +1301,21 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	/**
 	 * @ticket 31711
 	 */
-	function test_is_front_page_id_equals_the_title_of_other_page() {
-		$post_1 = $this->factory->post->create( array( 'post_type' => 'page' ) );
-		$post_2 = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => $post_1 ) );
+	public function test_is_front_page_id_equals_the_title_of_other_page() {
+		$post_1 = $this->factory->post->create(
+			array(
+				'post_type' => 'page'
+			)
+		);
+		$post_2 = $this->factory->post->create(
+			array(
+				'post_type' => 'page',
+				'post_title' => $post_1,
+			)
+		);
 
-		update_option('show_on_front', 'page');
-		update_option('page_on_front', $post_1);
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_on_front', $post_1 );
 
 		$this->go_to( "/?page_id=$post_1" );
 		$this->assertTrue( is_front_page() );

--- a/tests/phpunit/tests/query/conditionals.php
+++ b/tests/phpunit/tests/query/conditionals.php
@@ -1299,6 +1299,22 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 31711
+	 */
+	function test_is_front_page_id_equals_the_title_of_other_page() {
+		$post_1 = $this->factory->post->create( array( 'post_type' => 'page' ) );
+		$post_2 = $this->factory->post->create( array( 'post_type' => 'page', 'post_title' => $post_1 ) );
+
+		update_option('show_on_front', 'page');
+		update_option('page_on_front', $post_1);
+
+		$this->go_to( "/?page_id=$post_1" );
+		$this->assertTrue( is_front_page() );
+		$this->go_to( "/?page_id=$post_2" );
+		$this->assertFalse( is_front_page() );
+	}
+
+	/**
 	 * @ticket 35902
 	 */
 	public function test_is_attachment_should_not_match_numeric_id_to_post_title_beginning_with_id() {

--- a/tests/phpunit/tests/query/conditionals.php
+++ b/tests/phpunit/tests/query/conditionals.php
@@ -1304,7 +1304,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 	public function test_is_front_page_id_equals_the_title_of_other_page() {
 		$post_1 = $this->factory->post->create(
 			array(
-				'post_type' => 'page'
+				'post_type' => 'page',
 			)
 		);
 		$post_2 = $this->factory->post->create(


### PR DESCRIPTION
This code change updates original changes from the trac ticket below, to match the current code from WordPress Trunk. Everything should match what the original patch submitter added, with the exception of strict type checking between integers.

Trac ticket: See https://core.trac.wordpress.org/ticket/31711
