### PR TITLE
Template Hierarchy: Extend to include root taxonomy archives

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1165,7 +1165,6 @@ class WP_Query {
 		}
 
 		foreach ( get_taxonomies( array(), 'objects' ) as $taxonomy => $t ) {
-
 			if ( 'post_tag' === $taxonomy ) {
 				continue; // Handled further down in the $q['tag'] block.
 			}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1165,16 +1165,16 @@ class WP_Query {
 		}
 
 		foreach ( get_taxonomies( array(), 'objects' ) as $taxonomy => $t ) {
+
 			if ( 'post_tag' === $taxonomy ) {
 				continue; // Handled further down in the $q['tag'] block.
 			}
 
-			if ( $t->query_var && ! empty( $q[ $t->query_var ] ) ) {
+			if ( $t->query_var && ( ! empty( $q[ $t->query_var ] || '' === $q[ $t->query_var ] ) ) ) {
 				$tax_query_defaults = array(
 					'taxonomy' => $taxonomy,
 					'field'    => 'slug',
 				);
-
 				if ( ! empty( $t->rewrite['hierarchical'] ) ) {
 					$q[ $t->query_var ] = wp_basename( $q[ $t->query_var ] );
 				}
@@ -1195,13 +1195,24 @@ class WP_Query {
 							)
 						);
 					}
-				} else {
+				} elseif ( '' !== $term ) {
 					$tax_query[] = array_merge(
 						$tax_query_defaults,
 						array(
 							'terms' => preg_split( '/[,]+/', $term ),
 						)
 					);
+				} else {
+					// FIXME: Figure out why 'category' is automatically
+					// added as a query arg and what to do about it.
+					if ( 'category' !== $taxonomy ) {
+						$tax_query[] = array_merge(
+							$tax_query_defaults,
+							array(
+								'operator' => 'EXISTS',
+							)
+						);
+					}
 				}
 			}
 		}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1169,7 +1169,7 @@ class WP_Query {
 				continue; // Handled further down in the $q['tag'] block.
 			}
 
