### PR TITLE
Fixes possible Warning: Undefined array key "height"/"width" in wp_image_src_get_dimensions()

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1688,7 +1688,7 @@ function wp_image_src_get_dimensions( $image_src, $image_meta, $attachment_id = 
 
 	// Is it a full size image?
 	if (
-		isset( $image_meta['file'] ) &&
+		isset( $image_meta['file'], $image_meta['height'], $image_meta['width'] ) &&
 		str_contains( $image_src, wp_basename( $image_meta['file'] ) )
 	) {
 		$dimensions = array(


### PR DESCRIPTION
As originally pointed out by @donbowman, `wp_image_src_get_dimensions()` will not work properly for SVG, since they do not have sizes added to post meta. This is his original patch taken from https://core.trac.wordpress.org/ticket/57813#comment:2, just fixed the checks.

Optionally we could consider to check the mimetype here. Any thoughts on that?

Trac ticket: https://core.trac.wordpress.org/ticket/62312#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
