### PR TITLE
Fixed `upgrader_process_complete` runs issue when no `plugins` selected to `upgrade`

### DIFF
--- a/src/wp-admin/includes/class-plugin-upgrader.php
+++ b/src/wp-admin/includes/class-plugin-upgrader.php
@@ -410,17 +410,19 @@ class Plugin_Upgrader extends WP_Upgrader {
 		// Force refresh of plugin update information.
 		wp_clean_plugins_cache( $parsed_args['clear_update_cache'] );
 
-		/** This action is documented in wp-admin/includes/class-wp-upgrader.php */
-		do_action(
-			'upgrader_process_complete',
-			$this,
-			array(
-				'action'  => 'update',
-				'type'    => 'plugin',
-				'bulk'    => true,
-				'plugins' => $plugins,
-			)
-		);
+		if ( ! empty( $plugins ) ) {
+			/** This action is documented in wp-admin/includes/class-wp-upgrader.php */
+			do_action(
+				'upgrader_process_complete',
+				$this,
+				array(
+					'action'  => 'update',
+					'type'    => 'plugin',
+					'bulk'    => true,
+					'plugins' => $plugins,
+				)
+			);
+		}
 
 		$this->skin->bulk_footer();
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61940

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
