### PR TITLE
HTML API: Fix A tag active formatting element loop missing break

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -2357,8 +2357,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 						case 'A':
 							$this->run_adoption_agency_algorithm();
 							$this->state->active_formatting_elements->remove_node( $item );
-							$this->state->stack_of_open_elements->remove_node( $item );
-							break;
+							$this->state->stack_of_open_elements->remove_node( $item->token );
+							break 2;
 					}
 				}
 

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -2352,12 +2352,12 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				foreach ( $this->state->active_formatting_elements->walk_up() as $item ) {
 					switch ( $item->node_name ) {
 						case 'marker':
-							break;
+							break 2;
 
 						case 'A':
 							$this->run_adoption_agency_algorithm();
 							$this->state->active_formatting_elements->remove_node( $item );
-							$this->state->stack_of_open_elements->remove_node( $item->token );
+							$this->state->stack_of_open_elements->remove_node( $item );
 							break 2;
 					}
 				}


### PR DESCRIPTION
Fix a bug where a switch statement break should break the switch and the surrounding foreach loop to satisfy [these conditions in the standard](https://html.spec.whatwg.org/#parsing-main-inbody:list-of-active-formatting-elements):

> A start tag whose tag name is "a"
> If the [list of active formatting elements](https://html.spec.whatwg.org/#list-of-active-formatting-elements) contains an [a](https://html.spec.whatwg.org/#the-a-element) element between the end of the list and the last [marker](https://html.spec.whatwg.org/#concept-parser-marker) on the list (or the start of the list if there is no [marker](https://html.spec.whatwg.org/#concept-parser-marker) on the list), then this is a [parse error](https://html.spec.whatwg.org/#parse-errors); run the [adoption agency algorithm](https://html.spec.whatwg.org/#adoption-agency-algorithm) for the token, then remove that element from the [list of active formatting elements](https://html.spec.whatwg.org/#list-of-active-formatting-elements) and the [stack of open elements](https://html.spec.whatwg.org/#stack-of-open-elements) if the [adoption agency algorithm](https://html.spec.whatwg.org/#adoption-agency-algorithm) didn't already remove it (it might not have if the element is not [in table scope](https://html.spec.whatwg.org/#has-an-element-in-table-scope)).

Markers and an `A` element should break out of the loop that. As implemented now, the forEach will always continue up to the root.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
