### PR TITLE
Add Support for 'any' post status in get_pages()

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6233,6 +6233,7 @@ function get_page_uri( $page = 0 ) {
  *
  * @since 1.5.0
  * @since 6.3.0 Use WP_Query internally.
+ * @since 6.8.0 Added 'any' as an accepted `$post_status`.
  *
  * @param array|string $args {
  *     Optional. Array or string of arguments to retrieve pages.
@@ -6265,7 +6266,8 @@ function get_page_uri( $page = 0 ) {
  *                                      Default 0.
  *     @type string       $post_type    The post type to query. Default 'page'.
  *     @type string|array $post_status  A comma-separated list or array of post statuses to include.
- *                                      Default 'publish'.
+ *                                      Default 'publish'. If `$post_status` includes 'any' then any status
+ * 										post status with 'exclude_from_search' will also be included.
  * }
  * @return WP_Post[]|false Array of pages (or hierarchical post type items). Boolean false if the
  *                         specified post type is not hierarchical or the specified status is not
@@ -6316,6 +6318,14 @@ function get_pages( $args = array() ) {
 	if ( ! is_array( $post_status ) ) {
 		$post_status = explode( ',', $post_status );
 	}
+
+	if ( in_array( 'any', $post_status ) ) {
+		$post_status = array_unique( array_merge(
+			array_diff( $post_status, ['any'] ),
+			array_keys( get_post_stati( ['exclude_from_search' => false] ) )
+		) );
+	}
+
 	if ( array_diff( $post_status, get_post_stati() ) ) {
 		return false;
 	}

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6267,7 +6267,7 @@ function get_page_uri( $page = 0 ) {
  *     @type string       $post_type    The post type to query. Default 'page'.
  *     @type string|array $post_status  A comma-separated list or array of post statuses to include.
  *                                      Default 'publish'. If `$post_status` includes 'any' then any status
- * 										post status with 'exclude_from_search' will also be included.
+ * 									    post status with 'exclude_from_search' will also be included.
  * }
  * @return WP_Post[]|false Array of pages (or hierarchical post type items). Boolean false if the
  *                         specified post type is not hierarchical or the specified status is not

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6320,10 +6320,12 @@ function get_pages( $args = array() ) {
 	}
 
 	if ( in_array( 'any', $post_status ) ) {
-		$post_status = array_unique( array_merge(
-			array_diff( $post_status, ['any'] ),
-			array_keys( get_post_stati( ['exclude_from_search' => false] ) )
-		) );
+		$post_status = array_unique(
+			array_merge(
+				array_diff( $post_status, array( 'any' ) ),
+				array_keys( get_post_stati( array( 'exclude_from_search' => false ) ) )
+			)
+		);
 	}
 
 	if ( array_diff( $post_status, get_post_stati() ) ) {

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6267,7 +6267,7 @@ function get_page_uri( $page = 0 ) {
  *     @type string       $post_type    The post type to query. Default 'page'.
  *     @type string|array $post_status  A comma-separated list or array of post statuses to include.
  *                                      Default 'publish'. If `$post_status` includes 'any' then any status
- * 									    post status with 'exclude_from_search' will also be included.
+ *                                      post status with 'exclude_from_search' will also be included.
  * }
  * @return WP_Post[]|false Array of pages (or hierarchical post type items). Boolean false if the
  *                         specified post type is not hierarchical or the specified status is not

--- a/tests/phpunit/tests/post/getPages.php
+++ b/tests/phpunit/tests/post/getPages.php
@@ -1207,4 +1207,171 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 			'Check that ORDER is post modified when using modified_gmt.'
 		);
 	}
+
+	/**
+	 * Test that get_pages() accepts 'any' as a post_status value.
+	 *
+	 * @ticket 40650
+	 */
+	public function test_get_pages_post_status_any() {
+		$published_page = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			)
+		);
+
+		$draft_page = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'draft',
+			)
+		);
+
+		$private_page = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'private',
+			)
+		);
+
+		$trash_page = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'trash',
+			)
+		);
+
+		$pages = get_pages(
+			array(
+				'post_status' => 'any',
+			)
+		);
+
+		$page_ids = wp_list_pluck( $pages, 'ID' );
+
+		// Published, draft, and private pages should be included.
+		$this->assertContains( $published_page, $page_ids );
+		$this->assertContains( $draft_page, $page_ids );
+		$this->assertContains( $private_page, $page_ids );
+
+		// Trash pages should not be included.
+		$this->assertNotContains( $trash_page, $page_ids );
+	}
+
+	/**
+	 * Test that get_pages() handles 'any' with different input formats and combinations.
+	 *
+	 * @ticket 40650
+	 */
+	public function test_get_pages_post_status_any_combinations() {
+		$pages = array(
+			'published' => self::factory()->post->create(
+				array(
+					'post_type'   => 'page',
+					'post_status' => 'publish',
+				)
+			),
+			'draft' => self::factory()->post->create(
+				array(
+					'post_type'   => 'page',
+					'post_status' => 'draft',
+				)
+			),
+			'private' => self::factory()->post->create(
+				array(
+					'post_type'   => 'page',
+					'post_status' => 'private',
+				)
+			),
+			'trash' => self::factory()->post->create(
+				array(
+					'post_type'   => 'page',
+					'post_status' => 'trash',
+				)
+			),
+		);
+
+		// Test 1: 'any' combined with 'trash' using array format.
+		$result = get_pages(
+			array(
+				'post_status' => array( 'any', 'trash' ),
+			)
+		);
+		$page_ids = wp_list_pluck( $result, 'ID' );
+
+		$this->assertContains( $pages['published'], $page_ids );
+		$this->assertContains( $pages['draft'], $page_ids );
+		$this->assertContains( $pages['private'], $page_ids );
+		$this->assertContains( $pages['trash'], $page_ids );
+
+		// Test 2: 'any' with comma-separated string.
+		$result = get_pages(
+			array(
+				'post_status' => 'any,draft',
+			)
+		);
+		$page_ids = wp_list_pluck( $result, 'ID' );
+
+		$this->assertContains( $pages['published'], $page_ids );
+		$this->assertContains( $pages['draft'], $page_ids );
+	}
+
+	/**
+	 * Test that get_pages() with 'any' includes custom post statuses with exclude_from_search => false.
+	 *
+	 * @ticket 40650
+	 */
+	public function test_get_pages_post_status_any_with_custom_status() {
+		register_post_status(
+			'custom_searchable',
+			array(
+				'public'              => false,
+				'exclude_from_search' => false,
+				'show_in_admin_status_list' => true,
+			)
+		);
+
+		register_post_status(
+			'custom_hidden',
+			array(
+				'public'              => false,
+				'exclude_from_search' => true,
+				'show_in_admin_status_list' => true,
+			)
+		);
+
+		$published_page = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			)
+		);
+
+		$custom_searchable_page = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'custom_searchable',
+			)
+		);
+
+		$custom_hidden_page = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'custom_hidden',
+			)
+		);
+
+		$pages = get_pages(
+			array(
+				'post_status' => 'any',
+			)
+		);
+
+		$page_ids = wp_list_pluck( $pages, 'ID' );
+
+		$this->assertContains( $published_page, $page_ids );
+		$this->assertContains( $custom_searchable_page, $page_ids );
+		$this->assertNotContains( $custom_hidden_page, $page_ids );
+	}
 }

