### PR TITLE
Fix Twenty Sixteen: Quotes don't inherit group color settings

### DIFF
--- a/src/wp-content/themes/twentysixteen/css/blocks.css
+++ b/src/wp-content/themes/twentysixteen/css/blocks.css
@@ -77,7 +77,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 .wp-block-quote {
 	border-width: 0 0 0 4px;
 }
- 
+
 :where(.rtl) .wp-block-quote {
 	border-width: 0 4px 0 0;
 }
@@ -103,6 +103,11 @@ p.has-drop-cap:not(:focus)::first-letter {
 }
 
 .wp-block-quote.has-text-color cite {
+	color: inherit;
+}
+
+.has-text-color .wp-block-quote:not(.has-text-color),
+.has-text-color .wp-block-quote:not(.has-text-color) cite {
 	color: inherit;
 }
 

--- a/src/wp-content/themes/twentysixteen/css/editor-blocks.css
+++ b/src/wp-content/themes/twentysixteen/css/editor-blocks.css
@@ -321,7 +321,8 @@ figure[class*="wp-block-"] > figcaption {
 	margin-bottom: 1.4736842105em;
 }
 
-.wp-block-quote__citation {
+.wp-block-quote__citation,
+.wp-block-quote cite {
 	color: #1a1a1a;
 	display: block;
 	font-size: 16px;
@@ -330,6 +331,11 @@ figure[class*="wp-block-"] > figcaption {
 }
 
 .wp-block-quote.has-text-color .wp-block-quote__citation {
+	color: inherit;
+}
+
+.has-text-color .wp-block-quote:not(.has-text-color),
+.has-text-color .wp-block-quote:not(.has-text-color) cite {
 	color: inherit;
 }
 
@@ -546,7 +552,7 @@ figure[class*="wp-block-"] > figcaption {
 .wp-block-pullquote[style*="font-size"] cite {
 	font-size: inherit;
 }
-	
+
 .wp-block-pullquote[style*="line-height"] blockquote,
 .wp-block-pullquote[style*="line-height"] blockquote p,
 .wp-block-pullquote[style*="line-height"] cite {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

The purpose of this change is to ensure that the quote block and the quote block cite inherits the text color from the parent block, if:

- The parent has a text color set in the block settings, and
- The quote block does not have a text color set in the block settings.

Trac ticket: https://core.trac.wordpress.org/ticket/51236

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
