### PR TITLE
HTML API: Add missing NOBR end tag handling

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -2415,6 +2415,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '-EM':
 			case '-FONT':
 			case '-I':
+			case '-NOBR':
 			case '-S':
 			case '-SMALL':
 			case '-STRIKE':


### PR DESCRIPTION
The `NOBR` end tag handling seems to have been omitted [for this part of the HTML standard](https://html.spec.whatwg.org/#parsing-main-inbody:adoption-agency-algorithm-4):

> An end tag whose tag name is one of: "a", "b", "big", "code", "em", "font", "i", "nobr", "s", "small", "strike", "strong", "tt", "u"
> Run the [adoption agency algorithm](https://html.spec.whatwg.org/#adoption-agency-algorithm) for the token.

This does not seem to be intentional. Introduced in [[56274]](https://core.trac.wordpress.org/changeset/56274).


Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
