### PR TITLE
Try setting targetHints automatically.

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -639,26 +639,34 @@ class WP_REST_Server {
 				$attributes         = $item['attributes'];
 				$attributes['href'] = $item['href'];
 
-				if ( 'self' === $rel ) {
-					$request = WP_REST_Request::from_url( $item['href'] );
-					$match   = $server->match_request_to_handler( $request );
+				if ( 'self' !== $rel ) {
+					$data[ $rel ][] = $attributes;
+					continue;
+				}
 
-					if ( ! is_wp_error( $match ) ) {
-						$response = new WP_REST_Response();
-						$response->set_matched_route( $match[0] );
-						$response->set_matched_handler( $match[1] );
-						$headers = rest_send_allow_header( $response, $server, $request )->get_headers();
+				// Prefer targetHints that were specifically designated by the developer.
+				if ( isset( $attributes['targetHints']['allow'] ) ) {
+					$data[ $rel ][] = $attributes;
+					continue;
+				}
 
-						foreach ( $headers as $name => $value ) {
-							$name = WP_REST_Request::canonicalize_header_name( $name );
+				$request = WP_REST_Request::from_url( $item['href'] );
+				if ( ! $request ) {
+					$data[ $rel ][] = $attributes;
+					continue;
+				}
 
-							// Prefer targetHints that were specifically designated by the developer.
-							if ( isset( $attributes['targetHints'][ $name ] ) ) {
-								continue;
-							}
+				$match = $server->match_request_to_handler( $request );
+				if ( ! is_wp_error( $match ) ) {
+					$response = new WP_REST_Response();
+					$response->set_matched_route( $match[0] );
+					$response->set_matched_handler( $match[1] );
+					$headers = rest_send_allow_header( $response, $server, $request )->get_headers();
 
-							$attributes['targetHints'][ $name ] = array_map( 'trim', explode( ',', $value ) );
-						}
+					foreach ( $headers as $name => $value ) {
+						$name = WP_REST_Request::canonicalize_header_name( $name );
+
+						$attributes['targetHints'][ $name ] = array_map( 'trim', explode( ',', $value ) );
 					}
 				}
 

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -642,7 +642,7 @@ class WP_REST_Server {
 					continue;
 				}
 
-				$target_hints = self::get_target_hints_for_link( $item['href'] );
+				$target_hints = self::get_target_hints_for_link( $attributes );
 				if ( $target_hints ) {
 					$attributes['targetHints'] = $target_hints;
 				}
@@ -675,7 +675,7 @@ class WP_REST_Server {
 		}
 
 		$server = rest_get_server();
-		$match = $server->match_request_to_handler( $request );
+		$match  = $server->match_request_to_handler( $request );
 
 		if ( is_wp_error( $match ) ) {
 			return null;

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -9,6 +9,8 @@
  */
 class Tests_REST_Server extends WP_Test_REST_TestCase {
 	protected static $icon_id;
+	protected static $admin_id;
+	protected static $post_id;
 
 	/**
 	 * Called before setting up all tests.
@@ -23,10 +25,18 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		$filename      = DIR_TESTDATA . '/images/test-image-large.jpg';
 		self::$icon_id = $factory->attachment->create_upload_object( $filename );
+		self::$admin_id = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		self::$post_id = $factory->post->create();
 	}
 
 	public static function tear_down_after_class() {
 		wp_delete_attachment( self::$icon_id, true );
+		self::delete_user( self::$admin_id );
+		wp_delete_post( self::$post_id );
 
 		parent::tear_down_after_class();
 	}
@@ -2429,6 +2439,62 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 		$this->assertCount( 2, $mock_hook->get_events()[0]['args'] );
 		$this->assertInstanceOf( 'WP_REST_Request', $mock_hook->get_events()[0]['args'][1] );
 		$this->assertSame( '/test-allowed-cors-headers', $mock_hook->get_events()[0]['args'][1]->get_route() );
+	}
+
+	public function test_populates_target_hints_for_administrator() {
+		wp_set_current_user( self::$admin_id );
+		$response = rest_do_request( '/wp/v2/posts' );
+		$post     = $response->get_data()[0];
+
+		$link = $post['_links']['self'][0];
+		$this->assertArrayHasKey( 'targetHints', $link );
+		$this->assertArrayHasKey( 'allow', $link['targetHints'] );
+		$this->assertSame( array( 'GET', 'POST', 'PUT', 'PATCH', 'DELETE' ), $link['targetHints']['allow'] );
+	}
+
+	public function test_populates_target_hints_for_logged_out_user() {
+		$response = rest_do_request( '/wp/v2/posts' );
+		$post     = $response->get_data()[0];
+
+		$link = $post['_links']['self'][0];
+		$this->assertArrayHasKey( 'targetHints', $link );
+		$this->assertArrayHasKey( 'allow', $link['targetHints'] );
+		$this->assertSame( array( 'GET' ), $link['targetHints']['allow'] );
+	}
+
+	public function test_does_not_error_on_invalid_urls() {
+		$response = new WP_REST_Response();
+		$response->add_link( 'self', 'this is not a real URL' );
+
+		$links = rest_get_server()::get_response_links( $response );
+		$this->assertArrayNotHasKey( 'targetHints', $links['self'][0] );
+	}
+
+	public function test_does_not_error_on_bad_rest_api_routes() {
+		$response = new WP_REST_Response();
+		$response->add_link( 'self', rest_url( '/this/is/not/a/real/route' ) );
+
+		$links = rest_get_server()::get_response_links( $response );
+		$this->assertArrayNotHasKey( 'targetHints', $links['self'][0] );
+	}
+
+	public function test_prefers_developer_defined_target_hints() {
+		$response = new WP_REST_Response();
+		$response->add_link(
+			'self',
+			'/wp/v2/posts/' . self::$post_id,
+			array(
+				'targetHints' => array(
+					'allow' => array( 'GET', 'PUT' ),
+				),
+			)
+		);
+
+		$links = rest_get_server()::get_response_links( $response );
+		$link  = $links['self'][0];
+		$this->assertArrayHasKey( 'targetHints', $link );
+		$this->assertArrayHasKey( 'allow', $link['targetHints'] );
+		$this->assertSame( array( 'GET', 'PUT' ), $link['targetHints']['allow'] );
 	}
 
 	public function _validate_as_integer_123( $value, $request, $key ) {

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -23,14 +23,14 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 	}
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		$filename      = DIR_TESTDATA . '/images/test-image-large.jpg';
-		self::$icon_id = $factory->attachment->create_upload_object( $filename );
+		$filename       = DIR_TESTDATA . '/images/test-image-large.jpg';
+		self::$icon_id  = $factory->attachment->create_upload_object( $filename );
 		self::$admin_id = $factory->user->create(
 			array(
 				'role' => 'administrator',
 			)
 		);
-		self::$post_id = $factory->post->create();
+		self::$post_id  = $factory->post->create();
 	}
 
 	public static function tear_down_after_class() {

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -2466,7 +2466,7 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 
 		$links = rest_get_server()::get_response_links( $response );
 
-		$this->assertArrayHasKey( 'self', $links['self'] );
+		$this->assertArrayHasKey( 'self', $links );
 		$this->assertArrayNotHasKey( 'targetHints', $links['self'][0] );
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -2477,6 +2477,7 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 	 * @ticket 61739
 	 */
 	public function test_sanitizes_request_when_building_target_hints() {
+		$validated_param = null;
 		register_rest_route(
 			'test-ns/v1',
 			'/test/(?P<id>\d+)',
@@ -2486,8 +2487,8 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 					'callback'            => static function () {
 						return new \WP_REST_Response();
 					},
-					'permission_callback' => function ( WP_REST_Request $request ) {
-						$this->assertIsInt( $request['id'] );
+					'permission_callback' => function ( WP_REST_Request $request ) use ( &$validated_param ) {
+						$validated_param = $request['id'];
 
 						return true;
 					},
@@ -2507,6 +2508,7 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 
 		$this->assertArrayHasKey( 'self', $links );
 		$this->assertArrayHasKey( 'targetHints', $links['self'][0] );
+		$this->assertIsInt( $validated_param );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -2486,7 +2486,7 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 					'callback'            => static function () {
 						return new \WP_REST_Response();
 					},
-					'permission_callback' => function( WP_REST_Request $request ) {
+					'permission_callback' => function ( WP_REST_Request $request ) {
 						$this->assertIsInt( $request['id'] );
 
 						return true;

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -12334,7 +12334,16 @@ mockedApiResponse.PostsCollection = [
         "_links": {
             "self": [
                 {
-                    "href": "http://example.org/index.php?rest_route=/wp/v2/posts/4"
+                    "href": "http://example.org/index.php?rest_route=/wp/v2/posts/4",
+                    "targetHints": {
+                        "allow": [
+                            "GET",
+                            "POST",
+                            "PUT",
+                            "PATCH",
+                            "DELETE"
+                        ]
+                    }
                 }
             ],
             "collection": [
@@ -12641,7 +12650,16 @@ mockedApiResponse.PagesCollection = [
         "_links": {
             "self": [
                 {
-                    "href": "http://example.org/index.php?rest_route=/wp/v2/pages/7"
+                    "href": "http://example.org/index.php?rest_route=/wp/v2/pages/7",
+                    "targetHints": {
+                        "allow": [
+                            "GET",
+                            "POST",
+                            "PUT",
+                            "PATCH",
+                            "DELETE"
+                        ]
+                    }
                 }
             ],
             "collection": [
@@ -12932,7 +12950,16 @@ mockedApiResponse.MediaCollection = [
         "_links": {
             "self": [
                 {
-                    "href": "http://example.org/index.php?rest_route=/wp/v2/media/10"
+                    "href": "http://example.org/index.php?rest_route=/wp/v2/media/10",
+                    "targetHints": {
+                        "allow": [
+                            "GET",
+                            "POST",
+                            "PUT",
+                            "PATCH",
+                            "DELETE"
+                        ]
+                    }
                 }
             ],
             "collection": [
@@ -13629,7 +13656,15 @@ mockedApiResponse.CategoriesCollection = [
         "_links": {
             "self": [
                 {
-                    "href": "http://example.org/index.php?rest_route=/wp/v2/categories/1"
+                    "href": "http://example.org/index.php?rest_route=/wp/v2/categories/1",
+                    "targetHints": {
+                        "allow": [
+                            "GET",
+                            "POST",
+                            "PUT",
+                            "PATCH"
+                        ]
+                    }
                 }
             ],
             "collection": [
@@ -13694,7 +13729,16 @@ mockedApiResponse.TagsCollection = [
         "_links": {
             "self": [
                 {
-                    "href": "http://example.org/index.php?rest_route=/wp/v2/tags/2"
+                    "href": "http://example.org/index.php?rest_route=/wp/v2/tags/2",
+                    "targetHints": {
+                        "allow": [
+                            "GET",
+                            "POST",
+                            "PUT",
+                            "PATCH",
+                            "DELETE"
+                        ]
+                    }
                 }
             ],
             "collection": [
@@ -13758,7 +13802,16 @@ mockedApiResponse.UsersCollection = [
         "_links": {
             "self": [
                 {
-                    "href": "http://example.org/index.php?rest_route=/wp/v2/users/1"
+                    "href": "http://example.org/index.php?rest_route=/wp/v2/users/1",
+                    "targetHints": {
+                        "allow": [
+                            "GET",
+                            "POST",
+                            "PUT",
+                            "PATCH",
+                            "DELETE"
+                        ]
+                    }
                 }
             ],
             "collection": [
@@ -13786,7 +13839,16 @@ mockedApiResponse.UsersCollection = [
         "_links": {
             "self": [
                 {
-                    "href": "http://example.org/index.php?rest_route=/wp/v2/users/2"
+                    "href": "http://example.org/index.php?rest_route=/wp/v2/users/2",
+                    "targetHints": {
+                        "allow": [
+                            "GET",
+                            "POST",
+                            "PUT",
+                            "PATCH",
+                            "DELETE"
+                        ]
+                    }
                 }
             ],
             "collection": [
@@ -13859,7 +13921,16 @@ mockedApiResponse.CommentsCollection = [
         "_links": {
             "self": [
                 {
-                    "href": "http://example.org/index.php?rest_route=/wp/v2/comments/2"
+                    "href": "http://example.org/index.php?rest_route=/wp/v2/comments/2",
+                    "targetHints": {
+                        "allow": [
+                            "GET",
+                            "POST",
+                            "PUT",
+                            "PATCH",
+                            "DELETE"
+                        ]
+                    }
                 }
             ],
             "collection": [


### PR DESCRIPTION
This needs to be refactored to be less ugly, and handle errors from `WP_REST_Request::from_url`. But this is my thinking on how we could automatically add a targetHint.

Trac ticket: https://core.trac.wordpress.org/ticket/61739

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
