### PR TITLE
Send auto update emails in admin locale

### DIFF
--- a/src/wp-admin/includes/class-wp-automatic-updater.php
+++ b/src/wp-admin/includes/class-wp-automatic-updater.php
@@ -936,6 +936,14 @@ class WP_Automatic_Updater {
 			return;
 		}
 
+		$admin_user = get_user_by( 'email', get_site_option( 'admin_email' ) );
+
+		if ( $admin_user ) {
+			$switched_locale = switch_to_user_locale( $admin_user->ID );
+		} else {
+			$switched_locale = switch_to_locale( get_locale() );
+		}
+
 		switch ( $type ) {
 			case 'success': // We updated.
 				/* translators: Site updated notification email subject. 1: Site title, 2: WordPress version. */
@@ -1139,8 +1147,11 @@ class WP_Automatic_Updater {
 		$email = apply_filters( 'auto_core_update_email', $email, $type, $core_update, $result );
 
 		wp_mail( $email['to'], wp_specialchars_decode( $email['subject'] ), $email['body'], $email['headers'] );
-	}
 
+		if ( $switched_locale ) {
+			restore_previous_locale();
+		}
+	}
 
 	/**
 	 * Checks whether an email should be sent after attempting plugin or theme updates.
@@ -1253,6 +1264,14 @@ class WP_Automatic_Updater {
 			if ( ! $unique_failures ) {
 				return;
 			}
+		}
+
+		$admin_user = get_user_by( 'email', get_site_option( 'admin_email' ) );
+
+		if ( $admin_user ) {
+			$switched_locale = switch_to_user_locale( $admin_user->ID );
+		} else {
+			$switched_locale = switch_to_locale( get_locale() );
 		}
 
 		$body               = array();
@@ -1526,6 +1545,10 @@ class WP_Automatic_Updater {
 		if ( $result ) {
 			update_option( 'auto_plugin_theme_update_emails', $past_failure_emails );
 		}
+
+		if ( $switched_locale ) {
+			restore_previous_locale();
+		}
 	}
 
 	/**
@@ -1534,9 +1557,12 @@ class WP_Automatic_Updater {
 	 * @since 3.7.0
 	 */
 	protected function send_debug_email() {
-		$update_count = 0;
-		foreach ( $this->update_results as $type => $updates ) {
-			$update_count += count( $updates );
+		$admin_user = get_user_by( 'email', get_site_option( 'admin_email' ) );
+
+		if ( $admin_user ) {
+			$switched_locale = switch_to_user_locale( $admin_user->ID );
+		} else {
+			$switched_locale = switch_to_locale( get_locale() );
 		}
 
 		$body     = array();
@@ -1715,6 +1741,10 @@ Thanks! -- The WordPress Team"
 		$email = apply_filters( 'automatic_updates_debug_email', $email, $failures, $this->update_results );
 
 		wp_mail( $email['to'], wp_specialchars_decode( $email['subject'] ), $email['body'], $email['headers'] );
+
+		if ( $switched_locale ) {
+			restore_previous_locale();
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

```
I18N: Switch locale to admin locale when sending auto update emails.

If sending an auto update email to the site administrator's email address, look up if a user with the same email exists and switch to that user's locale. If not, explicitly switches to the site locale.

This is a follow-up to [59128] where this was previously added for other types of emails.

Props benniledl, swissspidy.
Fixes #62496.
```

Trac ticket: https://core.trac.wordpress.org/ticket/62496

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
