### PR TITLE
General: Add Learn WordPress links to admin Help panel and default comment

### DIFF
--- a/src/wp-admin/_index.php
+++ b/src/wp-admin/_index.php
@@ -131,6 +131,7 @@ $screen->set_help_sidebar(
 	'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 	'<p>' . __( '<a href="https://wordpress.org/documentation/article/dashboard-screen/">Documentation on Dashboard</a>' ) . '</p>' .
 	'<p>' . __( '<a href="https://wordpress.org/support/forums/">Support forums</a>' ) . '</p>' .
+	'<p>' . __( '<a href="https://learn.wordpress.org/">Learn WordPress</a>' ) . '</p>' .
 	'<p>' . $wp_version_text . '</p>'
 );
 

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -276,12 +276,12 @@ if ( ! function_exists( 'wp_install_defaults' ) ) :
 			__(
 				'Hi, this is a comment.
 				 To get started with moderating, editing, and deleting comments, please visit the Comments screen in the dashboard.
-				 Commenter avatars come from <a href="%1$s">Gravatar</a>. Click here to <a href="%2$s">Learn WordPress</a>.'
+				 Commenter avatars come from <a href="%1$s">Gravatar</a>. If you\'re new to WordPress, check these free <a href="%2$s">online courses at Learn WordPress</a>.'
 			),
 			/* translators: The localized Gravatar URL. */
 			esc_url( __( 'https://gravatar.com/' ) ),
 			/* translators: The localized Learn WordPress URL. */
-			esc_url( __( 'https://learn.wordpress.org/' ) )
+			esc_url( __( 'https://learn.wordpress.org/learning-pathway/user/' ) )
 		);
 		$wpdb->insert(
 			$wpdb->comments,

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -272,14 +272,16 @@ if ( ! function_exists( 'wp_install_defaults' ) ) :
 		$first_comment_email  = ! empty( $first_comment_email ) ? $first_comment_email : 'wapuu@wordpress.example';
 		$first_comment_url    = ! empty( $first_comment_url ) ? $first_comment_url : esc_url( __( 'https://wordpress.org/' ) );
 		$first_comment        = ! empty( $first_comment ) ? $first_comment : sprintf(
-			/* translators: %s: Gravatar URL. */
+			/* translators: %1$s: Gravatar URL, %2$s: Learn WordPress URL */
 			__(
 				'Hi, this is a comment.
-To get started with moderating, editing, and deleting comments, please visit the Comments screen in the dashboard.
-Commenter avatars come from <a href="%s">Gravatar</a>.'
+				 To get started with moderating, editing, and deleting comments, please visit the Comments screen in the dashboard.
+				 Commenter avatars come from <a href="%1$s">Gravatar</a>. Click here to <a href="%2$s">Learn WordPress</a>.'
 			),
 			/* translators: The localized Gravatar URL. */
-			esc_url( __( 'https://gravatar.com/' ) )
+			esc_url( __( 'https://gravatar.com/' ) ),
+			/* translators: The localized Learn WordPress URL. */
+			esc_url( __( 'https://learn.wordpress.org/' ) )
 		);
 		$wpdb->insert(
 			$wpdb->comments,


### PR DESCRIPTION
Trac ticket: [#62510](https://core.trac.wordpress.org/ticket/62510)

## Description
This PR adds Learn WordPress links to improve resource discoverability in two locations:
1. The wp-admin Help panel
2. The default comment text

## Why
- Helps users discover official WordPress learning resources more easily
- Provides direct access to learning materials from within wp-admin

## Screenshot:
![After Patch](https://github.com/user-attachments/assets/e28f0792-450d-4c18-b91e-0a84fc59d4b9)
