### PR TITLE
Fixed rtrim() Passing null to parameter PHP deprecated Error

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2816,7 +2816,7 @@ function trailingslashit( $value ) {
  * @return string String without the trailing slashes.
  */
 function untrailingslashit( $value ) {
-	return rtrim( $value, '/\\' );
+	return ! empty( $value ) && is_string( $value ) ? rtrim( $value, '/\\' ) : '';
 }
 
 /**

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2816,7 +2816,7 @@ function trailingslashit( $value ) {
  * @return string String without the trailing slashes.
  */
 function untrailingslashit( $value ) {
-	return ! empty( $value ) && is_string( $value ) ? rtrim( $value, '/\\' ) : '';
+	return ! empty( $value ) ? rtrim( $value, '/\\' ) : $value;
 }
 
 /**


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/62586

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
