### PR TITLE
Don't prepare the response body for HEAD requests in WP_REST_Terms_Controller

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-request.php
+++ b/src/wp-includes/rest-api/class-wp-rest-request.php
@@ -162,6 +162,18 @@ class WP_REST_Request implements ArrayAccess {
 	}
 
 	/**
+	 * Determines if the request is the given method.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @param string $method HTTP method.
+	 * @return bool Whether the request is of the given method.
+	 */
+	public function is_method( $method ) {
+		return $this->get_method() === strtoupper( $method );
+	}
+
+	/**
 	 * Canonicalizes the header name.
 	 *
 	 * Ensures that header names are always treated the same regardless of

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
@@ -464,7 +464,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 
 		$response = $this->prepare_item_for_response( $term, $request );
 
-		return reset_ensure_response( $response );
+		return rest_ensure_response( $response );
 	}
 
 	/**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
@@ -451,9 +451,13 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			return $term;
 		}
 
+		if ( $request->is_method( 'head' ) ) {
+			return new WP_REST_Response();
+		}
+
 		$response = $this->prepare_item_for_response( $term, $request );
 
-		return rest_ensure_response( $response );
+		return reset_ensure_response( $response );
 	}
 
 	/**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
@@ -337,14 +337,16 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			$total_terms = 0;
 		}
 
-		$response = array();
-
-		foreach ( $query_result as $term ) {
-			$data       = $this->prepare_item_for_response( $term, $request );
-			$response[] = $this->prepare_response_for_collection( $data );
+		$is_head_request = $request->is_method( 'head' );
+		if ( ! $is_head_request ) {
+			$response = array();
+			foreach ( $query_result as $term ) {
+				$data       = $this->prepare_item_for_response( $term, $request );
+				$response[] = $this->prepare_response_for_collection( $data );
+			}
 		}
 
-		$response = rest_ensure_response( $response );
+		$response = $is_head_request ? new WP_REST_Response() : rest_ensure_response( $response );
 
 		// Store pagination values for headers.
 		$per_page = (int) $prepared_args['number'];

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
@@ -295,6 +295,12 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			}
 		}
 
+		$is_head_request = $request->is_method( 'head' );
+		if ( $is_head_request ) {
+			// Force the 'fields' argument. For HEAD requests, only term IDs are required.
+			$prepared_args['fields'] = 'ids';
+		}
+
 		/**
 		 * Filters get_terms() arguments when querying terms via the REST API.
 		 *
@@ -337,7 +343,6 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			$total_terms = 0;
 		}
 
-		$is_head_request = $request->is_method( 'head' );
 		if ( ! $is_head_request ) {
 			$response = array();
 			foreach ( $query_result as $term ) {

--- a/tests/phpunit/tests/rest-api/rest-categories-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-categories-controller.php
@@ -609,17 +609,25 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertErrorResponse( 'rest_no_route', $response, 404 );
 	}
 
-	public function test_get_terms_pagination_headers() {
+	/**
+	 * @dataProvider data_readable_http_methods
+	 * @ticket 56481
+	 *
+	 * @param string $method HTTP method to use.
+	 */
+	public function test_get_terms_pagination_headers( $method ) {
 		$total_categories = self::$total_categories;
 		$total_pages      = (int) ceil( $total_categories / 10 );
 
 		// Start of the index + Uncategorized default term.
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/categories' );
+		$request  = new WP_REST_Request( $method, '/wp/v2/categories' );
 		$response = rest_get_server()->dispatch( $request );
 		$headers  = $response->get_headers();
 		$this->assertSame( $total_categories, $headers['X-WP-Total'] );
 		$this->assertSame( $total_pages, $headers['X-WP-TotalPages'] );
-		$this->assertCount( 10, $response->get_data() );
+		if ( 'HEAD' !== $method ) {
+			$this->assertCount( 10, $response->get_data() );
+		}
 		$next_link = add_query_arg(
 			array(
 				'page' => 2,
@@ -662,7 +670,9 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$headers  = $response->get_headers();
 		$this->assertSame( $total_categories, $headers['X-WP-Total'] );
 		$this->assertSame( $total_pages, $headers['X-WP-TotalPages'] );
-		$this->assertCount( 1, $response->get_data() );
+		if ( 'HEAD' !== $method ) {
+			$this->assertCount( 1, $response->get_data() );
+		}
 		$prev_link = add_query_arg(
 			array(
 				'page' => $total_pages - 1,
@@ -679,7 +689,9 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$headers  = $response->get_headers();
 		$this->assertSame( $total_categories, $headers['X-WP-Total'] );
 		$this->assertSame( $total_pages, $headers['X-WP-TotalPages'] );
-		$this->assertCount( 0, $response->get_data() );
+		if ( 'HEAD' !== $method ) {
+			$this->assertCount( 0, $response->get_data() );
+		}
 		$prev_link = add_query_arg(
 			array(
 				'page' => $total_pages,

--- a/tests/phpunit/tests/rest-api/rest-categories-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-categories-controller.php
@@ -1236,4 +1236,69 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$category = get_term( 1, 'category' );
 		$this->check_taxonomy_term( $category, $data, $response->get_links() );
 	}
+
+	/**
+	 * @dataProvider data_readable_http_methods
+	 * @ticket 56481
+	 *
+	 * @param string $method HTTP method to use.
+	 */
+	public function test_get_items_returns_only_fetches_ids_for_head_requests( $method ) {
+		$is_head_request = 'HEAD' === $method;
+		$request         = new WP_REST_Request( $method, '/wp/v2/categories' );
+
+		$filter = new MockAction();
+
+		add_filter( 'terms_pre_query', array( $filter, 'filter' ), 10, 2 );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		if ( $is_head_request ) {
+			$this->assertEmpty( $response->get_data() );
+		} else {
+			$this->assertNotEmpty( $response->get_data() );
+		}
+
+		$args = $filter->get_args();
+		$this->assertTrue( isset( $args[0][1] ), 'Query parameters were not captured.' );
+		$this->assertInstanceOf( WP_Term_Query::class, $args[0][1], 'Query parameters were not captured.' );
+
+		/** @var WP_Term_Query $query */
+		$query = $args[0][1];
+
+		if ( $is_head_request ) {
+			$this->assertArrayHasKey( 'fields', $query->query_vars, 'The fields parameter is not set in the query vars.' );
+			$this->assertSame( 'ids', $query->query_vars['fields'], 'The query must fetch only term IDs.' );
+		} else {
+			$this->assertTrue(
+				! array_key_exists( 'fields', $query->query_vars ) || 'ids' !== $query->query_vars['fields'],
+				'The fields parameter should not be forced to "ids" for non-HEAD requests.'
+			);
+		}
+
+		if ( ! $is_head_request ) {
+			return;
+		}
+
+		global $wpdb;
+		$terms_table = preg_quote( $wpdb->terms, '/' );
+
+		$pattern = '/SELECT\s+t\.term_id.+FROM\s+' . $terms_table . '\s+AS\s+t\s+INNER\s+JOIN/is';
+
+		// Assert that the SQL query only fetches the term_id column.
+		$this->assertMatchesRegularExpression( $pattern, $query->request, 'The SQL query does not match the expected string.' );
+	}
+
+	/**
+	 * Data provider intended to provide HTTP method names for testing GET and HEAD requests.
+	 *
+	 * @return array
+	 */
+	public function data_readable_http_methods() {
+		return array(
+			'GET request'  => array( 'GET' ),
+			'HEAD request' => array( 'HEAD' ),
+		);
+	}
 }

--- a/tests/phpunit/tests/rest-api/rest-categories-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-categories-controller.php
@@ -576,8 +576,14 @@ class WP_Test_REST_Categories_Controller extends WP_Test_REST_Controller_Testcas
 		$this->assertSame( 'Child', $data[0]['name'] );
 	}
 
-	public function test_get_terms_invalid_parent_arg() {
-		$request = new WP_REST_Request( 'GET', '/wp/v2/categories' );
+	/**
+	 * @dataProvider data_readable_http_methods
+	 * @ticket 56481
+	 *
+	 * @param string $method HTTP method to use.
+	 */
+	public function test_get_terms_invalid_parent_arg( $method ) {
+		$request = new WP_REST_Request( $method, '/wp/v2/categories' );
 		$request->set_param( 'parent', 'invalid-parent' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400 );

--- a/tests/phpunit/tests/rest-api/rest-tags-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-tags-controller.php
@@ -578,12 +578,18 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertErrorResponse( 'rest_no_route', $response, 404 );
 	}
 
-	public function test_get_terms_pagination_headers() {
+	/**
+	 * @dataProvider data_readable_http_methods
+	 * @ticket 56481
+	 *
+	 * @param string $method HTTP method to use.
+	 */
+	public function test_get_terms_pagination_headers ( $method ) {
 		$total_tags  = self::$total_tags;
 		$total_pages = (int) ceil( $total_tags / 10 );
 
 		// Start of the index.
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/tags' );
+		$request  = new WP_REST_Request( $method, '/wp/v2/tags' );
 		$response = rest_get_server()->dispatch( $request );
 		$headers  = $response->get_headers();
 		$this->assertSame( $total_tags, $headers['X-WP-Total'] );

--- a/tests/phpunit/tests/rest-api/rest-tags-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-tags-controller.php
@@ -1453,4 +1453,69 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 		$tag  = get_term( $id, 'post_tag' );
 		$this->check_taxonomy_term( $tag, $data, $response->get_links() );
 	}
+
+	/**
+	 * @dataProvider data_readable_http_methods
+	 * @ticket 56481
+	 *
+	 * @param string $method HTTP method to use.
+	 */
+	public function test_get_items_returns_only_fetches_ids_for_head_requests( $method ) {
+		$is_head_request = 'HEAD' === $method;
+		$request         = new WP_REST_Request( $method, '/wp/v2/tags' );
+
+		$filter = new MockAction();
+
+		add_filter( 'terms_pre_query', array( $filter, 'filter' ), 10, 2 );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		if ( $is_head_request ) {
+			$this->assertEmpty( $response->get_data() );
+		} else {
+			$this->assertNotEmpty( $response->get_data() );
+		}
+
+		$args = $filter->get_args();
+		$this->assertTrue( isset( $args[0][1] ), 'Query parameters were not captured.' );
+		$this->assertInstanceOf( WP_Term_Query::class, $args[0][1], 'Query parameters were not captured.' );
+
+		/** @var WP_Term_Query $query */
+		$query = $args[0][1];
+
+		if ( $is_head_request ) {
+			$this->assertArrayHasKey( 'fields', $query->query_vars, 'The fields parameter is not set in the query vars.' );
+			$this->assertSame( 'ids', $query->query_vars['fields'], 'The query must fetch only term IDs.' );
+		} else {
+			$this->assertTrue(
+				! array_key_exists( 'fields', $query->query_vars ) || 'ids' !== $query->query_vars['fields'],
+				'The fields parameter should not be forced to "ids" for non-HEAD requests.'
+			);
+		}
+
+		if ( ! $is_head_request ) {
+			return;
+		}
+
+		global $wpdb;
+		$terms_table = preg_quote( $wpdb->terms, '/' );
+
+		$pattern = '/SELECT\s+t\.term_id.+FROM\s+' . $terms_table . '\s+AS\s+t\s+INNER\s+JOIN/is';
+
+		// Assert that the SQL query only fetches the term_id column.
+		$this->assertMatchesRegularExpression( $pattern, $query->request, 'The SQL query does not match the expected string.' );
+	}
+
+	/**
+	 * Data provider intended to provide HTTP method names for testing GET and HEAD requests.
+	 *
+	 * @return array
+	 */
+	public function data_readable_http_methods() {
+		return array(
+			'GET request'  => array( 'GET' ),
+			'HEAD request' => array( 'HEAD' ),
+		);
+	}
 }

--- a/tests/phpunit/tests/rest-api/rest-tags-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-tags-controller.php
@@ -584,7 +584,7 @@ class WP_Test_REST_Tags_Controller extends WP_Test_REST_Controller_Testcase {
 	 *
 	 * @param string $method HTTP method to use.
 	 */
-	public function test_get_terms_pagination_headers ( $method ) {
+	public function test_get_terms_pagination_headers( $method ) {
 		$total_tags  = self::$total_tags;
 		$total_pages = (int) ceil( $total_tags / 10 );
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Trac ticket: https://core.trac.wordpress.org/ticket/56481

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
