### PR TITLE
Add style change for wp table list to make sticky table header.

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -406,6 +406,13 @@ table.media .column-title .filename {
 	transition: none;
 }
 
+.wp-list-table thead {
+	position: sticky;
+	top: var(--wp-admin--admin-bar--height);
+	z-index: 9;
+	background-color: #fff;
+}
+
 #the-list tr:last-child td,
 #the-list tr:last-child th {
 	border-bottom: none !important;

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -413,6 +413,12 @@ table.media .column-title .filename {
 	background-color: #fff;
 }
 
+@media screen and (max-width: 600px) {
+	.wp-list-table thead {
+		top: 0;
+	}
+}
+
 #the-list tr:last-child td,
 #the-list tr:last-child th {
 	border-bottom: none !important;


### PR DESCRIPTION
Trac Ticket: [Core-31284](https://core.trac.wordpress.org/ticket/31284)

## Description
This pull request introduces a UI improvement in the admin area's table list view. Issue: When users have many posts and need to scroll down, the table header disappears from view. This update ensures that the table header remains visible, which can also benefit plugin authors who create pages with extensive lists.

## Testing
- Verify that the table header stays fixed at the top, below the WP admin bar, for both desktop and mobile devices. This functionality should also apply to custom WordPress list table views.

