### PR TITLE
Test workflows with ubuntu-24.

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -49,7 +49,7 @@ jobs:
   # Runs the PHP coding standards checks.
   phpcs:
     name: PHP coding standards
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-php.yml@trunk
+    uses: ./.github/workflows/reusable-coding-standards-php.yml
     permissions:
       contents: read
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
@@ -57,7 +57,7 @@ jobs:
   # Runs the JavaScript coding standards checks.
   jshint:
     name: JavaScript coding standards
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-coding-standards-javascript.yml@trunk
+    uses: ./.github/workflows/reusable-coding-standards-javascript.yml
     permissions:
       contents: read
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
@@ -80,7 +80,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       actions: write
     needs: [ phpcs, jshint, slack-notifications ]

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -80,7 +80,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ phpcs, jshint, slack-notifications ]

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -67,7 +67,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ e2e-tests, slack-notifications ]

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -38,7 +38,7 @@ jobs:
   # Runs the end-to-end test suite.
   e2e-tests:
     name: Test with SCRIPT_DEBUG ${{ matrix.LOCAL_SCRIPT_DEBUG && 'enabled' || 'disabled' }}
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-end-to-end-tests.yml@trunk
+    uses: ./.github/workflows/reusable-end-to-end-tests.yml
     permissions:
       contents: read
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
@@ -67,7 +67,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       actions: write
     needs: [ e2e-tests, slack-notifications ]

--- a/.github/workflows/failed-workflow.yml
+++ b/.github/workflows/failed-workflow.yml
@@ -23,7 +23,7 @@ jobs:
   # - Restarts all failed jobs when the workflow fails or is cancelled for the first time.
   failed-workflow:
     name: Rerun a workflow
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     timeout-minutes: 30

--- a/.github/workflows/failed-workflow.yml
+++ b/.github/workflows/failed-workflow.yml
@@ -23,7 +23,7 @@ jobs:
   # - Restarts all failed jobs when the workflow fails or is cancelled for the first time.
   failed-workflow:
     name: Rerun a workflow
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       actions: write
     timeout-minutes: 30

--- a/.github/workflows/install-testing.yml
+++ b/.github/workflows/install-testing.yml
@@ -45,7 +45,7 @@ jobs:
   # - Fetches the versions of MySQL to test.
   build-matrix:
     name: Determine PHP Versions to test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     timeout-minutes: 5
     outputs:
@@ -111,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-24 ]
         php: ${{ fromJSON( needs.build-matrix.outputs.php-versions ) }}
         db-type: [ 'mysql' ]
         db-version: ${{ fromJSON( needs.build-matrix.outputs.mysql-versions ) }}
@@ -188,7 +188,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/install-testing.yml
+++ b/.github/workflows/install-testing.yml
@@ -45,7 +45,7 @@ jobs:
   # - Fetches the versions of MySQL to test.
   build-matrix:
     name: Determine PHP Versions to test
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     timeout-minutes: 5
     outputs:
@@ -111,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-24 ]
+        os: [ ubuntu-24.04 ]
         php: ${{ fromJSON( needs.build-matrix.outputs.php-versions ) }}
         db-type: [ 'mysql' ]
         db-version: ${{ fromJSON( needs.build-matrix.outputs.mysql-versions ) }}
@@ -188,7 +188,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -70,7 +70,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -47,7 +47,7 @@ jobs:
   # Runs the WordPress Core JavaScript tests.
   test-js:
     name: QUnit Tests
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-javascript-tests.yml@trunk
+    uses: ./.github/workflows/reusable-javascript-tests.yml
     permissions:
       contents: read
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
@@ -70,7 +70,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -64,7 +64,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -33,7 +33,7 @@ jobs:
   # Runs the performance test suite.
   performance:
     name: Performance tests ${{ matrix.memcached && '(with memcached)' || '' }}
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-performance.yml@trunk
+    uses: ./.github/workflows/reusable-performance.yml
     permissions:
       contents: read
     if: ${{ ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) && ! contains( github.event.before, '00000000' ) }}
@@ -64,7 +64,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -67,7 +67,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -51,7 +51,7 @@ jobs:
 
   slack-notifications:
     name: Slack Notifications
-    uses: WordPress/wordpress-develop/.github/workflows/slack-notifications.yml@trunk
+    uses: ./.github/workflows/slack-notifications.yml
     permissions:
       actions: read
       contents: read
