### PR TITLE
Block Bindings: Prepare the ground to define fieldsList on the server.

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -116,9 +116,10 @@ if ( ! empty( $registered_sources ) ) {
 	$filtered_sources = array();
 	foreach ( $registered_sources as $source ) {
 		$filtered_sources[] = array(
-			'name'        => $source->name,
-			'label'       => $source->label,
-			'usesContext' => $source->uses_context,
+			'name'          => $source->name,
+			'label'         => $source->label,
+			'usesContext'   => $source->uses_context,
+			'getFieldsList' => $source->get_fields_list,
 		);
 	}
 	$script = sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -119,7 +119,7 @@ if ( ! empty( $registered_sources ) ) {
 			'name'        => $source->name,
 			'label'       => $source->label,
 			'usesContext' => $source->uses_context,
-			'fields'      => $source->fields,
+			'args'        => $source->args,
 		);
 	}
 	$script = sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -116,10 +116,10 @@ if ( ! empty( $registered_sources ) ) {
 	$filtered_sources = array();
 	foreach ( $registered_sources as $source ) {
 		$filtered_sources[] = array(
-			'name'          => $source->name,
-			'label'         => $source->label,
-			'usesContext'   => $source->uses_context,
-			'getFieldsList' => $source->get_fields_list,
+			'name'        => $source->name,
+			'label'       => $source->label,
+			'usesContext' => $source->uses_context,
+			'fields'      => $source->fields,
 		);
 	}
 	$script = sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -142,9 +142,10 @@ if ( ! empty( $registered_sources ) ) {
 	$filtered_sources = array();
 	foreach ( $registered_sources as $source ) {
 		$filtered_sources[] = array(
-			'name'        => $source->name,
-			'label'       => $source->label,
-			'usesContext' => $source->uses_context,
+			'name'          => $source->name,
+			'label'         => $source->label,
+			'usesContext'   => $source->uses_context,
+			'getFieldsList' => $source->get_fields_list,
 		);
 	}
 	$script = sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -142,10 +142,10 @@ if ( ! empty( $registered_sources ) ) {
 	$filtered_sources = array();
 	foreach ( $registered_sources as $source ) {
 		$filtered_sources[] = array(
-			'name'          => $source->name,
-			'label'         => $source->label,
-			'usesContext'   => $source->uses_context,
-			'getFieldsList' => $source->get_fields_list,
+			'name'        => $source->name,
+			'label'       => $source->label,
+			'usesContext' => $source->uses_context,
+			'fields'      => $source->fields,
 		);
 	}
 	$script = sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -145,7 +145,7 @@ if ( ! empty( $registered_sources ) ) {
 			'name'        => $source->name,
 			'label'       => $source->label,
 			'usesContext' => $source->uses_context,
-			'fields'      => $source->fields,
+			'args'        => $source->args,
 		);
 	}
 	$script = sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );

--- a/src/wp-admin/widgets-form-blocks.php
+++ b/src/wp-admin/widgets-form-blocks.php
@@ -57,9 +57,10 @@ if ( ! empty( $registered_sources ) ) {
 	$filtered_sources = array();
 	foreach ( $registered_sources as $source ) {
 		$filtered_sources[] = array(
-			'name'        => $source->name,
-			'label'       => $source->label,
-			'usesContext' => $source->uses_context,
+			'name'          => $source->name,
+			'label'         => $source->label,
+			'usesContext'   => $source->uses_context,
+			'getFieldsList' => $source->get_fields_list,
 		);
 	}
 	$script = sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );

--- a/src/wp-admin/widgets-form-blocks.php
+++ b/src/wp-admin/widgets-form-blocks.php
@@ -60,7 +60,7 @@ if ( ! empty( $registered_sources ) ) {
 			'name'        => $source->name,
 			'label'       => $source->label,
 			'usesContext' => $source->uses_context,
-			'fields'      => $source->fields,
+			'args'        => $source->args,
 		);
 	}
 	$script = sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );

--- a/src/wp-admin/widgets-form-blocks.php
+++ b/src/wp-admin/widgets-form-blocks.php
@@ -57,10 +57,10 @@ if ( ! empty( $registered_sources ) ) {
 	$filtered_sources = array();
 	foreach ( $registered_sources as $source ) {
 		$filtered_sources[] = array(
-			'name'          => $source->name,
-			'label'         => $source->label,
-			'usesContext'   => $source->uses_context,
-			'getFieldsList' => $source->get_fields_list,
+			'name'        => $source->name,
+			'label'       => $source->label,
+			'usesContext' => $source->uses_context,
+			'fields'      => $source->fields,
 		);
 	}
 	$script = sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );

--- a/src/wp-includes/class-wp-block-bindings-registry.php
+++ b/src/wp-includes/class-wp-block-bindings-registry.php
@@ -42,6 +42,7 @@ final class WP_Block_Bindings_Registry {
 		'label',
 		'get_value_callback',
 		'uses_context',
+		'get_fields_list',
 	);
 
 	/**

--- a/src/wp-includes/class-wp-block-bindings-registry.php
+++ b/src/wp-includes/class-wp-block-bindings-registry.php
@@ -42,7 +42,7 @@ final class WP_Block_Bindings_Registry {
 		'label',
 		'get_value_callback',
 		'uses_context',
-		'fields',
+		'args',
 	);
 
 	/**

--- a/src/wp-includes/class-wp-block-bindings-registry.php
+++ b/src/wp-includes/class-wp-block-bindings-registry.php
@@ -42,7 +42,7 @@ final class WP_Block_Bindings_Registry {
 		'label',
 		'get_value_callback',
 		'uses_context',
-		'get_fields_list',
+		'fields',
 	);
 
 	/**

--- a/src/wp-includes/class-wp-block-bindings-source.php
+++ b/src/wp-includes/class-wp-block-bindings-source.php
@@ -44,6 +44,15 @@ final class WP_Block_Bindings_Source {
 	private $get_value_callback;
 
 	/**
+	 * The function used to get the fields to be shown in the UI
+	 * of Block Bindings.
+	 *
+	 * @since 6.8.0
+	 * @var callable
+	 */
+	public $get_fields_list;
+
+	/**
 	 * The context added to the blocks needed by the source.
 	 *
 	 * @since 6.5.0

--- a/src/wp-includes/class-wp-block-bindings-source.php
+++ b/src/wp-includes/class-wp-block-bindings-source.php
@@ -49,7 +49,7 @@ final class WP_Block_Bindings_Source {
 	 * @since 6.8.0
 	 * @var array
 	 */
