### PR TITLE
Backport PR for Fixes Aligned Images size in Lightbox

### DIFF
--- a/src/wp-includes/block-supports/layout.php
+++ b/src/wp-includes/block-supports/layout.php
@@ -1073,15 +1073,14 @@ function wp_restore_image_outer_container( $block_content, $block ) {
 
 	$wrapper_classnames = array( 'wp-block-image' );
 
-	// If the block has a classNames attribute these classnames need to be removed from the content and added back
+	// If the block has a classNames attribute these classnames need to be added back
 	// to the new wrapper div also.
 	if ( ! empty( $block['attrs']['className'] ) ) {
 		$wrapper_classnames = array_merge( $wrapper_classnames, explode( ' ', $block['attrs']['className'] ) );
 	}
-	$content_classnames          = explode( ' ', $matches[2] );
-	$filtered_content_classnames = array_diff( $content_classnames, $wrapper_classnames );
 
-	return '<div class="' . implode( ' ', $wrapper_classnames ) . '">' . $matches[1] . implode( ' ', $filtered_content_classnames ) . $matches[3] . '</div>';
+	// Wrap the existing content with the new wrapper div.
+	return '<div class="' . implode( ' ', $wrapper_classnames ) . '">' . $block_content . '</div>';
 }
 
 add_filter( 'render_block_core/image', 'wp_restore_image_outer_container', 10, 2 );


### PR DESCRIPTION
Backport PR for this https://github.com/WordPress/gutenberg/pull/67528

## What?
Fixes https://github.com/WordPress/gutenberg/issues/66692

## Why?
This PR fixes the position and size of images in the Image blocks of themes without a json file.

## How?
Updated the `function gutenberg_restore_image_outer_container` so that the lightbox does not affect the position and image size.