### PR TITLE
Chore: Remove invalid `@throws WP_Error` from `register_block_*()` doc-blocks

### DIFF
--- a/src/wp-includes/blocks/home-link.php
+++ b/src/wp-includes/blocks/home-link.php
@@ -166,7 +166,6 @@ function render_block_core_home_link( $attributes, $content, $block ) {
  * @since 6.0.0
  *
  * @uses render_block_core_home_link()
- * @throws WP_Error An WP_Error exception parsing the block definition.
  */
 function register_block_core_home_link() {
 	register_block_type_from_metadata(

--- a/src/wp-includes/blocks/navigation-link.php
+++ b/src/wp-includes/blocks/navigation-link.php
@@ -413,7 +413,6 @@ function block_core_navigation_link_build_variations() {
  * @since 5.9.0
  *
  * @uses render_block_core_navigation_link()
- * @throws WP_Error An WP_Error exception parsing the block definition.
  */
 function register_block_core_navigation_link() {
 	register_block_type_from_metadata(

--- a/src/wp-includes/blocks/navigation-submenu.php
+++ b/src/wp-includes/blocks/navigation-submenu.php
@@ -254,7 +254,6 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
  * @since 5.9.0
  *
  * @uses render_block_core_navigation_submenu()
- * @throws WP_Error An WP_Error exception parsing the block definition.
  */
 function register_block_core_navigation_submenu() {
 	register_block_type_from_metadata(


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/52217

This PR removes invalid `@throws WP_Error` annotations from the doc-blocks of the following functions:
- `register_block_core_home_link()`
- `register_block_core_navigation_link()`
- `register_block_core_navigation_submenu()`

These annotations are invalid for a few reasons:
- `WP_Error` is returnable, not `Throwable`
- `WP_Error` is not returned.
- A review of the functions' internals and `render_callbacks` doesn't show any attempts to either return a `WP_Error` or throw anything else.
   ( It's possible I missed something, but I'm pretty confident, as these are the only `register_()` functions in `blocks/` that have any `@throws` annotation )

While this issue was surfaced via PHPStan in https://github.com/WordPress/wordpress-develop/pull/7619 (trac: https://core.trac.wordpress.org/ticket/61175 ), it can be remediated independently of that ticket.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
