### PR TITLE
Block Styles: Ensure unique classname generation for variations

### DIFF
--- a/src/wp-includes/block-supports/block-style-variations.php
+++ b/src/wp-includes/block-supports/block-style-variations.php
@@ -8,24 +8,6 @@
  */
 
 /**
- * Generate block style variation instance name.
- *
- * @since 6.6.0
- * @deprecated 6.7.0 Use `wp_unique_id( $variation . '--' )` instead.
- *
- * @access private
- *
- * @param array  $block     Block object.
- * @param string $variation Slug for the block style variation.
- *
- * @return string The unique variation name.
- */
-function wp_create_block_style_variation_instance_name( $block, $variation ) {
-	_deprecated_function( __FUNCTION__, '6.7.0', 'wp_unique_id' );
-	return $variation . '--' . md5( serialize( $block ) );
-}
-
-/**
  * Determines the block style variation names within a CSS class string.
  *
  * @since 6.6.0

--- a/src/wp-includes/block-supports/block-style-variations.php
+++ b/src/wp-includes/block-supports/block-style-variations.php
@@ -11,6 +11,8 @@
  * Generate block style variation instance name.
  *
  * @since 6.6.0
+ * @deprecated 6.7.0 Use `wp_unique_id( $variation . '--' )` instead.
+ *
  * @access private
  *
  * @param array  $block     Block object.
@@ -19,6 +21,7 @@
  * @return string The unique variation name.
  */
 function wp_create_block_style_variation_instance_name( $block, $variation ) {
+	_deprecated_function( __FUNCTION__, '6.7.0', "wp_unique_id( \$variation . '--' )" );
 	return $variation . '--' . md5( serialize( $block ) );
 }
 
@@ -124,7 +127,7 @@ function wp_render_block_style_variation_support_styles( $parsed_block ) {
 	 */
 	wp_resolve_block_style_variation_ref_values( $variation_data, $theme_json );
 
-	$variation_instance = wp_create_block_style_variation_instance_name( $parsed_block, $variation );
+	$variation_instance = wp_unique_id( $variation . '--' );
 	$class_name         = "is-style-$variation_instance";
 	$updated_class_name = $parsed_block['attrs']['className'] . " $class_name";
 
@@ -230,11 +233,9 @@ function wp_render_block_style_variation_class_name( $block_content, $block ) {
 
 	/*
 	 * Matches a class prefixed by `is-style`, followed by the
-	 * variation slug, then `--`, and finally a hash.
-	 *
-	 * See `wp_create_block_style_variation_instance_name` for class generation.
+	 * variation slug, then `--`, and finally an instance number.
 	 */
-	preg_match( '/\bis-style-(\S+?--\w+)\b/', $block['attrs']['className'], $matches );
+	preg_match( '/\bis-style-(\S+?--\d+)\b/', $block['attrs']['className'], $matches );
 
 	if ( empty( $matches ) ) {
 		return $block_content;

--- a/src/wp-includes/block-supports/block-style-variations.php
+++ b/src/wp-includes/block-supports/block-style-variations.php
@@ -21,7 +21,7 @@
  * @return string The unique variation name.
  */
 function wp_create_block_style_variation_instance_name( $block, $variation ) {
-	_deprecated_function( __FUNCTION__, '6.7.0', "wp_unique_id( \$variation . '--' )" );
+	_deprecated_function( __FUNCTION__, '6.7.0', 'wp_unique_id' );
 	return $variation . '--' . md5( serialize( $block ) );
 }
 

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -6387,3 +6387,21 @@ function wp_enqueue_global_styles_custom_css() {
 		wp_add_inline_style( 'global-styles', $custom_css );
 	}
 }
+
+/**
+ * Generate block style variation instance name.
+ *
+ * @since 6.6.0
+ * @deprecated 6.7.0 Use `wp_unique_id( $variation . '--' )` instead.
+ *
+ * @access private
+ *
+ * @param array  $block     Block object.
+ * @param string $variation Slug for the block style variation.
+ *
+ * @return string The unique variation name.
+ */
+function wp_create_block_style_variation_instance_name( $block, $variation ) {
+	_deprecated_function( __FUNCTION__, '6.7.0', 'wp_unique_id' );
+	return $variation . '--' . md5( serialize( $block ) );
+}

--- a/tests/phpunit/tests/block-supports/wpCreateBlockStyleVariationInstanceName.php
+++ b/tests/phpunit/tests/block-supports/wpCreateBlockStyleVariationInstanceName.php
@@ -13,6 +13,7 @@ class Tests_Block_Supports_WpCreateBlockStyleVariationInstanceName extends WP_Un
 	 * @ticket 61312
 	 *
 	 * @covers ::wp_create_block_style_variation_instance_name
+	 * @expectedDeprecated wp_create_block_style_variation_instance_name
 	 */
 	public function test_block_style_variation_instance_name_generation() {
 		$block    = array( 'name' => 'test/block' );

--- a/tests/phpunit/tests/block-supports/wpCreateBlockStyleVariationInstanceName.php
+++ b/tests/phpunit/tests/block-supports/wpCreateBlockStyleVariationInstanceName.php
@@ -13,6 +13,7 @@ class Tests_Block_Supports_WpCreateBlockStyleVariationInstanceName extends WP_Un
 	 * @ticket 61312
 	 *
 	 * @covers ::wp_create_block_style_variation_instance_name
+	 *
 	 * @expectedDeprecated wp_create_block_style_variation_instance_name
 	 */
 	public function test_block_style_variation_instance_name_generation() {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61877

This PR backports the PHP changes from https://github.com/WordPress/gutenberg/pull/64511.

### What?
Simplifies block style variation class name generation to ensure unique class.

### Why?
Avoids potential for non-unique class names and conflicting styles when exact copies of a block are inserted via a repeated pattern.

Further background and context can be found over on https://github.com/WordPress/gutenberg/pull/64511.

### How?

Replace the hashing of block attributes in the block style variation classnames with a call to `wp_unique_id`.

### Testing Instructions

#### Confirm unique classnames on frontend

1. Create a pattern
2. Add a button with the Outline block styles to the pattern
3. Save the pattern and edit a post
4. Insert the above pattern 3 times in the post
5. Save and view the post on the frontend
6. Inspect a button and search the markup for `is-style-outline-`. You should find CSS with three styles matching that pattern however they should now all be unique.

#### Ensure no regressions for block style variations on the frontend

1. Add some custom block style variations to your theme. See [#57908](https://github.com/WordPress/gutenberg/pull/57908) for detailed examples or the snippet below for a quick option.
7. Add suitable content to a page, making sure there is enough that nested applications of block style variations can occur
8. In the site editor, apply the custom block style variations to various content, including in a nested fashion
9. Save and confirm the correct styling on the frontend

<details>
<summary>Example block style variation theme.json partial (place under `/styles`)</summary>

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 3,
	"title": "Section A",
	"slug": "section-a",
	"blockTypes": [ "core/group" ],
	"styles": {
		"color": {
			"background": "slategrey",
			"text": "snow"
		},
		"blocks": {
			"core/group": {
				"color": {
					"background": "darkslategrey",
					"text": "whitesmoke"
				}
			}
		}
	}
}
```
</details>


## Screenshots or screencast <!-- if applicable -->

### Simple unique classnames for exact copies of blocks

<img width="532" alt="Screenshot 2024-08-14 at 9 27 11 PM" src="https://github.com/user-attachments/assets/9c0116c7-36be-4a79-b343-002bdbfc9dcc">

### Block Style Variations still working

https://github.com/user-attachments/assets/42998ead-0b03-48ab-8968-f4b0688fb661

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
