### PR TITLE
Fixed Fatal Error coming in calling `wp_update_nav_menu_item()` with an `invalid taxonomy` causes a `fatal error`

### DIFF
--- a/src/wp-includes/nav-menu.php
+++ b/src/wp-includes/nav-menu.php
@@ -494,6 +494,7 @@ function wp_update_nav_menu_item( $menu_id = 0, $menu_item_db_id = 0, $menu_item
 		if ( 'taxonomy' === $args['menu-item-type'] ) {
 			$original_parent = get_term_field( 'parent', $args['menu-item-object-id'], $args['menu-item-object'], 'raw' );
 			$original_title  = get_term_field( 'name', $args['menu-item-object-id'], $args['menu-item-object'], 'raw' );
+			$original_title  = ! is_wp_error( $original_title ) ? $original_title : '';
 		} elseif ( 'post_type' === $args['menu-item-type'] ) {
 
 			$original_object = get_post( $args['menu-item-object-id'] );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61799

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
