### PR TITLE
Block Hooks: Apply to Post Content (on frontend and in editor)

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1043,10 +1043,9 @@ function set_ignored_hooked_blocks_metadata( &$parsed_anchor_block, $relative_po
  * @access private
  *
  * @param string                               $content  Serialized content.
- * @param WP_Block_Template|WP_Post|array|null $context  A block template, template part, post object,
- *                                                       or pattern that the blocks belong to. If set to `null`, the
- *                                                       current post is used.
- *                                                       Default: `null`.
+ * @param WP_Block_Template|WP_Post|array|null $context  A block template, template part, post object, or pattern
+ *                                                       that the blocks belong to. If set to `null`, the current
+ *                                                       post is used. Default: `null`.
  * @param callable                             $callback A function that will be called for each block to generate
  *                                                       the markup for a given list of blocks that are hooked to it.
  *                                                       Default: 'insert_hooked_blocks'.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1052,10 +1052,6 @@ function set_ignored_hooked_blocks_metadata( &$parsed_anchor_block, $relative_po
  * @return string The serialized markup.
  */
 function apply_block_hooks_to_content( $content, $context = null, $callback = 'insert_hooked_blocks' ) {
-	if ( ! $content ) {
-		return $content;
-	}
-
 	// Default to the current post if no context is provided.
 	if ( null === $context ) {
 		$context = get_post();

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1052,6 +1052,10 @@ function set_ignored_hooked_blocks_metadata( &$parsed_anchor_block, $relative_po
  * @return string The serialized markup.
  */
 function apply_block_hooks_to_content( $content, $context = null, $callback = 'insert_hooked_blocks' ) {
+	if ( ! $content ) {
+		return $content;
+	}
+
 	// Default to the current post if no context is provided.
 	if ( null === $context ) {
 		$context = get_post();

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -912,7 +912,7 @@ function insert_hooked_blocks( &$parsed_anchor_block, $relative_position, $hooke
 	 * @param string                          $relative_position  The relative position of the hooked blocks.
 	 *                                                            Can be one of 'before', 'after', 'first_child', or 'last_child'.
 	 * @param string                          $anchor_block_type  The anchor block type.
-	 * @param WP_Block_Template|WP_Post|array $context            The block template, template part, post type,
+	 * @param WP_Block_Template|WP_Post|array $context            The block template, template part, post object,
 	 *                                                            or pattern that the anchor block belongs to.
 	 */
 	$hooked_block_types = apply_filters( 'hooked_block_types', $hooked_block_types, $relative_position, $anchor_block_type, $context );
@@ -935,7 +935,7 @@ function insert_hooked_blocks( &$parsed_anchor_block, $relative_position, $hooke
 		 * @param string                          $hooked_block_type   The hooked block type name.
 		 * @param string                          $relative_position   The relative position of the hooked block.
 		 * @param array                           $parsed_anchor_block The anchor block, in parsed block array format.
-		 * @param WP_Block_Template|WP_Post|array $context             The block template, template part, post type,
+		 * @param WP_Block_Template|WP_Post|array $context             The block template, template part, post object,
 		 *                                                             or pattern that the anchor block belongs to.
 		 */
 		$parsed_hooked_block = apply_filters( 'hooked_block', $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block, $context );
@@ -951,7 +951,7 @@ function insert_hooked_blocks( &$parsed_anchor_block, $relative_position, $hooke
 		 * @param string                          $hooked_block_type   The hooked block type name.
 		 * @param string                          $relative_position   The relative position of the hooked block.
 		 * @param array                           $parsed_anchor_block The anchor block, in parsed block array format.
-		 * @param WP_Block_Template|WP_Post|array $context             The block template, template part, post type,
+		 * @param WP_Block_Template|WP_Post|array $context             The block template, template part, post object,
 		 *                                                             or pattern that the anchor block belongs to.
 		 */
 		$parsed_hooked_block = apply_filters( "hooked_block_{$hooked_block_type}", $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block, $context );

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1172,10 +1172,11 @@ function extract_serialized_parent_block( $serialized_block ) {
 }
 
 /**
- * Updates the wp_postmeta with the list of ignored hooked blocks where the inner blocks are stored as post content.
- * Currently only supports `wp_navigation` post types.
+ * Updates the wp_postmeta with the list of ignored hooked blocks
+ * where the inner blocks are stored as post content.
  *
  * @since 6.6.0
+ * @since 6.8.0 Support non-`wp_navigation` post types.
  * @access private
  *
  * @param stdClass $post Post object.
@@ -1183,7 +1184,7 @@ function extract_serialized_parent_block( $serialized_block ) {
  */
 function update_ignored_hooked_blocks_postmeta( $post ) {
 	/*
-	 * In this scenario the user has likely tried to create a navigation via the REST API.
+	 * In this scenario the user has likely tried to create a new post object via the REST API.
 	 * In which case we won't have a post ID to work with and store meta against.
 	 */
 	if ( empty( $post->ID ) ) {
@@ -1191,17 +1192,10 @@ function update_ignored_hooked_blocks_postmeta( $post ) {
 	}
 
 	/*
-	 * Skip meta generation when consumers intentionally update specific Navigation fields
+	 * Skip meta generation when consumers intentionally update specific fields
 	 * and omit the content update.
 	 */
 	if ( ! isset( $post->post_content ) ) {
-		return $post;
-	}
-
-	/*
-	 * Skip meta generation when the post content is not a navigation block.
-	 */
-	if ( ! isset( $post->post_type ) || 'wp_navigation' !== $post->post_type ) {
 		return $post;
 	}
 
@@ -1215,8 +1209,14 @@ function update_ignored_hooked_blocks_postmeta( $post ) {
 		);
 	}
 
+	if ( 'wp_navigation' === $post->post_type ) {
+		$wrapper_block_type = 'core/navigation';
+	} else {
+		$wrapper_block_type = 'core/post-content';
+	}
+
 	$markup = get_comment_delimited_block_content(
-		'core/navigation',
+		$wrapper_block_type,
 		$attributes,
 		$post->post_content
 	);

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1327,7 +1327,7 @@ function insert_hooked_blocks_into_rest_response( $response, $post ) {
 
 	$response->data['content']['raw'] = $content;
 
-	// No need to inject hooked blocks twice.
+	// `apply_block_hooks_to_content` is called above. Ensure it is not called again as a filter.
 	$priority = has_filter( 'the_content', 'apply_block_hooks_to_content' );
 	if ( false !== $priority ) {
 		remove_filter( 'the_content', 'apply_block_hooks_to_content', $priority );
@@ -1336,7 +1336,7 @@ function insert_hooked_blocks_into_rest_response( $response, $post ) {
 	/** This filter is documented in wp-includes/post-template.php */
 	$response->data['content']['rendered'] = apply_filters( 'the_content', $content );
 
-	// Add back the filter.
+	// Restore the filter if it was set initially.
 	if ( false !== $priority ) {
 		add_filter( 'the_content', 'apply_block_hooks_to_content', $priority );
 	}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1199,6 +1199,13 @@ function update_ignored_hooked_blocks_postmeta( $post ) {
 		return $post;
 	}
 
+	/*
+	 * Skip meta generation if post type is not set.
+	 */
+	if ( ! isset( $post->post_type ) ) {
+		return $post;
+	}
+
 	$attributes = array();
 
 	$ignored_hooked_blocks = get_post_meta( $post->ID, '_wp_ignored_hooked_blocks', true );

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1044,8 +1044,9 @@ function set_ignored_hooked_blocks_metadata( &$parsed_anchor_block, $relative_po
  *
  * @param string                               $content  Serialized content.
  * @param WP_Block_Template|WP_Post|array|null $context  A block template, template part, post object, or pattern
- *                                                       that the blocks belong to. If set to `null`, the current
- *                                                       post is used. Default: `null`.
+ *                                                       that the blocks belong to. If set to `null`, `get_post()`
+ *                                                       will be called to use the current post as context.
+ *                                                       Default: `null`.
  * @param callable                             $callback A function that will be called for each block to generate
  *                                                       the markup for a given list of blocks that are hooked to it.
  *                                                       Default: 'insert_hooked_blocks'.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1282,7 +1282,7 @@ function insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( &$parsed_a
  * @return WP_REST_Response The response object.
  */
 function insert_hooked_blocks_into_rest_response( $response, $post ) {
-	if ( ! isset( $response->data['content']['raw'] ) || ! isset( $response->data['content']['rendered'] ) ) {
+	if ( empty( $response->data['content']['raw'] ) || empty( $response->data['content']['rendered'] ) ) {
 		return $response;
 	}
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1039,17 +1039,25 @@ function set_ignored_hooked_blocks_metadata( &$parsed_anchor_block, $relative_po
  *
  * @since 6.6.0
  * @since 6.7.0 Injects the `theme` attribute into Template Part blocks, even if no hooked blocks are registered.
+ * @since 6.8.0 Have the `$context` parameter default to `null`, in which case the current post will be used.
  * @access private
  *
- * @param string                          $content  Serialized content.
- * @param WP_Block_Template|WP_Post|array $context  A block template, template part, `wp_navigation` post object,
- *                                                  or pattern that the blocks belong to.
- * @param callable                        $callback A function that will be called for each block to generate
- *                                                  the markup for a given list of blocks that are hooked to it.
- *                                                  Default: 'insert_hooked_blocks'.
+ * @param string                               $content  Serialized content.
+ * @param WP_Block_Template|WP_Post|array|null $context  A block template, template part, `wp_navigation` post object,
+ *                                                       or pattern that the blocks belong to. If set to `null`, the
+ *                                                       current post is used.
+ *                                                       Default: `null`.
+ * @param callable                             $callback A function that will be called for each block to generate
+ *                                                       the markup for a given list of blocks that are hooked to it.
+ *                                                       Default: 'insert_hooked_blocks'.
  * @return string The serialized markup.
  */
-function apply_block_hooks_to_content( $content, $context, $callback = 'insert_hooked_blocks' ) {
+function apply_block_hooks_to_content( $content, $context = null, $callback = 'insert_hooked_blocks' ) {
+	// Default to the current post if no context is provided.
+	if ( null === $context ) {
+		$context = get_post();
+	}
+
 	$hooked_blocks = get_hooked_blocks();
 
 	$before_block_visitor = '_inject_theme_attribute_in_template_part_block';
@@ -1130,21 +1138,6 @@ function apply_block_hooks_to_content( $content, $context, $callback = 'insert_h
 	remove_filter( 'hooked_block_types', $suppress_single_instance_blocks, PHP_INT_MAX );
 
 	return $content;
-}
-
-/**
- * Runs the Block Hooks algorithm on the post content of the current post.
- *
- * @since 6.8.0
- *
- * @param string $content
- * @return string The post content, with Block Hooks applied.
- */
-function apply_block_hooks_to_post_content( $content ) {
-	// The `the_content` filter does not provide the post that the content is coming from.
-	// However, we can infer it by calling `get_post()`, which will return the current post
-	// if no post ID is provided.
-	return apply_block_hooks_to_content( $content, get_post(), 'insert_hooked_blocks' );
 }
 
 /**

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1295,16 +1295,30 @@ function insert_hooked_blocks_into_rest_response( $response, $post ) {
 			'ignoredHookedBlocks' => $ignored_hooked_blocks,
 		);
 	}
-	$content = get_comment_delimited_block_content(
-		'core/navigation',
-		$attributes,
-		$response->data['content']['raw']
+
+	$post_type_to_wrapper_block_mappings = array(
+		'wp_navigation' => 'core/navigation',
+		'wp_post'       => 'core/post-content',
 	);
+
+	if ( isset( $post_type_to_wrapper_block_mappings[ $post->post_type ] ) ) {
+		$wrapper_block_type = $post_type_to_wrapper_block_mappings[ $post->post_type ];
+
+		$content = get_comment_delimited_block_content(
+			$wrapper_block_type,
+			$attributes,
+			$response->data['content']['raw']
+		);
+	} else {
+		$content = $response->data['content']['raw'];
+	}
 
 	$content = apply_block_hooks_to_content( $content, $post );
 
-	// Remove mock Navigation block wrapper.
-	$content = remove_serialized_parent_block( $content );
+	if ( isset( $post_type_to_wrapper_block_mappings[ $post->post_type ] ) ) {
+		// Remove mock block wrapper.
+		$content = remove_serialized_parent_block( $content );
+	}
 
 	$response->data['content']['raw'] = $content;
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1276,6 +1276,7 @@ function insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( &$parsed_a
  * Hooks into the REST API response for the Posts endpoint and adds the first and last inner blocks.
  *
  * @since 6.6.0
+ * @since 6.8.0 Support non-`wp_navigation` post types.
  *
  * @param WP_REST_Response $response The response object.
  * @param WP_Post          $post     Post object.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1133,6 +1133,21 @@ function apply_block_hooks_to_content( $content, $context, $callback = 'insert_h
 }
 
 /**
+ * Runs the Block Hooks algorithm on the post content of the current post.
+ *
+ * @since 6.8.0
+ *
+ * @param string $content
+ * @return string The post content, with Block Hooks applied.
+ */
+function apply_block_hooks_to_post_content( $content ) {
+	// The `the_content` filter does not provide the post that the content is coming from.
+	// However, we can infer it by calling `get_post()`, which will return the current post
+	// if no post ID is provided.
+	return apply_block_hooks_to_content( $content, get_post(), 'insert_hooked_blocks' );
+}
+
+/**
  * Accepts the serialized markup of a block and its inner blocks, and returns serialized markup of the inner blocks.
  *
  * @since 6.6.0

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -912,7 +912,7 @@ function insert_hooked_blocks( &$parsed_anchor_block, $relative_position, $hooke
 	 * @param string                          $relative_position  The relative position of the hooked blocks.
 	 *                                                            Can be one of 'before', 'after', 'first_child', or 'last_child'.
 	 * @param string                          $anchor_block_type  The anchor block type.
-	 * @param WP_Block_Template|WP_Post|array $context            The block template, template part, `wp_navigation` post type,
+	 * @param WP_Block_Template|WP_Post|array $context            The block template, template part, post type,
 	 *                                                            or pattern that the anchor block belongs to.
 	 */
 	$hooked_block_types = apply_filters( 'hooked_block_types', $hooked_block_types, $relative_position, $anchor_block_type, $context );
@@ -935,7 +935,7 @@ function insert_hooked_blocks( &$parsed_anchor_block, $relative_position, $hooke
 		 * @param string                          $hooked_block_type   The hooked block type name.
 		 * @param string                          $relative_position   The relative position of the hooked block.
 		 * @param array                           $parsed_anchor_block The anchor block, in parsed block array format.
-		 * @param WP_Block_Template|WP_Post|array $context             The block template, template part, `wp_navigation` post type,
+		 * @param WP_Block_Template|WP_Post|array $context             The block template, template part, post type,
 		 *                                                             or pattern that the anchor block belongs to.
 		 */
 		$parsed_hooked_block = apply_filters( 'hooked_block', $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block, $context );
@@ -951,7 +951,7 @@ function insert_hooked_blocks( &$parsed_anchor_block, $relative_position, $hooke
 		 * @param string                          $hooked_block_type   The hooked block type name.
 		 * @param string                          $relative_position   The relative position of the hooked block.
 		 * @param array                           $parsed_anchor_block The anchor block, in parsed block array format.
-		 * @param WP_Block_Template|WP_Post|array $context             The block template, template part, `wp_navigation` post type,
+		 * @param WP_Block_Template|WP_Post|array $context             The block template, template part, post type,
 		 *                                                             or pattern that the anchor block belongs to.
 		 */
 		$parsed_hooked_block = apply_filters( "hooked_block_{$hooked_block_type}", $parsed_hooked_block, $hooked_block_type, $relative_position, $parsed_anchor_block, $context );
@@ -1043,7 +1043,7 @@ function set_ignored_hooked_blocks_metadata( &$parsed_anchor_block, $relative_po
  * @access private
  *
  * @param string                               $content  Serialized content.
- * @param WP_Block_Template|WP_Post|array|null $context  A block template, template part, `wp_navigation` post object,
+ * @param WP_Block_Template|WP_Post|array|null $context  A block template, template part, post object,
  *                                                       or pattern that the blocks belong to. If set to `null`, the
  *                                                       current post is used.
  *                                                       Default: `null`.
@@ -1339,7 +1339,7 @@ function insert_hooked_blocks_into_rest_response( $response, $post ) {
  * @access private
  *
  * @param array                           $hooked_blocks An array of blocks hooked to another given block.
- * @param WP_Block_Template|WP_Post|array $context       A block template, template part, `wp_navigation` post object,
+ * @param WP_Block_Template|WP_Post|array $context       A block template, template part, post object,
  *                                                       or pattern that the blocks belong to.
  * @param callable                        $callback      A function that will be called for each block to generate
  *                                                       the markup for a given list of blocks that are hooked to it.
@@ -1396,7 +1396,7 @@ function make_before_block_visitor( $hooked_blocks, $context, $callback = 'inser
  * @access private
  *
  * @param array                           $hooked_blocks An array of blocks hooked to another block.
- * @param WP_Block_Template|WP_Post|array $context       A block template, template part, `wp_navigation` post object,
+ * @param WP_Block_Template|WP_Post|array $context       A block template, template part, post object,
  *                                                       or pattern that the blocks belong to.
  * @param callable                        $callback      A function that will be called for each block to generate
  *                                                       the markup for a given list of blocks that are hooked to it.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1318,8 +1318,19 @@ function insert_hooked_blocks_into_rest_response( $response, $post ) {
 
 	$response->data['content']['raw'] = $content;
 
+	// No need to inject hooked blocks twice.
+	$priority = has_filter( 'the_content', 'apply_block_hooks_to_content' );
+	if ( false !== $priority ) {
+		remove_filter( 'the_content', 'apply_block_hooks_to_content', $priority );
+	}
+
 	/** This filter is documented in wp-includes/post-template.php */
 	$response->data['content']['rendered'] = apply_filters( 'the_content', $content );
+
+	// Add back the filter.
+	if ( false !== $priority ) {
+		add_filter( 'the_content', 'apply_block_hooks_to_content', $priority );
+	}
 
 	return $response;
 }

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1039,7 +1039,7 @@ function set_ignored_hooked_blocks_metadata( &$parsed_anchor_block, $relative_po
  *
  * @since 6.6.0
  * @since 6.7.0 Injects the `theme` attribute into Template Part blocks, even if no hooked blocks are registered.
- * @since 6.8.0 Have the `$context` parameter default to `null`, in which case the current post will be used.
+ * @since 6.8.0 Have the `$context` parameter default to `null`, in which case `get_post()` will be called to use the current post as context.
  * @access private
  *
  * @param string                               $content  Serialized content.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1296,22 +1296,17 @@ function insert_hooked_blocks_into_rest_response( $response, $post ) {
 		);
 	}
 
-	$post_type_to_wrapper_block_mappings = array(
-		'wp_navigation' => 'core/navigation',
-		'wp_post'       => 'core/post-content',
-	);
-
-	if ( isset( $post_type_to_wrapper_block_mappings[ $post->post_type ] ) ) {
-		$wrapper_block_type = $post_type_to_wrapper_block_mappings[ $post->post_type ];
-
-		$content = get_comment_delimited_block_content(
-			$wrapper_block_type,
-			$attributes,
-			$response->data['content']['raw']
-		);
+	if ( 'wp_navigation' === $post->post_type ) {
+		$wrapper_block_type = 'core/navigation';
 	} else {
-		$content = $response->data['content']['raw'];
+		$wrapper_block_type = 'core/post-content';
 	}
+
+	$content = get_comment_delimited_block_content(
+		$wrapper_block_type,
+		$attributes,
+		$response->data['content']['raw']
+	);
 
 	$content = apply_block_hooks_to_content(
 		$content,
@@ -1319,10 +1314,8 @@ function insert_hooked_blocks_into_rest_response( $response, $post ) {
 		'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata'
 	);
 
-	if ( isset( $post_type_to_wrapper_block_mappings[ $post->post_type ] ) ) {
-		// Remove mock block wrapper.
-		$content = remove_serialized_parent_block( $content );
-	}
+	// Remove mock block wrapper.
+	$content = remove_serialized_parent_block( $content );
 
 	$response->data['content']['raw'] = $content;
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1274,7 +1274,7 @@ function insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata( &$parsed_a
 }
 
 /**
- * Hooks into the REST API response for the core/navigation block and adds the first and last inner blocks.
+ * Hooks into the REST API response for the Posts endpoint and adds the first and last inner blocks.
  *
  * @since 6.6.0
  *

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1313,7 +1313,11 @@ function insert_hooked_blocks_into_rest_response( $response, $post ) {
 		$content = $response->data['content']['raw'];
 	}
 
-	$content = apply_block_hooks_to_content( $content, $post );
+	$content = apply_block_hooks_to_content(
+		$content,
+		$post,
+		'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata'
+	);
 
 	if ( isset( $post_type_to_wrapper_block_mappings[ $post->post_type ] ) ) {
 		// Remove mock block wrapper.

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -763,8 +763,9 @@ add_filter( 'rest_pre_insert_wp_template_part', 'inject_ignored_hooked_blocks_me
 // Update ignoredHookedBlocks postmeta for wp_navigation post type.
 add_filter( 'rest_pre_insert_wp_navigation', 'update_ignored_hooked_blocks_postmeta' );
 
-// Inject hooked blocks into the post and wp_navigation post type REST response.
-add_filter( 'rest_prepare_wp_navigation', 'insert_hooked_blocks_into_rest_response', 10, 2 );
+// Inject hooked blocks into the Posts endpoint REST response for some given post types.
+add_filter( 'rest_prepare_page', 'insert_hooked_blocks_into_rest_response', 10, 2 );
 add_filter( 'rest_prepare_post', 'insert_hooked_blocks_into_rest_response', 10, 2 );
+add_filter( 'rest_prepare_wp_navigation', 'insert_hooked_blocks_into_rest_response', 10, 2 );
 
 unset( $filter, $action );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -763,7 +763,8 @@ add_filter( 'rest_pre_insert_wp_template_part', 'inject_ignored_hooked_blocks_me
 // Update ignoredHookedBlocks postmeta for wp_navigation post type.
 add_filter( 'rest_pre_insert_wp_navigation', 'update_ignored_hooked_blocks_postmeta' );
 
-// Inject hooked blocks into the wp_navigation post type REST response.
+// Inject hooked blocks into the post and wp_navigation post type REST response.
 add_filter( 'rest_prepare_wp_navigation', 'insert_hooked_blocks_into_rest_response', 10, 2 );
+add_filter( 'rest_prepare_post', 'insert_hooked_blocks_into_rest_response', 10, 2 );
 
 unset( $filter, $action );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -761,6 +761,8 @@ add_filter( 'rest_pre_insert_wp_template', 'inject_ignored_hooked_blocks_metadat
 add_filter( 'rest_pre_insert_wp_template_part', 'inject_ignored_hooked_blocks_metadata_attributes' );
 
 // Update ignoredHookedBlocks postmeta for wp_navigation post type.
+add_filter( 'rest_pre_insert_page', 'update_ignored_hooked_blocks_postmeta' );
+add_filter( 'rest_pre_insert_post', 'update_ignored_hooked_blocks_postmeta' );
 add_filter( 'rest_pre_insert_wp_navigation', 'update_ignored_hooked_blocks_postmeta' );
 
 // Inject hooked blocks into the Posts endpoint REST response for some given post types.

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -192,6 +192,7 @@ add_filter( 'the_title', 'wptexturize' );
 add_filter( 'the_title', 'convert_chars' );
 add_filter( 'the_title', 'trim' );
 
+add_filter( 'the_content', 'apply_block_hooks_to_post_content', 8 ); // BEFORE do_blocks().
 add_filter( 'the_content', 'do_blocks', 9 );
 add_filter( 'the_content', 'wptexturize' );
 add_filter( 'the_content', 'convert_smilies', 20 );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -192,7 +192,7 @@ add_filter( 'the_title', 'wptexturize' );
 add_filter( 'the_title', 'convert_chars' );
 add_filter( 'the_title', 'trim' );
 
-add_filter( 'the_content', 'apply_block_hooks_to_post_content', 8 ); // BEFORE do_blocks().
+add_filter( 'the_content', 'apply_block_hooks_to_content', 8 ); // BEFORE do_blocks().
 add_filter( 'the_content', 'do_blocks', 9 );
 add_filter( 'the_content', 'wptexturize' );
 add_filter( 'the_content', 'convert_smilies', 20 );

--- a/tests/phpunit/tests/blocks/applyBlockHooksToContent.php
+++ b/tests/phpunit/tests/blocks/applyBlockHooksToContent.php
@@ -92,6 +92,26 @@ class Tests_Blocks_ApplyBlockHooksToContent extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 61074
+	 */
+	public function test_apply_block_hooks_to_content_with_context_set_to_null() {
+		$content = '<!-- wp:tests/anchor-block /-->';
+
+		/*
+		 * apply_block_hooks_to_content() will fall back to the global $post object (via get_post())
+		 * if the $context parameter is null. However, we'd also like to ensure that the function
+		 * works as expected even when get_post() returns null.
+		 */
+		$this->assertNull( get_post() );
+
+		$actual = apply_block_hooks_to_content( $content, null, 'insert_hooked_blocks' );
+		$this->assertSame(
+			'<!-- wp:tests/anchor-block /--><!-- wp:tests/hooked-block /-->',
+			$actual
+		);
+	}
+
+	/**
 	 * @ticket 61902
 	 */
 	public function test_apply_block_hooks_to_content_respect_multiple_false() {


### PR DESCRIPTION
## Why does this work? And how?

It works the same way as in templates:
- If a post is loaded on the frontend, Block Hooks will be applied to the post content, thus inserting hooked blocks.
- If it is loaded in the editor, the Posts endpoint will inject both the hooked blocks, and the `ignoredHookedBlocks` metadata (into anchor blocks).
- This means that if the post is modified in the editor -- including moving or deleting of hooked blocks -- it will have that `ignoredHookedBlocks` metadata on individual anchor blocks persisted when saving.
- Thus, when loading the post again on the frontend, no hooked blocks will be inserted next to anchor blocks that list them in their `ignoredHookedBlocks`. OTOH, any hooked blocks that were present when saving the post have now simply become part of the markup.

## Testing Instructions, Part One

Start by installing the following plugin, but **do not activate it yet**:

<details>
<summary>Plugin code</summary>

```php
<?php
/**
 * Plugin Name:       Insert Separator blocks Before Headings.
 * Description:       Block Hooks demo plugin that inserts Separator blocks before Heading blocks.
 * Version:           0.1.0
 * Requires at least: 6.7
 */

defined( 'ABSPATH' ) || exit;

function insert_separators_before_headings( $hooked_blocks, $position, $anchor_block, $context ) {
	if ( ! $context instanceof WP_Post ) {
		return $hooked_blocks;
	}

	if ( $anchor_block === 'core/heading' && $position === 'before' ) {
		$hooked_blocks[] = 'core/separator';
	}

	return $hooked_blocks;
}
add_filter( 'hooked_block_types', 'insert_separators_before_headings', 10, 4 );

function set_separator_block_inner_html( $hooked_block, $hooked_block_type, $relative_position, $anchor_block ) {
	if ( $anchor_block['blockName'] === 'core/heading' && 'before' === $relative_position ) {
        $hooked_block['innerContent'] = array( '<hr class="wp-block-separator has-alpha-channel-opacity"/>' );
	}

	return $hooked_block;
}
add_filter( 'hooked_block_core/separator', 'set_separator_block_inner_html', 10, 4 );
```
</details>

- Create a new post that contains a number of headings and paragraphs.
- Save that post, and view it on the frontend. Keep it open in a tab.
- Activate the plugin.
- Go back to the tab with the post (on the frontend). Reload.
- Verify that before each heading, a separator (i.e. a horizontal line) has been inserted.
- Open the post in the editor, and verify that the separators are also present there.
- Modify the separators -- e.g. move one of them around and delete another. Save the post again.
- Reload it on the frontend again. Verify that the changes you made in the editor are respected.

## Screenshots or screencast

![block-hooks-post-content](https://github.com/user-attachments/assets/d52fd019-00d1-4c39-a3fb-176521ac4f17)

## Testing Instructions, Part Two

_Edit: The behavior covered by the following testing instructions changed after I wrote them, as @sirreal  noticed [here](https://github.com/WordPress/wordpress-develop/pull/7898#issuecomment-2535535295). We ended up deciding that the new behavior -- where hooked blocks would _not_ be inserted if the anchor block was added after the post was added might be preferable, see [this comment](https://github.com/WordPress/gutenberg/pull/67272#issuecomment-2539029074) on the companion GB PR._

- ~Now edit the post, and insert another heading at the bottom. _Note that no separator is inserted at the client side "right away"_ -- the reason is that Block Hooks are almost exclusively handled on the server side. This is one minor UX inconsistency -- the same inconsistency is present in templates.~
- ~Save the post, and reload it on the frontend. Note that a separator has now been inserted before the newly added heading!~ ✨
- ~Finally, reload the post in the editor. Note that the separator is now also present there.~

## Screenshots or screencast, Part Two

![block-hooks-post-content-additonal-block](https://github.com/user-attachments/assets/45700aa9-7b62-41ea-becd-6f13675e4ccf)

---

Trac ticket: https://core.trac.wordpress.org/ticket/61074

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
