### PR TITLE
Create basic workflow for testing the local Docker environment.

### DIFF
--- a/.github/workflows/install-testing.yml
+++ b/.github/workflows/install-testing.yml
@@ -42,7 +42,7 @@ jobs:
   # Determines the supported values for PHP and database versions based on the WordPress version being tested.
   build-test-matrix:
     name: Build Test Matrix
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-support-json-reader-v1.yml@trunk
+    uses: ./.github/workflows/reusable-support-json-reader-v1.yml
     permissions:
       contents: read
     secrets: inherit

--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -50,7 +50,7 @@ jobs:
 
   # Tests the local Docker environment.
   environment-tests-mysql:
-    name: ${{ contains( matrix.os, 'macos-' ) && 'MacOS' || contains( matrix.os, 'windows-' ) && 'Windows' || 'Linux' }}
+    name: PHP ${{ matrix.php }} / MySQL ${{ matrix.db-version }}
     uses: ./.github/workflows/reusable-test-local-docker-environment-v1.yml
     permissions:
       contents: read

--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -49,12 +49,13 @@ jobs:
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
 
   # Tests the local Docker environment.
-  docker-environment-tests-mysql:
+  environment-tests-mysql:
     name: ${{ contains( matrix.os, 'macos-' ) && 'MacOS' || contains( matrix.os, 'windows-' ) && 'Windows' || 'Linux' }}
     uses: ./.github/workflows/reusable-test-local-docker-environment-v1.yml
     permissions:
       contents: read
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    needs: [ build-test-matrix ]
     strategy:
       fail-fast: false
       matrix:
@@ -76,7 +77,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-    needs: [ docker-environment-tests ]
+    needs: [ build-test-matrix, environment-tests-mysql ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name != 'pull_request' && always() }}
     with:
       calling_status: ${{ contains( needs.*.result, 'cancelled' ) && 'cancelled' || contains( needs.*.result, 'failure' ) && 'failure' || 'success' }}
@@ -91,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
-    needs: [ docker-environment-tests, slack-notifications ]
+    needs: [ build-test-matrix, environment-tests-mysql, slack-notifications ]
     if: |
       always() &&
       github.repository == 'WordPress/wordpress-develop' &&

--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -6,6 +6,22 @@ on:
       - trunk
       - '[6-9].[8-9]'
       - '[7-9].[0-9]'
+    paths:
+      # Any changes to Docker related files.
+      - '.env.example'
+      - 'docker-compose.yml'
+      # Any changes to local environment related files
+      - 'tools/local-env/**'
+      # These files manage packages used by the local environment.
+      - 'package*.json'
+      # These files configure Composer. Changes could affect the local environment.
+      - 'composer.*'
+      # These files define the versions to test.
+      - '.version-support-*.json'
+      # Changes to this and related workflow files should always be verified.
+      - '.github/workflows/local-docker-environment.yml'
+      - '.github/workflows/reusable-support-json-reader-v1.yml'
+      - '.github/workflows/reusable-test-docker-environment-v1.yml'        
   pull_request:
     branches:
       - trunk

--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -82,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest ]
         memcached: [ false, true ]
         php: ${{ fromJSON( needs.build-test-matrix.outputs.php-versions ) }}
         db-version: ${{ fromJSON( needs.build-test-matrix.outputs.mysql-versions ) }}

--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -21,7 +21,7 @@ on:
       # Changes to this and related workflow files should always be verified.
       - '.github/workflows/local-docker-environment.yml'
       - '.github/workflows/reusable-support-json-reader-v1.yml'
-      - '.github/workflows/reusable-test-docker-environment-v1.yml'        
+      - '.github/workflows/reusable-test-docker-environment-v1.yml'
   pull_request:
     branches:
       - trunk
@@ -82,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, windows-latest ]
         memcached: [ false, true ]
         php: ${{ fromJSON( needs.build-test-matrix.outputs.php-versions ) }}
         db-version: ${{ fromJSON( needs.build-test-matrix.outputs.mysql-versions ) }}

--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -42,7 +42,7 @@ jobs:
   #
   build-test-matrix:
     name: Build Test Matrix
-    uses: desrosj/wordpress-develop/.github/workflows/reusable-support-json-reader-v1.yml@add/docker-environment-tests
+    uses: desrosj/wordpress-develop/.github/workflows/reusable-support-json-reader-v1.yml@add/docker-environment-testing
     permissions:
       contents: read
     secrets: inherit

--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -50,7 +50,7 @@ jobs:
 
   # Tests the local Docker environment.
   environment-tests-mysql:
-    name: PHP ${{ matrix.php }} / MySQL ${{ matrix.db-version }}
+    name: PHP ${{ matrix.php }}
     uses: ./.github/workflows/reusable-test-local-docker-environment-v1.yml
     permissions:
       contents: read