-			if ( $t->query_var && ( ! empty( $q[ $t->query_var ] || '' === $q[ $t->query_var ] ) ) ) {
+			if ( $t->query_var && isset( $q[ $t->query_var ] ) ) {
 				$tax_query_defaults = array(
 					'taxonomy' => $taxonomy,
 					'field'    => 'slug',
@@ -1195,14 +1195,14 @@ class WP_Query {
 							)
 						);
 					}
-				} elseif ( '' !== $term ) {
+				} elseif ( ! empty( $term ) ) {
 					$tax_query[] = array_merge(
 						$tax_query_defaults,
 						array(
 							'terms' => preg_split( '/[,]+/', $term ),
 						)
 					);
-				} else {
+				} elseif ( '' === $term ) {
 					// FIXME: Figure out why 'category' is automatically
 					// added as a query arg and what to do about it.
 					if ( 'category' !== $taxonomy ) {

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1175,6 +1175,7 @@ class WP_Query {
 					'taxonomy' => $taxonomy,
 					'field'    => 'slug',
 				);
+
 				if ( ! empty( $t->rewrite['hierarchical'] ) ) {
 					$q[ $t->query_var ] = wp_basename( $q[ $t->query_var ] );
 				}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1202,7 +1202,7 @@ class WP_Query {
 							'terms' => preg_split( '/[,]+/', $term ),
 						)
 					);
-				} elseif ( '' === $term ) {
+				} else {
 					// FIXME: Figure out why 'category' is automatically
 					// added as a query arg and what to do about it.
 					if ( 'category' !== $taxonomy ) {

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3933,7 +3933,7 @@ class WP_Query {
 				if ( $this->is_category && 'category' === $this->queried_object->taxonomy ) {
 					_make_cat_compat( $this->queried_object );
 				}
-			} else {
+			} elseif ( $this->is_tax_without_term ) {
 				// If no term is specified, return the queried taxonomy object instead.
 				return get_taxonomy( $matched_taxonomy );
 			}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -962,9 +962,8 @@ class WP_Query {
 							$this->is_tag = true;
 							break;
 						default:
-							if ( ! empty( $tax_query['terms'] ) ) {
-								$this->is_tax = true;
-							} else {
+							$this->is_tax = true;
+							if ( empty( $tax_query['terms'] ) ) {
 								$this->is_tax_without_term = true;
 							}
 					}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -963,7 +963,7 @@ class WP_Query {
 							break;
 						default:
 							$this->is_tax = true;
-							if ( empty( $tax_query['terms'] ) ) {
+							if ( empty( $tax_query['terms'] ) && 'EXISTS' === $tax_query['operator'] ) {
 								$this->is_tax_without_term = true;
 							}
 					}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3875,6 +3875,7 @@ class WP_Query {
 	 * query variable. After it is set up, it will be returned.
 	 *
 	 * @since 1.5.0
+	 * @since 6.8.0 Return the queried taxonomy object for taxonomy queries if no term is specified.
 	 *
 	 * @return WP_Term|WP_Post_Type|WP_Post|WP_User|null The queried object.
 	 */
@@ -3929,6 +3930,9 @@ class WP_Query {
 				if ( $this->is_category && 'category' === $this->queried_object->taxonomy ) {
 					_make_cat_compat( $this->queried_object );
 				}
+			} else {
+				// If no term is specified, return the queried taxonomy object instead.
+				return get_taxonomy( $matched_taxonomy );
 			}
 		} elseif ( $this->is_post_type_archive ) {
 			$post_type = $this->get( 'post_type' );

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1173,6 +1173,12 @@ class WP_Query {
 				continue;
 			}
 
+			if ( 'category' === $taxonomy && empty( $q[ $t->query_var ] ) ) {
+				// Unlike custom taxonomies, the category field is automatically added to every query.
+				// Thus, we need to skip it if it is empty.
+				continue;
+			}
+
 			$tax_query_defaults = array(
 				'taxonomy' => $taxonomy,
 				'field'    => 'slug',
@@ -1206,16 +1212,12 @@ class WP_Query {
 					)
 				);
 			} else {
-				// FIXME: Figure out why 'category' is automatically
-				// added as a query arg and what to do about it.
-				if ( 'category' !== $taxonomy ) {
-					$tax_query[] = array_merge(
-						$tax_query_defaults,
-						array(
-							'operator' => 'EXISTS',
-						)
-					);
-				}
+				$tax_query[] = array_merge(
+					$tax_query_defaults,
+					array(
+						'operator' => 'EXISTS',
+					)
+				);
 			}
 		}
 

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -989,7 +989,7 @@ class WP_Query {
 				}
 			}
 
-			if ( $this->is_post_type_archive || $this->is_date || $this->is_author || $this->is_category || $this->is_tag || $this->is_tax ) {
+			if ( $this->is_post_type_archive || $this->is_date || $this->is_author || $this->is_category || $this->is_tag || $this->is_tax_without_term || $this->is_tax ) {
 				$this->is_archive = true;
 			}
 		}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -1169,50 +1169,52 @@ class WP_Query {
 				continue; // Handled further down in the $q['tag'] block.
 			}
 
-			if ( $t->query_var && isset( $q[ $t->query_var ] ) ) {
-				$tax_query_defaults = array(
-					'taxonomy' => $taxonomy,
-					'field'    => 'slug',
-				);
+			if ( ! $t->query_var || ! isset( $q[ $t->query_var ] ) ) {
+				continue;
+			}
 
-				if ( ! empty( $t->rewrite['hierarchical'] ) ) {
-					$q[ $t->query_var ] = wp_basename( $q[ $t->query_var ] );
-				}
+			$tax_query_defaults = array(
+				'taxonomy' => $taxonomy,
+				'field'    => 'slug',
+			);
 
-				$term = $q[ $t->query_var ];
+			if ( ! empty( $t->rewrite['hierarchical'] ) ) {
+				$q[ $t->query_var ] = wp_basename( $q[ $t->query_var ] );
+			}
 
-				if ( is_array( $term ) ) {
-					$term = implode( ',', $term );
-				}
+			$term = $q[ $t->query_var ];
 
-				if ( str_contains( $term, '+' ) ) {
-					$terms = preg_split( '/[+]+/', $term );
-					foreach ( $terms as $term ) {
-						$tax_query[] = array_merge(
-							$tax_query_defaults,
-							array(
-								'terms' => array( $term ),
-							)
-						);
-					}
-				} elseif ( ! empty( $term ) ) {
+			if ( is_array( $term ) ) {
+				$term = implode( ',', $term );
+			}
+
+			if ( str_contains( $term, '+' ) ) {
+				$terms = preg_split( '/[+]+/', $term );
+				foreach ( $terms as $term ) {
 					$tax_query[] = array_merge(
 						$tax_query_defaults,
 						array(
-							'terms' => preg_split( '/[,]+/', $term ),
+							'terms' => array( $term ),
 						)
 					);
-				} else {
-					// FIXME: Figure out why 'category' is automatically
-					// added as a query arg and what to do about it.
-					if ( 'category' !== $taxonomy ) {
-						$tax_query[] = array_merge(
-							$tax_query_defaults,
-							array(
-								'operator' => 'EXISTS',
-							)
-						);
-					}
+				}
+			} elseif ( ! empty( $term ) ) {
+				$tax_query[] = array_merge(
+					$tax_query_defaults,
+					array(
+						'terms' => preg_split( '/[,]+/', $term ),
+					)
+				);
+			} else {
+				// FIXME: Figure out why 'category' is automatically
+				// added as a query arg and what to do about it.
+				if ( 'category' !== $taxonomy ) {
+					$tax_query[] = array_merge(
+						$tax_query_defaults,
+						array(
+							'operator' => 'EXISTS',
+						)
+					);
 				}
 			}
 		}

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -515,7 +515,7 @@ final class WP_Taxonomy {
 
 			// For the root taxonomy archive, the query string is simply the query var, with no value set,
 			// or, if no query var is defined, `taxonomy=$this->name`.
-			add_rewrite_tag( "%taxonomy-$this->name%", "$this->name", $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name" );
+			add_rewrite_tag( "%taxonomy-$this->name%", "$this->name", "taxonomy=$this->name" );
 			add_permastruct( "taxonomy-$this->name", "%taxonomy-$this->name%", $this->rewrite );
 		}
 	}

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -510,10 +510,12 @@ final class WP_Taxonomy {
 				$tag = '([^/]+)';
 			}
 
-			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
+			$query = $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=";
+
+			add_rewrite_tag( "%$this->name%", $tag, $query );
 			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
 
-			add_rewrite_tag( "%$this->name-taxonomy%", "(?:$this->name)", $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
+			add_rewrite_tag( "%$this->name-taxonomy%", "(?:$this->name)", $query );
 			add_permastruct( "$this->name-taxonomy", "%$this->name-taxonomy%", $this->rewrite );
 		}
 	}

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -511,10 +511,7 @@ final class WP_Taxonomy {
 			}
 
 			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
-			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
-
-			add_rewrite_tag( "%$this->name-taxonomy%", "(?:$this->name)", $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
-			add_permastruct( "$this->name-taxonomy", "%$this->name-taxonomy%", $this->rewrite );
+			add_permastruct( $this->name, "{$this->rewrite['slug']}(?:/%$this->name%)?", $this->rewrite );
 		}
 	}
 

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -538,6 +538,9 @@ final class WP_Taxonomy {
 
 		// Remove rewrite tags and permastructs.
 		if ( false !== $this->rewrite ) {
+			remove_rewrite_tag( "%$this->name-taxonomy%" );
+			remove_permastruct( "$this->name-taxonomy" );
+
 			remove_rewrite_tag( "%$this->name%" );
 			remove_permastruct( $this->name );
 		}

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -515,8 +515,8 @@ final class WP_Taxonomy {
 
 			// For the root taxonomy archive, the query string is simply the query var, with no value set,
 			// or, if no query var is defined, `taxonomy=$this->name`.
-			add_rewrite_tag( "%$this->name-taxonomy%", "(?:$this->name)", $this->query_var ? $this->query_var : "taxonomy=$this->name" );
-			add_permastruct( "$this->name-taxonomy", "%$this->name-taxonomy%", $this->rewrite );
+			add_rewrite_tag( "%taxonomy-$this->name%", "(?:$this->name)", $this->query_var ? $this->query_var : "taxonomy=$this->name" );
+			add_permastruct( "taxonomy-$this->name", "%taxonomy-$this->name%", $this->rewrite );
 		}
 	}
 
@@ -538,8 +538,8 @@ final class WP_Taxonomy {
 
 		// Remove rewrite tags and permastructs.
 		if ( false !== $this->rewrite ) {
-			remove_rewrite_tag( "%$this->name-taxonomy%" );
-			remove_permastruct( "$this->name-taxonomy" );
+			remove_rewrite_tag( "%taxonomy-$this->name%" );
+			remove_permastruct( "taxonomy-$this->name" );
 
 			remove_rewrite_tag( "%$this->name%" );
 			remove_permastruct( $this->name );

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -512,6 +512,10 @@ final class WP_Taxonomy {
 
 			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
 			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
+
+			// TODO: If rewrite tag exists, append taxonomy name to regex.
+			add_rewrite_tag( '%taxonomy%', "(?:$this->name)", $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
+			add_permastruct( 'taxonomy', '%taxonomy%', $this->rewrite );
 		}
 	}
 

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -510,15 +510,12 @@ final class WP_Taxonomy {
 				$tag = '([^/]+)';
 			}
 
-			if ( $this->query_var ) {
-				add_rewrite_tag( "%taxonomy-$this->name%", "$this->name()", "{$this->query_var}=" );
-			} else {
-				add_rewrite_tag( "%taxonomy-$this->name%", "($this->name)", 'taxonomy=' );
-			}
+			$query = $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=";
 
+			add_rewrite_tag( "%taxonomy-$this->name%", "$this->name()", $query );
 			add_permastruct( "taxonomy-$this->name", "%taxonomy-$this->name%", $this->rewrite );
 
-			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
+			add_rewrite_tag( "%$this->name%", $tag, $query );
 			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
 		}
 	}

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -511,7 +511,10 @@ final class WP_Taxonomy {
 			}
 
 			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
-			add_permastruct( $this->name, "{$this->rewrite['slug']}(?:/%$this->name%)?", $this->rewrite );
+			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
+
+			add_rewrite_tag( "%$this->name-taxonomy%", "(?:$this->name)", $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
+			add_permastruct( "$this->name-taxonomy", "%$this->name-taxonomy%", $this->rewrite );
 		}
 	}
 

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -510,7 +510,12 @@ final class WP_Taxonomy {
 				$tag = '([^/]+)';
 			}
 
