### PR TITLE
Block Bindings: Fix attributes panel in custom post types

### DIFF
--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -825,8 +825,8 @@ function map_meta_cap( $cap, $user_id, ...$args ) {
 				$caps[] = 'do_not_allow';
 				break;
 			}
-
-			$caps = map_meta_cap( "edit_{$object_subtype}", $user_id, $object_id );
+			$capability_type = get_post_type_object( $object_subtype )->capability_type;
+			$caps            = map_meta_cap( "edit_{$capability_type}", $user_id, $object_id );
 			break;
 		default:
 			// Handle meta capabilities for custom post types.

--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -825,8 +825,13 @@ function map_meta_cap( $cap, $user_id, ...$args ) {
 				$caps[] = 'do_not_allow';
 				break;
 			}
-			$capability_type = get_post_type_object( $object_subtype )->capability_type;
-			$caps            = map_meta_cap( "edit_{$capability_type}", $user_id, $object_id );
+			$post_type_object = get_post_type_object( $object_subtype );
+			// Initialize empty array if it doesn't exist.
+			if ( ! isset( $post_type_object->capabilities ) ) {
+				$post_type_object->capabilities = array();
+			}
+			$post_type_capabilities = get_post_type_capabilities( $post_type_object );
+			$caps                   = map_meta_cap( $post_type_capabilities->edit_post, $user_id, $object_id );
 			break;
 		default:
 			// Handle meta capabilities for custom post types.


### PR DESCRIPTION
While working on the compatibility filter of the mapping capabilities introduced [here](https://github.com/WordPress/wordpress-develop/pull/7258), I've realized that there is a bug where the attributes panel is not shown in custom post types. This is caused because each post type can define a `capability_type`, which by default is `post`, so the logic to map the capabilities wasn't correct and it was returning false.

This bug wasn't triggered by Gutenberg e2e tests because the old compat filter was overriding the setting introduced in core. This should be solved with [this change](https://github.com/WordPress/gutenberg/pull/65116#discussion_r1801016355).

Trac ticket: https://core.trac.wordpress.org/ticket/62226

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
