### PR TITLE
Utilize the reusable PHPUnit workflow for code coverage reporting.

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -36,7 +36,7 @@ jobs:
   #
   test-with-mysql:
     name: PHP ${{ matrix.php }}
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-phpunit-tests-v3.yml@trunk
+    uses: ./.github/workflows/reusable-phpunit-tests-v3.yml
     permissions:
       contents: read
     secrets: inherit
@@ -115,7 +115,7 @@ jobs:
   #
   test-with-mariadb:
     name: PHP ${{ matrix.php }}
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-phpunit-tests-v3.yml@trunk
+    uses: ./.github/workflows/reusable-phpunit-tests-v3.yml
     permissions:
       contents: read
     secrets: inherit

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -74,7 +74,7 @@ on:
 env:
   LOCAL_PHP: ${{ inputs.php }}-fpm
   LOCAL_PHP_XDEBUG: ${{ inputs.coverage-format && true || false }}
-  LOCAL_PHP_XDEBUG_MODE: ${{ inputs.coverage-format && 'coverage' || 'develop,debug' }}
+  LOCAL_PHP_XDEBUG_MODE: ${{ inputs.coverage-format && 'coverage' || false }}
   LOCAL_DB_TYPE: ${{ inputs.db-type }}
   LOCAL_DB_VERSION: ${{ inputs.db-version }}
   LOCAL_PHP_MEMCACHED: ${{ inputs.memcached }}
@@ -218,8 +218,8 @@ jobs:
         if: ${{ inputs.coverage-format == 'html' }}
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: wp-code-coverage${{ inputs.multisite && '-multisite' || 'single' }}-${{ github.sha }}
-          path: wp-code-coverage${{ inputs.multisite && '-multisite' || 'single' }}-${{ github.sha }}
+          name: wp-code-coverage${{ inputs.multisite && '-multisite' || '-single' }}-${{ github.sha }}
+          path: wp-code-coverage${{ inputs.multisite && '-multisite' || '-single' }}-${{ github.sha }}
           overwrite: true
 
       - name: Ensure version-controlled files are not modified or deleted

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -105,7 +105,7 @@ jobs:
   # - Checks out the WordPress Test reporter repository.
   # - Submit the test results to the WordPress.org host test results.
   phpunit-tests:
-    name: PHP ${{ inputs.php }} / ${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.multisite && ' multisite' || '' }}${{ inputs.phpunit-test-groups && format( ' ({0})', inputs.phpunit-test-groups ) || '' }}${{ inputs.memcached && ' with memcached' || '' }}${{ inputs.report && ' (test reporting enabled)' || '' }}${{ inputs.coverage-format && format( '({0} report)', inputs.coverage-format ) || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
+    name: PHP ${{ inputs.php }} / ${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.multisite && ' multisite' || '' }}${{ inputs.phpunit-test-groups && format( ' ({0})', inputs.phpunit-test-groups ) || '' }}${{ inputs.memcached && ' with memcached' || '' }}${{ inputs.report && ' (test reporting enabled)' || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
     runs-on: ${{ inputs.os }}
     timeout-minutes: ${{ inputs.coverage-format && 120 || 20 }}
 

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -182,7 +182,7 @@ jobs:
 
       - name: Run PHPUnit tests${{ inputs.phpunit-test-groups && format( ' ({0} groups)', inputs.phpunit-test-groups ) || '' }}${{ inputs.coverage-format && format( ' with {0} report', inputs.coverage-format ) || '' }}
         continue-on-error: ${{ inputs.allow-errors }}
-        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }}${{ inputs.phpunit-test-groups && format( ' --group {0}', inputs.phpunit-test-groups ) || '' }}${{ inputs.coverage-format && format( '--coverage-{0} wp-code-coverage-{1}-{2}{3}', inputs.coverage-format, ( inputs.multisite && 'multisite' || 'single' ), github.sha, ( inputs.coverage-format == 'clover' && '.xml' || '' ) ) }}
+        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }}${{ inputs.phpunit-test-groups && format( ' --group {0}', inputs.phpunit-test-groups ) || '' }}${{ inputs.coverage-format && format( ' --coverage-{0} wp-code-coverage-{1}-{2}{3}', inputs.coverage-format, ( inputs.multisite && 'multisite' || 'single' ), github.sha, ( inputs.coverage-format == 'clover' && '.xml' || '' ) ) }}
 
       - name: Run AJAX tests
         if: ${{ ! inputs.phpunit-test-groups && ! inputs.coverage-format }}

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -52,11 +52,11 @@ on:
         required: false
         type: 'string'
         default: 'example.org'
