### PR TITLE
Core: Use time_format setting in update-core.php screen instead of hardcoding

### DIFF
--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -1112,7 +1112,7 @@ if ( 'upgrade-core' === $action ) {
 		/* translators: Last update date format. See https://www.php.net/manual/datetime.format.php */
 		date_i18n( __( 'F j, Y' ), $last_update_check ),
 		/* translators: Last update time format. See https://www.php.net/manual/datetime.format.php */
-		date_i18n( __( 'g:i a T' ), $last_update_check )
+		date_i18n( get_option( 'time_format' ), $last_update_check )
 	);
 	echo ' <a href="' . esc_url( self_admin_url( 'update-core.php?force-check=1' ) ) . '">' . __( 'Check again.' ) . '</a>';
 	echo '</p>';

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -1110,7 +1110,7 @@ if ( 'upgrade-core' === $action ) {
 		/* translators: 1: Date, 2: Time. */
 		__( 'Last checked on %1$s at %2$s.' ),
 		/* translators: Last update date format. See https://www.php.net/manual/datetime.format.php */
-		date_i18n( __( 'F j, Y' ), $last_update_check ),
+		date_i18n( get_option( 'date_format' ), $last_update_check ),
 		/* translators: Last update time format. See https://www.php.net/manual/datetime.format.php */
 		date_i18n( get_option( 'time_format' ), $last_update_check )
 	);


### PR DESCRIPTION
Trac ticket: [62616](https://core.trac.wordpress.org/ticket/62616)

The update-core.php screen was displaying date and time using hardcoded formats instead of respecting the formats chosen by users in Settings > General.

This PR changes the hardcoded time format and date format to use `get_option('time_format')` and `get_option('date_format')`



