### PR TITLE
Feature: Add `wp_version_compare` function

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -9054,6 +9054,8 @@ function wp_admin_notice( $message, $args = array() ) {
  * particularly useful for compatibility checks where only major and minor
  * versions are relevant.
  *
+ * @since 6.7.0
+ *
  * @param string $version1     First version to compare.
  * @param string $version2     Second version to compare.
  * @param string $operator     The comparison operator (like '>', '<=', etc.).

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -9045,3 +9045,49 @@ function wp_admin_notice( $message, $args = array() ) {
 
 	echo wp_kses_post( wp_get_admin_notice( $message, $args ) );
 }
+
+/**
+ * Compare two versions with the option to ignore the patch version.
+ *
+ * This function allows for comparing software version strings, providing the
+ * option to ignore the patch version when performing the comparison. This is
+ * particularly useful for compatibility checks where only major and minor
+ * versions are relevant.
+ *
+ * @param string $version1     First version to compare.
+ * @param string $version2     Second version to compare.
+ * @param string $operator     The comparison operator (like '>', '<=', etc.).
+ * @param bool   $ignore_patch Optional. Whether to ignore the patch version. Default is false.
+ *
+ * @return bool Result of the version comparison. Returns false if invalid parameters are provided.
+ */
+function wp_version_compare( $version1, $version2, $operator, $ignore_patch = false ) {
+	// Validate the comparison operator.
+	$valid_operators = array(
+		'>',
+		'<',
+		'>=',
+		'<=',
+		'==',
+		'!=',
+		'===',
+		'!==',
+	);
+	if ( ! in_array( $operator, $valid_operators, true ) ) {
+		return false;
+	}
+
+	// Validate versions.
+	if ( ! is_string( $version1 ) || ! is_string( $version2 ) ) {
+		return false;
+	}
+
+	// Optionally ignore the patch version if `$ignore_patch` is true.
+	if ( $ignore_patch ) {
+		$version1 = implode( '.', array_slice( explode( '.', $version1 ), 0, 2 ) );
+		$version2 = implode( '.', array_slice( explode( '.', $version2 ), 0, 2 ) );
+	}
+
+	// Use version_compare with the modified or full versions.
+	return version_compare( $version1, $version2, $operator );
+}


### PR DESCRIPTION
Trac Ticket: [Core-62151](https://core.trac.wordpress.org/ticket/62151)

## Summary

- This pull request introduces the `wp_version_compare` function to enhance version comparison capabilities in WordPress by allowing the option to ignore the patch version. This is particularly useful for compatibility checks where only major and minor versions are relevant, simplifying the process of validating plugin and theme compatibility with WordPress core.

## Problem Statement

- The existing `version_compare()` function in PHP compares the full version number, including the patch (third number). In many scenarios, such as plugin development, only the major and minor versions are necessary for determining compatibility. For example, a plugin tested with WordPress version `6.6` should also be compatible with `6.6.2`, but the standard comparison would return false due to the patch difference.

## Proposed Solution

- The new `wp_version_compare` function provides:

    - `Customizable Version Comparison`: An option to ignore the patch version during comparisons, allowing developers to manage compatibility without altering API data.

    - `Input Validation`: Ensures that the provided versions are strings and that the comparison operator is valid, returning false for invalid parameters.

## Benefits

- `Simplifies Compatibility Checks`: By allowing developers to focus on major and minor version differences, the function enhances usability in compatibility scenarios.

- `Improved Validation`: Robust input validation helps prevent errors, ensuring reliable comparisons.

## Conclusion

- This enhancement aligns with WordPress's goal of providing developers with powerful and flexible tools for managing version compatibility. By integrating the `wp_version_compare` function, we empower developers to streamline their workflows and reduce potential compatibility issues.