### PR TITLE
Fix horizontal overflow on small screens in theme details section

### DIFF
--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -935,6 +935,7 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 	.theme-overlay .theme-screenshots {
 		width: 100%;
 		float: none;
+		margin: 0;
 	}
 
 	.theme-overlay .theme-info {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/62647

### Description

A margin of 30px was added to the right of the theme screenshots on larger screens (above 650px) to create a gap between the screenshots and the description. However, this margin was not being removed on smaller screens (below 650px), causing an overflow on the x-axis and resulting in a horizontal scroll.

I removed the margin for smaller screens, as it is unnecessary when the screenshots and description are stacked. This change resolves the issue.

### Steps to reproduce:
1. WP-Admin >. Appearance > Themes
2. Hover over any theme
3. Click on the 'Theme Details'
4. Notice that there is a margin-right added in the .theme-screenshots class, which is causing an overflow on the x-axis.


### Screencast:

Before the patch:

https://github.com/user-attachments/assets/f51782f1-dac0-4fe5-a837-5e6286f76dbb


After the patch:

https://github.com/user-attachments/assets/effadb0f-6c54-4282-857e-feeb1cef85ca


