### PR TITLE
Add get_page_by_template function to retrieve page by template

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -8467,3 +8467,34 @@ function wp_create_initial_post_meta() {
 		)
 	);
 }
+
+/**
+ * Retrieves the ID or permalink of a page based on its template.
+ *
+ * This function performs a query to find pages using a specific template
+ * and returns the ID or permalink of the first matching page.
+ *
+ * @param string $template The name of the template to search for.
+ * @param string $field The field to return: 'ID' for the page ID, 'permalink' for the page permalink.
+ * @return string|int The ID or permalink of the page, or null if no page is found.
+ */
+function get_page_by_template( $template, $field = 'permalink' ){
+    $query = new WP_Query([
+        'post_type'     => 'page',
+        'meta_query'    => [
+            [
+                'key'       => '_wp_page_template',
+                'value'     => $template,
+                'compare'   => '=='
+            ]
+        ]
+    ]);
+    while($query->have_posts()){
+        $query->the_post();
+        if($field == 'ID') {
+            return get_the_ID();
+        } elseif($field == 'permalink') {
+            return get_permalink();
+        }
+    }
+}

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -8476,25 +8476,32 @@ function wp_create_initial_post_meta() {
  *
  * @param string $template The name of the template to search for.
  * @param string $field The field to return: 'ID' for the page ID, 'permalink' for the page permalink.
- * @return string|int The ID or permalink of the page, or null if no page is found.
+ * @return string|int|null The ID or permalink of the page, or null if no page is found.
  */
-function get_page_by_template( $template, $field = 'permalink' ){
-    $query = new WP_Query([
-        'post_type'     => 'page',
-        'meta_query'    => [
-            [
-                'key'       => '_wp_page_template',
-                'value'     => $template,
-                'compare'   => '=='
-            ]
-        ]
-    ]);
-    while($query->have_posts()){
-        $query->the_post();
-        if($field == 'ID') {
-            return get_the_ID();
-        } elseif($field == 'permalink') {
-            return get_permalink();
-        }
-    }
+function get_page_by_template( $template, $field = 'permalink' ) {
+	global $post;
+
+	$query = new WP_Query(
+		array(
+			'post_type'  => 'page',
+			'meta_query' => array(
+				array(
+					'key'     => '_wp_page_template',
+					'value'   => $template,
+					'compare' => '==',
+				),
+			),
+		)
+	);
+
+	if ( $query->have_posts() ) {
+		$query->the_post();
+		if ( 'ID' === $field ) {
+			return get_the_ID();
+		} elseif ( 'permalink' === $field ) {
+			return get_permalink();
+		}
+	}
+
+	return null;
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This contribution implements a new function that retrieves the ID or permalink of a page based on its assigned template. The function performs a query to find pages using a specific template and returns either the ID or permalink of the first matching page.

Trac ticket: https://core.trac.wordpress.org/ticket/62666

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
