### PR TITLE
Add Playwright e2e test for quick edit of pages

### DIFF
--- a/tests/e2e/specs/pages/quick-edit-page.test.js
+++ b/tests/e2e/specs/pages/quick-edit-page.test.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Quick Edit Page', () => {
+	test.beforeEach( async ( { requestUtils, admin, editor } ) => {
+		await requestUtils.deleteAllPages();
+		await admin.createNewPost( { title: 'QA Page', postType: 'page' } );
+		await editor.publishPost();
+	} );
+
+	test( 'Should be able to quick edit a wp page', async ( {
+		page,
+		admin,
+	} ) => {
+		// navigate to All Pages
+		await admin.visitAdminPage( '/edit.php?post_type=page' );
+
+		// hover over the page created
+		await page.hover( 'role=link[name= "“QA Page” (Edit)"i]' );
+
+		// click on quick edit
+		await page.getByRole( 'button', { name: 'Quick Edit' } ).click();
+
+		// validate the title to check correct page is being edited
+		await expect(
+			page.getByRole( 'textbox', { name: 'Title', exact: true } )
+		).toHaveValue( 'QA Page' );
+
+		// Updated title of the page
+		await page
+			.getByRole( 'textbox', { name: 'Title' } )
+			.fill( 'Edited from quick edit' );
+
+		// click on the update page button
+		await page.getByRole( 'button', { name: 'Update' } ).click();
+
+		// Validate title after quick edit
+		await expect(
+			page.getByRole( 'link', { name: 'Edited from quick edit” (Edit)' } )
+		).toContainText( 'Edited from quick edit' );
+	} );
+} );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Added Playwright e2e test for quick edit of pages

Trac ticket: https://core.trac.wordpress.org/ticket/52895

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
