### PR TITLE
Accessibility issue with the logo on the login page

### DIFF
--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -140,6 +140,10 @@ p {
 	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
 }
 
+.login form h1 {
+	margin-bottom: 10px;
+}
+
 .login form.shake {
 	animation: shake 0.2s cubic-bezier(.19,.49,.38,.79) both;
 	animation-iteration-count: 3;

--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -215,7 +215,7 @@ p {
 	margin: 1.1em 0;
 }
 
-.login h1.admin-email__heading {
+.login .admin-email__heading {
 	border-bottom: 1px #f0f0f1 solid;
 	color: #50575e;
 	font-weight: normal;
@@ -256,10 +256,11 @@ p {
 }
 
 .login h1 {
-	text-align: center;
+	text-align: left;
+	font-size: 20px;
 }
 
-.login h1 a {
+.login .logo a {
 	background-image: url(../images/w-logo-blue.png?ver=20131202);
 	background-image: none, url(../images/wordpress-logo.svg?ver=20131107);
 	background-size: 84px;
@@ -309,13 +310,13 @@ p {
 
 .login #nav a:hover,
 .login #backtoblog a:hover,
-.login h1 a:hover {
+.login .logo a:hover {
 	color: #135e96;
 }
 
 .login #nav a:focus,
 .login #backtoblog a:focus,
-.login h1 a:focus {
+.login .logo a:focus {
 	color: #043959;
 }
 
@@ -376,7 +377,7 @@ body.interim-login {
 	margin: 5px auto 20px;
 }
 
-.interim-login.login h1 a {
+.interim-login.login .logo a {
 	width: auto;
 }
 

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -959,15 +959,6 @@ switch ( $action ) {
 		login_header( __( 'Reset Password' ), '<p class="message reset-pass">' . __( 'Enter your new password below or generate one.' ) . '</p>', $errors );
 
 		?>
-		<?php
-		/**
-		 * Login text 
-		 * 
-		 * @since 6.4.0
-		 * @param string Displays Login text.
-		 * */
-		sprintf( '<h1>%</h1>', _( 'Login' ) );
-		?>
 		<form name="resetpassform" id="resetpassform" action="<?php echo esc_url( network_site_url( 'wp-login.php?action=resetpass', 'login_post' ) ); ?>" method="post" autocomplete="off">
 			<input type="hidden" id="user_login" value="<?php echo esc_attr( $rp_login ); ?>" autocomplete="off" />
 
@@ -1434,6 +1425,7 @@ switch ( $action ) {
 		?>
 
 		<form name="loginform" id="loginform" action="<?php echo esc_url( site_url( 'wp-login.php', 'login_post' ) ); ?>" method="post">
+			<h1><?php echo __('Login'); ?></h1>
 			<p>
 				<label for="user_login"><?php _e( 'Username or Email Address' ); ?></label>
 				<input type="text" name="log" id="user_login"<?php echo $aria_describedby; ?> class="input" value="<?php echo esc_attr( $user_login ); ?>" size="20" autocapitalize="off" autocomplete="username" required="required" />

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -193,6 +193,7 @@ function login_header( $title = 'Log In', $message = '', $wp_error = null ) {
 	?>
 	</head>
 	<body class="login no-js <?php echo esc_attr( implode( ' ', $classes ) ); ?>">
+	<main role="main">
 	<script type="text/javascript">
 		document.body.className = document.body.className.replace('no-js','js');
 	</script>
@@ -206,7 +207,7 @@ function login_header( $title = 'Log In', $message = '', $wp_error = null ) {
 
 	?>
 	<div id="login">
-		<h1><a href="<?php echo esc_url( $login_header_url ); ?>"><?php echo $login_header_text; ?></a></h1>
+		<div class="logo"><a href="<?php echo esc_url( $login_header_url ); ?>"><?php echo $login_header_text; ?></a></div>
 	<?php
 	/**
 	 * Filters the message to display above the login form.
@@ -400,6 +401,7 @@ function login_footer( $input_id = '' ) {
 
 	?>
 	<div class="clear"></div>
+	</main>
 	</body>
 	</html>
 	<?php
@@ -956,6 +958,15 @@ switch ( $action ) {
 
 		login_header( __( 'Reset Password' ), '<p class="message reset-pass">' . __( 'Enter your new password below or generate one.' ) . '</p>', $errors );
 
+		?>
+		<?php
+		/**
+		 * Login text 
+		 * 
+		 * @since 6.4.0
+		 * @param string Displays Login text.
+		 * */
+		sprintf( '<h1>%</h1>', _( 'Login' ) );
 		?>
 		<form name="resetpassform" id="resetpassform" action="<?php echo esc_url( network_site_url( 'wp-login.php?action=resetpass', 'login_post' ) ); ?>" method="post" autocomplete="off">
 			<input type="hidden" id="user_login" value="<?php echo esc_attr( $rp_login ); ?>" autocomplete="off" />

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -1425,7 +1425,7 @@ switch ( $action ) {
 		?>
 
 		<form name="loginform" id="loginform" action="<?php echo esc_url( site_url( 'wp-login.php', 'login_post' ) ); ?>" method="post">
-			<h1><?php echo __('Login'); ?></h1>
+			<h1><?php _e( 'Login' ); ?></h1>
 			<p>
 				<label for="user_login"><?php _e( 'Username or Email Address' ); ?></label>
 				<input type="text" name="log" id="user_login"<?php echo $aria_describedby; ?> class="input" value="<?php echo esc_attr( $user_login ); ?>" size="20" autocapitalize="off" autocomplete="username" required="required" />


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

- I've added a "Login" text inside the form and moved the `<h1>` tag to it. So now the WordPress logo is inside a div.
- I also added a main tag to the page.

<img width="635" alt="login-screen" src="https://github.com/user-attachments/assets/b052f681-2f24-49c7-adaf-41797c4f356b">


Trac ticket: https://core.trac.wordpress.org/ticket/51786
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
