### PR TITLE
REST API: Add support for search_columns argument to the REST API

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -257,6 +257,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 	 * Retrieves all users.
 	 *
 	 * @since 4.7.0
+	 * @since 6.8.0 Added support for the search_columns query param.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -331,7 +331,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			if ( ! current_user_can( 'list_users' ) ) {
 				$prepared_args['search_columns'] = array( 'ID', 'user_login', 'user_nicename', 'display_name' );
 			}
-			$search_columns = $request->get_param( 'search_columns' );
+			$search_columns         = $request->get_param( 'search_columns' );
 			$valid_columns          = isset( $prepared_args['search_columns'] )
 				? $prepared_args['search_columns']
 				: array( 'ID', 'user_login', 'user_nicename', 'user_email', 'display_name' );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -331,6 +331,27 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			if ( ! current_user_can( 'list_users' ) ) {
 				$prepared_args['search_columns'] = array( 'ID', 'user_login', 'user_nicename', 'display_name' );
 			}
+			$search_columns = $request->get_param( 'search_columns' );
+			$valid_columns          = isset( $prepared_args['search_columns'] )
+				? $prepared_args['search_columns']
+				: array( 'ID', 'user_login', 'user_nicename', 'user_email', 'display_name' );
+			$search_columns_mapping = array(
+				'id'       => 'ID',
+				'username' => 'user_login',
+				'slug'     => 'user_nicename',
+				'email'    => 'user_email',
+				'name'     => 'display_name',
+			);
+			$search_columns         = array_map(
+				static function ( $column ) use ( $search_columns_mapping ) {
+					return $search_columns_mapping[ $column ];
+				},
+				$search_columns
+			);
+			$search_columns         = array_intersect( $search_columns, $valid_columns );
+			if ( ! empty( $search_columns ) ) {
+				$prepared_args['search_columns'] = $search_columns;
+			}
 			$prepared_args['search'] = '*' . $prepared_args['search'] . '*';
 		}
 		/**
@@ -1605,6 +1626,16 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			'items'       => array(
 				'type' => 'string',
 				'enum' => get_post_types( array( 'show_in_rest' => true ), 'names' ),
+			),
+		);
+
+		$query_params['search_columns'] = array(
+			'default'     => array(),
+			'description' => __( 'Array of column names to be searched.' ),
+			'type'        => 'array',
+			'items'       => array(
+				'enum' => array( 'email', 'name', 'id', 'username', 'slug' ),
+				'type' => 'string',
 			),
 		);
 

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -212,6 +212,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 				'search',
 				'slug',
 				'who',
+				'search_columns',
 				'has_published_posts',
 			),
 			$keys
@@ -710,6 +711,37 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		wp_set_current_user( self::$editor );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertCount( 0, $response->get_data() );
+	}
+
+	public function test_get_items_search_columns() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
+		$request->set_param( 'search', 'yololololo' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertCount( 0, $response->get_data() );
+
+		$yolo_id = self::factory()->user->create( array(
+			'display_name' => 'Adam',
+			'user_email'   => 'yololololo@example.localhost'
+		) );
+
+		wp_set_current_user( self::$user );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
+		$request->set_param( 'search', 'yololololo' );
+		$request->set_param( 'search_columns', 'email' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertCount( 1, $response->get_data() );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
+		$request->set_param( 'search', 'yololololo' );
+		$request->set_param( 'search_columns', 'name' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertCount( 0, $response->get_data() );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
+		$request->set_param( 'search', 'Adam' );
+		$request->set_param( 'search_columns', 'name' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertCount( 1, $response->get_data() );
 	}
 
 	public function test_get_items_slug_query() {

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -719,10 +719,12 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertCount( 0, $response->get_data() );
 
-		$yolo_id = self::factory()->user->create( array(
-			'display_name' => 'Adam',
-			'user_email'   => 'yololololo@example.localhost'
-		) );
+		$yolo_id = self::factory()->user->create(
+			array(
+				'display_name' => 'Adam',
+				'user_email'   => 'yololololo@example.localhost',
+			)
+		);
 
 		wp_set_current_user( self::$user );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -713,13 +713,16 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertCount( 0, $response->get_data() );
 	}
 
+	/**
+	 * @ticket 62596
+	 */
 	public function test_get_items_search_columns() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
 		$request->set_param( 'search', 'yololololo' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertCount( 0, $response->get_data() );
 
-		$yolo_id = self::factory()->user->create(
+		self::factory()->user->create(
 			array(
 				'display_name' => 'Adam',
 				'user_email'   => 'yololololo@example.localhost',
@@ -744,6 +747,27 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$request->set_param( 'search_columns', 'name' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertCount( 1, $response->get_data() );
+	}
+
+	/**
+	 * @ticket 62596
+	 */
+	public function test_get_items_search_columns_without_permission() {
+		self::factory()->user->create(
+			array(
+				'display_name' => 'Adam',
+				'user_email'   => 'yololololo@example.localhost',
+			)
+		);
+
+		// Test user without sufficient capabilities - 'list_users'.
+		wp_set_current_user( self::$editor );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
+		$request->set_param( 'search', 'yololololo' );
+		$request->set_param( 'search_columns', 'email' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertCount( 0, $response->get_data() );
 	}
 
 	public function test_get_items_slug_query() {

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -9595,6 +9595,22 @@ mockedApiResponse.Schema = {
                                 }
                             },
                             "required": false
+                        },
+                        "search_columns": {
+                            "default": [],
+                            "description": "Array of column names to be searched.",
+                            "type": "array",
+                            "items": {
+                                "enum": [
+                                    "email",
+                                    "name",
+                                    "id",
+                                    "username",
+                                    "slug"
+                                ],
+                                "type": "string"
+                            },
+                            "required": false
                         }
                     }
                 },


### PR DESCRIPTION
Backports to change originally made in https://github.com/WordPress/gutenberg/pull/67330

This adds support to search_columns to the user controller, mirroring a change that was done in the past for the post controller.

Trac ticket: https://core.trac.wordpress.org/ticket/62596

**Todo**

 - [x] Add unit test.