### PR TITLE
Block Bindings: Enable custom blocks in pattern overrides with `role: content` property

### DIFF
--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -253,11 +253,9 @@ class WP_Block {
 
 		// If the block doesn't have the bindings property, isn't one of the supported
 		// block types, or the bindings property is not an array, return the block content.
-		if (
-			! isset( $supported_block_attributes[ $this->name ] ) ||
-			empty( $parsed_block['attrs']['metadata']['bindings'] ) ||
-			! is_array( $parsed_block['attrs']['metadata']['bindings'] )
-		) {
+		$bindings_present = isset( $parsed_block['attrs']['metadata']['bindings'] ) && is_array( $parsed_block['attrs']['metadata']['bindings'] );
+		$is_core_block    = strpos( $this->name, 'core/' ) === 0;
+		if ( ! $bindings_present || ( $is_core_block && ! isset( $supported_block_attributes[ $this->name ] ) ) ) {
 			return $computed_attributes;
 		}
 
@@ -278,11 +276,24 @@ class WP_Block {
 			 * Note that this also omits the `__default` attribute from the
 			 * resulting array.
 			 */
-			foreach ( $supported_block_attributes[ $parsed_block['blockName'] ] as $attribute_name ) {
-				// Retain any non-pattern override bindings that might be present.
-				$updated_bindings[ $attribute_name ] = isset( $bindings[ $attribute_name ] )
-					? $bindings[ $attribute_name ]
-					: array( 'source' => 'core/pattern-overrides' );
+			if ( ! isset( $supported_block_attributes[ $parsed_block['blockName'] ] ) ) {
+				$attribute_definitions = $this->block_type->attributes;
+
+				foreach ( $attribute_definitions as $attribute_name => $attribute_definition ) {
+					// Include the attribute in the updated bindings if the role is set to 'content'.
+					if ( isset( $attribute_definition['role'] ) && 'content' === $attribute_definition['role'] ) {
+						$updated_bindings[ $attribute_name ] = isset( $bindings[ $attribute_name ] )
+							? $bindings[ $attribute_name ]
+							: array( 'source' => 'core/pattern-overrides' );
+					}
+				}
+			} else {
+				foreach ( $supported_block_attributes[ $parsed_block['blockName'] ] as $attribute_name ) {
+					// Retain any non-pattern override bindings that might be present.
+					$updated_bindings[ $attribute_name ] = isset( $bindings[ $attribute_name ] )
+						? $bindings[ $attribute_name ]
+						: array( 'source' => 'core/pattern-overrides' );
+				}
 			}
 			$bindings = $updated_bindings;
 			/*
@@ -297,7 +308,7 @@ class WP_Block {
 
 		foreach ( $bindings as $attribute_name => $block_binding ) {
 			// If the attribute is not in the supported list, process next attribute.
-			if ( ! in_array( $attribute_name, $supported_block_attributes[ $this->name ], true ) ) {
+			if ( $is_core_block && ! in_array( $attribute_name, $supported_block_attributes[ $this->name ], true ) ) {
 				continue;
 			}
 			// If no source is provided, or that source is not registered, process next attribute.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

<!-- Trac ticket: insert a link to the WordPress Trac ticket here -->

---

Experimenting with enabling pattern overrides for custom, dynamic blocks.
Meant to be tested in conjunction with https://github.com/WordPress/gutenberg/pull/66518 — see the PR description there.


**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
