### PR TITLE
Add pre-set-object-term-action

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2825,6 +2825,23 @@ function wp_set_object_terms( $object_id, $terms, $taxonomy, $append = false ) {
 		$old_tt_ids = array();
 	}
 
+	/**
+	 * Fires before terms are assigned to an object.
+	 *
+	 * This action allows manipulation or monitoring of terms assigned to a specified
+	 * object, such as a post, before the terms are set.
+	 *
+	 * @since 6.7.0
+	 *
+	 * @param int    $object_id  The ID of the object being updated.
+	 * @param array  $terms      An array of term IDs or slugs to be assigned to the object.
+	 * @param string $taxonomy   The taxonomy for the terms.
+	 * @param bool   $append     Whether to append the new terms to the existing terms.
+	 * @param array  $old_tt_ids The previous array of term taxonomy IDs.
+	 */
+	do_action( 'pre_set_object_terms', $object_id, $terms, $taxonomy, $append, $old_tt_ids );
+
+
 	$tt_ids     = array();
 	$new_tt_ids = array();
 

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2799,7 +2799,8 @@ function wp_insert_term( $term, $taxonomy, $args = array() ) {
 function wp_set_object_terms( $object_id, $terms, $taxonomy, $append = false ) {
 	global $wpdb;
 
-	$object_id = (int) $object_id;
+	$object_id  = (int) $object_id;
+	$old_tt_ids = array();
 
 	if ( ! taxonomy_exists( $taxonomy ) ) {
 		return new WP_Error( 'invalid_taxonomy', __( 'Invalid taxonomy.' ) );
@@ -2809,20 +2810,6 @@ function wp_set_object_terms( $object_id, $terms, $taxonomy, $append = false ) {
 		$terms = array();
 	} elseif ( ! is_array( $terms ) ) {
 		$terms = array( $terms );
-	}
-
-	if ( ! $append ) {
-		$old_tt_ids = wp_get_object_terms(
-			$object_id,
-			$taxonomy,
-			array(
-				'fields'                 => 'tt_ids',
-				'orderby'                => 'none',
-				'update_term_meta_cache' => false,
-			)
-		);
-	} else {
-		$old_tt_ids = array();
 	}
 
 	/**
@@ -2840,6 +2827,18 @@ function wp_set_object_terms( $object_id, $terms, $taxonomy, $append = false ) {
 	 * @param array  $old_tt_ids The previous array of term taxonomy IDs.
 	 */
 	do_action( 'pre_set_object_terms', $object_id, $terms, $taxonomy, $append, $old_tt_ids );
+
+	if ( ! $append ) {
+		$old_tt_ids = wp_get_object_terms(
+			$object_id,
+			$taxonomy,
+			array(
+				'fields'                 => 'tt_ids',
+				'orderby'                => 'none',
+				'update_term_meta_cache' => false,
+			)
+		);
+	}
 
 	$tt_ids     = array();
 	$new_tt_ids = array();

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2841,7 +2841,6 @@ function wp_set_object_terms( $object_id, $terms, $taxonomy, $append = false ) {
 	 */
 	do_action( 'pre_set_object_terms', $object_id, $terms, $taxonomy, $append, $old_tt_ids );
 
-
 	$tt_ids     = array();
 	$new_tt_ids = array();
 


### PR DESCRIPTION
This PR introduces a new pre_set_object_terms action that triggers before terms are assigned to an object in wp_set_object_terms. Currently, it is only possible to access term taxonomy IDs ($old_tt_ids) after terms have already been updated, which limits the ability to make adjustments prior to committing changes.

Trac ticket: https://core.trac.wordpress.org/ticket/60532

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
