### PR TITLE
Fix: Update `force_ssl_admin` to always return bool

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6239,15 +6239,16 @@ function validate_file( $file, $allowed_files = array() ) {
  *
  * @since 2.6.0
  *
- * @param string|bool $force Optional. Whether to force SSL in admin screens. Default null.
+ * @param string|bool|null $force Optional. Whether to force SSL in admin screens. Default null.
  * @return bool True if forced, false if not forced.
  */
 function force_ssl_admin( $force = null ) {
 	static $forced = false;
 
 	if ( ! is_null( $force ) ) {
+		// Check if $force is a boolean, typecast to boolean if it's not.
 		$old_forced = $forced;
-		$forced     = $force;
+		$forced     = (bool) $force; // Always cast to boolean.
 		return $old_forced;
 	}
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6246,9 +6246,8 @@ function force_ssl_admin( $force = null ) {
 	static $forced = false;
 
 	if ( ! is_null( $force ) ) {
-		// Check if $force is a boolean, typecast to boolean if it's not.
 		$old_forced = $forced;
-		$forced     = (bool) $force; // Always cast to boolean.
+		$forced     = (bool) $force;
 		return $old_forced;
 	}
 

--- a/tests/phpunit/tests/functions/forceSslAdmin.php
+++ b/tests/phpunit/tests/functions/forceSslAdmin.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Test cases for the `force_ssl_admin()` function.
+ *
+ * @package WordPress\UnitTests
+ *
+ * @since 6.8.0
+ *
+ * @group functions
+ *
+ * @covers ::force_ssl_admin
+ */
+class Tests_Functions_ForceSslAdmin extends WP_UnitTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+		// Reset the static variable before each test
+		force_ssl_admin( false );
+	}
+
+	/**
+	 * Data provider for testing force_ssl_admin.
+	 *
+	 * Provides various inputs and expected outcomes for the function.
+	 *
+	 * @return array[]
+	 */
+	public function data_should_return_expected_value_when_various_inputs_are_passed() {
+		return array(
+			'default'                     => array( null, false, false ),
+			'first_call_true'             => array( true, false, true ),
+			'first_call_false'            => array( false, false, false ),
+			'first_call_non_empty_string' => array( 'some string', false, true ),
+			'empty_string'                => array( '', false, false ),
+			'first_call_integer_1'        => array( 1, false, true ),
+			'integer_0'                   => array( 0, false, false ),
+		);
+	}
+
+	/**
+	 * Tests that force_ssl_admin returns expected values based on various inputs.
+	 *
+	 * @dataProvider data_should_return_expected_value_when_various_inputs_are_passed
+	 *
+	 * @param mixed $input                 The input value to test.
+	 * @param bool $expectedFirstCall      The expected result for the first call.
+	 * @param bool $expectedSubsequentCall The expected result for subsequent calls.
+	 */
+	public function test_should_return_expected_value_when_various_inputs_are_passed( $input, $expectedFirstCall, $expectedSubsequentCall ) {
+		$this->assertSame( $expectedFirstCall, force_ssl_admin( $input ), 'First call did not return expected value' );
+
+		// Call again to check subsequent behavior
+		$this->assertSame( $expectedSubsequentCall, force_ssl_admin( $input ), 'Subsequent call did not return expected value' );
+	}
+}

--- a/tests/phpunit/tests/functions/forceSslAdmin.php
+++ b/tests/phpunit/tests/functions/forceSslAdmin.php
@@ -42,14 +42,14 @@ class Tests_Functions_ForceSslAdmin extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_should_return_expected_value_when_various_inputs_are_passed
 	 *
-	 * @param mixed $input                 The input value to test.
-	 * @param bool $expectedFirstCall      The expected result for the first call.
-	 * @param bool $expectedSubsequentCall The expected result for subsequent calls.
+	 * @param mixed $input                   The input value to test.
+	 * @param bool $expected_first_call      The expected result for the first call.
+	 * @param bool $expected_subsequent_call The expected result for subsequent calls.
 	 */
-	public function test_should_return_expected_value_when_various_inputs_are_passed( $input, $expectedFirstCall, $expectedSubsequentCall ) {
-		$this->assertSame( $expectedFirstCall, force_ssl_admin( $input ), 'First call did not return expected value' );
+	public function test_should_return_expected_value_when_various_inputs_are_passed( $input, $expected_first_call, $expected_subsequent_call ) {
+		$this->assertSame( $expected_first_call, force_ssl_admin( $input ), 'First call did not return expected value' );
 
 		// Call again to check subsequent behavior
-		$this->assertSame( $expectedSubsequentCall, force_ssl_admin( $input ), 'Subsequent call did not return expected value' );
+		$this->assertSame( $expected_subsequent_call, force_ssl_admin( $input ), 'Subsequent call did not return expected value' );
 	}
 }


### PR DESCRIPTION
Trac Ticket: Core-60023

## Description

- This pull request addresses a potential issue with the force_ssl_admin function, ensuring that it always returns a boolean value, as intended by its documentation.

## Changes Made

- Modified the `force_ssl_admin` function to cast the `$force` parameter to a boolean type. This guarantees that any input, whether it's a string, integer, or null, is converted to a boolean value (true or false).

- Updated the function documentation to clarify that the `$force` parameter can accept `string`|`bool`|`null`, making it clear to developers what types are acceptable.

## Reasoning 

- The original implementation allowed for non-boolean values to be passed to the function, which could lead to unexpected behavior. By explicitly casting to boolean, we ensure consistency and prevent potential bugs caused by improperly handled input.

## Impact

- This change enhances the reliability of the force_ssl_admin function, making it safer to use in various contexts without worrying about the type of input provided.

## Testing

- Confirmed that the function behaves as expected with different input types, including boolean, string, and integer values.

- Validated that the function returns the correct boolean value in all scenarios.