### PR TITLE
Bundled Theme: Fix file block button padding and color

### DIFF
--- a/src/wp-content/themes/twentyten/blocks.css
+++ b/src/wp-content/themes/twentyten/blocks.css
@@ -110,6 +110,11 @@ p.has-drop-cap:not(:focus)::first-letter {
 	margin: 0 0 0 0.75em;
 }
 
+.wp-block-file .wp-block-file__button {
+	padding: 0.5em 1em;
+	color: #ffffff;
+}
+
 /*--------------------------------------------------------------
 3.0 Blocks - Formatting
 --------------------------------------------------------------*/

--- a/src/wp-content/themes/twentyten/blocks.css
+++ b/src/wp-content/themes/twentyten/blocks.css
@@ -112,7 +112,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 
 .wp-block-file .wp-block-file__button {
 	padding: 0.5em 1em;
-	color: #ffffff;
+	color: #fff;
 	line-height: 1.5;
 }
 

--- a/src/wp-content/themes/twentyten/blocks.css
+++ b/src/wp-content/themes/twentyten/blocks.css
@@ -113,6 +113,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 .wp-block-file .wp-block-file__button {
 	padding: 0.5em 1em;
 	color: #ffffff;
+	line-height: 1.5;
 }
 
 /*--------------------------------------------------------------


### PR DESCRIPTION
Before:
<img width="1920" alt="Screenshot 2025-01-09 at 12 59 46 PM" src="https://github.com/user-attachments/assets/eed9c5f1-ebbf-4e39-a46e-5add83f461ca" />


After:
<img width="1920" alt="Screenshot 2025-01-09 at 12 57 17 PM" src="https://github.com/user-attachments/assets/d71afef1-183d-4d0d-85b0-36b1bb9ab83b" />


Trac ticket: [#62793](https://core.trac.wordpress.org/ticket/62793)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
