### PR TITLE
HTML API: Prevent bookmarks from being set on virtual tokens

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -5640,6 +5640,9 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @return bool Whether the bookmark was successfully created.
 	 */
 	public function set_bookmark( $bookmark_name ): bool {
+		if ( $this->is_virtual() ) {
+			return false;
+		}
 		return parent::set_bookmark( "_{$bookmark_name}" );
 	}
 

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -5673,6 +5673,11 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * reaching for it, as inappropriate use could lead to broken
 	 * HTML structure or unwanted processing overhead.
 	 *
+	 * Bookmarks cannot be set on tokens that do no appear in the original
+	 * HTML text. For example, the HTML `<table><td>` stops at tags `TABLE`,
+	 * `TBODY`, `TR`, and `TD`. The `TBODY` and `TR` tags do not appear in
+	 * the original HTML and cannot be used as bookmarks.
+	 *
 	 * @since 6.4.0
 	 *
 	 * @param string $bookmark_name Identifies this particular bookmark.
@@ -5680,6 +5685,11 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 */
 	public function set_bookmark( $bookmark_name ): bool {
 		if ( $this->is_virtual() ) {
+			_doing_it_wrong(
+				__METHOD__,
+				__( 'Cannot set bookmarks on tokens that do no appear in the original HTML text.' ),
+				'6.8.0'
+			);
 			return false;
 		}
 		return parent::set_bookmark( "_{$bookmark_name}" );

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -303,7 +303,9 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		}
 
 		while ( $context_processor->next_tag() ) {
-			$context_processor->set_bookmark( 'final_node' );
+			if ( ! $context_processor->is_virtual() ) {
+				$context_processor->set_bookmark( 'final_node' );
+			}
 		}
 
 		if (

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor-bookmark.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor-bookmark.php
@@ -157,4 +157,15 @@ class Tests_HtmlApi_WpHtmlProcessor_Bookmark extends WP_UnitTestCase {
 			'Fragment parser' => array( array( WP_HTML_Processor::class, 'create_fragment' ) ),
 		);
 	}
+
+	/**
+	 * @ticket TBD
+	 */
+	public function test_bookmarks_not_allowed_on_virtual_nodes() {
+		$processor = WP_HTML_Processor::create_full_parser( 'text' );
+		$this->assertTrue( $processor->next_tag( 'BODY' ) );
+		$this->assertFalse( $processor->set_bookmark( 'mark' ) );
+		$this->assertTrue( $processor->next_token() );
+		$this->assertTrue( $processor->set_bookmark( 'mark' ) );
+	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor-bookmark.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor-bookmark.php
@@ -159,7 +159,7 @@ class Tests_HtmlApi_WpHtmlProcessor_Bookmark extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket TBD
+	 * @ticket 62521
 	 */
 	public function test_bookmarks_not_allowed_on_virtual_nodes() {
 		$processor = WP_HTML_Processor::create_full_parser( 'text' );

--- a/tests/phpunit/tests/html-api/wpHtmlProcessor-bookmark.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessor-bookmark.php
@@ -160,6 +160,8 @@ class Tests_HtmlApi_WpHtmlProcessor_Bookmark extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 62521
+	 *
+	 * @expectedIncorrectUsage WP_HTML_Processor::set_bookmark
 	 */
 	public function test_bookmarks_not_allowed_on_virtual_nodes() {
 		$processor = WP_HTML_Processor::create_full_parser( 'text' );


### PR DESCRIPTION
Prevent tokens (with unreliable seek behavior) from being set at virtual tokens.

> When an HTML_Processor bookmark is set at a virtual token (a node in the resulting document that does not correspond to an HTML token present in the input string), seek behavior becomes unreliable.
> 
> For example:
> 
> ```php
> $processor = WP_HTML_Processor::create_full_parser( 'text only' );
> 
> $advance_and_log_tag = function () use ( $processor ) {
>         assert( $processor->next_tag( array( 'tag_closers' => 'visit' ) ) );
>         echo str_repeat( '  ', $processor->get_current_depth() ) .
>                 ( $processor->is_tag_closer() ? '  /' : '' ) .
>                 $processor->get_token_name() .
>                 "\n";
> };
> 
> $advance_and_log_tag();
> $advance_and_log_tag();
> $advance_and_log_tag();
> $advance_and_log_tag();
> // Now at `<BODY>` virtual token, not present in the HTML string.
> assert( 'BODY' === $processor->get_token_name() && ! $processor->is_tag_closer() );
> assert( $processor->set_bookmark( 'apparently <BODY> open tag' ) );
> $advance_and_log_tag();
> $advance_and_log_tag();
> // Now at `</HTML>` virtual token, not present in the HTML string.
> assert( $processor->seek( 'apparently <BODY> open tag' ) );
> // Expected to return to `<BODY>` open tag.
> echo $processor->get_token_name() . "\n";
> // prints: #text
> assert( 'BODY' === $processor->get_token_name() );
> // AssertionError!
> ```
> 
> ```
> The above prints:
> 
>   HTML
>     HEAD
>     /HEAD
>     BODY
>     /BODY
>   /HTML
> #text
> 
> Fatal error: Uncaught AssertionError: assert('BODY' === $processor->get_token_name()) …
> ```


Trac ticket: https://core.trac.wordpress.org/ticket/62521

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
