### PR TITLE
PHP 8.4 | Remove use of xml_set_object() [1] (Trac 62061)

### DIFF
--- a/tests/phpunit/includes/utils.php
+++ b/tests/phpunit/includes/utils.php
@@ -295,7 +295,6 @@ class TestXMLParser {
 	 */
 	public function __construct( $in ) {
 		$this->xml = xml_parser_create();
-		xml_set_object( $this->xml, $this );
 		xml_parser_set_option( $this->xml, XML_OPTION_CASE_FOLDING, 0 );
 		xml_set_element_handler( $this->xml, array( $this, 'start_handler' ), array( $this, 'end_handler' ) );
 		xml_set_character_data_handler( $this->xml, array( $this, 'data_handler' ) );


### PR DESCRIPTION
The XML Parser extension still supports a quite dated mechanism for method based callbacks, where the object is first set via `xml_set_object()` and the callbacks are then set by passing only the name of the method to the relevant parameters on any of the `xml_set_*_handler()` functions.
```php
xml_set_object( $parser, $my_obj );
xml_set_character_data_handler( $parser, 'method_name_on_my_obj' );
```

Passing proper callables to the `xml_set_*_handler()` functions has been supported for the longest time and is cross-version compatible. So the above code is 100% equivalent to:
```php
xml_set_character_data_handler( $parser, [$my_obj, 'method_name_on_my_obj'] );
```

The mechanism of setting the callbacks with `xml_set_object()` has now been deprecated as of PHP 8.4, in favour of passing proper callables to the `xml_set_*_handler()` functions. This is also means that calling the `xml_set_object()` function is deprecated as well.

This commit fixes this deprecation for the `TestXMLParser` helper utility. In this case, the callbacks were already using the recommended format and the call to `xml_set_object()` was completely redundant.

As this is a test utility and was already causing pre-existing tests using the utility to fail, there is no need for dedicated tests to cover this change.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_4#xml_set_object_and_xml_set_handler_with_string_method_names
* https://www.php.net/manual/en/function.xml-set-object.php
* https://www.php.net/manual/en/ref.xml.php


Trac ticket: https://core.trac.wordpress.org/ticket/62061

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
