### PR TITLE
Match visual order to DOM order in Twenty Eleven single navigation and entry meta

### DIFF
--- a/src/wp-content/themes/twentyeleven/rtl.css
+++ b/src/wp-content/themes/twentyeleven/rtl.css
@@ -509,6 +509,9 @@ section.recent-posts .other-recent-posts .comments-link > span {
 		left: auto;
 		right: 0;
 	}
+	.singular #author-info {
+		margin: 2.2em -8.8% 0;
+	}
 	/* Make sure we have room for our comment avatars */
 	.commentlist > li.comment,
 	.commentlist .pingback {

--- a/src/wp-content/themes/twentyeleven/rtl.css
+++ b/src/wp-content/themes/twentyeleven/rtl.css
@@ -229,10 +229,6 @@ a.assistive-text:focus {
 .singular .entry-header .entry-meta {
 	padding-left: 0;
 }
-.singular .entry-header .entry-meta {
-	left: auto;
-	right: 0;
-}
 .singular .entry-meta .edit-link a {
 	left: auto;
 	right: 50px;
@@ -356,10 +352,6 @@ section.recent-posts .other-recent-posts .comments-link > span {
 }
 
 /* Singular navigation */
-#nav-single {
-	float: left;
-	text-align: left;
-}
 #nav-single .nav-next {
 	padding-left: 0;
 	padding-right: .5em;

--- a/src/wp-content/themes/twentyeleven/style.css
+++ b/src/wp-content/themes/twentyeleven/style.css
@@ -1129,7 +1129,7 @@ article.format-status .entry-content {
 /* Singular content styles for Posts and Pages */
 .singular .hentry {
 	border-bottom: none;
-	padding: 4.875em 0 0;
+	padding: 1.875em 0 0;
 	position: relative;
 }
 .singular.page .hentry {
@@ -1144,11 +1144,6 @@ article.format-status .entry-content {
 .singular .entry-title,
 .singular .entry-header .entry-meta {
 	padding-right: 0;
-}
-.singular .entry-header .entry-meta {
-	position: absolute;
-	top: 0;
-	left: 0;
 }
 blockquote.pull {
 	font-size: 21px;
@@ -1795,10 +1790,7 @@ video {
 
 /* Singular navigation */
 #nav-single {
-	float: right;
 	position: relative;
-	top: -0.3em;
-	text-align: right;
 	z-index: 1;
 }
 #nav-single .nav-previous,
@@ -2576,14 +2568,6 @@ p.comment-form-comment {
 		float: none;
 		margin-left: 0;
 		margin-right: 0;
-	}
-	/* Make sure the post-post navigation doesn't collide with anything */
-	#nav-single {
-		display: block;
-		position: static;
-	}
-	.singular .hentry {
-		padding: 1.625em 0 0;
 	}
 	.singular.page .hentry {
 		padding: 1.625em 0 0;

--- a/src/wp-content/themes/twentyeleven/style.css
+++ b/src/wp-content/themes/twentyeleven/style.css
@@ -1182,7 +1182,7 @@ blockquote.pull.alignright {
 	left: 50px;
 	position: absolute;
 	right: auto;
-	top: 80px;
+	top: 40px;
 }
 
 
@@ -2479,7 +2479,7 @@ p.comment-form-comment {
 	.singular .entry-meta .edit-link a {
 		left: 0;
 		position: absolute;
-		top: 40px;
+		top: 20px;
 	}
 	.singular #author-info {
 		margin: 2.2em -8.8% 0;


### PR DESCRIPTION
- Removes floating and absolute positioning from the single post navigation.
- Removes absolute positioning from the entry meta below the post title.
- Adjusts the top padding for the singular entry.
- Adjusts the `top` position of Edit links, at full width and at the 800px breakpoint.
- Corrects the RTL margins for post author description at the 800px breakpoint (when the author profile has a biography and the site has multiple authors).

[Trac 62008](https://core.trac.wordpress.org/ticket/62008)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
