### PR TITLE
Add Playwright e2e test for bulk edit pages

### DIFF
--- a/tests/e2e/specs/pages/bulk-edit-pages.test.js
+++ b/tests/e2e/specs/pages/bulk-edit-pages.test.js
@@ -1,0 +1,58 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Bulk Edit the wp-page', () => {
+	test.beforeEach( async ( { admin, editor, requestUtils } ) => {
+		// delete all pages
+		await requestUtils.deleteAllPages();
+
+		// create pages to use in test
+		const postTitles = [
+			'Test Post for bulk edit 1',
+			'Test Post for bulk edit 2',
+		];
+
+		for ( const title of postTitles ) {
+			await admin.createNewPost( { title, postType: 'page' } );
+			await editor.publishPost();
+		}
+	} );
+
+	test( 'Should able to edit the pages in bulk', async ( {
+		page,
+		admin,
+	} ) => {
+		await admin.visitAdminPage( '/edit.php?post_type=page' );
+
+		// click on select all checkbox
+		await page.locator( '#cb-select-all-1' ).click();
+
+		// select the edit option from the dropdown
+		await page.selectOption( '#bulk-action-selector-top', 'edit' );
+
+		// click on apply button
+		await page.click( 'role=button[name="Apply"i] >> nth=0' );
+
+		// select the draft option
+		await page
+			.getByRole( 'combobox', { name: 'Status' } )
+			.selectOption( 'draft' );
+
+		// click on the update button
+		await page.getByRole( 'button', { name: 'Update' } ).click();
+
+		await expect(
+			page.locator( "div[id='message'] p" ).first()
+		).toHaveText( /pages updated./ );
+
+		const listTable = page.getByRole( 'table', {
+			name: 'Table ordered by',
+		} );
+		const posts = listTable.locator( '.page-title  strong span' );
+
+		// Validate that the page is in draft status
+		await expect( posts.first() ).toHaveText( 'Draft' );
+	} );
+} );

--- a/tests/e2e/specs/pages/bulk-edit-pages.test.js
+++ b/tests/e2e/specs/pages/bulk-edit-pages.test.js
@@ -55,4 +55,5 @@ test.describe( 'Bulk Edit the wp-page', () => {
 		// Validate that the page is in draft status
 		await expect( posts.first() ).toHaveText( 'Draft' );
 	} );
+	
 } );

--- a/tests/e2e/specs/pages/bulk-edit-pages.test.js
+++ b/tests/e2e/specs/pages/bulk-edit-pages.test.js
@@ -27,13 +27,13 @@ test.describe( 'Bulk Edit the wp-page', () => {
 		await admin.visitAdminPage( '/edit.php?post_type=page' );
 
 		// click on select all checkbox
-		await page.locator( '#cb-select-all-1' ).click();
+		await page.getByRole( 'checkbox').first().click();
 
 		// select the edit option from the dropdown
 		await page.selectOption( '#bulk-action-selector-top', 'edit' );
 
 		// click on apply button
-		await page.click( 'role=button[name="Apply"i] >> nth=0' );
+		await page.getByRole('button', {name: 'Apply'}).first().click();
 
 		// select the draft option
 		await page
@@ -43,17 +43,13 @@ test.describe( 'Bulk Edit the wp-page', () => {
 		// click on the update button
 		await page.getByRole( 'button', { name: 'Update' } ).click();
 
-		await expect(
-			page.locator( "div[id='message'] p" ).first()
-		).toHaveText( /pages updated./ );
+		await expect(page.getByText(/pages updated./)).toBeVisible();
 
 		const listTable = page.getByRole( 'table', {
 			name: 'Table ordered by',
 		} );
-		const posts = listTable.locator( '.page-title  strong span' );
 
-		// Validate that the page is in draft status
-		await expect( posts.first() ).toHaveText( 'Draft' );
+		await expect(listTable.filter({hasText: 'Draft'})).toBeVisible();
 	} );
 	
 } );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Added Playwright e2e test for bulk edit pages

Trac ticket: https://core.trac.wordpress.org/ticket/52895

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
