### PR TITLE
fix(customize): Delay sortable on mobile menu

### DIFF
--- a/src/js/_enqueues/lib/nav-menu.js
+++ b/src/js/_enqueues/lib/nav-menu.js
@@ -639,7 +639,8 @@
 				prev, next, prevBottom, nextThreshold, helperHeight, transport,
 				menuEdge = api.menuList.offset().left,
 				body = $('body'), maxChildDepth,
-				menuMaxDepth = initialMenuMaxDepth();
+				menuMaxDepth = initialMenuMaxDepth(),
+				isMobile = $(document.body).hasClass('mobile');
 
 			if( 0 !== $( '#menu-to-edit li' ).length )
 				$( '.drag-instructions' ).show();
@@ -651,6 +652,7 @@
 				handle: '.menu-item-handle',
 				placeholder: 'sortable-placeholder',
 				items: api.options.sortableItems,
+				delay: (isMobile ? 200 : 0),
 				start: function(e, ui) {
 					var height, width, parent, children, tempHolder;
 
@@ -882,7 +884,7 @@
 		 * Handle toggling bulk selection checkboxes for menu items.
 		 *
 		 * @since 5.8.0
-		 */ 
+		 */
 		attachBulkSelectButtonListeners : function() {
 			var that = this;
 
@@ -901,7 +903,7 @@
 		 * Enable bulk selection checkboxes for menu items.
 		 *
 		 * @since 5.8.0
-		 */ 
+		 */
 		enableBulkSelection : function() {
 			var checkbox = $( '#menu-to-edit .menu-item-checkbox' );
 
@@ -918,7 +920,7 @@
 		 * Disable bulk selection checkboxes for menu items.
 		 *
 		 * @since 5.8.0
-		 */ 
+		 */
 		disableBulkSelection : function() {
 			var checkbox = $( '#menu-to-edit .menu-item-checkbox' );
 
@@ -942,7 +944,7 @@
 		 * Listen for state changes on bulk action checkboxes.
 		 *
 		 * @since 5.8.0
-		 */ 
+		 */
 		attachMenuCheckBoxListeners : function() {
 			var that = this;
 
@@ -955,7 +957,7 @@
 		 * Create delete button to remove menu items from collection.
 		 *
 		 * @since 5.8.0
-		 */ 
+		 */
 		attachMenuItemDeleteButton : function() {
 			var that = this;
 
@@ -996,7 +998,7 @@
 		 * List menu items awaiting deletion.
 		 *
 		 * @since 5.8.0
-		 */ 
+		 */
 		attachPendingMenuItemsListForDeletion : function() {
 			$( '#post-body-content' ).on( 'change', '.menu-item-checkbox', function() {
 				var menuItemName, menuItemType, menuItemID, listedMenuItem;
@@ -1033,7 +1035,7 @@
 		 * Set status of bulk delete checkbox.
 		 *
 		 * @since 5.8.0
-		 */ 
+		 */
 		setBulkDeleteCheckboxStatus : function() {
 			var that = this;
 			var checkbox = $( '#menu-to-edit .menu-item-checkbox' );
@@ -1057,7 +1059,7 @@
 		 * Set status of menu items removal button.
 		 *
 		 * @since 5.8.0
-		 */ 
+		 */
 		setRemoveSelectedButtonStatus : function() {
 			var button = $( '.menu-items-delete' );
 

--- a/src/js/_enqueues/lib/nav-menu.js
+++ b/src/js/_enqueues/lib/nav-menu.js
@@ -640,7 +640,7 @@
 				menuEdge = api.menuList.offset().left,
 				body = $('body'), maxChildDepth,
 				menuMaxDepth = initialMenuMaxDepth(),
-				isMobile = $(document.body).hasClass('mobile');
+				isMobile = $( document.body ).hasClass( 'mobile' );
 
 			if( 0 !== $( '#menu-to-edit li' ).length )
 				$( '.drag-instructions' ).show();
@@ -652,7 +652,7 @@
 				handle: '.menu-item-handle',
 				placeholder: 'sortable-placeholder',
 				items: api.options.sortableItems,
-				delay: (isMobile ? 200 : 0),
+				delay: ( isMobile ? 200 :  0),
 				start: function(e, ui) {
 					var height, width, parent, children, tempHolder;
 


### PR DESCRIPTION
I believe this is due to sortable and the accordion interfering with each other, so like the `postbox.js` file we set a delay of 200ms to try prevent this if on mobile.

Trac ticket: https://core.trac.wordpress.org/ticket/43494