### PR TITLE
Fix: Theme browser horizontal overflow in mobile layout

### DIFF
--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -935,6 +935,7 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 	.theme-overlay .theme-screenshots {
 		width: 100%;
 		float: none;
+		margin: 0;
 	}
 
 	.theme-overlay .theme-info {


### PR DESCRIPTION
Trac ticket: [Core - 62411](https://core.trac.wordpress.org/ticket/62411)

This PR fixes a UI issue where the theme browser creates unwanted horizontal scrolling on mobile devices. The issue occurs specifically when viewing theme details in the mobile layout.

When viewing theme details in mobile layout:
- Theme screenshot causes horizontal overflow
- Right margin extends beyond viewport
- Creates unnecessary horizontal scrolling
- Impacts mobile user experience

Solution
- Adjusted the theme screenshot container margins to ensure content stays within viewport bounds while maintaining the design integrity.

### Screenshots

![Before Fix](https://github.com/user-attachments/assets/a6e0985b-37a0-4973-90bb-486562e5094f)
![Before Fix (1)](https://github.com/user-attachments/assets/50ee9ace-49db-470c-92b6-087373680b65)


