### PR TITLE
HTML API: Fix the position update after changing the modifiable text when length differs

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2459,7 +2459,7 @@ class WP_HTML_Tag_Processor {
 			}
 
 			// Accumulate shift of the given pointer within this function call.
-			if ( $diff->start <= $shift_this_point ) {
+			if ( $diff->start < $shift_this_point ) {
 				$accumulated_shift_for_given_point += $shift;
 			}
 

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
@@ -82,7 +82,7 @@ class Tests_HtmlApi_WpHtmlTagProcessorModifiableText extends WP_UnitTestCase {
 	 * Ensures that `get_modifiable_text()` reads enqueued updates when read
 	 * from after writing; guarantees consistency through writes.
 	 *
-	 * @ticket 61617
+	 * @ticket 62241
 	 */
 	public function test_get_modifiable_text_is_consistent_after_writes_when_text_shorter() {
 		$before    = 'just some text';
@@ -121,7 +121,7 @@ class Tests_HtmlApi_WpHtmlTagProcessorModifiableText extends WP_UnitTestCase {
 	 * Ensures that `get_modifiable_text()` reads enqueued updates when read
 	 * from after writing; guarantees consistency through writes.
 	 *
-	 * @ticket 61617
+	 * @ticket 62241
 	 */
 	public function test_get_modifiable_text_is_consistent_after_writes_when_text_longer() {
 		$before    = 'just some text';
@@ -160,7 +160,7 @@ class Tests_HtmlApi_WpHtmlTagProcessorModifiableText extends WP_UnitTestCase {
 	 * Ensures that `get_modifiable_text()` reads enqueued updates when read
 	 * from after writing; guarantees consistency through writes.
 	 *
-	 * @ticket 61617
+	 * @ticket 62241
 	 */
 	public function test_get_modifiable_text_is_consistent_after_writes_when_text_after_closed_tag_element() {
 		$before    = '<p>some content</p>just some text';

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
@@ -40,135 +40,32 @@ class Tests_HtmlApi_WpHtmlTagProcessorModifiableText extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_get_modifiable_text_replacements() {
+		return array(
+			'shorter'     => array( 'just some text', 'shorter text' ),
+			'same length' => array( 'just some text', 'different text' ),
+			'longer'      => array( 'just some text', 'a bit longer text' ),
+		);
+	}
+
+	/**
 	 * Ensures that `get_modifiable_text()` reads enqueued updates when read
 	 * from after writing; guarantees consistency through writes.
 	 *
 	 * @ticket 61617
-	 */
-	public function test_get_modifiable_text_is_consistent_after_writes() {
-		$before    = 'just some text';
-		$after     = 'different text';
-		$processor = new WP_HTML_Tag_Processor( $before );
-		$processor->next_token();
-
-		$this->assertSame(
-			'#text',
-			$processor->get_token_name(),
-			"Should have found text node but found '{$processor->get_token_name()}' instead: check test setup."
-		);
-
-		$this->assertSame(
-			$before,
-			$processor->get_modifiable_text(),
-			'Should have found initial test text: check test setup.'
-		);
-
-		$processor->set_modifiable_text( $after );
-		$this->assertSame(
-			$after,
-			$processor->get_modifiable_text(),
-			'Should have found enqueued updated text.'
-		);
-
-		$processor->get_updated_html();
-		$this->assertSame(
-			$after,
-			$processor->get_modifiable_text(),
-			'Should have found updated text.'
-		);
-	}
-
-	/**
-	 * Ensures that `get_modifiable_text()` reads enqueued updates when read
-	 * from after writing; guarantees consistency through writes.
-	 *
 	 * @ticket 62241
-	 */
-	public function test_get_modifiable_text_is_consistent_after_writes_when_text_shorter() {
-		$before    = 'just some text';
-		$after     = 'shorter text';
-		$processor = new WP_HTML_Tag_Processor( $before );
-		$processor->next_token();
-
-		$this->assertSame(
-			'#text',
-			$processor->get_token_name(),
-			"Should have found text node but found '{$processor->get_token_name()}' instead: check test setup."
-		);
-
-		$this->assertSame(
-			$before,
-			$processor->get_modifiable_text(),
-			'Should have found initial test text: check test setup.'
-		);
-
-		$processor->set_modifiable_text( $after );
-		$this->assertSame(
-			$after,
-			$processor->get_modifiable_text(),
-			'Should have found enqueued updated text.'
-		);
-
-		$processor->get_updated_html();
-		$this->assertSame(
-			$after,
-			$processor->get_modifiable_text(),
-			'Should have found updated text.'
-		);
-	}
-
-	/**
-	 * Ensures that `get_modifiable_text()` reads enqueued updates when read
-	 * from after writing; guarantees consistency through writes.
 	 *
-	 * @ticket 62241
-	 */
-	public function test_get_modifiable_text_is_consistent_after_writes_when_text_longer() {
-		$before    = 'just some text';
-		$after     = 'a bit longer text';
-		$processor = new WP_HTML_Tag_Processor( $before );
-		$processor->next_token();
-
-		$this->assertSame(
-			'#text',
-			$processor->get_token_name(),
-			"Should have found text node but found '{$processor->get_token_name()}' instead: check test setup."
-		);
-
-		$this->assertSame(
-			$before,
-			$processor->get_modifiable_text(),
-			'Should have found initial test text: check test setup.'
-		);
-
-		$processor->set_modifiable_text( $after );
-		$this->assertSame(
-			$after,
-			$processor->get_modifiable_text(),
-			'Should have found enqueued updated text.'
-		);
-
-		$processor->get_updated_html();
-		$this->assertSame(
-			$after,
-			$processor->get_modifiable_text(),
-			'Should have found updated text.'
-		);
-	}
-
-	/**
-	 * Ensures that `get_modifiable_text()` reads enqueued updates when read
-	 * from after writing; guarantees consistency through writes.
+	 * @dataProvider data_get_modifiable_text_replacements
 	 *
-	 * @ticket 62241
+	 * @param string $initial     Initial text.
+	 * @param string $replacement Replacement text.
 	 */
-	public function test_get_modifiable_text_is_consistent_after_writes_when_text_after_closed_tag_element() {
-		$before    = '<p>some content</p>just some text';
-		$after     = 'a bit longer text';
-		$processor = new WP_HTML_Tag_Processor( $before );
-		$processor->next_token();
-		$processor->next_token();
-		$processor->next_token();
+	public function test_get_modifiable_text_is_consistent_after_writes( $initial, $replacement ) {
+		$processor = new WP_HTML_Tag_Processor( $initial );
 		$processor->next_token();
 
 		$this->assertSame(
@@ -178,26 +75,76 @@ class Tests_HtmlApi_WpHtmlTagProcessorModifiableText extends WP_UnitTestCase {
 		);
 
 		$this->assertSame(
-			'just some text',
+			$initial,
 			$processor->get_modifiable_text(),
 			'Should have found initial test text: check test setup.'
 		);
 
-		$processor->set_modifiable_text( $after );
+		$processor->set_modifiable_text( $replacement );
 		$this->assertSame(
-			$after,
+			$replacement,
 			$processor->get_modifiable_text(),
 			'Should have found enqueued updated text.'
 		);
-
 		$this->assertSame(
-			'<p>some content</p>' . $after,
+			$replacement,
 			$processor->get_updated_html(),
+			'Should match updated HTML.'
+		);
+		$this->assertSame(
+			$replacement,
+			$processor->get_modifiable_text(),
 			'Should have found updated text.'
+		);
+	}
+
+	/**
+	 * Ensures that `get_modifiable_text()` reads enqueued updates when read from
+	 * after writing; guarantees consistency through writes after closed tag element.
+	 *
+	 * @ticket 62241
+	 *
+	 * @dataProvider data_get_modifiable_text_replacements
+	 *
+	 * @param string $initial     Initial text.
+	 * @param string $replacement Replacement text.
+	 */
+	public function test_get_modifiable_text_is_consistent_after_writes_when_text_after_closed_tag_element( $initial, $replacement ) {
+		$html_before = '<p>some content</p>';
+		$processor   = new WP_HTML_Tag_Processor( $html_before . $initial );
+		// Move to the text node after the closing p tag.
+		$processor->next_token();
+		$processor->next_token();
+		$processor->next_token();
+		$processor->next_token();
+
+		$this->assertSame(
+			'#text',
+			$processor->get_token_name(),
+			"Should have found text node but found '{$processor->get_token_name()}' instead: check test setup."
 		);
 
 		$this->assertSame(
-			$after,
+			$initial,
+			$processor->get_modifiable_text(),
+			'Should have found initial test text: check test setup.'
+		);
+
+		$processor->set_modifiable_text( $replacement );
+		$this->assertSame(
+			$replacement,
+			$processor->get_modifiable_text(),
+			'Should have found enqueued updated text.'
+		);
+
+		$this->assertSame(
+			$html_before . $replacement,
+			$processor->get_updated_html(),
+			'Should match updated HTML.'
+		);
+
+		$this->assertSame(
+			$replacement,
 			$processor->get_modifiable_text(),
 			'Should have found updated text.'
 		);

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
@@ -190,9 +190,14 @@ class Tests_HtmlApi_WpHtmlTagProcessorModifiableText extends WP_UnitTestCase {
 			'Should have found enqueued updated text.'
 		);
 
-		$processor->get_updated_html();
 		$this->assertSame(
 			'<p>some content</p>' . $after,
+			$processor->get_updated_html(),
+			'Should have found updated text.'
+		);
+
+		$this->assertSame(
+			$after,
 			$processor->get_modifiable_text(),
 			'Should have found updated text.'
 		);

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessorModifiableText.php
@@ -79,6 +79,126 @@ class Tests_HtmlApi_WpHtmlTagProcessorModifiableText extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensures that `get_modifiable_text()` reads enqueued updates when read
+	 * from after writing; guarantees consistency through writes.
+	 *
+	 * @ticket 61617
+	 */
+	public function test_get_modifiable_text_is_consistent_after_writes_when_text_shorter() {
+		$before    = 'just some text';
+		$after     = 'shorter text';
+		$processor = new WP_HTML_Tag_Processor( $before );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#text',
+			$processor->get_token_name(),
+			"Should have found text node but found '{$processor->get_token_name()}' instead: check test setup."
+		);
+
+		$this->assertSame(
+			$before,
+			$processor->get_modifiable_text(),
+			'Should have found initial test text: check test setup.'
+		);
+
+		$processor->set_modifiable_text( $after );
+		$this->assertSame(
+			$after,
+			$processor->get_modifiable_text(),
+			'Should have found enqueued updated text.'
+		);
+
+		$processor->get_updated_html();
+		$this->assertSame(
+			$after,
+			$processor->get_modifiable_text(),
+			'Should have found updated text.'
+		);
+	}
+
+	/**
+	 * Ensures that `get_modifiable_text()` reads enqueued updates when read
+	 * from after writing; guarantees consistency through writes.
+	 *
+	 * @ticket 61617
+	 */
+	public function test_get_modifiable_text_is_consistent_after_writes_when_text_longer() {
+		$before    = 'just some text';
+		$after     = 'a bit longer text';
+		$processor = new WP_HTML_Tag_Processor( $before );
+		$processor->next_token();
+
+		$this->assertSame(
+			'#text',
+			$processor->get_token_name(),
+			"Should have found text node but found '{$processor->get_token_name()}' instead: check test setup."
+		);
+
+		$this->assertSame(
+			$before,
+			$processor->get_modifiable_text(),
+			'Should have found initial test text: check test setup.'
+		);
+
+		$processor->set_modifiable_text( $after );
+		$this->assertSame(
+			$after,
+			$processor->get_modifiable_text(),
+			'Should have found enqueued updated text.'
+		);
+
+		$processor->get_updated_html();
+		$this->assertSame(
+			$after,
+			$processor->get_modifiable_text(),
+			'Should have found updated text.'
+		);
+	}
+
+	/**
+	 * Ensures that `get_modifiable_text()` reads enqueued updates when read
+	 * from after writing; guarantees consistency through writes.
+	 *
+	 * @ticket 61617
+	 */
+	public function test_get_modifiable_text_is_consistent_after_writes_when_text_after_closed_tag_element() {
+		$before    = '<p>some content</p>just some text';
+		$after     = 'a bit longer text';
+		$processor = new WP_HTML_Tag_Processor( $before );
+		$processor->next_token();
+		$processor->next_token();
+		$processor->next_token();
+		$processor->next_token();
+
+		$this->assertSame(
+			'#text',
+			$processor->get_token_name(),
+			"Should have found text node but found '{$processor->get_token_name()}' instead: check test setup."
+		);
+
+		$this->assertSame(
+			'just some text',
+			$processor->get_modifiable_text(),
+			'Should have found initial test text: check test setup.'
+		);
+
+		$processor->set_modifiable_text( $after );
+		$this->assertSame(
+			$after,
+			$processor->get_modifiable_text(),
+			'Should have found enqueued updated text.'
+		);
+
+		$processor->get_updated_html();
+		$this->assertSame(
+			'<p>some content</p>' . $after,
+			$processor->get_modifiable_text(),
+			'Should have found updated text.'
+		);
+	}
+
+	/**
 	 * Ensures that `get_modifiable_text()` reads enqueued updates when read from after
 	 * writing when starting from an empty text; guarantees consistency through writes.
 	 *


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
Reported by @adamziel in https://github.com/WordPress/wordpress-develop/pull/7007#issuecomment-2412540433:

> I just isolated the problem:
> 
> ```php
> $p = new WP_HTML_Tag_Processor('Hello there');
> $p->next_token();
> $p->set_modifiable_text('Short');
> echo $p->get_updated_html();
> ```
> 
> It's not occurring with this patch:
> 
> ```diff
> -		$this->bytes_already_parsed = $before_current_tag;
> +		if ($this->get_token_type() === '#tag') {
> +			$this->bytes_already_parsed = $before_current_tag;
> +		}
> ```

Trac ticket: https://core.trac.wordpress.org/ticket/62241

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
