### PR TITLE
Soft-deprecate `load_*_textdomain()` functions

### DIFF
--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -983,6 +983,7 @@ function load_default_textdomain( $locale = null ) {
  *
  * @since 1.5.0
  * @since 4.6.0 The function now tries to load the .mo file from the languages directory first.
+ * @since 6.7.0 Translations are no longer immediately loaded, but handed off to the just-in-time loading mechanism.
  *
  * @param string       $domain          Unique identifier for retrieving translated strings
  * @param string|false $deprecated      Optional. Deprecated. Use the $plugin_rel_path parameter instead.
@@ -999,19 +1000,6 @@ function load_plugin_textdomain( $domain, $deprecated = false, $plugin_rel_path 
 		return false;
 	}
 
-	if ( ! doing_action( 'after_setup_theme' ) && ! did_action( 'after_setup_theme' ) ) {
-		_doing_it_wrong(
-			__FUNCTION__,
-			sprintf(
-				/* translators: 1: The text domain. 2: 'after_setup_theme'. */
-				__( 'Attempted to load translations for the %1$s domain too early. Translations should be loaded after the %2$s action has fired, to ensure that the current user is already set up.' ),
-				'<code>' . $domain . '</code>',
-				'<code>after_setup_theme</code>'
-			),
-			'6.7.0'
-		);
-	}
-
 	/**
 	 * Filters a plugin's locale.
 	 *
@@ -1024,11 +1012,6 @@ function load_plugin_textdomain( $domain, $deprecated = false, $plugin_rel_path 
 
 	$mofile = $domain . '-' . $locale . '.mo';
 
-	// Try to load from the languages directory first.
-	if ( load_textdomain( $domain, WP_LANG_DIR . '/plugins/' . $mofile, $locale ) ) {
-		return true;
-	}
-
 	if ( false !== $plugin_rel_path ) {
 		$path = WP_PLUGIN_DIR . '/' . trim( $plugin_rel_path, '/' );
 	} elseif ( false !== $deprecated ) {
@@ -1040,7 +1023,7 @@ function load_plugin_textdomain( $domain, $deprecated = false, $plugin_rel_path 
 
 	$wp_textdomain_registry->set_custom_path( $domain, $path );
 
-	return load_textdomain( $domain, $path . '/' . $mofile, $locale );
+	return true;
 }
 
 /**
@@ -1048,6 +1031,7 @@ function load_plugin_textdomain( $domain, $deprecated = false, $plugin_rel_path 
  *
  * @since 3.0.0
  * @since 4.6.0 The function now tries to load the .mo file from the languages directory first.
+ * @since 6.7.0 Translations are no longer immediately loaded, but handed off to the just-in-time loading mechanism.
  *
  * @global WP_Textdomain_Registry $wp_textdomain_registry WordPress Textdomain Registry.
  *
@@ -1064,34 +1048,16 @@ function load_muplugin_textdomain( $domain, $mu_plugin_rel_path = '' ) {
 		return false;
 	}
 
-	if ( ! doing_action( 'after_setup_theme' ) && ! did_action( 'after_setup_theme' ) ) {
-		_doing_it_wrong(
-			__FUNCTION__,
-			sprintf(
-				/* translators: 1: The text domain. 2: 'after_setup_theme'. */
-				__( 'Attempted to load translations for the %1$s domain too early. Translations should be loaded after the %2$s action has fired, to ensure that the current user is already set up.' ),
-				'<code>' . $domain . '</code>',
-				'<code>after_setup_theme</code>'
-			),
-			'6.7.0'
-		);
-	}
-
 	/** This filter is documented in wp-includes/l10n.php */
 	$locale = apply_filters( 'plugin_locale', determine_locale(), $domain );
 
 	$mofile = $domain . '-' . $locale . '.mo';
 
-	// Try to load from the languages directory first.
-	if ( load_textdomain( $domain, WP_LANG_DIR . '/plugins/' . $mofile, $locale ) ) {
-		return true;
-	}
-
 	$path = WPMU_PLUGIN_DIR . '/' . ltrim( $mu_plugin_rel_path, '/' );
 
 	$wp_textdomain_registry->set_custom_path( $domain, $path );
 
