### PR TITLE
Fixes the warning if null is given to prepare_items_query()

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1210,7 +1210,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 * @return array Items query arguments.
 	 */
 	protected function prepare_items_query( $prepared_args = array(), $request = null ) {
-		$query_args = array();
+		$query_args    = array();
+		$prepared_args = $prepared_args ?? array();
 
 		foreach ( $prepared_args as $key => $value ) {
 			/**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -441,8 +441,10 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		 * @param array           $args    Array of arguments for WP_Query.
 		 * @param WP_REST_Request $request The REST API request.
 		 */
-		$args       = apply_filters( "rest_{$this->post_type}_query", $args, $request );
-		$args       = is_array( $args ) ? $args : array();
+		$args = apply_filters( "rest_{$this->post_type}_query", $args, $request );
+		if ( ! is_array( $args ) ) {
+			$args = array();
+		}
 		$query_args = $this->prepare_items_query( $args, $request );
 
 		$posts_query  = new WP_Query();

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1214,7 +1214,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 */
 	protected function prepare_items_query( $prepared_args = array(), $request = null ) {
 		$query_args = array();
-		if ( is_array( ! $prepared_args ) ) {
+		if ( ! is_array( $prepared_args ) ) {
 			$prepared_args = array();
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -442,6 +442,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		 * @param WP_REST_Request $request The REST API request.
 		 */
 		$args       = apply_filters( "rest_{$this->post_type}_query", $args, $request );
+		$args       = is_array( $args ) ? $args : array();
 		$query_args = $this->prepare_items_query( $args, $request );
 
 		$posts_query  = new WP_Query();

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1211,8 +1211,10 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 	 * @return array Items query arguments.
 	 */
 	protected function prepare_items_query( $prepared_args = array(), $request = null ) {
-		$query_args    = array();
-		$prepared_args = $prepared_args ?? array();
+		$query_args = array();
+		if ( is_array( ! $prepared_args ) ) {
+			$prepared_args = array();
+		}
 
 		foreach ( $prepared_args as $key => $value ) {
 			/**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -549,8 +549,10 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	 * @return array Items query arguments.
 	 */
 	protected function prepare_items_query( $prepared_args = array(), $request = null ) {
-		$query_args    = array();
-		$prepared_args = $prepared_args ?? array();
+		$query_args = array();
+		if ( is_array( ! $prepared_args ) ) {
+			$prepared_args = array();
+		}
 
 		foreach ( $prepared_args as $key => $value ) {
 			/** This filter is documented in wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php */

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -298,8 +298,10 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 			}
 
 			/** This filter is documented in wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php */
-			$args       = apply_filters( 'rest_revision_query', $args, $request );
-			$args       = is_array( $args ) ? $args : array();
+			$args = apply_filters( 'rest_revision_query', $args, $request );
+			if ( ! is_array( $args ) ) {
+				$args = array();
+			}
 			$query_args = $this->prepare_items_query( $args, $request );
 
 			$revisions_query = new WP_Query();

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -548,7 +548,8 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	 * @return array Items query arguments.
 	 */
 	protected function prepare_items_query( $prepared_args = array(), $request = null ) {
-		$query_args = array();
+		$query_args    = array();
+		$prepared_args = $prepared_args ?? array();
 
 		foreach ( $prepared_args as $key => $value ) {
 			/** This filter is documented in wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php */

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -299,6 +299,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 
 			/** This filter is documented in wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php */
 			$args       = apply_filters( 'rest_revision_query', $args, $request );
+			$args       = is_array( $args ) ? $args : array();
 			$query_args = $this->prepare_items_query( $args, $request );
 
 			$revisions_query = new WP_Query();

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -552,7 +552,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 	 */
 	protected function prepare_items_query( $prepared_args = array(), $request = null ) {
 		$query_args = array();
-		if ( is_array( ! $prepared_args ) ) {
+		if ( ! is_array( $prepared_args ) ) {
 			$prepared_args = array();
 		}
 


### PR DESCRIPTION
As discribed in the track ticket, it is possible that `prepare_items_query()` can receive a null value as `$prepared_args` which results in a warning. This fixes this issue.

Trac ticket: https://core.trac.wordpress.org/ticket/62287

AI disclosure:

AI used for commit message.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
