### PR TITLE
Add Adam Zieliński to the mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -9,6 +9,7 @@
 Aaron D. Campbell <aaroncampbell@git.wordpress.org> <aaroncampbell@602fd350-edb4-49c9-b593-d223f7449a82>
 Aaron Jorbin <jorbin@git.wordpress.org> <jorbin@602fd350-edb4-49c9-b593-d223f7449a82>
 Adam Silverstein <adamsilverstein@git.wordpress.org> <adamsilverstein@602fd350-edb4-49c9-b593-d223f7449a82>
+Adam Zieliński <zieladam@git.wordpress.org> <zieladam@602fd350-edb4-49c9-b593-d223f7449a82>
 Alex King <alexkingorg@git.wordpress.org> <alexkingorg@602fd350-edb4-49c9-b593-d223f7449a82>
 Alex Shiels <tellyworth@git.wordpress.org> <tellyworth@602fd350-edb4-49c9-b593-d223f7449a82>
 André <oandregal@git.wordpress.org>
@@ -124,4 +125,3 @@ potbot <potbot@git.wordpress.org> <potbot@602fd350-edb4-49c9-b593-d223f7449a82>
 ramonopoly <ramonopoly@git.wordpress.org> <ramonopoly@602fd350-edb4-49c9-b593-d223f7449a82>
 rob1n <rob1n@git.wordpress.org> <rob1n@602fd350-edb4-49c9-b593-d223f7449a82>
 scribu <scribu@git.wordpress.org> <scribu@602fd350-edb4-49c9-b593-d223f7449a82>
-zieladam <zieladam@git.wordpress.org> <zieladam@602fd350-edb4-49c9-b593-d223f7449a82>


### PR DESCRIPTION
I'm adding my new w.org display name to the `.mailmap` file. See more context in this @dmsnell's post introducing the `.mailmap` file: https://make.wordpress.org/core/2024/08/14/control-your-contributions-with-mailmap/
