### PR TITLE
Fix icon/thumbnail spacing issue in Media Library after file upload

### DIFF
--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -174,7 +174,7 @@
 
 .media-item .pinkynail {
 	float: left;
-	margin: 0 10px 0 0;
+	margin: 14px;
 	max-height: 70px;
 	max-width: 70px;
 }
@@ -1266,7 +1266,7 @@ audio, video {
 	.edit-attachment-frame textarea {
 		line-height: 1.5;
 	}
-	
+
 	.wp_attachment_details label[for="content"] {
 		font-size: 14px;
 		line-height: 1.5;


### PR DESCRIPTION
This PR addresses a UI issue in the Media Library where icons or thumbnails of uploaded files appear to stick to the border of their containers after file upload.

### How to Test:
1. Navigate to `Media > Add New Media File` in the WordPress admin dashboard.
2. Upload a file using the drag-and-drop area or the "Select Files" button.
3. Verify that the thumbnails/icons of the uploaded files no longer stick to the container's border and are appropriately spaced.

Trac ticket: https://core.trac.wordpress.org/ticket/62573

![Screenshot 2024-11-26 at 4 13 32 PM](https://github.com/user-attachments/assets/ca3847f1-0150-44a6-b630-8a6d68a232dc)