@@ -67,7 +67,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -36,7 +36,7 @@ jobs:
   #
   test-with-mysql:
     name: PHP ${{ matrix.php }}
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-phpunit-tests-v3.yml@trunk
+    uses: ./.github/workflows/reusable-phpunit-tests-v3.yml
     permissions:
       contents: read
     secrets: inherit
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-24 ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4', '9.0' ]
@@ -54,14 +54,14 @@ jobs:
 
         include:
           # Include jobs for PHP 7.4 with memcached.
-          - os: ubuntu-latest
+          - os: ubuntu-24
             php: '7.4'
             db-type: 'mysql'
             db-version: '5.7'
             tests-domain: 'example.org'
             multisite: false
             memcached: true
-          - os: ubuntu-latest
+          - os: ubuntu-24
             php: '7.4'
             db-type: 'mysql'
             db-version: '5.7'
@@ -69,14 +69,14 @@ jobs:
             multisite: true
             memcached: true
           # Include jobs with a port on the test domain for both single and multisite.
-          - os: ubuntu-latest
+          - os: ubuntu-24
             php: '7.4'
             db-type: 'mysql'
             db-version: '5.7'
             tests-domain: 'example.org:8889'
             multisite: false
             memcached: false
-          - os: ubuntu-latest
+          - os: ubuntu-24
             php: '7.4'
             db-type: 'mysql'
             db-version: '5.7'
@@ -84,7 +84,7 @@ jobs:
             multisite: true
             memcached: false
           # Report test results to the Host Test Results.
-          - os: ubuntu-latest
+          - os: ubuntu-24
             db-type: 'mysql'
             db-version: '8.0'
             tests-domain: 'example.org'
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-24 ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         db-type: [ 'mariadb' ]
         db-version: [ '10.4', '10.6', '10.11', '11.2' ]
@@ -132,13 +132,13 @@ jobs:
 
         include:
         # Include jobs for PHP 7.4 with memcached.
-        - os: ubuntu-latest
+        - os: ubuntu-24
           php: '7.4'
           db-type: 'mariadb'
           db-version: '11.2'
           multisite: false
           memcached: true
-        - os: ubuntu-latest
+        - os: ubuntu-24
           php: '7.4'
           db-type: 'mariadb'
           db-version: '11.2'
