### PR TITLE
Backport r51179 to 5.3 branch

### DIFF
--- a/.env
+++ b/.env
@@ -70,10 +70,3 @@ LOCAL_SCRIPT_DEBUG=true
 
 # The URL to use when running e2e tests.
 WP_BASE_URL=http://localhost:${LOCAL_PORT}
-
-##
-# The revision number of the WordPress Importer plugin to use when running unit tests.
-#
-# This should be an SVN revision number from the official plugin repository on wordpress.org.
-##
-WP_IMPORTER_REVISION=2387243

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -51,7 +51,8 @@ function wp_cli( cmd ) {
  * Downloads the WordPress Importer plugin for use in tests.
  */
 function install_wp_importer() {
-	const test_plugin_directory = 'tests/phpunit/data/plugins/wordpress-importer';
+	const testPluginDirectory = 'tests/phpunit/data/plugins/wordpress-importer';
 
-	execSync( `docker compose exec -T php rm -rf ${test_plugin_directory} && svn checkout -r ${process.env.WP_IMPORTER_REVISION} https://plugins.svn.wordpress.org/wordpress-importer/trunk/ ${test_plugin_directory}`, { stdio: 'inherit' } );
+	execSync( `docker compose exec -T php rm -rf ${testPluginDirectory}`, { stdio: 'inherit' } );
+	execSync( `docker compose exec -T php git clone https://github.com/WordPress/wordpress-importer.git ${testPluginDirectory} --depth=1`, { stdio: 'inherit' } );
 }


### PR DESCRIPTION
See 5267e4a40cb4e63e6a0855b137cb0a3092544da9

Needs backporting because svn isn't available anymore on newer GitHub Actions runners

Needs to be done for 5.4-5.7 as well.

Trac ticket: https://core.trac.wordpress.org/ticket/62280

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
