### PR TITLE
Add Playwright e2e test for bulk delete of pages

### DIFF
--- a/tests/e2e/specs/pages/bulk-delete-pages.test.js
+++ b/tests/e2e/specs/pages/bulk-delete-pages.test.js
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Bulk Delete wp pages', () => {
+	test.beforeEach( async ( { page, admin, requestUtils, editor } ) => {
+		// delete all pages
+		await requestUtils.deleteAllPages();
+
+		const pageTitles = ['Bulk edit page 1', 'Bulk edit page 2']
+
+		// create pages
+		for (const title of pageTitles) {
+			await admin.createNewPost( {
+				title: title,
+				postType: 'page',
+			} );
+			await editor.publishPost();
+			
+		}
+
+	} );
+
+	test( 'Should able to delete the pages in bulk', async ( {
+		page,
+		admin,
+	} ) => {
+
+		// visit the page list
+		await admin.visitAdminPage( '/edit.php?post_type=page' );
+
+		await page.getByRole(' checkbox ', {name: 'Select All'}).first().check();
+
+		await page.getByRole(' combobox ', {name: "action"}).first().selectOption('trash');
+
+		await page.getByRole( 'button', {name: 'Apply'}).first().click();
+
+		await expect(
+			page.locator( "div[id='message'] p" ).first()
+		).toHaveText( /moved to the Trash./ );
+	} );
+} );

--- a/tests/e2e/specs/pages/bulk-delete-pages.test.js
+++ b/tests/e2e/specs/pages/bulk-delete-pages.test.js
@@ -36,8 +36,6 @@ test.describe( 'Bulk Delete wp pages', () => {
 
 		await page.getByRole( 'button', {name: 'Apply'}).first().click();
 
-		await expect(
-			page.locator( "div[id='message'] p" ).first()
-		).toHaveText( /moved to the Trash./ );
+		await expect(page.getByText(/moved to the Trash./)).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Added Playwright e2e test for bulk delete of pages

Trac ticket: https://core.trac.wordpress.org/ticket/52895

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
