### PR TITLE
Fixed: #61798 Not possible to assign author to unowned post in the primary edit form

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1113,7 +1113,7 @@ th.action-links {
 
 .wp-filter .search-form.search-plugins {
 	/* This element is a flex item: the inherited float won't have any effect. */
-	margin-top: 0;
+	margin: 0;
 }
 
 .wp-filter .search-form.search-plugins select,
@@ -1345,6 +1345,10 @@ th.action-links {
 
 	.filter-group li {
 		margin: 10px 0;
+	}
+
+	.wp-filter .search-form {
+		margin: 11px 0 15px;
 	}
 }
 

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3859,12 +3859,18 @@ function wp_untrash_post( $post_id = 0 ) {
 	delete_post_meta( $post_id, '_wp_trash_meta_status' );
 	delete_post_meta( $post_id, '_wp_trash_meta_time' );
 
-	$post_updated = wp_update_post(
-		array(
-			'ID'          => $post_id,
-			'post_status' => $post_status,
-		)
+	$args = array(
+		'ID'          => $post_id,
+		'post_status' => $post_status,
 	);
+
+	$post_author_id = get_post_field( 'post_author', $post_id );
+
+	if ( !( (bool) get_user_by( 'id', $post_author_id ) ) ) {
+		$args['post_author'] = get_current_user_id();
+	}
+
+	$post_updated = wp_update_post( $args );
 
 	if ( ! $post_updated ) {
 		return false;


### PR DESCRIPTION
Fixed: #61798 Not possible to assign author to unowned post in the primary edit form

We have checked the following issue
- When the post is untrash (restored from trash), it does not check whether the authors still exist or not... So in that case, we can check first "if author user no exists, then assign the current user as the author of that post"

By doing this, It will assign the current user as an author to that restored post - only if the author is not present.

Ticket link : https://core.trac.wordpress.org/ticket/61798