### PR TITLE
Editor: Hide "Skip to Editor" link for unsupported post types

### DIFF
--- a/src/wp-admin/edit-form-advanced.php
+++ b/src/wp-admin/edit-form-advanced.php
@@ -546,7 +546,13 @@ do_action( 'edit_form_top', $post );
 	?>
 	<label class="screen-reader-text" id="title-prompt-text" for="title"><?php echo $title_placeholder; ?></label>
 	<input type="text" name="post_title" size="30" value="<?php echo esc_attr( $post->post_title ); ?>" id="title" spellcheck="true" autocomplete="off" />
-	<a href="#content" class="button-secondary screen-reader-text skiplink" onclick="if (tinymce) { tinymce.execCommand( 'mceFocus', false, 'content' ); }"><?php esc_html_e( 'Skip to Editor' ); ?></a>
+	<?php
+	if ( post_type_supports( $post_type, 'editor' ) ) {
+		?>
+		<a href="#content" class="button-secondary screen-reader-text skiplink" onclick="if (tinymce) { tinymce.execCommand( 'mceFocus', false, 'content' ); }"><?php esc_html_e( 'Skip to Editor' ); ?></a>
+		<?php
+	}
+	?>
 </div>
 	<?php
 	/**


### PR DESCRIPTION
### Summary
This PR resolves an issue where the **"Skip to Editor"** button is displayed even when the post type does not support the editor, leading to focus loss when the link is accessed.

### Changes Introduced
Added a conditional check using `post_type_supports( $post_type, 'editor' )` to ensure the **"Skip to Editor"** link is displayed only if the editor is supported by the post type.

### Testing Instructions
1. Register a post type **without the editor** (exclude `'editor'` in the `supports` array during registration).
2. Go to the "Add New" screen for the registered post type.
3. Verify that the **"Skip to Editor"** link is no longer displayed.
4. Test with post types that do support the editor to confirm the link appears and functions as expected.

### Before fix
https://github.com/user-attachments/assets/545d1471-7d8a-42a9-a4ac-f7518c65617c

### After fix
https://github.com/user-attachments/assets/2b21f992-212f-4939-a7af-a6982f0877eb



---

Trac ticket: [#62623](https://core.trac.wordpress.org/ticket/62623)