### PR TITLE
Twenty Nineteen: Sanitize output of custom colors CSS

### DIFF
--- a/src/wp-content/themes/twentynineteen/functions.php
+++ b/src/wp-content/themes/twentynineteen/functions.php
@@ -318,7 +318,7 @@ function twentynineteen_editor_customizer_styles() {
 	if ( 'custom' === get_theme_mod( 'primary_color' ) ) {
 		// Include color patterns.
 		require_once get_parent_theme_file_path( '/inc/color-patterns.php' );
-		wp_add_inline_style( 'twentynineteen-editor-customizer-styles', twentynineteen_custom_colors_css() );
+		wp_add_inline_style( 'twentynineteen-editor-customizer-styles', wp_strip_all_tags( twentynineteen_custom_colors_css() ) );
 	}
 }
 add_action( 'enqueue_block_editor_assets', 'twentynineteen_editor_customizer_styles' );
@@ -342,7 +342,7 @@ function twentynineteen_colors_css_wrap() {
 	?>
 
 	<style type="text/css" id="custom-theme-colors" <?php echo is_customize_preview() ? 'data-hue="' . absint( $primary_color ) . '"' : ''; ?>>
-		<?php echo twentynineteen_custom_colors_css(); ?>
+		<?php echo wp_strip_all_tags( twentynineteen_custom_colors_css() ); ?>
 	</style>
 	<?php
 }


### PR DESCRIPTION
Trac ticket: [62787](https://core.trac.wordpress.org/ticket/62787)

This PR adds proper sanitization to the custom colors CSS output in the Twenty Nineteen theme. The twentynineteen_custom_colors_css() function's output is filterable and currently outputs unsanitized content in two locations:

- Frontend custom theme colors
- Block editor customizer styles

The PR wraps both outputs with wp_strip_all_tags() to ensure only CSS is included, preventing potential injection of unwanted HTML through filters.