### PR TITLE
Feature: Introduce `get_option_{$option}` action in `get_option` function

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -232,6 +232,19 @@ function get_option( $option, $default_value = false ) {
 	}
 
 	/**
+	 * Fires before an option value is returned.
+	 *
+	 * The dynamic portion of the hook name, `$option`, refers to the option name.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @param string $option      The name of the option being retrieved.
+	 * @param mixed  $value       The value of the option retrieved from the database (or default).
+	 * @param bool   $is_default  Whether the value is based on the default (false if looked up from the database).
+	 */
+	do_action( "get_option_{$option}", $option, $value, false === $value );
+
+	/**
 	 * Filters the value of an existing option.
 	 *
 	 * The dynamic portion of the hook name, `$option`, refers to the option name.


### PR DESCRIPTION
Trac Ticket: [Core-56548](https://core.trac.wordpress.org/ticket/56548)

## Overview

- This pull request introduces a new action for the get_option function in WordPress to allow developers to run specific logic when an option is being retrieved. The action is designed to facilitate the optimization of autoloaded options while ensuring backward compatibility.

## Changes Made

- `Added Action`: Introduced a new action named get_option that triggers when an option is read. This action accepts three 

- `parameters`:

    - `$option`: The name of the option being retrieved.

    - `$value`: The value of the option.

    - `$is_default`: A boolean indicating whether the value is based on the default rather than being retrieved from the database.

### Documentation 

Properly documented the new action to clarify its intended use and to guide developers on how to implement custom logic without impacting performance negatively.

## Purpose

The addition of this action allows developers to optimize their use of options without replacing the existing filter mechanism, which is more suited for filtering option values. This change aims to:

- Enhance the performance of retrieving autoloaded options.

- Provide a clear and structured way for developers to hook into option retrieval processes.

- Ensure that developers are not misled into thinking this is a filtering mechanism.

## Compatibility

This new action is fully backward compatible and will not affect existing functionality. It serves as an enhancement for cases where custom logic is necessary when retrieving options.