### PR TITLE
Enhance `update_option` Functionality: Autoload Behavior Update and Documentation Improvements

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -822,8 +822,8 @@ function wp_load_core_site_options( $network_id = null ) {
  * @param bool|null $autoload Optional. Whether to load the option when WordPress starts up.
  *                            Accepts a boolean, or `null` to stick with the initial value or, if no initial value is
  *                            set, to leave the decision up to default heuristics in WordPress.
- *                            For existing options, `$autoload` can only be updated using `update_option()` if `$value`
- *                            is also changed.
+ *                            For existing options, `$autoload` can only be updated using `update_option()`
+ *                            if `$value` is changed or `$autoload` is explicitly provided and changed.
  *                            For backward compatibility 'yes' and 'no' are also accepted, though using these values is
  *                            deprecated.
  *                            Autoloading too many options can lead to performance problems, especially if the
@@ -833,7 +833,7 @@ function wp_load_core_site_options( $network_id = null ) {
  *                            to not autoload them, by using false.
  *                            For non-existent options, the default is null, which means WordPress will determine
  *                            the autoload value.
- * @return bool True if the value was updated, false otherwise.
+ * @return bool True if the value or the autoload was updated, false otherwise.
  */
 function update_option( $option, $value, $autoload = null ) {
 	global $wpdb;
@@ -903,8 +903,19 @@ function update_option( $option, $value, $autoload = null ) {
 	 */
 	$value = apply_filters( 'pre_update_option', $value, $option, $old_value );
 
+	$raw_autoload = null;
+
+	if ( ! is_null( $autoload ) ) {
+		// Retrieve the current autoload value to reevaluate it in case it was set automatically.
+		$raw_autoload = $wpdb->get_var( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name = %s LIMIT 1", $option ) );
+	}
+
+	$serialized_value = maybe_serialize( $value );
+
+	$requested_autoload = wp_determine_option_autoload_value( $option, $value, $serialized_value, $autoload );
+
 	/*
-	 * If the new and old values are the same, no need to update.
+	 * If the values are the same, and autoload is either null or new and old autoload values are the same, no need to update.
 	 *
 	 * Unserialized values will be adequate in most cases. If the unserialized
 	 * data differs, the (maybe) serialized data is checked to avoid
@@ -912,7 +923,7 @@ function update_option( $option, $value, $autoload = null ) {
 	 *
 	 * See https://core.trac.wordpress.org/ticket/38903
 	 */
-	if ( $value === $old_value || maybe_serialize( $value ) === maybe_serialize( $old_value ) ) {
+	if ( ( $value === $old_value || $serialized_value === maybe_serialize( $old_value ) ) && ( is_null( $autoload ) || $raw_autoload === $requested_autoload ) ) {
 		return false;
 	}
 
@@ -920,8 +931,6 @@ function update_option( $option, $value, $autoload = null ) {
 	if ( apply_filters( "default_option_{$option}", false, $option, false ) === $old_value ) {
 		return add_option( $option, $value, '', $autoload );
 	}
-
-	$serialized_value = maybe_serialize( $value );
 
 	/**
 	 * Fires immediately before an option value is updated.
@@ -939,13 +948,14 @@ function update_option( $option, $value, $autoload = null ) {
 	);
 
 	if ( null !== $autoload ) {
-		$update_args['autoload'] = wp_determine_option_autoload_value( $option, $value, $serialized_value, $autoload );
+		$update_args['autoload'] = $requested_autoload;
 	} else {
-		// Retrieve the current autoload value to reevaluate it in case it was set automatically.
-		$raw_autoload = $wpdb->get_var( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name = %s LIMIT 1", $option ) );
+		$raw_autoload = is_null( $raw_autoload )
+			? $wpdb->get_var( $wpdb->prepare( "SELECT autoload FROM $wpdb->options WHERE option_name = %s LIMIT 1", $option ) )
+			: $raw_autoload;
 		$allow_values = array( 'auto-on', 'auto-off', 'auto' );
 		if ( in_array( $raw_autoload, $allow_values, true ) ) {
-			$autoload = wp_determine_option_autoload_value( $option, $value, $serialized_value, $autoload );
+			$autoload = $requested_autoload;
 			if ( $autoload !== $raw_autoload ) {
 				$update_args['autoload'] = $autoload;
 			}

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -923,7 +923,7 @@ function update_option( $option, $value, $autoload = null ) {
 	 *
 	 * See https://core.trac.wordpress.org/ticket/38903
 	 */
-	if ( ( $value === $old_value || $serialized_value === maybe_serialize( $old_value ) ) && ( is_null( $autoload ) || $raw_autoload === $requested_autoload ) ) {
+	if ( ( $value === $old_value || maybe_serialize( $old_value ) === $serialized_value ) && ( is_null( $autoload ) || $raw_autoload === $requested_autoload ) ) {
 		return false;
 	}
 

--- a/tests/phpunit/tests/customize/manager.php
+++ b/tests/phpunit/tests/customize/manager.php
@@ -282,10 +282,10 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 		wp_cache_delete( 'alloptions', 'options' );
 		wp_load_alloptions();
 
-		// Make sure no DB write is done when publishing and a site is already non-fresh.
+		// A DB write is done when publishing and a site is already non-fresh because it checks & compares the autoload parameter.
 		$query_count = get_num_queries();
 		do_action( 'customize_save_after', $wp_customize );
-		$this->assertSame( $query_count, get_num_queries() );
+		$this->assertSame( ++$query_count, get_num_queries() );
 	}
 
 	/**

--- a/tests/phpunit/tests/option/updateOption.php
+++ b/tests/phpunit/tests/option/updateOption.php
@@ -145,9 +145,9 @@ class Tests_Option_UpdateOption extends WP_UnitTestCase {
 	 * @covers ::wp_load_alloptions
 	 * @covers ::get_option
 	 */
-	public function test_autoload_should_not_be_updated_for_existing_option_when_value_is_unchanged() {
+	public function test_autoload_should_not_be_updated_for_existing_option_when_value_and_autoload_is_unchanged() {
 		add_option( 'foo', 'bar', '', true );
-		$updated = update_option( 'foo', 'bar', false );
+		$updated = update_option( 'foo', 'bar', true );
 		$this->assertFalse( $updated );
 
 		$this->flush_cache();
@@ -160,6 +160,30 @@ class Tests_Option_UpdateOption extends WP_UnitTestCase {
 
 		// 'foo' should still be autoload=yes, so we should see no additional querios.
 		$this->assertSame( $before, get_num_queries() );
+		$this->assertSame( $value, 'bar' );
+	}
+	
+	/**
+	 * @ticket 48393
+	 *
+	 * @covers ::update_option
+	 * @covers ::wp_load_alloptions
+	 * @covers ::get_option
+	 */
+	public function test_autoload_should_be_updated_for_existing_option_when_value_is_unchanged_but_autoload_is_changed() {
+		add_option( 'foo', 'bar', '', true );
+		$updated = update_option( 'foo', 'bar', false );
+		$this->assertTrue( $updated );
+
+		$this->flush_cache();
+
+		// Populate the alloptions cache, which includes autoload=yes options.
+		wp_load_alloptions();
+
+		$before = get_num_queries();
+		$value  = get_option( 'foo' );
+
+		$this->assertSame( ++$before, get_num_queries() );
 		$this->assertSame( $value, 'bar' );
 	}
 

--- a/tests/phpunit/tests/option/updateOption.php
+++ b/tests/phpunit/tests/option/updateOption.php
@@ -162,7 +162,7 @@ class Tests_Option_UpdateOption extends WP_UnitTestCase {
 		$this->assertSame( $before, get_num_queries() );
 		$this->assertSame( $value, 'bar' );
 	}
-	
+
 	/**
 	 * @ticket 48393
 	 *


### PR DESCRIPTION
Trac Ticket: Core-48393

## Summary

- This pull request introduces changes to the `update_option` function in WordPress, enhancing its functionality and updating the corresponding documentation.

## Code Changes

### Behavior Update:
- If the user explicitly provides the $autoload parameter and it differs from the existing value, the autoload status will be updated even if the $value remains unchanged.

- If both the $value and the $autoload parameters are the same as their existing values, the function will not perform an update.

- When the $autoload parameter is set to null, it is assumed that the user has not provided a value for autoloading, and the decision to update will be based solely on the comparison of the old and new values.

### Documentation Updates

- The documentation has been revised to reflect the new behavior of the $autoload parameter:
    - Clarified that $autoload can be updated when explicitly provided and different from the existing value, even if the $value is unchanged.
    - Enhanced explanations for better understanding of how the $autoload and $value parameters interact during the update process.

### Key Points

- This change improves the flexibility of the update_option function, allowing for more granular control over option updates.

- The documentation now accurately describes the behavior and implications of using the $autoload parameter.

## Additional Notes

- These updates aim to provide clearer guidance to developers on using the update_option function and to ensure that the behavior aligns with their expectations.
