### PR TITLE
Update: Make `get_current_blog_id()` & `$wpdb->blogid` consistent.

### DIFF
--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -754,6 +754,10 @@ class wpdb {
 			$this->show_errors();
 		}
 
+		if ( ! is_multisite() ) {
+			$this->blogid = 1;
+		}
+
 		$this->dbuser     = $dbuser;
 		$this->dbpassword = $dbpassword;
 		$this->dbname     = $dbname;


### PR DESCRIPTION
Trac Ticket: [Core-45761](https://core.trac.wordpress.org/ticket/45761)

## Problem Statement:

- In single-site WordPress installations, there is an inconsistency between the blogid property of the global $wpdb object and the value returned by get_current_blog_id(). Specifically:

```
$wpdb->blogid returns 0;
get_current_blog_id() returns 1;
```

This inconsistency is present in older installations and can lead to discrepancies in code that relies on the blogid value, especially in non-multisite environments.

## Fix:

- To resolve this issue, we have modified the `wpdb::__construct` constructor method. The fix includes:

- Adding an `is_multisite()` check within the constructor.
Setting `$wpdb->blogid` to 1 if `is_multisite()` returns false, ensuring consistency with the value returned by `get_current_blog_id()`.

