### PR TITLE
Refactor `wp_registration_url()` to accept an optional redirect parameter

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -481,7 +481,7 @@ function wp_registration_url( $redirect_to = null ) {
 	$register_url = site_url( 'wp-login.php?action=register', 'login' );
 
 	// Append redirect URL if provided.
-	if ( $redirect_to ) {
+	if ( ! empty( $redirect_to ) ) {
 		$register_url = add_query_arg( 'redirect_to', urlencode( $redirect_to ), $register_url );
 	}
 

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -476,8 +476,10 @@ function wp_login_url( $redirect = '', $force_reauth = false ) {
  * @return string User registration URL.
  */
 function wp_registration_url( $redirect = '' ) {
+	// Set base registration URL.
 	$register_url = site_url( 'wp-login.php?action=register', 'login' );
 
+	// Append redirect URL if provided.
 	if ( ! empty( $redirect ) ) {
 		$register_url = add_query_arg( 'redirect_to', urlencode( $redirect ), $register_url );
 	}

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -472,9 +472,16 @@ function wp_login_url( $redirect = '', $force_reauth = false ) {
  *
  * @since 3.6.0
  *
+ * @param  string $redirect Optional path to redirect to on registration.
  * @return string User registration URL.
  */
-function wp_registration_url() {
+function wp_registration_url( $redirect = '' ) {
+	$register_url = site_url( 'wp-login.php?action=register', 'login' );
+
+	if ( ! empty( $redirect ) ) {
+		$register_url = add_query_arg( 'redirect_to', urlencode( $redirect ), $register_url );
+	}
+
 	/**
 	 * Filters the user registration URL.
 	 *
@@ -482,7 +489,7 @@ function wp_registration_url() {
 	 *
 	 * @param string $register The user registration URL.
 	 */
-	return apply_filters( 'register_url', site_url( 'wp-login.php?action=register', 'login' ) );
+	return apply_filters( 'register_url', $register_url, $redirect );
 }
 
 /**

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -471,17 +471,18 @@ function wp_login_url( $redirect = '', $force_reauth = false ) {
  * Returns the URL that allows the user to register on the site.
  *
  * @since 3.6.0
+ * @since tba Optional `$redirect_to` parameter was added.
  *
- * @param  string $redirect Optional path to redirect to on registration.
+ * @param  string|null $redirect_to Optional path to redirect to on registration.
  * @return string User registration URL.
  */
-function wp_registration_url( $redirect = '' ) {
+function wp_registration_url( $redirect_to = null ) {
 	// Set base registration URL.
 	$register_url = site_url( 'wp-login.php?action=register', 'login' );
 
 	// Append redirect URL if provided.
-	if ( ! empty( $redirect ) ) {
-		$register_url = add_query_arg( 'redirect_to', urlencode( $redirect ), $register_url );
+	if ( $redirect_to ) {
+		$register_url = add_query_arg( 'redirect_to', urlencode( $redirect_to ), $register_url );
 	}
 
 	/**
@@ -491,7 +492,7 @@ function wp_registration_url( $redirect = '' ) {
 	 *
 	 * @param string $register The user registration URL.
 	 */
-	return apply_filters( 'register_url', $register_url, $redirect );
+	return apply_filters( 'register_url', $register_url );
 }
 
 /**


### PR DESCRIPTION
## Description

This PR adds an optional `$redirect` parameter to `wp_registration_url()`, enabling redirection after registration, similar to other WordPress URL functions. If a redirect URL is provided, it’s added as a `redirect_to` query argument.

## Changes Made

Added `$redirect` Parameter:
- Allows specifying a redirect URL for post-registration navigation.
- Checks if `$redirect` is provided, and if so, adds it as a `redirect_to` query argument to the base registration URL.
- The function now filters the updated `$register_url` and includes the `$redirect` parameter in the filter hook, ensuring custom modifications to the registration URL also have access to this parameter.

## Testing Instruction

- Check `wp_registration_url()` with and without a redirect parameter.
- Verify that the generated URL correctly includes the `redirect_to` parameter when specified.

## Trac ticket: https://core.trac.wordpress.org/ticket/27632
