### PR TITLE
Fix: Update the test case for `strip_invalid_text_for_column` test-cases

### DIFF
--- a/tests/phpunit/tests/db/charset.php
+++ b/tests/phpunit/tests/db/charset.php
@@ -682,19 +682,19 @@ class Tests_DB_Charset extends WP_UnitTestCase {
 	 *
 	 * @covers wpdb::strip_invalid_text_for_column
 	 */
-	public function test_strip_invalid_text_for_column($input, $expected, $charset) {
+	public function test_strip_invalid_text_for_column( $input, $expected, $charset ) {
 		global $wpdb;
-	
+
 		// Ensure the test is run on the correct charset
-		$currentCharset = $wpdb->get_col_charset($wpdb->posts, 'post_content');
-		if ($currentCharset !== $charset) {
+		$currentCharset = $wpdb->get_col_charset( $wpdb->posts, 'post_content' );
+		if ( $currentCharset !== $charset ) {
 			echo 'Skipping' . $charset;
-			$this->markTestSkipped("This test requires a {$charset} character set.");
+			$this->markTestSkipped( "This test requires a {$charset} character set." );
 		}
-	
+
 		// Running the data provider tests
-		$actual = $wpdb->strip_invalid_text_for_column($wpdb->posts, 'post_content', $input);
-		$this->assertSame($expected, $actual, "Failed asserting that input '{$input}' is stripped correctly for charset '{$charset}'.");
+		$actual = $wpdb->strip_invalid_text_for_column( $wpdb->posts, 'post_content', $input );
+		$this->assertSame( $expected, $actual, "Failed asserting that input '{$input}' is stripped correctly for charset '{$charset}'." );
 	}
 
 	/**
@@ -705,68 +705,68 @@ class Tests_DB_Charset extends WP_UnitTestCase {
 	public function data_strip_invalid_text_for_column() {
 		return array(
 			// Valid UTF-8 characters
-			'valid_utf8' => array(
-				'input' => 'Hello, 世界!', // Valid characters
+			'valid_utf8'                 => array(
+				'input'    => 'Hello, 世界!', // Valid characters
 				'expected' => 'Hello, 世界!',
-				'charset' => 'utf8mb4',
+				'charset'  => 'utf8mb4',
 			),
 			// Invalid UTF-8 sequences
-			'invalid_utf8' => array(
-				'input' => "H€llo\x80World", // Invalid byte sequence
+			'invalid_utf8'               => array(
+				'input'    => "H€llo\x80World", // Invalid byte sequence
 				'expected' => 'H€lloWorld',
-				'charset' => 'utf8mb4',
+				'charset'  => 'utf8mb4',
 			),
-			'mixed_characters' => array(
-            'input' => "H€llo\x80World\xf0\x9f\x98\x80!", // Valid and invalid
-            'expected' => "H€lloWorld\xf0\x9f\x98\x80!", // Emoji (4-byte) is valid in utf8mb4.
-            'charset' => 'utf8mb4',
+			'mixed_characters'           => array(
+				'input'    => "H€llo\x80World\xf0\x9f\x98\x80!", // Valid and invalid
+				'expected' => "H€lloWorld\xf0\x9f\x98\x80!", // Emoji (4-byte) is valid in utf8mb4.
+				'charset'  => 'utf8mb4',
 			),
 			// 4-byte character valid in utf8mb4
-			'valid_4byte' => array(
-				'input' => "H€llo\xf0\x9f\x98\x80World", // Valid 4-byte character (😄)
+			'valid_4byte'                => array(
+				'input'    => "H€llo\xf0\x9f\x98\x80World", // Valid 4-byte character (😄)
 				'expected' => "H€llo\xf0\x9f\x98\x80World",
-				'charset' => 'utf8mb4',
+				'charset'  => 'utf8mb4',
 			),
 			// 4-byte character invalid in utf8
-			'invalid_4byte' => array(
-				'input' => "H€llo\xf0\xff\xff\xffWorld", // Invalid 4-byte character
+			'invalid_4byte'              => array(
+				'input'    => "H€llo\xf0\xff\xff\xffWorld", // Invalid 4-byte character
 				'expected' => 'H€lloWorld',
-				'charset' => 'utf8mb4',
+				'charset'  => 'utf8mb4',
 			),
 			// Empty string
-			'empty_string' => array(
-				'input' => '',
+			'empty_string'               => array(
+				'input'    => '',
 				'expected' => '',
-				'charset' => 'utf8mb4',
+				'charset'  => 'utf8mb4',
 			),
 			// Special characters (should remain unchanged)
-			'special_chars' => array(
-				'input' => "!@#$%^&*()_+[]{}|;:'\",.<>?/~`",
+			'special_chars'              => array(
+				'input'    => "!@#$%^&*()_+[]{}|;:'\",.<>?/~`",
 				'expected' => "!@#$%^&*()_+[]{}|;:'\",.<>?/~`",
-				'charset' => 'utf8mb4',
+				'charset'  => 'utf8mb4',
 			),
 			// Existing invalid sequences
 			'existing_invalid_sequences' => array(
-				'input' => "H€llo\xe0\x80\x80World\xf0\xff\xff\xff¢", // Invalid sequences
+				'input'    => "H€llo\xe0\x80\x80World\xf0\xff\xff\xff¢", // Invalid sequences
 				'expected' => 'H€lloWorld¢', // Expected outcome
-				'charset' => 'utf8mb4',
+				'charset'  => 'utf8mb4',
 			),
 			// Testing with Latin1 charset
-			'latin1_valid' => array(
-				'input' => 'Héllo, Monde!', // Valid for Latin1
+			'latin1_valid'               => array(
+				'input'    => 'Héllo, Monde!', // Valid for Latin1
 				'expected' => 'Héllo, Monde!',
-				'charset' => 'latin1',
+				'charset'  => 'latin1',
 			),
-			'latin1_invalid' => array(
-				'input' => "Héllo\x80World", // Invalid byte sequence for Latin1
+			'latin1_invalid'             => array(
+				'input'    => "Héllo\x80World", // Invalid byte sequence for Latin1
 				'expected' => 'HélloWorld',
-				'charset' => 'latin1',
+				'charset'  => 'latin1',
 			),
 			// Testing with ASCII charset
-			'ascii' => array(
-				'input' => 'Hello, World!', // Valid ASCII
+			'ascii'                      => array(
+				'input'    => 'Hello, World!', // Valid ASCII
 				'expected' => 'Hello, World!',
-				'charset' => 'ascii',
+				'charset'  => 'ascii',
 			),
 		);
 	}

--- a/tests/phpunit/tests/db/charset.php
+++ b/tests/phpunit/tests/db/charset.php
@@ -700,7 +700,7 @@ class Tests_DB_Charset extends WP_UnitTestCase {
 	/**
 	 * Data provider for strip_invalid_text_for_column test cases.
 	 *
-	 * @return array
+	 * @return array[]
 	 */
 	public function data_strip_invalid_text_for_column() {
 		return array(

--- a/tests/phpunit/tests/db/charset.php
+++ b/tests/phpunit/tests/db/charset.php
@@ -774,6 +774,7 @@ class Tests_DB_Charset extends WP_UnitTestCase {
 	/**
 	 * Set of table definitions for testing wpdb::get_table_charset and wpdb::get_column_charset
 	 *
+	 * @var array
 	 */
 	protected $table_and_column_defs = array(
 		array(

--- a/tests/phpunit/tests/db/charset.php
+++ b/tests/phpunit/tests/db/charset.php
@@ -686,8 +686,8 @@ class Tests_DB_Charset extends WP_UnitTestCase {
 		global $wpdb;
 
 		// Ensure the test is run on the correct charset
-		$currentCharset = $wpdb->get_col_charset( $wpdb->posts, 'post_content' );
-		if ( $currentCharset !== $charset ) {
+		$current_charset = $wpdb->get_col_charset( $wpdb->posts, 'post_content' );
+		if ( $current_charset !== $charset ) {
 			echo 'Skipping' . $charset;
 			$this->markTestSkipped( "This test requires a {$charset} character set." );
 		}

--- a/tests/phpunit/tests/db/charset.php
+++ b/tests/phpunit/tests/db/charset.php
@@ -677,94 +677,99 @@ class Tests_DB_Charset extends WP_UnitTestCase {
 	/**
 	 * @ticket 21212
 	 *
+	 *
+	 * @dataProvider strip_invalid_text_provider
+	 *
 	 * @covers wpdb::strip_invalid_text_for_column
 	 */
-	public function test_strip_invalid_text_for_column() {
+	public function test_strip_invalid_text_for_column($input, $expected, $charset) {
 		global $wpdb;
-
-		$charset = $wpdb->get_col_charset( $wpdb->posts, 'post_content' );
-		if ( 'utf8' !== $charset && 'utf8mb4' !== $charset ) {
-			$this->markTestSkipped( 'This test requires a utf8 character set.' );
+	
+		// Ensure the test is run on the correct charset
+		$currentCharset = $wpdb->get_col_charset($wpdb->posts, 'post_content');
+		if ($currentCharset !== $charset) {
+			echo 'Skipping' . $charset;
+			$this->markTestSkipped("This test requires a {$charset} character set.");
 		}
-
-		// Invalid 3-byte and 4-byte sequences.
-		$value    = "H€llo\xe0\x80\x80World\xf0\xff\xff\xff¢";
-		$expected = 'H€lloWorld¢';
-		$actual   = $wpdb->strip_invalid_text_for_column( $wpdb->posts, 'post_content', $value );
-		$this->assertSame( $expected, $actual );
+	
+		// Running the data provider tests
+		$actual = $wpdb->strip_invalid_text_for_column($wpdb->posts, 'post_content', $input);
+		$this->assertSame($expected, $actual, "Failed asserting that input '{$input}' is stripped correctly for charset '{$charset}'.");
 	}
 
 	/**
-	 * Set of table definitions for testing wpdb::get_table_charset and wpdb::get_column_charset
+	 * Data provider for strip_invalid_text_for_column test cases.
 	 *
-	 * @var array
+	 * @return array
 	 */
-	protected $table_and_column_defs = array(
-		array(
-			'definition'      => '( a INT, b FLOAT )',
-			'table_expected'  => false,
-			'column_expected' => array(
-				'a' => false,
-				'b' => false,
+	public function strip_invalid_text_provider() {
+		return array(
+			// Valid UTF-8 characters
+			'valid_utf8' => array(
+				'input' => 'Hello, 世界!', // Valid characters
+				'expected' => 'Hello, 世界!',
+				'charset' => 'utf8mb4',
 			),
-		),
-		array(
-			'definition'      => '( a VARCHAR(50) CHARACTER SET big5, b TEXT CHARACTER SET big5 )',
-			'table_expected'  => 'big5',
-			'column_expected' => array(
-				'a' => 'big5',
-				'b' => 'big5',
+			// Invalid UTF-8 sequences
+			'invalid_utf8' => array(
+				'input' => "H€llo\x80World", // Invalid byte sequence
+				'expected' => 'H€lloWorld',
+				'charset' => 'utf8mb4',
 			),
-		),
-		array(
-			'definition'      => '( a VARCHAR(50) CHARACTER SET big5, b BINARY )',
-			'table_expected'  => 'binary',
-			'column_expected' => array(
-				'a' => 'big5',
-				'b' => false,
+			'mixed_characters' => array(
+            'input' => "H€llo\x80World\xf0\x9f\x98\x80!", // Valid and invalid
+            'expected' => "H€lloWorld\xf0\x9f\x98\x80!", // Emoji (4-byte) is valid in utf8mb4.
+            'charset' => 'utf8mb4',
 			),
-		),
-		array(
-			'definition'      => '( a VARCHAR(50) CHARACTER SET latin1, b BLOB )',
-			'table_expected'  => 'binary',
-			'column_expected' => array(
-				'a' => 'latin1',
-				'b' => false,
+			// 4-byte character valid in utf8mb4
+			'valid_4byte' => array(
+				'input' => "H€llo\xf0\x9f\x98\x80World", // Valid 4-byte character (😄)
+				'expected' => "H€llo\xf0\x9f\x98\x80World",
+				'charset' => 'utf8mb4',
 			),
-		),
-		array(
-			'definition'      => '( a VARCHAR(50) CHARACTER SET latin1, b TEXT CHARACTER SET koi8r )',
-			'table_expected'  => 'koi8r',
-			'column_expected' => array(
-				'a' => 'latin1',
-				'b' => 'koi8r',
+			// 4-byte character invalid in utf8
+			'invalid_4byte' => array(
+				'input' => "H€llo\xf0\xff\xff\xffWorld", // Invalid 4-byte character
+				'expected' => 'H€lloWorld',
+				'charset' => 'utf8mb4',
 			),
-		),
-		array(
-			'definition'      => '( a VARCHAR(50) CHARACTER SET utf8mb3, b TEXT CHARACTER SET utf8mb3 )',
-			'table_expected'  => 'utf8',
-			'column_expected' => array(
-				'a' => 'utf8',
-				'b' => 'utf8',
+			// Empty string
+			'empty_string' => array(
+				'input' => '',
+				'expected' => '',
+				'charset' => 'utf8mb4',
 			),
-		),
-		array(
-			'definition'      => '( a VARCHAR(50) CHARACTER SET utf8, b TEXT CHARACTER SET utf8mb4 )',
-			'table_expected'  => 'utf8',
-			'column_expected' => array(
-				'a' => 'utf8',
-				'b' => 'utf8mb4',
+			// Special characters (should remain unchanged)
+			'special_chars' => array(
+				'input' => "!@#$%^&*()_+[]{}|;:'\",.<>?/~`",
+				'expected' => "!@#$%^&*()_+[]{}|;:'\",.<>?/~`",
+				'charset' => 'utf8mb4',
 			),
-		),
-		array(
-			'definition'      => '( a VARCHAR(50) CHARACTER SET big5, b TEXT CHARACTER SET koi8r )',
-			'table_expected'  => 'ascii',
-			'column_expected' => array(
-				'a' => 'big5',
-				'b' => 'koi8r',
+			// Existing invalid sequences
+			'existing_invalid_sequences' => array(
+				'input' => "H€llo\xe0\x80\x80World\xf0\xff\xff\xff¢", // Invalid sequences
+				'expected' => 'H€lloWorld¢', // Expected outcome
+				'charset' => 'utf8mb4',
 			),
-		),
-	);
+			// Testing with Latin1 charset
+			'latin1_valid' => array(
+				'input' => 'Héllo, Monde!', // Valid for Latin1
+				'expected' => 'Héllo, Monde!',
+				'charset' => 'latin1',
+			),
+			'latin1_invalid' => array(
+				'input' => "Héllo\x80World", // Invalid byte sequence for Latin1
+				'expected' => 'HélloWorld',
+				'charset' => 'latin1',
+			),
+			// Testing with ASCII charset
+			'ascii' => array(
+				'input' => 'Hello, World!', // Valid ASCII
+				'expected' => 'Hello, World!',
+				'charset' => 'ascii',
+			),
+		);
+	}
 
 	/**
 	 * @ticket 21212

--- a/tests/phpunit/tests/db/charset.php
+++ b/tests/phpunit/tests/db/charset.php
@@ -678,7 +678,7 @@ class Tests_DB_Charset extends WP_UnitTestCase {
 	 * @ticket 21212
 	 *
 	 *
-	 * @dataProvider strip_invalid_text_provider
+	 * @dataProvider data_strip_invalid_text_for_column
 	 *
 	 * @covers wpdb::strip_invalid_text_for_column
 	 */
@@ -702,7 +702,7 @@ class Tests_DB_Charset extends WP_UnitTestCase {
 	 *
 	 * @return array
 	 */
-	public function strip_invalid_text_provider() {
+	public function data_strip_invalid_text_for_column() {
 		return array(
 			// Valid UTF-8 characters
 			'valid_utf8' => array(

--- a/tests/phpunit/tests/db/charset.php
+++ b/tests/phpunit/tests/db/charset.php
@@ -774,9 +774,6 @@ class Tests_DB_Charset extends WP_UnitTestCase {
 	/**
 	 * Set of table definitions for testing wpdb::get_table_charset and wpdb::get_column_charset
 	 *
-	 *
-	 * @var array
-	 * @return array
 	 */
 	protected $table_and_column_defs = array(
 		array(

--- a/tests/phpunit/tests/db/charset.php
+++ b/tests/phpunit/tests/db/charset.php
@@ -772,6 +772,80 @@ class Tests_DB_Charset extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Set of table definitions for testing wpdb::get_table_charset and wpdb::get_column_charset
+	 *
+	 *
+	 * @var array
+	 * @return array
+	 */
+	protected $table_and_column_defs = array(
+		array(
+			'definition'      => '( a INT, b FLOAT )',
+			'table_expected'  => false,
+			'column_expected' => array(
+				'a' => false,
+				'b' => false,
+			),
+		),
+		array(
+			'definition'      => '( a VARCHAR(50) CHARACTER SET big5, b TEXT CHARACTER SET big5 )',
+			'table_expected'  => 'big5',
+			'column_expected' => array(
+				'a' => 'big5',
+				'b' => 'big5',
+			),
+		),
+		array(
+			'definition'      => '( a VARCHAR(50) CHARACTER SET big5, b BINARY )',
+			'table_expected'  => 'binary',
+			'column_expected' => array(
+				'a' => 'big5',
+				'b' => false,
+			),
+		),
+		array(
+			'definition'      => '( a VARCHAR(50) CHARACTER SET latin1, b BLOB )',
+			'table_expected'  => 'binary',
+			'column_expected' => array(
+				'a' => 'latin1',
+				'b' => false,
+			),
+		),
+		array(
+			'definition'      => '( a VARCHAR(50) CHARACTER SET latin1, b TEXT CHARACTER SET koi8r )',
+			'table_expected'  => 'koi8r',
+			'column_expected' => array(
+				'a' => 'latin1',
+				'b' => 'koi8r',
+			),
+		),
+		array(
+			'definition'      => '( a VARCHAR(50) CHARACTER SET utf8mb3, b TEXT CHARACTER SET utf8mb3 )',
+			'table_expected'  => 'utf8',
+			'column_expected' => array(
+				'a' => 'utf8',
+				'b' => 'utf8',
+			),
+		),
+		array(
+			'definition'      => '( a VARCHAR(50) CHARACTER SET utf8, b TEXT CHARACTER SET utf8mb4 )',
+			'table_expected'  => 'utf8',
+			'column_expected' => array(
+				'a' => 'utf8',
+				'b' => 'utf8mb4',
+			),
+		),
+		array(
+			'definition'      => '( a VARCHAR(50) CHARACTER SET big5, b TEXT CHARACTER SET koi8r )',
+			'table_expected'  => 'ascii',
+			'column_expected' => array(
+				'a' => 'big5',
+				'b' => 'koi8r',
+			),
+		),
+	);
+
+	/**
 	 * @ticket 21212
 	 */
 	public function data_get_table_charset() {


### PR DESCRIPTION
Trac Ticket: Core-32917

## Summary

- This PR enhances the existing unit tests for the strip_invalid_text_for_column function in the $wpdb class. The changes aim to ensure that the function behaves correctly across different character sets (utf8, utf8mb4, latin1, and ascii) and handles various combinations of valid and invalid characters.

## Changes Made

### Extended Test Coverage

- Added a data provider strip_invalid_text_provider to supply multiple input scenarios for the test cases.

- The data provider now covers:

    - Valid and invalid UTF-8 sequences: Tests to ensure invalid byte sequences are stripped, while valid sequences are retained.

    - Support for 4-byte characters: Valid 4-byte characters (e.g., emojis) are supported when the charset is utf8mb4. This is tested explicitly.

    - Different character sets: Added tests for utf8mb4, latin1, and ascii to verify behavior across multiple charsets.

    - Special cases: Tests include empty strings, special characters, and various invalid sequences.

### Improved Existing Tests:

- Refactored the existing test (`test_strip_invalid_text_for_column`) to utilize the new data provider, ensuring consistent and comprehensive testing.

- Adjusted the expected output for test cases involving utf8mb4 to correctly allow 4-byte characters like emojis, reflecting the true behavior of the charset.

## Example Test Cases Added

- Valid UTF-8 String: Confirms that valid sequences remain unchanged.

- Mixed Characters: Verifies behavior when encountering a mix of valid and invalid sequences, including 4-byte characters.

- Latin1 and ASCII Tests: Ensures compatibility and correct text stripping when using latin1 and ascii charsets.

## Benefits

- Comprehensive Testing: The new data provider approach ensures consistent coverage across various scenarios, improving the robustness of the tests.

- Charset Compatibility: Explicitly tests different character sets, helping to identify and prevent charset-specific issues.
Future Flexibility: By leveraging a data provider, future test additions and adjustments will be more straightforward.

## Testing

- Run Tests: Executed the enhanced test suite to verify that the `strip_invalid_text_for_column` function behaves as expected.