### PR TITLE
style: adjust login form margins for consistency (#61667)

### DIFF
--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -139,9 +139,7 @@ p {
 }
 
 .login form {
-	margin-top: 24px;
-	margin-bottom: 24px;
-	margin-left: 0;
+	margin: 24px 0;
 	padding: 26px 24px;
 	font-weight: 400;
 	overflow: hidden;

--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -139,7 +139,8 @@ p {
 }
 
 .login form {
-	margin-top: 20px;
+	margin-top: 24px;
+	margin-bottom: 24px;
 	margin-left: 0;
 	padding: 26px 24px;
 	font-weight: 400;
@@ -284,7 +285,7 @@ p {
 	font-size: 20px;
 	font-weight: 400;
 	line-height: 1.3;
-	margin: 0 auto 25px;
+	margin: 0 auto 24px;
 	padding: 0;
 	text-decoration: none;
 	width: 84px;


### PR DESCRIPTION

### Trac Ticket
Trac ticket: https://core.trac.wordpress.org/ticket/61667

### Brief Description
This pull request addresses [Trac Ticket #61667](https://core.trac.wordpress.org/ticket/61667) by adjusting the margins around the login form for visual consistency. The margin above and below the form is now consistently set to 24px, and the margin below the logo has also been adjusted to 24px, as discussed in the Trac.