--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - trunk
-      - '[6-9].[8-9]'
+      - '6.[8-9]'
       - '[7-9].[0-9]'
     paths:
       # Any changes to Docker related files.

--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -79,6 +79,11 @@ jobs:
             db-version: '9.0'
           - php: '7.3'
             db-version: '9.0'
+          # Memcached container does not currently work with PHP >= 8.3
+          - php: '8.3'
+            memcached: true
+          - php: '8.4'
+            memcached: true
 
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -25,7 +25,7 @@ on:
   pull_request:
     branches:
       - trunk
-      - '[6-9].[8-9]'
+      - '6.[8-9]'
       - '[7-9].[0-9]'
     paths:
       # Any changes to Docker related files.

--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -63,6 +63,13 @@ jobs:
         memcached: [ false, true ]
         php: ${{ fromJSON( needs.build-test-matrix.outputs.php-versions ) }}
         db-version: ${{ fromJSON( needs.build-test-matrix.outputs.mysql-versions ) }}
+
+        exclude:
+          # MySQL 9.0+ will not work on PHP 7.2 & 7.3
+          - php: '7.2'
+            db-version: '9.0'
+          - php: '7.3'
+            db-version: '9.0'
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}

--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -42,7 +42,7 @@ jobs:
   #
   build-test-matrix:
     name: Build Test Matrix
-    uses: desrosj/wordpress-develop/.github/workflows/reusable-support-json-reader-v1.yml@add-docker-environment-tests.yml
+    uses: desrosj/wordpress-develop/.github/workflows/reusable-support-json-reader-v1.yml@add/docker-environment-tests
     permissions:
       contents: read
     secrets: inherit

--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -42,7 +42,7 @@ jobs:
   #
   build-test-matrix:
     name: Build Test Matrix
-    uses: desrosj/wordpress/develop/.github/workflows/reusable-support-json-reader-v1.yml@add-docker-environment-tests.yml
+    uses: desrosj/wordpress-develop/.github/workflows/reusable-support-json-reader-v1.yml@add-docker-environment-tests.yml
     permissions:
       contents: read
     secrets: inherit

--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -65,11 +65,14 @@ jobs:
         db-version: ${{ fromJSON( needs.build-test-matrix.outputs.mysql-versions ) }}
 
         exclude:
+          # The MySQL 5.5 containers will not start.
+          - db-version: '5.5'
           # MySQL 9.0+ will not work on PHP 7.2 & 7.3
           - php: '7.2'
             db-version: '9.0'
           - php: '7.3'
             db-version: '9.0'
+
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}

--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -47,7 +47,7 @@ jobs:
   #
   build-test-matrix:
     name: Build Test Matrix
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-support-json-reader-v1.yml@trunk
+    uses: ./.github/workflows/reusable-support-json-reader-v1.yml
     permissions:
       contents: read
     secrets: inherit

--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -1,0 +1,120 @@
+name: Local Docker Environment
+
+on:
+  push:
+    branches:
+      - trunk
+      - '[6-9].[0-9]'
+  pull_request:
+    branches:
+      - trunk
+      - '[6-9].[0-9]'
+    paths:
+      # Any changes to Docker related files.
+      - '.env.example'
+      - 'docker-compose.yml'
+      # Any changes to local environment related files
+      - 'tools/local-env/**'
+      # These files manage packages used by the local environment.
+      - 'package*.json'
+      # These files configure Composer. Changes could affect the local environment.
+      - 'composer.*'
+      # Changes to this and related workflow files should always be verified.
+      - '.github/workflows/local-docker-environment.yml'
+      - '.github/workflows/reusable-test-docker-environment-v1.yml'
+  workflow_dispatch:
+
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
+jobs:
+  #
+  # Determines the appropriate supported values for PHP and database versions based on the WordPress
+  # version being tested.
+  #
+  build-test-matrix:
+    name: Build Test Matrix
+    uses: ./.github/workflows/reusable-support-json-reader-v1.yml
+    permissions:
+      contents: read
+    secrets: inherit
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+
+  # Tests the local Docker environment.
+  docker-environment-tests-mysql:
+    name: ${{ contains( matrix.os, 'macos-' ) && 'MacOS' || contains( matrix.os, 'windows-' ) && 'Windows' || 'Linux' }}
+    uses: ./.github/workflows/reusable-test-local-docker-environment-v1.yml
+    permissions:
+      contents: read
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest ]
+        memcached: [ false, true ]
+        php: ${{ fromJSON( needs.build-test-matrix.outputs.php-versions ) }}
+        db-version: ${{ fromJSON( needs.build-test-matrix.outputs.mysql-versions ) }}
+    with:
+      os: ${{ matrix.os }}
+      php: ${{ matrix.php }}
+      db-type: 'mysql'
+      db-version: ${{ matrix.db-version }}
+      memcached: ${{ matrix.memcached }}
+      tests-domain: ${{ matrix.tests-domain }}
+
+  slack-notifications:
+    name: Slack Notifications
+    uses: WordPress/wordpress-develop/.github/workflows/slack-notifications.yml@trunk
+    permissions:
+      actions: read
+      contents: read
+    needs: [ docker-environment-tests ]
+    if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name != 'pull_request' && always() }}
+    with:
+      calling_status: ${{ contains( needs.*.result, 'cancelled' ) && 'cancelled' || contains( needs.*.result, 'failure' ) && 'failure' || 'success' }}
+    secrets:
+      SLACK_GHA_SUCCESS_WEBHOOK: ${{ secrets.SLACK_GHA_SUCCESS_WEBHOOK }}
+      SLACK_GHA_CANCELLED_WEBHOOK: ${{ secrets.SLACK_GHA_CANCELLED_WEBHOOK }}
+      SLACK_GHA_FIXED_WEBHOOK: ${{ secrets.SLACK_GHA_FIXED_WEBHOOK }}
+      SLACK_GHA_FAILURE_WEBHOOK: ${{ secrets.SLACK_GHA_FAILURE_WEBHOOK }}
+
+  failed-workflow:
+    name: Failed workflow tasks
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    needs: [ docker-environment-tests, slack-notifications ]
+    if: |
+      always() &&
+      github.repository == 'WordPress/wordpress-develop' &&
+      github.event_name != 'pull_request' &&
+      github.run_attempt < 2 &&
+      (
+        contains( needs.*.result, 'cancelled' ) ||
+        contains( needs.*.result, 'failure' )
+      )
+
+    steps:
+      - name: Dispatch workflow run
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          retries: 2
+          retry-exempt-status-codes: 418
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'failed-workflow.yml',
+              ref: 'trunk',
+              inputs: {
+                run_id: '${{ github.run_id }}'
+              }
+            });

