### PR TITLE
HTML API: Add support for foreign elements to stack operations.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-open-elements.php
+++ b/src/wp-includes/html-api/class-wp-html-open-elements.php
@@ -288,7 +288,7 @@ class WP_HTML_Open_Elements {
 	 * >   - SVG title
 	 *
 	 * @since 6.4.0
-	 * @since 6.7.0 Supports all required HTML elements.
+	 * @since 6.7.0 Full support.
 	 *
 	 * @see https://html.spec.whatwg.org/#has-an-element-in-scope
 	 *
@@ -309,19 +309,16 @@ class WP_HTML_Open_Elements {
 				'OBJECT',
 				'TEMPLATE',
 
-				/*
-				 * @todo Support SVG and MathML nodes when support for foreign content is added.
-				 *
-				 * - MathML mi
-				 * - MathML mo
-				 * - MathML mn
-				 * - MathML ms
-				 * - MathML mtext
-				 * - MathML annotation-xml
-				 * - SVG foreignObject
-				 * - SVG desc
-				 * - SVG title
-				 */
+				'math MI',
+				'math MO',
+				'math MN',
+				'math MS',
+				'math MTEXT',
+				'math ANNOTATION-XML',
+
+				'svg FOREIGNOBJECT',
+				'svg DESC',
+				'svg TITLE',
 			)
 		);
 	}
@@ -363,19 +360,16 @@ class WP_HTML_Open_Elements {
 				'TEMPLATE',
 				'UL',
 
-				/*
-				 * @todo Support SVG and MathML nodes when support for foreign content is added.
-				 *
-				 * - MathML mi
-				 * - MathML mo
-				 * - MathML mn
-				 * - MathML ms
-				 * - MathML mtext
-				 * - MathML annotation-xml
-				 * - SVG foreignObject
-				 * - SVG desc
-				 * - SVG title
-				 */
+				'math MI',
+				'math MO',
+				'math MN',
+				'math MS',
+				'math MTEXT',
+				'math ANNOTATION-XML',
+
+				'svg FOREIGNOBJECT',
+				'svg DESC',
+				'svg TITLE',
 			)
 		);
 	}
@@ -413,19 +407,16 @@ class WP_HTML_Open_Elements {
 				'OBJECT',
 				'TEMPLATE',
 
-				/*
-				 * @todo Support SVG and MathML nodes when support for foreign content is added.
-				 *
-				 * - MathML mi
-				 * - MathML mo
-				 * - MathML mn
-				 * - MathML ms
-				 * - MathML mtext
-				 * - MathML annotation-xml
-				 * - SVG foreignObject
-				 * - SVG desc
-				 * - SVG title
-				 */
+				'math MI',
+				'math MO',
+				'math MN',
+				'math MS',
+				'math MTEXT',
+				'math ANNOTATION-XML',
+
+				'svg FOREIGNOBJECT',
+				'svg DESC',
+				'svg TITLE',
 			)
 		);
 	}
@@ -707,6 +698,15 @@ class WP_HTML_Open_Elements {
 			case 'MARQUEE':
 			case 'OBJECT':
 			case 'TEMPLATE':
+			case 'math MI':
+			case 'math MO':
+			case 'math MN':
+			case 'math MS':
+			case 'math MTEXT':
+			case 'math ANNOTATION-XML':
+			case 'svg FOREIGNOBJECT':
+			case 'svg DESC':
+			case 'svg TITLE':
 				$this->has_p_in_button_scope = false;
 				break;
 
@@ -750,6 +750,15 @@ class WP_HTML_Open_Elements {
 			case 'MARQUEE':
 			case 'OBJECT':
 			case 'TEMPLATE':
+			case 'math MI':
+			case 'math MO':
+			case 'math MN':
+			case 'math MS':
+			case 'math MTEXT':
+			case 'math ANNOTATION-XML':
+			case 'svg FOREIGNOBJECT':
+			case 'svg DESC':
+			case 'svg TITLE':
 				$this->has_p_in_button_scope = $this->has_element_in_button_scope( 'P' );
 				break;
 		}


### PR DESCRIPTION
Trac ticket: Core-61576

As part of work to add more spec support to the HTML API, this patch adds support for the relevant foreign elements in the HTML algorithms within the stack of open elements. Although the HTML Processor cannot yet step into these elements, the format of how they will be represented was determined in the related work from which this patch is extracted.

This patch extracted from https://github.com/wordpress/wordpress-develop/pull/6006.

Developed in https://github.com/wordpress/wordpress-develop/pull/7157
Discussed in https://core.trac.wordpress.org/ticket/61576

Props: dmsnell, jonsurrell.
See #61576.