### PR TITLE
Site Health: Add dependencies information

### DIFF
--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -910,8 +910,9 @@ class WP_Debug_Data {
 		foreach ( $plugins as $plugin_path => $plugin ) {
 			$plugin_part = ( is_plugin_active( $plugin_path ) ) ? 'wp-plugins-active' : 'wp-plugins-inactive';
 
-			$plugin_version = $plugin['Version'];
-			$plugin_author  = $plugin['Author'];
+			$plugin_version      = $plugin['Version'];
+			$plugin_author       = $plugin['Author'];
+			$plugin_dependencies = $plugin['RequiresPlugins'];
 
 			$plugin_version_string       = __( 'No version or author information is available.' );
 			$plugin_version_string_debug = 'author: (undefined), version: (undefined)';
@@ -977,6 +978,12 @@ class WP_Debug_Data {
 					$auto_updates_string = __( 'Auto-updates disabled' );
 				}
 
+				if ( ! empty( $plugin_dependencies ) ) {
+					$plugin_dependencies_string = sprintf( __( 'Requires: %s' ), $plugin_dependencies );
+				} else {
+					$plugin_dependencies_string = __( 'No dependencies' );
+				}
+
 				/**
 				 * Filters the text string of the auto-updates setting for each plugin in the Site Health debug data.
 				 *
@@ -989,8 +996,8 @@ class WP_Debug_Data {
 				 */
 				$auto_updates_string = apply_filters( 'plugin_auto_update_debug_string', $auto_updates_string, $plugin_path, $plugin, $enabled );
 
-				$plugin_version_string       .= ' | ' . $auto_updates_string;
-				$plugin_version_string_debug .= ', ' . $auto_updates_string;
+				$plugin_version_string       .= ' | ' . $auto_updates_string . ' | ' . $plugin_dependencies_string;
+				$plugin_version_string_debug .= ', ' . $auto_updates_string . ', ' . $plugin_dependencies_string;
 			}
 
 			$fields[ $plugin_part ][ sanitize_text_field( $plugin['Name'] ) ] = array(


### PR DESCRIPTION
### Description
This pull request introduces details on plugin dependencies within the Site Health.

### Screenshot
![Screenshot 2024-12-03 at 10 32 39 AM](https://github.com/user-attachments/assets/0fe7719c-1d22-4d45-87c0-fabf626bd74f)


Trac ticket: https://core.trac.wordpress.org/ticket/62631

## Use of AI Tools

AI assistance: No

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
