### PR TITLE
Fix comment ID parameter for get_edit_comment_link filter.

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1618,9 +1618,6 @@ function get_edit_comment_link( $comment_id = 0, $context = 'display' ) {
 
 	$location = admin_url( $action ) . $comment->comment_ID;
 
-	// Ensure the $comment_id variable passed to the filter is always an ID.
-	$comment_id = (int) $comment->comment_ID;
-
 	/**
 	 * Filters the comment edit link.
 	 *

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1618,6 +1618,9 @@ function get_edit_comment_link( $comment_id = 0, $context = 'display' ) {
 
 	$location = admin_url( $action ) . $comment->comment_ID;
 
+	// Ensure the $comment_id variable passed to the filter is always an ID.
+	$comment_id = (int) $comment->comment_ID;
+
 	/**
 	 * Filters the comment edit link.
 	 *

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1626,9 +1626,9 @@ function get_edit_comment_link( $comment_id = 0, $context = 'display' ) {
 	 *
 	 * @since 6.7.0 The $comment_id and $context parameters are now being passed to the filter.
 	 *
-	 * @param string $location The edit link.
-	 * @param int    $comment_id Optional. Unique ID of the comment to generate an edit link.
-	 * @param string $context    Optional. Context to include HTML entities in link. Default 'display'.
+	 * @param string $location   The edit link.
+	 * @param int    $comment_id Unique ID of the comment to generate an edit link.
+	 * @param string $context    Context to include HTML entities in link. Default 'display'.
 	 */
 	return apply_filters( 'get_edit_comment_link', $location, $comment_id, $context );
 }

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1628,7 +1628,7 @@ function get_edit_comment_link( $comment_id = 0, $context = 'display' ) {
 	 *
 	 * @param string $location The edit link.
 	 * @param int    $comment_id Optional. Unique ID of the comment to generate an edit link.
-	 * @param int    $context    Optional. Context to include HTML entities in link. Default 'display'.
+	 * @param string $context    Optional. Context to include HTML entities in link. Default 'display'.
 	 */
 	return apply_filters( 'get_edit_comment_link', $location, $comment_id, $context );
 }

--- a/tests/phpunit/tests/link/getEditCommentLink.php
+++ b/tests/phpunit/tests/link/getEditCommentLink.php
@@ -127,4 +127,29 @@ class Tests_Link_GetEditCommentLink extends WP_UnitTestCase {
 		$this->assertSame( $expected_url_display, $actual_url_display );
 		$this->assertSame( $expected_url, $actual_url );
 	}
+
+	/**
+	 * Tests that the 'get_edit_comment_link' filter receives the comment ID, even when a comment object is passed.
+	 *
+	 * @ticket 61727
+	 */
+	public function test_get_edit_comment_link_filter_uses_id() {
+		// Add a filter just to catch the $comment_id filter parameter value.
+		$comment_id_filter_param = null;
+		add_filter(
+			'get_edit_comment_link',
+			function ( $location, $comment_id ) use ( &$comment_id_filter_param ) {
+				$comment_id_filter_param = $comment_id;
+				return $location;
+			},
+			10,
+			2
+		);
+
+		// Pass a comment object to get_edit_comment_link().
+		get_edit_comment_link( get_comment( self::$comment_id ) );
+
+		// The filter should still always receive the comment ID, not the object.
+		$this->assertSame( self::$comment_id, $comment_id_filter_param );
+	}
 }


### PR DESCRIPTION
This is a follow-up fix that addresses the bug in https://core.trac.wordpress.org/ticket/61727#comment:10.

Trac ticket: https://core.trac.wordpress.org/ticket/61727

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