-			add_rewrite_tag( "%taxonomy-$this->name%", "($this->name)", 'taxonomy=' );
+			if ( $this->query_var ) {
+				add_rewrite_tag( "%taxonomy-$this->name%", "$this->name()", "{$this->query_var}=" );
+			} else {
+				add_rewrite_tag( "%taxonomy-$this->name%", "($this->name)", 'taxonomy=' );
+			}
+
 			add_permastruct( "taxonomy-$this->name", "%taxonomy-$this->name%", $this->rewrite );
 
 			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -510,11 +510,11 @@ final class WP_Taxonomy {
 				$tag = '([^/]+)';
 			}
 
-			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
-			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
-
 			add_rewrite_tag( "%taxonomy-$this->name%", "($this->name)", 'taxonomy=' );
 			add_permastruct( "taxonomy-$this->name", "%taxonomy-$this->name%", $this->rewrite );
+
+			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
+			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
 		}
 	}
 
@@ -536,11 +536,11 @@ final class WP_Taxonomy {
 
 		// Remove rewrite tags and permastructs.
 		if ( false !== $this->rewrite ) {
-			remove_rewrite_tag( "%taxonomy-$this->name%" );
-			remove_permastruct( "taxonomy-$this->name" );
-
 			remove_rewrite_tag( "%$this->name%" );
 			remove_permastruct( $this->name );
+
+			remove_rewrite_tag( "%taxonomy-$this->name%" );
+			remove_permastruct( "taxonomy-$this->name" );
 		}
 	}
 

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -513,7 +513,7 @@ final class WP_Taxonomy {
 			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
 			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
 
-			add_rewrite_tag( "%taxonomy-$this->name%", "$this->name", "taxonomy=$this->name" );
+			add_rewrite_tag( "%taxonomy-$this->name%", "($this->name)", 'taxonomy=' );
 			add_permastruct( "taxonomy-$this->name", "%taxonomy-$this->name%", $this->rewrite );
 		}
 	}

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -510,12 +510,12 @@ final class WP_Taxonomy {
 				$tag = '([^/]+)';
 			}
 
