### PR TITLE
Fix:` wp_delete_attachment` to Handle Non-Standard Taxonomies

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6601,7 +6601,9 @@ function wp_delete_attachment( $post_id, $force_delete = false ) {
 	 */
 	do_action( 'delete_attachment', $post_id, $post );
 
-	if ( ( ! empty( $attachment_taxonomies = get_object_taxonomies( $post->post_type ) ) ) ) {
+	$attachment_taxonomies = get_object_taxonomies( $post->post_type );
+
+	if ( ! empty( $attachment_taxonomies ) ) {
 		wp_delete_object_term_relationships( $post_id, $attachment_taxonomies );
 	}
 

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6601,8 +6601,9 @@ function wp_delete_attachment( $post_id, $force_delete = false ) {
 	 */
 	do_action( 'delete_attachment', $post_id, $post );
 
-	wp_delete_object_term_relationships( $post_id, array( 'category', 'post_tag' ) );
-	wp_delete_object_term_relationships( $post_id, get_object_taxonomies( $post->post_type ) );
+	if ( ( ! empty( $attachment_taxonomies = get_object_taxonomies( $post->post_type ) ) ) ) {
+		wp_delete_object_term_relationships( $post_id, $attachment_taxonomies );
+	}
 
 	// Delete all for any posts.
 	delete_metadata( 'post', null, '_thumbnail_id', $post_id, true );

--- a/tests/phpunit/tests/post/wpDeleteAttachment.php
+++ b/tests/phpunit/tests/post/wpDeleteAttachment.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * @group post
+ * @group media
+ */
+class Tests_Media_WPDeleteAttachment extends WP_UnitTestCase {
+	protected $attachment_id;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		// Create a sample attachment for testing
+		$filename            = DIR_TESTDATA . '/images/test-image.jpg';
+		$this->attachment_id = self::factory()->attachment->create_upload_object( $filename );
+	}
+
+	public function tear_down(): void {
+		// Clean up the created attachment
+		if ( $this->attachment_id ) {
+			wp_delete_attachment( $this->attachment_id, true );
+		}
+
+		parent::tear_down();
+	}
+
+	public function test_should_delete_attachment_successfully() {
+		$result = wp_delete_attachment( $this->attachment_id );
+		$this->assertInstanceOf( 'WP_Post', $result ); // Check if it returns the post object
+		$this->assertEquals( 'attachment', $result->post_type ); // Ensure it's still an attachment post type
+		$this->assertNotEquals( 'trash', $result->post_status ); // Ensure it's not in trash
+	}
+
+	public function test_should_return_false_when_post_id_does_not_exist() {
+		$result = wp_delete_attachment( 99999 ); // ID that doesn't exist
+		$this->assertTrue( false === $result || is_null( $result ), 'Expected wp_delete_attachment to return false or null on failure.' );
+	}
+
+	public function test_should_return_false_when_post_is_not_attachment() {
+		$post_id = self::factory()->post->create( array( 'post_type' => 'post' ) ); // Create a regular post
+		$result  = wp_delete_attachment( $post_id );
+		$this->assertFalse( $result ); // Should return false since it's not an attachment
+	}
+
+	public function test_should_force_delete_attachment_when_forced() {
+
+		// Force delete the attachment
+		$result = wp_delete_attachment( $this->attachment_id, true );
+		$this->assertInstanceOf( 'WP_Post', $result ); // Check if it returns the post object
+		$this->assertEquals( 'attachment', $result->post_type ); // Ensure it's still an attachment post type
+		$this->assertNotEquals( 'trash', $result->post_status ); // Ensure it's not in trash
+	}
+
+	public function test_should_not_delete_if_pre_delete_filter_returns_non_null() {
+		add_filter( 'pre_delete_attachment', '__return_false' );
+
+		$result            = wp_delete_attachment( $this->attachment_id );
+		$attachment_object = get_post( $this->attachment_id );
+		$this->assertFalse( $result );
+		$this->assertInstanceOf( 'WP_Post', $attachment_object ); // Should return the post object, not delete it
+		$this->assertNotEquals( 'trash', $attachment_object->post_status ); // Should still be published
+	}
+
+	public function test_should_handle_non_standard_taxonomies_without_warnings() {
+		// Ensure the attachment does not have any default taxonomies
+		wp_set_object_terms( $this->attachment_id, array(), 'category' );
+		wp_set_object_terms( $this->attachment_id, array(), 'post_tag' );
+
+		// Register a new custom taxonomy.
+		register_taxonomy( 'custom_taxonomy', 'attachment' );
+		self::factory()->term->create(
+			array(
+				'taxonomy' => 'custom_taxonomy',
+				'name'     => 'custom_term',
+			)
+		);
+		// Ensure the attachment does not have 'category' or 'post_tag' taxonomies
+		wp_set_object_terms( $this->attachment_id, array( 'custom_term' ), 'custom_taxonomy' );
+
+		// Attempt to delete the attachment
+		$result = wp_delete_attachment( $this->attachment_id );
+		$this->assertInstanceOf( 'WP_Post', $result ); // Check if it returns the post object
+		$this->assertEquals( 'attachment', $result->post_type ); // Ensure it's still an attachment post type
+		$this->assertNotEquals( 'trash', $result->post_status ); // Ensure it's not in trash
+	}
+}


### PR DESCRIPTION
Trac Ticket: Core-36437

## Description:

- This pull request addresses an issue with the `wp_delete_attachment` function, which assumes that attachments use the category and post_tag taxonomies. This assumption can lead to warnings in wp_delete_object_term_relationships when the attachment's post type does not utilize these taxonomies.

## Changes Made:

- Updated the `wp_delete_attachment` function to check for existing taxonomies associated with the post type. This ensures that only relevant taxonomies are used when deleting term relationships, preventing unnecessary warnings.

- Removed hardcoded references to `category` and `post_tag`, allowing the function to dynamically handle any taxonomies related to the attachment's post type.

- Added unit tests to verify the new behavior, ensuring that attachments can be deleted without warnings even when custom taxonomies are used. The tests confirm that the function behaves correctly when no terms are associated with the attachment.

## Testing:

- All existing and new unit tests have been executed successfully, confirming that the changes do not introduce any regressions and that the new functionality works as intended.

## Conclusion:

- These changes enhance the robustness of the `wp_delete_attachment` function, making it more flexible and ensuring it can handle a wider range of use cases without generating warnings. Thank you for considering this pull request!



