### PR TITLE
Fix update_post_thumbnail_cache notice by ensuring $post is valid in loops

### DIFF
--- a/src/wp-includes/post-thumbnail-template.php
+++ b/src/wp-includes/post-thumbnail-template.php
@@ -130,6 +130,9 @@ function update_post_thumbnail_cache( $wp_query = null ) {
 	_prime_post_caches( $parent_post_ids, false, true );
 
 	foreach ( $wp_query->posts as $post ) {
+		if( $post instanceof WP_Post ) {
+			$post = $post->ID;
+		}
 		$id = get_post_thumbnail_id( $post );
 		if ( $id ) {
 			$thumb_ids[] = $id;

--- a/src/wp-includes/post-thumbnail-template.php
+++ b/src/wp-includes/post-thumbnail-template.php
@@ -130,7 +130,7 @@ function update_post_thumbnail_cache( $wp_query = null ) {
 	_prime_post_caches( $parent_post_ids, false, true );
 
 	foreach ( $wp_query->posts as $post ) {
-		if( $post instanceof WP_Post ) {
+		if ( $post instanceof WP_Post ) {
 			$post = $post->ID;
 		}
 		$id = get_post_thumbnail_id( $post );


### PR DESCRIPTION
This PR addresses an issue where notices such as "Trying to get property 'ID' of non-object" could occur when working with `$wp_query->posts` in loops. The code has been updated to validate that `$post` is an instance of `WP_Post` before attempting to access its properties. If `$post` is valid, it is converted to its post ID to ensure compatibility with `get_post_thumbnail_id()`. This change prevents errors in scenarios where `$post` may not be a proper object, improving the reliability and stability of the loop when handling post data.

Trac ticket: https://core.trac.wordpress.org/ticket/50847

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
