### PR TITLE
Remove unused .wp-login-logo class from HTML markup

### DIFF
--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -219,7 +219,7 @@ function login_header( $title = null, $message = '', $wp_error = null ) {
 	endif;
 	?>
 	<div id="login">
-		<h1 role="presentation" class="wp-login-logo"><a href="<?php echo esc_url( $login_header_url ); ?>"><?php echo $login_header_text; ?></a></h1>
+		<h1 role="presentation"><a href="<?php echo esc_url( $login_header_url ); ?>"><?php echo $login_header_text; ?></a></h1>
 	<?php
 	/**
 	 * Filters the message to display above the login form.


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/62609

The `.wp-login-logo` class is no longer used in any CSS files within WordPress Core. This PR removes the unused class from the HTML markup to improve code clarity and maintainability.
