### PR TITLE
Add Ctrl+S / Cmd+S shortcut to save files in Theme and Plugin Editor

### DIFF
--- a/src/js/_enqueues/wp/theme-plugin-editor.js
+++ b/src/js/_enqueues/wp/theme-plugin-editor.js
@@ -49,6 +49,13 @@ wp.themePluginEditor = (function( $ ) {
 		component.docsLookUpButton = component.form.find( '#docs-lookup' );
 		component.docsLookUpList = component.form.find( '#docs-list' );
 
+		$(document).on('keydown',function(e) {
+			if ((e.ctrlKey || e.metaKey) && 's' === e.key) {
+				e.preventDefault(); 
+				component.submitButton.trigger('click');
+			}
+		});
+
 		if ( component.warning.length > 0 ) {
 			component.showWarning();
 		}

--- a/src/wp-admin/plugin-editor.php
+++ b/src/wp-admin/plugin-editor.php
@@ -298,7 +298,7 @@ endif;
 			<input disabled id="docs-lookup" type="button" class="button" value="<?php esc_attr_e( 'Look Up' ); ?>" onclick="if ( '' !== jQuery('#docs-list').val() ) { window.open( 'https://api.wordpress.org/core/handbook/1.0/?function=' + escape( jQuery( '#docs-list' ).val() ) + '&amp;locale=<?php echo urlencode( get_user_locale() ); ?>&amp;version=<?php echo urlencode( get_bloginfo( 'version' ) ); ?>&amp;redirect=true'); }" />
 		</div>
 	<?php endif; ?>
-
+	<p class="save-shortcut-note"><?php esc_html_e( 'Tip: You can also use Ctrl+S (Cmd+S on Mac) to save changes.' ); ?> </p>
 	<?php if ( is_writable( $real_file ) ) : ?>
 		<div class="editor-notices">
 		<?php

--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -344,6 +344,7 @@ else :
 				endif;
 				?>
 			</div>
+			<p class="save-shortcut-note"> <?php esc_html_e( 'Tip: You can also use Ctrl+S (Cmd+S on Mac) to save changes.' ); ?> </p>
 			<?php
 			if ( is_writable( $file ) ) {
 				?>


### PR DESCRIPTION
Trac Ticket: [core 62080](https://core.trac.wordpress.org/ticket/62080)

### Description

This PR introduces a keyboard shortcut (Ctrl+S / Cmd+S) for saving files directly within the Theme and Plugin Editor in WordPress. This enhancement is aimed at improving user experience and efficiency when editing code in the editor.

### Changes Made

- Added JavaScript logic to listen for Ctrl+S or Cmd+S keypress events in the editor.
- Integrated the shortcut with the existing Update File functionality.
- Prevented the default browser save action to avoid conflicts.


### Screenshots / Videos :

https://github.com/user-attachments/assets/b6737ead-2815-4885-8643-00fd14384fa8
