### PR TITLE
App Passwords: Don't prevent non-unique App Password names.

### DIFF
--- a/src/wp-includes/class-wp-application-passwords.php
+++ b/src/wp-includes/class-wp-application-passwords.php
@@ -94,10 +94,6 @@ class WP_Application_Passwords {
 			return new WP_Error( 'application_password_empty_name', __( 'An application name is required to create an application password.' ), array( 'status' => 400 ) );
 		}
 
-		if ( self::application_name_exists_for_user( $user_id, $args['name'] ) ) {
-			return new WP_Error( 'application_password_duplicate_name', __( 'Each application name should be unique.' ), array( 'status' => 409 ) );
-		}
-
 		$new_password    = wp_generate_password( static::PW_LENGTH, false );
 		$hashed_password = wp_hash_password( $new_password );
 

--- a/tests/e2e/specs/profile/applications-passwords.test.js
+++ b/tests/e2e/specs/profile/applications-passwords.test.js
@@ -35,23 +35,6 @@ test.describe( 'Manage applications passwords', () => {
 		);
 	} );
 
-	test('should not allow to create two applications passwords with the same name', async ( {
-		page,
-		applicationPasswords
-	} ) => {
-		await applicationPasswords.create();
-		await applicationPasswords.create();
-
-		const errorMessage = page.getByRole( 'alert' );
-
-		await expect( errorMessage ).toHaveClass( /notice-error/ );
-		await expect(
-			errorMessage
-		).toContainText(
-			'Each application name should be unique.'
-		);
-	});
-
 	test( 'should correctly revoke a single application password', async ( {
 		page,
 		applicationPasswords

--- a/tests/phpunit/tests/rest-api/application-passwords.php
+++ b/tests/phpunit/tests/rest-api/application-passwords.php
@@ -194,8 +194,8 @@ class Test_WP_Application_Passwords extends WP_UnitTestCase {
 	 */
 	public function test_can_create_duplicate_app_password_names() {
 		$created = WP_Application_Passwords::create_new_application_password( self::$user_id, array( 'name' => 'My App' ) );
-		$this->assertNotWPError( $created );
+		$this->assertNotWPError( $created, 'First attempt to create an application password should not return an error' );
 		$created = WP_Application_Passwords::create_new_application_password( self::$user_id, array( 'name' => 'My App' ) );
-		$this->assertNotWPError( $created );
+		$this->assertNotWPError( $created, 'Second attempt to create an application password should not return an error' );
 	}
 }

--- a/tests/phpunit/tests/rest-api/application-passwords.php
+++ b/tests/phpunit/tests/rest-api/application-passwords.php
@@ -196,4 +196,14 @@ class Test_WP_Application_Passwords extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * @ticket 51941
+	 */
+	public function test_can_create_duplicate_app_password_names() {
+		$created = WP_Application_Passwords::create_new_application_password( self::$user_id, array( 'name' => 'My App' ) );
+		$this->assertNotWPError( $created );
+		$created = WP_Application_Passwords::create_new_application_password( self::$user_id, array( 'name' => 'My App' ) );
+		$this->assertNotWPError( $created );
+	}
 }

--- a/tests/phpunit/tests/rest-api/application-passwords.php
+++ b/tests/phpunit/tests/rest-api/application-passwords.php
@@ -77,14 +77,6 @@ class Test_WP_Application_Passwords extends WP_UnitTestCase {
 				),
 				'args'     => array( 'name' => '<script>console.log("Hello")</script>' ),
 			),
-			'application_password_duplicate_name when name exists' => array(
-				'expected' => array(
-					'error_code'    => 'application_password_duplicate_name',
-					'error_message' => 'Each application name should be unique.',
-				),
-				'args'     => array( 'name' => 'test2' ),
-				'names'    => array( 'test1', 'test2' ),
-			),
 		);
 	}
 


### PR DESCRIPTION
In [50030] we enforced that Application Passwords have unique names. This was done with the assumption that applications would not connect to a user multiple times. However, in practice we've seen applications run into issues with the unique name constraint. Depending on the app, they may not know if they've been authorized before, or they may intentionally allow connecting multiple times. To prevent friction, App developers need to make their App Name unique, and in doing so often include things like the current date & time, which is already included in the App Passwords list table.

This commit removes this requirement to simplify usage of the Authorize Application flow.

Props mark-k, Boniu91.
Fixes #54213.

Trac ticket: https://core.trac.wordpress.org/ticket/54213

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
