### PR TITLE
Interactivity Router: Update for latest package changes

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -1001,6 +1001,9 @@ CSS;
 	 */
 	public function print_router_loading_and_screen_reader_markup() {
 		_deprecated_function( __METHOD__, '6.7.0', 'WP_Interactivity_API::print_router_markup' );
+
+		// Call the new method.
+		$this->print_router_markup();
 	}
 
 	/**

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -994,6 +994,16 @@ CSS;
 	}
 
 	/**
+	 * Deprecated.
+	 *
+	 * @since 6.5.0
+	 * @deprecated 6.7.0 Use {@see WP_Interactivity_API::print_router_markup} instead.
+	 */
+	public function print_router_loading_and_screen_reader_markup() {
+		_deprecated_function( __METHOD__, '6.7.0', 'WP_Interactivity_API::print_router_markup' );
+	}
+
+	/**
 	 * Outputs markup for the @wordpress/interactivity-router script module.
 	 *
 	 * This method prints a div element representing a loading bar visible during

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-router-region.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-router-region.php
@@ -102,7 +102,7 @@ class Tests_WP_Interactivity_API_WP_Router_Region extends WP_UnitTestCase {
 	 *
 	 * @covers ::process_directives
 	 */
-	public function test_wp_router_region_adds_loading_bar_aria_live_region_only_once() {
+	public function test_wp_router_region_adds_loading_bar_region_only_once() {
 		$html     = '
 			<div data-wp-router-region="region A">Interactive region</div>
 			<div data-wp-router-region="region B">Another interactive region</div>
@@ -123,10 +123,6 @@ class Tests_WP_Interactivity_API_WP_Router_Region extends WP_UnitTestCase {
 		$footer = $this->render_wp_footer();
 		$query  = array( 'class_name' => 'wp-interactivity-router-loading-bar' );
 		$p      = new WP_HTML_Tag_Processor( $footer );
-		$this->assertTrue( $p->next_tag( $query ) );
-		$this->assertFalse( $p->next_tag( $query ) );
-		$query = array( 'class_name' => 'screen-reader-text' );
-		$p     = new WP_HTML_Tag_Processor( $footer );
 		$this->assertTrue( $p->next_tag( $query ) );
 		$this->assertFalse( $p->next_tag( $query ) );
 	}


### PR DESCRIPTION
Reapply changes from [[59097]](https://core.trac.wordpress.org/changeset/59097) / https://github.com/WordPress/wordpress-develop/pull/7304.
Restore and deprecated the renamed method `print_router_loading_and_screen_reader_markup`.

Description and testing instructions are the same as on the original PR:

> Accounts for changes to the `@wordpress/interactivity-router` module in:
> 
> - https://github.com/WordPress/gutenberg/pull/65123
> - https://github.com/WordPress/gutenberg/pull/65539
> 
> Static localized strings are passed via script module data passing instead of in Interactivity API store state.
> Redundant HTML used for `aria-live` regions is removed. This functionality is not handled by the `@wordpress/a11y` script module added in #7405.
> 
> ## Testing
> 
> Testing this requires package updates from https://github.com/WordPress/gutenberg/pull/65539. It anticipates the package being released and updated in Core.
> 
> (Copied from https://github.com/WordPress/gutenberg/pull/65539)
> 
> > This PR is difficult to test on its own because it requires the package to be updated as a Core dependency for proper testing. It does not affect Gutenberg behavior, only the package's behavior in Core. There are other ways of doing it but this works:
> > 
> > - Get a checkout of Core from https://github.com/WordPress/wordpress-develop/pull/7304. This is the build that will be running.
> > - Run `npm ci` in the Core checkout to install packages.
> > - Build the package from this PR (`npm run build:packages` in Gutenberg).
> > - Replace the `@wordpress/interactivity-router` package in Core's `node_modules` (`node_modules/@wordpress/interactivity-router`) with the package directory in Gutenberg (remove the directory and copy the directory from Gutenberg `packages/interactivity-router`).
> > - In Core, run the npm build script you use, in my case `npm run dev`.
> > 
> > Then test out that the interactivity router a11y functionality is working. A good way to test is the query block with "force page reload" option disabled. Specifically, the aria-live regions of the page should be updated (with localized text if in non-English locale) announcing "Page loaded."

Trac ticket: https://core.trac.wordpress.org/ticket/60647

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
