### PR TITLE
Chore: Add missing `void` to doc-blocks `return` types.

### DIFF
--- a/src/wp-admin/includes/class-wp-privacy-requests-table.php
+++ b/src/wp-admin/includes/class-wp-privacy-requests-table.php
@@ -430,7 +430,7 @@ abstract class WP_Privacy_Requests_Table extends WP_List_Table {
 	 * @since 4.9.6
 	 *
 	 * @param WP_User_Request $item Item being shown.
-	 * @return string Status column markup.
+	 * @return string|void Status column markup. Returns a string if no status is found, otherwise it echos the markup.
 	 */
 	public function column_status( $item ) {
 		$status        = get_post_status( $item->ID );

--- a/src/wp-includes/class-wp-recovery-mode.php
+++ b/src/wp-includes/class-wp-recovery-mode.php
@@ -161,9 +161,9 @@ class WP_Recovery_Mode {
 	 * @since 5.2.0
 	 *
 	 * @param array $error Error details from `error_get_last()`.
-	 * @return true|WP_Error True if the error was handled and headers have already been sent.
-	 *                       Or the request will exit to try and catch multiple errors at once.
-	 *                       WP_Error if an error occurred preventing it from being handled.
+	 * @return true|WP_Error|void True if the error was handled and headers have already been sent.
+	 *                            Or the request will exit to try and catch multiple errors at once.
+	 *                            WP_Error if an error occurred preventing it from being handled.
 	 */
 	public function handle_error( array $error ) {
 

--- a/src/wp-includes/class-wp-widget.php
+++ b/src/wp-includes/class-wp-widget.php
@@ -138,7 +138,7 @@ class WP_Widget {
 	 * @since 2.8.0
 	 *
 	 * @param array $instance The settings for the particular instance of the widget.
-	 * @return string Default return is 'noform'.
+	 * @return string|void Default return is 'noform'.
 	 */
 	public function form( $instance ) {
 		echo '<p class="no-options-widget">' . __( 'There are no options for this widget.' ) . '</p>';


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/52217

This PR adds missing `void` return types to (parent) methods that can _explicitly_ return void as one of their conditional paths.

While these issues were surfaced via PHPStan in #7619 (trac: https://core.trac.wordpress.org/ticket/61175 ), they can be addressed independently of that ticket.

### Addressed methods:
- `WP_Privacy_Requests_Table::column_status()`
- `WP_Recovery_Mode::handle_error()`
- `WP_Widget::form()` - unlike the others, it's the _child classes_ that return void when the method is correctly implemented.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
