### PR TITLE
Feature: Add unit_tests for `is_main_network()`

### DIFF
--- a/tests/phpunit/tests/functions/isMainNetwork.php
+++ b/tests/phpunit/tests/functions/isMainNetwork.php
@@ -1,53 +1,56 @@
 <?php
 
-/**
- * Tests the is_main_network() function.
- *
- * @group functions
- *
- * @covers ::is_main_network
- */
-class Tests_Functions_IsMainNetwork extends WP_UnitTestCase {
+if ( ! is_multisite() ) :
 
 	/**
-	 * Tests is_main_network() for single site.
+	 * Tests the is_main_network() function.
 	 *
-	 * @dataProvider data_should_return_true_for_single_site
+	 * @group functions
 	 *
-	 *
-	 * @param int|null $network_id The network ID to test.
-	 * @param bool     $expected   The expected result.
+	 * @covers ::is_main_network
 	 */
-	public function test_should_return_true_for_single_site( $network_id ) {
-		// Call the function being tested.
-		$this->assertTrue( is_main_network( $network_id ) );
-	}
+	class Tests_Functions_IsMainNetwork extends WP_UnitTestCase {
 
-	/**
-	 * Data provider for valid network IDs.
-	 *
-	 * @return array[]
-	 */
-	public function data_should_return_true_for_single_site() {
-		return array(
-			// Not in multisite context.
-			'not_in_multisite' => array(
-				'network_id' => null,
-			),
-			// In multisite scenarios with main network.
-			'main_network'     => array(
-				'network_id' => 1,
-			),
-			// Handling valid values.
-			'zero_value'       => array(
-				'network_id' => 0,
-			),
-			'empty_string'     => array(
-				'network_id' => '',
-			),
-			'non_main_network' => array(
-				'network_id' => 2,
-			),
-		);
+		/**
+		 * Tests is_main_network() for single site.
+		 *
+		 * @dataProvider data_should_return_true_for_single_site
+		 *
+		 *
+		 * @param int|null $network_id The network ID to test.
+		 * @param bool     $expected   The expected result.
+		 */
+		public function test_should_return_true_for_single_site( $network_id ) {
+			// Call the function being tested.
+			$this->assertTrue( is_main_network( $network_id ) );
+		}
+
+		/**
+		 * Data provider for valid network IDs.
+		 *
+		 * @return array[]
+		 */
+		public function data_should_return_true_for_single_site() {
+			return array(
+				// Not in multisite context.
+				'not_in_multisite' => array(
+					'network_id' => null,
+				),
+				// In multisite scenarios with main network.
+				'main_network'     => array(
+					'network_id' => 1,
+				),
+				// Handling valid values.
+				'zero_value'       => array(
+					'network_id' => 0,
+				),
+				'empty_string'     => array(
+					'network_id' => '',
+				),
+				'non_main_network' => array(
+					'network_id' => 2,
+				),
+			);
+		}
 	}
-}
+endif;

--- a/tests/phpunit/tests/functions/isMainNetwork.php
+++ b/tests/phpunit/tests/functions/isMainNetwork.php
@@ -10,7 +10,7 @@
 class Tests_Functions_IsMainNetwork extends WP_UnitTestCase {
 
 	/**
-	 * Tests is_main_network() for valid network IDs.
+	 * Tests is_main_network() for single site.
 	 *
 	 * @dataProvider data_should_return_true_for_single_site
 	 *

--- a/tests/phpunit/tests/functions/isMainNetwork.php
+++ b/tests/phpunit/tests/functions/isMainNetwork.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Tests the is_main_network() function.
+ *
+ * @group functions
+ *
+ * @covers ::is_main_network
+ */
+class Tests_Functions_IsMainNetwork extends WP_UnitTestCase {
+
+	/**
+	 * Tests is_main_network() for valid network IDs.
+	 *
+	 * @dataProvider data_should_return_true_for_single_site
+	 *
+	 *
+	 * @param int|null $network_id The network ID to test.
+	 * @param bool     $expected   The expected result.
+	 */
+	public function test_should_return_true_for_single_site( $network_id ) {
+		// Call the function being tested.
+		$this->assertTrue( is_main_network( $network_id ) );
+	}
+
+	/**
+	 * Data provider for valid network IDs.
+	 *
+	 * @return array[]
+	 */
+	public function data_should_return_true_for_single_site() {
+		return array(
+			// Not in multisite context.
+			'not_in_multisite' => array(
+				'network_id' => null,
+			),
+			// In multisite scenarios with main network.
+			'main_network'     => array(
+				'network_id' => 1,
+			),
+			// Handling valid values.
+			'zero_value'       => array(
+				'network_id' => 0,
+			),
+			'empty_string'     => array(
+				'network_id' => '',
+			),
+			'non_main_network' => array(
+				'network_id' => 2,
+			),
+		);
+	}
+}

--- a/tests/phpunit/tests/multisite/isMainNetwork.php
+++ b/tests/phpunit/tests/multisite/isMainNetwork.php
@@ -1,78 +1,82 @@
 <?php
 
-/**
- * Tests the is_main_network() function.
- *
- * @group ms-site
- *
- * @covers ::is_main_network
- */
-class Tests_Multisite_IsMainNetwork extends WP_UnitTestCase {
+if ( is_multisite() ) :
 
 	/**
-	 * Tests is_main_network() for valid network IDs.
+	 * Tests the is_main_network() function.
 	 *
-	 * @dataProvider data_should_return_true_for_valid_network_id
+	 * @group ms-site
 	 *
-	 *
-	 * @param int|null $network_id The network ID to test.
-	 * @param bool     $expected   The expected result.
+	 * @covers ::is_main_network
 	 */
-	public function test_should_return_true_for_valid_network_id( $network_id ) {
-		// Call the function being tested.
-		$this->assertTrue( is_main_network( $network_id ) );
+	class Tests_Multisite_IsMainNetwork extends WP_UnitTestCase {
+
+		/**
+		 * Tests is_main_network() for valid network IDs.
+		 *
+		 * @dataProvider data_should_return_true_for_valid_network_id
+		 *
+		 *
+		 * @param int|null $network_id The network ID to test.
+		 * @param bool     $expected   The expected result.
+		 */
+		public function test_should_return_true_for_valid_network_id( $network_id ) {
+			// Call the function being tested.
+			$this->assertTrue( is_main_network( $network_id ) );
+		}
+
+		/**
+		 * Data provider for valid network IDs.
+		 *
+		 * @return array[]
+		 */
+		public function data_should_return_true_for_valid_network_id() {
+			return array(
+				// Null value.
+				'null_value'   => array(
+					'network_id' => null,
+				),
+				// In multisite scenarios with main network.
+				'main_network' => array(
+					'network_id' => 1,
+				),
+			);
+		}
+
+		/**
+		 * Tests is_main_network() for invalid network IDs.
+		 *
+		 * @dataProvider data_should_return_false_for_invalid_network_id
+		 *
+		 *
+		 * @param int|null $network_id The network ID to test.
+		 * @param bool     $expected   The expected result.
+		 */
+		public function test_should_return_false_for_invalid_network_id( $network_id ) {
+			// Call the function being tested.
+			$this->assertFalse( is_main_network( $network_id ) );
+		}
+
+		/**
+		 * Data provider for invalid network IDs.
+		 *
+		 * @return array[]
+		 */
+		public function data_should_return_false_for_invalid_network_id() {
+			return array(
+				// In multisite scenarios with non-main network.
+				'non_main_network' => array(
+					'network_id' => 2,
+				),
+				// Handling valid values.
+				'zero_value'       => array(
+					'network_id' => 0,
+				),
+				'empty_string'     => array(
+					'network_id' => '',
+				),
+			);
+		}
 	}
 
-	/**
-	 * Data provider for valid network IDs.
-	 *
-	 * @return array[]
-	 */
-	public function data_should_return_true_for_valid_network_id() {
-		return array(
-			// Null value.
-			'null_value' => array(
-				'network_id' => null,
-			),
-			// In multisite scenarios with main network.
-			'main_network'     => array(
-				'network_id' => 1,
-			),
-		);
-	}
-
-	/**
-	 * Tests is_main_network() for invalid network IDs.
-	 *
-	 * @dataProvider data_should_return_false_for_invalid_network_id
-	 *
-	 *
-	 * @param int|null $network_id The network ID to test.
-	 * @param bool     $expected   The expected result.
-	 */
-	public function test_should_return_false_for_invalid_network_id( $network_id ) {
-		// Call the function being tested.
-		$this->assertFalse( is_main_network( $network_id ) );
-	}
-
-	/**
-	 * Data provider for invalid network IDs.
-	 *
-	 * @return array[]
-	 */
-	public function data_should_return_false_for_invalid_network_id() {
-		return array(
-			// In multisite scenarios with non-main network.
-			'non_main_network' => array(
-				'network_id' => 2,
-			),
-			// Handling valid values.
-			'zero_value'       => array(
-				'network_id' => 0,
-			),
-			'empty_string'     => array(
-				'network_id' => '',
-			),
-		);
-	}
-}
+endif;

--- a/tests/phpunit/tests/multisite/isMainNetwork.php
+++ b/tests/phpunit/tests/multisite/isMainNetwork.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Tests the is_main_network() function.
+ *
+ * @group ms-site
+ *
+ * @covers ::is_main_network
+ */
+class Tests_Multisite_IsMainNetwork extends WP_UnitTestCase {
+
+	/**
+	 * Tests is_main_network() for valid network IDs.
+	 *
+	 * @dataProvider data_should_return_true_for_valid_network_id
+	 *
+	 *
+	 * @param int|null $network_id The network ID to test.
+	 * @param bool     $expected   The expected result.
+	 */
+	public function test_should_return_true_for_valid_network_id( $network_id ) {
+		// Call the function being tested.
+		$this->assertTrue( is_main_network( $network_id ) );
+	}
+
+	/**
+	 * Data provider for valid network IDs.
+	 *
+	 * @return array[]
+	 */
+	public function data_should_return_true_for_valid_network_id() {
+		return array(
+			// Null value.
+			'null_value' => array(
+				'network_id' => null,
+			),
+			// In multisite scenarios with main network.
+			'main_network'     => array(
+				'network_id' => 1,
+			),
+		);
+	}
+
+	/**
+	 * Tests is_main_network() for invalid network IDs.
+	 *
+	 * @dataProvider data_should_return_false_for_invalid_network_id
+	 *
+	 *
+	 * @param int|null $network_id The network ID to test.
+	 * @param bool     $expected   The expected result.
+	 */
+	public function test_should_return_false_for_invalid_network_id( $network_id ) {
+		// Call the function being tested.
+		$this->assertFalse( is_main_network( $network_id ) );
+	}
+
+	/**
+	 * Data provider for invalid network IDs.
+	 *
+	 * @return array[]
+	 */
+	public function data_should_return_false_for_invalid_network_id() {
+		return array(
+			// In multisite scenarios with non-main network.
+			'non_main_network' => array(
+				'network_id' => 2,
+			),
+			// Handling valid values.
+			'zero_value'       => array(
+				'network_id' => 0,
+			),
+			'empty_string'     => array(
+				'network_id' => '',
+			),
+		);
+	}
+}


### PR DESCRIPTION
Trac Ticket:  Core-59981

## Description:

- This pull request introduces the initial set of unit tests for the is_main_network() function. The tests are designed to verify the function's behavior in both multisite and single-site scenarios.

## Changes Made:

- Added Multisite Tests:

    - Class: `Tests_Multisite_IsMainNetwork`

    - Purpose: Tests the behavior of is_main_network() for valid and invalid network IDs within a multisite environment.

    - Test Cases:

        - Valid network IDs that should return true:
            - null
            - 1 (main network)
        
        - Invalid network IDs that should return false:
            - 2
            - 0
            - Empty string

- Added Single-Site Tests:

    - Class: `Tests_Functions_IsMainNetwork`

    - Purpose: Tests the behavior of is_main_network() in a single-site context.

    - Test Cases:

        - Valid network IDs that should return true:
            - null
            - 1
            - 0
            - Empty string
            - Non-main network ID (2) which is also tested to ensure the function handles it correctly.

## Benefits:

- Coverage for Multisite and Single-Site

    - Ensures that the is_main_network() function is thoroughly tested in different contexts.

- Early Detection of Issues

    - The introduction of these tests will help catch any bugs or unexpected behavior early in the development process.

## Testing:

- The tests are designed to be run in the WordPress environment using PHPUnit.

- All tests have been verified to pass successfully.

## Commands

### Multisite

```
npm run test:php -- -c tests/phpunit/multisite.xml --group ms-site --filter Tests_MultiSite_is_main_network
```

### Single SIte

```
npm run test:php --filter Tests_Multisite_IsMainNetwork::test_should_return_true_for_valid_network_id
```