### PR TITLE
Script Modules: prevent broken links by using includes_url.

### DIFF
--- a/src/wp-includes/script-modules.php
+++ b/src/wp-includes/script-modules.php
@@ -169,7 +169,7 @@ function wp_default_script_modules() {
 				break;
 		}
 
-		$path = "/wp-includes/js/dist/script-modules/{$file_name}";
+		$path = includes_url( "js/dist/script-modules/{$file_name}" );
 		wp_register_script_module( $script_module_id, $path, $script_module_data['dependencies'], $script_module_data['version'] );
 	}
 }


### PR DESCRIPTION
[[59083]](https://core.trac.wordpress.org/changeset/59083) introduced an issue where Script Modules registered src does not correctly respect the includes path.

Before that change, script modules were registered using `includes_url`. The patch used a hard-coded path which breaks when sites are not served from the root, e.g. the site root is `https://example.com/wp` instead of `https://example.com/`.

Follow-up to [[59083]](https://core.trac.wordpress.org/changeset/59083)
Fixes [#62146](https://core.trac.wordpress.org/ticket/62146)

Trac ticket: https://core.trac.wordpress.org/ticket/62146

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
