### PR TITLE
#62029 Avoid outputting entire body content

### DIFF
--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -1787,6 +1787,8 @@ Thanks! -- The WordPress Team"
 		if ( $is_debug ) {
 			if ( str_contains( $response['body'], '###### wp_scraping_result_start:' ) ) {
 				error_log( 'true' );
+			} else {
+				error_log( 'fatal error detected' );
 			}
 		}
 

--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -1785,7 +1785,9 @@ Thanks! -- The WordPress Team"
 
 		// If this outputs `true` in the log, it means there were no fatal errors detected.
 		if ( $is_debug ) {
-			error_log( var_export( substr( $response['body'], strpos( $response['body'], '###### wp_scraping_result_start:' ) ), true ) );
+			if ( str_contains( $response['body'], '###### wp_scraping_result_start:' ) ) {
+				error_log( 'true' );
+			}
 		}
 
 		$body                   = wp_remote_retrieve_body( $response );


### PR DESCRIPTION
Simplifies debug code to output "true" and not the entire body html on failure.

Trac ticket: https://core.trac.wordpress.org/ticket/62029
