### PR TITLE
Theme JSON Resolver: remove theme json merge in resolve_theme_file_uris

### DIFF
--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -933,18 +933,14 @@ class WP_Theme_JSON_Resolver {
 			return $theme_json;
 		}
 
-		$resolved_theme_json_data = array(
-			'version' => WP_Theme_JSON::LATEST_SCHEMA,
-		);
+		$resolved_theme_json_data = $theme_json->get_raw_data();
 
 		foreach ( $resolved_urls as $resolved_url ) {
 			$path = explode( '.', $resolved_url['target'] );
 			_wp_array_set( $resolved_theme_json_data, $path, $resolved_url['href'] );
 		}
 
-		$theme_json->merge( new WP_Theme_JSON( $resolved_theme_json_data ) );
-
-		return $theme_json;
+		return new WP_Theme_JSON_Gutenberg( $resolved_theme_json_data );
 	}
 
 	/**

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -940,7 +940,7 @@ class WP_Theme_JSON_Resolver {
 			_wp_array_set( $resolved_theme_json_data, $path, $resolved_url['href'] );
 		}
 
-		return new WP_Theme_JSON_Gutenberg( $resolved_theme_json_data );
+		return new WP_Theme_JSON( $resolved_theme_json_data );
 	}
 
 	/**


### PR DESCRIPTION
This PR syncs Gutenberg PR https://github.com/WordPress/gutenberg/pull/66662

The change affects `WP_Theme_JSON_Resolver::resolve_theme_file_uris()`.

When setting resolved URIs in an incoming theme json object, remove the unnecessary call to `WP_Theme_JSON->merge()`.

Why?

`WP_Theme_JSON_Resolver::resolve_theme_file_uris()` only needs to set values for paths in the raw theme json object.

It can then return a new theme object based on the updated JSON source. There's no need for a full and possibly expensive merge.

### Testing

There is existing test coverage. Tests should pass.

Trac ticket: https://core.trac.wordpress.org/ticket/62329

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
