### PR TITLE
Add Playwright e2e test for edit page

### DIFF
--- a/tests/e2e/specs/pages/edit-page.test.js
+++ b/tests/e2e/specs/pages/edit-page.test.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Edit a wp page', () => {
+	// Create a new page before updating it
+	test.beforeEach( async ( { admin, requestUtils, editor } ) => {
+		await requestUtils.deleteAllPages();
+
+		//Create a new page
+		await admin.createNewPost( { postType: 'page', title: 'Test page' } );
+
+		// publish page
+		await editor.publishPost();
+	} );
+
+	test( 'should be able to edit page', async ( { page, admin } ) => {
+		// navigate to all pages
+		await admin.visitAdminPage( '/edit.php?post_type=page' );
+
+		// Click on the edit link
+		await page.hover( 'role=link[name="“Test page” (Edit)"i]' );
+		await page
+			.getByRole( 'link', { name: 'Edit “Test page”' } )
+			.first()
+			.click();
+
+		// Update the exiting page title
+		await page
+			.frameLocator( 'iframe[name="editor-canvas"]' )
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.fill( 'Test Page - Edited' );
+
+		// Click on save button
+		await page.getByRole( 'button', { name: 'Save', exact: true } ).click();
+
+		// A success notice should show up
+		await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
+		await admin.visitAdminPage( '/edit.php?post_type=page' );
+		expect(
+			page.getByRole( 'link', { name: 'Test Page – Edited” (Edit)' } )
+		).toBeVisible();
+	} );
+} );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Added Playwright e2e test for edit page

Trac ticket: https://core.trac.wordpress.org/ticket/52895

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
