### PR TITLE
Fix Pagination and Bulk Action Warning Conflict

### DIFF
--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -1310,9 +1310,20 @@ $( function() {
 		$document.trigger( 'wp-notice-added' );
 	};
 
+	/**
+	 * Stores initial pagination value for comparison.
+	 */
+	var initialPagedValue = document.querySelector( '#current-page-selector' ).value;
+
 	$( '.bulkactions' ).parents( 'form' ).on( 'submit', function( event ) {
 		var form = this,
 			submitterName = event.originalEvent && event.originalEvent.submitter ? event.originalEvent.submitter.name : false;
+
+		var currentPagedValue = form.querySelector( '#current-page-selector' ).value;
+
+		if ( initialPagedValue !== currentPagedValue ) {
+			return; // Pagination form submission.
+		}
 
 		// Observe submissions from posts lists for 'bulk_action' or users lists for 'new_role'.
 		var bulkFieldRelations = {

--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -1310,9 +1310,7 @@ $( function() {
 		$document.trigger( 'wp-notice-added' );
 	};
 
-	/**
-	 * Stores initial pagination value for comparison.
-	 */
+	// Stores initial pagination value for comparison.
 	var initialPagedValue = document.querySelector( '#current-page-selector' ).value;
 
 	$( '.bulkactions' ).parents( 'form' ).on( 'submit', function( event ) {

--- a/src/wp-admin/edit-tags.php
+++ b/src/wp-admin/edit-tags.php
@@ -216,6 +216,9 @@ if ( $location ) {
 	if ( $pagenum > 1 ) {
 		$location = add_query_arg( 'paged', $pagenum, $location ); // $pagenum takes care of $total_pages.
 	}
+	if ( 1 === $pagenum ) {
+		$location = remove_query_arg( 'paged', $location );
+	}
 
 	/**
 	 * Filters the taxonomy redirect destination URL.


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/62534

### Description
This fix compares the initial and current page numbers to differentiate between a bulk action submission and a pagination action. If the page number has changed, it indicates a pagination submission, preventing the bulk action warning from triggering. This restores proper pagination functionality while ensuring the warning only appears for bulk actions when no items are selected.

### Screencast Recording

https://github.com/user-attachments/assets/c5e490dd-ed45-48f5-9be9-5dd6868715c2





