### PR TITLE
Fix Customizer accordion button CSS

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -2462,7 +2462,7 @@ h1.nav-tab-wrapper, /* Back-compat for pre-4.4 */
 }
 .nav-menus-php .metabox-holder .accordion-section-title span.dashicons.dashicons-arrow-down::before {
 	position: relative;
-	left: -1px
+	left: -1px;
 }
 
 .nav-menus-php .metabox-holder .accordion-section.open .accordion-section-title span.dashicons.dashicons-arrow-down {

--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -553,7 +553,8 @@ body.trashing #publish-settings {
 		.15s border-color ease-in-out;
 }
 
-.accordion-section-title:has(button.accordion-trigger) {
+.accordion-section-title:has(button.accordion-trigger),
+#customize-controls .current-panel .control-section > h3.accordion-section-title:has(button.accordion-trigger) {
 	padding: 0;
 }
 
@@ -561,9 +562,10 @@ body.trashing #publish-settings {
 	all: unset;
 	width: 100%;
 	height: 100%;
-	padding: 10px 10px 11px 14px;
+	padding: 10px 30px 11px 14px;
 	display: flex;
 	align-items: center;
+	box-sizing: border-box;
 }
 
 .accordion-section-title button.accordion-trigger:has(.menu-in-location) {
@@ -587,6 +589,7 @@ body.trashing #publish-settings {
 #customize-outer-theme-controls .accordion-section-title:after {
 	content: "\f345";
 	color: #a7aaad;
+	pointer-events: none;
 }
 
 #customize-theme-controls .accordion-section-content,


### PR DESCRIPTION
- Adds `box-sizing: border-box` to the buttons so they do not cause a horizontal scroll (copied from patch.diff).
- Increases specificity to remove padding from [headings in the Menus and Widgets panels](https://github.com/WordPress/wordpress-develop/blob/7c7bcc0aadf1305c4d152d661956a72423d80245/src/wp-admin/css/customize-controls.css#L535-L537).
- Makes the chevron icon clickable.
- Adds padding to the buttons to avoid overlapping the chevron (30 pixels, to match what the child panel headings had).
- Adds a semicolon in `common.css`.

[Trac 62313](https://core.trac.wordpress.org/ticket/62313)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
