### PR TITLE
Check if error_reporting function exists, otherwise breaks php8 installs when disabled in the ini config

### DIFF
--- a/src/wp-admin/load-scripts.php
+++ b/src/wp-admin/load-scripts.php
@@ -5,7 +5,9 @@
  *
  * Set this to error_reporting( -1 ) for debugging.
  */
-error_reporting( 0 );
+if ( function_exists( 'error_reporting' ) ) {
+  error_reporting( 0 );
+}
 
 // Set ABSPATH for execution.
 if ( ! defined( 'ABSPATH' ) ) {

--- a/src/wp-admin/load-scripts.php
+++ b/src/wp-admin/load-scripts.php
@@ -6,7 +6,7 @@
  * Set this to error_reporting( -1 ) for debugging.
  */
 if ( function_exists( 'error_reporting' ) ) {
-  error_reporting( 0 );
+	error_reporting( 0 );
 }
 
 // Set ABSPATH for execution.

--- a/src/wp-admin/load-scripts.php
+++ b/src/wp-admin/load-scripts.php
@@ -1,11 +1,16 @@
 <?php
 
 /*
- * Disable error reporting.
- *
- * Set this to error_reporting( -1 ) for debugging.
+ * The error_reporting() function can be disabled in php.ini. On systems where that is the case,
+ * it's best to add a dummy function to the wp-config.php file, but as this call to the function
+ * is run prior to wp-config.php loading, it is wrapped in a function_exists() check.
  */
 if ( function_exists( 'error_reporting' ) ) {
+	/*
+	 * Disable error reporting.
+	 *
+	 * Set this to error_reporting( -1 ) for debugging.
+	 */
 	error_reporting( 0 );
 }
 

--- a/src/wp-admin/load-styles.php
+++ b/src/wp-admin/load-styles.php
@@ -5,7 +5,9 @@
  *
  * Set this to error_reporting( -1 ) for debugging.
  */
-error_reporting( 0 );
+if ( function_exists( 'error_reporting' ) ) {
+  error_reporting( 0 );
+}
 
 // Set ABSPATH for execution.
 if ( ! defined( 'ABSPATH' ) ) {

--- a/src/wp-admin/load-styles.php
+++ b/src/wp-admin/load-styles.php
@@ -6,7 +6,7 @@
  * Set this to error_reporting( -1 ) for debugging.
  */
 if ( function_exists( 'error_reporting' ) ) {
-  error_reporting( 0 );
+	error_reporting( 0 );
 }
 
 // Set ABSPATH for execution.

--- a/src/wp-admin/load-styles.php
+++ b/src/wp-admin/load-styles.php
@@ -1,11 +1,16 @@
 <?php
 
 /*
- * Disable error reporting.
- *
- * Set this to error_reporting( -1 ) for debugging.
+ * The error_reporting() function can be disabled in php.ini. On systems where that is the case,
+ * it's best to add a dummy function to the wp-config.php file, but as this call to the function
+ * is run prior to wp-config.php loading, it is wrapped in a function_exists() check.
  */
 if ( function_exists( 'error_reporting' ) ) {
+	/*
+	 * Disable error reporting.
+	 *
+	 * Set this to error_reporting( -1 ) for debugging.
+	 */
 	error_reporting( 0 );
 }
 


### PR DESCRIPTION
Short summary of the problem: When error_reporting function is disabled on the hosting provider, it breaks admin area due to the fact that wp-admin/load-styles.php and wp-admin/load-scripts.php are triggering it without checking.

Some work has been done to resolve the problem here https://core.trac.wordpress.org/ticket/52226

Unfortunately it doesn't address the issue completely as it only adds checks to the wp-load.php file.

Here is the great post that summarizes problem with error_reporting in WP for some additional context: https://phil.lavin.me.uk/2022/02/wordpress-changing-error_reporting-level/

Track ticket: https://core.trac.wordpress.org/ticket/61873


