### PR TITLE
About Page: `text-wrap: balance;`adds unintended new lines in Japaneese

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -15,14 +15,9 @@ $title = _x( 'About', 'page title' );
 
 list( $display_version ) = explode( '-', get_bloginfo( 'version' ) );
 
-$locale       = get_locale();
-$no_text_wrap_locales = array( 'ja-JP' );
-
-$no_text_wrap_class = in_array( $locale, $no_text_wrap_locales, true ) ? ' no-text-wrap' : '';
-
 require_once ABSPATH . 'wp-admin/admin-header.php';
 ?>
-	<div class="wrap about__container<?php echo esc_attr( $no_text_wrap_class ); ?>">
+	<div class="wrap about__container">
 
 		<div class="about__header">
 			<div class="about__header-title">

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -15,14 +15,14 @@ $title = _x( 'About', 'page title' );
 
 list( $display_version ) = explode( '-', get_bloginfo( 'version' ) );
 
-$curr_locale       = get_locale();
-$remove_prop_array = array( 'ja-JP' );
+$locale       = get_locale();
+$no_text_wrap_locales = array( 'ja-JP' );
 
-$additional_class = in_array( $curr_locale, $remove_prop_array, true ) ? 'no-text-wrap' : '';
+$no_text_wrap_class = in_array( $locale, $no_text_wrap_locales, true ) ? ' no-text-wrap' : '';
 
 require_once ABSPATH . 'wp-admin/admin-header.php';
 ?>
-	<div class="wrap about__container <?php echo esc_html( $additional_class ); ?>">
+	<div class="wrap about__container<?php echo esc_attr( $no_text_wrap_class ); ?>">
 
 		<div class="about__header">
 			<div class="about__header-title">

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -15,9 +15,14 @@ $title = _x( 'About', 'page title' );
 
 list( $display_version ) = explode( '-', get_bloginfo( 'version' ) );
 
+$curr_locale       = get_locale();
+$remove_prop_array = array( 'ja-JP' );
+
+$additional_class = in_array( $curr_locale, $remove_prop_array, true ) ? 'no-text-wrap' : '';
+
 require_once ABSPATH . 'wp-admin/admin-header.php';
 ?>
-	<div class="wrap about__container">
+	<div class="wrap about__container <?php echo esc_html( $additional_class ); ?>">
 
 		<div class="about__header">
 			<div class="about__header-title">

--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -403,7 +403,6 @@
 	line-height: 1.6;
 }
 
-
 .about__container h1,
 .about__container h2,
 .about__container h3,
@@ -412,10 +411,7 @@
 	color: inherit;
 }
 
-.about__container .no-text-wrap h1,
-.about__container .no-text-wrap h2,
-.about__container .no-text-wrap h3,
-.about__container .no-text-wrap h4 {
+.about__container :is(h1, h2, h3, h4):lang(ja) {
 	text-wrap: unset;
 }
 

--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -403,12 +403,6 @@
 	line-height: 1.6;
 }
 
-.about__container .no-text-wrap h1,
-.about__container .no-text-wrap h2,
-.about__container .no-text-wrap h3,
-.about__container .no-text-wrap h4 {
-	text-wrap: unset;
-}
 
 .about__container h1,
 .about__container h2,
@@ -416,6 +410,13 @@
 .about__container h4 {
 	text-wrap: balance;
 	color: inherit;
+}
+
+.about__container .no-text-wrap h1,
+.about__container .no-text-wrap h2,
+.about__container .no-text-wrap h3,
+.about__container .no-text-wrap h4 {
+	text-wrap: unset;
 }
 
 .about__container p {

--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -403,6 +403,13 @@
 	line-height: 1.6;
 }
 
+.about__container .no-text-wrap h1,
+.about__container .no-text-wrap h2,
+.about__container .no-text-wrap h3,
+.about__container .no-text-wrap h4 {
+	text-wrap: unset;
+}
+
 .about__container h1,
 .about__container h2,
 .about__container h3,

--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -415,6 +415,10 @@
 	text-wrap: unset;
 }
 
+.about__container :is(h1, h2, h3, h4):lang(ko) {
+	word-break: keep-all;
+}
+
 .about__container p {
 	text-wrap: pretty;
 }


### PR DESCRIPTION
This is a sample PR to conditionally add text-wrap property in about page CSS based on locale.
https://core.trac.wordpress.org/ticket/60892

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
