### PR TITLE
Media: Add file existence check in `wp_get_image_mime()`

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3322,6 +3322,11 @@ function wp_check_filetype_and_ext( $file, $filename, $mimes = null ) {
  * @return string|false The actual mime type or false if the type cannot be determined.
  */
 function wp_get_image_mime( $file ) {
+	// Return false if file doesn't exist or is not readable.
+	if ( ! file_exists( $file ) || ! is_readable( $file ) ) {
+		return false;
+	}
+
 	/*
 	 * Use exif_imagetype() to check the mimetype if available or fall back to
 	 * getimagesize() if exif isn't available. If either function throws an Exception


### PR DESCRIPTION
Trac ticket: [Core-62347](https://core.trac.wordpress.org/ticket/62347)

## Description
The `wp_get_image_mime()` function currently attempts to read file contents without first verifying if the file exists or is readable. This can result in PHP warnings being written to error logs, especially in environments where WP_DEBUG is enabled.

This PR adds appropriate checks at the beginning of the function to prevent these warnings while maintaining the existing behavior of returning `false` for invalid images.

## Changes proposed in this Pull Request:
- Add `file_exists()` check at the start of `wp_get_image_mime()`
- Add `is_readable()` check to ensure file permissions allow reading

## Benefits:
- **Reduced Error Logs**: Prevents unnecessary PHP warnings from filling up error logs, making actual errors easier to identify
- **Improved Debugging**: Makes debugging easier by eliminating noise from non-critical file access warnings
- **Better Error Handling**: Provides more predictable behavior by explicitly checking file accessibility before attempting operations
- **Best Practices**: Follows PHP best practices by validating resources before attempting to use them
