### PR TITLE
Fix undefined array key 'host' in canonical.php

### DIFF
--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -714,8 +714,8 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 		$redirect['path'] = trailingslashit( $redirect['path'] );
 	}
 
-	$original_host_low = strtolower( $original['host'] );
-	$redirect_host_low = strtolower( $redirect['host'] );
+	$original_host_low = strtolower( $original['host'] ?? '' );
+	$redirect_host_low = strtolower( $redirect['host'] ?? '' );
 
 	/*
 	 * Ignore differences in host capitalization, as this can lead to infinite redirects.
@@ -725,10 +725,10 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 		|| ( 'www.' . $original_host_low !== $redirect_host_low
 			&& 'www.' . $redirect_host_low !== $original_host_low )
 	) {
-		$redirect['host'] = $original['host'];
+		$redirect['host'] = $original['host'] ?? '';
 	}
 
-	$compare_original = array( $original['host'], $original['path'] );
+	$compare_original = array( $original['host'] ?? '', $original['path'] );
 
 	if ( ! empty( $original['port'] ) ) {
 		$compare_original[] = $original['port'];
@@ -749,7 +749,7 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 	}
 
 	if ( $compare_original !== $compare_redirect ) {
-		$redirect_url = $redirect['scheme'] . '://' . $redirect['host'];
+		$redirect_url = $redirect['scheme'] ?? 'http' . '://' . $redirect['host'];
 
 		if ( ! empty( $redirect['port'] ) ) {
 			$redirect_url .= ':' . $redirect['port'];


### PR DESCRIPTION
This PR addresses PHP warnings in the WordPress canonical.php file related to undefined host and scheme array keys, particularly in environments using HTTP/3 (QUIC) with Nginx, where these headers may be inconsistently set.

To resolve these warnings, fallback values have been introduced for the host and scheme keys as follows:

- ` host`: Defaults to an empty string ('') if not set. This prevents undefined key errors while allowing flexibility in URL handling logic.
- `scheme`: Defaults to 'http' if not set. This ensures URLs are built with a valid protocol if the scheme is missing.
These changes prevent PHP warnings while maintaining backward compatibility across HTTP/1.1, HTTP/2, and HTTP/3 requests.

Trac ticket: https://core.trac.wordpress.org/ticket/62334

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
