### PR TITLE
Fix: Missing yoda conditions from multiple files

### DIFF
--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -829,7 +829,7 @@ function iis7_rewrite_rule_exists( $filename ) {
 
 	$doc = new DOMDocument();
 
-	if ( $doc->load( $filename ) === false ) {
+	if ( false === $doc->load( $filename ) ) {
 		return false;
 	}
 
@@ -864,7 +864,7 @@ function iis7_delete_rewrite_rule( $filename ) {
 	$doc                     = new DOMDocument();
 	$doc->preserveWhiteSpace = false;
 
-	if ( $doc->load( $filename ) === false ) {
+	if ( false === $doc->load( $filename ) ) {
 		return false;
 	}
 
@@ -906,7 +906,7 @@ function iis7_add_rewrite_rule( $filename, $rewrite_rule ) {
 	$doc                     = new DOMDocument();
 	$doc->preserveWhiteSpace = false;
 
-	if ( $doc->load( $filename ) === false ) {
+	if ( false === $doc->load( $filename ) ) {
 		return false;
 	}
 

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -1697,7 +1697,7 @@ function upgrade_300() {
 		populate_roles_300();
 	}
 
-	if ( $wp_current_db_version < 14139 && is_multisite() && is_main_site() && ! defined( 'MULTISITE' ) && get_site_option( 'siteurl' ) === false ) {
+	if ( $wp_current_db_version < 14139 && is_multisite() && is_main_site() && ! defined( 'MULTISITE' ) && false === get_site_option( 'siteurl' ) ) {
 		add_site_option( 'siteurl', '' );
 	}
 

--- a/src/wp-admin/menu-header.php
+++ b/src/wp-admin/menu-header.php
@@ -233,7 +233,7 @@ function _wp_menu_output( $menu, $submenu, $submenu_as_parent = true ) {
 				} elseif (
 					( ! isset( $plugin_page ) && $self === $sub_item[2] )
 					|| ( isset( $plugin_page ) && $plugin_page === $sub_item[2]
-						&& ( $item[2] === $self_type || $item[2] === $self || file_exists( $menu_file ) === false ) )
+						&& ( $item[2] === $self_type || $item[2] === $self || false === file_exists( $menu_file ) ) )
 				) {
 					$class[]          = 'current';
 					$aria_attributes .= ' aria-current="page"';

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -330,9 +330,9 @@ function core_auto_updates_settings() {
 	$updater = new WP_Automatic_Updater();
 
 	// Defaults:
-	$upgrade_dev   = get_site_option( 'auto_update_core_dev', 'enabled' ) === 'enabled';
-	$upgrade_minor = get_site_option( 'auto_update_core_minor', 'enabled' ) === 'enabled';
-	$upgrade_major = get_site_option( 'auto_update_core_major', 'unset' ) === 'enabled';
+	$upgrade_dev   = 'enabled' === get_site_option( 'auto_update_core_dev', 'enabled' );
+	$upgrade_minor = 'enabled' === get_site_option( 'auto_update_core_minor', 'enabled' );
+	$upgrade_major = 'enabled' === get_site_option( 'auto_update_core_major', 'unset' );
 
 	$can_set_update_option = true;
 	// WP_AUTO_UPDATE_CORE = true (all), 'beta', 'rc', 'development', 'branch-development', 'minor', false.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2256,7 +2256,7 @@ function unregister_block_style( $block_name, $block_style_name ) {
 function block_has_support( $block_type, $feature, $default_value = false ) {
 	$block_support = $default_value;
 	if ( $block_type instanceof WP_Block_Type ) {
-		if ( is_array( $feature ) && count( $feature ) === 1 ) {
+		if ( is_array( $feature ) && 1 === count( $feature ) ) {
 			$feature = $feature[0];
 		}
 
@@ -2547,7 +2547,7 @@ function build_comment_query_vars_from_block( $block ) {
 		$comment_args['hierarchical'] = false;
 	}
 
-	if ( get_option( 'page_comments' ) === '1' || get_option( 'page_comments' ) === true ) {
+	if ( '1' === get_option( 'page_comments' ) || true === get_option( 'page_comments' ) ) {
 		$per_page     = get_option( 'comments_per_page' );
 		$default_page = get_option( 'default_comments_page' );
 		if ( $per_page > 0 ) {

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2262,7 +2262,7 @@ class WP_Query {
 				}
 				if ( ! $post_type ) {
 					$post_type = 'any';
-				} elseif ( count( $post_type ) === 1 ) {
+				} elseif ( 1 === count( $post_type ) ) {
 					$post_type = $post_type[0];
 				} else {
 					// Sort post types to ensure same cache key generation.

--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -1253,7 +1253,7 @@ class wpdb {
 	 * @return string
 	 */
 	public function _weak_escape( $data ) {
-		if ( func_num_args() === 1 && function_exists( '_deprecated_function' ) ) {
+		if ( 1 === func_num_args() && function_exists( '_deprecated_function' ) ) {
 			_deprecated_function( __METHOD__, '3.6.0', 'wpdb::prepare() or esc_sql()' );
 		}
 		return addslashes( $data );
@@ -1329,7 +1329,7 @@ class wpdb {
 	 * @return string|array Escaped data, in the same type as supplied.
 	 */
 	public function escape( $data ) {
-		if ( func_num_args() === 1 && function_exists( '_deprecated_function' ) ) {
+		if ( 1 === func_num_args() && function_exists( '_deprecated_function' ) ) {
 			_deprecated_function( __METHOD__, '3.6.0', 'wpdb::prepare() or esc_sql()' );
 		}
 		if ( is_array( $data ) ) {

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -446,7 +446,7 @@ function _wptexturize_pushpop_element( $text, &$stack, $disabled_elements ) {
 function wpautop( $text, $br = true ) {
 	$pre_tags = array();
 
-	if ( trim( $text ) === '' ) {
+	if ( '' === trim( $text ) ) {
 		return '';
 	}
 
@@ -2541,7 +2541,7 @@ function convert_invalid_entities( $content ) {
  * @return string Balanced text
  */
 function balanceTags( $text, $force = false ) {  // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
-	if ( $force || (int) get_option( 'use_balanceTags' ) === 1 ) {
+	if ( $force || 1 === (int) get_option( 'use_balanceTags' ) ) {
 		return force_balance_tags( $text );
 	} else {
 		return $text;
@@ -2977,7 +2977,7 @@ function _make_web_ftp_clickable_cb( $matches ) {
 
 	// Removed trailing [.,;:)] from URL.
 	$last_char = substr( $dest, -1 );
-	if ( in_array( $last_char, array( '.', ',', ';', ':', ')' ), true ) === true ) {
+	if ( true === in_array( $last_char, array( '.', ',', ';', ':', ')' ), true ) ) {
 		$ret  = $last_char;
 		$dest = substr( $dest, 0, strlen( $dest ) - 1 );
 	}
@@ -3300,7 +3300,7 @@ function wp_rel_ugc( $text ) {
  */
 function wp_targeted_link_rel( $text ) {
 	// Don't run (more expensive) regex if no links with targets.
-	if ( stripos( $text, 'target' ) === false || stripos( $text, '<a ' ) === false || is_serialized( $text ) ) {
+	if ( false === stripos( $text, 'target' ) || false === stripos( $text, '<a ' ) || is_serialized( $text ) ) {
 		return $text;
 	}
 
@@ -3560,7 +3560,7 @@ function is_email( $email, $deprecated = false ) {
 	}
 
 	// Test for an @ character after the first position.
-	if ( strpos( $email, '@', 1 ) === false ) {
+	if ( false === strpos( $email, '@', 1 ) ) {
 		/** This filter is documented in wp-includes/formatting.php */
 		return apply_filters( 'is_email', false, $email, 'email_no_at' );
 	}
@@ -3774,7 +3774,7 @@ function sanitize_email( $email ) {
 	}
 
 	// Test for an @ character after the first position.
-	if ( strpos( $email, '@', 1 ) === false ) {
+	if ( false === strpos( $email, '@', 1 ) ) {
 		/** This filter is documented in wp-includes/formatting.php */
 		return apply_filters( 'sanitize_email', '', $email, 'email_no_at' );
 	}
@@ -5346,7 +5346,7 @@ function wp_sprintf_l( $pattern, $args ) {
 
 	$args   = (array) $args;
 	$result = array_shift( $args );
-	if ( count( $args ) === 1 ) {
+	if ( 1 === count( $args ) ) {
 		$result .= $l['between_only_two'] . array_shift( $args );
 	}
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6644,7 +6644,7 @@ function wp_timezone_choice( $selected_zone, $locale = null ) {
 	}
 
 	// If this is a deprecated, but valid, timezone string, display it at the top of the list as-is.
-	if ( in_array( $selected_zone, $tz_identifiers, true ) === false
+	if ( false === in_array( $selected_zone, $tz_identifiers, true )
 		&& in_array( $selected_zone, timezone_identifiers_list( DateTimeZone::ALL_WITH_BC ), true )
 	) {
 		$structure[] = '<option selected="selected" value="' . esc_attr( $selected_zone ) . '">' . esc_html( $selected_zone ) . '</option>';

--- a/src/wp-includes/meta.php
+++ b/src/wp-includes/meta.php
@@ -240,7 +240,7 @@ function update_metadata( $meta_type, $object_id, $meta_key, $meta_value, $prev_
 	// Compare existing value to new value if no prev value given and the key exists only once.
 	if ( empty( $prev_value ) ) {
 		$old_value = get_metadata_raw( $meta_type, $object_id, $meta_key );
-		if ( is_countable( $old_value ) && count( $old_value ) === 1 ) {
+		if ( is_countable( $old_value ) && 1 === count( $old_value ) ) {
 			if ( $old_value[0] === $meta_value ) {
 				return false;
 			}

--- a/src/wp-includes/ms-load.php
+++ b/src/wp-includes/ms-load.php
@@ -331,7 +331,7 @@ function ms_load_current_site_and_network( $domain, $path, $subdomain = false ) 
 		if ( ! $current_site ) {
 			// Are there even two networks installed?
 			$networks = get_networks( array( 'number' => 2 ) );
-			if ( count( $networks ) === 1 ) {
+			if ( 1 === count( $networks ) ) {
 				$current_site = array_shift( $networks );
 				wp_cache_add( 'current_network', $current_site, 'site-options' );
 			} elseif ( empty( $networks ) ) {

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -2084,7 +2084,7 @@ function rest_validate_enum( $value, $args, $param ) {
 		$encoded_enum_values[] = is_scalar( $enum_value ) ? $enum_value : wp_json_encode( $enum_value );
 	}
 
-	if ( count( $encoded_enum_values ) === 1 ) {
+	if ( 1 === count( $encoded_enum_values ) ) {
 		/* translators: 1: Parameter, 2: Valid values. */
 		return new WP_Error( 'rest_not_in_enum', wp_sprintf( __( '%1$s is not %2$s.' ), $param, $encoded_enum_values[0] ) );
 	}

--- a/src/wp-includes/template.php
+++ b/src/wp-includes/template.php
@@ -152,7 +152,7 @@ function get_archive_template() {
 
 	$templates = array();
 
-	if ( count( $post_types ) === 1 ) {
+	if ( 1 === count( $post_types ) ) {
 		$post_type   = reset( $post_types );
 		$templates[] = "archive-{$post_type}.php";
 	}

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -955,7 +955,7 @@ switch ( $action ) {
 		if ( ! $user || is_wp_error( $user ) ) {
 			setcookie( $rp_cookie, ' ', time() - YEAR_IN_SECONDS, $rp_path, COOKIE_DOMAIN, is_ssl(), true );
 
-			if ( $user && $user->get_error_code() === 'expired_key' ) {
+			if ( $user && 'expired_key' === $user->get_error_code() ) {
 				wp_redirect( site_url( 'wp-login.php?action=lostpassword&error=expiredkey' ) );
 			} else {
 				wp_redirect( site_url( 'wp-login.php?action=lostpassword&error=invalidkey' ) );
@@ -1593,7 +1593,7 @@ switch ( $action ) {
 		} else {
 			$login_script .= 'd = document.getElementById( "user_login" );';
 
-			if ( $errors->get_error_code() === 'invalid_username' ) {
+			if ( 'invalid_username' === $errors->get_error_code() ) {
 				$login_script .= 'd.value = "";';
 			}
 		}


### PR DESCRIPTION
Trac Ticket: [Core-62033](https://core.trac.wordpress.org/ticket/62033)

## Problem Statement

- During a recent review of the codebase, it was observed that several comparison statements are missing Yoda conditions. This inconsistency may affect readability and increase the risk of errors due to potential assignment mistakes.

## Solution

- This PR addresses the issue by refactoring the code to include Yoda conditions where appropriate. Specifically, I have updated comparison statements to ensure that constants are placed on the left side of comparisons, in line with the coding standards.

## Changes Made

- Updated comparison statements to use Yoda conditions.

- Ensured that all modifications are thoroughly tested to maintain code functionality.

## Impact

- Improved readability and consistency in the codebase.

- Reduced risk of assignment errors in comparison statements.