### PR TITLE
Feat/remove html tags from output

### DIFF
--- a/src/wp-admin/site-health-info.php
+++ b/src/wp-admin/site-health-info.php
@@ -126,7 +126,7 @@ wp_admin_notice(
 						}
 
 						if ( in_array( $field_name, $sizes_fields, true ) ) {
-							printf( '<tr><td>%s efgh</td><td class="%s">%s</td></tr>', wp_strip_all_tags( $field['label'] ), esc_attr( $field_name ), $values );
+							printf( '<tr><td>%s</td><td class="%s">%s</td></tr>', wp_strip_all_tags( $field['label'] ), esc_attr( $field_name ), $values );
 						} else {
 							printf( '<tr><td>%s</td><td>%s</td></tr>', wp_strip_all_tags( $field['label'] ), $values );
 						}

--- a/src/wp-admin/site-health-info.php
+++ b/src/wp-admin/site-health-info.php
@@ -126,9 +126,9 @@ wp_admin_notice(
 						}
 
 						if ( in_array( $field_name, $sizes_fields, true ) ) {
-							printf( '<tr><td>%s</td><td class="%s">%s</td></tr>', esc_html( $field['label'] ), esc_attr( $field_name ), $values );
+							printf( '<tr><td>%s efgh</td><td class="%s">%s</td></tr>', wp_strip_all_tags( $field['label'] ), esc_attr( $field_name ), $values );
 						} else {
-							printf( '<tr><td>%s</td><td>%s</td></tr>', esc_html( $field['label'] ), $values );
+							printf( '<tr><td>%s</td><td>%s</td></tr>', wp_strip_all_tags( $field['label'] ), $values );
 						}
 					}
 


### PR DESCRIPTION
PR for https://core.trac.wordpress.org/ticket/62630

This PR fixes the problem of HTML tags appearing in the labels of plugin in site health. 