### PR TITLE
Tax Query: Allow querying for all posts with any term of a given taxonomy

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1165,7 +1165,6 @@ class WP_Query {
 		}
 
 		foreach ( get_taxonomies( array(), 'objects' ) as $taxonomy => $t ) {
-
 			if ( 'post_tag' === $taxonomy ) {
 				continue; // Handled further down in the $q['tag'] block.
 			}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1165,16 +1165,16 @@ class WP_Query {
 		}
 
 		foreach ( get_taxonomies( array(), 'objects' ) as $taxonomy => $t ) {
+
 			if ( 'post_tag' === $taxonomy ) {
 				continue; // Handled further down in the $q['tag'] block.
 			}
 
-			if ( $t->query_var && ! empty( $q[ $t->query_var ] ) ) {
+			if ( $t->query_var && ( ! empty( $q[ $t->query_var ] || '' === $q[ $t->query_var ] ) ) ) {
 				$tax_query_defaults = array(
 					'taxonomy' => $taxonomy,
 					'field'    => 'slug',
 				);
-
 				if ( ! empty( $t->rewrite['hierarchical'] ) ) {
 					$q[ $t->query_var ] = wp_basename( $q[ $t->query_var ] );
 				}
@@ -1195,13 +1195,24 @@ class WP_Query {
 							)
 						);
 					}
-				} else {
+				} elseif ( '' !== $term ) {
 					$tax_query[] = array_merge(
 						$tax_query_defaults,
 						array(
 							'terms' => preg_split( '/[,]+/', $term ),
 						)
 					);
+				} else {
+					// FIXME: Figure out why 'category' is automatically
+					// added as a query arg and what to do about it.
+					if ( 'category' !== $taxonomy ) {
+						$tax_query[] = array_merge(
+							$tax_query_defaults,
+							array(
+								'operator' => 'EXISTS',
+							)
+						);
+					}
 				}
 			}
 		}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1169,7 +1169,7 @@ class WP_Query {
 				continue; // Handled further down in the $q['tag'] block.
 			}
 
-			if ( $t->query_var && ( ! empty( $q[ $t->query_var ] || '' === $q[ $t->query_var ] ) ) ) {
+			if ( $t->query_var && isset( $q[ $t->query_var ] ) ) {
 				$tax_query_defaults = array(
 					'taxonomy' => $taxonomy,
 					'field'    => 'slug',
@@ -1195,14 +1195,14 @@ class WP_Query {
 							)
 						);
 					}
-				} elseif ( '' !== $term ) {
+				} elseif ( ! empty( $term ) ) {
 					$tax_query[] = array_merge(
 						$tax_query_defaults,
 						array(
 							'terms' => preg_split( '/[,]+/', $term ),
 						)
 					);
-				} else {
+				} elseif ( '' === $term ) {
 					// FIXME: Figure out why 'category' is automatically
 					// added as a query arg and what to do about it.
 					if ( 'category' !== $taxonomy ) {

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1175,6 +1175,7 @@ class WP_Query {
 					'taxonomy' => $taxonomy,
 					'field'    => 'slug',
 				);
+
 				if ( ! empty( $t->rewrite['hierarchical'] ) ) {
 					$q[ $t->query_var ] = wp_basename( $q[ $t->query_var ] );
 				}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1202,7 +1202,7 @@ class WP_Query {
 							'terms' => preg_split( '/[,]+/', $term ),
 						)
 					);
-				} elseif ( '' === $term ) {
+				} else {
 					// FIXME: Figure out why 'category' is automatically
 					// added as a query arg and what to do about it.
 					if ( 'category' !== $taxonomy ) {

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1173,6 +1173,12 @@ class WP_Query {
 				continue;
 			}
 
+			if ( 'category' === $taxonomy && empty( $q[ $t->query_var ] ) ) {
+				// Unlike custom taxonomies, the category field is automatically added to every query.
+				// Thus, we need to skip it if it is empty.
+				continue;
+			}
+
 			$tax_query_defaults = array(
 				'taxonomy' => $taxonomy,
 				'field'    => 'slug',
@@ -1206,16 +1212,12 @@ class WP_Query {
 					)
 				);
 			} else {
-				// FIXME: Figure out why 'category' is automatically
-				// added as a query arg and what to do about it.
-				if ( 'category' !== $taxonomy ) {
-					$tax_query[] = array_merge(
-						$tax_query_defaults,
-						array(
-							'operator' => 'EXISTS',
-						)
-					);
-				}
+				$tax_query[] = array_merge(
+					$tax_query_defaults,
+					array(
+						'operator' => 'EXISTS',
+					)
+				);
 			}
 		}
 

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1173,9 +1173,9 @@ class WP_Query {
 				continue;
 			}
 
