### PR TITLE
HTML API: Include doctype in full parser serialize

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1178,6 +1178,30 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		$token_type = $this->get_token_type();
 
 		switch ( $token_type ) {
+			case '#doctype':
+				$doctype = $this->get_doctype_info();
+				if ( null === $doctype ) {
+					break;
+				}
+
+				$html .= '<!DOCTYPE';
+
+				if ( $doctype->name ) {
+					$html .= " {$doctype->name}";
+				}
+
+				if ( null !== $doctype->public_identifier ) {
+					$html .= " PUBLIC \"{$doctype->public_identifier}\"";
+				}
+				if ( null !== $doctype->system_identifier ) {
+					if ( null === $doctype->public_identifier ) {
+						$html .= ' SYSTEM';
+					}
+					$html .= " \"{$doctype->system_identifier}\"";
+				}
+				$html .= '>';
+				break;
+
 			case '#text':
 				$html .= htmlspecialchars( $this->get_modifiable_text(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8' );
 				break;
@@ -1193,10 +1217,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 
 			case '#cdata-section':
 				$html .= "<![CDATA[{$this->get_modifiable_text()}]]>";
-				break;
-
-			case 'html':
-				$html .= '<!DOCTYPE html>';
 				break;
 		}
 

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1199,7 +1199,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					}
 					$html .= " \"{$doctype->system_identifier}\"";
 				}
-				$html .= '>';
+				$html .= ">\n";
 				break;
 
 			case '#text':

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1199,7 +1199,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					}
 					$html .= " \"{$doctype->system_identifier}\"";
 				}
-				$html .= ">\n";
+				$html .= '>';
 				break;
 
 			case '#text':

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor-serialize.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor-serialize.php
@@ -284,4 +284,17 @@ class Tests_HtmlApi_WpHtmlProcessor_Serialize extends WP_UnitTestCase {
 			'Comment text'         => array( "<!-- \x00 -->", "<!-- \u{FFFD} -->" ),
 		);
 	}
