### PR TITLE
made changes for comment rest api to support with block commenting

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -649,7 +649,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 
 		$prepared_comment['comment_approved'] = wp_allow_comment( $prepared_comment, true );
 		$prepared_comment['comment_approved'] = isset( $request['comment_approved'] ) ? $request['comment_approved'] : $prepared_comment['comment_approved'];
-		
+
 		if ( is_wp_error( $prepared_comment['comment_approved'] ) ) {
 			$error_code    = $prepared_comment['comment_approved']->get_error_code();
 			$error_message = $prepared_comment['comment_approved']->get_error_message();

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -574,21 +574,12 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			);
 		}
 
-		// Do not allow comments to be created with a non-default type.
-		if ( ! empty( $request['type'] ) && 'comment' !== $request['type'] ) {
-			return new WP_Error(
-				'rest_invalid_comment_type',
-				__( 'Cannot create a comment with that type.' ),
-				array( 'status' => 400 )
-			);
-		}
-
 		$prepared_comment = $this->prepare_item_for_database( $request );
 		if ( is_wp_error( $prepared_comment ) ) {
 			return $prepared_comment;
 		}
 
-		$prepared_comment['comment_type'] = 'comment';
+		$prepared_comment['comment_type'] = isset( $request['type'] ) ? $request['type'] : 'comment';
 
 		if ( ! isset( $prepared_comment['comment_content'] ) ) {
 			$prepared_comment['comment_content'] = '';
@@ -657,7 +648,8 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		}
 
 		$prepared_comment['comment_approved'] = wp_allow_comment( $prepared_comment, true );
-
+		$prepared_comment['comment_approved'] = isset( $request['comment_approved'] ) ? $request['comment_approved'] : $prepared_comment['comment_approved'];
+		
 		if ( is_wp_error( $prepared_comment['comment_approved'] ) ) {
 			$error_code    = $prepared_comment['comment_approved']->get_error_code();
 			$error_message = $prepared_comment['comment_approved']->get_error_message();

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -1593,7 +1593,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertFalse( is_wp_error( $response ) );
-		$this->assertEquals( 400, $response->get_status() );
+		$this->assertSame( 201, $response->get_status() );
 	}
 
 	public function test_create_comment_invalid_email() {

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -1592,8 +1592,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$request->set_body( wp_json_encode( $params ) );
 
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertFalse( is_wp_error( $response ) );
-		$this->assertEquals( $response['code'], 400 );
+		$this->assertErrorResponse( 'rest_invalid_comment_type', $response, 400 );
 	}
 
 	public function test_create_comment_invalid_email() {

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -1593,7 +1593,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertFalse( is_wp_error( $response ) );
-		$this->assertEquals( $response['code'], 400 );
+		$this->assertEquals( 400, $response->get_status() );
 	}
 
 	public function test_create_comment_invalid_email() {

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -1592,7 +1592,8 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$request->set_body( wp_json_encode( $params ) );
 
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_invalid_comment_type', $response, 400 );
+		$this->assertFalse( is_wp_error( $response ) );
+		$this->assertEquals( $response['code'], 400 );
 	}
 
 	public function test_create_comment_invalid_email() {


### PR DESCRIPTION
### Pull Request Description
Title: Modify Comment REST API to Support Block Comments

Overview: This pull request enhances the WordPress Comment REST API by adding support for [block comments](https://github.com/WordPress/gutenberg/pull/60622). This functionality aims to improve rest API add comment functionality to support the block commenting feature.

### Changes Made:

- Updated the Comment REST API to accept and process block comment type.
- Process comment status if a logged-in user adds block comment then it will not approved automatically.

### Why This Matters:

- As of now custom comment type is now allowed in the comment rest API but we can add it through `wp_insert_comment`
- If any logged-in user ports a comment then it will automatically approve and add the comment in the database with `comment_approved` as `1`.

### Related Tickets:

[Ticket #60622](https://github.com/WordPress/gutenberg/pull/60622): Discussion on block comments feature.
