### PR TITLE
HTML API: Ensure that HTML nodes in foreign content are handled

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -4501,7 +4501,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 
 					$this->state->stack_of_open_elements->pop();
 				}
-				return $this->step( self::REPROCESS_CURRENT_NODE );
+				goto in_foreign_content_process_in_current_insertion_mode;
 		}
 
 		/*
@@ -4577,6 +4577,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				goto in_foreign_content_end_tag_loop;
 			}
 
+			in_foreign_content_process_in_current_insertion_mode:
 			switch ( $this->state->insertion_mode ) {
 				case WP_HTML_Processor_State::INSERTION_MODE_INITIAL:
 					return $this->step_initial();


### PR DESCRIPTION
[In the rules for parsing tokens in foreign content](https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inforeign) there are 2 places that indicated tokens should be processed "according to the rules given in the section corresponding to the current [insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#insertion-mode) in HTML content."

First (bold mine):

> A start tag whose tag name is one of: "b", "big", "blockquote", "body", "br", "center", "code", "dd", "div", "dl", "dt", "em", "embed", "h1", "h2", "h3", "h4", "h5", "h6", "head", "hr", "i", "img", "li", "listing", "menu", "meta", "nobr", "ol", "p", "pre", "ruby", "s", "small", "span", "strong", "strike", "sub", "sup", "table", "tt", "u", "ul", "var"
> A start tag whose tag name is "font", if the token has any attributes named "color", "face", or "size"
> An end tag whose tag name is "br", "p"
> [Parse error](https://html.spec.whatwg.org/multipage/parsing.html#parse-errors).
> 
> While the [current node](https://html.spec.whatwg.org/multipage/parsing.html#current-node) is not a [MathML text integration point](https://html.spec.whatwg.org/multipage/parsing.html#mathml-text-integration-point), an [HTML integration point](https://html.spec.whatwg.org/multipage/parsing.html#html-integration-point), or an element in the [HTML namespace](https://infra.spec.whatwg.org/#html-namespace), pop elements from the [stack of open elements](https://html.spec.whatwg.org/multipage/parsing.html#stack-of-open-elements).
> 
> **Reprocess the token according to the rules given in the section corresponding to the current [insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#insertion-mode) in HTML content.**

And later (bold mine):

> Any other end tag
> Run these steps:
> 1. Initialize node to be the [current node](https://html.spec.whatwg.org/multipage/parsing.html#current-node) (the bottommost node of the stack).
> 1. If node's tag name, [converted to ASCII lowercase](https://infra.spec.whatwg.org/#ascii-lowercase), is not the same as the tag name of the token, then this is a [parse error](https://html.spec.whatwg.org/multipage/parsing.html#parse-errors).
> 1. Loop: If node is the topmost element in the [stack of open elements](https://html.spec.whatwg.org/multipage/parsing.html#stack-of-open-elements), then return. ([fragment case](https://html.spec.whatwg.org/multipage/parsing.html#fragment-case))
> 1. If node's tag name, [converted to ASCII lowercase](https://infra.spec.whatwg.org/#ascii-lowercase), is the same as the tag name of the token, pop elements from the [stack of open elements](https://html.spec.whatwg.org/multipage/parsing.html#stack-of-open-elements) until node has been popped from the stack, and then return.
> 1. Set node to the previous entry in the [stack of open elements](https://html.spec.whatwg.org/multipage/parsing.html#stack-of-open-elements).
> 1. If node is not an element in the [HTML namespace](https://infra.spec.whatwg.org/#html-namespace), return to the step labeled loop.
> 1. Otherwise, **process the token according to the rules given in the section corresponding to the current [insertion mode](https://html.spec.whatwg.org/multipage/parsing.html#insertion-mode) in HTML content.**

While working on fragment parsing and html5lib-tests in https://github.com/dmsnell/wordpress-develop/pull/22, I discovered an infinite loop that seems to occur in the following situation. At an `svg:svg` context node, create a fragment parser for with HTML `</p>`. This is the first condition mentioned.

In a full parser, the instruction "While the current node is not a MathML text integration point, an HTML integration point, or an element in the HTML namespace, pop elements from the stack of open elements." would ensure that when reprocessing the token it does not re-enter the foreign content rules because by popping elements the token would no longer be foreign content. However, in a fragment parser there may not be any nodes to pop and the context element may continue to cause foreign content handling to be applied, triggering an infinite loop. The instruction in the specification seems to indicate that the token should be handled in the current HTML insertion mode. This is fixed by moving to the same place in both cases which is a reproduction of the HTML handling switch on the current insertion mode.

This fixes the infinite loop that that appeared in https://github.com/dmsnell/wordpress-develop/pull/22.

Observed in https://github.com/dmsnell/wordpress-develop/pull/22.

Follow-up to [[58868](https://core.trac.wordpress.org/changeset/58868)]
See: [#61576](https://core.trac.wordpress.org/ticket/61576)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