-			if ( 'category' === $taxonomy && empty( $q[ $t->query_var ] ) ) {
-				// Unlike custom taxonomies, the category field is automatically added to every query.
-				// Thus, we need to skip it if it is empty.
+			if ( empty( $q[ $t->query_var ] ) && ! $t->root_taxonomy_archive ) {
+				// We only allow the term to be empty if the taxonomy is set up to
+				// show its root archive.
 				continue;
 			}
 

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1169,50 +1169,52 @@ class WP_Query {
 				continue; // Handled further down in the $q['tag'] block.
 			}
 
-			if ( $t->query_var && isset( $q[ $t->query_var ] ) ) {
-				$tax_query_defaults = array(
-					'taxonomy' => $taxonomy,
-					'field'    => 'slug',
-				);
+			if ( ! $t->query_var || ! isset( $q[ $t->query_var ] ) ) {
+				continue;
+			}
 
-				if ( ! empty( $t->rewrite['hierarchical'] ) ) {
-					$q[ $t->query_var ] = wp_basename( $q[ $t->query_var ] );
-				}
+			$tax_query_defaults = array(
+				'taxonomy' => $taxonomy,
+				'field'    => 'slug',
+			);
 
-				$term = $q[ $t->query_var ];
+			if ( ! empty( $t->rewrite['hierarchical'] ) ) {
+				$q[ $t->query_var ] = wp_basename( $q[ $t->query_var ] );
+			}
 
-				if ( is_array( $term ) ) {
-					$term = implode( ',', $term );
-				}
+			$term = $q[ $t->query_var ];
 
-				if ( str_contains( $term, '+' ) ) {
-					$terms = preg_split( '/[+]+/', $term );
-					foreach ( $terms as $term ) {
-						$tax_query[] = array_merge(
-							$tax_query_defaults,
-							array(
-								'terms' => array( $term ),
-							)
-						);
-					}
-				} elseif ( ! empty( $term ) ) {
+			if ( is_array( $term ) ) {
+				$term = implode( ',', $term );
+			}
+
+			if ( str_contains( $term, '+' ) ) {
+				$terms = preg_split( '/[+]+/', $term );
+				foreach ( $terms as $term ) {
 					$tax_query[] = array_merge(
 						$tax_query_defaults,
 						array(
-							'terms' => preg_split( '/[,]+/', $term ),
+							'terms' => array( $term ),
 						)
 					);
-				} else {
-					// FIXME: Figure out why 'category' is automatically
-					// added as a query arg and what to do about it.
-					if ( 'category' !== $taxonomy ) {
-						$tax_query[] = array_merge(
-							$tax_query_defaults,
-							array(
-								'operator' => 'EXISTS',
-							)
-						);
-					}
+				}
+			} elseif ( ! empty( $term ) ) {
+				$tax_query[] = array_merge(
+					$tax_query_defaults,
+					array(
+						'terms' => preg_split( '/[,]+/', $term ),
+					)
+				);
+			} else {
+				// FIXME: Figure out why 'category' is automatically
+				// added as a query arg and what to do about it.
+				if ( 'category' !== $taxonomy ) {
+					$tax_query[] = array_merge(
+						$tax_query_defaults,
+						array(
+							'operator' => 'EXISTS',
+						)
+					);
 				}
 			}
 		}

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -515,7 +515,7 @@ final class WP_Taxonomy {
 
 			// For the root taxonomy archive, the query string is simply the query var, with no value set,
 			// or, if no query var is defined, `taxonomy=$this->name`.
-			add_rewrite_tag( "%taxonomy-$this->name%", "$this->name", $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name" );
+			add_rewrite_tag( "%taxonomy-$this->name%", "$this->name", "taxonomy=$this->name" );
 			add_permastruct( "taxonomy-$this->name", "%taxonomy-$this->name%", $this->rewrite );
 		}
 	}

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -510,10 +510,12 @@ final class WP_Taxonomy {
 				$tag = '([^/]+)';
 			}
 
-			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
+			$query = $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=";
+
+			add_rewrite_tag( "%$this->name%", $tag, $query );
 			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
 
-			add_rewrite_tag( "%$this->name-taxonomy%", "(?:$this->name)", $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
+			add_rewrite_tag( "%$this->name-taxonomy%", "(?:$this->name)", $query );
 			add_permastruct( "$this->name-taxonomy", "%$this->name-taxonomy%", $this->rewrite );
 		}
 	}

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -511,10 +511,7 @@ final class WP_Taxonomy {
 			}
 
 			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
-			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
-
-			add_rewrite_tag( "%$this->name-taxonomy%", "(?:$this->name)", $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
-			add_permastruct( "$this->name-taxonomy", "%$this->name-taxonomy%", $this->rewrite );
+			add_permastruct( $this->name, "{$this->rewrite['slug']}(?:/%$this->name%)?", $this->rewrite );
 		}
 	}
 

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -538,6 +538,9 @@ final class WP_Taxonomy {
 
 		// Remove rewrite tags and permastructs.
 		if ( false !== $this->rewrite ) {
+			remove_rewrite_tag( "%$this->name-taxonomy%" );
+			remove_permastruct( "$this->name-taxonomy" );
+
 			remove_rewrite_tag( "%$this->name%" );
 			remove_permastruct( $this->name );
 		}

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -515,8 +515,8 @@ final class WP_Taxonomy {
 
 			// For the root taxonomy archive, the query string is simply the query var, with no value set,
 			// or, if no query var is defined, `taxonomy=$this->name`.
-			add_rewrite_tag( "%$this->name-taxonomy%", "(?:$this->name)", $this->query_var ? $this->query_var : "taxonomy=$this->name" );
-			add_permastruct( "$this->name-taxonomy", "%$this->name-taxonomy%", $this->rewrite );
+			add_rewrite_tag( "%taxonomy-$this->name%", "(?:$this->name)", $this->query_var ? $this->query_var : "taxonomy=$this->name" );
+			add_permastruct( "taxonomy-$this->name", "%taxonomy-$this->name%", $this->rewrite );
 		}
 	}
 
