### PR TITLE
Do not run updater when no plugins selected for update 61940

### DIFF
--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -730,7 +730,7 @@ if ( isset( $_GET['error'] ) ) {
 } elseif ( 'update-selected' === $action && ! isset( $_GET['plugins'] ) && ! isset( $_POST['checked'] ) ) {
 	$updated_notice_args['id']                 = 'no-items-selected';
 	$updated_notice_args['additional_classes'] = array( 'error' );
-	wp_admin_notice( __( 'No plugins selected to update.' ), $updated_notice_args );
+	wp_admin_notice( __( 'Please select at least one item to perform this action on.' ), $updated_notice_args );
 } elseif ( 'update-selected' === $action ) {
 	wp_admin_notice( __( 'All selected plugins are up to date.' ), $updated_notice_args );
 } elseif ( isset( $_GET['resume'] ) ) {

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -728,6 +728,7 @@ if ( isset( $_GET['error'] ) ) {
 } elseif ( isset( $_GET['deactivate-multi'] ) ) {
 	wp_admin_notice( __( 'Selected plugins deactivated.' ), $updated_notice_args );
 } elseif ( 'update-selected' === $action && ! isset( $_GET['plugins'] ) && ! isset( $_POST['checked'] ) ) {
+	$updated_notice_args['id']                 = 'no-items-selected';
 	$updated_notice_args['additional_classes'] = array( 'error' );
 	wp_admin_notice( __( 'No plugins selected to update.' ), $updated_notice_args );
 } elseif ( 'update-selected' === $action ) {

--- a/src/wp-admin/plugins.php
+++ b/src/wp-admin/plugins.php
@@ -152,7 +152,7 @@ if ( $action ) {
 			} elseif ( isset( $_POST['checked'] ) ) {
 				$plugins = (array) wp_unslash( $_POST['checked'] );
 			} else {
-				$plugins = array();
+				break;
 			}
 
 			// Used in the HTML title tag.
@@ -727,6 +727,9 @@ if ( isset( $_GET['error'] ) ) {
 	wp_admin_notice( __( 'Plugin deactivated.' ), $updated_notice_args );
 } elseif ( isset( $_GET['deactivate-multi'] ) ) {
 	wp_admin_notice( __( 'Selected plugins deactivated.' ), $updated_notice_args );
+} elseif ( 'update-selected' === $action && ! isset( $_GET['plugins'] ) && ! isset( $_POST['checked'] ) ) {
+	$updated_notice_args['additional_classes'] = array( 'error' );
+	wp_admin_notice( __( 'No plugins selected to update.' ), $updated_notice_args );
 } elseif ( 'update-selected' === $action ) {
 	wp_admin_notice( __( 'All selected plugins are up to date.' ), $updated_notice_args );
 } elseif ( isset( $_GET['resume'] ) ) {

--- a/tests/e2e/specs/plugins.test.js
+++ b/tests/e2e/specs/plugins.test.js
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+test.describe( 'plugins.php', () => {
+	test( 'Should display admin notice when bulk actions plugins updated but none selected with JS disabled #61940',
+		async ( { admin, page } ) => {
+
+			// Disable JavaScript.
+			await page.route( /.*\.js.*/, ( route ) => {
+				route.abort( 'blockedbyclient' );
+			} );
+
+			// Open plugins.php.
+			await admin.visitAdminPage( '/plugins.php' );
+
+			// Submit the "Bulk actions" form with "Update" selected, but no plugins checked in the list.
+			await page.locator( 'select#bulk-action-selector-top' ).selectOption( 'update-selected' );
+			await page.locator( 'input#doaction' ).click();
+
+			// The bug: without JS, the Update Plugins routine will start, but no plugins are selected.
+			await expect(
+				page.getByRole( 'heading', { name: 'Update Plugins', level: 1 } )
+			).not.toBeVisible();
+
+			// The desired behavior: an admin notice should be displayed.
+			await expect(
+				page.locator( '#no-items-selected' )
+			).toContainText( 'Please select at least one item to perform this action on.' );
+	} );
+} );

--- a/tests/e2e/specs/plugins.test.js
+++ b/tests/e2e/specs/plugins.test.js
@@ -9,7 +9,7 @@ test.describe( 'plugins.php', () => {
 
 			// Disable JavaScript.
 			await page.route( /.*\.js.*/, ( route ) => {
-				route.abort( 'blockedbyclient' );
+				route.fulfill( { status: 200, body: '' } );
 			} );
 
 			// Open plugins.php.


### PR DESCRIPTION
When JavaScript is disabled in the browser, it is possible to submit plugins.php's Bulk actions Update. The updater then runs and fires `upgrader_process_complete` with a `$plugins` array with only an empty string in it.

The changes here check are any plugins selected and if not, displays an admin notice.

Trac ticket: https://core.trac.wordpress.org/ticket/61940

Slack request for testing tips: https://wordpress.slack.com/archives/C03B0H5J0/p1724780845998239

I tried the following as a test but it fails with `Constant DB_NAME already defined`.

```php
public function test_submit_bulk_update_form_with_no_plugins_selected() {
	$_POST = array(
		'plugin_status'    => 'all',
		'paged'            => '1',
		'_wpnonce'         => wp_create_nonce( 'bulk-plugins' ),
		'_wp_http_referer' => '/wp-admin/plugins.php',
		'action'           => 'update-selected',
		'action2'          => '-1',
	);

	ob_start();
	require ABSPATH . 'wp-admin/plugins.php';
	$output = ob_get_clean();

	$this->assertNotContains( 'The update process is starting.', $output );

	$this->assertFalse( did_action( 'upgrader_process_complete' ) );
}
```

I will add a Playwright test showing the updater is not run and the new admin notice is displayed but it would be nice to test that the `upgrader_process_complete` action is never fired.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
