### PR TITLE
Fix: Update the documentation of `wp_get_active_and_valid_plugins()`

### DIFF
--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -979,7 +979,9 @@ function wp_get_mu_plugins() {
  * @since 3.0.0
  * @access private
  *
- * @return string[] Array of paths to plugin files relative to the plugins directory.
+ * @return string[] Array of absolute paths to plugin files.
+ *                  Each path is an absolute path to the plugin file,
+ *                  not relative to the plugins directory.
  */
 function wp_get_active_and_valid_plugins() {
 	$plugins        = array();


### PR DESCRIPTION
Trac Ticket: Core-49599

## Overview

- This pull request aims to improve the documentation for the wp_get_active_and_valid_plugins() function in wp-includes/load.php. The current documentation incorrectly states that the function returns paths to plugin files "relative to the plugins directory." This wording can lead to confusion, as the function actually returns absolute paths to the active plugin files.

## Changes Made

- Updated the @return annotation in the function's documentation to clarify that it returns an array of absolute paths to plugin files.

- Added a note explicitly stating that these paths are not relative to the plugins directory.

## Rationale

- Providing accurate documentation is crucial for developers using the WordPress API. By clearly indicating that the paths returned by this function are absolute, we can help prevent potential confusion and errors when developers attempt to work with plugin paths. This change aligns with the actual functionality of the method and enhances the overall clarity of the API documentation.

## Impact

- This change is purely a documentation update and will not affect existing functionality or backward compatibility. It aims to provide clearer guidance to developers, thereby improving their experience when working with WordPress plugins.