### PR TITLE
Fix return value documentation for get_*_meta() functions

### DIFF
--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -479,7 +479,8 @@ function delete_comment_meta( $comment_id, $meta_key, $meta_value = '' ) {
  * @return mixed An array of values if `$single` is false.
  *               The value of meta data field if `$single` is true.
  *               False for an invalid `$comment_id` (non-numeric, zero, or negative value).
- *               An empty string if a valid but non-existing comment ID is passed.
+ *               An empty string if a valid but non-existing comment ID is passed and `$single` is true.
+ *               An empty array if a valid but non-existing comment ID is passed and `$single` is false.
  */
 function get_comment_meta( $comment_id, $key = '', $single = false ) {
 	return get_metadata( 'comment', $comment_id, $key, $single );

--- a/src/wp-includes/meta.php
+++ b/src/wp-includes/meta.php
@@ -568,7 +568,8 @@ function delete_metadata( $meta_type, $object_id, $meta_key, $meta_value = '', $
  *               The value of the meta field if `$single` is true.
  *               False for an invalid `$object_id` (non-numeric, zero, or negative value),
  *               or if `$meta_type` is not specified.
- *               An empty string if a valid but non-existing object ID is passed.
+ *               An empty string if a valid but non-existing object ID is passed and `$single` is true.
+ *               An empty array if a valid but non-existing object ID is passed and `$single` is false.
  */
 function get_metadata( $meta_type, $object_id, $meta_key = '', $single = false ) {
 	$value = get_metadata_raw( $meta_type, $object_id, $meta_key, $single );

--- a/src/wp-includes/ms-site.php
+++ b/src/wp-includes/ms-site.php
@@ -1069,7 +1069,8 @@ function delete_site_meta( $site_id, $meta_key, $meta_value = '' ) {
  * @return mixed An array of values if `$single` is false.
  *               The value of meta data field if `$single` is true.
  *               False for an invalid `$site_id` (non-numeric, zero, or negative value).
- *               An empty string if a valid but non-existing site ID is passed.
+ *               An empty string if a valid but non-existing site ID is passed and `$single` is true.
+ *               An empty array if a valid but non-existing site ID is passed and `$single` is false.
  */
 function get_site_meta( $site_id, $key = '', $single = false ) {
 	return get_metadata( 'blog', $site_id, $key, $single );

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2607,7 +2607,8 @@ function delete_post_meta( $post_id, $meta_key, $meta_value = '' ) {
  * @return mixed An array of values if `$single` is false.
  *               The value of the meta field if `$single` is true.
  *               False for an invalid `$post_id` (non-numeric, zero, or negative value).
- *               An empty string if a valid but non-existing post ID is passed.
+ *               An empty string if a valid but non-existing post ID is passed and `$single` is true.
+ *               An empty array if a valid but non-existing post ID is passed and `$single` is false.
  */
 function get_post_meta( $post_id, $key = '', $single = false ) {
 	return get_metadata( 'post', $post_id, $key, $single );

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -1430,7 +1430,8 @@ function delete_term_meta( $term_id, $meta_key, $meta_value = '' ) {
  * @return mixed An array of values if `$single` is false.
  *               The value of the meta field if `$single` is true.
  *               False for an invalid `$term_id` (non-numeric, zero, or negative value).
- *               An empty string if a valid but non-existing term ID is passed.
+ *               An empty string if a valid but non-existing term ID is passed and `$single` is true.
+ *               An empty array if a valid but non-existing term ID is passed and `$single` is false.
  */
 function get_term_meta( $term_id, $key = '', $single = false ) {
 	return get_metadata( 'term', $term_id, $key, $single );

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -1185,7 +1185,8 @@ function delete_user_meta( $user_id, $meta_key, $meta_value = '' ) {
  * @return mixed An array of values if `$single` is false.
  *               The value of meta data field if `$single` is true.
  *               False for an invalid `$user_id` (non-numeric, zero, or negative value).
- *               An empty string if a valid but non-existing user ID is passed.
+ *               An empty string if a valid but non-existing user ID is passed and `$single` is true.
+ *               An empty array if a valid but non-existing user ID is passed and `$single` is false.
  */
 function get_user_meta( $user_id, $key = '', $single = false ) {
 	return get_metadata( 'user', $user_id, $key, $single );

--- a/tests/phpunit/tests/meta.php
+++ b/tests/phpunit/tests/meta.php
@@ -440,7 +440,7 @@ class Tests_Meta extends WP_UnitTestCase {
 				'expected' => array(),
 				'args'     => array( PHP_INT_MAX, 'meta_key', false ),
 			),
-			'Return value will be an empty array when `$single` is `true`' => array(
+			'Return value will be an empty string when `$single` is `true`' => array(
 				'expected' => '',
 				'args'     => array( PHP_INT_MAX, 'meta_key', true ),
 			),

--- a/tests/phpunit/tests/meta.php
+++ b/tests/phpunit/tests/meta.php
@@ -428,19 +428,19 @@ class Tests_Meta extends WP_UnitTestCase {
 
 	public function data_get_metadata_non_existent_object_id() {
 		return array(
-			'Default values for the $meta_key and $single params' => array(
+			'Return value will be an empty array when only required params are passed' => array(
 				'expected' => array(),
 				'args'     => array( PHP_INT_MAX ),
 			),
-			'Default value for the $single param' => array(
+			'Return value will be an empty array when all params are passed except `$single`' => array(
 				'expected' => array(),
 				'args'     => array( PHP_INT_MAX, 'meta_key' ),
 			),
-			'$single as `false`'                  => array(
+			'Return value will be an empty array when `$single` is `false`' => array(
 				'expected' => array(),
 				'args'     => array( PHP_INT_MAX, 'meta_key', false ),
 			),
-			'$single as `true`'                   => array(
+			'Return value will be an empty array when `$single` is `true`' => array(
 				'expected' => '',
 				'args'     => array( PHP_INT_MAX, 'meta_key', true ),
 			),

--- a/tests/phpunit/tests/meta.php
+++ b/tests/phpunit/tests/meta.php
@@ -428,19 +428,19 @@ class Tests_Meta extends WP_UnitTestCase {
 
 	public function data_get_metadata_non_existent_object_id() {
 		return array(
-			array(
+			'Default values for the $meta_key and $single params' => array(
 				'expected' => array(),
 				'args'     => array( PHP_INT_MAX ),
 			),
-			array(
+			'Default value for the $single param' => array(
 				'expected' => array(),
 				'args'     => array( PHP_INT_MAX, 'meta_key' ),
 			),
-			array(
+			'$single as `false`'                  => array(
 				'expected' => array(),
 				'args'     => array( PHP_INT_MAX, 'meta_key', false ),
 			),
-			array(
+			'$single as `true`'                   => array(
 				'expected' => '',
 				'args'     => array( PHP_INT_MAX, 'meta_key', true ),
 			),

--- a/tests/phpunit/tests/meta.php
+++ b/tests/phpunit/tests/meta.php
@@ -419,6 +419,13 @@ class Tests_Meta extends WP_UnitTestCase {
 		$this->assertSame( array( $value ), $found['foo'] );
 	}
 
+	public function test_get_metadata_non_existent_object_id() {
+		$this->assertSame( array(), get_metadata( 'user', PHP_INT_MAX ) );
+		$this->assertSame( array(), get_metadata( 'user', PHP_INT_MAX, 'meta_key' ) );
+		$this->assertSame( array(), get_metadata( 'user', PHP_INT_MAX, 'meta_key', false ) );
+		$this->assertSame( '', get_metadata( 'user', PHP_INT_MAX, 'meta_key', true ) );
+	}
+
 	/** Helpers */
 
 	public function updated_meta( $meta_id ) {

--- a/tests/phpunit/tests/meta.php
+++ b/tests/phpunit/tests/meta.php
@@ -419,11 +419,32 @@ class Tests_Meta extends WP_UnitTestCase {
 		$this->assertSame( array( $value ), $found['foo'] );
 	}
 
-	public function test_get_metadata_non_existent_object_id() {
-		$this->assertSame( array(), get_metadata( 'user', PHP_INT_MAX ) );
-		$this->assertSame( array(), get_metadata( 'user', PHP_INT_MAX, 'meta_key' ) );
-		$this->assertSame( array(), get_metadata( 'user', PHP_INT_MAX, 'meta_key', false ) );
-		$this->assertSame( '', get_metadata( 'user', PHP_INT_MAX, 'meta_key', true ) );
+	/**
+	 * @dataProvider data_get_metadata_non_existent_object_id
+	 */
+	public function test_get_metadata_non_existent_object_id( $expected, $args ) {
+		$this->assertSame( $expected, get_metadata( 'user', ...$args ) );
+	}
+
+	public function data_get_metadata_non_existent_object_id() {
+		return array(
+			array(
+				'expected' => array(),
+				'args'     => array( PHP_INT_MAX ),
+			),
+			array(
+				'expected' => array(),
+				'args'     => array( PHP_INT_MAX, 'meta_key' ),
+			),
+			array(
+				'expected' => array(),
+				'args'     => array( PHP_INT_MAX, 'meta_key', false ),
+			),
+			array(
+				'expected' => '',
+				'args'     => array( PHP_INT_MAX, 'meta_key', true ),
+			),
+		);
 	}
 
 	/** Helpers */


### PR DESCRIPTION
The return value documentation for the get_*_meta() and `get_metadata()` functions incorrectly stated that an empty string is returned if a valid but non-existing object ID is passed. Actually, an empty string is returned if a valid but non-existing object ID is passed and `$single` is `true`. Otherwise, an empty array is returned.

This PR fixes the return value documentation for those functions.

It also includes some very basic tests documenting this behavior for `get_metadata()`. Happy to add similar tests for the other functions if needed.

The documentation that is modified by this PR was added in https://core.trac.wordpress.org/changeset/50641.

Trac ticket: https://core.trac.wordpress.org/ticket/61608