### PR TITLE
Help/About: Fix button text overlapping in mobile view

### DIFF
--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -699,6 +699,14 @@
 		margin-right: 0;
 		font-size: 1.2em;
 	}
+
+	.about__section a.button.button-hero {
+		font-size: 1.3rem;
+		max-width: 100%;
+		text-wrap: balance;
+		line-height: 1.7;
+		padding: calc(var(--gap) / 2);
+	}
 }
 
 @media screen and (max-width: 600px) {


### PR DESCRIPTION
This PR addresses the issue of button text overlapping in mobile view About page. The following responsive styles have been added for a viewport width of 782px or less:

- Set text-wrap: balance for optimal text distribution
- Adjust line-height to 1.7
- Configure dynamic padding using --gap variable
- Update max-width properties

Preview after fixing:

https://github.com/user-attachments/assets/656a6b42-8ce3-4e97-bec0-dd5173337e20

https://github.com/user-attachments/assets/5811c8da-58e2-46dc-bf5c-e39efa38dfc7

Trac ticket: [#62380](https://core.trac.wordpress.org/ticket/62380)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
