### PR TITLE
Update: Use `network_site_url` instead of `site_url` in wp_login_url and `wp_logout_url`

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -419,7 +419,7 @@ function wp_logout_url( $redirect = '' ) {
 		$args['redirect_to'] = urlencode( $redirect );
 	}
 
-	$logout_url = add_query_arg( $args, site_url( 'wp-login.php?action=logout', 'login' ) );
+	$logout_url = add_query_arg( $args, network_site_url( 'wp-login.php?action=logout', 'login' ) );
 	$logout_url = wp_nonce_url( $logout_url, 'log-out' );
 
 	/**
@@ -444,7 +444,7 @@ function wp_logout_url( $redirect = '' ) {
  * @return string The login URL. Not HTML-encoded.
  */
 function wp_login_url( $redirect = '', $force_reauth = false ) {
-	$login_url = site_url( 'wp-login.php', 'login' );
+	$login_url = network_site_url( 'wp-login.php', 'login' );
 
 	if ( ! empty( $redirect ) ) {
 		$login_url = add_query_arg( 'redirect_to', urlencode( $redirect ), $login_url );


### PR DESCRIPTION
Trac Ticket: Core-62320

## Description

- This pull request updates the `wp_login_url` and `wp_logout_url` functions to use `network_site_url()` instead of `site_url()`. This change enhances compatibility with multisite environments, ensuring that these functions correctly generate URLs based on the network root when applicable.

## Background

- In WordPress multisite setups, network_site_url() is designed to handle URL generation based on the network’s primary site URL, while falling back to `site_url()` in single-site environments. Currently, `wp_login_url` and `wp_logout_url` use `site_url()`, which can lead to inconsistencies in multisite setups where URLs need to point to the network’s root URL.

## Changes Made
- Replaced `site_url()` with `network_site_url()` in both wp_login_url and `wp_logout_url` functions.

## Impact

- This change should be backward compatible and will primarily benefit multisite installations by ensuring URLs are correctly generated based on the network root.