### PR TITLE
Move `_wp_admin_html_begin()` before Customizer scripts

### DIFF
--- a/src/wp-admin/customize.php
+++ b/src/wp-admin/customize.php
@@ -100,6 +100,12 @@ if ( ! empty( $autofocus ) ) {
 	$wp_customize->set_autofocus( $autofocus );
 }
 
+// Let's roll.
+header( 'Content-Type: ' . get_option( 'html_type' ) . '; charset=' . get_option( 'blog_charset' ) );
+
+wp_user_settings();
+_wp_admin_html_begin();
+
 $registered             = $wp_scripts->registered;
 $wp_scripts             = new WP_Scripts();
 $wp_scripts->registered = $registered;
@@ -125,12 +131,6 @@ wp_enqueue_style( 'customize-controls' );
  * @since 3.4.0
  */
 do_action( 'customize_controls_enqueue_scripts' );
-
-// Let's roll.
-header( 'Content-Type: ' . get_option( 'html_type' ) . '; charset=' . get_option( 'blog_charset' ) );
-
-wp_user_settings();
-_wp_admin_html_begin();
 
 $body_class = 'wp-core-ui wp-customizer js';
 


### PR DESCRIPTION
Prevents printing styles and scripts before the `<!DOCTYPE>`.

The `_wp_admin_html_begin()` function could precede Customizer script hooks, in case a plugin prints markup inside a hook such as `admin_enqueue_scripts`.

[Trac 62629](https://core.trac.wordpress.org/ticket/62629)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
