### PR TITLE
Refactored WP_Debug_Data::debug_data() - get_wp_mu_plugins()

### DIFF
--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -81,7 +81,7 @@ class WP_Debug_Data {
 			'wp-active-theme'     => array(),
 			'wp-parent-theme'     => array(),
 			'wp-themes-inactive'  => array(),
-			'wp-mu-plugins'       => array(),
+			'wp-mu-plugins'       => self::get_wp_mu_plugins(),
 			'wp-plugins-active'   => array(),
 			'wp-plugins-inactive' => array(),
 			'wp-media'            => array(),
@@ -190,12 +190,6 @@ class WP_Debug_Data {
 
 		$info['wp-themes-inactive'] = array(
 			'label'      => __( 'Inactive Themes' ),
-			'show_count' => true,
-			'fields'     => array(),
-		);
-
-		$info['wp-mu-plugins'] = array(
-			'label'      => __( 'Must Use Plugins' ),
 			'show_count' => true,
 			'fields'     => array(),
 		);
@@ -721,41 +715,6 @@ class WP_Debug_Data {
 			'value' => wp_date( 'c', $_SERVER['REQUEST_TIME'] ),
 		);
 
-		// List must use plugins if there are any.
-		$mu_plugins = get_mu_plugins();
-
-		foreach ( $mu_plugins as $plugin_path => $plugin ) {
-			$plugin_version = $plugin['Version'];
-			$plugin_author  = $plugin['Author'];
-
-			$plugin_version_string       = __( 'No version or author information is available.' );
-			$plugin_version_string_debug = 'author: (undefined), version: (undefined)';
-
-			if ( ! empty( $plugin_version ) && ! empty( $plugin_author ) ) {
-				/* translators: 1: Plugin version number. 2: Plugin author name. */
-				$plugin_version_string       = sprintf( __( 'Version %1$s by %2$s' ), $plugin_version, $plugin_author );
-				$plugin_version_string_debug = sprintf( 'version: %s, author: %s', $plugin_version, $plugin_author );
-			} else {
-				if ( ! empty( $plugin_author ) ) {
-					/* translators: %s: Plugin author name. */
-					$plugin_version_string       = sprintf( __( 'By %s' ), $plugin_author );
-					$plugin_version_string_debug = sprintf( 'author: %s, version: (undefined)', $plugin_author );
-				}
-
-				if ( ! empty( $plugin_version ) ) {
-					/* translators: %s: Plugin version number. */
-					$plugin_version_string       = sprintf( __( 'Version %s' ), $plugin_version );
-					$plugin_version_string_debug = sprintf( 'author: (undefined), version: %s', $plugin_version );
-				}
-			}
-
-			$info['wp-mu-plugins']['fields'][ sanitize_text_field( $plugin['Name'] ) ] = array(
-				'label' => $plugin['Name'],
-				'value' => $plugin_version_string,
-				'debug' => $plugin_version_string_debug,
-			);
-		}
-
 		// List all available plugins.
 		$plugins        = get_plugins();
 		$plugin_updates = get_plugin_updates();
@@ -1244,6 +1203,57 @@ class WP_Debug_Data {
 		$info = apply_filters( 'debug_information', $info );
 
 		return $info;
+	}
+
+	/**
+	 * Gets the WordPress plugins section of the debug data.
+	 *
+	 * @since 6.7.0
+	 *
+	 * @return array
+	 */
+	public static function get_wp_mu_plugins(): array {
+		// List must use plugins if there are any.
+		$mu_plugins = get_mu_plugins();
+		$fields = array();
+
+		foreach ( $mu_plugins as $plugin_path => $plugin ) {
+			$plugin_version = $plugin['Version'];
+			$plugin_author  = $plugin['Author'];
+
+			$plugin_version_string       = __( 'No version or author information is available.' );
+			$plugin_version_string_debug = 'author: (undefined), version: (undefined)';
+
+			if ( ! empty( $plugin_version ) && ! empty( $plugin_author ) ) {
+				/* translators: 1: Plugin version number. 2: Plugin author name. */
+				$plugin_version_string       = sprintf( __( 'Version %1$s by %2$s' ), $plugin_version, $plugin_author );
+				$plugin_version_string_debug = sprintf( 'version: %s, author: %s', $plugin_version, $plugin_author );
+			} else {
+				if ( ! empty( $plugin_author ) ) {
+					/* translators: %s: Plugin author name. */
+					$plugin_version_string       = sprintf( __( 'By %s' ), $plugin_author );
+					$plugin_version_string_debug = sprintf( 'author: %s, version: (undefined)', $plugin_author );
+				}
+
+				if ( ! empty( $plugin_version ) ) {
+					/* translators: %s: Plugin version number. */
+					$plugin_version_string       = sprintf( __( 'Version %s' ), $plugin_version );
+					$plugin_version_string_debug = sprintf( 'author: (undefined), version: %s', $plugin_version );
+				}
+			}
+
+			$fields[ sanitize_text_field( $plugin['Name'] ) ] = array(
+				'label' => $plugin['Name'],
+				'value' => $plugin_version_string,
+				'debug' => $plugin_version_string_debug,
+			);
+		}
+
+		return array(
+			'label'      => __( 'Must Use Plugins' ),
+			'show_count' => true,
+			'fields'     => $fields,
+		);
 	}
 
 	/**


### PR DESCRIPTION
Changed: Moving $info['wp-mu-plugins'] to own function

I've started a second parallel PR, a little lower, so that we should not get too many merge conflicts.

---

Follow up to https://github.com/WordPress/wordpress-develop/pull/7027 as discussed with @dmsnell and @costdev 

Summary of the coming steps:

1. [wp-filesystem](https://github.com/WordPress/wordpress-develop/pull/7065)
2. [wp-constants](https://github.com/WordPress/wordpress-develop/pull/7106)
3. [wp-database](https://github.com/WordPress/wordpress-develop/pull/7143)
4. [wp-server](https://github.com/WordPress/wordpress-develop/pull/7283)
5. wp-media
6. wp-plugins-active & wp-plugins-inactive
7. **wp-mu-plugins** (we are here)
8. wp-themes-inactive
9. wp-parent-theme
10. wp-active-theme
11. wp-dropins
12. wp-paths-sizes
13. wp-core

Refactoring WP_Debug_Data::debug_data(); into smaller functions for

* better maintainability
* reduced complexity
* preparation for future unit tests
* improved extensibility (see trac for details)
* added php7.2 style type hints
* fixed an error with `$parent_theme_auto_update_string` showing the value from `$auto_updates_string` (This will be handled only in Step 9)

Trac ticket: https://core.trac.wordpress.org/ticket/61648#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