@@ -172,7 +172,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-24 ]
+        os: [ ubuntu-24.04 ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4', '9.0' ]
@@ -54,14 +54,14 @@ jobs:
 
         include:
           # Include jobs for PHP 7.4 with memcached.
-          - os: ubuntu-24
+          - os: ubuntu-24.04
             php: '7.4'
             db-type: 'mysql'
             db-version: '5.7'
             tests-domain: 'example.org'
             multisite: false
             memcached: true
-          - os: ubuntu-24
+          - os: ubuntu-24.04
             php: '7.4'
             db-type: 'mysql'
             db-version: '5.7'
@@ -69,14 +69,14 @@ jobs:
             multisite: true
             memcached: true
           # Include jobs with a port on the test domain for both single and multisite.
-          - os: ubuntu-24
+          - os: ubuntu-24.04
             php: '7.4'
             db-type: 'mysql'
             db-version: '5.7'
             tests-domain: 'example.org:8889'
             multisite: false
             memcached: false
-          - os: ubuntu-24
+          - os: ubuntu-24.04
             php: '7.4'
             db-type: 'mysql'
             db-version: '5.7'
@@ -84,7 +84,7 @@ jobs:
             multisite: true
             memcached: false
           # Report test results to the Host Test Results.
-          - os: ubuntu-24
+          - os: ubuntu-24.04
             db-type: 'mysql'
             db-version: '8.0'
             tests-domain: 'example.org'
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-24 ]
+        os: [ ubuntu-24.04 ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         db-type: [ 'mariadb' ]
         db-version: [ '10.4', '10.6', '10.11', '11.2' ]
@@ -132,13 +132,13 @@ jobs:
 
         include:
         # Include jobs for PHP 7.4 with memcached.
-        - os: ubuntu-24
+        - os: ubuntu-24.04
           php: '7.4'
           db-type: 'mariadb'
           db-version: '11.2'
           multisite: false
           memcached: true
-        - os: ubuntu-24
+        - os: ubuntu-24.04
           php: '7.4'
           db-type: 'mariadb'
           db-version: '11.2'
@@ -172,7 +172,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -48,7 +48,7 @@ jobs:
   # - Removes the props-bot label, if necessary.
   props-bot:
     name: Generate a list of props
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       # The action needs permission `write` permission for PRs in order to add a comment.
       pull-requests: write

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -48,7 +48,7 @@ jobs:
   # - Removes the props-bot label, if necessary.
   props-bot:
     name: Generate a list of props
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       # The action needs permission `write` permission for PRs in order to add a comment.
       pull-requests: write

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -22,7 +22,7 @@ permissions: {}
 jobs:
   # Comments on a pull request when the author is a first time contributor.
   post-welcome-message:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       issues: write
       pull-requests: write
@@ -80,7 +80,7 @@ jobs:
   # Leaves a comment on a pull request with a link to test the changes in a WordPress Playground instance.
   playground-details:
     name: Comment on a pull request with Playground details
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       issues: write
       pull-requests: write
@@ -167,7 +167,7 @@ jobs:
   # Manages comments reminding contributors to include a Trac ticket link when opening a pull request.
   trac-ticket-check:
     name: Manage Trac ticket reminders for pull requests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -22,7 +22,7 @@ permissions: {}
 jobs:
   # Comments on a pull request when the author is a first time contributor.
   post-welcome-message:
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
       pull-requests: write
@@ -80,7 +80,7 @@ jobs:
   # Leaves a comment on a pull request with a link to test the changes in a WordPress Playground instance.
   playground-details:
     name: Comment on a pull request with Playground details
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
       pull-requests: write
@@ -167,7 +167,7 @@ jobs:
   # Manages comments reminding contributors to include a Trac ticket link when opening a pull request.
   trac-ticket-check:
     name: Manage Trac ticket reminders for pull requests
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/reusable-coding-standards-javascript.yml
+++ b/.github/workflows/reusable-coding-standards-javascript.yml
@@ -23,7 +23,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   jshint:
     name: Run coding standards checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       contents: read
     timeout-minutes: 20

--- a/.github/workflows/reusable-coding-standards-javascript.yml
+++ b/.github/workflows/reusable-coding-standards-javascript.yml
@@ -23,7 +23,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   jshint:
     name: Run coding standards checks
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     timeout-minutes: 20

--- a/.github/workflows/reusable-coding-standards-php.yml
+++ b/.github/workflows/reusable-coding-standards-php.yml
@@ -35,7 +35,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   phpcs:
     name: Run coding standards checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       contents: read
     timeout-minutes: 20

--- a/.github/workflows/reusable-coding-standards-php.yml
+++ b/.github/workflows/reusable-coding-standards-php.yml
@@ -35,7 +35,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   phpcs:
     name: Run coding standards checks
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     timeout-minutes: 20

--- a/.github/workflows/reusable-end-to-end-tests.yml
+++ b/.github/workflows/reusable-end-to-end-tests.yml
@@ -55,7 +55,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   e2e-tests:
     name: Run E2E tests
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     timeout-minutes: 20

--- a/.github/workflows/reusable-end-to-end-tests.yml
+++ b/.github/workflows/reusable-end-to-end-tests.yml
@@ -55,7 +55,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   e2e-tests:
     name: Run E2E tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       contents: read
     timeout-minutes: 20

--- a/.github/workflows/reusable-javascript-tests.yml
+++ b/.github/workflows/reusable-javascript-tests.yml
@@ -18,7 +18,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   test-js:
     name: Run QUnit tests
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     timeout-minutes: 20

--- a/.github/workflows/reusable-javascript-tests.yml
+++ b/.github/workflows/reusable-javascript-tests.yml
@@ -18,7 +18,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   test-js:
     name: Run QUnit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       contents: read
     timeout-minutes: 20

--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -99,7 +99,7 @@ jobs:
   # - Ensure version-controlled files are not modified or deleted.
   performance:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       contents: read
     if: ${{ ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) && ! contains( github.event.before, '00000000' ) }}

--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -99,7 +99,7 @@ jobs:
   # - Ensure version-controlled files are not modified or deleted.
   performance:
     name: Run tests
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     if: ${{ ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) && ! contains( github.event.before, '00000000' ) }}

