### PR TITLE
HTML API: Fix expects closer behavior in foreign content

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -786,12 +786,14 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *                   or `null` if not matched on any token.
 	 */
 	public function expects_closer( WP_HTML_Token $node = null ): ?bool {
-		$token_name      = $node->node_name ?? $this->get_token_name();
-		$token_namespace = $node->namespace ?? $this->get_namespace();
+		$token_name = $node->node_name ?? $this->get_token_name();
 
 		if ( ! isset( $token_name ) ) {
 			return null;
 		}
+
+		$token_namespace        = $node->namespace ?? $this->get_namespace();
+		$token_has_self_closing = $node->has_self_closing_flag ?? $this->has_self_closing_flag();
 
 		return ! (
 			// Comments, text nodes, and other atomic tokens.
@@ -803,7 +805,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			// Special atomic elements.
 			( 'html' === $token_namespace && in_array( $token_name, array( 'IFRAME', 'NOEMBED', 'NOFRAMES', 'SCRIPT', 'STYLE', 'TEXTAREA', 'TITLE', 'XMP' ), true ) ) ||
 			// Self-closing elements in foreign content.
-			( isset( $node ) && 'html' !== $node->namespace && $node->has_self_closing_flag )
+			( 'html' !== $token_namespace && $token_has_self_closing )
 		);
 	}
 

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2921,7 +2921,7 @@ class WP_HTML_Tag_Processor {
 			return null;
 		}
 
-		$namespace = $this->get_namespace();
+		$namespace  = $this->get_namespace();
 		$lower_name = strtolower( $attribute_name );
 
 		if ( 'math' === $namespace && 'definitionurl' === $lower_name ) {

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor.php
@@ -503,4 +503,19 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 		$subclass_processor = call_user_func( array( get_class( $subclass_instance ), 'create_fragment' ), '' );
 		$this->assertInstanceOf( get_class( $subclass_instance ), $subclass_processor, '::create_fragment did not return subclass instance.' );
 	}
+
+	/**
+	 * @ticket TBD
+	 */
+	public function test_expects_closer_foreign_content_self_closing() {
+		$processor = WP_HTML_Processor::create_fragment( '<svg /><math>' );
+
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame( 'SVG', $processor->get_tag() );
+		$this->assertFalse( $processor->expects_closer() );
+
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame( 'MATH', $processor->get_tag() );
+		$this->assertTrue( $processor->expects_closer() );
+	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor.php
@@ -505,7 +505,7 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket TBD
+	 * @ticket 61576
 	 */
 	public function test_expects_closer_foreign_content_self_closing() {
 		$processor = WP_HTML_Processor::create_fragment( '<svg /><math>' );

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
@@ -207,11 +207,7 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 
 					$tag_indent = $indent_level;
 
-					if ( 'html' !== $namespace ) {
-						if ( ! $processor->has_self_closing_flag() ) {
-							++$indent_level;
-						}
-					} elseif ( ! WP_HTML_Processor::is_void( $tag_name ) ) {
+					if ( $processor->expects_closer() ) {
 						++$indent_level;
 					}
 
@@ -275,16 +271,12 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 					// Self-contained tags contain their inner contents as modifiable text.
 					$modifiable_text = $processor->get_modifiable_text();
 					if ( '' !== $modifiable_text ) {
-						$output .= str_repeat( $indent, $indent_level ) . "\"{$modifiable_text}\"\n";
+						$output .= str_repeat( $indent, $tag_indent + 1 ) . "\"{$modifiable_text}\"\n";
 					}
 
 					if ( 'html' === $namespace && 'TEMPLATE' === $token_name ) {
 						$output .= str_repeat( $indent, $indent_level ) . "content\n";
 						++$indent_level;
-					}
-
-					if ( ! $processor->is_void( $tag_name ) && ! $processor->expects_closer() ) {
-						--$indent_level;
 					}
 
 					break;


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61576

Follow-up to: [[58868]](https://core.trac.wordpress.org/changeset/58867) (GitHub https://github.com/WordPress/wordpress-develop/pull/6006).

A condition was added to `expects_closer` to correctly handle self-closing tags in foreign content. It was introduced with a logic bug when called with no arguments in foreign content with a self-closing tag.

This PR adds a test case demonstrating the issue and a bugfix.

The HTML5lib test runner was relying on the incorrect behavior. This is also corrected in this PR and the HTML5lib test now relies on the _correct_ behavior of `expects_closer`.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
