### PR TITLE
Pass `CODEVITALS_PROJECT_TOKEN` from root workflow to reusable workflow

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -43,6 +43,8 @@ jobs:
         memcached: [ true, false ]
     with:
       memcached: ${{ matrix.memcached }}
+    secrets:
+      CODEVITALS_PROJECT_TOKEN: ${{ secrets.CODEVITALS_PROJECT_TOKEN }}
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -43,8 +43,6 @@ jobs:
         memcached: [ true, false ]
     with:
       memcached: ${{ matrix.memcached }}
-    secrets:
-      CODEVITALS_PROJECT_TOKEN: ${{ secrets.CODEVITALS_PROJECT_TOKEN }}
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -33,7 +33,7 @@ jobs:
   # Runs the performance test suite.
   performance:
     name: Performance tests ${{ matrix.memcached && '(with memcached)' || '' }}
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-performance.yml@trunk
+    uses: ./.github/workflows/reusable-performance.yml
     permissions:
       contents: read
     if: ${{ ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) && ! contains( github.event.before, '00000000' ) }}

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -43,8 +43,7 @@ jobs:
         memcached: [ true, false ]
     with:
       memcached: ${{ matrix.memcached }}
-    secrets:
-      CODEVITALS_PROJECT_TOKEN: ${{ secrets.CODEVITALS_PROJECT_TOKEN }}
+    secrets: inherit
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -43,7 +43,8 @@ jobs:
         memcached: [ true, false ]
     with:
       memcached: ${{ matrix.memcached }}
-    secrets: inherit
+    secrets:
+      CODEVITALS_PROJECT_TOKEN: ${{ secrets.CODEVITALS_PROJECT_TOKEN }}
 
   slack-notifications:
     name: Slack Notifications

--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -287,9 +287,6 @@ jobs:
           name: performance-artifacts${{ inputs.memcached && '-memcached' || '' }}-${{ github.run_id }}
           path: artifacts
           if-no-files-found: ignore
-        env:
-          CODEVITALS_PROJECT_TOKEN: ${{ secrets.CODEVITALS_PROJECT_TOKEN }}
-          HAS_CODEVITALS_PROJECT_TOKEN: ${{ !! secrets.CODEVITALS_PROJECT_TOKEN && secrets.CODEVITALS_PROJECT_TOKEN != '' }}
 
       - name: Compare results
         run: node ./tests/performance/compare-results.js ${{ runner.temp }}/summary.md

--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -289,7 +289,7 @@ jobs:
           if-no-files-found: ignore
         env:
           CODEVITALS_PROJECT_TOKEN: ${{ secrets.CODEVITALS_PROJECT_TOKEN }}
-          HAS_CODEVITALS_PROJECT_TOKEN: ${{ !! secrets.CODEVITALS_PROJECT_TOKEN && secrets.CODEVITALS_PROJECT_TOKEN != '' }}
+          HAS_CODEVITALS_PROJECT_TOKEN: ${{ secrets.CODEVITALS_PROJECT_TOKEN && secrets.CODEVITALS_PROJECT_TOKEN != '' }}
 
       - name: Compare results
         run: node ./tests/performance/compare-results.js ${{ runner.temp }}/summary.md

--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -26,10 +26,6 @@ on:
         required: false
         type: 'boolean'
         default: false
-    secrets:
-      CODEVITALS_PROJECT_TOKEN:
-        description: 'The authorization token for https://www.codevitals.run/project/wordpress.'
-        required: true
 
 env:
   PUPPETEER_SKIP_DOWNLOAD: ${{ true }}

--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -291,6 +291,8 @@ jobs:
           name: performance-artifacts${{ inputs.memcached && '-memcached' || '' }}-${{ github.run_id }}
           path: artifacts
           if-no-files-found: ignore
+        env:
+          CODEVITALS_PROJECT_TOKEN: ${{ secrets.CODEVITALS_PROJECT_TOKEN }}
 
       - name: Compare results
         run: node ./tests/performance/compare-results.js ${{ runner.temp }}/summary.md

--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -289,6 +289,7 @@ jobs:
           if-no-files-found: ignore
         env:
           CODEVITALS_PROJECT_TOKEN: ${{ secrets.CODEVITALS_PROJECT_TOKEN }}
+          HAS_CODEVITALS_PROJECT_TOKEN: ${{ !! secrets.CODEVITALS_PROJECT_TOKEN && secrets.CODEVITALS_PROJECT_TOKEN != '' }}
 
       - name: Compare results
         run: node ./tests/performance/compare-results.js ${{ runner.temp }}/summary.md

--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -26,6 +26,10 @@ on:
         required: false
         type: 'boolean'
         default: false
+    secrets:
+      CODEVITALS_PROJECT_TOKEN:
+        description: 'The authorization token for https://www.codevitals.run/project/wordpress.'
+        required: true
 
 env:
   PUPPETEER_SKIP_DOWNLOAD: ${{ true }}

--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -289,7 +289,7 @@ jobs:
           if-no-files-found: ignore
         env:
           CODEVITALS_PROJECT_TOKEN: ${{ secrets.CODEVITALS_PROJECT_TOKEN }}
-          HAS_CODEVITALS_PROJECT_TOKEN: ${{ secrets.CODEVITALS_PROJECT_TOKEN && secrets.CODEVITALS_PROJECT_TOKEN != '' }}
+          HAS_CODEVITALS_PROJECT_TOKEN: ${{ !! secrets.CODEVITALS_PROJECT_TOKEN && secrets.CODEVITALS_PROJECT_TOKEN != '' }}
 
       - name: Compare results
         run: node ./tests/performance/compare-results.js ${{ runner.temp }}/summary.md

--- a/tests/performance/log-results.js
+++ b/tests/performance/log-results.js
@@ -108,6 +108,7 @@ const req = https.request( options, ( res ) => {
 
 req.on( 'error', ( error ) => {
 	console.error( error );
+	process.exit( 1 );
 } );
 
 req.write( data );


### PR DESCRIPTION
It looks like the `performance.yml` workflow started failing due to https://github.com/WordPress/wordpress-develop/commit/fe3bc4af1946e68201bb0fa51fede494f3edcbd6, because the `CODEVITALS_PROJECT_TOKEN` needed to send data to the dashboard is no longer available. That's because reusable workflows don't automatically inherit GitHub secrets, so we need to explicitly pass it from the called workflow to the reusable workflow.

For reference, see https://docs.github.com/en/actions/sharing-automations/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow

Trac ticket: https://core.trac.wordpress.org/ticket/62153

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