-      coverage-format:
-        description: 'The coverage report format to generate. Supported values are clover or html.'
+      coverage-report:
+        description: 'Whether to generate a code coverage report.'
         required: false
-        type: string
-        default: ''
+        type: boolean
+        default: false
       report:
         description: 'Whether to report results to WordPress.org Hosting Tests'
         required: false
@@ -73,8 +73,8 @@ on:
         required: false
 env:
   LOCAL_PHP: ${{ inputs.php }}-fpm
-  LOCAL_PHP_XDEBUG: ${{ inputs.coverage-format && true || false }}
-  LOCAL_PHP_XDEBUG_MODE: ${{ inputs.coverage-format && 'coverage' || 'develop,debug' }}
+  LOCAL_PHP_XDEBUG: ${{ inputs.coverage-report || false }}
+  LOCAL_PHP_XDEBUG_MODE: ${{ inputs.coverage-report && 'coverage' || 'develop,debug' }}
   LOCAL_DB_TYPE: ${{ inputs.db-type }}
   LOCAL_DB_VERSION: ${{ inputs.db-version }}
   LOCAL_PHP_MEMCACHED: ${{ inputs.memcached }}
@@ -107,7 +107,7 @@ jobs:
   phpunit-tests:
     name: PHP ${{ inputs.php }} / ${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.multisite && ' multisite' || '' }}${{ inputs.phpunit-test-groups && format( ' ({0})', inputs.phpunit-test-groups ) || '' }}${{ inputs.memcached && ' with memcached' || '' }}${{ inputs.report && ' (test reporting enabled)' || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
     runs-on: ${{ inputs.os }}
-    timeout-minutes: ${{ inputs.coverage-format && 120 || 20 }}
+    timeout-minutes: ${{ inputs.coverage-report && 120 || 20 }}
 
     steps:
       - name: Configure environment variables
@@ -180,42 +180,42 @@ jobs:
       - name: Install WordPress
         run: npm run env:install
 
-      - name: Run PHPUnit tests${{ inputs.phpunit-test-groups && format( ' ({0} groups)', inputs.phpunit-test-groups ) || '' }}${{ inputs.coverage-format && format( ' with {0} report', inputs.coverage-format ) || '' }}
+      - name: Run PHPUnit tests${{ inputs.phpunit-test-groups && format( ' ({0} groups)', inputs.phpunit-test-groups ) || '' }}${{ inputs.coverage-report && ' with coverage report' || '' }}
         continue-on-error: ${{ inputs.allow-errors }}
-        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }}${{ inputs.phpunit-test-groups && format( ' --group {0}', inputs.phpunit-test-groups ) || '' }}${{ inputs.coverage-format && format( ' --coverage-{0} wp-code-coverage-{1}-{2}{3}', inputs.coverage-format, ( inputs.multisite && 'multisite' || 'single' ), github.sha, ( inputs.coverage-format == 'clover' && '.xml' || '' ) ) }}
+        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }}${{ inputs.phpunit-test-groups && format( ' --group {0}', inputs.phpunit-test-groups ) || '' }}${{ inputs.coverage-report && format( ' --coverage-clover wp-code-coverage-{0}-{1}.xml --coverage-html wp-code-coverage-{0}-{1}', ( inputs.multisite && 'multisite' || 'single' ), github.sha ) }}
 
       - name: Run AJAX tests
-        if: ${{ ! inputs.phpunit-test-groups && ! inputs.coverage-format }}
+        if: ${{ ! inputs.phpunit-test-groups && ! inputs.coverage-report }}
         continue-on-error: ${{ inputs.allow-errors }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }} --group ajax
 
       - name: Run ms-files tests as a multisite install
-        if: ${{ inputs.multisite && ! inputs.phpunit-test-groups && ! inputs.coverage-format }}
+        if: ${{ inputs.multisite && ! inputs.phpunit-test-groups && ! inputs.coverage-report }}
         continue-on-error: ${{ inputs.allow-errors }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }} --group ms-files
 
       - name: Run external HTTP tests
-        if: ${{ ! inputs.multisite && ! inputs.phpunit-test-groups && ! inputs.coverage-format }}
+        if: ${{ ! inputs.multisite && ! inputs.phpunit-test-groups && ! inputs.coverage-report }}
         continue-on-error: ${{ inputs.allow-errors }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }} --group external-http
 
       # __fakegroup__ is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.
       - name: Run (Xdebug) tests
