### PR TITLE
Adds short circuit filter to wp_get_attachment_url

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6831,6 +6831,20 @@ function wp_get_attachment_url( $attachment_id = 0 ) {
 
 	$attachment_id = (int) $attachment_id;
 
+	/**
+	 * Short-circuits the wp_get_attachment_url function.
+	 *
+	 * Returning a value other than null from the filter will short-circuit retrieval
+	 * and return that value instead.
+	 *
+	 * @param mixed The value to return instead of the attachment URL. Default null (to skip past the short-circuit).
+	 * @param int $attachment_id The attachment ID.
+	 */
+	$pre = apply_filters( 'pre_wp_get_attachment_url', null, $attachment_id );
+	if ( null !== $pre ) {
+		return $pre;
+	}
+
 	$post = get_post( $attachment_id );
 
 	if ( ! $post ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Adds `pre_wp_get_attachment_url` filter to short-circuit the `wp_get_attachment_url` function (allows better use of CDN, shared media library, external URLs, etc).

Trac ticket: [https://core.trac.wordpress.org/ticket/57760](https://core.trac.wordpress.org/ticket/57760)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
