### PR TITLE
Update E2E global setup with current theme `twentytwentyfour`

### DIFF
--- a/tests/e2e/config/global-setup.js
+++ b/tests/e2e/config/global-setup.js
@@ -31,7 +31,7 @@ async function globalSetup( config ) {
 
 	// Reset the test environment before running the tests.
 	await Promise.all( [
-		requestUtils.activateTheme( 'twentytwentyone' ),
+		requestUtils.activateTheme( 'twentytwentyfour' ),
 		requestUtils.deleteAllPosts(),
 		requestUtils.deleteAllBlocks(),
 		requestUtils.resetPreferences(),

--- a/tests/e2e/specs/dashboard.test.js
+++ b/tests/e2e/specs/dashboard.test.js
@@ -62,13 +62,13 @@ test.describe( 'Quick Draft', () => {
 		// Check that new draft appears in Your Recent Drafts section
 		await expect(
 			page.locator( '.drafts .draft-title' ).first().getByRole( 'link' )
-		).toHaveText( 'Untitled' );
+		).toHaveText( '(no title)' );
 
 		// Check that new draft appears in Posts page
 		await admin.visitAdminPage( '/edit.php' );
 
 		await expect(
 			page.locator( '.type-post.status-draft .title' ).first()
-		).toContainText( 'Untitled' );
+		).toContainText( '(no title)' );
 	} );
 } );


### PR DESCRIPTION
E2E tests were running with `twentytwentyone`, made changes to work with current theme `twentytwentyfour` 

Also made the changes in `dashboard` test to make it work with new activated theme

Trac Ticket: https://core.trac.wordpress.org/ticket/52895