### PR TITLE
HTML API: Fix unclosed funky comment bug

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1909,6 +1909,8 @@ class WP_HTML_Tag_Processor {
 			if ( $this->is_closing_tag ) {
 				// No chance of finding a closer.
 				if ( $at + 3 > $doc_length ) {
+					$this->parser_state = self::STATE_INCOMPLETE_INPUT;
+
 					return false;
 				}
 

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2903,4 +2903,15 @@ HTML
 		$this->assertFalse( $processor->next_tag() );
 		$this->assertTrue( $processor->paused_at_incomplete_token() );
 	}
+
+	/**
+	 * Test a bugfix where the input ends abruptly with a funky comment started.
+	 *
+	 * @ticket 61831
+	 */
+	public function test_unclosed_funky_comment_input_too_short() {
+		$processor = new WP_HTML_Tag_Processor( '</#' );
+		$this->assertFalse( $processor->next_tag() );
+		$this->assertTrue( $processor->paused_at_incomplete_token() );
+	}
 }


### PR DESCRIPTION
- Fix an issue where `</#` is not treated as incomplete input but `</# ` is. Both should be incomplete input.
- Add a test for the issue.

---

The HTML Tag Processor may report ::paused_at_incomplete_token() === true correctly when the HTML ends in an open "funky comment."

The HTML </# should be handled the same as </# , in both cases a funky comment has been opened but no closer is found before the HTML document ends. Both cases should both be treated as incomplete input, however the former case (with no trailing space) does not report an incomplete token.

Trac ticket: https://core.trac.wordpress.org/ticket/61831

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
