### PR TITLE
Interactivity Router: Update for latest GB changes.

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -1011,12 +1011,6 @@ CSS;
 				data-wp-class--start-animation="state.navigation.hasStarted"
 				data-wp-class--finish-animation="state.navigation.hasFinished"
 			></div>
-			<div
-				class="screen-reader-text"
-				aria-live="polite"
-				data-wp-interactive="core/router"
-				data-wp-text="state.navigation.message"
-			></div>
 HTML;
 	}
 

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -1031,6 +1031,19 @@ HTML;
 		if ( 'enter' === $mode && ! $this->has_processed_router_region ) {
 			$this->has_processed_router_region = true;
 
+			// Initialize the `core/router` store.
+			$this->state(
+				'core/router',
+				array(
+					'navigation' => array(
+						'texts' => array(
+							'loading' => __( 'Loading page, please wait.' ),
+							'loaded'  => __( 'Page Loaded.' ),
+						),
+					),
+				)
+			);
+
 			// Enqueues as an inline style.
 			wp_register_style( 'wp-interactivity-router-animations', false );
 			wp_add_inline_style( 'wp-interactivity-router-animations', $this->get_router_animation_styles() );

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -1031,16 +1031,16 @@ HTML;
 		if ( 'enter' === $mode && ! $this->has_processed_router_region ) {
 			$this->has_processed_router_region = true;
 
-			// Initialize the `core/router` store.
+			/*
+			 * Initialize the `core/router` store.
+			 * If the store is not initialized like this with minimal
+			 * navigation object, the interactivity-router script module
+			 * errors.
+			 */
 			$this->state(
 				'core/router',
 				array(
-					'navigation' => array(
-						'texts' => array(
-							'loading' => __( 'Loading page, please wait.' ),
-							'loaded'  => __( 'Page Loaded.' ),
-						),
-					),
+					'navigation' => new stdClass(),
 				)
 			);
 

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -994,16 +994,14 @@ CSS;
 	}
 
 	/**
-	 * Outputs the markup for the top loading indicator and the screen reader
-	 * notifications during client-side navigations.
+	 * Outputs markup for the @wordpress/interactivity-router script module.
 	 *
 	 * This method prints a div element representing a loading bar visible during
-	 * navigation, as well as an aria-live region that can be read by screen
-	 * readers to announce navigation status.
+	 * navigation.
 	 *
-	 * @since 6.5.0
+	 * @since 6.7.0
 	 */
-	public function print_router_loading_and_screen_reader_markup() {
+	public function print_router_markup() {
 		echo <<<HTML
 			<div
 				class="wp-interactivity-router-loading-bar"
@@ -1050,7 +1048,7 @@ HTML;
 			wp_enqueue_style( 'wp-interactivity-router-animations' );
 
 			// Adds the necessary markup to the footer.
-			add_action( 'wp_footer', array( $this, 'print_router_loading_and_screen_reader_markup' ) );
+			add_action( 'wp_footer', array( $this, 'print_router_markup' ) );
 		}
 	}
 

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -1031,19 +1031,6 @@ HTML;
 		if ( 'enter' === $mode && ! $this->has_processed_router_region ) {
 			$this->has_processed_router_region = true;
 
-			// Initialize the `core/router` store.
-			$this->state(
-				'core/router',
-				array(
-					'navigation' => array(
-						'texts' => array(
-							'loading' => __( 'Loading page, please wait.' ),
-							'loaded'  => __( 'Page Loaded.' ),
-						),
-					),
-				)
-			);
-
 			// Enqueues as an inline style.
 			wp_register_style( 'wp-interactivity-router-animations', false );
 			wp_add_inline_style( 'wp-interactivity-router-animations', $this->get_router_animation_styles() );

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -200,6 +200,26 @@ final class WP_Interactivity_API {
 	}
 
 	/**
+	 * Set client-side interactivity-router data.
+	 *
+	 * Once in the browser, the state will be parsed and used to hydrate the client-side
+	 * interactivity stores and the configuration will be available using a `getConfig` utility.
+	 *
+	 * @since 6.7.0
+	 *
+	 * @param array $data Data to filter.
+	 * @return array Data for the Interactivity Router script module.
+	 */
+	public function filter_script_module_interactivity_router_data( array $data ): array {
+		if ( ! isset( $data['i18n'] ) ) {
+			$data['i18n'] = array();
+		}
+		$data['i18n']['loading'] = __( 'Loading page, please wait.' );
+		$data['i18n']['loaded']  = __( 'Page Loaded.' );
+		return $data;
+	}
+
+	/**
 	 * Set client-side interactivity data.
 	 *
 	 * Once in the browser, the state will be parsed and used to hydrate the client-side
@@ -296,6 +316,7 @@ final class WP_Interactivity_API {
 	 */
 	public function add_hooks() {
 		add_filter( 'script_module_data_@wordpress/interactivity', array( $this, 'filter_script_module_interactivity_data' ) );
+		add_filter( 'script_module_data_@wordpress/interactivity-router', array( $this, 'filter_script_module_interactivity_router_data' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-router-region.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-router-region.php
@@ -102,7 +102,7 @@ class Tests_WP_Interactivity_API_WP_Router_Region extends WP_UnitTestCase {
 	 *
 	 * @covers ::process_directives
 	 */
-	public function test_wp_router_region_adds_loading_bar_aria_live_region_only_once() {
+	public function test_wp_router_region_adds_loading_bar_region_only_once() {
 		$html     = '
 			<div data-wp-router-region="region A">Interactive region</div>
 			<div data-wp-router-region="region B">Another interactive region</div>
@@ -123,10 +123,6 @@ class Tests_WP_Interactivity_API_WP_Router_Region extends WP_UnitTestCase {
 		$footer = $this->render_wp_footer();
 		$query  = array( 'class_name' => 'wp-interactivity-router-loading-bar' );
 		$p      = new WP_HTML_Tag_Processor( $footer );
-		$this->assertTrue( $p->next_tag( $query ) );
-		$this->assertFalse( $p->next_tag( $query ) );
-		$query = array( 'class_name' => 'screen-reader-text' );
-		$p     = new WP_HTML_Tag_Processor( $footer );
 		$this->assertTrue( $p->next_tag( $query ) );
 		$this->assertFalse( $p->next_tag( $query ) );
 	}


### PR DESCRIPTION
Accounts for changes to the `@wordpress/interactivity-router` module in:

- https://github.com/WordPress/gutenberg/pull/65123
- https://github.com/WordPress/gutenberg/pull/65539

Static localized strings are passed via script module data passing instead of in Interactivity API store state.
Redundant HTML used for `aria-live` regions is removed. This functionality is not handled by the `@wordpress/a11y` script module added in #7405.

Trac ticket: https://core.trac.wordpress.org/ticket/60647

## Testing

Testing this requires package updates from https://github.com/WordPress/gutenberg/pull/65539. It anticipates the package being released and updated in Core.

(Copied from https://github.com/WordPress/gutenberg/pull/65539)

> This PR is difficult to test on its own because it requires the package to be updated as a Core dependency for proper testing. It does not affect Gutenberg behavior, only the package's behavior in Core. There are other ways of doing it but this works:
> 
> - Get a checkout of Core from https://github.com/WordPress/wordpress-develop/pull/7304. This is the build that will be running.
> - Run `npm ci` in the Core checkout to install packages.
> - Build the package from this PR (`npm run build:packages` in Gutenberg).
> - Replace the `@wordpress/interactivity-router` package in Core's `node_modules` (`node_modules/@wordpress/interactivity-router`) with the package directory in Gutenberg (remove the directory and copy the directory from Gutenberg `packages/interactivity-router`).
> - In Core, run the npm build script you use, in my case `npm run dev`.
> 
> Then test out that the interactivity router a11y functionality is working. A good way to test is the query block with "force page reload" option disabled. Specifically, the aria-live regions of the page should be updated (with localized text if in non-English locale) announcing "Page loaded."

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
