### PR TITLE
Admin: Fix welcome screen text spacing inconsistency

### DIFF
--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -337,6 +337,10 @@
 	.about__section.has-2-columns.has-gutters .column:last-child {
 		margin-bottom: 0;
 	}
+
+	.about__section .column:not(.is-edge-to-edge) {
+		padding: 0;
+	}
 }
 
 @media screen and (max-width: 480px) {


### PR DESCRIPTION
Trac ticket: [Core - 62387](https://core.trac.wordpress.org/ticket/62387)

This PR fixes the inconsistent spacing in the WordPress 6.8 Welcome screen. Currently, the descriptive text below "Welcome to WordPress 6.8" has inconsistent spacing causing an uneven visual appearance.

### Changes made:
- Removed extra padding to make the spacing consistent
- Improves visual alignment with the rest of the welcome screen content

### Before - 


![1](https://github.com/user-attachments/assets/94926c12-1835-4f9f-9408-f01e51bed1a1)


### After - 

![2](https://github.com/user-attachments/assets/0a39e473-89ca-4e43-831b-6d9ff8776928)

