### PR TITLE
Feature: Add `is_super_admin()` check in ms-files.php

### DIFF
--- a/src/wp-includes/ms-files.php
+++ b/src/wp-includes/ms-files.php
@@ -18,7 +18,7 @@ if ( ! is_multisite() ) {
 
 ms_file_constants();
 
-if ( ( '1' === $current_blog->archived || '1' === $current_blog->spam || '1' === $current_blog->deleted ) && ! is_super_admin() ) {
+if ( ! is_super_admin() && ( '1' === $current_blog->archived || '1' === $current_blog->spam || '1' === $current_blog->deleted ) ) {
 	status_header( 404 );
 	die( '404 &#8212; File not found.' );
 }

--- a/src/wp-includes/ms-files.php
+++ b/src/wp-includes/ms-files.php
@@ -18,7 +18,7 @@ if ( ! is_multisite() ) {
 
 ms_file_constants();
 
-if ( '1' === $current_blog->archived || '1' === $current_blog->spam || '1' === $current_blog->deleted ) {
+if ( ( '1' === $current_blog->archived || '1' === $current_blog->spam || '1' === $current_blog->deleted ) && ! is_super_admin() ) {
 	status_header( 404 );
 	die( '404 &#8212; File not found.' );
 }

--- a/src/wp-includes/ms-files.php
+++ b/src/wp-includes/ms-files.php
@@ -18,7 +18,7 @@ if ( ! is_multisite() ) {
 
 ms_file_constants();
 
-if ( ! is_super_admin() && ( '1' === $current_blog->archived || '1' === $current_blog->spam || '1' === $current_blog->deleted ) ) {
+if (! is_super_admin() && ( '1' === $current_blog->archived || '1' === $current_blog->spam || '1' === $current_blog->deleted ) ) {
 	status_header( 404 );
 	die( '404 &#8212; File not found.' );
 }

--- a/src/wp-includes/ms-files.php
+++ b/src/wp-includes/ms-files.php
@@ -18,7 +18,7 @@ if ( ! is_multisite() ) {
 
 ms_file_constants();
 
-if (! is_super_admin() && ( '1' === $current_blog->archived || '1' === $current_blog->spam || '1' === $current_blog->deleted ) ) {
+if ( ! is_super_admin() && ( '1' === $current_blog->archived || '1' === $current_blog->spam || '1' === $current_blog->deleted ) ) {
 	status_header( 404 );
 	die( '404 &#8212; File not found.' );
 }


### PR DESCRIPTION
Trac Ticket: Core-36803

## Description:

- An issue was identified in the multisite installations where archived sites remain accessible to network administrators, but the associated files do not. This behavior originates from the logic in ms-files.php, particularly around line 21:

```
if ( $current_blog->archived == '1' || $current_blog->spam == '1' || $current_blog->deleted == '1' ) {
    status_header( 404 );
    die( '404 &#8212; File not found.' );
}
```

- The current implementation checks if the blog is archived, marked as spam, or deleted, and subsequently returns a 404 error for file requests. However, this does not account for network administrators who should retain access to these files.

## Proposed Solution

- An additional check using is_super_admin() has been implemented. This adjustment allows network administrators to access files even if the site is archived, spam, or deleted. The modified code snippet is as follows:

```
if ( ( $current_blog->archived == '1' || $current_blog->spam == '1' || $current_blog->deleted == '1' ) && ! is_super_admin() ) {
    status_header( 404 );
    die( '404 &#8212; File not found.' );
}
```

## Benefits

- Enhanced Access for Network Administrators: This change ensures that network admins can access necessary files for archived sites, improving usability and functionality.

- Preservation of Current Logic: The existing restrictions remain in place for regular users, maintaining intended access controls.
