### PR TITLE
61837: REST API: Password should only be considered by permissions check when in query params

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -497,9 +497,9 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			);
 		}
 
-		if ( $post && ! empty( $request['password'] ) ) {
+		if ( $post && ! empty( $request->get_query_params()['password'] ) ) {
 			// Check post password, and return error if invalid.
-			if ( ! hash_equals( $post->post_password, $request['password'] ) ) {
+			if ( ! hash_equals( $post->post_password, $request->get_query_params()['password'] ) ) {
 				return new WP_Error(
 					'rest_post_incorrect_password',
 					__( 'Incorrect post password.' ),

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -2179,8 +2179,9 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_get_item_permissions_check_while_updating_password() {
 		$endpoint = new WP_REST_Posts_Controller( 'post' );
 
-		$request_with_post_password = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d', self::$post_id ) );
-		$request_with_post_password->set_body_params(
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d', self::$post_id ) );
+		$request->set_url_params( array( 'id' => self::$post_id ) );
+		$request->set_body_params(
 			$this->set_post_data(
 				array(
 					'id'       => self::$post_id,
@@ -2188,7 +2189,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 				)
 			)
 		);
-		$permission = $endpoint->get_item_permissions_check( $request_with_post_password );
+		$permission = $endpoint->get_item_permissions_check( $request );
 
 		// Password provided in POST data, password check should not kick in.
 		$this->assertNotInstanceOf( 'WP_Error', $permission, 'Password should be ignored by permissions check if provided in post body.' );
@@ -2201,8 +2202,9 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	public function test_get_item_permissions_check_while_updating_password_with_invalid_type() {
 		$endpoint = new WP_REST_Posts_Controller( 'post' );
 
-		$request_with_post_password = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d', self::$post_id ) );
-		$request_with_post_password->set_body_params(
+		$request = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d', self::$post_id ) );
+		$request->set_url_params( array( 'id' => self::$post_id ) );
+		$request->set_body_params(
 			$this->set_post_data(
 				array(
 					'id'       => self::$post_id,
@@ -2210,7 +2212,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 				)
 			)
 		);
-		$permission = $endpoint->get_item_permissions_check( $request_with_post_password );
+		$permission = $endpoint->get_item_permissions_check( $request );
 
 		$this->assertNotInstanceOf( 'WP_Error', $permission, 'Password should be ignored by permissions chedk even if invalid type' );
 		$this->assertTrue( $permission );

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -2174,6 +2174,49 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	}
 
 	/**
+	 * @ticket 61837
+	 */
+	public function test_get_item_permissions_check_while_updating_password() {
+		$endpoint = new WP_REST_Posts_Controller( 'post' );
+
+		$request_with_post_password = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d', self::$post_id ) );
+		$request_with_post_password->set_body_params(
+			$this->set_post_data(
+				array(
+					'id'       => self::$post_id,
+					'password' => '123',
+				)
+			)
+		);
+		$permission = $endpoint->get_item_permissions_check( $request_with_post_password );
+
+		// Password provided in POST data, password check should not kick in.
+		$this->assertNotInstanceOf( 'WP_Error', $permission, 'Password should be ignored by permissions check if provided in post body.' );
+		$this->assertTrue( $permission );
+	}
+
+	/**
+	 * @ticket 61837
+	 */
+	public function test_get_item_permissions_check_while_updating_password_with_invalid_type() {
+		$endpoint = new WP_REST_Posts_Controller( 'post' );
+
+		$request_with_post_password = new WP_REST_Request( 'POST', sprintf( '/wp/v2/posts/%d', self::$post_id ) );
+		$request_with_post_password->set_body_params(
+			$this->set_post_data(
+				array(
+					'id'       => self::$post_id,
+					'password' => 123,
+				)
+			)
+		);
+		$permission = $endpoint->get_item_permissions_check( $request_with_post_password );
+
+		$this->assertNotInstanceOf( 'WP_Error', $permission, 'Password should be ignored by permissions chedk even if invalid type' );
+		$this->assertTrue( $permission );
+	}
+
+	/**
 	 * The post response should not have `block_version` when in view context.
 	 *
 	 * @ticket 43887

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -2192,7 +2192,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$permission = $endpoint->get_item_permissions_check( $request );
 
 		// Password provided in POST data, password check should not kick in.
-		$this->assertNotInstanceOf( 'WP_Error', $permission, 'Password should be ignored by permissions check if provided in post body.' );
+		$this->assertNotWPError( $permission, 'Password should be ignored by permissions check if provided in post body.' );
 		$this->assertTrue( $permission );
 	}
 
@@ -2214,7 +2214,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		);
 		$permission = $endpoint->get_item_permissions_check( $request );
 
-		$this->assertNotInstanceOf( 'WP_Error', $permission, 'Password should be ignored by permissions chedk even if invalid type' );
+		$this->assertNotWPError( $permission, 'Password in post body should be ignored by permissions check even when invalid type' );
 		$this->assertTrue( $permission );
 	}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61837 <!-- insert a link to the WordPress Trac ticket here -->

`request[password]` is checked when calculating item permissions, and this check does not restrict itself to looking at the password provided as a query parameter.

Adding unit tests for failing situation described in ticket, then will update with a merged patch.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