--- a/tests/phpunit/tests/post/getPages.php
+++ b/tests/phpunit/tests/post/getPages.php
@@ -1272,19 +1272,19 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 					'post_status' => 'publish',
 				)
 			),
-			'draft' => self::factory()->post->create(
+			'draft'     => self::factory()->post->create(
 				array(
 					'post_type'   => 'page',
 					'post_status' => 'draft',
 				)
 			),
-			'private' => self::factory()->post->create(
+			'private'   => self::factory()->post->create(
 				array(
 					'post_type'   => 'page',
 					'post_status' => 'private',
 				)
 			),
-			'trash' => self::factory()->post->create(
+			'trash'     => self::factory()->post->create(
 				array(
 					'post_type'   => 'page',
 					'post_status' => 'trash',
@@ -1293,7 +1293,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 		);
 
 		// Test 1: 'any' combined with 'trash' using array format.
-		$result = get_pages(
+		$result   = get_pages(
 			array(
 				'post_status' => array( 'any', 'trash' ),
 			)
@@ -1306,7 +1306,7 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 		$this->assertContains( $pages['trash'], $page_ids );
 
 		// Test 2: 'any' with comma-separated string.
-		$result = get_pages(
+		$result   = get_pages(
 			array(
 				'post_status' => 'any,draft',
 			)
@@ -1326,8 +1326,8 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 		register_post_status(
 			'custom_searchable',
 			array(
-				'public'              => false,
-				'exclude_from_search' => false,
+				'public'                    => false,
+				'exclude_from_search'       => false,
 				'show_in_admin_status_list' => true,
 			)
 		);
@@ -1335,8 +1335,8 @@ class Tests_Post_GetPages extends WP_UnitTestCase {
 		register_post_status(
 			'custom_hidden',
 			array(
-				'public'              => false,
-				'exclude_from_search' => true,
+				'public'                    => false,
+				'exclude_from_search'       => true,
 				'show_in_admin_status_list' => true,
 			)
 		);


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/40650

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
