### PR TITLE
Fix: Double hashed value for background-color 

### DIFF
--- a/src/wp-admin/includes/class-custom-background.php
+++ b/src/wp-admin/includes/class-custom-background.php
@@ -288,7 +288,7 @@ class Custom_Background {
 			$background_styles = '';
 			$bgcolor           = get_background_color();
 			if ( $bgcolor ) {
-				$background_styles .= 'background-color: #' . $bgcolor . ';';
+				$background_styles .= 'background-color: ' . maybe_hash_hex_color( $bgcolor ) . ';';
 			}
 
 			$background_image_thumb = get_background_image();

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -1893,7 +1893,7 @@ function _custom_background_cb() {
 		return;
 	}
 
-	$style = $color ? "background-color: #$color;" : '';
+	$style = $color ? 'background-color: ' . maybe_hash_hex_color( $color ) . ';' : '';
 
 	if ( $background ) {
 		$image = ' background-image: url("' . sanitize_url( $background ) . '");';


### PR DESCRIPTION
If a theme developer sets a background color value that uses a hash (#) , WordPress should not add an additional hash when outputting the relevant CSS. Duplicate hash symbols (##) breaks the CSS for the background color.

By replacing the hardcoded hash symbol with [maybe_hash_hex_color](https://developer.wordpress.org/reference/functions/maybe_hash_hex_color/), the hash is only added if it is needed.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here --> https://core.trac.wordpress.org/ticket/40057

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
