### PR TITLE
Customize: Fix misplaced filter themes wrapper

### DIFF
--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -1780,7 +1780,7 @@ p.customize-section-description {
 
 .control-panel-themes .customize-themes-full-container {
 	position: fixed;
-	top: 0;
+	top: 20px;
 	left: 0;
 	transition: .18s left ease-in-out;
 	margin: 0 0 0 300px;


### PR DESCRIPTION
Trac ticket: [#62637](https://core.trac.wordpress.org/ticket/62637)

## Description
This PR addresses an issue where the "Filter themes" wrapper element was misplaced within the "Customize > Change Theme > .org themes browser" section of the application.

## Screenshot:
### Before Patch:
![image](https://github.com/user-attachments/assets/db2da439-a86d-4b55-8999-86d157d2d758)

### After Patch:
![image](https://github.com/user-attachments/assets/ebf6e152-446a-44cd-8a0c-b1d4e93fcc9e)