### PR TITLE
Administration: Sanitize `wp_http_referer` in user-edit.php using `sanitize_url`

### DIFF
--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -14,7 +14,7 @@ require_once ABSPATH . 'wp-admin/includes/translation-install.php';
 
 $action          = ! empty( $_REQUEST['action'] ) ? sanitize_text_field( $_REQUEST['action'] ) : '';
 $user_id         = ! empty( $_REQUEST['user_id'] ) ? absint( $_REQUEST['user_id'] ) : 0;
-$wp_http_referer = ! empty( $_REQUEST['wp_http_referer'] ) ? sanitize_text_field( $_REQUEST['wp_http_referer'] ) : '';
+$wp_http_referer = ! empty( $_REQUEST['wp_http_referer'] ) ? sanitize_url( $_REQUEST['wp_http_referer'] ) : '';
 
 $current_user = wp_get_current_user();
 


### PR DESCRIPTION
Replaced `sanitize_text_field()` with `sanitize_url()` for the `wp_http_referer` variable in `user-edit.php`.


Trac ticket: [#62659](https://core.trac.wordpress.org/ticket/62659)
