### PR TITLE
Removing trailing slash on void element

### DIFF
--- a/src/wp-includes/class-wp-styles.php
+++ b/src/wp-includes/class-wp-styles.php
@@ -227,7 +227,7 @@ class WP_Styles extends WP_Dependencies {
 		$title = isset( $obj->extra['title'] ) ? sprintf( " title='%s'", esc_attr( $obj->extra['title'] ) ) : '';
 
 		$tag = sprintf(
-			"<link rel='%s' id='%s-css'%s href='%s'%s media='%s' />\n",
+			"<link rel='%s' id='%s-css'%s href='%s'%s media='%s'>\n",
 			$rel,
 			$handle,
 			$title,
@@ -259,7 +259,7 @@ class WP_Styles extends WP_Dependencies {
 			}
 
 			$rtl_tag = sprintf(
-				"<link rel='%s' id='%s-rtl-css'%s href='%s'%s media='%s' />\n",
+				"<link rel='%s' id='%s-rtl-css'%s href='%s'%s media='%s'>\n",
 				$rel,
 				$handle,
 				$title,


### PR DESCRIPTION
Removing trailing slash on void element per W3C validator

Trac ticket: https://core.trac.wordpress.org/ticket/59432