### PR TITLE
Add `screen_admin_context` filter

### DIFF
--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -365,6 +365,19 @@ final class WP_Screen {
 				break;
 		}
 
+		/**
+		 * Filters the admin context of a screen in WordPress admin panels.
+		 *
+		 * Allows modification of the `$in_admin` property of a `WP_Screen` instance.
+		 *
+		 * @since 6.7.0
+		 *
+		 * @param string $in_admin  The current admin context. Possible values are 'site', 'network', 'user', etc.
+		 * @param string $hook_name The hook name for the current screen.
+		 * @param string $id        The unique ID of the screen.
+		 */
+		$in_admin = apply_filters( 'screen_admin_context', $in_admin, $hook_name, $id );
+
 		if ( 'network' === $in_admin ) {
 			$id   .= '-network';
 			$base .= '-network';


### PR DESCRIPTION
This PR introduces a new filter, `screen_admin_context`, to the `WP_Screen class`, enabling developers to modify the $in_admin property dynamically. This property is currently locked to specific values (such as 'site' for regular site admin and 'network' for network admin), making it challenging to accurately identify additional custom administration panels introduced by plugins. 

Trac ticket: https://core.trac.wordpress.org/ticket/37445

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
