### PR TITLE
Add a filter on wp_insert_user function regarding $user_pass (ticket #49639)

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2137,18 +2137,18 @@ function wp_insert_user( $userdata ) {
 	} else {
 		$update = false;
 
-        /**
-         * Filters a password before hashing it.
-         *
-         * @since 6.7.0
-         *
-         * @param string $userdata['user_pass'] The user's password.
-         */
-        $pre_hash_password = apply_filters( 'pre_hash_password', $userdata['user_pass'] );
+		/**
+		 * Filters a password before hashing it.
+		 *
+		 * @since 6.7.0
+		 *
+		 * @param string $userdata['user_pass'] The user's password.
+		 */
+		$pre_hash_password = apply_filters( 'pre_hash_password', $userdata['user_pass'] );
 
-        if ( empty( $pre_hash_password ) ) {
-            return new WP_Error( 'empty_pre_hash_password', __( 'Cannot create a user with an empty password.' ) );
-        }
+		if ( empty( $pre_hash_password ) ) {
+			return new WP_Error( 'empty_pre_hash_password', __( 'Cannot create a user with an empty password.' ) );
+		}
 
 		// Hash the password.
 		$user_pass = wp_hash_password( $pre_hash_password );
@@ -2606,16 +2606,16 @@ function wp_update_user( $userdata ) {
 
 	if ( ! empty( $userdata['user_pass'] ) && $userdata['user_pass'] !== $user_obj->user_pass ) {
 
-        /** This filter is documented in wp-includes/user.php */
-        $pre_hash_password = apply_filters( 'pre_hash_password', $userdata['user_pass'] );
+		/** This filter is documented in wp-includes/user.php */
+		$pre_hash_password = apply_filters( 'pre_hash_password', $userdata['user_pass'] );
 
-        if ( empty( $pre_hash_password ) ) {
-            return new WP_Error( 'empty_pre_hash_password', __( 'Empty password.' ) );
-        }
+		if ( empty( $pre_hash_password ) ) {
+			return new WP_Error( 'empty_pre_hash_password', __( 'Empty password.' ) );
+		}
 
-        if ( false !== strpos( $pre_hash_password, '\\' ) ) {
-            return new WP_Error( 'illegal_pre_hash_password', __( 'Passwords may not contain the character "\\".' ) );
-        }
+		if ( false !== strpos( $pre_hash_password, '\\' ) ) {
+			return new WP_Error( 'illegal_pre_hash_password', __( 'Passwords may not contain the character "\\".' ) );
+		}
 
 		// If password is changing, hash it now.
 		$plaintext_pass        = $pre_hash_password;

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2150,10 +2150,6 @@ function wp_insert_user( $userdata ) {
             return new WP_Error( 'empty_pre_hash_password', __( 'Cannot create a user with an empty password.' ) );
         }
 
-		if ( str_contains( ( $pre_hash_password ), '\\' ) ) {
-            return new WP_Error( 'illegal_pre_hash_password', __( 'Passwords may not contain the character "\\".' ) );
-        }
-
 		// Hash the password.
 		$user_pass = wp_hash_password( $pre_hash_password );
 	}

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2136,8 +2136,26 @@ function wp_insert_user( $userdata ) {
 		$user_pass = ! empty( $userdata['user_pass'] ) ? $userdata['user_pass'] : $old_user_data->user_pass;
 	} else {
 		$update = false;
+
+        /**
+         * Filters a password before hashing it.
+         *
+         * @since 5.7.3
+         *
+         * @param string $userdata['user_pass'] The user's password.
+         */
+        $pre_hash_password = apply_filters( 'pre_hash_password', $userdata['user_pass'] );
+
+        if ( empty( $pre_hash_password ) ) {
+            return new WP_Error( 'empty_pre_hash_password', __( 'Cannot create a user with an empty password.' ) );
+        }
+
+        if ( false !== strpos( $pre_hash_password, '\\' ) ) {
+            return new WP_Error( 'illegal_pre_hash_password', __( 'Passwords may not contain the character "\\".' ) );
+        }
+
 		// Hash the password.
-		$user_pass = wp_hash_password( $userdata['user_pass'] );
+		$user_pass = wp_hash_password( $pre_hash_password );
 	}
 
 	$sanitized_user_login = sanitize_user( $userdata['user_login'], true );
@@ -2591,9 +2609,21 @@ function wp_update_user( $userdata ) {
 	$user = add_magic_quotes( $user );
 
 	if ( ! empty( $userdata['user_pass'] ) && $userdata['user_pass'] !== $user_obj->user_pass ) {
+
+        /** This filter is documented in wp-includes/user.php */
+        $pre_hash_password = apply_filters( 'pre_hash_password', $userdata['user_pass'] );
+
+        if ( empty( $pre_hash_password ) ) {
+            return new WP_Error( 'empty_pre_hash_password', __( 'Empty password.' ) );
+        }
+
+        if ( false !== strpos( $pre_hash_password, '\\' ) ) {
+            return new WP_Error( 'illegal_pre_hash_password', __( 'Passwords may not contain the character "\\".' ) );
+        }
+
 		// If password is changing, hash it now.
-		$plaintext_pass        = $userdata['user_pass'];
-		$userdata['user_pass'] = wp_hash_password( $userdata['user_pass'] );
+		$plaintext_pass        = $pre_hash_password;
+		$userdata['user_pass'] = wp_hash_password( $pre_hash_password );
 
 		/**
 		 * Filters whether to send the password change email.

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2140,7 +2140,7 @@ function wp_insert_user( $userdata ) {
         /**
          * Filters a password before hashing it.
          *
-         * @since 5.7.3
+         * @since 6.7.0
          *
          * @param string $userdata['user_pass'] The user's password.
          */

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2150,7 +2150,7 @@ function wp_insert_user( $userdata ) {
             return new WP_Error( 'empty_pre_hash_password', __( 'Cannot create a user with an empty password.' ) );
         }
 
-        if ( false !== strpos( $pre_hash_password, '\\' ) ) {
+		if ( str_contains( wp_unslash( $pre_hash_password ), '\\' ) ) {
             return new WP_Error( 'illegal_pre_hash_password', __( 'Passwords may not contain the character "\\".' ) );
         }
 

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2150,7 +2150,7 @@ function wp_insert_user( $userdata ) {
             return new WP_Error( 'empty_pre_hash_password', __( 'Cannot create a user with an empty password.' ) );
         }
 
-		if ( str_contains( wp_unslash( $pre_hash_password ), '\\' ) ) {
+		if ( str_contains( ( $pre_hash_password ), '\\' ) ) {
             return new WP_Error( 'illegal_pre_hash_password', __( 'Passwords may not contain the character "\\".' ) );
         }
 

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -2204,23 +2204,4 @@ class Tests_User extends WP_UnitTestCase {
 		$this->assertSame( 'empty_pre_hash_password', $create_user->get_error_code() );
 		$this->assertSame( 'Cannot create a user with an empty password.', $create_user->get_error_message() );
 	}
-
-	/**
-	 * Test that an error is returned when the password contains a backslash.
-	 *
-	 * @ticket 49639
-	 */
-	public function test_wp_insert_user_password_with_backslash() {
-		$user_data = array(
-			'user_login' => 'test_user_backslash',
-			'user_email' => 'test_user_backslash@example.com',
-			'user_pass'  => 'password\\123',
-		);
-
-		$create_user = wp_insert_user( $user_data );
-
-		$this->assertWPError( $create_user );
-		$this->assertSame( 'illegal_pre_hash_password', $create_user->get_error_code() );
-		$this->assertSame( 'Passwords may not contain the character "\\".', $create_user->get_error_message() );
-	}
 }

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -2185,4 +2185,42 @@ class Tests_User extends WP_UnitTestCase {
 
 		return $additional_profile_data;
 	}
+
+	/**
+	 * Test that an error is returned when the password is empty.
+	 *
+	 * @ticket 49639
+	 */
+	public function test_wp_insert_user_empty_password() {
+		$user_data = array(
+			'user_login' => 'test_user_empty',
+			'user_email' => 'test_user_empty@example.com',
+			'user_pass'  => '', // Empty password
+		);
+
+		$create_user = wp_insert_user( $user_data );
+
+		$this->assertWPError( $create_user );
+		$this->assertSame( 'empty_pre_hash_password', $create_user->get_error_code() );
+		$this->assertSame( 'Cannot create a user with an empty password.', $create_user->get_error_message() );
+	}
+
+	/**
+	 * Test that an error is returned when the password contains a backslash.
+	 *
+	 * @ticket 49639
+	 */
+	public function test_wp_insert_user_password_with_backslash() {
+		$user_data = array(
+			'user_login' => 'test_user_backslash',
+			'user_email' => 'test_user_backslash@example.com',
+			'user_pass'  => 'password\\123',
+		);
+
+		$create_user = wp_insert_user( $user_data );
+
+		$this->assertWPError( $create_user );
+		$this->assertSame( 'illegal_pre_hash_password', $create_user->get_error_code() );
+		$this->assertSame( 'Passwords may not contain the character "\\".', $create_user->get_error_message() );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This PR adds filter on user typed password before hashing the password.
It also includes error check for empty password and a backslash. Unit test included for both.
`npm run test:php -- --group 49639`

Trac ticket: [49639](https://core.trac.wordpress.org/ticket/49639)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
