### PR TITLE
Refine `paths` for workflows.

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -29,8 +29,9 @@ on:
       - '.jshintrc'
       # This file configures PHPCS. Changes could affect the outcome.
       - 'phpcs.xml.dist'
-      # Changes to workflow files should always verify all workflows are successful.
-      - '.github/workflows/*.yml'
+      # Confirm any changes to relevant workflow files.
+      - '.github/workflows/coding-standards.yml'
+      - '.github/workflows/reusable-coding-standards-v[0-9]+.yml'
   workflow_dispatch:
 
 # Cancels all previous workflow runs for pull requests that have not completed.

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -31,7 +31,7 @@ on:
       - 'phpcs.xml.dist'
       # Confirm any changes to relevant workflow files.
       - '.github/workflows/coding-standards.yml'
-      - '.github/workflows/reusable-coding-standards-v[0-9]+.yml'
+      - '.github/workflows/reusable-coding-standards-*.yml'
   workflow_dispatch:
 
 # Cancels all previous workflow runs for pull requests that have not completed.

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -27,8 +27,9 @@ on:
       - '.jshintrc'
       # Any change to the QUnit directory should run tests.
       - 'tests/qunit/**'
-      # Changes to workflow files should always verify all workflows are successful.
-      - '.github/workflows/*.yml'
+      # Confirm any changes to relevant workflow files.
+      - '.github/workflows/javascript-tests.yml'
+      - '.github/workflows/reusable-javascript-tests.yml'
   workflow_dispatch:
 
 # Cancels all previous workflow runs for pull requests that have not completed.

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -24,8 +24,9 @@ on:
       - 'composer.*'
       # This file configures PHP compatibility scanning. Changes could affect the outcome.
       - 'phpcompat.xml.dist'
-      # Changes to workflow files should always verify all workflows are successful.
-      - '.github/workflows/*.yml'
+      # Confirm any changes to relevant workflow files.
+      - '.github/workflows/php-compatibility.yml'
+      - '.github/workflows/reusable-php-compatibility.yml'
   workflow_dispatch:
 
 # Cancels all previous workflow runs for pull requests that have not completed.

--- a/.github/workflows/test-old-branches.yml
+++ b/.github/workflows/test-old-branches.yml
@@ -7,8 +7,7 @@ on:
       - trunk
     paths:
       - '.github/workflows/test-old-branches.yml'
-      - '.github/workflows/reusable-phpunit-tests-v1.yml'
-      - '.github/workflows/reusable-phpunit-tests-v2.yml'
+      - '.github/workflows/reusable-phpunit-tests-v[0-9]+.yml'
   # Run twice a month on the 1st and 15th at 00:00 UTC.
   schedule:
     - cron: '0 0 1 * *'


### PR DESCRIPTION
Workflows with `path` filtering do not need to run when other workflow files are edited.

Trac ticket: https://core.trac.wordpress.org/ticket/61564

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
