### PR TITLE
This diff adds `d.m.Y` (day.month.year) as a supported date format in…

### DIFF
--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -480,7 +480,7 @@ if ( empty( $tzstring ) ) { // Create a UTC+- zone if no timezone string exists.
 	 *
 	 * @param string[] $default_date_formats Array of default date formats.
 	 */
-	$date_formats = array_unique( apply_filters( 'date_formats', array( __( 'F j, Y' ), 'Y-m-d', 'm/d/Y', 'd/m/Y' ) ) );
+	$date_formats = array_unique( apply_filters( 'date_formats', array( __( 'F j, Y' ), 'Y-m-d', 'm/d/Y', 'd/m/Y', 'd.m.Y' ) ) );
 
 	$custom = true;
 


### PR DESCRIPTION
… WordPress's general settings.  This gives users another option when selecting how dates are displayed on their site. The `array_unique` call ensures that if this format was already added by a plugin or theme, it won't be duplicated.  This change is relevant if you are concerned with internationalization or providing more date format choices for users in regions where this format is common.

Trac ticket: https://core.trac.wordpress.org/ticket/55685