### PR TITLE
HTML API: Serialize normative html5 doctype or nothing

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1184,22 +1184,9 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					break;
 				}
 
-				$html .= '<!DOCTYPE';
-
-				if ( $doctype->name ) {
-					$html .= " {$doctype->name}";
+				if ( 'no-quirks' === $doctype->indicated_compatability_mode ) {
+					$html = '<!DOCTYPE html>';
 				}
-
-				if ( null !== $doctype->public_identifier ) {
-					$html .= " PUBLIC \"{$doctype->public_identifier}\"";
-				}
-				if ( null !== $doctype->system_identifier ) {
-					if ( null === $doctype->public_identifier ) {
-						$html .= ' SYSTEM';
-					}
-					$html .= " \"{$doctype->system_identifier}\"";
-				}
-				$html .= '>';
 				break;
 
 			case '#text':

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1178,12 +1178,17 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		$token_type = $this->get_token_type();
 
 		switch ( $token_type ) {
+			/*
+			 * DOCTYPE determines whether the document mode is quirks or no-quirks.
+			 *
+			 * Normalize to the HTML5 doctype in case of no-quirks.
+			 * Omit the DOCTYPE in quirks mode which has the same result.
+			 */
 			case '#doctype':
 				$doctype = $this->get_doctype_info();
 				if ( null === $doctype ) {
 					break;
 				}
-
 				if ( 'no-quirks' === $doctype->indicated_compatability_mode ) {
 					$html = '<!DOCTYPE html>';
 				}

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor-serialize.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor-serialize.php
@@ -308,13 +308,13 @@ class Tests_HtmlApi_WpHtmlProcessor_Serialize extends WP_UnitTestCase {
 	public static function data_provider_serialize_doctype() {
 		return array(
 			'None'                   => array( '', '' ),
-			'Empty'                  => array( '<!DOCTYPE>', '<!DOCTYPE>' ),
+			'Empty'                  => array( '<!DOCTYPE>', '' ),
 			'HTML5'                  => array( '<!DOCTYPE html>', '<!DOCTYPE html>' ),
-			'Strange name'           => array( '<!DOCTYPE WordPress>', '<!DOCTYPE wordpress>' ),
-			'With public'            => array( '<!DOCTYPE html PUBLIC "x">', '<!DOCTYPE html PUBLIC "x">' ),
-			'With system'            => array( '<!DOCTYPE html SYSTEM "y">', '<!DOCTYPE html SYSTEM "y">' ),
-			'With public and system' => array( '<!DOCTYPE html PUBLIC "x" "y">', '<!DOCTYPE html PUBLIC "x" "y">' ),
-			'Weird casing'           => array( '<!docType HtmL pubLIc\'xxx\'"yyy" all this is ignored>', '<!DOCTYPE html PUBLIC "xxx" "yyy">' ),
+			'Strange name'           => array( '<!DOCTYPE WordPress>', '' ),
+			'With public'            => array( '<!DOCTYPE html PUBLIC "x">', '<!DOCTYPE html>' ),
+			'With system'            => array( '<!DOCTYPE html SYSTEM "y">', '<!DOCTYPE html>' ),
+			'With public and system' => array( '<!DOCTYPE html PUBLIC "x" "y">', '<!DOCTYPE html>' ),
+			'Weird casing'           => array( '<!docType HtmL pubLIc\'xxx\'"yyy" all this is ignored>', '<!DOCTYPE html>' ),
 		);
 	}
 }


### PR DESCRIPTION
[See this comment](https://core.trac.wordpress.org/ticket/62396#comment:7)

> //We ought to preserve the mode of the input document// but I don't think we should preserve the PUBLIC and SYSTEM identifiers. That is, **only return one of two predefined DOCTYPE declarations**.
> 
> If we have a standards document input, we return `<!DOCTYPE html>`. If we get a quirks-mode document input, we return something like `<!DOCTYPE html PUBLIC "-//WordPress/HTML/quirks-mode">` to fully identify the document as such.

Trac ticket: https://core.trac.wordpress.org/ticket/62396

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
