### PR TITLE
Interactivity API: Allow missing state negation on server

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -584,7 +584,8 @@ final class WP_Interactivity_API {
 			} elseif ( is_object( $current ) && isset( $current->$path_segment ) ) {
 				$current = $current->$path_segment;
 			} else {
-				return null;
+				$current = null;
+				break;
 			}
 
 			if ( $current instanceof Closure ) {

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -1080,6 +1080,38 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that the `evaluate` method operates correctly when used with the
+	 * negation operator (!) with non-existent paths.
+	 *
+	 * @ticket 62374
+	 *
+	 * @covers ::evaluate
+	 */
+	public function test_evaluate_value_negation_non_existent_path() {
+		$this->interactivity->state( 'myPlugin', array() );
+		$this->interactivity->state( 'otherPlugin', array() );
+		$this->set_internal_context_stack(
+			array(
+				'myPlugin'    => array(),
+				'otherPlugin' => array(),
+			)
+		);
+		$this->set_internal_namespace_stack( 'myPlugin' );
+
+		$result = $this->evaluate( '!state.missing' );
+		$this->assertTrue( $result );
+
+		$result = $this->evaluate( '!context.missing' );
+		$this->assertTrue( $result );
+
+		$result = $this->evaluate( 'otherPlugin::!state.deeply.nested.missing' );
+		$this->assertTrue( $result );
+
+		$result = $this->evaluate( 'otherPlugin::!context.deeply.nested.missing' );
+		$this->assertTrue( $result );
+	}
+
+	/**
 	 * Tests the `evaluate` method with non-existent paths.
 	 *
 	 * @ticket 60356


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/62374


> With a directive like the following:
> 
> ```html
> <div data-wp-bind--hidden="!state.missing.property">
> 	This should be hidden by the <code>hidden</code> attribute.
> </div>
> ```
> 
> The server will render the following HTML:
> 
> ```html
> <div data-wp-bind--hidden="!state.missing.property">
> 	This should be hidden by the <code>hidden</code> attribute.
> </div>
> ```
> 
> But the client will immediately set the hidden attribute (the expected behavior):
> 
> ```html
> <div data-wp-bind--hidden="!state.missing.property" hidden="">
> 	This should be hidden by the <code>hidden</code> attribute.
> </div>
> ```
> 
> The client and server should align on the behavior of the negation operator with directives to missing paths.

---

[The client side implementation allows negation to happen when state is missing.](https://github.com/WordPress/gutenberg/blob/1a1db8b014bcc431fb99e0df8e7624c8df48c12a/packages/interactivity/src/hooks.tsx#L243-L246)

The server side implementation skipped a possible negation when state is missing.

## Testing

CI is likely sufficient. The behavior can be confirmed by comparing source (before JavaScript processing) with the processed output. A directive like the following should have the `hidden` attribute set in both cases:

```html
<div data-wp-bind--hidden="!state.missing.property">
	This should be hidden by the <code>hidden</code> attribute.
</div>
```

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
