### PR TITLE
update default parameter of `retrieve_password()` for PHP8 compatibility

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -3106,7 +3106,7 @@ function check_password_reset_key( $key, $login ) {
  *                           Defaults to `$_POST['user_login']` if not set.
  * @return true|WP_Error True when finished, WP_Error object on error.
  */
-function retrieve_password( $user_login = null ) {
+function retrieve_password( $user_login = '' ) {
 	$errors    = new WP_Error();
 	$user_data = false;
 


### PR DESCRIPTION
Quick PR to update `retrieve_password()` for PHP8 compatibility. The parameter default should be`''` as line 3118 will throw a PHP Deprecation for passing `null` to `trim()`.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here --> https://core.trac.wordpress.org/ticket/62298

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
