### PR TITLE
Update: `is_email()` validation and `sanitize_email()` sanitization.

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3835,11 +3835,15 @@ function sanitize_email( $email ) {
 		}
 	}
 
+	$length_of_new_sub = count ( $new_subs );
+
 	// If there aren't 2 or more valid subs.
-	if ( 2 > count( $new_subs ) ) {
+	if ( 2 > $length_of_new_sub ) {
 		/** This filter is documented in wp-includes/formatting.php */
 		return apply_filters( 'sanitize_email', '', $email, 'domain_no_valid_subs' );
 	}
+
+	$new_subs[ $length_of_new_sub - 1 ] = preg_replace( '/\d*$/', '', $new_subs[ $length_of_new_sub - 1 ] );
 
 	// Join valid subs into the new domain.
 	$domain = implode( '.', $new_subs );

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -3584,17 +3584,17 @@ function is_email( $email, $deprecated = false ) {
 	// Check if the domain is an IP address enclosed in brackets.
 	if ( preg_match( '/^\[([0-9a-fA-F:\.]+)\]$/', $domain, $matches ) ) {
 		// If it's an IP address enclosed in brackets, validate it as an IP address.
-		if ( filter_var($matches[1], FILTER_VALIDATE_IP ) ) {
+		if ( filter_var( $matches[1], FILTER_VALIDATE_IP ) ) {
 			return apply_filters( 'is_email', $email, $email, null );
 		} else {
 			return apply_filters( 'is_email', false, $email, 'domain_invalid_ip_address' );
 		}
 	}
 
-	 // Check if the domain is a non-bracketed IP address
-	if ( filter_var($domain, FILTER_VALIDATE_IP ) ) {
-        return apply_filters( 'is_email', false, $email, 'domain_non_bracketed_ip_address' );
-    }
+	// Check if the domain is a non-bracketed IP address
+	if ( filter_var( $domain, FILTER_VALIDATE_IP ) ) {
+		return apply_filters( 'is_email', false, $email, 'domain_non_bracketed_ip_address' );
+	}
 	if ( preg_match( '/\.{2,}/', $domain ) ) {
 		/** This filter is documented in wp-includes/formatting.php */
 		return apply_filters( 'is_email', false, $email, 'domain_period_sequence' );
@@ -3633,8 +3633,8 @@ function is_email( $email, $deprecated = false ) {
 	}
 
 	if ( preg_match( '/\d+$/', $subs[ $length_of_subs - 1 ] ) ) {
-		/** 
-		 * This filter is documented in wp-includes/formatting.php 
+		/**
+		 * This filter is documented in wp-includes/formatting.php
 		 */
 		return apply_filters( 'is_email', false, $email, 'last_sub_ends_with_numbers' );
 	}
@@ -3821,13 +3821,13 @@ function sanitize_email( $email ) {
 	 */
 
 	// Check if domain is a bracketed IP address
-    if ( preg_match( '/^\[([0-9a-fA-F:\.]+)\]$/', $domain, $matches ) ) {
-        // Validate the IP address within brackets
-        if ( filter_var( $matches[1], FILTER_VALIDATE_IP ) ) {
-            // If valid IP, return sanitized email
-            $sanitized_email = $local . '@' . $domain;
-            return apply_filters( 'sanitize_email', $sanitized_email, $email, null );
-        }
+	if ( preg_match( '/^\[([0-9a-fA-F:\.]+)\]$/', $domain, $matches ) ) {
+		// Validate the IP address within brackets
+		if ( filter_var( $matches[1], FILTER_VALIDATE_IP ) ) {
+			// If valid IP, return sanitized email.
+			$sanitized_email = $local . '@' . $domain;
+			return apply_filters( 'sanitize_email', $sanitized_email, $email, null );
+		}
 	}
 	$domain = preg_replace( '/\.{2,}/', '', $domain );
 	if ( '' === $domain ) {
@@ -3865,9 +3865,9 @@ function sanitize_email( $email ) {
 		$sub = preg_replace( '/[^a-z0-9-]+/i', '', $sub );
 
 		// Check if the subdomain contains at least one alphabet character.
-        if (preg_match('/[a-zA-Z]/', $sub)) {
-            $contains_alphabet = true;
-        }
+		if ( preg_match( '/[a-zA-Z]/', $sub ) ) {
+			$contains_alphabet = true;
+		}
 
 		// If there's anything left, add it to the valid subs.
 		if ( '' !== $sub ) {
@@ -3875,7 +3875,7 @@ function sanitize_email( $email ) {
 		}
 	}
 
-	$length_of_new_subs = count ( $new_subs );
+	$length_of_new_subs = count( $new_subs );
 
 	// If there aren't 2 or more valid subs.
 	if ( 2 > $length_of_new_subs ) {

--- a/tests/phpunit/tests/formatting/isEmail.php
+++ b/tests/phpunit/tests/formatting/isEmail.php
@@ -28,7 +28,7 @@ class Tests_Formatting_IsEmail extends WP_UnitTestCase {
 			'com.exampleNOSPAMbob',
 			'bob@your mom',
 			'a@b.c',
-			'ace@204.32.222.14'
+			'ace@204.32.222.14',
 		);
 		foreach ( $data as $datum ) {
 			$this->assertFalse( is_email( $datum ), $datum );

--- a/tests/phpunit/tests/formatting/isEmail.php
+++ b/tests/phpunit/tests/formatting/isEmail.php
@@ -10,7 +10,7 @@ class Tests_Formatting_IsEmail extends WP_UnitTestCase {
 		$data = array(
 			'bob@example.com',
 			'phil@example.info',
-			'ace@204.32.222.14',
+			'ace@[204.32.222.14]',
 			'kevin@many.subdomains.make.a.happy.man.edu',
 			'a@b.co',
 			'bill+ted@example.com',
@@ -28,6 +28,7 @@ class Tests_Formatting_IsEmail extends WP_UnitTestCase {
 			'com.exampleNOSPAMbob',
 			'bob@your mom',
 			'a@b.c',
+			'ace@204.32.222.14'
 		);
 		foreach ( $data as $datum ) {
 			$this->assertFalse( is_email( $datum ), $datum );

--- a/tests/phpunit/tests/pluggable/wpMail.php
+++ b/tests/phpunit/tests/pluggable/wpMail.php
@@ -518,7 +518,7 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 	 */
 	public function test_phpmailer_validator() {
 		$phpmailer = $GLOBALS['phpmailer'];
-		$this->assertTrue( $phpmailer->validateAddress( 'foo@192.168.1.1' ), 'Assert PHPMailer accepts IP address email addresses' );
+		$this->assertTrue( $phpmailer->validateAddress( 'foo@[192.168.1.1]' ), 'Assert PHPMailer accepts IP address email addresses' );
 	}
 
 	/**


### PR DESCRIPTION
Trac Ticket: [Core-62038](https://core.trac.wordpress.org/ticket/62038)

Related Trac Ticket: [Core-47557](https://core.trac.wordpress.org/ticket/47557)

## Problem Statement
- It has been observed that certain email addresses are passing through the validation and sanitization processes with trailing numbers appended to them, such as:

- `example@example.com1234`
- `example@example.com1234567812345678`

- Also, `example@204.32.222.14` is validated as a valid email by `is_email`

- Currently, the `is_email` and `sanitize_email` functions are not handling these cases as expected. Importantly, according to `RFC 5321`, email validation rules dictate that only IP addresses enclosed in square brackets are considered valid domains. This RFC standard is currently not enforced correctly, leading to cases where email addresses like `abc@204.32.222.14` are improperly validated as valid.

## **Fixes Implemented**

- The fixes focus on adhering to standard email validation and sanitization criteria, including:

### `is_email()` Validation Changes:

- Bracketed IP Address Handling:
    - Validates bracketed IP addresses (e.g., user@[192.0.2.1]) as valid email addresses according to RFC 5321.
    - Rejects non-bracketed IP addresses (e.g., user@192.0.2.1) as invalid.
    - Trailing Numbers in Domain:
    - Updated validation logic to reject email addresses if the domain part contains trailing numbers, unless the domain also includes at least one alphabetic character.
    - `sanitize_email()` Sanitization Changes:

- **Bracketed IP Address**:
    - Ensures that emails with bracketed IP addresses are returned unchanged.
    - Trailing Numbers in Domain:
    - If the domain contains trailing numbers and includes alphabetic characters, the function will remove the trailing numbers as part of the sanitization process.
    
## **Detailed Changes**

### `is_email()`

- Added logic to validate IP addresses enclosed in square brackets as valid.
- Introduced a condition to reject email addresses with trailing numbers in the domain if the domain does not contain alphabetic characters.

### `sanitize_email()`

- Implemented logic to accept bracketed IP addresses without modification.
- Modified the sanitization process to remove trailing numbers from the domain if the domain contains alphabetic characters.

## **Example Updates**

### `Validation`

- `user@[192.0.2.1]` is considered a valid email address.
- `user@192.0.2.1` is considered an invalid email address.
- `example@example.com1234` is considered as invalid due to trailing numbers in domain.

### `Sanitization`:

- **Bracketed IP Address**: `user@[192.0.2.1]` remains unchanged.

- **Trailing Numbers**: example@example.com1234 is sanitized to example@example.com if the domain part includes alphabets.

## **Testing**

- `Bracketed IP Addresses`: Verified that bracketed IP addresses are correctly validated and sanitized.

- `Non-Bracketed IP Addresses`: Ensured non-bracketed IP addresses are rejected.

- `Trailing Numbers`: Confirmed that trailing numbers are handled correctly based on the presence of alphabetic characters in the domain.

- `General Email Validity`: Ensured that standard email addresses continue to pass without issues.

## **Considerations**

- `Backward Compatibility`: Ensured that the updated validation and sanitization rules do not negatively impact existing valid email addresses.

- `RFC Compliance`: The changes are aligned with email validation standards set by RFC 5321.
