### PR TITLE
Fix for trim deprecation warning in class-wp-user.php

### DIFF
--- a/src/wp-includes/class-wp-user.php
+++ b/src/wp-includes/class-wp-user.php
@@ -203,6 +203,10 @@ class WP_User {
 			$field = 'id';
 		}
 
+		if ( ! $value ) {
+			return false;
+		}
+
 		if ( 'id' === $field ) {
 			// Make sure the value is numeric to avoid casting objects, for example, to int 1.
 			if ( ! is_numeric( $value ) ) {
@@ -214,10 +218,6 @@ class WP_User {
 			}
 		} else {
 			$value = trim( $value );
-		}
-
-		if ( ! $value ) {
-			return false;
 		}
 
 		switch ( $field ) {


### PR DESCRIPTION
Moved the `null` check above the usage of `$value`, as this could be `null`. If the `$value` is `null`, a deprecation warning will be thrown for the `trim()` function.

Trac ticket: [https://core.trac.wordpress.org/ticket/62276](https://core.trac.wordpress.org/ticket/62276)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
