### PR TITLE
Fix Core Widget Fields Not Rendering "0" Value

### DIFF
--- a/src/wp-includes/widgets/class-wp-nav-menu-widget.php
+++ b/src/wp-includes/widgets/class-wp-nav-menu-widget.php
@@ -48,14 +48,18 @@ class WP_Nav_Menu_Widget extends WP_Widget {
 		}
 
 		$default_title = __( 'Menu' );
-		$title         = ! empty( $instance['title'] ) ? $instance['title'] : '';
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = $default_title;
+		}
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
 		echo $args['before_widget'];
 
-		if ( $title ) {
+		if ( '' !== $title ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 
@@ -123,7 +127,7 @@ class WP_Nav_Menu_Widget extends WP_Widget {
 	 */
 	public function update( $new_instance, $old_instance ) {
 		$instance = array();
-		if ( ! empty( $new_instance['title'] ) ) {
+		if ( isset( $new_instance['title'] ) && '' !== $new_instance['title'] ) {
 			$instance['title'] = sanitize_text_field( $new_instance['title'] );
 		}
 		if ( ! empty( $new_instance['nav_menu'] ) ) {

--- a/src/wp-includes/widgets/class-wp-widget-archives.php
+++ b/src/wp-includes/widgets/class-wp-widget-archives.php
@@ -42,7 +42,11 @@ class WP_Widget_Archives extends WP_Widget {
 	 */
 	public function widget( $args, $instance ) {
 		$default_title = __( 'Archives' );
-		$title         = ! empty( $instance['title'] ) ? $instance['title'] : $default_title;
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = $default_title;
+		}
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
@@ -52,7 +56,7 @@ class WP_Widget_Archives extends WP_Widget {
 
 		echo $args['before_widget'];
 
-		if ( $title ) {
+		if ( '' !== $title ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 

--- a/src/wp-includes/widgets/class-wp-widget-calendar.php
+++ b/src/wp-includes/widgets/class-wp-widget-calendar.php
@@ -48,13 +48,17 @@ class WP_Widget_Calendar extends WP_Widget {
 	 * @param array $instance The settings for the particular instance of the widget.
 	 */
 	public function widget( $args, $instance ) {
-		$title = ! empty( $instance['title'] ) ? $instance['title'] : '';
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = '';
+		}
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
 		echo $args['before_widget'];
-		if ( $title ) {
+		if ( '' !== $title ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 		if ( 0 === self::$instance ) {

--- a/src/wp-includes/widgets/class-wp-widget-categories.php
+++ b/src/wp-includes/widgets/class-wp-widget-categories.php
@@ -46,7 +46,11 @@ class WP_Widget_Categories extends WP_Widget {
 		static $first_dropdown = true;
 
 		$default_title = __( 'Categories' );
-		$title         = ! empty( $instance['title'] ) ? $instance['title'] : $default_title;
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = $default_title;
+		}
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
@@ -57,7 +61,7 @@ class WP_Widget_Categories extends WP_Widget {
 
 		echo $args['before_widget'];
 
-		if ( $title ) {
+		if ( '' !== $title ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 

--- a/src/wp-includes/widgets/class-wp-widget-meta.php
+++ b/src/wp-includes/widgets/class-wp-widget-meta.php
@@ -44,14 +44,18 @@ class WP_Widget_Meta extends WP_Widget {
 	 */
 	public function widget( $args, $instance ) {
 		$default_title = __( 'Meta' );
-		$title         = ! empty( $instance['title'] ) ? $instance['title'] : $default_title;
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = $default_title;
+		}
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
 		echo $args['before_widget'];
 
-		if ( $title ) {
+		if ( '' !== $title ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 

--- a/src/wp-includes/widgets/class-wp-widget-pages.php
+++ b/src/wp-includes/widgets/class-wp-widget-pages.php
@@ -42,7 +42,11 @@ class WP_Widget_Pages extends WP_Widget {
 	 */
 	public function widget( $args, $instance ) {
 		$default_title = __( 'Pages' );
-		$title         = ! empty( $instance['title'] ) ? $instance['title'] : $default_title;
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = $default_title;
+		}
 
 		/**
 		 * Filters the widget title.
@@ -88,7 +92,7 @@ class WP_Widget_Pages extends WP_Widget {
 
 		if ( ! empty( $output ) ) {
 			echo $args['before_widget'];
-			if ( $title ) {
+			if ( '' !== $title ) {
 				echo $args['before_title'] . $title . $args['after_title'];
 			}
 

--- a/src/wp-includes/widgets/class-wp-widget-recent-comments.php
+++ b/src/wp-includes/widgets/class-wp-widget-recent-comments.php
@@ -84,7 +84,11 @@ class WP_Widget_Recent_Comments extends WP_Widget {
 		$output = '';
 
 		$default_title = __( 'Recent Comments' );
-		$title         = ( ! empty( $instance['title'] ) ) ? $instance['title'] : $default_title;
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = $default_title;
+		}
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
@@ -118,7 +122,7 @@ class WP_Widget_Recent_Comments extends WP_Widget {
 		);
 
 		$output .= $args['before_widget'];
-		if ( $title ) {
+		if ( '' !== $title ) {
 			$output .= $args['before_title'] . $title . $args['after_title'];
 		}
 

--- a/src/wp-includes/widgets/class-wp-widget-recent-posts.php
+++ b/src/wp-includes/widgets/class-wp-widget-recent-posts.php
@@ -47,7 +47,11 @@ class WP_Widget_Recent_Posts extends WP_Widget {
 		}
 
 		$default_title = __( 'Recent Posts' );
-		$title         = ( ! empty( $instance['title'] ) ) ? $instance['title'] : $default_title;
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = $default_title;
+		}
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
@@ -90,7 +94,7 @@ class WP_Widget_Recent_Posts extends WP_Widget {
 		<?php echo $args['before_widget']; ?>
 
 		<?php
-		if ( $title ) {
+		if ( '' !== $title ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 
@@ -111,7 +115,11 @@ class WP_Widget_Recent_Posts extends WP_Widget {
 			<?php foreach ( $r->posts as $recent_post ) : ?>
 				<?php
 				$post_title   = get_the_title( $recent_post->ID );
-				$title        = ( ! empty( $post_title ) ) ? $post_title : __( '(no title)' );
+				if ( isset( $post_title ) && '' !== $post_title ) {
+					$title = $post_title;
+				} else {
+					$title = __( '(no title)' );
+				}
 				$aria_current = '';
 
 				if ( get_queried_object_id() === $recent_post->ID ) {

--- a/src/wp-includes/widgets/class-wp-widget-rss.php
+++ b/src/wp-includes/widgets/class-wp-widget-rss.php
@@ -64,13 +64,17 @@ class WP_Widget_RSS extends WP_Widget {
 		}
 
 		$rss   = fetch_feed( $url );
-		$title = $instance['title'];
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = '';
+		}
 		$desc  = '';
 		$link  = '';
 
 		if ( ! is_wp_error( $rss ) ) {
 			$desc = esc_attr( strip_tags( html_entity_decode( $rss->get_description(), ENT_QUOTES, get_option( 'blog_charset' ) ) ) );
-			if ( empty( $title ) ) {
+			if ( '' === $title ) {
 				$title = strip_tags( $rss->get_title() );
 			}
 			$link = strip_tags( $rss->get_permalink() );
@@ -79,14 +83,14 @@ class WP_Widget_RSS extends WP_Widget {
 			}
 		}
 
-		if ( empty( $title ) ) {
+		if ( '' === $title ) {
 			$title = ! empty( $desc ) ? $desc : __( 'Unknown Feed' );
 		}
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
-		if ( $title ) {
+		if ( '' !== $title ) {
 			$feed_link = '';
 			$feed_url  = strip_tags( $url );
 			$feed_icon = includes_url( 'images/rss.png' );
@@ -114,7 +118,7 @@ class WP_Widget_RSS extends WP_Widget {
 		}
 
 		echo $args['before_widget'];
-		if ( $title ) {
+		if ( '' !== $title ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 

--- a/src/wp-includes/widgets/class-wp-widget-search.php
+++ b/src/wp-includes/widgets/class-wp-widget-search.php
@@ -41,13 +41,17 @@ class WP_Widget_Search extends WP_Widget {
 	 * @param array $instance Settings for the current Search widget instance.
 	 */
 	public function widget( $args, $instance ) {
-		$title = ! empty( $instance['title'] ) ? $instance['title'] : '';
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = '';
+		}
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
 		echo $args['before_widget'];
-		if ( $title ) {
+		if ( '' !== $title ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 

--- a/src/wp-includes/widgets/class-wp-widget-tag-cloud.php
+++ b/src/wp-includes/widgets/class-wp-widget-tag-cloud.php
@@ -42,7 +42,7 @@ class WP_Widget_Tag_Cloud extends WP_Widget {
 	public function widget( $args, $instance ) {
 		$current_taxonomy = $this->_get_current_taxonomy( $instance );
 
-		if ( ! empty( $instance['title'] ) ) {
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
 			$title = $instance['title'];
 		} else {
 			if ( 'post_tag' === $current_taxonomy ) {
@@ -89,7 +89,7 @@ class WP_Widget_Tag_Cloud extends WP_Widget {
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
 		echo $args['before_widget'];
-		if ( $title ) {
+		if ( '' !== $title ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 
@@ -144,7 +144,11 @@ class WP_Widget_Tag_Cloud extends WP_Widget {
 	 * @param array $instance Current settings.
 	 */
 	public function form( $instance ) {
-		$title = ! empty( $instance['title'] ) ? $instance['title'] : '';
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = '';
+		}
 		$count = isset( $instance['count'] ) ? (bool) $instance['count'] : false;
 		?>
 		<p>

--- a/src/wp-includes/widgets/class-wp-widget-text.php
+++ b/src/wp-includes/widgets/class-wp-widget-text.php
@@ -227,12 +227,16 @@ class WP_Widget_Text extends WP_Widget {
 	public function widget( $args, $instance ) {
 		global $post;
 
-		$title = ! empty( $instance['title'] ) ? $instance['title'] : '';
+		if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
+			$title = $instance['title'];
+		} else {
+			$title = '';
+		}
 
 		/** This filter is documented in wp-includes/widgets/class-wp-widget-pages.php */
 		$title = apply_filters( 'widget_title', $title, $instance, $this->id_base );
 
-		$text                  = ! empty( $instance['text'] ) ? $instance['text'] : '';
+		$text                  = isset( $instance['text'] ) && '' !== $instance['text'] ? $instance['text'] : '';
 		$is_visual_text_widget = ( ! empty( $instance['visual'] ) && ! empty( $instance['filter'] ) );
 
 		// In 4.8.0 only, visual Text widgets get filter=content, without visual prop; upgrade instance props just-in-time.
@@ -328,7 +332,7 @@ class WP_Widget_Text extends WP_Widget {
 		}
 
 		echo $args['before_widget'];
-		if ( ! empty( $title ) ) {
+		if ( '' !== $title ) {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 

--- a/tests/phpunit/tests/widgets/wpWidgetCoreZeroValues.php
+++ b/tests/phpunit/tests/widgets/wpWidgetCoreZeroValues.php
@@ -1,0 +1,402 @@
+<?php
+/**
+ * Unit tests covering widget title handling for zero values.
+ *
+ * @package    WordPress
+ * @subpackage widgets
+ */
+
+/**
+ * Test widget title handling for zero values across core widgets.
+ *
+ * @group widgets
+ */
+class Tests_Widgets_wpWidgetCoreZeroValues extends WP_UnitTestCase {
+
+	/**
+	 * Clean up global scope.
+	 */
+	public function clean_up_global_scope() {
+		parent::clean_up_global_scope();
+	}
+
+	/**
+	 * Test WP_Widget_Archives handles title value of "0" correctly.
+	 *
+	 * @covers WP_Widget_Archives::widget
+	 */
+	public function test_archives_widget_title_zero_value() {
+		$widget = new WP_Widget_Archives();
+
+		$args = array(
+			'before_title'  => '<h2>',
+			'after_title'   => '</h2>',
+			'before_widget' => '<section>',
+			'after_widget'  => '</section>',
+		);
+
+		// Test with title set to "0"
+		$instance = array(
+			'title' => '0',
+		);
+
+		ob_start();
+		$widget->widget( $args, $instance );
+		$output = ob_get_clean();
+
+		// Should contain the title "0"
+		$this->assertStringContainsString( '<h2>0</h2>', $output );
+		$this->assertStringNotContainsString( '<h2>Archives</h2>', $output );
+	}
+
+	/**
+	 * Test WP_Widget_Calendar handles title value of "0" correctly.
+	 *
+	 * @covers WP_Widget_Calendar::widget
+	 */
+	public function test_calendar_widget_title_zero_value() {
+		$widget = new WP_Widget_Calendar();
+
+		$args = array(
+			'before_title'  => '<h2>',
+			'after_title'   => '</h2>',
+			'before_widget' => '<section>',
+			'after_widget'  => '</section>',
+		);
+
+		$instance = array(
+			'title' => '0',
+		);
+
+		ob_start();
+		$widget->widget( $args, $instance );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<h2>0</h2>', $output );
+	}
+
+	/**
+	 * Test WP_Widget_Categories handles title value of "0" correctly.
+	 *
+	 * @covers WP_Widget_Categories::widget
+	 */
+	public function test_categories_widget_title_zero_value() {
+		$category_id = self::factory()->category->create( array( 'name' => 'Test Category' ) );
+		$post_id     = self::factory()->post->create( array( 'post_category' => array( $category_id ) ) );
+
+		$widget = new WP_Widget_Categories();
+
+		$args = array(
+			'before_title'  => '<h2>',
+			'after_title'   => '</h2>',
+			'before_widget' => '<section>',
+			'after_widget'  => '</section>',
+		);
+
+		$instance = array(
+			'title' => '0',
+		);
+
+		ob_start();
+		$widget->widget( $args, $instance );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<h2>0</h2>', $output );
+		$this->assertStringNotContainsString( '<h2>Categories</h2>', $output );
+	}
+
+
+
+	/**
+	 * Test WP_Nav_Menu_Widget handles title value of "0" correctly.
+	 *
+	 * @covers WP_Nav_Menu_Widget::widget
+	 */
+	public function test_nav_menu_widget_title_zero_value() {
+		$menu_id = wp_create_nav_menu( 'Test Menu' );
+		wp_update_nav_menu_item(
+			$menu_id,
+			0,
+			array(
+				'menu-item-title'  => 'Home',
+				'menu-item-url'    => home_url( '/' ),
+				'menu-item-status' => 'publish',
+			)
+		);
+
+		$widget = new WP_Nav_Menu_Widget();
+
+		$args = array(
+			'before_title'  => '<h2>',
+			'after_title'   => '</h2>',
+			'before_widget' => '<section>',
+			'after_widget'  => '</section>',
+		);
+
+		$instance = array(
+			'title'    => '0',
+			'nav_menu' => $menu_id,
+		);
+
+		ob_start();
+		$widget->widget( $args, $instance );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<h2>0</h2>', $output );
+		$this->assertStringNotContainsString( '<h2>Menu</h2>', $output );
+
+		wp_delete_nav_menu( $menu_id );
+	}
+
+
+
+	/**
+	 * Test WP_Widget_Pages handles title value of "0" correctly.
+	 *
+	 * @covers WP_Widget_Pages::widget
+	 */
+	public function test_pages_widget_title_zero_value() {
+		$page_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_title'  => 'Test Page',
+				'post_status' => 'publish',
+			)
+		);
+
+		$widget = new WP_Widget_Pages();
+
+		$args = array(
+			'before_title'  => '<h2>',
+			'after_title'   => '</h2>',
+			'before_widget' => '<section>',
+			'after_widget'  => '</section>',
+		);
+
+		$instance = array(
+			'title' => '0',
+		);
+
+		ob_start();
+		$widget->widget( $args, $instance );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<h2>0</h2>', $output );
+		$this->assertStringNotContainsString( '<h2>Pages</h2>', $output );
+	}
+
+	/**
+	 * Test WP_Widget_Recent_Comments handles title value of "0" correctly.
+	 *
+	 * @covers WP_Widget_Recent_Comments::widget
+	 */
+	public function test_recent_comments_widget_title_zero_value() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'  => 'Test Post',
+				'post_status' => 'publish',
+			)
+		);
+
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_content'  => 'Test comment',
+				'comment_approved' => 1,
+			)
+		);
+
+		$widget = new WP_Widget_Recent_Comments();
+
+		$args = array(
+			'before_title'  => '<h2>',
+			'after_title'   => '</h2>',
+			'before_widget' => '<section>',
+			'after_widget'  => '</section>',
+		);
+
+		$instance = array(
+			'title' => '0',
+		);
+
+		ob_start();
+		$widget->widget( $args, $instance );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<h2>0</h2>', $output );
+		$this->assertStringNotContainsString( '<h2>Recent Comments</h2>', $output );
+	}
+
+	/**
+	 * Test WP_Widget_Recent_Posts handles title value of "0" correctly.
+	 *
+	 * @covers WP_Widget_Recent_Posts::widget
+	 */
+	public function test_recent_posts_widget_title_zero_value() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'  => 'Test Post',
+				'post_status' => 'publish',
+			)
+		);
+
+		$widget = new WP_Widget_Recent_Posts();
+
+		$args = array(
+			'before_title'  => '<h2>',
+			'after_title'   => '</h2>',
+			'before_widget' => '<section>',
+			'after_widget'  => '</section>',
+		);
+
+		$instance = array(
+			'title' => '0',
+		);
+
+		ob_start();
+		$widget->widget( $args, $instance );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<h2>0</h2>', $output );
+		$this->assertStringNotContainsString( '<h2>Recent Posts</h2>', $output );
+	}
+
+
+
+	/**
+	 * Test WP_Widget_Search handles title value of "0" correctly.
+	 *
+	 * @covers WP_Widget_Search::widget
+	 */
+	public function test_search_widget_title_zero_value() {
+		$widget = new WP_Widget_Search();
+
+		$args = array(
+			'before_title'  => '<h2>',
+			'after_title'   => '</h2>',
+			'before_widget' => '<section>',
+			'after_widget'  => '</section>',
+		);
+
+		$instance = array(
+			'title' => '0',
+		);
+
+		ob_start();
+		$widget->widget( $args, $instance );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<h2>0</h2>', $output );
+	}
+
+	/**
+	 * Test WP_Widget_Meta handles title value of "0" correctly.
+	 *
+	 * @covers WP_Widget_Meta::widget
+	 */
+	public function test_meta_widget_title_zero_value() {
+		$widget = new WP_Widget_Meta();
+
+		$args = array(
+			'before_title'  => '<h2>',
+			'after_title'   => '</h2>',
+			'before_widget' => '<section>',
+			'after_widget'  => '</section>',
+		);
+
+		$instance = array(
+			'title' => '0',
+		);
+
+		ob_start();
+		$widget->widget( $args, $instance );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<h2>0</h2>', $output );
+		$this->assertStringNotContainsString( '<h2>Meta</h2>', $output );
+	}
+
+
+
+	/**
+	 * Test WP_Widget_Text handles title value of "0" correctly.
+	 *
+	 * @covers WP_Widget_Text::widget
+	 */
+	public function test_text_widget_title_zero_value() {
+		$widget = new WP_Widget_Text();
+
+		$args = array(
+			'before_title'  => '<h2>',
+			'after_title'   => '</h2>',
+			'before_widget' => '<section>',
+			'after_widget'  => '</section>',
+		);
+
+		$instance = array(
+			'title' => '0',
+			'text'  => 'Sample text content',
+		);
+
+		ob_start();
+		$widget->widget( $args, $instance );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<h2>0</h2>', $output );
+		$this->assertStringContainsString( 'Sample text content', $output );
+	}
+
+	/**
+	 * Test WP_Widget_RSS update method handles title value of "0" correctly.
+	 *
+	 * @covers WP_Widget_RSS::update
+	 */
+	public function test_rss_widget_update_title_zero_value() {
+		$widget = new WP_Widget_RSS();
+
+		$new_instance = array(
+			'title' => '0',
+			'url'   => 'https://example.com/feed.xml',
+			'items' => 5,
+		);
+
+		$old_instance = array();
+
+		$result = $widget->update( $new_instance, $old_instance );
+
+		$this->assertSame( '0', $result['title'] );
+	}
+
+	/**
+	 * Test WP_Widget_Tag_Cloud handles title value of "0" correctly.
+	 *
+	 * @covers WP_Widget_Tag_Cloud::widget
+	 */
+	public function test_tag_cloud_widget_title_zero_value() {
+		$tag1 = self::factory()->tag->create( array( 'name' => 'Test Tag 1' ) );
+		$tag2 = self::factory()->tag->create( array( 'name' => 'Test Tag 2' ) );
+
+		$post1 = self::factory()->post->create( array( 'tags_input' => array( 'Test Tag 1' ) ) );
+		$post2 = self::factory()->post->create( array( 'tags_input' => array( 'Test Tag 2' ) ) );
+
+		$widget = new WP_Widget_Tag_Cloud();
+
+		$args = array(
+			'before_title'  => '<h2>',
+			'after_title'   => '</h2>',
+			'before_widget' => '<section>',
+			'after_widget'  => '</section>',
+		);
+
+		$instance = array(
+			'title' => '0',
+		);
+
+		ob_start();
+		$widget->widget( $args, $instance );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<h2>0</h2>', $output );
+		$this->assertStringNotContainsString( '<h2>Tags</h2>', $output );
+	}
+}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/38133

## Description
This PR fixes an issue where core widget fields fail to render when the value is "0". The problem occurs because `empty()` checks in widget fields treat "0" as an empty value, causing widgets to not display content when "0" is the only value.

## Problem
Currently, if you set a single "0" as the value in many default widgets (e.g., widget title or content), it won't output anything due to the use of `empty()` checks. The issue arises because `empty()` returns `TRUE` for "0" values, treating them as empty.

For example:
- Setting a widget title to "0" results in no title being displayed
- Multiple zeros ("00") or other values work correctly
- This affects multiple default widgets where `empty()` is used for validation

## Solution
Replace `empty()` checks with explicit `isset()` and string comparison:
```php
// Before
if ( ! empty( $instance['title'] ) ) {
    $title = $instance['title'];
}

// After
if ( isset( $instance['title'] ) && '' !== $instance['title'] ) {
    $title = $instance['title'];
}