### PR TITLE
HTML API: Fix normalized doctype pub/sys identifier quotes

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1191,14 +1191,17 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				}
 
 				if ( null !== $doctype->public_identifier ) {
-					$html .= " PUBLIC \"{$doctype->public_identifier}\"";
+					$quote = str_contains( $doctype->public_identifier, '"' ) ? "'" : '"';
+					$html .= " PUBLIC {$quote}{$doctype->public_identifier}{$quote}";
 				}
 				if ( null !== $doctype->system_identifier ) {
 					if ( null === $doctype->public_identifier ) {
 						$html .= ' SYSTEM';
 					}
-					$html .= " \"{$doctype->system_identifier}\"";
+					$quote = str_contains( $doctype->system_identifier, '"' ) ? "'" : '"';
+					$html .= " {$quote}{$doctype->system_identifier}{$quote}";
 				}
+
 				$html .= '>';
 				break;
 

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor-serialize.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor-serialize.php
@@ -307,14 +307,18 @@ class Tests_HtmlApi_WpHtmlProcessor_Serialize extends WP_UnitTestCase {
 	 */
 	public static function data_provider_serialize_doctype() {
 		return array(
-			'None'                   => array( '', '' ),
-			'Empty'                  => array( '<!DOCTYPE>', '<!DOCTYPE>' ),
-			'HTML5'                  => array( '<!DOCTYPE html>', '<!DOCTYPE html>' ),
-			'Strange name'           => array( '<!DOCTYPE WordPress>', '<!DOCTYPE wordpress>' ),
-			'With public'            => array( '<!DOCTYPE html PUBLIC "x">', '<!DOCTYPE html PUBLIC "x">' ),
-			'With system'            => array( '<!DOCTYPE html SYSTEM "y">', '<!DOCTYPE html SYSTEM "y">' ),
-			'With public and system' => array( '<!DOCTYPE html PUBLIC "x" "y">', '<!DOCTYPE html PUBLIC "x" "y">' ),
-			'Weird casing'           => array( '<!docType HtmL pubLIc\'xxx\'"yyy" all this is ignored>', '<!DOCTYPE html PUBLIC "xxx" "yyy">' ),
+			'None'                       => array( '', '' ),
+			'Empty'                      => array( '<!DOCTYPE>', '<!DOCTYPE>' ),
+			'HTML5'                      => array( '<!DOCTYPE html>', '<!DOCTYPE html>' ),
+			'Strange name'               => array( '<!DOCTYPE WordPress>', '<!DOCTYPE wordpress>' ),
+			'With public'                => array( '<!DOCTYPE html PUBLIC "x">', '<!DOCTYPE html PUBLIC "x">' ),
+			'With system'                => array( '<!DOCTYPE html SYSTEM "y">', '<!DOCTYPE html SYSTEM "y">' ),
+			'With public and system'     => array( '<!DOCTYPE html PUBLIC "x" "y">', '<!DOCTYPE html PUBLIC "x" "y">' ),
+			'Weird casing'               => array( '<!docType HtmL pubLIc\'xxx\'"yyy" all this is ignored>', '<!DOCTYPE html PUBLIC "xxx" "yyy">' ),
+			'Single quotes in public ID' => array( '<!DOCTYPE html PUBLIC "\'quoted\'">', '<!DOCTYPE html PUBLIC "\'quoted\'">' ),
+			'Double quotes in public ID' => array( '<!DOCTYPE html PUBLIC \'"quoted"\'\>', '<!DOCTYPE html PUBLIC \'"quoted"\'>' ),
+			'Single quotes in system ID' => array( '<!DOCTYPE html SYSTEM "\'quoted\'">', '<!DOCTYPE html SYSTEM "\'quoted\'">' ),
+			'Double quotes in system ID' => array( '<!DOCTYPE html SYSTEM \'"quoted"\'\>', '<!DOCTYPE html SYSTEM \'"quoted"\'>' ),
 		);
 	}
 }


### PR DESCRIPTION
Changeset [[59399]](https://core.trac.wordpress.org/changeset/59399) fixed missing DOCTYPEs in normalized HTML output. It missed an edge case where public and system identifiers may contain double quotes, in which case they must be quoted with single quotes.

This change addresses that issue and adds tests.

Trac ticket: https://core.trac.wordpress.org/ticket/62396
Follow-up to [[59399]](https://core.trac.wordpress.org/changeset/59399)

Examples:

[Broken normalization (arbitrary PR for a recent build)](https://playground.wordpress.net/?plugin=html-api-debugger&url=%2Fwp-admin%2Fadmin.php%3Fpage%3Dhtml-api-debugger%26html%3D%253C%2521DOCTYPE%2Bhtml%2BPUBLIC%2B%2527has%2B%2522%2Bquote%2527%2B%2527this%2B%2522%2Btoo%2527%253E%250A&core-pr=7803)
[Fixed normalization in this PR
](https://playground.wordpress.net/?plugin=html-api-debugger&url=%2Fwp-admin%2Fadmin.php%3Fpage%3Dhtml-api-debugger%26html%3D%253C%2521DOCTYPE%2Bhtml%2BPUBLIC%2B%2527has%2B%2522%2Bquote%2527%2B%2527this%2B%2522%2Btoo%2527%253E%250A&core-pr=7804)

With `<!DOCTYPE html PUBLIC 'has " quote' 'this " too'>` input:

## Before
Normalized: `<!DOCTYPE html PUBLIC "has " quote" "this " too">` (incorrect quoting)
![Screenshot 2024-11-14 at 16 33 33](https://github.com/user-attachments/assets/86e6aaac-aec5-4b3f-b17f-22f56a69c934)

## After
Normalized`<!DOCTYPE html PUBLIC 'has " quote' 'this " too'>`
![Screenshot 2024-11-14 at 16 34 30](https://github.com/user-attachments/assets/a68edb7c-9d83-4847-8630-25fca8fd831e)


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
