### PR TITLE
Add browser timezone detection and update option

### DIFF
--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -396,6 +396,23 @@ if ( empty( $tzstring ) ) { // Create a UTC+- zone if no timezone string exists.
 		'<abbr>UTC</abbr>'
 	);
 	?>
+	<script type="application/javascript">
+	(function($){
+
+	const browserTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+	const $tzSelect = $('#timezone_string');
+
+	if ( $tzSelect.val() !== browserTz ) {
+		$tzSelect.after( '<p>Your browser timezone is currently set to <code>' + browserTz + '</code> -- <a class="updateTzSelectToBrowser" href="#">would you like to update the WordPress timezone to match?</a></p>' );
+		$tzSelect.parent().find('.updateTzSelectToBrowser').on( 'click', function(e){
+			e.preventDefault();
+			$tzSelect.val( browserTz );
+			$(this).parents('p').text('Updated!').fadeOut('slow');
+		})
+	}
+
+})(jQuery);
+</script>
 </p>
 
 <p class="timezone-info">

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -403,7 +403,8 @@ if ( empty( $tzstring ) ) { // Create a UTC+- zone if no timezone string exists.
 	const $tzSelect = $('#timezone_string');
 
 	if ( $tzSelect.val() !== browserTz ) {
-		$tzSelect.after( '<p>Your browser timezone is currently set to <code>' + browserTz + '</code> -- <a class="updateTzSelectToBrowser" href="#">would you like to update the WordPress timezone to match?</a></p>' );
+		// translators: %s is the detected browser timezone
+		$tzSelect.after( '<p><?php sprintf( esc_html_e( 'Your browser timezone is currently set to <code>%s</code> -- ' ), browserTz ); ?> <a class="updateTzSelectToBrowser" href="#"><?php esc_html_e( 'would you like to update the WordPress timezone to match?' ); ?> </a></p>' );
 		$tzSelect.parent().find('.updateTzSelectToBrowser').on( 'click', function(e){
 			e.preventDefault();
 			$tzSelect.val( browserTz );


### PR DESCRIPTION
A script was added to detect the browser's timezone and prompt users to update the WordPress timezone setting accordingly. This improvement enhances the user experience by ensuring the WordPress timezone can easily match the user's local time.


Trac ticket: https://core.trac.wordpress.org/ticket/28988