### PR TITLE
GH Actions/install-testing: add missing job conditions

### DIFF
--- a/.github/workflows/install-testing.yml
+++ b/.github/workflows/install-testing.yml
@@ -46,6 +46,7 @@ jobs:
   build-matrix:
     name: Determine PHP Versions to test
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     timeout-minutes: 5
     outputs:
       major-wp-version: ${{ steps.major-wp-version.outputs.version }}
@@ -104,6 +105,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ${{ matrix.os }}
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     timeout-minutes: 10
     needs: [ build-matrix ]
     strategy:


### PR DESCRIPTION
These test jobs should not be run on forks (by default).

Trac ticket: https://core.trac.wordpress.org/ticket/61564

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
