### PR TITLE
HTML API: Recognize all uppercase tag names in tag processor

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1668,7 +1668,7 @@ class WP_HTML_Tag_Processor {
 				 *
 				 * @see https://html.spec.whatwg.org/#tag-open-state
 				 */
-				if ( 1 !== strspn( $html, '!/?abcdefghijklmnopqrstuvwxyzABCEFGHIJKLMNOPQRSTUVWXYZ', $at + 1, 1 ) ) {
+				if ( 1 !== strspn( $html, '!/?abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', $at + 1, 1 ) ) {
 					++$at;
 					continue;
 				}

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2984,4 +2984,58 @@ HTML
 		$this->assertNull( $doctype->public_identifier );
 		$this->assertNull( $doctype->system_identifier );
 	}
+
+	/**
+	 * @ticket 62522
+	 *
+	 * @dataProvider data_alphabet_by_characters_lowercase
+	 */
+	public function test_recognizes_lowercase_tag_name( string $char ) {
+		$html      = " <{$char}> </{$char}>";
+		$processor = new WP_HTML_Tag_Processor( $html );
+		$this->assertTrue( $processor->next_tag(), "Failed to find open tag in '{$html}'." );
+		$this->assertTrue(
+			$processor->next_tag( array( 'tag_closers' => 'visit' ) ),
+			"Failed to find close tag in '{$html}'."
+		);
+	}
+
+	/**
+	 * @ticket 62522
+	 *
+	 * @dataProvider data_alphabet_by_characters_uppercase
+	 */
+	public function test_recognizes_uppercase_tag_name( string $char ) {
+		$html      = " <{$char}> </{$char}>";
+		$processor = new WP_HTML_Tag_Processor( $html );
+		$this->assertTrue( $processor->next_tag(), "Failed to find open tag in '{$html}'." );
+		$this->assertTrue(
+			$processor->next_tag( array( 'tag_closers' => 'visit' ) ),
+			"Failed to find close tag in '{$html}'."
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return Generator<array>
+	 */
+	public static function data_alphabet_by_characters_lowercase() {
+		$char = 'a';
+		while ( $char <= 'z' ) {
+			yield $char => array( $char );
+			$char = chr( ord( $char ) + 1 );
+		}
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return Generator<array>
+	 */
+	public static function data_alphabet_by_characters_uppercase() {
+		foreach ( self::data_alphabet_by_characters_lowercase() as $data ) {
+			yield strtoupper( $data[0] ) => array( strtoupper( $data[0] ) );
+		}
+	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2991,6 +2991,10 @@ HTML
 	 * @dataProvider data_alphabet_by_characters_lowercase
 	 */
 	public function test_recognizes_lowercase_tag_name( string $char ) {
+		/*
+		 * The spacing in the HTML string is important to the problematic
+		 * codepath in ticket #62522.
+		 */
 		$html      = " <{$char}> </{$char}>";
 		$processor = new WP_HTML_Tag_Processor( $html );
 		$this->assertTrue( $processor->next_tag(), "Failed to find open tag in '{$html}'." );
@@ -3006,6 +3010,10 @@ HTML
 	 * @dataProvider data_alphabet_by_characters_uppercase
 	 */
 	public function test_recognizes_uppercase_tag_name( string $char ) {
+		/*
+		 * The spacing in the HTML string is important to the problematic
+		 * codepath in ticket #62522.
+		 */
 		$html      = " <{$char}> </{$char}>";
 		$processor = new WP_HTML_Tag_Processor( $html );
 		$this->assertTrue( $processor->next_tag(), "Failed to find open tag in '{$html}'." );


### PR DESCRIPTION
Ensure uppercase tag names are matched correctly by the tag processor.

[Ticket 62522](https://core.trac.wordpress.org/ticket/62522) describes an issue where a whitespace-prefixed tag was causing problems. With the help of @SantosGuillamot and @cbravobernal, this was narrowed down to an uppercase open tag name preceded by whitespace not being recognized by the tag processor.

There was a missing "D" in the character list used by `strspn` to find tag openers, causing tags starting with `D` to be skipped by the tag processor in some circumstances.


This only appears in rare cases because the tag name must appear in the correct position (preceded by whitespace) and must start with an uppercase `D`. Casing is not relevant for tag names, and most tag names are lowercase in the wild.

Trac ticket: https://core.trac.wordpress.org/ticket/62522
Follow up [[58613]](https://core.trac.wordpress.org/changeset/58613)

Closes https://github.com/WordPress/wordpress-develop/pull/7893 (supersedes).

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
