### PR TITLE
61898 - Use --wp-admin--admin-bar--height variable in css

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -2031,7 +2031,7 @@ p.auto-update-status {
 ------------------------------------------------------------------------------*/
 
 html.wp-toolbar {
-	padding-top: 32px;
+	padding-top: var(--wp-admin--admin-bar--height);
 	box-sizing: border-box;
 	-ms-overflow-style: scrollbar; /* See ticket #48545 */
 }


### PR DESCRIPTION
Resolves - https://core.trac.wordpress.org/ticket/61898