### PR TITLE
PHP Deprecation notice for passing null as parameter to certain lines in wp-includes/pomo/po.php

### DIFF
--- a/src/wp-includes/pomo/po.php
+++ b/src/wp-includes/pomo/po.php
@@ -124,7 +124,7 @@ if ( ! class_exists( 'PO', false ) ) :
 				"\t"     => '\t',
 			);
 
-			$input_string = str_replace( array_keys( $replaces ), array_values( $replaces ), $input_string );
+			$input_string = str_replace( array_keys( $replaces ), array_values( $replaces ), (string) $input_string );
 
 			$po = $quote . implode( "{$slash}n{$quote}{$newline}{$quote}", explode( $newline, $input_string ) ) . $quote;
 			// Add empty string on first line for readability.

--- a/src/wp-includes/pomo/po.php
+++ b/src/wp-includes/pomo/po.php
@@ -261,7 +261,7 @@ if ( ! class_exists( 'PO', false ) ) :
 		}
 
 		public static function match_begin_and_end_newlines( $translation, $original ) {
-			if ( '' === $translation ) {
+			if ( empty( $translation ) ) {
 				return $translation;
 			}
 


### PR DESCRIPTION
When running WP 6.6.1 and GlotPress 4.0.1 I have a debug log littered with PHP Warnings

```
PHP Deprecated: substr(): Passing null to parameter #1 ($string) of type string is deprecated in /sites/xxx/files/wp-includes/pomo/po.php on line 270
PHP Deprecated: substr(): Passing null to parameter #1 ($string) of type string is deprecated in /sites/xxx/files/wp-includes/pomo/po.php on line 271
PHP Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /sites/xxx/files/wp-includes/pomo/po.php on line 127
```

<!-- Insert a description of your changes here -->
The PR solves these errors by expanding a conditional check and casting a parameter to string.

Trac ticket: https://core.trac.wordpress.org/ticket/61895

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
