### PR TITLE
Fix writingMode support in dynamic blocks

### DIFF
--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -305,6 +305,12 @@ final class WP_Style_Engine {
 				),
 				'path'          => array( 'typography', 'letterSpacing' ),
 			),
+			'writingMode'    => array(
+				'property_keys' => array(
+					'default' => 'writing-mode',
+				),
+				'path'          => array( 'typography', 'writingMode' ),
+			),
 		),
 	);
 

--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -25,6 +25,7 @@
  * @since 6.4.0 Added support for background.backgroundImage.
  * @since 6.5.0 Added support for background.backgroundPosition,
  *              background.backgroundRepeat and dimensions.aspectRatio.
+ * @since 6.7.0 Added support for typography.writingMode.
  */
 #[AllowDynamicProperties]
 final class WP_Style_Engine {

--- a/tests/phpunit/tests/style-engine/styleEngine.php
+++ b/tests/phpunit/tests/style-engine/styleEngine.php
@@ -29,6 +29,7 @@ class Tests_wpStyleEngine extends WP_UnitTestCase {
 	 * @ticket 58590
 	 * @ticket 60175
 	 * @ticket 61720
+	 * @ticket 62189
 	 *
 	 * @covers ::wp_style_engine_get_styles
 	 *
@@ -228,11 +229,12 @@ class Tests_wpStyleEngine extends WP_UnitTestCase {
 						'textDecoration' => 'underline',
 						'textTransform'  => 'uppercase',
 						'letterSpacing'  => '2',
+						'writingMode'    => 'vertical-rl',
 					),
 				),
 				'options'         => null,
 				'expected_output' => array(
-					'css'          => 'font-size:clamp(2em, 2vw, 4em);font-family:Roboto,Oxygen-Sans,Ubuntu,sans-serif;font-style:italic;font-weight:800;line-height:1.3;column-count:2;text-decoration:underline;text-transform:uppercase;letter-spacing:2;',
+					'css'          => 'font-size:clamp(2em, 2vw, 4em);font-family:Roboto,Oxygen-Sans,Ubuntu,sans-serif;font-style:italic;font-weight:800;line-height:1.3;column-count:2;text-decoration:underline;text-transform:uppercase;letter-spacing:2;writing-mode:vertical-rl;',
 					'declarations' => array(
 						'font-size'       => 'clamp(2em, 2vw, 4em)',
 						'font-family'     => 'Roboto,Oxygen-Sans,Ubuntu,sans-serif',
@@ -243,6 +245,7 @@ class Tests_wpStyleEngine extends WP_UnitTestCase {
 						'text-decoration' => 'underline',
 						'text-transform'  => 'uppercase',
 						'letter-spacing'  => '2',
+						'writing-mode'    => 'vertical-rl',
 					),
 				),
 			),


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Add writingMode to the style engine, to support dynamic blocks. This backports some PHP changes that were missed in previous WP core releases:

* https://github.com/WordPress/gutenberg/pull/50822
* https://github.com/WordPress/gutenberg/pull/54581

For the issue this resolves, see: https://github.com/WordPress/gutenberg/issues/65910

Trac ticket: https://core.trac.wordpress.org/ticket/62189

This PR adds support for the writing mode (orientation) typography block support for dynamic blocks, such as the Site Title block. Without this change, currently (in WP 6.7 Beta 1 and Beta 2) if you go to update the Site Title block and give it a vertical orientation, it'll look fine within the site editor, but still display as horizontal on the site frontend.

To test this PR, open up the site editor, select the site title block, and switch its text orientation in the block inspector to be vertical. Save the template, and view the site frontend. Here is a quick screenshot to show where to update the text orientation (writing mode):

![image](https://github.com/user-attachments/assets/dc981712-b30e-4e28-97a5-439bad2f21dc)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
