### PR TITLE
Add reusable workflow for parsing matrix.

### DIFF
--- a/.github/workflows/install-testing.yml
+++ b/.github/workflows/install-testing.yml
@@ -14,8 +14,10 @@ on:
   pull_request:
     # Always test the workflow when changes are suggested.
     paths:
-      - '.github/workflows/install-testing.yml'
       - '.version-support-*.json'
+      - '.github/workflows/install-testing.yml'
+      - '.github/workflows/reusable-support-json-reader-v1.yml'
+
   schedule:
     - cron: '0 0 * * 1'
   workflow_dispatch:

--- a/.github/workflows/install-testing.yml
+++ b/.github/workflows/install-testing.yml
@@ -37,60 +37,19 @@ concurrency:
 permissions: {}
 
 jobs:
-  # Determines the appropriate values for PHP and database versions based on the WordPress version being tested.
   #
-  # Performs the following steps:
-  # - Checks out the repository.
-  # - Fetches the versions of PHP to test.
-  # - Fetches the versions of MySQL to test.
-  build-matrix:
-    name: Determine PHP Versions to test
-    runs-on: ubuntu-latest
+  # Determines the supported values for PHP and database versions based on the WordPress
+  # version being tested.
+  #
+  build-test-matrix:
+    name: Build Test Matrix
+    uses: desrosj/wordpress-develop/.github/workflows/reusable-support-json-reader-v1.yml@add/reusable-matrix-logic
+    permissions:
+      contents: read
+    secrets: inherit
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
-    timeout-minutes: 5
-    outputs:
-      major-wp-version: ${{ steps.major-wp-version.outputs.version }}
-      php-versions: ${{ steps.php-versions.outputs.versions }}
-      mysql-versions: ${{ steps.mysql-versions.outputs.versions }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-        with:
-          show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
-
-      - name: Determine the major WordPress version
-        id: major-wp-version
-        run: |
-          if [ "${{ inputs.wp-version }}" ] && [ "${{ inputs.wp-version }}" != "nightly" ] && [ "${{ inputs.wp-version }}" != "latest" ]; then
-            echo "version=$(echo "${{ inputs.wp-version }}" | tr '.' '-' | cut -d '-' -f1-2)" >> $GITHUB_OUTPUT
-          elif [ "${{ inputs.wp-version }}" ]; then
-            echo "version=$(echo "${{ inputs.wp-version }}")" >> $GITHUB_OUTPUT
-          else
-            echo "version=nightly" >> $GITHUB_OUTPUT
-          fi
-
-      # Look up the major version's specific PHP support policy when a version is provided.
-      # Otherwise, use the current PHP support policy.
-      - name: Get supported PHP versions
-        id: php-versions
-        run: |
-          if [ "${{ steps.major-wp-version.outputs.version }}" != "latest" ] && [ "${{ steps.major-wp-version.outputs.version }}" != "nightly" ]; then
-            echo "versions=$(jq -r '.["${{ steps.major-wp-version.outputs.version }}"] | @json' .version-support-php.json)" >> $GITHUB_OUTPUT
-          else
-            echo "versions=$(jq -r '.[ (keys[-1]) ] | @json' .version-support-php.json)" >> $GITHUB_OUTPUT
-          fi
-
-      # Look up the major version's specific MySQL support policy when a version is provided.
-      # Otherwise, use the current MySQL support policy.
-      - name: Get supported MySQL versions
-        id: mysql-versions
-        run: |
-          if [ "${{ steps.major-wp-version.outputs.version }}" != "latest" ] && [ "${{ steps.major-wp-version.outputs.version }}" != "nightly" ]; then
-            echo "versions=$(jq -r '.["${{ steps.major-wp-version.outputs.version }}"] | @json' .version-support-mysql.json)" >> $GITHUB_OUTPUT
-          else
-            echo "versions=$(jq -r '.[ (keys[-1]) ] | @json' .version-support-mysql.json)" >> $GITHUB_OUTPUT
-          fi
+    with:
+      wp-version: ${{ inputs.wp-version }}
 
   # Test the WordPress installation process through WP-CLI.
   #
@@ -106,14 +65,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
     timeout-minutes: 10
-    needs: [ build-matrix ]
+    needs: [ build-test-matrix ]
     strategy:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        php: ${{ fromJSON( needs.build-matrix.outputs.php-versions ) }}
+        php: ${{ fromJSON( needs.build-test-matrix.outputs.php-versions ) }}
         db-type: [ 'mysql' ]
-        db-version: ${{ fromJSON( needs.build-matrix.outputs.mysql-versions ) }}
+        db-version: ${{ fromJSON( needs.build-test-matrix.outputs.mysql-versions ) }}
         multisite: [ false, true ]
         memcached: [ false ]
 

--- a/.github/workflows/reusable-support-json-reader-v1.yml
+++ b/.github/workflows/reusable-support-json-reader-v1.yml
@@ -1,0 +1,102 @@
+##
+# A reusable workflow that reads the .version-support-*.json files and returns values for use in a
+# test matrix based on a WordPress version.
+##
+name: Determine test matrix values
+
+on:
+  workflow_call:
+    inputs:
+      wp-version:
+        description: 'The WordPress version to test . Accepts major and minor versions, "latest", or "nightly". Major releases must not end with ".0".'
+        type: string
+        default: 'nightly'
+    outputs:
+      major-wp-version:
+        description: "The major WordPress version based on the version provided in wp-version"
+        value: ${{ jobs.major-wp-version.outputs.version }}
+      php-versions:
+        description: "The PHP versions to test for the given wp-version"
+        value: ${{ jobs.php-versions.outputs.versions }}
+      mysql-versions:
+        description: "The MySQL versions to test for the given wp-version"
+        value: ${{ jobs.mysql-versions.outputs.versions }}
+
+jobs:
+
+  major-wp-version:
+    name: Determine major WordPress version
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.major-wp-version.outputs.version }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+
+      - name: Determine the major WordPress version
+        id: major-wp-version
+        run: |
+          if [ "${{ inputs.wp-version }}" ] && [ "${{ inputs.wp-version }}" != "nightly" ] && [ "${{ inputs.wp-version }}" != "latest" ]; then
+            echo "version=$(echo "${{ inputs.wp-version }}" | tr '.' '-' | cut -d '-' -f1-2)" >> $GITHUB_OUTPUT
+          elif [ "${{ inputs.wp-version }}" ]; then
+            echo "version=$(echo "${{ inputs.wp-version }}")" >> $GITHUB_OUTPUT
+          else
+            echo "version=nightly" >> $GITHUB_OUTPUT
+          fi
+
+  php-versions:
+    name: Determine PHP versions
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    needs: [ major-wp-version ]
+    timeout-minutes: 5
+    outputs:
+      versions: ${{ steps.php-versions.outputs.versions }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+
+      # Look up the major version's specific PHP support policy when a version is provided.
+      # Otherwise, use the current PHP support policy.
+      - name: Get supported PHP versions
+        id: php-versions
+        run: |
+          if [ "${{ needs.major-wp-version.outputs.version }}" != "latest" ] && [ "${{ needs.major-wp-version.outputs.version }}" != "nightly" ]; then
+            echo "versions=$(jq -r '.["${{ needs.major-wp-version.outputs.version }}"] | @json' .version-support-php.json)" >> $GITHUB_OUTPUT
+          else
+            echo "versions=$(jq -r '.[ (keys[-1]) ] | @json' .version-support-php.json)" >> $GITHUB_OUTPUT
+          fi
+
+  mysql-versions:
+    name: Determine MySQL versions
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    needs: [ major-wp-version ]
+    timeout-minutes: 5
+    outputs:
+      versions: ${{ steps.mysql-versions.outputs.versions }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+
+      # Look up the major version's specific MySQL support policy when a version is provided.
+      # Otherwise, use the current MySQL support policy.
+      - name: Get supported MySQL versions
+        id: mysql-versions
+        run: |
+          if [ "${{ needs.major-wp-version.outputs.version }}" != "latest" ] && [ "${{ needs.major-wp-version.outputs.version }}" != "nightly" ]; then
+            echo "versions=$(jq -r '.["${{ needs.major-wp-version.outputs.version }}"] | @json' .version-support-mysql.json)" >> $GITHUB_OUTPUT
+          else
+            echo "versions=$(jq -r '.[ (keys[-1]) ] | @json' .version-support-mysql.json)" >> $GITHUB_OUTPUT
+          fi


### PR DESCRIPTION
This extracts the workflow logic that parses the `.version-support-(php|mysql).json` files from the Installation testing workflow into a reusable one. This makes it accessible to other workflows that may want to automatically build a test matrix from these files.

Trac ticket: https://core.trac.wordpress.org/ticket/62221

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
