### PR TITLE
Bundled Theme: Update selector for table block in Twenty Seventeen.

### DIFF
--- a/src/wp-content/themes/twentyseventeen/assets/css/editor-blocks.css
+++ b/src/wp-content/themes/twentyseventeen/assets/css/editor-blocks.css
@@ -667,40 +667,40 @@ figure.wp-block-pullquote blockquote {
 
 /* Table */
 
-table.wp-block-table {
+figure.wp-block-table table {
 	border-collapse: collapse;
 	margin: 0 0 1.5em;
 	width: 100%;
 }
 
-table.wp-block-table thead th {
+figure.wp-block-table table thead th {
 	border: 0;
 	border-bottom: 2px solid #bbb;
 	padding-bottom: 0.5em;
 }
 
-table.wp-block-table th {
+figure.wp-block-table table th {
 	padding: 0.4em;
 	text-align: left;
 }
 
-table.wp-block-table tr {
+figure.wp-block-table table tr {
 	border-bottom: 1px solid #eee;
 }
 
-table.wp-block-table th,
-table.wp-block-table td {
+figure.wp-block-table table th,
+figure.wp-block-table table td {
 	border: 0;
 	padding: 0.4em;
 }
 
-table.wp-block-table th:first-child,
-table.wp-block-table td:first-child {
+figure.wp-block-table table th:first-child,
+figure.wp-block-table table td:first-child {
 	padding-left: 0;
 }
 
-table.wp-block-table th:last-child,
-table.wp-block-table td:last-child {
+figure.wp-block-table table th:last-child,
+figure.wp-block-table table td:last-child {
 	padding-right: 0;
 }
 
@@ -708,8 +708,8 @@ table.wp-block-table td:last-child {
 	padding: 0;
 }
 
-.rtl table.wp-block-table th,
-.rtl table.wp-block-table td {
+.rtl figure.wp-block-table table th,
+.rtl figure.wp-block-table table td {
 	text-align: right;
 }
 


### PR DESCRIPTION
This PR updates the CSS selectors for the table block in the Twenty Seventeen theme to ensure consistent styling between the editor and frontend. The .wp-block-table class was moved to the `<figure>` element in WordPress 5.3, but the theme still applied styles to a non-existent table element.

**Before:** 

<img width="1920" alt="Screenshot 2025-01-07 at 10 33 50 AM" src="https://github.com/user-attachments/assets/174a65be-c566-4f03-b8f8-1530fa2e3fe7" />

**After:**

<img width="1920" alt="Screenshot 2025-01-07 at 10 33 31 AM" src="https://github.com/user-attachments/assets/4322492b-61f1-4b7f-8b6b-ae17b413c1f7" />


Trac ticket: [#58297](https://core.trac.wordpress.org/ticket/58297)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
