### PR TITLE
Use boolean values for autoload parameters in core, unless explicitly about backward compatibility in tests

### DIFF
--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2340,7 +2340,7 @@ function upgrade_630() {
 			$can_compress_scripts = get_option( 'can_compress_scripts', false );
 			if ( false !== $can_compress_scripts ) {
 				delete_option( 'can_compress_scripts' );
-				add_option( 'can_compress_scripts', $can_compress_scripts, '', 'yes' );
+				add_option( 'can_compress_scripts', $can_compress_scripts, '', true );
 			}
 		}
 	}

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -1844,7 +1844,7 @@ function upgrade_340() {
 		if ( 'yes' === $wpdb->get_var( "SELECT autoload FROM $wpdb->options WHERE option_name = 'uninstall_plugins'" ) ) {
 			$uninstall_plugins = get_option( 'uninstall_plugins' );
 			delete_option( 'uninstall_plugins' );
-			add_option( 'uninstall_plugins', $uninstall_plugins, null, 'no' );
+			add_option( 'uninstall_plugins', $uninstall_plugins, null, false );
 		}
 	}
 }
@@ -2393,7 +2393,7 @@ function upgrade_650() {
 			)
 		);
 
-		$autoload = array_fill_keys( $theme_mods_options, 'no' );
+		$autoload = array_fill_keys( $theme_mods_options, false );
 		wp_set_option_autoload_values( $autoload );
 	}
 }

