### PR TITLE
Editor: Default attribute value not used with `get_block_wrapper_attributes`

### DIFF
--- a/src/wp-includes/class-wp-block-supports.php
+++ b/src/wp-includes/class-wp-block-supports.php
@@ -104,7 +104,7 @@ class WP_Block_Supports {
 		}
 
 		$block_attributes = array_key_exists( 'attrs', self::$block_to_render ) && is_array( self::$block_to_render['attrs'] )
-			? self::$block_to_render['attrs']
+			? $block_type->prepare_attributes_for_render( self::$block_to_render['attrs'] )
 			: array();
 
 		$output = array();

--- a/tests/phpunit/tests/blocks/render.php
+++ b/tests/phpunit/tests/blocks/render.php
@@ -287,25 +287,25 @@ class Tests_Blocks_Render extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 45109
+	 * @ticket 62114
 	 */
 	public function test_dynamic_block_with_default_attributes() {
 		$settings = array(
 			'attributes'      => array(
-				'content' => array(
+				'content'         => array(
 					'type'    => 'string',
 					'default' => 'Default content.',
 				),
-				'align' => array(
-					'type'   => 'string',
+				'align'           => array(
+					'type'    => 'string',
 					'default' => 'full',
 				),
 				'backgroundColor' => array(
-					'type' => 'string',
+					'type'    => 'string',
 					'default' => 'blueberry-1',
 				),
-				'textColor' => array(
-					'type' => 'string',
+				'textColor'       => array(
+					'type'    => 'string',
 					'default' => 'white',
 				),
 			),
@@ -313,12 +313,12 @@ class Tests_Blocks_Render extends WP_UnitTestCase {
 				'align' => array( 'wide', 'full' ),
 				'color' => array(
 					'background' => true,
-					'text' => true,
+					'text'       => true,
 				),
 			),
-			'render_callback' => function( $attributes ) {
-				return '<p ' . get_block_wrapper_attributes() . '>'  . $attributes['content'] . '</p>';
-			}
+			'render_callback' => function ( $attributes ) {
+				return '<p ' . get_block_wrapper_attributes() . '>' . $attributes['content'] . '</p>';
+			},
 		);
 		register_block_type( 'core/dynamic', $settings );
 

--- a/tests/phpunit/tests/blocks/render.php
+++ b/tests/phpunit/tests/blocks/render.php
@@ -289,6 +289,56 @@ class Tests_Blocks_Render extends WP_UnitTestCase {
 	/**
 	 * @ticket 45109
 	 */
+	public function test_dynamic_block_with_default_attributes() {
+		$settings = array(
+			'attributes'      => array(
+				'content' => array(
+					'type'    => 'string',
+					'default' => 'Default content.',
+				),
+				'align' => array(
+					'type'   => 'string',
+					'default' => 'full',
+				),
+				'backgroundColor' => array(
+					'type' => 'string',
+					'default' => 'blueberry-1',
+				),
+				'textColor' => array(
+					'type' => 'string',
+					'default' => 'white',
+				),
+			),
+			'supports'        => array(
+				'align' => array( 'wide', 'full' ),
+				'color' => array(
+					'background' => true,
+					'text' => true,
+				),
+			),
+			'render_callback' => function( $attributes ) {
+				return '<p ' . get_block_wrapper_attributes() . '>'  . $attributes['content'] . '</p>';
+			}
+		);
+		register_block_type( 'core/dynamic', $settings );
+
+		$post_content =
+			'before' .
+			'<!-- wp:core/dynamic --><!-- /wp:core/dynamic -->' .
+			'after';
+
+		$updated_post_content = do_blocks( $post_content );
+		$this->assertSame(
+			$updated_post_content,
+			'before' .
+			'<p class="alignfull wp-block-dynamic has-text-color has-white-color has-background has-blueberry-1-background-color">Default content.</p>' .
+			'after'
+		);
+	}
+
+	/**
+	 * @ticket 45109
+	 */
 	public function test_global_post_persistence() {
 		global $post;
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/62114

Filed on GitHub in Gutenberg repository as two different issues.

[Default attributes for block-support properties don't apply on dynamic blocks](https://github.com/WordPress/gutenberg/issues/50229) from @ryelle:

> I'm building a dynamic block, which supports a handful of the built-in style settings (colors, spacing, etc). I can set defaults in block.json that apply in the editor, but when I view the front end, it's like nothing is set. get_block_wrapper_attributes only returns the block class name, none of the color classes are set, and no style attribute.
> 
> It appears that the default attributes don't exist in parsed_block, which is what apply_block_supports uses to render the values in PHP.

[Default block alignment class is not in get_block_wrapper_attributes](https://github.com/WordPress/gutenberg/issues/50027) from @warudin:

> The block should have a full width alignment by default (mentioned here in the documentation: https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#align)
> 
> This works good in the editor. But in my render file, the get_block_wrapper_attributes() function is not outputting the align class.
> 
> The align class is only returned when I configure another block width then the one that’s in the attributes (so ‘none’ or ‘wide’). The default alignment is never returned, even after toggling another one and going back to the default alignment.

Implements the idea outlined by @youknowriad in https://github.com/WordPress/gutenberg/issues/50229#issuecomment-1531003958:

> This issue looks like a symptom of the fact that the block parsing in the server is not done "fully". It's just the grammar parse. Unfortunately, there's no solution for that at the moment as introducing the full HTML parsing is too impactful.
>
> I'm not really sure why we made sure the default attributes available when using $WP_Block instance, this feels like a hacky fix for me but there's a precedent, maybe we can find a way to use that in apply_block_supports as well?

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