-	return load_textdomain( $domain, $path . '/' . $mofile, $locale );
+	return true;
 }
 
 /**
@@ -1104,6 +1070,7 @@ function load_muplugin_textdomain( $domain, $mu_plugin_rel_path = '' ) {
  *
  * @since 1.5.0
  * @since 4.6.0 The function now tries to load the .mo file from the languages directory first.
+ * @since 6.7.0 Translations are no longer immediately loaded, but handed off to the just-in-time loading mechanism.
  *
  * @global WP_Textdomain_Registry $wp_textdomain_registry WordPress Textdomain Registry.
  *
@@ -1120,19 +1087,6 @@ function load_theme_textdomain( $domain, $path = false ) {
 		return false;
 	}
 
-	if ( ! doing_action( 'after_setup_theme' ) && ! did_action( 'after_setup_theme' ) ) {
-		_doing_it_wrong(
-			__FUNCTION__,
-			sprintf(
-				/* translators: 1: The text domain. 2: 'after_setup_theme'. */
-				__( 'Attempted to load translations for the %1$s domain too early. Translations should be loaded after the %2$s action has fired, to ensure that the current user is already set up.' ),
-				'<code>' . $domain . '</code>',
-				'<code>after_setup_theme</code>'
-			),
-			'6.7.0'
-		);
-	}
-
 	/**
 	 * Filters a theme's locale.
 	 *
@@ -1143,20 +1097,13 @@ function load_theme_textdomain( $domain, $path = false ) {
 	 */
 	$locale = apply_filters( 'theme_locale', determine_locale(), $domain );
 
-	$mofile = $domain . '-' . $locale . '.mo';
-
-	// Try to load from the languages directory first.
-	if ( load_textdomain( $domain, WP_LANG_DIR . '/themes/' . $mofile, $locale ) ) {
-		return true;
-	}
-
 	if ( ! $path ) {
 		$path = get_template_directory();
 	}
 
 	$wp_textdomain_registry->set_custom_path( $domain, $path );
 
-	return load_textdomain( $domain, $path . '/' . $locale . '.mo', $locale );
+	return true;
 }
 
 /**

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1345,9 +1345,10 @@ function _load_textdomain_just_in_time( $domain ) {
 		_doing_it_wrong(
 			__FUNCTION__,
 			sprintf(
-				/* translators: %s: The text domain. */
-				__( 'Translation loading for the %s domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early.' ),
-				'<code>' . $domain . '</code>'
+				/* translators: 1: The text domain. 2: 'init'. */
+				__( 'Translation loading for the %1$s domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the %2$s action or later.' ),
+				'<code>' . $domain . '</code>',
+				'<code>init</code>'
 			),
 			'6.7.0'
 		);

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1000,18 +1000,6 @@ function load_plugin_textdomain( $domain, $deprecated = false, $plugin_rel_path 
 		return false;
 	}
 
