### PR TITLE
Theme JSON: replace top-level background style objects on merge

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -3268,6 +3268,10 @@ class WP_Theme_JSON {
 			array(),
 			array( 'include_node_paths_only' => true )
 		);
+
+		// Add top-level styles.
+		$style_nodes[] = array( 'path' => array( 'styles' ) );
+
 		foreach ( $style_nodes as $style_node ) {
 			$path = $style_node['path'];
 			/*

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -2344,7 +2344,9 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 				'styles'  => array(
 					'background' => array(
 						'backgroundImage' => array(
-							'url' => 'http://example.org/quote.png',
+							'id'     => 'uploaded',
+							'source' => 'file',
+							'url'    => 'http://example.org/quote.png',
 						),
 						'backgroundSize'  => 'cover',
 					),
@@ -2376,7 +2378,10 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			'version' => WP_Theme_JSON::LATEST_SCHEMA,
 			'styles'  => array(
 				'background' => array(
-					'backgroundSize' => 'contain',
+					'backgroundImage' => array(
+						'url' => 'http://example.org/site.png',
+					),
+					'backgroundSize'  => 'contain',
 				),
 				'blocks'     => array(
 					'core/group' => array(
@@ -2406,7 +2411,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			'styles'  => array(
 				'background' => array(
 					'backgroundImage' => array(
-						'url' => 'http://example.org/quote.png',
+						'url' => 'http://example.org/site.png',
 					),
 					'backgroundSize'  => 'contain',
 				),


### PR DESCRIPTION

A PR that syncs the Gutenberg PR:

- https://github.com/WordPress/gutenberg/pull/66656


This PR fixes an omission in the theme json merge logic where top-level background image objects are not replaced, rather they are merged. Blocks are already catered for via ::get_block_nodes().

To test, run `npm run test:php -- --filter=Tests_Theme_wpThemeJson`

Trac ticket: https://core.trac.wordpress.org/ticket/62328

