### PR TITLE
Build/Test Tools: Pin Gutenberg version to 19.7.0

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -48,6 +48,7 @@ jobs:
         LOCAL_SCRIPT_DEBUG: [ true, false ]
     with:
       LOCAL_SCRIPT_DEBUG: ${{ matrix.LOCAL_SCRIPT_DEBUG }}
+      gutenberg-version: '19.7.0'
 
   slack-notifications:
     name: Slack Notifications


### PR DESCRIPTION
https://github.com/WordPress/gutenberg/pull/67117 bumped the Gutenberg plugin's minimum required WordPress version to 6.6. That change was first shipped as part of GB 19.8.0 (see https://github.com/WordPress/gutenberg/commit/58e2d4b7ef9df24c537b1a2cf9485c2b2849822d).

This means that GB 19.7.0 (i.e. the last release from the 19.7.x series) was the last version that supported WordPress 6.5.

As a consequence, the end-to-end tests on Core's 6.5 branch need to be updated to pin the Gutenberg version to that version, so that E2E test will use that version (rather than a newer one) for testing Core's compatibility with the Gutenberg plugin.

See https://core.trac.wordpress.org/changeset/59221 for the analogue change for the 6.4 branch.

Trac ticket: https://core.trac.wordpress.org/ticket/62488

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
