### PR TITLE
Block Hooks: Fix context in `update_ignored_hooked_blocks_postmeta`

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1217,6 +1217,7 @@ function update_ignored_hooked_blocks_postmeta( $post ) {
 	$existing_post = get_post( $post->ID );
 	// Merge the existing post object with the updated post object to pass to the block hooks algorithm for context.
 	$context          = (object) array_merge( (array) $existing_post, (array) $post );
+	$context          = new WP_Post( $context ); // Convert to WP_Post object.
 	$serialized_block = apply_block_hooks_to_content( $markup, $context, 'set_ignored_hooked_blocks_metadata' );
 	$root_block       = parse_blocks( $serialized_block )[0];
 

--- a/tests/phpunit/tests/blocks/updateIgnoredHookedBlocksPostMeta.php
+++ b/tests/phpunit/tests/blocks/updateIgnoredHookedBlocksPostMeta.php
@@ -193,4 +193,31 @@ class Tests_Blocks_UpdateIgnoredHookedBlocksPostMeta extends WP_UnitTestCase {
 			'Post content did not match the original markup.'
 		);
 	}
+
+	/**
+	 * @ticket 62639
+	 */
+	public function test_update_ignored_hooked_blocks_postmeta_sets_correct_context_type() {
+		$action = new MockAction();
+		add_filter( 'hooked_block_types', array( $action, 'filter' ), 10, 4 );
+
+		$original_markup    = '<!-- wp:navigation-link {"label":"News","type":"page","id":2,"url":"http://localhost:8888/?page_id=2","kind":"post-type"} /-->';
+		$post               = new stdClass();
+		$post->ID           = self::$navigation_post->ID;
+		$post->post_content = $original_markup;
+		$post->post_type    = 'wp_navigation';
+
+		$post = update_ignored_hooked_blocks_postmeta( $post );
+
+		$args     = $action->get_args();
+		$contexts = array_column( $args, 3 );
+
+		foreach ( $contexts as $context ) {
+			$this->assertInstanceOf(
+				WP_Post::class,
+				$context,
+				'The context passed to the hooked_block_types filter is not a WP_Post instance.'
+			);
+		}
+	}
 }


### PR DESCRIPTION
Discovered while working on #7898.

## Testing Instructions

_Also see the screencasts further below._

### Preparatory steps:

- Make sure you're using a Block Theme that uses a Navigation block in its home page template (e.g. in its header or footer). TT4 should work.
- Upload the following code as a new plugin (i.e. copy to a new PHP file, zip, and upload to your WP install). 

```php
<?php
/**
 * Plugin Name:       Add Login/out block to Header Navigation
 * Description:       Block Hooks API demonstration
 * Version:           0.1.0
 * Requires at least: 6.7
 */

function add_loginout_block_to_header_navigation( $hooked_block_types, $relative_position, $anchor_block_type, $context ) {

	// Is $context a Navigation menu?
	if ( ! $context instanceof WP_Post || 'wp_navigation' !== $context->post_type ) {
		return $hooked_block_types;
	}
	
	if ( 'last_child' === $relative_position && 'core/navigation' === $anchor_block_type ) {
		$hooked_block_types[] = 'core/loginout';
	}

	return $hooked_block_types;
}
add_filter( 'hooked_block_types', 'add_loginout_block_to_header_navigation', 10, 4 );
```

### To verify the issue (on `trunk`):
- Activate the plugin.
- On the frontend, verify that a new "Log in" link has been added as the last item in your Navigation block.
- Click on "Edit site", and move that Login/out block to a different position within the Nav block.
- Save your changes, and view them on the frontend once again.
- Note that while the block is present in your chosen position, it is _also_ still present as the Nav block's last child ❌ 
- Click on "Edit site" once again. The editor should now reflect what you just saw on the frontend.
- Deactivate the plugin.
- Reload the Site Editor. Only the instance of the Login/out block that you moved should still be present.
- Delete that instance, and save the template. View it on the frontend to verify that the Navigation block is now in its original state (i.e. no "Log in" links).

### To verify the fix (on this branch):
- Switch to this branch.
- Re-activate the plugin.
- On the frontend, verify that a new "Log in" link has been added as the last item in your Navigation block.
- Click on "Edit site", and move that Login/out block to a different position within the Nav block.
- Save your changes, and view them on the frontend once again.
- Note that the block was successfully moved to your chosen position, and is no longer present in its previous place (as the Nav block's last child) ✅ 
- Click on "Edit site" once again. The editor should reflect what you just saw on the frontend (Login/out block in desired position).

## Screencast

### Before
![login-out-block-before](https://github.com/user-attachments/assets/1c481519-fbe7-455b-802d-1486897a9d52)

## After
![login-out-block-after](https://github.com/user-attachments/assets/172a3bf6-1ae5-48f2-a6f5-c262edfab3df)

Trac ticket: https://core.trac.wordpress.org/ticket/62639

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
