### PR TITLE
Feature: Add role attribute support to Template Part block

### DIFF
--- a/src/wp-includes/blocks/template-part.php
+++ b/src/wp-includes/blocks/template-part.php
@@ -23,6 +23,7 @@ function render_block_core_template_part( $attributes ) {
 	$content          = null;
 	$area             = WP_TEMPLATE_PART_AREA_UNCATEGORIZED;
 	$theme            = isset( $attributes['theme'] ) ? $attributes['theme'] : get_stylesheet();
+	$role             = isset( $attributes['role'] ) ? $attributes['role'] : '';
 
 	if ( isset( $attributes['slug'] ) && get_stylesheet() === $theme ) {
 		$template_part_id    = $theme . '//' . $attributes['slug'];
@@ -171,6 +172,10 @@ function render_block_core_template_part( $attributes ) {
 		$html_tag = esc_attr( $attributes['tagName'] );
 	}
 	$wrapper_attributes = get_block_wrapper_attributes();
+
+	if ( ! empty( $role ) ) {
+		$wrapper_attributes .= ' role="' . esc_attr( $role ) . '"';
+	}
 
 	return "<$html_tag $wrapper_attributes>" . str_replace( ']]>', ']]&gt;', $content ) . "</$html_tag>";
 }

--- a/src/wp-includes/blocks/template-part/block.json
+++ b/src/wp-includes/blocks/template-part/block.json
@@ -18,6 +18,9 @@
 		},
 		"area": {
 			"type": "string"
+		},
+		"role": {
+			"type": "string"
 		}
 	},
 	"supports": {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/62338

This PR adds support for specifying an ARIA role on Template Part blocks through block attributes.
For example:
`<!-- wp:template-part {"slug":"news", "tagName":"section", "role":"main", "theme":"mytheme"} /-->`

Will output:
`<section class="wp-block-template-part" role="main">...</section>`

This is particularly useful when:
- The semantic meaning needs to be explicitly defined
- Template parts serve different purposes (e.g., complementary, banner, navigation)
- Additional accessibility context is needed beyond the HTML element
