### PR TITLE
Comments: Pass `$page` as argument to comments functions

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2564,11 +2564,6 @@ function build_comment_query_vars_from_block( $block ) {
 					$comment_args['paged'] = $max_num_pages;
 				}
 			}
-			// Set the `cpage` query var to ensure the previous and next pagination links are correct
-			// when inheriting the Discussion Settings.
-			if ( 0 === $page && isset( $comment_args['paged'] ) && $comment_args['paged'] > 0 ) {
-				set_query_var( 'cpage', $comment_args['paged'] );
-			}
 		}
 	}
 

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -3109,21 +3109,25 @@ function get_comments_pagenum_link( $pagenum = 1, $max_page = 0 ) {
  * Retrieves the link to the next comments page.
  *
  * @since 2.7.1
+ * @since 6.7.0 Added the `page` parameter.
  *
  * @global WP_Query $wp_query WordPress Query object.
  *
- * @param string $label    Optional. Label for link text. Default empty.
- * @param int    $max_page Optional. Max page. Default 0.
+ * @param string   $label    Optional. Label for link text. Default empty.
+ * @param int      $max_page Optional. Max page. Default 0.
+ * @param int|null $page     Optional. Page number. Default null.
  * @return string|void HTML-formatted link for the next page of comments.
  */
-function get_next_comments_link( $label = '', $max_page = 0 ) {
+function get_next_comments_link( $label = '', $max_page = 0, $page = null ) {
 	global $wp_query;
 
 	if ( ! is_singular() ) {
 		return;
 	}
 
-	$page = get_query_var( 'cpage' );
+	if ( is_null( $page ) ) {
+		$page = get_query_var( 'cpage' );
+	}
 
 	if ( ! $page ) {
 		$page = 1;
@@ -3180,16 +3184,20 @@ function next_comments_link( $label = '', $max_page = 0 ) {
  * Retrieves the link to the previous comments page.
  *
  * @since 2.7.1
+ * @since 6.7.0 Added the `page` parameter.
  *
- * @param string $label Optional. Label for comments link text. Default empty.
+ * @param string   $label Optional. Label for comments link text. Default empty.
+ * @param int|null $page  Optional. Page number. Default null.
  * @return string|void HTML-formatted link for the previous page of comments.
  */
-function get_previous_comments_link( $label = '' ) {
+function get_previous_comments_link( $label = '', $page = null ) {
 	if ( ! is_singular() ) {
 		return;
 	}
 
-	$page = get_query_var( 'cpage' );
+	if ( is_null( $page ) ) {
+		$page = get_query_var( 'cpage' );
+	}
 
 	if ( (int) $page <= 1 ) {
 		return;

--- a/tests/phpunit/tests/blocks/renderCommentTemplate.php
+++ b/tests/phpunit/tests/blocks/renderCommentTemplate.php
@@ -219,12 +219,12 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 	/**
 	 * Test that both "Older Comments" and "Newer Comments" are displayed in the correct order
 	 * inside the Comment Query Loop when we enable pagination on Discussion Settings.
-	 * In order to do that, it should exist a query var 'cpage' set with the $comment_args['paged'] value.
 	 *
 	 * @ticket 55505
+	 * @ticket 60806
 	 * @covers ::build_comment_query_vars_from_block
 	 */
-	public function test_build_comment_query_vars_from_block_sets_cpage_var() {
+	public function test_build_comment_query_vars_from_block_sets_max_num_pages() {
 
 		// This could be any number, we set a fixed one instead of a random for better performance.
 		$comment_query_max_num_pages = 5;

--- a/tests/phpunit/tests/blocks/renderCommentTemplate.php
+++ b/tests/phpunit/tests/blocks/renderCommentTemplate.php
@@ -253,7 +253,6 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 		);
 		$actual = build_comment_query_vars_from_block( $block );
 		$this->assertSame( $comment_query_max_num_pages, $actual['paged'] );
-		$this->assertSame( $comment_query_max_num_pages, get_query_var( 'cpage' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/link/getNextCommentsLink.php
+++ b/tests/phpunit/tests/link/getNextCommentsLink.php
@@ -46,13 +46,13 @@ class Tests_Link_GetNextCommentsLink extends WP_UnitTestCase {
 		$this->go_to( get_permalink( $p ) );
 
 		// Check setting the query var is ignored.
-		$cpage = get_query_var( 'cpage' );
+		$old_cpage = get_query_var( 'cpage' );
 		set_query_var( 'cpage', 2 );
 
 		$link = get_next_comments_link( 'Next', 5, 3 );
 
-		$this->assertStringContainsString( 'cpage=4', $link );
+		set_query_var( 'cpage', $old_cpage );
 
-		set_query_var( 'cpage', $cpage );
+		$this->assertStringContainsString( 'cpage=4', $link );
 	}
 }

--- a/tests/phpunit/tests/link/getNextCommentsLink.php
+++ b/tests/phpunit/tests/link/getNextCommentsLink.php
@@ -11,14 +11,14 @@ class Tests_Link_GetNextCommentsLink extends WP_UnitTestCase {
 		$p = self::factory()->post->create();
 		$this->go_to( get_permalink( $p ) );
 
-		$cpage = get_query_var( 'cpage' );
+		$old_cpage = get_query_var( 'cpage' );
 		set_query_var( 'cpage', 3 );
 
 		$link = get_next_comments_link( 'Next', 5 );
 
-		$this->assertStringContainsString( 'cpage=4', $link );
+		set_query_var( 'cpage', $old_cpage );
 
-		set_query_var( 'cpage', $cpage );
+		$this->assertStringContainsString( 'cpage=4', $link );
 	}
 
 	/**
@@ -28,14 +28,14 @@ class Tests_Link_GetNextCommentsLink extends WP_UnitTestCase {
 		$p = self::factory()->post->create();
 		$this->go_to( get_permalink( $p ) );
 
-		$cpage = get_query_var( 'cpage' );
+		$old_cpage = get_query_var( 'cpage' );
 		set_query_var( 'cpage', '' );
 
 		$link = get_next_comments_link( 'Next', 5 );
 
-		$this->assertStringContainsString( 'cpage=2', $link );
+		set_query_var( 'cpage', $old_cpage );
 
-		set_query_var( 'cpage', $cpage );
+		$this->assertStringContainsString( 'cpage=2', $link );
 	}
 
 	/**

--- a/tests/phpunit/tests/link/getNextCommentsLink.php
+++ b/tests/phpunit/tests/link/getNextCommentsLink.php
@@ -37,4 +37,16 @@ class Tests_Link_GetNextCommentsLink extends WP_UnitTestCase {
 
 		set_query_var( 'cpage', $cpage );
 	}
+
+	/**
+	 * @ticket 60806
+	 */
+	public function test_page_should_respect_value_of_page_argument() {
+		$p = self::factory()->post->create();
+		$this->go_to( get_permalink( $p ) );
+
+		$link = get_next_comments_link( 'Next', 5, 3 );
+
+		$this->assertStringContainsString( 'cpage=4', $link );
+	}
 }

--- a/tests/phpunit/tests/link/getNextCommentsLink.php
+++ b/tests/phpunit/tests/link/getNextCommentsLink.php
@@ -45,8 +45,14 @@ class Tests_Link_GetNextCommentsLink extends WP_UnitTestCase {
 		$p = self::factory()->post->create();
 		$this->go_to( get_permalink( $p ) );
 
+		// Check setting the query var is ignored.
+		$cpage = get_query_var( 'cpage' );
+		set_query_var( 'cpage', 2 );
+
 		$link = get_next_comments_link( 'Next', 5, 3 );
 
 		$this->assertStringContainsString( 'cpage=4', $link );
+
+		set_query_var( 'cpage', $cpage );
 	}
 }

--- a/tests/phpunit/tests/link/getPreviousCommentsLink.php
+++ b/tests/phpunit/tests/link/getPreviousCommentsLink.php
@@ -11,29 +11,29 @@ class Tests_Link_GetPreviousCommentsLink extends WP_UnitTestCase {
 		$p = self::factory()->post->create();
 		$this->go_to( get_permalink( $p ) );
 
-		$cpage = get_query_var( 'cpage' );
+		$old_cpage = get_query_var( 'cpage' );
 		set_query_var( 'cpage', 3 );
 
 		$link = get_previous_comments_link( 'Previous' );
 
-		$this->assertStringContainsString( 'cpage=2', $link );
+		set_query_var( 'cpage', $old_cpage );
 
-		set_query_var( 'cpage', $cpage );
+		$this->assertStringContainsString( 'cpage=2', $link );
 	}
 
 	public function test_page_should_default_to_1_when_no_cpage_query_var_is_found() {
 		$p = self::factory()->post->create();
 		$this->go_to( get_permalink( $p ) );
 
-		$cpage = get_query_var( 'cpage' );
+		$old_cpage = get_query_var( 'cpage' );
 		set_query_var( 'cpage', '' );
 
 		$link = get_previous_comments_link( 'Previous' );
 
+		set_query_var( 'cpage', $old_cpage );
+
 		// Technically, it returns null here.
 		$this->assertNull( $link );
-
-		set_query_var( 'cpage', $cpage );
 	}
 
 	/**

--- a/tests/phpunit/tests/link/getPreviousCommentsLink.php
+++ b/tests/phpunit/tests/link/getPreviousCommentsLink.php
@@ -35,4 +35,16 @@ class Tests_Link_GetPreviousCommentsLink extends WP_UnitTestCase {
 
 		set_query_var( 'cpage', $cpage );
 	}
+
+	/**
+	 * @ticket 60806
+	 */
+	public function test_page_should_respect_value_of_page_argument() {
+		$p = self::factory()->post->create();
+		$this->go_to( get_permalink( $p ) );
+
+		$link = get_previous_comments_link( 'Next', 3 );
+
+		$this->assertStringContainsString( 'cpage=2', $link );
+	}
 }

--- a/tests/phpunit/tests/link/getPreviousCommentsLink.php
+++ b/tests/phpunit/tests/link/getPreviousCommentsLink.php
@@ -14,7 +14,7 @@ class Tests_Link_GetPreviousCommentsLink extends WP_UnitTestCase {
 		$cpage = get_query_var( 'cpage' );
 		set_query_var( 'cpage', 3 );
 
-		$link = get_previous_comments_link( 'Next' );
+		$link = get_previous_comments_link( 'Previous' );
 
 		$this->assertStringContainsString( 'cpage=2', $link );
 
@@ -28,7 +28,7 @@ class Tests_Link_GetPreviousCommentsLink extends WP_UnitTestCase {
 		$cpage = get_query_var( 'cpage' );
 		set_query_var( 'cpage', '' );
 
-		$link = get_previous_comments_link( 'Next' );
+		$link = get_previous_comments_link( 'Previous' );
 
 		// Technically, it returns null here.
 		$this->assertNull( $link );
@@ -43,7 +43,7 @@ class Tests_Link_GetPreviousCommentsLink extends WP_UnitTestCase {
 		$p = self::factory()->post->create();
 		$this->go_to( get_permalink( $p ) );
 
-		$link = get_previous_comments_link( 'Next', 3 );
+		$link = get_previous_comments_link( 'Previous', 3 );
 
 		$this->assertStringContainsString( 'cpage=2', $link );
 	}

--- a/tests/phpunit/tests/link/getPreviousCommentsLink.php
+++ b/tests/phpunit/tests/link/getPreviousCommentsLink.php
@@ -43,8 +43,14 @@ class Tests_Link_GetPreviousCommentsLink extends WP_UnitTestCase {
 		$p = self::factory()->post->create();
 		$this->go_to( get_permalink( $p ) );
 
+		// Check setting the query var is ignored.
+		$cpage = get_query_var( 'cpage' );
+		set_query_var( 'cpage', 4 );
+
 		$link = get_previous_comments_link( 'Previous', 3 );
 
 		$this->assertStringContainsString( 'cpage=2', $link );
+
+		set_query_var( 'cpage', $cpage );
 	}
 }

--- a/tests/phpunit/tests/link/getPreviousCommentsLink.php
+++ b/tests/phpunit/tests/link/getPreviousCommentsLink.php
@@ -44,13 +44,13 @@ class Tests_Link_GetPreviousCommentsLink extends WP_UnitTestCase {
 		$this->go_to( get_permalink( $p ) );
 
 		// Check setting the query var is ignored.
-		$cpage = get_query_var( 'cpage' );
+		$old_cpage = get_query_var( 'cpage' );
 		set_query_var( 'cpage', 4 );
 
 		$link = get_previous_comments_link( 'Previous', 3 );
 
-		$this->assertStringContainsString( 'cpage=2', $link );
+		set_query_var( 'cpage', $old_cpage );
 
-		set_query_var( 'cpage', $cpage );
+		$this->assertStringContainsString( 'cpage=2', $link );
 	}
 }


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/wordpress-develop/pull/6291

As discussed in the original pull request and ticket, it seems `set_query_var` should be removed. However, that change was breaking the comments pagination in some scenarios (see https://github.com/WordPress/wordpress-develop/pull/6291#pullrequestreview-2185357355). In this pull request I'm removing `set_query_var` while fixing the mentioned issue.

In order to do that, I'm passing a new `$page` argument to the relevant functions and only use the `cpage` query var if that is not defined.


This pull request has to be tested with https://github.com/WordPress/gutenberg/pull/63698#issuecomment-2318796798, which modifies the comment pagination blocks to pass the `$page` argument.

Trac ticket: https://core.trac.wordpress.org/ticket/60806

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**