### PR TITLE
Fix thumbnail height on embeds.

### DIFF
--- a/src/wp-includes/embed.php
+++ b/src/wp-includes/embed.php
@@ -721,7 +721,7 @@ function get_oembed_response_data_rich( $data, $post, $width, $height ) {
 	}
 
 	if ( $thumbnail_id ) {
-		list( $thumbnail_url, $thumbnail_width, $thumbnail_height ) = wp_get_attachment_image_src( $thumbnail_id, array( $width, 99999 ) );
+		list( $thumbnail_url, $thumbnail_width, $thumbnail_height ) = wp_get_attachment_image_src( $thumbnail_id, array( $width, 0 ) );
 		$data['thumbnail_url']                                      = $thumbnail_url;
 		$data['thumbnail_width']                                    = $thumbnail_width;
 		$data['thumbnail_height']                                   = $thumbnail_height;

--- a/tests/phpunit/tests/oembed/getResponseData.php
+++ b/tests/phpunit/tests/oembed/getResponseData.php
@@ -251,6 +251,26 @@ class Tests_oEmbed_Response_Data extends WP_UnitTestCase {
 		$this->assertLessThanOrEqual( 400, $data['thumbnail_width'] );
 	}
 
+	/**
+	 * @ticket 62094
+	 */
+	public function test_get_oembed_response_data_has_correct_thumbnail_size() {
+		$post = self::factory()->post->create_and_get();
+
+		/* Use a large image as post thumbnail */
+		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/images/33772.jpg' );
+		set_post_thumbnail( $post, $attachment_id );
+
+		/* Get the image, sized for 400x??? pixels display */
+		$image = wp_get_attachment_image_src( $attachment_id, array( 400, 0 ) );
+
+		/* Get the oembed data array for a 400 pixels wide embed */
+		$data = get_oembed_response_data( $post, 400 );
+
+		/* Make sure the embed references the small image, not the full-size one. */
+		$this->assertSame( $image[0], $data['thumbnail_url'] );
+	}
+
 	public function test_get_oembed_response_data_for_attachment() {
 		$parent = self::factory()->post->create();
 		$file   = DIR_TESTDATA . '/images/canola.jpg';


### PR DESCRIPTION
<!-- Insert a description of your changes here -->

Use 0 as height, so that the closest bigger available image size will be used as thumbnail_url, instead of 99999 which prevented scaling down from happening at all.

Trac ticket: https://core.trac.wordpress.org/ticket/62094

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
