### PR TITLE
HTML API: Lower-case HTML tag names in `get_qualified_tag_name()`.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2903,10 +2903,39 @@ class WP_HTML_Tag_Processor {
 	}
 
 	/**
-	 * Returns the adjusted tag name for a given token, taking into
-	 * account the current parsing context, whether HTML, SVG, or MathML.
+	 * Returns the normative adjusted tag name for an element in its given
+	 * namespace, usually for display or XML output only.
+	 *
+	 * For checking if a tag has a given name, rely on {@see static::get_tag()}
+	 * which takes HTML case-folding rules into account and always returns an
+	 * ASCII upper-case variant of the matched tag name.
+	 *
+	 *  - Some SVG tags are mixed-case, such as `altGlyph`.
+	 *  - HTML custom elements’ casing is preserved.
+	 *  - All other tag names will be lower-cased.
+	 *
+	 * Example:
+	 *
+	 *     $processor = new WP_HTML_Tag_Processor( '<div><Task-Item>' );
+	 *     $processor->next_tag();
+	 *     'DIV' === $processor->get_tag();
+	 *     'div' === $processor->get_qualified_tag_name();
+	 *
+	 *     $processor->next_tag();
+	 *     'TASK-ITEM' === $processor->get_tag();
+	 *     'Task-Item' === $processor->get_qualified_tag_name();
+	 *
+	 *     $processor = WP_HTML_Processor::create_fragment( '<svg><altglyph/><rect/></svg>' );
+	 *     $processor->next_tag( 'altglyph' );
+	 *     'ALTGLYPH' === $processor->get_tag();
+	 *     'altGlyph' === $processor->get_qualified_tag_name();
+	 *
+	 *     $processor->next_tag();
+	 *     'RECT' === $processor->get_tag();
+	 *     'rect' === $processor->get_qualified_tag_name();
 	 *
 	 * @since 6.7.0
+	 * @since 6.9.0 Respects mixed-case SVG and case-sensitive custome element tag names.
 	 *
 	 * @return string|null Name of current tag name.
 	 */
@@ -2916,140 +2945,160 @@ class WP_HTML_Tag_Processor {
 			return null;
 		}
 
