### PR TITLE
Fixed Margin issue in the search box in the 'Add Plugins' Page

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -1116,10 +1116,6 @@ th.action-links {
 	align-items: center;
 }
 
-.wp-filter .search-form.search-plugins {
-	/* This element is a flex item: the inherited float won't have any effect. */
-	margin-top: 0;
-}
 
 .wp-filter .search-form.search-plugins select,
 .wp-filter .search-form.search-plugins .wp-filter-search,
@@ -1351,6 +1347,12 @@ th.action-links {
 	display: block;
 	margin: 40px auto 0;
 	float: none;
+}
+
+@media only screen and (max-width: 1138px) {
+	.wp-filter .search-form {
+		margin: 11px 0;
+	}
 }
 
 @media only screen and (max-width: 1120px) {


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/61785

The margin in the search input box on the 'Add New Plugins' page was breaking below 1138px before the fix. Specifically, the top margin was set to 0px, and the overall appearance of the search box was inconsistent between 1000px and 1138px. There was no margin at the top or bottom during this range. Now, the margin is consistent across all breakpoints.

### Before: 

<img width="782" alt="image" src="https://github.com/user-attachments/assets/7e0ddba6-80b2-40f8-ace3-da54c9ffe8b2">

### After:
#### Chrome Browser:

https://github.com/user-attachments/assets/4117aa3a-6603-44a0-8d2d-ecc141e41475

#### Brave Browser:

https://github.com/user-attachments/assets/aae70082-d3d5-4afd-8cd7-632e9bc2dfe8

#### Safari Browser:

https://github.com/user-attachments/assets/ca4f855e-59dd-44f1-b618-9f9370c0373d


