### PR TITLE
Add optional $dbh parameter to set_sql_mode method

### DIFF
--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -944,7 +944,7 @@ class wpdb {
 	public function set_sql_mode( $modes = array(), $dbh = null ) {
 		if ( is_null( $dbh ) ) {
 			$dbh = $this->dbh;
- 	    }
+		}
 		if ( empty( $modes ) ) {
 			$res = mysqli_query( $dbh, 'SELECT @@SESSION.sql_mode' );
 

--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -941,9 +941,12 @@ class wpdb {
 	 *
 	 * @param array $modes Optional. A list of SQL modes to set. Default empty array.
 	 */
-	public function set_sql_mode( $modes = array() ) {
+	public function set_sql_mode( $modes = array(), $dbh = null ) {
+		if ( is_null( $dbh ) ) {
+			$dbh = $this->dbh;
+ 	    }
 		if ( empty( $modes ) ) {
-			$res = mysqli_query( $this->dbh, 'SELECT @@SESSION.sql_mode' );
+			$res = mysqli_query( $dbh, 'SELECT @@SESSION.sql_mode' );
 
 			if ( empty( $res ) ) {
 				return;
@@ -983,7 +986,7 @@ class wpdb {
 
 		$modes_str = implode( ',', $modes );
 
-		mysqli_query( $this->dbh, "SET SESSION sql_mode='$modes_str'" );
+		mysqli_query( $dbh, "SET SESSION sql_mode='$modes_str'" );
 	}
 
 	/**
@@ -2032,7 +2035,7 @@ class wpdb {
 			$this->set_charset( $this->dbh );
 
 			$this->ready = true;
-			$this->set_sql_mode();
+			$this->set_sql_mode( array(), $this->dbh );
 			$this->select( $this->dbname, $this->dbh );
 
 			return true;


### PR DESCRIPTION
This change allows specifying a database handle when setting SQL mode, providing more flexibility in handling different database connections. It defaults to using the existing class property if no argument is passed. This ensures backward compatibility while enhancing functionality.


Trac ticket: https://core.trac.wordpress.org/ticket/36242