### PR TITLE
Feature: Add `is_post_publicly_viewable` filter

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2478,7 +2478,7 @@ function is_post_publicly_viewable( $post = null ) {
 	 * function returning false, which maintains backwards compatibility and
 	 * guards against potential type errors in PHP 8.1+.
 	 *
-	 * @since 6.7
+	 * @since 6.7.0
 	 *
 	 * @param bool       $is_viewable Whether the post is publicly viewable (strict type).
 	 * @param WP_Post    $post       Post object being checked for visibility.

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2466,7 +2466,26 @@ function is_post_publicly_viewable( $post = null ) {
 	$post_type   = get_post_type( $post );
 	$post_status = get_post_status( $post );
 
-	return is_post_type_viewable( $post_type ) && is_post_status_viewable( $post_status );
+	$is_viewable = is_post_type_viewable( $post_type ) && is_post_status_viewable( $post_status );
+
+	/**
+	 * Filters whether a post is publicly viewable.
+	 *
+	 * This filter allows for external modification of the publicly viewable status
+	 * of a post. The returned value must be a boolean to ensure that the function
+	 * `is_post_publicly_viewable()` behaves consistently and reliably. Returning
+	 * a non-boolean value (including falsey and truthy values) will result in the
+	 * function returning false, which maintains backwards compatibility and
+	 * guards against potential type errors in PHP 8.1+.
+	 *
+	 * @since 6.7
+	 *
+	 * @param bool       $is_viewable Whether the post is publicly viewable (strict type).
+	 * @param WP_Post    $post       Post object being checked for visibility.
+	 *
+	 * @return bool The filtered publicly viewable status of the post, which must be a boolean.
+	 */
+	return true === apply_filters( 'is_post_publicly_viewable', $is_viewable, $post );
 }
 
 /**

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2478,7 +2478,7 @@ function is_post_publicly_viewable( $post = null ) {
 	 * function returning false, which maintains backwards compatibility and
 	 * guards against potential type errors in PHP 8.1+.
 	 *
-	 * @since 6.7.0
+	 * @since 6.7
 	 *
 	 * @param bool       $is_viewable Whether the post is publicly viewable (strict type).
 	 * @param WP_Post    $post       Post object being checked for visibility.


### PR DESCRIPTION
Trac Ticket: [Core-54376](https://core.trac.wordpress.org/ticket/54376)

## Summary
- This pull request introduces the is_post_publicly_viewable filter to enhance the flexibility of post visibility checks in WordPress. This allows developers to customize the publicly viewable status of posts, providing greater control over content accessibility without modifying core functionality.

## Features

- New Filter: `is_post_publicly_viewable`

### Parameters:

- `bool $is_viewable`: The current visibility status of the post, strictly typed.

- `WP_Post $post`: The post object being evaluated.

### Implementation Details

- The filter is added within the `is_post_publicly_viewable` function, enabling developers to hook into the visibility logic.
A strict type check ensures that the return value is a boolean. If the returned value is not boolean, the function will default to false. This approach preserves backward compatibility and protects against potential type errors, particularly with PHP 8.1+.

## Benefits

- `Customization`: Developers can implement custom visibility logic based on specific criteria or business rules without altering core WordPress files.

- `Backward Compatibility`: By enforcing a boolean return type and handling non-boolean values appropriately, we ensure that existing implementations relying on this function remain stable and functional.

## Conclusion

- This enhancement aligns with the ongoing efforts to improve the extensibility of WordPress. By introducing the `is_post_publicly_viewable` filter, we empower developers to create more dynamic and tailored content experiences while maintaining the integrity and reliability of the core system.