+
+	/**
+	 * @ticket TBD
+	 */
+	public function test_full_document_serialize_includes_doctype() {
+		$processor = WP_HTML_Processor::create_full_parser(
+			'<!doCTYpe HtmL pubLIC "xxx" \'yyy\'zzz>👌'
+		);
+		$this->assertSame(
+			'<!DOCTYPE html PUBLIC "xxx" "yyy"><html><head></head><body>👌</body></html>',
+			$processor->serialize()
+		);
+	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor-serialize.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor-serialize.php
@@ -286,7 +286,7 @@ class Tests_HtmlApi_WpHtmlProcessor_Serialize extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket TBD
+	 * @ticket 62396
 	 *
 	 * @dataProvider data_provider_serialize_doctype
 	 */

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor-serialize.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor-serialize.php
@@ -308,13 +308,13 @@ class Tests_HtmlApi_WpHtmlProcessor_Serialize extends WP_UnitTestCase {
 	public static function data_provider_serialize_doctype() {
 		return array(
 			'None'                   => array( '', '' ),
-			'Empty'                  => array( '<!DOCTYPE>', '<!DOCTYPE>' ),
-			'HTML5'                  => array( '<!DOCTYPE html>', '<!DOCTYPE html>' ),
-			'Strange name'           => array( '<!DOCTYPE WordPress>', '<!DOCTYPE wordpress>' ),
-			'With public'            => array( '<!DOCTYPE html PUBLIC "x">', '<!DOCTYPE html PUBLIC "x">' ),
-			'With system'            => array( '<!DOCTYPE html SYSTEM "y">', '<!DOCTYPE html SYSTEM "y">' ),
-			'With public and system' => array( '<!DOCTYPE html PUBLIC "x" "y">', '<!DOCTYPE html PUBLIC "x" "y">' ),
-			'Weird casing'           => array( '<!docType HtmL pubLIc\'xxx\'"yyy" all this is ignored>', '<!DOCTYPE html PUBLIC "xxx" "yyy">' ),
+			'Empty'                  => array( '<!DOCTYPE>', "<!DOCTYPE>\n" ),
+			'HTML5'                  => array( '<!DOCTYPE html>', "<!DOCTYPE html>\n" ),
+			'Strange name'           => array( '<!DOCTYPE WordPress>', "<!DOCTYPE wordpress>\n" ),
+			'With public'            => array( '<!DOCTYPE html PUBLIC "x">', "<!DOCTYPE html PUBLIC \"x\">\n" ),
+			'With system'            => array( '<!DOCTYPE html SYSTEM "y">', "<!DOCTYPE html SYSTEM \"y\">\n" ),
+			'With public and system' => array( '<!DOCTYPE html PUBLIC "x" "y">', "<!DOCTYPE html PUBLIC \"x\" \"y\">\n" ),
+			'Weird casing'           => array( '<!docType HtmL pubLIc\'xxx\'"yyy" all this is ignored>', "<!DOCTYPE html PUBLIC \"xxx\" \"yyy\">\n" ),
 		);
 	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor-serialize.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor-serialize.php
@@ -308,13 +308,13 @@ class Tests_HtmlApi_WpHtmlProcessor_Serialize extends WP_UnitTestCase {
 	public static function data_provider_serialize_doctype() {
 		return array(
 			'None'                   => array( '', '' ),
-			'Empty'                  => array( '<!DOCTYPE>', "<!DOCTYPE>\n" ),
-			'HTML5'                  => array( '<!DOCTYPE html>', "<!DOCTYPE html>\n" ),
-			'Strange name'           => array( '<!DOCTYPE WordPress>', "<!DOCTYPE wordpress>\n" ),
-			'With public'            => array( '<!DOCTYPE html PUBLIC "x">', "<!DOCTYPE html PUBLIC \"x\">\n" ),
-			'With system'            => array( '<!DOCTYPE html SYSTEM "y">', "<!DOCTYPE html SYSTEM \"y\">\n" ),
-			'With public and system' => array( '<!DOCTYPE html PUBLIC "x" "y">', "<!DOCTYPE html PUBLIC \"x\" \"y\">\n" ),
-			'Weird casing'           => array( '<!docType HtmL pubLIc\'xxx\'"yyy" all this is ignored>', "<!DOCTYPE html PUBLIC \"xxx\" \"yyy\">\n" ),
+			'Empty'                  => array( '<!DOCTYPE>', '<!DOCTYPE>' ),
+			'HTML5'                  => array( '<!DOCTYPE html>', '<!DOCTYPE html>' ),
+			'Strange name'           => array( '<!DOCTYPE WordPress>', '<!DOCTYPE wordpress>' ),
+			'With public'            => array( '<!DOCTYPE html PUBLIC "x">', '<!DOCTYPE html PUBLIC "x">' ),
+			'With system'            => array( '<!DOCTYPE html SYSTEM "y">', '<!DOCTYPE html SYSTEM "y">' ),
+			'With public and system' => array( '<!DOCTYPE html PUBLIC "x" "y">', '<!DOCTYPE html PUBLIC "x" "y">' ),
+			'Weird casing'           => array( '<!docType HtmL pubLIc\'xxx\'"yyy" all this is ignored>', '<!DOCTYPE html PUBLIC "xxx" "yyy">' ),
 		);
 	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor-serialize.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor-serialize.php
@@ -287,14 +287,34 @@ class Tests_HtmlApi_WpHtmlProcessor_Serialize extends WP_UnitTestCase {
 
 	/**
 	 * @ticket TBD
+	 *
+	 * @dataProvider data_provider_serialize_doctype
 	 */
-	public function test_full_document_serialize_includes_doctype() {
+	public function test_full_document_serialize_includes_doctype( string $doctype_input, string $doctype_output ) {
 		$processor = WP_HTML_Processor::create_full_parser(
-			'<!doCTYpe HtmL pubLIC "xxx" \'yyy\'zzz>👌'
+			"{$doctype_input}👌"
 		);
 		$this->assertSame(
-			'<!DOCTYPE html PUBLIC "xxx" "yyy"><html><head></head><body>👌</body></html>',
+			"{$doctype_output}<html><head></head><body>👌</body></html>",
 			$processor->serialize()
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_provider_serialize_doctype() {
+		return array(
+			'None'                   => array( '', '' ),
+			'Empty'                  => array( '<!DOCTYPE>', '<!DOCTYPE>' ),
+			'HTML5'                  => array( '<!DOCTYPE html>', '<!DOCTYPE html>' ),
+			'Strange name'           => array( '<!DOCTYPE WordPress>', '<!DOCTYPE wordpress>' ),
+			'With public'            => array( '<!DOCTYPE html PUBLIC "x">', '<!DOCTYPE html PUBLIC "x">' ),
+			'With system'            => array( '<!DOCTYPE html SYSTEM "y">', '<!DOCTYPE html SYSTEM "y">' ),
+			'With public and system' => array( '<!DOCTYPE html PUBLIC "x" "y">', '<!DOCTYPE html PUBLIC "x" "y">' ),
+			'Weird casing'           => array( '<!docType HtmL pubLIc\'xxx\'"yyy" all this is ignored>', '<!DOCTYPE html PUBLIC "xxx" "yyy">' ),
 		);
 	}
 }


### PR DESCRIPTION
Output DOCTYPE when calling `WP_HTML_Processor::serialize` on a full document including a DOCTYPE.

The DOCTYPE should be included in the serialized/normalized HTML output, it has an impact in how the document is handled, in particular whether the document should be handled in quirks or no-quirks mode.

Trac ticket: https://core.trac.wordpress.org/ticket/62396

This only affects the serialization of full parsers at this time becuase DOCTYPE tokens are currently ignored in all possible fragments. The omission of the DOCTYPE is subtle but can change the serialized document's quirks/no-quirks mode.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
