### PR TITLE
HTML API: phpstan check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
 		"squizlabs/php_codesniffer": "3.10.3",
 		"wp-coding-standards/wpcs": "~3.1.0",
 		"phpcompatibility/phpcompatibility-wp": "~2.1.3",
-		"yoast/phpunit-polyfills": "^1.1.0"
+		"yoast/phpunit-polyfills": "^1.1.0",
+		"phpstan/phpstan": "^2.0"
 	},
 	"config": {
 		"allow-plugins": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,12 @@
+parameters:
+	level: 2
+	phpVersion: 70224
+	paths:
+		- src/wp-includes/html-api
+		- src/wp-includes/class-wp-token-map.php
+	scanFiles:
+		- src/wp-includes/compat.php
+		- src/wp-includes/formatting.php
+		- src/wp-includes/functions.php
+		- src/wp-includes/kses.php
+		- src/wp-includes/l10n.php

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -3159,9 +3159,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			}
 
 			$this->generate_implied_end_tags( $token_name );
-			if ( $node !== $this->state->stack_of_open_elements->current_node() ) {
-				// @todo Record parse error: this error doesn't impact parsing.
-			}
+			// @todo record parse error if $node is not the current node.
 
 			foreach ( $this->state->stack_of_open_elements->walk_up() as $item ) {
 				$this->state->stack_of_open_elements->pop();

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -566,6 +566,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @since 6.7.0
 	 *
 	 * @param string $message Explains support is missing in order to parse the current node.
+	 *
+	 * @return never
 	 */
 	private function bail( string $message ) {
 		$here  = $this->bookmarks[ $this->state->current_token->bookmark_name ];

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1547,12 +1547,11 @@ class WP_HTML_Tag_Processor {
 				continue;
 			}
 
-			if ( '/' === $html[ $at ] ) {
+			$is_closing = '/' === $html[ $at ];
+
+			if ( $is_closing ) {
 				$closer_potentially_starts_at = $at - 1;
-				$is_closing                   = true;
 				++$at;
-			} else {
-				$is_closing = false;
 			}
 
 			/*


### PR DESCRIPTION
```sh
composer install
./vendor/bin/phpstan --memory-limit=4G analyze
```

```
  ------ ----------------------------------------------------------------------------- 
  Line   html-api/class-wp-html-decoder.php                                           
 ------ ----------------------------------------------------------------------------- 
  69     Variable $token_length might not be defined.                                 
         🪪  variable.undefined                                                       
  149    Variable $character_reference in isset() always exists and is not nullable.  
         🪪  isset.variable                                                           
 ------ ----------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------- 
  Line   html-api/class-wp-html-processor-state.php                                                    
 ------ ---------------------------------------------------------------------------------------------- 
  366    PHPDoc tag @var has invalid value ([string, array]|null): Unexpected token "]", expected '('  
         at offset 202 on line 8                                                                       
         🪪  phpDoc.parseError                                                                         
 ------ ---------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------- 
  Line   html-api/class-wp-html-processor.php                                                           
 ------ ----------------------------------------------------------------------------------------------- 
  300    Unsafe usage of new static().                                                                  
         🪪  new.static                                                                                 
         💡 See: https://phpstan.org/blog/solving-phpstan-error-unsafe-usage-of-new-static              
  351    Unsafe usage of new static().                                                                  
         🪪  new.static                                                                                 
         💡 See: https://phpstan.org/blog/solving-phpstan-error-unsafe-usage-of-new-static              
  917    Method WP_HTML_Processor::step() should return bool but return statement is missing.           
  3016   Variable $node might not be defined.                                                           
         🪪  variable.undefined                                                                         
  3022   Variable $node might not be defined.                                                           
         🪪  variable.undefined                                                                         
  3286   Method WP_HTML_Processor::step_in_table() should return bool but return statement is missing.  
  3305   Method WP_HTML_Processor::step_in_table_text() should return bool but return statement is      
         missing.                                                                                       
  3917   Variable $parent might not be defined.                                                         
         🪪  variable.undefined                                                                         
  5693   Method WP_HTML_Processor::reconstruct_active_formatting_elements() should return bool but      
         return statement is missing.                                                                   
 ------ ----------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------- 
  Line   html-api/class-wp-html-tag-processor.php                             
 ------ --------------------------------------------------------------------- 
  1603   Variable $closer_potentially_starts_at might not be defined.         
         🪪  variable.undefined                                               
  1604   Variable $closer_potentially_starts_at might not be defined.         
         🪪  variable.undefined                                               
  3508   Variable $replacement in isset() always exists and is not nullable.  
         🪪  isset.variable                                                   
  3875   Function wp_kses_uri_attributes not found.                           
         🪪  function.notFound                                                
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols  
 ------ --------------------------------------------------------------------- 

 [ERROR] Found 17 errors                                                                                

```

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
