### PR TITLE
Script Modules: Add method to include modules in importmap

### DIFF
--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -31,6 +31,18 @@ class WP_Script_Modules {
 	private $enqueued_before_registered = array();
 
 	/**
+	 * Holds script module identifiers that have been requested for exposure.
+	 *
+	 * "Exposed" indicates that the script module should be exposed in the
+	 * import map regardless of whether it is a dependency of another script
+	 * module.
+	 *
+	 * @since 6.8.0
+	 * @var array<string, true>
+	 */
+	private $exposed = array();
+
+	/**
 	 * Tracks whether the @wordpress/a11y script module is available.
 	 *
 	 * Some additional HTML is required on the page for the module to work. Track
@@ -149,6 +161,17 @@ class WP_Script_Modules {
 	}
 
 	/**
+	 * Marks the script module so it will be exposed in the import map.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @param string $id The identifier of the script module.
+	 */
+	public function expose( string $id ) {
+		$this->exposed[ $id ] = true;
+	}
+
+	/**
 	 * Unmarks the script module so it will no longer be enqueued in the page.
 	 *
 	 * @since 6.5.0
@@ -262,12 +285,14 @@ class WP_Script_Modules {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @return array Array with an `imports` key mapping to an array of script module identifiers and their respective
-	 *               URLs, including the version query.
+	 * @return array Array with an `imports` key mapping to an array of script
+	 *               module identifiers and their respective URLs, including
+	 *               the version query.
 	 */
 	private function get_import_map(): array {
-		$imports = array();
-		foreach ( $this->get_dependencies( array_keys( $this->get_marked_for_enqueue() ) ) as $id => $script_module ) {
+		$imports           = array();
+		$script_module_ids = array_unique( array_keys( $this->exposed ) + array_keys( $this->get_marked_for_enqueue() ) );
+		foreach ( $this->get_dependencies( $script_module_ids ) as $id => $script_module ) {
 			$imports[ $id ] = $this->get_src( $id );
 		}
 		return array( 'imports' => $imports );

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -231,10 +231,15 @@ class WP_Script_Modules {
 	 */
 	public function print_enqueued_script_modules() {
 		foreach ( $this->get_marked_for_enqueue() as $id => $script_module ) {
+			$src = $this->get_src( $id );
+			if ( null === $src ) {
+				continue;
+			}
+
 			wp_print_script_tag(
 				array(
 					'type' => 'module',
-					'src'  => $this->get_src( $id ),
+					'src'  => $src,
 					'id'   => $id . '-js-module',
 				)
 			);
@@ -251,11 +256,16 @@ class WP_Script_Modules {
 	 */
 	public function print_script_module_preloads() {
 		foreach ( $this->get_dependencies( array_keys( $this->get_marked_for_enqueue() ), array( 'static' ) ) as $id => $script_module ) {
+			$src = $this->get_src( $id );
+			if ( null === $src ) {
+				continue;
+			}
+
 			// Don't preload if it's marked for enqueue.
 			if ( true !== $script_module['enqueue'] ) {
 				echo sprintf(
 					'<link rel="modulepreload" href="%s" id="%s">',
-					esc_url( $this->get_src( $id ) ),
+					esc_url( $src ),
 					esc_attr( $id . '-js-modulepreload' )
 				);
 			}
@@ -293,7 +303,11 @@ class WP_Script_Modules {
 		$imports           = array();
 		$script_module_ids = array_unique( array_keys( $this->exposed ) + array_keys( $this->get_marked_for_enqueue() ) );
 		foreach ( $this->get_dependencies( $script_module_ids ) as $id => $script_module ) {
-			$imports[ $id ] = $this->get_src( $id );
+			$src = $this->get_src( $id );
+			if ( null === $src ) {
+				continue;
+			}
+			$imports[ $id ] = $src;
 		}
 		return array( 'imports' => $imports );
 	}
@@ -360,11 +374,11 @@ class WP_Script_Modules {
 	 * @since 6.5.0
 	 *
 	 * @param string $id The script module identifier.
-	 * @return string The script module src with a version if relevant.
+	 * @return string|null The script module src with a version if relevant.
 	 */
-	private function get_src( string $id ): string {
+	private function get_src( string $id ): ?string {
 		if ( ! isset( $this->registered[ $id ] ) ) {
-			return '';
+			return null;
 		}
 
 		$script_module = $this->registered[ $id ];

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -305,7 +305,7 @@ class WP_Script_Modules {
 	 */
 	private function get_import_map(): array {
 		$imports           = array();
-		$script_module_ids = $this->marked_for_inclusion + array_keys( $this->get_marked_for_enqueue() );
+		$script_module_ids = array_merge( $this->marked_for_inclusion, array_keys( $this->get_marked_for_enqueue() ) );
 
 		foreach ( $this->get_dependencies( $script_module_ids ) as $id => $script_module ) {
 			$src = $this->get_src( $id );

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -163,9 +163,9 @@ class WP_Script_Modules {
 	/**
 	 * Marks the script module for inclusion in the import map.
 	 *
-	 * Script Modules can rely on the script module dependency graph to include script modules
-	 * in the import map. This method makes it possible to mark a script module for inclusion
-	 * in the import map without relying on the script module dependency graph.
+	 * This method is intended for use outside of the script module dependency system.
+	 * It's recommended that script modules rely on the script module dependency system
+	 * to manage the import map.
 	 *
 	 * @since 6.8.0
 	 *

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -34,15 +34,11 @@ class WP_Script_Modules {
 	 * Holds script module identifiers that have been marked for inclusion in the import map.
 	 *
 	 * A script module that appears here should be include in the import map regardless of
-	 * whether it is a dependency of another script module.
-	 *
-	 * The values in this array are always `null`. The presence of a Module IDs
-	 * as an array key marks the script module for inclusion in the import map.
-	 * Different values are reserved for possible future use.
+	 * whether it is in the dependency graph of enqueued script modules.
 	 *
 	 * @since 6.8.0
 	 *
-	 * @var array<string, null>
+	 * @var string[]
 	 */
 	private $marked_for_inclusion = array();
 
@@ -176,7 +172,7 @@ class WP_Script_Modules {
 	 * @param string $id The identifier of the script module.
 	 */
 	public function include_in_import_map( string $id ) {
-		$this->marked_for_inclusion[ $id ] = null;
+		$this->marked_for_inclusion[] = $id;
 	}
 
 	/**
@@ -309,7 +305,7 @@ class WP_Script_Modules {
 	 */
 	private function get_import_map(): array {
 		$imports           = array();
-		$script_module_ids = array_unique( array_keys( $this->marked_for_inclusion ) + array_keys( $this->get_marked_for_enqueue() ) );
+		$script_module_ids = $this->marked_for_inclusion + array_keys( $this->get_marked_for_enqueue() );
 
 		foreach ( $this->get_dependencies( $script_module_ids ) as $id => $script_module ) {
 			$src = $this->get_src( $id );
@@ -318,7 +314,7 @@ class WP_Script_Modules {
 			}
 			$imports[ $id ] = $src;
 		}
-		foreach ( $this->marked_for_inclusion as $id => $_ ) {
+		foreach ( $this->marked_for_inclusion as $id ) {
 			$src = $this->get_src( $id );
 			if ( null === $src ) {
 				continue;


### PR DESCRIPTION
This is a first step towards [61500](https://core.trac.wordpress.org/ticket/61500), it adds a method to the script modules class to allow modules to be flagged for inclusion in the import map.

This means that a module can be flagged for inclusion and it will appear in the import map regardless of whether it's absent from the script module dependency graph.

This can be useful for developers to force modules to appear in the import map where they can be imported on the browser console. I expect this method to be used in the future so that classic scripts can create a dependency on script modules, where this new method will act the script dependency system to request that modules appear in the importmap.

~Internally it uses an array: `moduleId => null`. The value is always null, but other values could be used, e.g. to request that it appear in the import map _and_ in module preloads the value might by `moduleId => true` or `moduleId => 'preload'. Only `null` is used at this time. This would also appear as an argument to the `include_in_import_map` method, but again that is not implemented at this time and only presented for consideration.~

Trac ticket: https://core.trac.wordpress.org/ticket/61500

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
