### PR TITLE
allow custom comment type to fetch avatar urls in comment api

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -4341,9 +4341,9 @@ function is_avatar_comment_type( $comment_type ) {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param array $types An array of content types. Default only contains 'comment'.
+	 * @param array $types An array of content types.
 	 */
-	$allowed_comment_types = apply_filters( 'get_avatar_comment_types', array( 'comment' ) );
+	$allowed_comment_types = apply_filters( 'get_avatar_comment_types', array( '' ) );
 
 	return in_array( $comment_type, (array) $allowed_comment_types, true );
 }

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -4341,9 +4341,9 @@ function is_avatar_comment_type( $comment_type ) {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param array $types An array of content types.
+	 * @param array $types An array of content types. Default only contains 'comment'.
 	 */
-	$allowed_comment_types = apply_filters( 'get_avatar_comment_types', array( '' ) );
+	$allowed_comment_types = apply_filters( 'get_avatar_comment_types', array( 'comment', 'block_comment' ) );
 
 	return in_array( $comment_type, (array) $allowed_comment_types, true );
 }

--- a/tests/phpunit/tests/avatar.php
+++ b/tests/phpunit/tests/avatar.php
@@ -256,7 +256,7 @@ class Tests_Avatar extends WP_UnitTestCase {
 	 * @ticket 44033
 	 */
 	public function test_get_avatar_data_should_return_gravatar_url_when_input_avatar_comment_type() {
-		$comment_type = 'comment';
+		$comment_type = '';
 		$comment      = self::factory()->comment->create_and_get(
 			array(
 				'comment_author_email' => 'commenter@example.com',

--- a/tests/phpunit/tests/avatar.php
+++ b/tests/phpunit/tests/avatar.php
@@ -256,7 +256,7 @@ class Tests_Avatar extends WP_UnitTestCase {
 	 * @ticket 44033
 	 */
 	public function test_get_avatar_data_should_return_gravatar_url_when_input_avatar_comment_type() {
-		$comment_type = '';
+		$comment_type = 'comment';
 		$comment      = self::factory()->comment->create_and_get(
 			array(
 				'comment_author_email' => 'commenter@example.com',


### PR DESCRIPTION
### Pull Request Description
Title: Allow Avatar URL for Custom Comment Type in Comment API

### Overview:
This PR introduces a new feature that enables the inclusion of an avatar URL for custom comment types in the WordPress Comment API. This enhancement allows developers to specify custom avatar URLs, improving the flexibility and usability of the comment system for custom comment types.

### Changes Made:

- Updated the Comment API to accept an avatar_url parameter for custom comment types.

### Why This Matters:

- If any custom comment type is passed on comment API then avatar URLs is not fetching so need to add support avatar URLs for custom comment type.

### Related Tickets:
[Ticket: #60622](https://github.com/WordPress/gutenberg/pull/60622): Discussion on block comments feature.
