### PR TITLE
Add Playwright e2e test for undo trashed post and delete posts permanently

### DIFF
--- a/tests/e2e/specs/posts/restore-from-trash-empty-trash.test.js
+++ b/tests/e2e/specs/posts/restore-from-trash-empty-trash.test.js
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Undo trashed & delete posts permanantly from Trash', () => {
+	const POST_TITLE = 'Test Title';
+
+	test.beforeEach( async ( { requestUtils, editor, admin } ) => {
+		await requestUtils.deleteAllPosts();
+		await admin.createNewPost( { postType: 'post', title: POST_TITLE } );
+		await editor.publishPost();
+	} );
+
+	test( 'Restore trash post', async ( { page, admin, editor } ) => {
+		await admin.visitAdminPage( '/edit.php' );
+
+		// Move one post to trash.
+		await page.hover( `[aria-label^="“${ POST_TITLE }”"]` );
+		await page
+			.getByRole( `link`, {
+				name: `Move “${ POST_TITLE }” to the Trash`,
+			} )
+			.first()
+			.click();
+
+		await expect( page.locator( '.no-items' ) ).toHaveText(
+			'No posts found.'
+		);
+		// Remove post from trash.
+		await page.getByRole( 'link', { name: 'Undo' } ).click();
+
+		await expect( page.locator( '#message p' ) ).toHaveText(
+			'1 post restored from the Trash.'
+		);
+	} );
+
+	test( 'Empty Trash', async ( { page, admin, editor } ) => {
+		await admin.visitAdminPage( '/edit.php' );
+
+		// Move post to trash
+		await page.hover( `[aria-label^="“${ POST_TITLE }”"]` );
+		await page
+			.getByRole( `link`, {
+				name: `Move “${ POST_TITLE }” to the Trash`,
+			} )
+			.first()
+			.click();
+
+		await page.getByRole( 'link', { name: 'Trash' } ).click();
+
+		// Delete all post.
+		await page
+			.getByRole( 'button', { name: 'Empty Trash' } )
+			.first()
+			.click();
+
+		await expect( page.locator( '#message' ) ).toHaveText(
+			/\d+ posts? permanently deleted\./
+		);
+	} );
+} );

--- a/tests/e2e/specs/posts/restore-from-trash-empty-trash.test.js
+++ b/tests/e2e/specs/posts/restore-from-trash-empty-trash.test.js
@@ -59,5 +59,4 @@ test.describe( 'Undo trashed & delete posts permanantly from Trash', () => {
 			/\d+ posts? permanently deleted\./
 		);
 	} );
-    
 } );

--- a/tests/e2e/specs/posts/restore-from-trash-empty-trash.test.js
+++ b/tests/e2e/specs/posts/restore-from-trash-empty-trash.test.js
@@ -59,4 +59,5 @@ test.describe( 'Undo trashed & delete posts permanantly from Trash', () => {
 			/\d+ posts? permanently deleted\./
 		);
 	} );
+    
 } );


### PR DESCRIPTION
…antly from trash

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Added Playwright e2e test for undo trashed post and delete posts permanently

Trac ticket: https://core.trac.wordpress.org/ticket/52895

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
