### PR TITLE
Try casting options, etc to strings

### DIFF
--- a/src/wp-content/themes/twentytwenty/classes/class-twentytwenty-walker-page.php
+++ b/src/wp-content/themes/twentytwenty/classes/class-twentytwenty-walker-page.php
@@ -63,7 +63,7 @@ if ( ! class_exists( 'TwentyTwenty_Walker_Page' ) ) {
 				} elseif ( $_current_page && $page->ID === $_current_page->post_parent ) {
 					$css_class[] = 'current_page_parent';
 				}
-			} elseif ( get_option( 'page_for_posts' ) === $page->ID ) {
+			} elseif ( (int) get_option( 'page_for_posts' ) === $page->ID ) {
 				$css_class[] = 'current_page_parent';
 			}
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2865,8 +2865,8 @@ function build_comment_query_vars_from_block( $block ) {
 		$comment_args['hierarchical'] = false;
 	}
 
-	if ( get_option( 'page_comments' ) === '1' || get_option( 'page_comments' ) === true ) {
-		$per_page     = get_option( 'comments_per_page' );
+	if ( (bool) get_option( 'page_comments' ) === true ) {
+		$per_page     = (int) get_option( 'comments_per_page' );
 		$default_page = get_option( 'default_comments_page' );
 		if ( $per_page > 0 ) {
 			$comment_args['number'] = $per_page;

--- a/src/wp-includes/class-wp-site.php
+++ b/src/wp-includes/class-wp-site.php
@@ -329,7 +329,7 @@ final class WP_Site {
 			}
 			$details->blogname   = get_option( 'blogname' );
 			$details->siteurl    = get_option( 'siteurl' );
-			$details->post_count = get_option( 'post_count' );
+			$details->post_count = (int) get_option( 'post_count' );
 			$details->home       = get_option( 'home' );
 			restore_current_blog();
 

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -2615,7 +2615,7 @@ function get_space_allowed() {
 	$space_allowed = get_option( 'blog_upload_space' );
 
 	if ( ! is_numeric( $space_allowed ) ) {
-		$space_allowed = get_site_option( 'blog_upload_space' );
+		$space_allowed = (int) get_site_option( 'blog_upload_space' );
 	}
 
 	if ( ! is_numeric( $space_allowed ) ) {

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -2615,12 +2615,15 @@ function get_space_allowed() {
 	$space_allowed = get_option( 'blog_upload_space' );
 
 	if ( ! is_numeric( $space_allowed ) ) {
-		$space_allowed = (int) get_site_option( 'blog_upload_space' );
+		$space_allowed = get_site_option( 'blog_upload_space' );
 	}
 
 	if ( ! is_numeric( $space_allowed ) ) {
 		$space_allowed = 100;
 	}
+
+	// Cast the value to an integer.
+	$space_allowed = (int) $space_allowed;
 
 	/**
 	 * Filters the upload quota for the current site.

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -912,6 +912,8 @@ function update_option( $option, $value, $autoload = null ) {
 	 */
 	$value = apply_filters( 'pre_update_option', $value, $option, $old_value );
 
+	$serialized_value = maybe_serialize( $value );
+
 	/*
 	 * If the new and old values are the same, no need to update.
 	 *
@@ -921,7 +923,7 @@ function update_option( $option, $value, $autoload = null ) {
 	 *
 	 * See https://core.trac.wordpress.org/ticket/38903
 	 */
-	if ( $value === $old_value || maybe_serialize( $value ) === maybe_serialize( $old_value ) ) {
+	if ( sprintf( '%s', $serialized_value ) === $old_value || maybe_serialize( $old_value ) === $serialized_value ) {
 		return false;
 	}
 
@@ -929,8 +931,6 @@ function update_option( $option, $value, $autoload = null ) {
 	if ( apply_filters( "default_option_{$option}", false, $option, false ) === $old_value ) {
 		return add_option( $option, $value, '', $autoload );
 	}
-
-	$serialized_value = maybe_serialize( $value );
 
 	/**
 	 * Fires immediately before an option value is updated.
@@ -2426,6 +2426,8 @@ function update_network_option( $network_id, $option, $value ) {
 	 */
 	$value = apply_filters( "pre_update_site_option_{$option}", $value, $old_value, $option, $network_id );
 
+	$serialized_value = maybe_serialize( $value );
+
 	/*
 	 * If the new and old values are the same, no need to update.
 	 *
@@ -2435,7 +2437,7 @@ function update_network_option( $network_id, $option, $value ) {
 	 *
 	 * See https://core.trac.wordpress.org/ticket/44956
 	 */
-	if ( $value === $old_value || maybe_serialize( $value ) === maybe_serialize( $old_value ) ) {
+	if ( sprintf( '%s', $serialized_value ) === $old_value || maybe_serialize( $old_value ) === $serialized_value ) {
 		return false;
 	}
 
@@ -2456,7 +2458,6 @@ function update_network_option( $network_id, $option, $value ) {
 	} else {
 		$value = sanitize_option( $option, $value );
 
-		$serialized_value = maybe_serialize( $value );
 		/*
 		 * Ensure the serialized value is a string.
 		 *

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -943,6 +943,15 @@ function update_option( $option, $value, $autoload = null ) {
 	 */
 	do_action( 'update_option', $option, $old_value, $value );
 
+	/*
+	 * Ensure the serialized value is a string.
+	 *
+	 * This ensure that the option is stored in the cache in the same format as the
+	 * option is stored in the database. Rather than type casting, sprintf is used to
+	 * match the process used by wpdb::prepare().
+	 */
+	$serialized_value = sprintf( '%s', $serialized_value );
+
 	$update_args = array(
 		'option_value' => $serialized_value,
 	);
@@ -1139,6 +1148,15 @@ function add_option( $option, $value = '', $deprecated = '', $autoload = null ) 
 	 * @param mixed  $value  Value of the option.
 	 */
 	do_action( 'add_option', $option, $value );
+
+	/*
+	 * Ensure the serialized value is a string.
+	 *
+	 * This ensure that the option is stored in the cache in the same format as the
+	 * option is stored in the database. Rather than type casting, sprintf is used to
+	 * match the process used by wpdb::prepare().
+	 */
+	$serialized_value = sprintf( '%s', $serialized_value );
 
 	$result = $wpdb->query( $wpdb->prepare( "INSERT INTO `$wpdb->options` (`option_name`, `option_value`, `autoload`) VALUES (%s, %s, %s) ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)", $option, $serialized_value, $autoload ) );
 	if ( ! $result ) {
@@ -2186,6 +2204,16 @@ function add_network_option( $network_id, $option, $value ) {
 		$value = sanitize_option( $option, $value );
 
 		$serialized_value = maybe_serialize( $value );
+
+		/*
+		 * Ensure the serialized value is a string.
+		 *
+		 * This ensure that the option is stored in the cache in the same format as the
+		 * option is stored in the database. Rather than type casting, sprintf is used to
+		 * match the process used by wpdb::prepare().
+		 */
+		$serialized_value = sprintf( '%s', $serialized_value );
+
 		$result           = $wpdb->insert(
 			$wpdb->sitemeta,
 			array(
@@ -2429,6 +2457,15 @@ function update_network_option( $network_id, $option, $value ) {
 		$value = sanitize_option( $option, $value );
 
 		$serialized_value = maybe_serialize( $value );
+		/*
+		 * Ensure the serialized value is a string.
+		 *
+		 * This ensure that the option is stored in the cache in the same format as the
+		 * option is stored in the database. Rather than type casting, sprintf is used to
+		 * match the process used by wpdb::prepare().
+		 */
+		$serialized_value = sprintf( '%s', $serialized_value );
+
 		$result           = $wpdb->update(
 			$wpdb->sitemeta,
 			array( 'meta_value' => $serialized_value ),

--- a/tests/phpunit/tests/ajax/wpAjaxWpCompressionTest.php
+++ b/tests/phpunit/tests/ajax/wpAjaxWpCompressionTest.php
@@ -148,7 +148,7 @@ class Tests_Ajax_wpAjaxWpCompressionTest extends WP_Ajax_UnitTestCase {
 		}
 
 		// Check the site option is not changed due to lack of nonce.
-		$this->assertSame( 0, get_site_option( 'can_compress_scripts' ) );
+		$this->assertSame( '0', get_site_option( 'can_compress_scripts' ) );
 
 		// Add a nonce.
 		$_GET['_ajax_nonce'] = wp_create_nonce( 'update_can_compress_scripts' );
@@ -161,7 +161,7 @@ class Tests_Ajax_wpAjaxWpCompressionTest extends WP_Ajax_UnitTestCase {
 		}
 
 		// Check the site option is changed.
-		$this->assertSame( 1, get_site_option( 'can_compress_scripts' ) );
+		$this->assertSame( '1', get_site_option( 'can_compress_scripts' ) );
 	}
 
 	/**
@@ -186,7 +186,7 @@ class Tests_Ajax_wpAjaxWpCompressionTest extends WP_Ajax_UnitTestCase {
 		}
 
 		// Check the site option is not changed due to lack of nonce.
-		$this->assertSame( 1, get_site_option( 'can_compress_scripts' ) );
+		$this->assertSame( '1', get_site_option( 'can_compress_scripts' ) );
 
 		// Add a nonce.
 		$_GET['_ajax_nonce'] = wp_create_nonce( 'update_can_compress_scripts' );
@@ -199,7 +199,7 @@ class Tests_Ajax_wpAjaxWpCompressionTest extends WP_Ajax_UnitTestCase {
 		}
 
 		// Check the site option is changed.
-		$this->assertSame( 0, get_site_option( 'can_compress_scripts' ) );
+		$this->assertSame( '0', get_site_option( 'can_compress_scripts' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/https-migration.php
+++ b/tests/phpunit/tests/https-migration.php
@@ -109,7 +109,7 @@ class Tests_HTTPS_Migration extends WP_UnitTestCase {
 		// Changing HTTP to HTTPS on a site with content should result in flag being set, requiring migration.
 		update_option( 'fresh_site', '0' );
 		wp_update_https_migration_required( 'http://example.org', 'https://example.org' );
-		$this->assertTrue( get_option( 'https_migration_required' ) );
+		$this->assertTrue( (bool) get_option( 'https_migration_required' ) );
 
 		// Changing another part than the scheme should delete/reset the flag because changing those parts (e.g. the
 		// domain) can have further implications.

--- a/tests/phpunit/tests/option/getOptions.php
+++ b/tests/phpunit/tests/option/getOptions.php
@@ -115,6 +115,12 @@ class Tests_Option_GetOptions extends WP_UnitTestCase {
 
 		// Check that the return type is the same.
 		$this->assertSame( gettype( $option_cached ), gettype( $option_uncached ), 'The return type is not the same.' );
+		/*
+		 * Check canonicalized value.
+		 *
+		 * This is done separately from the above check to avoid false negatives
+		 * for objects as assertSame checks for the same instance.
+		 */
 		$this->assertEqualsCanonicalizing( $option_cached, $option_uncached, 'The option values are not the same.' );
 	}
 

--- a/tests/phpunit/tests/option/getOptions.php
+++ b/tests/phpunit/tests/option/getOptions.php
@@ -88,4 +88,63 @@ class Tests_Option_GetOptions extends WP_UnitTestCase {
 
 		$this->assertFalse( $options['nonexistent_option'], 'nonexistent_option is present in option.' );
 	}
+
+	/**
+	 * Test get_option() returns the same type when cached and uncached.
+	 *
+	 * @ticket 32848
+	 *
+	 * @dataProvider data_get_option_return_type_cached_and_uncached
+	 *
+	 * @param mixed $option_vale The value to test.
+	 */
+	public function test_get_option_return_type_cached_and_uncached( $option_vale ) {
+		$option_name = 'option_for_type_testing';
+
+		// Set the option value.
+		update_option( $option_name, $option_vale, false );
+
+		// Get the option while cached.
+		$option_cached = get_option( $option_name );
+
+		// Clear the cache.
+		wp_cache_delete( $option_name, 'options' );
+
+		// Get the option while uncached.
+		$option_uncached = get_option( $option_name );
+
+		// Check that the return type is the same.
+		$this->assertSame( gettype( $option_cached ), gettype( $option_uncached ), 'The return type is not the same.' );
+		$this->assertEqualsCanonicalizing( $option_cached, $option_uncached, 'The option values are not the same.' );
+	}
+
+	/**
+	 * Data provider for test_get_option_return_type_cached_and_uncached().
+	 *
+	 * @return array[]
+	 */
+	public function data_get_option_return_type_cached_and_uncached() {
+		return array(
+			'an empty string'                => array( '' ),
+			'a string with spaces'           => array( '   ' ),
+			'a string with tabs'             => array( "\t" ),
+			'a string with new lines'        => array( "\n" ),
+			'a string with carriage returns' => array( "\r" ),
+			'int -1'                         => array( -1 ),
+			'int 0'                          => array( 0 ),
+			'int 1'                          => array( 1 ),
+			'float -1.0'                     => array( -1.0 ),
+			'float 0.0'                      => array( 0.0 ),
+			'float 1.0'                      => array( 1.0 ),
+			'false'                          => array( false ),
+			'true'                           => array( true ),
+			'null'                           => array( null ),
+			'an empty array'                 => array( array() ),
+			'a non-empty array'              => array( array( 'value' ) ),
+			'an empty object'                => array( new stdClass() ),
+			'a non-empty object'             => array( (object) array( 'value' ) ),
+			'INF'                            => array( INF ),
+			'NAN'                            => array( NAN ),
+		);
+	}
 }

--- a/tests/phpunit/tests/option/networkOption.php
+++ b/tests/phpunit/tests/option/networkOption.php
@@ -420,4 +420,72 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 		$this->assertIsArray( $network_notoptions_cache_after, 'Multisite notoptions cache should be set.' );
 		$this->assertArrayHasKey( 'ticket_61730_notoption', $network_notoptions_cache_after, 'The option should be in the notoptions cache.' );
 	}
+
+	/**
+	 * Test get_network_option() returns the same type when cached and uncached.
+	 *
+	 * @ticket 32848
+	 *
+	 * @covers ::get_network_option
+
+	 * @dataProvider data_get_network_option_return_type_cached_and_uncached
+	 *
+	 * @param mixed $option_vale The value to test.
+	 */
+	public function test_get_network_option_return_type_cached_and_uncached( $option_vale ) {
+		$option_name = 'option_for_type_testing';
+		if ( is_multisite() ) {
+			$cache_key   = "1:$option_name";
+			$cache_group = 'site-options';
+		} else {
+			$cache_key   = $option_name;
+			$cache_group = 'options';
+		}
+
+		// Set the option value.
+		update_network_option( 1, $option_name, $option_vale, false );
+
+		// Get the option while cached.
+		$option_cached = get_network_option( 1, $option_name );
+
+		// Clear the cache.
+		wp_cache_delete( $cache_key, $cache_group );
+
+		// Get the option while uncached.
+		$option_uncached = get_network_option( 1, $option_name );
+
+		// Check that the return type is the same.
+		$this->assertSame( gettype( $option_cached ), gettype( $option_uncached ), 'The return type is not the same.' );
+		$this->assertEqualsCanonicalizing( $option_cached, $option_uncached, 'The option values are not the same.' );
+	}
+
+	/**
+	 * Data provider for test_get_network_option_return_type_cached_and_uncached().
+	 *
+	 * @return array[]
+	 */
+	public function data_get_network_option_return_type_cached_and_uncached() {
+		return array(
+			'an empty string'                => array( '' ),
+			'a string with spaces'           => array( '   ' ),
+			'a string with tabs'             => array( "\t" ),
+			'a string with new lines'        => array( "\n" ),
+			'a string with carriage returns' => array( "\r" ),
+			'int -1'                         => array( -1 ),
+			'int 0'                          => array( 0 ),
+			'int 1'                          => array( 1 ),
+			'float -1.0'                     => array( -1.0 ),
+			'float 0.0'                      => array( 0.0 ),
+			'float 1.0'                      => array( 1.0 ),
+			'false'                          => array( false ),
+			'true'                           => array( true ),
+			'null'                           => array( null ),
+			'an empty array'                 => array( array() ),
+			'a non-empty array'              => array( array( 'value' ) ),
+			'an empty object'                => array( new stdClass() ),
+			'a non-empty object'             => array( (object) array( 'value' ) ),
+			'INF'                            => array( INF ),
+			'NAN'                            => array( NAN ),
+		);
+	}
 }

--- a/tests/phpunit/tests/option/networkOption.php
+++ b/tests/phpunit/tests/option/networkOption.php
@@ -456,6 +456,12 @@ class Tests_Option_NetworkOption extends WP_UnitTestCase {
 
 		// Check that the return type is the same.
 		$this->assertSame( gettype( $option_cached ), gettype( $option_uncached ), 'The return type is not the same.' );
+		/*
+		 * Check canonicalized value.
+		 *
+		 * This is done separately from the above check to avoid false negatives
+		 * for objects as assertSame checks for the same instance.
+		 */
 		$this->assertEqualsCanonicalizing( $option_cached, $option_uncached, 'The option values are not the same.' );
 	}
 

--- a/tests/phpunit/tests/taxonomy.php
+++ b/tests/phpunit/tests/taxonomy.php
@@ -1076,7 +1076,7 @@ class Tests_Taxonomy extends WP_UnitTestCase {
 
 		// Test default term.
 		$term = wp_get_post_terms( $post_id, $tax );
-		$this->assertSame( get_option( 'default_term_' . $tax ), $term[0]->term_id );
+		$this->assertSame( get_option( 'default_term_' . $tax ), (string) $term[0]->term_id );
 
 		// Test default term deletion.
 		$this->assertSame( wp_delete_term( $term[0]->term_id, $tax ), 0 );
@@ -1097,7 +1097,7 @@ class Tests_Taxonomy extends WP_UnitTestCase {
 
 		// Test default term.
 		$term = wp_get_post_terms( $post_id, $tax );
-		$this->assertSame( get_option( 'default_term_' . $tax ), $term[0]->term_id );
+		$this->assertSame( get_option( 'default_term_' . $tax ), (string) $term[0]->term_id );
 
 		// wp_set_object_terms() should not assign default term.
 		wp_set_object_terms( $post_id, array(), $tax );

--- a/tests/phpunit/tests/term/splitSharedTerm.php
+++ b/tests/phpunit/tests/term/splitSharedTerm.php
@@ -183,12 +183,12 @@ class Tests_Term_SplitSharedTerm extends WP_UnitTestCase {
 		);
 		clean_term_cache( $t1['term_id'], 'category' );
 
-		$this->assertSame( $t1['term_id'], get_option( 'default_category', -1 ) );
+		$this->assertSame( $t1['term_id'], (int) get_option( 'default_category', -1 ) );
 
 		$new_term_id = _split_shared_term( $t1['term_id'], $t1['term_taxonomy_id'] );
 
 		$this->assertNotEquals( $new_term_id, $t1['term_id'] );
-		$this->assertSame( $new_term_id, get_option( 'default_category', -1 ) );
+		$this->assertSame( $new_term_id, (int) get_option( 'default_category', -1 ) );
 	}
 
 	/**


### PR DESCRIPTION
This casts the cached value of options to a string in `update_option()`, `update_network_option()`, `add_option()` and `add_network_option()`.

Currently the cached value of an option can be in either of the original type or a string, depending on whether the cache was primed after a database query in `get_(network)_option()` (always a string) or primed while updating or adding an option (type as passed to the function).

The effect of this is that the result of `get_(network)_option()` can be inconsistent depending on whether the cache was primed or required a database query.

This change ensures that the options always use the same type (a string) regardless of how the cache is primed.

**Risks**

Yes.

On hosting providers that prevent the options cache/all options cache from being flushed the type would consistently be as set by the code while adding or updating the value. Following this change, that will no longer be the case.

Trac ticket: https://core.trac.wordpress.org/ticket/32848

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
