### PR TITLE
Script Loader: Prevent normalizing absolute paths in `_wp_normalize_relative_css_links()`

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3056,7 +3056,7 @@ function _wp_normalize_relative_css_links( $css, $stylesheet_url ) {
 			if (
 				str_starts_with( $url, 'http:' ) ||
 				str_starts_with( $url, 'https:' ) ||
-				str_starts_with( $url, '//' ) ||
+				str_starts_with( $url, '/' ) ||
 				str_starts_with( $url, '#' ) ||
 				str_starts_with( $url, 'data:' )
 			) {

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -228,6 +228,10 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 				'css'      => 'p {background-image: url(\'../image1.jpg\');}',
 				'expected' => 'p {background-image: url(\'/wp-content/themes/test/../image1.jpg\');}',
 			),
+			'URLs with absolute path, shouldn\'t change'   => array(
+				'css'      => 'p {background:url( "/image0.svg" );}',
+				'expected' => 'p {background:url( "/image0.svg" );}',
+			),
 			'External URLs, shouldn\'t change'             => array(
 				'css'      => 'p {background-image: url(\'http://foo.com/image2.png\');}',
 				'expected' => 'p {background-image: url(\'http://foo.com/image2.png\');}',


### PR DESCRIPTION
Currently _wp_normalize_relative_css_links() normalizes all non-absolute URLs regardless if it's a relative-path or an absolute-path. The normalization should only happen for relative-paths (paths without a leading /) and not for absolute paths.

Trac ticket: https://core.trac.wordpress.org/ticket/61909

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