--- a/.github/workflows/reusable-php-compatibility.yml
+++ b/.github/workflows/reusable-php-compatibility.yml
@@ -29,7 +29,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   php-compatibility:
     name: Run compatibility checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       contents: read
     timeout-minutes: 20

--- a/.github/workflows/reusable-php-compatibility.yml
+++ b/.github/workflows/reusable-php-compatibility.yml
@@ -29,7 +29,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   php-compatibility:
     name: Run compatibility checks
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     timeout-minutes: 20

--- a/.github/workflows/reusable-phpunit-tests-v1.yml
+++ b/.github/workflows/reusable-phpunit-tests-v1.yml
@@ -14,7 +14,7 @@ on:
         description: 'Operating system to run tests on'
         required: false
         type: 'string'
-        default: 'ubuntu-24'
+        default: 'ubuntu-24.04'
       php:
         description: 'The version of PHP to use, in the format of X.Y'
         required: true

--- a/.github/workflows/reusable-phpunit-tests-v1.yml
+++ b/.github/workflows/reusable-phpunit-tests-v1.yml
@@ -14,7 +14,7 @@ on:
         description: 'Operating system to run tests on'
         required: false
         type: 'string'
-        default: 'ubuntu-latest'
+        default: 'ubuntu-24'
       php:
         description: 'The version of PHP to use, in the format of X.Y'
         required: true

--- a/.github/workflows/reusable-phpunit-tests-v2.yml
+++ b/.github/workflows/reusable-phpunit-tests-v2.yml
@@ -14,7 +14,7 @@ on:
         description: 'Operating system to run tests on'
         required: false
         type: 'string'
-        default: 'ubuntu-24'
+        default: 'ubuntu-24.04'
       php:
         description: 'The version of PHP to use, in the format of X.Y'
         required: true

--- a/.github/workflows/reusable-phpunit-tests-v2.yml
+++ b/.github/workflows/reusable-phpunit-tests-v2.yml
@@ -14,7 +14,7 @@ on:
         description: 'Operating system to run tests on'
         required: false
         type: 'string'
-        default: 'ubuntu-latest'
+        default: 'ubuntu-24'
       php:
         description: 'The version of PHP to use, in the format of X.Y'
         required: true

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -12,7 +12,7 @@ on:
         description: 'Operating system to run tests on'
         required: false
         type: 'string'
-        default: 'ubuntu-24'
+        default: 'ubuntu-24.04'
       php:
         description: 'The version of PHP to use, in the format of X.Y'
         required: true

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -12,7 +12,7 @@ on:
         description: 'Operating system to run tests on'
         required: false
         type: 'string'
-        default: 'ubuntu-latest'
+        default: 'ubuntu-24'
       php:
         description: 'The version of PHP to use, in the format of X.Y'
         required: true

--- a/.github/workflows/reusable-test-core-build-process.yml
+++ b/.github/workflows/reusable-test-core-build-process.yml
@@ -10,7 +10,7 @@ on:
         description: 'Operating system to run tests on'
         required: false
         type: 'string'
-        default: 'ubuntu-24'
+        default: 'ubuntu-24.04'
       directory:
         description: 'Directory to run WordPress from. Valid values are `src` or `build`'
         required: false
@@ -91,7 +91,7 @@ jobs:
         run: git diff --exit-code
 
       - name: Create ZIP of built files
-        if: ${{ inputs.directory == 'build' && 'ubuntu-24' == inputs.os }}
+        if: ${{ inputs.directory == 'build' && 'ubuntu-24.04' == inputs.os }}
         run: zip -r wordpress.zip build/.
 
       - name: Clean after building to run from ${{ inputs.directory }}

--- a/.github/workflows/reusable-test-core-build-process.yml
+++ b/.github/workflows/reusable-test-core-build-process.yml
@@ -10,7 +10,7 @@ on:
         description: 'Operating system to run tests on'
         required: false
         type: 'string'
-        default: 'ubuntu-latest'
+        default: 'ubuntu-24'
       directory:
         description: 'Directory to run WordPress from. Valid values are `src` or `build`'
         required: false
@@ -91,7 +91,7 @@ jobs:
         run: git diff --exit-code
 
       - name: Create ZIP of built files
