### PR TITLE
Claim bundled theme copyright for contributors too.

### DIFF
--- a/src/wp-content/themes/twentyeleven/readme.txt
+++ b/src/wp-content/themes/twentyeleven/readme.txt
@@ -23,7 +23,7 @@ For more information about Twenty Eleven please go to https://codex.wordpress.or
 
 == Copyright ==
 
-Twenty Eleven WordPress Theme, Copyright 2011-2024 WordPress.org, Automattic.com and contributors.
+Twenty Eleven WordPress Theme, Copyright 2011-2024 WordPress.org, Automattic Inc and contributors.
 Twenty Eleven is Distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentyeleven/readme.txt
+++ b/src/wp-content/themes/twentyeleven/readme.txt
@@ -23,7 +23,7 @@ For more information about Twenty Eleven please go to https://codex.wordpress.or
 
 == Copyright ==
 
-Twenty Eleven WordPress Theme, Copyright 2011-2024 WordPress.org, Automattic Inc and contributors.
+Twenty Eleven WordPress Theme, Copyright 2011-2024 WordPress.org, Automattic Inc., and contributors.
 Twenty Eleven is Distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentyeleven/readme.txt
+++ b/src/wp-content/themes/twentyeleven/readme.txt
@@ -23,7 +23,7 @@ For more information about Twenty Eleven please go to https://codex.wordpress.or
 
 == Copyright ==
 
-Twenty Eleven WordPress Theme, Copyright 2011-2024 WordPress.org & Automattic.com
+Twenty Eleven WordPress Theme, Copyright 2011-2024 WordPress.org, Automattic.com and contributors.
 Twenty Eleven is Distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentyfifteen/readme.txt
+++ b/src/wp-content/themes/twentyfifteen/readme.txt
@@ -31,7 +31,7 @@ For more information about Twenty Fifteen please go to https://wordpress.org/doc
 
 == Copyright ==
 
-Twenty Fifteen WordPress Theme, Copyright 2014-2024 WordPress.org, Automattic.com and contributors.
+Twenty Fifteen WordPress Theme, Copyright 2014-2024 WordPress.org, Automattic Inc and contributors.
 Twenty Fifteen is distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify
@@ -50,7 +50,7 @@ HTML5 Shiv v3.7.0, Copyright 2014 Alexander Farkas
 Licenses: MIT/GPL2
 Source: https://github.com/aFarkas/html5shiv
 
-Genericons icon font, Copyright 2013-2017 Automattic.com
+Genericons icon font, Copyright 2013-2017 Automattic Inc
 License: GNU GPL, Version 2 (or later)
 Source: http://www.genericons.com
 

--- a/src/wp-content/themes/twentyfifteen/readme.txt
+++ b/src/wp-content/themes/twentyfifteen/readme.txt
@@ -31,7 +31,7 @@ For more information about Twenty Fifteen please go to https://wordpress.org/doc
 
 == Copyright ==
 
-Twenty Fifteen WordPress Theme, Copyright 2014-2024 WordPress.org & Automattic.com
+Twenty Fifteen WordPress Theme, Copyright 2014-2024 WordPress.org, Automattic.com and contributors.
 Twenty Fifteen is distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentyfifteen/readme.txt
+++ b/src/wp-content/themes/twentyfifteen/readme.txt
@@ -31,7 +31,7 @@ For more information about Twenty Fifteen please go to https://wordpress.org/doc
 
 == Copyright ==
 
-Twenty Fifteen WordPress Theme, Copyright 2014-2024 WordPress.org, Automattic Inc and contributors.
+Twenty Fifteen WordPress Theme, Copyright 2014-2024 WordPress.org, Automattic Inc., and contributors.
 Twenty Fifteen is distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentyfifteen/readme.txt
+++ b/src/wp-content/themes/twentyfifteen/readme.txt
@@ -50,7 +50,7 @@ HTML5 Shiv v3.7.0, Copyright 2014 Alexander Farkas
 Licenses: MIT/GPL2
 Source: https://github.com/aFarkas/html5shiv
 
