### PR TITLE
PHP 8.4 | wpdb::check_connection(): handle deprecation of mysqli_ping() (Trac 62061)

### DIFF
--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -2114,7 +2114,8 @@ class wpdb {
 	 * @return bool|void True if the connection is up.
 	 */
 	public function check_connection( $allow_bail = true ) {
-		if ( ! empty( $this->dbh ) && mysqli_ping( $this->dbh ) ) {
+		// Check if the connection is alive.
+		if ( ! empty( $this->dbh ) && mysqli_query( $this->dbh, 'DO 1' ) !== false ) {
 			return true;
 		}
 

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -2458,6 +2458,8 @@ class Tests_DB extends WP_UnitTestCase {
 
 	/**
 	 * Verify "pinging" the database works cross-version PHP.
+	 *
+	 * @ticket 62061
 	 */
 	public function test_check_connection_returns_true_when_there_is_a_connection() {
 		global $wpdb;

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -2455,4 +2455,13 @@ class Tests_DB extends WP_UnitTestCase {
 
 		$this->assertTrue( $wpdb->use_mysqli );
 	}
+
+	/**
+	 * Verify "pinging" the database works cross-version PHP.
+	 */
+	public function test_check_connection_returns_true_when_there_is_a_connection() {
+		global $wpdb;
+
+		$this->assertTrue( $wpdb->check_connection( false ) );
+	}
 }


### PR DESCRIPTION
The `mysqli_ping()` function is deprecated as of PHP 8.4, though, in reality, the function wasn't working according to spec anymore since PHP 8.2 when the `libmysql` driver was dropped in favour of `libmysqlnd`, which was already the default (and recommended) driver since PHP 5.4.

The `mysqli_ping()` method was also not really correctly named as its functionality was to reconnect to the database, not just ping.

The alternative is to "manually" ping the database by sending a `DO 1` query (the cheapest possible SQL query).

Now, I considered adding a PHP version based toggle, but as mentioned above, the default driver has been `libmysqlnd` since PHP 5.4 and in that case, the function never worked anyway, so in reality `mysqli_ping()` was only really functional for the odd custom PHP compilation where `mysqli` was build against `libmysql` AND `reconnect` was not disabled.

With this in mind, I'm proposing to replace the call to `mysqli_ping()` with the `DO 1` query completely. If that query succeeds, we can conclude the database connection is still alive. This solution should be the most stable as it will work for both PHP 7.2 <= 8.1, independently of which driver `mysqli` was compiled with, as well as for PHP 8.2+.

Note: It could also be considered to remove the function call to `mysqli_ping()` completely and rely on standard error handling in case the connection would have dropped, as after all, the fact that the connection existed at the moment the "ping" happened, is no guarantee that the connection will still exist when the next query is send.... I choose not to do so as WP has custom error handling and does not use the PHP native mysqli exceptions for this, which would make implementing this more awkward.

Includes a test to verify that the connection check works when there is a valid connection (this was previously not covered by tests).

Refs:
* https://wiki.php.net/rfc/deprecations_php_8_4#mysqli_ping_and_mysqliping
* https://github.com/php/php-src/pull/11912#issuecomment-1671762583
* https://stackoverflow.com/questions/2546868/cheapest-way-to-determine-if-a-mysql-connection-is-still-alive/2546922#2546922
* php/php-src#11945
* https://wiki.php.net/rfc/mysqli_support_for_libmysql
* https://www.php.net/mysqli_ping

Trac ticket: https://core.trac.wordpress.org/ticket/62061

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
