### PR TITLE
Props Bot: update to correct event type

### DIFF
--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -18,7 +18,7 @@ on:
   # You cannot filter this event for PR comments only.
   # However, the logic below does short-circuit the workflow for issues.
   issue_comment:
-    type:
+    types:
       - created
   # This event will run everytime a new PR review is initially submitted.
   pull_request_review:


### PR DESCRIPTION
When wanting to filter by event type, we must use `types`, and not `type`.

Reference: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#issue_comment

Trac ticket: https://core.trac.wordpress.org/ticket/61883

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