--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - trunk
-      - '[6-9].[0-9]'
+      - '[6-9].[8-9]'
+      - '[7-9].[0-9]'
   pull_request:
     branches:
       - trunk
-      - '[6-9].[0-9]'
+      - '[6-9].[8-9]'
+      - '[7-9].[0-9]'
     paths:
       # Any changes to Docker related files.
       - '.env.example'
@@ -19,8 +21,11 @@ on:
       - 'package*.json'
       # These files configure Composer. Changes could affect the local environment.
       - 'composer.*'
+      # These files define the versions to test.
+      - '.version-support-*.json'
       # Changes to this and related workflow files should always be verified.
       - '.github/workflows/local-docker-environment.yml'
+      - '.github/workflows/reusable-support-json-reader-v1.yml'
       - '.github/workflows/reusable-test-docker-environment-v1.yml'
   workflow_dispatch:
 
@@ -42,11 +47,13 @@ jobs:
   #
   build-test-matrix:
     name: Build Test Matrix
-    uses: desrosj/wordpress-develop/.github/workflows/reusable-support-json-reader-v1.yml@add/docker-environment-testing
+    uses: WordPress/wordpress-develop/.github/workflows/reusable-support-json-reader-v1.yml@trunk
     permissions:
       contents: read
     secrets: inherit
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    with:
+      wp-version: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
 
   # Tests the local Docker environment.
   environment-tests-mysql:

--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -42,7 +42,7 @@ jobs:
   #
   build-test-matrix:
     name: Build Test Matrix
-    uses: ./.github/workflows/reusable-support-json-reader-v1.yml
+    uses: desrosj/wordpress/develop/.github/workflows/reusable-support-json-reader-v1.yml@add-docker-environment-tests.yml
     permissions:
       contents: read
     secrets: inherit

--- a/.github/workflows/reusable-support-json-reader-v1.yml
+++ b/.github/workflows/reusable-support-json-reader-v1.yml
@@ -47,9 +47,9 @@ jobs:
       - name: Determine the major WordPress version
         id: major-wp-version
         run: |
-          if [ "${{ inputs.wp-version }}" ] && [ "${{ inputs.wp-version }}" != "nightly" ] && [ "${{ inputs.wp-version }}" != "latest" ]; then
+          if [ "${{ inputs.wp-version }}" ] && [ "${{ inputs.wp-version }}" != "nightly" ] && [ "${{ inputs.wp-version }}" != "latest" ] && [ "${{ inputs.wp-version }}" != "trunk" ]; then
             echo "version=$(echo "${{ inputs.wp-version }}" | tr '.' '-' | cut -d '-' -f1-2)" >> $GITHUB_OUTPUT
-          elif [ "${{ inputs.wp-version }}" ]; then
+          elif [ "${{ inputs.wp-version }}" ] && [ "${{ inputs.wp-version }}" != "trunk" ]; then
             echo "version=$(echo "${{ inputs.wp-version }}")" >> $GITHUB_OUTPUT
           else
             echo "version=nightly" >> $GITHUB_OUTPUT

