### PR TITLE
HTML API: Test and fix svg script handling

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -4239,17 +4239,22 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			/*
 			 * > If the token has its self-closing flag set, then run
 			 * > the appropriate steps from the following list:
+			 * >
+			 * >   ↪ the token's tag name is "script", and the new current node is in the SVG namespace
+			 * >         Acknowledge the token's self-closing flag, and then act as
+			 * >         described in the steps for a "script" end tag below.
+			 * >
+			 * >   ↪ Otherwise
+			 * >         Pop the current node off the stack of open elements and
+			 * >         acknowledge the token's self-closing flag.
+			 *
+			 * Since the rules for SCRIPT below indicate to pop the element off of the stack of
+			 * open elements, which is the same for the Otherwise condition, there's no need to
+			 * separate these checks. The difference comes when a parser operates with the scripting
+			 * flag enabled, and executes the script, which this parser does not support.
 			 */
 			if ( $this->state->current_token->has_self_closing_flag ) {
-				if ( 'SCRIPT' === $this->state->current_token->node_name && 'svg' === $this->state->current_token->namespace ) {
-					/*
-					 * > Acknowledge the token's self-closing flag, and then act as
-					 * > described in the steps for a "script" end tag below.
-					 */
-					goto in_foreign_content_svg_script_close_tag;
-				} else {
-					$this->state->stack_of_open_elements->pop();
-				}
+				$this->state->stack_of_open_elements->pop();
 			}
 			return true;
 		}
@@ -4258,7 +4263,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		 * > An end tag whose name is "script", if the current node is an SVG script element.
 		 */
 		if ( $this->is_tag_closer() && 'SCRIPT' === $this->state->current_token->node_name && 'svg' === $this->state->current_token->namespace ) {
-			in_foreign_content_svg_script_close_tag:
 			$this->state->stack_of_open_elements->pop();
 			return true;
 		}

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -4243,12 +4243,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					/*
 					 * > Acknowledge the token's self-closing flag, and then act as
 					 * > described in the steps for a "script" end tag below.
-					 *
-					 * @todo Verify that this shouldn't be handled by the rule for
-					 *       "An end tag whose name is 'script', if the current node
-					 *       is an SVG script element."
 					 */
-					goto in_foreign_content_any_other_end_tag;
+					goto in_foreign_content_svg_script_close_tag;
 				} else {
 					$this->state->stack_of_open_elements->pop();
 				}
@@ -4260,14 +4256,15 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		 * > An end tag whose name is "script", if the current node is an SVG script element.
 		 */
 		if ( $this->is_tag_closer() && 'SCRIPT' === $this->state->current_token->node_name && 'svg' === $this->state->current_token->namespace ) {
+			in_foreign_content_svg_script_close_tag:
 			$this->state->stack_of_open_elements->pop();
+			return true;
 		}
 
 		/*
 		 * > Any other end tag
 		 */
 		if ( $this->is_tag_closer() ) {
-			in_foreign_content_any_other_end_tag:
 			$node = $this->state->stack_of_open_elements->current_node();
 			if ( $tag_name !== $node->node_name ) {
 				// @todo Indicate a parse error once it's possible.

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor.php
@@ -503,4 +503,12 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 		$subclass_processor = call_user_func( array( get_class( $subclass_instance ), 'create_fragment' ), '' );
 		$this->assertInstanceOf( get_class( $subclass_instance ), $subclass_processor, '::create_fragment did not return subclass instance.' );
 	}
+
+	/**
+	 * @ticket 61576
+	 */
+	public function test_foreign_content_script_self_closing() {
+		$processor = WP_HTML_Processor::create_fragment( '<svg><script />' );
+		$this->assertTrue( $processor->next_tag( 'script' ) );
+	}
 }


### PR DESCRIPTION


Trac ticket: https://core.trac.wordpress.org/ticket/61576

Follow-up to: [[58868]](https://core.trac.wordpress.org/changeset/58867) (GitHub https://github.com/WordPress/wordpress-develop/pull/6006).

- Add a unit test for a bug that was discovered in manual testing and fixed in [[58868]](https://core.trac.wordpress.org/changeset/58867).
- Modify behavior to follow-spec (resolves todo).

The spec states the following:

> If the token has its [self-closing flag](https://html.spec.whatwg.org/#self-closing-flag) set, then run the appropriate steps from the following list:
> 
> If the token's tag name is "script", and the new [current node](https://html.spec.whatwg.org/#current-node) is in the [SVG namespace](https://infra.spec.whatwg.org/#svg-namespace)
> [Acknowledge the token's self-closing flag](https://html.spec.whatwg.org/#acknowledge-self-closing-flag), and then act as described in the steps for a "script" end tag below.
> 
> An end tag whose tag name is "script", if the [current node](https://html.spec.whatwg.org/#current-node) is an [SVG script](https://svgwg.org/svg2-draft/interact.html#ScriptElement) element
> …
> Any other end tag
> …

I believe the original implementation was incorrect and the intention is to move into the **An end tag whose tag name is "script", if the [current node](https://html.spec.whatwg.org/#current-node) is an [SVG script](https://svgwg.org/svg2-draft/interact.html#ScriptElement) element** instructions and not the **Any other end tag**. Ultimately, the result was the same.

This also adds a missing `return true` from the script end tag block.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
