### PR TITLE
Site Health: Improve fonts directory check

### DIFF
--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -1651,7 +1651,8 @@ class WP_Debug_Data {
 		$is_writable_upload_dir         = wp_is_writable( $upload_dir['basedir'] );
 		$is_writable_wp_plugin_dir      = wp_is_writable( WP_PLUGIN_DIR );
 		$is_writable_template_directory = wp_is_writable( get_theme_root( get_template() ) );
-		$is_writable_fonts_dir          = wp_is_writable( wp_get_font_dir()['basedir'] );
+		$is_fonts_dir_exist             = file_exists( wp_get_font_dir()['basedir'] );
+		$is_writable_fonts_dir          = $is_fonts_dir_exist ? wp_is_writable( wp_get_font_dir()['basedir'] ) : false;
 
 		$fields = array(
 			'wordpress'  => array(
@@ -1681,8 +1682,12 @@ class WP_Debug_Data {
 			),
 			'fonts'      => array(
 				'label' => __( 'The fonts directory' ),
-				'value' => ( $is_writable_fonts_dir ? __( 'Writable' ) : __( 'Not writable' ) ),
-				'debug' => ( $is_writable_fonts_dir ? 'writable' : 'not writable' ),
+				'value' => $is_fonts_dir_exist
+					? ( $is_writable_fonts_dir ? __( 'Writable' ) : __( 'Not writable' ) )
+					: __( 'Does not exist' ),
+				'debug' => $is_fonts_dir_exist
+					? ( $is_writable_fonts_dir ? 'writable' : 'not writable' )
+					: 'does not exist',
 			),
 		);
 

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -1646,13 +1646,13 @@ class WP_Debug_Data {
 	 */
 	private static function get_wp_filesystem(): array {
 		$upload_dir                     = wp_upload_dir();
+		$fonts_dir_exists               = file_exists( wp_get_font_dir()['basedir'] );
 		$is_writable_abspath            = wp_is_writable( ABSPATH );
 		$is_writable_wp_content_dir     = wp_is_writable( WP_CONTENT_DIR );
 		$is_writable_upload_dir         = wp_is_writable( $upload_dir['basedir'] );
 		$is_writable_wp_plugin_dir      = wp_is_writable( WP_PLUGIN_DIR );
 		$is_writable_template_directory = wp_is_writable( get_theme_root( get_template() ) );
-		$is_fonts_dir_exist             = file_exists( wp_get_font_dir()['basedir'] );
-		$fonts_dir_exists               = $is_fonts_dir_exist ? wp_is_writable( wp_get_font_dir()['basedir'] ) : false;
+		$is_writable_fonts_dir          = $fonts_dir_exists ? wp_is_writable( wp_get_font_dir()['basedir'] ) : false;
 
 		$fields = array(
 			'wordpress'  => array(
@@ -1682,11 +1682,11 @@ class WP_Debug_Data {
 			),
 			'fonts'      => array(
 				'label' => __( 'The fonts directory' ),
-				'value' => $is_fonts_dir_exist
-					? ( $fonts_dir_exists ? __( 'Writable' ) : __( 'Not writable' ) )
+				'value' => $fonts_dir_exists
+					? ( $is_writable_fonts_dir ? __( 'Writable' ) : __( 'Not writable' ) )
 					: __( 'Does not exist' ),
-				'debug' => $is_fonts_dir_exist
-					? ( $fonts_dir_exists ? 'writable' : 'not writable' )
+				'debug' => $fonts_dir_exists
+					? ( $is_writable_fonts_dir ? 'writable' : 'not writable' )
 					: 'does not exist',
 			),
 		);

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -1652,7 +1652,7 @@ class WP_Debug_Data {
 		$is_writable_wp_plugin_dir      = wp_is_writable( WP_PLUGIN_DIR );
 		$is_writable_template_directory = wp_is_writable( get_theme_root( get_template() ) );
 		$is_fonts_dir_exist             = file_exists( wp_get_font_dir()['basedir'] );
-		$is_writable_fonts_dir          = $is_fonts_dir_exist ? wp_is_writable( wp_get_font_dir()['basedir'] ) : false;
+		$fonts_dir_exists               = $is_fonts_dir_exist ? wp_is_writable( wp_get_font_dir()['basedir'] ) : false;
 
 		$fields = array(
 			'wordpress'  => array(
@@ -1683,10 +1683,10 @@ class WP_Debug_Data {
 			'fonts'      => array(
 				'label' => __( 'The fonts directory' ),
 				'value' => $is_fonts_dir_exist
-					? ( $is_writable_fonts_dir ? __( 'Writable' ) : __( 'Not writable' ) )
+					? ( $fonts_dir_exists ? __( 'Writable' ) : __( 'Not writable' ) )
 					: __( 'Does not exist' ),
 				'debug' => $is_fonts_dir_exist
-					? ( $is_writable_fonts_dir ? 'writable' : 'not writable' )
+					? ( $fonts_dir_exists ? 'writable' : 'not writable' )
 					: 'does not exist',
 			),
 		);


### PR DESCRIPTION
This PR enhances the filesystem checks in the Site Health debug data by addressing the following:

#### 1. Existence Check
- Before checking if the fonts directory is writable, it first verifies whether the directory exists.

#### 2. Improved Messaging
- If the fonts directory does not exist, the debug output now reflects this scenario as "Does not exist".
- If the directory exists, it shows whether it is writable or not.

### Changes Made

- Updated the `get_wp_filesystem()` method in `class-wp-debug-data.php`.
- Added a directory existence check (`file_exists`) for the fonts directory (`wp_get_font_dir()['basedir']`).
- Adjusted the debug data output to handle cases where the fonts directory does not exist.

### Before fix:
**Without Font directory**

<img width="799" alt="Screenshot 2024-12-03 at 1 50 10 AM" src="https://github.com/user-attachments/assets/44a3dae9-b07c-4c7e-9b78-15432d0a917b">

### After fix: 

**Without Font directory**

<img width="798" alt="Screenshot 2024-12-03 at 1 47 35 AM" src="https://github.com/user-attachments/assets/9943a774-c931-45ba-85df-aba06caa10ba">


**With Font directory**

<img width="799" alt="Screenshot 2024-12-03 at 1 23 20 AM" src="https://github.com/user-attachments/assets/0127b587-96a7-4969-aafe-6a7dee99214e">


Trac ticket: [#62633](https://core.trac.wordpress.org/ticket/62633)