### PR TITLE
Proposal: Add `label` argument to `register_meta` function

### DIFF
--- a/src/wp-includes/meta.php
+++ b/src/wp-includes/meta.php
@@ -1368,6 +1368,7 @@ function sanitize_meta( $meta_key, $meta_value, $object_type, $object_subtype = 
  * @since 5.3.0 Valid meta types expanded to include "array" and "object".
  * @since 5.5.0 The `$default` argument was added to the arguments array.
  * @since 6.4.0 The `$revisions_enabled` argument was added to the arguments array.
+ * @since 6.7.0 The `label` argument was added to the arguments array.
  *
  * @param string       $object_type Type of object metadata is for. Accepts 'post', 'comment', 'term', 'user',
  *                                  or any other object type with an associated meta table.

--- a/src/wp-includes/meta.php
+++ b/src/wp-includes/meta.php
@@ -1379,6 +1379,7 @@ function sanitize_meta( $meta_key, $meta_value, $object_type, $object_subtype = 
  *                                         the meta key will be registered on the entire object type. Default empty.
  *     @type string     $type              The type of data associated with this meta key.
  *                                         Valid values are 'string', 'boolean', 'integer', 'number', 'array', and 'object'.
+ *     @type string     $label             A human-readable label of the data attached to this meta key.
  *     @type string     $description       A description of the data attached to this meta key.
  *     @type bool       $single            Whether the meta key has one value per object, or an array of values per object.
  *     @type mixed      $default           The default value returned from get_metadata() if no value has been set yet.
@@ -1411,6 +1412,7 @@ function register_meta( $object_type, $meta_key, $args, $deprecated = null ) {
 	$defaults = array(
 		'object_subtype'    => '',
 		'type'              => 'string',
+		'label'             => '',
 		'description'       => '',
 		'default'           => '',
 		'single'            => false,

--- a/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
+++ b/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
@@ -478,6 +478,7 @@ abstract class WP_REST_Meta_Fields {
 
 			$default_schema = array(
 				'type'        => $default_args['type'],
+				'label'       => empty( $args['label'] ) ? '' : $args['label'],
 				'description' => empty( $args['description'] ) ? '' : $args['description'],
 				'default'     => isset( $args['default'] ) ? $args['default'] : null,
 			);

--- a/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
+++ b/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
@@ -478,7 +478,7 @@ abstract class WP_REST_Meta_Fields {
 
 			$default_schema = array(
 				'type'        => $default_args['type'],
-				'label'       => empty( $args['label'] ) ? '' : $args['label'],
+				'title'       => empty( $args['label'] ) ? '' : $args['label'],
 				'description' => empty( $args['description'] ) ? '' : $args['description'],
 				'default'     => isset( $args['default'] ) ? $args['default'] : null,
 			);

--- a/tests/phpunit/tests/meta/registerMeta.php
+++ b/tests/phpunit/tests/meta/registerMeta.php
@@ -92,6 +92,7 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 				'' => array(
 					'flight_number' => array(
 						'type'              => 'string',
+						'label'             => '',
 						'description'       => '',
 						'single'            => false,
 						'sanitize_callback' => null,
@@ -117,6 +118,7 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 				'' => array(
 					'category_icon' => array(
 						'type'              => 'string',
+						'label'             => '',
 						'description'       => '',
 						'single'            => false,
 						'sanitize_callback' => null,
@@ -172,6 +174,7 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 				'' => array(
 					'flight_number' => array(
 						'type'              => 'string',
+						'label'             => '',
 						'description'       => '',
 						'single'            => false,
 						'sanitize_callback' => array( $this, '_new_sanitize_meta_cb' ),
@@ -254,6 +257,16 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 		unregister_meta_key( 'post', 'registered_key2' );
 
 		$this->assertEmpty( $meta_keys );
+	}
+
+	public function test_get_registered_meta_keys_label_arg() {
+		register_meta( 'post', 'registered_key1', array( 'label' => 'Field label' ) );
+
+		$meta_keys = get_registered_meta_keys( 'post' );
+
+		unregister_meta_key( 'post', 'registered_key1' );
+
+		$this->assertSame( 'Field label', $meta_keys['registered_key1']['label'] );
 	}
 
 	public function test_get_registered_meta_keys_description_arg() {
@@ -340,6 +353,7 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 				$subtype => array(
 					'flight_number' => array(
 						'type'              => 'string',
+						'label'             => '',
 						'description'       => '',
 						'single'            => false,
 						'sanitize_callback' => null,
@@ -394,6 +408,7 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 				$subtype => array(
 					'flight_number' => array(
 						'type'              => 'string',
+						'label'             => '',
 						'description'       => '',
 						'single'            => false,
 						'sanitize_callback' => null,

--- a/tests/phpunit/tests/meta/registerMeta.php
+++ b/tests/phpunit/tests/meta/registerMeta.php
@@ -259,6 +259,9 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 		$this->assertEmpty( $meta_keys );
 	}
 
+	/**
+	 * @ticket 61998
+	 */
 	public function test_get_registered_meta_keys_label_arg() {
 		register_meta( 'post', 'registered_key1', array( 'label' => 'Field label' ) );
 

--- a/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
+++ b/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
@@ -243,6 +243,18 @@ class WP_Test_REST_Post_Meta_Fields extends WP_Test_REST_TestCase {
 			)
 		);
 
+		register_post_meta(
+			'post',
+			'with_label',
+			array(
+				'type'         => 'string',
+				'single'       => true,
+				'show_in_rest' => true,
+				'label'        => 'Meta Label',
+				'default'      => '',
+			)
+		);
+
 		/** @var WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;
 		$wp_rest_server = new Spy_REST_Server();
@@ -3093,6 +3105,19 @@ class WP_Test_REST_Post_Meta_Fields extends WP_Test_REST_TestCase {
 		$schema = $response->get_data()['schema']['properties']['meta']['properties']['with_default'];
 		$this->assertArrayHasKey( 'default', $schema );
 		$this->assertSame( 'Goodnight Moon', $schema['default'] );
+	}
+
+	/**
+	 * @ticket 61998
+	 */
+	public function test_title_is_added_to_schema() {
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts' );
+		$response = rest_do_request( $request );
+
+		$schema = $response->get_data()['schema']['properties']['meta']['properties']['with_label'];
+
+		$this->assertArrayHasKey( 'default', $schema );
+		$this->assertSame( 'Meta Label', $schema['title'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
+++ b/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
@@ -3103,8 +3103,8 @@ class WP_Test_REST_Post_Meta_Fields extends WP_Test_REST_TestCase {
 		$response = rest_do_request( $request );
 
 		$schema = $response->get_data()['schema']['properties']['meta']['properties']['with_default'];
-		$this->assertArrayHasKey( 'default', $schema );
-		$this->assertSame( 'Goodnight Moon', $schema['default'] );
+		$this->assertArrayHasKey( 'default', $schema, 'Schema is expected to have the default property' );
+		$this->assertSame( 'Goodnight Moon', $schema['default'], 'Schema default is expected to be defined and contain the value of the meta default argument.' );
 	}
 
 	/**
@@ -3116,8 +3116,8 @@ class WP_Test_REST_Post_Meta_Fields extends WP_Test_REST_TestCase {
 
 		$schema = $response->get_data()['schema']['properties']['meta']['properties']['with_label'];
 
-		$this->assertArrayHasKey( 'default', $schema );
-		$this->assertSame( 'Meta Label', $schema['title'] );
+		$this->assertArrayHasKey( 'title', $schema, 'Schema is expected to have the title property' );
+		$this->assertSame( 'Meta Label', $schema['title'], 'Schema title is expected to be defined and contain the value of the meta label argument.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/user/wpRegisterPersistedPreferencesMeta.php
+++ b/tests/phpunit/tests/user/wpRegisterPersistedPreferencesMeta.php
@@ -31,6 +31,7 @@ class Tests_User_WpRegisterPersistedPreferencesMeta extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				'type'              => 'object',
+				'label'             => '',
 				'description'       => '',
 				'single'            => true,
 				'sanitize_callback' => null,


### PR DESCRIPTION
With the introduction of Block Bindings, it is more  common to see workflows where users need to see the custom fields that are available or connected. Right now, they are relying on the meta key, however, as reported [here](https://github.com/WordPress/gutenberg/issues/65066), it feels too technical sometimes.

In this pull request I'm exploring the possibility of adding a new `label` argument to include a human-readable name that can be used across the UI. 

Trac ticket: https://core.trac.wordpress.org/ticket/61998.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
