### PR TITLE
Fluid typography: allow individual preset overrides

### DIFF
--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -518,7 +518,7 @@ function wp_get_computed_fluid_typography_value( $args = array() ) {
  * @since 6.3.0 Using layout.wideSize as max viewport width, and logarithmic scale factor to calculate minimum font scale.
  * @since 6.4.0 Added configurable min and max viewport width values to the typography.fluid theme.json schema.
  * @since 6.6.0 Deprecated bool argument $should_use_fluid_typography.
- * @since 6.7.0 Enabled individual block fluid typography settings overrides.
+ * @since 6.7.0 Font size presets can enable fluid typography individually, even if it’s disabled globally.
  *
  * @param array      $preset   {
  *     Required. fontSizes preset value as seen in theme.json.
@@ -579,7 +579,6 @@ function wp_get_typography_font_size_value( $preset, $settings = array() ) {
 		return $preset['size'];
 	}
 
-	// $typography_settings['fluid'] can be a bool or an array. Normalize to array.
 	$fluid_settings  = isset( $typography_settings['fluid'] ) ? $typography_settings['fluid'] : array();
 	$layout_settings = isset( $settings['layout'] ) ? $settings['layout'] : array();
 

--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -518,6 +518,7 @@ function wp_get_computed_fluid_typography_value( $args = array() ) {
  * @since 6.3.0 Using layout.wideSize as max viewport width, and logarithmic scale factor to calculate minimum font scale.
  * @since 6.4.0 Added configurable min and max viewport width values to the typography.fluid theme.json schema.
  * @since 6.6.0 Deprecated bool argument $should_use_fluid_typography.
+ * @since 6.7.0 Enabled individual block fluid typography settings overrides.
  *
  * @param array      $preset   {
  *     Required. fontSizes preset value as seen in theme.json.
@@ -538,10 +539,11 @@ function wp_get_typography_font_size_value( $preset, $settings = array() ) {
 	}
 
 	/*
-	 * Catches empty values and 0/'0'.
-	 * Fluid calculations cannot be performed on 0.
+	 * Catches falsy values and 0/'0'. Fluid calculations cannot be performed on `0`.
+	 * Also returns early when a preset font size explicitly disables fluid typography with `false`.
 	 */
-	if ( empty( $preset['size'] ) ) {
+	$fluid_font_size_settings = $preset['fluid'] ?? null;
+	if ( false === $fluid_font_size_settings || empty( $preset['size'] ) ) {
 		return $preset['size'];
 	}
 
@@ -564,15 +566,21 @@ function wp_get_typography_font_size_value( $preset, $settings = array() ) {
 		$global_settings
 	);
 
-	$typography_settings         = isset( $settings['typography'] ) ? $settings['typography'] : array();
-	$should_use_fluid_typography = ! empty( $typography_settings['fluid'] );
+	$typography_settings = $settings['typography'] ?? array();
 
-	if ( ! $should_use_fluid_typography ) {
+	/*
+	 * Return early when fluid typography is disabled in the settings, and there
+	 * are no local settings to enable it for the individual preset.
+	 *
+	 * If this condition isn't met, either the settings or individual prest settings
+	 * have enabled fluid typography.
+	 */
+	if ( empty( $typography_settings['fluid'] ) && empty( $fluid_font_size_settings ) ) {
 		return $preset['size'];
 	}
 
 	// $typography_settings['fluid'] can be a bool or an array. Normalize to array.
-	$fluid_settings  = is_array( $typography_settings['fluid'] ) ? $typography_settings['fluid'] : array();
+	$fluid_settings  = isset( $typography_settings['fluid'] ) ? $typography_settings['fluid'] : array();
 	$layout_settings = isset( $settings['layout'] ) ? $settings['layout'] : array();
 
 	// Defaults.
@@ -591,14 +599,6 @@ function wp_get_typography_font_size_value( $preset, $settings = array() ) {
 	}
 	$has_min_font_size       = isset( $fluid_settings['minFontSize'] ) && ! empty( wp_get_typography_value_and_unit( $fluid_settings['minFontSize'] ) );
 	$minimum_font_size_limit = $has_min_font_size ? $fluid_settings['minFontSize'] : $default_minimum_font_size_limit;
-
-	// Font sizes.
-	$fluid_font_size_settings = isset( $preset['fluid'] ) ? $preset['fluid'] : null;
-
-	// A font size has explicitly bypassed fluid calculations.
-	if ( false === $fluid_font_size_settings ) {
-		return $preset['size'];
-	}
 
 	// Try to grab explicit min and max fluid font sizes.
 	$minimum_font_size_raw = isset( $fluid_font_size_settings['min'] ) ? $fluid_font_size_settings['min'] : null;

--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -572,7 +572,7 @@ function wp_get_typography_font_size_value( $preset, $settings = array() ) {
 	 * Return early when fluid typography is disabled in the settings, and there
 	 * are no local settings to enable it for the individual preset.
 	 *
-	 * If this condition isn't met, either the settings or individual prest settings
+	 * If this condition isn't met, either the settings or individual preset settings
 	 * have enabled fluid typography.
 	 */
 	if ( empty( $typography_settings['fluid'] ) && empty( $fluid_font_size_settings ) ) {

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -359,7 +359,11 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 				'font_size_preset' => array(
 					'size' => null,
 				),
-				'settings'         => null,
+				'settings'         => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
 				'expected_output'  => null,
 			),
 
@@ -429,8 +433,7 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 			),
 			'returns already clamped value'              => array(
 				'font_size_preset' => array(
-					'size'  => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
-					'fluid' => false,
+					'size' => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
 				),
 				'settings'         => array(
 					'typography' => array(
@@ -442,8 +445,7 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 
 			'returns value with unsupported unit'        => array(
 				'font_size_preset' => array(
-					'size'  => '1000%',
-					'fluid' => false,
+					'size' => '1000%',
 				),
 				'settings'         => array(
 					'typography' => array(
@@ -772,6 +774,33 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 					),
 				),
 				'expected_output' => 'clamp(100px, 6.25rem + ((1vw - 3.2px) * 7.813), 200px)',
+			),
+
+			// Individual preset settings override global settings.
+			'should convert individual preset size to fluid if fluid is disabled in global settings' => array(
+				'font_size'       => array(
+					'size'  => '17px',
+					'fluid' => true,
+				),
+				'settings'        => array(
+					'typography' => array(),
+				),
+				'expected_output' => 'clamp(14px, 0.875rem + ((1vw - 3.2px) * 0.234), 17px)',
+			),
+			'should use individual preset settings if fluid is disabled in global settings' => array(
+				'font_size'       => array(
+					'size'  => '17px',
+					'fluid' => array(
+						'min' => '16px',
+						'max' => '26px',
+					),
+				),
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => false,
+					),
+				),
+				'expected_output' => 'clamp(16px, 1rem + ((1vw - 3.2px) * 0.781), 26px)',
 			),
 		);
 	}

--- a/tests/phpunit/tests/block-supports/typography.php
+++ b/tests/phpunit/tests/block-supports/typography.php
@@ -295,6 +295,7 @@ class Tests_Block_Supports_Typography extends WP_UnitTestCase {
 	 * @ticket 57065
 	 * @ticket 58523
 	 * @ticket 61118
+	 * @ticket 61932
 	 *
 	 * @covers ::wp_get_typography_font_size_value
 	 *


### PR DESCRIPTION
This PR syncs the following Gutenberg PR:

- https://github.com/WordPress/gutenberg/pull/64790

cc @matiasbenedetto

## What?

This PR allows individual font preset overrides. 

So, if fluid typography is disabled or not active but an individual font preset does enable it, calculate the clamp value for that individual preset.

## Why?

Individual font sizes may opt out of fluid typography if it is turned on globally.

This PR does the opposite: individual font size presets can opt in to fluid typography if it is not turned on globally.

## How?

Check if fluid settings on individual font size presets are present. 

## Testing Instructions

1. In a theme's theme.json, enable fluid typography for some individual font size presets by adding `"fluid": true` to the preset object.  See the below example theme.json.
2. Make sure fluid typography is not enabled globally in the general "settings.typography" settings.
3. In the editor, apply some of your presets and save.
4. The presets that have fluid settings should have fluid font sizes in the frontend. 
5. The presets that have no fluid settings should behave as static font sizes.

> [!NOTE]
> This only affects the frontend site, not the editor.

<details>

<summary>Here is some test theme.json</summary>

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 3,
	"settings": {
		"typography": {
			"fontSizes": [
				{
					"name": "Big bill",
					"size": "59px",
					"slug": "big-bill"
				},
				{
					"name": "Medium Matt",
					"size": "30px",
					"slug": "med-matt",
					"fluid": true
				},
				{
					"name": "Small Ted",
					"size": "1rem",
					"slug": "small-ted",
					"fluid": {
						"max": "60px",
						"min": "30px"
					}
				}
			]
		}
	}
}


```

</details>

Trac ticket: https://core.trac.wordpress.org/ticket/61932

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
