### PR TITLE
Replace `wp_update_https_detection_errors()` with `wp_get_https_detection_errors()`

### DIFF
--- a/src/wp-includes/https-detection.php
+++ b/src/wp-includes/https-detection.php
@@ -72,7 +72,7 @@ function wp_is_https_supported() {
 
 	// If option has never been set by the Cron hook before, run it on-the-fly as fallback.
 	if ( false === $https_detection_errors ) {
-		wp_update_https_detection_errors();
+		wp_get_https_detection_errors();
 
 		$https_detection_errors = get_option( 'https_detection_errors' );
 	}


### PR DESCRIPTION
Replaced the deprecated `wp_update_https_detection_errors()` function with `wp_get_https_detection_errors()` to align with the latest WordPress standards and avoid deprecation warnings.

Trac ticket: https://core.trac.wordpress.org/ticket/62252

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
