### PR TITLE
Remove unnecessary wp_kses_post call in wp_admin_notice function

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -9279,7 +9279,7 @@ function wp_admin_notice( $message, $args = array() ) {
 	 */
 	do_action( 'wp_admin_notice', $message, $args );
 
-	echo wp_kses_post( wp_get_admin_notice( $message, $args ) );
+	echo wp_get_admin_notice( $message, $args );
 }
 
 /**


### PR DESCRIPTION
### Description
The implementation of the wp_admin_notice function has been updated to remove the use of wp_kses_post for rendering admin notices. This change addresses recent bugs identified in the previous approach.

Trac ticket: https://core.trac.wordpress.org/ticket/62619

## Use of AI Tools

AI assistance: No

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
