### PR TITLE
Block Bindings: Bootstrap block bindings sources with inline script from server

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -117,7 +117,7 @@ if ( ! empty( $registered_sources ) ) {
 			'usesContext' => $source->uses_context,
 		);
 	}
-	$script .= sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );
+	$script = sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );
 	wp_add_inline_script(
 		'wp-blocks',
 		$script

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -106,6 +106,24 @@ wp_add_inline_script(
 	'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
 );
 
+// Preload server-registered block bindings sources.
+$registered_sources = get_all_registered_block_bindings_sources();
+if ( ! empty( $registered_sources ) ) {
+	$filtered_sources = array();
+	foreach ( $registered_sources as $source ) {
+		$filtered_sources[] = array(
+			'name'        => $source->name,
+			'label'       => $source->label,
+			'usesContext' => $source->uses_context,
+		);
+	}
+	$script .= sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );
+	wp_add_inline_script(
+		'wp-blocks',
+		$script
+	);
+}
+
 // Get admin url for handling meta boxes.
 $meta_box_url = admin_url( 'post.php' );
 $meta_box_url = add_query_arg(

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -135,6 +135,24 @@ wp_add_inline_script(
 	'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
 );
 
+// Preload server-registered block bindings sources.
+$registered_sources = get_all_registered_block_bindings_sources();
+if ( ! empty( $registered_sources ) ) {
+	$filtered_sources = array();
+	foreach ( $registered_sources as $source ) {
+		$filtered_sources[] = array(
+			'name'        => $source->name,
+			'label'       => $source->label,
+			'usesContext' => $source->uses_context,
+		);
+	}
+	$script .= sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );
+	wp_add_inline_script(
+		'wp-blocks',
+		$script
+	);
+}
+
 wp_add_inline_script(
 	'wp-blocks',
 	sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( isset( $editor_settings['blockCategories'] ) ? $editor_settings['blockCategories'] : array() ) ),

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -146,7 +146,7 @@ if ( ! empty( $registered_sources ) ) {
 			'usesContext' => $source->uses_context,
 		);
 	}
-	$script .= sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );
+	$script = sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );
 	wp_add_inline_script(
 		'wp-blocks',
 		$script

--- a/src/wp-admin/widgets-form-blocks.php
+++ b/src/wp-admin/widgets-form-blocks.php
@@ -51,6 +51,24 @@ wp_add_inline_script(
 	'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
 );
 
+// Preload server-registered block bindings sources.
+$registered_sources = get_all_registered_block_bindings_sources();
+if ( ! empty( $registered_sources ) ) {
+	$filtered_sources = array();
+	foreach ( $registered_sources as $source ) {
+		$filtered_sources[] = array(
+			'name'        => $source->name,
+			'label'       => $source->label,
+			'usesContext' => $source->uses_context,
+		);
+	}
+	$script .= sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );
+	wp_add_inline_script(
+		'wp-blocks',
+		$script
+	);
+}
+
 wp_add_inline_script(
 	'wp-blocks',
 	sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( get_block_categories( $block_editor_context ) ) ),

--- a/src/wp-admin/widgets-form-blocks.php
+++ b/src/wp-admin/widgets-form-blocks.php
@@ -62,7 +62,7 @@ if ( ! empty( $registered_sources ) ) {
 			'usesContext' => $source->uses_context,
 		);
 	}
-	$script .= sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );
+	$script = sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );
 	wp_add_inline_script(
 		'wp-blocks',
 		$script

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -648,23 +648,6 @@ function get_block_editor_settings( array $custom_settings, $block_editor_contex
 		$editor_settings['postContentAttributes'] = $post_content_block_attributes;
 	}
 
-	// Expose block bindings sources in the editor settings.
-	$registered_block_bindings_sources = get_all_registered_block_bindings_sources();
-	if ( ! empty( $registered_block_bindings_sources ) ) {
-		// Initialize array.
-		$editor_settings['blockBindingsSources'] = array();
-		foreach ( $registered_block_bindings_sources as $source_name => $source_properties ) {
-			// Add source with the label to editor settings.
-			$editor_settings['blockBindingsSources'][ $source_name ] = array(
-				'label' => $source_properties->label,
-			);
-			// Add `usesContext` property if exists.
-			if ( ! empty( $source_properties->uses_context ) ) {
-				$editor_settings['blockBindingsSources'][ $source_name ]['usesContext'] = $source_properties->uses_context;
-			}
-		}
-	}
-
 	$editor_settings['canUpdateBlockBindings'] = current_user_can( 'edit_block_binding', $block_editor_context );
 
 	/**

--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -877,7 +877,7 @@ final class WP_Customize_Widgets {
 						'usesContext' => $source->uses_context,
 					);
 				}
-				$script .= sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );
+				$script = sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );
 				wp_add_inline_script(
 					'wp-blocks',
 					$script

--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -866,6 +866,24 @@ final class WP_Customize_Widgets {
 				'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . wp_json_encode( get_block_editor_server_block_settings() ) . ');'
 			);
 
+			// Preload server-registered block bindings sources.
+			$registered_sources = get_all_registered_block_bindings_sources();
+			if ( ! empty( $registered_sources ) ) {
+				$filtered_sources = array();
+				foreach ( $registered_sources as $source ) {
+					$filtered_sources[] = array(
+						'name'        => $source->name,
+						'label'       => $source->label,
+						'usesContext' => $source->uses_context,
+					);
+				}
+				$script .= sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );
+				wp_add_inline_script(
+					'wp-blocks',
+					$script
+				);
+			}
+
 			wp_add_inline_script(
 				'wp-blocks',
 				sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( get_block_categories( $block_editor_context ) ) ),

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -720,38 +720,4 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 			),
 		);
 	}
-
-	/**
-	 * @ticket 61641
-	 */
-	public function test_get_block_editor_settings_block_bindings_sources() {
-		$block_editor_context = new WP_Block_Editor_Context();
-		register_block_bindings_source(
-			'test/source-one',
-			array(
-				'label'              => 'Source One',
-				'get_value_callback' => function () {},
-				'uses_context'       => array( 'postId' ),
-			)
-		);
-		register_block_bindings_source(
-			'test/source-two',
-			array(
-				'label'              => 'Source Two',
-				'get_value_callback' => function () {},
-			)
-		);
-		$settings        = get_block_editor_settings( array(), $block_editor_context );
-		$exposed_sources = $settings['blockBindingsSources'];
-		unregister_block_bindings_source( 'test/source-one' );
-		unregister_block_bindings_source( 'test/source-two' );
-		// It is expected to have 4 sources: the 2 registered sources in the test, and the 2 core sources.
-		$this->assertCount( 4, $exposed_sources );
-		$source_one = $exposed_sources['test/source-one'];
-		$this->assertSame( 'Source One', $source_one['label'] );
-		$this->assertSameSets( array( 'postId' ), $source_one['usesContext'] );
-		$source_two = $exposed_sources['test/source-two'];
-		$this->assertSame( 'Source Two', $source_two['label'] );
-		$this->assertArrayNotHasKey( 'usesContext', $source_two );
-	}
 }


### PR DESCRIPTION
Fixes the issue reported here: https://github.com/WordPress/gutenberg/issues/66031

Basically, we need to ensure the bootstrap happens early in the process to ensure extenders code runs after it. The current implementation runs after `domReady` which seems to be too late.

In this pull request, I propose changing the approach and using an inline script like we are doing for bootstrapping block types.

Trac ticket: https://core.trac.wordpress.org/ticket/62225

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
