### PR TITLE
Theme Info: Reset margin for theme screenshots on mobile viewports

### DIFF
--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -935,6 +935,7 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 	.theme-overlay .theme-screenshots {
 		width: 100%;
 		float: none;
+		margin: 0;
 	}
 
 	.theme-overlay .theme-info {


### PR DESCRIPTION
<!-- Insert a description of your changes here -->
### Description:
This PR fixes an unexpected horizontal scroll detected on mobile viewports under the Theme Info page.

Trac ticket: https://core.trac.wordpress.org/ticket/62607

### Screenshot of the changes:

**Before**
![Screenshot 2024-11-29 at 12 11 22 PM](https://github.com/user-attachments/assets/1f750552-92f6-420a-a63a-21b1d45011ea)


**After**
![Screenshot 2024-11-29 at 12 05 56 PM](https://github.com/user-attachments/assets/4db10c14-6f7c-4144-9a5a-08d4cd69db4a)


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
