### PR TITLE
Resolve theme relative font faces uris in theme.json and style variations

### DIFF
--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -848,7 +848,7 @@ class WP_Theme_JSON_Resolver {
 	 * as the value of `_link` object in REST API responses.
 	 *
 	 * @since 6.6.0
-	 * @since 6.7.0 Resolve relative paths in block styles.
+	 * @since 6.7.0 Added support for resolving block style and font face URIs.
 	 *
 	 * @param WP_Theme_JSON $theme_json A theme json instance.
 	 * @return array An array of resolved paths.
@@ -866,6 +866,35 @@ class WP_Theme_JSON_Resolver {
 		 * See: WP_Font_Face_Resolver::to_theme_file_uri.
 		 */
 		$placeholder = 'file:./';
+
+		// Add font URIs.
+		if ( ! empty( $theme_json_data['settings']['typography']['fontFamilies'] ) ) {
+			$font_families = array_merge(
+				$theme_json_data['settings']['typography']['fontFamilies']['theme'] ?? array(),
+				$theme_json_data['settings']['typography']['fontFamilies']['custom'] ?? array(),
+				$theme_json_data['settings']['typography']['fontFamilies']['default'] ?? array()
+			);
+			foreach ( $font_families as $font_family ) {
+				if ( ! empty( $font_family['fontFace'] ) ) {
+					foreach ( $font_family['fontFace'] as $font_face ) {
+						if ( ! empty( $font_face['src'] ) ) {
+							$sources = is_string( $font_face['src'] )
+								? array( $font_face['src'] )
+								: $font_face['src'];
+							foreach ( $sources as $source ) {
+								if ( str_starts_with( $source, $placeholder ) ) {
+									$resolved_theme_uris[] = array(
+										'name'   => $source,
+										'href'   => sanitize_url( get_theme_file_uri( str_replace( $placeholder, '', $source ) ) ),
+										'target' => "typography.fontFamilies.{$font_family['slug']}.fontFace.src",
+									);
+								}
+							}
+						}
+					}
+				}
+			}
+		}
 
 		// Top level styles.
 		$background_image_url = $theme_json_data['styles']['background']['backgroundImage']['url'] ?? null;

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -1331,7 +1331,7 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 	public function test_get_resolved_theme_uris() {
 		$theme_json = new WP_Theme_JSON(
 			array(
-				'version' => WP_Theme_JSON::LATEST_SCHEMA,
+				'version'  => WP_Theme_JSON::LATEST_SCHEMA,
 				'settings' => array(
 					'typography' => array(
 						'fontFamilies' => array(
@@ -1368,7 +1368,7 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 						),
 					),
 				),
-				'styles'  => array(
+				'styles'   => array(
 					'background' => array(
 						'backgroundImage' => array(
 							'url' => 'file:./assets/image.png',

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -1342,7 +1342,7 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 										'fontStyle'  => 'normal',
 										'fontWeight' => '400',
 										'src'        => array(
-											'file:./example/fonts/tocco/tocco-400-normal.woff2',
+											'file:./assets/tocco-400-normal.woff2',
 										),
 									),
 								),
@@ -1357,7 +1357,7 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 										'fontStyle'  => 'normal',
 										'fontWeight' => '400',
 										'src'        => array(
-											'file:./example/fonts/strozzapreti/strozzapreti-400-normal.woff2',
+											'file:./assets/strozzapreti-400-normal.woff2',
 										),
 									),
 								),
@@ -1396,13 +1396,13 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 
 		$expected_data = array(
 			array(
-				'name'   => 'file:./example/fonts/tocco/tocco-400-normal.woff2',
-				'href'   => 'https://example.org/wp-content/themes/example-theme/example/fonts/tocco/tocco-400-normal.woff2',
+				'name'   => 'file:./assets/tocco-400-normal.woff2',
+				'href'   => 'https://example.org/wp-content/themes/example-theme/assets/tocco-400-normal.woff2',
 				'target' => 'typography.fontFamilies.secondary.fontFace.src',
 			),
 			array(
-				'name'   => 'file:./example/fonts/strozzapreti/strozzapreti-400-normal.woff2',
-				'href'   => 'https://example.org/wp-content/themes/example-theme/example/fonts/strozzapreti/strozzapreti-400-normal.woff2',
+				'name'   => 'file:./assets/strozzapreti-400-normal.woff2',
+				'href'   => 'https://example.org/wp-content/themes/example-theme/assets/strozzapreti-400-normal.woff2',
 				'target' => 'typography.fontFamilies.primary.fontFace.src',
 			),
 			array(

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -1332,6 +1332,42 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 		$theme_json = new WP_Theme_JSON(
 			array(
 				'version' => WP_Theme_JSON::LATEST_SCHEMA,
+				'settings' => array(
+					'typography' => array(
+						'fontFamilies' => array(
+							array(
+								'fontFace'   => array(
+									array(
+										'fontFamily' => 'Tocco',
+										'fontStyle'  => 'normal',
+										'fontWeight' => '400',
+										'src'        => array(
+											'file:./example/fonts/tocco/tocco-400-normal.woff2',
+										),
+									),
+								),
+								'fontFamily' => 'Tocco, system-ui',
+								'name'       => 'Tocco',
+								'slug'       => 'secondary',
+							),
+							array(
+								'fontFace'   => array(
+									array(
+										'fontFamily' => '"Strozzapreti"',
+										'fontStyle'  => 'normal',
+										'fontWeight' => '400',
+										'src'        => array(
+											'file:./example/fonts/strozzapreti/strozzapreti-400-normal.woff2',
+										),
+									),
+								),
+								'fontFamily' => '"Strozzapreti", cursive',
+								'name'       => 'Strozzapreti',
+								'slug'       => 'primary',
+							),
+						),
+					),
+				),
 				'styles'  => array(
 					'background' => array(
 						'backgroundImage' => array(
@@ -1359,6 +1395,16 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 		);
 
 		$expected_data = array(
+			array(
+				'name'   => 'file:./example/fonts/tocco/tocco-400-normal.woff2',
+				'href'   => 'https://example.org/wp-content/themes/example-theme/example/fonts/tocco/tocco-400-normal.woff2',
+				'target' => 'typography.fontFamilies.secondary.fontFace.src',
+			),
+			array(
+				'name'   => 'file:./example/fonts/strozzapreti/strozzapreti-400-normal.woff2',
+				'href'   => 'https://example.org/wp-content/themes/example-theme/example/fonts/strozzapreti/strozzapreti-400-normal.woff2',
+				'target' => 'typography.fontFamilies.primary.fontFace.src',
+			),
 			array(
 				'name'   => 'file:./assets/image.png',
 				'href'   => 'https://example.org/wp-content/themes/example-theme/assets/image.png',


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Resolve theme relative font faces URIs in theme.json and style variations.
Porting this change from Gutenberg repo: https://github.com/WordPress/gutenberg/pull/65019

Trac ticket: https://core.trac.wordpress.org/ticket/62231

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
