### PR TITLE
Twenty Twenty-Five: Update schema version to wp/6.7 in all JSON files 

### DIFF
--- a/src/wp-content/themes/twentytwentyfive/styles/01-evening.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/01-evening.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"title": "Evening",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/02-noon.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/02-noon.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"title": "Noon",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/03-dusk.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/03-dusk.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"title": "Dusk",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/04-afternoon.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/04-afternoon.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"title": "Afternoon",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/05-twilight.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/05-twilight.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"title": "Twilight",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/06-morning.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/06-morning.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"title": "Morning",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/07-sunrise.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/07-sunrise.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"title": "Sunrise",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/08-midnight.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/08-midnight.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"title": "Midnight",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/blocks/01-display.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/blocks/01-display.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"title": "Display",
 	"slug": "text-display",

--- a/src/wp-content/themes/twentytwentyfive/styles/blocks/02-subtitle.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/blocks/02-subtitle.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"title": "Subtitle",
 	"slug": "text-subtitle",

--- a/src/wp-content/themes/twentytwentyfive/styles/blocks/03-annotation.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/blocks/03-annotation.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"title": "Annotation",
 	"slug": "text-annotation",

--- a/src/wp-content/themes/twentytwentyfive/styles/blocks/post-terms-1.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/blocks/post-terms-1.json
@@ -1,6 +1,6 @@
 {
 	"version": 3,
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"title": "Pill shaped",
 	"slug": "post-terms-1",
 	"blockTypes": ["core/post-terms"],

--- a/src/wp-content/themes/twentytwentyfive/styles/colors/01-evening.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/colors/01-evening.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"title": "Evening",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/colors/02-noon.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/colors/02-noon.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"title": "Noon",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/colors/03-dusk.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/colors/03-dusk.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"title": "Dusk",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/colors/04-afternoon.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/colors/04-afternoon.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"title": "Afternoon",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/colors/05-twilight.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/colors/05-twilight.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"title": "Twilight",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/colors/06-morning.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/colors/06-morning.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"title": "Morning",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/colors/07-sunrise.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/colors/07-sunrise.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"title": "Sunrise",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/colors/08-midnight.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/colors/08-midnight.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"title": "Midnight",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/sections/section-1.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/sections/section-1.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"slug": "section-1",
 	"title": "Style 1",

--- a/src/wp-content/themes/twentytwentyfive/styles/sections/section-2.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/sections/section-2.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"slug": "section-2",
 	"title": "Style 2",

--- a/src/wp-content/themes/twentytwentyfive/styles/sections/section-3.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/sections/section-3.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"slug": "section-3",
 	"title": "Style 3",

--- a/src/wp-content/themes/twentytwentyfive/styles/sections/section-4.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/sections/section-4.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"slug": "section-4",
 	"title": "Style 4",

--- a/src/wp-content/themes/twentytwentyfive/styles/sections/section-5.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/sections/section-5.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"version": 3,
 	"slug": "section-5",
 	"title": "Style 5",

--- a/src/wp-content/themes/twentytwentyfive/styles/typography/typography-preset-1.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/typography/typography-preset-1.json
@@ -1,6 +1,6 @@
 {
 	"version": 3,
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"title": "Beiruti & Literata",
 	"slug": "typography-preset-1",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/typography/typography-preset-2.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/typography/typography-preset-2.json
@@ -1,6 +1,6 @@
 {
 	"version": 3,
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"title": "Vollkorn & Fira Code",
 	"slug": "typography-preset-2",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/typography/typography-preset-3.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/typography/typography-preset-3.json
@@ -1,6 +1,6 @@
 {
 	"version": 3,
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"title": "Platypi & Ysabeau Office",
 	"slug": "typography-preset-3",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/typography/typography-preset-4.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/typography/typography-preset-4.json
@@ -1,6 +1,6 @@
 {
 	"version": 3,
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"title": "Roboto Slab & Manrope",
 	"slug": "typography-preset-4",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/typography/typography-preset-5.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/typography/typography-preset-5.json
@@ -1,6 +1,6 @@
 {
 	"version": 3,
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"title": "Literata & Ysabeau Office",
 	"slug": "typography-preset-5",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/typography/typography-preset-6.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/typography/typography-preset-6.json
@@ -1,6 +1,6 @@
 {
 	"version": 3,
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"title": "Platypi & Literata",
 	"slug": "typography-preset-6",
 	"settings": {

--- a/src/wp-content/themes/twentytwentyfive/styles/typography/typography-preset-7.json
+++ b/src/wp-content/themes/twentytwentyfive/styles/typography/typography-preset-7.json
@@ -1,6 +1,6 @@
 {
 	"version": 3,
-	"$schema": "https://schemas.wp.org/trunk/theme.json",
+	"$schema": "https://schemas.wp.org/wp/6.7/theme.json",
 	"title": "Literata & Fira Sans",
 	"slug": "typography-preset-7",
 	"settings": {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/62455

This PR updates the `$schema` URL in all JSON files for the Twenty Twenty-Five theme to use the wp/6.7 schema version instead of the trunk version. 