### PR TITLE
Docs: Clarify multi-select behavior in collection and gallery add controllers

### DIFF
--- a/src/js/media/controllers/collection-add.js
+++ b/src/js/media/controllers/collection-add.js
@@ -17,7 +17,9 @@ var Selection = wp.media.model.Selection,
  * @param {object}                     [attributes]                         The attributes hash passed to the state.
  * @param {string}                     [attributes.id=library]              Unique identifier.
  * @param {string}                     attributes.title                     Title for the state. Displays in the frame's title region.
- * @param {boolean}                    [attributes.multiple=add]            Whether multi-select is enabled. @todo 'add' doesn't seem do anything special, and gets used as a boolean.
+ * @param {boolean|string}             [attributes.multiple=add]            Whether multi-select is enabled. Accepts 'add' or true.
+ *                                                                          When set to true, requires SHIFT/CMD/CTRL to select multiple items. 
+ *                                                                          When set to 'add', allows selecting multiple items by clicking thumbnails.
  * @param {wp.media.model.Attachments} [attributes.library]                 The attachments collection to browse.
  *                                                                          If one is not supplied, a collection of attachments of the specified type will be created.
  * @param {boolean|string}             [attributes.filterable=uploaded]     Whether the library is filterable, and if so what filters should be shown.

--- a/src/js/media/controllers/gallery-add.js
+++ b/src/js/media/controllers/gallery-add.js
@@ -20,7 +20,9 @@ var Selection = wp.media.model.Selection,
  * @param {Object}                     [attributes]                         The attributes hash passed to the state.
  * @param {string}                     [attributes.id=gallery-library]      Unique identifier.
  * @param {string}                     [attributes.title=Add to Gallery]    Title for the state. Displays in the frame's title region.
- * @param {boolean}                    [attributes.multiple=add]            Whether multi-select is enabled. @todo 'add' doesn't seem do anything special, and gets used as a boolean.
+ * @param {boolean|string}             [attributes.multiple=add]            Whether multi-select is enabled. Accepts 'add' or true.
+ *                                                                          When set to true, requires SHIFT/CMD/CTRL to select multiple items. 
+ *                                                                          When set to 'add', allows selecting multiple items by clicking thumbnails.
  * @param {wp.media.model.Attachments} [attributes.library]                 The attachments collection to browse.
  *                                                                          If one is not supplied, a collection of all images will be created.
  * @param {boolean|string}             [attributes.filterable=uploaded]     Whether the library is filterable, and if so what filters should be shown.


### PR DESCRIPTION
## Description
Updated the JSDoc documentation for the `multiple` attribute in `GalleryAdd` and `CollectionAdd` media controllers to accurately reflect its behavior with different values.

### Context
The `multiple` attribute accepts both boolean and string values, with different behaviors:
- `multiple=true`: Requires SHIFT/CMD/CTRL key to select multiple items
- `multiple='add'`: Allows selecting multiple items by clicking thumbnails directly

### Technical Changes
- Updated JSDoc type annotation to `{boolean|string}` in both controllers
- Added detailed description of behavior differences between `true` and `'add'` values
- Removed outdated TODO comment that incorrectly suggested `'add'` had no special behavior

### Files Changed
- `src/js/media/controllers/gallery-add.js`
- `src/js/media/controllers/collection-add.js`

Trac ticket: https://core.trac.wordpress.org/ticket/62696

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
