### PR TITLE
Fixed : `wptexturize()` - Hyphen may be replaced with ndash

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -103,7 +103,7 @@ function wptexturize( $text, $reset = false ) {
 		/* translators: Em dash. */
 		$em_dash = _x( '&#8212;', 'em dash' );
 
-		$default_no_texturize_tags       = array( 'pre', 'code', 'kbd', 'style', 'script', 'tt' );
+		$default_no_texturize_tags       = array( 'pre', 'code', 'kbd', 'style', 'script', 'tt', 'mark' );
 		$default_no_texturize_shortcodes = array( 'code' );
 
 		// If a plugin has provided an autocorrect array, use it.


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61817

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