-        if: ${{ inputs.php != '8.4' && ! inputs.phpunit-test-groups && ! inputs.coverage-format }}
+        if: ${{ inputs.php != '8.4' && ! inputs.phpunit-test-groups && ! inputs.coverage-report }}
         continue-on-error: ${{ inputs.allow-errors }}
         run: LOCAL_PHP_XDEBUG=true node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit -v --group xdebug --exclude-group __fakegroup__
 
       - name: Upload test coverage report to Codecov
-        if: ${{ inputs.coverage-format == 'clover' }}
+        if: ${{ inputs.coverage-report }}
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: wp-code-coverage${{ inputs.multisite && '-multisite' || '-single' }}-${{ github.sha }}${{ 'clover' == inputs.coverage-format && '.xml' || '' }}
+          file: wp-code-coverage${{ inputs.multisite && '-multisite' || '-single' }}-${{ github.sha }}.xml
           flags: ${{ inputs.multisite && 'multisite' || 'single' }},php
           fail_ci_if_error: true
 
       - name: Upload HTML coverage report as artifact
-        if: ${{ inputs.coverage-format == 'html' }}
+        if: ${{ inputs.coverage-report }}
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: wp-code-coverage${{ inputs.multisite && '-multisite' || '-single' }}-${{ github.sha }}

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -67,6 +67,10 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      CODECOV_TOKEN:
+        description: 'The Codecov token required for uploading reports.'
+        required: false
 env:
   LOCAL_PHP: ${{ inputs.php }}-fpm
   LOCAL_PHP_XDEBUG: ${{ inputs.coverage-format && true || false }}
@@ -101,7 +105,7 @@ jobs:
   # - Checks out the WordPress Test reporter repository.
   # - Submit the test results to the WordPress.org host test results.
   phpunit-tests:
-    name: PHP ${{ inputs.php }} / ${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.multisite && ' multisite' || '' }}${{ inputs.phpunit-test-groups && format( ' ({0})', inputs.phpunit-test-groups ) || '' }}${{ inputs.memcached && ' with memcached' || '' }}${{ inputs.report && ' (test reporting enabled)' || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
+    name: PHP ${{ inputs.php }} / ${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.multisite && ' multisite' || '' }}${{ inputs.phpunit-test-groups && format( ' ({0})', inputs.phpunit-test-groups ) || '' }}${{ inputs.memcached && ' with memcached' || '' }}${{ inputs.report && ' (test reporting enabled)' || '' }}${{ inputs.coverage-format && format( '({0} report)' ) || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
     runs-on: ${{ inputs.os }}
     timeout-minutes: ${{ inputs.coverage-format && 120 || 20 }}
 
@@ -176,7 +180,7 @@ jobs:
       - name: Install WordPress
         run: npm run env:install
 
-      - name: Run PHPUnit tests${{ inputs.phpunit-test-groups && format( ' ({0} groups)', inputs.phpunit-test-groups ) || '' }}
+      - name: Run PHPUnit tests${{ inputs.phpunit-test-groups && format( ' ({0} groups)', inputs.phpunit-test-groups ) || '' }}${{ inputs.coverage-format && format( ' with {0} report', inputs.coverage-format ) || '' }}
         continue-on-error: ${{ inputs.allow-errors }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }}${{ inputs.phpunit-test-groups && format( ' --group {0}', inputs.phpunit-test-groups ) || '' }}
 

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -182,7 +182,7 @@ jobs:
 
       - name: Run PHPUnit tests${{ inputs.phpunit-test-groups && format( ' ({0} groups)', inputs.phpunit-test-groups ) || '' }}${{ inputs.coverage-format && format( ' with {0} report', inputs.coverage-format ) || '' }}
         continue-on-error: ${{ inputs.allow-errors }}
-        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }}${{ inputs.phpunit-test-groups && format( ' --group {0}', inputs.phpunit-test-groups ) || '' }}${{ inputs.coverage-format && format( '--coverage-{0} wp-code-coverage-{1}-{2}{3}', inputs.coverage-format, github.sha, ( inputs.coverage-format == 'clover' && '.xml' || '' ) ) }}
+        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }}${{ inputs.phpunit-test-groups && format( ' --group {0}', inputs.phpunit-test-groups ) || '' }}${{ inputs.coverage-format && format( '--coverage-{0} wp-code-coverage-{1}-{2}{3}', inputs.coverage-format, ( inputs.multisite && 'multisite' || 'single' ), github.sha, ( inputs.coverage-format == 'clover' && '.xml' || '' ) ) }}
 
       - name: Run AJAX tests
         if: ${{ ! inputs.phpunit-test-groups && ! inputs.coverage-format }}

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -182,7 +182,7 @@ jobs:
 
       - name: Run PHPUnit tests${{ inputs.phpunit-test-groups && format( ' ({0} groups)', inputs.phpunit-test-groups ) || '' }}${{ inputs.coverage-format && format( ' with {0} report', inputs.coverage-format ) || '' }}
         continue-on-error: ${{ inputs.allow-errors }}