@@ -538,8 +538,8 @@ final class WP_Taxonomy {
 
 		// Remove rewrite tags and permastructs.
 		if ( false !== $this->rewrite ) {
-			remove_rewrite_tag( "%$this->name-taxonomy%" );
-			remove_permastruct( "$this->name-taxonomy" );
+			remove_rewrite_tag( "%taxonomy-$this->name%" );
+			remove_permastruct( "taxonomy-$this->name" );
 
 			remove_rewrite_tag( "%$this->name%" );
 			remove_permastruct( $this->name );

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -512,6 +512,10 @@ final class WP_Taxonomy {
 
 			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
 			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
+
+			// TODO: If rewrite tag exists, append taxonomy name to regex.
+			add_rewrite_tag( '%taxonomy%', "(?:$this->name)", $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
+			add_permastruct( 'taxonomy', '%taxonomy%', $this->rewrite );
 		}
 	}
 

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -510,15 +510,12 @@ final class WP_Taxonomy {
 				$tag = '([^/]+)';
 			}
 
-			if ( $this->query_var ) {
-				add_rewrite_tag( "%taxonomy-$this->name%", "$this->name()", "{$this->query_var}=" );
-			} else {
-				add_rewrite_tag( "%taxonomy-$this->name%", "($this->name)", 'taxonomy=' );
-			}
+			$query = $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=";
 
+			add_rewrite_tag( "%taxonomy-$this->name%", "$this->name()", $query );
 			add_permastruct( "taxonomy-$this->name", "%taxonomy-$this->name%", $this->rewrite );
 
-			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
+			add_rewrite_tag( "%$this->name%", $tag, $query );
 			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
 		}
 	}

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -511,7 +511,10 @@ final class WP_Taxonomy {
 			}
 
 			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
