### PR TITLE
Fix to bug #62361: activate_tinymce_for_media_description = true breaks media_description content

### DIFF
--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -3277,7 +3277,7 @@ function edit_form_image_editor( $post ) {
 		'tinymce'       => apply_filters( 'activate_tinymce_for_media_description', false ),
 		'quicktags'     => $quicktags_settings,
 	);
-	if ( $editor_args['tinymce'] === true ) {
+	if ( true === $editor_args['tinymce'] ) {
 		$editor_args['textarea_rows'] = 20;
 	}
 

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -3277,6 +3277,9 @@ function edit_form_image_editor( $post ) {
 		'tinymce'       => apply_filters( 'activate_tinymce_for_media_description', false ),
 		'quicktags'     => $quicktags_settings,
 	);
+	if ($editor_args['tinymce'] === true) {
+		$editor_args['textarea_rows'] = 20;
+	}
 
 	?>
 
@@ -3289,7 +3292,7 @@ function edit_form_image_editor( $post ) {
 
 	?>
 	</label>
-	<?php wp_editor( format_to_edit( $post->post_content ), 'attachment_content', $editor_args ); ?>
+	<?php wp_editor( format_to_edit( $post->post_content, $editor_args['tinymce'] ), 'attachment_content', $editor_args ); ?>
 
 	</div>
 	<?php

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -3277,7 +3277,7 @@ function edit_form_image_editor( $post ) {
 		'tinymce'       => apply_filters( 'activate_tinymce_for_media_description', false ),
 		'quicktags'     => $quicktags_settings,
 	);
-	if ($editor_args['tinymce'] === true) {
+	if ( $editor_args['tinymce'] === true ) {
 		$editor_args['textarea_rows'] = 20;
 	}
 


### PR DESCRIPTION
Using tinymce with media_description will convert all HTML tags to a sanitized version. This way tinymce is not usable with media_content since TinyMCE will show the HTML tas insted of interpreting them as styles, eg. `<h2>` will be show instead of the heading style.

This PR fixes this bug and changes the textarea_rows value if tinymce is used.

Trac ticket: [https://core.trac.wordpress.org/ticket/62361](https://core.trac.wordpress.org/ticket/62361)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