-Genericons icon font, Copyright 2013-2017 Automattic Inc
+Genericons icon font, Copyright 2013-2017 Automattic Inc.
 License: GNU GPL, Version 2 (or later)
 Source: http://www.genericons.com
 

--- a/src/wp-content/themes/twentyfourteen/readme.txt
+++ b/src/wp-content/themes/twentyfourteen/readme.txt
@@ -23,7 +23,7 @@ For more information about Twenty Fourteen please go to https://codex.wordpress.
 
 == Copyright ==
 
-Twenty Fourteen WordPress Theme, Copyright 2013-2024 WordPress.org, Automattic.com and contributors.
+Twenty Fourteen WordPress Theme, Copyright 2013-2024 WordPress.org, Automattic Inc and contributors.
 Twenty Fourteen is Distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify
@@ -45,7 +45,7 @@ HTML5 Shiv v3.7.0, Copyright 2014 Alexander Farkas
 Licenses: MIT/GPL2
 Source: https://github.com/aFarkas/html5shiv
 
-Genericons icon font, Copyright 2013-2017 Automattic.com
+Genericons icon font, Copyright 2013-2017 Automattic Inc
 License: GNU GPL, Version 2 (or later)
 Source: http://www.genericons.com
 

--- a/src/wp-content/themes/twentyfourteen/readme.txt
+++ b/src/wp-content/themes/twentyfourteen/readme.txt
@@ -23,7 +23,7 @@ For more information about Twenty Fourteen please go to https://codex.wordpress.
 
 == Copyright ==
 
-Twenty Fourteen WordPress Theme, Copyright 2013-2024 WordPress.org, Automattic Inc and contributors.
+Twenty Fourteen WordPress Theme, Copyright 2013-2024 WordPress.org, Automattic Inc., and contributors.
 Twenty Fourteen is Distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentyfourteen/readme.txt
+++ b/src/wp-content/themes/twentyfourteen/readme.txt
@@ -45,7 +45,7 @@ HTML5 Shiv v3.7.0, Copyright 2014 Alexander Farkas
 Licenses: MIT/GPL2
 Source: https://github.com/aFarkas/html5shiv
 
-Genericons icon font, Copyright 2013-2017 Automattic Inc
+Genericons icon font, Copyright 2013-2017 Automattic Inc.
 License: GNU GPL, Version 2 (or later)
 Source: http://www.genericons.com
 

--- a/src/wp-content/themes/twentyfourteen/readme.txt
+++ b/src/wp-content/themes/twentyfourteen/readme.txt
@@ -23,7 +23,7 @@ For more information about Twenty Fourteen please go to https://codex.wordpress.
 
 == Copyright ==
 
-Twenty Fourteen WordPress Theme, Copyright 2013-2024 WordPress.org & Automattic.com
+Twenty Fourteen WordPress Theme, Copyright 2013-2024 WordPress.org, Automattic.com and contributors.
 Twenty Fourteen is Distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentynineteen/readme.txt
+++ b/src/wp-content/themes/twentynineteen/readme.txt
@@ -25,7 +25,7 @@ For more information about Twenty Nineteen please go to https://wordpress.org/do
 
 == Copyright ==
 
-Twenty Nineteen WordPress Theme, Copyright 2018-2024 WordPress.org
+Twenty Nineteen WordPress Theme, Copyright 2018-2024 WordPress.org and contributors.
 Twenty Nineteen is distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentynineteen/readme.txt
+++ b/src/wp-content/themes/twentynineteen/readme.txt
@@ -25,7 +25,7 @@ For more information about Twenty Nineteen please go to https://wordpress.org/do
 
 == Copyright ==
 
-Twenty Nineteen WordPress Theme, Copyright 2018-2024 WordPress.org and contributors.
+Twenty Nineteen WordPress Theme, Copyright 2018-2024 WordPress.org, and contributors.
 Twenty Nineteen is distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentyseventeen/readme.txt
+++ b/src/wp-content/themes/twentyseventeen/readme.txt
@@ -24,7 +24,7 @@ For more information about Twenty Seventeen please go to https://wordpress.org/d
 
 == Copyright ==
 
