### PR TITLE
Block bindings: Add filter for supported block attributes

### DIFF
--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -237,6 +237,7 @@ class WP_Block {
 	 *
 	 * @since 6.5.0
 	 * @since 6.6.0 Handle the `__default` attribute for pattern overrides.
+	 * @since 6.7.0 Add filter for supported block attributes for block bindings.
 	 *
 	 * @return array The computed block attributes for the provided block bindings.
 	 */
@@ -253,9 +254,11 @@ class WP_Block {
 		/**
 		 * Filters the supported block attributes for block bindings.
 		 *
-		 * @since 6.6.0
+		 * @since 6.7.0
 		 *
 		 * @param array $supported_block_attributes The default supported block attributes.
+		 *
+		 * @return array The updated supported block attributes.
 		 */
 		$supported_block_attributes = apply_filters(
 			'block_bindings_supported_block_attributes',

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -250,6 +250,18 @@ class WP_Block {
 			'core/button'    => array( 'url', 'text', 'linkTarget', 'rel' ),
 		);
 
+		/**
+		 * Filters the supported block attributes for block bindings.
+		 *
+		 * @since 6.6.0
+		 *
+		 * @param array $supported_block_attributes The default supported block attributes.
+		 */
+		$supported_block_attributes = apply_filters(
+			'block_bindings_supported_block_attributes',
+			$supported_block_attributes
+		);
+
 		// If the block doesn't have the bindings property, isn't one of the supported
 		// block types, or the bindings property is not an array, return the block content.
 		if (

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -302,17 +302,17 @@ HTML;
 	/**
 	 * Tests that filter `block_bindings_supported_block_attributes` is applied.
 	 *
-	 * @ticket 61181
+	 * @ticket 62090
 	 */
 	public function test_filter_block_bindings_supported_block_attributes() {
-		$filter_supported_attributes = function( $supported_block_attributes ) {
+		$filter_supported_attributes = function ( $supported_block_attributes ) {
 			$supported_block_attributes['core/custom-block'] = array( 'custom_attribute' );
 			return $supported_block_attributes;
 		};
 
 		add_filter( 'block_bindings_supported_block_attributes', $filter_supported_attributes );
 
-		$get_value_callback = function() {
+		$get_value_callback = function () {
 			return 'Custom value';
 		};
 

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -366,7 +366,7 @@ HTML;
 	 */
 	public function test_filter_block_bindings_supported_block_attributes_custom_block_custom_attribute() {
 		register_block_type(
-			'plugin/custom-block',
+			'plugin/custom-block-with-custom-attr',
 			array(
 				'attributes'      => array(
 					'customAttribute' => array(
@@ -381,7 +381,7 @@ HTML;
 		);
 
 		$filter_supported_attributes = function ( $supported_block_attributes ) {
-			$supported_block_attributes['plugin/custom-block'] = array( 'customAttribute' );
+			$supported_block_attributes['plugin/custom-block-with-custom-attr'] = array( 'customAttribute' );
 			return $supported_block_attributes;
 		};
 
@@ -398,9 +398,8 @@ HTML;
 		);
 
 		$block_content = <<<HTML
-<!-- wp:plugin/custom-block {"metadata":{"bindings":{"customAttribute":{"source":"test/source", "args": {"key": "custom_key"}}}}} -->
-<div>Default value</div>
-<!-- /wp:plugin/custom-block -->
+<!-- wp:plugin/custom-block-with-custom-attr {"metadata":{"bindings":{"customAttribute":{"source":"test/source", "args": {"key": "custom_key"}}}}} -->
+<!-- /wp:plugin/custom-block-with-custom-attr -->
 HTML;
 
 		$parsed_blocks = parse_blocks( $block_content );

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -304,7 +304,7 @@ HTML;
 	 *
 	 * @ticket 62090
 	 */
-	public function test_filter_block_bindings_supported_block_attributes() {
+	public function test_filter_block_bindings_supported_block_attributes_custom_block_content_attribute() {
 		register_block_type(
 			'plugin/custom-block',
 			array(
@@ -356,6 +356,63 @@ HTML;
 			'<p>Source value: custom_attribute</p>',
 			trim( $result ),
 			'The block content should show the custom attribute value after applying the filter.'
+		);
+	}
+
+	/**
+	 * Tests that the 'block_bindings_supported_block_attributes' filter works for custom blocks and attributes.
+	 *
+	 * @ticket 61181
+	 */
+	public function test_filter_block_bindings_supported_block_attributes_custom_block_custom_attribute() {
+		register_block_type(
+			'plugin/custom-block',
+			array(
+				'attributes'      => array(
+					'customAttribute' => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+				),
+				'render_callback' => function ( $attributes ) {
+					return '<div data-value="' . ( $attributes['customAttribute'] ?? 'Default value' ) . '">static content</div>';
+				},
+			)
+		);
+
+		$filter_supported_attributes = function ( $supported_block_attributes ) {
+			$supported_block_attributes['plugin/custom-block'] = array( 'customAttribute' );
+			return $supported_block_attributes;
+		};
+
+		add_filter( 'block_bindings_supported_block_attributes', $filter_supported_attributes );
+
+		register_block_bindings_source(
+			self::SOURCE_NAME,
+			array(
+				'label'              => self::SOURCE_LABEL,
+				'get_value_callback' => function ( $source_args ) {
+					return "Bound value: {$source_args['key']}";
+				},
+			)
+		);
+
+		$block_content = <<<HTML
+<!-- wp:plugin/custom-block {"metadata":{"bindings":{"customAttribute":{"source":"test/source", "args": {"key": "custom_key"}}}}} -->
+<div>Default value</div>
+<!-- /wp:plugin/custom-block -->
+HTML;
+
+		$parsed_blocks = parse_blocks( $block_content );
+		$block         = new WP_Block( $parsed_blocks[0] );
+		$result        = $block->render();
+
+		remove_filter( 'block_bindings_supported_block_attributes', $filter_supported_attributes );
+
+		$this->assertSame(
+			'<div data-value="Bound value: custom_key">static content</div>',
+			trim( $result ),
+			'The block content should show the bound value for the custom attribute after applying the filter.'
 		);
 	}
 


### PR DESCRIPTION
Adds a filter called block_bindings_supported_block_attributes to allow adding blocks / attributes to the supported list.

This list of allowed attributes for block bindings is the only thing in core keeping us from making larger use of block bindings for our [Remote Data Blocks](https://remotedatablocks.com) plugin. The bindings already work how we need them to, they just aren't allowed on custom blocks, and this filter will allow us to add additional blocks / attributes to the list so we can hook remote data up to dynamic blocks using the standard block binding functionality.

For our use case, the use of this will be abstracted away by our plugin and it would not be super problematic to deprecate this filter if another approach is decided on in the future. But without this change making it into 6.7, it means our RDB plugin will be severely limited in functionality until at least 6.8, so getting this merged would be huge for us.

Trac ticket: https://core.trac.wordpress.org/ticket/62090

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
