### PR TITLE
Bundled Theme: Fix social links text decoration

### DIFF
--- a/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
+++ b/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
@@ -950,6 +950,11 @@
 		}
 	}
 
+	//! wp-block-social-links
+	.wp-block-social-links .wp-block-social-link.wp-social-link .wp-block-social-link-anchor {
+		text-decoration: none;
+	}
+
 	//! Font Sizes
 	.has-small-font-size {
 		font-size: $font__size-sm;

--- a/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
+++ b/src/wp-content/themes/twentynineteen/sass/blocks/_blocks.scss
@@ -950,8 +950,8 @@
 		}
 	}
 
-	//! wp-block-social-links
-	.wp-block-social-links .wp-block-social-link.wp-social-link .wp-block-social-link-anchor {
+	//! Social Icons
+	a:where(.wp-block-social-link-anchor) {
 		text-decoration: none;
 	}
 

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -6328,6 +6328,10 @@ body.page .main-navigation {
   font-size: 0.71111em;
 }
 
+.entry .entry-content a:where(.wp-block-social-link-anchor) {
+  text-decoration: none;
+}
+
 .entry .entry-content .has-small-font-size {
   font-size: 0.88889em;
 }

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -6340,6 +6340,10 @@ body.page .main-navigation {
   font-size: 0.71111em;
 }
 
+.entry .entry-content a:where(.wp-block-social-link-anchor) {
+  text-decoration: none;
+}
+
 .entry .entry-content .has-small-font-size {
   font-size: 0.88889em;
 }


### PR DESCRIPTION
This pull request fixes an issue in the Twenty Nineteen theme where social icons in the wp-block-social-links block appear without underlines in the editor but are incorrectly displayed with underlines on the frontend. This PR resolves the issue by adding a text-decoration: none; rule for anchor tags in the frontend, ensuring consistent styling with the editor.

Trac ticket: [#61904](https://core.trac.wordpress.org/ticket/61904)

### Before:
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/375a317a-36c1-40e7-a977-ba6423cc76c2">

### After:
<img width="1920" alt="image" src="https://github.com/user-attachments/assets/dddd9514-9605-4263-a88d-68b47c511ab8">

