### PR TITLE
Detect the presence of docker-compose.override.yml files.

### DIFF
--- a/tools/local-env/scripts/utils.js
+++ b/tools/local-env/scripts/utils.js
@@ -1,3 +1,5 @@
+const { existsSync } = require( 'node:fs' );
+
 const local_env_utils = {
 
 	/**
@@ -12,6 +14,11 @@ const local_env_utils = {
 	get_compose_files: function() {
 		var composeFiles = '-f docker-compose.yml';
 
+		if ( existsSync( 'docker-compose.override.yml' ) ) {
+			composeFiles = composeFiles + ' -f docker-compose.override.yml';
+		}
+
+		console.log( composeFiles );
 		if ( process.env.LOCAL_DB_TYPE !== 'mysql' ) {
 			return composeFiles;
 		}

--- a/tools/local-env/scripts/utils.js
+++ b/tools/local-env/scripts/utils.js
@@ -18,7 +18,6 @@ const local_env_utils = {
 			composeFiles = composeFiles + ' -f docker-compose.override.yml';
 		}
 
-		console.log( composeFiles );
 		if ( process.env.LOCAL_DB_TYPE !== 'mysql' ) {
 			return composeFiles;
 		}


### PR DESCRIPTION
After the changes in [Core-59279](https://core.trac.wordpress.org/changeset/59279), Compose files are manually passed to the Docker commands. If a `docker-compose.override.yml` file is present, it won't be utilized. This attempts to detect that and include the file in the list that is passed.

Trac ticket: https://core.trac.wordpress.org/ticket/61218

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