-Twenty Seventeen WordPress Theme, Copyright 2016-2024 WordPress.org and contributors.
+Twenty Seventeen WordPress Theme, Copyright 2016-2024 WordPress.org, and contributors.
 Twenty Seventeen is distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentyseventeen/readme.txt
+++ b/src/wp-content/themes/twentyseventeen/readme.txt
@@ -24,7 +24,7 @@ For more information about Twenty Seventeen please go to https://wordpress.org/d
 
 == Copyright ==
 
-Twenty Seventeen WordPress Theme, Copyright 2016-2024 WordPress.org
+Twenty Seventeen WordPress Theme, Copyright 2016-2024 WordPress.org and contributors.
 Twenty Seventeen is distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentysixteen/readme.txt
+++ b/src/wp-content/themes/twentysixteen/readme.txt
@@ -49,7 +49,7 @@ HTML5 Shiv v3.7.0, Copyright 2014 Alexander Farkas
 Licenses: MIT/GPL2
 Source: https://github.com/aFarkas/html5shiv
 
-Genericons icon font, Copyright 2013-2017 Automattic.com
+Genericons icon font, Copyright 2013-2017 Automattic Inc
 License: GNU GPL, Version 2 (or later)
 Source: http://www.genericons.com
 

--- a/src/wp-content/themes/twentysixteen/readme.txt
+++ b/src/wp-content/themes/twentysixteen/readme.txt
@@ -30,7 +30,7 @@ For more information about Twenty Sixteen please go to https://wordpress.org/doc
 
 == Copyright ==
 
-Twenty Sixteen WordPress Theme, Copyright 2014-2024 WordPress.org and contributors.
+Twenty Sixteen WordPress Theme, Copyright 2014-2024 WordPress.org, and contributors.
 Twenty Sixteen is distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentysixteen/readme.txt
+++ b/src/wp-content/themes/twentysixteen/readme.txt
@@ -49,7 +49,7 @@ HTML5 Shiv v3.7.0, Copyright 2014 Alexander Farkas
 Licenses: MIT/GPL2
 Source: https://github.com/aFarkas/html5shiv
 
-Genericons icon font, Copyright 2013-2017 Automattic Inc
+Genericons icon font, Copyright 2013-2017 Automattic Inc.
 License: GNU GPL, Version 2 (or later)
 Source: http://www.genericons.com
 

--- a/src/wp-content/themes/twentysixteen/readme.txt
+++ b/src/wp-content/themes/twentysixteen/readme.txt
@@ -30,7 +30,7 @@ For more information about Twenty Sixteen please go to https://wordpress.org/doc
 
 == Copyright ==
 
-Twenty Sixteen WordPress Theme, Copyright 2014-2024 WordPress.org
+Twenty Sixteen WordPress Theme, Copyright 2014-2024 WordPress.org and contributors.
 Twenty Sixteen is distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentyten/readme.txt
+++ b/src/wp-content/themes/twentyten/readme.txt
@@ -23,7 +23,7 @@ For more information about Twenty Ten theme please go to https://codex.wordpress
 
 == Copyright ==
 
-Twenty Ten WordPress Theme, Copyright 2010-2024 WordPress.org & Automattic.com
+Twenty Ten WordPress Theme, Copyright 2010-2024 WordPress.org, Automattic.com and contributors.
 Twenty Ten is Distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentyten/readme.txt
+++ b/src/wp-content/themes/twentyten/readme.txt
@@ -23,7 +23,7 @@ For more information about Twenty Ten theme please go to https://codex.wordpress
 
 == Copyright ==
 
-Twenty Ten WordPress Theme, Copyright 2010-2024 WordPress.org, Automattic Inc and contributors.
+Twenty Ten WordPress Theme, Copyright 2010-2024 WordPress.org, Automattic Inc., and contributors.
 Twenty Ten is Distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentyten/readme.txt
+++ b/src/wp-content/themes/twentyten/readme.txt
@@ -23,7 +23,7 @@ For more information about Twenty Ten theme please go to https://codex.wordpress
 
 == Copyright ==
 
