### PR TITLE
Improve tests for default themes.

### DIFF
--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -241,7 +241,7 @@ class Tests_Theme extends WP_UnitTestCase {
 		 * The test suite sets the constant to `default` while this is intended to
 		 * test the value defined in default-constants.php.
 		 *
-		 * Therefore this reads the file in via file_get_contents and extract the value.
+		 * Therefore this reads the file in via file_get_contents to extract the value.
 		 */
 		$default_constants = file_get_contents( ABSPATH . WPINC . '/default-constants.php' );
 		preg_match( '/define\( \'WP_DEFAULT_THEME\', \'(.*)\' \);/', $default_constants, $matches );

--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -213,7 +213,26 @@ class Tests_Theme extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Make sure we the latest default theme matches the WP_DEFAULT_THEME constant.
+	 * Tests the default themes list in the test suite matches the runtime default themes.
+	 */
+	public function test_default_default_theme_list_match_in_test_suite_and_at_runtime() {
+		// Use a reflection to make WP_THEME::$default_themes accessible.
+		$reflection = new ReflectionClass( 'WP_Theme' );
+		$property   = $reflection->getProperty( 'default_themes' );
+		$property->setAccessible( true );
+
+		/*
+		 * `default` and `classic` are included in `WP_Theme::$default_themes` but not included
+		 * in the test suite default themes list. These are excluded from the comparison.
+		 */
+		$default_themes = array_keys( $property->getValue() );
+		$default_themes = array_diff( $default_themes, array( 'default', 'classic' ) );
+
+		$this->assertSameSets( $default_themes, $this->default_themes, 'Test suite default themes should match the runtime default themes.' );
+	}
+
+	/**
+	 * Test the default theme in WP_Theme matches the WP_DEFAULT_THEME constant.
 	 */
 	public function test_default_theme_matches_constant() {
 		$latest_default_theme = WP_Theme::get_core_default_theme();

--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -212,6 +212,25 @@ class Tests_Theme extends WP_UnitTestCase {
 		$this->assertContains( $latest_default_theme->get_stylesheet(), $this->default_themes );
 	}
 
+	/**
+	 * Make sure we the latest default theme matches the WP_DEFAULT_THEME constant.
+	 */
+	public function test_default_theme_matches_constant() {
+		$latest_default_theme = WP_Theme::get_core_default_theme();
+
+		/*
+		 * The test suite sets the constant to `default` while this is intended to
+		 * test the value defined in default-constants.php.
+		 *
+		 * Therefore this reads the file in via file_get_contents and extract the value.
+		 */
+		$default_constants = file_get_contents( ABSPATH . WPINC . '/default-constants.php' );
+		preg_match( '/define\( \'WP_DEFAULT_THEME\', \'(.*)\' \);/', $default_constants, $matches );
+		$wp_default_theme_constant = $matches[1];
+
+		$this->assertSame( $wp_default_theme_constant, $latest_default_theme->get_stylesheet(), 'WP_DEFAULT_THEME should match the latest default theme.' );
+	}
+
 	public function test_default_themes_have_textdomain() {
 		foreach ( $this->default_themes as $theme ) {
 			if ( wp_get_theme( $theme )->exists() ) {


### PR DESCRIPTION
Additional tests for default themes:

* Ensure test suite and WP_Theme default lists match
* Ensure the constant matches the list in WP_Theme

I'd like to test the workflow file includes all of the themes but as not all systems include the yaml extension, I've left it out.

We could do a test via `substr_count()` but it seems pretty hacky.

Trac ticket: Core-61530

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
