### PR TITLE
Help/About: Add top margin to header nav in mobile view

### DIFF
--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -716,6 +716,7 @@
 
 	.about__header-navigation {
 		display: block;
+		margin-top: calc(var(--gap) / 2);
 	}
 
 	.about__header-navigation .nav-tab {


### PR DESCRIPTION
Added a top margin to the active navigation link in mobile view to improve visual clarity and spacing between the “WordPress 6.7” header and the “What’s New” link. This adjustment ensures that the active link’s left border doesn’t appear to stick to the header, creating a cleaner and more balanced layout

**Before:**

<img width="375" alt="image" src="https://github.com/user-attachments/assets/4c4bb4ea-b1d6-4cb6-abbb-fdb7e84cb7ba">


**After:**

<img width="376" alt="image" src="https://github.com/user-attachments/assets/8e551b35-c6ac-45c1-a527-8becbbfe4cfa">

Trac ticket: [#62387](https://core.trac.wordpress.org/ticket/62387)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
