### PR TITLE
Add escaping and sanitize the output of custom colors CSS into the Twentyseventeen theme.

### DIFF
--- a/src/wp-content/themes/twentyseventeen/functions.php
+++ b/src/wp-content/themes/twentyseventeen/functions.php
@@ -439,8 +439,8 @@ function twentyseventeen_colors_css_wrap() {
 		$customize_preview_data_hue = 'data-hue="' . $hue . '"';
 	}
 	?>
-	<style type="text/css" id="custom-theme-colors" <?php echo $customize_preview_data_hue; ?>>
-		<?php echo twentyseventeen_custom_colors_css(); ?>
+	<style type="text/css" id="custom-theme-colors" <?php echo esc_attr( $customize_preview_data_hue ); ?>>
+		<?php echo wp_strip_all_tags( twentyseventeen_custom_colors_css() );  ?>
 	</style>
 	<?php
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/62798

This PR adds proper sanitization to the custom colors CSS output in the Twenty Seventeen theme. The twentyseventeen_custom_colors_css() function's output is filterable and currently outputs unsanitized content.

The PR wraps outputs with wp_strip_all_tags() to ensure only CSS is included, preventing potential injection of unwanted HTML through filters.

Thanks,