### PR TITLE
feature: Add filter to short-circuit `get_edit_user_link`

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1739,6 +1739,25 @@ function edit_bookmark_link( $link = '', $before = '', $after = '', $bookmark = 
  * @return string URL to edit user page or empty string.
  */
 function get_edit_user_link( $user_id = null ) {
+
+	/**
+	 * Short-circuits the retrieval of the user edit link.
+	 *
+	 * Returning a non-empty string from this filter will effectively short-circuit
+	 * the function, returning the passed value instead of continuing with the
+	 * standard link generation process.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @param string|null $link    The edit link. Default is an empty string.
+	 * @param int        $user_id  User ID.
+	 */
+	$link = apply_filters( 'pre_get_edit_user_link', '', $user_id );
+
+	if ( ! empty( $link ) ) {
+		return $link;
+	}
+
 	if ( ! $user_id ) {
 		$user_id = get_current_user_id();
 	}


### PR DESCRIPTION
Trac Ticket: Core-53405

## Description

- This pull request introduces a mechanism for short-circuiting the get_edit_user_link function in order to improve performance, especially in multisite environments. The implementation allows for early exits from the function when certain conditions are met, minimizing unnecessary processing and memory usage.

## Changes Made

- Added a `filter pre_get_edit_user_link` to allow early return of a custom edit link.

- Refactored the function to check the filter result at the beginning, enabling short-circuit behavior before any resource-intensive operations are performed.

- Updated the function documentation to include the new filter, providing clarity on its usage and purpose.

## Benefits

- Performance Improvement
    - Reduces overhead in scenarios where the edit user link can be determined early, preventing heavy operations in multisite setups.

- Enhanced Flexibility

    - Allows developers to customize the edit user link easily via the new filter without modifying core logic.