### PR TITLE
HTML API: Remove unused processor state context_node property

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor-state.php
+++ b/src/wp-includes/html-api/class-wp-html-processor-state.php
@@ -357,17 +357,6 @@ class WP_HTML_Processor_State {
 	public $insertion_mode = self::INSERTION_MODE_INITIAL;
 
 	/**
-	 * Context node initializing fragment parser, if created as a fragment parser.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @see https://html.spec.whatwg.org/#concept-frag-parse-context
-	 *
-	 * @var [string, array]|null
-	 */
-	public $context_node = null;
-
-	/**
 	 * The recognized encoding of the input byte stream.
 	 *
 	 * > The stream of code points that comprises the input to the tokenization

--- a/src/wp-includes/html-api/class-wp-html-processor-state.php
+++ b/src/wp-includes/html-api/class-wp-html-processor-state.php
@@ -357,6 +357,16 @@ class WP_HTML_Processor_State {
 	public $insertion_mode = self::INSERTION_MODE_INITIAL;
 
 	/**
+	 * Context node initializing fragment parser, if created as a fragment parser.
+	 *
+	 * @since 6.4.0
+	 * @deprecated 6.8.0 WP_HTML_Processor tracks the context_node internally.
+	 *
+	 * @var null
+	 */
+	public $context_node = null;
+
+	/**
 	 * The recognized encoding of the input byte stream.
 	 *
 	 * > The stream of code points that comprises the input to the tokenization

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -298,7 +298,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		}
 
 		$processor                             = new static( $html, self::CONSTRUCTOR_UNLOCK_CODE );
-		$processor->state->context_node        = array( 'BODY', array() );
 		$processor->state->insertion_mode      = WP_HTML_Processor_State::INSERTION_MODE_IN_BODY;
 		$processor->state->encoding            = $encoding;
 		$processor->state->encoding_confidence = 'certain';
@@ -317,7 +316,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 
 		$context_node = new WP_HTML_Token(
 			'context-node',
-			$processor->state->context_node[0],
+			'BODY',
 			false
 		);
 
@@ -491,15 +490,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		$fragment_processor->context_node                = clone $this->state->current_token;
 		$fragment_processor->context_node->bookmark_name = 'context-node';
 		$fragment_processor->context_node->on_destroy    = null;
-
-		$fragment_processor->state->context_node = array( $fragment_processor->context_node->node_name, array() );
-
-		$attribute_names = $this->get_attribute_names_with_prefix( '' );
-		if ( null !== $attribute_names ) {
-			foreach ( $attribute_names as $name ) {
-				$fragment_processor->state->context_node[1][ $name ] = $this->get_attribute( $name );
-			}
-		}
 
 		$fragment_processor->breadcrumbs = array( 'HTML', $fragment_processor->context_node->node_name );
 


### PR DESCRIPTION
The processor state `context_node` property is unused and redundant. Remove it.
The processor uses a `context_node` property on itself.

The `$state` property is private, so it should not be accessible to subclasses.
The class itself is marked with `access private` so should also be unused.

https://github.com/WordPress/wordpress-develop/blob/8cd0ec0234cf09b275031073274283cc860334e6/src/wp-includes/html-api/class-wp-html-processor-state.php#L10-L22
https://github.com/WordPress/wordpress-develop/blob/8cd0ec0234cf09b275031073274283cc860334e6/src/wp-includes/html-api/class-wp-html-processor.php#L164-L166

See https://github.com/WordPress/wordpress-develop/pull/7348#discussion_r1851827222.

Trac ticket: https://core.trac.wordpress.org/ticket/62518

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
