### PR TITLE
Rename wp_register_block_template() to register_block_template()

### DIFF
--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -390,6 +390,6 @@ function register_block_template( $template_name, $args = array() ) {
  * @return WP_Block_Template|WP_Error The unregistered template object on success, WP_Error object on failure or if the
  *                                    template doesn't exist.
  */
-function wp_unregister_block_template( $template_name ) {
+function unregister_block_template( $template_name ) {
 	return WP_Block_Templates_Registry::get_instance()->unregister( $template_name );
 }

--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -377,7 +377,7 @@ function _resolve_template_for_new_post( $wp_query ) {
  * }
  * @return WP_Block_Template|WP_Error The registered template object on success, WP_Error object on failure.
  */
-function wp_register_block_template( $template_name, $args = array() ) {
+function register_block_template( $template_name, $args = array() ) {
 	return WP_Block_Templates_Registry::get_instance()->register( $template_name, $args );
 }
 

--- a/tests/phpunit/tests/block-template.php
+++ b/tests/phpunit/tests/block-template.php
@@ -443,7 +443,7 @@ class Tests_Block_Template extends WP_UnitTestCase {
 	public function test_get_block_templates_from_registry() {
 		$template_name = 'test-plugin//test-template';
 
-		wp_register_block_template( $template_name );
+		register_block_template( $template_name );
 
 		$templates = get_block_templates();
 
@@ -465,7 +465,7 @@ class Tests_Block_Template extends WP_UnitTestCase {
 			'title' => 'Test Template',
 		);
 
-		wp_register_block_template( $template_name, $args );
+		register_block_template( $template_name, $args );
 
 		$template = get_block_template( 'block-theme//test-template' );
 

--- a/tests/phpunit/tests/block-template.php
+++ b/tests/phpunit/tests/block-template.php
@@ -449,7 +449,7 @@ class Tests_Block_Template extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( $template_name, $templates );
 
-		wp_unregister_block_template( $template_name );
+		unregister_block_template( $template_name );
 	}
 
 	/**
@@ -471,7 +471,7 @@ class Tests_Block_Template extends WP_UnitTestCase {
 
 		$this->assertSame( 'Test Template', $template->title );
 
-		wp_unregister_block_template( $template_name );
+		unregister_block_template( $template_name );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -546,7 +546,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 			'post_types'  => array( 'post', 'page' ),
 		);
 
-		wp_register_block_template( $template_name, $args );
+		register_block_template( $template_name, $args );
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/templates/test-plugin//test-template' );
 		$response = rest_get_server()->dispatch( $request );

--- a/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestTemplatesController.php
@@ -566,7 +566,7 @@ class Tests_REST_WpRestTemplatesController extends WP_Test_REST_Controller_Testc
 		$this->assertSame( 'Test Template', $data['title']['rendered'], 'Template title mismatch.' );
 		$this->assertSame( 'test-plugin', $data['plugin'], 'Plugin name mismatch.' );
 
-		wp_unregister_block_template( $template_name );
+		unregister_block_template( $template_name );
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/templates/test-plugin//test-template' );
 		$response = rest_get_server()->dispatch( $request );


### PR DESCRIPTION
This PR includes the changes from https://github.com/WordPress/gutenberg/pull/65958 that need to be backported into WP core.

Trac ticket: https://core.trac.wordpress.org/ticket/62193

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
