### PR TITLE
WP_Term: Remove unset of filter prop in tests

### DIFF
--- a/tests/phpunit/tests/term/cache.php
+++ b/tests/phpunit/tests/term/cache.php
@@ -116,9 +116,6 @@ class Tests_Term_Cache extends WP_UnitTestCase {
 
 		$num_queries = get_num_queries();
 
-		// get_term() will only be update the cache if the 'filter' prop is unset.
-		unset( $term_object->filter );
-
 		$term_object_2 = get_term( $term_object, 'wptests_tax' );
 
 		// No new queries should have fired.

--- a/tests/phpunit/tests/term/getTerm.php
+++ b/tests/phpunit/tests/term/getTerm.php
@@ -98,7 +98,6 @@ class Tests_Term_GetTerm extends WP_UnitTestCase {
 
 		$num_queries = get_num_queries();
 
-		unset( $term->filter );
 		$term_a = get_term( $term, 'wptests_tax' );
 
 		$this->assertSame( $num_queries, get_num_queries() );


### PR DESCRIPTION
Removes the `unset()` of the `filter` property within the term tests.

Why?

Prior to the introduction of `WP_Term`, the term was added to the cache _when_ its `filter` property was empty. To test the cache, the tests unset this property to trigger `wp_cache_add()` in `get_term()`. [r34997](https://core.trac.wordpress.org/changeset/34997/) changed that behavior to trigger `wp_cache_add` when the term was not found after `wp_cache_get()` (i.e. happened in `WP_Term::get_instance()`.

Unsetting the `filter` property is and was not needed. Prior to `WP_Term`, the condition was an empty value. With `WP_Term`, the `filter` property is no longer part of the conditional logic for caching.

Follow-up to [34997], [30954], [34035].

Trac ticket: https://core.trac.wordpress.org/ticket/61890

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
