### PR TITLE
Theme JSON: include block style variations in path only output of get_block_nodes

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2722,9 +2722,21 @@ class WP_Theme_JSON {
 		foreach ( $theme_json['styles']['blocks'] as $name => $node ) {
 			$node_path = array( 'styles', 'blocks', $name );
 			if ( $include_node_paths_only ) {
-				$nodes[] = array(
+				$variation_paths = array();
+				if ( $include_variations && isset( $node['variations'] ) ) {
+					foreach ( $node['variations'] as $variation => $variation_node ) {
+						$variation_paths[] = array(
+							'path' => array( 'styles', 'blocks', $name, 'variations', $variation ),
+						);
+					}
+				}
+				$node = array(
 					'path' => $node_path,
 				);
+				if ( ! empty( $variation_paths ) ) {
+					$node['variations'] = $variation_paths;
+				}
+				$nodes[] = $node;
 			} else {
 				$selector = null;
 				if ( isset( $selectors[ $name ]['selector'] ) ) {

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -2503,6 +2503,83 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	}
 
 	/**
+	 * This test covers `get_block_nodes` with the `$include_node_paths_only`
+	 * and `include_block_style_variations` options.
+	 */
+	public function test_return_block_node_paths_with_variations() {
+		$theme_json = new ReflectionClass( 'WP_Theme_JSON' );
+
+		$func = $theme_json->getMethod( 'get_block_nodes' );
+		$func->setAccessible( true );
+
+		$theme_json = array(
+			'version' => WP_Theme_JSON::LATEST_SCHEMA,
+			'styles'  => array(
+				'typography' => array(
+					'fontSize' => '16px',
+				),
+				'blocks'     => array(
+					'core/button' => array(
+						'color'      => array(
+							'background' => 'red',
+						),
+						'variations' => array(
+							'cheese' => array(
+								'color' => array(
+									'background' => 'cheese',
+								),
+							),
+						),
+					),
+					'core/group'  => array(
+						'color'      => array(
+							'background' => 'blue',
+						),
+						'variations' => array(
+							'apricot' => array(
+								'color' => array(
+									'background' => 'apricot',
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$block_nodes = $func->invoke(
+			null,
+			$theme_json,
+			array(),
+			array(
+				'include_node_paths_only'        => true,
+				'include_block_style_variations' => true,
+			)
+		);
+
+		$expected = array(
+			array(
+				'path'       => array( 'styles', 'blocks', 'core/button' ),
+				'variations' => array(
+					array(
+						'path' => array( 'styles', 'blocks', 'core/button', 'variations', 'cheese' ),
+					),
+				),
+			),
+			array(
+				'path'       => array( 'styles', 'blocks', 'core/group' ),
+				'variations' => array(
+					array(
+						'path' => array( 'styles', 'blocks', 'core/group', 'variations', 'apricot' ),
+					),
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, $block_nodes );
+	}
+
+	/**
 	 * @ticket 54336
 	 */
 	public function test_remove_insecure_properties_removes_unsafe_styles() {

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -2506,7 +2506,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	 * This test covers `get_block_nodes` with the `$include_node_paths_only`
 	 * and `include_block_style_variations` options.
 	 *
-	 * @ticket 62399	 
+	 * @ticket 62399
 	 */
 	public function test_return_block_node_paths_with_variations() {
 		$theme_json = new ReflectionClass( 'WP_Theme_JSON' );

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -2505,6 +2505,8 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	/**
 	 * This test covers `get_block_nodes` with the `$include_node_paths_only`
 	 * and `include_block_style_variations` options.
+	 *
+	 * @ticket 62399	 
 	 */
 	public function test_return_block_node_paths_with_variations() {
 		$theme_json = new ReflectionClass( 'WP_Theme_JSON' );


### PR DESCRIPTION
Syncing Gutenberg PR:

- https://github.com/WordPress/gutenberg/pull/66948

Follow up to:

- https://github.com/WordPress/wordpress-develop/pull/7486
- https://core.trac.wordpress.org/ticket/61858

Including variations in the nodes array when 'include_node_paths_only' => true


Discussed here: https://github.com/WordPress/gutenberg/pull/66731/files#r1830311575

## Why?
https://github.com/WordPress/gutenberg/pull/66002 added and  `$include_node_paths_only` option to `get_block_nodes()` to improve performance.

When `true` this option tells the function to only return paths, and not selectors, for consumers that only needed paths to style values.

For [one of the conditional blocks](https://github.com/WordPress/gutenberg/pull/66002/files#diff-b03597cc3da199e5aa5a94950e8241135904853e7c3b82d758e42744878afae7R2751), block style variations wasn't included. 

This PR adds them to the array of paths following the existing model `$node[]['path' => [], 'variations' => ['path' => []]]`

## How?
Just adding the same loop but in the `$include_node_paths_only` condition block.

## Testing Instructions

PHP unit tests should pass.
Smoke test the editor.  Should be all 👍🏻 


Trac ticket: https://core.trac.wordpress.org/ticket/62399

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