-        if: ${{ inputs.directory == 'build' && 'ubuntu-latest' == inputs.os }}
+        if: ${{ inputs.directory == 'build' && 'ubuntu-24' == inputs.os }}
         run: zip -r wordpress.zip build/.
 
       - name: Clean after building to run from ${{ inputs.directory }}

--- a/.github/workflows/reusable-test-gutenberg-build-process.yml
+++ b/.github/workflows/reusable-test-gutenberg-build-process.yml
@@ -10,7 +10,7 @@ on:
         description: 'Operating system to run tests on'
         required: false
         type: 'string'
-        default: 'ubuntu-latest'
+        default: 'ubuntu-24'
       directory:
         description: 'Directory to run WordPress from. Valid values are `src` or `build`'
         required: false

--- a/.github/workflows/reusable-test-gutenberg-build-process.yml
+++ b/.github/workflows/reusable-test-gutenberg-build-process.yml
@@ -10,7 +10,7 @@ on:
         description: 'Operating system to run tests on'
         required: false
         type: 'string'
-        default: 'ubuntu-24'
+        default: 'ubuntu-24.04'
       directory:
         description: 'Directory to run WordPress from. Valid values are `src` or `build`'
         required: false

--- a/.github/workflows/reusable-upgrade-testing.yml
+++ b/.github/workflows/reusable-upgrade-testing.yml
@@ -8,7 +8,7 @@ on:
         description: 'Operating system to run tests on.'
         required: false
         type: 'string'
-        default: 'ubuntu-24'
+        default: 'ubuntu-24.04'
       wp:
         description: 'The version of WordPress to start with.'
         required: true

--- a/.github/workflows/reusable-upgrade-testing.yml
+++ b/.github/workflows/reusable-upgrade-testing.yml
@@ -8,7 +8,7 @@ on:
         description: 'Operating system to run tests on.'
         required: false
         type: 'string'
-        default: 'ubuntu-latest'
+        default: 'ubuntu-24'
       wp:
         description: 'The version of WordPress to start with.'
         required: true

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -47,7 +47,7 @@ jobs:
   # - Constructs and stores a message payload as an output.
   prepare:
     name: Prepare notifications
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       actions: read
       contents: read
@@ -160,7 +160,7 @@ jobs:
   # Posts notifications when a workflow fails.
   failure:
     name: Failure notifications
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     continue-on-error: true
     timeout-minutes: 5
     needs: [ prepare ]
@@ -177,7 +177,7 @@ jobs:
   # Posts notifications the first time a workflow run succeeds after previously failing.
   fixed:
     name: Fixed notifications
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     continue-on-error: true
     timeout-minutes: 5
     needs: [ prepare ]
@@ -194,7 +194,7 @@ jobs:
   # Posts notifications when a workflow is successful.
   success:
     name: Success notifications
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     continue-on-error: true
     timeout-minutes: 5
     needs: [ prepare ]
@@ -211,7 +211,7 @@ jobs:
   # Posts notifications when a workflow is cancelled.
   cancelled:
     name: Cancelled notifications
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     continue-on-error: true
     timeout-minutes: 5
     needs: [ prepare ]

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -47,7 +47,7 @@ jobs:
   # - Constructs and stores a message payload as an output.
   prepare:
     name: Prepare notifications
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read
@@ -160,7 +160,7 @@ jobs:
   # Posts notifications when a workflow fails.
   failure:
     name: Failure notifications
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     continue-on-error: true
     timeout-minutes: 5
     needs: [ prepare ]
@@ -177,7 +177,7 @@ jobs:
   # Posts notifications the first time a workflow run succeeds after previously failing.
   fixed:
     name: Fixed notifications
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     continue-on-error: true
     timeout-minutes: 5
     needs: [ prepare ]
@@ -194,7 +194,7 @@ jobs:
   # Posts notifications when a workflow is successful.
   success:
     name: Success notifications
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     continue-on-error: true
     timeout-minutes: 5
     needs: [ prepare ]
@@ -211,7 +211,7 @@ jobs:
   # Posts notifications when a workflow is cancelled.
   cancelled:
     name: Cancelled notifications
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     continue-on-error: true
     timeout-minutes: 5
     needs: [ prepare ]

