### PR TITLE
Fix quote block font-weight inconsistency in Twenty Twenty theme

### DIFF
--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
@@ -682,7 +682,7 @@ hr.wp-block-separator.is-style-dots::before {
 
 .editor-styles-wrapper .wp-block-quote p {
 	color: inherit;
-	font-weight: 400;
+	font-weight: inherit;
 	margin: 0 0 20px 0;
 	letter-spacing: inherit;
 }

--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
@@ -682,7 +682,6 @@ hr.wp-block-separator.is-style-dots::before {
 
 .editor-styles-wrapper .wp-block-quote p {
 	color: inherit;
-	font-weight: inherit;
 	margin: 0 0 20px 0;
 	letter-spacing: inherit;
 }

--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
@@ -686,7 +686,7 @@ hr.wp-block-separator.is-style-dots::before {
 
 .editor-styles-wrapper .wp-block-quote p {
 	color: inherit;
-	font-weight: 400;
+	font-weight: inherit;
 	margin: 0 0 20px 0;
 	letter-spacing: inherit;
 }

--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
@@ -686,7 +686,6 @@ hr.wp-block-separator.is-style-dots::before {
 
 .editor-styles-wrapper .wp-block-quote p {
 	color: inherit;
-	font-weight: inherit;
 	margin: 0 0 20px 0;
 	letter-spacing: inherit;
 }


### PR DESCRIPTION
This PR resolves a styling inconsistency for quote blocks between the editor and frontend in the Twenty Twenty theme.

**Changes:**
- Updated font-weight for .wp-block-quote p from 400 to inherit.
- Applied changes to editor-style-block.css and editor-style-block-rtl.css.

**Video**

https://github.com/user-attachments/assets/58c65b19-bb66-43f0-ac4a-0780fbb5439a


Trac ticket: [#62753](https://core.trac.wordpress.org/ticket/62753)