### PR TITLE
Fix extensibility of WP_HTML_Processor::next_token()

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -604,6 +604,22 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	}
 
 	/**
+	 * Finds the next token in the HTML document.
+	 *
+	 * This doesn't currently have a way to represent non-tags and doesn't process
+	 * semantic rules for text nodes. For access to the raw tokens consider using
+	 * WP_HTML_Tag_Processor instead.
+	 *
+	 * @since 6.5.0 Added for internal support; do not use.
+	 * @since 6.7.0 Refactored so subclasses may extend.
+	 *
+	 * @return bool Whether a token was parsed.
+	 */
+	public function next_token(): bool {
+		return $this->_next_token();
+	}
+
+	/**
 	 * Ensures internal accounting is maintained for HTML semantic rules while
 	 * the underlying Tag Processor class is seeking to a bookmark.
 	 *
@@ -611,13 +627,13 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * semantic rules for text nodes. For access to the raw tokens consider using
 	 * WP_HTML_Tag_Processor instead.
 	 *
-	 * @since 6.5.0 Added for internal support; do not use.
+	 * @since 6.7.0 Added for internal support; do not use.
 	 *
 	 * @access private
 	 *
 	 * @return bool
 	 */
-	public function next_token(): bool {
+	private function _next_token(): bool {
 		$this->current_element = null;
 
 		if ( isset( $this->last_error ) ) {
@@ -635,7 +651,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		 *       tokens works in the meantime and isn't obviously wrong.
 		 */
 		if ( empty( $this->element_queue ) && $this->step() ) {
-			return $this->next_token();
+			return $this->_next_token();
 		}
 
 		// Process the next event on the queue.
@@ -646,7 +662,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				continue;
 			}
 
-			return empty( $this->element_queue ) ? false : $this->next_token();
+			return empty( $this->element_queue ) ? false : $this->_next_token();
 		}
 
 		$is_pop = WP_HTML_Stack_Event::POP === $this->current_element->operation;
@@ -657,7 +673,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		 * the breadcrumbs.
 		 */
 		if ( 'root-node' === $this->current_element->token->bookmark_name ) {
-			return $this->next_token();
+			return $this->_next_token();
 		}
 
 		// Adjust the breadcrumbs for this event.
@@ -669,7 +685,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 
 		// Avoid sending close events for elements which don't expect a closing.
 		if ( $is_pop && ! $this->expects_closer( $this->current_element->token ) ) {
-			return $this->next_token();
+			return $this->_next_token();
 		}
 
 		return true;

--- a/tests/phpunit/data/html-api/html-xpath-generating-processor.php
+++ b/tests/phpunit/data/html-api/html-xpath-generating-processor.php
@@ -1,0 +1,88 @@
+<?php
+
+class HTML_XPath_Generating_Processor extends WP_HTML_Processor {
+
+	/**
+	 * List of tokens that have already been seen.
+	 *
+	 * @var array<string, int>
+	 */
+	public $token_seen_count = array();
+
+	/**
+	 * Previous depth.
+	 *
+	 * @var int
+	 */
+	private $previous_depth = 0;
+
+	/**
+	 * Open stack indices.
+	 *
+	 * @since n.e.x.t
+	 * @var array<int, array{tag_name: string, index: int}>
+	 */
+	private $open_stack_indices = array();
+
+	/**
+	 * Gets XPath for the current open tag.
+	 *
+	 * @return string XPath.
+	 */
+	public function get_xpath(): string {
+		$xpath = '';
+		foreach ( $this->open_stack_indices as $level ) {
+			$xpath .= sprintf( '/*[%d][self::%s]', $level['index'] + 1, $level['tag_name'] );
+		}
+		return $xpath;
+	}
+
+	/**
+	 * Gets next token.
+	 *
+	 * @return bool Whether next token was matched.
+	 */
+	public function next_token(): bool {
+		$result        = parent::next_token();
+		$current_depth = $this->get_current_depth();
+		$current_tag   = $this->get_tag();
+
+		$current_depth--; // Because HTML starts at depth 1.
+
+		if ( $this->get_token_type() === '#tag' ) {
+			$token_name = ( $this->is_tag_closer() ? '-' : '+' ) . $current_tag;
+		} else {
+			$token_name = $this->get_token_name();
+		}
+
+		if ( ! isset( $this->token_seen_count[ $token_name ] ) ) {
+			$this->token_seen_count[ $token_name ] = 1;
+		} else {
+			++$this->token_seen_count[ $token_name ];
+		}
+
+		if ( $this->get_token_type() === '#tag' && ! $this->is_tag_closer() ) {
+			if ( $current_depth < $this->previous_depth ) {
+				array_splice(
+					$this->open_stack_indices,
+					$current_depth + 1
+				);
+			}
+
+			if ( ! isset( $this->open_stack_indices[ $current_depth ] ) ) {
+				$this->open_stack_indices[ $current_depth ] = array(
+					'tag_name' => $current_tag,
+					'index'    => 0,
+				);
+			} else {
+				$this->open_stack_indices[ $current_depth ]['tag_name'] = $current_tag;
+				++$this->open_stack_indices[ $current_depth ]['index'];
+			}
+
+			$this->previous_depth = $current_depth;
+		}
+
+		return $result;
+	}
+
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Trac ticket: https://core.trac.wordpress.org/ticket/62269

# Commit Message

HTML API: Fix extensibility of `WP_HTML_Processor::next_token()`.

Break out logic from the `next_token()` method into a private method which may call itself recursively. This allows for subclasses to override the `next_token()` method and be assured that each call to `next_token()` corresponds with the consumption of one single token. This also parallels how `WP_HTML_Tag_Processor::next_token()` wraps a private `base_class_next_token()` method.

Props westonruter, jonsurrell.
Fixes #62269.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
