### PR TITLE
Post Thumbnails: Fix squashed featured image in wp-admin

### DIFF
--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -307,7 +307,6 @@ ul.wp-tab-bar li {
 
 #postimagediv .inside img {
 	max-width: 100%;
-	width: auto;
 	vertical-align: top;
 	background-image: linear-gradient(45deg, #c3c4c7 25%, transparent 25%, transparent 75%, #c3c4c7 75%, #c3c4c7), linear-gradient(45deg, #c3c4c7 25%, transparent 25%, transparent 75%, #c3c4c7 75%, #c3c4c7);
 	background-position: 0 0, 10px 10px;

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -307,6 +307,7 @@ ul.wp-tab-bar li {
 
 #postimagediv .inside img {
 	max-width: 100%;
+	height: auto;
 	vertical-align: top;
 	background-image: linear-gradient(45deg, #c3c4c7 25%, transparent 25%, transparent 75%, #c3c4c7 75%, #c3c4c7), linear-gradient(45deg, #c3c4c7 25%, transparent 25%, transparent 75%, #c3c4c7 75%, #c3c4c7);
 	background-position: 0 0, 10px 10px;

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -307,7 +307,6 @@ ul.wp-tab-bar li {
 
 #postimagediv .inside img {
 	max-width: 100%;
-	height: auto;
 	width: auto;
 	vertical-align: top;
 	background-image: linear-gradient(45deg, #c3c4c7 25%, transparent 25%, transparent 75%, #c3c4c7 75%, #c3c4c7), linear-gradient(45deg, #c3c4c7 25%, transparent 25%, transparent 75%, #c3c4c7 75%, #c3c4c7);


### PR DESCRIPTION
This PR resolves an issue where the featured image appears squashed in the wp-admin post editor.

### Changes:
- Removed the height: auto CSS rule from #postimagediv .inside img.

### Before:
<img src="https://utfs.io/f/PL8E4NiPUWyOw8uAHFBwjlD9K4qhAts3a26Vvd1rSI0xfioP" width="600" />

### After:
<img src="https://utfs.io/f/PL8E4NiPUWyOXFUatYSeCihSp8qN7F5mY1za0TyZAwxIXkeR" width="600" />

Trac ticket: [#62597](https://core.trac.wordpress.org/ticket/62597)