### PR TITLE
HTML API: Fix possible infinite loop parsing incomplete script tags

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1433,7 +1433,7 @@ class WP_HTML_Tag_Processor {
 
 			// Everything of interest past here starts with "<".
 			if ( $at + 1 >= $doc_length || '<' !== $html[ $at + 1 ] ) {
-				$at += 1;
+				++$at;
 				continue;
 			}
 

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1431,9 +1431,15 @@ class WP_HTML_Tag_Processor {
 				continue;
 			}
 
-			// Everything of interest past here starts with "<".
-			if ( $at + 1 >= $doc_length || '<' !== $html[ $at + 1 ] ) {
-				++$at;
+			if ( $at + 1 >= $doc_length ) {
+				break;
+			}
+
+			/*
+			 * Everything of interest past here starts with "<".
+			 * Check this character and advance position regardless.
+			 */
+			if ( '<' !== $html[ $at++ ] ) {
 				continue;
 			}
 

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1432,7 +1432,8 @@ class WP_HTML_Tag_Processor {
 			}
 
 			// Everything of interest past here starts with "<".
-			if ( $at + 1 >= $doc_length || '<' !== $html[ $at++ ] ) {
+			if ( $at + 1 >= $doc_length || '<' !== $html[ $at + 1 ] ) {
+				$at += 1;
 				continue;
 			}
 

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1432,7 +1432,7 @@ class WP_HTML_Tag_Processor {
 			}
 
 			if ( $at + 1 >= $doc_length ) {
-				break;
+				return false;
 			}
 
 			/*

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2875,4 +2875,18 @@ HTML
 			'Should have properly applied the update from in front of the cursor.'
 		);
 	}
+
+	/**
+	 * Test an infinite loop bugfix in script tag processing.
+	 *
+	 * @small
+	 *
+	 * @ticket TBD
+	 */
+	public function test_script_tag_processing_no_infinite_loop() {
+		$processor = new WP_HTML_Tag_Processor( '<script type="data">-' );
+
+		$this->assertFalse( $processor->next_tag() );
+		$this->assertTrue( $processor->paused_at_incomplete_token() );
+	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2877,14 +2877,28 @@ HTML
 	}
 
 	/**
-	 * Test an infinite loop bugfix in script tag processing.
+	 * Test an infinite loop bugfix in incomplete script tag parsing.
 	 *
 	 * @small
 	 *
-	 * @ticket TBD
+	 * @ticket 61810
 	 */
-	public function test_script_tag_processing_no_infinite_loop() {
-		$processor = new WP_HTML_Tag_Processor( '<script type="data">-' );
+	public function test_script_tag_processing_no_infinite_loop_final_dash() {
+		$processor = new WP_HTML_Tag_Processor( '<script>-' );
+
+		$this->assertFalse( $processor->next_tag() );
+		$this->assertTrue( $processor->paused_at_incomplete_token() );
+	}
+
+	/**
+	 * Test an infinite loop bugfix in incomplete script tag parsing.
+	 *
+	 * @small
+	 *
+	 * @ticket 61810
+	 */
+	public function test_script_tag_processing_no_infinite_loop_final_left_angle_bracket() {
+		$processor = new WP_HTML_Tag_Processor( '<script><' );
 
 		$this->assertFalse( $processor->next_tag() );
 		$this->assertTrue( $processor->paused_at_incomplete_token() );


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/61810

When the Tag Processor (or HTML Processor) attempts to parse certain incomplete script tags, the parser enters an infinite loop and will hang indefinitely. The conditions to reach this situation are:

- Input HTML ends with an open script tag.
- The final character of input is `-` or `<`.
 
If these conditions are satisfied, the parser will enter an infinite loop and hang when it attempts to parse the script tag.

Example problematic inputs:
- `<script>-`
- `<script><`

Creating a processor and calling `next_tag()` will hang. In both cases, `next_tag()` should return false with the processor in incomplete token state.

## Diagnosis

This bug was caused by essential code for advancing the parser position (`$at++`) never being reached by a short-circuit condition: `if ( $too_short || '<' !== $html[ $at++ ] ) {}`. If the left-hand side is true, the RHS is never evaluated and the processor may not advance.

Other code in the block would advance the parser under most conditions, it was only when `-` or `<` were in the final position in the document that the LHS would evaluate to true and the parser would enter an infinite loop.

This was difficult to spot because of its similarity to many other blocks in the parser like this:

```php
if (
  $at + 2 < $doc_length &&
  '-' === $html[ $at ] &&
  '-' === $html[ $at + 1 ] &&
  '>' === $html[ $at + 2 ]
) {}
```

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
