### PR TITLE
Updated several typos in script-modules.php file

### DIFF
--- a/src/wp-includes/script-modules.php
+++ b/src/wp-includes/script-modules.php
@@ -154,7 +154,7 @@ function wp_default_script_modules() {
 		switch ( $script_module_id ) {
 			/*
 			 * Interactivity exposes two entrypoints, "/index" and "/debug".
-			 * "/debug" should replalce "/index" in devlopment.
+			 * "/debug" should replace "/index" in development.
 			 */
 			case '@wordpress/interactivity/debug':
 				if ( ! SCRIPT_DEBUG ) {


### PR DESCRIPTION
Updated several typos in script-modules.php file

- `replalce` it should be `replace`
- `devlopment` it should be `development`

Trac Ticket: https://core.trac.wordpress.org/ticket/62213