### PR TITLE
REST API: Terms: Respect taxonomy's default query args

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
@@ -227,6 +227,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	 * Retrieves terms associated with a taxonomy.
 	 *
 	 * @since 4.7.0
+	 * @since 6.8.0 Respect default query arguments set for the taxonomy upon registration.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
@@ -293,6 +294,14 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 					$prepared_args['parent'] = $request['parent'];
 				}
 			}
+		}
+
+		/*
+		 * When a taxonomy is registered with an 'args' array,
+		 * those params override the `$args` passed to this function.
+		 */
+		if ( isset( $taxonomy_obj->args ) && is_array( $taxonomy_obj->args ) ) {
+			$args = array_merge( $args, $taxonomy_obj->args );
 		}
 
 		/**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
@@ -299,8 +299,16 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		/*
 		 * When a taxonomy is registered with an 'args' array,
 		 * those params override the `$args` passed to this function.
+		 *
+		 * We only need to do this if no `post` argument is provided.
+		 * Otherwise, terms will be fetched using `wp_get_object_terms()`,
+		 * which respects the default query arguments set for the taxonomy.
 		 */
-		if ( isset( $taxonomy_obj->args ) && is_array( $taxonomy_obj->args ) ) {
+		if (
+			empty( $prepared_args['post'] ) &&
+			isset( $taxonomy_obj->args ) &&
+			is_array( $taxonomy_obj->args )
+		) {
 			$prepared_args = array_merge( $prepared_args, $taxonomy_obj->args );
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
@@ -301,7 +301,7 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 		 * those params override the `$args` passed to this function.
 		 */
 		if ( isset( $taxonomy_obj->args ) && is_array( $taxonomy_obj->args ) ) {
-			$args = array_merge( $args, $taxonomy_obj->args );
+			$prepared_args = array_merge( $prepared_args, $taxonomy_obj->args );
 		}
 
 		/**


### PR DESCRIPTION
Port of https://github.com/WordPress/gutenberg/pull/67154.

## What

It is possible to supply a set of default query `args` to [`register_taxonomy()`](https://developer.wordpress.org/reference/functions/register_taxonomy/) which will be used when querying a list of terms -- for example, `orderby` in order to specify how the resulting list of terms should be sorted. This PR makes it so that the list of terms returned by the Terms REST API controller respects that order if no post ID is included in the REST API request.

## How

The controller's `get_items()` method has [two code branches](https://github.com/WordPress/wordpress-develop/blob/193f6eb26e65216576a10492dd4103044c3a079c/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php#L320-L327):

1. If a post ID is given in the network request, `get_items()` uses [`wp_get_object_terms()`](https://developer.wordpress.org/reference/functions/wp_get_object_terms/) to get the terms associated with the given post. That function already includes [code](https://github.com/WordPress/wordpress-develop/blob/654475fa25c88a2fecf9290ffcd9512b553a8574/src/wp-includes/taxonomy.php#L2292-L2310) to respect the default query `args` specified when the taxonomy was registered.
2. If no post ID is given, it uses [`get_terms()`](https://developer.wordpress.org/reference/functions/get_terms/), which does not respect the default query args.

This PR adds code to respect the default query args if no post ID is given.

Trac ticket: https://core.trac.wordpress.org/ticket/62500

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
