### PR TITLE
Add a body class for singular theme templates

### DIFF
--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -676,6 +676,8 @@ function get_body_class( $css_class = '' ) {
 		$post_id   = $post->ID;
 		$post_type = $post->post_type;
 
+		$classes[] = 'wp-singular';
+
 		if ( is_page_template() ) {
 			$classes[] = "{$post_type}-template";
 

--- a/tests/phpunit/tests/post/getBodyClass.php
+++ b/tests/phpunit/tests/post/getBodyClass.php
@@ -105,6 +105,7 @@ class Tests_Post_GetBodyClass extends WP_UnitTestCase {
 		$this->assertContains( 'single-post', $class );
 		$this->assertContains( "postid-{$post_id}", $class );
 		$this->assertContains( 'single-format-standard', $class );
+		$this->assertContains( 'wp-singular', $class );
 	}
 
 	public function test_page_template_body_classes_no_template() {


### PR DESCRIPTION
Themes: Add wp-singular to the list of body classes when viewing a single post object.

wp-singular includes a wp prefix to reduce conflicts with existing classes.

Updates test_singular_body_classes in Tests_Post_GetBodyClass to include the new CSS class.

Trac ticket: https://core.trac.wordpress.org/ticket/35164

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
