### PR TITLE
Help/About: Allow "See everything new" button to wrap

### DIFF
--- a/src/wp-admin/css/about.css
+++ b/src/wp-admin/css/about.css
@@ -454,7 +454,12 @@
 }
 
 .about__section a.button.button-hero {
+	padding-top: 1.1875rem;
+	padding-bottom: 1.1875rem;
 	font-size: 1.5rem;
+	line-height: 1.4;
+	white-space: normal;
+	text-wrap: pretty;
 }
 
 .about__container ul {


### PR DESCRIPTION
On some screen sizes and languages, the "See everything new" button expands out of the content area. This change allows the button to wrap at all screen sizes.

This pulls CSS from both #7769 and #7771, the changes I made were to fix some padding, and apply to all screen sizes.

Trac ticket: https://core.trac.wordpress.org/ticket/62380

**Screenshots**

|  | 1200px | 800px | 400px |
|---|---|---|---|
| English | ![about-0-en_US](https://github.com/user-attachments/assets/eaa31350-d472-485a-ae54-211889f38fec) | ![about-1-en_US](https://github.com/user-attachments/assets/1524dd38-05a3-46be-913f-991676113af5) | ![about-3-en_US](https://github.com/user-attachments/assets/2010ae41-0ec0-46ae-8108-25d68620fec9) |
| French | ![about-0-fr_FR](https://github.com/user-attachments/assets/c0bb8913-017f-44c8-b1af-7d951d3a811a) | ![about-1-fr_FR](https://github.com/user-attachments/assets/c3a43c6d-dd72-43ad-8820-4a73418878f2) | ![about-3-fr_FR](https://github.com/user-attachments/assets/ba1be8be-9d08-4591-b734-6511fd9d69bf) |
| Japanese | ![about-0-ja](https://github.com/user-attachments/assets/abdf6380-5300-4016-874d-282f843b65ed) | ![about-1-ja](https://github.com/user-attachments/assets/b558c69c-e926-4532-b136-dff18c052d2d) | ![about-3-ja](https://github.com/user-attachments/assets/160d3727-3005-41da-95c9-7b70e713974d) |
| Uighur (RTL) | ![about-0-ug_CN](https://github.com/user-attachments/assets/555bdba2-2668-47b8-9d01-255c4e9c2470) | ![about-1-ug_CN](https://github.com/user-attachments/assets/92421813-d84a-4b8a-b6df-416f644dba3c) | ![about-3-ug_CN](https://github.com/user-attachments/assets/4f306150-f8f0-48c8-9548-cb4bb597793c) |

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
