### PR TITLE
Composer: prevent a lock file from being created

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
 	"config": {
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
-		}
+		},
+		"lock": false
 	},
 	"scripts": {
 		"compat": "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --standard=phpcompat.xml.dist --report=summary,source",


### PR DESCRIPTION
Composer 1.10.0 introduced a `lock` config option, which, when set to `false` will prevent a `composer.lock` file from being created and will ignore it when one exists.

This is a useful option for packages like WordPress where the `lock` file has no meaning.

It also makes life more straight-forward for contributors as they don't have to remember that for this repo they should use `composer update` instead of `composer install`. Both will now work the same.

Refs:
https://getcomposer.org/doc/06-config.md#lock


Trac ticket: https://core.trac.wordpress.org/ticket/61530

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
