### PR TITLE
REST API: new endpoint to fetch post counts by post status 

### DIFF
--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -161,6 +161,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertCount( 2, $routes['/wp/v2/posts'] );
 		$this->assertArrayHasKey( '/wp/v2/posts/(?P<id>[\d]+)', $routes );
 		$this->assertCount( 3, $routes['/wp/v2/posts/(?P<id>[\d]+)'] );
+		$this->assertArrayHasKey( '/wp/v2/pages/count', $routes );
 	}
 
 	public function test_context_param() {


### PR DESCRIPTION

### TODO

- [ ] Add the missing tests from https://github.com/WordPress/gutenberg/pull/67719




## What?


Syncs https://github.com/WordPress/gutenberg/pull/67719

The PR proposes  to extend `WP_REST_Posts_Controller` with a new route `/count` to fetch page counts, e.g., `wp/v2/pages/count`.






## Why?

The need for a performant post counts check for the block editor. See: https://github.com/WordPress/gutenberg/pull/65223#issuecomment-2381323815

Contrast this with `$query->found_posts` which returns the total count for a specific query only and would degrade performance given `n` posts.

## How?
Via `wp/v2/pages/count`, the editor can fetch the total number of post counts. 

This is done using [wp_count_posts](https://developer.wordpress.org/reference/functions/wp_count_posts/).



## Testing Instructions



Examples to run in the browser console (in the editor):

```js

await wp.apiFetch( { path: '/wp/v2/pages/count' } )

/*
{
    "publish": 1,
    "future": 0,
    "draft": 2,
    "pending": 0,
    "private": 0,
    "trash": 0,
    "auto-draft": 0
}
*/

```

Also add a custom post status and ensure it appears in the response:

```php
/**
 * Create initial post types.
 */
function create_initial_post_status_test() {
	register_post_status( 'ridgy_didge', array( 'public' => true ) );
}

add_action( 'init', 'create_initial_post_status_test', 0 ); // Highest priority
```

```js

await wp.apiFetch( { path: '/wp/v2/pages/count' } )

/*
{
    "publish": 1,
    "future": 0,
    "draft": 2,
    "pending": 0,
    "private": 0,
    "trash": 0,
    "ridgy_didge": 0,
    "auto-draft": 0
}
*/

```


Trac ticket: https://core.trac.wordpress.org/ticket/62390

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
