### PR TITLE
HTML API: Allow bookmarks to be set on body close tag'

### DIFF
--- a/tests/phpunit/tests/html-api/wpHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor.php
@@ -882,4 +882,21 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 		$this->assertSame( 'FORM', $processor->get_tag() );
 		$this->assertTrue( $processor->is_tag_closer() );
 	}
+
+	/**
+	 * Ensures that the processor reaches the </body> tag and can set a bookmark.
+	 *
+	 * @ticket 62270
+	 */
+	public function test_ensure_body_close_tag_is_bookmarkable() {
+		$processor = WP_HTML_Processor::create_full_parser( '<!DOCTYPE html><body></body>' );
+
+		// Advance to </body>.
+		$processor->next_tag( 'BODY' );
+		$processor->next_token();
+
+		$this->assertSame( 'BODY', $processor->get_tag() );
+		$this->assertTrue( $processor->is_tag_closer() );
+		$this->assertTrue( $processor->set_bookmark( 'body tag' ) );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/62270

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
