### PR TITLE
chore: fix invalid `@var` type for `WP_HTML_Processor_State::$context_node`

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor-state.php
+++ b/src/wp-includes/html-api/class-wp-html-processor-state.php
@@ -363,7 +363,7 @@ class WP_HTML_Processor_State {
 	 *
 	 * @see https://html.spec.whatwg.org/#concept-frag-parse-context
 	 *
-	 * @var [string, array]|null
+	 * @var array{string,array}|null
 	 */
 	public $context_node = null;
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/52217

This PR fixes the PHPDoc `@var` type used for `WP_HTML_Processor_State::$context_node` to "correctly" indicate that it is an array where the first item is a `string` and the second is an `array`.

"Correctly" in this context means recognized by IDEs and tooling and following preexisting code patterns for array shapes (e.g. https://github.com/WordPress/wordpress-develop/blob/695476ea5e51d1c92f389ac236b138ceeaee8a99/src/wp-includes/interactivity-api/class-wp-interactivity-api.php#L104).

While this issue was surfaced via PHPStan in https://github.com/WordPress/wordpress-develop/pull/7619 (trac: https://core.trac.wordpress.org/ticket/61175 ), it can be remediated independently of that ticket.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
