### PR TITLE
Refactoring - wp-themes-inactive, wp-parent-theme & wp-active-theme

### DIFF
--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -35,8 +35,6 @@ class WP_Debug_Data {
 	 * @return array The debug data for the site.
 	 */
 	public static function debug_data() {
-		global $_wp_theme_features;
-
 		// Save few function calls.
 		$upload_dir             = wp_upload_dir();
 		$is_multisite           = is_multisite();
@@ -46,7 +44,7 @@ class WP_Debug_Data {
 		 *
 		 * When iterating through the debug data, the ordering of the sections
 		 * occurs in insertion-order of the assignments into this array. Setting
-		 * up empty values here preserves that specific ordering so it doesn't
+		 * up empty values here preserves that specific ordering, so it doesn't
 		 * depend on when inside this method each section is otherwise assigned.
 		 *
 		 * When all sections have been modularized, this will be the final single
@@ -58,9 +56,9 @@ class WP_Debug_Data {
 			'wp-core'             => self::get_wp_core(),
 			'wp-paths-sizes'      => array(),
 			'wp-dropins'          => self::get_wp_dropins(),
-			'wp-active-theme'     => array(),
-			'wp-parent-theme'     => array(),
-			'wp-themes-inactive'  => array(),
+			'wp-active-theme'     => self::get_wp_active_theme(),
+			'wp-parent-theme'     => self::get_wp_parent_theme(),
+			'wp-themes-inactive'  => self::get_wp_themes_inactive(),
 			'wp-mu-plugins'       => self::get_wp_mu_plugins(),
 			'wp-plugins-active'   => self::get_wp_plugins_active(),
 			'wp-plugins-inactive' => self::get_wp_plugins_inactive(),
@@ -83,22 +81,6 @@ class WP_Debug_Data {
 				'fields' => array(),
 			);
 		}
-
-		$info['wp-active-theme'] = array(
-			'label'  => __( 'Active Theme' ),
-			'fields' => array(),
-		);
-
-		$info['wp-parent-theme'] = array(
-			'label'  => __( 'Parent Theme' ),
-			'fields' => array(),
-		);
-
-		$info['wp-themes-inactive'] = array(
-			'label'      => __( 'Inactive Themes' ),
-			'show_count' => true,
-			'fields'     => array(),
-		);
 
 		// Remove accordion for Directories and Sizes if in Multisite.
 		if ( ! $is_multisite ) {
@@ -160,325 +142,6 @@ class WP_Debug_Data {
 					'value' => $loading,
 					'debug' => 'loading...',
 				),
-			);
-		}
-
-		// Populate the section for the currently active theme.
-		$theme_features = array();
-
-		if ( ! empty( $_wp_theme_features ) ) {
-			foreach ( $_wp_theme_features as $feature => $options ) {
-				$theme_features[] = $feature;
-			}
-		}
-
-		$active_theme  = wp_get_theme();
-		$theme_updates = get_theme_updates();
-		$transient     = get_site_transient( 'update_themes' );
-
-		$active_theme_version       = $active_theme->version;
-		$active_theme_version_debug = $active_theme_version;
-
-		$auto_updates         = array();
-		$auto_updates_enabled = wp_is_auto_update_enabled_for_type( 'theme' );
-		if ( $auto_updates_enabled ) {
-			$auto_updates = (array) get_site_option( 'auto_update_themes', array() );
-		}
-
-		if ( array_key_exists( $active_theme->stylesheet, $theme_updates ) ) {
-			$theme_update_new_version = $theme_updates[ $active_theme->stylesheet ]->update['new_version'];
-
-			/* translators: %s: Latest theme version number. */
-			$active_theme_version       .= ' ' . sprintf( __( '(Latest version: %s)' ), $theme_update_new_version );
-			$active_theme_version_debug .= sprintf( ' (latest version: %s)', $theme_update_new_version );
-		}
-
-		$active_theme_author_uri = $active_theme->display( 'AuthorURI' );
-
-		if ( $active_theme->parent_theme ) {
-			$active_theme_parent_theme = sprintf(
-				/* translators: 1: Theme name. 2: Theme slug. */
-				__( '%1$s (%2$s)' ),
-				$active_theme->parent_theme,
-				$active_theme->template
-			);
-			$active_theme_parent_theme_debug = sprintf(
-				'%s (%s)',
-				$active_theme->parent_theme,
-				$active_theme->template
-			);
-		} else {
-			$active_theme_parent_theme       = __( 'None' );
-			$active_theme_parent_theme_debug = 'none';
-		}
-
-		$info['wp-active-theme']['fields'] = array(
-			'name'           => array(
-				'label' => __( 'Name' ),
-				'value' => sprintf(
-					/* translators: 1: Theme name. 2: Theme slug. */
-					__( '%1$s (%2$s)' ),
-					$active_theme->name,
-					$active_theme->stylesheet
-				),
-			),
-			'version'        => array(
-				'label' => __( 'Version' ),
-				'value' => $active_theme_version,
-				'debug' => $active_theme_version_debug,
-			),
-			'author'         => array(
-				'label' => __( 'Author' ),
-				'value' => wp_kses( $active_theme->author, array() ),
-			),
-			'author_website' => array(
-				'label' => __( 'Author website' ),
-				'value' => ( $active_theme_author_uri ? $active_theme_author_uri : __( 'Undefined' ) ),
-				'debug' => ( $active_theme_author_uri ? $active_theme_author_uri : '(undefined)' ),
-			),
-			'parent_theme'   => array(
-				'label' => __( 'Parent theme' ),
-				'value' => $active_theme_parent_theme,
-				'debug' => $active_theme_parent_theme_debug,
-			),
-			'theme_features' => array(
-				'label' => __( 'Theme features' ),
-				'value' => implode( ', ', $theme_features ),
-			),
-			'theme_path'     => array(
-				'label' => __( 'Theme directory location' ),
-				'value' => get_stylesheet_directory(),
-			),
-		);
-
-		if ( $auto_updates_enabled ) {
-			if ( isset( $transient->response[ $active_theme->stylesheet ] ) ) {
-				$item = $transient->response[ $active_theme->stylesheet ];
-			} elseif ( isset( $transient->no_update[ $active_theme->stylesheet ] ) ) {
-				$item = $transient->no_update[ $active_theme->stylesheet ];
-			} else {
-				$item = array(
-					'theme'        => $active_theme->stylesheet,
-					'new_version'  => $active_theme->version,
-					'url'          => '',
-					'package'      => '',
-					'requires'     => '',
-					'requires_php' => '',
-				);
-			}
-
-			$auto_update_forced = wp_is_auto_update_forced_for_item( 'theme', null, (object) $item );
-
-			if ( ! is_null( $auto_update_forced ) ) {
-				$enabled = $auto_update_forced;
-			} else {
-				$enabled = in_array( $active_theme->stylesheet, $auto_updates, true );
-			}
-
-			if ( $enabled ) {
-				$auto_updates_string = __( 'Enabled' );
-			} else {
-				$auto_updates_string = __( 'Disabled' );
-			}
-
-			/** This filter is documented in wp-admin/includes/class-wp-debug-data.php */
-			$auto_updates_string = apply_filters( 'theme_auto_update_debug_string', $auto_updates_string, $active_theme, $enabled );
-
-			$info['wp-active-theme']['fields']['auto_update'] = array(
-				'label' => __( 'Auto-updates' ),
-				'value' => $auto_updates_string,
-				'debug' => $auto_updates_string,
-			);
-		}
-
-		$parent_theme = $active_theme->parent();
-
-		if ( $parent_theme ) {
-			$parent_theme_version       = $parent_theme->version;
-			$parent_theme_version_debug = $parent_theme_version;
-
-			if ( array_key_exists( $parent_theme->stylesheet, $theme_updates ) ) {
-				$parent_theme_update_new_version = $theme_updates[ $parent_theme->stylesheet ]->update['new_version'];
-
-				/* translators: %s: Latest theme version number. */
-				$parent_theme_version       .= ' ' . sprintf( __( '(Latest version: %s)' ), $parent_theme_update_new_version );
-				$parent_theme_version_debug .= sprintf( ' (latest version: %s)', $parent_theme_update_new_version );
-			}
-
-			$parent_theme_author_uri = $parent_theme->display( 'AuthorURI' );
-
-			$info['wp-parent-theme']['fields'] = array(
-				'name'           => array(
-					'label' => __( 'Name' ),
-					'value' => sprintf(
-						/* translators: 1: Theme name. 2: Theme slug. */
-						__( '%1$s (%2$s)' ),
-						$parent_theme->name,
-						$parent_theme->stylesheet
-					),
-				),
-				'version'        => array(
-					'label' => __( 'Version' ),
-					'value' => $parent_theme_version,
-					'debug' => $parent_theme_version_debug,
-				),
-				'author'         => array(
-					'label' => __( 'Author' ),
-					'value' => wp_kses( $parent_theme->author, array() ),
-				),
-				'author_website' => array(
-					'label' => __( 'Author website' ),
-					'value' => ( $parent_theme_author_uri ? $parent_theme_author_uri : __( 'Undefined' ) ),
-					'debug' => ( $parent_theme_author_uri ? $parent_theme_author_uri : '(undefined)' ),
-				),
-				'theme_path'     => array(
-					'label' => __( 'Theme directory location' ),
-					'value' => get_template_directory(),
-				),
-			);
-
-			if ( $auto_updates_enabled ) {
-				if ( isset( $transient->response[ $parent_theme->stylesheet ] ) ) {
-					$item = $transient->response[ $parent_theme->stylesheet ];
-				} elseif ( isset( $transient->no_update[ $parent_theme->stylesheet ] ) ) {
-					$item = $transient->no_update[ $parent_theme->stylesheet ];
-				} else {
-					$item = array(
-						'theme'        => $parent_theme->stylesheet,
-						'new_version'  => $parent_theme->version,
-						'url'          => '',
-						'package'      => '',
-						'requires'     => '',
-						'requires_php' => '',
-					);
-				}
-
-				$auto_update_forced = wp_is_auto_update_forced_for_item( 'theme', null, (object) $item );
-
-				if ( ! is_null( $auto_update_forced ) ) {
-					$enabled = $auto_update_forced;
-				} else {
-					$enabled = in_array( $parent_theme->stylesheet, $auto_updates, true );
-				}
-
-				if ( $enabled ) {
-					$parent_theme_auto_update_string = __( 'Enabled' );
-				} else {
-					$parent_theme_auto_update_string = __( 'Disabled' );
-				}
-
-				/** This filter is documented in wp-admin/includes/class-wp-debug-data.php */
-				$parent_theme_auto_update_string = apply_filters( 'theme_auto_update_debug_string', $parent_theme_auto_update_string, $parent_theme, $enabled );
-
-				$info['wp-parent-theme']['fields']['auto_update'] = array(
-					'label' => __( 'Auto-update' ),
-					'value' => $parent_theme_auto_update_string,
-					'debug' => $parent_theme_auto_update_string,
-				);
-			}
-		}
-
-		// Populate a list of all themes available in the install.
-		$all_themes = wp_get_themes();
-
-		foreach ( $all_themes as $theme_slug => $theme ) {
-			// Exclude the currently active theme from the list of all themes.
-			if ( $active_theme->stylesheet === $theme_slug ) {
-				continue;
-			}
-
-			// Exclude the currently active parent theme from the list of all themes.
-			if ( ! empty( $parent_theme ) && $parent_theme->stylesheet === $theme_slug ) {
-				continue;
-			}
-
-			$theme_version = $theme->version;
-			$theme_author  = $theme->author;
-
-			// Sanitize.
-			$theme_author = wp_kses( $theme_author, array() );
-
-			$theme_version_string       = __( 'No version or author information is available.' );
-			$theme_version_string_debug = 'undefined';
-
-			if ( ! empty( $theme_version ) && ! empty( $theme_author ) ) {
-				/* translators: 1: Theme version number. 2: Theme author name. */
-				$theme_version_string       = sprintf( __( 'Version %1$s by %2$s' ), $theme_version, $theme_author );
-				$theme_version_string_debug = sprintf( 'version: %s, author: %s', $theme_version, $theme_author );
-			} else {
-				if ( ! empty( $theme_author ) ) {
-					/* translators: %s: Theme author name. */
-					$theme_version_string       = sprintf( __( 'By %s' ), $theme_author );
-					$theme_version_string_debug = sprintf( 'author: %s, version: (undefined)', $theme_author );
-				}
-
-				if ( ! empty( $theme_version ) ) {
-					/* translators: %s: Theme version number. */
-					$theme_version_string       = sprintf( __( 'Version %s' ), $theme_version );
-					$theme_version_string_debug = sprintf( 'author: (undefined), version: %s', $theme_version );
-				}
-			}
-
-			if ( array_key_exists( $theme_slug, $theme_updates ) ) {
-				/* translators: %s: Latest theme version number. */
-				$theme_version_string       .= ' ' . sprintf( __( '(Latest version: %s)' ), $theme_updates[ $theme_slug ]->update['new_version'] );
-				$theme_version_string_debug .= sprintf( ' (latest version: %s)', $theme_updates[ $theme_slug ]->update['new_version'] );
-			}
-
-			if ( $auto_updates_enabled ) {
-				if ( isset( $transient->response[ $theme_slug ] ) ) {
-					$item = $transient->response[ $theme_slug ];
-				} elseif ( isset( $transient->no_update[ $theme_slug ] ) ) {
-					$item = $transient->no_update[ $theme_slug ];
-				} else {
-					$item = array(
-						'theme'        => $theme_slug,
-						'new_version'  => $theme->version,
-						'url'          => '',
-						'package'      => '',
-						'requires'     => '',
-						'requires_php' => '',
-					);
-				}
-
-				$auto_update_forced = wp_is_auto_update_forced_for_item( 'theme', null, (object) $item );
-
-				if ( ! is_null( $auto_update_forced ) ) {
-					$enabled = $auto_update_forced;
-				} else {
-					$enabled = in_array( $theme_slug, $auto_updates, true );
-				}
-
-				if ( $enabled ) {
-					$auto_updates_string = __( 'Auto-updates enabled' );
-				} else {
-					$auto_updates_string = __( 'Auto-updates disabled' );
-				}
-
-				/**
-				 * Filters the text string of the auto-updates setting for each theme in the Site Health debug data.
-				 *
-				 * @since 5.5.0
-				 *
-				 * @param string   $auto_updates_string The string output for the auto-updates column.
-				 * @param WP_Theme $theme               An object of theme data.
-				 * @param bool     $enabled             Whether auto-updates are enabled for this item.
-				 */
-				$auto_updates_string = apply_filters( 'theme_auto_update_debug_string', $auto_updates_string, $theme, $enabled );
-
-				$theme_version_string       .= ' | ' . $auto_updates_string;
-				$theme_version_string_debug .= ', ' . $auto_updates_string;
-			}
-
-			$info['wp-themes-inactive']['fields'][ sanitize_text_field( $theme->name ) ] = array(
-				'label' => sprintf(
-					/* translators: 1: Theme name. 2: Theme slug. */
-					__( '%1$s (%2$s)' ),
-					$theme->name,
-					$theme_slug
-				),
-				'value' => $theme_version_string,
-				'debug' => $theme_version_string_debug,
 			);
 		}
 
@@ -1332,6 +995,391 @@ class WP_Debug_Data {
 		}
 
 		return $fields;
+	}
+
+	/**
+	 * Gets the WordPress active theme section of the debug data.
+	 *
+	 * @since 6.7.0
+	 *
+	 * @return array
+	 */
+	private static function get_wp_active_theme(): array {
+		global $_wp_theme_features;
+
+		// Populate the section for the currently active theme.
+		$theme_features = array();
+
+		if ( ! empty( $_wp_theme_features ) ) {
+			foreach ( $_wp_theme_features as $feature => $options ) {
+				$theme_features[] = $feature;
+			}
+		}
+
+		$active_theme  = wp_get_theme();
+		$theme_updates = get_theme_updates();
+		$transient     = get_site_transient( 'update_themes' );
+
+		$active_theme_version       = $active_theme->version;
+		$active_theme_version_debug = $active_theme_version;
+
+		$auto_updates         = array();
+		$auto_updates_enabled = wp_is_auto_update_enabled_for_type( 'theme' );
+		if ( $auto_updates_enabled ) {
+			$auto_updates = (array) get_site_option( 'auto_update_themes', array() );
+		}
+
+		if ( array_key_exists( $active_theme->stylesheet, $theme_updates ) ) {
+			$theme_update_new_version = $theme_updates[ $active_theme->stylesheet ]->update['new_version'];
+
+			/* translators: %s: Latest theme version number. */
+			$active_theme_version       .= ' ' . sprintf( __( '(Latest version: %s)' ), $theme_update_new_version );
+			$active_theme_version_debug .= sprintf( ' (latest version: %s)', $theme_update_new_version );
+		}
+
+		$active_theme_author_uri = $active_theme->display( 'AuthorURI' );
+
+		if ( $active_theme->parent_theme ) {
+			$active_theme_parent_theme = sprintf(
+			/* translators: 1: Theme name. 2: Theme slug. */
+				__( '%1$s (%2$s)' ),
+				$active_theme->parent_theme,
+				$active_theme->template
+			);
+			$active_theme_parent_theme_debug = sprintf(
+				'%s (%s)',
+				$active_theme->parent_theme,
+				$active_theme->template
+			);
+		} else {
+			$active_theme_parent_theme       = __( 'None' );
+			$active_theme_parent_theme_debug = 'none';
+		}
+
+		$fields = array(
+			'name'           => array(
+				'label' => __( 'Name' ),
+				'value' => sprintf(
+				/* translators: 1: Theme name. 2: Theme slug. */
+					__( '%1$s (%2$s)' ),
+					$active_theme->name,
+					$active_theme->stylesheet
+				),
+			),
+			'version'        => array(
+				'label' => __( 'Version' ),
+				'value' => $active_theme_version,
+				'debug' => $active_theme_version_debug,
+			),
+			'author'         => array(
+				'label' => __( 'Author' ),
+				'value' => wp_kses( $active_theme->author, array() ),
+			),
+			'author_website' => array(
+				'label' => __( 'Author website' ),
+				'value' => ( $active_theme_author_uri ? $active_theme_author_uri : __( 'Undefined' ) ),
+				'debug' => ( $active_theme_author_uri ? $active_theme_author_uri : '(undefined)' ),
+			),
+			'parent_theme'   => array(
+				'label' => __( 'Parent theme' ),
+				'value' => $active_theme_parent_theme,
+				'debug' => $active_theme_parent_theme_debug,
+			),
+			'theme_features' => array(
+				'label' => __( 'Theme features' ),
+				'value' => implode( ', ', $theme_features ),
+			),
+			'theme_path'     => array(
+				'label' => __( 'Theme directory location' ),
+				'value' => get_stylesheet_directory(),
+			),
+		);
+
+		if ( $auto_updates_enabled ) {
+			if ( isset( $transient->response[ $active_theme->stylesheet ] ) ) {
+				$item = $transient->response[ $active_theme->stylesheet ];
+			} elseif ( isset( $transient->no_update[ $active_theme->stylesheet ] ) ) {
+				$item = $transient->no_update[ $active_theme->stylesheet ];
+			} else {
+				$item = array(
+					'theme'        => $active_theme->stylesheet,
+					'new_version'  => $active_theme->version,
+					'url'          => '',
+					'package'      => '',
+					'requires'     => '',
+					'requires_php' => '',
+				);
+			}
+
+			$auto_update_forced = wp_is_auto_update_forced_for_item( 'theme', null, (object) $item );
+
+			if ( ! is_null( $auto_update_forced ) ) {
+				$enabled = $auto_update_forced;
+			} else {
+				$enabled = in_array( $active_theme->stylesheet, $auto_updates, true );
+			}
+
+			if ( $enabled ) {
+				$auto_updates_string = __( 'Enabled' );
+			} else {
+				$auto_updates_string = __( 'Disabled' );
+			}
+
+			/** This filter is documented in wp-admin/includes/class-wp-debug-data.php */
+			$auto_updates_string = apply_filters( 'theme_auto_update_debug_string', $auto_updates_string, $active_theme, $enabled );
+
+			$fields['auto_update'] = array(
+				'label' => __( 'Auto-updates' ),
+				'value' => $auto_updates_string,
+				'debug' => $auto_updates_string,
+			);
+		}
+
+		return array(
+			'label'  => __( 'Active Theme' ),
+			'fields' => $fields,
+		);
+	}
+
+	/**
+	 * Gets the WordPress parent theme section of the debug data.
+	 *
+	 * @since 6.7.0
+	 *
+	 * @return array
+	 */
+	private static function get_wp_parent_theme(): array {
+		$theme_updates = get_theme_updates();
+		$transient     = get_site_transient( 'update_themes' );
+
+		$auto_updates         = array();
+		$auto_updates_enabled = wp_is_auto_update_enabled_for_type( 'theme' );
+		if ( $auto_updates_enabled ) {
+			$auto_updates = (array) get_site_option( 'auto_update_themes', array() );
+		}
+
+		$active_theme  = wp_get_theme();
+		$parent_theme = $active_theme->parent();
+
+		if ( $parent_theme ) {
+			$parent_theme_version       = $parent_theme->version;
+			$parent_theme_version_debug = $parent_theme_version;
+
+			if ( array_key_exists( $parent_theme->stylesheet, $theme_updates ) ) {
+				$parent_theme_update_new_version = $theme_updates[ $parent_theme->stylesheet ]->update['new_version'];
+
+				/* translators: %s: Latest theme version number. */
+				$parent_theme_version       .= ' ' . sprintf( __( '(Latest version: %s)' ), $parent_theme_update_new_version );
+				$parent_theme_version_debug .= sprintf( ' (latest version: %s)', $parent_theme_update_new_version );
+			}
+
+			$parent_theme_author_uri = $parent_theme->display( 'AuthorURI' );
+
+			$fields = array(
+				'name'           => array(
+					'label' => __( 'Name' ),
+					'value' => sprintf(
+					/* translators: 1: Theme name. 2: Theme slug. */
+						__( '%1$s (%2$s)' ),
+						$parent_theme->name,
+						$parent_theme->stylesheet
+					),
+				),
+				'version'        => array(
+					'label' => __( 'Version' ),
+					'value' => $parent_theme_version,
+					'debug' => $parent_theme_version_debug,
+				),
+				'author'         => array(
+					'label' => __( 'Author' ),
+					'value' => wp_kses( $parent_theme->author, array() ),
+				),
+				'author_website' => array(
+					'label' => __( 'Author website' ),
+					'value' => ( $parent_theme_author_uri ? $parent_theme_author_uri : __( 'Undefined' ) ),
+					'debug' => ( $parent_theme_author_uri ? $parent_theme_author_uri : '(undefined)' ),
+				),
+				'theme_path'     => array(
+					'label' => __( 'Theme directory location' ),
+					'value' => get_template_directory(),
+				),
+			);
+
+			if ( $auto_updates_enabled ) {
+				if ( isset( $transient->response[ $parent_theme->stylesheet ] ) ) {
+					$item = $transient->response[ $parent_theme->stylesheet ];
+				} elseif ( isset( $transient->no_update[ $parent_theme->stylesheet ] ) ) {
+					$item = $transient->no_update[ $parent_theme->stylesheet ];
+				} else {
+					$item = array(
+						'theme'        => $parent_theme->stylesheet,
+						'new_version'  => $parent_theme->version,
+						'url'          => '',
+						'package'      => '',
+						'requires'     => '',
+						'requires_php' => '',
+					);
+				}
+
+				$auto_update_forced = wp_is_auto_update_forced_for_item( 'theme', null, (object) $item );
+
+				if ( ! is_null( $auto_update_forced ) ) {
+					$enabled = $auto_update_forced;
+				} else {
+					$enabled = in_array( $parent_theme->stylesheet, $auto_updates, true );
+				}
+
+				if ( $enabled ) {
+					$parent_theme_auto_update_string = __( 'Enabled' );
+				} else {
+					$parent_theme_auto_update_string = __( 'Disabled' );
+				}
+
+				/** This filter is documented in wp-admin/includes/class-wp-debug-data.php */
+				$parent_theme_auto_update_string = apply_filters( 'theme_auto_update_debug_string', $parent_theme_auto_update_string, $parent_theme, $enabled );
+
+				$fields['auto_update'] = array(
+					'label' => __( 'Auto-update' ),
+					'value' => $parent_theme_auto_update_string,
+					'debug' => $parent_theme_auto_update_string,
+				);
+			}
+		}
+
+		return array(
+			'label'  => __( 'Parent Theme' ),
+			'fields' => $fields,
+		);
+	}
+
+	/**
+	 * Gets the WordPress inactive themes section of the debug data.
+	 *
+	 * @since 6.7.0
+	 *
+	 * @return array
+	 */
+	private static function get_wp_themes_inactive(): array {
+		$active_theme  = wp_get_theme();
+		$parent_theme  = $active_theme->parent();
+		$theme_updates = get_theme_updates();
+
+		$auto_updates         = array();
+		$auto_updates_enabled = wp_is_auto_update_enabled_for_type( 'theme' );
+		if ( $auto_updates_enabled ) {
+			$auto_updates = (array) get_site_option( 'auto_update_themes', array() );
+		}
+
+		// Populate a list of all themes available in the installation.
+		$all_themes = wp_get_themes();
+		$fields     = array();
+
+		foreach ( $all_themes as $theme_slug => $theme ) {
+			// Exclude the currently active theme from the list of all themes.
+			if ( $active_theme->stylesheet === $theme_slug ) {
+				continue;
+			}
+
+			// Exclude the currently active parent theme from the list of all themes.
+			if ( ! empty( $parent_theme ) && $parent_theme->stylesheet === $theme_slug ) {
+				continue;
+			}
+
+			$theme_version = $theme->version;
+			$theme_author  = $theme->author;
+
+			// Sanitize.
+			$theme_author = wp_kses( $theme_author, array() );
+
+			$theme_version_string       = __( 'No version or author information is available.' );
+			$theme_version_string_debug = 'undefined';
+
+			if ( ! empty( $theme_version ) && ! empty( $theme_author ) ) {
+				/* translators: 1: Theme version number. 2: Theme author name. */
+				$theme_version_string       = sprintf( __( 'Version %1$s by %2$s' ), $theme_version, $theme_author );
+				$theme_version_string_debug = sprintf( 'version: %s, author: %s', $theme_version, $theme_author );
+			} else {
+				if ( ! empty( $theme_author ) ) {
+					/* translators: %s: Theme author name. */
+					$theme_version_string       = sprintf( __( 'By %s' ), $theme_author );
+					$theme_version_string_debug = sprintf( 'author: %s, version: (undefined)', $theme_author );
+				}
+
+				if ( ! empty( $theme_version ) ) {
+					/* translators: %s: Theme version number. */
+					$theme_version_string       = sprintf( __( 'Version %s' ), $theme_version );
+					$theme_version_string_debug = sprintf( 'author: (undefined), version: %s', $theme_version );
+				}
+			}
+
+			if ( array_key_exists( $theme_slug, $theme_updates ) ) {
+				/* translators: %s: Latest theme version number. */
+				$theme_version_string       .= ' ' . sprintf( __( '(Latest version: %s)' ), $theme_updates[ $theme_slug ]->update['new_version'] );
+				$theme_version_string_debug .= sprintf( ' (latest version: %s)', $theme_updates[ $theme_slug ]->update['new_version'] );
+			}
+
+			if ( $auto_updates_enabled ) {
+				if ( isset( $transient->response[ $theme_slug ] ) ) {
+					$item = $transient->response[ $theme_slug ];
+				} elseif ( isset( $transient->no_update[ $theme_slug ] ) ) {
+					$item = $transient->no_update[ $theme_slug ];
+				} else {
+					$item = array(
+						'theme'        => $theme_slug,
+						'new_version'  => $theme->version,
+						'url'          => '',
+						'package'      => '',
+						'requires'     => '',
+						'requires_php' => '',
+					);
+				}
+
+				$auto_update_forced = wp_is_auto_update_forced_for_item( 'theme', null, (object) $item );
+
+				if ( ! is_null( $auto_update_forced ) ) {
+					$enabled = $auto_update_forced;
+				} else {
+					$enabled = in_array( $theme_slug, $auto_updates, true );
+				}
+
+				if ( $enabled ) {
+					$auto_updates_string = __( 'Auto-updates enabled' );
+				} else {
+					$auto_updates_string = __( 'Auto-updates disabled' );
+				}
+
+				/**
+				 * Filters the text string of the auto-updates setting for each theme in the Site Health debug data.
+				 *
+				 * @since 5.5.0
+				 *
+				 * @param string   $auto_updates_string The string output for the auto-updates column.
+				 * @param WP_Theme $theme               An object of theme data.
+				 * @param bool     $enabled             Whether auto-updates are enabled for this item.
+				 */
+				$auto_updates_string = apply_filters( 'theme_auto_update_debug_string', $auto_updates_string, $theme, $enabled );
+
+				$theme_version_string       .= ' | ' . $auto_updates_string;
+				$theme_version_string_debug .= ', ' . $auto_updates_string;
+			}
+
+			$fields[ sanitize_text_field( $theme->name ) ] = array(
+				'label' => sprintf(
+				/* translators: 1: Theme name. 2: Theme slug. */
+					__( '%1$s (%2$s)' ),
+					$theme->name,
+					$theme_slug
+				),
+				'value' => $theme_version_string,
+				'debug' => $theme_version_string_debug,
+			);
+		}
+
+		return array(
+			'label'      => __( 'Inactive Themes' ),
+			'show_count' => true,
+			'fields'     => $fields,
+		);
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -35,10 +35,6 @@ class WP_Debug_Data {
 	 * @return array The debug data for the site.
 	 */
 	public static function debug_data() {
-		// Save few function calls.
-		$upload_dir             = wp_upload_dir();
-		$is_multisite           = is_multisite();
-
 		/*
 		 * Set up the array that holds all debug information.
 		 *
@@ -1057,7 +1053,7 @@ class WP_Debug_Data {
 
 		if ( $active_theme->parent_theme ) {
 			$active_theme_parent_theme = sprintf(
-			/* translators: 1: Theme name. 2: Theme slug. */
+				/* translators: 1: Theme name. 2: Theme slug. */
 				__( '%1$s (%2$s)' ),
 				$active_theme->parent_theme,
 				$active_theme->template
@@ -1076,7 +1072,7 @@ class WP_Debug_Data {
 			'name'           => array(
 				'label' => __( 'Name' ),
 				'value' => sprintf(
-				/* translators: 1: Theme name. 2: Theme slug. */
+					/* translators: 1: Theme name. 2: Theme slug. */
 					__( '%1$s (%2$s)' ),
 					$active_theme->name,
 					$active_theme->stylesheet
@@ -1174,92 +1170,97 @@ class WP_Debug_Data {
 			$auto_updates = (array) get_site_option( 'auto_update_themes', array() );
 		}
 
-		$active_theme  = wp_get_theme();
+		$active_theme = wp_get_theme();
 		$parent_theme = $active_theme->parent();
 
-		if ( $parent_theme ) {
-			$parent_theme_version       = $parent_theme->version;
-			$parent_theme_version_debug = $parent_theme_version;
-
-			if ( array_key_exists( $parent_theme->stylesheet, $theme_updates ) ) {
-				$parent_theme_update_new_version = $theme_updates[ $parent_theme->stylesheet ]->update['new_version'];
-
-				/* translators: %s: Latest theme version number. */
-				$parent_theme_version       .= ' ' . sprintf( __( '(Latest version: %s)' ), $parent_theme_update_new_version );
-				$parent_theme_version_debug .= sprintf( ' (latest version: %s)', $parent_theme_update_new_version );
-			}
-
-			$parent_theme_author_uri = $parent_theme->display( 'AuthorURI' );
-
-			$fields = array(
-				'name'           => array(
-					'label' => __( 'Name' ),
-					'value' => sprintf(
-					/* translators: 1: Theme name. 2: Theme slug. */
-						__( '%1$s (%2$s)' ),
-						$parent_theme->name,
-						$parent_theme->stylesheet
-					),
-				),
-				'version'        => array(
-					'label' => __( 'Version' ),
-					'value' => $parent_theme_version,
-					'debug' => $parent_theme_version_debug,
-				),
-				'author'         => array(
-					'label' => __( 'Author' ),
-					'value' => wp_kses( $parent_theme->author, array() ),
-				),
-				'author_website' => array(
-					'label' => __( 'Author website' ),
-					'value' => ( $parent_theme_author_uri ? $parent_theme_author_uri : __( 'Undefined' ) ),
-					'debug' => ( $parent_theme_author_uri ? $parent_theme_author_uri : '(undefined)' ),
-				),
-				'theme_path'     => array(
-					'label' => __( 'Theme directory location' ),
-					'value' => get_template_directory(),
-				),
+		if ( ! $parent_theme ) {
+			return array(
+				'label'  => __( 'Parent Theme' ),
+				'fields' => array(),
 			);
+		}
 
-			if ( $auto_updates_enabled ) {
-				if ( isset( $transient->response[ $parent_theme->stylesheet ] ) ) {
-					$item = $transient->response[ $parent_theme->stylesheet ];
-				} elseif ( isset( $transient->no_update[ $parent_theme->stylesheet ] ) ) {
-					$item = $transient->no_update[ $parent_theme->stylesheet ];
-				} else {
-					$item = array(
-						'theme'        => $parent_theme->stylesheet,
-						'new_version'  => $parent_theme->version,
-						'url'          => '',
-						'package'      => '',
-						'requires'     => '',
-						'requires_php' => '',
-					);
-				}
+		$parent_theme_version       = $parent_theme->version;
+		$parent_theme_version_debug = $parent_theme_version;
 
-				$auto_update_forced = wp_is_auto_update_forced_for_item( 'theme', null, (object) $item );
+		if ( array_key_exists( $parent_theme->stylesheet, $theme_updates ) ) {
+			$parent_theme_update_new_version = $theme_updates[ $parent_theme->stylesheet ]->update['new_version'];
 
-				if ( ! is_null( $auto_update_forced ) ) {
-					$enabled = $auto_update_forced;
-				} else {
-					$enabled = in_array( $parent_theme->stylesheet, $auto_updates, true );
-				}
+			/* translators: %s: Latest theme version number. */
+			$parent_theme_version       .= ' ' . sprintf( __( '(Latest version: %s)' ), $parent_theme_update_new_version );
+			$parent_theme_version_debug .= sprintf( ' (latest version: %s)', $parent_theme_update_new_version );
+		}
 
-				if ( $enabled ) {
-					$parent_theme_auto_update_string = __( 'Enabled' );
-				} else {
-					$parent_theme_auto_update_string = __( 'Disabled' );
-				}
+		$parent_theme_author_uri = $parent_theme->display( 'AuthorURI' );
 
-				/** This filter is documented in wp-admin/includes/class-wp-debug-data.php */
-				$parent_theme_auto_update_string = apply_filters( 'theme_auto_update_debug_string', $parent_theme_auto_update_string, $parent_theme, $enabled );
+		$fields = array(
+			'name'           => array(
+				'label' => __( 'Name' ),
+				'value' => sprintf(
+					/* translators: 1: Theme name. 2: Theme slug. */
+					__( '%1$s (%2$s)' ),
+					$parent_theme->name,
+					$parent_theme->stylesheet
+				),
+			),
+			'version'        => array(
+				'label' => __( 'Version' ),
+				'value' => $parent_theme_version,
+				'debug' => $parent_theme_version_debug,
+			),
+			'author'         => array(
+				'label' => __( 'Author' ),
+				'value' => wp_kses( $parent_theme->author, array() ),
+			),
+			'author_website' => array(
+				'label' => __( 'Author website' ),
+				'value' => ( $parent_theme_author_uri ? $parent_theme_author_uri : __( 'Undefined' ) ),
+				'debug' => ( $parent_theme_author_uri ? $parent_theme_author_uri : '(undefined)' ),
+			),
+			'theme_path'     => array(
+				'label' => __( 'Theme directory location' ),
+				'value' => get_template_directory(),
+			),
+		);
 
-				$fields['auto_update'] = array(
-					'label' => __( 'Auto-update' ),
-					'value' => $parent_theme_auto_update_string,
-					'debug' => $parent_theme_auto_update_string,
+		if ( $auto_updates_enabled ) {
+			if ( isset( $transient->response[ $parent_theme->stylesheet ] ) ) {
+				$item = $transient->response[ $parent_theme->stylesheet ];
+			} elseif ( isset( $transient->no_update[ $parent_theme->stylesheet ] ) ) {
+				$item = $transient->no_update[ $parent_theme->stylesheet ];
+			} else {
+				$item = array(
+					'theme'        => $parent_theme->stylesheet,
+					'new_version'  => $parent_theme->version,
+					'url'          => '',
+					'package'      => '',
+					'requires'     => '',
+					'requires_php' => '',
 				);
 			}
+
+			$auto_update_forced = wp_is_auto_update_forced_for_item( 'theme', null, (object) $item );
+
+			if ( ! is_null( $auto_update_forced ) ) {
+				$enabled = $auto_update_forced;
+			} else {
+				$enabled = in_array( $parent_theme->stylesheet, $auto_updates, true );
+			}
+
+			if ( $enabled ) {
+				$parent_theme_auto_update_string = __( 'Enabled' );
+			} else {
+				$parent_theme_auto_update_string = __( 'Disabled' );
+			}
+
+			/** This filter is documented in wp-admin/includes/class-wp-debug-data.php */
+			$parent_theme_auto_update_string = apply_filters( 'theme_auto_update_debug_string', $parent_theme_auto_update_string, $parent_theme, $enabled );
+
+			$fields['auto_update'] = array(
+				'label' => __( 'Auto-update' ),
+				'value' => $parent_theme_auto_update_string,
+				'debug' => $parent_theme_auto_update_string,
+			);
 		}
 
 		return array(
@@ -1381,7 +1382,7 @@ class WP_Debug_Data {
 
 			$fields[ sanitize_text_field( $theme->name ) ] = array(
 				'label' => sprintf(
-				/* translators: 1: Theme name. 2: Theme slug. */
+					/* translators: 1: Theme name. 2: Theme slug. */
 					__( '%1$s (%2$s)' ),
 					$theme->name,
 					$theme_slug


### PR DESCRIPTION
'wp-active-theme'     => self::get_wp_active_theme(),
'wp-parent-theme'     => self::get_wp_parent_theme(),
'wp-themes-inactive'  => self::get_wp_themes_inactive(),

---

Follow up to https://github.com/WordPress/wordpress-develop/pull/7027 as discussed with @dmsnell and @costdev 

Summary of the coming steps:

1. [wp-filesystem](https://github.com/WordPress/wordpress-develop/pull/7065)
2. [wp-constants](https://github.com/WordPress/wordpress-develop/pull/7106)
3. [wp-database](https://github.com/WordPress/wordpress-develop/pull/7143)
4. [wp-server](https://github.com/WordPress/wordpress-develop/pull/7283)
5. [wp-media](https://github.com/WordPress/wordpress-develop/pull/7356)
6. [wp-plugins-active & wp-plugins-inactive](https://github.com/WordPress/wordpress-develop/pull/7458)
7. [wp-mu-plugins](https://github.com/WordPress/wordpress-develop/pull/7305)
8. & 9. & 10.  **wp-themes-inactive, wp-parent-theme & wp-active-theme** (we are here)
11. [wp-dropins](https://github.com/WordPress/wordpress-develop/pull/7418)
12. [wp-paths-sizes](https://github.com/WordPress/wordpress-develop/pull/7445)
13. [wp-core](https://github.com/WordPress/wordpress-develop/pull/7357)

Refactoring WP_Debug_Data::debug_data(); into smaller functions for

* better maintainability
* reduced complexity
* preparation for future unit tests
* improved extensibility (see trac for details)
* added php7.2 style type hints

Trac ticket: https://core.trac.wordpress.org/ticket/61648#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
