### PR TITLE
Resolve UI breakage because of long application password name.

### DIFF
--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -1008,6 +1008,7 @@ table.form-table td .updated p {
 
 .auth-app-card.card {
 	max-width: 768px;
+	word-wrap: break-word;
 }
 
 .authorize-application-php .form-wrap p {


### PR DESCRIPTION

## PR Description.

- Fix UI breaking in "new password" of authorisation application page by adding word wrap.

## Screenshots
<img width="564" alt="Screenshot 2024-11-04 at 1 03 36 PM" src="https://github.com/user-attachments/assets/e71464c7-eb48-4fac-a745-9b12ba67b993">
<img width="566" alt="Screenshot 2024-11-04 at 1 05 17 PM" src="https://github.com/user-attachments/assets/87221d79-46a3-451d-83a6-57fc07f38bf0">

Trac ticket: https://core.trac.wordpress.org/ticket/62340
---
