### PR TITLE
Add test coverage command and update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ wp-tests-config.php
 
 # Visual regression test diffs
 tests/visual-regression/specs/__snapshots__
+
+# phpUnit coverage reports target nad cache
+/coverage

--- a/.gitignore
+++ b/.gitignore
@@ -106,4 +106,3 @@ wp-tests-config.php
 
 # Visual regression test diffs
 tests/visual-regression/specs/__snapshots__
-

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ wp-tests-config.php
 /packagehash.txt
 /artifacts
 /setup.log
+/coverage
 
 # Files and folders that get created in wp-content
 /src/wp-content/blogs.dir
@@ -106,5 +107,3 @@ wp-tests-config.php
 # Visual regression test diffs
 tests/visual-regression/specs/__snapshots__
 
-# phpUnit coverage reports target nad cache
-/coverage

--- a/README.md
+++ b/README.md
@@ -95,22 +95,18 @@ npm run test:php -- --group <group name or ticket number>
 ```
 
 #### Generating a code coverage report
-Code coverage reports are [generated daily](https://github.com/WordPress/wordpress-develop/actions/workflows/test-coverage.yml) and [submitted to Codecov.io](https://app.codecov.io/gh/WordPress/wordpress-develop).
+PHP code coverage reports are [generated daily](https://github.com/WordPress/wordpress-develop/actions/workflows/test-coverage.yml) and [submitted to Codecov.io](https://app.codecov.io/gh/WordPress/wordpress-develop).
 
-These command run to create HTML coverage report:
+After the local Docker environment has [been installed and started](#to-start-the-development-environment-for-the-first-time), the following command can be used to generate a code coverage report. 
 
 ```
 npm run test:coverage
 ```
-Notes:
 
-This slows the tests down it can take an hour for the report to be created
+The command will generate three coverage reports in HTML, PHP, and text formats, saving them in the `coverage` folder.
 
-You can pass options call, but you need to use 2 -- in the call. But only the tests run will show as covered. This be good to see if you have all the paths in function/class covered 
+**Note:** xDebug is required to generate a code coverage report, which can slow down PHPUnit significantly. Passing selection-based options such as `--group` or `--filter` can decrease the overall time required but will result in an incomplete report.
 
-```
- npm run test:coverage -- -- --filter Tests_Formatting_BalanceTags
-```
 #### To restart the development environment
 
 You may want to restart the environment if you've made changes to the configuration in the `docker-compose.yml` or `.env` files. Restart the environment with:

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ An online version can be found at https://app.codecov.io/gh/WordPress/wordpress-
 These command run to create HTML coverage report:
 
 ```
-npm run test:test-coverage
+npm run test:coverage
 ```
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ npm run test:php -- --group <group name or ticket number>
 ```
 
 #### Generating a code coverage report