-			$query = $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=";
-
-			add_rewrite_tag( "%$this->name%", $tag, $query );
+			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
 			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
 
-			add_rewrite_tag( "%$this->name-taxonomy%", "(?:$this->name)", $query );
+			// For the root taxonomy archive, the query string is simply the query var, with no value set,
+			// or, if no query var is defined, `taxonomy=$this->name`.
+			add_rewrite_tag( "%$this->name-taxonomy%", "(?:$this->name)", $this->query_var ? $this->query_var : "taxonomy=$this->name" );
 			add_permastruct( "$this->name-taxonomy", "%$this->name-taxonomy%", $this->rewrite );
 		}
 	}

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -513,9 +513,8 @@ final class WP_Taxonomy {
 			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
 			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
 
-			// TODO: If rewrite tag exists, append taxonomy name to regex.
-			add_rewrite_tag( '%taxonomy%', "(?:$this->name)", $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
-			add_permastruct( 'taxonomy', '%taxonomy%', $this->rewrite );
+			add_rewrite_tag( "%$this->name-taxonomy%", "(?:$this->name)", $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
+			add_permastruct( "$this->name-taxonomy", "%$this->name-taxonomy%", $this->rewrite );
 		}
 	}
 

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -515,7 +515,7 @@ final class WP_Taxonomy {
 
 			// For the root taxonomy archive, the query string is simply the query var, with no value set,
 			// or, if no query var is defined, `taxonomy=$this->name`.
-			add_rewrite_tag( "%taxonomy-$this->name%", "(?:$this->name)", $this->query_var ? $this->query_var : "taxonomy=$this->name" );
+			add_rewrite_tag( "%taxonomy-$this->name%", "$this->name", $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name" );
 			add_permastruct( "taxonomy-$this->name", "%taxonomy-$this->name%", $this->rewrite );
 		}
 	}

--- a/src/wp-includes/class-wp-taxonomy.php
+++ b/src/wp-includes/class-wp-taxonomy.php
@@ -513,8 +513,6 @@ final class WP_Taxonomy {
 			add_rewrite_tag( "%$this->name%", $tag, $this->query_var ? "{$this->query_var}=" : "taxonomy=$this->name&term=" );
 			add_permastruct( $this->name, "{$this->rewrite['slug']}/%$this->name%", $this->rewrite );
 
-			// For the root taxonomy archive, the query string is simply the query var, with no value set,
-			// or, if no query var is defined, `taxonomy=$this->name`.
 			add_rewrite_tag( "%taxonomy-$this->name%", "$this->name", "taxonomy=$this->name" );
 			add_permastruct( "taxonomy-$this->name", "%taxonomy-$this->name%", $this->rewrite );
 		}

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -1760,7 +1760,7 @@ function get_the_archive_title() {
 		$prefix = _x( 'Archives:', 'post type archive title prefix' );
 	} elseif ( is_tax() ) {
 		$queried_object = get_queried_object();
-		if ( $queried_object ) {
+		if ( $queried_object instanceof WP_Term ) {
 			$tax    = get_taxonomy( $queried_object->taxonomy );
 			$title  = single_term_title( '', false );
 			$prefix = sprintf(
@@ -1768,6 +1768,9 @@ function get_the_archive_title() {
 				_x( '%s:', 'taxonomy term archive title prefix' ),
 				$tax->labels->singular_name
 			);
+		} elseif ( $queried_object instanceof WP_Taxonomy ) {
+			$title  = $queried_object->labels->singular_name;
+			$prefix = _x( 'Archives:', 'taxonomy archive title prefix' );
 		}
 	}
 

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -1758,9 +1758,15 @@ function get_the_archive_title() {
 	} elseif ( is_post_type_archive() ) {
 		$title  = post_type_archive_title( '', false );
 		$prefix = _x( 'Archives:', 'post type archive title prefix' );
+	} elseif ( is_tax_without_term() ) {
+		$queried_object = get_queried_object();
+		if ( $queried_object ) {
+			$title  = $queried_object->labels->singular_name;
+			$prefix = _x( 'Archives:', 'taxonomy archive title prefix' );
+		}
 	} elseif ( is_tax() ) {
 		$queried_object = get_queried_object();
-		if ( $queried_object instanceof WP_Term ) {
+		if ( $queried_object ) {
 			$tax    = get_taxonomy( $queried_object->taxonomy );
 			$title  = single_term_title( '', false );
 			$prefix = sprintf(
@@ -1768,9 +1774,6 @@ function get_the_archive_title() {
 				_x( '%s:', 'taxonomy term archive title prefix' ),
 				$tax->labels->singular_name
 			);
-		} elseif ( $queried_object instanceof WP_Taxonomy ) {
-			$title  = $queried_object->labels->singular_name;
-			$prefix = _x( 'Archives:', 'taxonomy archive title prefix' );
 		}
 	}
 

--- a/src/wp-includes/query.php
+++ b/src/wp-includes/query.php
@@ -309,6 +309,37 @@ function is_tag( $tag = '' ) {
 }
 
 /**
+ * Determines whether the query is for an existing custom taxonomy root archive page.
+ *
+ * If the $taxonomy parameter is specified, this function will additionally
+ * check if the query is for that specific $taxonomy.
+ *
+ * For more information on this and similar theme functions, check out
+ * the {@link https://developer.wordpress.org/themes/basics/conditional-tags/
+ * Conditional Tags} article in the Theme Developer Handbook.
+ *
+ * @since 6.8.0
+ *
+ * @global WP_Query $wp_query WordPress Query object.
+ *
+ * @param string|string[] $taxonomy Optional. Taxonomy slug or slugs to check against.
+ *                                  Default empty.
+ * @return bool Whether the query is for an existing custom taxonomy root archive page.
+ *              True for custom taxonomy root archive pages, false for built-in taxonomies
+ *              (category and tag archives).
+ */
+function is_tax_without_term( $taxonomy = '' ) {
+	global $wp_query;
+
+	if ( ! isset( $wp_query ) ) {
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		return false;
+	}
+
+	return $wp_query->is_tax_without_term( $taxonomy );
+}
+
+/**
  * Determines whether the query is for an existing custom taxonomy archive page.
  *
  * If the $taxonomy parameter is specified, this function will additionally

--- a/src/wp-includes/template-loader.php
+++ b/src/wp-includes/template-loader.php
@@ -62,6 +62,7 @@ if ( wp_using_themes() ) {
 		'is_home'              => 'get_home_template',
 		'is_privacy_policy'    => 'get_privacy_policy_template',
 		'is_post_type_archive' => 'get_post_type_archive_template',
+		'is_tax_without_term'  => 'get_root_taxonomy_template',
 		'is_tax'               => 'get_taxonomy_template',
 		'is_attachment'        => 'get_attachment_template',
 		'is_single'            => 'get_single_template',

--- a/src/wp-includes/template.php
+++ b/src/wp-includes/template.php
@@ -344,11 +344,12 @@ function get_tag_template() {
  * @return string Full path to custom taxonomy term template file.
  */
 function get_taxonomy_template() {
-	$term = get_queried_object();
+	$term_or_tax = get_queried_object();
 
 	$templates = array();
 
-	if ( ! empty( $term->slug ) ) {
+	if ( $term_or_tax instanceof WP_Term && ! empty( $term_or_tax->slug ) ) {
+		$term     = $term_or_tax;
 		$taxonomy = $term->taxonomy;
 
 		$slug_decoded = urldecode( $term->slug );
@@ -357,6 +358,9 @@ function get_taxonomy_template() {
 		}
 
 		$templates[] = "taxonomy-$taxonomy-{$term->slug}.php";
+		$templates[] = "taxonomy-$taxonomy.php";
+	} elseif ( $term_or_tax instanceof WP_Taxonomy ) {
+		$taxonomy    = $term_or_tax->name;
 		$templates[] = "taxonomy-$taxonomy.php";
 	}
 	$templates[] = 'taxonomy.php';

--- a/src/wp-includes/template.php
+++ b/src/wp-includes/template.php
@@ -318,6 +318,45 @@ function get_tag_template() {
 }
 
 /**
+ * Retrieves path of custom taxonomy root template in current or parent template.
+ *
+ * The hierarchy for this template looks like:
+ *
+ * 1. root-taxonomy-{taxonomy_slug}.php
+ * 2. taxonomy-{taxonomy_slug}.php
+ * 3. root-taxonomy.php
+ * 4. taxonomy.php
+ *
+ * An example of this is:
+ *
+ * 1. root-taxonomy-location.php
+ * 2. taxonomy-location.php
+ * 3. root-taxonomy.php
+ * 4. taxonomy.php
+ *
+ * The template hierarchy and template path are filterable via the {@see '$type_template_hierarchy'}
+ * and {@see '$type_template'} dynamic hooks, where `$type` is 'taxonomy'.
+ *
+ * @since 6.8.0
+ *
+ * @see get_query_template()
+ *
+ * @return string Full path to custom taxonomy term template file.
+ */
+function get_root_taxonomy_template() {
+	$tax = get_queried_object();
+
+	$templates = array();
+
+	$templates[] = "root-taxonomy-$taxonomy.php";
+	$templates[] = "taxonomy-$taxonomy.php";
+	$templates[] = 'root-taxonomy.php';
+	$templates[] = 'taxonomy.php';
+
+	return get_query_template( 'taxonomy', $templates );
+}
+
+/**
  * Retrieves path of custom taxonomy term template in current or parent template.
  *
  * The hierarchy for this template looks like:
@@ -344,12 +383,11 @@ function get_tag_template() {
  * @return string Full path to custom taxonomy term template file.
  */
 function get_taxonomy_template() {
-	$term_or_tax = get_queried_object();
+	$term = get_queried_object();
 
 	$templates = array();
 
-	if ( $term_or_tax instanceof WP_Term && ! empty( $term_or_tax->slug ) ) {
-		$term     = $term_or_tax;
+	if ( ! empty( $term->slug ) ) {
 		$taxonomy = $term->taxonomy;
 
 		$slug_decoded = urldecode( $term->slug );
@@ -358,9 +396,6 @@ function get_taxonomy_template() {
 		}
 
 		$templates[] = "taxonomy-$taxonomy-{$term->slug}.php";
-		$templates[] = "taxonomy-$taxonomy.php";
-	} elseif ( $term_or_tax instanceof WP_Taxonomy ) {
-		$taxonomy    = $term_or_tax->name;
 		$templates[] = "taxonomy-$taxonomy.php";
 	}
 	$templates[] = 'taxonomy.php';

--- a/src/wp-includes/template.php
+++ b/src/wp-includes/template.php
@@ -323,16 +323,12 @@ function get_tag_template() {
  * The hierarchy for this template looks like:
  *
  * 1. root-taxonomy-{taxonomy_slug}.php
- * 2. taxonomy-{taxonomy_slug}.php
- * 3. root-taxonomy.php
- * 4. taxonomy.php
+ * 2. root-taxonomy.php
  *
  * An example of this is:
  *
  * 1. root-taxonomy-location.php
- * 2. taxonomy-location.php
- * 3. root-taxonomy.php
- * 4. taxonomy.php
+ * 2. root-taxonomy.php
  *
  * The template hierarchy and template path are filterable via the {@see '$type_template_hierarchy'}
  * and {@see '$type_template'} dynamic hooks, where `$type` is 'taxonomy'.
@@ -350,9 +346,7 @@ function get_root_taxonomy_template() {
 	$templates = array();
 
 	$templates[] = "root-taxonomy-$taxonomy.php";
-	$templates[] = "taxonomy-$taxonomy.php";
 	$templates[] = 'root-taxonomy.php';
-	$templates[] = 'taxonomy.php';
 
 	return get_query_template( 'root-taxonomy', $templates );
 }

--- a/src/wp-includes/template.php
+++ b/src/wp-includes/template.php
@@ -353,7 +353,7 @@ function get_root_taxonomy_template() {
 	$templates[] = 'root-taxonomy.php';
 	$templates[] = 'taxonomy.php';
 
-	return get_query_template( 'taxonomy', $templates );
+	return get_query_template( 'root-taxonomy', $templates );
 }
 
 /**

--- a/src/wp-includes/template.php
+++ b/src/wp-includes/template.php
@@ -341,7 +341,7 @@ function get_tag_template() {
  *
  * @see get_query_template()
  *
- * @return string Full path to custom taxonomy term template file.
+ * @return string Full path to custom taxonomy root template file.
  */
 function get_root_taxonomy_template() {
 	$tax      = get_queried_object();

--- a/src/wp-includes/template.php
+++ b/src/wp-includes/template.php
@@ -344,7 +344,8 @@ function get_tag_template() {
  * @return string Full path to custom taxonomy term template file.
  */
 function get_root_taxonomy_template() {
-	$tax = get_queried_object();
+	$tax      = get_queried_object();
+	$taxonomy = $tax->name;
 
 	$templates = array();
 

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -91,7 +91,7 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 				'/category/',
 				array(
 					'url' => '/category/',
-					'qv'  => array( 'taxonomy' => 'category' ),
+					'qv'  => array( 'category_name' => '' ),
 				),
 			),
 			array(
@@ -106,8 +106,8 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 				array(
 					'url' => '/category/page/2/',
 					'qv'  => array(
-						'taxonomy' => 'category',
-						'paged'    => 2,
+						'category_name' => '',
+						'paged'         => 2,
 					),
 				),
 			),
@@ -126,8 +126,8 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 				array(
 					'url' => '/category/page/2/',
 					'qv'  => array(
-						'taxonomy' => 'category',
-						'paged'    => 2,
+						'category_name' => '',
+						'paged'         => 2,
 					),
 				),
 			),

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -158,6 +158,17 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 
 			// Categories & intersections with other vars.
 			array(
+				'/category/?tag=post-formats',
+				array(
+					'url' => '/category/?tag=post-formats',
+					'qv'  => array(
+						'category_name' => '',
+						'tag'           => 'post-formats',
+					),
+				),
+				61957,
+			),
+			array(
 				'/category/uncategorized/?tag=post-formats',
 				array(
 					'url' => '/category/uncategorized/?tag=post-formats',
@@ -176,6 +187,7 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 			),
 
 			// Taxonomies with extra query vars.
+			array( '/category/page/1/?test=one%20two', '/category/?test=one%20two', 61957 ), // Extra query vars should stay encoded.
 			array( '/category/cat-a/page/1/?test=one%20two', '/category/cat-a/?test=one%20two', 18086 ), // Extra query vars should stay encoded.
 
 			// Categories with dates.

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -88,10 +88,27 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 			array( '?cat=%d', array( 'url' => '/category/parent/child-1/' ), 15256 ),
 			array( '?cat=%d', array( 'url' => '/category/parent/child-1/child-2/' ) ), // No children.
 			array(
+				'/category/',
+				array(
+					'url' => '/category/',
+					'qv'  => array( 'taxonomy' => 'category' ),
+				),
+			),
+			array(
 				'/category/uncategorized/',
 				array(
 					'url' => '/category/uncategorized/',
 					'qv'  => array( 'category_name' => 'uncategorized' ),
+				),
+			),
+			array(
+				'/category/page/2/',
+				array(
+					'url' => '/category/page/2/',
+					'qv'  => array(
+						'taxonomy' => 'category',
+						'paged'    => 2,
+					),
 				),
 			),
 			array(
@@ -101,6 +118,16 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 					'qv'  => array(
 						'category_name' => 'uncategorized',
 						'paged'         => 2,
+					),
+				),
+			),
+			array(
+				'/category/?paged=2',
+				array(
+					'url' => '/category/page/2/',
+					'qv'  => array(
+						'taxonomy' => 'category',
+						'paged'    => 2,
 					),
 				),
 			),

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -93,6 +93,7 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 					'url' => '/category/',
 					'qv'  => array( 'category_name' => '' ),
 				),
+				61957,
 			),
 			array(
 				'/category/uncategorized/',
@@ -110,6 +111,7 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 						'paged'         => 2,
 					),
 				),
+				61957,
 			),
 			array(
 				'/category/uncategorized/page/2/',
@@ -130,6 +132,7 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 						'paged'         => 2,
 					),
 				),
+				61957,
 			),
 			array(
 				'/category/uncategorized/?paged=2',

--- a/tests/phpunit/tests/taxonomy.php
+++ b/tests/phpunit/tests/taxonomy.php
@@ -917,7 +917,7 @@ class Tests_Taxonomy extends WP_UnitTestCase {
 		$this->assertTrue( unregister_taxonomy( 'foo' ) );
 		$this->assertNotContains( '%foo%', $wp_rewrite->rewritecode );
 		$this->assertNotContains( 'bar=', $wp_rewrite->queryreplace );
-		$this->assertCount( --$count_before, $wp_rewrite->rewritereplace ); // Array was reduced by one value.
+		$this->assertCount( $count_before - 2, $wp_rewrite->rewritereplace ); // Array was reduced by two values.
 	}
 
 	/**


### PR DESCRIPTION
WIP. Based on #7271. More details to follow.

## Nomenclature

For a given taxonomy `projects` that has terms such as `film` or `tv`:
1. The **root taxonomy route** is `/projects`.
2. **Non-root taxonomy routes** are any routes that include not only the taxonomy but also any of the taxonomy's terms, e.g. `/projects/film` or `/projects/tv`.

## What

WordPress currently only supports non-root taxonomy routes. They are handled by this part of the [template hierarchy](https://developer.wordpress.org/themes/templates/template-hierarchy/#visual-overview):

![image](https://github.com/user-attachments/assets/dc6b40af-9026-4301-a30d-bab05604d8e6)

(With an eventual fallback to `archive.html` and finally `index.html`, not depicted above.)

In #7271, I'm proposing a new flag to `register_taxonomy()` that will allow WordPress to support root taxonomy routes for a given taxonomy; however, that PR doesn't make any changes to the template hierarchy -- instead falling back to the generic archive template (`archive.html`).

_This_ PR proposes to extend the template hierarchy to include a dedicated template for root taxonomy routes. 

## How

As discussed in [`#13816`](https://core.trac.wordpress.org/ticket/13816), there are two major options for _what_ a root taxonomy archive should display:

1. A list of all the taxonomy’s terms (i.e. `/projects` shows a list of items called `TV`, `Films`, etc, but _not_ the individual posts that have those terms assigned). 
2. A list of all posts that have any of the taxonomy’s terms assigned (i.e. `/projects` shows a list of all posts that have either `tv` or `film` or any other term from the `projects` taxonomy assigned).

While 1. is somewhat more consistent with the existing (non-root) taxonomy templates, a majority of people in [`#13816`](https://core.trac.wordpress.org/ticket/13816) seem to have been in favor of 2. My own use case would be a template that can be shared by both non-root and root taxonomy routes.

I thus believe that we should accommodate for both options.

AFAICS, this is best done by introducing two new templates for the root taxonomy archives that take precedence, and eventually fall back to the (non-root) taxonomy templates, like so:

![image](https://github.com/user-attachments/assets/4fc43109-e4b7-4b35-ac62-a007c9fde0a3)

Trac ticket:

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
