### PR TITLE
Feature: Add `read_post_meta` capability.

### DIFF
--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -442,15 +442,6 @@ function map_meta_cap( $cap, $user_id, ...$args ) {
 				break;
 			}
 
-			// Check for revision post type.
-			if ( 'revision' === $post->post_type ) {
-				$post = get_post( $post->post_parent );
-				if ( ! $post ) {
-					$caps[] = 'do_not_allow';
-					break;
-				}
-			}
-
 			// Retrieve the object subtype (not strictly necessary for 'post').
 			$object_subtype = get_object_subtype( $object_type, $object_id );
 

--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -418,7 +418,7 @@ function map_meta_cap( $cap, $user_id, ...$args ) {
 		case 'read_post_meta':
 			// Extract the object type from the capability (expected to be 'post').
 			$object_type = explode( '_', $cap )[1];
-		
+
 			// Check if the first argument (object ID) is provided.
 			if ( ! isset( $args[0] ) ) {
 				/* translators: %s: Capability name. */
@@ -431,17 +431,17 @@ function map_meta_cap( $cap, $user_id, ...$args ) {
 				$caps[] = 'do_not_allow';
 				break;
 			}
-		
+
 			// Get the object ID and ensure it is an integer.
 			$object_id = (int) $args[0];
-		
+
 			// Retrieve the post object to validate existence.
-			$post = get_post($object_id);
+			$post = get_post( $object_id );
 			if ( ! $post ) {
 				$caps[] = 'do_not_allow';
 				break;
 			}
-		
+
 			// Check for revision post type.
 			if ( 'revision' === $post->post_type ) {
 				$post = get_post( $post->post_parent );
@@ -450,27 +450,27 @@ function map_meta_cap( $cap, $user_id, ...$args ) {
 					break;
 				}
 			}
-		
+
 			// Retrieve the object subtype (not strictly necessary for 'post').
 			$object_subtype = get_object_subtype( $object_type, $object_id );
-		
+
 			// If the object subtype is empty, deny access.
 			if ( empty( $object_subtype ) ) {
 				$caps[] = 'do_not_allow';
 				break;
 			}
-		
+
 			// Map the read capability for the specific object type.
 			$caps = map_meta_cap( "read_{$object_type}", $user_id, $object_id );
-		
+
 			// Check if a specific meta key is provided.
 			$meta_key = isset( $args[1] ) ? $args[1] : false;
-		
+
 			// If a meta key is provided, perform additional checks.
 			if ( $meta_key ) {
 				// Check if the meta key is protected (i.e., cannot be accessed).
 				$allowed = ! is_protected_meta( $meta_key, $object_type );
-		
+
 				/**
 				 * Filters whether the user is allowed to read a specific meta key of a specific object type.
 				 *
@@ -489,7 +489,7 @@ function map_meta_cap( $cap, $user_id, ...$args ) {
 				 * @param string[] $caps      Array of the user's capabilities.
 				 */
 				$allowed = apply_filters( "auth_{$object_type}_meta_{$meta_key}", $allowed, $meta_key, $object_id, $user_id, $cap, $caps );
-		
+
 				// If there's an object subtype, check for specific subtype filters
 				if ( ! empty( $object_subtype ) ) {
 					/**

--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -414,6 +414,111 @@ function map_meta_cap( $cap, $user_id, ...$args ) {
 
 			$caps[] = $post_type->cap->publish_posts;
 			break;
+
+		case 'read_post_meta':
+			// Extract the object type from the capability (expected to be 'post').
+			$object_type = explode( '_', $cap )[1];
+		
+			// Check if the first argument (object ID) is provided.
+			if ( ! isset( $args[0] ) ) {
+				/* translators: %s: Capability name. */
+				$message = __( 'When checking for the %s capability, you must always check it against a specific post.' );
+				_doing_it_wrong(
+					__FUNCTION__,
+					sprintf( $message, '<code>' . $cap . '</code>' ),
+					'6.7.0' // Version number for the function.
+				);
+				$caps[] = 'do_not_allow';
+				break;
+			}
+		
+			// Get the object ID and ensure it is an integer.
+			$object_id = (int) $args[0];
+		
+			// Retrieve the post object to validate existence.
+			$post = get_post($object_id);
+			if ( ! $post ) {
+				$caps[] = 'do_not_allow';
+				break;
+			}
+		
+			// Check for revision post type.
+			if ( 'revision' === $post->post_type ) {
+				$post = get_post( $post->post_parent );
+				if ( ! $post ) {
+					$caps[] = 'do_not_allow';
+					break;
+				}
+			}
+		
+			// Retrieve the object subtype (not strictly necessary for 'post').
+			$object_subtype = get_object_subtype( $object_type, $object_id );
+		
+			// If the object subtype is empty, deny access.
+			if ( empty( $object_subtype ) ) {
+				$caps[] = 'do_not_allow';
+				break;
+			}
+		
+			// Map the read capability for the specific object type.
+			$caps = map_meta_cap( "read_{$object_type}", $user_id, $object_id );
+		
+			// Check if a specific meta key is provided.
+			$meta_key = isset( $args[1] ) ? $args[1] : false;
+		
+			// If a meta key is provided, perform additional checks.
+			if ( $meta_key ) {
+				// Check if the meta key is protected (i.e., cannot be accessed).
+				$allowed = ! is_protected_meta( $meta_key, $object_type );
+		
+				/**
+				 * Filters whether the user is allowed to read a specific meta key of a specific object type.
+				 *
+				 * Return true to allow access to the meta key.
+				 *
+				 * The dynamic portion of the hook name, `$object_type` refers to the object type being filtered.
+				 * The dynamic portion of the hook name, `$meta_key` refers to the meta key being checked.
+				 *
+				 * @since 6.7.0
+				 *
+				 * @param bool     $allowed   Whether the user can read the object meta. Default false.
+				 * @param string   $meta_key  The meta key.
+				 * @param int      $object_id Object ID.
+				 * @param int      $user_id   User ID.
+				 * @param string   $cap       Capability name.
+				 * @param string[] $caps      Array of the user's capabilities.
+				 */
+				$allowed = apply_filters( "auth_{$object_type}_meta_{$meta_key}", $allowed, $meta_key, $object_id, $user_id, $cap, $caps );
+		
+				// If there's an object subtype, check for specific subtype filters
+				if ( ! empty( $object_subtype ) ) {
+					/**
+					 * Filters whether the user is allowed to read a specific meta key of a specific object subtype.
+					 *
+					 * Return true to allow access to the meta key for this specific subtype.
+					 *
+					 * The dynamic portion of the hook name, `$object_type` refers to the object type being filtered.
+					 * The dynamic portion of the hook name, `$object_subtype` refers to the subtype being checked.
+					 * The dynamic portion of the hook name, `$meta_key` refers to the meta key being checked.
+					 *
+					 * @since 6.7.0
+					 *
+					 * @param bool     $allowed   Whether the user can read the object meta. Default false.
+					 * @param string   $meta_key  The meta key.
+					 * @param int      $object_id Object ID.
+					 * @param int      $user_id   User ID.
+					 * @param string   $cap       Capability name.
+					 * @param string[] $caps      Array of the user's capabilities.
+					 */
+					$allowed = apply_filters( "auth_{$object_type}_meta_{$meta_key}_for_{$object_subtype}", $allowed, $meta_key, $object_id, $user_id, $cap, $caps );
+				}
+
+				// If access is not allowed for the specific meta key, deny access
+				if ( ! $allowed ) {
+					$caps[] = $cap; // Append the capability to deny access
+				}
+			}
+			break;
 		case 'edit_post_meta':
 		case 'delete_post_meta':
 		case 'add_post_meta':

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -548,6 +548,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 			$expected['read_post'],
 			$expected['read_page'],
 			$expected['publish_post'],
+			$expected['read_post_meta'],
 			$expected['edit_post_meta'],
 			$expected['delete_post_meta'],
 			$expected['add_post_meta'],


### PR DESCRIPTION
Trac Ticket : [Core-29786](https://core.trac.wordpress.org/ticket/29786)

## Description:

- This pull request addresses the need for more granular control over metadata access in WordPress by introducing the `read_post_meta` capability. Currently, the existing capabilities for editing, deleting, and adding post metadata (`edit_post_meta`, `delete_post_meta`, and `add_post_meta`) do not provide a mechanism to determine if specific metadata keys can be accessed publicly.

## Problem Statement

- The current implementation relies on the is_protected_meta function, which only checks if a meta key is prefixed (usually with an underscore). This does not adequately control access permissions for individual metadata keys, as it lacks the flexibility to allow or deny access based on custom conditions. Consequently, metadata that should be exposed publicly may inadvertently remain restricted, leading to potential issues with transparency and accessibility.

## Proposed Solution

- The proposed implementation introduces the `read_post_meta` capability, allowing developers to define access permissions for specific metadata keys. This new capability utilizes filters to assess whether a user has permission to read a given meta key associated with a post. It checks the following:

    - Ensures that the requested post exists and is accessible.

    - Validates the post type and its associated capabilities.

    - Applies filters for individual meta keys, providing a flexible and extensible mechanism to control access.

    - This enhancement not only adheres to WordPress coding standards but also promotes better security practices by allowing more nuanced permissions for accessing metadata.

## Impact

- `Improved Access Control`: The ability to control access to individual metadata keys enhances security and flexibility in handling metadata.

- `Customizability`: Developers can leverage the provided filters to implement custom permission checks tailored to their specific use cases.

- `Consistency`: This approach aligns with existing capabilities in WordPress, ensuring a cohesive experience for developers.

- `Public Data Exposure`: The implementation facilitates safe exposure of necessary metadata while restricting access to sensitive information.

##

**This pull request is a step toward making metadata handling more robust and user-friendly in WordPress, fostering a more secure environment for managing and exposing post metadata.**

