### PR TITLE
Replace more toolbar height values with CSS custom property

### DIFF
--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -852,6 +852,6 @@ li#wp-admin-bar-menu-toggle {
 	}
 
 	.auto-fold #adminmenu {
-		top: var(--wp-admin--admin-bar--height);
+		top: var(--wp-admin--admin-bar--height, 32px);
 	}
 }

--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -852,6 +852,6 @@ li#wp-admin-bar-menu-toggle {
 	}
 
 	.auto-fold #adminmenu {
-		top: 46px;
+		top: var(--wp-admin--admin-bar--height);
 	}
 }

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -160,7 +160,7 @@
 }
 
 .screen-reader-shortcut:focus {
-	top: -25px;
+	top: calc(7px - var(--wp-admin--admin-bar--height));
 	/* Overrides a:focus in the admin. See ticket #56789. */
 	color: #2271b1;
 	box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
@@ -2033,7 +2033,6 @@ p.auto-update-status {
 html.wp-toolbar {
 	padding-top: var(--wp-admin--admin-bar--height);
 	box-sizing: border-box;
-	-ms-overflow-style: scrollbar; /* See ticket #48545 */
 }
 
 .widefat th,
@@ -3839,12 +3838,8 @@ img {
 }
 
 @media screen and (max-width: 782px) {
-	html.wp-toolbar {
-		padding-top: var(--wp-admin--admin-bar--height);
-	}
-
-	.screen-reader-shortcut:focus {
-		top: -39px;
+	.block-editor-page .screen-reader-shortcut:focus {
+		top: 7px;
 	}
 
 	body {
@@ -4163,7 +4158,7 @@ img {
 	}
 
 	#wpbody {
-		padding-top: 46px;
+		padding-top: var(--wp-admin--admin-bar--height);
 	}
 
 	/* Keep full-width boxes on Edit Post page from causing horizontal scroll */

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -160,7 +160,7 @@
 }
 
 .screen-reader-shortcut:focus {
-	top: calc(7px - var(--wp-admin--admin-bar--height));
+	top: calc(7px - var(--wp-admin--admin-bar--height, 32px));
 	/* Overrides a:focus in the admin. See ticket #56789. */
 	color: #2271b1;
 	box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
@@ -2031,7 +2031,7 @@ p.auto-update-status {
 ------------------------------------------------------------------------------*/
 
 html.wp-toolbar {
-	padding-top: var(--wp-admin--admin-bar--height);
+	padding-top: var(--wp-admin--admin-bar--height, 32px);
 	box-sizing: border-box;
 }
 
@@ -4158,7 +4158,7 @@ img {
 	}
 
 	#wpbody {
-		padding-top: var(--wp-admin--admin-bar--height);
+		padding-top: var(--wp-admin--admin-bar--height, 32px);
 	}
 
 	/* Keep full-width boxes on Edit Post page from causing horizontal scroll */

--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -583,7 +583,7 @@ border color while dragging a file over the uploader drop area */
 
 .media-frame.mode-select .attachments-browser.fixed .media-toolbar {
 	position: fixed;
-	top: 32px;
+	top: var(--wp-admin--admin-bar--height);
 	left: auto;
 	right: 20px;
 	margin-top: 0;
@@ -1368,7 +1368,6 @@ audio, video {
 
 @media only screen and (max-width: 782px) {
 	.media-frame.mode-select .attachments-browser.fixed .media-toolbar {
-		top: 46px;
 		right: 10px;
 	}
 }

--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -583,7 +583,7 @@ border color while dragging a file over the uploader drop area */
 
 .media-frame.mode-select .attachments-browser.fixed .media-toolbar {
 	position: fixed;
-	top: var(--wp-admin--admin-bar--height);
+	top: var(--wp-admin--admin-bar--height, 32px);
 	left: auto;
 	right: 20px;
 	margin-top: 0;


### PR DESCRIPTION
- Replaces hardcoded values with `--wp-admin--admin-bar--height`, including the media toolbar and admin skip links.
- Adds a consistent fallback for the variable in case it is undefined (if the core stylesheet is replaced).
- Removes the `-ms-overflow-style` rule because these changes would break the toolbar in Internet Explorer anyway.
- Adjusts the skip link position in the block editor at the 782px breakpoint so it is not hidden by `overflow-y: auto` at viewport widths between 600 and 782 pixels ([GB28959](https://github.com/WordPress/gutenberg/pull/28959)).

![skip link mostly hidden at 640 pixels wide](https://github.com/user-attachments/assets/2d8fd6ef-b3db-48d6-b9bc-ca2fc74211a8)

[Trac 61898](https://core.trac.wordpress.org/ticket/61898)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
