### PR TITLE
Notify about double serialization. - 62483

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -637,6 +637,12 @@ function maybe_serialize( $data ) {
 	 * Also the world will end. See WP 3.6.1.
 	 */
 	if ( is_serialized( $data, false ) ) {
+		// While double serialization needs to be supported for backwards compatibility, let's inform the developer.
+		_doing_it_wrong(
+			'maybe_serialize',
+			'Double serialization detected, serialized data is likely sent to update_option(), add_option(), update_*_meta(), add_*_meta() and similar functions. These functions will automatically serialize if needed.',
+			'3.6.1'
+		);
 		return serialize( $data );
 	}
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -674,8 +674,8 @@ function maybe_unserialize( $data ) {
  * @since 2.0.5
  * @since 6.1.0 Added Enum support.
  *
- * @param string $data   Value to check to see if was serialized.
- * @param bool   $strict Optional. Whether to be strict about the end of the string. Default true.
+ * @param mixed $data   Value to check to see if was serialized.
+ * @param bool  $strict Optional. Whether to be strict about the end of the string. Default true.
  * @return bool False if not serialized and true if it was.
  */
 function is_serialized( $data, $strict = true ) {

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -636,6 +636,7 @@ function maybe_serialize( $data ) {
 	 * See https://core.trac.wordpress.org/ticket/12930
 	 * Also the world will end. See WP 3.6.1.
 	 */
+	
 	if ( is_serialized( $data, false ) ) {
 		// While double serialization needs to be supported for backwards compatibility, let's inform the developer.
 		_doing_it_wrong(

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -641,7 +641,7 @@ function maybe_serialize( $data ) {
 		_doing_it_wrong(
 			'maybe_serialize',
 			'Double serialization detected, serialized data is likely sent to update_option(), add_option(), update_*_meta(), add_*_meta() and similar functions. These functions will automatically serialize if needed.',
-			'3.6.1'
+			'6.8.0'
 		);
 		return serialize( $data );
 	}

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -636,7 +636,6 @@ function maybe_serialize( $data ) {
 	 * See https://core.trac.wordpress.org/ticket/12930
 	 * Also the world will end. See WP 3.6.1.
 	 */
-	
 	if ( is_serialized( $data, false ) ) {
 		// While double serialization needs to be supported for backwards compatibility, let's inform the developer.
 		_doing_it_wrong(

--- a/tests/phpunit/tests/functions/maybeSerialize.php
+++ b/tests/phpunit/tests/functions/maybeSerialize.php
@@ -27,6 +27,7 @@ class Tests_Functions_MaybeSerialize extends WP_UnitTestCase {
 	 * @dataProvider data_is_serialized
 	 */
 	public function test_maybe_serialize_with_double_serialization( $value ) {
+		$this->setExpectedIncorrectUsage( 'maybe_serialize' );
 		$expected = serialize( $value );
 
 		$this->assertSame( $expected, maybe_serialize( $value ) );

--- a/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
@@ -219,6 +219,9 @@ class Tests_Privacy_wpPrivacyGeneratePersonalDataExportFile extends WP_UnitTestC
 	 * @param mixed $groups '_export_data_grouped' post meta value.
 	 */
 	public function test_doing_it_wrong_for_export_data_grouped_invalid_type( $groups ) {
+		if ( is_serialized( $groups ) ) {
+			$this->setExpectedIncorrectUsage( 'maybe_serialize' );
+		}
 		update_post_meta( self::$export_request_id, '_export_data_grouped', $groups );
 
 		$this->setExpectedIncorrectUsage( 'wp_privacy_generate_personal_data_export_file' );

--- a/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
@@ -220,6 +220,7 @@ class Tests_Privacy_wpPrivacyGeneratePersonalDataExportFile extends WP_UnitTestC
 	 */
 	public function test_doing_it_wrong_for_export_data_grouped_invalid_type( $groups ) {
 		if ( is_serialized( $groups ) ) {
+			// If groups is a serialized string, update_post_meta() will throw a _doing_it_wrong notice since 6.8.0.
 			$this->setExpectedIncorrectUsage( 'maybe_serialize' );
 		}
 		update_post_meta( self::$export_request_id, '_export_data_grouped', $groups );


### PR DESCRIPTION

Added _doing_it_wrong() to maybe_serialize to notify about double serialization.

Trac ticket: https://core.trac.wordpress.org/ticket/62483#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
