### PR TITLE
HTML API: Replace null chars in attribute values

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2666,7 +2666,7 @@ class WP_HTML_Tag_Processor {
 			return true;
 		}
 
-		$raw_value = substr( $this->html, $attribute->value_starts_at, $attribute->value_length );
+		$raw_value = str_replace( "\x00", "\u{FFFD}", substr( $this->html, $attribute->value_starts_at, $attribute->value_length ) );
 
 		return WP_HTML_Decoder::decode_attribute( $raw_value );
 	}

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2914,4 +2914,34 @@ HTML
 		$this->assertFalse( $processor->next_tag() );
 		$this->assertTrue( $processor->paused_at_incomplete_token() );
 	}
+
+	/**
+	 * @ticket TBD
+	 *
+	 * @dataProvider data_null_byte_attribute_html
+	 */
+	public function test_attributes_handle_null_byte_replacement( string $html, string $attribute_name, string $expected_value ) {
+		$processor = new WP_HTML_Tag_Processor( $html );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame( $expected_value, $processor->get_attribute( $attribute_name) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_null_byte_attribute_html(): array {
+		return array(
+			'Double-quoted class'          => array( "<div class=\"null-\x00-null\">", 'class', "null-\u{FFFD}-null" ),
+			'Single-quoted class'          => array( "<div class='null-\x00-null'>", 'class', "null-\u{FFFD}-null" ),
+			'Unquoted class'               => array( "<div class=null-\x00-null>", 'class', "null-\u{FFFD}-null" ),
+			'Double-quoted data-attribute' => array( "<div data-att=\"null-\x00-null\">", 'data-att', "null-\u{FFFD}-null" ),
+			'Single-quoted data-attribute' => array( "<div data-att='null-\x00-null'>", 'data-att', "null-\u{FFFD}-null" ),
+			'Unquoted data-attribute'      => array( "<div data-att=null-\x00-null>", 'data-att', "null-\u{FFFD}-null" ),
+			'Leading null byte'            => array( "<div class=\"\x00-null\">", 'class', "\u{FFFD}-null" ),
+			'Trailing null byte'           => array( "<div class=\"null-\x00\">", 'class', "null-\u{FFFD}" ),
+			'Only null byte'               => array( "<div class=\"\x00\">", 'class', "\u{FFFD}" ),
+		);
+	}
 }


### PR DESCRIPTION
This change may or may not be desirable, it's something to consider. This behavior may be best as a new method, such as `get_attribute_value`.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
