### PR TITLE
Tests: Remove assert for 'errors' when not WP_Error in Tests_Term_WpInsertTerm::test_wp_insert_term_duplicate_name().

### DIFF
--- a/tests/phpunit/tests/term/wpInsertTerm.php
+++ b/tests/phpunit/tests/term/wpInsertTerm.php
@@ -186,7 +186,6 @@ class Tests_Term_WpInsertTerm extends WP_UnitTestCase {
 	public function test_wp_insert_term_duplicate_name() {
 		$term = self::factory()->tag->create_and_get( array( 'name' => 'Bozo' ) );
 		$this->assertNotWPError( $term );
-		$this->assertEmpty( $term->errors );
 
 		// Test existing term name with unique slug.
 		$term1 = self::factory()->tag->create(


### PR DESCRIPTION
Removes the assertion checking if the 'errors' property is empty. This property exists on `WP_Error` but not on `WP_Term`.  Checking that the term created is not a WP Error is sufficient in this test.

Trac ticket: https://core.trac.wordpress.org/ticket/61890

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
