### PR TITLE
Use Alt text for images within media library

### DIFF
--- a/src/wp-includes/media-template.php
+++ b/src/wp-includes/media-template.php
@@ -599,20 +599,20 @@ function wp_print_media_templates() {
 					<div class="media-progress-bar"><div style="width: {{ data.percent }}%"></div></div>
 				<# } else if ( 'image' === data.type && data.size && data.size.url ) { #>
 					<div class="centered">
-						<img src="{{ data.size.url }}" draggable="false" alt="" />
+						<img src="{{ data.size.url }}" draggable="false" alt="{{ data.alt }}" />
 					</div>
 				<# } else { #>
 					<div class="centered">
 						<# if ( data.image && data.image.src && data.image.src !== data.icon ) { #>
-							<img src="{{ data.image.src }}" class="thumbnail" draggable="false" alt="" />
+							<img src="{{ data.image.src }}" class="thumbnail" draggable="false" alt="{{ data.alt }}" />
 						<# } else if ( data.sizes ) { 
 								if ( data.sizes.medium ) { #>
-									<img src="{{ data.sizes.medium.url }}" class="thumbnail" draggable="false" alt="" />
+									<img src="{{ data.sizes.medium.url }}" class="thumbnail" draggable="false" alt="{{ data.alt }}" />
 								<# } else { #>
-									<img src="{{ data.sizes.full.url }}" class="thumbnail" draggable="false" alt="" />
+									<img src="{{ data.sizes.full.url }}" class="thumbnail" draggable="false" alt="{{ data.alt }}" />
 								<# } #>
 						<# } else { #>
-							<img src="{{ data.icon }}" class="icon" draggable="false" alt="" />
+							<img src="{{ data.icon }}" class="icon" draggable="false" alt="{{ data.alt }}" />
 						<# } #>
 					</div>
 					<div class="filename">


### PR DESCRIPTION
<!-- Insert a description of your changes here -->

- Use images alt text when they're represented in the media library

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

https://core.trac.wordpress.org/ticket/62107

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
