### PR TITLE
Don't prepare the response body for HEAD requests in WP_REST_Taxonomies_Controller 

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-request.php
+++ b/src/wp-includes/rest-api/class-wp-rest-request.php
@@ -162,6 +162,18 @@ class WP_REST_Request implements ArrayAccess {
 	}
 
 	/**
+	 * Determines if the request is the given method.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @param string $method HTTP method.
+	 * @return bool Whether the request is of the given method.
+	 */
+	public function is_method( $method ) {
+		return $this->get_method() === strtoupper( $method );
+	}
+
+	/**
 	 * Canonicalizes the header name.
 	 *
 	 * Ensures that header names are always treated the same regardless of

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php
@@ -191,6 +191,10 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 			);
 		}
 
+		if ( $request->is_method( 'head' ) ) {
+			return new WP_REST_Response();
+		}
+
 		$data = $this->prepare_item_for_response( $tax_obj, $request );
 
 		return rest_ensure_response( $data );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-taxonomies-controller.php
@@ -114,6 +114,11 @@ class WP_REST_Taxonomies_Controller extends WP_REST_Controller {
 	 */
 	public function get_items( $request ) {
 
+		if ( $request->is_method( 'head' ) ) {
+			// Return early as this method doesn't add any headers.
+			return new WP_REST_Response();
+		}
+
 		// Retrieve the list of registered collection query parameters.
 		$registered = $this->get_collection_params();
 

--- a/tests/phpunit/tests/rest-api/rest-taxonomies-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-taxonomies-controller.php
@@ -124,14 +124,8 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 		);
 	}
 
-	/**
-	 * @dataProvider data_readable_http_methods
-	 * @ticket 56481
-	 *
-	 * @param string $method HTTP method to use.
-	 */
-	public function test_get_taxonomies_for_type( $method ) {
-		$request = new WP_REST_Request( $method, '/wp/v2/taxonomies' );
+	public function test_get_taxonomies_for_type() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/taxonomies' );
 		$request->set_param( 'type', 'post' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->check_taxonomies_for_type_response( 'post', $response );

--- a/tests/phpunit/tests/rest-api/rest-taxonomies-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-taxonomies-controller.php
@@ -71,9 +71,7 @@ class WP_Test_REST_Taxonomies_Controller extends WP_Test_REST_Controller_Testcas
 		add_filter( $hook_name, $callback );
 		$response = rest_get_server()->dispatch( $request );
 		remove_filter( $hook_name, $callback );
-
 		$this->assertSame( 200, $response->get_status(), 'The response status should be 200.' );
-
 		$this->assertSame( 0, $filter->get_call_count(), 'The "' . $hook_name . '" filter was called when it should not be for HEAD requests.' );
 		$this->assertNull( $response->get_data(), 'The server should not generate a body in response to a HEAD request.' );
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Trac ticket: https://core.trac.wordpress.org/ticket/56481

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
