### PR TITLE
Theme JSON: cached resolved URIs

### DIFF
--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -92,6 +92,14 @@ class WP_Theme_JSON_Resolver {
 	protected static $theme_json_file_cache = array();
 
 	/**
+	 * Cache for resolved files per theme.
+	 *
+	 * @since 6.8.0
+	 * @var array
+	 */
+	protected static $resolved_theme_uris_cache = array();
+
+	/**
 	 * Processes a file that adheres to the theme.json schema
 	 * and returns an array with its contents, or a void array if none found.
 	 *
@@ -739,20 +747,22 @@ class WP_Theme_JSON_Resolver {
 	 *              and `$i18n_schema` variables to reset.
 	 * @since 6.1.0 Added the `$blocks` and `$blocks_cache` variables
 	 *              to reset.
+	 * @since 6.8.0 Added the `$resolved_theme_uris_cache` variable to reset.
 	 */
 	public static function clean_cached_data() {
-		static::$core                     = null;
-		static::$blocks                   = null;
-		static::$blocks_cache             = array(
+		static::$core                      = null;
+		static::$blocks                    = null;
+		static::$blocks_cache              = array(
 			'core'   => array(),
 			'blocks' => array(),
 			'theme'  => array(),
 			'user'   => array(),
 		);
-		static::$theme                    = null;
-		static::$user                     = null;
-		static::$user_custom_post_type_id = null;
-		static::$i18n_schema              = null;
+		static::$theme                     = null;
+		static::$user                      = null;
+		static::$user_custom_post_type_id  = null;
+		static::$i18n_schema               = null;
+		static::$resolved_theme_uris_cache = array();
 	}
 
 	/**
@@ -849,6 +859,7 @@ class WP_Theme_JSON_Resolver {
 	 *
 	 * @since 6.6.0
 	 * @since 6.7.0 Resolve relative paths in block styles.
+	 * @since 6.8.0 Added caching for resolved theme URIs.
 	 *
 	 * @param WP_Theme_JSON $theme_json A theme json instance.
 	 * @return array An array of resolved paths.
@@ -858,6 +869,11 @@ class WP_Theme_JSON_Resolver {
 
 		if ( ! $theme_json instanceof WP_Theme_JSON ) {
 			return $resolved_theme_uris;
+		}
+
+		$current_stylesheet_directory = get_stylesheet_directory();
+		if ( $current_stylesheet_directory && ! empty( static::$resolved_theme_uris_cache[ $current_stylesheet_directory ] ) ) {
+			return static::$resolved_theme_uris_cache[ $current_stylesheet_directory ];
 		}
 
 		$theme_json_data = $theme_json->get_raw_data();
@@ -914,7 +930,9 @@ class WP_Theme_JSON_Resolver {
 				}
 			}
 		}
-
+		if ( $current_stylesheet_directory ) {
+			static::$resolved_theme_uris_cache[ $current_stylesheet_directory ] = $resolved_theme_uris;
+		}
 		return $resolved_theme_uris;
 	}
 

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -871,12 +871,13 @@ class WP_Theme_JSON_Resolver {
 			return $resolved_theme_uris;
 		}
 
-		$current_stylesheet_directory = get_stylesheet_directory();
-		if ( $current_stylesheet_directory && ! empty( static::$resolved_theme_uris_cache[ $current_stylesheet_directory ] ) ) {
-			return static::$resolved_theme_uris_cache[ $current_stylesheet_directory ];
+		$theme_json_data               = $theme_json->get_raw_data();
+		$resolved_theme_uris_cache_key = md5( wp_json_encode( $theme_json_data ) );
+
+		if ( ! empty( static::$resolved_theme_uris_cache[ $resolved_theme_uris_cache_key ] ) ) {
+			return static::$resolved_theme_uris_cache[ $resolved_theme_uris_cache_key ];
 		}
 
-		$theme_json_data = $theme_json->get_raw_data();
 		/*
 		 * The same file convention when registering web fonts.
 		 * See: WP_Font_Face_Resolver::to_theme_file_uri.
@@ -930,9 +931,7 @@ class WP_Theme_JSON_Resolver {
 				}
 			}
 		}
-		if ( $current_stylesheet_directory ) {
-			static::$resolved_theme_uris_cache[ $current_stylesheet_directory ] = $resolved_theme_uris;
-		}
+		static::$resolved_theme_uris_cache[ $resolved_theme_uris_cache_key ] = $resolved_theme_uris;
 		return $resolved_theme_uris;
 	}
 

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -1405,8 +1405,8 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 		$this->assertSame( $expected_data, $actual, 'Resolved theme uris do not match.' );
 
 		// Test that resolved theme uris are cached.
-		$cache_key                    = md5( wp_json_encode( $theme_json->get_raw_data() ) );
-		$expected_cache_data          = array( "$cache_key" => $actual );
+		$cache_key           = md5( wp_json_encode( $theme_json->get_raw_data() ) );
+		$expected_cache_data = array( "$cache_key" => $actual );
 
 		$this->assertSame( $expected_cache_data, static::$property_resolved_theme_uris_cache->getValue(), 'Resolved theme uris cache data does not match.' );
 	}

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -1405,8 +1405,8 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 		$this->assertSame( $expected_data, $actual, 'Resolved theme uris do not match.' );
 
 		// Test that resolved theme uris are cached.
-		$current_stylesheet_directory = get_stylesheet_directory();
-		$expected_cache_data          = array( "$current_stylesheet_directory" => $actual );
+		$cache_key                    = md5( wp_json_encode( $theme_json->get_raw_data() ) );
+		$expected_cache_data          = array( "$cache_key" => $actual );
 
 		$this->assertSame( $expected_cache_data, static::$property_resolved_theme_uris_cache->getValue(), 'Resolved theme uris cache data does not match.' );
 	}

--- a/tests/phpunit/tests/theme/wpThemeJsonResolver.php
+++ b/tests/phpunit/tests/theme/wpThemeJsonResolver.php
@@ -34,6 +34,20 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 	private static $property_blocks_cache_orig_value;
 
 	/**
+	 * WP_Theme_JSON_Resolver::$resolved_theme_uris_cache property.
+	 *
+	 * @var ReflectionProperty
+	 */
+	private static $property_resolved_theme_uris_cache;
+
+	/**
+	 * Original value of the WP_Theme_JSON_Resolver::$resolved_theme_uris_cache property.
+	 *
+	 * @var array
+	 */
+	private static $property_resolved_theme_uris_cache_orig_value;
+
+	/**
 	 * WP_Theme_JSON_Resolver::$core property.
 	 *
 	 * @var ReflectionProperty
@@ -83,11 +97,16 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 		static::$property_core = new ReflectionProperty( WP_Theme_JSON_Resolver::class, 'core' );
 		static::$property_core->setAccessible( true );
 		static::$property_core_orig_value = static::$property_core->getValue();
+
+		static::$property_resolved_theme_uris_cache = new ReflectionProperty( WP_Theme_JSON_Resolver::class, 'resolved_theme_uris_cache' );
+		static::$property_resolved_theme_uris_cache->setAccessible( true );
+		static::$property_resolved_theme_uris_cache_orig_value = static::$property_resolved_theme_uris_cache->getValue();
 	}
 
 	public static function tear_down_after_class() {
 		static::$property_blocks_cache->setValue( null, static::$property_blocks_cache_orig_value );
 		static::$property_core->setValue( null, static::$property_core_orig_value );
+		static::$property_resolved_theme_uris_cache->setValue( null, static::$property_resolved_theme_uris_cache_orig_value );
 		parent::tear_down_after_class();
 	}
 
@@ -1322,11 +1341,13 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that them uris are resolved and bundled with other metadata in an array.
+	 * Tests that them uris are resolved and bundled with other metadata in an array
+	 * and cached.
 	 *
 	 * @covers WP_Theme_JSON_Resolver::get_resolved_theme_uris
 	 * @ticket 61273
 	 * @ticket 61588
+	 * @ticket 62261
 	 */
 	public function test_get_resolved_theme_uris() {
 		$theme_json = new WP_Theme_JSON(
@@ -1381,7 +1402,13 @@ class Tests_Theme_wpThemeJsonResolver extends WP_UnitTestCase {
 
 		$actual = WP_Theme_JSON_Resolver::get_resolved_theme_uris( $theme_json );
 
-		$this->assertSame( $expected_data, $actual );
+		$this->assertSame( $expected_data, $actual, 'Resolved theme uris do not match.' );
+
+		// Test that resolved theme uris are cached.
+		$current_stylesheet_directory = get_stylesheet_directory();
+		$expected_cache_data          = array( "$current_stylesheet_directory" => $actual );
+
+		$this->assertSame( $expected_cache_data, static::$property_resolved_theme_uris_cache->getValue(), 'Resolved theme uris cache data does not match.' );
 	}
 
 	/**


### PR DESCRIPTION
Syncing https://github.com/WordPress/gutenberg/pull/66155

Trac ticket: https://core.trac.wordpress.org/ticket/62261



<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Implement "pretty basic caching" for resolved theme URIs in `WP_Theme_JSON_Resolver::get_resolved_theme_uris`.



## Why?

The intention to improve performance, even if slightly. 

`WP_Theme_JSON_Resolver::get_resolved_theme_uris`, and `WP_Theme_JSON_Resolver::resolve_theme_file_uris` which calls it, is fired multiple times in a single session to:

1. Generate styles
2. Deliver resolved URIs in a global styles controller response.

Here are some preliminary, but pretty inconclusive performance results (higher response time is worse):

| Uncached | This PR (cached) |
|--------|--------|
| <img width="400" alt="uncached" src="https://github.com/user-attachments/assets/1783cdd2-9b90-4e41-96c1-ebab9dbfe503"> | <img width="400" alt="cached" src="https://github.com/user-attachments/assets/53942b30-4e47-4d1d-8475-cf0fc7647cad"> | 


I'd expect results will become more pronounced as other relative paths are introduced, e.g., [fonts](https://github.com/WordPress/gutenberg/pull/65019), and more blocks support background images.

Cached data is not be stored persistently across page loads.

## How?

Simple object caching.

## Testing Instructions

PHP CI tests should pass.

Create a theme.json with background image paths defined for several blocks.

Ensure these appear as expected in the editor and frontend.

In the theme.json file, replace one or several paths with new asset paths. Check that the styles have been updated and the editor/frontend looks good.

Here is some test JSON based on current assets in TT5:

```json
{
	"$schema": "../../schemas/json/theme.json",
	"version": 3,
	"settings": {
		"appearanceTools": true
	},
	"styles": {
		"background": {
			"backgroundImage": {
				"url": "file:./assets/images/category-anthuriums.webp"
			}
		},
		"blocks": {
			"core/group": {
				"background": {
					"backgroundImage": {
						"url": "file:./assets/images/category-cactus.webp"
					}
				}
			},
			"core/post-content": {
				"background": {
					"backgroundImage": {
						"url": "file:./assets/images/hero-podcast.webp"
					}
				}
			},
			"core/quote": {
				"background": {
					"backgroundImage": {
						"url": "file:./assets/images/category-sunflowers.webp"
					}
				}
			},
			"core/pullquote": {
				"background": {
					"backgroundImage": {
						"url": "file:./assets/images/dallas-creek-square.webp"
					}
				}
			}
		}
	}
}

```