-			add_permastruct( $this->name, "{$this->rewrite['slug']}(?:/%$this->name%)?", $this->rewrite );
+			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
+
+			add_rewrite_tag( "%$this->name-taxonomy%", "(?:$this->name)", $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
+			add_permastruct( "$this->name-taxonomy", "%$this->name-taxonomy%", $this->rewrite );
 		}
 	}
 

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -510,7 +510,12 @@ final class WP_Taxonomy {
 				$tag = '([^/]+)';
 			}
 
-			add_rewrite_tag( "%taxonomy-$this->name%", "($this->name)", 'taxonomy=' );
+			if ( $this->query_var ) {
+				add_rewrite_tag( "%taxonomy-$this->name%", "$this->name()", "{$this->query_var}=" );
+			} else {
+				add_rewrite_tag( "%taxonomy-$this->name%", "($this->name)", 'taxonomy=' );
+			}
+
 			add_permastruct( "taxonomy-$this->name", "%taxonomy-$this->name%", $this->rewrite );
 
 			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -510,11 +510,11 @@ final class WP_Taxonomy {
 				$tag = '([^/]+)';
 			}
 
-			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
-			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
-
 			add_rewrite_tag( "%taxonomy-$this->name%", "($this->name)", 'taxonomy=' );
 			add_permastruct( "taxonomy-$this->name", "%taxonomy-$this->name%", $this->rewrite );
+
+			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
+			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
 		}
 	}
 
@@ -536,11 +536,11 @@ final class WP_Taxonomy {
 
 		// Remove rewrite tags and permastructs.
 		if ( false !== $this->rewrite ) {
-			remove_rewrite_tag( "%taxonomy-$this->name%" );
-			remove_permastruct( "taxonomy-$this->name" );
-
 			remove_rewrite_tag( "%$this->name%" );
 			remove_permastruct( $this->name );
+
+			remove_rewrite_tag( "%taxonomy-$this->name%" );
+			remove_permastruct( "taxonomy-$this->name" );
 		}
 	}
 

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -513,7 +513,7 @@ final class WP_Taxonomy {
 			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
 			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
 
-			add_rewrite_tag( "%taxonomy-$this->name%", "$this->name", "taxonomy=$this->name" );
+			add_rewrite_tag( "%taxonomy-$this->name%", "($this->name)", 'taxonomy=' );
 			add_permastruct( "taxonomy-$this->name", "%taxonomy-$this->name%", $this->rewrite );
 		}
 	}

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -510,12 +510,12 @@ final class WP_Taxonomy {
 				$tag = '([^/]+)';
 			}
 
-			$query = $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=";
-
-			add_rewrite_tag( "%$this->name%", $tag, $query );
+			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
 			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
 
