### PR TITLE
Add Playwright e2e test to validate preview a page

### DIFF
--- a/tests/e2e/specs/pages/preview-page.test.js
+++ b/tests/e2e/specs/pages/preview-page.test.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Preview page', () => {
+	test.beforeEach( async ( { admin, editor, requestUtils } ) => {
+		requestUtils.deleteAllPages();
+
+		await admin.createNewPost( { postType: 'page', title: 'qa page' } );
+
+		// publish post
+		await editor.publishPost();
+	} );
+
+	test( 'Should be able to preview page in different viewport', async ( {
+		page,
+		admin,
+	} ) => {
+		await admin.visitAdminPage( '/edit.php?post_type=page' );
+
+		await page.getByRole( 'link', { name: '“qa page” (Edit)' } ).click();
+
+		// Click Preview button
+		await page.getByRole( 'button', { name: 'View', exact: true } ).click();
+
+		//Check for tablet preview
+		await page.getByRole( 'menuitemradio', { name: 'Tablet' } ).click();
+		await expect( page.isVisible( '.is-tablet-preview' ) ).toBeTruthy();
+
+		//Check for Mobile preview
+		await page.getByRole( 'menuitemradio', { name: 'Mobile' } ).click();
+		await expect( page.isVisible( '.is-mobile-preview' ) ).toBeTruthy();
+
+		// Check for Desktop preview
+		await page.getByRole( 'menuitemradio', { name: 'Desktop' } ).click();
+		await expect( page.isVisible( '.is-mobile-preview' ) ).toBeTruthy();
+
+		// click on the preview in new tab link and wait for new tab to be triggered
+		const [ newPage ] = await Promise.all( [
+			page.waitForEvent( 'popup' ),
+			page.locator( 'text=Preview in new tab' ).click(),
+		] );
+
+		// wait for the new page to load and validate the URL
+		await newPage.waitForLoadState();
+		await expect( newPage ).toHaveURL( /preview=true/ );
+	} );
+} );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Added Playwright e2e test to validate previewing a page

Trac ticket: https://core.trac.wordpress.org/ticket/52895

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
