### PR TITLE
Fix: Proper spacing for theme count in mobile view

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -4254,6 +4254,10 @@ img {
 		display: inline-block;
 		padding: 2px;
 	}
+
+	.wp-filter {
+		padding-top: 10px;
+	}
 }
 
 @media screen and (max-width: 320px) {
@@ -4262,5 +4266,9 @@ img {
 	#network_dashboard_right_now .subsubsub {
 		font-size: 14px;
 		text-align: left;
+	}
+
+	.wp-filter {
+		padding-top: 0;
 	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/62499

This PR fixes the UI issue where the theme count in the "Add Themes" screen touches the border in mobile view.

![Screenshot 2024-11-21 at 3 29 11 PM](https://github.com/user-attachments/assets/577cad00-3cc2-475d-8aa0-a52139ae4cbf)
