### PR TITLE
Block Hooks: Respect `"multiple": false`

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -916,6 +916,29 @@ function insert_hooked_blocks( &$parsed_anchor_block, $relative_position, $hooke
 
 	$markup = '';
 	foreach ( $hooked_block_types as $hooked_block_type ) {
+		$hooked_block_type_definition = WP_Block_Type_Registry::get_instance()->get_registered( $hooked_block_type );
+		if ( ! $hooked_block_type_definition ) {
+			continue;
+		}
+		if ( false === block_has_support( $hooked_block_type_definition, 'multiple', true ) ) {
+			if ( $context instanceof WP_Block_Template ) {
+				// Template or template part.
+				$content = $context->content;
+			} elseif ( $context instanceof WP_Post ) {
+				// wp_navigation post.
+				$content = $context->post_content;
+			} elseif ( is_array( $context ) && isset( $context['content'] ) ) {
+				// Pattern.
+				$content = $context['content'];
+			} else {
+				$content = '';
+			}
+
+			if ( ! empty( $content ) && has_block( $hooked_block_type, $content ) ) {
+				continue;
+			}
+		}
+
 		$parsed_hooked_block = array(
 			'blockName'    => $hooked_block_type,
 			'attrs'        => array(),

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -36,6 +36,9 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 				'block_hooks' => array(
 					self::ANCHOR_BLOCK_TYPE => 'before',
 				),
+				'supports' => array(
+					'multiple' => false,
+				),
 			)
 		);
 	}
@@ -119,6 +122,28 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 			'<!-- wp:' . self::OTHER_HOOKED_BLOCK_TYPE . ' /-->',
 			$actual,
 			"Markup for newly hooked block should've been generated."
+		);
+	}
+
+	/**
+	 * @ticket 61902
+	 *
+	 * @covers ::insert_hooked_blocks
+	 */
+	public function test_insert_hooked_blocks_if_block_has_multiple_false_and_is_already_present() {
+		$anchor_block = array(
+			'blockName' => 'tests/anchor-block',
+		);
+
+		$context           = new WP_Block_Template();
+		$context->content  = '<!-- wp:' . self::ANCHOR_BLOCK_TYPE . ' /-->';
+		$context->content .= '<!-- wp:' . self::OTHER_HOOKED_BLOCK_TYPE . ' /-->';
+
+		$actual = insert_hooked_blocks( $anchor_block, 'before', get_hooked_blocks(), $context );
+		$this->assertSame(
+			'',
+			$actual,
+			'Hooked block with "multiple": false should not be inserted if another instance is already present.'
 		);
 	}
 

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -22,7 +22,12 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 		),
 	);
 