--- a/.github/workflows/test-and-zip-default-themes.yml
+++ b/.github/workflows/test-and-zip-default-themes.yml
@@ -59,7 +59,7 @@ jobs:
   # - Checks for zero-byte (empty) files.
   check-for-empty-files:
     name: ${{ matrix.theme }} empty file check
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     timeout-minutes: 10
@@ -106,7 +106,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   test-build-scripts:
     name: Test ${{ matrix.theme }} build script
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     timeout-minutes: 10
@@ -154,7 +154,7 @@ jobs:
   # - Uploads the theme files as a workflow artifact (files uploaded as an artifact are automatically zipped).
   bundle-theme:
     name: Create ${{ matrix.theme }} ZIP file
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     needs: [ check-for-empty-files, test-build-scripts ]
@@ -214,7 +214,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/test-and-zip-default-themes.yml
+++ b/.github/workflows/test-and-zip-default-themes.yml
@@ -59,7 +59,7 @@ jobs:
   # - Checks for zero-byte (empty) files.
   check-for-empty-files:
     name: ${{ matrix.theme }} empty file check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       contents: read
     timeout-minutes: 10
@@ -106,7 +106,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   test-build-scripts:
     name: Test ${{ matrix.theme }} build script
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       contents: read
     timeout-minutes: 10
@@ -154,7 +154,7 @@ jobs:
   # - Uploads the theme files as a workflow artifact (files uploaded as an artifact are automatically zipped).
   bundle-theme:
     name: Create ${{ matrix.theme }} ZIP file
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       contents: read
     needs: [ check-for-empty-files, test-build-scripts ]
@@ -214,7 +214,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -31,18 +31,18 @@ jobs:
   # Tests the WordPress Core build process on multiple operating systems.
   test-core-build-process:
     name: Core running from ${{ matrix.directory }}
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
+    uses: ./.github/workflows/reusable-test-core-build-process.yml
     permissions:
       contents: read
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-24, windows-latest ]
         directory: [ 'src', 'build' ]
         include:
           # Only prepare artifacts for Playground once.
-          - os: ubuntu-latest
+          - os: ubuntu-24
             directory: 'build'
             save-build: true
             prepare-playground: ${{ github.event_name == 'pull_request' && true || '' }}
@@ -63,7 +63,7 @@ jobs:
   # See https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability.
   test-core-build-process-macos:
     name: Core running from ${{ matrix.directory }}
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-test-core-build-process.yml@trunk
+    uses: ./.github/workflows/reusable-test-core-build-process.yml
     permissions:
       contents: read
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -79,14 +79,14 @@ jobs:
   # Tests the Gutenberg plugin build process on multiple operating systems when run within a wordpress-develop checkout.
   test-gutenberg-build-process:
     name: Gutenberg running from ${{ matrix.directory }}
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-test-gutenberg-build-process.yml@trunk
+    uses: ./.github/workflows/reusable-test-gutenberg-build-process.yml
     permissions:
       contents: read
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-24, windows-latest ]
         directory: [ 'src', 'build' ]
     with:
       os: ${{ matrix.os }}
@@ -102,7 +102,7 @@ jobs:
   # See https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability.
   test-gutenberg-build-process-macos:
     name: Gutenberg running from ${{ matrix.directory }}
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-test-gutenberg-build-process.yml@trunk
+    uses: ./.github/workflows/reusable-test-gutenberg-build-process.yml
     permissions:
       contents: read
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -133,7 +133,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -38,11 +38,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-24, windows-latest ]
+        os: [ ubuntu-24.04, windows-latest ]
         directory: [ 'src', 'build' ]
         include:
           # Only prepare artifacts for Playground once.
-          - os: ubuntu-24
+          - os: ubuntu-24.04
             directory: 'build'
             save-build: true
             prepare-playground: ${{ github.event_name == 'pull_request' && true || '' }}
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-24, windows-latest ]
+        os: [ ubuntu-24.04, windows-latest ]
         directory: [ 'src', 'build' ]
     with:
       os: ${{ matrix.os }}
