### PR TITLE
Fix get_post_oembed_url_function for draft and schedule posts

### DIFF
--- a/src/wp-includes/embed.php
+++ b/src/wp-includes/embed.php
@@ -411,10 +411,17 @@ function get_post_embed_url( $post = null ) {
 		return false;
 	}
 
-	$embed_url     = trailingslashit( get_permalink( $post ) ) . user_trailingslashit( 'embed' );
-	$path_conflict = get_page_by_path( str_replace( home_url(), '', $embed_url ), OBJECT, get_post_types( array( 'public' => true ) ) );
+	$is_published = 'publish' === $post->post_status;
 
-	if ( ! get_option( 'permalink_structure' ) || $path_conflict ) {
+	if ( $is_published ) {
+		$embed_url = trailingslashit( get_permalink( $post ) ) . user_trailingslashit( 'embed' );
+
+		$path_conflict = get_page_by_path( str_replace( home_url(), '', $embed_url ), OBJECT, get_post_types( array( 'public' => true ) ) );
+
+		if ( ! get_option( 'permalink_structure' ) || $path_conflict ) {
+			$embed_url = add_query_arg( array( 'embed' => 'true' ), get_permalink( $post ) );
+		}
+	} else {
 		$embed_url = add_query_arg( array( 'embed' => 'true' ), get_permalink( $post ) );
 	}
 

--- a/src/wp-includes/embed.php
+++ b/src/wp-includes/embed.php
@@ -411,12 +411,14 @@ function get_post_embed_url( $post = null ) {
 		return false;
 	}
 
-	$is_published = 'publish' === $post->post_status;
-
-	if ( $is_published ) {
+	if ( 'publish' === $post->post_status ) {
 		$embed_url = trailingslashit( get_permalink( $post ) ) . user_trailingslashit( 'embed' );
 
-		$path_conflict = get_page_by_path( str_replace( home_url(), '', $embed_url ), OBJECT, get_post_types( array( 'public' => true ) ) );
+		$path_conflict = get_page_by_path(
+			str_replace( home_url(), '', $embed_url ),
+			OBJECT,
+			get_post_types( array( 'public' => true ) )
+		);
 
 		if ( ! get_option( 'permalink_structure' ) || $path_conflict ) {
 			$embed_url = add_query_arg( array( 'embed' => 'true' ), get_permalink( $post ) );

--- a/tests/phpunit/tests/oembed/postEmbedUrl.php
+++ b/tests/phpunit/tests/oembed/postEmbedUrl.php
@@ -107,4 +107,68 @@ class Tests_Post_Embed_URL extends WP_UnitTestCase {
 	public function filter_unique_post_slug() {
 		return 'embed';
 	}
+
+	/**
+	 * Test should return embed URL with '/embed/' for a published post.
+	 */
+	public function test_should_return_embed_url_with_embed_suffix_when_post_is_published() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		$post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
+
+		$embed_url = get_post_embed_url( $post );
+
+		$this->assertStringContainsString( 'embed', $embed_url );
+		$this->assertStringEndsWith( '/embed/', $embed_url );
+	}
+
+	/**
+	 * Test should return embed URL with '?embed=true' for a draft post.
+	 */
+	public function test_should_return_embed_url_with_embed_query_when_post_is_draft() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		$post = self::factory()->post->create_and_get( array( 'post_status' => 'draft' ) );
+
+		$embed_url = get_post_embed_url( $post );
+
+		$this->assertStringContainsString( '&embed=true', $embed_url );
+		$this->assertStringNotContainsString( '/embed/', $embed_url );
+	}
+
+	/**
+	 * Test should return embed URL with '?embed=true' for a scheduled post.
+	 */
+	public function test_should_return_embed_url_with_embed_query_when_post_is_scheduled() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		$future_post = self::factory()->post->create_and_get(
+			array(
+				'post_status' => 'future',
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '+1 hour' ) ),
+			)
+		);
+
+		$embed_url = get_post_embed_url( $future_post );
+
+		$this->assertStringContainsString( '&embed=true', $embed_url );
+		$this->assertStringNotContainsString( '/embed/', $embed_url );
+	}
+
+	/**
+	 * Test should return the embed URL for the current post when no post ID is provided.
+	 */
+	public function test_should_return_embed_url_for_current_post_when_no_post_id_is_provided() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		$custom_post = self::factory()->post->create_and_get( array( 'post_status' => 'publish' ) );
+
+		global $post;
+		$post = $custom_post;
+
+		$embed_url = get_post_embed_url();
+
+		$this->assertStringContainsString( 'embed', $embed_url );
+		$this->assertStringEndsWith( '/embed/', $embed_url );
+	}
 }


### PR DESCRIPTION
Trac Ticket: Core-42733

## Problem

The `get_post_embed_url()` function was failing to generate the correct embed URLs for draft and scheduled posts when pretty permalinks were enabled. The issue specifically occurred for these draft and scheduled posts, where the embed URLs were being generated incorrectly:

- When pretty permalinks were disabled, the function correctly generated embed URLs for draft and scheduled posts with the `?embed=true` query parameter (e.g., http://example.com/?p=8&embed=true), which is recognized as a valid embed URL by WordPress.

- When pretty permalinks were enabled, the function incorrectly generated URLs like http://example.com/?p=8/embed/ for draft and scheduled posts. These URLs were not recognized as embed URLs, causing the `is_embed()` check to fail (returning false instead of the expected true).

- This discrepancy occurred because `get_permalink()` does not return pretty permalinks for draft or scheduled posts. As a result, the embed URL logic was inconsistent for draft and scheduled posts, leading to test failures.

## Solution

- To address this issue, the logic in `get_post_embed_url()` has been updated to consistently generate correct embed URLs for all posts (published, draft, or scheduled), regardless of whether pretty permalinks are enabled.

## Key changes include

### For Published Posts

- When pretty permalinks are enabled, the embed URL now correctly ends with /embed/ (e.g., http://example.com/my-post/embed/), as expected.

- If pretty permalinks are disabled, the function falls back to using the ?embed=true query parameter format (e.g., http://example.com/?p=8&embed=true).

### For Draft and Scheduled Posts

- The function now consistently generates embed URLs with the ?embed=true query parameter for draft and scheduled posts, regardless of whether pretty permalinks are enabled. This ensures that draft and scheduled posts are always recognized as embed URLs.

### Fallback Logic:

- The function now gracefully handles conflicts between the post's permalink structure and the `/embed/` path to avoid generating invalid URLs. In cases where the permalink structure conflicts, the function defaults to the query string format (`?embed=true`).

## Benefits

- Consistent URL Format: Ensures that embed URLs are correctly generated for all post statuses (published, draft, and scheduled), regardless of the permalink structure.

- Correct Handling of Pretty Permalinks: Fixes the issue where pretty permalinks caused the function to generate invalid embed URLs for draft and scheduled posts. Now, `get_post_embed_url()` always returns a valid embed URL with the correct format.