### PR TITLE
HTML API: Implement spawn_fragment_parser method

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -423,6 +423,55 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	}
 
 	/**
+	 * Creates a fragment processor with the current node as its context element.
+	 *
+	 * @see https://html.spec.whatwg.org/multipage/parsing.html#html-fragment-parsing-algorithm
+	 *
+	 * @param string $html     Input HTML fragment to process.
+	 * @return static|null     The created processor if successful, otherwise null.
+	 */
+	private function spawn_fragment_parser( string $html ): ?self {
+		if ( $this->get_token_type() !== '#tag' ) {
+			return null;
+		}
+
+		/*
+		 * Prevent creating fragments at "self-contained" nodes.
+		 *
+		 * @see https://github.com/WordPress/wordpress-develop/pull/7141
+		 * @see https://github.com/WordPress/wordpress-develop/pull/7198
+		 */
+		if (
+			'html' === $this->get_namespace() &&
+			in_array( $this->get_tag(), array( 'IFRAME', 'NOEMBED', 'NOFRAMES', 'SCRIPT', 'STYLE', 'TEXTAREA', 'TITLE', 'XMP' ), true )
+		) {
+			return null;
+		}
+
+		$fragment_processor              = self::create_fragment( $html );
+		$fragment_processor->compat_mode = $this->compat_mode;
+
+		// @todo The context element probably needs a namespace{
+		$context_element = array( $this->get_tag(), array() );
+		foreach ( $this->get_attribute_names_with_prefix( '' ) as $name => $value ) {
+			$context_element[1][ $name ] = $value;
+		}
+		$fragment_processor->state->context_node = $context_element;
+
+		if ( 'TEMPLATE' === $context_element[0] ) {
+			$fragment_processor->state->stack_of_template_insertion_modes[] = WP_HTML_Processor_State::INSERTION_MODE_IN_TEMPLATE;
+		}
+
+		$fragment_processor->reset_insertion_mode_appropriately();
+
+		// @todo Set the parser's form element pointer.
+
+		$fragment_processor->state->encoding_confidence = 'irrelevant';
+
+		return $fragment_processor;
+	}
+
+	/**
 	 * Stops the parser and terminates its execution when encountering unsupported markup.
 	 *
 	 * @throws WP_HTML_Unsupported_Exception Halts execution of the parser.

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -4727,17 +4727,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 
 		$tag_name = parent::get_tag();
 
-		switch ( $tag_name ) {
-			case 'IMAGE':
-				/*
-				 * > A start tag whose tag name is "image"
-				 * > Change the token's tag name to "img" and reprocess it. (Don't ask.)
-				 */
-				return 'IMG';
-
-			default:
-				return $tag_name;
-		}
+		/*
+		 * > A start tag whose tag name is "image"
+		 * > Change the token's tag name to "img" and reprocess it. (Don't ask.)
+		 */
+		return ( 'IMAGE' === $tag_name && 'html' === $this->get_namespace() )
+			? 'IMG'
+			: $tag_name;
 	}
 
 	/**
@@ -5101,6 +5097,11 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					$html .= '="' . htmlspecialchars( $value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5 ) . '"';
 				}
 			}
+
+			if ( 'html' !== $this->get_namespace() && $this->has_self_closing_flag() ) {
+				$html .= '/';
+			}
+
 			$html .= '>';
 		}
 

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -5027,9 +5027,12 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Normalize an HTML string by serializing it.
 	 *
+	 * This removes any partial syntax at the end of the string.
+	 *
 	 * @since 6.7.0
 	 *
 	 * @param string $html Input HTML to normalize.
+	 *
 	 * @return string|null Normalized output, or `null` if unable to normalize.
 	 */
 	public static function normalize( string $html ): ?string {
@@ -5038,6 +5041,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 
 	/**
 	 * Generate normalized markup for the HTML in the provided processor.
+	 *
+	 * This removes any partial syntax at the end of the string.
 	 *
 	 * @since 6.7.0
 	 *
@@ -5093,13 +5098,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				$value = $this->get_attribute( $attribute_name );
 
 				if ( is_string( $value ) ) {
-					$html .= '"' . htmlspecialchars( $value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5 ) . '"';
+					$html .= '="' . htmlspecialchars( $value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5 ) . '"';
 				}
 			}
 			$html .= '>';
 		}
 
-		if ( $this->paused_at_incomplete_token() || null !== $this->get_last_error() ) {
+		if ( null !== $this->get_last_error() ) {
 			return null;
 		}
 

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2840,7 +2840,7 @@ class WP_HTML_Tag_Processor {
 		}
 
 		if ( 'html' === $this->get_namespace() ) {
-			return $tag_name;
+			return strtolower( $tag_name );
 		}
 
 		$lower_tag_name = strtolower( $tag_name );


### PR DESCRIPTION
## WORK IN PROGRESS

Implement a method to create a fragment parser from a tag in an HTML API processor.

Intended for use in #7326 

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