@@ -133,7 +133,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -49,7 +49,7 @@ jobs:
   #
   test-coverage-report:
     name: ${{ matrix.multisite && 'Multisite' || 'Single site' }} report
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-phpunit-tests-v3.yml@trunk
+    uses: ./.github/workflows/reusable-phpunit-tests-v3.yml
     permissions:
       contents: read
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -83,7 +83,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -83,7 +83,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/test-old-branches.yml
+++ b/.github/workflows/test-old-branches.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   dispatch-workflows-for-old-branches:
     name: ${{ matrix.workflow }} for ${{ matrix.branch }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       actions: write
     timeout-minutes: 20

--- a/.github/workflows/test-old-branches.yml
+++ b/.github/workflows/test-old-branches.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   dispatch-workflows-for-old-branches:
     name: ${{ matrix.workflow }} for ${{ matrix.branch }}
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     timeout-minutes: 20

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-24' ]
+        os: [ 'ubuntu-24.04' ]
         php: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-24' ]
+        os: [ 'ubuntu-24.04' ]
         php: [ '7.2', '7.3', '7.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-24' ]
+        os: [ 'ubuntu-24.04' ]
         php: [ '7.2', '7.3', '7.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
@@ -130,7 +130,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-24' ]
+        os: [ 'ubuntu-24.04' ]
         php: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
@@ -153,7 +153,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-24' ]
+        os: [ 'ubuntu-24.04' ]
         php: [ '7.2', '7.3', '7.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
@@ -186,7 +186,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-24' ]
+        os: [ 'ubuntu-24.04' ]
         php: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
@@ -219,7 +219,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-24
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -35,14 +35,14 @@ jobs:
   # Spawns upgrade testing from WordPress 6.x versions on PHP 8.x with MySQL.
   upgrade-tests-wp-6x-php-8x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-upgrade-testing.yml@trunk
+    uses: ./.github/workflows/reusable-upgrade-testing.yml
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest' ]
+        os: [ 'ubuntu-24' ]
         php: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
@@ -61,14 +61,14 @@ jobs:
   # Spawns upgrade testing from WordPress 6.x versions on PHP 7.x with MySQL.
   upgrade-tests-wp-6x-php-7x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-upgrade-testing.yml@trunk
+    uses: ./.github/workflows/reusable-upgrade-testing.yml
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest' ]
+        os: [ 'ubuntu-24' ]
         php: [ '7.2', '7.3', '7.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
@@ -92,12 +92,12 @@ jobs:
   # Spawns upgrade testing from WordPress 5.x versions on PHP 7.x with MySQL.
   upgrade-tests-wp-5x-php-7x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-upgrade-testing.yml@trunk
+    uses: ./.github/workflows/reusable-upgrade-testing.yml
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest' ]
+        os: [ 'ubuntu-24' ]
         php: [ '7.2', '7.3', '7.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
@@ -125,12 +125,12 @@ jobs:
   # - array/string offset with curly braces.
   upgrade-tests-wp-5x-php-8x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-upgrade-testing.yml@trunk
+    uses: ./.github/workflows/reusable-upgrade-testing.yml
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest' ]
+        os: [ 'ubuntu-24' ]
         php: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
@@ -148,12 +148,12 @@ jobs:
   # Spawns upgrade testing from WordPress 4.x versions on PHP 7.x with MySQL.
   upgrade-tests-wp-4x-php-7x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-upgrade-testing.yml@trunk
+    uses: ./.github/workflows/reusable-upgrade-testing.yml
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest' ]
+        os: [ 'ubuntu-24' ]
         php: [ '7.2', '7.3', '7.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
@@ -181,12 +181,12 @@ jobs:
   # - array/string offset with curly braces.
   upgrade-tests-wp-4x-php-8x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
-    uses: WordPress/wordpress-develop/.github/workflows/reusable-upgrade-testing.yml@trunk
+    uses: ./.github/workflows/reusable-upgrade-testing.yml
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest' ]
+        os: [ 'ubuntu-24' ]
         php: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
@@ -203,7 +203,7 @@ jobs:
 
   slack-notifications:
     name: Slack Notifications
-    uses: WordPress/wordpress-develop/.github/workflows/slack-notifications.yml@trunk
+    uses: ./.github/workflows/slack-notifications.yml
     permissions:
       actions: read
       contents: read
@@ -219,7 +219,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     permissions:
       actions: write
     needs: [ slack-notifications ]


### PR DESCRIPTION
The `ubuntu-latest` runner will soon be updated to point to Ubuntu 24, which has a different set of available tools.

This PR is meant to test Core's workflows against this runner image to check for potential problems.

See https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/.

Trac ticket: https://core.trac.wordpress.org/ticket/62221.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
