### PR TITLE
REST API: Allow sorting terms by term_order; expose args field in taxonomies controller

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php
@@ -201,6 +201,7 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 	 *
 	 * @since 4.7.0
 	 * @since 5.9.0 Renamed `$taxonomy` to `$item` to match parent class for PHP 8 named parameter support.
+	 * @since 6.8.0 Expose `$args` field.
 	 *
 	 * @param WP_Taxonomy     $item    Taxonomy data.
 	 * @param WP_REST_Request $request Full details about the request.
@@ -245,6 +246,10 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 
 		if ( in_array( 'hierarchical', $fields, true ) ) {
 			$data['hierarchical'] = $taxonomy->hierarchical;
+		}
+
+		if ( in_array( 'args', $fields, true ) ) {
+			$data['args'] = isset( $taxonomy->args ) ? $taxonomy->args : new stdClass();
 		}
 
 		if ( in_array( 'rest_base', $fields, true ) ) {
@@ -316,6 +321,7 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 	 * @since 4.7.0
 	 * @since 5.0.0 The `visibility` property was added.
 	 * @since 5.9.0 The `rest_namespace` property was added.
+	 * @since 6.8.0 The `args` property was added.
 	 *
 	 * @return array Item schema data.
 	 */
@@ -329,6 +335,12 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 			'title'      => 'taxonomy',
 			'type'       => 'object',
 			'properties' => array(
+				'args'           => array(
+					'description' => __( 'Arguments automatically used inside `wp_get_object_terms()` for this taxonomy.' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
 				'capabilities'   => array(
 					'description' => __( 'All capabilities used by the taxonomy.' ),
 					'type'        => 'object',

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
@@ -1088,6 +1088,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	 * Retrieves the query params for collections.
 	 *
 	 * @since 4.7.0
+	 * @since 6.8.0 Added 'term_order' to the list of allowed orderby parameters.
 	 *
 	 * @return array Collection parameters.
 	 */
@@ -1145,6 +1146,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 				'term_group',
 				'description',
 				'count',
+				'term_order',
 			),
 		);
 


### PR DESCRIPTION
WIP. Required for https://github.com/WordPress/gutenberg/pull/64471. Details to follow.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
