### PR TITLE
Feature: Add `get_month_genitive` function 

### DIFF
--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -337,6 +337,25 @@ class WP_Locale {
 	}
 
 	/**
+	 * Retrieves translated version of month genitive string.
+	 *
+	 * The $month_number parameter has to be a string
+	 * because it must have the '0' in front of any number
+	 * that is less than 10. Starts from '01' and ends at
+	 * '12'.
+	 *
+	 * You can use an integer instead and it will add the
+	 * '0' before the numbers less than 10 for you.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @param string|int $month_number '01' through '12'.
+	 */
+	public function get_month_genitive( $month_number ) {
+		return $this->month_genitive[ zeroise( $month_number, 2 ) ];
+	}
+
+	/**
 	 * Retrieves translated version of meridiem string.
 	 *
 	 * The $meridiem parameter is expected to not be translated.


### PR DESCRIPTION
### Summary

This pull request introduces a new utility function, get_month_genitive(), in the WP_Locale class to enhance localization capabilities. This function provides the genitive form of month names, which is necessary for languages that require different grammatical cases depending on context. The function accepts a month number as a string (e.g., ‘01’ for January) or an integer (e.g., 1 for January), and zero-pads numbers less than 10 automatically when an integer is provided.

### Changes

Added `get_month_genitive()` Function:
 - The function accepts month numbers from ‘01’ to ‘12’ as a string or as an integer from 1 to 12.
 - If provided as an integer, the function pads single-digit months to two digits automatically, ensuring consistent formatting.
 - Returns the translated month name in genitive case based on the site locale.
 
 ### Benefits

- **Enhanced Localization:** Improves date formatting for languages that require genitive forms, making WordPress output more natural and grammatically correct in languages such as Russian or Polish.
- **Flexible Input Handling:** The function accommodates both string and integer inputs, providing flexibility and simplifying month number handling.

### Example Usage

```php
// Example of retrieving the genitive form of a month in a localized context.
$date_locale = new WP_Locale();
$genitive_month = $date_locale->get_month_genitive(1); // Outputs 'января' in Russian.
```