### PR TITLE
Preserve `target="_blank"` in Biographical Info and Category Description

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -895,9 +895,11 @@ function wp_kses_allowed_html( $context = '' ) {
 			return $tags;
 
 		case 'user_description':
+		case 'pre_term_description':
 		case 'pre_user_description':
-			$tags             = $allowedtags;
-			$tags['a']['rel'] = true;
+			$tags                = $allowedtags;
+			$tags['a']['rel']    = true;
+			$tags['a']['target'] = true;
 			/** This filter is documented in wp-includes/kses.php */
 			return apply_filters( 'wp_kses_allowed_html', $tags, $context );
 

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -5,7 +5,6 @@
  * @group formatting
  * @group kses
  */
-
 class Tests_Kses extends WP_UnitTestCase {
 
 	/**

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -5,6 +5,7 @@
  * @group formatting
  * @group kses
  */
+
 class Tests_Kses extends WP_UnitTestCase {
 
 	/**

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -2246,54 +2246,74 @@ HTML;
 	}
 
 	/**
-	 * Tests that the target attribute is preserved in the user description context.
+	 * Tests that the target attribute is preserved in various contexts.
+	 *
+	 * @dataProvider data_target_attribute_preserved_in_descriptions
 	 *
 	 * @ticket 12056
+	 *
+	 * @param string $context  The context to test ('user_description' or 'pre_term_description').
+	 * @param string $input    The input HTML string.
+	 * @param string $expected The expected output HTML string.
 	 */
-	public function test_target_attribute_preserved_in_user_description() {
-		$allowed = wp_kses_allowed_html( 'user_description' );
-		$this->assertTrue( isset( $allowed['a']['target'] ), 'Target attribute not allowed in user description' );
-
-		$input    = '<a href="https://example.com" target="_blank">Example</a>';
-		$expected = '<a href="https://example.com" target="_blank">Example</a>';
-		$this->assertEquals( $expected, wp_kses( $input, 'user_description' ) );
+	public function test_target_attribute_preserved_in_context( $context, $input, $expected ) {
+		$allowed = wp_kses_allowed_html( $context );
+		$this->assertTrue( isset( $allowed['a']['target'] ), "Target attribute not allowed in {$context}" );
+		$this->assertEquals( $expected, wp_kses( $input, $context ) );
 	}
 
 	/**
-	 * Tests that the target attribute is preserved in the term description context.
+	 * Data provider for test_target_attribute_preserved_in_context.
 	 *
-	 * @ticket 12056
+	 * @return array
 	 */
-	public function test_target_attribute_preserved_in_term_description() {
-		$allowed = wp_kses_allowed_html( 'pre_term_description' );
-		$this->assertTrue( isset( $allowed['a']['target'] ), 'Target attribute not allowed in term description' );
-
-		$input    = '<a href="https://example.com" target="_blank">Example</a>';
-		$expected = '<a href="https://example.com" target="_blank">Example</a>';
-		$this->assertEquals( $expected, wp_kses( $input, 'pre_term_description' ) );
+	public function data_target_attribute_preserved_in_descriptions() {
+		return array(
+			array(
+				'user_description',
+				'<a href="https://example.com" target="_blank">Example</a>',
+				'<a href="https://example.com" target="_blank">Example</a>',
+			),
+			array(
+				'pre_term_description',
+				'<a href="https://example.com" target="_blank">Example</a>',
+				'<a href="https://example.com" target="_blank">Example</a>',
+			),
+		);
 	}
 
 	/**
-	 * Tests that the target attribute is preserved in the user description context along with other attributes.
+	 * Tests that specific attributes are preserved in various contexts.
+	 *
+	 * @dataProvider data_allowed_attributes_in_descriptions
 	 *
 	 * @ticket 12056
+	 *
+	 * @param string $context    The context to test ('user_description' or 'pre_term_description').
+	 * @param array  $attributes List of attributes to check for.
 	 */
-	public function test_target_attribute_preserved_in_user_description_with_other_attributes() {
-		$allowed = wp_kses_allowed_html( 'user_description' );
-		$this->assertTrue( isset( $allowed['a']['target'] ), 'Target attribute not allowed in user description' );
-		$this->assertTrue( isset( $allowed['a']['href'] ), 'href attribute not allowed in user description' );
-		$this->assertTrue( isset( $allowed['a']['rel'] ), 'rel attribute not allowed in user description' );
+	public function test_specific_attributes_preserved_in_context( $context, $attributes ) {
+		$allowed = wp_kses_allowed_html( $context );
+		foreach ( $attributes as $attribute ) {
+			$this->assertTrue( isset( $allowed['a'][ $attribute ] ), "{$attribute} attribute not allowed in {$context}" );
+		}
 	}
 
 	/**
-	 * Tests that the target attribute is preserved in the term description context along with other attributes.
+	 * Data provider for test_specific_attributes_preserved_in_context.
 	 *
-	 * @ticket 12056
+	 * @return array
 	 */
-	public function test_target_attribute_preserved_in_term_description_with_other_attributes() {
-		$allowed = wp_kses_allowed_html( 'pre_term_description' );
-		$this->assertTrue( isset( $allowed['a']['target'] ), 'target attribute not allowed in term description' );
-		$this->assertTrue( isset( $allowed['a']['href'] ), 'href attribute not allowed in term description' );
-		$this->assertTrue( isset( $allowed['a']['rel'] ), 'rel attribute not allowed in term description' );
+	public function data_allowed_attributes_in_descriptions() {
+		return array(
+			array(
+				'user_description',
+				array( 'target', 'href', 'rel' ),
+			),
+			array(
+				'pre_term_description',
+				array( 'target', 'href', 'rel' ),
+			),
+		);
 	}
 }

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -2244,4 +2244,56 @@ HTML;
 
 		return $this->text_array_to_dataprovider( $required_kses_globals );
 	}
+
+	/**
+	 * Tests that the target attribute is preserved in the user description context.
+	 *
+	 * @ticket 12056
+	 */
+	public function test_target_attribute_preserved_in_user_description() {
+		$allowed = wp_kses_allowed_html( 'user_description' );
+		$this->assertTrue( isset( $allowed['a']['target'] ), 'Target attribute not allowed in user description' );
+
+		$input    = '<a href="https://example.com" target="_blank">Example</a>';
+		$expected = '<a href="https://example.com" target="_blank">Example</a>';
+		$this->assertEquals( $expected, wp_kses( $input, 'user_description' ) );
+	}
+
+	/**
+	 * Tests that the target attribute is preserved in the term description context.
+	 *
+	 * @ticket 12056
+	 */
+	public function test_target_attribute_preserved_in_term_description() {
+		$allowed = wp_kses_allowed_html( 'pre_term_description' );
+		$this->assertTrue( isset( $allowed['a']['target'] ), 'Target attribute not allowed in term description' );
+
+		$input    = '<a href="https://example.com" target="_blank">Example</a>';
+		$expected = '<a href="https://example.com" target="_blank">Example</a>';
+		$this->assertEquals( $expected, wp_kses( $input, 'pre_term_description' ) );
+	}
+
+	/**
+	 * Tests that the target attribute is preserved in the user description context along with other attributes.
+	 *
+	 * @ticket 12056
+	 */
+	public function test_target_attribute_preserved_in_user_description_with_other_attributes() {
+		$allowed = wp_kses_allowed_html( 'user_description' );
+		$this->assertTrue( isset( $allowed['a']['target'] ), 'Target attribute not allowed in user description' );
+		$this->assertTrue( isset( $allowed['a']['href'] ), 'href attribute not allowed in user description' );
+		$this->assertTrue( isset( $allowed['a']['rel'] ), 'rel attribute not allowed in user description' );
+	}
+
+	/**
+	 * Tests that the target attribute is preserved in the term description context along with other attributes.
+	 *
+	 * @ticket 12056
+	 */
+	public function test_target_attribute_preserved_in_term_description_with_other_attributes() {
+		$allowed = wp_kses_allowed_html( 'pre_term_description' );
+		$this->assertTrue( isset( $allowed['a']['target'] ), 'target attribute not allowed in term description' );
+		$this->assertTrue( isset( $allowed['a']['href'] ), 'href attribute not allowed in term description' );
+		$this->assertTrue( isset( $allowed['a']['rel'] ), 'rel attribute not allowed in term description' );
+	}
 }


### PR DESCRIPTION
## Preserve `target="_blank"` in Biographical Info and Category Description

### Description
This pull request ensures that the `target="_blank"` attribute is preserved when adding links in the Biographical Info and Category Description fields. Previously, this attribute was being stripped by the kses sanitization process.

Additionally, new unit tests have been added to verify the preservation of the `target="_blank"` attribute in these specific contexts.

### Changes Made
- Added the `target` attribute to the allowed tags in the `user_description` and `pre_term_description` contexts in `wp_kses_allowed_html()`.
- Added the following new unit tests:
  - `test_target_attribute_preserved_in_user_description()`
  - `test_target_attribute_preserved_in_term_description()`
  - `test_target_attribute_preserved_in_user_description_with_other_attributes()`
  - `test_target_attribute_preserved_in_term_description_with_other_attributes()`

Trac ticket: https://core.trac.wordpress.org/ticket/12056
