### PR TITLE
Add a repository input.

### DIFF
--- a/.github/workflows/reusable-support-json-reader-v1.yml
+++ b/.github/workflows/reusable-support-json-reader-v1.yml
@@ -79,6 +79,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          repository: ${{ inputs.repository }}
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
       # Look up the major version's specific PHP support policy when a version is provided.
@@ -111,6 +112,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          repository: ${{ inputs.repository }}
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
       # Look up the major version's specific MySQL support policy when a version is provided.

--- a/.github/workflows/reusable-support-json-reader-v1.yml
+++ b/.github/workflows/reusable-support-json-reader-v1.yml
@@ -11,6 +11,10 @@ on:
         description: 'The WordPress version to test . Accepts major and minor versions, "latest", or "nightly". Major releases must not end with ".0".'
         type: string
         default: 'nightly'
+      repository:
+        description: 'The repository to read the support JSON files from.'
+        type: string
+        default: 'WordPress/wordpress-develop'
     outputs:
       major-wp-version:
         description: "The major WordPress version based on the version provided in wp-version"
@@ -42,6 +46,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          repository: ${{ inputs.repository }}
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
       - name: Determine the major WordPress version


### PR DESCRIPTION
This adds a repository input that allows a different repository than the current one to be defined for pulling the JSON support files. This can be used to customize the matrix that is built.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
