### PR TITLE
HTML API: Use locked tokens to implement safe fragment parsing

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-active-formatting-elements.php
+++ b/src/wp-includes/html-api/class-wp-html-active-formatting-elements.php
@@ -141,6 +141,10 @@ class WP_HTML_Active_Formatting_Elements {
 				continue;
 			}
 
+			if ( $item->locked ) {
+				throw new WP_HTML_Stack_Exception( 'Cannot remove a locked element from the stack of active formatting elements.' );
+			}
+
 			$position_from_start = $this->count() - $position_from_end - 1;
 			array_splice( $this->stack, $position_from_start, 1 );
 			return true;
@@ -220,6 +224,9 @@ class WP_HTML_Active_Formatting_Elements {
 	 */
 	public function clear_up_to_last_marker(): void {
 		foreach ( $this->walk_up() as $item ) {
+			if ( $item->locked ) {
+				throw new WP_HTML_Stack_Exception( 'Cannot clear up to a locked element from the stack of active formatting elements.' );
+			}
 			array_pop( $this->stack );
 			if ( 'marker' === $item->node_name ) {
 				break;

--- a/src/wp-includes/html-api/class-wp-html-open-elements.php
+++ b/src/wp-includes/html-api/class-wp-html-open-elements.php
@@ -515,11 +515,14 @@ class WP_HTML_Open_Elements {
 	 * @return bool Whether a node was popped off of the stack.
 	 */
 	public function pop(): bool {
-		$item = array_pop( $this->stack );
-		if ( null === $item ) {
+		$item = end( $this->stack );
+		if ( ! $item ) {
 			return false;
 		}
-
+		if ( $item->locked ) {
+			throw new WP_HTML_Stack_Exception( 'Cannot pop a locked element from the stack of open elements.' );
+		}
+		array_pop( $this->stack );
 		$this->after_element_pop( $item );
 		return true;
 	}
@@ -583,6 +586,10 @@ class WP_HTML_Open_Elements {
 		foreach ( $this->walk_up() as $position_from_end => $item ) {
 			if ( $token->bookmark_name !== $item->bookmark_name ) {
 				continue;
+			}
+
+			if ( $item->locked ) {
+				throw new WP_HTML_Stack_Exception( 'Cannot remove a locked element from the stack of open elements.' );
 			}
 
 			$position_from_start = $this->count() - $position_from_end - 1;

--- a/src/wp-includes/html-api/class-wp-html-open-elements.php
+++ b/src/wp-includes/html-api/class-wp-html-open-elements.php
@@ -520,7 +520,7 @@ class WP_HTML_Open_Elements {
 			return false;
 		}
 		if ( $item->locked ) {
-			throw new WP_HTML_Stack_Exception( 'Cannot pop a locked element from the stack of open elements.' );
+			throw new WP_HTML_Stack_Exception( 'Cannot remove a locked element from the stack of open elements.' );
 		}
 		array_pop( $this->stack );
 		$this->after_element_pop( $item );

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -589,10 +589,12 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			$fragment_processor->context_node->integration_node_type ? 'html' : $namespace
 		);
 
-		// Advance to the end of the context stack.
+		// Consume activitity from the context stack and clear parsing state.
 		while ( array() !== $fragment_processor->element_queue ) {
 			$fragment_processor->next_token();
 		}
+		$fragment_processor->current_element      = null;
+		$fragment_processor->state->current_token = null;
 
 		return $fragment_processor;
 	}

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -844,7 +844,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 					continue;
 				}
 			} catch ( WP_HTML_Stack_Exception $e ) {
-				// Pop until we reach the context stack.
+				// A fragment processor would reach a context stack and throw here.
 			}
 
 			return empty( $this->element_queue ) ? false : $this->next_visitable_token();
@@ -5540,19 +5540,17 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * When moving backward, stateful stacks should be cleared.
 			 */
 			foreach ( $this->state->stack_of_open_elements->walk_up() as $item ) {
-				try {
-					$this->state->stack_of_open_elements->remove_node( $item );
-				} catch ( WP_HTML_Stack_Exception $e ) {
+				if ( $item->locked ) {
 					break;
 				}
+				$this->state->stack_of_open_elements->remove_node( $item );
 			}
 
 			foreach ( $this->state->active_formatting_elements->walk_up() as $item ) {
-				try {
-					$this->state->active_formatting_elements->remove_node( $item );
-				} catch ( WP_HTML_Stack_Exception $e ) {
+				if ( $item->locked ) {
 					break;
 				}
+				$this->state->active_formatting_elements->remove_node( $item );
 			}
 
 			/*

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -566,6 +566,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			$fragment_processor->state->stack_of_template_insertion_modes[] = WP_HTML_Processor_State::INSERTION_MODE_IN_TEMPLATE;
 		}
 
+		// @todo should there be a seek to the context element here?
 		$fragment_processor->reset_insertion_mode_appropriately();
 
 		/*

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -547,10 +547,15 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		$fragment_processor->context_node = $fragment_context_element;
 
 		foreach ( $this->state->active_formatting_elements->walk_down() as $item ) {
-			$cloned                    = clone $item;
+			$cloned = clone $item;
+			if ( $cloned->bookmark_name === $current_element_bookmark_name ) {
+				$cloned->bookmark_name    = 'context-node';
+				$fragment_context_element = $cloned;
+			} else {
 				$cloned->bookmark_name = null;
-			$cloned->on_destroy        = null;
-			$cloned->locked            = true;
+			}
+			$cloned->on_destroy = null;
+			$cloned->locked     = true;
 
 			$fragment_processor->state->active_formatting_elements->push( $cloned );
 		}
@@ -5540,10 +5545,16 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * When moving backward, stateful stacks should be cleared.
 			 */
 			foreach ( $this->state->stack_of_open_elements->walk_up() as $item ) {
+				if ( 'context-node' === $item->bookmark_name ) {
+					break;
+				}
 				$this->state->stack_of_open_elements->remove_node( $item );
 			}
 
 			foreach ( $this->state->active_formatting_elements->walk_up() as $item ) {
+				if ( 'context-node' === $item->bookmark_name ) {
+					break;
+				}
 				$this->state->active_formatting_elements->remove_node( $item );
 			}
 
@@ -5573,21 +5584,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				parent::seek( 'initial' );
 				unset( $this->bookmarks['initial'] );
 			} else {
-
-				/*
-				 * Push the root-node (HTML) back onto the stack of open elements.
-				 *
-				 * Fragment parsers require this extra bit of setup.
-				 * It's handled in full parsers by advancing the processor state.
-				 */
-				$this->state->stack_of_open_elements->push(
-					new WP_HTML_Token(
-						'root-node',
-						'HTML',
-						false
-					)
-				);
-
 				$this->change_parsing_namespace(
 					$this->context_node->integration_node_type
 						? 'html'
@@ -5599,7 +5595,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				}
 
 				$this->reset_insertion_mode_appropriately();
-				$this->breadcrumbs = array_slice( $this->breadcrumbs, 0, 2 );
 				parent::seek( $this->context_node->bookmark_name );
 			}
 		}

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -529,35 +529,23 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		$fragment_processor->bookmarks['root-node']    = new WP_HTML_Span( 0, 0 );
 		$fragment_processor->bookmarks['context-node'] = new WP_HTML_Span( 0, 0 );
 
-		$current_element_token    = $this->current_element->token;
 		$fragment_context_element = null;
 		foreach ( $this->state->stack_of_open_elements->walk_down() as $item ) {
-			$cloned = clone $item;
-			if ( $cloned->bookmark_name !== 'root-node' ) {
-				$cloned->bookmark_name = null;
-			}
-			if ( $cloned === $current_element_token ) {
-				\sirreal\d( 'got CET', $cloned, $current_element_token );
-				$cloned->bookmark_name = 'context-node';
-			}
-			$cloned->on_destroy = null;
-			$cloned->locked     = true;
-
+			$cloned                = clone $item;
+			$cloned->bookmark_name = null;
+			$cloned->on_destroy    = null;
+			$cloned->locked        = true;
 			$fragment_processor->state->stack_of_open_elements->push( $cloned );
-			if ( $cloned->bookmark_name === 'context-node' ) {
-				$fragment_processor->context_node = $cloned;
-			}
+			$fragment_context_element = $cloned;
 		}
+		$fragment_processor->context_node                = $fragment_context_element;
+		$fragment_processor->context_node->bookmark_name = 'context-node';
+
 		foreach ( $this->state->active_formatting_elements->walk_down() as $item ) {
-			$cloned = clone $item;
-			if ( $cloned->bookmark_name !== 'root-node' ) {
+			$cloned                    = clone $item;
 				$cloned->bookmark_name = null;
-			}
-			if ( $cloned === $current_element_token ) {
-				$cloned->bookmark_name = 'context-node';
-			}
-			$cloned->on_destroy = null;
-			$cloned->locked     = true;
+			$cloned->on_destroy        = null;
+			$cloned->locked            = true;
 
 			$fragment_processor->state->active_formatting_elements->push( $cloned );
 		}
@@ -592,7 +580,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		 * elements does not change the parsing namespace.
 		 */
 		$fragment_processor->change_parsing_namespace(
-			$current_element_token->integration_node_type ? 'html' : $namespace
+			$fragment_processor->context_node->integration_node_type ? 'html' : $namespace
 		);
 
 		return $fragment_processor;

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1095,80 +1095,84 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 		);
 
 		try {
-			if ( ! $parse_in_current_insertion_mode ) {
-				return $this->step_in_foreign_content();
-			}
+			try {
+				if ( ! $parse_in_current_insertion_mode ) {
+					return $this->step_in_foreign_content();
+				}
 
-			switch ( $this->state->insertion_mode ) {
-				case WP_HTML_Processor_State::INSERTION_MODE_INITIAL:
-					return $this->step_initial();
+				switch ( $this->state->insertion_mode ) {
+					case WP_HTML_Processor_State::INSERTION_MODE_INITIAL:
+						return $this->step_initial();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_BEFORE_HTML:
-					return $this->step_before_html();
+					case WP_HTML_Processor_State::INSERTION_MODE_BEFORE_HTML:
+						return $this->step_before_html();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_BEFORE_HEAD:
-					return $this->step_before_head();
+					case WP_HTML_Processor_State::INSERTION_MODE_BEFORE_HEAD:
+						return $this->step_before_head();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_IN_HEAD:
-					return $this->step_in_head();
+					case WP_HTML_Processor_State::INSERTION_MODE_IN_HEAD:
+						return $this->step_in_head();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_IN_HEAD_NOSCRIPT:
-					return $this->step_in_head_noscript();
+					case WP_HTML_Processor_State::INSERTION_MODE_IN_HEAD_NOSCRIPT:
+						return $this->step_in_head_noscript();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_AFTER_HEAD:
-					return $this->step_after_head();
+					case WP_HTML_Processor_State::INSERTION_MODE_AFTER_HEAD:
+						return $this->step_after_head();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_IN_BODY:
-					return $this->step_in_body();
+					case WP_HTML_Processor_State::INSERTION_MODE_IN_BODY:
+						return $this->step_in_body();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_IN_TABLE:
-					return $this->step_in_table();
+					case WP_HTML_Processor_State::INSERTION_MODE_IN_TABLE:
+						return $this->step_in_table();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_IN_TABLE_TEXT:
-					return $this->step_in_table_text();
+					case WP_HTML_Processor_State::INSERTION_MODE_IN_TABLE_TEXT:
+						return $this->step_in_table_text();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_IN_CAPTION:
-					return $this->step_in_caption();
+					case WP_HTML_Processor_State::INSERTION_MODE_IN_CAPTION:
+						return $this->step_in_caption();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_IN_COLUMN_GROUP:
-					return $this->step_in_column_group();
+					case WP_HTML_Processor_State::INSERTION_MODE_IN_COLUMN_GROUP:
+						return $this->step_in_column_group();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_IN_TABLE_BODY:
-					return $this->step_in_table_body();
+					case WP_HTML_Processor_State::INSERTION_MODE_IN_TABLE_BODY:
+						return $this->step_in_table_body();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_IN_ROW:
-					return $this->step_in_row();
+					case WP_HTML_Processor_State::INSERTION_MODE_IN_ROW:
+						return $this->step_in_row();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_IN_CELL:
-					return $this->step_in_cell();
+					case WP_HTML_Processor_State::INSERTION_MODE_IN_CELL:
+						return $this->step_in_cell();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_IN_SELECT:
-					return $this->step_in_select();
+					case WP_HTML_Processor_State::INSERTION_MODE_IN_SELECT:
+						return $this->step_in_select();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_IN_SELECT_IN_TABLE:
-					return $this->step_in_select_in_table();
+					case WP_HTML_Processor_State::INSERTION_MODE_IN_SELECT_IN_TABLE:
+						return $this->step_in_select_in_table();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_IN_TEMPLATE:
-					return $this->step_in_template();
+					case WP_HTML_Processor_State::INSERTION_MODE_IN_TEMPLATE:
+						return $this->step_in_template();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_AFTER_BODY:
-					return $this->step_after_body();
+					case WP_HTML_Processor_State::INSERTION_MODE_AFTER_BODY:
+						return $this->step_after_body();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_IN_FRAMESET:
-					return $this->step_in_frameset();
+					case WP_HTML_Processor_State::INSERTION_MODE_IN_FRAMESET:
+						return $this->step_in_frameset();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_AFTER_FRAMESET:
-					return $this->step_after_frameset();
+					case WP_HTML_Processor_State::INSERTION_MODE_AFTER_FRAMESET:
+						return $this->step_after_frameset();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_AFTER_AFTER_BODY:
-					return $this->step_after_after_body();
+					case WP_HTML_Processor_State::INSERTION_MODE_AFTER_AFTER_BODY:
+						return $this->step_after_after_body();
 
-				case WP_HTML_Processor_State::INSERTION_MODE_AFTER_AFTER_FRAMESET:
-					return $this->step_after_after_frameset();
+					case WP_HTML_Processor_State::INSERTION_MODE_AFTER_AFTER_FRAMESET:
+						return $this->step_after_after_frameset();
 
-				// This should be unreachable but PHP doesn't have total type checking on switch.
-				default:
-					$this->bail( "Unaware of the requested parsing mode: '{$this->state->insertion_mode}'." );
+					// This should be unreachable but PHP doesn't have total type checking on switch.
+					default:
+						$this->bail( "Unaware of the requested parsing mode: '{$this->state->insertion_mode}'." );
+				}
+			} catch ( WP_HTML_Stack_Exception $e ) {
+				$this->bail( $e->getMessage() );
 			}
 		} catch ( WP_HTML_Unsupported_Exception $e ) {
 			/*

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -279,24 +279,44 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * form is provided because a context element may have attributes that
 	 * impact the parse, such as with a SCRIPT tag and its `type` attribute.
 	 *
-	 * ## Current HTML Support
+	 * Example:
 	 *
-	 *  - The only supported context is `<body>`, which is the default value.
-	 *  - The only supported document encoding is `UTF-8`, which is the default value.
+	 *     // Usually, snippets of HTML ought to be processed in the default `<body>` context:
+	 *     $processor = WP_HTML_Processor::create_fragment( '<p>Hi</p>' );
+	 *
+	 *     // Some fragments should be processed in the correct context like this SVG:
+	 *     $processor = WP_HTML_Processor::create_fragment( '<rect width="10" height="10" />', '<svg>' );
+	 *
+	 *     // This fragment with TD tags should be processed in a TR context:
+	 *     $processor = WP_HTML_Processor::create_fragment(
+	 *         '<td>1<td>2<td>3',
+	 *         '<table><tbody><tr>'
+	 *     );
+	 *
+	 * In order to create a fragment processor at the correct location, the
+	 * provided fragment will be processed as part of a full HTML document.
+	 * The processor will search for the last opener tag in the document and
+	 * create a fragment processor at that location. The document will be
+	 * forced into "no-quirks" mode by including the HTML5 doctype.
+	 *
+	 * For advanced usage and precise control over the context element, use
+	 * `WP_HTML_Processor::create_full_processor()` and
+	 * `WP_HTML_Processor::create_fragment_at_current_node()`.
+	 *
+	 * UTF-8 is the only allowed encoding. If working with a document that
+	 * isn't UTF-8, first convert the document to UTF-8, then pass in the
+	 * converted HTML.
 	 *
 	 * @since 6.4.0
 	 * @since 6.6.0 Returns `static` instead of `self` so it can create subclass instances.
+	 * @since 6.8.0 Can create fragments with any context element.
 	 *
 	 * @param string $html     Input HTML fragment to process.
-	 * @param string $context  Context element for the fragment, must be default of `<body>`.
+	 * @param string $context  Context element for the fragment. Defaults to `<body>`.
 	 * @param string $encoding Text encoding of the document; must be default of 'UTF-8'.
 	 * @return static|null The created processor if successful, otherwise null.
 	 */
 	public static function create_fragment( $html, $context = '<body>', $encoding = 'UTF-8' ) {
-		if ( '<body>' !== $context || 'UTF-8' !== $encoding ) {
-			return null;
-		}
-
 		$context_processor = static::create_full_parser( "<!DOCTYPE html>{$context}", $encoding );
 		if ( null === $context_processor ) {
 			return null;
@@ -455,7 +475,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @param string $html Input HTML fragment to process.
 	 * @return static|null The created processor if successful, otherwise null.
 	 */
-	private function create_fragment_at_current_node( string $html ) {
+	public function create_fragment_at_current_node( string $html ) {
 		if ( $this->get_token_type() !== '#tag' || $this->is_tag_closer() ) {
 			_doing_it_wrong(
 				__METHOD__,

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -5540,11 +5540,19 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			 * When moving backward, stateful stacks should be cleared.
 			 */
 			foreach ( $this->state->stack_of_open_elements->walk_up() as $item ) {
-				$this->state->stack_of_open_elements->remove_node( $item );
+				try {
+					$this->state->stack_of_open_elements->remove_node( $item );
+				} catch ( WP_HTML_Stack_Exception $e ) {
+					break;
+				}
 			}
 
 			foreach ( $this->state->active_formatting_elements->walk_up() as $item ) {
-				$this->state->active_formatting_elements->remove_node( $item );
+				try {
+					$this->state->active_formatting_elements->remove_node( $item );
+				} catch ( WP_HTML_Stack_Exception $e ) {
+					break;
+				}
 			}
 
 			/*

--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -236,15 +236,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	private $breadcrumbs = array();
 
 	/**
-	 * Stores the context breadcrumbs.
-	 *
-	 * @since 6.7.0
-	 *
-	 * @var string[]|null
-	 */
-	private $context_breadcrumbs = null;
-
-	/**
 	 * Current stack event, if set, representing a matched token.
 	 *
 	 * Because the parser may internally point to a place further along in a document
@@ -607,9 +598,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			$fragment_processor->next_token();
 		}
 
-		$fragment_processor->context_breadcrumbs = $fragment_processor->breadcrumbs;
-		$fragment_processor->breadcrumbs         = array();
-
 		return $fragment_processor;
 	}
 
@@ -968,9 +956,8 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			return false;
 		}
 
-		$breadcrumbs = $this->get_breadcrumbs();
-		for ( $i = count( $breadcrumbs ) - 1; $i >= 0; $i-- ) {
-			$node  = $breadcrumbs[ $i ];
+		for ( $i = count( $this->breadcrumbs ) - 1; $i >= 0; $i-- ) {
+			$node  = $this->breadcrumbs[ $i ];
 			$crumb = strtoupper( current( $breadcrumbs ) );
 
 			if ( '*' !== $crumb && $node !== $crumb ) {
@@ -1222,9 +1209,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @return string[]|null Array of tag names representing path to matched node, if matched, otherwise NULL.
 	 */
 	public function get_breadcrumbs(): ?array {
-		return null === $this->context_breadcrumbs
-			? $this->breadcrumbs
-			: array_merge( $this->context_breadcrumbs, $this->breadcrumbs );
+		return $this->breadcrumbs;
 	}
 
 	/**
@@ -1253,7 +1238,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @return int Nesting-depth of current location in the document.
 	 */
 	public function get_current_depth(): int {
-		return count( $this->get_breadcrumbs() );
+		return count( $this->breadcrumbs );
 	}
 
 	/**
@@ -5585,7 +5570,6 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			$this->state->current_token                     = null;
 			$this->current_element                          = null;
 			$this->element_queue                            = array();
-			$this->breadcrumbs                              = array();
 
 			/*
 			 * The absence of a context node indicates a full parse.
@@ -5594,6 +5578,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			if ( null === $this->context_node ) {
 				$this->change_parsing_namespace( 'html' );
 				$this->state->insertion_mode = WP_HTML_Processor_State::INSERTION_MODE_INITIAL;
+				$this->breadcrumbs           = array();
 
 				$this->bookmarks['initial'] = new WP_HTML_Span( 0, 0 );
 				parent::seek( 'initial' );

--- a/src/wp-includes/html-api/class-wp-html-token.php
+++ b/src/wp-includes/html-api/class-wp-html-token.php
@@ -86,6 +86,13 @@ class WP_HTML_Token {
 	public $on_destroy = null;
 
 	/**
+	 * The token can be locked to prevent it from being removed from a stack.
+	 *
+	 * @var bool
+	 */
+	public $locked = false;
+
+	/**
 	 * Constructor - creates a reference to a token in some external HTML string.
 	 *
 	 * @since 6.4.0

--- a/src/wp-includes/html-api/class-wp-html-unsupported-exception.php
+++ b/src/wp-includes/html-api/class-wp-html-unsupported-exception.php
@@ -113,3 +113,8 @@ class WP_HTML_Unsupported_Exception extends Exception {
 		$this->active_formatting_elements = $active_formatting_elements;
 	}
 }
+
+// @todo file for the class
+// phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound
+class WP_HTML_Stack_Exception extends Exception {
+}

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorFragmentParsing.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorFragmentParsing.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Unit tests covering WP_HTML_Processor fragment parsing functionality.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ *
+ * @since 6.8.0
+ *
+ * @group html-api
+ *
+ * @coversDefaultClass WP_HTML_Processor
+ */
+class Tests_HtmlApi_WpHtmlProcessorFragmentParsing extends WP_UnitTestCase {
+	/**
+	 * @ticket 62357
+	 */
+	public function test_create_fragment_at_current_node_in_foreign_content() {
+		$processor = WP_HTML_Processor::create_full_parser( '<svg>' );
+		$this->assertTrue( $processor->next_tag( 'SVG' ) );
+
+		$fragment = $processor->create_fragment_at_current_node( "\0preceded-by-nul-byte<rect /><circle></circle><foreignobject><div></div></foreignobject><g>" );
+
+		$this->assertSame( 'svg', $fragment->get_namespace() );
+		$this->assertTrue( $fragment->next_token() );
+
+		/*
+		 * In HTML parsing, a nul byte would be ignored.
+		 * In SVG it should be replaced with a replacement character.
+		 */
+		$this->assertSame( '#text', $fragment->get_token_type() );
+		$this->assertSame( "\u{FFFD}", $fragment->get_modifiable_text() );
+
+		$this->assertTrue( $fragment->next_tag( 'RECT' ) );
+		$this->assertSame( 'svg', $fragment->get_namespace() );
+
+		$this->assertTrue( $fragment->next_tag( 'CIRCLE' ) );
+		$this->assertSame( array( 'HTML', 'SVG', 'CIRCLE' ), $fragment->get_breadcrumbs() );
+		$this->assertTrue( $fragment->next_tag( 'foreignObject' ) );
+		$this->assertSame( 'svg', $fragment->get_namespace() );
+	}
+
+	/**
+	 * @ticket 62357
+	 */
+	public function test_create_fragment_at_current_node_in_foreign_content_integration_point() {
+		$processor = WP_HTML_Processor::create_full_parser( '<svg><foreignObject>' );
+		$this->assertTrue( $processor->next_tag( 'foreignObject' ) );
+
+		$fragment = $processor->create_fragment_at_current_node( "<image>\0not-preceded-by-nul-byte<rect />" );
+
+		// Nothing has been processed, the html namespace should be used for parsing as an integration point.
+		$this->assertSame( 'html', $fragment->get_namespace() );
+
+		// HTML parsing transforms IMAGE into IMG.
+		$this->assertTrue( $fragment->next_tag( 'IMG' ) );
+
+		$this->assertTrue( $fragment->next_token() );
+
+		// In HTML parsing, the nul byte is ignored and the text is reached.
+		$this->assertSame( '#text', $fragment->get_token_type() );
+		$this->assertSame( 'not-preceded-by-nul-byte', $fragment->get_modifiable_text() );
+
+		/*
+		 * svg:foreignObject is an HTML integration point, so the processor should be in the HTML namespace.
+		 * RECT is an HTML element here, meaning it may have the self-closing flag but does not self-close.
+		 */
+		$this->assertTrue( $fragment->next_tag( 'RECT' ) );
+		$this->assertSame( array( 'HTML', 'FOREIGNOBJECT', 'RECT' ), $fragment->get_breadcrumbs() );
+		$this->assertSame( 'html', $fragment->get_namespace() );
+		$this->assertTrue( $fragment->has_self_closing_flag() );
+		$this->assertTrue( $fragment->expects_closer() );
+	}
+
+	/**
+	 * @expectedIncorrectUsage WP_HTML_Processor::create_fragment_at_current_node
+	 * @ticket 62357
+	 */
+	public function test_prevent_fragment_creation_on_closers() {
+		$processor = WP_HTML_Processor::create_full_parser( '<p></p>' );
+		$processor->next_tag( 'P' );
+		$processor->next_tag(
+			array(
+				'tag_name'    => 'P',
+				'tag_closers' => 'visit',
+			)
+		);
+		$this->assertSame( 'P', $processor->get_tag() );
+		$this->assertTrue( $processor->is_tag_closer() );
+		$this->assertNull( $processor->create_fragment_at_current_node( '<i>fragment HTML</i>' ) );
+	}
+
+	/**
+	 * Verifies that the fragment parser doesn't allow invalid context nodes.
+	 *
+	 * This includes void elements and self-contained elements because they can
+	 * contain no inner HTML. Operations on self-contained elements should occur
+	 * through methods such as {@see WP_HTML_Tag_Processor::set_modifiable_text}.
+	 *
+	 * @ticket 62584
+	 *
+	 * @dataProvider data_invalid_fragment_contexts
+	 *
+	 * @param string $context Invalid context node for fragment parser.
+	 */
+	public function test_rejects_invalid_fragment_contexts( string $context, string $doing_it_wrong_method_name ) {
+		$this->setExpectedIncorrectUsage( "WP_HTML_Processor::{$doing_it_wrong_method_name}" );
+		$this->assertNull(
+			WP_HTML_Processor::create_fragment( 'just a test', $context ),
+			"Should not have been able to create a fragment parser with context node {$context}"
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public static function data_invalid_fragment_contexts() {
+		return array(
+			/*
+			 * Invalid contexts.
+			 */
+			/*
+			 * The text node is confused with a virtual body open tag.
+			 * This should fail to set a bookmark in `create_fragment`
+			 * but currently does not, it slips through and fails in
+			 * `create_fragment_at_current_node`.
+			 */
+			'Invalid text'          => array( 'just some text', 'create_fragment_at_current_node' ),
+			'Invalid comment'       => array( '<!-- comment -->', 'create_fragment' ),
+			'Invalid closing'       => array( '</div>', 'create_fragment' ),
+			'Invalid DOCTYPE'       => array( '<!DOCTYPE html>', 'create_fragment' ),
+			/*
+			 * PLAINTEXT should appear in the unsupported elements, but at the
+			 * moment it's completely unsupported by the processor so
+			 * the context element cannot be found.
+			 */
+			'Unsupported PLAINTEXT' => array( '<plaintext>', 'create_fragment' ),
+
+			/*
+			 * Invalid contexts.
+			 */
+			'AREA'                  => array( '<area>', 'create_fragment_at_current_node' ),
+			'BASE'                  => array( '<base>', 'create_fragment_at_current_node' ),
+			'BASEFONT'              => array( '<basefont>', 'create_fragment_at_current_node' ),
+			'BGSOUND'               => array( '<bgsound>', 'create_fragment_at_current_node' ),
+			'BR'                    => array( '<br>', 'create_fragment_at_current_node' ),
+			'COL'                   => array( '<table><colgroup><col>', 'create_fragment_at_current_node' ),
+			'EMBED'                 => array( '<embed>', 'create_fragment_at_current_node' ),
+			'FRAME'                 => array( '<frameset><frame>', 'create_fragment_at_current_node' ),
+			'HR'                    => array( '<hr>', 'create_fragment_at_current_node' ),
+			'IMG'                   => array( '<img>', 'create_fragment_at_current_node' ),
+			'INPUT'                 => array( '<input>', 'create_fragment_at_current_node' ),
+			'KEYGEN'                => array( '<keygen>', 'create_fragment_at_current_node' ),
+			'LINK'                  => array( '<link>', 'create_fragment_at_current_node' ),
+			'META'                  => array( '<meta>', 'create_fragment_at_current_node' ),
+			'PARAM'                 => array( '<param>', 'create_fragment_at_current_node' ),
+			'SOURCE'                => array( '<source>', 'create_fragment_at_current_node' ),
+			'TRACK'                 => array( '<track>', 'create_fragment_at_current_node' ),
+			'WBR'                   => array( '<wbr>', 'create_fragment_at_current_node' ),
+
+			/*
+			 * Unsupported elements. Include a tag closer to ensure the element can be found
+			 * and does not pause the parser at an incomplete token.
+			 */
+			'IFRAME'                => array( '<iframe></iframe>', 'create_fragment_at_current_node' ),
+			'NOEMBED'               => array( '<noembed></noembed>', 'create_fragment_at_current_node' ),
+			'NOFRAMES'              => array( '<noframes></noframes>', 'create_fragment_at_current_node' ),
+			'SCRIPT'                => array( '<script></script>', 'create_fragment_at_current_node' ),
+			'SCRIPT with type'      => array( '<script type="javascript"></script>', 'create_fragment_at_current_node' ),
+			'STYLE'                 => array( '<style></style>', 'create_fragment_at_current_node' ),
+			'TEXTAREA'              => array( '<textarea></textarea>', 'create_fragment_at_current_node' ),
+			'TITLE'                 => array( '<title></title>', 'create_fragment_at_current_node' ),
+			'XMP'                   => array( '<xmp></xmp>', 'create_fragment_at_current_node' ),
+		);
+	}
+}

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorFragmentParsing.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorFragmentParsing.php
@@ -48,10 +48,10 @@ class Tests_HtmlApi_WpHtmlProcessorFragmentParsing extends WP_UnitTestCase {
 		$this->assertTrue( $processor->next_tag( 'foreignObject' ) );
 
 		$fragment = $processor->create_fragment_at_current_node( "<image>\0not-preceded-by-nul-byte<rect />" );
-		$this->assertSame( 'svg', $fragment->get_namespace() );
 
 		// HTML parsing transforms IMAGE into IMG.
 		$this->assertTrue( $fragment->next_tag( 'IMG' ) );
+		$this->assertSame( 'html', $fragment->get_namespace() );
 
 		$this->assertTrue( $fragment->next_token() );
 

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorFragmentParsing.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorFragmentParsing.php
@@ -215,7 +215,8 @@ class Tests_HtmlApi_WpHtmlProcessorFragmentParsing extends WP_UnitTestCase {
 			'OPTION in OPTION'       => array( '<select><option>', '<option>' ),
 			'DIV in SVG'             => array( '<svg>', '<div>' ),
 
-			'Active formatting'      => array( '<div><span><i><i><i></span><div>', '</i>' ),
+			'Active formatting i'    => array( '<div><span><i><i><i></span><div>', '</i>' ),
+			'Active formatting a'    => array( '<div><span><a></span><div>', '</a>' ),
 		);
 	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorFragmentParsing.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorFragmentParsing.php
@@ -191,8 +191,8 @@ class Tests_HtmlApi_WpHtmlProcessorFragmentParsing extends WP_UnitTestCase {
 			// Just progressing through the document.
 		}
 		$this->assertSame( 'unsupported', $processor->get_last_error() );
-		$this->assertSame(
-			'Cannot pop a locked element from the stack of open elements.',
+		$this->assertMatchesRegularExpression(
+			'/^Cannot remove a locked element from the stack of [a-z ]+ elements.$/',
 			$processor->get_unsupported_exception()->getMessage()
 		);
 	}
@@ -214,6 +214,8 @@ class Tests_HtmlApi_WpHtmlProcessorFragmentParsing extends WP_UnitTestCase {
 			'LI in LI'               => array( '<ul><li>', '<li>' ),
 			'OPTION in OPTION'       => array( '<select><option>', '<option>' ),
 			'DIV in SVG'             => array( '<svg>', '<div>' ),
+
+			'Active formatting'      => array( '<div><span><i><i><i></span><div>', '</i>' ),
 		);
 	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorFragmentParsing.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorFragmentParsing.php
@@ -35,7 +35,7 @@ class Tests_HtmlApi_WpHtmlProcessorFragmentParsing extends WP_UnitTestCase {
 		$this->assertSame( 'svg', $fragment->get_namespace() );
 
 		$this->assertTrue( $fragment->next_tag( 'CIRCLE' ) );
-		$this->assertSame( array( 'HTML', 'SVG', 'CIRCLE' ), $fragment->get_breadcrumbs() );
+		$this->assertSame( array( 'HTML', 'BODY', 'SVG', 'CIRCLE' ), $fragment->get_breadcrumbs() );
 		$this->assertTrue( $fragment->next_tag( 'foreignObject' ) );
 		$this->assertSame( 'svg', $fragment->get_namespace() );
 	}
@@ -48,9 +48,7 @@ class Tests_HtmlApi_WpHtmlProcessorFragmentParsing extends WP_UnitTestCase {
 		$this->assertTrue( $processor->next_tag( 'foreignObject' ) );
 
 		$fragment = $processor->create_fragment_at_current_node( "<image>\0not-preceded-by-nul-byte<rect />" );
-
-		// Nothing has been processed, the html namespace should be used for parsing as an integration point.
-		$this->assertSame( 'html', $fragment->get_namespace() );
+		$this->assertSame( 'svg', $fragment->get_namespace() );
 
 		// HTML parsing transforms IMAGE into IMG.
 		$this->assertTrue( $fragment->next_tag( 'IMG' ) );
@@ -66,7 +64,7 @@ class Tests_HtmlApi_WpHtmlProcessorFragmentParsing extends WP_UnitTestCase {
 		 * RECT is an HTML element here, meaning it may have the self-closing flag but does not self-close.
 		 */
 		$this->assertTrue( $fragment->next_tag( 'RECT' ) );
-		$this->assertSame( array( 'HTML', 'FOREIGNOBJECT', 'RECT' ), $fragment->get_breadcrumbs() );
+		$this->assertSame( array( 'HTML', 'BODY', 'SVG', 'FOREIGNOBJECT', 'RECT' ), $fragment->get_breadcrumbs() );
 		$this->assertSame( 'html', $fragment->get_namespace() );
 		$this->assertTrue( $fragment->has_self_closing_flag() );
 		$this->assertTrue( $fragment->expects_closer() );

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorHtml5lib.php
@@ -138,10 +138,6 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 	 * @return bool True if the test case should be skipped. False otherwise.
 	 */
 	private static function should_skip_test( ?string $test_context_element, string $test_name ): bool {
-		if ( null !== $test_context_element && 'body' !== $test_context_element ) {
-			return true;
-		}
-
 		if ( array_key_exists( $test_name, self::SKIP_TESTS ) ) {
 			return true;
 		}
@@ -157,11 +153,63 @@ class Tests_HtmlApi_Html5lib extends WP_UnitTestCase {
 	 * @return string|null Tree structure of parsed HTML, if supported, else null.
 	 */
 	private static function build_tree_representation( ?string $fragment_context, string $html ) {
-		$processor = $fragment_context
-			? WP_HTML_Processor::create_fragment( $html, "<{$fragment_context}>" )
-			: WP_HTML_Processor::create_full_parser( $html );
-		if ( null === $processor ) {
-			throw new WP_HTML_Unsupported_Exception( "Could not create a parser with the given fragment context: {$fragment_context}.", '', 0, '', array(), array() );
+		if ( $fragment_context ) {
+			/*
+			 * If the string of characters starts with "svg ", the context
+			 * element is in the SVG namespace and the substring after
+			 * "svg " is the local name. If the string of characters starts
+			 * with "math ", the context element is in the MathML namespace
+			 * and the substring after "math " is the local name.
+			 * Otherwise, the context element is in the HTML namespace and
+			 * the string is the local name.
+			 */
+			if ( str_starts_with( $fragment_context, 'svg ' ) ) {
+				$tag_name = substr( $fragment_context, 4 );
+				if ( 'svg' === $tag_name ) {
+					$fragment_context_html = '<svg>';
+				} else {
+					$fragment_context_html = "<svg><{$tag_name}>";
+				}
+			} elseif ( str_starts_with( $fragment_context, 'math ' ) ) {
+				$tag_name = substr( $fragment_context, 5 );
+				if ( 'math' === $tag_name ) {
+					$fragment_context_html = '<math>';
+				} else {
+					$fragment_context_html = "<math><{$tag_name}>";
+				}
+			} else {
+				// Tags that only appear in tables need a special case.
+				if ( in_array(
+					$fragment_context,
+					array(
+						'caption',
+						'col',
+						'colgroup',
+						'tbody',
+						'td',
+						'tfoot',
+						'th',
+						'thead',
+						'tr',
+					),
+					true
+				) ) {
+					$fragment_context_html = "<table><{$fragment_context}>";
+				} else {
+					$fragment_context_html = "<{$fragment_context}>";
+				}
+			}
+
+			$processor = WP_HTML_Processor::create_fragment( $html, $fragment_context_html );
+
+			if ( null === $processor ) {
+				throw new WP_HTML_Unsupported_Exception( "Could not create a parser with the given fragment context: {$fragment_context}.", '', 0, '', array(), array() );
+			}
+		} else {
+			$processor = WP_HTML_Processor::create_full_parser( $html );
+			if ( null === $processor ) {
+				throw new Exception( 'Could not create a full parser.' );
+			}
 		}
 
 		$output       = '';

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRules.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRules.php
@@ -124,18 +124,18 @@ class Tests_HtmlApi_WpHtmlProcessorSemanticRules extends WP_UnitTestCase {
 	public function test_in_body_skips_unexpected_button_closer() {
 		$processor = WP_HTML_Processor::create_fragment( '<div>Test</button></div>' );
 
-		$processor->step();
+		$processor->next_token();
 		$this->assertSame( 'DIV', $processor->get_tag(), 'Did not stop at initial DIV tag.' );
 		$this->assertFalse( $processor->is_tag_closer(), 'Did not find that initial DIV tag is an opener.' );
 
-		$processor->step();
+		$processor->next_token();
 		$this->assertSame( '#text', $processor->get_token_type(), 'Should have found the text node.' );
 
 		/*
 		 * When encountering the BUTTON closing tag, there is no BUTTON in the stack of open elements.
 		 * It should be ignored as there's no BUTTON to close.
 		 */
-		$this->assertTrue( $processor->step(), 'Found no further tags when it should have found the closing DIV' );
+		$this->assertTrue( $processor->next_token(), 'Found no further tags when it should have found the closing DIV' );
 		$this->assertSame( 'DIV', $processor->get_tag(), "Did not skip unexpected BUTTON; stopped at {$processor->get_tag()}." );
 		$this->assertTrue( $processor->is_tag_closer(), 'Did not find that the terminal DIV tag is a closer.' );
 	}

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRules.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorSemanticRules.php
@@ -124,18 +124,18 @@ class Tests_HtmlApi_WpHtmlProcessorSemanticRules extends WP_UnitTestCase {
 	public function test_in_body_skips_unexpected_button_closer() {
 		$processor = WP_HTML_Processor::create_fragment( '<div>Test</button></div>' );
 
-		$processor->next_token();
+		$processor->step();
 		$this->assertSame( 'DIV', $processor->get_tag(), 'Did not stop at initial DIV tag.' );
 		$this->assertFalse( $processor->is_tag_closer(), 'Did not find that initial DIV tag is an opener.' );
 
-		$processor->next_token();
+		$processor->step();
 		$this->assertSame( '#text', $processor->get_token_type(), 'Should have found the text node.' );
 
 		/*
 		 * When encountering the BUTTON closing tag, there is no BUTTON in the stack of open elements.
 		 * It should be ignored as there's no BUTTON to close.
 		 */
-		$this->assertTrue( $processor->next_token(), 'Found no further tags when it should have found the closing DIV' );
+		$this->assertTrue( $processor->step(), 'Found no further tags when it should have found the closing DIV' );
 		$this->assertSame( 'DIV', $processor->get_tag(), "Did not skip unexpected BUTTON; stopped at {$processor->get_tag()}." );
 		$this->assertTrue( $processor->is_tag_closer(), 'Did not find that the terminal DIV tag is a closer.' );
 	}


### PR DESCRIPTION
Address problems using the HTML specification for fragment parsing which can lead to documents that are impossible to represent in HTML.

As an HTML processor, documents that cannot be represented in HTML should be rejected. This includes and document fragment (a document with a context) where the fragment could leak out of the context.

This PR includes a number of tests with examples of problematic HTML, but a simple example is the HTML `<p>` in the context of a `P` element. If this is naively parsed, it would lead to a tree like `P > P`, which _cannot be represented in HTML_. This document would bail with an unsupported error upon encountering the `<p>` tag in the context of the P element.

---

**Implementation**

Instead of using a simple _context element_ in the fragment parser, this change moves a copy of the stack of open elements, the stack of active formatting elements, and the head and form element pointers into the context processor. These elements have a new `locked` property set. The implementation is adapted to prevent locked items from being modified on the stack or element pointers from being modified.

The goal is to maintain a coherent HTML structure of the fragment document inside its context.

Trac ticket: https://core.trac.wordpress.org/ticket/62584


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
