### PR TITLE
Fix: Long first/last names breaking mobile layout

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -597,6 +597,7 @@ code {
 .wrap h1.wp-heading-inline {
 	display: inline-block;
 	margin-right: 5px;
+	word-break: break-all;
 }
 
 .wp-header-end {

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -872,6 +872,7 @@ ul#add-to-blog-users {
 .form-table td p {
 	margin-top: 4px;
 	margin-bottom: 0;
+	word-break: break-all;
 }
 
 .form-table .date-time-doc {


### PR DESCRIPTION
Fixed the issue where long first/last names without spaces broke the mobile layout by overflowing their containers.

Trac ticket: https://core.trac.wordpress.org/ticket/62513

![mobile-long-name-overflow-after](https://github.com/user-attachments/assets/52605d52-fac1-478b-a36f-a2bae542ed3f)
