### PR TITLE
PHP 8.4 | Text_Diff::_check(): fix trigger_error() with E_USER_ERROR is deprecated (Trac 62061)

### DIFF
--- a/src/wp-includes/Text/Diff.php
+++ b/src/wp-includes/Text/Diff.php
@@ -276,7 +276,7 @@ class Text_Diff {
 
         $prevtype = null;
         foreach ($this->_edits as $edit) {
-            if ($edit instanceof $prevtype) {
+            if ($prevtype !== null && $edit instanceof $prevtype) {
                 trigger_error("Edit sequence is non-optimal", E_USER_ERROR);
             }
             $prevtype = get_class($edit);

--- a/src/wp-includes/Text/Diff.php
+++ b/src/wp-includes/Text/Diff.php
@@ -350,15 +350,12 @@ class Text_MappedDiff extends Text_Diff {
  *
  * @access private
  */
-class Text_Diff_Op {
+abstract class Text_Diff_Op {
 
     var $orig;
     var $final;
 
-    function &reverse()
-    {
-        trigger_error('Abstract method', E_USER_ERROR);
-    }
+    abstract function &reverse();
 
     function norig()
     {

--- a/src/wp-includes/Text/Diff.php
+++ b/src/wp-includes/Text/Diff.php
@@ -260,24 +260,24 @@ class Text_Diff {
     function _check($from_lines, $to_lines)
     {
         if (serialize($from_lines) != serialize($this->getOriginal())) {
-            trigger_error("Reconstructed original does not match", E_USER_ERROR);
+            throw new Text_Exception("Reconstructed original does not match");
         }
         if (serialize($to_lines) != serialize($this->getFinal())) {
-            trigger_error("Reconstructed final does not match", E_USER_ERROR);
+            throw new Text_Exception("Reconstructed final does not match");
         }
 
         $rev = $this->reverse();
         if (serialize($to_lines) != serialize($rev->getOriginal())) {
-            trigger_error("Reversed original does not match", E_USER_ERROR);
+            throw new Text_Exception("Reversed original does not match");
         }
         if (serialize($from_lines) != serialize($rev->getFinal())) {
-            trigger_error("Reversed final does not match", E_USER_ERROR);
+            throw new Text_Exception("Reversed final does not match");
         }
 
         $prevtype = null;
         foreach ($this->_edits as $edit) {
             if ($prevtype !== null && $edit instanceof $prevtype) {
-                trigger_error("Edit sequence is non-optimal", E_USER_ERROR);
+                throw new Text_Exception("Edit sequence is non-optimal");
             }
             $prevtype = get_class($edit);
         }

--- a/src/wp-includes/Text/Exception.php
+++ b/src/wp-includes/Text/Exception.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Exception for errors from the Text_Diff package.
+ *
+ * {@internal This is a WP native addition to the external Text_Diff package.}
+ *
+ * @package WordPress
+ * @subpackage Text_Diff
+ */
+
+class Text_Exception extends Exception {}

--- a/src/wp-includes/wp-diff.php
+++ b/src/wp-includes/wp-diff.php
@@ -15,6 +15,8 @@ if ( ! class_exists( 'Text_Diff', false ) ) {
 	require ABSPATH . WPINC . '/Text/Diff/Renderer.php';
 	/** Text_Diff_Renderer_inline class */
 	require ABSPATH . WPINC . '/Text/Diff/Renderer/inline.php';
+	/** Text_Exception class */
+	require ABSPATH . WPINC . '/Text/Exception.php';
 }
 
 require ABSPATH . WPINC . '/class-wp-text-diff-renderer-table.php';

--- a/tests/phpunit/tests/diff/Text_Diff_Check_Test.php
+++ b/tests/phpunit/tests/diff/Text_Diff_Check_Test.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Tests for WP native customizations added to the Text_Diff::check() method.
+ *
+ * @group diff
+ *
+ * @covers Text_Diff::_check
+ */
+final class Text_Diff_Check_Test extends WP_UnitTestCase {
+
+	const FILE_A = array(
+		'Line 1',
+		'Line 2',
+		'Line 3',
+	);
+
+	const FILE_B = array(
+		'Line 11',
+		'Line 2',
+		'Line 13',
+	);
+
+	public static function set_up_before_class() {
+		require_once ABSPATH . 'wp-includes/Text/Diff.php';
+	}
+
+	/**
+	 * Disable WP specific set up as it is not needed.
+	 */
+	public function set_up() {}
+
+	public function test_check_passes_when_passed_same_input() {
+		$diff = new Text_Diff( 'auto', array( self::FILE_A, self::FILE_B ) );
+		$this->assertTrue( $diff->_check( self::FILE_A, self::FILE_B ) );
+	}
+}

--- a/tests/phpunit/tests/diff/Text_Diff_Check_Test.php
+++ b/tests/phpunit/tests/diff/Text_Diff_Check_Test.php
@@ -23,6 +23,7 @@ final class Text_Diff_Check_Test extends WP_UnitTestCase {
 
 	public static function set_up_before_class() {
 		require_once ABSPATH . 'wp-includes/Text/Diff.php';
+		require_once ABSPATH . 'wp-includes/Text/Exception.php';
 	}
 
 	/**
@@ -33,5 +34,21 @@ final class Text_Diff_Check_Test extends WP_UnitTestCase {
 	public function test_check_passes_when_passed_same_input() {
 		$diff = new Text_Diff( 'auto', array( self::FILE_A, self::FILE_B ) );
 		$this->assertTrue( $diff->_check( self::FILE_A, self::FILE_B ) );
+	}
+
+	public function test_check_throws_exception_when_from_is_not_same_as_original() {
+		$this->expectException( Text_Exception::class );
+		$this->expectExceptionMessage( 'Reconstructed original does not match' );
+
+		$diff = new Text_Diff( 'auto', array( self::FILE_A, self::FILE_B ) );
+		$diff->_check( self::FILE_B, self::FILE_B );
+	}
+
+	public function test_check_throws_exception_when_to_is_not_same_as_final() {
+		$this->expectException( Text_Exception::class );
+		$this->expectExceptionMessage( 'Reconstructed final does not match' );
+
+		$diff = new Text_Diff( 'auto', array( self::FILE_A, self::FILE_B ) );
+		$diff->_check( self::FILE_A, self::FILE_A );
 	}
 }


### PR DESCRIPTION
### Text_Diff::_check(): add basic test + fix a bug

This commit adds a simple test for the `Text_Diff::_check()` method and as that test could never pass with the code as-is, it also fixes the bug discoved by this test.

Bug symptom: `Error: Class name must be a valid object or a string` on line 279.

### PHP 8.4 | Text_Diff::_check(): fix trigger_error() with E_USER_ERROR is deprecated

PHP 8.4 deprecates the use of `trigger_errror()` with `E_USER_ERROR` as the error level, as there are a number of gotchas to this way of creating a `Fatal Error` (`finally` blocks not executing, destructors not executing).
The recommended replacements are either to use exceptions or to do a hard `exit`.

Considering this is an unmaintained external dependency, I'm propose we fix this in the WP specific copy of the dependency.

Now, there were basically three options:
* Silence the deprecation until PHP 9.0 and delay properly solving this until then.
    This would lead to an awkward solution, as prior to PHP 8.0, error silencing would apply to all errors, while, as of PHP 8.0, it will no longer apply to fatal errors.
    It also would only buy us some time and wouldn't actually solve anything.
* Use `exit($status)`.
    This would make the code untestable and would disable handling of these errors via custom error handlers, which makes this an undesirable solution.
* Throw an exception.
    This makes for the most elegant solution with the least BC-breaking impact.

This commit implements the third option. It introduces a new `Text_Exception` class and starts using that in the `Text_Diff::_check()` method in all applicable places.

It also adds tests for the first two error conditions.

Unfortunately, I have not been able to get a test set up to test the other three exceptions, as without hacking the object under test, i.e. manually editing the `$_edits` property between the instantiating the object and running the `_check()`, I have not found a way to trigger those exceptions.

Ref:
* https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_e_user_error_to_trigger_error
* https://www.php.net/manual/en/migration80.incompatible.php

### PHP 8.4 | Text_Diff_Op::reverse(): fix trigger_error() with E_USER_ERROR is deprecated

PHP 8.4 deprecates the use of `trigger_errror()` with `E_USER_ERROR` as the error level, as there are a number of gotchas to this way of creating a `Fatal Error` (`finally` blocks not executing, destructors not executing).
The recommended replacements are either to use exceptions or to do a hard `exit`.

Considering this is an unmaintained external dependency, I'm propose we fix this in the WP specific copy of the dependency.

In this case, the `trigger_error()` call looks to be a remnant of the PHP 4 era before a class could be declared as `abstract`, so I've fixed this in the most straight-forward manner: by making both the method as well as the class `abstract` and removing the call to `trigger_error()`.


Trac ticket: https://core.trac.wordpress.org/ticket/62061

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
