### PR TITLE
Trim down the upgrade testing workflow.

### DIFF
--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -76,7 +76,7 @@ jobs:
         os: [ 'ubuntu-latest' ]
         php: [ '7.2', '7.4', '8.0', '8.4' ]
         db-type: [ 'mysql' ]
-        db-version: [ '5.7', '8.0', '8.4' ]
+        db-version: [ '5.7', '8.4' ]
         wp: [ '6.0', '6.1', '6.2', '6.3', '6.4', '6.5' ]
         multisite: [ false, true ]
 
@@ -105,7 +105,7 @@ jobs:
         os: [ 'ubuntu-latest' ]
         php: [ '7.2', '7.4' ]
         db-type: [ 'mysql' ]
-        db-version: [ '5.7', '8.0', '8.4' ]
+        db-version: [ '5.7', '8.4' ]
         wp: [ '5.0', '5.1', '5.3', '5.4', '5.5', '5.6', '5.9' ]
         multisite: [ false, true ]
 
@@ -138,7 +138,7 @@ jobs:
         os: [ 'ubuntu-latest' ]
         php: [ '8.0', '8.4' ]
         db-type: [ 'mysql' ]
-        db-version: [ '5.7', '8.0', '8.4' ]
+        db-version: [ '5.7', '8.4' ]
         wp: [ '5.3', '5.4', '5.5', '5.6', '5.9' ]
         multisite: [ false, true ]
     with:
@@ -163,7 +163,7 @@ jobs:
         os: [ 'ubuntu-latest' ]
         php: [ '7.2', '7.4' ]
         db-type: [ 'mysql' ]
-        db-version: [ '5.7', '8.0', '8.4' ]
+        db-version: [ '5.7', '8.4' ]
         wp: [ '4.1', '4.2', '4.3', '4.4', '4.5', '4.6', '4.7' ]
         multisite: [ false, true ]
 
@@ -198,7 +198,7 @@ jobs:
         os: [ 'ubuntu-latest' ]
         php: [ '8.0', '8.4' ]
         db-type: [ 'mysql' ]
-        db-version: [ '5.7', '8.0', '8.4' ]
+        db-version: [ '5.7', '8.4' ]
         wp: [ '4.1', '4.2', '4.3', '4.4', '4.5' ]
         multisite: [ false, true ]
     with:

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -35,7 +35,7 @@ concurrency:
 permissions: {}
 
 # Because the number of jobs spawned can balloon out of control quickly, the following methodology is applied when
-# building ou the matrix below:
+# building out the matrix below:
 #
 # - The last two releases of WordPress are tested against all PHP and MySQL LTS version combinations and the most recent
 #   innovation release.

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -34,16 +34,16 @@ concurrency:
 # Any needed permissions should be configured at the job level.
 permissions: {}
 
-# Because the number of jobs spawned can balloon out of control quickly, the following methodology is applied when
+# Because the number of jobs spawned can quickly balloon out of control, the following methodology is applied when
 # building out the matrix below:
 #
-# - The last two releases of WordPress are tested against all PHP and MySQL LTS version combinations and the most recent
+# - The last two releases of WordPress are tested against all PHP/MySQL LTS version combinations and the most recent
 #   innovation release.
 # - The next 6 oldest versions of WordPress are tested against both the oldest and newest releases of PHP currently
 #   supported for both PHP 7 & 8 along with the oldest and newest MySQL LTS versions currently supported (no innovation
-#   releases).
-# - For the remaining versions of WordPress receiving security updates, they are only included if the database version
-#   was different that the previous major release.
+#   releases). At the current 3 releases per year pace, this accounts for 2 additional years worth of releases.
+# - Of the remaining versions of WordPress still receiving security updates, only test the ones where the database
+#   version was updated since the previous major release.
 # - The oldest version of WordPress receiving security updates should always be tested.
 
 #  Notes about chosen MySQL versions:

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -32,8 +32,8 @@ concurrency:
 permissions: {}
 
 jobs:
