### PR TITLE
HTML API: Replace internal logic of `force_balance_tags()`

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2549,10 +2549,12 @@ function balanceTags( $text, $force = false ) {  // phpcs:ignore WordPress.Namin
 }
 
 /**
- * Balances tags of string using a modified stack.
+ * "Balances" an input HTML string by normalizing, ensuring that all missing
+ * implicit tags, or overlapping tags, are present and accounted for.
  *
  * @since 2.0.4
  * @since 5.3.0 Improve accuracy and add support for custom element tags.
+ * @since 6.7.0 Internal logic replaced by HTML API.
  *
  * @author Leonard Lin <leonard@acm.org>
  * @license GPL
@@ -2568,6 +2570,11 @@ function balanceTags( $text, $force = false ) {  // phpcs:ignore WordPress.Namin
  * @return string Balanced text.
  */
 function force_balance_tags( $text ) {
+	$normalized = WP_HTML_Processor::normalize( $text );
+	if ( is_string( $normalized ) ) {
+		return $normalized;
+	}
+
 	$tagstack  = array();
 	$stacksize = 0;
 	$tagqueue  = '';


### PR DESCRIPTION
## Resolved

Trac ticket: Core-55027 (February 2022)
Trac ticket: Core-44571 (July 2018)
Trac ticket: Core-40958 (June 2017)
Trac ticket: Core-39847 (February 2017)

## Related

Trac ticket: Core-47514 (June 2019)

The concept of `force_balance_tags()` is tricky at best. It's purpose, however is clear: clean up HTML input no matter how "bad" it appears.

The HTML API introduces a new tool based on a systematic approach to normalizing by serializing. `WP_HTML_Processor::normalize()` produces clear and consistent output HTML regardless of the input and without any special-casing for "edge cases." As a spec-compliant parser, everything is a basic case of applying the parsing rules.

Since there are still documents that the HTML API cannot parse, this is an optimistic refactor. For the cases of unsupported HTML, the behavior falls back to the legacy code. When the HTML API finished supporting all content it may be possible to eliminate the legacy code, but until then, most inputs will be handled by the HTML API.