### PR TITLE
Skip escaping for data URI in WP_HTML_Tag_Processor

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -3196,7 +3196,12 @@ class WP_HTML_Tag_Processor {
 			 *
 			 * @see https://html.spec.whatwg.org/#attributes-3
 			 */
-			$escaped_new_value = in_array( $comparable_name, wp_kses_uri_attributes() ) ? esc_url( $value ) : esc_attr( $value );
+			if ( 'src' === $comparable_name && strpos( $value, 'data:' ) === 0 ) {
+				// Skip esc_url for data URIs.
+				$escaped_new_value = $value;
+			} else {
+				$escaped_new_value = in_array( $comparable_name, wp_kses_uri_attributes() ) ? esc_url( $value ) : esc_attr( $value );
+			}
 			$updated_attribute = "{$name}=\"{$escaped_new_value}\"";
 		}
 

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -3196,12 +3196,12 @@ class WP_HTML_Tag_Processor {
 			 *
 			 * @see https://html.spec.whatwg.org/#attributes-3
 			 */
-			if ( 'src' === $comparable_name && strpos( $value, 'data:' ) === 0 ) {
-				// Skip esc_url for data URIs.
-				$escaped_new_value = $value;
-			} else {
-				$escaped_new_value = in_array( $comparable_name, wp_kses_uri_attributes() ) ? esc_url( $value ) : esc_attr( $value );
+			$escaped_new_value = in_array( $comparable_name, wp_kses_uri_attributes() ) ? esc_url( $value ) : esc_attr( $value );
+
+			if ( '' === $escaped_new_value ) {
+				return false;
 			}
+
 			$updated_attribute = "{$name}=\"{$escaped_new_value}\"";
 		}
 

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -3196,7 +3196,7 @@ class WP_HTML_Tag_Processor {
 			 *
 			 * @see https://html.spec.whatwg.org/#attributes-3
 			 */
-			if ( 'src' === $comparable_name && strpos( $value, 'data:' ) === 0 ) {
+			if ( 'src' === $comparable_name && str_starts_with( $value, 'data:' ) ) {
 				// Skip esc_url for data URIs.
 				$escaped_new_value = $value;
 			} else {

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -3198,6 +3198,7 @@ class WP_HTML_Tag_Processor {
 			 */
 			$escaped_new_value = in_array( $comparable_name, wp_kses_uri_attributes() ) ? esc_url( $value ) : esc_attr( $value );
 
+			// If the escaping functions wiped out the update, reject it and indicate it was rejected.
 			if ( '' === $escaped_new_value && '' !== $value ) {
 				return false;
 			}

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -3198,7 +3198,7 @@ class WP_HTML_Tag_Processor {
 			 */
 			$escaped_new_value = in_array( $comparable_name, wp_kses_uri_attributes() ) ? esc_url( $value ) : esc_attr( $value );
 
-			if ( '' === $escaped_new_value ) {
+			if ( '' === $escaped_new_value && '' !== $value ) {
 				return false;
 			}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61719

## What:
This pull request updates the set_attribute method in WP_HTML_Tag_Processor to properly handle inline data URIs, such as SVGs.

## Description
Previously, data URIs were altered or stripped due to the use of esc_url(), causing issues with attributes like src when using data URIs. This fix ensures data URIs are preserved as intended.
