### PR TITLE
fix(admin): Keep role selection when removing user

### DIFF
--- a/src/wp-admin/users.php
+++ b/src/wp-admin/users.php
@@ -181,6 +181,7 @@ switch ( $wp_list_table->current_action() ) {
 		}
 
 		$user_ids = array_map( 'intval', (array) $_REQUEST['users'] );
+		$role = isset($_REQUEST['role']) ? $_REQUEST['role'] : null;
 
 		if ( empty( $_REQUEST['delete_option'] ) ) {
 			$url = self_admin_url( 'users.php?action=delete&users[]=' . implode( '&users[]=', $user_ids ) . '&error=true' );
@@ -222,6 +223,7 @@ switch ( $wp_list_table->current_action() ) {
 			array(
 				'delete_count' => $delete_count,
 				'update'       => $update,
+				'role'		   => $role
 			),
 			$redirect
 		);

--- a/src/wp-admin/users.php
+++ b/src/wp-admin/users.php
@@ -223,7 +223,7 @@ switch ( $wp_list_table->current_action() ) {
 			array(
 				'delete_count' => $delete_count,
 				'update'       => $update,
-				'role'		   => $role
+				'role'         => $role
 			),
 			$redirect
 		);

--- a/src/wp-admin/users.php
+++ b/src/wp-admin/users.php
@@ -181,7 +181,7 @@ switch ( $wp_list_table->current_action() ) {
 		}
 
 		$user_ids = array_map( 'intval', (array) $_REQUEST['users'] );
-		$role = isset($_REQUEST['role']) ? $_REQUEST['role'] : null;
+		$role = isset( $_REQUEST['role'] ) ? $_REQUEST['role'] : null;
 
 		if ( empty( $_REQUEST['delete_option'] ) ) {
 			$url = self_admin_url( 'users.php?action=delete&users[]=' . implode( '&users[]=', $user_ids ) . '&error=true' );
@@ -223,7 +223,7 @@ switch ( $wp_list_table->current_action() ) {
 			array(
 				'delete_count' => $delete_count,
 				'update'       => $update,
-				'role'         => $role
+				'role'         => $role,
 			),
 			$redirect
 		);


### PR DESCRIPTION
This just keeps the role attribute around after a user has been deleted if done by filtering on a role, it is already provided by the form submission so just getting it out if it exists and passing it to the redirect.

Note that it will show a blank table if no more users exist in that group, we could add a check if we should then go to "all" or not. Happy to hear suggestions

Trac ticket: https://core.trac.wordpress.org/ticket/57398