-        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }}${{ inputs.phpunit-test-groups && format( ' --group {0}', inputs.phpunit-test-groups ) || '' }}
+        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }}${{ inputs.phpunit-test-groups && format( ' --group {0}', inputs.phpunit-test-groups ) || '' }}${{ inputs.coverage-format && format( '--coverage-{0} wp-code-coverage-{1}-{2}{3}', inputs.coverage-format, github.sha, ( inputs.coverage-format == 'clover' && '.xml' || '' ) ) }}
 
       - name: Run AJAX tests
         if: ${{ ! inputs.phpunit-test-groups && ! inputs.coverage-format }}

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -52,6 +52,11 @@ on:
         required: false
         type: 'string'
         default: 'example.org'
+      coverage-format:
+        description: 'The coverage report format to generate. Should be clover or html.'
+        required: false
+        type: string
+        default: ''
       report:
         description: 'Whether to report results to WordPress.org Hosting Tests'
         required: false
@@ -64,6 +69,8 @@ on:
         default: false
 env:
   LOCAL_PHP: ${{ inputs.php }}-fpm
+  LOCAL_PHP_XDEBUG: ${{ inputs.coverage-format && true || false }}
+  LOCAL_PHP_XDEBUG_MODE: ${{ inputs.coverage-format && 'coverage' || 'develop,debug' }}
   LOCAL_DB_TYPE: ${{ inputs.db-type }}
   LOCAL_DB_VERSION: ${{ inputs.db-version }}
   LOCAL_PHP_MEMCACHED: ${{ inputs.memcached }}
@@ -88,13 +95,15 @@ jobs:
   # - Logs debug information about what's installed within the WordPress Docker containers.
   # - Install WordPress within the Docker container.
   # - Run the PHPUnit tests.
+  # - Upload the code coverage report to Codecov.io.
+  # - Upload the HTML code coverage report as an artifact.
   # - Ensures version-controlled files are not modified or deleted.
   # - Checks out the WordPress Test reporter repository.
   # - Submit the test results to the WordPress.org host test results.
   phpunit-tests:
     name: PHP ${{ inputs.php }} / ${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.multisite && ' multisite' || '' }}${{ inputs.phpunit-test-groups && format( ' ({0})', inputs.phpunit-test-groups ) || '' }}${{ inputs.memcached && ' with memcached' || '' }}${{ inputs.report && ' (test reporting enabled)' || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
     runs-on: ${{ inputs.os }}
-    timeout-minutes: 20
+    timeout-minutes: ${{ inputs.coverage-format && 120 || 20 }}
 
     steps:
       - name: Configure environment variables
@@ -172,25 +181,42 @@ jobs:
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }}${{ inputs.phpunit-test-groups && format( ' --group {0}', inputs.phpunit-test-groups ) || '' }}
 
       - name: Run AJAX tests
-        if: ${{ ! inputs.phpunit-test-groups }}
+        if: ${{ ! inputs.phpunit-test-groups && ! inputs.coverage-format }}
         continue-on-error: ${{ inputs.allow-errors }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }} --group ajax
 
       - name: Run ms-files tests as a multisite install
-        if: ${{ inputs.multisite && ! inputs.phpunit-test-groups }}
+        if: ${{ inputs.multisite && ! inputs.phpunit-test-groups && ! inputs.coverage-format }}
         continue-on-error: ${{ inputs.allow-errors }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }} --group ms-files
 
       - name: Run external HTTP tests
-        if: ${{ ! inputs.multisite && ! inputs.phpunit-test-groups }}
+        if: ${{ ! inputs.multisite && ! inputs.phpunit-test-groups && ! inputs.coverage-format }}
         continue-on-error: ${{ inputs.allow-errors }}
         run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }} --group external-http
 
       # __fakegroup__ is excluded to force PHPUnit to ignore the <exclude> settings in phpunit.xml.dist.
       - name: Run (Xdebug) tests
-        if: ${{ inputs.php != '8.4' && ! inputs.phpunit-test-groups }}
+        if: ${{ inputs.php != '8.4' && ! inputs.phpunit-test-groups && ! inputs.coverage-format }}
         continue-on-error: ${{ inputs.allow-errors }}
         run: LOCAL_PHP_XDEBUG=true node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit -v --group xdebug --exclude-group __fakegroup__
