### PR TITLE
Enhance wp_hash function to support custom hashing algorithms

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2564,7 +2564,7 @@ if ( ! function_exists( 'wp_hash' ) ) :
 		if ( ! in_array( $algo, hash_hmac_algos(), true ) ) {
 			throw new InvalidArgumentException(
 				sprintf(
-					'Unsupported hashing algorithm: %s. Supported algorithms are: %s',
+					'Unsupported hashing algorithm: %1$s. Supported algorithms are: %2$s',
 					$algo,
 					implode( ', ', hash_hmac_algos() )
 				)

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2553,12 +2553,19 @@ if ( ! function_exists( 'wp_hash' ) ) :
 	 *
 	 * @param string $data   Plain text to hash.
 	 * @param string $scheme Authentication scheme (auth, secure_auth, logged_in, nonce).
+	 * @param string $algo   Hashing algorithm to use (default: md5).
 	 * @return string Hash of $data.
 	 */
-	function wp_hash( $data, $scheme = 'auth' ) {
+	function wp_hash( $data, $scheme = 'auth', $algo = 'md5' ) {
 		$salt = wp_salt( $scheme );
 
-		return hash_hmac( 'md5', $data, $salt );
+		// Ensure the algorithm is supported by the hash_hmac function.
+		if ( ! in_array( $algo, hash_hmac_algos(), true ) ) {
+			// Fall back to 'md5' if the provided algorithm is not supported.
+			$algo = 'md5';
+		}
+
+		return hash_hmac( $algo, $data, $salt );
 	}
 endif;
 

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2570,7 +2570,8 @@ if ( ! function_exists( 'wp_hash' ) ) :
 		if ( ! in_array( $algo, hash_hmac_algos(), true ) ) {
 			throw new InvalidArgumentException(
 				sprintf(
-					'Unsupported hashing algorithm: %1$s. Supported algorithms are: %2$s',
+					/** translators: 1: Name of a cryptographic hash algorithm. 2: List of supported algorithms. */
+					__( 'Unsupported hashing algorithm: %1$s. Supported algorithms are: %2$s' ),
 					$algo,
 					implode( ', ', hash_hmac_algos() )
 				)

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2547,15 +2547,21 @@ endif;
 
 if ( ! function_exists( 'wp_hash' ) ) :
 	/**
-	 * Gets hash of given string.
+	 * Gets the hash of the given string.
+	 *
+	 * The default algorithm is md5 but can be changed to any algorithm supported by
+	 * `hash_hmac()`. Use the `hash_hmac_algos()` function to check the supported
+	 * algorithms.
 	 *
 	 * @since 2.0.3
+	 * @since 6.8.0 The `$algo` parameter was added.
+	 *
+	 * @throws InvalidArgumentException if the hashing algorithm is not supported.
 	 *
 	 * @param string $data   Plain text to hash.
 	 * @param string $scheme Authentication scheme (auth, secure_auth, logged_in, nonce).
-	 * @param string $algo   Hashing algorithm to use (default: md5).
+	 * @param string $algo   Hashing algorithm to use. Default: 'md5'.
 	 * @return string Hash of $data.
-	 * @throws InvalidArgumentException if the hashing algorithm is not supported.
 	 */
 	function wp_hash( $data, $scheme = 'auth', $algo = 'md5' ) {
 		$salt = wp_salt( $scheme );

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2555,14 +2555,19 @@ if ( ! function_exists( 'wp_hash' ) ) :
 	 * @param string $scheme Authentication scheme (auth, secure_auth, logged_in, nonce).
 	 * @param string $algo   Hashing algorithm to use (default: md5).
 	 * @return string Hash of $data.
+	 * @throws InvalidArgumentException if the hashing algorithm is not supported.
 	 */
 	function wp_hash( $data, $scheme = 'auth', $algo = 'md5' ) {
 		$salt = wp_salt( $scheme );
 
 		// Ensure the algorithm is supported by the hash_hmac function.
 		if ( ! in_array( $algo, hash_hmac_algos(), true ) ) {
-			// Fall back to 'md5' if the provided algorithm is not supported.
-			$algo = 'md5';
+			throw new InvalidArgumentException( 
+				sprintf( 'Unsupported hashing algorithm: %s. Supported algorithms are: %s', 
+					$algo, 
+					implode( ', ', hash_hmac_algos() ) 
+				) 
+			);
 		}
 
 		return hash_hmac( $algo, $data, $salt );

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2562,11 +2562,12 @@ if ( ! function_exists( 'wp_hash' ) ) :
 
 		// Ensure the algorithm is supported by the hash_hmac function.
 		if ( ! in_array( $algo, hash_hmac_algos(), true ) ) {
-			throw new InvalidArgumentException( 
-				sprintf( 'Unsupported hashing algorithm: %s. Supported algorithms are: %s', 
-					$algo, 
-					implode( ', ', hash_hmac_algos() ) 
-				) 
+			throw new InvalidArgumentException(
+				sprintf(
+					'Unsupported hashing algorithm: %s. Supported algorithms are: %s',
+					$algo,
+					implode( ', ', hash_hmac_algos() )
+				)
 			);
 		}
 

--- a/tests/phpunit/tests/functions/wpHash.php
+++ b/tests/phpunit/tests/functions/wpHash.php
@@ -36,5 +36,4 @@ class Tests_Functions_wpHash extends WP_UnitTestCase {
 
 		wp_hash( 'data', 'auth', 'invalid' );
 	}
-
 }

--- a/tests/phpunit/tests/functions/wpHash.php
+++ b/tests/phpunit/tests/functions/wpHash.php
@@ -20,7 +20,7 @@ class Tests_Functions_wpHash extends WP_UnitTestCase {
 		$this->assertSame( $expected_length, strlen( $hash ) );
 	}
 
-	function data_wp_hash_uses_specified_algorithm() {
+	public function data_wp_hash_uses_specified_algorithm() {
 		return array(
 			array( 'md5', 32 ),
 			array( 'sha1', 40 ),

--- a/tests/phpunit/tests/functions/wpHash.php
+++ b/tests/phpunit/tests/functions/wpHash.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Tests for the behavior of `wp_hash()`
+ *
+ * @group functions
+ *
+ * @covers ::wp_hash
+ */
+class Tests_Functions_wpHash extends WP_UnitTestCase {
+
+	/**
+	 * @dataProvider data_wp_hash_uses_specified_algorithm
+	 *
+	 * @ticket 62005
+	 */
+	public function test_wp_hash_uses_specified_algorithm( string $algo, int $expected_length ) {
+		$hash = wp_hash( 'data', 'auth', $algo );
+
+		$this->assertSame( $expected_length, strlen( $hash ) );
+	}
+
+	function data_wp_hash_uses_specified_algorithm() {
+		return array(
+			array( 'md5', 32 ),
+			array( 'sha1', 40 ),
+			array( 'sha256', 64 ),
+		);
+	}
+
+	/**
+	 * @ticket 62005
+	 */
+	public function test_wp_hash_throws_exception_on_invalid_algorithm() {
+		$this->expectException( 'InvalidArgumentException' );
+
+		wp_hash( 'data', 'auth', 'invalid' );
+	}
+
+}

--- a/tests/phpunit/tests/pluggable/signatures.php
+++ b/tests/phpunit/tests/pluggable/signatures.php
@@ -209,6 +209,7 @@ class Tests_Pluggable_Signatures extends WP_UnitTestCase {
 			'wp_hash'                         => array(
 				'data',
 				'scheme' => 'auth',
+				'algo'   => 'md5',
 			),
 			'wp_hash_password'                => array( 'password' ),
 			'wp_check_password'               => array(


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/62005<!-- insert a link to the WordPress Trac ticket here -->

### Summary
This PR updates the `wp_hash` function to allow users to specify a custom hashing algorithm, enhancing the security and flexibility of the function. Previously, the function hardcoded the `md5` algorithm, which is vulnerable to collision attacks.

### Changes:
- Added a new parameter `$algo` to the `wp_hash` function, allowing users to specify the hashing algorithm. The default remains `md5` for backward compatibility.
- Implemented a check using `hash_hmac_algos()` to ensure the provided algorithm is supported. If not, the function will fall back to `md5`.

### Benefits:
- Users can now choose more secure hashing algorithms like `sha256`.
- Improved security by allowing the use of modern, collision-resistant hashing algorithms.

### Backward Compatibility:
- The function retains `md5` as the default algorithm, ensuring backward compatibility with existing code.

### Testing:
- Tested with various algorithms (`md5`, `sha256`, `sha512`) to confirm correct functionality.
- Validated fallback to `md5` when an unsupported algorithm is provided.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
