### PR TITLE
Add default duotones to Twenty Twenty-Five theme

### DIFF
--- a/src/wp-content/themes/twentytwentyfive/styles/01-evening.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/01-evening.json
@@ -4,6 +4,24 @@
 	"title": "Evening",
 	"settings": {
 		"color": {
+			"duotone": [
+				{
+					"colors": [
+						"#1B1B1B",
+						"#F0F0F0"
+					],
+					"name": "Evening Grayscale",
+					"slug": "evening-grayscale"
+				},
+				{
+					"colors": [
+						"#786D0A",
+						"#CBCBCB"
+					],
+					"name": "Evening Sepia",
+					"slug": "evening-sepia"
+				}
+			],
 			"palette": [
 				{
 					"color": "#1B1B1B",

--- a/src/wp-content/themes/twentytwentyfive/styles/02-noon.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/02-noon.json
@@ -4,6 +4,16 @@
 	"title": "Noon",
 	"settings": {
 		"color": {
+			"duotone": [
+				{
+					"colors": [
+						"#5F5F5F",
+						"#F8F7F5"
+					],
+					"name": "Noon Filter",
+					"slug": "noon-filter"
+				}
+			],
 			"palette": [
 				{
 					"color": "#F8F7F5",

--- a/src/wp-content/themes/twentytwentyfive/styles/03-dusk.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/03-dusk.json
@@ -4,6 +4,24 @@
 	"title": "Dusk",
 	"settings": {
 		"color": {
+			"duotone": [
+				{
+					"colors": [
+						"#650DD4",
+						"#F5EDFF"
+					],
+					"name": "Dusk Purple",
+					"slug": "dusk-purple"
+				},
+				{
+					"colors": [
+						"#191919",
+						"#DBDBDB"
+					],
+					"name": "Dusk Grayscale",
+					"slug": "dusk-grayscale"
+				}
+			],
 			"palette": [
 				{
 					"color": "#E2E2E2",

--- a/src/wp-content/themes/twentytwentyfive/styles/04-afternoon.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/04-afternoon.json
@@ -4,6 +4,16 @@
 	"title": "Afternoon",
 	"settings": {
 		"color": {
+			"duotone": [
+				{
+					"colors": [
+						"#516028",
+						"#EBF6D3"
+					],
+					"name": "Afternoon filter",
+					"slug": "afternoon-filter"
+				}
+			],
 			"palette": [
 				{
 					"color": "#DAE7BD",

--- a/src/wp-content/themes/twentytwentyfive/styles/05-twilight.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/05-twilight.json
@@ -4,6 +4,32 @@
 	"title": "Twilight",
 	"settings": {
 		"color": {
+			"duotone": [
+				{
+					"colors": [
+						"#4B52FF",
+						"#FF7A5C"
+					],
+					"name": "Twilight Vibrant",
+					"slug": "twilight-vibrant"
+				},
+				{
+					"colors": [
+						"#131313",
+						"#4B52FF"
+					],
+					"name": "Twilight Blue",
+					"slug": "twilight-blue"
+				},
+				{
+					"colors": [
+						"#131313",
+						"#FFFFFF"
+					],
+					"name": "Twilight Grayscale",
+					"slug": "twilight-grayscale"
+				}
+			],
 			"palette": [
 				{
 					"color": "#131313",

--- a/src/wp-content/themes/twentytwentyfive/styles/06-morning.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/06-morning.json
@@ -4,6 +4,16 @@
 	"title": "Morning",
 	"settings": {
 		"color": {
+			"duotone": [
+				{
+					"colors": [
+						"#7A9BDB",
+						"#DFDCD7"
+					],
+					"name": "Morning filter",
+					"slug": "morning-filter"
+				}
+			],
 			"palette": [
 				{
 					"color": "#DFDCD7",

--- a/src/wp-content/themes/twentytwentyfive/styles/07-sunrise.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/07-sunrise.json
@@ -4,6 +4,16 @@
 	"title": "Sunrise",
 	"settings": {
 		"color": {
+			"duotone": [
+				{
+					"colors": [
+						"#4A1628",
+						"#C1E4E7"
+					],
+					"name": "Sunrise filter",
+					"slug": "sunrise-filter"
+				}
+			],
 			"palette": [
 				{
 					"color": "#330616",

--- a/src/wp-content/themes/twentytwentyfive/styles/colors/01-evening.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/colors/01-evening.json
@@ -4,6 +4,24 @@
 	"title": "Evening",
 	"settings": {
 		"color": {
+			"duotone": [
+				{
+					"colors": [
+						"#1B1B1B",
+						"#F0F0F0"
+					],
+					"name": "Evening Grayscale",
+					"slug": "evening-grayscale"
+				},
+				{
+					"colors": [
+						"#786D0A",
+						"#CBCBCB"
+					],
+					"name": "Evening Sepia",
+					"slug": "evening-sepia"
+				}
+			],
 			"palette": [
 				{
 					"color": "#1B1B1B",

--- a/src/wp-content/themes/twentytwentyfive/styles/colors/02-noon.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/colors/02-noon.json
@@ -4,6 +4,16 @@
 	"title": "Noon",
 	"settings": {
 		"color": {
+			"duotone": [
+				{
+					"colors": [
+						"#5F5F5F",
+						"#F8F7F5"
+					],
+					"name": "Noon Filter",
+					"slug": "noon-filter"
+				}
+			],
 			"palette": [
 				{
 					"color": "#F8F7F5",

--- a/src/wp-content/themes/twentytwentyfive/styles/colors/03-dusk.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/colors/03-dusk.json
@@ -4,6 +4,24 @@
 	"title": "Dusk",
 	"settings": {
 		"color": {
+			"duotone": [
+				{
+					"colors": [
+						"#650DD4",
+						"#F5EDFF"
+					],
+					"name": "Dusk Purple",
+					"slug": "dusk-purple"
+				},
+				{
+					"colors": [
+						"#191919",
+						"#DBDBDB"
+					],
+					"name": "Dusk Grayscale",
+					"slug": "dusk-grayscale"
+				}
+			],
 			"palette": [
 				{
 					"color": "#E2E2E2",

--- a/src/wp-content/themes/twentytwentyfive/styles/colors/04-afternoon.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/colors/04-afternoon.json
@@ -4,6 +4,16 @@
 	"title": "Afternoon",
 	"settings": {
 		"color": {
+			"duotone": [
+				{
+					"colors": [
+						"#516028",
+						"#EBF6D3"
+					],
+					"name": "Afternoon filter",
+					"slug": "afternoon-filter"
+				}
+			],
 			"palette": [
 				{
 					"color": "#DAE7BD",

--- a/src/wp-content/themes/twentytwentyfive/styles/colors/05-twilight.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/colors/05-twilight.json
@@ -4,6 +4,32 @@
 	"title": "Twilight",
 	"settings": {
 		"color": {
+			"duotone": [
+				{
+					"colors": [
+						"#4B52FF",
+						"#FF7A5C"
+					],
+					"name": "Twilight Vibrant",
+					"slug": "twilight-vibrant"
+				},
+				{
+					"colors": [
+						"#131313",
+						"#4B52FF"
+					],
+					"name": "Twilight Blue",
+					"slug": "twilight-blue"
+				},
+				{
+					"colors": [
+						"#131313",
+						"#FFFFFF"
+					],
+					"name": "Twilight Grayscale",
+					"slug": "twilight-grayscale"
+				}
+			],
 			"palette": [
 				{
 					"color": "#131313",

--- a/src/wp-content/themes/twentytwentyfive/styles/colors/06-morning.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/colors/06-morning.json
@@ -4,6 +4,16 @@
 	"title": "Morning",
 	"settings": {
 		"color": {
+			"duotone": [
+				{
+					"colors": [
+						"#7A9BDB",
+						"#DFDCD7"
+					],
+					"name": "Morning filter",
+					"slug": "morning-filter"
+				}
+			],
 			"palette": [
 				{
 					"color": "#DFDCD7",

--- a/src/wp-content/themes/twentytwentyfive/styles/colors/07-sunrise.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/colors/07-sunrise.json
@@ -4,6 +4,16 @@
 	"title": "Sunrise",
 	"settings": {
 		"color": {
+			"duotone": [
+				{
+					"colors": [
+						"#4A1628",
+						"#C1E4E7"
+					],
+					"name": "Sunrise filter",
+					"slug": "sunrise-filter"
+				}
+			],
 			"palette": [
 				{
 					"color": "#330616",

--- a/src/wp-content/themes/twentytwentyfive/theme.json
+++ b/src/wp-content/themes/twentytwentyfive/theme.json
@@ -120,7 +120,14 @@
 					"slug": "80"
 				}
 			],
-			"units": [ "%", "px", "em", "rem", "vh", "vw" ]
+			"units": [
+				"%",
+				"px",
+				"em",
+				"rem",
+				"vh",
+				"vw"
+			]
 		},
 		"typography": {
 			"writingMode": true,
@@ -396,12 +403,12 @@
 				}
 			},
 			"core/post-date": {
-				"color": {
+				"color":{
 					"text": "var:preset|color|accent-4"
 				},
 				"elements": {
 					"link": {
-						"color": {
+						"color" : {
 							"text": "var:preset|color|accent-4"
 						},
 						":hover": {
@@ -541,7 +548,7 @@
 								"left": "1.125rem"
 							}
 						},
-						":hover": {
+						":hover" : {
 							"border": {
 								"color": "transparent"
 							}
@@ -720,6 +727,7 @@
 			"area": "header",
 			"name": "header-large-title",
 			"title": "Header with large title"
+
 		},
 		{
 			"area": "footer",
@@ -745,7 +753,7 @@
 	"customTemplates": [
 		{
 			"name": "page-no-title",
-			"postTypes": [ "page" ],
+			"postTypes": ["page"],
 			"title": "Page No Title"
 		}
 	]

--- a/src/wp-content/themes/twentytwentyfive/theme.json
+++ b/src/wp-content/themes/twentytwentyfive/theme.json
@@ -7,6 +7,24 @@
 			"defaultDuotone": false,
 			"defaultGradients": false,
 			"defaultPalette": false,
+			"duotone": [
+				{
+					"colors": [
+						"#111111",
+						"#FFFFFF"
+					],
+					"name": "Grayscale Filter",
+					"slug": "grayscale-filter"
+				},
+				{
+					"colors": [
+						"#686868",
+						"#FBFAF3"
+					],
+					"name": "Sepia Filter",
+					"slug": "sepia-filter"
+				}
+			],
 			"palette": [
 				{
 					"color": "#FFFFFF",
@@ -47,33 +65,6 @@
 					"color": "color-mix(in srgb, currentColor 20%, transparent)",
 					"name": "Accent 6",
 					"slug": "accent-6"
-				}
-			],
-			"duotone": [
-				{
-					"colors": [ "#111111", "#ffffff" ],
-					"slug": "duotone-1",
-					"name": "Black and white"
-				},
-				{
-					"colors": [ "#111111", "#C2A990" ],
-					"slug": "duotone-2",
-					"name": "Black and sandstone"
-				},
-				{
-					"colors": [ "#111111", "#D8613C" ],
-					"slug": "duotone-3",
-					"name": "Black and rust"
-				},
-				{
-					"colors": [ "#111111", "#B1C5A4" ],
-					"slug": "duotone-4",
-					"name": "Black and sage"
-				},
-				{
-					"colors": [ "#111111", "#B5BDBC" ],
-					"slug": "duotone-5",
-					"name": "Black and pastel blue"
 				}
 			]
 		},

--- a/src/wp-content/themes/twentytwentyfive/theme.json
+++ b/src/wp-content/themes/twentytwentyfive/theme.json
@@ -48,6 +48,33 @@
 					"name": "Accent 6",
 					"slug": "accent-6"
 				}
+			],
+			"duotone": [
+				{
+					"colors": [ "#111111", "#ffffff" ],
+					"slug": "duotone-1",
+					"name": "Black and white"
+				},
+				{
+					"colors": [ "#111111", "#C2A990" ],
+					"slug": "duotone-2",
+					"name": "Black and sandstone"
+				},
+				{
+					"colors": [ "#111111", "#D8613C" ],
+					"slug": "duotone-3",
+					"name": "Black and rust"
+				},
+				{
+					"colors": [ "#111111", "#B1C5A4" ],
+					"slug": "duotone-4",
+					"name": "Black and sage"
+				},
+				{
+					"colors": [ "#111111", "#B5BDBC" ],
+					"slug": "duotone-5",
+					"name": "Black and pastel blue"
+				}
 			]
 		},
 		"layout": {
@@ -93,14 +120,7 @@
 					"slug": "80"
 				}
 			],
-			"units": [
-				"%",
-				"px",
-				"em",
-				"rem",
-				"vh",
-				"vw"
-			]
+			"units": [ "%", "px", "em", "rem", "vh", "vw" ]
 		},
 		"typography": {
 			"writingMode": true,
@@ -376,12 +396,12 @@
 				}
 			},
 			"core/post-date": {
-				"color":{
+				"color": {
 					"text": "var:preset|color|accent-4"
 				},
 				"elements": {
 					"link": {
-						"color" : {
+						"color": {
 							"text": "var:preset|color|accent-4"
 						},
 						":hover": {
@@ -521,7 +541,7 @@
 								"left": "1.125rem"
 							}
 						},
-						":hover" : {
+						":hover": {
 							"border": {
 								"color": "transparent"
 							}
@@ -700,7 +720,6 @@
 			"area": "header",
 			"name": "header-large-title",
 			"title": "Header with large title"
-
 		},
 		{
 			"area": "footer",
@@ -726,7 +745,7 @@
 	"customTemplates": [
 		{
 			"name": "page-no-title",
-			"postTypes": ["page"],
+			"postTypes": [ "page" ],
 			"title": "Page No Title"
 		}
 	]


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/62475

Key Changes:

This PR includes the duotones from the theme zip file, as suggested in the linked ticket comment. The necessary changes have been implemented to incorporate these duotones.




