### PR TITLE
Fix inline image display issue in Twenty Twenty theme

### DIFF
--- a/src/wp-content/themes/twentytwenty/style-rtl.css
+++ b/src/wp-content/themes/twentytwenty/style-rtl.css
@@ -3573,6 +3573,7 @@ figure.wp-block-table.is-style-stripes {
 	line-height: 1.4;
 }
 
+.entry-content p img,
 .entry-content li img {
 	display: inline-block;
 }

--- a/src/wp-content/themes/twentytwenty/style.css
+++ b/src/wp-content/themes/twentytwenty/style.css
@@ -3597,6 +3597,7 @@ figure.wp-block-table.is-style-stripes {
 	line-height: 1.4;
 }
 
+.entry-content p img,
 .entry-content li img {
 	display: inline-block;
 }


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/50418

This PR resolves the issue where inline images inside paragraph blocks were displaying as block elements on the front end in the Twenty Twenty theme. The fix ensures that inline images display properly as inline or inline-block elements, and it addresses the issue for both LTR and RTL languages.

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/f8fdf27c-dd76-4ec0-97fc-f809c8acc240) | ![After](https://github.com/user-attachments/assets/2e058a52-a98b-483b-835c-0d184da875f0) |


| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/2ee89ebf-2fdf-4502-9ab1-61fa52d87cba) | ![After](https://github.com/user-attachments/assets/44f99590-470e-43c2-a385-4a9ee43fd194) |


