### PR TITLE
HTML API: Improve skipped test reporting with unsupported exception

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,6 +28,7 @@
 			<group>ms-files</group>
 			<group>ms-required</group>
 			<group>external-http</group>
+			<group>html-api-html5lib-tests</group>
 		</exclude>
 	</groups>
 	<logging>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,7 +28,6 @@
 			<group>ms-files</group>
 			<group>ms-required</group>
 			<group>external-http</group>
-			<group>html-api-html5lib-tests</group>
 		</exclude>
 	</groups>
 	<logging>

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
@@ -57,7 +57,7 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 		try {
 			$processed_tree = self::build_tree_representation( $fragment_context, $html );
 		} catch ( WP_HTML_Unsupported_Exception $e ) {
-			$this->markTestSkipped( $e->getMessage() );
+			$this->markTestSkipped( "Unsupported markup: {$e->getMessage()}" );
 			return;
 		}
 
@@ -344,7 +344,11 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 			}
 		}
 
-		if ( ! is_null( $processor->get_last_error() ) ) {
+		if ( null !== $processor->get_unsupported_exception() ) {
+			throw $processor->get_unsupported_exception();
+		}
+
+		if ( null !== $processor->get_last_error() ) {
 			return null;
 		}
 

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
@@ -65,6 +65,7 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 			$this->markTestSkipped( 'Test includes unsupported markup.' );
 			return;
 		}
+
 		$fragment_detail = $fragment_context ? " in context <{$fragment_context}>" : '';
 
 		/*
@@ -161,7 +162,7 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 			? WP_HTML_Processor::create_fragment( $html, "<{$fragment_context}>" )
 			: WP_HTML_Processor::create_full_parser( $html );
 		if ( null === $processor ) {
-			return null;
+			throw new WP_HTML_Unsupported_Exception( "Could not create a parser with the given fragment context: {$fragment_context}.", '', 0, '', array(), array() );
 		}
 
 		/*
@@ -346,11 +347,11 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 		}
 
 		if ( null !== $processor->get_last_error() ) {
-			return null;
+			throw new WP_HTML_Unsupported_Exception( "Parser error: {$processor->get_last_error()}", '', 0, '', array(), array() );
 		}
 
 		if ( $processor->paused_at_incomplete_token() ) {
-			return null;
+			throw new WP_HTML_Unsupported_Exception( "Paused at incomplete token.", '', 0, '', array(), array() );
 		}
 
 		if ( '' !== $text_node ) {

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
@@ -176,11 +176,8 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 		$text_node    = '';
 
 		while ( $processor->next_token() ) {
-			if ( null !== $processor->get_unsupported_exception() ) {
-				throw $processor->get_unsupported_exception();
-			}
 			if ( null !== $processor->get_last_error() ) {
-				return null;
+				break;
 			}
 
 			$token_name = $processor->get_token_name();

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
@@ -351,7 +351,7 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 		}
 
 		if ( $processor->paused_at_incomplete_token() ) {
-			throw new WP_HTML_Unsupported_Exception( "Paused at incomplete token.", '', 0, '', array(), array() );
+			throw new WP_HTML_Unsupported_Exception( 'Paused at incomplete token.', '', 0, '', array(), array() );
 		}
 
 		if ( '' !== $text_node ) {

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
@@ -54,10 +54,16 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 	 * @param string $expected_tree    Tree structure of parsed HTML.
 	 */
 	public function test_parse( ?string $fragment_context, string $html, string $expected_tree ) {
-		$processed_tree = self::build_tree_representation( $fragment_context, $html );
+		try {
+			$processed_tree = self::build_tree_representation( $fragment_context, $html );
+		} catch ( WP_HTML_Unsupported_Exception $e ) {
+			$this->markTestSkipped( $e->getMessage() );
+			return;
+		}
 
 		if ( null === $processed_tree ) {
 			$this->markTestSkipped( 'Test includes unsupported markup.' );
+			return;
 		}
 		$fragment_detail = $fragment_context ? " in context <{$fragment_context}>" : '';
 
@@ -170,7 +176,10 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 		$text_node    = '';
 
 		while ( $processor->next_token() ) {
-			if ( ! is_null( $processor->get_last_error() ) ) {
+			if ( null !== $processor->get_unsupported_exception() ) {
+				throw $processor->get_unsupported_exception();
+			}
+			if ( null !== $processor->get_last_error() ) {
 				return null;
 			}
 


### PR DESCRIPTION
Trac ticket: Core-61646

Improve unsupported markup skipped test information.

The html5lib-tests suite skips a number of tests due to unsupported markup. At the moment, these tests all report "Test includes unsupported markup." Use the `get_unsupported_exception` method to improve these skip messages so they're more informative: "Unsupported markup: Foster parenting is not supported."

There is no diff in the test statistics comparing this branch to trunk.

To test this, run the following and the improved error messages will be shown:

```sh
phpunit --group html-api-html5lib-tests --verbose
```

Here are a selection of test outputs for skipped tests.

**Before**
<img width="1039" alt="Screenshot 2024-09-03 at 11 16 25 AM" src="https://github.com/user-attachments/assets/3e920c80-e39c-4517-9665-445aa29d4beb">

**After**
<img width="1145" alt="Screenshot 2024-09-03 at 11 15 55 AM" src="https://github.com/user-attachments/assets/1e09af13-5a2c-49d3-8b9e-91029bee2094">

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
