### PR TITLE
PHP 8.4 | Remove use of xml_set_object() [4] (Trac 62061)

### DIFF
--- a/src/wp-includes/rss.php
+++ b/src/wp-includes/rss.php
@@ -74,11 +74,10 @@ class MagpieRSS {
 		# pass in parser, and a reference to this object
 		# set up handlers
 		#
-		xml_set_object( $this->parser, $this );
 		xml_set_element_handler($this->parser,
-				'feed_start_element', 'feed_end_element' );
+				array( $this, 'feed_start_element' ), array( $this, 'feed_end_element' ) );
 
-		xml_set_character_data_handler( $this->parser, 'feed_cdata' );
+		xml_set_character_data_handler( $this->parser, array( $this, 'feed_cdata' ) );
 
 		$status = xml_parse( $this->parser, $source );
 


### PR DESCRIPTION
The XML Parser extension still supports a quite dated mechanism for method based callbacks, where the object is first set via `xml_set_object()` and the callbacks are then set by passing only the name of the method to the relevant parameters on any of the `xml_set_*_handler()` functions.
```php
xml_set_object( $parser, $my_obj );
xml_set_character_data_handler( $parser, 'method_name_on_my_obj' );
```

Passing proper callables to the `xml_set_*_handler()` functions has been supported for the longest time and is cross-version compatible. So the above code is 100% equivalent to:
```php
xml_set_character_data_handler( $parser, [$my_obj, 'method_name_on_my_obj'] );
```

The mechanism of setting the callbacks with `xml_set_object()` has now been deprecated as of PHP 8.4, in favour of passing proper callables to the `xml_set_*_handler()` functions. This is also means that calling the `xml_set_object()` function is deprecated as well.

This commit fixes this deprecation for the `MagpieRSS::__construct()` method.

The change has not been not covered by tests. This class has been deprecated since WP 3.0.0 and is not covered by tests at all. Adding those now seems superfluous, all the more as the principle of the fix is no different than for the other files, so we can be sure it works anyway.

Note: I recognize that this is "officially" an external library, but AFAIK, this package is no longer externally maintained. The code style of the fix in the source file is in line with the existing code style for the file.

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_4#xml_set_object_and_xml_set_handler_with_string_method_names
* https://www.php.net/manual/en/function.xml-set-object.php
* https://www.php.net/manual/en/ref.xml.php

Trac ticket: https://core.trac.wordpress.org/ticket/62061

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
