### PR TITLE
Moved wp_parse_str from formatting.php to functions.php

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5129,27 +5129,6 @@ function map_deep( $value, $callback ) {
 }
 
 /**
- * Parses a string into variables to be stored in an array.
- *
- * @since 2.2.1
- *
- * @param string $input_string The string to be parsed.
- * @param array  $result       Variables will be stored in this array.
- */
-function wp_parse_str( $input_string, &$result ) {
-	parse_str( (string) $input_string, $result );
-
-	/**
-	 * Filters the array of variables derived from a parsed string.
-	 *
-	 * @since 2.2.1
-	 *
-	 * @param array $result The array populated with variables.
-	 */
-	$result = apply_filters( 'wp_parse_str', $result );
-}
-
-/**
  * Converts lone less than signs.
  *
  * KSES already converts lone greater than signs.

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -4920,6 +4920,27 @@ function smilies_init() {
 }
 
 /**
+ * Parses a string into variables to be stored in an array.
+ *
+ * @since 2.2.1
+ *
+ * @param string $input_string The string to be parsed.
+ * @param array  $result       Variables will be stored in this array.
+ */
+function wp_parse_str( $input_string, &$result ) {
+	parse_str( (string) $input_string, $result );
+
+	/**
+	 * Filters the array of variables derived from a parsed string.
+	 *
+	 * @since 2.2.1
+	 *
+	 * @param array $result The array populated with variables.
+	 */
+	$result = apply_filters( 'wp_parse_str', $result );
+}
+
+/**
  * Merges user defined arguments into defaults array.
  *
  * This function is used throughout WordPress to allow for both string or array


### PR DESCRIPTION
This PR addresses a potential fatal error in the `wp_parse_args() `function, which can occur if `wp_parse_args()` is called with an empty string as the first parameter before `wp_parse_str()` is defined. The issue arises because `wp_parse_str()`, which is required by `wp_parse_args(`), is located in `formatting.php`, which is loaded later in the WordPress load order than `functions.php`. This results in an `undefined function` fatal error when `wp_parse_args()` calls `wp_parse_str()` before `formatting.php` has been loaded.

Trac ticket: https://core.trac.wordpress.org/ticket/40552

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
