### PR TITLE
Improve Doc comment for profile screen action hook.

### DIFF
--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -871,7 +871,7 @@ switch ( $action ) {
 					<?php
 					if ( IS_PROFILE_PAGE ) {
 						/**
-						 * Fires after the 'About Yourself' settings table on the 'Profile' editing screen.
+						 * Fires after the 'Application Passwords' section is loaded on the 'Profile' editing screen.
 						 *
 						 * The action only fires if the current user is editing their own profile.
 						 *
@@ -882,7 +882,9 @@ switch ( $action ) {
 						do_action( 'show_user_profile', $profile_user );
 					} else {
 						/**
-						 * Fires after the 'About the User' settings table on the 'Edit User' screen.
+						 * Fires after the 'Application Passwords' section is loaded on the 'Profile' editing screen.
+						 * 
+						 * The action only fires if the current user is editing another user's profile.
 						 *
 						 * @since 2.0.0
 						 *

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -882,7 +882,7 @@ switch ( $action ) {
 						do_action( 'show_user_profile', $profile_user );
 					} else {
 						/**
-						 * Fires after the 'Application Passwords' section is loaded on the 'Profile' editing screen.
+						 * Fires after the 'Application Passwords' section is loaded on 'Edit User' screen.
 						 *
 						 * The action only fires if the current user is editing another user's profile.
 						 *

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -883,7 +883,7 @@ switch ( $action ) {
 					} else {
 						/**
 						 * Fires after the 'Application Passwords' section is loaded on the 'Profile' editing screen.
-						 * 
+						 *
 						 * The action only fires if the current user is editing another user's profile.
 						 *
 						 * @since 2.0.0


### PR DESCRIPTION
This PR changes document description for `show_user_profile` & `edit_user_profile`  action hooks on profile screen. 
These both hooks fire after application Passwords Section is loaded and not after About Yourself table.

It goes this way 
About Yourself Table -> Account Management -> Application Password Section -> `show_user_profile` OR `edit_user_profile` action hook

Trac ticket: https://core.trac.wordpress.org/ticket/62062

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket.
