### PR TITLE
Added unit tests for ticket 62658

### DIFF
--- a/src/wp-includes/revision.php
+++ b/src/wp-includes/revision.php
@@ -270,42 +270,34 @@ function wp_save_post_revision( $post_id ) {
  *
  * @since 2.6.0
  *
- * @global wpdb $wpdb WordPress database abstraction object.
- *
  * @param int $post_id The post ID.
  * @param int $user_id Optional. The post author ID. Default 0.
  * @return WP_Post|false The autosaved data or false on failure or when no autosave exists.
  */
 function wp_get_post_autosave( $post_id, $user_id = 0 ) {
-	global $wpdb;
-
-	$autosave_name = $post_id . '-autosave-v1';
-	$user_id_query = ( 0 !== $user_id ) ? "AND post_author = $user_id" : null;
-
-	// Construct the autosave query.
-	$autosave_query = "
-		SELECT *
-		FROM $wpdb->posts
-		WHERE post_parent = %d
-		AND post_type = 'revision'
-		AND post_status = 'inherit'
-		AND post_name   = %s " . $user_id_query . '
-		ORDER BY post_date DESC
-		LIMIT 1';
-
-	$autosave = $wpdb->get_results(
-		$wpdb->prepare(
-			$autosave_query,
-			$post_id,
-			$autosave_name
-		)
+	$args = array(
+		'post_type'      => 'revision',
+		'post_status'    => 'inherit',
+		'post_parent'    => $post_id,
+		'name'           => $post_id . '-autosave-v1',
+		'posts_per_page' => 1,
+		'orderby'        => 'date',
+		'order'          => 'DESC',
+		'fields'         => 'ids',
+		'no_found_rows'  => true,
 	);
 
-	if ( ! $autosave ) {
+	if ( 0 !== $user_id ) {
+		$args['author'] = $user_id;
+	}
+
+	$query = new WP_Query( $args );
+
+	if ( ! $query->have_posts() ) {
 		return false;
 	}
 
-	return get_post( $autosave[0] );
+	return get_post( $query->posts[0] );
 }
 
 /**

--- a/tests/phpunit/tests/post/wpGetAutoSave.php
+++ b/tests/phpunit/tests/post/wpGetAutoSave.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * @group post
+ */
+class Tests_Post_GetPostAutosave extends WP_UnitTestCase {
+
+	/**
+	 * Admin user ID.
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * Editor user ID.
+	 *
+	 * @var int
+	 */
+	protected static $editor_id;
+
+	/**
+	 * Post ID.
+	 *
+	 * @var int
+	 */
+	protected static $post_id;
+
+	/**
+	 * Ticket #62658
+	 *
+	 * @see https://core.trac.wordpress.org/ticket/62658
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id  = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$editor_id = $factory->user->create( array( 'role' => 'editor' ) );
+
+		wp_set_current_user( self::$admin_id );
+		self::$post_id = $factory->post->create( array( 'post_status' => 'publish' ) );
+	}
+
+	/**
+	 * Test when no autosave exists for a post.
+	 */
+	public function test_no_autosave_exists() {
+		$autosave = wp_get_post_autosave( self::$post_id );
+		$this->assertFalse( $autosave, 'Expected no autosave.' );
+	}
+
+	/**
+	 * Test when an autosave exists for a post.
+	 */
+	public function test_autosave_exists() {
+		$autosave_id = wp_insert_post(
+			array(
+				'post_type'    => 'revision',
+				'post_status'  => 'inherit',
+				'post_parent'  => self::$post_id,
+				'post_author'  => self::$admin_id,
+				'post_content' => 'Autosaved content',
+				'post_name'    => self::$post_id . '-autosave-v1',
+			)
+		);
+
+		$autosave = wp_get_post_autosave( self::$post_id );
+
+		$this->assertInstanceOf( 'WP_Post', $autosave );
+		$this->assertSame( $autosave_id, $autosave->ID, 'Autosave ID does not match.' );
+		$this->assertSame( self::$post_id, (int) $autosave->post_parent, 'Post parent ID does not match.' );
+	}
+
+	/**
+	 * Test when an autosave exists for a specific user.
+	 */
+	public function test_autosave_for_specific_user() {
+		$autosave_id = wp_insert_post(
+			array(
+				'post_type'    => 'revision',
+				'post_status'  => 'inherit',
+				'post_parent'  => self::$post_id,
+				'post_author'  => self::$editor_id,
+				'post_content' => 'Editor-specific autosave',
+				'post_name'    => self::$post_id . '-autosave-v1',
+			)
+		);
+
+		$autosave = wp_get_post_autosave( self::$post_id, self::$editor_id );
+
+		$this->assertInstanceOf( 'WP_Post', $autosave );
+		$this->assertSame( self::$editor_id, (int) $autosave->post_author, 'Post author does not match.' );
+		$this->assertSame( $autosave_id, $autosave->ID, 'Autosave ID does not match.' );
+	}
+}


### PR DESCRIPTION

Trac ticket:  https://core.trac.wordpress.org/ticket/62658

This PR adds unit tests for the `wp_get_post_autosave()` function. The tests cover:

1. Checking if a post has no autosave.
2. Verifying that an autosave is created after a revision.
3. Ensuring autosaves are added for a specific user.