-			add_rewrite_tag( "%$this->name-taxonomy%", "(?:$this->name)", $query );
+			// For the root taxonomy archive, the query string is simply the query var, with no value set,
+			// or, if no query var is defined, `taxonomy=$this->name`.
+			add_rewrite_tag( "%$this->name-taxonomy%", "(?:$this->name)", $this->query_var ? $this->query_var : "taxonomy=$this->name" );
 			add_permastruct( "$this->name-taxonomy", "%$this->name-taxonomy%", $this->rewrite );
 		}
 	}

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -513,9 +513,8 @@ final class WP_Taxonomy {
 			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
 			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
 
-			// TODO: If rewrite tag exists, append taxonomy name to regex.
-			add_rewrite_tag( '%taxonomy%', "(?:$this->name)", $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
-			add_permastruct( 'taxonomy', '%taxonomy%', $this->rewrite );
+			add_rewrite_tag( "%$this->name-taxonomy%", "(?:$this->name)", $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
+			add_permastruct( "$this->name-taxonomy", "%$this->name-taxonomy%", $this->rewrite );
 		}
 	}
 

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -515,7 +515,7 @@ final class WP_Taxonomy {
 
 			// For the root taxonomy archive, the query string is simply the query var, with no value set,
 			// or, if no query var is defined, `taxonomy=$this->name`.
-			add_rewrite_tag( "%taxonomy-$this->name%", "(?:$this->name)", $this->query_var ? $this->query_var : "taxonomy=$this->name" );
+			add_rewrite_tag( "%taxonomy-$this->name%", "$this->name", $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name" );
 			add_permastruct( "taxonomy-$this->name", "%taxonomy-$this->name%", $this->rewrite );
 		}
 	}

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -513,8 +513,6 @@ final class WP_Taxonomy {
 			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
 			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
 
-			// For the root taxonomy archive, the query string is simply the query var, with no value set,
-			// or, if no query var is defined, `taxonomy=$this->name`.
 			add_rewrite_tag( "%taxonomy-$this->name%", "$this->name", "taxonomy=$this->name" );
 			add_permastruct( "taxonomy-$this->name", "%taxonomy-$this->name%", $this->rewrite );
 		}

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -246,6 +246,15 @@ final class WP_Taxonomy {
 	public $default_term;
 
 	/**
+	 * Whether to show a page for the root taxonomy route, displaying all
+	 * posts that have any term from the taxonomy assigned.
+	 *
+	 * @since 6.8.0
+	 * @var bool
+	 */
+	public $root_taxonomy_archive = false;
+
+	/**
 	 * Whether terms in this taxonomy should be sorted in the order they are provided to `wp_set_object_terms()`.
 	 *
 	 * Use this in combination with `'orderby' => 'term_order'` when fetching terms.
@@ -359,6 +368,7 @@ final class WP_Taxonomy {
 			'rest_namespace'        => false,
 			'rest_controller_class' => false,
 			'default_term'          => null,
+			'root_taxonomy_archive' => false,
 			'sort'                  => null,
 			'args'                  => null,
 			'_builtin'              => false,

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -426,6 +426,7 @@ function is_taxonomy_hierarchical( $taxonomy ) {
  * @since 5.4.0 Added the registered taxonomy object as a return value.
  * @since 5.5.0 Introduced `default_term` argument.
  * @since 5.9.0 Introduced `rest_namespace` argument.
+ * @since 6.8.0 Introduced `root_taxonomy_archive` argument.
  *
  * @global WP_Taxonomy[] $wp_taxonomies Registered taxonomies.
  *
@@ -506,6 +507,8 @@ function is_taxonomy_hierarchical( $taxonomy ) {
  *         @type string $slug         Slug for default term. Default empty.
  *         @type string $description  Description for default term. Default empty.
  *     }
+ *     @type bool          $root_taxonomy_archive Whether to show a page at the root taxonomy route, displaying all
+ *                                                posts that have any term from the taxonomy assigned. Default false.
  *     @type bool          $sort                  Whether terms in this taxonomy should be sorted in the order they are
  *                                                provided to `wp_set_object_terms()`. Default null which equates to false.
  *     @type array         $args                  Array of arguments to automatically use inside `wp_get_object_terms()`

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -91,7 +91,7 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 				'/category/',
 				array(
 					'url' => '/category/',
-					'qv'  => array( 'taxonomy' => 'category' ),
+					'qv'  => array( 'category_name' => '' ),
 				),
 			),
 			array(
@@ -106,8 +106,8 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 				array(
 					'url' => '/category/page/2/',
 					'qv'  => array(
-						'taxonomy' => 'category',
-						'paged'    => 2,
+						'category_name' => '',
+						'paged'         => 2,
 					),
 				),
 			),
@@ -126,8 +126,8 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 				array(
 					'url' => '/category/page/2/',
 					'qv'  => array(
-						'taxonomy' => 'category',
-						'paged'    => 2,
+						'category_name' => '',
+						'paged'         => 2,
 					),
 				),
 			),

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -158,6 +158,17 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 
 			// Categories & intersections with other vars.
 			array(
+				'/category/?tag=post-formats',
+				array(
+					'url' => '/category/?tag=post-formats',
+					'qv'  => array(
+						'category_name' => '',
+						'tag'           => 'post-formats',
+					),
+				),
+				61957,
+			),
+			array(
 				'/category/uncategorized/?tag=post-formats',
 				array(
 					'url' => '/category/uncategorized/?tag=post-formats',
@@ -176,6 +187,7 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 			),
 
 			// Taxonomies with extra query vars.
+			array( '/category/page/1/?test=one%20two', '/category/?test=one%20two', 61957 ), // Extra query vars should stay encoded.
 			array( '/category/cat-a/page/1/?test=one%20two', '/category/cat-a/?test=one%20two', 18086 ), // Extra query vars should stay encoded.
 
 			// Categories with dates.

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -88,10 +88,27 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 			array( '?cat=%d', array( 'url' => '/category/parent/child-1/' ), 15256 ),
 			array( '?cat=%d', array( 'url' => '/category/parent/child-1/child-2/' ) ), // No children.
 			array(
+				'/category/',
+				array(
+					'url' => '/category/',
+					'qv'  => array( 'taxonomy' => 'category' ),
+				),
+			),
+			array(
 				'/category/uncategorized/',
 				array(
 					'url' => '/category/uncategorized/',
 					'qv'  => array( 'category_name' => 'uncategorized' ),
+				),
+			),
+			array(
+				'/category/page/2/',
+				array(
+					'url' => '/category/page/2/',
+					'qv'  => array(
+						'taxonomy' => 'category',
+						'paged'    => 2,
+					),
 				),
 			),
 			array(
@@ -101,6 +118,16 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 					'qv'  => array(
 						'category_name' => 'uncategorized',
 						'paged'         => 2,
+					),
+				),
+			),
+			array(
+				'/category/?paged=2',
+				array(
+					'url' => '/category/page/2/',
+					'qv'  => array(
+						'taxonomy' => 'category',
+						'paged'    => 2,
 					),
 				),
 			),

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -93,6 +93,7 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 					'url' => '/category/',
 					'qv'  => array( 'category_name' => '' ),
 				),
+				61957,
 			),
 			array(
 				'/category/uncategorized/',
@@ -110,6 +111,7 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 						'paged'         => 2,
 					),
 				),
+				61957,
 			),
 			array(
 				'/category/uncategorized/page/2/',
@@ -130,6 +132,7 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 						'paged'         => 2,
 					),
 				),
+				61957,
 			),
 			array(
 				'/category/uncategorized/?paged=2',

--- a/tests/phpunit/tests/taxonomy.php
+++ b/tests/phpunit/tests/taxonomy.php
@@ -917,7 +917,7 @@ class Tests_Taxonomy extends WP_UnitTestCase {
 		$this->assertTrue( unregister_taxonomy( 'foo' ) );
 		$this->assertNotContains( '%foo%', $wp_rewrite->rewritecode );
 		$this->assertNotContains( 'bar=', $wp_rewrite->queryreplace );
-		$this->assertCount( --$count_before, $wp_rewrite->rewritereplace ); // Array was reduced by one value.
+		$this->assertCount( $count_before - 2, $wp_rewrite->rewritereplace ); // Array was reduced by two values.
 	}
 
 	/**


### PR DESCRIPTION
**Diff best viewed [with whitespace changes hidden](https://github.com/WordPress/wordpress-develop/pull/7271/files?diff=split&w=1).**

## What

Introduce a new `register_taxonomy()` flag (tentatively called `root_taxonomy_archive`) which, for a given taxonomy — e.g. `projects` — will enable the "root" route (`/projects`) (so it no longer is interpreted as a page that doesn’t exists and thus 404s).

_Note that this does **not** extend the template hierarchy to include a dedicated template for root taxonomy archives; that is a different problem that I’d like to tackle [separately](https://github.com/WordPress/wordpress-develop/pull/7989). For now, root taxonomy routes fall back to the generic archive template._

## How

To solve this problem, we need some understanding of WordPress' routing. Internally, there are two important concepts:

- To represent route parameters, WordPress uses the concept of so-called _rewrite tags_ (no relation to post tags). They are denoted by a leading and trailing percent sign, e.g. `%year%` or `%postname%`, and defined via [`add_rewrite_tag()`](https://developer.wordpress.org/reference/functions/add_rewrite_tag/), where the matching regular expression is provided as an argument; e.g. for `%year%` – a four-digit number – the RegEx is `([0-9]{4})`.
- These rewrite tags are then used to compose the higher-level _permalink structure_ ("permastruct"), which defines the list of all permissible route patterns. For single post routes, these permalink structures can be customized via Settings > Permalinks. When a visitor then browses a URL of the site, WordPress matches the route against those patterns. It then goes through all rewrite tags one by one, and translates them individually to `key=value` pairs, from which it assembles a query string -- which is the canonical representation for any route! E.g. `/2024/12/hello-world` is matched by `/%year%/%month%/%postname%`, which is then translated into `/?year=2024&month=12&name=hello-world`.

For a taxonomy called `projects`, the [permastruct is `/projects/%project%`](https://github.com/WordPress/wordpress-develop/blob/2ae4473373b49873132ed687c008979533f04d84/src/wp-includes/class-wp-taxonomy.php#L514). Then, a route such as `/projects/film` is mapped to the query string `?projects=film`, as can be easily verified using the [Query Monitor plugin](https://wordpress.org/plugins/query-monitor/).
 
<img width="726" alt="134VYPNmm0pJ7njR2L8-ySRCOCfdzgNs2eg18Szd2" src="https://github.com/user-attachments/assets/4432d504-fb04-4208-86be-f8930e37f581">

The crux here is WordPress' rigid mapping of any rewrite tag to a key/value pair, used in a query string (like `?key=value`). Thus, the first part of the solution found in this PR is to allow a "dangling" query string, i.e. `?projects=` (with no value assigned). _Note that this is [not in violation of the URI RFC](https://stackoverflow.com/questions/4557387/is-a-url-query-parameter-valid-if-it-has-no-value)!_

The second part is to define a permastruct that matches a route like `/projects` and translates it to that "dangling" `?projects=` query string. The tricky part here is that WordPress really, really wants us to use a rewrite tag that it will match against the route, and use the value it finds as the value in the query string. We work around this by adding a RegEx capturing group that will match the empty string: `()`.

### Testing instructions
 
1. Add the following code (e.g. to your theme's `functions.php`). Create a number of new posts, and use the "Project Types" panel in the block inspector to create a number of "Project Type" terms and assign them to each given post. Use terms such as "Film" or "TV".

<details>
<summary>
Code
</summary>

```php
function register_taxonomies() {
	/**
	 * Taxonomy: Project Types.
	 */
	 $labels = array(
		'name'          => __( 'Project Types' ),
		'singular_name' => __( 'Project Type' ),
		'add_new_item'  => __( 'Add Project Type' ),
		'new_item_name' => __( 'New Project Type' ),
	);

	$args = array(
		'label'                 => __( 'Project Types' ),
		'labels'                => $labels,
		'show_in_rest'          => true,
		'show_tagcloud'         => false,
	);
	register_taxonomy( 'projects', array( 'post' ), $args );
}
add_action( 'init', 'register_taxonomies', 0 );
```
</details>

2. Go to Settings > Permalinks, and click the "Save changes" button at the bottom. (This is required for WordPress to update its internal routing to include routes for the newly added taxonomy.)

3. Manually navigate to `/projects/film` and verify that it still works, displaying an archive of posts that have the "Film" term assigned.

4. Manually navigate to `/projects` and verify that it also works: It should show an archive of all posts that have at least one term from the `projects` taxonomy assigned. (It will currently use the generic archive template. Adding a template for the root taxonomy route will be handled in a follow-up.)

(You can compare this behavior to `trunk`, where `/projects` will 404.)

Finally, also try the query strings `?projects=film` and `?projects=`. They should also display the correct archives.

## Follow-up work

In https://github.com/WordPress/wordpress-develop/pull/7989, I've started exploring extending the permalink structure to include a dedicated _template_ for the root taxonomy route.

## References

Some relevant documentation [here](https://make.wordpress.org/plugins/2012/06/07/rewrite-endpoints-api/).

## Screencast

![taxonomy-root-archives](https://github.com/user-attachments/assets/bd5c70ff-125a-4b20-b77c-11f74fa3e84e)

Trac ticket: https://core.trac.wordpress.org/ticket/61957

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