--- a/tests/phpunit/tests/option/option.php
+++ b/tests/phpunit/tests/option/option.php
@@ -143,7 +143,7 @@ class Tests_Option_Option extends WP_UnitTestCase {
 	 * @covers ::get_option
 	 */
 	public function test_get_option_notoptions_do_not_load_cache() {
-		add_option( 'foo', 'bar', '', 'no' );
+		add_option( 'foo', 'bar', '', false );
 		wp_cache_delete( 'notoptions', 'options' );
 
 		$before = get_num_queries();
@@ -360,11 +360,13 @@ class Tests_Option_Option extends WP_UnitTestCase {
 	public function data_option_autoloading() {
 		return array(
 			// Supported values.
-			array( 'autoload_yes', 'yes', 'on' ),
 			array( 'autoload_true', true, 'on' ),
-			array( 'autoload_no', 'no', 'off' ),
 			array( 'autoload_false', false, 'off' ),
 			array( 'autoload_null', null, 'auto' ),
+
+			// Values supported for backward compatibility.
+			array( 'autoload_yes', 'yes', 'on' ),
+			array( 'autoload_no', 'no', 'off' ),
 
 			// Technically unsupported values.
 			array( 'autoload_string', 'foo', 'auto' ),
@@ -457,8 +459,8 @@ class Tests_Option_Option extends WP_UnitTestCase {
 	 * @covers ::update_option
 	 */
 	public function test_update_option_with_autoload_change_no_to_yes() {
-		add_option( 'foo', 'value1', '', 'no' );
-		update_option( 'foo', 'value2', 'yes' );
+		add_option( 'foo', 'value1', '', false );
+		update_option( 'foo', 'value2', true );
 		delete_option( 'foo' );
 		$this->assertFalse( get_option( 'foo' ) );
 	}
@@ -473,8 +475,8 @@ class Tests_Option_Option extends WP_UnitTestCase {
 	 * @covers ::update_option
 	 */
 	public function test_update_option_with_autoload_change_yes_to_no() {
-		add_option( 'foo', 'value1', '', 'yes' );
-		update_option( 'foo', 'value2', 'no' );
+		add_option( 'foo', 'value1', '', true );
+		update_option( 'foo', 'value2', false );
 		delete_option( 'foo' );
 		$this->assertFalse( get_option( 'foo' ) );
 	}

--- a/tests/phpunit/tests/option/updateOption.php
+++ b/tests/phpunit/tests/option/updateOption.php
@@ -75,7 +75,7 @@ class Tests_Option_UpdateOption extends WP_UnitTestCase {
 	 */
 	public function test_should_set_autoload_no_for_nonexistent_option_when_autoload_param_is_no() {
 		$this->flush_cache();
-		update_option( 'test_update_option_default', 'value', 'no' );
+		update_option( 'test_update_option_default', 'value', false );
 		$this->flush_cache();
 
 		// Populate the alloptions cache, which does not include autoload=no options.
@@ -122,7 +122,7 @@ class Tests_Option_UpdateOption extends WP_UnitTestCase {
 	 * @covers ::get_option
 	 */
 	public function test_autoload_should_be_updated_for_existing_option_when_value_is_changed() {
-		add_option( 'foo', 'bar', '', 'no' );
+		add_option( 'foo', 'bar', '', false );
 		$updated = update_option( 'foo', 'bar2', true );
 		$this->assertTrue( $updated );
 

--- a/tests/phpunit/tests/option/updateOption.php
+++ b/tests/phpunit/tests/option/updateOption.php
@@ -52,7 +52,7 @@ class Tests_Option_UpdateOption extends WP_UnitTestCase {
 	 */
 	public function test_should_set_autoload_yes_for_nonexistent_option_when_autoload_param_is_yes() {
 		$this->flush_cache();
-		update_option( 'test_update_option_default', 'value', 'yes' );
+		update_option( 'test_update_option_default', 'value', true );
 		$this->flush_cache();
 
 		// Populate the alloptions cache, which includes autoload=yes options.
@@ -146,7 +146,7 @@ class Tests_Option_UpdateOption extends WP_UnitTestCase {
 	 * @covers ::get_option
 	 */
 	public function test_autoload_should_not_be_updated_for_existing_option_when_value_is_unchanged() {
-		add_option( 'foo', 'bar', '', 'yes' );
+		add_option( 'foo', 'bar', '', true );
 		$updated = update_option( 'foo', 'bar', false );
 		$this->assertFalse( $updated );
 
@@ -171,7 +171,7 @@ class Tests_Option_UpdateOption extends WP_UnitTestCase {
 	 * @covers ::get_option
 	 */
 	public function test_autoload_should_not_be_updated_for_existing_option_when_value_is_changed_but_no_value_of_autoload_is_provided() {
-		add_option( 'foo', 'bar', '', 'yes' );
+		add_option( 'foo', 'bar', '', true );
 
 		// Don't pass a value for `$autoload`.
 		$updated = update_option( 'foo', 'bar2' );

--- a/tests/phpunit/tests/option/wpLoadAlloptions.php
+++ b/tests/phpunit/tests/option/wpLoadAlloptions.php
@@ -39,7 +39,7 @@ class Tests_Option_wpLoadAlloptions extends WP_UnitTestCase {
 	 */
 	public function test_default_and_no() {
 		add_option( 'foo', 'bar' );
-		add_option( 'bar', 'foo', '', 'no' );
+		add_option( 'bar', 'foo', '', false );
 		$alloptions = wp_load_alloptions();
 		$this->assertArrayHasKey( 'foo', $alloptions );
 		$this->assertArrayNotHasKey( 'bar', $alloptions );

--- a/tests/phpunit/tests/option/wpLoadAlloptions.php
+++ b/tests/phpunit/tests/option/wpLoadAlloptions.php
@@ -26,7 +26,7 @@ class Tests_Option_wpLoadAlloptions extends WP_UnitTestCase {
 	 */
 	public function test_default_and_yes() {
 		add_option( 'foo', 'bar' );
-		add_option( 'bar', 'foo', '', 'yes' );
+		add_option( 'bar', 'foo', '', true );
 		$alloptions = wp_load_alloptions();
 		$this->assertArrayHasKey( 'foo', $alloptions );
 		$this->assertArrayHasKey( 'bar', $alloptions );

--- a/tests/phpunit/tests/option/wpSetOptionAutoload.php
+++ b/tests/phpunit/tests/option/wpSetOptionAutoload.php
@@ -11,6 +11,8 @@ class Tests_Option_WpSetOptionAutoload extends WP_UnitTestCase {
 	/**
 	 * Tests that setting an option's autoload value to 'yes' works as expected.
 	 *
+	 * The values 'yes' and 'no' are only supported for backward compatibility.
+	 *
 	 * @ticket 58964
 	 */
 	public function test_wp_set_option_autoload_yes() {
@@ -29,6 +31,8 @@ class Tests_Option_WpSetOptionAutoload extends WP_UnitTestCase {
 
 	/**
 	 * Tests that setting an option's autoload value to 'no' works as expected.
+	 *
+	 * The values 'yes' and 'no' are only supported for backward compatibility.
 	 *
 	 * @ticket 58964
 	 */
@@ -56,9 +60,9 @@ class Tests_Option_WpSetOptionAutoload extends WP_UnitTestCase {
 		$option = 'test_option';
 		$value  = 'value';
 
-		add_option( $option, $value, '', 'yes' );
+		add_option( $option, $value, '', true );
 
-		$this->assertFalse( wp_set_option_autoload( $option, 'yes' ), 'Function did unexpectedly succeed' );
+		$this->assertFalse( wp_set_option_autoload( $option, true ), 'Function did unexpectedly succeed' );
 		$this->assertSame( 'on', $wpdb->get_var( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name = %s", $option ) ), 'Option autoload value unexpectedly updated in database' );
 	}
 
@@ -72,7 +76,7 @@ class Tests_Option_WpSetOptionAutoload extends WP_UnitTestCase {
 
 		$option = 'test_option';
 
-		$this->assertFalse( wp_set_option_autoload( $option, 'yes' ), 'Function did unexpectedly succeed' );
+		$this->assertFalse( wp_set_option_autoload( $option, true ), 'Function did unexpectedly succeed' );
 		$this->assertNull( $wpdb->get_var( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name = %s", $option ) ), 'Missing option autoload value was set in database' );
 		$this->assertArrayNotHasKey( $option, wp_cache_get( 'alloptions', 'options' ), 'Missing option found in alloptions cache' );
 		$this->assertFalse( wp_cache_get( $option, 'options' ), 'Missing option found in individual cache' );

--- a/tests/phpunit/tests/option/wpSetOptionAutoloadValues.php
+++ b/tests/phpunit/tests/option/wpSetOptionAutoloadValues.php
@@ -11,6 +11,8 @@ class Tests_Option_WpSetOptionAutoloadValues extends WP_UnitTestCase {
 	/**
 	 * Tests setting options' autoload to 'yes' where for some options this is already the case.
 	 *
+	 * The values 'yes' and 'no' are only supported for backward compatibility.
+	 *
 	 * @ticket 58964
 	 */
 	public function test_wp_set_option_autoload_values_all_yes_partial_update() {
@@ -20,8 +22,8 @@ class Tests_Option_WpSetOptionAutoloadValues extends WP_UnitTestCase {
 			'test_option1' => 'yes',
 			'test_option2' => 'yes',
 		);
-		add_option( 'test_option1', 'value1', '', 'yes' );
-		add_option( 'test_option2', 'value2', '', 'no' );
+		add_option( 'test_option1', 'value1', '', true );
+		add_option( 'test_option2', 'value2', '', false );
 		$expected = array(
 			'test_option1' => false,
 			'test_option2' => true,
@@ -42,6 +44,8 @@ class Tests_Option_WpSetOptionAutoloadValues extends WP_UnitTestCase {
 	 *
 	 * In this case, the 'alloptions' cache should not be cleared, but only its options set to 'no' should be deleted.
 	 *
+	 * The values 'yes' and 'no' are only supported for backward compatibility.
+	 *
 	 * @ticket 58964
 	 */
 	public function test_wp_set_option_autoload_values_all_no_partial_update() {
@@ -51,8 +55,8 @@ class Tests_Option_WpSetOptionAutoloadValues extends WP_UnitTestCase {
 			'test_option1' => 'no',
 			'test_option2' => 'no',
 		);
-		add_option( 'test_option1', 'value1', '', 'yes' );
-		add_option( 'test_option2', 'value2', '', 'no' );
+		add_option( 'test_option1', 'value1', '', true );
+		add_option( 'test_option2', 'value2', '', false );
 		$expected = array(
 			'test_option1' => true,
 			'test_option2' => false,
@@ -70,6 +74,8 @@ class Tests_Option_WpSetOptionAutoloadValues extends WP_UnitTestCase {
 	/**
 	 * Tests setting options' autoload to 'yes' where for all of them this is already the case.
 	 *
+	 * The values 'yes' and 'no' are only supported for backward compatibility.
+	 *
 	 * @ticket 58964
 	 */
 	public function test_wp_set_option_autoload_values_all_yes_no_update() {
@@ -79,8 +85,8 @@ class Tests_Option_WpSetOptionAutoloadValues extends WP_UnitTestCase {
 			'test_option1' => 'yes',
 			'test_option2' => 'yes',
 		);
-		add_option( 'test_option1', 'value1', '', 'yes' );
-		add_option( 'test_option2', 'value2', '', 'yes' );
+		add_option( 'test_option1', 'value1', '', true );
+		add_option( 'test_option2', 'value2', '', true );
 		$expected = array(
 			'test_option1' => false,
 			'test_option2' => false,
@@ -96,7 +102,7 @@ class Tests_Option_WpSetOptionAutoloadValues extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests setting options' autoload to either 'yes' or 'no' where for some options this is already the case.
+	 * Tests setting options' autoload to either true or false where for some options this is already the case.
 	 *
 	 * The test also covers one option that is entirely missing.
 	 *
@@ -106,14 +112,14 @@ class Tests_Option_WpSetOptionAutoloadValues extends WP_UnitTestCase {
 		global $wpdb;
 
 		$options = array(
-			'test_option1' => 'yes',
-			'test_option2' => 'no',
-			'test_option3' => 'yes',
-			'missing_opt'  => 'yes',
+			'test_option1' => true,
+			'test_option2' => false,
+			'test_option3' => true,
+			'missing_opt'  => true,
 		);
-		add_option( 'test_option1', 'value1', '', 'no' );
-		add_option( 'test_option2', 'value2', '', 'yes' );
-		add_option( 'test_option3', 'value3', '', 'yes' );
+		add_option( 'test_option1', 'value1', '', false );
+		add_option( 'test_option2', 'value2', '', true );
+		add_option( 'test_option3', 'value3', '', true );
 		$expected = array(
 			'test_option1' => true,
 			'test_option2' => true,
@@ -132,7 +138,7 @@ class Tests_Option_WpSetOptionAutoloadValues extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests setting options' autoload to either 'yes' or 'no' while only the 'no' options actually need to be updated.
+	 * Tests setting options' autoload to either true or false while only the false options actually need to be updated.
 	 *
 	 * In this case, the 'alloptions' cache should not be cleared, but only its options set to 'no' should be deleted.
 	 *
@@ -142,13 +148,13 @@ class Tests_Option_WpSetOptionAutoloadValues extends WP_UnitTestCase {
 		global $wpdb;
 
 		$options = array(
-			'test_option1' => 'yes',
-			'test_option2' => 'no',
-			'test_option3' => 'yes',
+			'test_option1' => true,
+			'test_option2' => false,
+			'test_option3' => true,
 		);
-		add_option( 'test_option1', 'value1', '', 'yes' );
-		add_option( 'test_option2', 'value2', '', 'yes' );
-		add_option( 'test_option3', 'value3', '', 'yes' );
+		add_option( 'test_option1', 'value1', '', true );
+		add_option( 'test_option2', 'value2', '', true );
+		add_option( 'test_option3', 'value3', '', true );
 		$expected = array(
 			'test_option1' => false,
 			'test_option2' => true,
@@ -160,7 +166,7 @@ class Tests_Option_WpSetOptionAutoloadValues extends WP_UnitTestCase {
 		$this->assertSame( $num_queries + 2, get_num_queries(), 'Function made unexpected amount of database queries' );
 		$this->assertSameSets( array( 'on', 'off', 'on' ), $wpdb->get_col( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name IN (" . implode( ',', array_fill( 0, count( $options ), '%s' ) ) . ')', ...array_keys( $options ) ) ), 'Option autoload values not updated in database' );
 		foreach ( $options as $option => $autoload ) {
-			if ( 'no' === $autoload ) {
+			if ( false === $autoload ) {
 				$this->assertArrayNotHasKey( $option, wp_cache_get( 'alloptions', 'options' ), sprintf( 'Option %s not deleted from alloptions cache', $option ) );
 			} else {
 				$this->assertArrayHasKey( $option, wp_cache_get( 'alloptions', 'options' ), sprintf( 'Option %s unexpectedly deleted from alloptions cache', $option ) );
@@ -177,11 +183,11 @@ class Tests_Option_WpSetOptionAutoloadValues extends WP_UnitTestCase {
 		global $wpdb;
 
 		$options = array(
-			'test_option1' => 'yes',
-			'test_option2' => 'yes',
+			'test_option1' => true,
+			'test_option2' => true,
 		);
-		add_option( 'test_option1', 'value1', '', 'no' );
-		add_option( 'test_option2', 'value2', '', 'no' );
+		add_option( 'test_option1', 'value1', '', false );
+		add_option( 'test_option2', 'value2', '', false );
 
 		// Force UPDATE queries to fail, leading to no autoload values being updated.
 		add_filter(
@@ -203,7 +209,7 @@ class Tests_Option_WpSetOptionAutoloadValues extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests setting options' autoload with boolean values.
+	 * Tests setting options' autoload with now encouraged boolean values.
 	 *
 	 * @ticket 58964
 	 */

--- a/tests/phpunit/tests/option/wpSetOptionsAutoload.php
+++ b/tests/phpunit/tests/option/wpSetOptionsAutoload.php
@@ -11,6 +11,8 @@ class Tests_Option_WpSetOptionsAutoload extends WP_UnitTestCase {
 	/**
 	 * Tests that setting options' autoload value to 'yes' works as expected.
 	 *
+	 * The values 'yes' and 'no' are only supported for backward compatibility.
+	 *
 	 * @ticket 58964
 	 */
 	public function test_wp_set_options_autoload_yes() {
@@ -23,7 +25,7 @@ class Tests_Option_WpSetOptionsAutoload extends WP_UnitTestCase {
 
 		$expected = array();
 		foreach ( $options as $option => $value ) {
-			add_option( $option, $value, '', 'no' );
+			add_option( $option, $value, '', false );
 			$expected[ $option ] = true;
 		}
 
@@ -40,6 +42,8 @@ class Tests_Option_WpSetOptionsAutoload extends WP_UnitTestCase {
 	/**
 	 * Tests that setting options' autoload value to 'no' works as expected.
 	 *
+	 * The values 'yes' and 'no' are only supported for backward compatibility.
+	 *
 	 * @ticket 58964
 	 */
 	public function test_wp_set_options_autoload_no() {
@@ -52,7 +56,7 @@ class Tests_Option_WpSetOptionsAutoload extends WP_UnitTestCase {
 
 		$expected = array();
 		foreach ( $options as $option => $value ) {
-			add_option( $option, $value, '', 'yes' );
+			add_option( $option, $value, '', true );
 			$expected[ $option ] = true;
 		}
 
@@ -80,12 +84,12 @@ class Tests_Option_WpSetOptionsAutoload extends WP_UnitTestCase {
 
 		$expected = array();
 		foreach ( $options as $option => $value ) {
-			add_option( $option, $value, '', 'yes' );
+			add_option( $option, $value, '', true );
 			$expected[ $option ] = false;
 		}
 
 		$num_queries = get_num_queries();
-		$this->assertSame( $expected, wp_set_options_autoload( array_keys( $options ), 'yes' ), 'Function did unexpectedly succeed' );
+		$this->assertSame( $expected, wp_set_options_autoload( array_keys( $options ), true ), 'Function did unexpectedly succeed' );
 		$this->assertSame( $num_queries + 1, get_num_queries(), 'Function attempted to update options autoload value in database' );
 		$this->assertSame( array( 'on', 'on' ), $wpdb->get_col( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name IN (" . implode( ',', array_fill( 0, count( $options ), '%s' ) ) . ')', ...array_keys( $options ) ) ), 'Options autoload value unexpectedly updated in database' );
 	}
@@ -108,7 +112,7 @@ class Tests_Option_WpSetOptionsAutoload extends WP_UnitTestCase {
 			$expected[ $option ] = false;
 		}
 
-		$this->assertSame( $expected, wp_set_options_autoload( $options, 'yes' ), 'Function did unexpectedly succeed' );
+		$this->assertSame( $expected, wp_set_options_autoload( $options, true ), 'Function did unexpectedly succeed' );
 		$this->assertSame( array(), $wpdb->get_col( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name IN (" . implode( ',', array_fill( 0, count( $options ), '%s' ) ) . ')', ...array_keys( $options ) ) ), 'Missing options autoload value was set in database' );
 	}
 
@@ -125,14 +129,14 @@ class Tests_Option_WpSetOptionsAutoload extends WP_UnitTestCase {
 			'test_option2' => 'value2',
 		);
 
-		add_option( 'test_option1', $options['test_option1'], '', 'yes' );
-		add_option( 'test_option2', $options['test_option2'], '', 'no' );
+		add_option( 'test_option1', $options['test_option1'], '', true );
+		add_option( 'test_option2', $options['test_option2'], '', false );
 		$expected = array(
 			'test_option1' => false,
 			'test_option2' => true,
 		);
 
-		$this->assertSame( $expected, wp_set_options_autoload( array_keys( $options ), 'yes' ), 'Function produced unexpected result' );
+		$this->assertSame( $expected, wp_set_options_autoload( array_keys( $options ), true ), 'Function produced unexpected result' );
 		$this->assertSame( array( 'on', 'on' ), $wpdb->get_col( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name IN (" . implode( ',', array_fill( 0, count( $options ), '%s' ) ) . ')', ...array_keys( $options ) ) ), 'Option autoload values not updated in database' );
 		foreach ( $options as $option => $value ) {
 			$this->assertFalse( wp_cache_get( $option, 'options' ), sprintf( 'Option %s not deleted from individual cache', $option ) );


### PR DESCRIPTION
This PR includes no functional changes. All it does change `'yes'` to `true` and `'no'` to `false` in the various function calls where an `$autoload` parameter is passed. The only places where `'yes'` and `'no'` continue to be used is in some PHPUnit tests that are more explicitly about these values (now for backward compatibility).

Trac ticket: https://core.trac.wordpress.org/ticket/61939

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
