### PR TITLE
Replace id by class in the wp-fonts-local style tag printer by wp_print_font_faces()

### DIFF
--- a/src/wp-includes/fonts/class-wp-font-face.php
+++ b/src/wp-includes/fonts/class-wp-font-face.php
@@ -229,7 +229,7 @@ class WP_Font_Face {
 	private function get_style_element() {
 		$attributes = $this->generate_style_element_attributes();
 
-		return "<style id='wp-fonts-local'{$attributes}>\n%s\n</style>\n";
+		return "<style class='wp-fonts-local'{$attributes}>\n%s\n</style>\n";
 	}
 
 	/**

--- a/tests/phpunit/tests/fonts/font-face/wpFontFace/generateAndPrint.php
+++ b/tests/phpunit/tests/fonts/font-face/wpFontFace/generateAndPrint.php
@@ -31,7 +31,7 @@ class Tests_Fonts_WPFontFace_GenerateAndPrint extends WP_UnitTestCase {
 	 */
 	public function test_should_generate_and_print_given_fonts( array $fonts, $expected ) {
 		$font_face       = new WP_Font_Face();
-		$style_element   = "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n";
+		$style_element   = "<style class='wp-fonts-local' type='text/css'>\n%s\n</style>\n";
 		$expected_output = sprintf( $style_element, $expected );
 
 		$this->expectOutputString( $expected_output );

--- a/tests/phpunit/tests/fonts/font-face/wpPrintFontFaces.php
+++ b/tests/phpunit/tests/fonts/font-face/wpPrintFontFaces.php
@@ -55,7 +55,7 @@ class Tests_Fonts_WpPrintFontFaces extends WP_Font_Face_UnitTestCase {
 		);
 
 		$expected_output = <<<CSS
-<style id='wp-fonts-local' type='text/css'>
+<style class='wp-fonts-local' type='text/css'>
 @font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-display:fallback;src:url('http://example.com/assets/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');font-stretch:;}
 </style>
 
@@ -76,7 +76,7 @@ CSS;
 	}
 
 	private function get_expected_styles_output( $styles ) {
-		$style_element = "<style id='wp-fonts-local' type='text/css'>\n%s\n</style>\n";
+		$style_element = "<style class='wp-fonts-local' type='text/css'>\n%s\n</style>\n";
 		return sprintf( $style_element, $styles );
 	}
 }


### PR DESCRIPTION
Replace id by class in the wp-fonts-local style tag printed by wp_print_font_faces()

Trac ticket: https://core.trac.wordpress.org/ticket/62246

