### PR TITLE
Fix: Dismiss Button for Media Upload Errors Not Working

### DIFF
--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -2222,6 +2222,14 @@ $( function( $ ) {
 	}
 })();
 
+// Attach a click event listener to the dismiss button for media upload errors.
+$( document ).on( 'click', 'button.button-link.dismiss', function( event ) {
+    event.preventDefault();
+    $( this ).parents( 'div.media-item' ).slideUp( 200, function() {
+        $( this ).remove();
+    });
+});
+
 }( jQuery, window ));
 
 /**

--- a/src/wp-admin/async-upload.php
+++ b/src/wp-admin/async-upload.php
@@ -118,7 +118,7 @@ if ( is_wp_error( $id ) ) {
 	$message = sprintf(
 		'%s <strong>%s</strong><br />%s',
 		sprintf(
-			'<button type="button" class="dismiss button-link" onclick="jQuery(this).parents(\'div.media-item\').slideUp(200, function(){jQuery(this).remove();});">%s</button>',
+			'<button type="button" class="dismiss button-link">%s</button>',
 			__( 'Dismiss' )
 		),
 		sprintf(


### PR DESCRIPTION
This PR fixes an issue where the dismiss button in the media upload error messages was not working.

Trac ticket: https://core.trac.wordpress.org/ticket/62606



https://github.com/user-attachments/assets/edf67b4b-2c3b-4df0-89f0-da6c7997dc87

