### PR TITLE
Fix: Menu Item Without Label Being Removed

### DIFF
--- a/src/wp-admin/includes/nav-menu.php
+++ b/src/wp-admin/includes/nav-menu.php
@@ -1420,8 +1420,8 @@ function wp_nav_menu_update_menu_items( $nav_menu_selected_id, $nav_menu_selecte
 	if ( ! empty( $_POST['menu-item-db-id'] ) ) {
 		foreach ( (array) $_POST['menu-item-db-id'] as $_key => $k ) {
 
-			// Menu item title can't be blank.
-			if ( ! isset( $_POST['menu-item-title'][ $_key ] ) || '' === $_POST['menu-item-title'][ $_key ] ) {
+			// Menu item title should be set, but it can be left empty.
+			if ( ! isset( $_POST['menu-item-title'][ $_key ] ) ) {
 				continue;
 			}
 

--- a/src/wp-includes/nav-menu-template.php
+++ b/src/wp-includes/nav-menu-template.php
@@ -398,6 +398,11 @@ function _wp_menu_item_classes_by_context( &$menu_items ) {
 		$classes[] = 'menu-item-type-' . $menu_item->type;
 		$classes[] = 'menu-item-object-' . $menu_item->object;
 
+		// This menu item has no label.
+		if ( '' === $menu_item->post_title ) {
+			$classes[] = 'no-title';
+		}
+
 		// This menu item is set as the 'Front Page'.
 		if ( 'post_type' === $menu_item->type && $front_page_id === (int) $menu_item->object_id ) {
 			$classes[] = 'menu-item-home';


### PR DESCRIPTION
## Description

This PR addresses the issue where menu items without labels were being removed.

## Changes Made

- Remove check for empty labels for menu item
- Add `no-title` class for empty label menu item

## Why?

- Menu items were being deleted silently, without prompting the user to confirm whether the item should be removed.
- Users couldn't create a menu item with an empty label, which they might want to use for custom purposes—for example, to display an icon using the `fa fa-envelope` class without any label text.

## Steps to Reproduce

- Create a new menu.
- Add two custom links (e.g., https://example.com/) with link text labeled "test1" and "test2," then add each to the menu.
- Save the menu.
- Assign this menu to a theme location that is visible on the site, then save your changes.
- Visit the site to confirm that both menu items are displayed.
- Return to the Edit Menus section, edit the "test2" menu item and remove the label and hit the save button.
- The item will be removed.

## Trac ticket: https://core.trac.wordpress.org/ticket/24146
