### PR TITLE
Taxonomies: Return terms in term order if taxonomy is registered with `sort`: true

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2300,7 +2300,7 @@ function wp_get_object_terms( $object_ids, $taxonomies, $args = array() ) {
 	if ( count( $taxonomies ) > 1 ) {
 		foreach ( $taxonomies as $index => $taxonomy ) {
 			$t = get_taxonomy( $taxonomy );
-			if ( ! isset( $t->args['orderby'] ) && isset( $t->sort ) && $t->sort ) {
+			if ( ! isset( $t->args['orderby'] ) && ! isset( $args['orderby'] ) && isset( $t->sort ) && $t->sort ) {
 				$t->args['orderby'] = 'term_order';
 			}
 			if ( isset( $t->args ) && is_array( $t->args ) && array_merge( $args, $t->args ) != $args ) {
@@ -2310,7 +2310,7 @@ function wp_get_object_terms( $object_ids, $taxonomies, $args = array() ) {
 		}
 	} else {
 		$t = get_taxonomy( $taxonomies[0] );
-		if ( ! isset( $t->args['orderby'] ) && isset( $t->sort ) && $t->sort ) {
+		if ( ! isset( $t->args['orderby'] ) && ! isset( $args['orderby'] ) && isset( $t->sort ) && $t->sort ) {
 			$t->args['orderby'] = 'term_order';
 		}
 		if ( isset( $t->args ) && is_array( $t->args ) ) {

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2292,11 +2292,17 @@ function wp_get_object_terms( $object_ids, $taxonomies, $args = array() ) {
 	/*
 	 * When one or more queried taxonomies is registered with an 'args' array,
 	 * those params override the `$args` passed to this function.
+	 *
+	 * If a queried taxonomy is registered with `sort` set to `true`
+	 * and `orderby` is not set in `$args`, set `orderby` to `term_order`.
 	 */
 	$terms = array();
 	if ( count( $taxonomies ) > 1 ) {
 		foreach ( $taxonomies as $index => $taxonomy ) {
 			$t = get_taxonomy( $taxonomy );
+			if ( ! isset( $args['orderby'] ) && isset( $t->sort ) && $t->sort ) {
+				$args['orderby'] = 'term_order';
+			}
 			if ( isset( $t->args ) && is_array( $t->args ) && array_merge( $args, $t->args ) != $args ) {
 				unset( $taxonomies[ $index ] );
 				$terms = array_merge( $terms, wp_get_object_terms( $object_ids, $taxonomy, array_merge( $args, $t->args ) ) );
@@ -2304,6 +2310,9 @@ function wp_get_object_terms( $object_ids, $taxonomies, $args = array() ) {
 		}
 	} else {
 		$t = get_taxonomy( $taxonomies[0] );
+		if ( ! isset( $args['orderby'] ) && isset( $t->sort ) && $t->sort ) {
+			$args['orderby'] = 'term_order';
+		}
 		if ( isset( $t->args ) && is_array( $t->args ) ) {
 			$args = array_merge( $args, $t->args );
 		}

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2300,8 +2300,8 @@ function wp_get_object_terms( $object_ids, $taxonomies, $args = array() ) {
 	if ( count( $taxonomies ) > 1 ) {
 		foreach ( $taxonomies as $index => $taxonomy ) {
 			$t = get_taxonomy( $taxonomy );
-			if ( ! isset( $args['orderby'] ) && isset( $t->sort ) && $t->sort ) {
-				$args['orderby'] = 'term_order';
+			if ( ! isset( $t->args['orderby'] ) && isset( $t->sort ) && $t->sort ) {
+				$t->args['orderby'] = 'term_order';
 			}
 			if ( isset( $t->args ) && is_array( $t->args ) && array_merge( $args, $t->args ) != $args ) {
 				unset( $taxonomies[ $index ] );
@@ -2310,8 +2310,8 @@ function wp_get_object_terms( $object_ids, $taxonomies, $args = array() ) {
 		}
 	} else {
 		$t = get_taxonomy( $taxonomies[0] );
-		if ( ! isset( $args['orderby'] ) && isset( $t->sort ) && $t->sort ) {
-			$args['orderby'] = 'term_order';
+		if ( ! isset( $t->args['orderby'] ) && isset( $t->sort ) && $t->sort ) {
+			$t->args['orderby'] = 'term_order';
 		}
 		if ( isset( $t->args ) && is_array( $t->args ) ) {
 			$args = array_merge( $args, $t->args );


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/issues/65052 for details.

Use this alongside https://github.com/WordPress/gutenberg/pull/64471.

## Testing Instructions

Refer to the testing instructions of https://github.com/WordPress/gutenberg/pull/64471. Note that with both that PR and this PR applied, term order is also retained when _saving_ the post (not just while editing).

However, note that it's still not reflected properly on the frontend, e.g. when using the Post Terms block. The latter uses `get_the_terms()`, [which (somewhere along the line) sets `$args['orderby']` to `name`](https://github.com/WordPress/wordpress-develop/blob/fb40fe915efab59d54d5bf812e2a4574ae525510/src/wp-includes/taxonomy.php#L3829-L3837). Currently, if `$args['orderby']` is set, we're choosing _not_ to override it with `term_order`, even if the taxonomy was registered with `'sort': true`; we might consider revisiting that choice.

## TODO

- [ ] Fix on frontend
- [ ] Add test coverage

## Screenshots

| Editor | Frontend |
|-------|----------|
| <img width="265" alt="image" src="https://github.com/user-attachments/assets/ac93283c-8f5e-40b6-ac1f-5ee610f1543b"> | <img width="619" alt="image" src="https://github.com/user-attachments/assets/2084196b-f249-401c-a3a4-6acb5e3b5ce9"> |

Trac ticket to follow.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
