### PR TITLE
Twenty Twenty-One: Latest comments block color inconsistency in editor and frontend

### DIFF
--- a/src/wp-content/themes/twentytwentyone/assets/css/style-editor.css
+++ b/src/wp-content/themes/twentytwentyone/assets/css/style-editor.css
@@ -520,10 +520,6 @@ a:hover {
 	outline: 2px dotted var(--wp--style--color--link, var(--global--color-primary));
 }
 
-.has-background .has-link-color a,
-.has-background.has-link-color a {
-	color: var(--wp--style--color--link, var(--global--color-primary));
-}
 
 .wp-block-button__link {
 	border: var(--button--border-width) solid transparent;
@@ -2355,11 +2351,6 @@ body {
 .wp-block a:focus {
 	outline: 2px solid var(--wp--style--color--link, var(--global--color-primary));
 	text-decoration: none;
-}
-
-.has-background .has-link-color a,
-.has-background.has-link-color a {
-	color: var(--wp--style--color--link, var(--global--color-primary));
 }
 
 button,


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/62636

There was inconsistency in the text and anchor tag colors when the background was added in the latest comments block.


### Steps to Reproduce:

1. Activate the Twenty Twenty-One theme.
2. Create a new post and add a Latest Comments block.
3. Set a background color using the inspector controls.
4. Set a text color using the inspector controls.
5. Observe the inconsistency between color in the editor and the frontend.
6. Change the link color in the editor; note that the changes are not visible in the editor but are applied on the frontend.

### Before : 

https://github.com/user-attachments/assets/febfe9b7-a8fd-45c9-9beb-a2ec0d0bf6ba


### After: 

https://github.com/user-attachments/assets/1360245e-021b-4911-9097-dded0cd653a0


