### PR TITLE
Fixed: #61785 Misalignment of Search Text Box and Keywords Dropdown on Add New Plugin Page

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1113,7 +1113,7 @@ th.action-links {
 
 .wp-filter .search-form.search-plugins {
 	/* This element is a flex item: the inherited float won't have any effect. */
-	margin-top: 0;
+	margin: 0;
 }
 
 .wp-filter .search-form.search-plugins select,
@@ -1345,6 +1345,10 @@ th.action-links {
 
 	.filter-group li {
 		margin: 10px 0;
+	}
+
+	.wp-filter .search-form {
+		margin: 11px 0 15px;
 	}
 }
 


### PR DESCRIPTION
We have tested it with the patch provided above... But it seems like this is not working with many devices. Therefore we have attached the patch file for the solution and made it work across all devices.
Attached image: [https://tinyurl.com/28xxju56]
Trac ticket URL : https://core.trac.wordpress.org/ticket/61785