-	public function set_up() {
+	/**
+	 * Set up.
+	 *
+	 * @ticket 61902.
+	 */
+	public static function wpSetUpBeforeClass() {
 		register_block_type(
 			self::HOOKED_BLOCK_TYPE,
 			array(
@@ -43,20 +48,15 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tear down each test method.
+	 * Tear down.
+	 *
+	 * @ticket 61902.
 	 */
-	public function tear_down() {
+	public static function wpTearDownAfterClass() {
 		$registry = WP_Block_Type_Registry::get_instance();
 
-		if ( $registry->is_registered( self::HOOKED_BLOCK_TYPE ) ) {
-			$registry->unregister( self::HOOKED_BLOCK_TYPE );
-		}
-
-		if ( $registry->is_registered( self::OTHER_HOOKED_BLOCK_TYPE ) ) {
-			$registry->unregister( self::OTHER_HOOKED_BLOCK_TYPE );
-		}
-
-		parent::tear_down();
+		$registry->unregister( self::HOOKED_BLOCK_TYPE );
+		$registry->unregister( self::OTHER_HOOKED_BLOCK_TYPE );
 	}
 
 	/**

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -145,6 +145,42 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 			$actual,
 			'Hooked block with "multiple": false should not be inserted if another instance is already present.'
 		);
+		$actual = insert_hooked_blocks( $anchor_block, 'before', get_hooked_blocks(), $context );
+		$this->assertSame(
+			'',
+			$actual,
+			'Hooked block with "multiple": false should not be inserted if another instance is already present.'
+		);
+	}
+
+	/**
+	 * @ticket 61902
+	 *
+	 * @covers ::insert_hooked_blocks
+	 */
+	public function test_insert_hooked_blocks_if_block_has_multiple_false_but_is_not_yet_present() {
+		$anchor_block = array(
+			'blockName' => 'tests/anchor-block',
+		);
+
+		$context          = new WP_Block_Template();
+		$context->content = '<!-- wp:' . self::ANCHOR_BLOCK_TYPE . ' /-->';
+
+		$expected = '<!-- wp:' . self::OTHER_HOOKED_BLOCK_TYPE . ' /-->';
+		$actual   = insert_hooked_blocks( $anchor_block, 'before', get_hooked_blocks(), $context );
+		$this->assertSame(
+			$expected,
+			$actual,
+			'Hooked block with "multiple": false should be inserted if another instance is not present.'
+		);
+
+		$context->content = $expected . $context->content; // Simulate result of first insertion.
+		$actual           = insert_hooked_blocks( $anchor_block, 'before', get_hooked_blocks(), $context );
+		$this->assertSame(
+			'',
+			$actual,
+			'Hooked block with "multiple": false should not be inserted if another instance is already present.'
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -36,7 +36,7 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 				'block_hooks' => array(
 					self::ANCHOR_BLOCK_TYPE => 'before',
 				),
-				'supports' => array(
+				'supports'    => array(
 					'multiple' => false,
 				),
 			)

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -22,6 +22,43 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 		),
 	);
 
+	public function set_up() {
+		register_block_type(
+			self::HOOKED_BLOCK_TYPE,
+			array(
+				'block_hooks' => array(
+					self::ANCHOR_BLOCK_TYPE => 'after',
+				),
+			)
+		);
+
+		register_block_type(
+			self::OTHER_HOOKED_BLOCK_TYPE,
+			array(
+				'block_hooks' => array(
+					self::ANCHOR_BLOCK_TYPE => 'before',
+				),
+			)
+		);
+	}
+
+	/**
+	 * Tear down each test method.
+	 */
+	public function tear_down() {
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		if ( $registry->is_registered( self::HOOKED_BLOCK_TYPE ) ) {
+			$registry->unregister( self::HOOKED_BLOCK_TYPE );
+		}
+
+		if ( $registry->is_registered( self::OTHER_HOOKED_BLOCK_TYPE ) ) {
+			$registry->unregister( self::OTHER_HOOKED_BLOCK_TYPE );
+		}
+
+		parent::tear_down();
+	}
+
 	/**
 	 * @ticket 59572
 	 * @ticket 60126

--- a/tests/phpunit/tests/blocks/insertHookedBlocks.php
+++ b/tests/phpunit/tests/blocks/insertHookedBlocks.php
@@ -15,13 +15,6 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 	const HOOKED_BLOCK_TYPE       = 'tests/hooked-block';
 	const OTHER_HOOKED_BLOCK_TYPE = 'tests/other-hooked-block';
 
-	const HOOKED_BLOCKS = array(
-		self::ANCHOR_BLOCK_TYPE => array(
-			'after'  => array( self::HOOKED_BLOCK_TYPE ),
-			'before' => array( self::OTHER_HOOKED_BLOCK_TYPE ),
-		),
-	);
-
 	/**
 	 * Set up.
 	 *
@@ -71,7 +64,7 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 			'blockName' => self::ANCHOR_BLOCK_TYPE,
 		);
 
-		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		$actual = insert_hooked_blocks( $anchor_block, 'after', get_hooked_blocks(), array() );
 		$this->assertSame(
 			'<!-- wp:' . self::HOOKED_BLOCK_TYPE . ' /-->',
 			$actual,
@@ -96,7 +89,7 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 			),
 		);
 
-		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		$actual = insert_hooked_blocks( $anchor_block, 'after', get_hooked_blocks(), array() );
 		$this->assertSame(
 			'',
 			$actual,
@@ -121,7 +114,7 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 			),
 		);
 
-		$actual = insert_hooked_blocks( $anchor_block, 'before', self::HOOKED_BLOCKS, array() );
+		$actual = insert_hooked_blocks( $anchor_block, 'before', get_hooked_blocks(), array() );
 		$this->assertSame(
 			'<!-- wp:' . self::OTHER_HOOKED_BLOCK_TYPE . ' /-->',
 			$actual,
@@ -162,7 +155,7 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 			return $parsed_hooked_block;
 		};
 		add_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 4 );
-		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		$actual = insert_hooked_blocks( $anchor_block, 'after', get_hooked_blocks(), array() );
 		remove_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter );
 
 		$this->assertSame(
@@ -208,7 +201,7 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 			);
 		};
 		add_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 3 );
-		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		$actual = insert_hooked_blocks( $anchor_block, 'after', get_hooked_blocks(), array() );
 		remove_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter );
 
 		$this->assertSame(
@@ -250,7 +243,7 @@ class Tests_Blocks_InsertHookedBlocks extends WP_UnitTestCase {
 			return $parsed_hooked_block;
 		};
 		add_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter, 10, 4 );
-		$actual = insert_hooked_blocks( $anchor_block, 'after', self::HOOKED_BLOCKS, array() );
+		$actual = insert_hooked_blocks( $anchor_block, 'after', get_hooked_blocks(), array() );
 		remove_filter( 'hooked_block_' . self::HOOKED_BLOCK_TYPE, $filter );
 
 		$this->assertSame( '', $actual, "No markup should've been generated for hooked block suppressed by filter." );


### PR DESCRIPTION
WIP. Details to follow.

TODO:
- [ ] Cache
- [ ] Cover case where block isn't present at first, but multiple anchor blocks are (and so it would be inserted more than once).

Trac ticket: https://core.trac.wordpress.org/ticket/61902

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
