### PR TITLE
Only prime salt options early once

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2510,30 +2510,36 @@ if ( ! function_exists( 'wp_salt' ) ) :
 		 * option. These options will be primed to avoid repeated
 		 * database requests for undefined salts.
 		 */
-		$options_to_prime = array();
-		foreach ( array( 'auth', 'secure_auth', 'logged_in', 'nonce' ) as $key ) {
-			foreach ( array( 'key', 'salt' ) as $second ) {
-				$const = strtoupper( "{$key}_{$second}" );
-				if ( ! defined( $const ) || true === $duplicated_keys[ constant( $const ) ] ) {
-					$options_to_prime[] = "{$key}_{$second}";
+		static $options_are_primed = false;
+
+		if ( ! $options_are_primed ) {
+			$options_to_prime = array();
+			foreach ( array( 'auth', 'secure_auth', 'logged_in', 'nonce' ) as $key ) {
+				foreach ( array( 'key', 'salt' ) as $second ) {
+					$const = strtoupper( "{$key}_{$second}" );
+					if ( ! defined( $const ) || true === $duplicated_keys[ constant( $const ) ] ) {
+						$options_to_prime[] = "{$key}_{$second}";
+					}
 				}
 			}
-		}
 
-		if ( ! empty( $options_to_prime ) ) {
-			/*
-			 * Also prime `secret_key` used for undefined salting schemes.
-			 *
-			 * If the scheme is unknown, the default value for `secret_key` will be
-			 * used too for the salt. This should rarely happen, so the option is only
-			 * primed if other salts are undefined.
-			 *
-			 * At this point of execution it is known that a database call will be made
-			 * to prime salts, so the `secret_key` option can be primed regardless of the
-			 * constants status.
-			 */
-			$options_to_prime[] = 'secret_key';
-			wp_prime_site_option_caches( $options_to_prime );
+			if ( ! empty( $options_to_prime ) ) {
+				/*
+				* Also prime `secret_key` used for undefined salting schemes.
+				*
+				* If the scheme is unknown, the default value for `secret_key` will be
+				* used too for the salt. This should rarely happen, so the option is only
+				* primed if other salts are undefined.
+				*
+				* At this point of execution it is known that a database call will be made
+				* to prime salts, so the `secret_key` option can be primed regardless of the
+				* constants status.
+				*/
+				$options_to_prime[] = 'secret_key';
+				wp_prime_site_option_caches( $options_to_prime );
+			}
+
+			$options_are_primed = true;
 		}
 
 		$values = array(

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2510,8 +2510,7 @@ if ( ! function_exists( 'wp_salt' ) ) :
 		 * option. These options will be primed to avoid repeated
 		 * database requests for undefined salts.
 		 */
-		static $options_are_primed = false;
-
+		static $options_are_primed;
 		if ( ! $options_are_primed ) {
 			$options_to_prime = array();
 			foreach ( array( 'auth', 'secure_auth', 'logged_in', 'nonce' ) as $key ) {


### PR DESCRIPTION
> [!Warning]
> This is pushed for testing purposes, currently is incomplete.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This adds a check to see if `wp_salt()` related options have already been primed before attempting to prime them again. This is necessary because the `wp_salt()` function can be called multiple times during the bootstrap process, and we need to ensure that the options are only primed once.

This also avoids an error that can occur if the salt related constants are defined after the first time `wp_salt()` is called, in which case the salt will not be present in the `$duplicated_keys` array.

Trac ticket: https://core.trac.wordpress.org/ticket/62424

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
