### PR TITLE
Fixes possible Warning: Undefined array key "height" in wp_get_missing_image_subsizes()

### DIFF
--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -107,8 +107,8 @@ function wp_get_missing_image_subsizes( $attachment_id ) {
 		$full_width  = $imagesize[0];
 		$full_height = $imagesize[1];
 	} else {
-		$full_width  = (int) $image_meta['width'];
-		$full_height = (int) $image_meta['height'];
+		$full_width  = isset( $image_meta['width'] ) ? (int) $image_meta['width'] : 0;
+		$full_height = isset( $image_meta['height'] ) ? (int) $image_meta['height'] : 0;
 	}
 
 	$possible_sizes = array();


### PR DESCRIPTION
Added a check if `$image_meta['width']` and `$image_meta['height']` are set, similar to other places in WordPress Core.

While this is rare case, it popped up in my sentry issues.

Trac ticket: https://core.trac.wordpress.org/ticket/57813

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
