### PR TITLE
Docs: Update parameter type hints to include null for thumbnail-relat…

### DIFF
--- a/src/wp-includes/post-thumbnail-template.php
+++ b/src/wp-includes/post-thumbnail-template.php
@@ -157,9 +157,9 @@ function update_post_thumbnail_cache( $wp_query = null ) {
  * @since 4.4.0 `$post` can be a post ID or WP_Post object.
  *
  * @param int|WP_Post|null  $post Optional. Post ID or WP_Post object.  Default is global `$post`.
- * @param string|int[] 		  $size Optional. Image size. Accepts any registered image size name, or an array of
+ * @param string|int[]      $size Optional. Image size. Accepts any registered image size name, or an array of
  *                          width and height values in pixels (in that order). Default 'post-thumbnail'.
- * @param string|array 			$attr Optional. Query string or array of attributes. Default empty.
+ * @param string|array      $attr Optional. Query string or array of attributes. Default empty.
  * @return string The post thumbnail image tag.
  */
 function get_the_post_thumbnail( $post = null, $size = 'post-thumbnail', $attr = '' ) {
@@ -242,7 +242,7 @@ function get_the_post_thumbnail( $post = null, $size = 'post-thumbnail', $attr =
  * @since 4.4.0
  *
  * @param int|WP_Post|null  $post Optional. Post ID or WP_Post object.  Default is global `$post`.
- * @param string|int[] 			$size Optional. Registered image size to retrieve the source for or a flat array
+ * @param string|int[]      $size Optional. Registered image size to retrieve the source for or a flat array
  *                          of height and width dimensions. Default 'post-thumbnail'.
  * @return string|false Post thumbnail URL or false if no image is available. If `$size` does not match
  *                      any registered image size, the original image URL will be returned.

--- a/src/wp-includes/post-thumbnail-template.php
+++ b/src/wp-includes/post-thumbnail-template.php
@@ -19,7 +19,7 @@
  * @since 2.9.0
  * @since 4.4.0 `$post` can be a post ID or WP_Post object.
  *
- * @param int|WP_Post $post Optional. Post ID or WP_Post object. Default is global `$post`.
+ * @param int|WP_Post|null $post Optional. Post ID or WP_Post object. Default is global `$post`.
  * @return bool Whether the post has an image attached.
  */
 function has_post_thumbnail( $post = null ) {
@@ -46,7 +46,7 @@ function has_post_thumbnail( $post = null ) {
  * @since 5.5.0 The return value for a non-existing post
  *              was changed to false instead of an empty string.
  *
- * @param int|WP_Post $post Optional. Post ID or WP_Post object. Default is global `$post`.
+ * @param int|WP_Post|null $post Optional. Post ID or WP_Post object. Default is global `$post`.
  * @return int|false Post thumbnail ID (which can be 0 if the thumbnail is not set),
  *                   or false if the post does not exist.
  */
@@ -99,7 +99,7 @@ function the_post_thumbnail( $size = 'post-thumbnail', $attr = '' ) {
  *
  * @global WP_Query $wp_query WordPress Query object.
  *
- * @param WP_Query $wp_query Optional. A WP_Query instance. Defaults to the $wp_query global.
+ * @param WP_Query|null $wp_query Optional. A WP_Query instance. Defaults to the $wp_query global.
  */
 function update_post_thumbnail_cache( $wp_query = null ) {
 	if ( ! $wp_query ) {
@@ -156,10 +156,10 @@ function update_post_thumbnail_cache( $wp_query = null ) {
  * @since 2.9.0
  * @since 4.4.0 `$post` can be a post ID or WP_Post object.
  *
- * @param int|WP_Post  $post Optional. Post ID or WP_Post object.  Default is global `$post`.
- * @param string|int[] $size Optional. Image size. Accepts any registered image size name, or an array of
- *                           width and height values in pixels (in that order). Default 'post-thumbnail'.
- * @param string|array $attr Optional. Query string or array of attributes. Default empty.
+ * @param int|WP_Post|null  $post Optional. Post ID or WP_Post object.  Default is global `$post`.
+ * @param string|int[] 		  $size Optional. Image size. Accepts any registered image size name, or an array of
+ *                          width and height values in pixels (in that order). Default 'post-thumbnail'.
+ * @param string|array 			$attr Optional. Query string or array of attributes. Default empty.
  * @return string The post thumbnail image tag.
  */
 function get_the_post_thumbnail( $post = null, $size = 'post-thumbnail', $attr = '' ) {
@@ -241,9 +241,9 @@ function get_the_post_thumbnail( $post = null, $size = 'post-thumbnail', $attr =
  *
  * @since 4.4.0
  *
- * @param int|WP_Post  $post Optional. Post ID or WP_Post object.  Default is global `$post`.
- * @param string|int[] $size Optional. Registered image size to retrieve the source for or a flat array
- *                           of height and width dimensions. Default 'post-thumbnail'.
+ * @param int|WP_Post|null  $post Optional. Post ID or WP_Post object.  Default is global `$post`.
+ * @param string|int[] 			$size Optional. Registered image size to retrieve the source for or a flat array
+ *                          of height and width dimensions. Default 'post-thumbnail'.
  * @return string|false Post thumbnail URL or false if no image is available. If `$size` does not match
  *                      any registered image size, the original image URL will be returned.
  */
@@ -291,7 +291,7 @@ function the_post_thumbnail_url( $size = 'post-thumbnail' ) {
  *
  * @since 4.6.0
  *
- * @param int|WP_Post $post Optional. Post ID or WP_Post object. Default is global `$post`.
+ * @param int|WP_Post|null $post Optional. Post ID or WP_Post object. Default is global `$post`.
  * @return string Post thumbnail caption.
  */
 function get_the_post_thumbnail_caption( $post = null ) {
@@ -315,7 +315,7 @@ function get_the_post_thumbnail_caption( $post = null ) {
  *
  * @since 4.6.0
  *
- * @param int|WP_Post $post Optional. Post ID or WP_Post object. Default is global `$post`.
+ * @param int|WP_Post|null $post Optional. Post ID or WP_Post object. Default is global `$post`.
  */
 function the_post_thumbnail_caption( $post = null ) {
 	/**


### PR DESCRIPTION
As described in ticket 62720, we found several missing types in phpdocs throughout `post-thumbnail-template.php`.
This PR fixes all missing occurrences of `null` -types throughout the file.


Trac ticket: https://core.trac.wordpress.org/ticket/62720#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
