### PR TITLE
Fix notice on deprecated parameter on formatting.php line 4720

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4717,7 +4717,7 @@ function esc_attr( $text ) {
  * @return string
  */
 function esc_textarea( $text ) {
-	$text = is_null($text) ? '' : $text;
+	$text = is_null( $text ) ? '' : $text;
 	$safe_text = htmlspecialchars( $text, ENT_QUOTES, get_option( 'blog_charset' ) );
 	/**
 	 * Filters a string cleaned and escaped for output in a textarea element.

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4717,7 +4717,7 @@ function esc_attr( $text ) {
  * @return string
  */
 function esc_textarea( $text ) {
-	$text = is_null( $text ) ? '' : $text;
+	$text      = is_null( $text ) ? '' : $text;
 	$safe_text = htmlspecialchars( $text, ENT_QUOTES, get_option( 'blog_charset' ) );
 	/**
 	 * Filters a string cleaned and escaped for output in a textarea element.

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4717,6 +4717,7 @@ function esc_attr( $text ) {
  * @return string
  */
 function esc_textarea( $text ) {
+	$text = is_null($text) ? '' : $text;
 	$safe_text = htmlspecialchars( $text, ENT_QUOTES, get_option( 'blog_charset' ) );
 	/**
 	 * Filters a string cleaned and escaped for output in a textarea element.


### PR DESCRIPTION
Fix warning for NOTICE: PHP message: PHP Deprecated: htmlspecialchars(): Passing null to parameter [#1](https://core.trac.wordpress.org/ticket/1) ($string) of type string is deprecated in /public/wordpress/wp-includes/formatting.php on line 4720

Trac ticket: https://core.trac.wordpress.org/ticket/61879

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
