### PR TITLE
fix(wpadmin): Fix URL sanitization for handling Unicode

### DIFF
--- a/src/wp-admin/customize.php
+++ b/src/wp-admin/customize.php
@@ -83,6 +83,7 @@ if ( $wp_customize->changeset_post_id() ) {
 		);
 	}
 }
+
 $url       = ! empty( $_REQUEST['url'] ) ? esc_url_raw( wp_unslash( $_REQUEST['url'] ) ) : '';
 $return    = ! empty( $_REQUEST['return'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['return'] ) ) : '';
 $autofocus = ! empty( $_REQUEST['autofocus'] ) && is_array( $_REQUEST['autofocus'] )

--- a/src/wp-admin/customize.php
+++ b/src/wp-admin/customize.php
@@ -83,8 +83,7 @@ if ( $wp_customize->changeset_post_id() ) {
 		);
 	}
 }
-
-$url       = ! empty( $_REQUEST['url'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['url'] ) ) : '';
+$url       = ! empty( $_REQUEST['url'] ) ? esc_url_raw( wp_unslash( $_REQUEST['url'] ) ) : '';
 $return    = ! empty( $_REQUEST['return'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['return'] ) ) : '';
 $autofocus = ! empty( $_REQUEST['autofocus'] ) && is_array( $_REQUEST['autofocus'] )
 	? array_map( 'sanitize_text_field', wp_unslash( $_REQUEST['autofocus'] ) )

--- a/src/wp-admin/customize.php
+++ b/src/wp-admin/customize.php
@@ -85,7 +85,7 @@ if ( $wp_customize->changeset_post_id() ) {
 }
 
 $url       = ! empty( $_REQUEST['url'] ) ? esc_url_raw( wp_unslash( $_REQUEST['url'] ) ) : '';
-$return    = ! empty( $_REQUEST['return'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['return'] ) ) : '';
+$return    = ! empty( $_REQUEST['return'] ) ? esc_url_raw( wp_unslash( $_REQUEST['return'] ) ) : '';
 $autofocus = ! empty( $_REQUEST['autofocus'] ) && is_array( $_REQUEST['autofocus'] )
 	? array_map( 'sanitize_text_field', wp_unslash( $_REQUEST['autofocus'] ) )
 	: array();


### PR DESCRIPTION
Replaced sanitize_text_field() with esc_url_raw() for sanitizing URLs passed via `$_REQUEST['url']`. This change fixes an issue where the URL `example.com/หน้าภาษาไทย` would incorrectly return `example.com//` due to improper sanitization when clicking on the Customize button through the admin bar.

This ensures that URLs containing non-Latin characters are correctly preserved and prevents unexpected behavior in the customizer.

Happy to hear feedback on this approach or if there's a better way to handle this scenario! Let me know if this change introduces any concerns.

Trac ticket: https://core.trac.wordpress.org/ticket/61317