### PR TITLE
Fix heading typography in the editor Twenty Twelve theme.

### DIFF
--- a/src/wp-content/themes/twentytwelve/css/editor-blocks.css
+++ b/src/wp-content/themes/twentytwelve/css/editor-blocks.css
@@ -18,21 +18,25 @@ Description: Used to style blocks in the editor.
 /*--------------------------------------------------------------
 1.0 General Typography
 --------------------------------------------------------------*/
-
+.editor-styles-wrapper,
+.editor-styles-wrapper p,
 .edit-post-visual-editor .editor-block-list__block,
 .edit-post-visual-editor .editor-block-list__block p,
 .editor-default-block-appender textarea.editor-default-block-appender__content {
 	font-size: 14px;
 }
 
+.editor-styles-wrapper,
 .editor-default-block-appender textarea.editor-default-block-appender__content {
 	font-family: "Open Sans", Helvetica, Arial, sans-serif;
 }
 
+.editor-styles-wrapper,
 .edit-post-visual-editor .editor-block-list__block {
 	color: #444;
 }
 
+.editor-styles-wrapper .wp-block-post-title,
 .editor-post-title__block .editor-post-title__input {
 	font-family: "Open Sans", Helvetica, Arial, sans-serif;
 	font-size: 20px;
@@ -40,31 +44,38 @@ Description: Used to style blocks in the editor.
 }
 
 @media screen and (min-width: 600px) {
+	.editor-styles-wrapper .wp-block-post-title,
 	.editor-post-title__block .editor-post-title__input {
 		font-size: 22px;
 	}
 }
 
+.editor-styles-wrapper h1,
 .wp-block-freeform.block-library-rich-text__tinymce h1 {
 	font-size: 21px;
 }
 
+.editor-styles-wrapper h2,
 .wp-block-freeform.block-library-rich-text__tinymce h2 {
 	font-size: 18px;
 }
 
+.editor-styles-wrapper h3,
 .wp-block-freeform.block-library-rich-text__tinymce h3 {
 	font-size: 16px;
 }
 
+.editor-styles-wrapper h4,
 .wp-block-freeform.block-library-rich-text__tinymce h4 {
 	font-size: 14px;
 }
 
+.editor-styles-wrapper h5,
 .wp-block-freeform.block-library-rich-text__tinymce h5 {
 	font-size: 13px;
 }
 
+.editor-styles-wrapper h6,
 .wp-block-freeform.block-library-rich-text__tinymce h6 {
 	font-size: 12px;
 }

--- a/src/wp-content/themes/twentytwelve/css/editor-blocks.css
+++ b/src/wp-content/themes/twentytwelve/css/editor-blocks.css
@@ -23,7 +23,7 @@ Description: Used to style blocks in the editor.
 .edit-post-visual-editor .editor-block-list__block,
 .edit-post-visual-editor .editor-block-list__block p,
 .editor-default-block-appender textarea.editor-default-block-appender__content {
-	font-size: 14px;
+	font-size: 16px;
 }
 
 .editor-styles-wrapper,
@@ -39,45 +39,45 @@ Description: Used to style blocks in the editor.
 .editor-styles-wrapper .wp-block-post-title,
 .editor-post-title__block .editor-post-title__input {
 	font-family: "Open Sans", Helvetica, Arial, sans-serif;
-	font-size: 20px;
+	font-size: 36px;
 	font-weight: 400;
 }
 
 @media screen and (min-width: 600px) {
 	.editor-styles-wrapper .wp-block-post-title,
 	.editor-post-title__block .editor-post-title__input {
-		font-size: 22px;
+		font-size: 24px;
 	}
 }
 
 .editor-styles-wrapper h1,
 .wp-block-freeform.block-library-rich-text__tinymce h1 {
-	font-size: 21px;
+	font-size: 36px;
 }
 
 .editor-styles-wrapper h2,
 .wp-block-freeform.block-library-rich-text__tinymce h2 {
-	font-size: 18px;
+	font-size: 30px;
 }
 
 .editor-styles-wrapper h3,
 .wp-block-freeform.block-library-rich-text__tinymce h3 {
-	font-size: 16px;
+	font-size: 24px;
 }
 
 .editor-styles-wrapper h4,
 .wp-block-freeform.block-library-rich-text__tinymce h4 {
-	font-size: 14px;
+	font-size: 21px;
 }
 
 .editor-styles-wrapper h5,
 .wp-block-freeform.block-library-rich-text__tinymce h5 {
-	font-size: 13px;
+	font-size: 18px;
 }
 
 .editor-styles-wrapper h6,
 .wp-block-freeform.block-library-rich-text__tinymce h6 {
-	font-size: 12px;
+	font-size: 16px;
 }
 
 /*--------------------------------------------------------------

--- a/src/wp-content/themes/twentytwelve/css/editor-blocks.css
+++ b/src/wp-content/themes/twentytwelve/css/editor-blocks.css
@@ -18,8 +18,8 @@ Description: Used to style blocks in the editor.
 /*--------------------------------------------------------------
 1.0 General Typography
 --------------------------------------------------------------*/
+
 .editor-styles-wrapper,
-.editor-styles-wrapper p,
 .edit-post-visual-editor .editor-block-list__block,
 .edit-post-visual-editor .editor-block-list__block p,
 .editor-default-block-appender textarea.editor-default-block-appender__content {


### PR DESCRIPTION
## PR Description 
- Fix Heading Typography for Theme twenty twelve, for different viewports, in the hierarchy of 14, 16, 18, 21, 24, 30, 36 for tags, h1, h2, h3, h4, h5, h6 respectively.

- Post titles are now set to 24px for narrow viewports and 36px for wider viewports, consistent with frontend design. Editor styles have been updated to reflect these sizes, providing a cohesive editing experience.

Trac ticket: https://core.trac.wordpress.org/ticket/62010

---
