### PR TITLE
REST API: use strict comparison to check for empty arrays

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -738,7 +738,7 @@ class WP_REST_Server {
 				// Relation now changes from '$uri' to '$curie:$relation'.
 				$rel_regex = str_replace( '\{rel\}', '(.+)', preg_quote( $curie['href'], '!' ) );
 				preg_match( '!' . $rel_regex . '!', $rel, $matches );
-				if ( $matches ) {
+				if ( array() !== $matches ) {
 					$new_rel                       = $curie['name'] . ':' . $matches[1];
 					$used_curies[ $curie['name'] ] = $curie;
 					$links[ $new_rel ]             = $items;
@@ -749,7 +749,7 @@ class WP_REST_Server {
 		}
 
 		// Push the curies onto the start of the links array.
-		if ( $used_curies ) {
+		if ( array() !== $used_curies ) {
 			$links['curies'] = array_values( $used_curies );
 		}
 
@@ -836,7 +836,7 @@ class WP_REST_Server {
 			}
 		}
 
-		if ( ! empty( $embedded ) ) {
+		if ( array() !== $embedded ) {
 			$data['_embedded'] = $embedded;
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -567,7 +567,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 				);
 			}
 
-			if ( 0 === count( $modifiers ) ) {
+			if ( array() === $modifiers ) {
 				return new WP_Error(
 					'rest_image_not_edited',
 					__( 'The image was not edited. Edit the image before applying the changes.' ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -2721,7 +2721,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		// Emit a _doing_it_wrong warning if user tries to add new properties using this filter.
 		$new_fields = array_diff( array_keys( $schema['properties'] ), $schema_fields );
-		if ( count( $new_fields ) > 0 ) {
+		if ( array() !== $new_fields ) {
 			_doing_it_wrong(
 				__METHOD__,
 				sprintf(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -459,7 +459,7 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 			return $post_id;
 		}
 		$posts = get_block_templates( array( 'wp_id' => $post_id ), $this->post_type );
-		if ( ! count( $posts ) ) {
+		if ( array() === $posts ) {
 			return new WP_Error( 'rest_template_insert_error', __( 'No templates exist with that id.' ), array( 'status' => 400 ) );
 		}
 		$id            = $posts[0]->id;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

- [x] don't use `count()` to check for empty arrays (suboptimal performance).

Trac ticket: https://core.trac.wordpress.org/ticket/62333

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
