### PR TITLE
Changed Document Order

### DIFF
--- a/src/wp-includes/block-supports/block-style-variations.php
+++ b/src/wp-includes/block-supports/block-style-variations.php
@@ -198,10 +198,10 @@ function wp_render_block_style_variation_support_styles( $parsed_block ) {
  * block attributes in the `render_block_data` filter gets applied to the
  * block's markup.
  *
- * @see wp_render_block_style_variation_support_styles
- *
  * @since 6.6.0
  * @access private
+ *
+ * @see wp_render_block_style_variation_support_styles
  *
  * @param  string $block_content Rendered block content.
  * @param  array  $block         Block object.


### PR DESCRIPTION
Fixes: https://core.trac.wordpress.org/ticket/62730

`@since` Should add before `@see` tag in inline documentation According to [Php Coding Standard](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php) in Below File 

- src/wp-includes/block-supports/block-style-variations.php
