### PR TITLE
Don't prepare the response body for HEAD requests in WP_REST_Users_Controller 

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-request.php
+++ b/src/wp-includes/rest-api/class-wp-rest-request.php
@@ -162,6 +162,18 @@ class WP_REST_Request implements ArrayAccess {
 	}
 
 	/**
+	 * Determines if the request is the given method.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @param string $method HTTP method.
+	 * @return bool Whether the request is of the given method.
+	 */
+	public function is_method( $method ) {
+		return $this->get_method() === strtoupper( $method );
+	}
+
+	/**
 	 * Canonicalizes the header name.
 	 *
 	 * Ensures that header names are always treated the same regardless of

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -334,7 +334,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			$prepared_args['search'] = '*' . $prepared_args['search'] . '*';
 		}
 
- 		$is_head_request = $request->is_method( 'head' );
+		$is_head_request = $request->is_method( 'head' );
 		if ( $is_head_request ) {
 			// Force the 'fields' argument. For HEAD requests, only user IDs are required.
 			$prepared_args['fields'] = 'id';

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -480,6 +480,10 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			return $user;
 		}
 
+		if ( $request->is_method( 'head' ) ) {
+			return new WP_REST_Response();
+		}
+
 		$user     = $this->prepare_item_for_response( $user, $request );
 		$response = rest_ensure_response( $user );
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -334,10 +334,10 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			$prepared_args['search'] = '*' . $prepared_args['search'] . '*';
 		}
 
-		$is_head_request = $request->is_method( 'head' );
+ 		$is_head_request = $request->is_method( 'head' );
 		if ( $is_head_request ) {
 			// Force the 'fields' argument. For HEAD requests, only user IDs are required.
-			$prepared_args['fields'] = 'ids';
+			$prepared_args['fields'] = 'id';
 		}
 		/**
 		 * Filters WP_User_Query arguments when querying users via the REST API.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -333,6 +333,12 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			}
 			$prepared_args['search'] = '*' . $prepared_args['search'] . '*';
 		}
+
+		$is_head_request = $request->is_method( 'head' );
+		if ( $is_head_request ) {
+			// Force the 'fields' argument. For HEAD requests, only user IDs are required.
+			$prepared_args['fields'] = 'ids';
+		}
 		/**
 		 * Filters WP_User_Query arguments when querying users via the REST API.
 		 *
@@ -347,14 +353,16 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 
 		$query = new WP_User_Query( $prepared_args );
 
-		$users = array();
+		if ( ! $is_head_request ) {
+			$users = array();
 
-		foreach ( $query->get_results() as $user ) {
-			$data    = $this->prepare_item_for_response( $user, $request );
-			$users[] = $this->prepare_response_for_collection( $data );
+			foreach ( $query->get_results() as $user ) {
+				$data    = $this->prepare_item_for_response( $user, $request );
+				$users[] = $this->prepare_response_for_collection( $data );
+			}
 		}
 
-		$response = rest_ensure_response( $users );
+		$response = $is_head_request ? new WP_REST_Response() : rest_ensure_response( $users );
 
 		// Store pagination values for headers then unset for count query.
 		$per_page = (int) $prepared_args['number'];

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -3226,7 +3226,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 
 		global $wpdb;
 		$users_table = preg_quote( $wpdb->users, '/' );
-		$pattern     = '/SELECT SQL_CALC_FOUND_ROWS wptests_users.ID\n\s+FROM\s+' . $users_table . '\n\s+WHERE 1=1/is';
+		$pattern     = '/SELECT SQL_CALC_FOUND_ROWS wptests_users.ID\n\s+FROM\s+' . $users_table . '/is';
 
 		// Assert that the SQL query only fetches the id column.
 		$this->assertMatchesRegularExpression( $pattern, $query->request, 'The SQL query does not match the expected string.' );

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -3207,7 +3207,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertTrue( isset( $args[0][0] ), 'Query parameters were not captured.' );
 		$this->assertInstanceOf( WP_User_Query::class, $args[0][0], 'Query parameters were not captured.' );
 
-		/** @var WP_Term_Query $query */
+		/** @var WP_User $query */
 		$query = $args[0][0];
 
 		if ( $is_head_request ) {
@@ -3228,7 +3228,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$users_table = preg_quote( $wpdb->users, '/' );
 		$pattern     = '/SELECT SQL_CALC_FOUND_ROWS wptests_users.ID\n\s+FROM\s+' . $users_table . '\n\s+WHERE 1=1/is';
 
-		// Assert that the SQL query only fetches the term_id column.
+		// Assert that the SQL query only fetches the id column.
 		$this->assertMatchesRegularExpression( $pattern, $query->request, 'The SQL query does not match the expected string.' );
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -3215,8 +3215,8 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 			$this->assertSame( 'id', $query->query_vars['fields'], 'The query must fetch only user IDs.' );
 		} else {
 			$this->assertTrue(
-				! array_key_exists( 'fields', $query->query_vars ) || 'ids' !== $query->query_vars['fields'],
-				'The fields parameter should not be forced to "ids" for non-HEAD requests.'
+				! array_key_exists( 'fields', $query->query_vars ) || 'id' !== $query->query_vars['fields'],
+				'The fields parameter should not be forced to "id" for non-HEAD requests.'
 			);
 		}
 

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -3245,5 +3245,4 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 
 		return;
 	}