-	/**
-	 * Filters a plugin's locale.
-	 *
-	 * @since 3.0.0
-	 *
-	 * @param string $locale The plugin's current locale.
-	 * @param string $domain Text domain. Unique identifier for retrieving translated strings.
-	 */
-	$locale = apply_filters( 'plugin_locale', determine_locale(), $domain );
-
-	$mofile = $domain . '-' . $locale . '.mo';
-
 	if ( false !== $plugin_rel_path ) {
 		$path = WP_PLUGIN_DIR . '/' . trim( $plugin_rel_path, '/' );
 	} elseif ( false !== $deprecated ) {
@@ -1048,11 +1036,6 @@ function load_muplugin_textdomain( $domain, $mu_plugin_rel_path = '' ) {
 		return false;
 	}
 
-	/** This filter is documented in wp-includes/l10n.php */
-	$locale = apply_filters( 'plugin_locale', determine_locale(), $domain );
-
-	$mofile = $domain . '-' . $locale . '.mo';
-
 	$path = WPMU_PLUGIN_DIR . '/' . ltrim( $mu_plugin_rel_path, '/' );
 
 	$wp_textdomain_registry->set_custom_path( $domain, $path );
@@ -1086,16 +1069,6 @@ function load_theme_textdomain( $domain, $path = false ) {
 	if ( ! is_string( $domain ) ) {
 		return false;
 	}
-
-	/**
-	 * Filters a theme's locale.
-	 *
-	 * @since 3.0.0
-	 *
-	 * @param string $locale The theme's current locale.
-	 * @param string $domain Text domain. Unique identifier for retrieving translated strings.
-	 */
-	$locale = apply_filters( 'theme_locale', determine_locale(), $domain );
 
 	if ( ! $path ) {
 		$path = get_template_directory();

--- a/tests/phpunit/tests/l10n/loadTextdomain.php
+++ b/tests/phpunit/tests/l10n/loadTextdomain.php
@@ -5,7 +5,6 @@
  * @group i18n
  */
 class Tests_L10n_LoadTextdomain extends WP_UnitTestCase {
-	protected $locale;
 	protected static $user_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
@@ -19,11 +18,6 @@ class Tests_L10n_LoadTextdomain extends WP_UnitTestCase {
 
 	public function set_up() {
 		parent::set_up();
-
-		$this->locale = '';
-
-		add_filter( 'plugin_locale', array( $this, 'store_locale' ) );
-		add_filter( 'theme_locale', array( $this, 'store_locale' ) );
 
 		/** @var WP_Textdomain_Registry $wp_textdomain_registry */
 		global $wp_textdomain_registry;
@@ -39,12 +33,6 @@ class Tests_L10n_LoadTextdomain extends WP_UnitTestCase {
 		$wp_textdomain_registry = new WP_Textdomain_Registry();
 
 		parent::tear_down();
-	}
-
-	public function store_locale( $locale ) {
-		$this->locale = $locale;
-
-		return $locale;
 	}
 
 	/**
@@ -230,75 +218,6 @@ class Tests_L10n_LoadTextdomain extends WP_UnitTestCase {
 		$l10n[ $domain ] = &$mo;
 
 		return true;
-	}
-
-	/**
-	 * @covers ::load_muplugin_textdomain
-	 */
-	public function test_load_muplugin_textdomain_site_locale() {
-		load_muplugin_textdomain( 'wp-tests-domain' );
-
-		$this->assertSame( get_locale(), $this->locale );
-	}
-
-	/**
-	 * @ticket 38485
-	 *
-	 * @covers ::load_muplugin_textdomain
-	 */
-	public function test_load_muplugin_textdomain_user_locale() {
-		set_current_screen( 'dashboard' );
-		wp_set_current_user( self::$user_id );
-
-		load_muplugin_textdomain( 'wp-tests-domain' );
-
-		$this->assertSame( get_user_locale(), $this->locale );
-	}
-
-	/**
-	 * @covers ::load_plugin_textdomain
-	 */
-	public function test_load_plugin_textdomain_site_locale() {
-		load_plugin_textdomain( 'wp-tests-domain' );
-
-		$this->assertSame( get_locale(), $this->locale );
-	}
-
-	/**
-	 * @ticket 38485
-	 *
-	 * @covers ::load_plugin_textdomain
-	 */
-	public function test_load_plugin_textdomain_user_locale() {
-		set_current_screen( 'dashboard' );
-		wp_set_current_user( self::$user_id );
-
-		load_plugin_textdomain( 'wp-tests-domain' );
-
-		$this->assertSame( get_user_locale(), $this->locale );
-	}
-
-	/**
-	 * @covers ::load_theme_textdomain
-	 */
-	public function test_load_theme_textdomain_site_locale() {
-		load_theme_textdomain( 'wp-tests-domain' );
-
-		$this->assertSame( get_locale(), $this->locale );
-	}
-
-	/**
-	 * @ticket 38485
-	 *
-	 * @covers ::load_theme_textdomain
-	 */
-	public function test_load_theme_textdomain_user_locale() {
-		set_current_screen( 'dashboard' );
-		wp_set_current_user( self::$user_id );
-
-		load_theme_textdomain( 'wp-tests-domain' );
-
-		$this->assertSame( get_user_locale(), $this->locale );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -582,8 +582,8 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = self::perform_active_theme_request();
 		$result   = $response->get_data();
 		$this->assertArrayHasKey( 'tags', $result[0] );
-		$this->assertSame( array( 'holiday', 'custom-menu' ), $result[0]['tags']['raw'] );
-		$this->assertSame( 'holiday, custom-menu', $result[0]['tags']['rendered'] );
+		$this->assertSame( array( 'Holiday', 'custom-menu' ), $result[0]['tags']['raw'] );
+		$this->assertSame( 'Holiday, custom-menu', $result[0]['tags']['rendered'] );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

(Soft) deprecate `load_plugin_textdomain()` and `load_theme_textdomain()` and rely solely on the just-in-time loading and `WP_Textdomain_Registry`.

This would avoid any `_doing_it_wrong` messages for plugins still using `load_plugin_textdomain()`, which seems to be the most common case and affects even very big plugins. So it would drastically reduce the noise.

It would still trigger a `_doing_it_wrong` message if accidentally causing the just-in-time loading too early.

Trac ticket: https://core.trac.wordpress.org/ticket/44937

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
