### PR TITLE
Add excerpt_allowed_block filter

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1990,7 +1990,19 @@ function excerpt_remove_blocks( $content ) {
 	$output         = '';
 
 	foreach ( $blocks as $block ) {
-		if ( in_array( $block['blockName'], $allowed_blocks, true ) ) {
+
+		/**
+		 * Filters whether the block can contribute to the excerpt.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param bool   $is_allowed Whether the block is allowed.
+		 * @param array  $block   The block being checked.
+		 * @return bool Modified allowed status.
+		 */
+		$is_allowed = apply_filters( 'excerpt_allowed_block', true, $block );
+
+		if ( in_array( $block['blockName'], $allowed_blocks, true ) && $is_allowed ) {
 			if ( ! empty( $block['innerBlocks'] ) ) {
 				if ( in_array( $block['blockName'], $allowed_wrapper_blocks, true ) ) {
 					$output .= _excerpt_render_inner_blocks( $block, $allowed_blocks );
@@ -2052,6 +2064,20 @@ function _excerpt_render_inner_blocks( $parsed_block, $allowed_blocks ) {
 
 	foreach ( $parsed_block['innerBlocks'] as $inner_block ) {
 		if ( ! in_array( $inner_block['blockName'], $allowed_blocks, true ) ) {
+			continue;
+		}
+
+		/**
+		 * Filters whether the block can contribute to the excerpt.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param bool   $is_allowed Whether the block is allowed.
+		 * @param array  $block   The block being checked.
+		 * @return bool Modified allowed status.
+		 */
+		$is_allowed = apply_filters( 'excerpt_block_attributes_check', true, $inner_block );
+		if ( ! $is_allowed ) {
 			continue;
 		}
 


### PR DESCRIPTION
Trac Ticket: Core-60544

## Overview

- This pull request enhances the `excerpt_remove_blocks()` and `_excerpt_render_inner_blocks()` function by introducing a new filter, `excerpt_allowed_block`, which allows developers to control whether individual blocks should be included in post excerpts based on custom criteria.

## Problem Statement

- The current implementation of `excerpt_remove_blocks()` relies on a fixed list of allowed blocks, limiting the ability to customize excerpts according to specific needs. Developers may want to exclude blocks based on their attributes, but doing so requires forking core functionality, which can lead to maintenance issues.

## Proposed Solution

- Addition of excerpt_allowed_block Filter:

    - This new filter enables developers to modify the inclusion criteria for individual blocks within excerpts. By allowing a boolean return value based on custom logic, developers can easily control which blocks are allowed.
Benefits

- Increased Flexibility: 

    - Developers can now exclude specific blocks based on custom attributes or other criteria without modifying core functions.

- Enhanced Extensibility: 
    - The introduction of the filter supports easier integration with themes and plugins.

- Improved Maintainability: 
    - Cleaner code structure and the reduction of fixed logic help facilitate future updates.