### PR TITLE
check on is_email() to be more RFC5322 compliant

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3578,6 +3578,16 @@ function is_email( $email, $deprecated = false ) {
 	}
 
 	/*
+	 * LOCAL PART
+	 * Test for invalid usage of periods.
+	 * Complies with RFC5322.
+	 */
+	if ( preg_match( '/(^\.|\.\.|\.$)/', $local ) ) {
+		/** This filter is documented in wp-includes/formatting.php */
+		return apply_filters( 'is_email', false, $email, 'local_invalid_chars' );
+	}
+
+	/*
 	 * DOMAIN PART
 	 * Test for sequences of periods.
 	 */


### PR DESCRIPTION
I've seen an increased abuse on our different form plugins lately, which are basicly relying on this function as a basis to very if an e-mailaddress is valid. 

I've added another RegEx that checks if there are misplaced periods in the local part of the e-mailaddress. 
It checks wether if it has a dot at the start, end or a dot sequence.
This is based on the RFC5322 standard.

Trac ticket: https://core.trac.wordpress.org/ticket/17491

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
