### PR TITLE
Tests: fix some test failures for Windows OS

### DIFF
--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -1071,6 +1071,40 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	}
 
 	/**
+	 * Assert that two text strings representing file paths are the same, while ignoring
+	 * OS-specific differences in the directory separators.
+	 *
+	 * This allows for tests to be compatible for running on both *nix based as well as Windows OS.
+	 *
+	 * @since 6.7.0
+	 *
+	 * @param string $path_a File or directory path.
+	 * @param string $path_b File or directory path.
+	 */
+	public function assertSamePathIgnoringDirectorySeparators( $path_a, $path_b ) {
+		$path_a = $this->normalizeDirectorySeparatorsInPath( $path_a );
+		$path_b = $this->normalizeDirectorySeparatorsInPath( $path_b );
+
+		$this->assertSame( $path_a, $path_b );
+	}
+
+	/**
+	 * Normalize directory separators in a file path to be a forward slash.
+	 *
+	 * @since 6.7.0
+	 *
+	 * @param string $path File or directory path.
+	 * @return string The normalized file or directory path.
+	 */
+	public function normalizeDirectorySeparatorsInPath( $path ) {
+		if ( ! is_string( $path ) || PHP_OS_FAMILY !== 'Windows' ) {
+			return $path;
+		}
+
+		return strtr( $path, '\\', '/' );
+	}
+
+	/**
 	 * Checks each of the WP_Query is_* functions/properties against expected boolean value.
 	 *
 	 * Any properties that are listed by name as parameters will be expected to be true; all others are

--- a/tests/phpunit/tests/admin/includesFile.php
+++ b/tests/phpunit/tests/admin/includesFile.php
@@ -15,7 +15,7 @@ class Tests_Admin_IncludesFile extends WP_UnitTestCase {
 		$home    = get_option( 'home' );
 		$siteurl = get_option( 'siteurl' );
 		$sfn     = $_SERVER['SCRIPT_FILENAME'];
-		$this->assertSame( str_replace( '\\', '/', ABSPATH ), get_home_path() );
+		$this->assertSamePathIgnoringDirectorySeparators( ABSPATH, get_home_path() );
 
 		update_option( 'home', 'http://localhost' );
 		update_option( 'siteurl', 'http://localhost/wp' );

--- a/tests/phpunit/tests/block-template.php
+++ b/tests/phpunit/tests/block-template.php
@@ -395,7 +395,7 @@ class Tests_Block_Template extends WP_UnitTestCase {
 	 * @covers ::_get_block_templates_paths
 	 */
 	public function test_get_block_templates_paths_dir_exists() {
-		$theme_dir = get_template_directory();
+		$theme_dir = $this->normalizeDirectorySeparatorsInPath( get_template_directory() );
 		// Templates in the current theme.
 		$templates = array(
 			'parts/small-header.html',
@@ -415,6 +415,8 @@ class Tests_Block_Template extends WP_UnitTestCase {
 		);
 
 		$template_paths = _get_block_templates_paths( $theme_dir );
+		$template_paths = array_map( array( $this, 'normalizeDirectorySeparatorsInPath' ), _get_block_templates_paths( $theme_dir ) );
+
 		$this->assertSameSets( $expected_template_paths, $template_paths );
 	}
 

--- a/tests/phpunit/tests/filesystem/wpFilesystemDirect/chdir.php
+++ b/tests/phpunit/tests/filesystem/wpFilesystemDirect/chdir.php
@@ -86,7 +86,7 @@ class Tests_Filesystem_WpFilesystemDirect_Chdir extends WP_Filesystem_Direct_Uni
 			'Changing working directory failed.'
 		);
 
-		$this->assertSame(
+		$this->assertSamePathIgnoringDirectorySeparators(
 			$path,
 			$cwd_result,
 			'The current working directory was incorrect.'

--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -925,7 +925,7 @@ class Tests_Theme extends WP_UnitTestCase {
 	 */
 	public function test_get_stylesheet_directory() {
 		switch_theme( 'block-theme-child' );
-		$this->assertSame( realpath( DIR_TESTDATA ) . '/themedir1/block-theme-child', get_stylesheet_directory() );
+		$this->assertSamePathIgnoringDirectorySeparators( realpath( DIR_TESTDATA ) . '/themedir1/block-theme-child', get_stylesheet_directory() );
 	}
 
 	/**
@@ -937,7 +937,7 @@ class Tests_Theme extends WP_UnitTestCase {
 	 */
 	public function test_get_template_directory() {
 		switch_theme( 'block-theme-child' );
-		$this->assertSame( realpath( DIR_TESTDATA ) . '/themedir1/block-theme', get_template_directory() );
+		$this->assertSamePathIgnoringDirectorySeparators( realpath( DIR_TESTDATA ) . '/themedir1/block-theme', get_template_directory() );
 	}
 
 	/**


### PR DESCRIPTION
### WP_UnitTestCase_Base: introduce a new assertion and a new helper method

Introduces `WP_UnitTestCase_Base::assertSamePathIgnoringDirectorySeparators()` and an associated helper method `WP_UnitTestCase_Base::normalizeDirectorySeparatorsInPath()` to allow for comparing two file path strings independently of OS-specific differences.

The normalization is done in a separate method to also allow this method to be used for path normalization within test methods themselves, like for normalizing a group of paths in an array.

The pretty specific method name for the helper (`normalizeDirectorySeparatorsInPath()`) is an attempt to prevent naming conflicts with methods which may exist in plugin test suites build on top of the WP Core test suite.

### Tests: start using the new assertion and helper method 

Trac ticket: https://core.trac.wordpress.org/ticket/61530

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
