### PR TITLE
Adds a check for any registered post_meta keys to the Custom Fields form when editing a post

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -731,7 +731,7 @@ function meta_form( $post = null ) {
 		);
 	}
 
-	if ( !$keys ){
+	if ( ! $keys ) {
 		$registered_meta = get_registered_meta_keys( 'post', $post->post_type );
 		$keys = array_keys( $registered_meta );
 	}

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -731,6 +731,11 @@ function meta_form( $post = null ) {
 		);
 	}
 
+	if ( !$keys ){
+		$registered_meta = get_registered_meta_keys( 'post', $post->post_type );
+		$keys = array_keys( $registered_meta );
+	}
+
 	if ( $keys ) {
 		natcasesort( $keys );
 	}


### PR DESCRIPTION
Once the query has been run to fetch any post_meta keys from the table, this checks if that array contains values. If it does not, it fetches any registered post meta keys and uses that array instead.

Trac ticket: https://core.trac.wordpress.org/ticket/62664#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
