### PR TITLE
HTML API: Remove foreign content insertion mode (it's not a mode).

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor-state.php
+++ b/src/wp-includes/html-api/class-wp-html-processor-state.php
@@ -300,18 +300,6 @@ class WP_HTML_Processor_State {
 	const INSERTION_MODE_AFTER_AFTER_FRAMESET = 'insertion-mode-after-after-frameset';
 
 	/**
-	 * In foreign content insertion mode for full HTML parser.
-	 *
-	 * @since 6.7.0
-	 *
-	 * @see https://html.spec.whatwg.org/#parsing-main-inforeign
-	 * @see WP_HTML_Processor_State::$insertion_mode
-	 *
-	 * @var string
-	 */
-	const INSERTION_MODE_IN_FOREIGN_CONTENT = 'insertion-mode-in-foreign-content';
-
-	/**
 	 * No-quirks mode document compatability mode.
 	 *
 	 * > In no-quirks mode, the behavior is (hopefully) the desired behavior

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -923,9 +923,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				case WP_HTML_Processor_State::INSERTION_MODE_AFTER_AFTER_FRAMESET:
 					return $this->step_after_after_frameset();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_IN_FOREIGN_CONTENT:
-					return $this->step_in_foreign_content();
-
 				// This should be unreachable but PHP doesn't have total type checking on switch.
 				default:
 					$this->bail( "Unaware of the requested parsing mode: '{$this->state->insertion_mode}'." );
@@ -4069,7 +4066,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @return bool Whether an element was found.
 	 */
 	private function step_in_foreign_content(): bool {
-		$this->bail( 'No support for parsing in the ' . WP_HTML_Processor_State::INSERTION_MODE_IN_FOREIGN_CONTENT . ' state.' );
+		$this->bail( 'No support for parsing in the foreign content.' );
 	}
 
 	/*


### PR DESCRIPTION
Trac ticket: Core-61576

As part of work to add more spec support to the HTML API, this patch removes an insertion mode that was added but shouldn't have been. The rules for parsing foreign content are real, but they don't change the insertion mode for the parser - the interactions are more complex than this.

Follow-up to [58679].
Props dmsnell, jonsurrell.
See #61576.