### PR TITLE
About page: WordPress 6.7 for consistency 

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -141,7 +141,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 					</svg>
 				</div>
 				<h3><?php _e( 'Performance updates' ); ?></h3>
-				<p><?php _e( '6.7 delivers important performance updates, including faster pattern loading, optimized previews in the data views component, improved PHP 8+ support and removal of deprecated code, auto sizes for lazy-loaded images, and more efficient tag processing in the HTML API.' ); ?></p>
+				<p><?php _e( 'WordPress 6.7 delivers important performance updates, including faster pattern loading, optimized previews in the data views component, improved PHP 8+ support and removal of deprecated code, auto sizes for lazy-loaded images, and more efficient tag processing in the HTML API.' ); ?></p>
 			</div>
 			<div class="column">
 				<div class="about__image">


### PR DESCRIPTION
Replaces "6.7" in the performance section with "WordPress 6.7" for consistency with other mentions on the page.

I don't think it's a blocker but will check with the polyglots.

Trac ticket: https://core.trac.wordpress.org/ticket/61961

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