-	public $fields;
+	public $args;
 
 	/**
 	 * The context added to the blocks needed by the source.

--- a/src/wp-includes/class-wp-block-bindings-source.php
+++ b/src/wp-includes/class-wp-block-bindings-source.php
@@ -44,13 +44,12 @@ final class WP_Block_Bindings_Source {
 	private $get_value_callback;
 
 	/**
-	 * The function used to get the fields to be shown in the UI
-	 * of Block Bindings.
+	 * Provide arguments that will be shown in the Block Bindings UI.
 	 *
 	 * @since 6.8.0
-	 * @var callable
+	 * @var array
 	 */
-	public $get_fields_list;
+	public $arguments;
 
 	/**
 	 * The context added to the blocks needed by the source.

--- a/src/wp-includes/class-wp-block-bindings-source.php
+++ b/src/wp-includes/class-wp-block-bindings-source.php
@@ -44,12 +44,12 @@ final class WP_Block_Bindings_Source {
 	private $get_value_callback;
 
 	/**
-	 * Provide arguments that will be shown in the Block Bindings UI.
+	 * Provide fields that will be shown in the Block Bindings UI.
 	 *
 	 * @since 6.8.0
 	 * @var array
 	 */
-	public $arguments;
+	public $fields;
 
 	/**
 	 * The context added to the blocks needed by the source.

--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -872,9 +872,10 @@ final class WP_Customize_Widgets {
 				$filtered_sources = array();
 				foreach ( $registered_sources as $source ) {
 					$filtered_sources[] = array(
-						'name'        => $source->name,
-						'label'       => $source->label,
-						'usesContext' => $source->uses_context,
+						'name'          => $source->name,
+						'label'         => $source->label,
+						'usesContext'   => $source->uses_context,
+						'getFieldsList' => $source->get_fields_list,
 					);
 				}
 				$script = sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );

--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -875,7 +875,7 @@ final class WP_Customize_Widgets {
 						'name'        => $source->name,
 						'label'       => $source->label,
 						'usesContext' => $source->uses_context,
-						'fields'      => $source->fields,
+						'args'        => $source->args,
 					);
 				}
 				$script = sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );

--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -872,10 +872,10 @@ final class WP_Customize_Widgets {
 				$filtered_sources = array();
 				foreach ( $registered_sources as $source ) {
 					$filtered_sources[] = array(
-						'name'          => $source->name,
-						'label'         => $source->label,
-						'usesContext'   => $source->uses_context,
-						'getFieldsList' => $source->get_fields_list,
+						'name'        => $source->name,
+						'label'       => $source->label,
+						'usesContext' => $source->uses_context,
+						'fields'      => $source->fields,
 					);
 				}
 				$script = sprintf( 'for ( const source of %s ) { wp.blocks.registerBlockBindingsSource( source ); }', wp_json_encode( $filtered_sources ) );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Trac ticket: https://core.trac.wordpress.org/ticket/62705

## What?
I'm experimenting if it is possible to add sources to the UI just by defining them on the server side. It will need a PR in Gutenberg to be landed.

This registration:

```php
register_block_bindings_source(
			'bbe/now-date',
			array(
				'label'              => __( 'Current dates', 'custom-bindings' ),
				'get_value_callback' => function ( array $source_args, $block_instance ) {
					switch ( $source_args['key'] ) {
						case 'y_m_d':
							return gmdate( 'Y M D' );
						case 'y_m_d_h_i_s':
							return gmdate( 'Y M D h i s' );
						default:
							return gmdate( 'Y M D h i s' );
					}
				},
				'args'               => array(
					'y_m_d'       => array(
						'type'  => 'string',
						'label' => __( 'Y M D', 'custom-bindings' ),
						'value' => gmdate( 'Y M D' ),
					),
					'y_m_d_h_i_s' => array(
						'type'  => 'string',
						'label' => __( 'Y M D h i s', 'custom-bindings' ),
						'value' => gmdate( 'Y M D h i s' ),
					),
				),
			),
		);
```

will return:

<img width="514" alt="Screenshot 2024-12-17 at 22 12 20" src="https://github.com/user-attachments/assets/0e08f37c-829a-46c9-880c-511453bc20d4" />

We are using keys as the source arguments to decide the format. It's an approach I'm not 100% comfortable with. We may need to update the JS API.
<img width="1052" alt="Screenshot 2024-12-17 at 22 13 32" src="https://github.com/user-attachments/assets/71246745-a02f-432c-b6b0-69157bdccec4" />


<img width="258" alt="Screenshot 2024-12-17 at 22 13 47" src="https://github.com/user-attachments/assets/60f7934a-e772-457f-8be7-f9ca32fd1a1e" />
