### PR TITLE
Docs: Fix script module data filter documentation examples

### DIFF
--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -412,7 +412,7 @@ class WP_Script_Modules {
 			 *     add_filter(
 			 *         'script_module_data_MyScriptModuleID',
 			 *         function ( array $data ): array {
-			 *             $data['script-needs-this-data'] = 'ok';
+			 *             $data['dataForClient'] = 'ok';
 			 *             return $data;
 			 *         }
 			 *     );
@@ -433,6 +433,7 @@ class WP_Script_Modules {
 			 *             data = JSON.parse( dataContainer.textContent );
 			 *         } catch {}
 			 *     }
+			 *     // data.dataForClient === 'ok';
 			 *     initMyScriptModuleWithData( data );
 			 *
 			 * @since 6.7.0

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -407,14 +407,15 @@ class WP_Script_Modules {
 			 * initialization or immediately on page load. It does not replace the REST API or
 			 * fetching data from the client.
 			 *
-			 * @example
-			 *   add_filter(
-			 *     'script_module_data_MyScriptModuleID',
-			 *     function ( array $data ): array {
-			 *       $data['script-needs-this-data'] = 'ok';
-			 *       return $data;
-			 *     }
-			 *   );
+			 * Example:
+			 *
+			 *     add_filter(
+			 *         'script_module_data_MyScriptModuleID',
+			 *         function ( array $data ): array {
+			 *             $data['script-needs-this-data'] = 'ok';
+			 *             return $data;
+			 *         }
+			 *     );
 			 *
 			 * If the filter returns no data (an empty array), nothing will be embedded in the page.
 			 *
@@ -423,15 +424,16 @@ class WP_Script_Modules {
 			 *
 			 * The data can be read on the client with a pattern like this:
 			 *
-			 * @example
-			 *   const dataContainer = document.getElementById( 'wp-script-module-data-MyScriptModuleID' );
-			 *   let data = {};
-			 *   if ( dataContainer ) {
-			 *     try {
-			 *       data = JSON.parse( dataContainer.textContent );
-			 *     } catch {}
-			 *   }
-			 *   initMyScriptModuleWithData( data );
+			 * Example:
+			 *
+			 *     const dataContainer = document.getElementById( 'wp-script-module-data-MyScriptModuleID' );
+			 *     let data = {};
+			 *     if ( dataContainer ) {
+			 *         try {
+			 *             data = JSON.parse( dataContainer.textContent );
+			 *         } catch {}
+			 *     }
+			 *     initMyScriptModuleWithData( data );
 			 *
 			 * @since 6.7.0
 			 *


### PR DESCRIPTION
[The `script_module_data_{$module_id}` filter documentation is truncated.](https://developer.wordpress.org/reference/hooks/script_module_data_module_id/). It seems that the `example` tag is not processed and instead ends the description section of the documentation.

Change the examples for this filter to use `Example:` and an indented code block. This [seems to work](https://developer.wordpress.org/reference/functions/is_utf8_charset/) in other places:

https://github.com/WordPress/wordpress-develop/blob/b6f639737c5fa722dd5a80f0ad94e48c67c37ffd/src/wp-includes/functions.php#L7514-L7525

Trac ticket: https://core.trac.wordpress.org/ticket/62281

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
