### PR TITLE
Accept `ticket:` prefix as a link to a trac ticket.

### DIFF
--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -195,7 +195,7 @@ jobs:
             const prBody = pr.body ?? '';
             const prTitle = pr.title ?? '';
 
-            const tracTicketRegex = new RegExp( '(https?://core.trac.wordpress.org/ticket/|Core-)([0-9]+)', 'g' );
+            const tracTicketRegex = new RegExp( '(https?://core.trac.wordpress.org/ticket/|Core-|ticket:)([0-9]+)', 'g' );
             const tracTicketMatches = prBody.match( tracTicketRegex ) || prTitle.match( tracTicketRegex );
 
             if ( ! tracTicketMatches ) {


### PR DESCRIPTION
Accepts `ticket:` as a prefix for linking to a trac ticket. This is also a permitted autolink reference.

> [!Note]
> This will not have an affect on this Pull Request as the action uses `pull_request_target` rather than `pull_request` for security reasons.

![Screenshot 2024-08-27 at 8 56 01 AM](https://github.com/user-attachments/assets/40b763c6-1204-4f7a-8467-63628842ba24)

Trac ticket: ticket:61865


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