--- a/.github/workflows/reusable-support-json-reader-v1.yml
+++ b/.github/workflows/reusable-support-json-reader-v1.yml
@@ -14,7 +14,7 @@ on:
     outputs:
       major-wp-version:
         description: "The major WordPress version based on the version provided in wp-version"
-        value: ${{ jobs.major-wp-version.outputs.version }}
+        value: ${{ jobs.major-wp-version.outputs.wp-version }}
       php-versions:
         description: "The PHP versions to test for the given wp-version"
         value: ${{ jobs.php-versions.outputs.versions }}
@@ -30,7 +30,7 @@ jobs:
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     timeout-minutes: 5
     outputs:
-      version: ${{ steps.major-wp-version.outputs.major-wp-version }}
+      wp-version: ${{ steps.major-wp-version.outputs.major-wp-version }}
 
     steps:
       - name: Checkout repository
@@ -69,8 +69,8 @@ jobs:
       - name: Get supported PHP versions
         id: php-versions
         run: |
-          if [ "${{ needs.major-wp-version.outputs.version }}" != "latest" ] && [ "${{ needs.major-wp-version.outputs.version }}" != "nightly" ]; then
-            echo "versions=$(jq -r '.["${{ needs.major-wp-version.outputs.version }}"] | @json' .version-support-php.json)" >> $GITHUB_OUTPUT
+          if [ "${{ needs.major-wp-version.outputs.wp-version }}" != "latest" ] && [ "${{ needs.major-wp-version.outputs.wp-version }}" != "nightly" ]; then
+            echo "versions=$(jq -r '.["${{ needs.major-wp-version.outputs.wp-version }}"] | @json' .version-support-php.json)" >> $GITHUB_OUTPUT
           else
             echo "versions=$(jq -r '.[ (keys[-1]) ] | @json' .version-support-php.json)" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/reusable-support-json-reader-v1.yml
+++ b/.github/workflows/reusable-support-json-reader-v1.yml
@@ -69,8 +69,8 @@ jobs:
       - name: Get supported PHP versions
         id: php-versions
         run: |
-          if [ "${{ jobs.major-wp-version.outputs.version }}" != "latest" ] && [ "${{ jobs.major-wp-version.outputs.version }}" != "nightly" ]; then
-            echo "versions=$(jq -r '.["${{ jobs.major-wp-version.outputs.version }}"] | @json' .version-support-php.json)" >> $GITHUB_OUTPUT
+          if [ "${{ needs.major-wp-version.outputs.version }}" != "latest" ] && [ "${{ needs.major-wp-version.outputs.version }}" != "nightly" ]; then
+            echo "versions=$(jq -r '.["${{ needs.major-wp-version.outputs.version }}"] | @json' .version-support-php.json)" >> $GITHUB_OUTPUT
           else
             echo "versions=$(jq -r '.[ (keys[-1]) ] | @json' .version-support-php.json)" >> $GITHUB_OUTPUT
           fi
@@ -95,8 +95,8 @@ jobs:
       - name: Get supported MySQL versions
         id: mysql-versions
         run: |
-          if [ "${{ jobs.major-wp-version.outputs.version }}" != "latest" ] && [ "${{ jobs.major-wp-version.outputs.version }}" != "nightly" ]; then
-            echo "versions=$(jq -r '.["${{ jobs.major-wp-version.outputs.version }}"] | @json' .version-support-mysql.json)" >> $GITHUB_OUTPUT
+          if [ "${{ needs.major-wp-version.outputs.version }}" != "latest" ] && [ "${{ needs.major-wp-version.outputs.version }}" != "nightly" ]; then
+            echo "versions=$(jq -r '.["${{ needs.major-wp-version.outputs.version }}"] | @json' .version-support-mysql.json)" >> $GITHUB_OUTPUT
           else
             echo "versions=$(jq -r '.[ (keys[-1]) ] | @json' .version-support-mysql.json)" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/reusable-support-json-reader-v1.yml
+++ b/.github/workflows/reusable-support-json-reader-v1.yml
@@ -14,7 +14,7 @@ on:
     outputs:
       major-wp-version:
         description: "The major WordPress version based on the version provided in wp-version"
-        value: ${{ jobs.major-wp-version.outputs.wp-version }}
+        value: ${{ jobs.major-wp-version.outputs.version }}
       php-versions:
         description: "The PHP versions to test for the given wp-version"
         value: ${{ jobs.php-versions.outputs.versions }}
@@ -30,7 +30,7 @@ jobs:
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     timeout-minutes: 5
     outputs:
-      wp-version: ${{ steps.major-wp-version.outputs.major-wp-version }}
+      version: ${{ steps.major-wp-version.outputs.version }}
 
     steps:
       - name: Checkout repository
@@ -69,8 +69,8 @@ jobs:
       - name: Get supported PHP versions
         id: php-versions
         run: |
