### PR TITLE
Block Bindings: Add `canUpdateBlockBindings` editor setting

### DIFF
--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -665,7 +665,7 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 		}
 	}
 
-	$editor_settings['canUpdateBlockBindings'] = current_user_can( 'edit_block_binding', $block_editor_context->post->ID );
+	$editor_settings['canUpdateBlockBindings'] = current_user_can( 'edit_block_binding', $block_editor_context );
 
 	/**
 	 * Filters the settings to pass to the block editor for all editor type.

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -665,7 +665,7 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 		}
 	}
 
-	$editor_settings['canUpdateBlockBindings'] = current_user_can( 'manage_block_bindings' );
+	$editor_settings['canUpdateBlockBindings'] = current_user_can( 'edit_block_binding', $block_editor_context->post->ID );
 
 	/**
 	 * Filters the settings to pass to the block editor for all editor type.

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -665,6 +665,8 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 		}
 	}
 
+	$editor_settings['canUpdateBlockBindings'] = current_user_can( 'manage_options' );
+
 	/**
 	 * Filters the settings to pass to the block editor for all editor type.
 	 *

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -665,7 +665,7 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 		}
 	}
 
-	$editor_settings['canUpdateBlockBindings'] = current_user_can( 'manage_options' );
+	$editor_settings['canUpdateBlockBindings'] = current_user_can( 'manage_block_bindings' );
 
 	/**
 	 * Filters the settings to pass to the block editor for all editor type.

--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -801,6 +801,9 @@ function map_meta_cap( $cap, $user_id, ...$args ) {
 		case 'delete_app_password':
 			$caps = map_meta_cap( 'edit_user', $user_id, $args[0] );
 			break;
+		case 'manage_block_bindings':
+			$caps[] = 'manage_options';
+			break;
 		default:
 			// Handle meta capabilities for custom post types.
 			global $post_type_meta_caps;

--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -802,13 +802,16 @@ function map_meta_cap( $cap, $user_id, ...$args ) {
 			$caps = map_meta_cap( 'edit_user', $user_id, $args[0] );
 			break;
 		case 'edit_block_binding':
+			$block_editor_context = $args[0];
+			if ( isset( $block_editor_context ) && isset( $block_editor_context->post ) ) {
+				$object_id = $block_editor_context->post->ID;
+			}
 			/*
 			 * If the post ID is null, check if the context is the site editor.
 			 * Fall back to the edit_theme_options in that case.
 			 */
-			if ( ! isset( $args[0] ) ) {
-				$screen = get_current_screen();
-				if ( ! isset( $screen->id ) || 'site-editor' !== $screen->id ) {
+			if ( ! isset( $object_id ) ) {
+				if ( ! isset( $block_editor_context->name ) || 'core/edit-site' !== $block_editor_context->name ) {
 					$caps[] = 'do_not_allow';
 					break;
 				}
@@ -816,8 +819,7 @@ function map_meta_cap( $cap, $user_id, ...$args ) {
 				break;
 			}
 
-			$object_id      = (int) $args[0];
-			$object_subtype = get_object_subtype( 'post', $object_id );
+			$object_subtype = get_object_subtype( 'post', (int) $object_id );
 			if ( empty( $object_subtype ) ) {
 				$caps[] = 'do_not_allow';
 				break;

--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -803,7 +803,7 @@ function map_meta_cap( $cap, $user_id, ...$args ) {
 			break;
 		case 'edit_block_binding':
 			$block_editor_context = $args[0];
-			if ( isset( $block_editor_context ) && isset( $block_editor_context->post ) ) {
+			if ( isset( $block_editor_context->post ) ) {
 				$object_id = $block_editor_context->post->ID;
 			}
 			/*

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -571,7 +571,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 			$expected['edit_app_password'],
 			$expected['delete_app_passwords'],
 			$expected['delete_app_password'],
-			$expected['manage_block_bindings']
+			$expected['edit_block_binding']
 		);
 
 		$expected = array_keys( $expected );

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -571,7 +571,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 			$expected['edit_app_password'],
 			$expected['delete_app_passwords'],
 			$expected['delete_app_password'],
-			$expected['manage_block_bindings'],
+			$expected['manage_block_bindings']
 		);
 
 		$expected = array_keys( $expected );

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -570,7 +570,8 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 			$expected['read_app_password'],
 			$expected['edit_app_password'],
 			$expected['delete_app_passwords'],
-			$expected['delete_app_password']
+			$expected['delete_app_password'],
+			$expected['manage_block_bindings'],
 		);
 
 		$expected = array_keys( $expected );

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -2377,4 +2377,52 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 
 		return $data;
 	}
+
+	/**
+	 * Test `edit_block_binding` meta capability is properly mapped.
+	 *
+	 * @ticket 61945
+	 */
+	public function test_edit_block_binding_caps_are_mapped_correctly() {
+		$author = self::$users['administrator'];
+		$post   = self::factory()->post->create_and_get(
+			array(
+				'post_author' => $author->ID,
+				'post_type'   => 'post',
+			)
+		);
+
+		foreach ( self::$users as $role => $user ) {
+			// It should map to `edit_{post_type}` if editing a post.
+			$this->assertSame(
+				user_can( $user->ID, 'edit_post', $post->ID ),
+				user_can(
+					$user->ID,
+					'edit_block_binding',
+					new WP_Block_Editor_Context(
+						array(
+							'post' => $post,
+							'name' => 'core/edit-post',
+						)
+					)
+				),
+				"Role: {$role} in post editing"
+			);
+			// It should map to `edit_theme_options` if editing a template.
+			$this->assertSame(
+				user_can( $user->ID, 'edit_theme_options' ),
+				user_can(
+					$user->ID,
+					'edit_block_binding',
+					new WP_Block_Editor_Context(
+						array(
+							'post' => null,
+							'name' => 'core/edit-site',
+						)
+					)
+				),
+				"Role: {$role} in template editing"
+			);
+		}
+	}
 }


### PR DESCRIPTION
Needed for [https://github.com/WordPress/gutenberg/pull/64570](https://github.com/WordPress/gutenberg/pull/64570)

Adds a `canUpdateBlockBindings` editor setting that will be read to decide if the user should be able to create and modify bindings through the UI. By default, only admin users can do it, but it can be overridden with `block_editor_settings_all` filter.

Trac ticket: https://core.trac.wordpress.org/ticket/61945

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
