### PR TITLE
Announce comment reply errors in Dashboard

### DIFF
--- a/src/js/_enqueues/admin/edit-comments.js
+++ b/src/js/_enqueues/admin/edit-comments.js
@@ -1188,6 +1188,7 @@ window.commentReply = {
 		if ( er ) {
 			$errorNotice.removeClass( 'hidden' );
 			$error.html( er );
+			wp.a11y.speak( er );
 		}
 	},
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1397,7 +1397,7 @@ function wp_default_scripts( $scripts ) {
 		$scripts->add( 'admin-tags', "/wp-admin/js/tags$suffix.js", array( 'jquery', 'wp-ajax-response' ), false, 1 );
 		$scripts->set_translations( 'admin-tags' );
 
-		$scripts->add( 'admin-comments', "/wp-admin/js/edit-comments$suffix.js", array( 'wp-lists', 'quicktags', 'jquery-query' ), false, 1 );
+		$scripts->add( 'admin-comments', "/wp-admin/js/edit-comments$suffix.js", array( 'wp-lists', 'quicktags', 'jquery-query', 'wp-a11y' ), false, 1 );
 		$scripts->set_translations( 'admin-comments' );
 		did_action( 'init' ) && $scripts->localize(
 			'admin-comments',


### PR DESCRIPTION
* Uses wp.speak to announce an error when replying to comments within the dashboard
* Adds wp-a11y as a dependency to the JavaScript

Trac ticket: https://core.trac.wordpress.org/ticket/61480

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
