### PR TITLE
Block Hooks: Respect `"multiple": false`

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1091,7 +1091,7 @@ function apply_block_hooks_to_content( $content, $context, $callback = 'insert_h
 	 * We also need to cover the case where there the hooked block is not present in
 	 * `$content` at first and we're allowed to insert it once -- but not again.
 	 */
-	$suppress_single_instance_blocks = static function ( $hooked_block_types, $relative_position, $anchor_block_name ) use ( &$block_allows_multiple_instances, &$single_instance_blocks_present_in_content, $content ) {
+	$suppress_single_instance_blocks = static function ( $hooked_block_types ) use ( &$block_allows_multiple_instances, &$single_instance_blocks_present_in_content, $content ) {
 		foreach ( $hooked_block_types as $index => $hooked_block_type ) {
 			if ( ! isset( $block_allows_multiple_instances[ $hooked_block_type ] ) ) {
 				$hooked_block_type_definition =
@@ -1118,7 +1118,7 @@ function apply_block_hooks_to_content( $content, $context, $callback = 'insert_h
 		}
 		return $hooked_block_types;
 	};
-	add_filter( 'hooked_block_types', $suppress_single_instance_blocks, PHP_INT_MAX, 3 );
+	add_filter( 'hooked_block_types', $suppress_single_instance_blocks, PHP_INT_MAX );
 	$content = traverse_and_serialize_blocks(
 		parse_blocks( $content ),
 		$before_block_visitor,

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1087,7 +1087,7 @@ function apply_block_hooks_to_content( $content, $context, $callback = 'insert_h
 	}
 
 	/*
-	 * We also need to cover the case where there the hooked block is not present in
+	 * We also need to cover the case where the hooked block is not present in
 	 * `$content` at first and we're allowed to insert it once -- but not again.
 	 */
 	$suppress_single_instance_blocks = static function ( $hooked_block_types ) use ( &$block_allows_multiple_instances, $content ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1061,20 +1061,20 @@ function apply_block_hooks_to_content( $content, $context, $callback = 'insert_h
 	 * Remove hooked blocks from `$hooked_block_types` if they have `multiple` set to false and
 	 * are already present in `$content`.
 	 */
-	foreach ( $hooked_blocks as &$relative_positions ) {
-		foreach ( $relative_positions as &$hooked_block_types ) {
-			foreach ( $hooked_block_types as &$hooked_block_type ) {
+	foreach ( $hooked_blocks as $anchor_block_type => $relative_positions ) {
+		foreach ( $relative_positions as $relative_position => $hooked_block_types ) {
+			foreach ( $hooked_block_types as $index => $hooked_block_type ) {
 				$hooked_block_type_definition =
 					WP_Block_Type_Registry::get_instance()->get_registered( $hooked_block_type );
 				if ( block_has_support( $hooked_block_type_definition, 'multiple', true ) ) {
 					$block_allows_multiple_instances[ $hooked_block_type ] = true;
 				} elseif ( has_block( $hooked_block_type, $content ) ) {
-					unset( $hooked_block_type );
-					if ( empty( $hooked_block_types ) ) {
-						unset( $hooked_block_types );
+					unset( $hooked_blocks[ $anchor_block_type ][ $relative_position ][ $index ] );
+					if ( empty( $hooked_blocks[ $anchor_block_type ][ $relative_position ] ) ) {
+						unset( $hooked_blocks[ $anchor_block_type ][ $relative_position ] );
 					}
-					if ( empty( $relative_positions ) ) {
-						unset( $relative_positions );
+					if ( empty( $hooked_blocks[ $anchor_block_type ] ) ) {
+						unset( $hooked_blocks[ $anchor_block_type ] );
 					}
 				}
 			}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1057,8 +1057,10 @@ function apply_block_hooks_to_content( $content, $context, $callback = 'insert_h
 	}
 
 	$block_allows_multiple_instances = array();
-	// Remove hooked blocks from the list if they have `multiple` set to false and are already
-	// present in `$content`.
+	/*
+	 * Remove hooked blocks from the list if they have `multiple` set to false and are already
+	 * present in `$content`.
+	 */
 	foreach ( $hooked_blocks as &$relative_positions ) {
 		foreach ( $relative_positions as &$hooked_block_types ) {
 			foreach ( $hooked_block_types as &$hooked_block_type ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1070,14 +1070,14 @@ function apply_block_hooks_to_content( $content, $context, $callback = 'insert_h
 					$block_allows_multiple_instances[ $hooked_block_type ] = true;
 				} elseif ( has_block( $hooked_block_type, $content ) ) {
 					unset( $hooked_blocks[ $anchor_block_type ][ $relative_position ][ $index ] );
-					if ( empty( $hooked_blocks[ $anchor_block_type ][ $relative_position ] ) ) {
-						unset( $hooked_blocks[ $anchor_block_type ][ $relative_position ] );
-					}
-					if ( empty( $hooked_blocks[ $anchor_block_type ] ) ) {
-						unset( $hooked_blocks[ $anchor_block_type ] );
-					}
 				}
 			}
+			if ( empty( $hooked_blocks[ $anchor_block_type ][ $relative_position ] ) ) {
+				unset( $hooked_blocks[ $anchor_block_type ][ $relative_position ] );
+			}
+		}
+		if ( empty( $hooked_blocks[ $anchor_block_type ] ) ) {
+			unset( $hooked_blocks[ $anchor_block_type ] );
 		}
 	}
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1081,8 +1081,10 @@ function apply_block_hooks_to_content( $content, $context, $callback = 'insert_h
 		}
 	}
 
-	// We also need to cover the case where there the hooked block is not present in
-	// `$content` at first and we're allowed to insert it once -- but not again.
+	/*
+	 * We also need to cover the case where there the hooked block is not present in
+	 * `$content` at first and we're allowed to insert it once -- but not again.
+	 */
 	$suppress_single_instance_blocks = static function ( $hooked_block_types, $relative_position, $anchor_block_name ) use ( &$block_allows_multiple_instances, $content ) {
 		foreach ( $hooked_block_types as $index => $hooked_block_type ) {
 			if ( ! isset( $block_allows_multiple_instances[ $hooked_block_type ] ) ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1058,8 +1058,8 @@ function apply_block_hooks_to_content( $content, $context, $callback = 'insert_h
 
 	$block_allows_multiple_instances = array();
 	/*
-	 * Remove hooked blocks from the list if they have `multiple` set to false and are already
-	 * present in `$content`.
+	 * Remove hooked blocks from `$hooked_block_types` if they have `multiple` set to false and
+	 * are already present in `$content`.
 	 */
 	foreach ( $hooked_blocks as &$relative_positions ) {
 		foreach ( $relative_positions as &$hooked_block_types ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1081,7 +1081,7 @@ function apply_block_hooks_to_content( $content, $context, $callback = 'insert_h
 
 	// We also need to cover the case where there the hooked block is not present in
 	// `$content` at first and we're allowed to insert it once -- but not again.
-	$suppress_single_instance_blocks = function ( $hooked_block_types, $relative_position, $anchor_block_name ) use ( &$block_allows_multiple_instances, $content ) {
+	$suppress_single_instance_blocks = static function ( $hooked_block_types, $relative_position, $anchor_block_name ) use ( &$block_allows_multiple_instances, $content ) {
 		foreach ( $hooked_block_types as $index => $hooked_block_type ) {
 			if ( ! isset( $block_allows_multiple_instances[ $hooked_block_type ] ) ) {
 				$hooked_block_type_definition =

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1086,12 +1086,12 @@ function apply_block_hooks_to_content( $content, $context, $callback = 'insert_h
 		}
 	}
 
-	$single_instance_blocks_present_in_content = array();
 	/*
 	 * We also need to cover the case where there the hooked block is not present in
 	 * `$content` at first and we're allowed to insert it once -- but not again.
 	 */
-	$suppress_single_instance_blocks = static function ( $hooked_block_types ) use ( &$block_allows_multiple_instances, &$single_instance_blocks_present_in_content, $content ) {
+	$suppress_single_instance_blocks = static function ( $hooked_block_types ) use ( &$block_allows_multiple_instances, $content ) {
+		static $single_instance_blocks_present_in_content = array();
 		foreach ( $hooked_block_types as $index => $hooked_block_type ) {
 			if ( ! isset( $block_allows_multiple_instances[ $hooked_block_type ] ) ) {
 				$hooked_block_type_definition =

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1112,7 +1112,7 @@ function apply_block_hooks_to_content( $content, $context, $callback = 'insert_h
 			) {
 				unset( $hooked_block_types[ $index ] );
 			} else {
-				// Remember not to insert this block again.
+				// We can insert the block once, but need to remember not to insert it again.
 				$single_instance_blocks_present_in_content[] = $hooked_block_type;
 			}
 		}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1102,14 +1102,14 @@ function apply_block_hooks_to_content( $content, $context, $callback = 'insert_h
 		return $hooked_block_types;
 	};
 	add_filter( 'hooked_block_types', $suppress_single_instance_blocks, PHP_INT_MAX, 3 );
-
-	$blocks = parse_blocks( $content );
-
-	$updated_content = traverse_and_serialize_blocks( $blocks, $before_block_visitor, $after_block_visitor );
-
+	$content = traverse_and_serialize_blocks(
+		parse_blocks( $content ),
+		$before_block_visitor,
+		$after_block_visitor
+	);
 	remove_filter( 'hooked_block_types', $suppress_single_instance_blocks, PHP_INT_MAX );
 
-	return $updated_content;
+	return $content;
 }
 
 /**

--- a/tests/phpunit/tests/blocks/applyBlockHooksToContent.php
+++ b/tests/phpunit/tests/blocks/applyBlockHooksToContent.php
@@ -27,6 +27,27 @@ class Tests_Blocks_ApplyBlockHooksToContent extends WP_UnitTestCase {
 				),
 			)
 		);
+
+		register_block_type(
+			'tests/hooked-block-with-multiple-false',
+			array(
+				'block_hooks' => array(
+					'tests/other-anchor-block' => 'after',
+				),
+				'supports'    => array(
+					'multiple' => false,
+				),
+			)
+		);
+
+		register_block_type(
+			'tests/dynamically-hooked-block-with-multiple-false',
+			array(
+				'supports' => array(
+					'multiple' => false,
+				),
+			)
+		);
 	}
 
 	/**
@@ -38,6 +59,8 @@ class Tests_Blocks_ApplyBlockHooksToContent extends WP_UnitTestCase {
 		$registry = WP_Block_Type_Registry::get_instance();
 
 		$registry->unregister( 'tests/hooked-block' );
+		$registry->unregister( 'tests/hooked-block-with-multiple-false' );
+		$registry->unregister( 'tests/dynamically-hooked-block-with-multiple-false' );
 	}
 
 	/**
@@ -64,6 +87,84 @@ class Tests_Blocks_ApplyBlockHooksToContent extends WP_UnitTestCase {
 		$actual = apply_block_hooks_to_content( $context->content, $context, 'insert_hooked_blocks' );
 		$this->assertSame(
 			'<!-- wp:tests/anchor-block /--><!-- wp:tests/hooked-block /-->',
+			$actual
+		);
+	}
+
+	/**
+	 * @ticket 61902
+	 */
+	public function test_apply_block_hooks_to_content_respect_multiple_false() {
+		$context          = new WP_Block_Template();
+		$context->content = '<!-- wp:tests/hooked-block-with-multiple-false /--><!-- wp:tests/other-anchor-block /-->';
+
+		$actual = apply_block_hooks_to_content( $context->content, $context, 'insert_hooked_blocks' );
+		$this->assertSame(
+			'<!-- wp:tests/hooked-block-with-multiple-false /--><!-- wp:tests/other-anchor-block /-->',
+			$actual
+		);
+	}
+
+	/**
+	 * @ticket 61902
+	 */
+	public function test_apply_block_hooks_to_content_respect_multiple_false_after_inserting_once() {
+		$context          = new WP_Block_Template();
+		$context->content = '<!-- wp:tests/other-anchor-block /--><!-- wp:tests/other-block /--><!-- wp:tests/other-anchor-block /-->';
+
+		$actual = apply_block_hooks_to_content( $context->content, $context, 'insert_hooked_blocks' );
+		$this->assertSame(
+			'<!-- wp:tests/other-anchor-block /--><!-- wp:tests/hooked-block-with-multiple-false /--><!-- wp:tests/other-block /--><!-- wp:tests/other-anchor-block /-->',
+			$actual
+		);
+	}
+
+	/**
+	 * @ticket 61902
+	 */
+	public function test_apply_block_hooks_to_content_respect_multiple_false_with_filter() {
+		$filter = function ( $hooked_block_types, $relative_position, $anchor_block_type ) {
+			if ( 'tests/yet-another-anchor-block' === $anchor_block_type && 'after' === $relative_position ) {
+				$hooked_block_types[] = 'tests/dynamically-hooked-block-with-multiple-false';
+			}
+
+			return $hooked_block_types;
+		};
+
+		$context          = new WP_Block_Template();
+		$context->content = '<!-- wp:tests/dynamically-hooked-block-with-multiple-false /--><!-- wp:tests/yet-another-anchor-block /-->';
+
+		add_filter( 'hooked_block_types', $filter, 10, 3 );
+		$actual = apply_block_hooks_to_content( $context->content, $context, 'insert_hooked_blocks' );
+		remove_filter( 'hooked_block_types', $filter, 10 );
+
+		$this->assertSame(
+			'<!-- wp:tests/dynamically-hooked-block-with-multiple-false /--><!-- wp:tests/yet-another-anchor-block /-->',
+			$actual
+		);
+	}
+
+	/**
+	 * @ticket 61902
+	 */
+	public function test_apply_block_hooks_to_content_respect_multiple_false_after_inserting_once_with_filter() {
+		$filter = function ( $hooked_block_types, $relative_position, $anchor_block_type ) {
+			if ( 'tests/yet-another-anchor-block' === $anchor_block_type && 'after' === $relative_position ) {
+				$hooked_block_types[] = 'tests/dynamically-hooked-block-with-multiple-false';
+			}
+
+			return $hooked_block_types;
+		};
+
+		$context          = new WP_Block_Template();
+		$context->content = '<!-- wp:tests/yet-another-anchor-block /--><!-- wp:tests/other-block /--><!-- wp:tests/yet-another-anchor-block /-->';
+
+		add_filter( 'hooked_block_types', $filter, 10, 3 );
+		$actual = apply_block_hooks_to_content( $context->content, $context, 'insert_hooked_blocks' );
+		remove_filter( 'hooked_block_types', $filter, 10 );
+
+		$this->assertSame(
+			'<!-- wp:tests/yet-another-anchor-block /--><!-- wp:tests/dynamically-hooked-block-with-multiple-false /--><!-- wp:tests/other-block /--><!-- wp:tests/yet-another-anchor-block /-->',
 			$actual
 		);
 	}


### PR DESCRIPTION
Block Hooks currently do not respect the `"multiple": false` setting: If this is set in a prospective hooked block's `block.json`, and there's already an instance of that block present in a given context (i.e. template, template part, pattern, or navigation menu), then Block Hooks should not insert another instance of that block.

In a similar vein, if no other instance of that block is present in the given context, then Block Hooks should insert only one instance of that block -- i.e. the first time a matching anchor block is encountered, but not for any other matching anchor blocks.

This will help extenders avoid checking for the presence of another instance of their hooked block inside of the `hooked_block_types` filter, which is called for every block found in a given context -- thus introducing an unnecessary performance overhead.

## Implementation notes

This is implemented in `apply_block_hooks_to_content` -- which as of [`59101`](https://core.trac.wordpress.org/changeset/59101) is the main entrypoint for applying Block Hooks to block markup -- as follows:

First, we iterate over all "statically" registered hooked blocks (i.e. via a `block.json`'s `blockHooks` field) and check for each of them if it has `multiple` set to `false`. If it does, and if there's already an instance of the block present in the markup, then we remove the block from the list of hooked blocks passed to the Block Hooks logic. Otherwise (i.e. if `multiple` is `true`, or if the block is not present in the markup), we cache the value of its `multiple` field in the `$block_allows_multiple_instances` array.

We then create an anonymous function for use with the `hooked_block_types` filter, with `PHP_INT_MAX` as its priority. This allows us to keep track if we've already inserted one instance of a hooked block that has `"multiple": false`, and to also "intercept" hooked blocks that are "dynamically" added, i.e. via the `hooked_block_types` filter.

## Architectural notes

The chosen architecture has several benefits. One, unlike most other Block Hooks related functions, `apply_block_hooks_to_content` gets `$content` as an argument (i.e. a block markup string), which means we don't have to awkwardly extract it from the `$context` variable (that's conte**X**t, not conte**N**t), as seen e.g. [here](https://github.com/WordPress/wordpress-develop/pull/7296/files#diff-8c99af92e4ec0fdb307ddd9b42be1e1ef1efe4a9f31287c23f346244dddd1ce9R923-R941) in this [alternative PR](https://github.com/WordPress/wordpress-develop/pull/7296).

Two, using the `hooked_block_types` filter (at maximum priority) allows us to communicate both the aforementioned `$content` string further "down" (so we can check for the presence of the hooked block in the markup), as well as the `$block_allows_multiple_instances` cache. Otherwise, we'd likely have to add those as arguments to all functions along the call stack from `apply_block_hooks_to_content` all the way down to `insert_hooked_blocks` (thus also diluting separation of concerns). The present approach OTOH keeps things neatly separated.

## Testing instructions

You can use the Like Button block plugin to test; the [latest version (0.9.0)](https://github.com/ockham/like-button/releases/latest) has `"multiple": false` set in its `block.json`.

**However, note that you need to modify the plugin prior to activating it:** 

1. You need to disable the `hooked_block_types` filter that would normally auto-insert the block. (You can also do this manually via _Tools > Plugin File Editor_ after installing the plugin -- just make sure it's before activating it!)

```diff
diff --git a/like-button.php b/like-button.php
index 67c41ca..09ef0a7 100644
--- a/like-button.php
+++ b/like-button.php
@@ -26,7 +26,7 @@ function add_like_button_block_after_post_content_block( $hooked_block_types, $r
        }
        return $hooked_block_types;
 }
-add_filter( 'hooked_block_types', 'add_like_button_block_after_post_content_block', 10, 4 );
+//add_filter( 'hooked_block_types', 'add_like_button_block_after_post_content_block', 10, 4 );
 
 function set_like_button_block_layout_attribute_based_on_adjacent_block( $hooked_block, $hooked_block_type, $relative_position, $anchor_block ) {
        // Is the hooked block adjacent to the anchor block?
```

2. Now activate the plugin, and use the Site Editor to insert the Like Button block into the Single template. Choose a position where the plugin would normally auto-insert it, i.e. not directly below the Post Content block. However, it needs to be inside the actual Single template, and not inside an area that's actually handled by a template part or Navigation menu. Then, save the template and verify on the frontend that the block is present where it should be.
3. Now re-enable auto-insertion, i.e. revert step 1.
4. Reload the frontend to verify that the block is indeed _not_ auto-inserted, as it respects the `"multiple": false" setting.
5. Bonus points if you remove the `"multiple": false` line from `block.json` to verify that it will auto-insert the block if that line is not present.

Trac ticket: https://core.trac.wordpress.org/ticket/61902