### PR TITLE
Comment: match disallowed list on unprocessed HTML

### DIFF
--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -2276,9 +2276,13 @@ function wp_new_comment( $commentdata, $wp_error = false ) {
 		$commentdata['comment_type'] = 'comment';
 	}
 
+	$commentdata['comment_approved'] = wp_allow_comment( $commentdata, $wp_error );
+
 	$commentdata = wp_filter_comment( $commentdata );
 
-	$commentdata['comment_approved'] = wp_allow_comment( $commentdata, $wp_error );
+	if ( $commentdata['comment_approved'] !== 'trash' ) {
+		$commentdata['comment_approved'] = wp_allow_comment( $commentdata, $wp_error );
+	}
 
 	if ( is_wp_error( $commentdata['comment_approved'] ) ) {
 		return $commentdata['comment_approved'];

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -2280,9 +2280,7 @@ function wp_new_comment( $commentdata, $wp_error = false ) {
 
 	$commentdata = wp_filter_comment( $commentdata );
 
-	if ( $commentdata['comment_approved'] !== 'trash' ) {
-		$commentdata['comment_approved'] = wp_allow_comment( $commentdata, $wp_error );
-	}
+	$commentdata['comment_approved'] = ( 'trash' === $commentdata['comment_approved'] ) ? $commentdata['comment_approved'] : wp_allow_comment( $commentdata, $wp_error );
 
 	if ( is_wp_error( $commentdata['comment_approved'] ) ) {
 		return $commentdata['comment_approved'];

--- a/tests/phpunit/tests/comment/wpHandleCommentSubmission.php
+++ b/tests/phpunit/tests/comment/wpHandleCommentSubmission.php
@@ -976,4 +976,37 @@ class Tests_Comment_wpHandleCommentSubmission extends WP_UnitTestCase {
 			'a non-existent parent comment' => array( 'exists' => false ),
 		);
 	}
+
+	public function test_disallowed_keys_match_gives_approved_status_of_trash() {
+		$data    = array(
+			'comment_post_ID' => self::$post->ID,
+			'comment'         => 'Comment',
+			'author'          => 'Comment Author',
+			'email'           => 'comment@example.org',
+		);
+		update_option( 'disallowed_keys', "Comment\nfoo" );
+		$comment = wp_handle_comment_submission( $data );
+
+		$this->assertNotWPError( $comment );
+		$this->assertInstanceOf( 'WP_Comment', $comment );
+		$this->assertSame( 'trash', $comment->comment_approved );
+	}
+
+	/**
+	 * @ticket 61827
+	 */
+	public function test_disallowed_keys_html_match_gives_approved_status_of_trash() {
+		$data    = array(
+			'comment_post_ID' => self::$post->ID,
+			'comment'         => '<a href=http://example.com/>example</a>',
+			'author'          => 'Comment Author',
+			'email'           => 'comment@example.org',
+		);
+		update_option( 'disallowed_keys', "href=http\nfoo" );
+		$comment = wp_handle_comment_submission( $data );
+
+		$this->assertNotWPError( $comment );
+		$this->assertInstanceOf( 'WP_Comment', $comment );
+		$this->assertSame( 'trash', $comment->comment_approved );
+	}
 }

--- a/tests/phpunit/tests/comment/wpHandleCommentSubmission.php
+++ b/tests/phpunit/tests/comment/wpHandleCommentSubmission.php
@@ -978,7 +978,7 @@ class Tests_Comment_wpHandleCommentSubmission extends WP_UnitTestCase {
 	}
 
 	public function test_disallowed_keys_match_gives_approved_status_of_trash() {
-		$data    = array(
+		$data = array(
 			'comment_post_ID' => self::$post->ID,
 			'comment'         => 'Comment',
 			'author'          => 'Comment Author',
@@ -996,7 +996,7 @@ class Tests_Comment_wpHandleCommentSubmission extends WP_UnitTestCase {
 	 * @ticket 61827
 	 */
 	public function test_disallowed_keys_html_match_gives_approved_status_of_trash() {
-		$data    = array(
+		$data = array(
 			'comment_post_ID' => self::$post->ID,
 			'comment'         => '<a href=http://example.com/>example</a>',
 			'author'          => 'Comment Author',


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

When handling a comment submission, run `wp_allow_comment` on comment data before it is filtered with `wp_filter_comment`. If the approved status is `trash`, preserve this status. If not, run `wp_allow_comment` after comment data is filtered.

This change makes the disallowed list more powerful by looking for matches on unfiltered HTML as well as filtered HTML.

Trac ticket: https://core.trac.wordpress.org/ticket/61827

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
