### PR TITLE
Add closed plugin status to plugins.php listing.

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1540,6 +1540,7 @@ div.error {
 }
 
 .update-message p:before,
+.closed-message p:before,
 .updating-message p:before,
 .updated-message p:before,
 .import-php .updating-message:before,
@@ -1600,6 +1601,12 @@ div.error {
 .plugins .column-auto-updates .dashicons-update.spin,
 .theme-overlay .theme-autoupdate .dashicons-update.spin {
 	animation: rotation 2s infinite linear;
+}
+
+/* Closed icon */
+.closed-message p:before {
+	color: #d63638;
+	content: "\f534";
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1299,10 +1299,14 @@ ul.cat-checklist input[name="post_category[]"]:indeterminate::before {
 .upgrade .plugins tr:last-of-type th,
 .plugins tr.active + tr.inactive.update th,
 .plugins tr.active + tr.inactive.update td,
+.plugins tr.active + tr.inactive.closed th,
+.plugins tr.active + tr.inactive.closed td,
 .plugins .updated td,
 .plugins .updated th,
 .plugins tr.active + tr.inactive.updated th,
-.plugins tr.active + tr.inactive.updated td {
+.plugins tr.active + tr.inactive.updated td,
+.plugins tr.active + tr.inactive.closed th,
+.plugins tr.active + tr.inactive.closed td {
 	box-shadow: none;
 }
 

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1283,6 +1283,8 @@ ul.cat-checklist input[name="post_category[]"]:indeterminate::before {
 
 .plugins tr.active.plugin-update-tr + tr.inactive th,
 .plugins tr.active.plugin-update-tr + tr.inactive td,
+.plugins tr.active.plugin-closed-tr + tr.inactive th,
+.plugins tr.active.plugin-closed-tr + tr.inactive td,
 .plugins tr.active + tr.inactive th,
 .plugins tr.active + tr.inactive td {
 	border-top: 1px solid rgba(0, 0, 0, 0.03);
@@ -1291,6 +1293,8 @@ ul.cat-checklist input[name="post_category[]"]:indeterminate::before {
 
 .plugins .update td,
 .plugins .update th,
+.plugins .closed td,
+.plugins .closed th,
 .upgrade .plugins tr:last-of-type td,
 .upgrade .plugins tr:last-of-type th,
 .plugins tr.active + tr.inactive.update th,
@@ -1303,7 +1307,8 @@ ul.cat-checklist input[name="post_category[]"]:indeterminate::before {
 }
 
 .plugins .active th.check-column,
-.plugin-update-tr.active td {
+.plugin-update-tr.active td,
+.plugin-closed-tr.active td {
 	border-left: 4px solid #72aee6;
 }
 
@@ -1365,13 +1370,15 @@ ul.cat-checklist input[name="post_category[]"]:indeterminate::before {
 	border-top-width: 1px;
 }
 
-.plugins .plugin-update-tr .plugin-update {
+.plugins .plugin-update-tr .plugin-update,
+.plugins .plugin-closed-tr .plugin-closed {
 	box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.1);
 	overflow: hidden; /* clearfix */
 	padding: 0;
 }
 
 .plugins .plugin-update-tr .notice,
+.plugins .plugin-closed-tr .notice,
 .plugins .plugin-update-tr div[class="update-message"] { /* back-compat for pre-4.6 */
 	margin: 5px 20px 15px 40px;
 }
@@ -2272,7 +2279,8 @@ div.action-links,
 
 	.plugins tr.active + tr.inactive th.check-column,
 	.plugins tr.active + tr.inactive td.column-description,
-	.plugins .plugin-update-tr:before {
+	.plugins .plugin-update-tr:before,
+	.plugins .plugin-closed-tr:before {
 		box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.1);
 	}
 
@@ -2282,26 +2290,32 @@ div.action-links,
 	}
 
 	/* mimic the checkbox th */
-	.plugins .plugin-update-tr:before {
+	.plugins .plugin-update-tr:before,
+	.plugins .plugin-closed-tr:before  {
 		content: "";
 		display: table-cell;
 	}
 
-	.plugins #the-list .plugin-update-tr .plugin-update {
+	.plugins #the-list .plugin-update-tr .plugin-update,
+	.plugins #the-list .plugin-closed-tr .plugin-closed {
 		border-left: none;
 	}
 
-	.plugin-update-tr .update-message {
+	.plugin-update-tr .update-message,
+	.plugin-closed-tr .closed-message {
 		margin-left: 0;
 	}
 
 	.plugins .active.update + .plugin-update-tr:before,
-	.plugins .active.updated + .plugin-update-tr:before {
+	.plugins .active.updated + .plugin-update-tr:before,
+	.plugins .active.update + .plugin-closed-tr:before,
+	.plugins .active.updated + .plugin-closed-tr:before {
 		background-color: #f0f6fc;
 		border-left: 4px solid #72aee6;
 	}
 
-	.plugins .plugin-update-tr .update-message {
+	.plugins .plugin-update-tr .update-message,
+	.plugins .plugin-closed-tr .closed-message {
 		margin-left: 0;
 	}
 

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -205,6 +205,8 @@ class WP_Plugins_List_Table extends WP_List_Table {
 				$plugin_data = array_merge( (array) $plugin_info->response[ $plugin_file ], array( 'update-supported' => true ), $plugin_data );
 			} elseif ( isset( $plugin_info->no_update[ $plugin_file ] ) ) {
 				$plugin_data = array_merge( (array) $plugin_info->no_update[ $plugin_file ], array( 'update-supported' => true ), $plugin_data );
+			} elseif ( isset( $plugin_info->closed[ $plugin_file ] ) ) {
+				$plugin_data = array_merge( (array) $plugin_info->closed[ $plugin_file ], array( 'update-supported' => false, 'closed' => true ), $plugin_data );
 			} elseif ( empty( $plugin_data['update-supported'] ) ) {
 				$plugin_data['update-supported'] = false;
 			}
@@ -1120,6 +1122,10 @@ class WP_Plugins_List_Table extends WP_List_Table {
 			! $compatible_wp
 		) {
 			$class .= ' update';
+		}
+
+		if ( ! empty( $plugin_data['closed'] ) ) {
+			$class .= ' closed';
 		}
 
 		$paused = ! $screen->in_admin( 'network' ) && is_plugin_paused( $plugin_file );

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -431,12 +431,22 @@ function wp_plugin_update_rows() {
 	$plugins = get_site_transient( 'update_plugins' );
 
 	if ( isset( $plugins->response ) && is_array( $plugins->response ) ) {
-		$plugins = array_keys( $plugins->response );
+		$plugin_files = array_keys( $plugins->response );
 
-		foreach ( $plugins as $plugin_file ) {
+		foreach ( $plugin_files as $plugin_file ) {
 			add_action( "after_plugin_row_{$plugin_file}", 'wp_plugin_update_row', 10, 2 );
 		}
 	}
+
+	// And closed plugins.
+	if ( isset( $plugins->closed ) && is_array( $plugins->closed ) ) {
+		$plugin_files = array_keys( $plugins->closed );
+
+		foreach ( $plugin_files as $plugin_file ) {
+			add_action( "after_plugin_row_{$plugin_file}", 'wp_plugin_closed_row', 10, 2 );
+		}
+	}
+
 }
 
 /**
@@ -617,6 +627,115 @@ function wp_plugin_update_row( $file, $plugin_data ) {
 
 		echo '</p></div></td></tr>';
 	}
+}
+
+/**
+ * Displays closed plugin notice.
+ *
+ * @since 6.8.0
+ *
+ * @param string $file        Plugin basename.
+ * @param array  $plugin_data Plugin information.
+ * @return void|false
+ */
+function wp_plugin_closed_row( $file, $plugin_data ) {
+	$current = get_site_transient( 'update_plugins' );
+
+	if ( ! isset( $current->closed[ $file ] ) ) {
+		return false;
+	}
+
+	$response    = $current->closed[ $file ];
+	$plugin_slug = isset( $response->slug ) ? $response->slug : $response->id;
+
+	/** @var WP_Plugins_List_Table $wp_list_table */
+	$wp_list_table = _get_list_table(
+		'WP_Plugins_List_Table',
+		array(
+			'screen' => get_current_screen(),
+		)
+	);
+
+	if ( is_multisite() && ! is_network_admin() ) {
+		return;
+	}
+
+	if ( is_network_admin() ) {
+		$active_class = is_plugin_active_for_network( $file ) ? ' active' : '';
+	} else {
+		$active_class = is_plugin_active( $file ) ? ' active' : '';
+	}
+
+	printf(
+		'<tr class="plugin-closed-tr%s" id="%s" data-slug="%s" data-plugin="%s">' .
+		'<td colspan="%s" class="plugin-closed colspanchange">' .
+		'<div class="closed-message notice inline notice-warning notice-alt"><p>',
+		$active_class,
+		esc_attr( $plugin_slug . '-closed' ),
+		esc_attr( $plugin_slug ),
+		esc_attr( $file ),
+		esc_attr( $wp_list_table->get_column_count() ),
+	);
+
+	$closure_reasons = [
+		// TODO: Make these more human friendly.
+		'security-issue'                => _x( 'Security Issue', 'Plugin closure reason' ),
+		'author-request'                => _x( 'Author Request', 'Plugin closure reason' ),
+		'guideline-violation'           => _x( 'Guideline Violation', 'Plugin closure reason' ),
+		'licensing-trademark-violation' => _x( 'Licensing/Trademark Violation', 'Plugin closure reason' ),
+		'merged-into-core'              => _x( 'Merged into WordPress Core', 'Plugin closure reason' ),
+		'unused'                        => _x( 'Unused', 'Plugin closure reason' ),
+		'unknown'                       => _x( 'Unknown', 'Plugin closure reason' ),
+	];
+
+	/**
+	 * Filters the list of plugin closure reasons.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @param array $closure_reasons An array of plugin closure reasons.
+	 * @return array An array of plugin closure reasons.
+	 */
+	$closure_reasons = apply_filters( 'plugin_closure_reasons', $closure_reasons );
+
+	// We must always have an unknown reason.
+	if ( ! isset( $closure_reasons['unknown'] ) ) {
+		$closure_reasons['unknown'] = _x( 'Unknown', 'Plugin closure reason' );
+	}
+
+	printf(
+		/* translators: 1: Date the plugin was closed, 2: Reason the plugin was closed. */
+		__( 'This plugin has been closed as of %1$s and is no longer available for new installs. Reason: %2$s.' ),
+		date_i18n( get_option( 'date_format' ), strtotime( $response->closed_at ) ),
+		isset( $closure_reasons[ $response->closed_reason ] ) ? $closure_reasons[ $response->closed_reason ] : $closure_reasons['unknown']
+	);
+
+	/**
+	 * Fires at the end of the closed message container in each
+	 * row of the plugins list table.
+	 *
+	 * The dynamic portion of the hook name, `$file`, refers to the path
+	 * of the plugin's primary file relative to the plugins directory.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @param array  $plugin_data An array of plugin metadata. See get_plugin_data()
+	 *                            and the {@see 'plugin_row_meta'} filter for the list
+	 *                            of possible values.
+	 * @param object $response {
+	 *     An object of metadata about the closed plugin.
+	 *
+	 *     @type string $id            Plugin ID, e.g. `w.org/plugins/[plugin-name]`.
+	 *     @type string $slug          Plugin slug.
+	 *     @type string $plugin        Plugin basename.
+	 *     @type string $url           Plugin URL.
+	 *     @type string $closed_at     The date of which the plugin was closed.
+	 *     @type string $closed_reason A code which represents the reason the plugin was closed.
+	 * }
+	 */
+	do_action( "in_plugin_closed_message-{$file}", $plugin_data, $response ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+
+	echo '</p></div></td></tr>';
 }
 
 /**

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -446,7 +446,6 @@ function wp_plugin_update_rows() {
 			add_action( "after_plugin_row_{$plugin_file}", 'wp_plugin_closed_row', 10, 2 );
 		}
 	}
-
 }
 
 /**
@@ -674,10 +673,10 @@ function wp_plugin_closed_row( $file, $plugin_data ) {
 		esc_attr( $plugin_slug . '-closed' ),
 		esc_attr( $plugin_slug ),
 		esc_attr( $file ),
-		esc_attr( $wp_list_table->get_column_count() ),
+		esc_attr( $wp_list_table->get_column_count() )
 	);
 
-	$closure_reasons = [
+	$closure_reasons = array(
 		'security-issue'                => _x( 'A security issue is known to exist within the plugin.', 'Plugin closure reason' ),
 		'author-request'                => _x( 'The author of this plugin no longer supports it, and requested the plugin be closed.', 'Plugin closure reason' ),
 		'guideline-violation'           => _x( 'The plugin has been suspended due to a Guideline Violation.', 'Plugin closure reason' ),
@@ -685,7 +684,7 @@ function wp_plugin_closed_row( $file, $plugin_data ) {
 		'merged-into-core'              => _x( 'This plugin is no longer required, as the functionality is now provided by WordPress.', 'Plugin closure reason' ),
 		'unused'                        => _x( 'This plugin is unused.', 'Plugin closure reason' ),
 		'unknown'                       => _x( 'The reason is unknown.', 'Plugin closure reason' ),
-	];
+	);
 
 	/* translators: %s: is an error code returned by WordPress.org, this is a fallback for when no reason is known. */
 	$unknown_closure_reason                    = _x( 'The plugin has been closed due to: %s.', 'Plugin closure reason' );

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -678,7 +678,7 @@ function wp_plugin_closed_row( $file, $plugin_data ) {
 	);
 
 	$closure_reasons = [
-		'security-issue'                => _x( 'An unfixed security issue is known to exist within the plugin.', 'Plugin closure reason' ),
+		'security-issue'                => _x( 'A security issue is known to exist within the plugin.', 'Plugin closure reason' ),
 		'author-request'                => _x( 'The author of this plugin no longer supports it, and requested the plugin be closed.', 'Plugin closure reason' ),
 		'guideline-violation'           => _x( 'The plugin has been suspended due to a Guideline Violation.', 'Plugin closure reason' ),
 		'licensing-trademark-violation' => _x( 'The plugin has been suspended due to a Licensing/Trademark Violation', 'Plugin closure reason' ),

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -717,7 +717,7 @@ function wp_plugin_closed_row( $file, $plugin_data ) {
 	printf(
 		/* translators: 1: Date the plugin was closed, 2: Reason the plugin was closed. */
 		__( 'This plugin has been closed as of %1$s and is no longer available for new installs. %2$s.' ),
-		date_i18n( get_option( 'date_format' ), strtotime( $response->closed_at ) ),
+		date_i18n( get_option( 'date_format' ), strtotime( $response->closed_on ) ),
 		$closure_reason_text
 	);
 
@@ -740,7 +740,7 @@ function wp_plugin_closed_row( $file, $plugin_data ) {
 	 *     @type string $slug          Plugin slug.
 	 *     @type string $plugin        Plugin basename.
 	 *     @type string $url           Plugin URL.
-	 *     @type string $closed_at     The date of which the plugin was closed.
+	 *     @type string $closed_on     The date of which the plugin was closed.
 	 *     @type string $closed_reason A code which represents the reason the plugin was closed.
 	 * }
 	 */

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -687,6 +687,10 @@ function wp_plugin_closed_row( $file, $plugin_data ) {
 		'unknown'                       => _x( 'The reason is unknown.', 'Plugin closure reason' ),
 	];
 
+	/* translators: %s: is an error code returned by WordPress.org, this is a fallback for when no reason is known. */
+	$unknown_closure_reason                    = _x( 'The plugin has been closed due to: %s.', 'Plugin closure reason' );
+	$closure_reasons['unknown-closure-reason'] = $unknown_closure_reason;
+
 	/**
 	 * Filters the list of plugin closure reasons.
 	 *
@@ -697,16 +701,24 @@ function wp_plugin_closed_row( $file, $plugin_data ) {
 	 */
 	$closure_reasons = apply_filters( 'plugin_closure_reasons', $closure_reasons );
 
-	// We must always have an unknown reason.
-	if ( ! isset( $closure_reasons['unknown'] ) ) {
-		$closure_reasons['unknown'] = _x( 'Unknown', 'Plugin closure reason' );
+	if ( isset( $closure_reasons[ $response->closed_reason ] ) ) {
+		$closure_reason_text = $closure_reasons[ $response->closed_reason ];
+	} else {
+		if ( isset( $closure_reasons['unknown-closure-reason'] ) ) {
+			$unknown_closure_reason = $closure_reasons['unknown-closure-reason'];
+		}
+
+		$closure_reason_text = sprintf(
+			$unknown_closure_reason,
+			'<code>' . esc_html( $response->closed_reason ) . '</code>'
+		);
 	}
 
 	printf(
 		/* translators: 1: Date the plugin was closed, 2: Reason the plugin was closed. */
 		__( 'This plugin has been closed as of %1$s and is no longer available for new installs. %2$s.' ),
 		date_i18n( get_option( 'date_format' ), strtotime( $response->closed_at ) ),
-		isset( $closure_reasons[ $response->closed_reason ] ) ? $closure_reasons[ $response->closed_reason ] : $closure_reasons['unknown']
+		$closure_reason_text
 	);
 
 	/**

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -678,14 +678,13 @@ function wp_plugin_closed_row( $file, $plugin_data ) {
 	);
 
 	$closure_reasons = [
-		// TODO: Make these more human friendly.
-		'security-issue'                => _x( 'Security Issue', 'Plugin closure reason' ),
-		'author-request'                => _x( 'Author Request', 'Plugin closure reason' ),
-		'guideline-violation'           => _x( 'Guideline Violation', 'Plugin closure reason' ),
-		'licensing-trademark-violation' => _x( 'Licensing/Trademark Violation', 'Plugin closure reason' ),
-		'merged-into-core'              => _x( 'Merged into WordPress Core', 'Plugin closure reason' ),
-		'unused'                        => _x( 'Unused', 'Plugin closure reason' ),
-		'unknown'                       => _x( 'Unknown', 'Plugin closure reason' ),
+		'security-issue'                => _x( 'An unfixed security issue is known to exist within the plugin.', 'Plugin closure reason' ),
+		'author-request'                => _x( 'The author of this plugin no longer supports it, and requested the plugin be closed.', 'Plugin closure reason' ),
+		'guideline-violation'           => _x( 'The plugin has been suspended due to a Guideline Violation.', 'Plugin closure reason' ),
+		'licensing-trademark-violation' => _x( 'The plugin has been suspended due to a Licensing/Trademark Violation', 'Plugin closure reason' ),
+		'merged-into-core'              => _x( 'This plugin is no longer required, as the functionality is now provided by WordPress.', 'Plugin closure reason' ),
+		'unused'                        => _x( 'This plugin is unused.', 'Plugin closure reason' ),
+		'unknown'                       => _x( 'The reason is unknown.', 'Plugin closure reason' ),
 	];
 
 	/**
@@ -705,7 +704,7 @@ function wp_plugin_closed_row( $file, $plugin_data ) {
 
 	printf(
 		/* translators: 1: Date the plugin was closed, 2: Reason the plugin was closed. */
-		__( 'This plugin has been closed as of %1$s and is no longer available for new installs. Reason: %2$s.' ),
+		__( 'This plugin has been closed as of %1$s and is no longer available for new installs. %2$s.' ),
 		date_i18n( get_option( 'date_format' ), strtotime( $response->closed_at ) ),
 		isset( $closure_reasons[ $response->closed_reason ] ) ? $closure_reasons[ $response->closed_reason ] : $closure_reasons['unknown']
 	);

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -421,7 +421,6 @@ function wp_update_plugins( $extra_stats = array() ) {
 			'plugins'      => wp_json_encode( $to_send ),
 			'translations' => wp_json_encode( $translations ),
 			'locale'       => wp_json_encode( $locales ),
-			'all'          => wp_json_encode( true ),
 		),
 		'user-agent' => 'WordPress/' . wp_get_wp_version() . '; ' . home_url( '/' ),
 	);
@@ -430,7 +429,7 @@ function wp_update_plugins( $extra_stats = array() ) {
 		$options['body']['update_stats'] = wp_json_encode( $extra_stats );
 	}
 
-	$url      = 'http://api.wordpress.org/plugins/update-check/1.1/';
+	$url      = 'http://api.wordpress.org/plugins/update-check/1.2/';
 	$http_url = $url;
 	$ssl      = wp_http_supports( array( 'ssl' ) );
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/30465

<img width="919" alt="Screenshot 2024-10-29 at 4 53 16 pm" src="https://github.com/user-attachments/assets/4e1d56ac-ed3d-46e4-b090-08e53ae24281">

This is partially reliant upon https://core.trac.wordpress.org/ticket/53333 / #1332 as the v1.2 updates API will currently return autoupdate data in a different manner. (This is a merge blocker)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