+
+      - name: Upload site report to Codecov
+        if: ${{ inputs.coverage-format == 'clover' }}
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: wp-code-coverage${{ inputs.multisite && '-multisite' || 'single' }}-${{ github.sha }}${{ 'clover' == inputs.coverage-format && '.xml' || '' }}
+          flags: ${{ inputs.multisite && 'multisite' || 'single' }},php
+          fail_ci_if_error: true
+
+      - name: Upload HTML coverage report as artifact
+        if: ${{ inputs.coverage-format == 'html' }}
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: wp-code-coverage${{ inputs.multisite && '-multisite' || 'single' }}-${{ github.sha }}
+          path: wp-code-coverage${{ inputs.multisite && '-multisite' || 'single' }}-${{ github.sha }}
+          overwrite: true
 
       - name: Ensure version-controlled files are not modified or deleted
         run: git diff --exit-code

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -182,7 +182,7 @@ jobs:
 
       - name: Run PHPUnit tests${{ inputs.phpunit-test-groups && format( ' ({0} groups)', inputs.phpunit-test-groups ) || '' }}${{ inputs.coverage-report && ' with coverage report' || '' }}
         continue-on-error: ${{ inputs.allow-errors }}
-        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }}${{ inputs.phpunit-test-groups && format( ' --group {0}', inputs.phpunit-test-groups ) || '' }}${{ inputs.coverage-report && format( ' --coverage-clover wp-code-coverage-{0}-{1}.xml --coverage-html wp-code-coverage-{0}-{1}', ( inputs.multisite && 'multisite' || 'single' ), github.sha ) || false }}
+        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }}${{ inputs.phpunit-test-groups && format( ' --group {0}', inputs.phpunit-test-groups ) || '' }}${{ inputs.coverage-report && format( ' --coverage-clover wp-code-coverage-{0}-{1}.xml --coverage-html wp-code-coverage-{0}-{1}', ( inputs.multisite && 'multisite' || 'single' ), github.sha ) || '' }}
 
       - name: Run AJAX tests
         if: ${{ ! inputs.phpunit-test-groups && ! inputs.coverage-report }}

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -105,7 +105,7 @@ jobs:
   # - Checks out the WordPress Test reporter repository.
   # - Submit the test results to the WordPress.org host test results.
   phpunit-tests:
