### PR TITLE
PHP 8.4 | `wp_trigger_error(): fix trigger_error() with E_USER_ERROR is deprecated (Trac 62061)

### DIFF
--- a/src/wp-includes/class-wp-exception.php
+++ b/src/wp-includes/class-wp-exception.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * WP_Exception class
+ *
+ * @package WordPress
+ * @since 6.7.0
+ */
+
+/**
+ * Core base Exception class.
+ *
+ * Future, more specific, Exceptions should always extend this base class.
+ *
+ * @since 6.7.0
+ */
+class WP_Exception extends Exception {
+}

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6092,6 +6092,10 @@ function wp_trigger_error( $function_name, $message, $error_level = E_USER_NOTIC
 		array( 'http', 'https' )
 	);
 
+	if ( E_USER_ERROR === $error_level ) {
+		throw new WP_Exception( $message );
+	}
+
 	trigger_error( $message, $error_level );
 }
 

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -110,6 +110,7 @@ require ABSPATH . WPINC . '/class-wp-list-util.php';
 require ABSPATH . WPINC . '/class-wp-token-map.php';
 require ABSPATH . WPINC . '/formatting.php';
 require ABSPATH . WPINC . '/meta.php';
+require ABSPATH . WPINC . '/class-wp-exception.php';
 require ABSPATH . WPINC . '/functions.php';
 require ABSPATH . WPINC . '/class-wp-meta-query.php';
 require ABSPATH . WPINC . '/class-wp-matchesmapregex.php';

--- a/tests/phpunit/tests/functions/wpTriggerError.php
+++ b/tests/phpunit/tests/functions/wpTriggerError.php
@@ -20,9 +20,9 @@ class Tests_Functions_WpTriggerError extends WP_UnitTestCase {
 	 * @param string $message          The message to test.
 	 * @param string $expected_message The expected error message.
 	 */
-	public function test_should_trigger_error( $function_name, $message, $expected_message ) {
-		$this->expectError();
-		$this->expectErrorMessage( $expected_message );
+	public function test_should_throw_exception( $function_name, $message, $expected_message ) {
+		$this->expectException( WP_Exception::class );
+		$this->expectExceptionMessage( $expected_message );
 
 		wp_trigger_error( $function_name, $message, E_USER_ERROR );
 	}


### PR DESCRIPTION
PHP 8.4 deprecates the use of `trigger_errror()` with `E_USER_ERROR` as the error level, as there are a number of gotchas to this way of creating a `Fatal Error` (`finally` blocks not executing, destructors not executing). The recommended replacements are either to use exceptions or to do a hard `exit`.

WP has its own `wp_trigger_error()` function, which under the hood calls `trigger_error()`. If passed `E_USER_ERROR` as the `$error_level`, this will hit the PHP 8.4 deprecation.

Now, there were basically three options:
* Silence the deprecation until PHP 9.0 and delay properly solving this until then. This would lead to an awkward solution, as prior to PHP 8.0, error silencing would apply to all errors, while, as of PHP 8.0, it will no longer apply to fatal errors. It also would only buy us some time and wouldn't actually solve anything.
* Use `exit($status)` when `wp_trigger_error()` is called with `E_USER_ERROR`. This would make the code untestable and would disable handling of these errors via custom error handlers, which makes this an undesirable solution.
* Throw an exception when `wp_trigger_error()` is called with `E_USER_ERROR`. This makes for the most elegant solution with the least BC-breaking impact, though it does open it up to the error potential being "caught" via a `try-catch`. In my opinion, that's not actually a bad thing and is likely to only happen for those errors which can be worked around, in which case, it's a bonus that that's now possible.

So, this commit implements the third option. It introduces a new `WP_Exception` class and starts using that in the `wp_trigger_error()` function is the `$error_level` is set to `E_USER_ERROR`.

This change is covered by pre-existing tests, which have been updated to expect the exception instead of a PHP error.

Now, why did I not use `WP_Error` ?

Well, for one, this would lead to completely different behaviour as `WP_Error` doesn't extend `Exception`, which means that the program would not be stopped, but would continue running, which would be a much bigger breaking change and carries security risks. WP_Error also doesn't natively trigger displaying/logging of the error message, so in that case, it would still need an `exit` with the error message, bringing us back to point 2 above.

Basically, `WP_Error` is an arcane left-over from the PHP 4 days, before PHP natively supported `try-catch` statements with `Exception`s. If it were up to me, we'd burn it with fire, but considering how much would break if we would (any and all plugins/themes/Core checks which check a function return value for `is_wp_error()` instead of using `try-catch`), that's not really an option.

Having said that, I would strongly recommend, going forward, to not allow any _new_ code to return a `WP_Error` and to encourage the use of dedicated exception classes instead (for new code). I'd recommend for additional exception classes to be placed in a new `wp-includes/exceptions` directory and for these, in principle, to extend `WP_Exception`.

**_Note: this change will need to be mentioned in the WP 6.7 dev-note!_**

Ref:
* https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_e_user_error_to_trigger_error
* https://www.php.net/manual/en/migration80.incompatible.php

Trac ticket: https://core.trac.wordpress.org/ticket/62061

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
