### PR TITLE
Login and Registration: Fix inconsistent margin in login form input

### DIFF
--- a/src/wp-admin/css/login.css
+++ b/src/wp-admin/css/login.css
@@ -347,7 +347,7 @@ p {
 	width: 100%;
 	border-width: 0.0625rem;
 	padding: 0.1875rem 0.3125rem; /* 3px 5px */
-	margin: 0 6px 16px 0;
+	margin-bottom: 16px;
 	min-height: 40px;
 	max-height: none;
 }


### PR DESCRIPTION
This PR removes the extra 6px margin on the right side of input fields in the login form. The change ensures consistent spacing on both the left and right sides, improving visual alignment and design consistency.

| **Before**                                                                                         | **After**                                                                                          |
|----------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
| <img width="361" alt="Before" src="https://github.com/user-attachments/assets/dbee8aab-d84b-484a-994b-f18e9a337628"> | <img width="389" alt="After" src="https://github.com/user-attachments/assets/450102c5-c8dc-4869-95ed-6b0683de6371"> |

Trac ticket: [#62601](https://core.trac.wordpress.org/ticket/62601)
