### PR TITLE
Update: wrap get_permalink call in a esc_url

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -4892,7 +4892,7 @@ function wp_insert_post( $postarr, $wp_error = false, $fire_after_hooks = true )
 
 	// Set GUID.
 	if ( ! $update && '' === $current_guid ) {
-		$wpdb->update( $wpdb->posts, array( 'guid' => get_permalink( $post_id ) ), $where );
+		$wpdb->update( $wpdb->posts, array( 'guid' => esc_url( get_permalink( $post_id ) ) ), $where );
 	}
 
 	if ( 'attachment' === $postarr['post_type'] ) {
@@ -7790,7 +7790,7 @@ function _transition_post_status( $new_status, $old_status, $post ) {
 	if ( 'publish' !== $old_status && 'publish' === $new_status ) {
 		// Reset GUID if transitioning to publish and it is empty.
 		if ( '' === get_the_guid( $post->ID ) ) {
-			$wpdb->update( $wpdb->posts, array( 'guid' => get_permalink( $post->ID ) ), array( 'ID' => $post->ID ) );
+			$wpdb->update( $wpdb->posts, array( 'guid' => esc_url( get_permalink( $post->ID ) ) ), array( 'ID' => $post->ID ) );
 		}
 
 		/**


### PR DESCRIPTION
Trac Ticket: Core-61969

## Problem Statement

- In WordPress, a post's GUID is intended to be invariant once set. However, there is an inconsistency in how GUIDs are handled for custom post types.

- When a post is created for a custom post type, the GUID is generated in a specific format. Upon updating the post, the GUID changes due to the esc_url filter applied to the post_guid, which is executed during the update process but not during creation. This results in different GUID values for the same post, violating the principle of invariance.

## Solution

- This PR implements the second approach by wrapping the call to `get_permalink` in wp_insert_post with `esc_url`, ensuring the GUID remains consistent and invariant during both post creation and updates.

## Changes Made

- Updated the wp_insert_post function to apply esc_url to the GUID generation process.

- Ensured that the change maintains backward compatibility with existing functionality.

## Benefits

- Resolves the inconsistency in GUID handling for custom post types.

- Maintains the integrity of the GUID, adhering to the principle of invariance.

- Enhances code reliability and improves the user experience by preventing unintended GUID changes.

## Testing

- Verified the changes by creating and updating custom post types, ensuring the GUID remains consistent.

- Conducted unit tests to confirm that no other functionality was affected by the modifications.