-Twenty Ten WordPress Theme, Copyright 2010-2024 WordPress.org, Automattic.com and contributors.
+Twenty Ten WordPress Theme, Copyright 2010-2024 WordPress.org, Automattic Inc and contributors.
 Twenty Ten is Distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentythirteen/readme.txt
+++ b/src/wp-content/themes/twentythirteen/readme.txt
@@ -23,7 +23,7 @@ For more information about Twenty Thirteen please go to https://codex.wordpress.
 
 == Copyright ==
 
-Twenty Thirteen WordPress Theme, Copyright 2013-2024 WordPress.org, Automattic Inc and contributors.
+Twenty Thirteen WordPress Theme, Copyright 2013-2024 WordPress.org, Automattic Inc., and contributors.
 Twenty Thirteen is Distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentythirteen/readme.txt
+++ b/src/wp-content/themes/twentythirteen/readme.txt
@@ -23,7 +23,7 @@ For more information about Twenty Thirteen please go to https://codex.wordpress.
 
 == Copyright ==
 
-Twenty Thirteen WordPress Theme, Copyright 2013-2024 WordPress.org & Automattic.com
+Twenty Thirteen WordPress Theme, Copyright 2013-2024 WordPress.org, Automattic.com and contributors.
 Twenty Thirteen is Distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentythirteen/readme.txt
+++ b/src/wp-content/themes/twentythirteen/readme.txt
@@ -42,7 +42,7 @@ HTML5 Shiv v3.7.0, Copyright 2014 Alexander Farkas
 Licenses: MIT/GPL2
 Source: https://github.com/aFarkas/html5shiv
 
-Genericons icon font, Copyright 2013-2017 Automattic Inc
+Genericons icon font, Copyright 2013-2017 Automattic Inc.
 License: GNU GPL, Version 2 (or later)
 Source: http://www.genericons.com
 

--- a/src/wp-content/themes/twentythirteen/readme.txt
+++ b/src/wp-content/themes/twentythirteen/readme.txt
@@ -23,7 +23,7 @@ For more information about Twenty Thirteen please go to https://codex.wordpress.
 
 == Copyright ==
 
-Twenty Thirteen WordPress Theme, Copyright 2013-2024 WordPress.org, Automattic.com and contributors.
+Twenty Thirteen WordPress Theme, Copyright 2013-2024 WordPress.org, Automattic Inc and contributors.
 Twenty Thirteen is Distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify
@@ -42,7 +42,7 @@ HTML5 Shiv v3.7.0, Copyright 2014 Alexander Farkas
 Licenses: MIT/GPL2
 Source: https://github.com/aFarkas/html5shiv
 
-Genericons icon font, Copyright 2013-2017 Automattic.com
+Genericons icon font, Copyright 2013-2017 Automattic Inc
 License: GNU GPL, Version 2 (or later)
 Source: http://www.genericons.com
 

--- a/src/wp-content/themes/twentytwelve/readme.txt
+++ b/src/wp-content/themes/twentytwelve/readme.txt
@@ -23,7 +23,7 @@ For more information about Twenty Twelve please go to https://codex.wordpress.or
 
 == Copyright ==
 
-Twenty Twelve WordPress Theme, Copyright 2012-2024 WordPress.org & Automattic.com
+Twenty Twelve WordPress Theme, Copyright 2012-2024 WordPress.org, Automattic.com and contributors.
 Twenty Twelve is Distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentytwelve/readme.txt
+++ b/src/wp-content/themes/twentytwelve/readme.txt
@@ -23,7 +23,7 @@ For more information about Twenty Twelve please go to https://codex.wordpress.or
 
 == Copyright ==
 
-Twenty Twelve WordPress Theme, Copyright 2012-2024 WordPress.org, Automattic.com and contributors.
+Twenty Twelve WordPress Theme, Copyright 2012-2024 WordPress.org, Automattic Inc and contributors.
 Twenty Twelve is Distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentytwelve/readme.txt
+++ b/src/wp-content/themes/twentytwelve/readme.txt
@@ -23,7 +23,7 @@ For more information about Twenty Twelve please go to https://codex.wordpress.or
 
 == Copyright ==
 
