### PR TITLE
Replace 'delete_users' capability with 'manage_network_options' in check is_super_admin()

### DIFF
--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -1169,7 +1169,7 @@ function is_super_admin( $user_id = false ) {
 		if ( is_array( $super_admins ) && in_array( $user->user_login, $super_admins, true ) ) {
 			return true;
 		}
-	} elseif ( $user->has_cap( 'delete_users' ) ) {
+	} elseif ( $user->has_cap( 'manage_network_options' ) ) {
 		return true;
 	}
 


### PR DESCRIPTION
This PR updates the is_super_admin function by replacing the delete_users capability check with manage_network_options. This change provides a more accurate way to verify super admin status in multisite setups, as manage_network_options is exclusively available to super admins. This improves role accuracy and ensures the function's logic aligns better with WordPress’s intended permissions structure.


Trac ticket: https://core.trac.wordpress.org/ticket/47338

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
