### PR TITLE
Block Bindings: Add private HTML API subclass with experimental set_inner_html

### DIFF
--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -351,62 +351,25 @@ class WP_Block {
 		switch ( $block_type->attributes[ $attribute_name ]['source'] ) {
 			case 'html':
 			case 'rich-text':
-				$block_reader = new WP_HTML_Tag_Processor( $block_content );
+				$block_reader = PrivateProcessor::create_fragment( $block_content );
 
 				// TODO: Support for CSS selectors whenever they are ready in the HTML API.
 				// In the meantime, support comma-separated selectors by exploding them into an array.
+				// NOTE! This assumes the selectors are element selectors, e.g. "a, button" or "p".
 				$selectors = explode( ',', $block_type->attributes[ $attribute_name ]['selector'] );
+
 				// Add a bookmark to the first tag to be able to iterate over the selectors.
 				$block_reader->next_tag();
 				$block_reader->set_bookmark( 'iterate-selectors' );
 
-				// TODO: This shouldn't be needed when the `set_inner_html` function is ready.
-				// Store the parent tag and its attributes to be able to restore them later in the button.
-				// The button block has a wrapper while the paragraph and heading blocks don't.
-				if ( 'core/button' === $this->name ) {
-					$button_wrapper                 = $block_reader->get_tag();
-					$button_wrapper_attribute_names = $block_reader->get_attribute_names_with_prefix( '' );
-					$button_wrapper_attrs           = array();
-					foreach ( $button_wrapper_attribute_names as $name ) {
-						$button_wrapper_attrs[ $name ] = $block_reader->get_attribute( $name );
-					}
-				}
-
 				foreach ( $selectors as $selector ) {
-					// If the parent tag, or any of its children, matches the selector, replace the HTML.
+					// If the current or any other tags match the selector, replace the HTML.
 					if ( strcasecmp( $block_reader->get_tag(), $selector ) === 0 || $block_reader->next_tag(
-						array(
-							'tag_name' => $selector,
-						)
+						array( 'tag_name' => $selector )
 					) ) {
 						$block_reader->release_bookmark( 'iterate-selectors' );
-
-						// TODO: Use `set_inner_html` method whenever it's ready in the HTML API.
-						// Until then, it is hardcoded for the paragraph, heading, and button blocks.
-						// Store the tag and its attributes to be able to restore them later.
-						$selector_attribute_names = $block_reader->get_attribute_names_with_prefix( '' );
-						$selector_attrs           = array();
-						foreach ( $selector_attribute_names as $name ) {
-							$selector_attrs[ $name ] = $block_reader->get_attribute( $name );
-						}
-						$selector_markup = "<$selector>" . wp_kses_post( $source_value ) . "</$selector>";
-						$amended_content = new WP_HTML_Tag_Processor( $selector_markup );
-						$amended_content->next_tag();
-						foreach ( $selector_attrs as $attribute_key => $attribute_value ) {
-							$amended_content->set_attribute( $attribute_key, $attribute_value );
-						}
-						if ( 'core/paragraph' === $this->name || 'core/heading' === $this->name ) {
-							return $amended_content->get_updated_html();
-						}
-						if ( 'core/button' === $this->name ) {
-							$button_markup  = "<$button_wrapper>{$amended_content->get_updated_html()}</$button_wrapper>";
-							$amended_button = new WP_HTML_Tag_Processor( $button_markup );
-							$amended_button->next_tag();
-							foreach ( $button_wrapper_attrs as $attribute_key => $attribute_value ) {
-								$amended_button->set_attribute( $attribute_key, $attribute_value );
-							}
-							return $amended_button->get_updated_html();
-						}
+						$block_reader->set_inner_html( wp_kses_post( $source_value ) );
+						return $block_reader->get_updated_html();
 					} else {
 						$block_reader->seek( 'iterate-selectors' );
 					}
@@ -609,6 +572,13 @@ class WP_Block {
 }
 
 // phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+/**
+ * HTML API Processor subclass implementing experimental set_inner_html.
+ *
+ * DO NOT USE THIS CLASS. Internal usage only.
+ *
+ * @access private
+ */
 class PrivateProcessor extends WP_HTML_Processor {
 
 	public function set_inner_html( ?string $html ) {
@@ -655,31 +625,31 @@ class PrivateProcessor extends WP_HTML_Processor {
 		}
 
 		// @todo apply modifications if there are any???
-		if ( ! parent::set_bookmark( 'SET_INNER_HTML: opener' ) ) {
+		if ( ! $this->set_bookmark( 'SET_INNER_HTML: opener' ) ) {
 			return false;
 		}
 
 		if ( ! $this->proceed_to_matching_closer() ) {
-			parent::seek( 'SET_INNER_HTML: opener' );
+			$this->seek( 'SET_INNER_HTML: opener' );
 			return false;
 		}
 
-		if ( ! parent::set_bookmark( 'SET_INNER_HTML: closer' ) ) {
+		if ( ! $this->set_bookmark( 'SET_INNER_HTML: closer' ) ) {
 			return false;
 		}
 
-		$inner_html_start  = $this->bookmarks['SET_INNER_HTML: opener']->start + $this->bookmarks['SET_INNER_HTML: opener']->length;
-		$inner_html_length = $this->bookmarks['SET_INNER_HTML: closer']->start - $inner_html_start;
+		$inner_html_start  = $this->bookmarks['_SET_INNER_HTML: opener']->start + $this->bookmarks['_SET_INNER_HTML: opener']->length;
+		$inner_html_length = $this->bookmarks['_SET_INNER_HTML: closer']->start - $inner_html_start;
 
-		$this->lexical_updates['innerHTML'] = new WP_HTML_Text_Replacement(
+		$this->lexical_updates[] = new WP_HTML_Text_Replacement(
 			$inner_html_start,
 			$inner_html_length,
 			$html
 		);
 
-		parent::seek( 'SET_INNER_HTML: opener' );
-		parent::release_bookmark( 'SET_INNER_HTML: opener' );
-		parent::release_bookmark( 'SET_INNER_HTML: closer' );
+		$this->seek( 'SET_INNER_HTML: opener' );
+		$this->release_bookmark( 'SET_INNER_HTML: opener' );
+		$this->release_bookmark( 'SET_INNER_HTML: closer' );
 
 		// @todo check for whether that html will make a mess!
 		// Will it break out of tags?

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -364,9 +364,10 @@ class WP_Block {
 
 				foreach ( $selectors as $selector ) {
 					// If the current or any other tags match the selector, replace the HTML.
-					if ( strcasecmp( $block_reader->get_tag(), $selector ) === 0 || $block_reader->next_tag(
-						array( 'tag_name' => $selector )
-					) ) {
+					if (
+						strcasecmp( $block_reader->get_tag(), $selector ) === 0 ||
+						$block_reader->next_tag( $selector )
+					) {
 						$block_reader->release_bookmark( 'iterate-selectors' );
 						$block_reader->set_inner_html( wp_kses_post( $source_value ) );
 						return $block_reader->get_updated_html();

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -582,7 +582,12 @@ class WP_Block {
  */
 class PrivateProcessor extends WP_HTML_Processor {
 
-	public function set_inner_html( ?string $html ) {
+	/**
+	 * @param string $html
+	 *
+	 * @return bool
+	 */
+	public function set_inner_html( string $html ): bool {
 		if ( $this->is_virtual() ) {
 			return false;
 		}
@@ -607,14 +612,9 @@ class PrivateProcessor extends WP_HTML_Processor {
 		/*  return false;*/
 		/*}*/
 
-		if ( null === $html ) {
-			$html = '';
-		}
 		if ( '' !== $html ) {
-			$fragment_parser = $this->spawn_fragment_parser( $html );
-			if (
-				null === $fragment_parser
-			) {
+			$fragment_parser = $this->create_fragment_at_current_node( $html );
+			if ( null === $fragment_parser ) {
 				return false;
 			}
 

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -657,6 +657,9 @@ class PrivateProcessor extends WP_HTML_Processor {
 		return true;
 	}
 
+	/**
+	 * @todo check for self-closing foreign content tags
+	 */
 	public function proceed_to_matching_closer(): bool {
 		$tag_name = $this->get_tag();
 

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -583,9 +583,13 @@ class WP_Block {
 class PrivateProcessor extends WP_HTML_Processor {
 
 	/**
-	 * @param string $html
+	 * Set the inner HTML of the currrent node.
 	 *
-	 * @return bool
+	 * @todo This method needs to check if the inner HTML can leak out of the current node.
+	 *
+	 * @param string $html The inner HTML to set.
+	 *
+	 * @return bool True if the inner HTML was set, false otherwise.
 	 */
 	public function set_inner_html( string $html ): bool {
 		if ( $this->is_virtual() ) {
@@ -659,6 +663,7 @@ class PrivateProcessor extends WP_HTML_Processor {
 
 	/**
 	 * @todo check for self-closing foreign content tags
+	 * @todo document
 	 */
 	public function proceed_to_matching_closer(): bool {
 		$tag_name = $this->get_tag();

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -844,7 +844,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * @return bool Whether the current token is virtual.
 	 */
-	private function is_virtual(): bool {
+	protected function is_virtual(): bool {
 		return (
 			isset( $this->current_element->provenance ) &&
 			'virtual' === $this->current_element->provenance

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -463,7 +463,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @param string $html Input HTML fragment to process.
 	 * @return static|null The created processor if successful, otherwise null.
 	 */
-	public function create_fragment_at_current_node( string $html ) {
+	protected function create_fragment_at_current_node( string $html ) {
 		if ( $this->get_token_type() !== '#tag' || $this->is_tag_closer() ) {
 			return null;
 		}


### PR DESCRIPTION
Depends on #7348 

Uses an implementation from https://github.com/sirreal/wordpress-develop/pull/9



<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
