### PR TITLE
HTML API: Ensure that `get_modifiable_text()` reads enqueued updates.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -614,7 +614,7 @@ class WP_HTML_Tag_Processor {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @var string
+	 * @var int
 	 */
 	private $text_length;
 
@@ -2894,11 +2894,13 @@ class WP_HTML_Tag_Processor {
 	 * @return string
 	 */
 	public function get_modifiable_text(): string {
-		if ( null === $this->text_starts_at || 0 === $this->text_length ) {
+		$has_enqueued_update = isset( $this->lexical_updates['modifiable text'] );
+
+		if ( ! $has_enqueued_update && ( null === $this->text_starts_at || 0 === $this->text_length ) ) {
 			return '';
 		}
 
-		$text = isset( $this->lexical_updates['modifiable text'] )
+		$text = $has_enqueued_update
 			? $this->lexical_updates['modifiable text']->text
 			: substr( $this->html, $this->text_starts_at, $this->text_length );
 

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -614,7 +614,7 @@ class WP_HTML_Tag_Processor {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @var string
+	 * @var int
 	 */
 	private $text_length;
 
@@ -2898,7 +2898,7 @@ class WP_HTML_Tag_Processor {
 			return '';
 		}
 
-		$text = isset( $this->lexical_updates['modifiable text'] )
+		$text = $has_enqueued_update
 			? $this->lexical_updates['modifiable text']->text
 			: substr( $this->html, $this->text_starts_at, $this->text_length );
 

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
@@ -79,6 +79,44 @@ class Tests_HtmlApi_WpHtmlTagProcessorModifiableText extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures that `get_modifiable_text()` reads enqueued updates when read from after
+	 * writing when starting from an empty text; guarantees consistency through writes.
+	 *
+	 * @ticket 61617
+	 */
+	public function test_get_modifiable_text_is_consistent_after_writes_to_empty_text() {
+		$after     = 'different text';
+		$processor = new WP_HTML_Tag_Processor( '<script></script>' );
+		$processor->next_token();
+
+		$this->assertSame(
+			'SCRIPT',
+			$processor->get_token_name(),
+			"Should have found text node but found '{$processor->get_token_name()}' instead: check test setup."
+		);
+
+		$this->assertSame(
+			'',
+			$processor->get_modifiable_text(),
+			'Should have found initial test text: check test setup.'
+		);
+
+		$processor->set_modifiable_text( $after );
+		$this->assertSame(
+			$after,
+			$processor->get_modifiable_text(),
+			'Should have found enqueued updated text.'
+		);
+
+		$processor->get_updated_html();
+		$this->assertSame(
+			$after,
+			$processor->get_modifiable_text(),
+			'Should have found updated text.'
+		);
+	}
+
+	/**
 	 * Ensures that updates to modifiable text that are shorter than the
 	 * original text do not cause the parser to lose its orientation.
 	 *

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
@@ -40,6 +40,45 @@ class Tests_HtmlApi_WpHtmlTagProcessorModifiableText extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures that `get_modifiable_text()` reads enqueued updates when read
+	 * from after writing; guarantees consistency through writes.
+	 *
+	 * @ticket 61617
+	 */
+	public function test_get_modifiable_text_is_consistent_after_writes() {
+		$before    = 'just some text';
+		$after     = 'different text';
+		$processor = new WP_HTML_Tag_Processor( $before );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#text',
+			$processor->get_token_name(),
+			"Should have found text node but found '{$processor->get_token_name()}' instead: check test setup."
+		);
+
+		$this->assertSame(
+			$before,
+			$processor->get_modifiable_text(),
+			'Should have found initial test text: check test setup.'
+		);
+
+		$processor->set_modifiable_text( $after );
+		$this->assertSame(
+			$after,
+			$processor->get_modifiable_text(),
+			'Should have found enqueued updated text.'
+		);
+
+		$processor->get_updated_html();
+		$this->assertSame(
+			$after,
+			$processor->get_modifiable_text(),
+			'Should have found updated text.'
+		);
+	}
+
+	/**
 	 * Ensures that updates to modifiable text that are shorter than the
 	 * original text do not cause the parser to lose its orientation.
 	 *


### PR DESCRIPTION
Trac ticket: Core-61617

When `set_modifiable_text()` was added to the Tag Processor, it was overlooked that the same information could be queried after setting its value and before proceeding to the next token.

This means that reads following writes return the wrong value.

In this patch, `get_modifiable_text()` will read any enqueued values before reading from the input HTML document to ensure consistency.

Follow-up to [58829].
Props dmsnell, ramonopoly.