### PR TITLE
Fix excerpt generation to include list-item block content in excerpts

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1948,6 +1948,7 @@ function excerpt_remove_blocks( $content ) {
 		'core/heading',
 		'core/html',
 		'core/list',
+		'core/list-item',
 		'core/media-text',
 		'core/paragraph',
 		'core/preformatted',


### PR DESCRIPTION
This PR resolves an issue where content within list-item blocks was excluded from post excerpts. The function excerpt_remove_blocks() now allows core/list-item as part of $allowed_inner_blocks, ensuring that list content is correctly included in generated excerpts.

Trac ticket: https://core.trac.wordpress.org/ticket/62417

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
