### PR TITLE
Set `WP_Network` properties via setters upon creation

### DIFF
--- a/src/wp-includes/class-wp-network.php
+++ b/src/wp-includes/class-wp-network.php
@@ -131,7 +131,7 @@ class WP_Network {
 	 */
 	public function __construct( $network ) {
 		foreach ( get_object_vars( $network ) as $key => $value ) {
-			$this->$key = $value;
+			$this->__set( $key, $value );
 		}
 
 		$this->_set_site_name();

--- a/tests/phpunit/tests/multisite/network.php
+++ b/tests/phpunit/tests/multisite/network.php
@@ -137,6 +137,27 @@ if ( is_multisite() ) :
 		}
 
 		/**
+		 * Test that the network id property is stored as int.
+		 * Use reflection to access the private property.
+		 * Differs from using the public getter method, which casts to int.
+		 *
+		 * @ticket 62035
+		 *
+		 * @covers WP_Network::__construct
+		 */
+		public function test_wp_network_object_id_property_stored_as_int() {
+			$id = self::factory()->network->create();
+
+			$network = WP_Network::get_instance( $id );
+
+			$reflection = new ReflectionObject( $network );
+			$property   = $reflection->getProperty( 'id' );
+			$property->setAccessible( true );
+
+			$this->assertSame( (int) $id, $property->getValue( $network ) );
+		}
+
+		/**
 		 * @ticket 22917
 		 */
 		public function test_get_blog_count_no_filter_applied() {


### PR DESCRIPTION
Uses setters when constructing a `WP_Network` object. Ensures that `WP_Network::id` is stored internally as `int`, as follow-up to [changeset 37870](https://core.trac.wordpress.org/changeset/37870).

Trac ticket: https://core.trac.wordpress.org/ticket/62035

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
