### PR TITLE
HTML API: Improve html5lib tests

### DIFF
--- a/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
@@ -51,9 +51,9 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_external_html5lib_tests
 	 *
-	 * @param string $fragment_context Context element in which to parse HTML, such as BODY or SVG.
-	 * @param string $html             Given test HTML.
-	 * @param string $expected_tree    Tree structure of parsed HTML.
+	 * @param string|null $fragment_context Context element in which to parse HTML, such as BODY or SVG.
+	 * @param string      $html             Given test HTML.
+	 * @param string      $expected_tree    Tree structure of parsed HTML.
 	 */
 	public function test_parse( ?string $fragment_context, string $html, string $expected_tree ) {
 		try {

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
@@ -449,7 +449,7 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 				 * context element as context.
 				 */
 				case 'document-fragment':
-					$test_context_element = explode( ' ', $line )[0];
+					$test_context_element = trim( $line );
 					break;
 
 				/*

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
@@ -170,8 +170,8 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 		 * and requires adjustment to initial parameters.
 		 * The full parser will not.
 		 */
-		$output       = $fragment_context ? "<html>\n  <head>\n  <body>\n" : '';
-		$indent_level = $fragment_context ? 2 : 0;
+		$output       = '';
+		$indent_level = 0;
 		$indent       = '  ';
 		$was_text     = null;
 		$text_node    = '';

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
@@ -21,6 +21,8 @@
  * @group html-api-html5lib-tests
  */
 class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
+	const TREE_INDENT = '  ';
+
 	/**
 	 * Skip specific tests that may not be supported or have known issues.
 	 */
@@ -172,7 +174,6 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 		 */
 		$output       = '';
 		$indent_level = 0;
-		$indent       = '  ';
 		$was_text     = null;
 		$text_node    = '';
 
@@ -225,7 +226,7 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 						++$indent_level;
 					}
 
-					$output .= str_repeat( $indent, $tag_indent ) . "<{$tag_name}>\n";
+					$output .= str_repeat( self::TREE_INDENT, $tag_indent ) . "<{$tag_name}>\n";
 
 					$attribute_names = $processor->get_attribute_names_with_prefix( '' );
 					if ( $attribute_names ) {
@@ -278,18 +279,18 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 							if ( true === $val ) {
 								$val = '';
 							}
-							$output .= str_repeat( $indent, $tag_indent + 1 ) . "{$display_name}=\"{$val}\"\n";
+							$output .= str_repeat( self::TREE_INDENT, $tag_indent + 1 ) . "{$display_name}=\"{$val}\"\n";
 						}
 					}
 
 					// Self-contained tags contain their inner contents as modifiable text.
 					$modifiable_text = $processor->get_modifiable_text();
 					if ( '' !== $modifiable_text ) {
-						$output .= str_repeat( $indent, $tag_indent + 1 ) . "\"{$modifiable_text}\"\n";
+						$output .= str_repeat( self::TREE_INDENT, $tag_indent + 1 ) . "\"{$modifiable_text}\"\n";
 					}
 
 					if ( 'html' === $namespace && 'TEMPLATE' === $token_name ) {
-						$output .= str_repeat( $indent, $indent_level ) . "content\n";
+						$output .= str_repeat( self::TREE_INDENT, $indent_level ) . "content\n";
 						++$indent_level;
 					}
 
@@ -303,14 +304,14 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 					}
 					$was_text = true;
 					if ( '' === $text_node ) {
-						$text_node .= str_repeat( $indent, $indent_level ) . '"';
+						$text_node .= str_repeat( self::TREE_INDENT, $indent_level ) . '"';
 					}
 					$text_node .= $text_content;
 					break;
 
 				case '#funky-comment':
 					// Comments must be "<" then "!-- " then the data then " -->".
-					$output .= str_repeat( $indent, $indent_level ) . "<!-- {$processor->get_modifiable_text()} -->\n";
+					$output .= str_repeat( self::TREE_INDENT, $indent_level ) . "<!-- {$processor->get_modifiable_text()} -->\n";
 					break;
 
 				case '#comment':
@@ -333,7 +334,7 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 							throw new Error( "Unhandled comment type for tree construction: {$processor->get_comment_type()}" );
 					}
 					// Comments must be "<" then "!-- " then the data then " -->".
-					$output .= str_repeat( $indent, $indent_level ) . "<!-- {$comment_text_content} -->\n";
+					$output .= str_repeat( self::TREE_INDENT, $indent_level ) . "<!-- {$comment_text_content} -->\n";
 					break;
 
 				default:


### PR DESCRIPTION
Applies some improvements extracted from https://github.com/dmsnell/wordpress-develop/pull/22 to HTML API Html5lib-tests for tests with fragments.

- The document fragment should be trimmed, not split. This maintains (currently unsupported) contexts like `svg rect` but fixes previously broken contexts that should be supported like `body` (was `body\n`).
- Previously, fragments were used instead of full processors. In these cases, parts of the tree before `body` were always missing and the part of the tree before body was artificially constructed. This is no longer necessary and is wrong in fragments and is removed.
- Move a static indent text for tree construction `"  "` from a local variable to a class constant.

Test improvements from trunk:

```diff
 OK, but incomplete, skipped, or risky tests!
-Tests: 1500, Assertions: 1079, Skipped: 421.
+Tests: 1505, Assertions: 1084, Skipped: 421.
```

There are likely 5 tests with a `body` document context that were hidden because its context was reported as `body\n`.

Trac ticket: https://core.trac.wordpress.org/ticket/61646

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
