### PR TITLE
Add consistency of non empty post id check for attachment functions

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6829,6 +6829,16 @@ function wp_get_attachment_url( $attachment_id = 0 ) {
 
 	$attachment_id = (int) $attachment_id;
 
+	if ( ! $attachment_id ) {
+		$post = get_post();
+
+		if ( ! $post ) {
+			return false;
+		}
+
+		$attachment_id = $post->ID;
+	}
+
 	$post = get_post( $attachment_id );
 
 	if ( ! $post ) {
@@ -6900,7 +6910,18 @@ function wp_get_attachment_url( $attachment_id = 0 ) {
  */
 function wp_get_attachment_caption( $post_id = 0 ) {
 	$post_id = (int) $post_id;
-	$post    = get_post( $post_id );
+
+	if ( ! $post_id ) {
+		$post = get_post();
+
+		if ( ! $post ) {
+			return false;
+		}
+
+		$post_id = $post->ID;
+	}
+
+	$post = get_post( $post_id );
 
 	if ( ! $post ) {
 		return false;
@@ -6934,6 +6955,16 @@ function wp_get_attachment_caption( $post_id = 0 ) {
  */
 function wp_get_attachment_thumb_url( $post_id = 0 ) {
 	$post_id = (int) $post_id;
+
+	if ( ! $post_id ) {
+		$post = get_post();
+
+		if ( ! $post ) {
+			return false;
+		}
+
+		$post_id = $post->ID;
+	}
 
 	/*
 	 * This uses image_downsize() which also looks for the (very) old format $image_meta['thumb']


### PR DESCRIPTION
Trac Ticket:  [Core-52389](https://core.trac.wordpress.org/ticket/52389)

## Summary
This PR enhances the consistency of attachment functions in WordPress by ensuring that `wp_get_attachment_metadata()`,` wp_get_attachment_url()`, `wp_get_attachment_caption()`, and `wp_get_attachment_thumb_url()` consistently check for a non-empty post ID.

## Problem Statement

Currently, the `wp_get_attachment_metadata()` function checks for the ID conditionally, calling `get_post()` only when an ID is not provided. In contrast, other attachment functions, such as `wp_get_attachment_url()`, `wp_get_attachment_caption()`, and `wp_get_attachment_thumb_url()`, always assume a valid ID. This inconsistency can create confusion for developers who expect uniform behavior across all attachment functions. To improve usability and maintainability, it is essential to standardize how these functions validate and retrieve the post ID.

## Proposed Changes

- Update the specified attachment functions to implement a consistent check for non-empty post IDs.
Ensure that `get_post()` is called only when necessary to retrieve the current post if no attachment ID is provided.

## Benefits:

- `Consistency`: Ensuring that all relevant functions perform uniform checks for post IDs will reduce confusion for developers and improve code clarity.

- `Simplicity`: This change simplifies the logic in attachment functions, making them easier to understand and maintain.

This PR seeks to improve the consistency and clarity of attachment functions in WordPress.