### PR TITLE
Remove double database start.

### DIFF
--- a/.github/workflows/install-testing.yml
+++ b/.github/workflows/install-testing.yml
@@ -96,7 +96,6 @@ jobs:
   #
   # Performs the following steps:
   # - Sets up PHP.
-  # - Starts the database server.
   # - Downloads the specified version of WordPress.
   # - Creates a `wp-config.php` file.
   # - Installs WordPress.
@@ -156,10 +155,6 @@ jobs:
           php-version: '${{ matrix.php }}'
           coverage: none
           tools: wp-cli${{ contains( fromJSON('["5.4", "5.5"]'), matrix.php ) && ':2.4.0' || '' }}
-
-      - name: Start the database server
-        run: |
-          sudo systemctl start ${{ matrix.db-type }}
 
       - name: Download WordPress
         run: wp core download ${{ inputs.wp-version && format( '--version={0}', inputs.wp-version ) || '--version=nightly' }}

--- a/.github/workflows/reusable-upgrade-testing.yml
+++ b/.github/workflows/reusable-upgrade-testing.yml
@@ -42,7 +42,6 @@ jobs:
   #
   # Performs the following steps:
   # - Sets up PHP.
-  # - Starts the database server.
   # - Downloads the specified version of WordPress.
   # - Creates a `wp-config.php` file.
   # - Installs WordPress.
@@ -76,10 +75,6 @@ jobs:
           php-version: '${{ inputs.php }}'
           coverage: none
           tools: wp-cli
-
-      - name: Start the database server
-        run: |
-          sudo systemctl start ${{ inputs.db-type }}
 
       - name: Download WordPress ${{ inputs.wp }}
         run: wp core download --version=${{ inputs.wp }}


### PR DESCRIPTION
The database container is initialized when `services` are set up. The additional `systemctl start` is not required.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/62221

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
