### PR TITLE
feat(admin): Add last modified column to pages and posts

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -304,7 +304,8 @@ table.fixed {
 	width: 10%;
 }
 
-.fixed .column-date {
+.fixed .column-date,
+.fixed .column-post_modified {
 	width: 14%;
 }
 

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1259,7 +1259,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 	}
 
 	/**
-	 * Handles the post date column output.
+	 * Handles the post last modified date column output.
 	 *
 	 * @since 6.7.0
 	 *

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1698,7 +1698,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 			'tags'          => true,
 			'comments'      => true,
 			'author'        => true,
-			'post_modified' => true
+			'post_modified' => true,
 		);
 		?>
 

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1270,7 +1270,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 	public function column_post_modified( $post ) {
 		global $mode;
 
-		if ( '0000-00-00 00:00:00' === $post->post_date ) {
+		if ( '0000-00-00 00:00:00' === $post->post_modified ) {
 			$t_time    = __( 'Unpublished' );
 		} else {
 			$t_time = sprintf(
@@ -1286,17 +1286,13 @@ class WP_Posts_List_Table extends WP_List_Table {
 		/**
 		 * Filters the published, scheduled, or unpublished time of the post.
 		 *
-		 * @since 2.5.1
-		 * @since 5.5.0 Removed the difference between 'excerpt' and 'list' modes.
-		 *              The published time and date are both displayed now,
-		 *              which is equivalent to the previous 'excerpt' mode.
-		 *
+		 * @since 6.7.0
 		 * @param string  $t_time      The published time.
 		 * @param WP_Post $post        Post object.
 		 * @param string  $column_name The column name.
 		 * @param string  $mode        The list display mode ('excerpt' or 'list').
 		 */
-		echo apply_filters( 'post_date_column_time', $t_time, $post, 'date', $mode );
+		echo apply_filters( 'post_date_modified_column_time', $t_time, $post, 'post_modified', $mode );
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -716,6 +716,8 @@ class WP_Posts_List_Table extends WP_List_Table {
 
 		$posts_columns['date'] = __( 'Date' );
 
+		$posts_columns['post_modified'] = __( 'Last Modified' );
+
 		if ( 'page' === $post_type ) {
 
 			/**
@@ -775,6 +777,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 				'parent'   => array( 'parent', false ),
 				'comments' => array( 'comment_count', false, __( 'Comments' ), __( 'Table ordered by Comments.' ) ),
 				'date'     => array( 'date', true, __( 'Date' ), __( 'Table ordered by Date.' ) ),
+				'post_modified' => array( 'post_modified', true, __( 'Last Modified' ), __( 'Take ordered by Last Modified Date.' ) ),
 			);
 		} else {
 			$sortables = array(
@@ -782,6 +785,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 				'parent'   => array( 'parent', false ),
 				'comments' => array( 'comment_count', false, __( 'Comments' ), __( 'Table ordered by Comments.' ) ),
 				'date'     => array( 'date', true, __( 'Date' ), __( 'Table ordered by Date.' ), 'desc' ),
+				'post_modified' => array( 'post_modified', true, __( 'Last Modified' ), __( 'Take ordered by Last Modified.' ) ),
 			);
 		}
 		// Custom Post Types: there's a filter for that, see get_column_info().
@@ -1255,6 +1259,47 @@ class WP_Posts_List_Table extends WP_List_Table {
 	}
 
 	/**
+	 * Handles the post date column output.
+	 *
+	 * @since 6.7.0
+	 *
+	 * @global string $mode List table view mode.
+	 *
+	 * @param WP_Post $post The current WP_Post object.
+	 */
+	public function column_post_modified( $post ) {
+		global $mode;
+
+		if ( '0000-00-00 00:00:00' === $post->post_date ) {
+			$t_time    = __( 'Unpublished' );
+		} else {
+			$t_time = sprintf(
+				/* translators: 1: Post date, 2: Post time. */
+				__( '%1$s at %2$s' ),
+				/* translators: Post date format. See https://www.php.net/manual/datetime.format.php */
+				get_the_modified_time( __( 'Y/m/d' ), $post ),
+				/* translators: Post time format. See https://www.php.net/manual/datetime.format.php */
+				get_the_modified_time( __( 'g:i a' ), $post )
+			);
+		}
+
+		/**
+		 * Filters the published, scheduled, or unpublished time of the post.
+		 *
+		 * @since 2.5.1
+		 * @since 5.5.0 Removed the difference between 'excerpt' and 'list' modes.
+		 *              The published time and date are both displayed now,
+		 *              which is equivalent to the previous 'excerpt' mode.
+		 *
+		 * @param string  $t_time      The published time.
+		 * @param WP_Post $post        Post object.
+		 * @param string  $column_name The column name.
+		 * @param string  $mode        The list display mode ('excerpt' or 'list').
+		 */
+		echo apply_filters( 'post_date_column_time', $t_time, $post, 'date', $mode );
+	}
+
+	/**
 	 * Handles the comments column output.
 	 *
 	 * @since 4.3.0
@@ -1650,13 +1695,14 @@ class WP_Posts_List_Table extends WP_List_Table {
 		$m            = ( isset( $mode ) && 'excerpt' === $mode ) ? 'excerpt' : 'list';
 		$can_publish  = current_user_can( $post_type_object->cap->publish_posts );
 		$core_columns = array(
-			'cb'         => true,
-			'date'       => true,
-			'title'      => true,
-			'categories' => true,
-			'tags'       => true,
-			'comments'   => true,
-			'author'     => true,
+			'cb'            => true,
+			'date'          => true,
+			'title'         => true,
+			'categories'    => true,
+			'tags'          => true,
+			'comments'      => true,
+			'author'        => true,
+			'post_modified' => true
 		);
 		?>
 


### PR DESCRIPTION
The ability to see the last modified for posts and pages on the overview table. We could possibly make it disable by default, happy to hear more thoughts on this. I apologise this seems like quite an old ticket but could still be useful, please let me know if I have missed anything.

Trac ticket: https://core.trac.wordpress.org/ticket/51663
