### PR TITLE
Fix:  Improve Charset Handling in `wpdb::get_table_charset` Method

### DIFF
--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -3236,45 +3236,40 @@ class wpdb {
 
 		foreach ( $columns as $column ) {
 			if ( ! empty( $column->Collation ) ) {
-				list( $charset ) = explode( '_', $column->Collation );
-
+				list( $charset )                    = explode( '_', $column->Collation );
 				$charsets[ strtolower( $charset ) ] = true;
 			}
 
 			list( $type ) = explode( '(', $column->Type );
 
-			// A binary/blob means the whole query gets treated like this.
+			// Handle binary/blob types.
 			if ( in_array( strtoupper( $type ), array( 'BINARY', 'VARBINARY', 'TINYBLOB', 'MEDIUMBLOB', 'BLOB', 'LONGBLOB' ), true ) ) {
 				$this->table_charset[ $tablekey ] = 'binary';
 				return 'binary';
 			}
 		}
 
-		// utf8mb3 is an alias for utf8.
+		// Handle utf8mb3 as an alias for utf8.
 		if ( isset( $charsets['utf8mb3'] ) ) {
 			$charsets['utf8'] = true;
 			unset( $charsets['utf8mb3'] );
 		}
 
-		// Check if we have more than one charset in play.
+		// Determine charset based on the presence of multiple charsets.
 		$count = count( $charsets );
 		if ( 1 === $count ) {
 			$charset = key( $charsets );
 		} elseif ( 0 === $count ) {
-			// No charsets, assume this table can store whatever.
 			$charset = false;
 		} else {
-			// More than one charset. Remove latin1 if present and recalculate.
 			unset( $charsets['latin1'] );
 			$count = count( $charsets );
 			if ( 1 === $count ) {
-				// Only one charset (besides latin1).
 				$charset = key( $charsets );
 			} elseif ( 2 === $count && isset( $charsets['utf8'], $charsets['utf8mb4'] ) ) {
-				// Two charsets, but they're utf8 and utf8mb4, use utf8.
-				$charset = 'utf8';
+				// Use utf8mb4 when both utf8 and utf8mb4 are present.
+				$charset = 'utf8mb4';
 			} else {
-				// Two mixed character sets. ascii.
 				$charset = 'ascii';
 			}
 		}
@@ -3282,6 +3277,7 @@ class wpdb {
 		$this->table_charset[ $tablekey ] = $charset;
 		return $charset;
 	}
+
 
 	/**
 	 * Retrieves the character set for the given column.

--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -3278,7 +3278,6 @@ class wpdb {
 		return $charset;
 	}
 
-
 	/**
 	 * Retrieves the character set for the given column.
 	 *

--- a/tests/phpunit/tests/db/charset.php
+++ b/tests/phpunit/tests/db/charset.php
@@ -750,7 +750,7 @@ class Tests_DB_Charset extends WP_UnitTestCase {
 		),
 		array(
 			'definition'      => '( a VARCHAR(50) CHARACTER SET utf8, b TEXT CHARACTER SET utf8mb4 )',
-			'table_expected'  => 'utf8',
+			'table_expected'  => 'utf8mb4',
 			'column_expected' => array(
 				'a' => 'utf8',
 				'b' => 'utf8mb4',
@@ -903,7 +903,7 @@ class Tests_DB_Charset extends WP_UnitTestCase {
 				// utf8/utf8mb4 tables default to utf8.
 				'create'   => '( a VARCHAR(50) CHARACTER SET utf8, b VARCHAR(50) CHARACTER SET utf8mb4 )',
 				'query'    => "('foo\xf0\x9f\x98\x88bar', 'foo')",
-				'expected' => "('foobar', 'foo')",
+				'expected' => "('foo\xf0\x9f\x98\x88bar', 'foo')",
 			),
 		);
 


### PR DESCRIPTION
Trac Ticket: Core-59868

## Summary

- This pull request addresses an issue with the `wpdb::get_table_charset` function regarding character set determination for database tables with mixed charset definitions. The previous implementation prioritized utf8 when both utf8 and utf8mb4 were present, leading to potential data loss for 4-byte characters (e.g., emojis). This change ensures that utf8mb4 is used when applicable.

## Changes Made

### Updated Charset Logic:

- The logic in the get_table_charset function was modified to return utf8mb4 when both `utf8` and `utf8mb4` character sets are detected in the table's columns.

- This ensures that columns defined with utf8mb4 can store all valid characters, including 4-byte characters.

## Test Updates:

- Adjusted the test cases in `Tests_DB_Charset::test_get_table_charset` to reflect the new behavior, specifically modifying expectations where the charset was previously set to utf8 when utf8mb4 should now be expected.

## Rationale

- The changes are crucial for maintaining data integrity and supporting modern applications that require the storage of a wider range of characters. By ensuring that the database can correctly handle 4-byte characters, we prevent potential insert errors and improve the overall robustness of the character handling in WordPress.

## Impact

- This improvement should enhance compatibility with rich media content and internationalization, benefiting developers and users alike.

## Testing

- Updated tests to reflect new charset logic.

- All tests have been run and passed successfully.
