### PR TITLE
Theme JSON: remove redundant check and relocate $selectors assignment

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2703,17 +2703,13 @@ class WP_Theme_JSON {
 	 * @return array The block nodes in theme.json.
 	 */
 	private static function get_block_nodes( $theme_json, $selectors = array(), $options = array() ) {
-		$selectors = empty( $selectors ) ? static::get_blocks_metadata() : $selectors;
-		$nodes     = array();
-		if ( ! isset( $theme_json['styles'] ) ) {
-			return $nodes;
-		}
+		$nodes = array();
 
-		// Blocks.
 		if ( ! isset( $theme_json['styles']['blocks'] ) ) {
 			return $nodes;
 		}
 
+		$selectors               = empty( $selectors ) ? static::get_blocks_metadata() : $selectors;
 		$include_variations      = $options['include_block_style_variations'] ?? false;
 		$include_node_paths_only = $options['include_node_paths_only'] ?? false;
 

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2709,9 +2709,13 @@ class WP_Theme_JSON {
 			return $nodes;
 		}
 
-		$selectors               = empty( $selectors ) ? static::get_blocks_metadata() : $selectors;
 		$include_variations      = $options['include_block_style_variations'] ?? false;
 		$include_node_paths_only = $options['include_node_paths_only'] ?? false;
+
+		// If only node paths are to be returned, skip selector assignment.
+		if ( ! $include_node_paths_only ) {
+			$selectors = empty( $selectors ) ? static::get_blocks_metadata() : $selectors;
+		}
 
 		foreach ( $theme_json['styles']['blocks'] as $name => $node ) {
 			$node_path = array( 'styles', 'blocks', $name );


### PR DESCRIPTION
Backporting:

- https://github.com/WordPress/gutenberg/pull/66154

## What? Why? How?

In `WP_Theme_JSON::get_block_nodes()`, remove redundant check for `$theme_json['styles']`, which means `WP_Theme_JSON::get_blocks_metadata()` is only called if necessary.

This also has the potential to slightly improve the performance of functions such as [wp_add_global_styles_for_blocks](https://github.com/wordpress/wordpress-develop/blob/trunk/src/wp-includes/global-styles-and-settings.php#L254) that call `WP_Theme_JSON::get_styles_block_nodes()`, where no block styles exist.


## Testing Instructions
CI tests should pass.
Smoke test in a block theme with lots of block styles, like TT4 and a theme with none, like Emptytheme


Trac ticket: https://core.trac.wordpress.org/ticket/62234
