### PR TITLE
Block bindings: Ensure the block receives the fully expanded __default bindings when rendering

### DIFF
--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -286,9 +286,9 @@ class WP_Block {
 			}
 			$bindings = $updated_bindings;
 			/*
-			* Update the bindings metadata of the computed attributes.
-			* This ensures the block receives the expanded __default binding metadata when it renders.
-			*/
+			 * Update the bindings metadata of the computed attributes.
+			 * This ensures the block receives the expanded __default binding metadata when it renders.
+			 */
 			$computed_attributes['metadata'] = array_merge(
 				$parsed_block['attrs']['metadata'],
 				array( 'bindings' => $bindings )

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -237,6 +237,7 @@ class WP_Block {
 	 *
 	 * @since 6.5.0
 	 * @since 6.6.0 Handle the `__default` attribute for pattern overrides.
+	 * @since 6.7.0 Return any updated bindings metadata in the computed attributes.
 	 *
 	 * @return array The computed block attributes for the provided block bindings.
 	 */
@@ -310,8 +311,8 @@ class WP_Block {
 			}
 		}
 
-		// Update the bindings in the computed attributes.
-		// This ensures the block receives the expanded __default binding when it renders.
+		// Update the bindings metadata in the computed attributes.
+		// This ensures the block receives the expanded __default binding metadata when it renders.
 		$computed_attributes['metadata'] = array_merge(
 			$parsed_block['attrs']['metadata'],
 			array( 'bindings' => $bindings )

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -285,6 +285,14 @@ class WP_Block {
 					: array( 'source' => 'core/pattern-overrides' );
 			}
 			$bindings = $updated_bindings;
+			/*
+			* Update the bindings metadata of the computed attributes.
+			* This ensures the block receives the expanded __default binding metadata when it renders.
+			*/
+			$computed_attributes['metadata'] = array_merge(
+				$parsed_block['attrs']['metadata'],
+				array( 'bindings' => $bindings )
+			);
 		}
 
 		foreach ( $bindings as $attribute_name => $block_binding ) {
@@ -310,15 +318,6 @@ class WP_Block {
 				$computed_attributes[ $attribute_name ] = $source_value;
 			}
 		}
-
-		/*
-		 * Update the bindings metadata of the computed attributes.
-		 * This ensures the block receives the expanded __default binding metadata when it renders.
-		 */
-		$computed_attributes['metadata'] = array_merge(
-			$parsed_block['attrs']['metadata'],
-			array( 'bindings' => $bindings )
-		);
 
 		return $computed_attributes;
 	}

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -311,8 +311,10 @@ class WP_Block {
 			}
 		}
 
-		// Update the bindings metadata in the computed attributes.
-		// This ensures the block receives the expanded __default binding metadata when it renders.
+		/*
+		 * Update the bindings metadata of the computed attributes.
+		 * This ensures the block receives the expanded __default binding metadata when it renders.
+		 */
 		$computed_attributes['metadata'] = array_merge(
 			$parsed_block['attrs']['metadata'],
 			array( 'bindings' => $bindings )

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -310,6 +310,13 @@ class WP_Block {
 			}
 		}
 
