### PR TITLE
Update: The description of `wp_script_add_data()`

### DIFF
--- a/src/wp-includes/functions.wp-scripts.php
+++ b/src/wp-includes/functions.wp-scripts.php
@@ -420,20 +420,32 @@ function wp_script_is( $handle, $status = 'enqueued' ) {
 }
 
 /**
- * Adds metadata to a script.
+ * Adds metadata to a registered script.
  *
- * Works only if the script has already been registered.
+ * This function is a wrapper for WP_Scripts::add_data() and is used to add specific metadata
+ * to scripts that have already been registered. It does not support adding arbitrary attributes
+ * to the script tag itself. Instead, it allows for the addition of specific keys, primarily
+ * 'conditional' and 'strategy', to dictate loading behavior in specific contexts.
  *
- * Possible values for $key and $value:
- * 'conditional' string Comments for IE 6, lte IE 7, etc.
+ * Possible values for $key:
+ * - `conditional`: Primarily used for IE conditional comments (e.g., IE 6, lte IE 7).
+ * - `strategy`: Defines the loading strategy of the script, but it is limited to supported strategies
+ * by WordPress (e.g., 'defer' and 'async').
+ *
+ * For adding arbitrary attributes to the script tag, you should use the `script_loader_tag`
+ * filter or the `wp_script_attributes` filter instead.
+ *
  *
  * @since 4.2.0
  *
  * @see WP_Dependencies::add_data()
  *
  * @param string $handle Name of the script.
- * @param string $key    Name of data point for which we're storing a value.
- * @param mixed  $value  String containing the data to be added.
+ * @param string $key    Name of the metadata point for which we're storing a value.
+ *                       Possible values include:
+ *                       - 'conditional': string for comments targeting specific IE versions.
+ *                       - 'strategy': string to define loading behavior.
+ * @param string  $value  String containing the data to be added.
  * @return bool True on success, false on failure.
  */
 function wp_script_add_data( $handle, $key, $value ) {


### PR DESCRIPTION
Trac Ticket: [Core-59972](https://core.trac.wordpress.org/ticket/59972)

## Overview

- This PR enhances the documentation for the `wp_script_add_data` function to clarify its purpose and usage. It updates the comments to provide more detailed information on the allowed keys, specifically highlighting the `conditional` and `strategy` options. The documentation now explicitly states that this function is a wrapper for `WP_Scripts::add_data()` and does not support adding arbitrary attributes to the script tag.

## Changes Made

### Updated the function comments to:

- Clarify that `wp_script_add_data` does not support arbitrary attributes for the script tag.

- Provide examples of possible values for the `$key` parameter, including `conditional` and `strategy`.

- Mention supported strategies such as `defer` and `async`.

## Benefits

- Improves clarity and usability of the documentation for developers using the `wp_script_add_data` function.

- Helps prevent misuse of the function by clearly stating its limitations regarding arbitrary attributes.

- Provides concrete examples to guide developers in effectively utilizing the `strategy` key.
