### PR TITLE
Improve the error message shown when fetching Twemoji fails

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1066,7 +1066,7 @@ module.exports = function(grunt) {
 								files = spawn( 'gh', [ 'api', 'graphql', '-f', query] );
 
 								if ( 0 !== files.status ) {
-									grunt.fatal( 'Unable to fetch Twemoji file list' );
+									grunt.fatal( files.stderr.toString() );
 								}
 
 								try {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/62382

## Before

<img width="408" alt="" src="https://github.com/user-attachments/assets/9988cb29-7a6e-433d-9f03-a8b8c1d412b4">

## After

<img width="517" alt="" src="https://github.com/user-attachments/assets/c7f575f3-5123-4ea0-aa06-07fad4dedde7">
