### PR TITLE
Interactivity API: add `wp_interactivity_get_element` function

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -96,6 +96,17 @@ final class WP_Interactivity_API {
 	private $context_stack = null;
 
 	/**
+	 * Representation in array format of the element currently being processed.
+	 *
+	 * This is only available during directive processing, otherwise it is `null`.
+	 *
+	 * @since 6.7.0
+	 * @var array<mixed>|null
+	 */
+	private $current_element = null;
+
+
+	/**
 	 * Gets and/or sets the initial state of an Interactivity API store for a
 	 * given namespace.
 	 *
@@ -277,6 +288,25 @@ final class WP_Interactivity_API {
 			? $context[ $store_namespace ]
 			: array();
 	}
+	/**
+	 * Returns an array representation of the current element being processed.
+	 *
+	 * The returned array contains a copy of the element attributes.
+	 *
+	 * @since 6.7.0
+	 */
+	public function get_element(): array {
+		if ( null === $this->current_element ) {
+			_doing_it_wrong(
+				__METHOD__,
+				__( 'The element can only be read during directive processing.' ),
+				'6.7.0'
+			);
+			return array();
+		}
+
+		return $this->current_element;
+	}
 
 	/**
 	 * Registers the `@wordpress/interactivity` script modules.
@@ -428,6 +458,19 @@ final class WP_Interactivity_API {
 				'exit'  => $p->is_tag_closer() || ! $p->has_and_visits_its_closer_tag(),
 			);
 
+			// Get the element attributes to include them in the element representation.
+			$element_attrs = array();
+			$attr_names    = $p->get_attribute_names_with_prefix( '' ) ?? array();
+
+			foreach ( $attr_names as $name ) {
+				$element_attrs[ $name ] = $p->get_attribute( $name );
+			}
+
+			// Assign the current element right before running its directive processors.
+			$this->current_element = array(
+				'attributes' => $element_attrs,
+			);
+
 			foreach ( $modes as $mode => $should_run ) {
 				if ( ! $should_run ) {
 					continue;
@@ -449,6 +492,9 @@ final class WP_Interactivity_API {
 					call_user_func_array( $func, array( $p, $mode, &$tag_stack ) );
 				}
 			}
+
+			// Clear the current element.
+			$this->current_element = null;
 		}
 
 		if ( $unbalanced ) {

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -104,8 +104,6 @@ final class WP_Interactivity_API {
 	 * @var array<mixed>|null
 	 */
 	private $current_element = null;
-
-
 	/**
 	 * Gets and/or sets the initial state of an Interactivity API store for a
 	 * given namespace.

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -294,6 +294,8 @@ final class WP_Interactivity_API {
 	 * The returned array contains a copy of the element attributes.
 	 *
 	 * @since 6.7.0
+	 *
+	 * @return array|null Current element.
 	 */
 	public function get_element(): ?array {
 		if ( null === $this->current_element ) {

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -295,14 +295,13 @@ final class WP_Interactivity_API {
 	 *
 	 * @since 6.7.0
 	 */
-	public function get_element(): array {
+	public function get_element(): array|null {
 		if ( null === $this->current_element ) {
 			_doing_it_wrong(
 				__METHOD__,
 				__( 'The element can only be read during directive processing.' ),
 				'6.7.0'
 			);
-			return array();
 		}
 
 		return $this->current_element;

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -295,7 +295,7 @@ final class WP_Interactivity_API {
 	 *
 	 * @since 6.7.0
 	 */
-	public function get_element(): array|null {
+	public function get_element(): ?array {
 		if ( null === $this->current_element ) {
 			_doing_it_wrong(
 				__METHOD__,

--- a/src/wp-includes/interactivity-api/interactivity-api.php
+++ b/src/wp-includes/interactivity-api/interactivity-api.php
@@ -133,8 +133,8 @@ function wp_interactivity_get_context( ?string $store_namespace = null ): array 
  *
  * @since 6.7.0
  *
- * @return array Current element.
+ * @return array|null Current element.
  */
-function wp_interactivity_get_element(): array {
+function wp_interactivity_get_element(): array|null {
 	return wp_interactivity()->get_element();
 }

--- a/src/wp-includes/interactivity-api/interactivity-api.php
+++ b/src/wp-includes/interactivity-api/interactivity-api.php
@@ -125,3 +125,16 @@ function wp_interactivity_data_wp_context( array $context, string $store_namespa
 function wp_interactivity_get_context( ?string $store_namespace = null ): array {
 	return wp_interactivity()->get_context( $store_namespace );
 }
+
+/**
+ * Returns an array representation of the current element being processed.
+ *
+ * The function should be used only during directive processing.
+ *
+ * @since 6.7.0
+ *
+ * @return array Current element.
+ */
+function wp_interactivity_get_element(): array {
+	return wp_interactivity()->get_element();
+}

--- a/src/wp-includes/interactivity-api/interactivity-api.php
+++ b/src/wp-includes/interactivity-api/interactivity-api.php
@@ -135,6 +135,6 @@ function wp_interactivity_get_context( ?string $store_namespace = null ): array 
  *
  * @return array|null Current element.
  */
-function wp_interactivity_get_element(): array|null {
+function wp_interactivity_get_element(): ?array {
 	return wp_interactivity()->get_element();
 }

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -1380,6 +1380,8 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 	 * Tests that `wp_interactivity_get_element` returns an array with the
 	 * current element's attributes.
 	 *
+	 * @ticket 62136
+	 *
 	 * @covers wp_interactivity_get_element
 	 * @covers ::process_directives
 	 */
@@ -1432,6 +1434,8 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 	/**
 	 * Tests that the attributes returned by `wp_interactivity_get_element` are
 	 * those originally present before directives are processed.
+	 *
+	 * @ticket 62136
 	 *
 	 * @covers wp_interactivity_get_element
 	 * @covers ::process_directives
@@ -1493,6 +1497,8 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 	/**
 	 * Tests that `wp_interactivity_get_element` should not be called outside of
 	 * `process_directives` execution.
+	 *
+	 * @ticket 62136
 	 *
 	 * @covers wp_interactivity_get_element
 	 * @expectedIncorrectUsage WP_Interactivity_API::get_element

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -1440,7 +1440,7 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 	 * @covers wp_interactivity_get_element
 	 * @covers ::process_directives
 	 */
-	public function test_process_directives_generates_element_only_original_attributes() {
+	public function test_get_element_returns_original_attributes_only() {
 		/*
 		 * The global WP_Interactivity_API instance is momentarily replaced to
 		 * make the global function `wp_interactivity_get_element` work as expected.

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -1404,7 +1404,7 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 			)
 		);
 
-		$html           = '
+		$html = <<<HTML
 			<section data-wp-interactive="myPlugin">
 				<div class="buttons">
 					<button
@@ -1419,7 +1419,8 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 					></button>
 				</div>
 			</section>
-		';
+HTML;
+
 		$processed_html = $this->interactivity->process_directives( $html );
 		$p              = new WP_HTML_Tag_Processor( $processed_html );
 		$p->next_tag( 'button' );
@@ -1462,7 +1463,7 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 			)
 		);
 
-		$html           = '
+		$html = <<<HTML
 			<section data-wp-interactive="myPlugin">
 				<div class="buttons">
 					<button
@@ -1473,7 +1474,8 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 					></button>
 				</div>
 			</section>
-		';
+HTML;
+
 		$processed_html = $this->interactivity->process_directives( $html );
 
 		$this->assertSame(


### PR DESCRIPTION
This PR adds a PHP function named `wp_interactivity_get_element`, analogous to the `getElement()` function exposed in the `@wordpress/interactivity` JavaScript module (see [docs](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/api-reference/#store-client-methods)).

The function is intended to be used in [derived state props](https://make.wordpress.org/core/2024/06/28/updates-to-the-interactivity-api-in-6-6/#support-for-derived-state-props-inside-wp-interactivity-state) inside `wp_interactivity_state`, same as `wp_interactivity_get_context`.

For now, the returned value is an array that contains only the `attributes` property, which lists the originally defined attributes present in the element. That means attributes added or modified by directive processing don't appear.

Example:

```php
wp_interactivity_state( 'myPlugin', array(
    'buttonText' => function() {
        $context = wp_interactivity_get_context();
        $element = wp_interactivity_get_element();
        return isset( $context['buttonText'] )
          ? $context['buttonText']
          : $element['attributes']['data-default-button-text'];
    },
) );
```

Trac ticket: https://core.trac.wordpress.org/ticket/62136

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