-          if [ "${{ needs.major-wp-version.outputs.wp-version }}" != "latest" ] && [ "${{ needs.major-wp-version.outputs.wp-version }}" != "nightly" ]; then
-            echo "versions=$(jq -r '.["${{ needs.major-wp-version.outputs.wp-version }}"] | @json' .version-support-php.json)" >> $GITHUB_OUTPUT
+          if [ "${{ needs.major-wp-version.outputs.version }}" != "latest" ] && [ "${{ needs.major-wp-version.outputs.version }}" != "nightly" ]; then
+            echo "versions=$(jq -r '.["${{ needs.major-wp-version.outputs.version }}"] | @json' .version-support-php.json)" >> $GITHUB_OUTPUT
           else
             echo "versions=$(jq -r '.[ (keys[-1]) ] | @json' .version-support-php.json)" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/reusable-support-json-reader-v1.yml
+++ b/.github/workflows/reusable-support-json-reader-v1.yml
@@ -1,0 +1,102 @@
+##
+# A reusable workflow that reads the .version-support-*.json files and returns values for use in a
+# test matrix based on a WordPress version.
+##
+name: Determine test matrix values
+
+on:
+  workflow_call:
+    inputs:
+      wp-version:
+        description: 'The WordPress version to test . Accepts major and minor versions, "latest", or "nightly". Major releases must not end with ".0".'
+        type: string
+        default: 'nightly'
+    outputs:
+      major-wp-version:
+        description: "The major WordPress version based on the version provided in wp-version"
+        value: ${{ jobs.major-wp-version.outputs.version }}
+      php-versions:
+        description: "The PHP versions to test for the given wp-version"
+        value: ${{ jobs.php-versions.outputs.versions }}
+      mysql-versions:
+        description: "The MySQL versions to test for the given wp-version"
+        value: ${{ jobs.mysql-versions.outputs.versions }}
+
+jobs:
+
+  major-wp-version:
+    name: Determine major WordPress version
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.major-wp-version.outputs.major-wp-version }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+
+      - name: Determine the major WordPress version
+        id: major-wp-version
+        run: |
+          if [ "${{ inputs.wp-version }}" ] && [ "${{ inputs.wp-version }}" != "nightly" ] && [ "${{ inputs.wp-version }}" != "latest" ]; then
+            echo "version=$(echo "${{ inputs.wp-version }}" | tr '.' '-' | cut -d '-' -f1-2)" >> $GITHUB_OUTPUT
+          elif [ "${{ inputs.wp-version }}" ]; then
+            echo "version=$(echo "${{ inputs.wp-version }}")" >> $GITHUB_OUTPUT
+          else
+            echo "version=nightly" >> $GITHUB_OUTPUT
+          fi
+
+  php-versions:
+    name: Determine PHP versions
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    needs: [ determine-major-version ]
+    timeout-minutes: 5
+    outputs:
+      versions: ${{ steps.php-versions.outputs.versions }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+
+      # Look up the major version's specific PHP support policy when a version is provided.
+      # Otherwise, use the current PHP support policy.
+      - name: Get supported PHP versions
+        id: php-versions
+        run: |
+          if [ "${{ jobs.major-wp-version.outputs.version }}" != "latest" ] && [ "${{ jobs.major-wp-version.outputs.version }}" != "nightly" ]; then
+            echo "versions=$(jq -r '.["${{ jobs.major-wp-version.outputs.version }}"] | @json' .version-support-php.json)" >> $GITHUB_OUTPUT
+          else
+            echo "versions=$(jq -r '.[ (keys[-1]) ] | @json' .version-support-php.json)" >> $GITHUB_OUTPUT
+          fi
+
+  mysql-versions:
+    name: Determine MySQL versions
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    needs: [ determine-major-version ]
+    timeout-minutes: 5
+    outputs:
+      versions: ${{ steps.mysql-versions.outputs.versions }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+
+      # Look up the major version's specific MySQL support policy when a version is provided.
+      # Otherwise, use the current MySQL support policy.
+      - name: Get supported MySQL versions
+        id: mysql-versions
+        run: |
+          if [ "${{ jobs.major-wp-version.outputs.version }}" != "latest" ] && [ "${{ jobs.major-wp-version.outputs.version }}" != "nightly" ]; then
+            echo "versions=$(jq -r '.["${{ jobs.major-wp-version.outputs.version }}"] | @json' .version-support-mysql.json)" >> $GITHUB_OUTPUT
+          else
+            echo "versions=$(jq -r '.[ (keys[-1]) ] | @json' .version-support-mysql.json)" >> $GITHUB_OUTPUT
+          fi

--- a/.github/workflows/reusable-support-json-reader-v1.yml
+++ b/.github/workflows/reusable-support-json-reader-v1.yml
@@ -53,7 +53,7 @@ jobs:
     name: Determine PHP versions
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
-    needs: [ determine-major-version ]
+    needs: [ major-wp-version ]
     timeout-minutes: 5
     outputs:
       versions: ${{ steps.php-versions.outputs.versions }}
@@ -79,7 +79,7 @@ jobs:
     name: Determine MySQL versions
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
-    needs: [ determine-major-version ]
+    needs: [ major-wp-version ]
     timeout-minutes: 5
     outputs:
       versions: ${{ steps.mysql-versions.outputs.versions }}

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -1,0 +1,162 @@
+##
+# A reusable workflow that checks that the local Docker environment is working properly.
+#
+# This workflow is used by `trunk` and branches >= 6.7.
+##
+name: Test the local Docker environment
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: 'Operating system to test'
+        required: false
+        type: 'string'
+        default: 'ubuntu-latest'
+      php:
+        description: 'The version of PHP to use, in the format of X.Y'
+        required: false
+        type: 'string'
+        default: 'latest'
+      db-type:
+        description: 'Database type. Valid types are mysql and mariadb'
+        required: false
+        type: 'string'
+        default: 'mysql'
+      db-version:
+        description: 'Database version'
+        required: false
+        type: 'string'
+        default: '8.0'
+      memcached:
+        description: 'Whether to enable memcached'
+        required: false
+        type: 'boolean'
+        default: false
+      tests-domain:
+        description: 'The domain to use for the tests'
+        required: false
+        type: 'string'
+        default: 'example.org'
+
+env:
+  LOCAL_PHP: ${{ inputs.php == 'latest' && 'latest' || inputs.php && '-fpm' }}
+  LOCAL_DB_TYPE: ${{ inputs.db-type }}
+  LOCAL_DB_VERSION: ${{ inputs.db-version }}
+  LOCAL_PHP_MEMCACHED: ${{ inputs.memcached }}
+  LOCAL_WP_TESTS_DOMAIN: ${{ inputs.tests-domain }}
+  PUPPETEER_SKIP_DOWNLOAD: ${{ true }}
+
+jobs:
+  # Runs the PHPUnit tests for WordPress.
+  #
+  # Performs the following steps:
+  # - Sets environment variables.
+  # - Checks out the repository.
+  # - Sets up Node.js.
+  # - Sets up PHP.
+  # - Installs Composer dependencies.
+  # - Installs npm dependencies
+  # - Logs general debug information about the runner.
+  # - Logs Docker debug information (about the Docker installation within the runner).
+  # - Starts the WordPress Docker container.
+  # - Logs the running Docker containers.
+  # - Logs debug information about what's installed within the WordPress Docker containers.
+  # - Install WordPress within the Docker container.
+  # - Run the PHPUnit tests.
+  # - Ensures version-controlled files are not modified or deleted.
+  # - Checks out the WordPress Test reporter repository.
+  # - Submit the test results to the WordPress.org host test results.
+  local-docker-environment-tests:
+    name: ${{ contains( inputs.os, 'macos-' ) && 'MacOS' || contains( inputs.os, 'windows-' ) && 'Windows' || 'Linux' }} / ${{ inputs.memcached && 'Memcached enabled' || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
+    runs-on: ${{ inputs.os }}
+    timeout-minutes: 20
+
+    steps:
+      - name: Configure environment variables
+        run: |
+          echo "PHP_FPM_UID=$(id -u)" >> $GITHUB_ENV
+          echo "PHP_FPM_GID=$(id -g)" >> $GITHUB_ENV
+
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+
+      ##
+      # This allows Composer dependencies to be installed using a single step.
+      #
+      # Since tests are currently run within the Docker containers where the PHP version varies,
+      # the same PHP version needs to be configured for the action runner machine so that the correct
+      # dependency versions are installed and cached.
+      ##
+      - name: Set up PHP
+        uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # v2.31.1
+        with:
+          php-version: '${{ inputs.php }}'
+          coverage: none
+
+      # Since Composer dependencies are installed using `composer update` and no lock file is in version control,
+      # passing a custom cache suffix ensures that the cache is flushed at least once per week.
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@57532f8be5bda426838819c5ee9afb8af389d51a # v3.0.0
+        with:
+          custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: General debug information
+        run: |
+          npm --version
+          node --version
+          curl --version
+          git --version
+          composer --version
+          locale -a
+
+      - name: Docker debug information
+        run: |
+          docker -v
+      - name: Switch to the Linux Docker engine
+        if: contains( inputs.os, 'windows-' )
+        run: |
+          powershell.exe -Command "& \"$Env:ProgramFiles\Docker\Docker\DockerCli.exe\" -SwitchLinuxEngine"
+      - name: Start Docker environment
+        run: |
+          npm run env:start
+
+      - name: Log running Docker containers
+        run: docker ps -a
+
+      - name: WordPress Docker container debug information
+        run: |
+          docker compose run --rm mysql ${{ env.LOCAL_DB_TYPE }} --version
+          docker compose run --rm php php --version
+          docker compose run --rm php php -m
+          docker compose run --rm php php -i
+          docker compose run --rm php locale -a
+
+      - name: Install WordPress
+        run: npm run env:install
+
+      - name: Restart Docker environment
+        run: npm run env:restart
+
+      - name: Test a CLI command
+        run: npm run env:cli wp option get siteurl
+
+      - name: Test logs command
+        run: npm run env:logs
+
+      - name: Reset the Docker environment
+        run: npm run env:reset
+
+      - name: Ensure version-controlled files are not modified or deleted
+        run: git diff --exit-code

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -1,5 +1,5 @@
 ##
-# A reusable workflow that checks that the local Docker environment is working properly.
+# A reusable workflow that ensures the local Docker environment is working properly.
 #
 # This workflow is used by `trunk` and branches >= 6.8.
 ##
@@ -48,7 +48,7 @@ env:
   PUPPETEER_SKIP_DOWNLOAD: ${{ true }}
 
 jobs:
-  # Runs the PHPUnit tests for WordPress.
+  # Tests the local Docker environment.
   #
   # Performs the following steps:
   # - Sets environment variables.
@@ -63,10 +63,11 @@ jobs:
   # - Logs the running Docker containers.
   # - Logs debug information about what's installed within the WordPress Docker containers.
   # - Install WordPress within the Docker container.
-  # - Run the PHPUnit tests.
+  # - Restarts the Docker environment.
+  # - Runs a WP CLI command.
+  # - Tests the logs command.
+  # - Tests the reset command.
   # - Ensures version-controlled files are not modified or deleted.
-  # - Checks out the WordPress Test reporter repository.
-  # - Submit the test results to the WordPress.org host test results.
   local-docker-environment-tests:
     name: PHP ${{ inputs.php }} / ${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.memcached && ' with memcached' || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
     runs-on: ${{ inputs.os }}
@@ -124,10 +125,7 @@ jobs:
       - name: Docker debug information
         run: |
           docker -v
-      - name: Switch to the Linux Docker engine
-        if: contains( inputs.os, 'windows-' )
-        run: |
-          powershell.exe -Command "& \"$Env:ProgramFiles\Docker\Docker\DockerCli.exe\" -SwitchLinuxEngine"
+
       - name: Start Docker environment
         run: |
           npm run env:start

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -74,6 +74,10 @@ jobs:
     timeout-minutes: 20
 
     steps:
+      - name: Set up Docker
+        if: ${{ contains( 'windows', inputs.os ) }}
+        uses: crazy-max/ghaction-setup-docker@v3
+
       - name: Configure environment variables
         run: |
           echo "PHP_FPM_UID=$(id -u)" >> $GITHUB_ENV

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -1,9 +1,9 @@
 ##
 # A reusable workflow that checks that the local Docker environment is working properly.
 #
-# This workflow is used by `trunk` and branches >= 6.7.
+# This workflow is used by `trunk` and branches >= 6.8.
 ##
-name: Test the local Docker environment
+name: Test local Docker environment
 
 on:
   workflow_call:
@@ -40,7 +40,7 @@ on:
         default: 'example.org'
 
 env:
-  LOCAL_PHP: ${{ inputs.php == 'latest' && 'latest' || inputs.php && '-fpm' }}
+  LOCAL_PHP: ${{ inputs.php == 'latest' && 'latest' || format( '{0}-fpm', inputs.php ) }}
   LOCAL_DB_TYPE: ${{ inputs.db-type }}
   LOCAL_DB_VERSION: ${{ inputs.db-version }}
   LOCAL_PHP_MEMCACHED: ${{ inputs.memcached }}
@@ -68,7 +68,7 @@ jobs:
   # - Checks out the WordPress Test reporter repository.
   # - Submit the test results to the WordPress.org host test results.
   local-docker-environment-tests:
-    name: PHP ${{ matrix.php }} / MySQL ${{ matrix.db-version }} / ${{ inputs.memcached && 'Memcached enabled' || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
+    name: PHP ${{ inputs.php }} / MySQL ${{ inputs.db-version }} / ${{ inputs.memcached && 'Memcached enabled' || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
     runs-on: ${{ inputs.os }}
     timeout-minutes: 20
 

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -68,7 +68,7 @@ jobs:
   # - Checks out the WordPress Test reporter repository.
   # - Submit the test results to the WordPress.org host test results.
   local-docker-environment-tests:
-    name: ${{ contains( inputs.os, 'macos-' ) && 'MacOS' || contains( inputs.os, 'windows-' ) && 'Windows' || 'Linux' }} / ${{ inputs.memcached && 'Memcached enabled' || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
+    name: PHP ${{ matrix.php }} / MySQL ${{ matrix.db-version }} / ${{ inputs.memcached && 'Memcached enabled' || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
     runs-on: ${{ inputs.os }}
     timeout-minutes: 20
 

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -68,7 +68,7 @@ jobs:
   # - Checks out the WordPress Test reporter repository.
   # - Submit the test results to the WordPress.org host test results.
   local-docker-environment-tests:
-    name: PHP ${{ inputs.php }} / MySQL ${{ inputs.db-version }} / ${{ inputs.memcached && 'Memcached enabled' || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
+    name: PHP ${{ inputs.php }} / ${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.memcached && ' with memcached' || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
     runs-on: ${{ inputs.os }}
     timeout-minutes: 20
 

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -69,13 +69,13 @@ jobs:
   # - Tests the reset command.
   # - Ensures version-controlled files are not modified or deleted.
   local-docker-environment-tests:
-    name: PHP ${{ inputs.php }} / ${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.memcached && ' with memcached' || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
+    name: PHP ${{ inputs.php }} / ${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.memcached && ' with memcached' || '' }}${{ 'example.org' != inputs.tests-domain && format( ' {0}', inputs.tests-domain ) || '' }}${{ inputs.os }}
     runs-on: ${{ inputs.os }}
     timeout-minutes: 20
 
     steps:
       - name: Set up Docker
-        if: ${{ contains( 'windows', inputs.os ) }}
+        if: ${{ 'windows-latest' == inputs.os }}
         uses: crazy-max/ghaction-setup-docker@v3
 
       - name: Configure environment variables

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -69,15 +69,11 @@ jobs:
   # - Tests the reset command.
   # - Ensures version-controlled files are not modified or deleted.
   local-docker-environment-tests:
-    name: PHP ${{ inputs.php }} / ${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.memcached && ' with memcached' || '' }}${{ 'example.org' != inputs.tests-domain && format( ' {0}', inputs.tests-domain ) || '' }}${{ inputs.os }}
+    name: PHP ${{ inputs.php }} / ${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.memcached && ' with memcached' || '' }}${{ 'example.org' != inputs.tests-domain && format( ' {0}', inputs.tests-domain ) || '' }}
     runs-on: ${{ inputs.os }}
     timeout-minutes: 20
 
     steps:
-      - name: Set up Docker
-        if: ${{ 'windows-latest' == inputs.os }}
-        uses: crazy-max/ghaction-setup-docker@v3
-
       - name: Configure environment variables
         run: |
           echo "PHP_FPM_UID=$(id -u)" >> $GITHUB_ENV

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
   ##
   wordpress-develop:
     image: nginx:alpine
-    platform: linux/amd64
 
     networks:
       - wpdevnet
@@ -34,7 +33,6 @@ services:
   ##
   php:
     image: wordpressdevelop/php:${LOCAL_PHP-latest}
-    platform: linux/amd64
 
     networks:
       - wpdevnet
@@ -66,7 +64,6 @@ services:
   ##
   mysql:
     image: ${LOCAL_DB_TYPE-mysql}:${LOCAL_DB_VERSION-latest}
-    platform: linux/amd64
 
     networks:
       - wpdevnet
@@ -95,7 +92,6 @@ services:
   ##
   cli:
     image: wordpressdevelop/cli:${LOCAL_PHP-latest}
-    platform: linux/amd64
 
     networks:
       - wpdevnet
@@ -126,7 +122,6 @@ services:
   ##
   memcached:
     image: memcached
-    platform: linux/amd64
 
     networks:
       - wpdevnet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
   ##
   wordpress-develop:
     image: nginx:alpine
+    platform: linux/amd64
 
     networks:
       - wpdevnet
@@ -33,6 +34,7 @@ services:
   ##
   php:
     image: wordpressdevelop/php:${LOCAL_PHP-latest}
+    platform: linux/amd64
 
     networks:
       - wpdevnet
@@ -64,6 +66,7 @@ services:
   ##
   mysql:
     image: ${LOCAL_DB_TYPE-mysql}:${LOCAL_DB_VERSION-latest}
+    platform: linux/amd64
 
     networks:
       - wpdevnet
@@ -92,6 +95,7 @@ services:
   ##
   cli:
     image: wordpressdevelop/cli:${LOCAL_PHP-latest}
+    platform: linux/amd64
 
     networks:
       - wpdevnet
@@ -122,6 +126,7 @@ services:
   ##
   memcached:
     image: memcached
+    platform: linux/amd64
 
     networks:
       - wpdevnet


### PR DESCRIPTION
This creates a basic workflow that tests the local Docker environment to ensure that it runs smoothly when updated.

Eventually the PHPUnit tests will be moved out of the Docker containers (ticket coming soon) to benefit from better performance and more flexibility. When that happens, the container will no longer be tested regularly.

Trac ticket: https://core.trac.wordpress.org/ticket/62197

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
