### PR TITLE
Make the theme and plugin file editors more consistent

### DIFF
--- a/src/wp-admin/plugin-editor.php
+++ b/src/wp-admin/plugin-editor.php
@@ -85,6 +85,9 @@ if ( empty( $file ) ) {
 $file      = validate_file_to_edit( $file, $plugin_files );
 $real_file = WP_PLUGIN_DIR . '/' . $file;
 
+$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin_files[0] );
+$plugin_name = $plugin_data['Name'];
+
 // Handle fallback editing of file when JavaScript is not available.
 $edit_error     = null;
 $posted_content = null;
@@ -220,23 +223,30 @@ endif;
 	<?php
 	if ( is_plugin_active( $plugin ) ) {
 		if ( is_writable( $real_file ) ) {
-			/* translators: %s: Plugin file name. */
-			printf( __( 'Editing %s (active)' ), '<strong>' . esc_html( $file ) . '</strong>' );
+			/* translators: %s: Plugin name. */
+			printf( __( 'Editing %s (active)' ), '<strong>' . esc_html( $plugin_name ) . '</strong>' );
 		} else {
-			/* translators: %s: Plugin file name. */
-			printf( __( 'Browsing %s (active)' ), '<strong>' . esc_html( $file ) . '</strong>' );
+			/* translators: %s: Plugin name. */
+			printf( __( 'Browsing %s (active)' ), '<strong>' . esc_html( $plugin_name ) . '</strong>' );
 		}
 	} else {
 		if ( is_writable( $real_file ) ) {
-			/* translators: %s: Plugin file name. */
-			printf( __( 'Editing %s (inactive)' ), '<strong>' . esc_html( $file ) . '</strong>' );
+			/* translators: %s: Plugin name. */
+			printf( __( 'Editing %s (inactive)' ), '<strong>' . esc_html( $plugin_name ) . '</strong>' );
 		} else {
-			/* translators: %s: Plugin file name. */
-			printf( __( 'Browsing %s (inactive)' ), '<strong>' . esc_html( $file ) . '</strong>' );
+			/* translators: %s: Plugin name. */
+			printf( __( 'Browsing %s (inactive)' ), '<strong>' . esc_html( $plugin_name ) . '</strong>' );
 		}
 	}
 	?>
 </h2>
+<?php
+printf(
+	/* translators: %s: File path. */
+	' <span><strong>' . __( 'File: %s' ) . '</strong></span>',
+	esc_html( $file )
+);
+?>
 </div>
 <div class="alignright">
 	<form action="plugin-editor.php" method="get">

--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -182,12 +182,7 @@ if ( ! empty( $posted_content ) ) {
 	$content = esc_textarea( $content );
 }
 
-$file_description = get_file_description( $relative_file );
-$file_show        = array_search( $file, array_filter( $allowed_files ), true );
-$description      = esc_html( $file_description );
-if ( $file_description !== $file_show ) {
-	$description .= ' <span>(' . esc_html( $file_show ) . ')</span>';
-}
+$file_show = array_search( $file, array_filter( $allowed_files ), true );
 ?>
 <div class="wrap">
 <h1><?php echo esc_html( $title ); ?></h1>
@@ -235,12 +230,23 @@ if ( preg_match( '/\.css$/', $file ) && ! wp_is_block_theme() && current_user_ca
 <div class="alignleft">
 <h2>
 	<?php
-	echo $theme->display( 'Name' );
-	if ( $description ) {
-		echo ': ' . $description;
+	if ( wp_get_theme()->get( 'Name' ) === $theme->display( 'Name' ) ) {
+		/* translators: %s: Theme name. */
+		printf( __( 'Editing %s (active)' ), '<strong>' . $theme->display( 'Name' ) . '</strong>' );
+	} else {
+		/* translators: %s: Theme name. */
+		printf( __( 'Editing %s (inactive)' ), '<strong>' . $theme->display( 'Name' ) . '</strong>' );
 	}
+
 	?>
 </h2>
+<?php
+printf(
+	/* translators: %s: File path. */
+	' <span><strong>' . __( 'File: %s' ) . '</strong></span>',
+	esc_html( $file_show )
+);
+?>
 </div>
 <div class="alignright">
 	<form action="theme-editor.php" method="get">


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
Update the header area of the theme and plugin file editor pages to be more consistent.

Display the name of theme or plugin, the active or inactive state, and the path to the file that is selected (including the file name).

Trac ticket: https://core.trac.wordpress.org/ticket/41142

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
