### PR TITLE
I18n: Fix wording of accessibility text on revisions slider

### DIFF
--- a/src/wp-admin/includes/revision.php
+++ b/src/wp-admin/includes/revision.php
@@ -380,7 +380,7 @@ function wp_print_revision_templates() {
 
 	<script id="tmpl-revisions-slider-hidden-help" type="text/html">
 		<h2 class="screen-reader-text"><?php esc_html_e( 'Select a revision' ); ?></h2>
-		<p id="revisions-slider-hidden-help" hidden><?php esc_html_e( 'Change revision by using the left and arrow keys' ); ?></p>
+		<p id="revisions-slider-hidden-help" hidden><?php esc_html_e( 'Change revision by using the left and right arrow keys' ); ?></p>
 	</script>
 
 	<script id="tmpl-revisions-checkbox" type="text/html">


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Update the wording of the accessibility text on the revisions slider about using the left and right arrow keys.
Fix to: _Change revision by using the left and **right** arrow keys_

Trac ticket: https://core.trac.wordpress.org/ticket/62306

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
