### PR TITLE
Theme: Update wording in theme installer skin for clarity

### DIFF
--- a/src/wp-admin/includes/class-theme-installer-skin.php
+++ b/src/wp-admin/includes/class-theme-installer-skin.php
@@ -251,7 +251,7 @@ class Theme_Installer_Skin extends WP_Upgrader_Skin {
 		);
 
 		$table  = '<table class="update-from-upload-comparison"><tbody>';
-		$table .= '<tr><th></th><th>' . esc_html_x( 'Active', 'theme' ) . '</th><th>' . esc_html_x( 'Uploaded', 'theme' ) . '</th></tr>';
+		$table .= '<tr><th></th><th>' . esc_html_x( 'Installed', 'theme' ) . '</th><th>' . esc_html_x( 'Uploaded', 'theme' ) . '</th></tr>';
 
 		$is_same_theme = true; // Let's consider only these rows.
 
@@ -333,7 +333,7 @@ class Theme_Installer_Skin extends WP_Upgrader_Skin {
 			if ( $this->is_downgrading ) {
 				$warning = sprintf(
 					/* translators: %s: Documentation URL. */
-					__( 'You are uploading an older version of the active theme. You can continue to install the older version, but be sure to <a href="%s">back up your database and files</a> first.' ),
+					__( 'You are uploading an older version of the installed theme. You can continue to install the older version, but be sure to <a href="%s">back up your database and files</a> first.' ),
 					__( 'https://developer.wordpress.org/advanced-administration/security/backup/' )
 				);
 			} else {
@@ -351,7 +351,7 @@ class Theme_Installer_Skin extends WP_Upgrader_Skin {
 			$install_actions['overwrite_theme'] = sprintf(
 				'<a class="button button-primary update-from-upload-overwrite" href="%s" target="_parent">%s</a>',
 				wp_nonce_url( add_query_arg( 'overwrite', $overwrite, $this->url ), 'theme-upload' ),
-				_x( 'Replace active with uploaded', 'theme' )
+				_x( 'Replace installed with uploaded', 'theme' )
 			);
 		} else {
 			echo $blocked_message;


### PR DESCRIPTION
Trac ticket: [62603](https://core.trac.wordpress.org/ticket/62603)


When uploading a theme that's already installed, some UI text incorrectly refers to the existing theme as "active" even when it's not the currently active theme. This could be confusing for users who are trying to replace an installed but not active theme.

This PR updates the wording to be more accurate by using "installed" instead of "active" in several places:

* Changes table header from "Active" to "Installed" 
* Updates version warning message to say "installed theme" instead of "active theme"
* Updates button text from "Replace active with uploaded" to "Replace installed with uploaded"


### Screenshot

Before 

![image](https://github.com/user-attachments/assets/dd31314d-3899-4fe6-8387-14220852310d)


After 

![image](https://github.com/user-attachments/assets/d0456d1a-c9bd-448e-b741-e79256c8e1a1)
