### PR TITLE
fix: cast `wp_count_terms()` result to `int` before using in `ceil()`

### DIFF
--- a/src/wp-admin/includes/nav-menu.php
+++ b/src/wp-admin/includes/nav-menu.php
@@ -875,7 +875,7 @@ function wp_nav_menu_item_taxonomy_meta_box( $data_object, $box ) {
 	}
 
 	$num_pages = (int) ceil(
-		wp_count_terms(
+		(int) wp_count_terms(
 			array_merge(
 				$args,
 				array(

--- a/src/wp-includes/sitemaps/providers/class-wp-sitemaps-taxonomies.php
+++ b/src/wp-includes/sitemaps/providers/class-wp-sitemaps-taxonomies.php
@@ -171,7 +171,7 @@ class WP_Sitemaps_Taxonomies extends WP_Sitemaps_Provider {
 
 		$term_count = wp_count_terms( $this->get_taxonomies_query_args( $taxonomy ) );
 
-		return (int) ceil( $term_count / wp_sitemaps_get_max_urls( $this->object_type ) );
+		return (int) ceil( (int) $term_count / wp_sitemaps_get_max_urls( $this->object_type ) );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/52217

This PR fixes two instances of the (numeric `string`) return value from `wp_count_terms()` being used directly in `ceil()`, which [expects an `int|float`](https://www.php.net/manual/en/function.ceil.php).

Affected methods:
- `WP_Sitemaps_Taxonomies::get_max_num_pages()`
- `wp_nav_menu_item_taxonomy_meta_box()`

While this issue was surfaced via PHPStan in https://github.com/WordPress/wordpress-develop/pull/7619 (trac: https://core.trac.wordpress.org/ticket/61175 ), it can be remediated independently of that ticket.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
