### PR TITLE
Customize: Resolve horizontal overflow in customizer panel

### DIFF
--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -564,6 +564,7 @@ body.trashing #publish-settings {
 	padding: 10px 10px 11px 14px;
 	display: flex;
 	align-items: center;
+	box-sizing: border-box;
 }
 
 .accordion-section-title button.accordion-trigger:has(.menu-in-location) {
@@ -694,7 +695,6 @@ body.trashing #publish-settings {
 	height: auto;
 	max-height: none;
 	overflow: auto;
-	overflow-x: hidden;
 	transform: none;
 }
 

--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -694,6 +694,7 @@ body.trashing #publish-settings {
 	height: auto;
 	max-height: none;
 	overflow: auto;
+	overflow-x: hidden;
 	transform: none;
 }
 


### PR DESCRIPTION
Trac ticket: [#62443](https://core.trac.wordpress.org/ticket/62443)

This PR addresses the issue of horizontal overflow in the customizer panel, which was causing unintended horizontal scrolling. The overflow issue has been resolved by modifying the overflow-x to ensure the panel content stays within the bounds of the viewport.

### Screenshots:
![image](https://github.com/user-attachments/assets/464cdf70-3a70-452b-a46c-735cf7780d4f)
![image](https://github.com/user-attachments/assets/ef8d30ff-c254-4660-bae1-9d4f292d29d9)