### PR TITLE
Admin: Adjust submenu padding in admin menu

### DIFF
--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -127,7 +127,7 @@
 	left: 160px;
 	overflow: visible;
 	word-wrap: break-word;
-	padding: 8px 0;
+	padding: 6px 0;
 	z-index: 9999;
 	background-color: #2c3338;
 	box-shadow: 0 3px 5px rgba(0, 0, 0, 0.2);
@@ -579,7 +579,7 @@ li#wp-admin-bar-menu-toggle {
 		position: absolute;
 		top: -1000em;
 		margin-right: -1px;
-		padding: 8px 0;
+		padding: 6px 0;
 		z-index: 9999;
 	}
 

--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -127,7 +127,7 @@
 	left: 160px;
 	overflow: visible;
 	word-wrap: break-word;
-	padding: 7px 0 8px;
+	padding: 8px 0;
 	z-index: 9999;
 	background-color: #2c3338;
 	box-shadow: 0 3px 5px rgba(0, 0, 0, 0.2);
@@ -579,7 +579,7 @@ li#wp-admin-bar-menu-toggle {
 		position: absolute;
 		top: -1000em;
 		margin-right: -1px;
-		padding: 7px 0 8px;
+		padding: 8px 0;
 		z-index: 9999;
 	}
 


### PR DESCRIPTION
 Trac ticket: https://core.trac.wordpress.org/ticket/61689

This PR fixes #61689 by adjusting the padding for submenu link groups in the admin menu, ensuring consistent top and bottom padding.

**For Big Screen Layouts:**
<img width="500" alt="image" src="https://github.com/user-attachments/assets/89ae6f2e-e1bb-4479-a1e6-15e4d1babfb7">

**For Small Screen Layout:**
<img width="500" alt="image" src="https://github.com/user-attachments/assets/b810dde1-24c4-4205-957f-ac99237b60f4">
