### PR TITLE
PHP 8.4 | Remove use of xml_set_object() [3] (Trac 62061)

### DIFF
--- a/src/wp-includes/atomlib.php
+++ b/src/wp-includes/atomlib.php
@@ -86,6 +86,10 @@ class AtomParser {
 
     var $feed;
     var $current;
+    var $map_attrs_func;
+    var $map_xmlns_func;
+    var $error;
+    var $content;
 
 	/**
 	 * PHP5 constructor.

--- a/src/wp-includes/atomlib.php
+++ b/src/wp-includes/atomlib.php
@@ -157,14 +157,13 @@ class AtomParser {
         }
 
         $parser = xml_parser_create_ns();
-        xml_set_object($parser, $this);
-        xml_set_element_handler($parser, "start_element", "end_element");
+        xml_set_element_handler($parser, array($this, "start_element"), array($this, "end_element"));
         xml_parser_set_option($parser,XML_OPTION_CASE_FOLDING,0);
         xml_parser_set_option($parser,XML_OPTION_SKIP_WHITE,0);
-        xml_set_character_data_handler($parser, "cdata");
-        xml_set_default_handler($parser, "_default");
-        xml_set_start_namespace_decl_handler($parser, "start_ns");
-        xml_set_end_namespace_decl_handler($parser, "end_ns");
+        xml_set_character_data_handler($parser, array($this, "cdata"));
+        xml_set_default_handler($parser, array($this, "_default"));
+        xml_set_start_namespace_decl_handler($parser, array($this, "start_ns"));
+        xml_set_end_namespace_decl_handler($parser, array($this, "end_ns"));
 
         $this->content = '';
 

--- a/tests/phpunit/data/feed/AtomParser_Parse_Test.xml
+++ b/tests/phpunit/data/feed/AtomParser_Parse_Test.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Author:       Sam Ruby <rubys@intertwingly.net>
+-->
+
+<!--
+  Description:  No errors should be produced by the extensive feed
+  Expect:       !Error
+-->
+
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title type="text">dive into mark</title>
+  <subtitle type="html">
+    A &lt;em&gt;lot&lt;/em&gt; of effort
+    went into making this effortless
+  </subtitle>
+  <updated>2005-07-11T12:29:29Z</updated>
+  <id>tag:example.org,2003:3</id>
+  <link rel="alternate" type="text/html"
+   hreflang="en" href="http://example.org/"/>
+  <link rel="self" type="application/atom+xml"
+   href="http://example.org/feed.atom"/>
+  <rights>Copyright (c) 2003, Mark Pilgrim</rights>
+  <generator uri="http://www.example.com/" version="1.0">
+    Example Toolkit
+  </generator>
+  <entry>
+    <title>Atom draft-07 snapshot</title>
+    <link rel="alternate" type="text/html"
+     href="http://example.org/2005/04/02/atom"/>
+    <link rel="enclosure" type="audio/mpeg" length="1337"
+     href="http://example.org/audio/ph34r_my_podcast.mp3"/>
+    <id>tag:example.org,2003:3.2397</id>
+    <updated>2005-07-11T12:29:29Z</updated>
+    <published>2003-12-13T08:29:29-04:00</published>
+    <author>
+      <name>Mark Pilgrim</name>
+      <uri>http://example.org/</uri>
+      <email>f8dy@example.com</email>
+    </author>
+    <contributor>
+      <name>Sam Ruby</name>
+    </contributor>
+    <contributor>
+      <name>Joe Gregorio</name>
+    </contributor>
+    <content type="xhtml" xml:lang="en"
+     xml:base="http://diveintomark.org/">
+      <div xmlns="http://www.w3.org/1999/xhtml">
+        <p><i>[Update: The Atom draft is finished.]</i></p>
+      </div>
+    </content>
+  </entry>
+</feed>

--- a/tests/phpunit/tests/atomlib/AtomParser_Parse_Test.php
+++ b/tests/phpunit/tests/atomlib/AtomParser_Parse_Test.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Unit tests covering AtomParser functionality.
+ *
+ * @package    WordPress
+ * @subpackage AtomLib
+ */
+
+/**
+ * Test Atom Syndication Format.
+ *
+ * @requires extension xml
+ *
+ * @covers AtomParser::parse
+ */
+final class AtomParser_Parse_Test extends WP_UnitTestCase {
+
+	/**
+	 * Ensure the class being tested is loaded.
+	 */
+	public function set_up() {
+		require_once dirname( __DIR__, 4 ) . '/src/wp-includes/atomlib.php';
+	}
+
+	/**
+	 * Test that the `AtomParser::parse()` method correctly sets callback functions to handle certain parts of the XML.
+	 *
+	 * Safeguards handling of the PHP 8.4 deprecation of `xml_set_object()`.
+	 */
+	public function test_parse_sets_handlers() {
+		$atom = new class() extends AtomParser {
+			public $start_element_call_counter = 0;
+			public $end_element_call_counter   = 0;
+			public $start_ns_call_counter      = 0;
+			public $end_ns_call_counter        = 0;
+			public $cdata_call_counter         = 0;
+			public $default_call_counter       = 0;
+
+			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase -- Overloading property of upstream class.
+			public $FILE = __DIR__ . '/../../data/feed/AtomParser_Parse_Test.xml';
+
+			public function start_element( $parser, $name, $attrs ) {
+				++$this->start_element_call_counter;
+			}
+			public function end_element( $parser, $name ) {
+				++$this->end_element_call_counter;
+			}
+			public function start_ns( $parser, $prefix, $uri ) {
+				++$this->start_ns_call_counter;
+			}
+			public function end_ns( $parser, $prefix ) {
+				++$this->end_ns_call_counter;
+			}
+			public function cdata( $parser, $data ) {
+				++$this->cdata_call_counter;
+			}
+			public function _default( $parser, $data ) {
+				++$this->default_call_counter;
+			}
+		};
+
+		$this->assertTrue( $atom->parse(), 'Parsing of XML file failed' );
+
+		// Ensure no errors were logged.
+		$this->assertNull( $atom->error, 'Unexpected errors encountered' );
+
+		$msg = '%s() handler did not get called expected nr of times';
+		$this->assertSame( 28, $atom->start_element_call_counter, sprintf( $msg, 'start_element' ) );
+		$this->assertSame( 28, $atom->end_element_call_counter, sprintf( $msg, 'end_element' ) );
+		$this->assertSame( 2, $atom->start_ns_call_counter, sprintf( $msg, 'start_ns' ) );
+		$this->assertSame( 0, $atom->end_ns_call_counter, sprintf( $msg, 'end_ns' ) );
+		$this->assertSame( 57, $atom->cdata_call_counter, sprintf( $msg, 'cdata' ) );
+		$this->assertSame( 2, $atom->default_call_counter, sprintf( $msg, '_default' ) );
+	}
+}


### PR DESCRIPTION
Note: the first commit is necessary to allow the tests being added in the second commit to pass.

---

### PHP 8.2 | AtomParser: explicitly declare all properties

Dynamic (non-explicitly declared) properties are deprecated as of PHP 8.2 and are expected to become a fatal error in PHP 9.0.

There are a number of ways to mitigate this:
* If it's an accidental typo for a declared property: fix the typo.
* For known properties: declare them on the class.
* For unknown properties: add the magic `__get()`, `__set()` et al methods to the class or let the class extend `stdClass` which has highly optimized versions of these magic methods build in.
* For unknown _use of_ dynamic properties, the `#[AllowDynamicProperties]` attribute can be added to the class. The attribute will automatically be inherited by child classes.

In this case, the property added are explicitly referenced in this class, so fall in the "known property" category.

Refs:
* https://wiki.php.net/rfc/deprecate_dynamic_properties

### PHP 8.4 | Remove use of xml_set_object() [3]

The XML Parser extension still supports a quite dated mechanism for method based callbacks, where the object is first set via `xml_set_object()` and the callbacks are then set by passing only the name of the method to the relevant parameters on any of the `xml_set_*_handler()` functions.
```php
xml_set_object( $parser, $my_obj );
xml_set_character_data_handler( $parser, 'method_name_on_my_obj' );
```

Passing proper callables to the `xml_set_*_handler()` functions has been supported for the longest time and is cross-version compatible. So the above code is 100% equivalent to:
```php
xml_set_character_data_handler( $parser, [$my_obj, 'method_name_on_my_obj'] );
```

The mechanism of setting the callbacks with `xml_set_object()` has now been deprecated as of PHP 8.4, in favour of passing proper callables to the `xml_set_*_handler()` functions. This is also means that calling the `xml_set_object()` function is deprecated as well.

This commit fixes this deprecation for the `AtomParser::parse()` method.

This change is safeguarded via the new `AtomParser_Parse_Test` class.

Notes:
* I recognize that this is "officially" an external library, but AFAIK, this package is no longer externally maintained. The code style of the fix in the source file is in line with the existing code style for the file.
* It appears that this class is not actually used by WP Core itself, so it could be considered to deprecate the class. However, as the class is not currently deprecated, safeguarding the change with a test seemed prudent.
* The fixture used for the test reuses a fixture from the original package: https://code.google.com/archive/p/phpatomlib/source/default/source
* The new test class follows the recommended test format (naming convention of the class, `@covers` tag at class level, only testing one method) as per Trac tickets 62004 / 53010.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_4#xml_set_object_and_xml_set_handler_with_string_method_names
* https://www.php.net/manual/en/function.xml-set-object.php
* https://www.php.net/manual/en/ref.xml.php


Trac ticket: https://core.trac.wordpress.org/ticket/62061

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
