### PR TITLE
Editor: Update terminology from `Active` to `Current` in theme installer.

### DIFF
--- a/src/wp-admin/includes/class-theme-installer-skin.php
+++ b/src/wp-admin/includes/class-theme-installer-skin.php
@@ -333,7 +333,7 @@ class Theme_Installer_Skin extends WP_Upgrader_Skin {
 			if ( $this->is_downgrading ) {
 				$warning = sprintf(
 					/* translators: %s: Documentation URL. */
-					__( 'You are uploading an older version of the active theme. You can continue to install the older version, but be sure to <a href="%s">back up your database and files</a> first.' ),
+					__( 'You are uploading an older version of the current theme. You can continue to install the older version, but be sure to <a href="%s">back up your database and files</a> first.' ),
 					__( 'https://developer.wordpress.org/advanced-administration/security/backup/' )
 				);
 			} else {

--- a/src/wp-admin/includes/class-theme-installer-skin.php
+++ b/src/wp-admin/includes/class-theme-installer-skin.php
@@ -251,7 +251,7 @@ class Theme_Installer_Skin extends WP_Upgrader_Skin {
 		);
 
 		$table  = '<table class="update-from-upload-comparison"><tbody>';
-		$table .= '<tr><th></th><th>' . esc_html_x( 'Active', 'theme' ) . '</th><th>' . esc_html_x( 'Uploaded', 'theme' ) . '</th></tr>';
+		$table .= '<tr><th></th><th>' . esc_html_x( 'Current', 'theme' ) . '</th><th>' . esc_html_x( 'Uploaded', 'theme' ) . '</th></tr>';
 
 		$is_same_theme = true; // Let's consider only these rows.
 
@@ -351,7 +351,7 @@ class Theme_Installer_Skin extends WP_Upgrader_Skin {
 			$install_actions['overwrite_theme'] = sprintf(
 				'<a class="button button-primary update-from-upload-overwrite" href="%s" target="_parent">%s</a>',
 				wp_nonce_url( add_query_arg( 'overwrite', $overwrite, $this->url ), 'theme-upload' ),
-				_x( 'Replace active with uploaded', 'theme' )
+				_x( 'Replace current with uploaded', 'theme' )
 			);
 		} else {
 			echo $blocked_message;


### PR DESCRIPTION
### Description
This PR updates the terminology on the Theme Installer page from `Active` to `Current`, as described in the Trac Ticket below.

Trac ticket: https://core.trac.wordpress.org/ticket/62603

### Screenshots
<img width="1470" alt="Screenshot 2024-11-29 at 9 24 36 AM" src="https://github.com/user-attachments/assets/f82c3fe1-ffd6-4bdb-858c-e91de76800e4">


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
