### PR TITLE
Remove title attributes from `Walker_Nav_Menu`

### DIFF
--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -217,7 +217,7 @@ class Walker_Nav_Menu extends Walker {
 		$title = apply_filters( 'the_title', $menu_item->title, $menu_item->ID );
 
 		// Save filtered value before filtering again.
-		$title_filtered = $title;
+		$the_title_filtered = $title;
 
 		/**
 		 * Filters a menu item's title.
@@ -254,7 +254,7 @@ class Walker_Nav_Menu extends Walker {
 		// Add title attribute only if it does not match the link text (before or after filtering).
 		if ( ! empty( $menu_item->attr_title )
 			&& trim( strtolower( $menu_item->attr_title ) ) !== trim( strtolower( $menu_item->title ) )
-			&& trim( strtolower( $menu_item->attr_title ) ) !== trim( strtolower( $title_filtered ) )
+			&& trim( strtolower( $menu_item->attr_title ) ) !== trim( strtolower( $the_title_filtered ) )
 			&& trim( strtolower( $menu_item->attr_title ) ) !== trim( strtolower( $title ) )
 		) {
 			$atts['title'] = $menu_item->attr_title;

--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -126,6 +126,7 @@ class Walker_Nav_Menu extends Walker {
 	 * @since 4.4.0 The {@see 'nav_menu_item_args'} filter was added.
 	 * @since 5.9.0 Renamed `$item` to `$data_object` and `$id` to `$current_object_id`
 	 *              to match parent class for PHP 8 named parameter support.
+	 * @since 6.7.0 Removed redundant title attributes.
 	 *
 	 * @see Walker::start_el()
 	 *
@@ -212,8 +213,22 @@ class Walker_Nav_Menu extends Walker {
 
 		$output .= $indent . '<li' . $li_attributes . '>';
 
+		/** This filter is documented in wp-includes/post-template.php */
+		$title = apply_filters( 'the_title', $menu_item->title, $menu_item->ID );
+
+		/**
+		 * Filters a menu item's title.
+		 *
+		 * @since 4.4.0
+		 *
+		 * @param string   $title     The menu item's title.
+		 * @param WP_Post  $menu_item The current menu item object.
+		 * @param stdClass $args      An object of wp_nav_menu() arguments.
+		 * @param int      $depth     Depth of menu item. Used for padding.
+		 */
+		$title = apply_filters( 'nav_menu_item_title', $title, $menu_item, $args, $depth );
+
 		$atts           = array();
-		$atts['title']  = ! empty( $menu_item->attr_title ) ? $menu_item->attr_title : '';
 		$atts['target'] = ! empty( $menu_item->target ) ? $menu_item->target : '';
 		if ( '_blank' === $menu_item->target && empty( $menu_item->xfn ) ) {
 			$atts['rel'] = 'noopener';
@@ -232,6 +247,14 @@ class Walker_Nav_Menu extends Walker {
 		}
 
 		$atts['aria-current'] = $menu_item->current ? 'page' : '';
+
+		if ( ! empty( $menu_item->attr_title )
+			&& trim( strtolower( $menu_item->attr_title ) ) !== trim( strtolower( $title ) )
+		) {
+			$atts['title'] = $menu_item->attr_title;
+		} else {
+			$atts['title'] = '';
+		}
 
 		/**
 		 * Filters the HTML attributes applied to a menu item's anchor element.
@@ -254,21 +277,6 @@ class Walker_Nav_Menu extends Walker {
 		 */
 		$atts       = apply_filters( 'nav_menu_link_attributes', $atts, $menu_item, $args, $depth );
 		$attributes = $this->build_atts( $atts );
-
-		/** This filter is documented in wp-includes/post-template.php */
-		$title = apply_filters( 'the_title', $menu_item->title, $menu_item->ID );
-
-		/**
-		 * Filters a menu item's title.
-		 *
-		 * @since 4.4.0
-		 *
-		 * @param string   $title     The menu item's title.
-		 * @param WP_Post  $menu_item The current menu item object.
-		 * @param stdClass $args      An object of wp_nav_menu() arguments.
-		 * @param int      $depth     Depth of menu item. Used for padding.
-		 */
-		$title = apply_filters( 'nav_menu_item_title', $title, $menu_item, $args, $depth );
 
 		$item_output  = $args->before;
 		$item_output .= '<a' . $attributes . '>';

--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -216,6 +216,9 @@ class Walker_Nav_Menu extends Walker {
 		/** This filter is documented in wp-includes/post-template.php */
 		$title = apply_filters( 'the_title', $menu_item->title, $menu_item->ID );
 
+		// Save filtered value before filtering again.
+		$title_filtered = $title;
+
 		/**
 		 * Filters a menu item's title.
 		 *
@@ -248,7 +251,10 @@ class Walker_Nav_Menu extends Walker {
 
 		$atts['aria-current'] = $menu_item->current ? 'page' : '';
 
+		// Add title attribute only if it does not match the link text (before or after filtering).
 		if ( ! empty( $menu_item->attr_title )
+			&& trim( strtolower( $menu_item->attr_title ) ) !== trim( strtolower( $menu_item->title ) )
+			&& trim( strtolower( $menu_item->attr_title ) ) !== trim( strtolower( $title_filtered ) )
 			&& trim( strtolower( $menu_item->attr_title ) ) !== trim( strtolower( $title ) )
 		) {
 			$atts['title'] = $menu_item->attr_title;


### PR DESCRIPTION
Removes redundant tooltips from `Walker_Nav_Menu::start_el()`

[Trac 51299](https://core.trac.wordpress.org/ticket/51299)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
