### PR TITLE
Add test coverage for user preference checkbox handling

### DIFF
--- a/src/wp-admin/includes/user.php
+++ b/src/wp-admin/includes/user.php
@@ -132,8 +132,8 @@ function edit_user( $user_id = 0 ) {
 	}
 
 	if ( $update ) {
-		$user->rich_editing         = isset( $_POST['rich_editing'] ) && 'false' === $_POST['rich_editing'] ? 'false' : 'true';
-		$user->syntax_highlighting  = isset( $_POST['syntax_highlighting'] ) && 'false' === $_POST['syntax_highlighting'] ? 'false' : 'true';
+		$user->rich_editing         = isset( $_POST['rich_editing'] ) ? 'true' : 'false';
+		$user->syntax_highlighting  = isset( $_POST['syntax_highlighting'] ) ? 'true' : 'false';
 		$user->admin_color          = isset( $_POST['admin_color'] ) ? sanitize_text_field( $_POST['admin_color'] ) : 'fresh';
 		$user->show_admin_bar_front = isset( $_POST['admin_bar_front'] ) ? 'true' : 'false';
 	}

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -300,8 +300,8 @@ switch ( $action ) {
 						<tr class="user-rich-editing-wrap">
 							<th scope="row"><?php _e( 'Visual Editor' ); ?></th>
 							<td>
-								<label for="rich_editing"><input name="rich_editing" type="checkbox" id="rich_editing" value="false" <?php checked( 'false', $profile_user->rich_editing ); ?> />
-									<?php _e( 'Disable the visual editor when writing' ); ?>
+								<label for="rich_editing"><input name="rich_editing" type="checkbox" id="rich_editing" value="true"<?php checked( 'true', $profile_user->rich_editing ); ?> />
+									<?php _e( 'Enable the visual editor when writing' ); ?>
 								</label>
 							</td>
 						</tr>
@@ -324,8 +324,8 @@ switch ( $action ) {
 					<tr class="user-syntax-highlighting-wrap">
 						<th scope="row"><?php _e( 'Syntax Highlighting' ); ?></th>
 						<td>
-							<label for="syntax_highlighting"><input name="syntax_highlighting" type="checkbox" id="syntax_highlighting" value="false" <?php checked( 'false', $profile_user->syntax_highlighting ); ?> />
-								<?php _e( 'Disable syntax highlighting when editing code' ); ?>
+							<label for="syntax_highlighting"><input name="syntax_highlighting" type="checkbox" id="syntax_highlighting" value="true"<?php checked( 'true', $profile_user->syntax_highlighting ); ?> />
+								<?php _e( 'Enable syntax highlighting when editing code' ); ?>
 							</label>
 						</td>
 					</tr>
@@ -370,7 +370,7 @@ switch ( $action ) {
 						<th scope="row"><?php _e( 'Toolbar' ); ?></th>
 						<td>
 							<label for="admin_bar_front">
-								<input name="admin_bar_front" type="checkbox" id="admin_bar_front" value="1"<?php checked( _get_admin_bar_pref( 'front', $profile_user->ID ) ); ?> />
+								<input name="admin_bar_front" type="checkbox" id="admin_bar_front" value="true"<?php checked( _get_admin_bar_pref( 'front', $profile_user->ID ) ); ?> />
 								<?php _e( 'Show Toolbar when viewing site' ); ?>
 							</label><br />
 						</td>

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -2289,4 +2289,46 @@ class Tests_User extends WP_UnitTestCase {
 		// Verify there are no updates to 'use_ssl' user meta.
 		$this->assertSame( 1, $db_update_count );
 	}
+
+	/**
+	 * Test user preference checkbox handling.
+	 *
+	 * @ticket 57393
+	 *
+	 * @covers ::edit_user
+	 */
+	public function test_user_preferences_checkbox_handling() {
+		wp_set_current_user( self::$admin_id );
+
+		// Test when preferences are enabled.
+		$_POST = array(
+			'nickname'           => 'Test User',
+			'email'             => 'test@example.com',
+			'rich_editing'      => 'true',
+			'syntax_highlighting' => 'true',
+			'admin_bar_front'   => 'true',
+		);
+
+		$result = edit_user( self::$author_id );
+		$this->assertNotWPError( $result );
+
+		$user = get_user_by( 'id', self::$author_id );
+		$this->assertSame( 'true', $user->rich_editing );
+		$this->assertSame( 'true', $user->syntax_highlighting );
+		$this->assertSame( 'true', $user->show_admin_bar_front );
+
+		// Test when preferences are disabled.
+		$_POST = array(
+			'nickname' => 'Test User',
+			'email'    => 'author@email.com',
+		);
+
+		$result = edit_user( self::$author_id );
+		$this->assertNotWPError( $result );
+
+		$user = get_user_by( 'id', self::$author_id );
+		$this->assertSame( 'false', $user->rich_editing );
+		$this->assertSame( 'false', $user->syntax_highlighting );
+		$this->assertSame( 'false', $user->show_admin_bar_front );
+	}
 }

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -2302,11 +2302,11 @@ class Tests_User extends WP_UnitTestCase {
 
 		// Test when preferences are enabled.
 		$_POST = array(
-			'nickname'           => 'Test User',
-			'email'             => 'test@example.com',
-			'rich_editing'      => 'true',
+			'nickname'            => 'Test User',
+			'email'               => 'test@example.com',
+			'rich_editing'        => 'true',
 			'syntax_highlighting' => 'true',
-			'admin_bar_front'   => 'true',
+			'admin_bar_front'     => 'true',
 		);
 
 		$result = edit_user( self::$author_id );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/57393

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
