### PR TITLE
Set the heartbeat interval to 10 seconds when the block editor is used

### DIFF
--- a/src/js/_enqueues/admin/inline-edit-post.js
+++ b/src/js/_enqueues/admin/inline-edit-post.js
@@ -250,7 +250,7 @@ window.wp = window.wp || {};
 				if ( ! $( this ).parent().find( 'input[name="indeterminate_post_category[]"]' ).length ) {
 					// Get the term label text.
 					var label = $( this ).parent().text();
-					// Set indeterminate states for the backend. Add accessible text for indeterminate inputs. 
+					// Set indeterminate states for the backend. Add accessible text for indeterminate inputs.
 					$( this ).after( '<input type="hidden" name="indeterminate_post_category[]" value="' + $( this ).val() + '">' ).attr( 'aria-label', label.trim() + ': ' + wp.i18n.__( 'Some selected posts have this category' ) );
 				}
 			}
@@ -603,9 +603,9 @@ $( function() { inlineEditPost.init(); } );
 // Show/hide locks on posts.
 $( function() {
 
-	// Set the heartbeat interval to 15 seconds.
+	// Set the heartbeat interval to 10 seconds.
 	if ( typeof wp !== 'undefined' && wp.heartbeat ) {
-		wp.heartbeat.interval( 15 );
+		wp.heartbeat.interval( 10 );
 	}
 }).on( 'heartbeat-tick.wp-check-locked-posts', function( e, data ) {
 	var locked = data['wp-check-locked-posts'] || {};

--- a/src/js/_enqueues/admin/post.js
+++ b/src/js/_enqueues/admin/post.js
@@ -343,9 +343,9 @@ jQuery( function($) {
 		}
 	}).filter(':visible').find('.wp-tab-first').trigger( 'focus' );
 
-	// Set the heartbeat interval to 15 seconds if post lock dialogs are enabled.
+	// Set the heartbeat interval to 10 seconds if post lock dialogs are enabled.
 	if ( wp.heartbeat && $('#post-lock-dialog').length ) {
-		wp.heartbeat.interval( 15 );
+		wp.heartbeat.interval( 10 );
 	}
 
 	// The form is being submitted by the user.

--- a/src/js/_enqueues/wp/heartbeat.js
+++ b/src/js/_enqueues/wp/heartbeat.js
@@ -724,8 +724,8 @@
 		 *
 		 * @param {string|number} speed Interval: 'fast' or integer between 1 and 3600 (seconds).
 		 *                              Fast equals 5.
-		 * @param {number}        ticks Tells how many ticks before the interval reverts
-		 *                              back. Used with speed = 'fast' or 5.
+		 * @param {number}        ticks Tells how many ticks before the interval reverts back.
+		 *                              Value must be between 1 and 30. Used with speed = 'fast' or 5.
 		 *
 		 * @return {number} Current interval in seconds.
 		 */

--- a/src/js/_enqueues/wp/heartbeat.js
+++ b/src/js/_enqueues/wp/heartbeat.js
@@ -132,16 +132,17 @@
 				}
 
 				/*
-				 * The interval can be from 15 to 120 seconds and can be set temporarily to 5 seconds.
-				 * It can be set in the initial options or changed later through JS and/or through PHP.
+				 * Sanity check: the interval can be from 1 to 3600 seconds and can be set temporarily
+				 * to 5 seconds. It can be set in the initial options or changed later from JS
+				 * or from PHP through the AJAX responses.
 				 */
 				if ( options.interval ) {
 					settings.mainInterval = options.interval;
 
-					if ( settings.mainInterval < 15 ) {
-						settings.mainInterval = 15;
-					} else if ( settings.mainInterval > 120 ) {
-						settings.mainInterval = 120;
+					if ( settings.mainInterval < 1 ) {
+						settings.mainInterval = 1;
+					} else if ( settings.mainInterval > 3600 ) {
+						settings.mainInterval = 3600;
 					}
 				}
 
@@ -721,9 +722,9 @@
 		 *
 		 * @memberOf wp.heartbeat.prototype
 		 *
-		 * @param {string|number} speed Interval: 'fast' or 5, 15, 30, 60, 120.
+		 * @param {string|number} speed Interval: 'fast' or integer between 1 and 3600 (seconds).
 		 *                              Fast equals 5.
-		 * @param {string}        ticks Tells how many ticks before the interval reverts
+		 * @param {number}        ticks Tells how many ticks before the interval reverts
 		 *                              back. Used with speed = 'fast' or 5.
 		 *
 		 * @return {number} Current interval in seconds.
@@ -733,35 +734,28 @@
 				oldInterval = settings.tempInterval ? settings.tempInterval : settings.mainInterval;
 
 			if ( speed ) {
-				switch ( speed ) {
-					case 'fast':
-					case 5:
-						newInterval = 5000;
-						break;
-					case 15:
-						newInterval = 15000;
-						break;
-					case 30:
-						newInterval = 30000;
-						break;
-					case 60:
-						newInterval = 60000;
-						break;
-					case 120:
-						newInterval = 120000;
-						break;
-					case 'long-polling':
-						// Allow long polling (experimental).
-						settings.mainInterval = 0;
-						return 0;
-					default:
+				if ( 'fast' === speed ) {
+					// Special case, see below.
+					newInterval = 5000;
+				} else if ( 'long-polling' === speed ) {
+					// Allow long polling (experimental).
+					settings.mainInterval = 0;
+					return 0;
+				} else {
+					speed = parseInt( speed, 10 );
+
+					if ( speed >= 1 && speed <= 3600 ) {
+						newInterval = speed * 1000;
+					} else {
 						newInterval = settings.originalInterval;
+					}
 				}
 
 				if ( settings.minimalInterval && newInterval < settings.minimalInterval ) {
 					newInterval = settings.minimalInterval;
 				}
 
+				// Special case, runs for a number of ticks then reverts to the previous interval.
 				if ( 5000 === newInterval ) {
 					ticks = parseInt( ticks, 10 ) || 30;
 					ticks = ticks < 1 || ticks > 30 ? 30 : ticks;

--- a/src/js/_enqueues/wp/heartbeat.js
+++ b/src/js/_enqueues/wp/heartbeat.js
@@ -132,7 +132,7 @@
 				}
 
 				/*
-				 * Sanity check: the interval can be from 1 to 3600 seconds and can be set temporarily
+				 * Logic check: the interval can be from 1 to 3600 seconds and can be set temporarily
 				 * to 5 seconds. It can be set in the initial options or changed later from JS
 				 * or from PHP through the AJAX responses.
 				 */

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -123,6 +123,14 @@ wp_add_inline_script(
 	'before'
 );
 
+// Set Heartbeat interval to 10 seconds, used to refresh post locks.
+wp_add_inline_script(
+	'heartbeat',
+	'if ( window.wp && window.wp.heartbeat ) {
+		window.wp.heartbeat.interval( 10 );
+	}'
+);
+
 /*
  * Get all available templates for the post/page attributes meta-box.
  * The "Default template" array element should only be added if the array is


### PR DESCRIPTION
Also set it to 10 seconds (down from 15) on the Posts screen so post locks can be set and removed faster.

Update Heartbeat: remove interval limitations; now the interval can be from 1 to 3600 seconds.

Trac ticket: https://core.trac.wordpress.org/ticket/61960

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
