### PR TITLE
Add Twenty Twenty-five to Performance Tests

### DIFF
--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -15,7 +15,7 @@ on:
         description: 'The version being used for baseline measurements.'
         required: false
         type: 'string'
-        default: '6.1.1'
+        default: '6.6.2'
       php-version:
         description: 'The PHP version to use.'
         required: false

--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -15,7 +15,7 @@ on:
         description: 'The version being used for baseline measurements.'
         required: false
         type: 'string'
-        default: '6.6.2'
+        default: '6.7'
       php-version:
         description: 'The PHP version to use.'
         required: false

--- a/tests/performance/specs/home.test.js
+++ b/tests/performance/specs/home.test.js
@@ -14,7 +14,7 @@ const results = {
 	lcpMinusTtfb: [],
 };
 
-const themes = [ 'twentytwentyone', 'twentytwentythree', 'twentytwentyfour' ];
+const themes = [ 'twentytwentyone', 'twentytwentythree', 'twentytwentyfour', 'twentytwentyfive' ];
 
 const locales = [ 'en_US', 'de_DE' ];
 


### PR DESCRIPTION
Changed the default value of the baseline version from 6.1.1 to 6.6.2 in the reusable-performance.yml workflow file. This ensures the workflow uses the latest baseline version for performance measurements.


Trac ticket: https://core.trac.wordpress.org/ticket/62148