-Twenty Twelve WordPress Theme, Copyright 2012-2024 WordPress.org, Automattic Inc and contributors.
+Twenty Twelve WordPress Theme, Copyright 2012-2024 WordPress.org, Automattic Inc., and contributors.
 Twenty Twelve is Distributed under the terms of the GNU GPL
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentytwenty/readme.txt
+++ b/src/wp-content/themes/twentytwenty/readme.txt
@@ -116,7 +116,7 @@ Initial release
 
 == Copyright ==
 
-Twenty Twenty WordPress Theme, Copyright 2019-2024 WordPress.org
+Twenty Twenty WordPress Theme, Copyright 2019-2024 WordPress.org and contributors.
 Twenty Twenty is distributed under the terms of the GNU GPL.
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentytwentyfour/readme.txt
+++ b/src/wp-content/themes/twentytwentyfour/readme.txt
@@ -30,7 +30,7 @@ https://wordpress.org/documentation/article/twenty-twenty-four-changelog/#Versio
 
 == Copyright ==
 
-Twenty Twenty-Four WordPress Theme, (C) 2023 WordPress.org and contributors.
+Twenty Twenty-Four WordPress Theme, (C) 2023-2024 WordPress.org and contributors.
 Twenty Twenty-Four is distributed under the terms of the GNU GPL.
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentytwentyfour/readme.txt
+++ b/src/wp-content/themes/twentytwentyfour/readme.txt
@@ -30,7 +30,7 @@ https://wordpress.org/documentation/article/twenty-twenty-four-changelog/#Versio
 
 == Copyright ==
 
-Twenty Twenty-Four WordPress Theme, (C) 2023 WordPress.org
+Twenty Twenty-Four WordPress Theme, (C) 2023 WordPress.org and contributors.
 Twenty Twenty-Four is distributed under the terms of the GNU GPL.
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentytwentyone/readme.txt
+++ b/src/wp-content/themes/twentytwentyone/readme.txt
@@ -102,7 +102,7 @@ https://wordpress.org/documentation/article/twenty-twenty-one-changelog/#Version
 
 == Copyright ==
 
-Twenty Twenty-One WordPress Theme, 2020-2024 WordPress.org
+Twenty Twenty-One WordPress Theme, 2020-2024 WordPress.org and contributors.
 Twenty Twenty-One is distributed under the terms of the GNU GPL.
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentytwentythree/readme.txt
+++ b/src/wp-content/themes/twentytwentythree/readme.txt
@@ -47,7 +47,7 @@ https://wordpress.org/documentation/article/twenty-twenty-three-changelog/#Versi
 
 == Copyright ==
 
-Twenty Twenty-Three WordPress Theme, (C) 2022-2024 WordPress.org
+Twenty Twenty-Three WordPress Theme, (C) 2022-2024 WordPress.org and contributors.
 Twenty Twenty-Three is distributed under the terms of the GNU GPL.
 
 This program is free software: you can redistribute it and/or modify

--- a/src/wp-content/themes/twentytwentytwo/readme.txt
+++ b/src/wp-content/themes/twentytwentytwo/readme.txt
@@ -64,7 +64,7 @@ https://wordpress.org/documentation/article/twenty-twenty-two-changelog/#Version
 
 == Copyright ==
 
-Twenty Twenty-Two WordPress Theme, 2021-2024 WordPress.org
+Twenty Twenty-Two WordPress Theme, 2021-2024 WordPress.org and contributors.
 Twenty Twenty-Two is distributed under the terms of the GNU GPL.
 
 This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
Updates the copyright notice for bundled themes to include contributors.

When contributing to WordPress, WordPress requires contributors license their code under the GPL. Unlike some projects there is no requirement to assign the copyright to WordPress.org or an associated entity. 

> By contributing code to WordPress, you grant its use under the GNU General Public License v2 (or later).

This updates the copyright claim in the bundled themes to indicate copyright is retained by contributors.

Trac ticket: https://core.trac.wordpress.org/ticket/61943

