### PR TITLE
HTML API: Fix typo in error message in html processor.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1116,7 +1116,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		if ( WP_HTML_Tag_Processor::STATE_READY !== $this->parser_state ) {
 			wp_trigger_error(
 				__METHOD__,
-				"An HTML Processor which has already started processing cannot serialize it's contents. Serialize immediately after creating the instance.",
+				"An HTML Processor which has already started processing cannot serialize its contents. Serialize immediately after creating the instance.",
 				E_USER_WARNING
 			);
 			return null;

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1116,7 +1116,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		if ( WP_HTML_Tag_Processor::STATE_READY !== $this->parser_state ) {
 			wp_trigger_error(
 				__METHOD__,
-				"An HTML Processor which has already started processing cannot serialize its contents. Serialize immediately after creating the instance.",
+				'An HTML Processor which has already started processing cannot serialize its contents. Serialize immediately after creating the instance.',
 				E_USER_WARNING
 			);
 			return null;


### PR DESCRIPTION
Possesive "it's" should be "its."


Trac ticket: https://core.trac.wordpress.org/ticket/62036
Follow-up to https://core.trac.wordpress.org/changeset/59076


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
