### PR TITLE
HTML API: Prevent fragment creation on close tag

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -464,7 +464,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @return static|null The created processor if successful, otherwise null.
 	 */
 	public function create_fragment_at_current_node( string $html ) {
-		if ( $this->get_token_type() !== '#tag' ) {
+		if ( $this->get_token_type() !== '#tag' || $this->is_tag_closer() ) {
 			return null;
 		}
 

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor.php
@@ -1117,7 +1117,7 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 		);
 		$this->assertSame( 'P', $processor->get_tag() );
 		$this->assertTrue( $processor->is_tag_closer() );
-		$this->assertNull( $processor->create_fragment_at_current_node( '' ) );
+		$this->assertNull( $processor->create_fragment_at_current_node( '<i>fragment HTML</i>' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor.php
@@ -1104,6 +1104,23 @@ class Tests_HtmlApi_WpHtmlProcessor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 62357
+	 */
+	public function test_prevent_fragment_creation_on_closers() {
+		$processor = WP_HTML_Processor::create_full_parser( '<p></p>' );
+		$processor->next_tag( 'P' );
+		$processor->next_tag(
+			array(
+				'tag_name'    => 'P',
+				'tag_closers' => 'visit',
+			)
+		);
+		$this->assertSame( 'P', $processor->get_tag() );
+		$this->assertTrue( $processor->is_tag_closer() );
+		$this->assertNull( $processor->create_fragment_at_current_node( '' ) );
+	}
+
+	/**
 	 * Ensure that lowercased tag_name query matches tags case-insensitively.
 	 *
 	 * @group 62427


### PR DESCRIPTION
Prevent fragments from being created at tag closers. This was noticed by @ockham in https://github.com/WordPress/wordpress-develop/pull/7348:

> This got me thinking -- should we disallow create_fragment_at_current_node from being called when the processor is paused on a tag closer?
> 
> (If we do, then we should be able to remove this guard, as it would be guaranteed that we're at a tag opener.)

Follow-up [[59444]](https://core.trac.wordpress.org/changeset/59444)
Trac ticket: https://core.trac.wordpress.org/ticket/62357

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
