### PR TITLE
Themes: Nicely format the matching count

### DIFF
--- a/src/js/_enqueues/wp/theme.js
+++ b/src/js/_enqueues/wp/theme.js
@@ -1082,10 +1082,10 @@ themes.view.Themes = wp.Backbone.View.extend({
 		// Update theme count to full result set when available.
 		this.listenTo( self.collection, 'query:success', function( count ) {
 			if ( _.isNumber( count ) ) {
-				self.count.text( count );
+				this.renderThemeCount( count );
 				self.announceSearchResults( count );
 			} else {
-				self.count.text( self.collection.length );
+				this.renderThemeCount( count );
 				self.announceSearchResults( self.collection.length );
 			}
 		});
@@ -1132,6 +1132,12 @@ themes.view.Themes = wp.Backbone.View.extend({
 		});
 	},
 
+	renderThemeCount: function( count ) {
+		this.liveThemeCount = count;
+		var currentLocale = document.documentElement.lang;
+		this.count.text( this.liveThemeCount.toLocaleString( currentLocale ) );
+	},
+
 	// Manages rendering of theme pages
 	// and keeping theme count in sync.
 	render: function() {
@@ -1161,7 +1167,7 @@ themes.view.Themes = wp.Backbone.View.extend({
 
 		// Display a live theme count for the collection.
 		this.liveThemeCount = this.collection.count ? this.collection.count : this.collection.length;
-		this.count.text( this.liveThemeCount );
+		this.renderThemeCount( this.liveThemeCount );
 
 		/*
 		 * In the theme installer the themes count is already announced

--- a/src/js/_enqueues/wp/theme.js
+++ b/src/js/_enqueues/wp/theme.js
@@ -1082,10 +1082,10 @@ themes.view.Themes = wp.Backbone.View.extend({
 		// Update theme count to full result set when available.
 		this.listenTo( self.collection, 'query:success', function( count ) {
 			if ( _.isNumber( count ) ) {
-				this.renderThemeCount( count );
+				self.renderThemeCount( count );
 				self.announceSearchResults( count );
 			} else {
-				this.renderThemeCount( count );
+				self.renderThemeCount( self.collection.length );
 				self.announceSearchResults( self.collection.length );
 			}
 		});

--- a/src/js/_enqueues/wp/theme.js
+++ b/src/js/_enqueues/wp/theme.js
@@ -1134,7 +1134,7 @@ themes.view.Themes = wp.Backbone.View.extend({
 
 	renderThemeCount: function( count ) {
 		this.liveThemeCount = count;
-		var currentLocale = document.documentElement.lang;
+		const currentLocale = document.documentElement.lang;
 		this.count.text( this.liveThemeCount.toLocaleString( currentLocale ) );
 	},
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

The theme navigation includes a count of themes matching the current query. It's currently displayed as a straight number e.g. "6916". It is slightly nicer if the number is displayed with a locale-specific thousands separator.

Before | After
-------|------
 <img width="1009" alt="Screenshot 2024-09-30 at 18 23 58" src="https://github.com/user-attachments/assets/4873438c-45ce-4cb8-9ac2-00f69f1f35ee"> | <img width="1009" alt="Screenshot 2024-09-30 at 18 20 56" src="https://github.com/user-attachments/assets/53b3a246-dcfa-4fcd-b259-476134d8ae3e">

Trac ticket: https://core.trac.wordpress.org/ticket/62138

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