-    name: PHP ${{ inputs.php }} / ${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.multisite && ' multisite' || '' }}${{ inputs.phpunit-test-groups && format( ' ({0})', inputs.phpunit-test-groups ) || '' }}${{ inputs.memcached && ' with memcached' || '' }}${{ inputs.report && ' (test reporting enabled)' || '' }}${{ inputs.coverage-format && format( '({0} report)' ) || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
+    name: PHP ${{ inputs.php }} / ${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.multisite && ' multisite' || '' }}${{ inputs.phpunit-test-groups && format( ' ({0})', inputs.phpunit-test-groups ) || '' }}${{ inputs.memcached && ' with memcached' || '' }}${{ inputs.report && ' (test reporting enabled)' || '' }}${{ inputs.coverage-format && format( '({0} report)', inputs.coverage-format ) || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
     runs-on: ${{ inputs.os }}
     timeout-minutes: ${{ inputs.coverage-format && 120 || 20 }}
 

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -105,7 +105,7 @@ jobs:
   # - Checks out the WordPress Test reporter repository.
   # - Submit the test results to the WordPress.org host test results.
   phpunit-tests:
-    name: PHP ${{ inputs.php }} / ${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.multisite && ' multisite' || '' }}${{ inputs.phpunit-test-groups && format( ' ({0})', inputs.phpunit-test-groups ) || '' }}${{ inputs.memcached && ' with memcached' || '' }}${{ inputs.report && ' (test reporting enabled)' || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
+    name: PHP ${{ inputs.php }} ${{ ! inputs.coverage-report && '/ ' || '' }}${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.multisite && ' multisite' || '' }}${{ inputs.phpunit-test-groups && format( ' ({0})', inputs.phpunit-test-groups ) || '' }}${{ inputs.memcached && ' with memcached' || '' }}${{ inputs.report && ' (test reporting enabled)' || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
     runs-on: ${{ inputs.os }}
     timeout-minutes: ${{ inputs.coverage-report && 120 || 20 }}
 
@@ -182,7 +182,7 @@ jobs:
 
       - name: Run PHPUnit tests${{ inputs.phpunit-test-groups && format( ' ({0} groups)', inputs.phpunit-test-groups ) || '' }}${{ inputs.coverage-report && ' with coverage report' || '' }}
         continue-on-error: ${{ inputs.allow-errors }}
-        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }}${{ inputs.phpunit-test-groups && format( ' --group {0}', inputs.phpunit-test-groups ) || '' }}${{ inputs.coverage-report && format( ' --coverage-clover wp-code-coverage-{0}-{1}.xml --coverage-html wp-code-coverage-{0}-{1}', ( inputs.multisite && 'multisite' || 'single' ), github.sha ) }}
+        run: node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit --verbose -c ${{ env.PHPUNIT_CONFIG }}${{ inputs.phpunit-test-groups && format( ' --group {0}', inputs.phpunit-test-groups ) || '' }}${{ inputs.coverage-report && format( ' --coverage-clover wp-code-coverage-{0}-{1}.xml --coverage-html wp-code-coverage-{0}-{1}', ( inputs.multisite && 'multisite' || 'single' ), github.sha ) || false }}
 
       - name: Run AJAX tests
         if: ${{ ! inputs.phpunit-test-groups && ! inputs.coverage-report }}

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -53,7 +53,7 @@ on:
         type: 'string'
         default: 'example.org'
       coverage-format:
-        description: 'The coverage report format to generate. Should be clover or html.'
+        description: 'The coverage report format to generate. Supported values are clover or html.'
         required: false
         type: string
         default: ''
@@ -74,7 +74,7 @@ on:
 env:
   LOCAL_PHP: ${{ inputs.php }}-fpm
   LOCAL_PHP_XDEBUG: ${{ inputs.coverage-format && true || false }}
-  LOCAL_PHP_XDEBUG_MODE: ${{ inputs.coverage-format && 'coverage' || false }}
+  LOCAL_PHP_XDEBUG_MODE: ${{ inputs.coverage-format && 'coverage' || 'develop,debug' }}
   LOCAL_DB_TYPE: ${{ inputs.db-type }}
   LOCAL_DB_VERSION: ${{ inputs.db-version }}
   LOCAL_PHP_MEMCACHED: ${{ inputs.memcached }}
@@ -99,8 +99,8 @@ jobs:
   # - Logs debug information about what's installed within the WordPress Docker containers.
   # - Install WordPress within the Docker container.
   # - Run the PHPUnit tests.
-  # - Upload the code coverage report to Codecov.io.
-  # - Upload the HTML code coverage report as an artifact.
+  # - Upload the code coverage report to Codecov.io when coverage format is provided.
+  # - Upload the HTML code coverage report as an artifact when coverage format is provided.
   # - Ensures version-controlled files are not modified or deleted.
   # - Checks out the WordPress Test reporter repository.
   # - Submit the test results to the WordPress.org host test results.
@@ -205,12 +205,12 @@ jobs:
         continue-on-error: ${{ inputs.allow-errors }}
         run: LOCAL_PHP_XDEBUG=true node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit -v --group xdebug --exclude-group __fakegroup__
 
-      - name: Upload site report to Codecov
+      - name: Upload test coverage report to Codecov
         if: ${{ inputs.coverage-format == 'clover' }}
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: wp-code-coverage${{ inputs.multisite && '-multisite' || 'single' }}-${{ github.sha }}${{ 'clover' == inputs.coverage-format && '.xml' || '' }}
+          file: wp-code-coverage${{ inputs.multisite && '-multisite' || '-single' }}-${{ github.sha }}${{ 'clover' == inputs.coverage-format && '.xml' || '' }}
           flags: ${{ inputs.multisite && 'multisite' || 'single' }},php
           fail_ci_if_error: true
 

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -105,7 +105,7 @@ jobs:
   # - Checks out the WordPress Test reporter repository.
   # - Submit the test results to the WordPress.org host test results.
   phpunit-tests:
-    name: PHP ${{ inputs.php }} ${{ ! inputs.coverage-report && '/ ' || '' }}${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.multisite && ' multisite' || '' }}${{ inputs.phpunit-test-groups && format( ' ({0})', inputs.phpunit-test-groups ) || '' }}${{ inputs.memcached && ' with memcached' || '' }}${{ inputs.report && ' (test reporting enabled)' || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
+    name: PHP ${{ inputs.php }} ${{ ! inputs.coverage-report && '/ ' || 'with ' }}${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.multisite && ' multisite' || '' }}${{ inputs.phpunit-test-groups && format( ' ({0})', inputs.phpunit-test-groups ) || '' }}${{ inputs.memcached && ' with memcached' || '' }}${{ inputs.report && ' (test reporting enabled)' || '' }} ${{ 'example.org' != inputs.tests-domain && inputs.tests-domain || '' }}
     runs-on: ${{ inputs.os }}
     timeout-minutes: ${{ inputs.coverage-report && 120 || 20 }}
 

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -50,7 +50,7 @@ jobs:
         multisite: [ false, true ]
         format: [ clover, html ]
     with:
-      php: '8.3-fpm'
+      php: '8.3'
       multisite: ${{ matrix.multisite }}
       coverage-format: ${{ matrix.format }}
     secrets:

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -39,7 +39,7 @@ jobs:
   # Creates a PHPUnit test jobs for generating code coverage reports.
   #
   test-coverage-report:
-    name: ${{ matrix.multisite && 'Multisite' || 'Single site' }} report (${{ matrix.format }})
+    name: ${{ matrix.multisite && 'Multisite' || 'Single site' }} report
     uses: ./.github/workflows/reusable-phpunit-tests-v3.yml
     permissions:
       contents: read
@@ -48,11 +48,11 @@ jobs:
       fail-fast: false
       matrix:
         multisite: [ false, true ]
-        format: [ clover, html ]
+        coverage-report: [ true ]
     with:
       php: '8.3'
       multisite: ${{ matrix.multisite }}
-      coverage-format: ${{ matrix.format }}
+      coverage-report: ${{ matrix.coverage-report }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -24,6 +24,13 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
 permissions: {}

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -40,7 +40,7 @@ jobs:
   #
   test-coverage-report:
     name: ${{ matrix.multisite && 'Multisite' || 'Single site' }} report (${{ matrix.format }})
-    uses: desrosj/wordpress-develop/.github/workflows/reusable-phpunit-tests-v3.yml@use/reusable-php-for-coverage
+    uses: ./.github/workflows/reusable-phpunit-tests-v3.yml
     permissions:
       contents: read
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -35,160 +35,26 @@ env:
   PUPPETEER_SKIP_DOWNLOAD: ${{ true }}
 
 jobs:
-  # Runs the PHPUnit tests for WordPress.
   #
-  # Performs the following steps:
-  # - Sets environment variables.
-  # - Checks out the repository.
-  # - Sets up Node.js.
-  # - Sets up PHP.
-  # - Installs Composer dependencies.
-  # - Installs npm dependencies
-  # - Logs general debug information about the runner.
-  # - Logs Docker debug information (about the Docker installation within the runner).
-  # - Starts the WordPress Docker container.
-  # - Logs the running Docker containers.
-  # - Logs debug information about what's installed within the WordPress Docker containers.
-  # - Install WordPress within the Docker container.
-  # - Run the PHPUnit tests as a single site.
-  # - Ensures version-controlled files are not modified or deleted.
-  # - Upload the single site code coverage report to Codecov.io.
-  # - Run the PHPUnit tests as a multisite installation.
-  # - Ensures version-controlled files are not modified or deleted.
-  # - Upload the multisite code coverage report to Codecov.io.
+  # Creates a PHPUnit test jobs for generating code coverage reports.
+  #
   test-coverage-report:
     name: ${{ matrix.multisite && 'Multisite' || 'Single site' }} report (${{ matrix.format }})
-    runs-on: ubuntu-latest
+    uses: desrosj/wordpress-develop/.github/workflows/reusable-phpunit-tests-v3.yml@use/reusable-php-for-coverage
     permissions:
       contents: read
-    timeout-minutes: 120
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     strategy:
       fail-fast: false
       matrix:
         multisite: [ false, true ]
         format: [ clover, html ]
-
-    steps:
-      - name: Configure environment variables
-        run: |
-          echo "PHP_FPM_UID=$(id -u)" >> $GITHUB_ENV
-          echo "PHP_FPM_GID=$(id -g)" >> $GITHUB_ENV
-
-      - name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
-
-      - name: Set up Node.js
-        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
-        with:
-          node-version-file: '.nvmrc'
-          cache: npm
-
-      ##
-      # This allows Composer dependencies to be installed using a single step.
-      #
-      # Since the tests are currently run within the Docker containers where the PHP version varies,
-      # the same PHP version needs to be configured for the action runner machine so that the correct
-      # dependency versions are installed and cached.
-      ##
-      - name: Set up PHP
-        uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # v2.31.1
-        with:
-          php-version: '7.4'
-          coverage: none
-
-      # Since Composer dependencies are installed using `composer update` and no lock file is in version control,
-      # passing a custom cache suffix ensures that the cache is flushed at least once per week.
-      - name: Install Composer dependencies
-        uses: ramsey/composer-install@57532f8be5bda426838819c5ee9afb8af389d51a # v3.0.0
-        with:
-          custom-cache-suffix: $(/bin/date -u --date='last Mon' "+%F")
-
-      - name: Install npm Dependencies
-        run: npm ci
-
-      - name: Log debug information
-        run: |
-          echo "$GITHUB_REF"
-          echo "$GITHUB_EVENT_NAME"
-          npm --version
-          node --version
-          curl --version
-          git --version
-          composer --version
-          locale -a
-
-      - name: Docker debug information
-        run: |
-          docker -v
-
-      - name: Start Docker environment
-        run: |
-          npm run env:start
-
-      - name: Log running Docker containers
-        run: docker ps -a
-
-      - name: WordPress Docker container debug information
-        run: |
-          docker compose run --rm mysql mysql --version
-          docker compose run --rm php php --version
-          docker compose run --rm php php -m
-          docker compose run --rm php php -i
-          docker compose run --rm php locale -a
-
-      - name: Install WordPress
-        run: npm run env:install
-
-      - name: Run tests as a single site
-        if: ${{ ! matrix.multisite }}
-        run: npm run test:php -- --verbose -c phpunit.xml.dist --coverage-${{ 'html' == matrix.format && 'html' || 'clover' }} wp-code-coverage-single-${{ github.sha }}${{ 'clover' == matrix.format && '.xml' || '' }}
-
-      - name: Ensure version-controlled files are not modified during the tests
-        run: git diff --exit-code
-
-      - name: Upload single site report to Codecov
-        if: ${{ ! matrix.multisite && matrix.format == 'clover' && github.event_name != 'pull_request' }}
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: wp-code-coverage-single-${{ github.sha }}${{ 'clover' == matrix.format && '.xml' || '' }}
-          flags: single,php
-          fail_ci_if_error: true
-
-      - name: Upload single site HTML report as artifact
-        if: ${{ ! matrix.multisite && matrix.format == 'html' }}
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        with:
-          name: wp-code-coverage-single-${{ github.sha }}
-          path: wp-code-coverage-single-${{ github.sha }}
-          overwrite: true
-
-      - name: Run tests as a multisite install
-        if: ${{ matrix.multisite }}
-        run: npm run test:php -- --verbose -c tests/phpunit/multisite.xml --coverage-${{ 'html' == matrix.format && 'html' || 'clover' }} wp-code-coverage-multisite-${{ github.sha }}${{ 'clover' == matrix.format && '.xml' || '' }}
-
-      - name: Ensure version-controlled files are not modified during the tests
-        run: git diff --exit-code
-
-      - name: Upload multisite report to Codecov
-        if: ${{ matrix.multisite && matrix.format == 'clover' && github.event_name != 'pull_request' }}
-        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: wp-code-coverage-multisite-${{ github.sha }}${{ 'clover' == matrix.format && '.xml' || '' }}
-          flags: multisite,php
-          fail_ci_if_error: true
-
-      - name: Upload multisite HTML report as artifact
-        if: ${{ matrix.multisite && matrix.format == 'html' }}
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
-        with:
-          name: wp-code-coverage-multisite-${{ github.sha }}
-          path: wp-code-coverage-multisite-${{ github.sha }}
-          overwrite: true
+    with:
+      php: '8.3-fpm'
+      multisite: ${{ matrix.multisite }}
+      coverage-format: ${{ matrix.format }}
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   slack-notifications:
     name: Slack Notifications


### PR DESCRIPTION
The workflow responsible for generating code coverage reports and submitting them to Codecov.io ([coverage analysis page](https://app.codecov.io/gh/WordPress/wordpress-develop/)) has a few shortcomings. Mainly, the logic for setting up and running PHPUnit tests is duplicated making more work for maintaining.

The workflow should be updated to make use of the reusable-phpunit-tests-v#.yml reusable workflow file.

Other improvements that can be made:

- There is currently no concurrency configured for this workflow. This prevents multiple workflows for the same change from being run at the same time. For PRs, only the newest one should run, and there should only ever be one running at a time for a specific commit.
- The workflow currently runs 4 different jobs to generate two report formats each for multisite and single site. PHPUnit supports generating multiple reports at the same time. The number of jobs can be cut in half.
- The workflow only runs for PRs when related files are changed. But when it runs, the report is not submitted to Codecov.io. This is supported and should be done as a way to fully test the workflow.

Trac ticket: https://core.trac.wordpress.org/ticket/62296

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
