### PR TITLE
Preload: fix multiple regressions around global styles

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -51,6 +51,8 @@ wp_enqueue_script( 'wp-edit-post' );
 
 $rest_path = rest_get_route_for_post( $post );
 
+$stylesheet = get_stylesheet();
+
 // Preload common data.
 $preload_paths = array(
 	'/wp/v2/types?context=view',
@@ -65,8 +67,10 @@ $preload_paths = array(
 	sprintf( '%s/autosaves?context=edit', $rest_path ),
 	'/wp/v2/settings',
 	array( '/wp/v2/settings', 'OPTIONS' ),
-	'/wp/v2/global-styles/themes/' . get_stylesheet(),
+	'/wp/v2/global-styles/themes/' . $stylesheet . '?context=view',
+	'/wp/v2/global-styles/themes/' . $stylesheet . '/variations?context=view'
 	'/wp/v2/themes?context=edit&status=active',
+	array( '/wp/v2/global-styles/' . WP_Theme_JSON_Resolver::get_user_global_styles_post_id(), 'OPTIONS' )
 	'/wp/v2/global-styles/' . WP_Theme_JSON_Resolver::get_user_global_styles_post_id() . '?context=edit',
 );
 

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -51,7 +51,7 @@ wp_enqueue_script( 'wp-edit-post' );
 
 $rest_path = rest_get_route_for_post( $post );
 
-$stylesheet = get_stylesheet();
+$active_theme = get_stylesheet();
 
 // Preload common data.
 $preload_paths = array(
@@ -67,8 +67,8 @@ $preload_paths = array(
 	sprintf( '%s/autosaves?context=edit', $rest_path ),
 	'/wp/v2/settings',
 	array( '/wp/v2/settings', 'OPTIONS' ),
-	'/wp/v2/global-styles/themes/' . $stylesheet . '?context=view',
-	'/wp/v2/global-styles/themes/' . $stylesheet . '/variations?context=view',
+	'/wp/v2/global-styles/themes/' . $active_theme . '?context=view',
+	'/wp/v2/global-styles/themes/' . $active_theme . '/variations?context=view',
 	'/wp/v2/themes?context=edit&status=active',
 	array( '/wp/v2/global-styles/' . WP_Theme_JSON_Resolver::get_user_global_styles_post_id(), 'OPTIONS' ),
 	'/wp/v2/global-styles/' . WP_Theme_JSON_Resolver::get_user_global_styles_post_id() . '?context=edit',

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -68,9 +68,9 @@ $preload_paths = array(
 	'/wp/v2/settings',
 	array( '/wp/v2/settings', 'OPTIONS' ),
 	'/wp/v2/global-styles/themes/' . $stylesheet . '?context=view',
-	'/wp/v2/global-styles/themes/' . $stylesheet . '/variations?context=view'
+	'/wp/v2/global-styles/themes/' . $stylesheet . '/variations?context=view',
 	'/wp/v2/themes?context=edit&status=active',
-	array( '/wp/v2/global-styles/' . WP_Theme_JSON_Resolver::get_user_global_styles_post_id(), 'OPTIONS' )
+	array( '/wp/v2/global-styles/' . WP_Theme_JSON_Resolver::get_user_global_styles_post_id(), 'OPTIONS' ),
 	'/wp/v2/global-styles/' . WP_Theme_JSON_Resolver::get_user_global_styles_post_id() . '?context=edit',
 );
 

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -97,8 +97,9 @@ $preload_paths = array(
 	'/wp/v2/template-parts?context=edit&per_page=-1',
 	'/wp/v2/themes?context=edit&status=active',
 	'/wp/v2/global-styles/' . $active_global_styles_id . '?context=edit',
-	'/wp/v2/global-styles/' . $active_global_styles_id,
-	'/wp/v2/global-styles/themes/' . $active_theme,
+	array( '/wp/v2/global-styles/' . $active_global_styles_id, 'OPTIONS' )
+	'/wp/v2/global-styles/themes/' . $active_theme . '?context=view',
+	'/wp/v2/global-styles/themes/' . $active_theme . '/variations?context=view',
 	array( $navigation_rest_route, 'OPTIONS' ),
 	array(
 		add_query_arg(

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -97,7 +97,7 @@ $preload_paths = array(
 	'/wp/v2/template-parts?context=edit&per_page=-1',
 	'/wp/v2/themes?context=edit&status=active',
 	'/wp/v2/global-styles/' . $active_global_styles_id . '?context=edit',
-	array( '/wp/v2/global-styles/' . $active_global_styles_id, 'OPTIONS' )
+	array( '/wp/v2/global-styles/' . $active_global_styles_id, 'OPTIONS' ),
 	'/wp/v2/global-styles/themes/' . $active_theme . '?context=view',
 	'/wp/v2/global-styles/themes/' . $active_theme . '/variations?context=view',
 	array( $navigation_rest_route, 'OPTIONS' ),


### PR DESCRIPTION
A PR to track the backporting of https://github.com/WordPress/gutenberg/pull/66468

This fixes a regression whereby requests to global styles endpoints were not being preloaded, resulting in several requests being fired clientside unnecessarily.

For performance reasons, we should preload the requests so that the data is in the store and ready to use straight away.

The outcome is that the editor loads more quickly.

### Testing

Fire up this branch and head to the site editor.

Check that global-styles endpoints aren't fetched client side, but are, rather, preloaded via [rest_preload_api_request](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/rest-api.php#L2918)

Do the same for the post editor.

<!-- Insert a description of your changes here -->

Trac ticket:  https://core.trac.wordpress.org/ticket/62315

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
