### PR TITLE
fix PHP notice "Trying to access array offset on null"

### DIFF
--- a/src/wp-admin/includes/menu.php
+++ b/src/wp-admin/includes/menu.php
@@ -282,6 +282,8 @@ uksort( $menu, 'strnatcasecmp' ); // Make it all pretty.
  * @param bool $custom Whether custom ordering is enabled. Default false.
  */
 if ( apply_filters( 'custom_menu_order', false ) ) {
+	// This might not be in global context, if it's called from outside of global context or with eval().
+	global $menu_order, $default_menu_order;
 	$menu_order = array();
 
 	foreach ( $menu as $menu_item ) {


### PR DESCRIPTION
Fix PHP notice "Trying to access array offset on null" when doing a wp-admin request with CLI since we are in eval() and the variables are therefore not in global context

Trac ticket: https://core.trac.wordpress.org/ticket/62286

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
