### PR TITLE
Fix: Remove non yoda condition and non strict comparision

### DIFF
--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -1433,7 +1433,7 @@ function newblog_notify_siteadmin( $blog_id, $deprecated = '' ) {
 
 	$email = get_site_option( 'admin_email' );
 
-	if ( is_email( $email ) == false ) {
+	if ( ! is_email( $email ) ) {
 		return false;
 	}
 
@@ -1494,7 +1494,7 @@ function newuser_notify_siteadmin( $user_id ) {
 
 	$email = get_site_option( 'admin_email' );
 
-	if ( is_email( $email ) == false ) {
+	if ( ! is_email( $email ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
Trac Ticket: [Core-63032](https://core.trac.wordpress.org/ticket/62032)

## Problem Statement:

- In the `ms-functions.php` file, there are two functions — `newuser_notify_siteadmin()` and `newblog_notify_siteadmin()` —that perform email validation using if statements without employing Yoda conditions or strict comparisons. This can potentially lead to issues with robustness and consistency in the validation logic.

## Fix:

- To enhance the code quality and align with WordPress coding standards, the following updates have been made:

```
if ( ! is_email( $email ) )
```