### PR TITLE
Update: Add medium_large size for `wp_prepare_attachment_for_js()`

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -4513,10 +4513,11 @@ function wp_prepare_attachment_for_js( $attachment ) {
 		$possible_sizes = apply_filters(
 			'image_size_names_choose',
 			array(
-				'thumbnail' => __( 'Thumbnail' ),
-				'medium'    => __( 'Medium' ),
-				'large'     => __( 'Large' ),
-				'full'      => __( 'Full Size' ),
+				'thumbnail'    => __( 'Thumbnail' ),
+				'medium'       => __( 'Medium' ),
+				'medium_large' => __( 'Medium Large' ),
+				'large'        => __( 'Large' ),
+				'full'         => __( 'Full Size' ),
 			)
 		);
 		unset( $possible_sizes['full'] );


### PR DESCRIPTION
Trac Ticket: Core-43413

## Overview

- This pull request introduces the addition of the medium_large image size to the `wp_prepare_attachment_for_js` function in WordPress. This enhancement allows for better handling and retrieval of the medium_large image size in the JavaScript context, providing developers with more flexibility when working with media attachments.

## Changes Made

- Modified the `wp_prepare_attachment_for_js` function to include the `medium_large` image size.
Ensured that the new size is appropriately registered and available for use in the media library.

## Benefits

- Improved Media Management: By including the medium_large size, users can more effectively manage and display images without needing to generate additional sizes manually.

- Better Performance: Utilizing the appropriate image size can improve page load times and overall performance, particularly on responsive designs where image dimensions are critical.