-		if ( 'html' === $this->get_namespace() ) {
-			return $tag_name;
+		$lower_tag_name = strtolower( $tag_name );
+		$namespace      = $this->get_namespace();
+
+		switch ( $namespace ) {
+			case 'html':
+				// Preserve casing of custom elements.
+				return str_contains( $tag_name, '-' )
+					? substr( $this->html, $this->tag_name_starts_at, $this->tag_name_length )
+					: $lower_tag_name;
+
+			case 'math':
+				return $lower_tag_name;
 		}
 
-		$lower_tag_name = strtolower( $tag_name );
-		if ( 'math' === $this->get_namespace() ) {
+		if ( 'svg' !== $namespace ) {
+			// This should be unreachable, but prevents tools from inaccurately reporting type errors.
 			return $lower_tag_name;
 		}
 
-		if ( 'svg' === $this->get_namespace() ) {
-			switch ( $lower_tag_name ) {
-				case 'altglyph':
-					return 'altGlyph';
+		switch ( $lower_tag_name ) {
+			case 'altglyph':
+				return 'altGlyph';
 
-				case 'altglyphdef':
-					return 'altGlyphDef';
+			case 'altglyphdef':
+				return 'altGlyphDef';
 
-				case 'altglyphitem':
-					return 'altGlyphItem';
+			case 'altglyphitem':
+				return 'altGlyphItem';
 
-				case 'animatecolor':
-					return 'animateColor';
+			case 'animatecolor':
+				return 'animateColor';
 
-				case 'animatemotion':
-					return 'animateMotion';
+			case 'animatemotion':
+				return 'animateMotion';
 
-				case 'animatetransform':
-					return 'animateTransform';
+			case 'animatetransform':
+				return 'animateTransform';
 
-				case 'clippath':
-					return 'clipPath';
+			case 'clippath':
+				return 'clipPath';
 
-				case 'feblend':
-					return 'feBlend';
+			case 'feblend':
+				return 'feBlend';
 
-				case 'fecolormatrix':
-					return 'feColorMatrix';
+			case 'fecolormatrix':
+				return 'feColorMatrix';
 
-				case 'fecomponenttransfer':
-					return 'feComponentTransfer';
+			case 'fecomponenttransfer':
+				return 'feComponentTransfer';
 
-				case 'fecomposite':
-					return 'feComposite';
+			case 'fecomposite':
+				return 'feComposite';
 
-				case 'feconvolvematrix':
-					return 'feConvolveMatrix';
+			case 'feconvolvematrix':
+				return 'feConvolveMatrix';
 
-				case 'fediffuselighting':
-					return 'feDiffuseLighting';
+			case 'fediffuselighting':
+				return 'feDiffuseLighting';
 
-				case 'fedisplacementmap':
-					return 'feDisplacementMap';
+			case 'fedisplacementmap':
+				return 'feDisplacementMap';
 
-				case 'fedistantlight':
-					return 'feDistantLight';
+			case 'fedistantlight':
+				return 'feDistantLight';
 
-				case 'fedropshadow':
-					return 'feDropShadow';
+			case 'fedropshadow':
+				return 'feDropShadow';
 
-				case 'feflood':
-					return 'feFlood';
+			case 'feflood':
+				return 'feFlood';
 
-				case 'fefunca':
-					return 'feFuncA';
+			case 'fefunca':
+				return 'feFuncA';
 
-				case 'fefuncb':
-					return 'feFuncB';
+			case 'fefuncb':
+				return 'feFuncB';
 
-				case 'fefuncg':
-					return 'feFuncG';
+			case 'fefuncg':
+				return 'feFuncG';
 
-				case 'fefuncr':
-					return 'feFuncR';
+			case 'fefuncr':
+				return 'feFuncR';
 
-				case 'fegaussianblur':
-					return 'feGaussianBlur';
+			case 'fegaussianblur':
+				return 'feGaussianBlur';
 
-				case 'feimage':
-					return 'feImage';
+			case 'feimage':
+				return 'feImage';
 
-				case 'femerge':
-					return 'feMerge';
+			case 'femerge':
+				return 'feMerge';
 
-				case 'femergenode':
-					return 'feMergeNode';
+			case 'femergenode':
+				return 'feMergeNode';
 
-				case 'femorphology':
-					return 'feMorphology';
+			case 'femorphology':
+				return 'feMorphology';
 
-				case 'feoffset':
-					return 'feOffset';
+			case 'feoffset':
+				return 'feOffset';
 
-				case 'fepointlight':
-					return 'fePointLight';
+			case 'fepointlight':
+				return 'fePointLight';
 
-				case 'fespecularlighting':
-					return 'feSpecularLighting';
+			case 'fespecularlighting':
+				return 'feSpecularLighting';
 
-				case 'fespotlight':
-					return 'feSpotLight';
+			case 'fespotlight':
+				return 'feSpotLight';
 
-				case 'fetile':
-					return 'feTile';
+			case 'fetile':
+				return 'feTile';
 
-				case 'feturbulence':
-					return 'feTurbulence';
+			case 'feturbulence':
+				return 'feTurbulence';
 
-				case 'foreignobject':
-					return 'foreignObject';
+			case 'foreignobject':
+				return 'foreignObject';
 
-				case 'glyphref':
-					return 'glyphRef';
+			case 'glyphref':
+				return 'glyphRef';
 
-				case 'lineargradient':
-					return 'linearGradient';
+			case 'lineargradient':
+				return 'linearGradient';
 
-				case 'radialgradient':
-					return 'radialGradient';
+			case 'radialgradient':
+				return 'radialGradient';
 
-				case 'textpath':
-					return 'textPath';
+			case 'solidcolor':
+				return 'solidColor';
 
-				default:
-					return $lower_tag_name;
-			}
+			case 'textarea':
+				return 'textArea';
+
+			case 'textpath':
+				return 'textPath';
 		}
 
-		// This unnecessary return prevents tools from inaccurately reporting type errors.
-		return $tag_name;
+		return $lower_tag_name;
 	}
 
 	/**
-	 * Returns the adjusted attribute name for a given attribute, taking into
-	 * account the current parsing context, whether HTML, SVG, or MathML.
+	 * Returns the normative adjusted attribute name for an element’s attribute
+	 * in the element’s namespace, usually for display or XML output only.
+	 *
+	 * For checking which attributes are present on a given tag, rely on
+	 * {@see static::get_attribute_names_with_prefix()} which takes into account
+	 * HTML case-folding rules and always returns an ASCII lower-case variant of
+	 * the attribute names.
+	 *
+	 *  - Some SVG attribute names are mixed-case, such as `baseFrequency`.
+	 *  - The `definitionURL` in SVG and MathML is mixed-case.
+	 *  - Some HTML attributes which have special meaning in XML are separated
+	 *    into a namespace and local name, such as `xml:lang` turning into `xml lang`.
 	 *
 	 * @since 6.7.0
 	 *
@@ -3074,12 +3123,14 @@ class WP_HTML_Tag_Processor {
 				case 'attributename':
 					return 'attributeName';
 
+				// @todo Is this right?
 				case 'attributetype':
 					return 'attributeType';
 
 				case 'basefrequency':
 					return 'baseFrequency';
 
+				// @todo Is this right?
 				case 'baseprofile':
 					return 'baseProfile';
 
@@ -3191,6 +3242,7 @@ class WP_HTML_Tag_Processor {
 				case 'requiredextensions':
 					return 'requiredExtensions';
 
+				// @todo Is this right?
 				case 'requiredfeatures':
 					return 'requiredFeatures';
 


### PR DESCRIPTION
Trac ticket: Core-61576.

Since this method is meant for printing and display, a more expected return value would be the lower-case variant of a given HTML tag name.

This patch changes the behavior accordingly. No tests are impacted by this change.

Diff best viewed ignoring whitespace changes.

Follow-up to [58867].