### PR TITLE
Only convert image if the output MIME type is different from the input MIME type

### DIFF
--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -301,7 +301,11 @@ function wp_create_image_subsizes( $file, $attachment_id ) {
 			// The image may need to be converted regardless of its dimensions.
 			$output_format = wp_get_image_editor_output_format( $file, $imagesize['mime'] );
 
-			if ( is_array( $output_format ) && array_key_exists( $imagesize['mime'], $output_format ) ) {
+			if (
+				is_array( $output_format ) &&
+				array_key_exists( $imagesize['mime'], $output_format ) &&
+				$output_format[ $imagesize['mime'] ] !== $imagesize['mime']
+			) {
 				$convert = true;
 			}
 		}


### PR DESCRIPTION
Minor follow up fix to https://core.trac.wordpress.org/changeset/59317, see https://core.trac.wordpress.org/ticket/62305#comment:34.

Trac ticket: https://core.trac.wordpress.org/ticket/62305

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
