### PR TITLE
Login: Update lost password form action URL

### DIFF
--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -893,7 +893,7 @@ switch ( $action ) {
 
 		?>
 
-		<form name="lostpasswordform" id="lostpasswordform" action="<?php echo esc_url( network_site_url( 'wp-login.php?action=lostpassword', 'login_post' ) ); ?>" method="post">
+		<form name="lostpasswordform" id="lostpasswordform" action="<?php echo esc_url( wp_lostpassword_url( $redirect_to ) ); ?>" method="post">
 			<p>
 				<label for="user_login"><?php _e( 'Username or Email Address' ); ?></label>
 				<input type="text" name="user_login" id="user_login" class="input" value="<?php echo esc_attr( $user_login ); ?>" size="20" autocapitalize="off" autocomplete="username" required="required" />


### PR DESCRIPTION
This PR updates the Lost Password form action in wp-login.php to use `wp_lostpassword_url()` instead of `network_site_url()`. This change ensures compatibility with the lostpassword_url filter, allowing for greater flexibility in customizing the URL.

### URL before changes:
<img width="1101" alt="image" src="https://github.com/user-attachments/assets/7371b40f-a7ee-42bf-8b53-d40104ec4002">

### URL after changes:
<img width="1117" alt="Screenshot 2024-11-20 at 6 14 14 PM" src="https://github.com/user-attachments/assets/f9ab85f9-657d-4fb4-bf44-1933bfad1f32">

---
Trac ticket: [#62485](https://core.trac.wordpress.org/ticket/62485)