### PR TITLE
Fixed error : `class-wp-site-health-auto-updates.php` triggers error when `basedir` restrictions in effect

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health-auto-updates.php
+++ b/src/wp-admin/includes/class-wp-site-health-auto-updates.php
@@ -229,7 +229,7 @@ class WP_Site_Health_Auto_Updates {
 		foreach ( $vcs_dirs as $vcs_dir ) {
 			foreach ( $check_dirs as $check_dir ) {
 				// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition,Squiz.PHP.DisallowMultipleAssignments
-				if ( $checkout = @is_dir( rtrim( $check_dir, '\\/' ) . "/$vcs_dir" ) ) {
+				if ( @is_readable( rtrim( $check_dir, '\\/' ) . "/$vcs_dir" ) && ( $checkout = @is_dir( rtrim( $check_dir, '\\/' ) . "/$vcs_dir" ) ) ) {
 					break 2;
 				}
 			}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61834

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
