### PR TITLE
Change host to one we can trust on not being resolvable

### DIFF
--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -535,7 +535,7 @@ function send_origin_headers() {
  * - ftp://example.com/caniload.php - Invalid protocol - only http and https are allowed.
  * - http:///example.com/caniload.php - Malformed URL.
  * - http://user:pass@example.com/caniload.php - Login information.
- * - http://exampleeeee.com/caniload.php - Invalid hostname, as the IP cannot be looked up in DNS.
+ * - http://notworking.example.com/caniload.php - Invalid hostname, as the IP cannot be looked up in DNS.
  *
  * Examples of URLs that are considered unsafe by default:
  *

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -535,7 +535,7 @@ function send_origin_headers() {
  * - ftp://example.com/caniload.php - Invalid protocol - only http and https are allowed.
  * - http:///example.com/caniload.php - Malformed URL.
  * - http://user:pass@example.com/caniload.php - Login information.
- * - http://notworking.example.com/caniload.php - Invalid hostname, as the IP cannot be looked up in DNS.
+ * - http://example.invalid/caniload.php - Invalid hostname, as the IP cannot be looked up in DNS.
  *
  * Examples of URLs that are considered unsafe by default:
  *

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -549,7 +549,7 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 				'url' => 'http://[exam]ple.com/caniload.php',
 			),
 			'a host whose IPv4 address cannot be resolved' => array(
-				'url' => 'http://notworking.example.com/caniload.php',
+				'url' => 'http://example.invalid/caniload.php',
 			),
 			'an external request when not allowed'         => array(
 				'url'           => 'http://192.168.0.1/caniload.php',

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -549,7 +549,7 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 				'url' => 'http://[exam]ple.com/caniload.php',
 			),
 			'a host whose IPv4 address cannot be resolved' => array(
-				'url' => 'http://exampleeeee.com/caniload.php',
+				'url' => 'http://notworking.example.com/caniload.php',
 			),
 			'an external request when not allowed'         => array(
 				'url'           => 'http://192.168.0.1/caniload.php',


### PR DESCRIPTION
exampleeeee.com got registered and A-record added so it's not invalid anymore. Example.com is IANA domain and safer to use than some random domain.

Trac ticket: https://core.trac.wordpress.org/ticket/62303

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
