### PR TITLE
`WP_Theme_JSON::get_blocks_metadata()`: Check registered styles only upon change

### DIFF
--- a/src/wp-includes/class-wp-block-styles-registry.php
+++ b/src/wp-includes/class-wp-block-styles-registry.php
@@ -32,6 +32,7 @@ final class WP_Block_Styles_Registry {
 	 */
 	private static $instance = null;
 
+	private $update_counter = 0;
 	/**
 	 * Registers a block style for the given block type.
 	 *
@@ -100,6 +101,7 @@ final class WP_Block_Styles_Registry {
 			$this->registered_block_styles[ $name ][ $block_style_name ] = $style_properties;
 		}
 
+		$this->update_counter++;
 		return true;
 	}
 
@@ -125,6 +127,7 @@ final class WP_Block_Styles_Registry {
 
 		unset( $this->registered_block_styles[ $block_name ][ $block_style_name ] );
 
+		$this->update_counter++;
 		return true;
 	}
 
@@ -199,5 +202,9 @@ final class WP_Block_Styles_Registry {
 		}
 
 		return self::$instance;
+	}
+
+	public function get_update_counter() {
+		return $this->update_counter;
 	}
 }

--- a/src/wp-includes/class-wp-block-styles-registry.php
+++ b/src/wp-includes/class-wp-block-styles-registry.php
@@ -32,7 +32,18 @@ final class WP_Block_Styles_Registry {
 	 */
 	private static $instance = null;
 
-	private $update_counter = 0;
+	/**
+	 * Counter for tracking updates to the registered block styles.
+	 *
+	 * This variable increments each time a block style is registered or unregistered,
+	 * allowing for tracking changes and potential cache invalidation or UI updates.
+	 *
+	 * @since X.X.X
+	 *
+	 * @var int $style_update_count Number of updates made to the block styles registry.
+	 */
+	private $style_update_count = 0;
+
 	/**
 	 * Registers a block style for the given block type.
 	 *
@@ -101,7 +112,7 @@ final class WP_Block_Styles_Registry {
 			$this->registered_block_styles[ $name ][ $block_style_name ] = $style_properties;
 		}
 
-		$this->update_counter++;
+		$this->style_update_count++;
 		return true;
 	}
 
@@ -127,7 +138,7 @@ final class WP_Block_Styles_Registry {
 
 		unset( $this->registered_block_styles[ $block_name ][ $block_style_name ] );
 
-		$this->update_counter++;
+		$this->style_update_count++;
 		return true;
 	}
 
@@ -204,7 +215,17 @@ final class WP_Block_Styles_Registry {
 		return self::$instance;
 	}
 
-	public function get_update_counter() {
-		return $this->update_counter;
+	/**
+	 * Retrieves the current style update count.
+	 *
+	 * This method returns the number of times the block styles registry has been updated,
+	 * either through registration or unregistration of block styles.
+	 *
+	 * @since 5.3.0
+	 *
+	 * @return int The current value of the style update count.
+	 */
+	public function get_style_update_count() {
+		return $this->style_update_count;
 	}
 }

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -38,7 +38,18 @@ class WP_Theme_JSON {
 	 */
 	protected static $blocks_metadata = array();
 
-	protected static $last_style_check_counter = 0;
+	/**
+	 * The counter value of the last style update check.
+	 *
+	 * This variable stores the value of the style update counter at the last time
+	 * the block metadata was checked for updates. It is used to determine if
+	 * new style updates have occurred since the last check.
+	 *
+	 * @since X.X.X
+	 *
+	 * @var int $last_style_update_count The last recorded value of the style update counter.
+	 */
+	protected static $last_style_update_count = 0;
 
 	/**
 	 * The CSS selector for the top-level preset settings.
@@ -1155,8 +1166,8 @@ class WP_Theme_JSON {
 		// Is there metadata for all currently registered blocks?
 		$blocks = array_diff_key( $blocks, static::$blocks_metadata );
 		if ( empty( $blocks ) ) {
-			$current_update_counter = $style_registry->get_update_counter();
-			if ( $current_update_counter > static::$last_style_check_counter ) {
+			$current_style_update_count = $style_registry->get_style_update_count();
+			if ( $current_style_update_count > static::$last_style_update_count ) {
 				/*
 				* New block styles may have been registered within WP_Block_Styles_Registry.
 				* Update block metadata for any new block style variations.
@@ -1175,7 +1186,7 @@ class WP_Theme_JSON {
 						static::$blocks_metadata[ $block_name ]['styleVariations'] = $style_selectors;
 					}
 				}
-				static::$last_style_check_counter = $current_update_counter;
+				static::$last_style_update_count = $current_style_update_count;
 			}
 			return static::$blocks_metadata;
 		}


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/62191
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
