### PR TITLE
Disable autosave endpoints for Templates and Template Parts

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -408,6 +408,8 @@ function create_initial_post_types() {
 			),
 		)
 	);
+	// Disable autosave endpoints for templates.
+	remove_post_type_support( 'wp_template', 'autosave' );
 
 	register_post_type(
 		'wp_template_part',
@@ -472,6 +474,8 @@ function create_initial_post_types() {
 			),
 		)
 	);
+	// Disable autosave endpoints for template parts.
+	remove_post_type_support( 'wp_template_part', 'autosave' );
 
 	register_post_type(
 		'wp_global_styles',


### PR DESCRIPTION
These two post types were missing while working on the original ticket.

Gutenberg issue: https://github.com/WordPress/gutenberg/pull/64733.
Trac ticket: https://core.trac.wordpress.org/ticket/41172

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