-An online version can be found at https://app.codecov.io/gh/WordPress/wordpress-develop
+Code coverage reports are [generated daily](https://github.com/WordPress/wordpress-develop/actions/workflows/test-coverage.yml) and [submitted to Codecov.io](https://app.codecov.io/gh/WordPress/wordpress-develop).
 
 These command run to create HTML coverage report:
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ This slows the tests down it can take an hour for the report to be created
 You can pass options call, but you need to use 2 -- in the call. But only the tests run will show as covered. This be good to see if you have all the paths in function/class covered 
 
 ```
- npm run test:test-coverage -- -- --filter Tests_Formatting_BalanceTags
+ npm run test:coverage -- -- --filter Tests_Formatting_BalanceTags
 ```
 #### To restart the development environment
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ npm run test:php -- --filter <test name>
 npm run test:php -- --group <group name or ticket number>
 ```
 
-#### To run the coverage report
+#### Generating a code coverage report
 An online version can be found at https://app.codecov.io/gh/WordPress/wordpress-develop
 
 These command run to create HTML coverage report:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,23 @@ npm run test:php -- --filter <test name>
 npm run test:php -- --group <group name or ticket number>
 ```
 
+#### To run the coverage report
+An online version can be found at https://app.codecov.io/gh/WordPress/wordpress-develop
+
+These command run to create HTML coverage report:
+
+```
+npm run test:test-coverage
+```
+Notes:
+
+This slows the tests down it can take an hour for the report to be created
+
+You can pass options call, but you need to use 2 -- in the call. But only the tests run will show as covered. This be good to see if you have all the paths in function/class covered 
+
+```
+ npm run test:test-coverage -- -- --filter Tests_Formatting_BalanceTags
+```
 #### To restart the development environment
 
 You may want to restart the environment if you've made changes to the configuration in the `docker-compose.yml` or `.env` files. Restart the environment with:

--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
 		"env:pull": "node ./tools/local-env/scripts/docker.js pull",
 		"test:performance": "wp-scripts test-playwright --config tests/performance/playwright.config.js",
 		"test:php": "node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit",
+		"test:test-coverage": "npm run test:php -- --coverage-html ./coverage",
 		"test:e2e": "wp-scripts test-playwright --config tests/e2e/playwright.config.js",
 		"test:visual": "wp-scripts test-playwright --config tests/visual-regression/playwright.config.js",
 		"sync-gutenberg-packages": "grunt sync-gutenberg-packages",

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
 		"env:pull": "node ./tools/local-env/scripts/docker.js pull",
 		"test:performance": "wp-scripts test-playwright --config tests/performance/playwright.config.js",
 		"test:php": "node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit",
-		"test:test-coverage": "npm run test:php -- --coverage-html ./coverage",
+		"test:coverage": "npm run test:php -- --coverage-html ./coverage/html/ --coverage-php ./coverage/php/report.php --coverage-text ./coverage/text/report.txt",
 		"test:e2e": "wp-scripts test-playwright --config tests/e2e/playwright.config.js",
 		"test:visual": "wp-scripts test-playwright --config tests/visual-regression/playwright.config.js",
 		"sync-gutenberg-packages": "grunt sync-gutenberg-packages",

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
 		"env:pull": "node ./tools/local-env/scripts/docker.js pull",
 		"test:performance": "wp-scripts test-playwright --config tests/performance/playwright.config.js",
 		"test:php": "node ./tools/local-env/scripts/docker.js run php ./vendor/bin/phpunit",
-		"test:coverage": "npm run test:php -- --coverage-html ./coverage/html/ --coverage-php ./coverage/php/report.php --coverage-text ./coverage/text/report.txt",
+		"test:coverage": "npm run test:php -- --coverage-html ./coverage/html/ --coverage-php ./coverage/php/report.php --coverage-text=./coverage/text/report.txt",
 		"test:e2e": "wp-scripts test-playwright --config tests/e2e/playwright.config.js",
 		"test:visual": "wp-scripts test-playwright --config tests/visual-regression/playwright.config.js",
 		"sync-gutenberg-packages": "grunt sync-gutenberg-packages",

--- a/tools/local-env/scripts/docker.js
+++ b/tools/local-env/scripts/docker.js
@@ -7,5 +7,10 @@ dotenvExpand.expand( dotenv.config() );
 
 const composeFiles = local_env_utils.get_compose_files();
 
+if (process.argv.includes('--coverage-html')) {
+	process.env.LOCAL_PHP_XDEBUG = 'true';
+	process.env.LOCAL_PHP_XDEBUG_MODE = process.env.LOCAL_PHP_XDEBUG_MODE + ',coverage';
+}
+
 // Execute any docker compose command passed to this script.
 execSync( 'docker compose ' + composeFiles + ' ' + process.argv.slice( 2 ).join( ' ' ), { stdio: 'inherit' } );

--- a/tools/local-env/scripts/docker.js
+++ b/tools/local-env/scripts/docker.js
@@ -9,7 +9,7 @@ const composeFiles = local_env_utils.get_compose_files();
 
 if (process.argv.includes('--coverage-html')) {
 	process.env.LOCAL_PHP_XDEBUG = 'true';
-	process.env.LOCAL_PHP_XDEBUG_MODE = process.env.LOCAL_PHP_XDEBUG_MODE + ',coverage';
+	process.env.LOCAL_PHP_XDEBUG_MODE = 'coverage';
 }
 
 // Execute any docker compose command passed to this script.


### PR DESCRIPTION
Introduced a new `npm run test:test-coverage` command for generating HTML test coverage reports. Updated README to reflect the new command and usage, and modified `.gitignore` to exclude coverage report files.


Trac ticket: https://core.trac.wordpress.org/ticket/53414