### PR TITLE
Site Editor: Update preloaded paths

### DIFF
--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -88,7 +88,7 @@ $navigation_rest_route = rest_get_route_for_post_type_items(
 );
 
 $preload_paths = array(
-	array( '/wp/v2/media', 'OPTIONS' ),
+	array( rest_get_route_for_post_type_items( 'attachment' ), 'OPTIONS' ),
 	array( rest_get_route_for_post_type_items( 'page' ), 'OPTIONS' ),
 	'/wp/v2/types?context=view',
 	'/wp/v2/types/wp_template?context=edit',

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -89,6 +89,7 @@ $navigation_rest_route = rest_get_route_for_post_type_items(
 
 $preload_paths = array(
 	array( '/wp/v2/media', 'OPTIONS' ),
+	array( rest_get_route_for_post_type_items( 'page' ), 'OPTIONS' ),
 	'/wp/v2/types?context=view',
 	'/wp/v2/types/wp_template?context=edit',
 	'/wp/v2/types/wp_template_part?context=edit',


### PR DESCRIPTION
> Permissions for creating pages (`OPTIONS /wp/v2/pages`). Both requests are made in the `useBlockEditorSettings` hook, at the top of the post editor React tree.

Matches the preloaded path for the posts editor and hopefully will improve the Site Editor loading time a bit.

Gutenberg Issue: https://github.com/WordPress/gutenberg/pull/64890
Trac ticket: https://core.trac.wordpress.org/ticket/61884