### PR TITLE
WP_Block_Styles_Registry: Add a fallback if the label is missing

### DIFF
--- a/src/wp-includes/class-wp-block-styles-registry.php
+++ b/src/wp-includes/class-wp-block-styles-registry.php
@@ -93,6 +93,11 @@ final class WP_Block_Styles_Registry {
 		$block_style_name = $style_properties['name'];
 		$block_names      = is_string( $block_name ) ? array( $block_name ) : $block_name;
 
+		// Ensure there is a label defined.
+		if ( empty( $style_properties['label'] ) ) {
+			$style_properties['label'] = $block_style_name;
+		}
+
 		foreach ( $block_names as $name ) {
 			if ( ! isset( $this->registered_block_styles[ $name ] ) ) {
 				$this->registered_block_styles[ $name ] = array();


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/52592

Both the name and label properties are required when registering a block style. If the label is missing, assign the name as the value for the label, to ensure that the label is defined.

Testing instructions:
With WP_DEBUG and WP_DEBUG_DISPLAY enabled:

Register an incomplete block style in a theme or plugin file using `register_block_style.`

```
register_block_style(
    'core/quote',
    array(
        'name'           => 'test',
        'inline_style' => '.wp-block-quote.is-style-blue-quote { color: blue; }',
    )
);
```

Open the block editor. Confirm that there is no PHP warning about the label being undefined.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
