### PR TITLE
Load fonts from style variations in the editor and the admin

### DIFF
--- a/src/wp-admin/includes/admin-filters.php
+++ b/src/wp-admin/includes/admin-filters.php
@@ -172,3 +172,4 @@ add_filter( 'list_pages', '_wp_privacy_settings_filter_draft_page_titles', 10, 2
 
 // Font management.
 add_action( 'admin_print_styles', 'wp_print_font_faces', 50 );
+add_action( 'admin_print_styles', 'wp_print_font_faces_from_style_variations', 50 );

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -366,6 +366,7 @@ function _wp_get_iframed_editor_assets() {
 	ob_start();
 	wp_print_styles();
 	wp_print_font_faces();
+	wp_print_font_faces_from_style_variations();
 	$styles = ob_get_clean();
 
 	if ( $has_emoji_styles ) {

--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -58,7 +58,7 @@ function wp_print_font_faces( $fonts = array() ) {
  * Generates and prints font-face styles defined the the theme style variations.
  *
  * @since 6.7.0
- * 
+ *
  */
 function wp_print_font_faces_from_style_variations() {
 	$fonts = WP_Font_Face_Resolver::get_fonts_from_style_variations();

--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -55,6 +55,22 @@ function wp_print_font_faces( $fonts = array() ) {
 }
 
 /**
+ * Generates and prints font-face styles defined the the theme style variations.
+ *
+ * @since 6.7.0
+ * 
+ */
+function wp_print_font_faces_from_style_variations() {
+	$fonts = WP_Font_Face_Resolver::get_fonts_from_style_variations();
+
+	if ( empty( $fonts ) ) {
+		return;
+	}
+
+	wp_print_font_faces( $fonts );
+}
+
+/**
  * Registers a new font collection in the font library.
  *
  * See {@link https://schemas.wp.org/trunk/font-collection.json} for the schema

--- a/src/wp-includes/fonts/class-wp-font-face-resolver.php
+++ b/src/wp-includes/fonts/class-wp-font-face-resolver.php
@@ -45,7 +45,7 @@ class WP_Font_Face_Resolver {
 	 */
 	public static function get_fonts_from_style_variations() {
 		$variations = WP_Theme_JSON_Resolver::get_style_variations();
-		$fonts = array();
+		$fonts      = array();
 
 		if ( empty( $variations ) ) {
 			return $fonts;
@@ -56,7 +56,7 @@ class WP_Font_Face_Resolver {
 				$fonts = array_merge( $fonts, $variation['settings']['typography']['fontFamilies']['theme'] );
 			}
 		}
-		
+
 		$settings = array(
 			'typography' => array(
 				'fontFamilies' => array(

--- a/src/wp-includes/fonts/class-wp-font-face-resolver.php
+++ b/src/wp-includes/fonts/class-wp-font-face-resolver.php
@@ -37,6 +37,38 @@ class WP_Font_Face_Resolver {
 	}
 
 	/**
+	 * Gets fonts defined in style variations.
+	 *
+	 * @since 6.7.0
+	 *
+	 * @return array Returns an array of font-families.
+	 */
+	public static function get_fonts_from_style_variations() {
+		$variations = WP_Theme_JSON_Resolver::get_style_variations();
+		$fonts = array();
+
+		if ( empty( $variations ) ) {
+			return $fonts;
+		}
+
+		foreach ( $variations as $variation ) {
+			if ( ! empty( $variation['settings']['typography']['fontFamilies']['theme'] ) ) {
+				$fonts = array_merge( $fonts, $variation['settings']['typography']['fontFamilies']['theme'] );
+			}
+		}
+		
+		$settings = array(
+			'typography' => array(
+				'fontFamilies' => array(
+					'theme' => $fonts,
+				),
+			),
+		);
+
+		return static::parse_settings( $settings );
+	}
+
+	/**
 	 * Parse theme.json settings to extract font definitions with variations grouped by font-family.
 	 *
 	 * @since 6.4.0

--- a/tests/phpunit/tests/fonts/font-face/wp-font-face-tests-dataset.php
+++ b/tests/phpunit/tests/fonts/font-face/wp-font-face-tests-dataset.php
@@ -471,9 +471,19 @@ CSS
 			),
 		);
 
+		$expected_styles = <<<CSS
+@font-face{font-family:"DM Sans";font-style:normal;font-weight:400;font-display:fallback;src:url('{$uri}dm-sans/DMSans-Regular.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"DM Sans";font-style:normal;font-weight:700;font-display:fallback;src:url('{$uri}dm-sans/DMSans-Bold.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"Open Sans";font-style:normal;font-weight:400;font-display:fallback;src:url('{$uri}open-sans/OpenSans-VariableFont_wdth,wght.ttf') format('truetype');font-stretch:normal;}
+@font-face{font-family:"Open Sans";font-style:italic;font-weight:400;font-display:fallback;src:url('{$uri}open-sans/OpenSans-Italic-VariableFont_wdth,wght.ttf') format('truetype');font-stretch:normal;}
+@font-face{font-family:"DM Sans";font-style:normal;font-weight:500;font-display:fallback;src:url('{$uri}dm-sans/DMSans-Medium.woff2') format('woff2');font-stretch:normal;}
+@font-face{font-family:"DM Sans";font-style:italic;font-weight:500;font-display:fallback;src:url('{$uri}dm-sans/DMSans-Medium-Italic.woff2') format('woff2');font-stretch:normal;}
+CSS;
+
 		if ( null === $data ) {
 			$data = array(
-				'expected' => $expected_font_families,
+				'expected'        => $expected_font_families,
+				'expected_styles' => $expected_styles,
 			);
 		}
 

--- a/tests/phpunit/tests/fonts/font-face/wp-font-face-tests-dataset.php
+++ b/tests/phpunit/tests/fonts/font-face/wp-font-face-tests-dataset.php
@@ -407,12 +407,13 @@ CSS
 	public static function get_custom_style_variations( $key = '' ) {
 		static $data = null;
 
+		$path                   = get_stylesheet_directory() . '/assets/fonts/';
 		$uri                    = get_stylesheet_directory_uri() . '/assets/fonts/';
 		$expected_font_families = array(
 			array(
 				array(
 					'src'          => array(
-						'/var/www/tests/phpunit/data/themedir1/fonts-block-theme/assets/fonts/dm-sans/DMSans-Regular.woff2',
+						"{$path}dm-sans/DMSans-Regular.woff2",
 					),
 					'font-family'  => 'DM Sans',
 					'font-stretch' => 'normal',
@@ -421,7 +422,7 @@ CSS
 				),
 				array(
 					'src'          => array(
-						'/var/www/tests/phpunit/data/themedir1/fonts-block-theme/assets/fonts/dm-sans/DMSans-Bold.woff2',
+						"{$path}dm-sans/DMSans-Bold.woff2",
 					),
 					'font-family'  => 'DM Sans',
 					'font-stretch' => 'normal',
@@ -432,7 +433,7 @@ CSS
 			array(
 				array(
 					'src'          => array(
-						'/var/www/tests/phpunit/data/themedir1/fonts-block-theme/assets/fonts/open-sans/OpenSans-VariableFont_wdth,wght.ttf',
+						"{$path}open-sans/OpenSans-VariableFont_wdth,wght.ttf",
 					),
 					'font-family'  => 'Open Sans',
 					'font-stretch' => 'normal',
@@ -441,7 +442,7 @@ CSS
 				),
 				array(
 					'src'          => array(
-						'/var/www/tests/phpunit/data/themedir1/fonts-block-theme/assets/fonts/open-sans/OpenSans-Italic-VariableFont_wdth,wght.ttf',
+						"{$path}open-sans/OpenSans-Italic-VariableFont_wdth,wght.ttf",
 					),
 					'font-family'  => 'Open Sans',
 					'font-stretch' => 'normal',
@@ -452,7 +453,7 @@ CSS
 			array(
 				array(
 					'src'          => array(
-						'/var/www/tests/phpunit/data/themedir1/fonts-block-theme/assets/fonts/dm-sans/DMSans-Medium.woff2',
+						"{$path}dm-sans/DMSans-Medium.woff2",
 					),
 					'font-family'  => 'DM Sans',
 					'font-stretch' => 'normal',
@@ -461,7 +462,7 @@ CSS
 				),
 				array(
 					'src'          => array(
-						'/var/www/tests/phpunit/data/themedir1/fonts-block-theme/assets/fonts/dm-sans/DMSans-Medium-Italic.woff2',
+						"{$path}dm-sans/DMSans-Medium-Italic.woff2",
 					),
 					'font-family'  => 'DM Sans',
 					'font-stretch' => 'normal',

--- a/tests/phpunit/tests/fonts/font-face/wp-font-face-tests-dataset.php
+++ b/tests/phpunit/tests/fonts/font-face/wp-font-face-tests-dataset.php
@@ -403,4 +403,84 @@ CSS
 
 		return $data;
 	}
+
+	public static function get_custom_style_variations( $key = '' ) {
+		static $data = null;
+
+		$uri                    = get_stylesheet_directory_uri() . '/assets/fonts/';
+		$expected_font_families = array(
+			array(
+				array(
+					'src'          => array(
+						'/var/www/tests/phpunit/data/themedir1/fonts-block-theme/assets/fonts/dm-sans/DMSans-Regular.woff2',
+					),
+					'font-family'  => 'DM Sans',
+					'font-stretch' => 'normal',
+					'font-style'   => 'normal',
+					'font-weight'  => '400',
+				),
+				array(
+					'src'          => array(
+						'/var/www/tests/phpunit/data/themedir1/fonts-block-theme/assets/fonts/dm-sans/DMSans-Bold.woff2',
+					),
+					'font-family'  => 'DM Sans',
+					'font-stretch' => 'normal',
+					'font-style'   => 'normal',
+					'font-weight'  => '700',
+				),
+			),
+			array(
+				array(
+					'src'          => array(
+						'/var/www/tests/phpunit/data/themedir1/fonts-block-theme/assets/fonts/open-sans/OpenSans-VariableFont_wdth,wght.ttf',
+					),
+					'font-family'  => 'Open Sans',
+					'font-stretch' => 'normal',
+					'font-style'   => 'normal',
+					'font-weight'  => '400',
+				),
+				array(
+					'src'          => array(
+						'/var/www/tests/phpunit/data/themedir1/fonts-block-theme/assets/fonts/open-sans/OpenSans-Italic-VariableFont_wdth,wght.ttf',
+					),
+					'font-family'  => 'Open Sans',
+					'font-stretch' => 'normal',
+					'font-style'   => 'italic',
+					'font-weight'  => '400',
+				),
+			),
+			array(
+				array(
+					'src'          => array(
+						'/var/www/tests/phpunit/data/themedir1/fonts-block-theme/assets/fonts/dm-sans/DMSans-Medium.woff2',
+					),
+					'font-family'  => 'DM Sans',
+					'font-stretch' => 'normal',
+					'font-style'   => 'normal',
+					'font-weight'  => '500',
+				),
+				array(
+					'src'          => array(
+						'/var/www/tests/phpunit/data/themedir1/fonts-block-theme/assets/fonts/dm-sans/DMSans-Medium-Italic.woff2',
+					),
+					'font-family'  => 'DM Sans',
+					'font-stretch' => 'normal',
+					'font-style'   => 'italic',
+					'font-weight'  => '500',
+				),
+			),
+		);
+
+		if ( null === $data ) {
+			$data = array(
+				'expected' => $expected_font_families,
+			);
+		}
+
+		if ( isset( $data[ $key ] ) ) {
+			return $data[ $key ];
+		}
+
+		return $data;
+	}
 }

--- a/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromStyleVariations.php
+++ b/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromStyleVariations.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Test case for WP_Font_Face_Resolver::get_fonts_from_style_variations().
+ *
+ * @package    WordPress
+ * @subpackage Fonts
+ *
+ * @since 6.7.0
+ *
+ * @group fonts
+ * @group fontface
+ *
+ * @covers WP_Font_Face_Resolver::get_fonts_from_style_variations
+ */
+class Tests_Fonts_WPFontFaceResolver_GetFontsFromStyleVariations extends WP_Font_Face_UnitTestCase {
+	const FONTS_THEME = 'fonts-block-theme';
+
+	public static function set_up_before_class() {
+		self::$requires_switch_theme_fixtures = true;
+
+		parent::set_up_before_class();
+	}
+
+	public function test_should_return_empty_array_when_theme_has_no_style_variations() {
+		switch_theme( 'block-theme' );
+
+		$fonts = WP_Font_Face_Resolver::get_fonts_from_style_variations();
+		$this->assertIsArray( $fonts, 'Should return an array data type' );
+		$this->assertEmpty( $fonts, 'Should return an empty array' );
+	}
+
+	public function test_should_return_all_fonts_from_all_style_variations() {
+		switch_theme( static::FONTS_THEME );
+
+		$actual   = WP_Font_Face_Resolver::get_fonts_from_style_variations();
+		$expected = self::get_custom_style_variations( 'expected' );
+
+		$this->assertSame( $expected, $actual, 'All the fonts from the theme variations should be returned.' );
+	}
+
+	public function test_should_replace_src_file_placeholder() {
+		switch_theme( static::FONTS_THEME );
+
+		$fonts = WP_Font_Face_Resolver::get_fonts_from_style_variations();
+
+		// check that the there is no theme relative url in the src list.
+		foreach ( $fonts as $family ) {
+			foreach ( $family as $font ) {
+				foreach ( $font['src'] as $src ) {
+					$this->assertStringNotContainsString( 'file:./', $src, 'Font src should not contain the "file:./" placeholder' );
+				}
+			}
+		}
+	}
+}

--- a/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromStyleVariations.php
+++ b/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromStyleVariations.php
@@ -58,7 +58,7 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromStyleVariations extends WP_Font
 
 		$fonts = WP_Font_Face_Resolver::get_fonts_from_style_variations();
 
-		// check that the there is no theme relative url in the src list.
+		// Check that the there is no theme relative url in the src list.
 		foreach ( $fonts as $family ) {
 			foreach ( $family as $font ) {
 				foreach ( $font['src'] as $src ) {

--- a/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromStyleVariations.php
+++ b/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromStyleVariations.php
@@ -21,6 +21,11 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromStyleVariations extends WP_Font
 		parent::set_up_before_class();
 	}
 
+	/**
+	 * Ensure that an empty array is returned when the theme has no style variations.
+	 *
+	 * @ticket 62231
+	 */
 	public function test_should_return_empty_array_when_theme_has_no_style_variations() {
 		switch_theme( 'block-theme' );
 
@@ -29,6 +34,11 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromStyleVariations extends WP_Font
 		$this->assertEmpty( $fonts, 'Should return an empty array' );
 	}
 
+	/**
+	 * Ensure that all variations are loaded from a theme.
+	 *
+	 * @ticket 62231
+	 */
 	public function test_should_return_all_fonts_from_all_style_variations() {
 		switch_theme( static::FONTS_THEME );
 
@@ -38,6 +48,11 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromStyleVariations extends WP_Font
 		$this->assertSame( $expected, $actual, 'All the fonts from the theme variations should be returned.' );
 	}
 
+	/**
+	 * Ensure that file:./ is replaced in the src list.
+	 *
+	 * @ticket 62231
+	 */
 	public function test_should_replace_src_file_placeholder() {
 		switch_theme( static::FONTS_THEME );
 

--- a/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromStyleVariations.php
+++ b/tests/phpunit/tests/fonts/font-face/wpFontFaceResolver/getFontsFromStyleVariations.php
@@ -62,7 +62,8 @@ class Tests_Fonts_WPFontFaceResolver_GetFontsFromStyleVariations extends WP_Font
 		foreach ( $fonts as $family ) {
 			foreach ( $family as $font ) {
 				foreach ( $font['src'] as $src ) {
-					$this->assertStringNotContainsString( 'file:./', $src, 'Font src should not contain the "file:./" placeholder' );
+					$src_basename = basename( $src );
+					$this->assertStringNotContainsString( 'file:./', $src, "Font $src_basename should not contain the 'file:./' placeholder" );
 				}
 			}
 		}

--- a/tests/phpunit/tests/fonts/font-face/wpPrintFontFacesFromStyleVariations.php
+++ b/tests/phpunit/tests/fonts/font-face/wpPrintFontFacesFromStyleVariations.php
@@ -20,6 +20,11 @@ class Tests_Fonts_WpPrintFontFacesFromStyleVariations extends WP_Font_Face_UnitT
 		self::$requires_switch_theme_fixtures = true;
 	}
 
+	/**
+	 * Ensure that no fonts are printed when the theme has no fonts.
+	 *
+	 * @ticket 62231
+	 */
 	public function test_should_not_print_when_no_fonts() {
 		switch_theme( 'block-theme' );
 
@@ -27,6 +32,11 @@ class Tests_Fonts_WpPrintFontFacesFromStyleVariations extends WP_Font_Face_UnitT
 		wp_print_font_faces_from_style_variations();
 	}
 
+	/**
+	 * Ensure that all fonts are printed from the theme style variations.
+	 *
+	 * @ticket 62231
+	 */
 	public function test_should_print_fonts_in_style_variations() {
 		switch_theme( static::FONTS_THEME );
 

--- a/tests/phpunit/tests/fonts/font-face/wpPrintFontFacesFromStyleVariations.php
+++ b/tests/phpunit/tests/fonts/font-face/wpPrintFontFacesFromStyleVariations.php
@@ -16,9 +16,8 @@ class Tests_Fonts_WpPrintFontFacesFromStyleVariations extends WP_Font_Face_UnitT
 	const FONTS_THEME = 'fonts-block-theme';
 
 	public static function set_up_before_class() {
-		self::$requires_switch_theme_fixtures = true;
-
 		parent::set_up_before_class();
+		self::$requires_switch_theme_fixtures = true;
 	}
 
 	public function test_should_not_print_when_no_fonts() {

--- a/tests/phpunit/tests/fonts/font-face/wpPrintFontFacesFromStyleVariations.php
+++ b/tests/phpunit/tests/fonts/font-face/wpPrintFontFacesFromStyleVariations.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Test case for wp_print_font_faces_from_style_variations().
+ *
+ * @package    WordPress
+ * @subpackage Fonts
+ *
+ * @since 6.7.0
+ *
+ * @group fonts
+ * @group fontface
+ *
+ * @covers wp_print_font_faces_from_style_variations
+ */
+class Tests_Fonts_WpPrintFontFacesFromStyleVariations extends WP_Font_Face_UnitTestCase {
+	const FONTS_THEME = 'fonts-block-theme';
+
+	public static function set_up_before_class() {
+		self::$requires_switch_theme_fixtures = true;
+
+		parent::set_up_before_class();
+	}
+
+	public function test_should_not_print_when_no_fonts() {
+		switch_theme( 'block-theme' );
+
+		$this->expectOutputString( '' );
+		wp_print_font_faces_from_style_variations();
+	}
+
+	public function test_should_print_fonts_in_style_variations() {
+		switch_theme( static::FONTS_THEME );
+
+		$expected        = $this->get_custom_style_variations( 'expected_styles' );
+		$expected_output = $this->get_expected_styles_output( $expected );
+
+		$this->expectOutputString( $expected_output );
+		wp_print_font_faces_from_style_variations();
+	}
+
+	private function get_expected_styles_output( $styles ) {
+		$style_element = "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n";
+		return sprintf( $style_element, $styles );
+	}
+}

--- a/tests/phpunit/tests/fonts/font-face/wpPrintFontFacesFromStyleVariations.php
+++ b/tests/phpunit/tests/fonts/font-face/wpPrintFontFacesFromStyleVariations.php
@@ -39,7 +39,7 @@ class Tests_Fonts_WpPrintFontFacesFromStyleVariations extends WP_Font_Face_UnitT
 	}
 
 	private function get_expected_styles_output( $styles ) {
-		$style_element = "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n";
+		$style_element = "<style class='wp-fonts-local' type='text/css'>\n%s\n</style>\n";
 		return sprintf( $style_element, $styles );
 	}
 }


### PR DESCRIPTION
## What:
Load fonts from style variations only in the editor and admin, not in the public frontend.

This is an alternative and probably simpler alternative to the Gutenberg PR:  https://github.com/WordPress/gutenberg/pull/65019 and it core port PR: https://github.com/WordPress/wordpress-develop/pull/7570


Trac ticket: https://core.trac.wordpress.org/ticket/62231


## Testing Instructions:
Try to load a style variation and check that the fonts referenced in those style variations load as expected. 

I created a theme to test this quickly and visually:
[font-variants.zip](https://github.com/user-attachments/files/17413874/font-variants.zip)
In this theme, the alternative font families and font faces with theme-relative URLs are defined in the style variations.


## Sceencast

https://github.com/user-attachments/assets/c416ae7b-e0b7-475d-b02c-30af5ee0dedc



