### PR TITLE
REST API: Replace simple if/else statements with ternary operators, and refactor return values

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-response.php
+++ b/src/wp-includes/rest-api/class-wp-rest-response.php
@@ -85,11 +85,9 @@ class WP_REST_Response extends WP_HTTP_Response {
 			return;
 		}
 
-		if ( $href ) {
-			$this->links[ $rel ] = wp_list_filter( $this->links[ $rel ], array( 'href' => $href ), 'NOT' );
-		} else {
-			$this->links[ $rel ] = array();
-		}
+		$this->links[ $rel ] = $href
+			? wp_list_filter( $this->links[ $rel ], array( 'href' => $href ), 'NOT' )
+			: array();
 
 		if ( ! $this->links[ $rel ] ) {
 			unset( $this->links[ $rel ] );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -457,11 +457,9 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, WP_Error object on failure.
 	 */
 	public function post_process_item( $request ) {
-		switch ( $request['action'] ) {
-			case 'create-image-subsizes':
-				require_once ABSPATH . 'wp-admin/includes/image.php';
-				wp_update_image_subsizes( $request['id'] );
-				break;
+		if ( 'create-image-subsizes' === $request['action'] ) {
+			require_once ABSPATH . 'wp-admin/includes/image.php';
+			wp_update_image_subsizes( $request['id'] );
 		}
 
 		$request['context'] = 'edit';

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-menu-items-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-menu-items-controller.php
@@ -1014,11 +1014,10 @@ class WP_REST_Menu_Items_Controller extends WP_REST_Posts_Controller {
 	 */
 	protected function get_menu_id( $menu_item_id ) {
 		$menu_ids = wp_get_post_terms( $menu_item_id, 'nav_menu', array( 'fields' => 'ids' ) );
-		$menu_id  = 0;
 		if ( $menu_ids && ! is_wp_error( $menu_ids ) ) {
-			$menu_id = array_shift( $menu_ids );
+			return array_shift( $menu_ids );
 		}
 
-		return $menu_id;
+		return 0;
 	}
 }

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -2008,12 +2008,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		if ( rest_is_field_included( 'template', $fields ) ) {
-			$template = get_page_template_slug( $post->ID );
-			if ( $template ) {
-				$data['template'] = $template;
-			} else {
-				$data['template'] = '';
-			}
+			$template         = get_page_template_slug( $post->ID );
+			$data['template'] = $template ? $template : '';
 		}
 
 		if ( rest_is_field_included( 'format', $fields ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-site-health-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-site-health-controller.php
@@ -295,19 +295,15 @@ class WP_REST_Site_Health_Controller extends WP_REST_Controller {
 			$data = array();
 
 			if ( isset( $value['size'] ) ) {
-				if ( is_string( $value['size'] ) ) {
-					$data['size'] = sanitize_text_field( $value['size'] );
-				} else {
-					$data['size'] = (int) $value['size'];
-				}
+				$data['size'] = is_string( $value['size'] )
+					? sanitize_text_field( $value['size'] )
+					: (int) $value['size'];
 			}
 
 			if ( isset( $value['debug'] ) ) {
-				if ( is_string( $value['debug'] ) ) {
-					$data['debug'] = sanitize_text_field( $value['debug'] );
-				} else {
-					$data['debug'] = (int) $value['debug'];
-				}
+				$data['debug'] = is_string( $value['debug'] )
+					? sanitize_text_field( $value['debug'] )
+					: (int) $value['debug'];
 			}
 
 			if ( ! empty( $value['raw'] ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php
@@ -126,7 +126,11 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 		$data = array();
 
 		foreach ( $taxonomies as $tax_type => $value ) {
-			if ( empty( $value->show_in_rest ) || ( 'edit' === $request['context'] && ! current_user_can( $value->cap->assign_terms ) ) ) {
+			if ( empty( $value->show_in_rest ) ) {
+				continue;
+			}
+
+			if ( 'edit' === $request['context'] && ! current_user_can( $value->cap->assign_terms ) ) {
 				continue;
 			}
 
@@ -441,12 +445,12 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 	 * @return array Collection parameters.
 	 */
 	public function get_collection_params() {
-		$new_params            = array();
-		$new_params['context'] = $this->get_context_param( array( 'default' => 'view' ) );
-		$new_params['type']    = array(
-			'description' => __( 'Limit results to taxonomies associated with a specific post type.' ),
-			'type'        => 'string',
+		return array(
+			'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+			'type'    => array(
+				'description' => __( 'Limit results to taxonomies associated with a specific post type.' ),
+				'type'        => 'string',
+			),
 		);
-		return $new_params;
 	}
 }

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
@@ -164,13 +164,8 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 			return true;
 		}
 
-		// Otherwise grant access if the post is readable by the logged-in user.
-		if ( current_user_can( 'read_post', $post->ID ) ) {
-			return true;
-		}
-
-		// Otherwise, deny access.
-		return false;
+		// Deny access if the post is not readable by the logged-in user.
+		return current_user_can( 'read_post', $post->ID );
 	}
 
 	/**

--- a/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
+++ b/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
@@ -85,12 +85,7 @@ abstract class WP_REST_Meta_Fields {
 			$all_values = get_metadata( $this->get_meta_type(), $object_id, $meta_key, false );
 
 			if ( $args['single'] ) {
-				if ( empty( $all_values ) ) {
-					$value = $args['schema']['default'];
-				} else {
-					$value = $all_values[0];
-				}
-
+				$value = empty( $all_values ) ? $args['schema']['default'] : $all_values[0];
 				$value = $this->prepare_value_for_response( $value, $request, $args );
 			} else {
 				$value = array();
@@ -554,11 +549,7 @@ abstract class WP_REST_Meta_Fields {
 	 * @return mixed Value prepared for output. If a non-JsonSerializable object, null.
 	 */
 	public static function prepare_value( $value, $request, $args ) {
-		if ( $args['single'] ) {
-			$schema = $args['schema'];
-		} else {
-			$schema = $args['schema']['items'];
-		}
+		$schema = $args['single'] ? $args['schema'] : $args['schema']['items'];
 
 		if ( '' === $value && in_array( $schema['type'], array( 'boolean', 'integer', 'number' ), true ) ) {
 			$value = static::get_empty_value_for_type( $schema['type'] );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

- [x] replace "simple" `if`/`else` statements with ternary operators;
- [x] refactor complex `if`/`continue` statements into two simpler `continue` statements;
- [x] refactor return values in certain methods by creating arrays all at once, rather than adding values to an array one by one.

Trac ticket: https://core.trac.wordpress.org/ticket/62333

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
