### PR TITLE
Fixes  registered templates access in get_block_templates()

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -1175,7 +1175,7 @@ function get_block_templates( $query = array(), $template_type = 'wp_template' )
 
 		if ( 'wp_template' === $template_type ) {
 			// Add templates registered in the template registry. Filtering out the ones which have a theme file.
-			$registered_templates          = WP_Block_Templates_Registry::get_instance()->get_by_query( $query );
+			$registered_templates          = array_values( WP_Block_Templates_Registry::get_instance()->get_by_query( $query ) );
 			$matching_registered_templates = array_filter(
 				$registered_templates,
 				function ( $registered_template ) use ( $template_files ) {

--- a/tests/phpunit/tests/block-template.php
+++ b/tests/phpunit/tests/block-template.php
@@ -447,6 +447,7 @@ class Tests_Block_Template extends WP_UnitTestCase {
 
 		$templates = get_block_templates();
 
+		# ensure our contributed plugin template is in the list
 		$templates_by_title = array_column( $templates, null, 'title' );
 		$this->assertArrayHasKey( $template_name, $templates_by_title );
 

--- a/tests/phpunit/tests/block-template.php
+++ b/tests/phpunit/tests/block-template.php
@@ -447,7 +447,8 @@ class Tests_Block_Template extends WP_UnitTestCase {
 
 		$templates = get_block_templates();
 
-		$this->assertArrayHasKey( $template_name, $templates );
+		$templates_by_title = array_column( $templates, null, 'title' );
+		$this->assertArrayHasKey( $template_name, $templates_by_title );
 
 		unregister_block_template( $template_name );
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This ticket fixes using templates registered by register_block_template() in the Gutenberg editor.

Function `get_block_templates()` tries to accumulate registered block templates from the Block Template Registry

The problem is that the Block Template Registry call `get_by_query( $query )` returns an associative array but the Gutenberg code expects a indexed array. 
  
Trac ticket: https://core.trac.wordpress.org/ticket/62407

Could you have a look into it, @noisysocks ?  

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
