### PR TITLE
Add logic to sort posts by hierarchy

### DIFF
--- a/src/wp-includes/class-hierarchical-sort.php
+++ b/src/wp-includes/class-hierarchical-sort.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * Implements sorting posts by parent-child relationship.
+ *
+ * @package WordPress
+ * @since   6.8.0
+ */
+
+/**
+ * Sort post by hierarchy (parent-child relationship).
+ *
+ * @since 6.8.0
+ */
+class Hierarchical_Sort {
+
+	private static $post_ids = array();
+	private static $levels   = array();
+	private static $instance;
+
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	public function run( $args ) {
+		$new_args = array_merge(
+			$args,
+			array(
+				'fields'         => 'id=>parent',
+				'posts_per_page' => -1,
+			)
+		);
+		$query    = new WP_Query( $new_args );
+		$posts    = $query->posts;
+		$result   = self::sort( $posts );
+
+		self::$post_ids = $result['post_ids'];
+		self::$levels   = $result['levels'];
+	}
+
+	/**
+	 * Check if the request is eligible for hierarchical sorting.
+	 *
+	 * @param array $request The request data.
+	 *
+	 * @return bool Return true if the request is eligible for hierarchical sorting.
+	 */
+	public static function is_eligible( $request ) {
+		if ( ! isset( $request['orderby_hierarchy'] ) || true !== $request['orderby_hierarchy'] ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	public static function get_ancestor( $post_id ) {
+		return get_post( $post_id )->post_parent ?? 0;
+	}
+
+	/**
+	 * Sort posts by hierarchy.
+	 *
+	 * Takes an array of posts and sorts them based on their parent-child relationships.
+	 * It also tracks the level depth of each post in the hierarchy.
+	 *
+	 * Example input:
+	 * ```
+	 * [
+	 *   ['ID' => 4, 'post_parent' => 2],
+	 *   ['ID' => 2, 'post_parent' => 0],
+	 *   ['ID' => 3, 'post_parent' => 2],
+	 * ]
+	 * ```
+	 *
+	 * Example output:
+	 * ```
+	 * [
+	 *   'post_ids' => [2, 4, 3],
+	 *   'levels'   => [0, 1, 1]
+	 * ]
+	 * ```
+	 *
+	 * @param array $posts Array of post objects containing ID and post_parent properties.
+	 *
+	 * @return array {
+	 *     Sorted post IDs and their hierarchical levels
+	 *
+	 *     @type array $post_ids Array of post IDs
+	 *     @type array $levels   Array of levels for the corresponding post ID in the same index
+	 * }
+	 */
+	public static function sort( $posts ) {
+		/*
+		 * Arrange pages in two arrays:
+		 *
+		 * - $top_level: posts whose parent is 0
+		 * - $children: post ID as the key and an array of children post IDs as the value.
+		 *   Example: $children[10][] contains all sub-pages whose parent is 10.
+		 *
+		 * Additionally, keep track of the levels of each post in $levels.
+		 * Example: $levels[10] = 0 means the post ID is a top-level page.
+		 *
+		 */
+		$top_level = array();
+		$children  = array();
+		foreach ( $posts as $post ) {
+			if ( empty( $post->post_parent ) ) {
+				$top_level[] = $post->ID;
+			} else {
+				$children[ $post->post_parent ][] = $post->ID;
+			}
+		}
+
+		$ids    = array();
+		$levels = array();
+		self::add_hierarchical_ids( $ids, $levels, 0, $top_level, $children );
+
+		// Process remaining children.
+		if ( ! empty( $children ) ) {
+			foreach ( $children as $parent_id => $child_ids ) {
+				$level    = 0;
+				$ancestor = $parent_id;
+				while ( 0 !== $ancestor ) {
+					++$level;
+					$ancestor = self::get_ancestor( $ancestor );
+				}
+				self::add_hierarchical_ids( $ids, $levels, $level, $child_ids, $children );
+			}
+		}
+
+		return array(
+			'post_ids' => $ids,
+			'levels'   => $levels,
+		);
+	}
+
+	private static function add_hierarchical_ids( &$ids, &$levels, $level, $to_process, $children ) {
+		foreach ( $to_process as $id ) {
+			if ( in_array( $id, $ids, true ) ) {
+				continue;
+			}
+			$ids[]         = $id;
+			$levels[ $id ] = $level;
+
+			if ( isset( $children[ $id ] ) ) {
+				self::add_hierarchical_ids( $ids, $levels, $level + 1, $children[ $id ], $children );
+				unset( $children[ $id ] );
+			}
+		}
+	}
+
+	public static function get_post_ids() {
+		return self::$post_ids;
+	}
+
+	public static function get_levels() {
+		return self::$levels;
+	}
+}
+
+function rest_page_query_hierarchical_sort_filter_by_post_in( $args, $request ) {
+	if ( ! Hierarchical_Sort::is_eligible( $request ) ) {
+		return $args;
+	}
+
+	$hs = Hierarchical_Sort::get_instance();
+	$hs->run( $args );
+
+	// Reconfigure the args to display only the ids in the list.
+	$args['post__in'] = $hs->get_post_ids();
+	$args['orderby']  = 'post__in';
+
+	return $args;
+}
+
+function rest_prepare_page_hierarchical_sort_add_levels( $response, $post, $request ) {
+	if ( ! Hierarchical_Sort::is_eligible( $request ) ) {
+		return $response;
+	}
+
+	$hs                      = Hierarchical_Sort::get_instance();
+	$response->data['level'] = $hs->get_levels()[ $post->ID ];
+
+	return $response;
+}

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -772,8 +772,4 @@ add_filter( 'rest_prepare_post', 'insert_hooked_blocks_into_rest_response', 10, 
 add_filter( 'rest_prepare_wp_block', 'insert_hooked_blocks_into_rest_response', 10, 2 );
 add_filter( 'rest_prepare_wp_navigation', 'insert_hooked_blocks_into_rest_response', 10, 2 );
 
-// Filter the pages endpoint to consider orderby_hierarchy.
-add_filter( 'rest_page_query', 'rest_page_query_hierarchical_sort_filter_by_post_in', 10, 2 );
-add_filter( 'rest_prepare_page', 'rest_prepare_page_hierarchical_sort_add_levels', 10, 3 );
-
 unset( $filter, $action );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -772,4 +772,8 @@ add_filter( 'rest_prepare_post', 'insert_hooked_blocks_into_rest_response', 10, 
 add_filter( 'rest_prepare_wp_block', 'insert_hooked_blocks_into_rest_response', 10, 2 );
 add_filter( 'rest_prepare_wp_navigation', 'insert_hooked_blocks_into_rest_response', 10, 2 );
 
+// Filter the pages endpoint to consider orderby_hierarchy.
+add_filter( 'rest_page_query', 'rest_page_query_hierarchical_sort_filter_by_post_in', 10, 2 );
+add_filter( 'rest_prepare_page', 'rest_prepare_page_hierarchical_sort_add_levels', 10, 3 );
+
 unset( $filter, $action );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -3007,8 +3007,10 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				),
 				'default'     => array(),
 			);
+		}
+		if ( $post_type->hierarchical ) {
 			$query_params['orderby_hierarchy'] = array(
-				'description' => 'Sort pages by hierarchy.',
+				'description' => __( 'Whether the post should be grouped by parent-child relationship (hierarchy).' ),
 				'type'        => 'boolean',
 				'default'     => false,
 			);

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -411,10 +411,10 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		if ( Hierarchical_Sort::is_eligible( $request ) ) {
 			$result       = Hierarchical_Sort::run( $args );
-			$this->levels = $result[ 'levels' ];
+			$this->levels = $result['levels'];
 
-			$args[ 'post__in' ] = $result[ 'post_ids' ];
-			$args[ 'orderby' ]  = 'post__in';
+			$args['post__in'] = $result['post_ids'];
+			$args['orderby']  = 'post__in';
 		}
 
 		/**
@@ -3010,7 +3010,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$post_type = get_post_type_object( $this->post_type );
 
 		if ( $post_type->hierarchical || 'attachment' === $this->post_type ) {
-			$query_params['parent']            = array(
+			$query_params['parent']         = array(
 				'description' => __( 'Limit result set to items with particular parent IDs.' ),
 				'type'        => 'array',
 				'items'       => array(
@@ -3018,7 +3018,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				),
 				'default'     => array(),
 			);
-			$query_params['parent_exclude']    = array(
+			$query_params['parent_exclude'] = array(
 				'description' => __( 'Limit result set to all items except those of a particular parent ID.' ),
 				'type'        => 'array',
 				'items'       => array(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -2991,7 +2991,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		$post_type = get_post_type_object( $this->post_type );
 
 		if ( $post_type->hierarchical || 'attachment' === $this->post_type ) {
-			$query_params['parent']         = array(
+			$query_params['parent']            = array(
 				'description' => __( 'Limit result set to items with particular parent IDs.' ),
 				'type'        => 'array',
 				'items'       => array(
@@ -2999,13 +2999,18 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				),
 				'default'     => array(),
 			);
-			$query_params['parent_exclude'] = array(
+			$query_params['parent_exclude']    = array(
 				'description' => __( 'Limit result set to all items except those of a particular parent ID.' ),
 				'type'        => 'array',
 				'items'       => array(
 					'type' => 'integer',
 				),
 				'default'     => array(),
+			);
+			$query_params['orderby_hierarchy'] = array(
+				'description' => 'Sort pages by hierarchy.',
+				'type'        => 'boolean',
+				'default'     => false,
 			);
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -402,6 +402,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		// Force the post_type argument, since it's not a user input variable.
 		$args['post_type'] = $this->post_type;
 
+		$args = rest_page_query_hierarchical_sort_filter_by_post_in( $args, $request );
+
 		/**
 		 * Filters WP_Query arguments when querying posts via the REST API.
 		 *
@@ -2089,6 +2091,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 				}
 			}
 		}
+
+		$response = rest_prepare_page_hierarchical_sort_add_levels( $response, $post, $request );
 
 		/**
 		 * Filters the post data for a REST API response.

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -404,6 +404,7 @@ require ABSPATH . WPINC . '/interactivity-api/class-wp-interactivity-api.php';
 require ABSPATH . WPINC . '/interactivity-api/class-wp-interactivity-api-directives-processor.php';
 require ABSPATH . WPINC . '/interactivity-api/interactivity-api.php';
 require ABSPATH . WPINC . '/class-wp-plugin-dependencies.php';
+require ABSPATH . WPINC . '/class-hierarchical-sort.php';
 
 add_action( 'after_setup_theme', array( wp_script_modules(), 'add_hooks' ) );
 add_action( 'after_setup_theme', array( wp_interactivity(), 'add_hooks' ) );

--- a/tests/phpunit/includes/class-hierarchical-sort-test.php
+++ b/tests/phpunit/includes/class-hierarchical-sort-test.php
@@ -1,0 +1,207 @@
+<?php
+
+/**
+ * Test the Hierarchical_Sort class.
+ *
+ * @package WordPress
+ */
+class HierarchicalSortTest extends WP_UnitTestCase {
+
+	public function test_return_all_post_ids() {
+		/*
+		 * Keep this updated as the input array changes.
+		 * The sorted hierarchy would be as follows:
+		 *
+		 * 12
+		 * - 3
+		 * -- 6
+		 * -- 5
+		 * - 4
+		 * -- 7
+		 * 8
+		 * - 9
+		 * -- 11
+		 * - 10
+		 *
+		 */
+		$input = array(
+			(object) array(
+				'ID'          => 11,
+				'post_parent' => 9,
+			),
+			(object) array(
+				'ID'          => 12,
+				'post_parent' => 0,
+			),
+			(object) array(
+				'ID'          => 8,
+				'post_parent' => 0,
+			),
+			(object) array(
+				'ID'          => 3,
+				'post_parent' => 12,
+			),
+			(object) array(
+				'ID'          => 6,
+				'post_parent' => 3,
+			),
+			(object) array(
+				'ID'          => 7,
+				'post_parent' => 4,
+			),
+			(object) array(
+				'ID'          => 9,
+				'post_parent' => 8,
+			),
+			(object) array(
+				'ID'          => 4,
+				'post_parent' => 12,
+			),
+			(object) array(
+				'ID'          => 5,
+				'post_parent' => 3,
+			),
+			(object) array(
+				'ID'          => 10,
+				'post_parent' => 8,
+			),
+		);
+
+		$hs     = Hierarchical_Sort::get_instance();
+		$result = $hs->sort( $input );
+		$this->assertEquals( array( 12, 3, 6, 5, 4, 7, 8, 9, 11, 10 ), $result['post_ids'] );
+		$this->assertEquals(
+			array(
+				12 => 0,
+				3  => 1,
+				6  => 2,
+				5  => 2,
+				4  => 1,
+				7  => 2,
+				8  => 0,
+				9  => 1,
+				11 => 2,
+				10 => 1,
+			),
+			$result['levels']
+		);
+	}
+
+	public function test_return_orphans() {
+		/*
+		 * Keep this updated as the input array changes.
+		 * The sorted hierarchy would be as follows:
+		 *
+		 * - 11 (orphan)
+		 * - 4 (orphan)
+		 * -- 7
+		 *
+		 */
+		$input = array(
+			(object) array(
+				'ID'          => 11,
+				'post_parent' => 2,
+			),
+			(object) array(
+				'ID'          => 7,
+				'post_parent' => 4,
+			),
+			(object) array(
+				'ID'          => 4,
+				'post_parent' => 2,
+			),
+		);
+
+		$hs     = Hierarchical_Sort::get_instance();
+		$result = $hs->sort( $input );
+		$this->assertEquals( array( 11, 4, 7 ), $result['post_ids'] );
+		$this->assertEquals(
+			array(
+				11 => 1,
+				4  => 1,
+				7  => 2,
+			),
+			$result['levels']
+		);
+	}
+
+	public function test_post_with_empty_post_parent_are_considered_top_level() {
+		/*
+		 * Keep this updated as the input array changes.
+		 * The sorted hierarchy would be as follows:
+		 *
+		 * 2
+		 * - 3
+		 * -- 5
+		 * -- 6
+		 * - 4
+		 * -- 7
+		 * 8
+		 * - 9
+		 * -- 11
+		 * - 10
+		 *
+		 */
+		$input = array(
+			(object) array(
+				'ID'          => 11,
+				'post_parent' => 9,
+			),
+			(object) array(
+				'ID'          => 2,
+				'post_parent' => 0,
+			),
+			(object) array(
+				'ID'          => 8,
+				'post_parent' => '', // Empty post parent, should be considered top-level.
+			),
+			(object) array(
+				'ID'          => 3,
+				'post_parent' => 2,
+			),
+			(object) array(
+				'ID'          => 5,
+				'post_parent' => 3,
+			),
+			(object) array(
+				'ID'          => 7,
+				'post_parent' => 4,
+			),
+			(object) array(
+				'ID'          => 9,
+				'post_parent' => 8,
+			),
+			(object) array(
+				'ID'          => 4,
+				'post_parent' => 2,
+			),
+			(object) array(
+				'ID'          => 6,
+				'post_parent' => 3,
+			),
+			(object) array(
+				'ID'          => 10,
+				'post_parent' => 8,
+			),
+		);
+
+		$hs     = Hierarchical_Sort::get_instance();
+		$result = $hs->sort( $input );
+		$this->assertEquals( array( 2, 3, 5, 6, 4, 7, 8, 9, 11, 10 ), $result['post_ids'] );
+		$this->assertEquals(
+			array(
+				2  => 0,
+				3  => 1,
+				5  => 2,
+				6  => 2,
+				4  => 1,
+				7  => 2,
+				8  => 0,
+				9  => 1,
+				11 => 2,
+				10 => 1,
+			),
+			$result['levels']
+		);
+	}
+}

--- a/tests/phpunit/includes/class-hierarchical-sort-test.php
+++ b/tests/phpunit/includes/class-hierarchical-sort-test.php
@@ -67,8 +67,7 @@ class HierarchicalSortTest extends WP_UnitTestCase {
 			),
 		);
 
-		$hs     = Hierarchical_Sort::get_instance();
-		$result = $hs->sort( $input );
+		$result = Hierarchical_Sort::run( $input );
 		$this->assertEquals( array( 12, 3, 6, 5, 4, 7, 8, 9, 11, 10 ), $result['post_ids'] );
 		$this->assertEquals(
 			array(
@@ -112,8 +111,7 @@ class HierarchicalSortTest extends WP_UnitTestCase {
 			),
 		);
 
-		$hs     = Hierarchical_Sort::get_instance();
-		$result = $hs->sort( $input );
+		$result = Hierarchical_Sort::run( $input );
 		$this->assertEquals( array( 11, 4, 7 ), $result['post_ids'] );
 		$this->assertEquals(
 			array(
@@ -185,8 +183,7 @@ class HierarchicalSortTest extends WP_UnitTestCase {
 			),
 		);
 
-		$hs     = Hierarchical_Sort::get_instance();
-		$result = $hs->sort( $input );
+		$result = Hierarchical_Sort::run( $input );
 		$this->assertEquals( array( 2, 3, 5, 6, 4, 7, 8, 9, 11, 10 ), $result['post_ids'] );
 		$this->assertEquals(
 			array(

--- a/tests/phpunit/tests/rest-api/rest-pages-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-pages-controller.php
@@ -79,6 +79,7 @@ class WP_Test_REST_Pages_Controller extends WP_Test_REST_Post_Type_Controller_Te
 				'offset',
 				'order',
 				'orderby',
+				'orderby_hierarchy',
 				'page',
 				'parent',
 				'parent_exclude',

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -1808,6 +1808,12 @@ mockedApiResponse.Schema = {
                             "default": [],
                             "required": false
                         },
+                        "orderby_hierarchy": {
+                            "description": "Whether the post should be grouped by parent-child relationship (hierarchy).",
+                            "type": "boolean",
+                            "default": false,
+                            "required": false
+                        },
                         "search_columns": {
                             "default": [],
                             "description": "Array of column names to be searched.",


### PR DESCRIPTION
Trac ticket https://core.trac.wordpress.org/ticket/62701

See related Gutenberg issues/PRs:

- Issue https://github.com/WordPress/gutenberg/issues/55957
- PR https://github.com/WordPress/gutenberg/pull/66479

## What

This PR expands the post controller to allow returning the data by parent-child relationship (sort by hierarchy).

## Why 

We want to display data in a hierarchical way in the site editor, similarly to what we do in wp-admin:

| wp-admin | site editor |
| --- | --- |
| <img width="2545" alt="Screenshot 2024-12-17 at 17 15 12" src="https://github.com/user-attachments/assets/6facad5b-acad-4671-a166-9ececeba5ccc" /> | <img width="2545" alt="Screenshot 2024-12-17 at 17 14 43" src="https://github.com/user-attachments/assets/81f94e96-12c1-49f5-8c05-664f4ae27ddd" /> |

## How to test

Added a new test suite to test the logic.

Steps to test this manually:

_(alternatively, you may want to generate a gutenberg zip from `trunk`, use the normal `wordpress-develop` setup and change the gutenberg's PHP code in the plugin directory)_

- In this PR, execute `npm install && npm run build:dev`.
- Have a clone of the Gutenberg repository, switch to `trunk`, create a `.wp-env.override.json` with the following contents (core is the local path of this PR's repository, so change accordingly):

```sh
{
 "core": "../wordpress-develop/src"
}
```
- In the Gutenberg codebase, comment the 3 filters defined [here](https://github.com/WordPress/gutenberg/blob/trunk/lib/compat/wordpress-6.8/class-gutenberg-hierarchical-sort.php#L159).
- In the Gutenberg codebase, run `npm run wp-env start`. Then `npm install && npm run dev`.
- Visit `localhost:8888`, open the wp-admin, and go to "Tools > Import". Import this [theme test data file](https://github.com/WordPress/theme-test-data/blob/master/themeunittestdata.wordpress.xml), that comes with hierarchical pages (or create your own set of pages).
- Visit the Site Editor > Pages. Then switch to the table layout. You should see something like this:

<img width="2545" alt="Screenshot 2024-12-17 at 17 14 43" src="https://github.com/user-attachments/assets/81f94e96-12c1-49f5-8c05-664f4ae27ddd" />