### PR TITLE
Add view transitions using MPA pattern to Twenty Seventeen theme.

### DIFF
--- a/src/wp-content/themes/twentyseventeen/assets/js/global.js
+++ b/src/wp-content/themes/twentyseventeen/assets/js/global.js
@@ -249,4 +249,14 @@
 		$body.addClass( 'has-header-video' );
 	});
 
+	
+    $(document).ready(function() {
+        $('a').each(function() {
+            if (this.href && this.href !== window.location.href) {
+                $(this).attr('view-transition', 'page-transition');
+            }
+        });
+    });
+
+
 })( jQuery );

--- a/src/wp-content/themes/twentyseventeen/assets/js/global.js
+++ b/src/wp-content/themes/twentyseventeen/assets/js/global.js
@@ -249,14 +249,4 @@
 		$body.addClass( 'has-header-video' );
 	});
 
-	
-    $(document).ready(function() {
-        $('a').each(function() {
-            if (this.href && this.href !== window.location.href) {
-                $(this).attr('view-transition', 'page-transition');
-            }
-        });
-    });
-
-
 })( jQuery );

--- a/src/wp-content/themes/twentyseventeen/style.css
+++ b/src/wp-content/themes/twentyseventeen/style.css
@@ -61,17 +61,8 @@ html {
 	-webkit-text-size-adjust: 100%;
 }
 
-@keyframes page-transition {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 1;
-    }
-}
-
-.site-content {
-    view-transition-name: page-transition;
+@view-transition {
+	navigation: auto;
 }
 
 body {

--- a/src/wp-content/themes/twentyseventeen/style.css
+++ b/src/wp-content/themes/twentyseventeen/style.css
@@ -65,6 +65,40 @@ html {
 	navigation: auto;
 }
 
+/* Mark the `<main>` element as the element that should transition */
+#content {
+  view-transition-name: my-main-content;
+}
+
+/* Apply animations to the snapshots */
+/* Note, `main-content` is the view transition name specified in the previous CSS block */
+::view-transition-old(my-main-content) {
+  animation: 500ms ease-out both slide-out;
+}
+
+::view-transition-new(my-main-content) {
+  animation: 500ms ease-out both slide-in;
+}
+
+/* Define the animations */
+@keyframes slide-out {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-100%);
+  }
+}
+
+@keyframes slide-in {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
 body {
 	margin: 0;
 }

--- a/src/wp-content/themes/twentyseventeen/style.css
+++ b/src/wp-content/themes/twentyseventeen/style.css
@@ -61,6 +61,19 @@ html {
 	-webkit-text-size-adjust: 100%;
 }
 
+@keyframes page-transition {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+.site-content {
+    view-transition-name: page-transition;
+}
+
 body {
 	margin: 0;
 }


### PR DESCRIPTION
Implements view transitions in the Twenty Seventeen theme using the MPA pattern of the View Transitions API.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