+		// Update the bindings in the computed attributes.
+		// This ensures the block receives the expanded __default binding when it renders.
+		$computed_attributes['metadata'] = array_merge(
+			$parsed_block['attrs']['metadata'],
+			array( 'bindings' => $bindings )
+		);
+
 		return $computed_attributes;
 	}
 

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -272,30 +272,40 @@ HTML;
 	}
 
 	/**
-	 * Tests if the `__default` attribute is replaced with real attribues for
+	 * Tests if the `__default` attribute is replaced with real attributes for
 	 * pattern overrides.
 	 *
 	 * @ticket 61333
+	 * @ticket 62069
 	 *
 	 * @covers WP_Block::process_block_bindings
 	 */
 	public function test_default_binding_for_pattern_overrides() {
-		$expected_content = 'This is the content value';
-
 		$block_content = <<<HTML
 <!-- wp:paragraph {"metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"Test"}} -->
 <p>This should not appear</p>
 <!-- /wp:paragraph -->
 HTML;
 
-		$parsed_blocks = parse_blocks( $block_content );
-		$block         = new WP_Block( $parsed_blocks[0], array( 'pattern/overrides' => array( 'Test' => array( 'content' => $expected_content ) ) ) );
-		$result        = $block->render();
+		$expected_content = 'This is the content value';
+		$parsed_blocks    = parse_blocks( $block_content );
+		$block            = new WP_Block( $parsed_blocks[0], array( 'pattern/overrides' => array( 'Test' => array( 'content' => $expected_content ) ) ) );
+
+		$result = $block->render();
 
 		$this->assertSame(
 			"<p>$expected_content</p>",
 			trim( $result ),
 			'The `__default` attribute should be replaced with the real attribute prior to the callback.'
+		);
+
+		$expected_bindings_metadata = array(
+			'content' => array( 'source' => 'core/pattern-overrides' ),
+		);
+		$this->assertSame(
+			$expected_bindings_metadata,
+			$block->attributes['metadata']['bindings'],
+			'The __default binding should be updated with the individual binding attributes in the block metadata.'
 		);
 	}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/62069
Gutenberg issue: https://github.com/WordPress/gutenberg/issues/64688


## What
Fixes an issue with the image block when using pattern overrides caused by a bug in the block binding logic.

## Why does the bug happen?
The pattern overrides feature is built upon block bindings, and uses a special __default binding that means all block attributes that support binding are bound:
```js
bindings: {
    __default: 'core/pattern-overrides'
}
```

During processing of the bindings, this single __default binding is replaced with the individual binding attributes - e.g.:
```js
bindings: {
    src: 'core/pattern-overrides',
    id: 'core/pattern-overrides',
    caption: 'core/pattern-overrides',
}
```

In the gutenberg plugin this updated bindings metadata is assigned back to the block before rendering so that the block can reason about which individual attributes are bound:
https://github.com/WordPress/gutenberg/blob/98b8d415830fa9ebf7b4b0a2b95d65b9fd1e813a/lib/compat/wordpress-6.6/blocks.php#L40

This allows blocks like the image block to check whether an individual attribute, like `id`, has a binding:
https://github.com/WordPress/gutenberg/blob/98b8d415830fa9ebf7b4b0a2b95d65b9fd1e813a/packages/block-library/src/image/index.php#L31

Unfortunately core doesn't have the same logic to assign the updated binding metadata back to the block before rendering, which means the image block's logic fails. The block only receives the individual `__default` binding in its metadata.

## How has it been fixed?
The fix in this PR is to ensure that the `process_block_bindings` method returns any updates to the block's binding metadata along with other computed attributes.

Prior to rendering, the block's attributes are updated with the result of this method (it's where the binding attribute values are updated for a block):
https://github.com/WordPress/wordpress-develop/blob/d8e05446b7d109f8b3c48cbeebf6241d3f6e3946/src/wp-includes/class-wp-block.php#L465-L470

So this will achieve the same result as the code in the Gutenberg plugin.

## Steps for reproduction
1. Add an image block to a new post and add an image to the block
2. Preview the post and inspect the image, make a note of the image's id in the classname attribute (e.g. `wp-image-123`)
2. Back in the editor, click on the image block, go to settings, and Create Pattern (make it a synced pattern)
3. Edit the pattern by clicking 'Edit original'
4. Click the image block and go to Advanced > Enable Overrides
5. Enter a name for the block and enable the override
6. Save Pattern and return to post
7. Click on the image block in the pattern and replace with a new image
8. Save page and view on front-end
9. Inspect the image and check that the id in the classname was updated to the new image's id
10. Check that the image has html additional attributes like `fetchpriority` (which are missing in `trunk`)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
