### PR TITLE
Tests/Importer: don't fail tests which should be skipped

### DIFF
--- a/tests/phpunit/includes/bootstrap.php
+++ b/tests/phpunit/includes/bootstrap.php
@@ -214,6 +214,12 @@ tests_reset__SERVER();
 define( 'WP_TESTS_TABLE_PREFIX', $table_prefix );
 define( 'DIR_TESTDATA', __DIR__ . '/../data' );
 define( 'DIR_TESTROOT', realpath( dirname( __DIR__ ) ) );
+define( 'IMPORTER_PLUGIN_FOR_TESTS', DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php' );
+
+if ( ! file_exists( IMPORTER_PLUGIN_FOR_TESTS ) ) {
+	echo 'The test suite requires the WordPress Importer plugin to be available in the `/data/plugins/` directory. See: https://make.wordpress.org/core/handbook/contribute/git/#unit-tests' . PHP_EOL,
+	exit( 1 );
+}
 
 define( 'WP_LANG_DIR', realpath( DIR_TESTDATA . '/languages' ) );
 

--- a/tests/phpunit/tests/import/import.php
+++ b/tests/phpunit/tests/import/import.php
@@ -7,11 +7,6 @@ require_once __DIR__ . '/base.php';
  */
 class Tests_Import_Import extends WP_Import_UnitTestCase {
 	public function set_up() {
-		$importer = DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php';
-		if ( ! file_exists( $importer ) ) {
-			$this->markTestSkipped( 'This test requires the WordPress Importer plugin to be installed in the test suite. See: https://make.wordpress.org/core/handbook/contribute/git/#unit-tests' );
-		}
-
 		parent::set_up();
 
 		if ( ! defined( 'WP_IMPORTING' ) ) {
@@ -24,7 +19,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 
 		add_filter( 'import_allow_create_users', '__return_true' );
 
-		require_once $importer;
+		require_once IMPORTER_PLUGIN_FOR_TESTS;
 
 		global $wpdb;
 		// Crude but effective: make sure there's no residual data in the main tables.

--- a/tests/phpunit/tests/import/import.php
+++ b/tests/phpunit/tests/import/import.php
@@ -7,6 +7,11 @@ require_once __DIR__ . '/base.php';
  */
 class Tests_Import_Import extends WP_Import_UnitTestCase {
 	public function set_up() {
+		$importer = DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php';
+		if ( ! file_exists( $importer ) ) {
+			$this->markTestSkipped( 'This test requires the WordPress Importer plugin to be installed in the test suite. See: https://make.wordpress.org/core/handbook/contribute/git/#unit-tests' );
+		}
+
 		parent::set_up();
 
 		if ( ! defined( 'WP_IMPORTING' ) ) {
@@ -19,11 +24,7 @@ class Tests_Import_Import extends WP_Import_UnitTestCase {
 
 		add_filter( 'import_allow_create_users', '__return_true' );
 
-		if ( ! file_exists( DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php' ) ) {
-			$this->fail( 'This test requires the WordPress Importer plugin to be installed in the test suite. See: https://make.wordpress.org/core/handbook/contribute/git/#unit-tests' );
-		}
-
-		require_once DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php';
+		require_once $importer;
 
 		global $wpdb;
 		// Crude but effective: make sure there's no residual data in the main tables.

--- a/tests/phpunit/tests/import/parser.php
+++ b/tests/phpunit/tests/import/parser.php
@@ -7,6 +7,11 @@ require_once __DIR__ . '/base.php';
  */
 class Tests_Import_Parser extends WP_Import_UnitTestCase {
 	public function set_up() {
+		$importer = DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php';
+		if ( ! file_exists( $importer ) ) {
+			$this->markTestSkipped( 'This test requires the WordPress Importer plugin to be installed in the test suite. See: https://make.wordpress.org/core/handbook/contribute/git/#unit-tests' );
+		}
+
 		parent::set_up();
 
 		if ( ! defined( 'WP_IMPORTING' ) ) {
@@ -17,11 +22,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 			define( 'WP_LOAD_IMPORTERS', true );
 		}
 
-		if ( ! file_exists( DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php' ) ) {
-			$this->fail( 'This test requires the WordPress Importer plugin to be installed in the test suite. See: https://make.wordpress.org/core/handbook/contribute/git/#unit-tests' );
-		}
-
-		require_once DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php';
+		require_once $importer;
 	}
 
 	/**

--- a/tests/phpunit/tests/import/parser.php
+++ b/tests/phpunit/tests/import/parser.php
@@ -7,11 +7,6 @@ require_once __DIR__ . '/base.php';
  */
 class Tests_Import_Parser extends WP_Import_UnitTestCase {
 	public function set_up() {
-		$importer = DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php';
-		if ( ! file_exists( $importer ) ) {
-			$this->markTestSkipped( 'This test requires the WordPress Importer plugin to be installed in the test suite. See: https://make.wordpress.org/core/handbook/contribute/git/#unit-tests' );
-		}
-
 		parent::set_up();
 
 		if ( ! defined( 'WP_IMPORTING' ) ) {
@@ -22,7 +17,7 @@ class Tests_Import_Parser extends WP_Import_UnitTestCase {
 			define( 'WP_LOAD_IMPORTERS', true );
 		}
 
-		require_once $importer;
+		require_once IMPORTER_PLUGIN_FOR_TESTS;
 	}
 
 	/**

--- a/tests/phpunit/tests/import/postmeta.php
+++ b/tests/phpunit/tests/import/postmeta.php
@@ -9,6 +9,11 @@ require_once __DIR__ . '/base.php';
  */
 class Tests_Import_Postmeta extends WP_Import_UnitTestCase {
 	public function set_up() {
+		$importer = DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php';
+		if ( ! file_exists( $importer ) ) {
+			$this->markTestSkipped( 'This test requires the WordPress Importer plugin to be installed in the test suite. See: https://make.wordpress.org/core/handbook/contribute/git/#unit-tests' );
+		}
+
 		parent::set_up();
 
 		if ( ! defined( 'WP_IMPORTING' ) ) {
@@ -19,11 +24,7 @@ class Tests_Import_Postmeta extends WP_Import_UnitTestCase {
 			define( 'WP_LOAD_IMPORTERS', true );
 		}
 
-		if ( ! file_exists( DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php' ) ) {
-			$this->fail( 'This test requires the WordPress Importer plugin to be installed in the test suite. See: https://make.wordpress.org/core/handbook/contribute/git/#unit-tests' );
-		}
-
-		require_once DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php';
+		require_once $importer;
 	}
 
 	public function test_serialized_postmeta_no_cdata() {

--- a/tests/phpunit/tests/import/postmeta.php
+++ b/tests/phpunit/tests/import/postmeta.php
@@ -9,11 +9,6 @@ require_once __DIR__ . '/base.php';
  */
 class Tests_Import_Postmeta extends WP_Import_UnitTestCase {
 	public function set_up() {
-		$importer = DIR_TESTDATA . '/plugins/wordpress-importer/wordpress-importer.php';
-		if ( ! file_exists( $importer ) ) {
-			$this->markTestSkipped( 'This test requires the WordPress Importer plugin to be installed in the test suite. See: https://make.wordpress.org/core/handbook/contribute/git/#unit-tests' );
-		}
-
 		parent::set_up();
 
 		if ( ! defined( 'WP_IMPORTING' ) ) {
@@ -24,7 +19,7 @@ class Tests_Import_Postmeta extends WP_Import_UnitTestCase {
 			define( 'WP_LOAD_IMPORTERS', true );
 		}
 
-		require_once $importer;
+		require_once IMPORTER_PLUGIN_FOR_TESTS;
 	}
 
 	public function test_serialized_postmeta_no_cdata() {


### PR DESCRIPTION
Tests which can not run because a prerequisite is not fulfilled should be marked as "skipped", not as _failed_ (as they haven't failed, they didn't run).

Now, I can imagine the choice to mark the tests as "failed" may have been to prevent contributors missing the message about the need to install the Importer plugin. If that's the case, I'd suggest adding a `file_exists()` check for the importer plugin to the test `bootstrap.php` file and exiting the test run if that prerequisite is not fulfilled, along the same lines as the check that the database connection can be made and that the correct version of the Polyfills is installed.

I'll happily update the test bootstrap to add this, but would like some more opinions on whether or not this is really a necessity.

Trac ticket: https://core.trac.wordpress.org/ticket/61530

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
