### PR TITLE
Twenty Nineteen: adjust avatar dimensions for comment author

### DIFF
--- a/src/wp-content/themes/twentynineteen/sass/media/_media.scss
+++ b/src/wp-content/themes/twentynineteen/sass/media/_media.scss
@@ -20,9 +20,7 @@ object {
 .avatar {
 	border-radius: 100%;
 	display: block;
-	height: auto;
 	min-height: inherit;
-	width: auto;
 }
 
 svg {

--- a/src/wp-content/themes/twentynineteen/sass/site/primary/_comments.scss
+++ b/src/wp-content/themes/twentynineteen/sass/site/primary/_comments.scss
@@ -205,8 +205,10 @@
 
 		.avatar {
 			float: left;
+			height: calc(2.25 * #{$size__spacing-unit});
 			margin-right: $size__spacing-unit;
 			position: relative;
+			width: calc(2.25 * #{$size__spacing-unit});
 
 			@include media(tablet) {
 				float: inherit;

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -4776,8 +4776,10 @@ body.page .main-navigation {
 
 .comment .comment-author .avatar {
   float: right;
+  height: calc(2.25 * 1rem);
   margin-left: 1rem;
   position: relative;
+  width: calc(2.25 * 1rem);
 }
 
 @media only screen and (min-width: 768px) {
@@ -6482,9 +6484,7 @@ object {
 .avatar {
   border-radius: 100%;
   display: block;
-  height: auto;
   min-height: inherit;
-  width: auto;
 }
 
 svg {

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -4782,8 +4782,10 @@ body.page .main-navigation {
 
 .comment .comment-author .avatar {
   float: left;
+  height: calc(2.25 * 1rem);
   margin-right: 1rem;
   position: relative;
+  width: calc(2.25 * 1rem);
 }
 
 @media only screen and (min-width: 768px) {
@@ -6494,9 +6496,7 @@ object {
 .avatar {
   border-radius: 100%;
   display: block;
-  height: auto;
   min-height: inherit;
-  width: auto;
 }
 
 svg {


### PR DESCRIPTION
- Restores 49.5 by 49.5 dimensions for comment author avatar next to each comment
- Removes unnecessary `auto` dimensions
- **Does not** assign dimensions for the images in Avatar, Author or Latest Comments blocks

[Trac 62096](https://core.trac.wordpress.org/ticket/62096)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
