### PR TITLE
#45197 Switch over to `user_can_for_site()` and `current_user_can_for_site()`

### DIFF
--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -913,24 +913,23 @@ function current_user_can( $capability, ...$args ) {
  * capabilities such as `edit_post` and `edit_user` are capabilities used by the `map_meta_cap()` function to
  * map to primitive capabilities that a user or role has, such as `edit_posts` and `edit_others_posts`.
  *
+ * This function replaces the current_user_can_for_blog() function.
+ *
  * Example usage:
  *
- *     current_user_can_for_blog( $blog_id, 'edit_posts' );
- *     current_user_can_for_blog( $blog_id, 'edit_post', $post->ID );
- *     current_user_can_for_blog( $blog_id, 'edit_post_meta', $post->ID, $meta_key );
+ *     current_user_can_for_site( $site_id, 'edit_posts' );
+ *     current_user_can_for_site( $site_id, 'edit_post', $post->ID );
+ *     current_user_can_for_site( $site_id, 'edit_post_meta', $post->ID, $meta_key );
  *
- * @since 3.0.0
- * @since 5.3.0 Formalized the existing and already documented `...$args` parameter
- *              by adding it to the function signature.
- * @since 5.8.0 Wraps current_user_can() after switching to blog.
+ * @since 6.7.0
  *
- * @param int    $blog_id    Site ID.
+ * @param int    $site_id    Site ID.
  * @param string $capability Capability name.
  * @param mixed  ...$args    Optional further parameters, typically starting with an object ID.
  * @return bool Whether the user has the given capability.
  */
-function current_user_can_for_blog( $blog_id, $capability, ...$args ) {
-	$switched = is_multisite() ? switch_to_blog( $blog_id ) : false;
+function current_user_can_for_site( $site_id, $capability, ...$args ) {
+	$switched = is_multisite() ? switch_to_blog( $site_id ) : false;
 
 	$can = current_user_can( $capability, ...$args );
 
@@ -1023,19 +1022,19 @@ function user_can( $user, $capability, ...$args ) {
  *
  * Example usage:
  *
- *     user_can_for_blog( $user->ID, $blog_id, 'edit_posts' );
- *     user_can_for_blog( $user->ID, $blog_id, 'edit_post', $post->ID );
- *     user_can_for_blog( $user->ID, $blog_id, 'edit_post_meta', $post->ID, $meta_key );
+ *     user_can_for_site( $user->ID, $site_id, 'edit_posts' );
+ *     user_can_for_site( $user->ID, $site_id, 'edit_post', $post->ID );
+ *     user_can_for_site( $user->ID, $site_id, 'edit_post_meta', $post->ID, $meta_key );
  *
  * @since 6.7.0
  *
  * @param int|WP_User $user       User ID or object.
- * @param int         $blog_id    Site ID.
+ * @param int         $site_id    Site ID.
  * @param string      $capability Capability name.
  * @param mixed       ...$args    Optional further parameters, typically starting with an object ID.
  * @return bool Whether the user has the given capability.
  */
-function user_can_for_blog( $user, $blog_id, $capability, ...$args ) {
+function user_can_for_site( $user, $site_id, $capability, ...$args ) {
 	if ( ! is_object( $user ) ) {
 		$user = get_userdata( $user );
 	}
@@ -1047,11 +1046,11 @@ function user_can_for_blog( $user, $blog_id, $capability, ...$args ) {
 	}
 
 	// Check if the blog ID is valid.
-	if ( ! is_numeric( $blog_id ) || $blog_id <= 0 ) {
+	if ( ! is_numeric( $site_id ) || $site_id <= 0 ) {
 		return false;
 	}
 
-	$switched = is_multisite() ? switch_to_blog( $blog_id ) : false;
+	$switched = is_multisite() ? switch_to_blog( $site_id ) : false;
 
 	$can = user_can( $user->ID, $capability, ...$args );
 

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -6406,3 +6406,21 @@ function wp_create_block_style_variation_instance_name( $block, $variation ) {
 	_deprecated_function( __FUNCTION__, '6.7.0', 'wp_unique_id' );
 	return $variation . '--' . md5( serialize( $block ) );
 }
+
+/**
+ * Returns whether the current user has the specified capability for a given site.
+ *
+ * @since 3.0.0
+ * @since 5.3.0 Formalized the existing and already documented `...$args` parameter
+ *              by adding it to the function signature.
+ * @since 5.8.0 Wraps current_user_can() after switching to blog.
+ * @deprecated 6.7.0 Use current_user_can_for_site() instead.
+ *
+ * @param int    $blog_id    Site ID.
+ * @param string $capability Capability name.
+ * @param mixed  ...$args    Optional further parameters, typically starting with an object ID.
+ * @return bool Whether the user has the given capability.
+ */
+function current_user_can_for_blog( $blog_id, $capability, ...$args ) {
+	return current_user_can_for_site( $blog_id, $capability, ...$args );
+}

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -1654,92 +1654,92 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @group can_for_blog
+	 * @group can_for_site
 	 */
-	public function test_current_user_can_for_blog() {
+	public function test_current_user_can_for_site() {
 		global $wpdb;
 
 		$user    = self::$users['administrator'];
 		$old_uid = get_current_user_id();
 		wp_set_current_user( $user->ID );
 
-		$this->assertTrue( current_user_can_for_blog( get_current_blog_id(), 'edit_posts' ) );
-		$this->assertFalse( current_user_can_for_blog( get_current_blog_id(), 'foo_the_bar' ) );
+		$this->assertTrue( current_user_can_for_site( get_current_blog_id(), 'edit_posts' ) );
+		$this->assertFalse( current_user_can_for_site( get_current_blog_id(), 'foo_the_bar' ) );
 
 		if ( ! is_multisite() ) {
-			$this->assertTrue( current_user_can_for_blog( 12345, 'edit_posts' ) );
-			$this->assertFalse( current_user_can_for_blog( 12345, 'foo_the_bar' ) );
+			$this->assertTrue( current_user_can_for_site( 12345, 'edit_posts' ) );
+			$this->assertFalse( current_user_can_for_site( 12345, 'foo_the_bar' ) );
 			return;
 		}
 
 		$suppress = $wpdb->suppress_errors();
-		$this->assertFalse( current_user_can_for_blog( 12345, 'edit_posts' ) );
+		$this->assertFalse( current_user_can_for_site( 12345, 'edit_posts' ) );
 		$wpdb->suppress_errors( $suppress );
 
 		$blog_id = self::factory()->blog->create( array( 'user_id' => $user->ID ) );
 
 		$this->assertNotWPError( $blog_id );
-		$this->assertTrue( current_user_can_for_blog( $blog_id, 'edit_posts' ) );
-		$this->assertFalse( current_user_can_for_blog( $blog_id, 'foo_the_bar' ) );
+		$this->assertTrue( current_user_can_for_site( $blog_id, 'edit_posts' ) );
+		$this->assertFalse( current_user_can_for_site( $blog_id, 'foo_the_bar' ) );
 
 		$another_blog_id = self::factory()->blog->create( array( 'user_id' => self::$users['author']->ID ) );
 
 		$this->assertNotWPError( $another_blog_id );
 
 		// Verify the user doesn't have a capability
-		$this->assertFalse( current_user_can_for_blog( $another_blog_id, 'edit_posts' ) );
+		$this->assertFalse( current_user_can_for_site( $another_blog_id, 'edit_posts' ) );
 
 		// Add the current user to the site
 		add_user_to_blog( $another_blog_id, $user->ID, 'author' );
 
 		// Verify they now have the capability
-		$this->assertTrue( current_user_can_for_blog( $another_blog_id, 'edit_posts' ) );
+		$this->assertTrue( current_user_can_for_site( $another_blog_id, 'edit_posts' ) );
 
 		wp_set_current_user( $old_uid );
 	}
 
 	/**
-	 * @group can_for_blog
+	 * @group can_for_site
 	 */
-	public function test_user_can_for_blog() {
+	public function test_user_can_for_site() {
 		$user = self::$users['editor'];
 
-		$this->assertTrue( user_can_for_blog( $user->ID, get_current_blog_id(), 'edit_posts' ) );
-		$this->assertFalse( user_can_for_blog( $user->ID, get_current_blog_id(), 'foo_the_bar' ) );
+		$this->assertTrue( user_can_for_site( $user->ID, get_current_blog_id(), 'edit_posts' ) );
+		$this->assertFalse( user_can_for_site( $user->ID, get_current_blog_id(), 'foo_the_bar' ) );
 
 		if ( ! is_multisite() ) {
-			$this->assertTrue( user_can_for_blog( $user->ID, 12345, 'edit_posts' ) );
-			$this->assertFalse( user_can_for_blog( $user->ID, 12345, 'foo_the_bar' ) );
+			$this->assertTrue( user_can_for_site( $user->ID, 12345, 'edit_posts' ) );
+			$this->assertFalse( user_can_for_site( $user->ID, 12345, 'foo_the_bar' ) );
 			return;
 		}
 
 		$blog_id = self::factory()->blog->create( array( 'user_id' => $user->ID ) );
 
 		$this->assertNotWPError( $blog_id );
-		$this->assertTrue( user_can_for_blog( $user->ID, $blog_id, 'edit_posts' ) );
-		$this->assertFalse( user_can_for_blog( $user->ID, $blog_id, 'foo_the_bar' ) );
+		$this->assertTrue( user_can_for_site( $user->ID, $blog_id, 'edit_posts' ) );
+		$this->assertFalse( user_can_for_site( $user->ID, $blog_id, 'foo_the_bar' ) );
 
 		$author = self::$users['author'];
 
 		// Verify another user doesn't have a capability
 		$this->assertFalse( is_user_member_of_blog( $author->ID, $blog_id ) );
-		$this->assertFalse( user_can_for_blog( $author->ID, $blog_id, 'edit_posts' ) );
+		$this->assertFalse( user_can_for_site( $author->ID, $blog_id, 'edit_posts' ) );
 
 		// Add the author to the site
 		add_user_to_blog( $blog_id, $author->ID, 'author' );
 
 		// Verify they now have the capability
 		$this->assertTrue( is_user_member_of_blog( $author->ID, $blog_id ) );
-		$this->assertTrue( user_can_for_blog( $author->ID, $blog_id, 'edit_posts' ) );
+		$this->assertTrue( user_can_for_site( $author->ID, $blog_id, 'edit_posts' ) );
 
 		// Verify the user doesn't have a capability for a non-existent site
-		$this->assertFalse( user_can_for_blog( $user->ID, -1, 'edit_posts' ) );
+		$this->assertFalse( user_can_for_site( $user->ID, -1, 'edit_posts' ) );
 	}
 
 	/**
 	 * @group ms-required
 	 */
-	public function test_borked_current_user_can_for_blog() {
+	public function test_borked_current_user_can_for_site() {
 		$orig_blog_id = get_current_blog_id();
 		$blog_id      = self::factory()->blog->create();
 
@@ -1747,7 +1747,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 
 		add_action( 'switch_blog', array( $this, 'nullify_current_user_and_keep_nullifying_user' ) );
 
-		current_user_can_for_blog( $blog_id, 'edit_posts' );
+		current_user_can_for_site( $blog_id, 'edit_posts' );
 
 		$this->assertSame( $orig_blog_id, get_current_blog_id() );
 	}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/45197

* Renames the newly introduced `user_can_for_blog()` to `user_can_for_site()`
* Deprecates `current_user_can_for_blog()` and introduces `current_user_can_for_site()`
  - This is a soft deprecation which doesn't trigger a deprecation warning at runtime, my preference would be to wait until 6.8 to add the call to `_deprecated_function()`
* Updates docs and tests