### PR TITLE
Interactivity API: Support .length on numeric arrays and strings on the server

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -579,6 +579,12 @@ final class WP_Interactivity_API {
 		$path_segments = explode( '.', $path );
 		$current       = $store;
 		foreach ( $path_segments as $path_segment ) {
+			// Special case for numeric arrays to add a length property like JavaScript arrays.
+			if ( 'length' === $path_segment && is_array( $current ) && array_is_list( $current ) ) {
+				$current = count( $current );
+				break;
+			}
+
 			if ( ( is_array( $current ) || $current instanceof ArrayAccess ) && isset( $current[ $path_segment ] ) ) {
 				$current = $current[ $path_segment ];
 			} elseif ( is_object( $current ) && isset( $current->$path_segment ) ) {

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -579,13 +579,31 @@ final class WP_Interactivity_API {
 		$path_segments = explode( '.', $path );
 		$current       = $store;
 		foreach ( $path_segments as $path_segment ) {
-			// Special case for numeric arrays to add a length property like JavaScript arrays.
+			/*
+			 * Special case for numeric arrays and strings. Add length
+			 * property mimicking JavaScript behavior.
+			 *
+			 * @since 6.8.0
+			 */
 			if ( 'length' === $path_segment ) {
 				if ( is_array( $current ) && array_is_list( $current ) ) {
 					$current = count( $current );
 					break;
 				}
+
 				if ( is_string( $current ) ) {
+					/*
+					 * Differences in encoding between PHP strings and
+					 * JavaScript mean that it's complicated to calculate
+					 * the string length JavaScript would see from PHP.
+					 * `strlen` is a reasonable approximation.
+					 *
+					 * Users that desire a more precise length likely have
+					 * more precise needs than "bytelength" and should
+					 * implement their own length calculation in derived
+					 * state taking into account encoding and their desired
+					 * output (codepints, graphemes, bytes, etc.).
+					 */
 					$current = strlen( $current );
 					break;
 				}

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -580,9 +580,15 @@ final class WP_Interactivity_API {
 		$current       = $store;
 		foreach ( $path_segments as $path_segment ) {
 			// Special case for numeric arrays to add a length property like JavaScript arrays.
-			if ( 'length' === $path_segment && is_array( $current ) && array_is_list( $current ) ) {
-				$current = count( $current );
-				break;
+			if ( 'length' === $path_segment ) {
+				if ( is_array( $current ) && array_is_list( $current ) ) {
+					$current = count( $current );
+					break;
+				}
+				if ( is_string( $current ) ) {
+					$current = strlen( $current );
+					break;
+				}
 			}
 
 			if ( ( is_array( $current ) || $current instanceof ArrayAccess ) && isset( $current[ $path_segment ] ) ) {

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -1541,4 +1541,44 @@ HTML;
 		$element = $this->interactivity->get_element();
 		$this->assertNull( $element );
 	}
+
+	/**
+	 * Verify behavior of .length directive access.
+	 *
+	 * @ticket 62582
+	 *
+	 * @covers ::process_directives
+	 *
+	 * @dataProvider data_length_directives
+	 */
+	public function test_process_directives_string_array_length( mixed $value, string $expected ) {
+		$this->interactivity->state(
+			'myPlugin',
+			array( 'prop' => $value )
+		);
+		$html           = '<div data-wp-text="myPlugin::state.prop.length"></div>';
+		$processed_html = $this->interactivity->process_directives( $html );
+		$processor      = new WP_HTML_Tag_Processor( $processed_html );
+		$processor->next_tag( 'DIV' );
+		$processor->next_token();
+		$this->assertSame( $expected, $processor->get_modifiable_text() );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public static function data_length_directives(): array {
+		return array(
+			'numeric array'     => array( array( 'a', 'b', 'c' ), '3' ),
+			'empty array'       => array( array(), '0' ),
+			'string'            => array( 'abc', '3' ),
+			'empty string'      => array( '', '0' ),
+
+			// Failure cases resulting in empty string.
+			'non-numeric array' => array( array( 'a' => 'a' ), '' ),
+			'object'            => array( new stdClass(), '' ),
+		);
+	}
 }

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -1550,8 +1550,12 @@ HTML;
 	 * @covers ::process_directives
 	 *
 	 * @dataProvider data_length_directives
+	 *
+	 * @param mixed $value     The property value.
+	 * @param string $expected The expected property length as a string,
+	 *                         or "" if no length is expected.
 	 */
-	public function test_process_directives_string_array_length( mixed $value, string $expected ) {
+	public function test_process_directives_string_array_length( $value, string $expected ) {
 		$this->interactivity->state(
 			'myPlugin',
 			array( 'prop' => $value )


### PR DESCRIPTION
Add `.length` to directives processing on the server on strings and numeric arrays.



> The Interactivity API does not support the .length property on numeric arrays or strings on the server. This is one place where the behavior of server rendering is markedly different from client side rendering. The Interactivity API tries to align client and server rendering so that the behavior is the same.
> 
> [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length) and [array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/length) have a .length property in JavaScript that the directives processor can provide in order to support directives like the following:
> 
> ```html
> <div data-wp-interactive="example">
>   <div data-wp-bind--hidden="!state.list.length">
>     <input type="range" min="1" data-wp-bind--max="state.list.length">
>   </div>
>   <div data-wp-bind--hidden="!state.string.length">
>     <h1 data-wp-text="state.string"></h1>
>   </div>
> </div>
> ```
> Testing for falsy .length is a common JavaScript idiom.

Trac ticket: https://core.trac.wordpress.org/ticket/62582

---
## Known issues

Differences in string encodings may result in different results for the `.length` of a string between what the server reports and what JavaScript would detect.

For example:
```php
$s = "foo";
var_dump(
    $s,
    strlen( $s ),
    mb_strlen( mb_convert_encoding( $s, 'UTF-16', mb_internal_encoding() ), 'UTF-16' ),
);
// string(3) "foo"
// int(3)
// int(3)

$s = "é";
var_dump(
    $s,
    strlen( $s ),
    mb_strlen( mb_convert_encoding( $s, 'UTF-16', mb_internal_encoding() ), 'UTF-16' ),
);
// string(2) "é"
// int(2)
// int(1)
```

While in JavaScript:

```js
var s = 'foo';
console.log( "%o", s.length );
// 3
s = 'é'
console.log( "%o", s.length );
// 1
```

The proposed implementation for string length checking currently relies on `strlen`. This should be correct for any single-byte strings, but will often be incorrect with multibyte strings.

JavaScript strings are UTF-16 encoded. This can be calculated in PHP, but doing so relies on knowing the input string encoding and relying on encoding conversions that may be costly, like `mb_strlen( mb_convert_encoding( $s, 'UTF-16', mb_internal_encoding() )` in the example above.

This seems sufficient at the moment, if the precise length of a string must be known on the server then derived state or a static state property can be used with the appropriate conversion. What I suspect is the most common use case for string length checking (whether the string is empty or not) will always work correctly. Including information about this caveat in a dev note and documentation with workarounds will help.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
