### PR TITLE
Ensure Consistent Font Family for Excerpt and Full Post in Latest Posts Block (Editor)

### DIFF
--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
@@ -1049,6 +1049,10 @@ hr.wp-block-separator.is-style-dots::before {
 	margin-top: 15px;
 }
 
+.wp-block-latest-posts__post-full-content p {
+	font-family: inherit;
+}
+
 /* STYLE: GRID */
 
 .editor-styles-wrapper .wp-block-latest-posts.is-grid li {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/62242

The font-family for the "Latest Post" block was previously inconsistent between the excerpt and full post in the editor. This change ensures the font-family remains the same when switching between excerpt and full post in the editor.

Changes made:
Added font-family: inherit; to `.wp-block-latest-posts__post-full-content p` to ensure font consistency in the editor.
This resolves the issue where the font family for the full post in the editor was different from the excerpt, ensuring consistency in the editing experience.

**Before**: (The full post content is having an inconsistent font family as compared to the excerpt in editor, excerpt in the frontend and, full content in the frontend)
**After**: (After the change the full content is consistent in the editor and the frontend just like how the excerpt is)


**Before**:

https://github.com/user-attachments/assets/13bf0f8b-d74f-47f9-807d-a78d6f44d3ce

**After**:

https://github.com/user-attachments/assets/c866d5d5-52ca-4374-a1dc-b2017e3ed96d






