### PR TITLE
Functions: Add type safety to number_format_i18n()

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -420,6 +420,8 @@ function wp_maybe_decline_date( $date, $format = '' ) {
 function number_format_i18n( $number, $decimals = 0 ) {
 	global $wp_locale;
 
+	$number = (float) $number;
+
 	if ( isset( $wp_locale ) ) {
 		$formatted = number_format( $number, absint( $decimals ), $wp_locale->number_format['decimal_point'], $wp_locale->number_format['thousands_sep'] );
 	} else {


### PR DESCRIPTION
Trac ticket: [Core: 62474](https://core.trac.wordpress.org/ticket/62474)

Currently in WordPress 6.6, passing non-numeric values to `number_format_i18n()` can trigger PHP errors in PHP 8. This PR adds float-type casting to safely handle all input types.
