### PR TITLE
REST API: fix handling of the epoch

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1304,6 +1304,10 @@ function rest_get_avatar_sizes() {
 /**
  * Parses an RFC3339 time into a Unix timestamp.
  *
+ * Warning: This function returns Boolean false on failure, but it may also
+ * return zero (which evaluates to false) on success. Use the === operator when
+ * checking for failure.
+ *
  * @since 4.4.0
  *
  * @param string $date      RFC3339 timestamp.
@@ -1369,7 +1373,7 @@ function rest_get_date_with_gmt( $date, $is_utc = false ) {
 
 	$date = rest_parse_date( $date );
 
-	if ( empty( $date ) ) {
+	if ( false === $date ) {
 		return null;
 	}
 
@@ -2259,7 +2263,7 @@ function rest_validate_value_from_schema( $value, $args, $param = '' ) {
 				break;
 
 			case 'date-time':
-				if ( ! rest_parse_date( $value ) ) {
+				if ( false === rest_parse_date( $value ) ) {
 					return new WP_Error( 'rest_invalid_date', __( 'Invalid date.' ) );
 				}
 				break;

--- a/tests/phpunit/tests/rest-api/rest-schema-validation.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-validation.php
@@ -1020,6 +1020,17 @@ class WP_Test_REST_Schema_Validation extends WP_UnitTestCase {
 		$this->assertSame( 'Invalid date.', $error->get_error_message() );
 	}
 
+	/**
+	 * @ticket 60184
+	 */
+	public function test_epoch() {
+		$schema = array(
+			'type'   => 'string',
+			'format' => 'date-time',
+		);
+		$this->assertTrue( rest_validate_value_from_schema( '1970-01-01T00:00:00Z', $schema ) );
+	}
+
 	public function test_object_or_string() {
 		$schema = array(
 			'type'       => array( 'object', 'string' ),


### PR DESCRIPTION
This fixes handling of dates representing the Unix epoch (1970-01-01T00:00:00Z).

Trac ticket: https://core.trac.wordpress.org/ticket/60184

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
