### PR TITLE
REST API: simplify ternary operators and remove redundant type casting

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -955,7 +955,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			return $comment;
 		}
 
-		$force = isset( $request['force'] ) ? (bool) $request['force'] : false;
+		$force = isset( $request['force'] ) && $request['force'];
 
 		/**
 		 * Filters whether a comment can be trashed via the REST API.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-font-faces-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-font-faces-controller.php
@@ -417,7 +417,7 @@ class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
 			);
 		}
 
-		$force = isset( $request['force'] ) ? (bool) $request['force'] : false;
+		$force = isset( $request['force'] ) && $request['force'];
 
 		// We don't support trashing for font faces.
 		if ( ! $force ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-font-families-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-font-families-controller.php
@@ -204,7 +204,7 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function delete_item( $request ) {
-		$force = isset( $request['force'] ) ? (bool) $request['force'] : false;
+		$force = isset( $request['force'] ) && $request['force'];
 
 		// We don't support trashing for font families.
 		if ( ! $force ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-revisions-controller.php
@@ -473,7 +473,7 @@ class WP_REST_Revisions_Controller extends WP_REST_Controller {
 			return $revision;
 		}
 
-		$force = isset( $request['force'] ) ? (bool) $request['force'] : false;
+		$force = isset( $request['force'] ) && $request['force'];
 
 		// We don't support trashing for revisions.
 		if ( ! $force ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
@@ -743,7 +743,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			return $term;
 		}
 
-		$force = isset( $request['force'] ) ? (bool) $request['force'] : false;
+		$force = isset( $request['force'] ) && $request['force'];
 
 		// We don't support trashing for terms.
 		if ( ! $force ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -623,7 +623,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 			),
 		);
 
-		foreach ( get_registered_theme_features() as $feature => $config ) {
+		foreach ( get_registered_theme_features() as $config ) {
 			if ( ! is_array( $config['show_in_rest'] ) ) {
 				continue;
 			}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -896,7 +896,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 
 		$id       = $user->ID;
 		$reassign = false === $request['reassign'] ? null : absint( $request['reassign'] );
-		$force    = isset( $request['force'] ) ? (bool) $request['force'] : false;
+		$force    = isset( $request['force'] ) && $request['force'];
 
 		// We don't support trashing for users.
 		if ( ! $force ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

 - [x] simplify ternary operators and remove redundant type casting;
 - [x] remove unused variable in `WP_REST_Themes_Controller::get_item_schema`;

Trac ticket: https://core.trac.wordpress.org/ticket/62333

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
