### PR TITLE
Try: Set `show_in_rest` to `true` by default when `label` argument is defined

### DIFF
--- a/src/wp-includes/meta.php
+++ b/src/wp-includes/meta.php
@@ -1368,6 +1368,7 @@ function sanitize_meta( $meta_key, $meta_value, $object_type, $object_subtype = 
  * @since 5.3.0 Valid meta types expanded to include "array" and "object".
  * @since 5.5.0 The `$default` argument was added to the arguments array.
  * @since 6.4.0 The `$revisions_enabled` argument was added to the arguments array.
+ * @since 6.7.0 The `label` argument was added to the arguments array.
  *
  * @param string       $object_type Type of object metadata is for. Accepts 'post', 'comment', 'term', 'user',
  *                                  or any other object type with an associated meta table.

--- a/src/wp-includes/meta.php
+++ b/src/wp-includes/meta.php
@@ -1454,6 +1454,9 @@ function register_meta( $object_type, $meta_key, $args, $deprecated = null ) {
 	 * @param string $meta_key    Meta key.
 	 */
 	$args = apply_filters( 'register_meta_args', $args, $defaults, $object_type, $meta_key );
+	if ( isset( $args['label'] ) && ! isset( $args['show_in_rest'] ) ) {
+		$args['show_in_rest'] = true;
+	}
 	unset( $defaults['default'] );
 	$args = wp_parse_args( $args, $defaults );
 

--- a/src/wp-includes/meta.php
+++ b/src/wp-includes/meta.php
@@ -1379,6 +1379,7 @@ function sanitize_meta( $meta_key, $meta_value, $object_type, $object_subtype = 
  *                                         the meta key will be registered on the entire object type. Default empty.
  *     @type string     $type              The type of data associated with this meta key.
  *                                         Valid values are 'string', 'boolean', 'integer', 'number', 'array', and 'object'.
+ *     @type string     $label             A human-readable label of the data attached to this meta key.
  *     @type string     $description       A description of the data attached to this meta key.
  *     @type bool       $single            Whether the meta key has one value per object, or an array of values per object.
  *     @type mixed      $default           The default value returned from get_metadata() if no value has been set yet.
@@ -1411,6 +1412,7 @@ function register_meta( $object_type, $meta_key, $args, $deprecated = null ) {
 	$defaults = array(
 		'object_subtype'    => '',
 		'type'              => 'string',
+		'label'             => '',
 		'description'       => '',
 		'default'           => '',
 		'single'            => false,

--- a/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
+++ b/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
@@ -478,6 +478,7 @@ abstract class WP_REST_Meta_Fields {
 
 			$default_schema = array(
 				'type'        => $default_args['type'],
+				'label'       => empty( $args['label'] ) ? '' : $args['label'],
 				'description' => empty( $args['description'] ) ? '' : $args['description'],
 				'default'     => isset( $args['default'] ) ? $args['default'] : null,
 			);

--- a/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
+++ b/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
@@ -478,7 +478,7 @@ abstract class WP_REST_Meta_Fields {
 
 			$default_schema = array(
 				'type'        => $default_args['type'],
-				'label'       => empty( $args['label'] ) ? '' : $args['label'],
+				'title'       => empty( $args['label'] ) ? '' : $args['label'],
 				'description' => empty( $args['description'] ) ? '' : $args['description'],
 				'default'     => isset( $args['default'] ) ? $args['default'] : null,
 			);

--- a/tests/phpunit/tests/meta/registerMeta.php
+++ b/tests/phpunit/tests/meta/registerMeta.php
@@ -92,6 +92,7 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 				'' => array(
 					'flight_number' => array(
 						'type'              => 'string',
+						'label'             => '',
 						'description'       => '',
 						'single'            => false,
 						'sanitize_callback' => null,
@@ -117,6 +118,7 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 				'' => array(
 					'category_icon' => array(
 						'type'              => 'string',
+						'label'             => '',
 						'description'       => '',
 						'single'            => false,
 						'sanitize_callback' => null,
@@ -172,6 +174,7 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 				'' => array(
 					'flight_number' => array(
 						'type'              => 'string',
+						'label'             => '',
 						'description'       => '',
 						'single'            => false,
 						'sanitize_callback' => array( $this, '_new_sanitize_meta_cb' ),
@@ -254,6 +257,16 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 		unregister_meta_key( 'post', 'registered_key2' );
 
 		$this->assertEmpty( $meta_keys );
+	}
+
+	public function test_get_registered_meta_keys_label_arg() {
+		register_meta( 'post', 'registered_key1', array( 'label' => 'Field label' ) );
+
+		$meta_keys = get_registered_meta_keys( 'post' );
+
+		unregister_meta_key( 'post', 'registered_key1' );
+
+		$this->assertSame( 'Field label', $meta_keys['registered_key1']['label'] );
 	}
 
 	public function test_get_registered_meta_keys_description_arg() {
@@ -340,6 +353,7 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 				$subtype => array(
 					'flight_number' => array(
 						'type'              => 'string',
+						'label'             => '',
 						'description'       => '',
 						'single'            => false,
 						'sanitize_callback' => null,
@@ -394,6 +408,7 @@ class Tests_Meta_Register_Meta extends WP_UnitTestCase {
 				$subtype => array(
 					'flight_number' => array(
 						'type'              => 'string',
+						'label'             => '',
 						'description'       => '',
 						'single'            => false,
 						'sanitize_callback' => null,

--- a/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
+++ b/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
@@ -243,6 +243,18 @@ class WP_Test_REST_Post_Meta_Fields extends WP_Test_REST_TestCase {
 			)
 		);
 
+		register_post_meta(
+			'post',
+			'with_label',
+			array(
+				'type'         => 'string',
+				'single'       => true,
+				'show_in_rest' => true,
+				'label'        => 'Meta Label',
+				'default'      => '',
+			)
+		);
+
 		/** @var WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;
 		$wp_rest_server = new Spy_REST_Server();
@@ -3093,6 +3105,19 @@ class WP_Test_REST_Post_Meta_Fields extends WP_Test_REST_TestCase {
 		$schema = $response->get_data()['schema']['properties']['meta']['properties']['with_default'];
 		$this->assertArrayHasKey( 'default', $schema );
 		$this->assertSame( 'Goodnight Moon', $schema['default'] );
+	}
+
+	/**
+	 * @ticket 61998
+	 */
+	public function test_title_is_added_to_schema() {
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/posts' );
+		$response = rest_do_request( $request );
+
+		$schema = $response->get_data()['schema']['properties']['meta']['properties']['with_label'];
+
+		$this->assertArrayHasKey( 'default', $schema );
+		$this->assertSame( 'Meta Label', $schema['title'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
+++ b/tests/phpunit/tests/rest-api/rest-post-meta-fields.php
@@ -80,6 +80,7 @@ class WP_Test_REST_Post_Meta_Fields extends WP_Test_REST_TestCase {
 			'post',
 			'test_rest_disabled',
 			array(
+				'label'        => 'Test REST Disabled',
 				'show_in_rest' => false,
 				'type'         => 'string',
 			)
@@ -252,6 +253,17 @@ class WP_Test_REST_Post_Meta_Fields extends WP_Test_REST_TestCase {
 				'show_in_rest' => true,
 				'label'        => 'Meta Label',
 				'default'      => '',
+			)
+		);
+
+		register_post_meta(
+			'post',
+			'test_label_and_no_rest',
+			array(
+				'type'    => 'string',
+				'single'  => true,
+				'label'   => 'Meta Label',
+				'default' => '',
 			)
 		);
 
@@ -3973,6 +3985,24 @@ class WP_Test_REST_Post_Meta_Fields extends WP_Test_REST_TestCase {
 
 		unregister_post_meta( $post_type, 'foo' );
 		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * @ticket 61998
+	 */
+	public function test_get_registered_label_without_rest() {
+		add_post_meta( self::$post_id, 'test_label_and_no_rest', 'val1' );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/posts/%d', self::$post_id ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'meta', $data );
+
+		$meta = (array) $data['meta'];
+		$this->assertArrayHasKey( 'test_label_and_no_rest', $meta );
+		$this->assertSame( 'val1', $meta['test_label_and_no_rest'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/user/wpRegisterPersistedPreferencesMeta.php
+++ b/tests/phpunit/tests/user/wpRegisterPersistedPreferencesMeta.php
@@ -31,6 +31,7 @@ class Tests_User_WpRegisterPersistedPreferencesMeta extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				'type'              => 'object',
+				'label'             => '',
 				'description'       => '',
 				'single'            => true,
 				'sanitize_callback' => null,


### PR DESCRIPTION
This pull request is built on top of https://github.com/WordPress/wordpress-develop/pull/7298

As suggested by @gziolo [here](https://github.com/WordPress/wordpress-develop/pull/7298#issuecomment-2332177875), in this pull request I'm exploring the possibility of setting the `show_in_rest` argument to `true` by default when the new potential `label` argument is defined. With the introduction of a new human-readable argument, which hasn't been used before, it could make sense to expose it automatically in the REST API.

Basically, these are the use cases:
* If `show_in_rest` is defined, that value is always respected.
* No `label` and no `show_in_rest`: It keeps working as before and uses `show_in_rest` false, which is the default. This is a pretty common use case right now.
* Defined `label` and no `show_in_rest`: It sets `show_in_rest` to true. This would be the change introduced.

It seems I can't compare against my other branch. The relevant code changes in this PR are:
* New conditional to change `show_in_rest`: [link](https://github.com/WordPress/wordpress-develop/compare/trunk...SantosGuillamot:add/inherit-show-in-rest-from-label?expand=1#diff-d97fcbb3af195369ae1e21d1a5672911069350809eddaac39e17c5458b7086caR1457-R1459).
* Add a new unit test to cover this use case: [link](https://github.com/WordPress/wordpress-develop/compare/trunk...SantosGuillamot:add/inherit-show-in-rest-from-label?expand=1#diff-455eceaced7b1c4dfdf608247dc3d2770cd03459416e1a58b54b993b211a7161R3990-R4006).

Trac ticket: https://core.trac.wordpress.org/ticket/62000

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
