### PR TITLE
PHP 8.4 | Test Helpers: fix trigger_error() with E_USER_ERROR is deprecated (Trac 62061)

### DIFF
--- a/tests/phpunit/includes/class-wp-test-stream.php
+++ b/tests/phpunit/includes/class-wp-test-stream.php
@@ -57,7 +57,7 @@ class WP_Test_Stream {
 		$this->file   = $components['path'] ? $components['path'] : '/';
 
 		if ( empty( $this->bucket ) ) {
-			trigger_error( 'Cannot use an empty bucket name', E_USER_ERROR );
+			throw new Exception( 'Cannot use an empty bucket name' );
 		}
 
 		if ( ! isset( WP_Test_Stream::$data[ $this->bucket ] ) ) {

--- a/tests/phpunit/includes/utils.php
+++ b/tests/phpunit/includes/utils.php
@@ -305,13 +305,12 @@ class TestXMLParser {
 	public function parse( $in ) {
 		$parse = xml_parse( $this->xml, $in, true );
 		if ( ! $parse ) {
-			trigger_error(
+			throw new Exception(
 				sprintf(
 					'XML error: %s at line %d',
 					xml_error_string( xml_get_error_code( $this->xml ) ),
 					xml_get_current_line_number( $this->xml )
-				),
-				E_USER_ERROR
+				)
 			);
 			xml_parser_free( $this->xml );
 		}


### PR DESCRIPTION
### PHP 8.4 | WP_Test_Stream::open(): fix trigger_error() with E_USER_ERROR is deprecated

PHP 8.4 deprecates the use of `trigger_errror()` with `E_USER_ERROR` as the error level, as there are a number of gotchas to this way of creating a `Fatal Error` (`finally` blocks not executing, destructors not executing).
The recommended replacements are either to use exceptions or to do a hard `exit`.

As this is a test-only class, we don't have to take BC-breaks into account.

Also, as this is a test helper, throwing a exception is the most appropriate solution.

Ref:
* https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_e_user_error_to_trigger_error

### PHP 8.4 | TestXMLParser::parse(): fix trigger_error() with E_USER_ERROR is deprecated

PHP 8.4 deprecates the use of `trigger_errror()` with `E_USER_ERROR` as the error level, as there are a number of gotchas to this way of creating a `Fatal Error` (`finally` blocks not executing, destructors not executing).
The recommended replacements are either to use exceptions or to do a hard `exit`.

As this is a test-only class, we don't have to take BC-breaks into account.

Also, as this is a test helper, throwing a exception is the most appropriate solution.

Ref:
* https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_e_user_error_to_trigger_error


Trac ticket: https://core.trac.wordpress.org/ticket/62061

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
