### PR TITLE
Global Styles: allow read access to users with `edit_posts` capabilities

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -67,7 +67,7 @@ $preload_paths = array(
 	array( '/wp/v2/settings', 'OPTIONS' ),
 	'/wp/v2/global-styles/themes/' . get_stylesheet(),
 	'/wp/v2/themes?context=edit&status=active',
-	'/wp/v2/global-styles/' . WP_Theme_JSON_Resolver::get_user_global_styles_post_id() . '?context=edit',
+	'/wp/v2/global-styles/' . WP_Theme_JSON_Resolver::get_user_global_styles_post_id(),
 );
 
 block_editor_rest_api_preload( $preload_paths, $block_editor_context );

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -67,7 +67,7 @@ $preload_paths = array(
 	array( '/wp/v2/settings', 'OPTIONS' ),
 	'/wp/v2/global-styles/themes/' . get_stylesheet(),
 	'/wp/v2/themes?context=edit&status=active',
-	'/wp/v2/global-styles/' . WP_Theme_JSON_Resolver::get_user_global_styles_post_id(),
+	'/wp/v2/global-styles/' . WP_Theme_JSON_Resolver::get_user_global_styles_post_id() . '?context=edit',
 );
 
 block_editor_rest_api_preload( $preload_paths, $block_editor_context );

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -489,7 +489,7 @@ function create_initial_post_types() {
 			'revisions_rest_controller_class' => 'WP_REST_Global_Styles_Revisions_Controller',
 			'late_route_registration'         => true,
 			'capabilities'                    => array(
-				'read'                   => 'edit_theme_options',
+				'read'                   => 'edit_posts',
 				'create_posts'           => 'edit_theme_options',
 				'edit_posts'             => 'edit_theme_options',
 				'edit_published_posts'   => 'edit_theme_options',

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
@@ -529,6 +529,13 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Posts_Controller {
 			}
 		}
 
+		/*
+		 * Verify if the current user has edit_theme_options capability.
+		 */
+		if ( current_user_can( 'edit_theme_options' ) ) {
+			return true;
+		}
+
 		return new WP_Error(
 			'rest_cannot_read_global_styles',
 			__( 'Sorry, you are not allowed to access the global styles on this site.' ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-controller.php
@@ -509,26 +509,33 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Posts_Controller {
 	 * Checks if a given request has access to read a single theme global styles config.
 	 *
 	 * @since 5.9.0
+	 * @since 6.7.0 Allow users with edit post capabilities to view theme global styles.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
 	 */
 	public function get_theme_item_permissions_check( $request ) {
 		/*
-		 * Verify if the current user has edit_theme_options capability.
-		 * This capability is required to edit/view/delete global styles.
+		 * Verify if the current user has edit_posts capability.
+		 * This capability is required to view global styles.
 		 */
-		if ( ! current_user_can( 'edit_theme_options' ) ) {
-			return new WP_Error(
-				'rest_cannot_manage_global_styles',
-				__( 'Sorry, you are not allowed to access the global styles on this site.' ),
-				array(
-					'status' => rest_authorization_required_code(),
-				)
-			);
+		if ( current_user_can( 'edit_posts' ) ) {
+			return true;
 		}
 
-		return true;
+		foreach ( get_post_types( array( 'show_in_rest' => true ), 'objects' ) as $post_type ) {
+			if ( current_user_can( $post_type->cap->edit_posts ) ) {
+				return true;
+			}
+		}
+
+		return new WP_Error(
+			'rest_cannot_read_global_styles',
+			__( 'Sorry, you are not allowed to access the global styles on this site.' ),
+			array(
+				'status' => rest_authorization_required_code(),
+			)
+		);
 	}
 
 	/**
@@ -589,26 +596,13 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Posts_Controller {
 	 * Checks if a given request has access to read a single theme global styles config.
 	 *
 	 * @since 6.0.0
+	 * @since 6.7.0 Allow users with edit post capabilities to view theme global styles.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
 	 */
 	public function get_theme_items_permissions_check( $request ) {
-		/*
-		 * Verify if the current user has edit_theme_options capability.
-		 * This capability is required to edit/view/delete global styles.
-		 */
-		if ( ! current_user_can( 'edit_theme_options' ) ) {
-			return new WP_Error(
-				'rest_cannot_manage_global_styles',
-				__( 'Sorry, you are not allowed to access the global styles on this site.' ),
-				array(
-					'status' => rest_authorization_required_code(),
-				)
-			);
-		}
-
-		return true;
+		return $this->get_theme_item_permissions_check( $request );
 	}
 
 	/**
@@ -632,7 +626,7 @@ class WP_REST_Global_Styles_Controller extends WP_REST_Posts_Controller {
 			);
 		}
 
-		$response   = array();
+		$response = array();
 
 		// Register theme-defined variations e.g. from block style variation partials under `/styles`.
 		$partials = WP_Theme_JSON_Resolver::get_style_variations( 'block' );

--- a/tests/phpunit/tests/rest-api/rest-global-styles-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-global-styles-controller.php
@@ -289,7 +289,7 @@ class WP_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controller_Test
 	}
 
 	/**
-	 * @covers WP_REST_Global_Styles_Controller_Gutenberg::get_theme_item
+	 * @covers WP_REST_Global_Styles_Controller::get_theme_item
 	 * @ticket 62042
 	 */
 	public function test_get_theme_item_editor_permission_check() {
@@ -633,7 +633,7 @@ class WP_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controller_Test
 	 * within a theme style variation and wouldn't be registered at the time
 	 * of saving via the API.
 	 *
-	 * @covers WP_REST_Global_Styles_Controller_Gutenberg::update_item
+	 * @covers WP_REST_Global_Styles_Controller::update_item
 	 * @ticket 61312
 	 * @ticket 61451
 	 */

--- a/tests/phpunit/tests/rest-api/rest-global-styles-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-global-styles-controller.php
@@ -15,14 +15,21 @@ class WP_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controller_Test
 	 * @var int
 	 */
 	protected static $admin_id;
+
 	/**
 	 * @var int
 	 */
 	protected static $editor_id;
+
 	/**
 	 * @var int
 	 */
 	protected static $subscriber_id;
+
+	/**
+	 * @var int
+	 */
+	protected static $theme_manager_id;
 
 	/**
 	 * @var int
@@ -69,6 +76,18 @@ class WP_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controller_Test
 			)
 		);
 
+		self::$theme_manager_id = $factory->user->create(
+			array(
+				'role' => 'subscriber',
+			)
+		);
+
+		// Add the 'edit_theme_options' capability to the theme manager (subscriber).
+		$theme_manager_id = get_user_by( 'id', self::$theme_manager_id );
+		if ( $theme_manager_id instanceof WP_User ) {
+			$theme_manager_id->add_cap( 'edit_theme_options' );
+		}
+
 		// This creates the global styles for the current theme.
 		self::$global_styles_id = $factory->post->create(
 			array(
@@ -87,11 +106,13 @@ class WP_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controller_Test
 	}
 
 	/**
-	 *
+	 * Clean up after our tests run.
 	 */
 	public static function wpTearDownAfterClass() {
 		self::delete_user( self::$admin_id );
+		self::delete_user( self::$editor_id );
 		self::delete_user( self::$subscriber_id );
+		self::delete_user( self::$theme_manager_id );
 	}
 
 	/*
@@ -295,6 +316,23 @@ class WP_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controller_Test
 	public function test_get_theme_item_editor_permission_check() {
 		wp_set_current_user( self::$editor_id );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/themes/tt1-blocks' );
+		$response = rest_get_server()->dispatch( $request );
+		// Checks that the response has the expected keys.
+		$data  = $response->get_data();
+		$links = $response->get_links();
+		$this->assertArrayHasKey( 'settings', $data, 'Data does not have "settings" key' );
+		$this->assertArrayHasKey( 'styles', $data, 'Data does not have "styles" key' );
+		$this->assertArrayHasKey( 'self', $links, 'Links do not have a "self" key' );
+	}
+
+	/**
+	 * @covers WP_REST_Global_Styles_Controller_Gutenberg::get_theme_item
+	 * @ticket 62042
+	 */
+	public function test_get_theme_item_theme_options_manager_permission_check() {
+		wp_set_current_user( self::$theme_manager_id );
+		switch_theme( 'emptytheme' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/themes/emptytheme' );
 		$response = rest_get_server()->dispatch( $request );
 		// Checks that the response has the expected keys.
 		$data  = $response->get_data();


### PR DESCRIPTION
This PR syncs https://github.com/WordPress/gutenberg/pull/65071

## What

The patch allows any role that can

1. edit a post, including custom post types
2. edit theme options

to read global styles from the API and in the editor.


## Why

Block style variations and other global styles are not available to non-admin editors. See https://github.com/WordPress/gutenberg/issues/64755 and also read-only style book ideas in https://github.com/WordPress/gutenberg/issues/41119

Furthermore, having global styles available in the post editor will, one day, allow block controls to reflect any values inherited from the theme/global styles. See: https://github.com/WordPress/gutenberg/issues/64670

## Testing

Manual testing in the editor is limited without package changes, however you can login using different roles (e.g., admin/editor) and try to fetch global styles in the console.

```
// Admin only
await wp.data.resolveSelect( 'core' ).getEntityRecord( 'root', 'globalStyles', await wp.data.resolveSelect( 'core' ).__experimentalGetCurrentGlobalStylesId(), { context: 'edit' } )
```

```
// Edit post/theme options
await wp.data.resolveSelect( 'core' ).getEntityRecord( 'root', 'globalStyles', await wp.data.resolveSelect( 'core' ).__experimentalGetCurrentGlobalStylesId(), { context: 'view' } )
```

Trac ticket: https://core.trac.wordpress.org/ticket/62042

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
