### PR TITLE
Fixed Twenty Twenty: `Separator block (dots)` does not render anymore

### DIFF
--- a/src/wp-content/themes/twentytwenty/style-rtl.css
+++ b/src/wp-content/themes/twentytwenty/style-rtl.css
@@ -3365,6 +3365,10 @@ hr.wp-block-separator {
 	content: none;
 }
 
+.wp-block-separator.is-style-dots {
+	height: auto;
+}
+
 
 /* Block: Search ----------------------------- */
 

--- a/src/wp-content/themes/twentytwenty/style-rtl.css
+++ b/src/wp-content/themes/twentytwenty/style-rtl.css
@@ -3350,6 +3350,7 @@ hr.wp-block-separator {
 .wp-block-separator.is-style-dots::before {
 	background: none;
 	color: inherit;
+	content: "···";
 	font-size: 3.2rem;
 	font-weight: 700;
 	height: auto;

--- a/src/wp-content/themes/twentytwenty/style-rtl.css
+++ b/src/wp-content/themes/twentytwenty/style-rtl.css
@@ -3369,7 +3369,6 @@ hr.wp-block-separator {
 	height: auto;
 }
 
-
 /* Block: Search ----------------------------- */
 
 .wp-block-search .wp-block-search__input {

--- a/src/wp-content/themes/twentytwenty/style.css
+++ b/src/wp-content/themes/twentytwenty/style.css
@@ -3385,6 +3385,10 @@ hr.wp-block-separator {
 	content: none;
 }
 
+.wp-block-separator.is-style-dots {
+	height: auto;
+}
+
 
 /* Block: Search ----------------------------- */
 

--- a/src/wp-content/themes/twentytwenty/style.css
+++ b/src/wp-content/themes/twentytwenty/style.css
@@ -3389,7 +3389,6 @@ hr.wp-block-separator {
 	height: auto;
 }
 
-
 /* Block: Search ----------------------------- */
 
 .wp-block-search .wp-block-search__input {

--- a/src/wp-content/themes/twentytwenty/style.css
+++ b/src/wp-content/themes/twentytwenty/style.css
@@ -3370,6 +3370,7 @@ hr.wp-block-separator {
 .wp-block-separator.is-style-dots::before {
 	background: none;
 	color: inherit;
+	content: "···";
 	font-size: 3.2rem;
 	font-weight: 700;
 	height: auto;


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61787

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
