### PR TITLE
Feat: Trigger An Action Hook When Transient Expires

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1459,6 +1459,9 @@ function get_transient( $transient ) {
 					delete_option( $transient_option );
 					delete_option( $transient_timeout );
 					$value = false;
+
+					// Trigger the hook when the transient expires.
+					do_action( 'transient_expired', $transient );
 				}
 			}
 		}


### PR DESCRIPTION
## Description

This PR introduces a feature enhancement to `get_transient()` by adding a new action hook, `transient_expired`, which triggers when a transient has expired.

## Changes Made

- Introduced a new action hook, `transient_expired`, which is triggered when an expired transient is detected.

## Trac ticket: https://core.trac.wordpress.org/ticket/22369
