### PR TITLE
change add new to add new user on Network Settings page

### DIFF
--- a/src/wp-admin/network/settings.php
+++ b/src/wp-admin/network/settings.php
@@ -250,7 +250,7 @@ if ( isset( $_GET['updated'] ) ) {
 			<tr id="addnewusers">
 				<th scope="row"><?php _e( 'Add New Users' ); ?></th>
 				<td>
-					<label><input name="add_new_users" type="checkbox" id="add_new_users" value="1"<?php checked( get_site_option( 'add_new_users' ) ); ?> /> <?php _e( 'Allow site administrators to add new users to their site via the "Users &rarr; Add New" page' ); ?></label>
+					<label><input name="add_new_users" type="checkbox" id="add_new_users" value="1"<?php checked( get_site_option( 'add_new_users' ) ); ?> /> <?php _e( 'Allow site administrators to add new users to their site via the "Users &rarr; Add New User" page' ); ?></label>
 				</td>
 			</tr>
 


### PR DESCRIPTION
On Network Settings is an outdated link to "add new user" page. The wording was changed a long time ago.

outdated:
Allow site administrators to add new users to their site via the "Users → Add New" page

Users → Add New
should be
Users → Add New User

Trac ticket: https://core.trac.wordpress.org/ticket/62458
