### PR TITLE
Ensure duplicated keys existence before validation

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2514,7 +2514,8 @@ if ( ! function_exists( 'wp_salt' ) ) :
 		foreach ( array( 'auth', 'secure_auth', 'logged_in', 'nonce' ) as $key ) {
 			foreach ( array( 'key', 'salt' ) as $second ) {
 				$const = strtoupper( "{$key}_{$second}" );
-				if ( ! defined( $const ) || true === $duplicated_keys[ constant( $const ) ] ) {
+
+				if ( ! defined( $const ) || ( isset( $duplicated_keys[ constant( $const ) ] ) && true === $duplicated_keys[ constant( $const ) ] ) ) {
 					$options_to_prime[] = "{$key}_{$second}";
 				}
 			}


### PR DESCRIPTION
Trac Ticket: [core 62424](https://core.trac.wordpress.org/ticket/62424)

### Description
Enhances the validation logic for duplicated keys by adding proper existence checks before accessing array values. This prevents potential PHP notices/warnings for undefined array indices.

### Changes
- Added `isset()` check before accessing `$duplicated_keys` array values
- Maintains strict comparison (`===`) with boolean `true`
- Preserves original conditional logic while making it more robust

### Screenshot
![Before Adding Patch](https://github.com/user-attachments/assets/cd27f3ff-e4f6-45ff-b4a3-3c2779841be5)


