### PR TITLE
Allow a Gutenberg plugin version to be passed to E2E workflow.

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -38,7 +38,7 @@ jobs:
   # Runs the end-to-end test suite.
   e2e-tests:
     name: Test with SCRIPT_DEBUG ${{ matrix.LOCAL_SCRIPT_DEBUG && 'enabled' || 'disabled' }}
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-end-to-end-tests.yml@trunk
+    uses: ./.github/workflows/reusable-end-to-end-tests.yml
     permissions:
       contents: read
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}

--- a/.github/workflows/reusable-end-to-end-tests.yml
+++ b/.github/workflows/reusable-end-to-end-tests.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Install Gutenberg
         if: ${{ inputs.install-gutenberg }}
-        run: npm run env:cli -- plugin install gutenberg${{ inputs.gutenberg-version && ' --version=' && inputs.gutenberg-version || '' }} --path=/var/www/${{ env.LOCAL_DIR }}
+        run: npm run env:cli -- plugin install gutenberg${{ inputs.gutenberg-version && format( ' --version={0}', inputs.gutenberg-version ) || '' }} --path=/var/www/${{ env.LOCAL_DIR }}
 
       - name: Install additional languages
         run: |

--- a/.github/workflows/reusable-end-to-end-tests.yml
+++ b/.github/workflows/reusable-end-to-end-tests.yml
@@ -24,6 +24,10 @@ on:
         required: false
         type: 'boolean'
         default: true
+      gutenberg-version:
+        description: 'A specific version of Gutenberg to install.'
+        required: false
+        type: 'string'
 
 env:
   LOCAL_DIR: build
@@ -113,7 +117,7 @@ jobs:
 
       - name: Install Gutenberg
         if: ${{ inputs.install-gutenberg }}
-        run: npm run env:cli -- plugin install gutenberg --path=/var/www/${{ env.LOCAL_DIR }}
+        run: npm run env:cli -- plugin install gutenberg${{ inputs.gutenberg-version && ' --version=' && inputs.gutenberg-version || '' }} --path=/var/www/${{ env.LOCAL_DIR }}
 
       - name: Install additional languages
         run: |


### PR DESCRIPTION
This allows old versions to continue running E2E tests that require the Gutenberg plugin even after the minimum required version of WordPress is increased for the plugin.

Here is a recent failure for 6.4: https://github.com/WordPress/wordpress-develop/actions/runs/11279557060/job/31370928618.

See #7554 for an example of how this would be used in the 6.4 branch.

Trac ticket: https://core.trac.wordpress.org/ticket/61530

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