-
 }

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -1528,8 +1528,8 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 				$this->assertSame( 'Sorry, that username already exists!', $error['message'] );
 			} else {
 				$expected = '<strong>Error:</strong> This email address is already registered. ' .
-				            '<a href="http://rest.wordpress.org/wp-login.php">Log in</a> with ' .
-				            'this address or choose another one.';
+							'<a href="http://rest.wordpress.org/wp-login.php">Log in</a> with ' .
+							'this address or choose another one.';
 				$this->assertSame( $expected, $error['message'] );
 			}
 		}
@@ -2433,7 +2433,6 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		// Not implemented in multisite.
 		if ( is_multisite() ) {
 			$this->assertErrorResponse( 'rest_cannot_delete', $response, 501 );
-
 			return;
 		}
 
@@ -2459,7 +2458,6 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		// Not implemented in multisite.
 		if ( is_multisite() ) {
 			$this->assertErrorResponse( 'rest_cannot_delete', $response, 501 );
-
 			return;
 		}
 
@@ -2494,7 +2492,6 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		// Not implemented in multisite.
 		if ( is_multisite() ) {
 			$this->assertErrorResponse( 'rest_cannot_delete', $response, 501 );
-
 			return;
 		}
 
@@ -2523,7 +2520,6 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		// Not implemented in multisite.
 		if ( is_multisite() ) {
 			$this->assertErrorResponse( 'rest_cannot_delete', $response, 501 );
-
 			return;
 		}
 
@@ -2600,7 +2596,6 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		// Not implemented in multisite.
 		if ( is_multisite() ) {
 			$this->assertErrorResponse( 'rest_cannot_delete', $response, 501 );
-
 			return;
 		}
 
@@ -2626,7 +2621,6 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		// Not implemented in multisite.
 		if ( is_multisite() ) {
 			$this->assertErrorResponse( 'rest_cannot_delete', $response, 501 );
-
 			return;
 		}
 
@@ -2669,7 +2663,6 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		// Not implemented in multisite.
 		if ( is_multisite() ) {
 			$this->assertErrorResponse( 'rest_cannot_delete', $response, 501 );
-
 			return;
 		}
 
@@ -2698,7 +2691,6 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		// Not implemented in multisite.
 		if ( is_multisite() ) {
 			$this->assertErrorResponse( 'rest_cannot_delete', $response, 501 );
-
 			return;
 		}
 
@@ -2727,7 +2719,6 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		// Not implemented in multisite.
 		if ( is_multisite() ) {
 			$this->assertErrorResponse( 'rest_cannot_delete', $response, 501 );
-
 			return;
 		}
 
@@ -2756,7 +2747,6 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		// Not implemented in multisite.
 		if ( is_multisite() ) {
 			$this->assertErrorResponse( 'rest_cannot_delete', $response, 501 );
-
 			return;
 		}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/56481

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
