### PR TITLE
PasswordHash: sync with upstream

### DIFF
--- a/src/wp-includes/class-phpass.php
+++ b/src/wp-includes/class-phpass.php
@@ -10,7 +10,7 @@
 #
 # Portable PHP password hashing framework.
 #
-# Version 0.5 / WordPress.
+# Version 0.5.4 / WordPress.
 #
 # Written by Solar Designer <solar at openwall.com> in 2004-2006 and placed in
 # the public domain.  Revised in subsequent years, still public domain.
@@ -51,15 +51,17 @@ class PasswordHash {
 	{
 		$this->itoa64 = './0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 
-		if ($iteration_count_log2 < 4 || $iteration_count_log2 > 31)
+		if ($iteration_count_log2 < 4 || $iteration_count_log2 > 31) {
 			$iteration_count_log2 = 8;
+		}
 		$this->iteration_count_log2 = $iteration_count_log2;
 
 		$this->portable_hashes = $portable_hashes;
 
 		$this->random_state = microtime();
-		if (function_exists('getmypid'))
+		if (function_exists('getmypid')) {
 			$this->random_state .= getmypid();
+		}
 	}
 
 	function PasswordHash($iteration_count_log2, $portable_hashes)
@@ -96,16 +98,20 @@ class PasswordHash {
 		do {
 			$value = ord($input[$i++]);
 			$output .= $this->itoa64[$value & 0x3f];
-			if ($i < $count)
+			if ($i < $count) {
 				$value |= ord($input[$i]) << 8;
+			}
 			$output .= $this->itoa64[($value >> 6) & 0x3f];
-			if ($i++ >= $count)
+			if ($i++ >= $count) {
 				break;
-			if ($i < $count)
+			}
+			if ($i < $count) {
 				$value |= ord($input[$i]) << 16;
+			}
 			$output .= $this->itoa64[($value >> 12) & 0x3f];
-			if ($i++ >= $count)
+			if ($i++ >= $count) {
 				break;
+			}
 			$output .= $this->itoa64[($value >> 18) & 0x3f];
 		} while ($i < $count);
 
@@ -115,8 +121,8 @@ class PasswordHash {
 	function gensalt_private($input)
 	{
 		$output = '$P$';
-		$output .= $this->itoa64[min($this->iteration_count_log2 +
-			((PHP_VERSION >= '5') ? 5 : 3), 30)];
+		$output .= $this->itoa64[min($this->iteration_count_log2 + 5,
+		    30)];
 		$output .= $this->encode64($input, 6);
 
 		return $output;
@@ -125,23 +131,27 @@ class PasswordHash {
 	function crypt_private($password, $setting)
 	{
 		$output = '*0';
-		if (substr($setting, 0, 2) === $output)
+		if (substr($setting, 0, 2) === $output) {
 			$output = '*1';
+		}
 
 		$id = substr($setting, 0, 3);
 		# We use "$P$", phpBB3 uses "$H$" for the same thing
-		if ($id !== '$P$' && $id !== '$H$')
+		if ($id !== '$P$' && $id !== '$H$') {
 			return $output;
+		}
 
 		$count_log2 = strpos($this->itoa64, $setting[3]);
-		if ($count_log2 < 7 || $count_log2 > 30)
+		if ($count_log2 < 7 || $count_log2 > 30) {
 			return $output;
+		}
 
 		$count = 1 << $count_log2;
 
 		$salt = substr($setting, 4, 8);
-		if (strlen($salt) !== 8)
+		if (strlen($salt) !== 8) {
 			return $output;
+		}
 
 		# We were kind of forced to use MD5 here since it's the only
 		# cryptographic primitive that was available in all versions
@@ -174,7 +184,7 @@ class PasswordHash {
 
 		$output = '$2a$';
 		$output .= chr((int)(ord('0') + $this->iteration_count_log2 / 10));
-		$output .= chr((ord('0') + $this->iteration_count_log2 % 10));
+		$output .= chr(ord('0') + $this->iteration_count_log2 % 10);
 		$output .= '$';
 
 		$i = 0;
@@ -213,17 +223,20 @@ class PasswordHash {
 			$random = $this->get_random_bytes(16);
 			$hash =
 			    crypt($password, $this->gensalt_blowfish($random));
-			if (strlen($hash) === 60)
+			if (strlen($hash) === 60) {
 				return $hash;
+			}
 		}
 
-		if (strlen($random) < 6)
+		if (strlen($random) < 6) {
 			$random = $this->get_random_bytes(6);
+		}
 		$hash =
 		    $this->crypt_private($password,
 		    $this->gensalt_private($random));
-		if (strlen($hash) === 34)
+		if (strlen($hash) === 34) {
 			return $hash;
+		}
 
 		# Returning '*' on error is safe here, but would _not_ be safe
 		# in a crypt(3)-like function used _both_ for generating new
@@ -238,8 +251,9 @@ class PasswordHash {
 		}
 
 		$hash = $this->crypt_private($password, $stored_hash);
-		if ($hash[0] === '*')
+		if ($hash[0] === '*') {
 			$hash = crypt($password, $stored_hash);
+		}
 
 		# This is not constant-time.  In order to keep the code simple,
 		# for timing safety we currently rely on the salts being


### PR DESCRIPTION
There have been some small changes made in the upstream script. Nothing very significant, but still worth porting over to make future comparisons easier.

In particular:
* Use of curly braces for control structures.
* Removal of a ternary related to PHP 4.
* Removal of some unnecessary parentheses.

Ref: https://github.com/openwall/phpass

Trac ticket: https://core.trac.wordpress.org/ticket/62058

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
