### PR TITLE
Sync "Most Used" and "All Categories" tabs when using classic editor

### DIFF
--- a/src/js/_enqueues/admin/post.js
+++ b/src/js/_enqueues/admin/post.js
@@ -660,8 +660,8 @@ jQuery( function($) {
 			function() {
 				var t = $(this), c = t.is(':checked'), id = t.val();
 				if ( id && t.parents('#taxonomy-'+taxonomy).length ) {
-					$('#in-' + taxonomy + '-' + id + ', [id^="in-' + taxonomy + '-' + id + '-"]').prop('checked', c);
-					$('#in-popular-' + taxonomy + '-' + id).prop('checked', c);
+					$('input[id^="in-' + taxonomy + '-' + id + '"]').prop('checked', c);
+					$('input#in-popular-' + taxonomy + '-' + id).prop('checked', c);
 				}
 			}
 		);

--- a/src/js/_enqueues/admin/post.js
+++ b/src/js/_enqueues/admin/post.js
@@ -659,8 +659,10 @@ jQuery( function($) {
 			'li.popular-category > label input[type="checkbox"]',
 			function() {
 				var t = $(this), c = t.is(':checked'), id = t.val();
-				if ( id && t.parents('#taxonomy-'+taxonomy).length )
-					$('#in-' + taxonomy + '-' + id + ', #in-popular-' + taxonomy + '-' + id).prop( 'checked', c );
+				if ( id && t.parents('#taxonomy-'+taxonomy).length ) {
+					$('#in-' + taxonomy + '-' + id + ', [id^="in-' + taxonomy + '-' + id + '-"]').prop('checked', c);
+					$('#in-popular-' + taxonomy + '-' + id).prop('checked', c);
+				}
 			}
 		);
 


### PR DESCRIPTION
Trac ticket:https://core.trac.wordpress.org/ticket/62440

### Description:
This PR addresses a bug where the "Most Used" category tab was not synced with the "All Categories" tab in the Classic Editor. When selecting categories in the "Most Used" tab, the changes were not reflected in the "All Categories" tab, causing inconsistency in category selection.

### Fix:

- Added functionality to ensure the category selection in the "Most Used" tab correctly updates the "All Categories" tab.
- Updated the event listeners to ensure proper syncing of checkbox states between the two tabs.
- The issue occurred because the 'All Categories' section had a suffix appended to it, as shown in the screenshot below.

<img width="553" alt="Screenshot 2024-11-15 at 7 06 06 PM" src="https://github.com/user-attachments/assets/1cc7d93a-0590-4ede-ab27-77d3d30d9d0f">

### Steps to Test:

1. Open the Classic Editor in WordPress.
2. Go to the "Categories" section.
3. Select a category from the Most used section.
4. Notice that the category won't be checked in the "All categories" section.
5. Their is No sync between categories checked in the "Most used" section and "All categories" section

### Video demonstration

Before:

https://github.com/user-attachments/assets/1f2975ba-12e8-47f1-b9ec-671325dbf6ea

After:

https://github.com/user-attachments/assets/0830a5a3-67e8-4131-8b1d-406adc5fcf8d