-  # Spawns upgrade testing from WordPress 6.x versions on PHP 8.x with MySQL.
-  upgrade-tests-wp-6x-php-8x-mysql:
+  # Tests the full list of PHP/MySQL combinations for the last two versions of WordPress.
+  upgrade-tests-last-two-releases:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: WordPress/wordpress-develop/.github/workflows/reusable-upgrade-testing.yml@trunk
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
@@ -43,10 +43,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        php: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
-        wp: [ '6.0', '6.1', '6.2', '6.3', '6.4', '6.5', '6.6', '6.7' ]
+        wp: [ '6.6', '6.7' ]
         multisite: [ false, true ]
 
     with:
@@ -58,8 +58,8 @@ jobs:
       new-version: ${{ inputs.new-version && inputs.new-version || 'latest' }}
       multisite: ${{ matrix.multisite }}
 
-  # Spawns upgrade testing from WordPress 6.x versions on PHP 7.x with MySQL.
-  upgrade-tests-wp-6x-php-7x-mysql:
+  # Tests the remaining 6.x releases on the oldest and newest supported versions of PHP 7 & 8.
+  upgrade-tests-wp-6x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: WordPress/wordpress-develop/.github/workflows/reusable-upgrade-testing.yml@trunk
     if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
@@ -69,10 +69,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        php: [ '7.2', '7.3', '7.4' ]
+        php: [ '7.2', '7.4', '8.0', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
-        wp: [ '6.0', '6.1', '6.2', '6.3', '6.4', '6.5', '6.6', '6.7' ]
+        wp: [ '6.0', '6.1', '6.2', '6.3', '6.4', '6.5' ]
         multisite: [ false, true ]
 
         exclude:
@@ -89,7 +89,7 @@ jobs:
       new-version: ${{ inputs.new-version && inputs.new-version || 'latest' }}
       multisite: ${{ matrix.multisite }}
 
-  # Spawns upgrade testing from WordPress 5.x versions on PHP 7.x with MySQL.
+  # Tests 5.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 7.
   upgrade-tests-wp-5x-php-7x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: WordPress/wordpress-develop/.github/workflows/reusable-upgrade-testing.yml@trunk
@@ -98,10 +98,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        php: [ '7.2', '7.3', '7.4' ]
+        php: [ '7.2', '7.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
-        wp: [ '5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7', '5.8', '5.9' ]
+        wp: [ '5.0', '5.1', '5.3', '5.4', '5.5', '5.6', '5.9' ]
         multisite: [ false, true ]
 
         exclude:
@@ -118,7 +118,7 @@ jobs:
       new-version: ${{ inputs.new-version && inputs.new-version || 'latest' }}
       multisite: ${{ matrix.multisite }}
 
-  # Spawns upgrade testing from WordPress 5.x versions on PHP 8.x with MySQL.
+  # Tests 5.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 8.
   #
   # WordPress 5.0-5.2 are excluded from PHP 8+ testing because of the following fatal errors:
   # - Use of __autoload().
@@ -131,10 +131,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        php: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '8.0', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
-        wp: [ '5.3', '5.4', '5.5', '5.6', '5.7', '5.8', '5.9' ]
+        wp: [ '5.3', '5.4', '5.5', '5.6', '5.9' ]
         multisite: [ false, true ]
     with:
       os: ${{ matrix.os }}
@@ -145,7 +145,9 @@ jobs:
       new-version: ${{ inputs.new-version && inputs.new-version || 'latest' }}
       multisite: ${{ matrix.multisite }}
 
-  # Spawns upgrade testing from WordPress 4.x versions on PHP 7.x with MySQL.
+  # Tests 4.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 7.
+  #
+  # The oldest version of WordPress receiving security updates should always be tested.
   upgrade-tests-wp-4x-php-7x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: WordPress/wordpress-develop/.github/workflows/reusable-upgrade-testing.yml@trunk
@@ -154,10 +156,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        php: [ '7.2', '7.3', '7.4' ]
+        php: [ '7.2', '7.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
-        wp: [ '4.1', '4.2', '4.3', '4.4', '4.5', '4.6', '4.7', '4.8', '4.9' ]
+        wp: [ '4.1', '4.2', '4.3', '4.4', '4.5', '4.6', '4.7' ]
         multisite: [ false, true ]
 
         exclude:
@@ -174,7 +176,9 @@ jobs:
       new-version: ${{ inputs.new-version && inputs.new-version || 'latest' }}
       multisite: ${{ matrix.multisite }}
 
-  # Spawns upgrade testing from WordPress 4.x versions on PHP 8.x with MySQL.
+  # Tests 4.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 8.
+  #
+  # The oldest version of WordPress receiving security updates should always be tested.
   #
   # WordPress 4.6-4.9 are excluded from PHP 8+ testing because of the following fatal errors:
   # - Use of __autoload().
@@ -187,10 +191,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        php: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '8.0', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
-        wp: [ '4.1', '4.2', '4.3', '4.4', '4.5' ]
+        wp: [ '4.1', '4.2', '4.3', '4.4', '4.5', '4.6', '4.7' ]
         multisite: [ false, true ]
     with:
       os: ${{ matrix.os }}
@@ -207,7 +211,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-    needs: [ upgrade-tests-wp-6x-php-8x-mysql, upgrade-tests-wp-6x-php-7x-mysql, upgrade-tests-wp-5x-php-7x-mysql, upgrade-tests-wp-5x-php-8x-mysql, upgrade-tests-wp-4x-php-7x-mysql, upgrade-tests-wp-4x-php-8x-mysql ]
+    needs: [ upgrade-tests-last-two-releases, upgrade-tests-wp-6x-mysql, upgrade-tests-wp-5x-php-7x-mysql, upgrade-tests-wp-5x-php-8x-mysql, upgrade-tests-wp-4x-php-7x-mysql, upgrade-tests-wp-4x-php-8x-mysql ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name != 'pull_request' && always() }}
     with:
       calling_status: ${{ contains( needs.*.result, 'cancelled' ) && 'cancelled' || contains( needs.*.result, 'failure' ) && 'failure' || 'success' }}

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -1,3 +1,6 @@
+# Confirms that updating WordPress using WP-CLI works successfully.
+#
+# This workflow is not meant to test wordpress-develop checkouts, but rather tagged versions officially available on WordPress.org.
 name: Upgrade Tests
 
 on:
@@ -31,6 +34,23 @@ concurrency:
 # Any needed permissions should be configured at the job level.
 permissions: {}
 
+# Because the number of jobs spawned can balloon out of control quickly, the following methodology is applied when
+# building ou the matrix below:
+#
+# - The last two releases of WordPress are tested against all PHP and MySQL LTS version combinations and the most recent
+#   innovation release.
+# - The next 6 oldest versions of WordPress are tested against both the oldest and newest releases of PHP currently
+#   supported for both PHP 7 & 8 along with the oldest and newest MySQL LTS versions currently supported.
+# - For the remaining versions of WordPress receiving security updates, they should only be included if the database
+#   version was changed from the one used in the previous major release.
+# - The oldest version of WordPress receiving security updates should always be tested.
+
+#  Notes about chosen MySQL versions:
+#    - Only the most recent innovation release should be included in testing.
+#    - Even though MySQL >= 5.5.5 is currently supported, there are no 5.5.x Docker containers available that work on
+#      modern architectures.
+#    - 5.6.x Docker containers are available and work, but 5.6 only accounts for ~2.3% of installs as of 12/6/2024.defaults:
+#    - 5.7.x accounts for ~2-% of installs, so this is used below instead.
 jobs:
   # Tests the full list of PHP/MySQL combinations for the last two versions of WordPress.
   upgrade-tests-last-two-releases:
@@ -45,7 +65,7 @@ jobs:
         os: [ 'ubuntu-latest' ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         db-type: [ 'mysql' ]
-        db-version: [ '5.7', '8.0', '8.4' ]
+        db-version: [ '5.7', '8.0', '8.4', '9.1' ]
         wp: [ '6.6', '6.7' ]
         multisite: [ false, true ]
 
@@ -54,6 +74,11 @@ jobs:
             db-version: '8.4'
           - php: '7.3'
             db-version: '8.4'
+          # MySQL 9.0+ will not work on PHP 7.2 & 7.3
+          - php: '7.2'
+            db-version: '9.0'
+          - php: '7.3'
+            db-version: '9.0'
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -40,9 +40,10 @@ permissions: {}
 # - The last two releases of WordPress are tested against all PHP and MySQL LTS version combinations and the most recent
 #   innovation release.
 # - The next 6 oldest versions of WordPress are tested against both the oldest and newest releases of PHP currently
-#   supported for both PHP 7 & 8 along with the oldest and newest MySQL LTS versions currently supported.
-# - For the remaining versions of WordPress receiving security updates, they should only be included if the database
-#   version was changed from the one used in the previous major release.
+#   supported for both PHP 7 & 8 along with the oldest and newest MySQL LTS versions currently supported (no innovation
+#   releases).
+# - For the remaining versions of WordPress receiving security updates, they are only included if the database version
+#   was different that the previous major release.
 # - The oldest version of WordPress receiving security updates should always be tested.
 
 #  Notes about chosen MySQL versions:
@@ -76,9 +77,9 @@ jobs:
             db-version: '8.4'
           # MySQL 9.0+ will not work on PHP 7.2 & 7.3
           - php: '7.2'
-            db-version: '9.0'
+            db-version: '9.1'
           - php: '7.3'
-            db-version: '9.0'
+            db-version: '9.1'
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -51,7 +51,7 @@ permissions: {}
 #    - Even though MySQL >= 5.5.5 is currently supported, there are no 5.5.x Docker containers available that work on
 #      modern architectures.
 #    - 5.6.x Docker containers are available and work, but 5.6 only accounts for ~2.3% of installs as of 12/6/2024.defaults:
-#    - 5.7.x accounts for ~2-% of installs, so this is used below instead.
+#    - 5.7.x accounts for ~20% of installs, so this is used below instead.
 jobs:
   # Tests the full list of PHP/MySQL combinations for the last two versions of WordPress.
   upgrade-tests-last-two-releases:

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -44,7 +44,8 @@ permissions: {}
 #   releases). At the current 3 releases per year pace, this accounts for 2 additional years worth of releases.
 # - Of the remaining versions of WordPress still receiving security updates, only test the ones where the database
 #   version was updated since the previous major release.
-# - The oldest version of WordPress receiving security updates should always be tested.
+# - The oldest version of WordPress receiving security updates should always be tested against the same combinations as
+#   detailed for the last two releases.
 
 #  Notes about chosen MySQL versions:
 #    - Only the most recent innovation release should be included in testing.
@@ -236,13 +237,48 @@ jobs:
       new-version: ${{ inputs.new-version && inputs.new-version || 'latest' }}
       multisite: ${{ matrix.multisite }}
 
+  # The oldest version of WordPress receiving security updates should always be tested against the full list of
+  # PHP/MySQL combinations.
+  upgrade-tests-oldest-wp-mysql:
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
+    uses: WordPress/wordpress-develop/.github/workflows/reusable-upgrade-testing.yml@trunk
+    if: ${{ github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'ubuntu-latest' ]
+        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        db-type: [ 'mysql' ]
+        db-version: [ '5.7', '8.0', '8.4', '9.1' ]
+        wp: [ '4.1' ]
+        multisite: [ false, true ]
+
+        exclude:
+          - php: '7.2'
+            db-version: '8.4'
+          - php: '7.3'
+            db-version: '8.4'
+          # MySQL 9.0+ will not work on PHP 7.2 & 7.3
+          - php: '7.2'
+            db-version: '9.1'
+          - php: '7.3'
+            db-version: '9.1'
+    with:
+      os: ${{ matrix.os }}
+      php: ${{ matrix.php }}
+      db-type: ${{ matrix.db-type }}
+      db-version: ${{ matrix.db-version }}
+      wp: ${{ matrix.wp }}
+      new-version: ${{ inputs.new-version && inputs.new-version || 'latest' }}
+      multisite: ${{ matrix.multisite }}
+
   slack-notifications:
     name: Slack Notifications
     uses: WordPress/wordpress-develop/.github/workflows/slack-notifications.yml@trunk
     permissions:
       actions: read
       contents: read
-    needs: [ upgrade-tests-last-two-releases, upgrade-tests-wp-6x-mysql, upgrade-tests-wp-5x-php-7x-mysql, upgrade-tests-wp-5x-php-8x-mysql, upgrade-tests-wp-4x-php-7x-mysql, upgrade-tests-wp-4x-php-8x-mysql ]
+    needs: [ upgrade-tests-last-two-releases, upgrade-tests-wp-6x-mysql, upgrade-tests-wp-5x-php-7x-mysql, upgrade-tests-wp-5x-php-8x-mysql, upgrade-tests-wp-4x-php-7x-mysql, upgrade-tests-wp-4x-php-8x-mysql, upgrade-tests-oldest-wp-mysql ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name != 'pull_request' && always() }}
     with:
       calling_status: ${{ contains( needs.*.result, 'cancelled' ) && 'cancelled' || contains( needs.*.result, 'failure' ) && 'failure' || 'success' }}

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -43,12 +43,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        php: [ '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
         wp: [ '6.6', '6.7' ]
         multisite: [ false, true ]
 
+        exclude:
+          - php: '7.2'
+            db-version: '8.4'
+          - php: '7.3'
+            db-version: '8.4'
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -194,7 +199,7 @@ jobs:
         php: [ '8.0', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
-        wp: [ '4.1', '4.2', '4.3', '4.4', '4.5', '4.6', '4.7' ]
+        wp: [ '4.1', '4.2', '4.3', '4.4', '4.5' ]
         multisite: [ false, true ]
     with:
       os: ${{ matrix.os }}


### PR DESCRIPTION
As it stands today, the upgrade testing workflow is currently at ~978 jobs created. While it's great to test all possible combinations, GitHub's UI cannot keep up with tracking that number of jobs, and that is 2x the total number of allowed jobs for the organization (which slows everything down even more).

This PR trims down the number of combinations included in the testing matrices to be a bit more thoughtful following the following methodology:

- The last two releases of WordPress are tested against all PHP and MySQL LTS version combinations and the most recent innovation release.
- The next 6 oldest versions of WordPress are tested against both the oldest and newest releases of PHP currently supported for both PHP 7 & 8 along with the oldest and newest MySQL LTS versions currently supported (no innovation releases).
- For the remaining versions of WordPress receiving security updates, they are only included if the database version was different that the previous major release.
- The oldest version of WordPress receiving security updates should always be tested.

Some additional notes about the chosen MySQL versions:
- Only the most recent innovation release should be included in testing.
- Even though MySQL >= 5.5.5 is currently supported, there are no 5.5.x Docker containers available that work on  modern architectures.
- 5.6.x Docker containers are available and work, but 5.6 only accounts for ~2.3% of installs as of 12/6/2024.defaults:
- 5.7.x accounts for ~20% of installs, so this is used below instead.

The contents of this PR description are included as inline documentation in the workflow to help guide contributors when updating this workflow in the future.

The changes in this workflow decrease the total number of jobs from 978 to 360 (a 63% reduction) and results in the entire job completing in less than 10 minutes (it currently takes anywhere from 20-40 minutes for the workflow to reflect the outcome of all spawned jobs).

Trac ticket: https://core.trac.wordpress.org/ticket/62221

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
