### PR TITLE
Block bindings: Fix button processing returning uppercase tag

### DIFF
--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -364,7 +364,7 @@ class WP_Block {
 				// Store the parent tag and its attributes to be able to restore them later in the button.
 				// The button block has a wrapper while the paragraph and heading blocks don't.
 				if ( 'core/button' === $this->name ) {
-					$button_wrapper                 = $block_reader->get_tag();
+					$button_wrapper                 = strtolower( $block_reader->get_tag() );
 					$button_wrapper_attribute_names = $block_reader->get_attribute_names_with_prefix( '' );
 					$button_wrapper_attrs           = array();
 					foreach ( $button_wrapper_attribute_names as $name ) {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/62522

Fixes a bug where processing the button block with bindings returns the HTML wrapper DIV in uppercase, which breaks other processing, like the Interactivity API directives.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
