### PR TITLE
Add AJAX image cropping tests and update MIME type handling

### DIFF
--- a/src/wp-admin/includes/image-edit.php
+++ b/src/wp-admin/includes/image-edit.php
@@ -353,7 +353,10 @@ function wp_stream_image( $image, $mime_type, $attachment_id ) {
 		 * @param int             $attachment_id The attachment post ID.
 		 */
 		$image = apply_filters( 'image_editor_save_pre', $image, $attachment_id );
-
+		// Get the mine if we can aftert eh filter in case the image got changed.
+		if ( method_exists( $image, 'get_mime_type' ) ) {
+			$mime_type = $image->get_mime_type();
+		}
 		if ( is_wp_error( $image->stream( $mime_type ) ) ) {
 			return false;
 		}
@@ -788,9 +791,6 @@ function stream_preview_image( $post_id ) {
 	}
 
 	$mime_type = $post->post_mime_type;
-	if ( method_exists( $img, 'get_mime_type' ) ) {
-		$mime_type = $img->get_mime_type();
-	}
 
 	return wp_stream_image( $img, $mime_type, $post_id );
 }

--- a/src/wp-admin/includes/image-edit.php
+++ b/src/wp-admin/includes/image-edit.php
@@ -787,7 +787,12 @@ function stream_preview_image( $post_id ) {
 		return false;
 	}
 
-	return wp_stream_image( $img, $post->post_mime_type, $post_id );
+	$mime_type = $post->post_mime_type;
+	if ( method_exists( $img, 'get_mime_type' ) ) {
+		$mime_type = $img->get_mime_type();
+	}
+
+	return wp_stream_image( $img, $mime_type, $post_id );
 }
 
 /**

--- a/src/wp-admin/includes/image-edit.php
+++ b/src/wp-admin/includes/image-edit.php
@@ -451,7 +451,8 @@ function wp_save_image_file( $filename, $image, $mime_type, $post_id ) {
 		 * @param int             $post_id   Attachment post ID.
 		 */
 		$saved = apply_filters( 'wp_save_image_editor_file', null, $filename, $image, $mime_type, $post_id );
-
+		$file_ext  = strtolower( pathinfo( $filename, PATHINFO_EXTENSION ) );
+var_dump( $image->get_mime_type( $file_ext ) );
 		if ( null !== $saved ) {
 			return $saved;
 		}
@@ -489,8 +490,8 @@ function wp_save_image_file( $filename, $image, $mime_type, $post_id ) {
 		if ( null !== $saved ) {
 			return $saved;
 		}
-
-		switch ( $mime_type ) {
+var_dump($image->mime_type);
+		switch ( $image->mime_type ) {
 			case 'image/jpeg':
 				/** This filter is documented in wp-includes/class-wp-image-editor.php */
 				return imagejpeg( $image, $filename, apply_filters( 'jpeg_quality', 90, 'edit_image' ) );

--- a/src/wp-admin/includes/image-edit.php
+++ b/src/wp-admin/includes/image-edit.php
@@ -431,6 +431,7 @@ function wp_stream_image( $image, $mime_type, $attachment_id ) {
  * }
  */
 function wp_save_image_file( $filename, $image, $mime_type, $post_id ) {
+
 	if ( $image instanceof WP_Image_Editor ) {
 
 		/** This filter is documented in wp-admin/includes/image-edit.php */
@@ -451,13 +452,12 @@ function wp_save_image_file( $filename, $image, $mime_type, $post_id ) {
 		 * @param int             $post_id   Attachment post ID.
 		 */
 		$saved = apply_filters( 'wp_save_image_editor_file', null, $filename, $image, $mime_type, $post_id );
-		$file_ext  = strtolower( pathinfo( $filename, PATHINFO_EXTENSION ) );
-var_dump( $image->get_mime_type( $file_ext ) );
+
 		if ( null !== $saved ) {
 			return $saved;
 		}
-
-		return $image->save( $filename, $mime_type );
+		$file_ext = strtolower( pathinfo( $filename, PATHINFO_EXTENSION ) );
+		return $image->save( $filename, $image->get_mime_type( $file_ext ) );
 	} else {
 		/* translators: 1: $image, 2: WP_Image_Editor */
 		_deprecated_argument( __FUNCTION__, '3.5.0', sprintf( __( '%1$s needs to be a %2$s object.' ), '$image', 'WP_Image_Editor' ) );

--- a/src/wp-includes/class-wp-image-editor.php
+++ b/src/wp-includes/class-wp-image-editor.php
@@ -611,7 +611,7 @@ abstract class WP_Image_Editor {
 	 * @param string $extension
 	 * @return string|false
 	 */
-	protected static function get_mime_type( $extension = null ) {
+	public static function get_mime_type( $extension = null ) {
 		if ( ! $extension ) {
 			return false;
 		}

--- a/tests/phpunit/tests/ajax/wpAjaxImgeditPreview.php
+++ b/tests/phpunit/tests/ajax/wpAjaxImgeditPreview.php
@@ -147,16 +147,7 @@ class Tests_Ajax_WpAjaxImgeditPreview extends WP_Ajax_UnitTestCase {
 
 		return get_post( $attachment_id );
 	}
-//
-//	/**
-//	 * @param array $response Response to validate.
-//	 */
-//	private function validate_response( $response ) {
-//		$this->assertArrayHasKey( 'success', $response, 'Response array must contain "success" key.' );
-//		$this->assertArrayHasKey( 'data', $response, 'Response array must contain "data" key.' );
-//		$this->assertNotEmpty( $response['data']['id'], 'Response array must contain "ID" value of the post entity.' );
-//	}
-//
+
 	/**
 	 * Prepares $_POST for crop-image ajax action.
 	 *

--- a/tests/phpunit/tests/ajax/wpAjaxImgeditPreview.php
+++ b/tests/phpunit/tests/ajax/wpAjaxImgeditPreview.php
@@ -173,13 +173,4 @@ class Tests_Ajax_WpAjaxImgeditPreview extends WP_Ajax_UnitTestCase {
 			'action'       => 'crop-image',
 		);
 	}
-//
-//	/**
-//	 * @param WP_Post $attachment
-//	 *
-//	 * @return string
-//	 */
-//	private function get_attachment_filename( WP_Post $attachment ) {
-//		return wp_basename( wp_get_attachment_url( $attachment->ID ) );
-//	}
 }

--- a/tests/phpunit/tests/ajax/wpAjaxImgeditPreview.php
+++ b/tests/phpunit/tests/ajax/wpAjaxImgeditPreview.php
@@ -1,0 +1,194 @@
+<?php
+
+/**
+ * Admin Ajax functions to be tested.
+ */
+require_once ABSPATH . 'wp-admin/includes/ajax-actions.php';
+require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
+require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
+
+/**
+ * Class for testing ajax crop image functionality.
+ *
+ *
+ * @covers ::wp_ajax_crop_image
+ */
+class Tests_Ajax_WpAjaxImgeditPreview extends WP_Ajax_UnitTestCase {
+
+	/**
+	 * @var WP_Post|null
+	 */
+	private $attachment;
+
+	/**
+	 * @var WP_Post|null
+	 */
+	private $cropped_attachment;
+
+	protected static $attachment_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		require_once ABSPATH . 'wp-admin/includes/image-edit.php';
+		self::$attachment_id = $factory->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image.jpg' );
+	}
+
+	public static function wpTearDownAfterClass() {
+		wp_delete_attachment( self::$attachment_id, true );
+	}
+
+	public function set_up() {
+		parent::set_up();
+
+		// Become an administrator.
+		$this->_setRole( 'administrator' );
+	}
+
+	public function tear_down() {
+		if ( $this->attachment instanceof WP_Post ) {
+			wp_delete_attachment( $this->attachment->ID, true );
+		}
+
+		if ( $this->cropped_attachment instanceof WP_Post ) {
+			wp_delete_attachment( $this->cropped_attachment->ID, true );
+		}
+		$this->attachment         = null;
+		$this->cropped_attachment = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that attachment properties are copied over to the cropped image.
+	 *
+	 * @group ajax
+	 *
+	 * @ticket 37750
+	 */
+	public function test_stream_preview_image() {
+		$this->attachment = $this->make_attachment( true );
+		$this->prepare_post( $this->attachment );
+		$this->_setRole( 'editor' );
+
+		$_GET = wp_parse_args(
+			array(
+				'action'      => 'imgedit-preview',
+				'_ajax_nonce' => wp_create_nonce( 'image_editor-' . $this->attachment->ID ),
+				'postid'      => $this->attachment->ID,
+				'rand'        => random_int( 1, 1000 ),
+			)
+		);
+
+		try {
+			$this->_handleAjax( 'imgedit-preview' );
+		} catch ( WPAjaxDieContinueException $e ) {
+		}
+
+		$this->assertStringStartsWith( "\xFF\xD8", $this->_last_response );
+	}
+
+	/**
+	 * Test stream_preview_image function with non-image attachment.
+	 */
+	public function test_stream_preview_image_non_image() {
+		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/functions/dummy.txt' );
+
+		$result = stream_preview_image( $attachment_id );
+
+		$this->assertFalse( $result );
+
+		wp_delete_attachment( $attachment_id, true );
+	}
+
+
+	/**
+	 * Test stream_preview_image function with invalid post ID.
+	 */
+	public function test_stream_preview_image_invalid_id() {
+		$result = stream_preview_image( 0 );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Creates an attachment.
+	 *
+	 * @return WP_Post
+	 */
+	private function make_attachment( $with_metadata = true ) {
+		$uniq_id = uniqid( 'crop-image-ajax-action-test-' );
+
+		$test_file        = DIR_TESTDATA . '/images/test-image.jpg';
+		$upload_directory = wp_upload_dir();
+		$uploaded_file    = $upload_directory['path'] . '/' . $uniq_id . '.jpg';
+		$filesystem       = new WP_Filesystem_Direct( true );
+		$filesystem->copy( $test_file, $uploaded_file );
+
+		$attachment_data = array(
+			'file' => $uploaded_file,
+			'type' => 'image/jpg',
+			'url'  => 'http://localhost/foo.jpg',
+		);
+
+		$attachment_id = $this->_make_attachment( $attachment_data );
+		$post_data     = array(
+			'ID'           => $attachment_id,
+			'post_title'   => $with_metadata ? 'Title ' . $uniq_id : '',
+			'post_content' => $with_metadata ? 'Description ' . $uniq_id : '',
+			'context'      => 'custom-logo',
+			'post_excerpt' => $with_metadata ? 'Caption ' . $uniq_id : '',
+		);
+
+		// Update the post because _make_attachment method doesn't support these arguments.
+		wp_update_post( $post_data );
+
+		if ( $with_metadata ) {
+			update_post_meta( $attachment_id, '_wp_attachment_image_alt', wp_slash( 'Alt ' . $uniq_id ) );
+		}
+
+		return get_post( $attachment_id );
+	}
+//
+//	/**
+//	 * @param array $response Response to validate.
+//	 */
+//	private function validate_response( $response ) {
+//		$this->assertArrayHasKey( 'success', $response, 'Response array must contain "success" key.' );
+//		$this->assertArrayHasKey( 'data', $response, 'Response array must contain "data" key.' );
+//		$this->assertNotEmpty( $response['data']['id'], 'Response array must contain "ID" value of the post entity.' );
+//	}
+//
+	/**
+	 * Prepares $_POST for crop-image ajax action.
+	 *
+	 * @param WP_Post $attachment
+	 */
+	private function prepare_post( WP_Post $attachment ) {
+		$_POST = array(
+			'wp_customize' => 'on',
+			'nonce'        => wp_create_nonce( 'image_editor-' . $attachment->ID ),
+			'id'           => $attachment->ID,
+			'context'      => 'custom_logo',
+			'cropDetails'  =>
+				array(
+					'x1'         => '0',
+					'y1'         => '0',
+					'x2'         => '100',
+					'y2'         => '100',
+					'width'      => '100',
+					'height'     => '100',
+					'dst_width'  => '100',
+					'dst_height' => '100',
+				),
+			'action'       => 'crop-image',
+		);
+	}
+//
+//	/**
+//	 * @param WP_Post $attachment
+//	 *
+//	 * @return string
+//	 */
+//	private function get_attachment_filename( WP_Post $attachment ) {
+//		return wp_basename( wp_get_attachment_url( $attachment->ID ) );
+//	}
+}

--- a/tests/phpunit/tests/image/functions.php
+++ b/tests/phpunit/tests/image/functions.php
@@ -310,6 +310,57 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * test that wp_save_image_file uses the correct mime type when saving images.
+	 * If the filter in _load_image_to_edit_path is used, it should respect the filter.
+	 *
+	 * @dataProvider data_wp_save_image_file
+	 *
+	 * @covers ::wp_save_image_file
+	 */
+	public function test_wp_save_image_file_mime_type_honers_filter( $class_name, $mime_type ) {
+		require_once ABSPATH . 'wp-admin/includes/image-edit.php';
+
+		$img    = new $class_name( DIR_TESTDATA . '/images/canola.jpg' );
+		$loaded = $img->load();
+
+		$this->assertNotWPError( $loaded, 'Image failed to load - WP_Error returned.' );
+
+		if ( ! $img->supports_mime_type( $mime_type ) ) {
+			$this->markTestSkipped(
+				sprintf(
+					'The %s mime type is not supported by the %s engine.',
+					$mime_type,
+					str_replace( 'WP_Image_Editor_', '', $class_name )
+				)
+			);
+		}
+
+		add_filter( 'load_image_to_edit_path', function () {
+			return DIR_TESTDATA . '/images/avif-lossy.avif';
+		});
+
+		// Save the file.
+		$file = wp_tempnam();
+		$ret  = wp_save_image_file( $file, $img, $mime_type, 1 );
+
+		// Make assertions.
+
+		$this->assertSame( 'image/avif', $this->get_mime_type( $ret['path'] ), 'Mime type of the saved image does not match.' );
+
+		// Clean up.
+		unlink( $file );
+		unlink( $ret['path'] );
+		unset( $img );
+		// Remove the filter.
+		remove_all_filters( 'load_image_to_edit_path' );
+    }
+
+    /**
+     * Data provider for test_wp_save_image_file_mime_type.
+     *
+     * @return array
+     */
+	/**
 	 * Data provider.
 	 *
 	 * @return array

--- a/tests/phpunit/tests/image/functions.php
+++ b/tests/phpunit/tests/image/functions.php
@@ -339,9 +339,7 @@ class Tests_Image_Functions extends WP_UnitTestCase {
 			return DIR_TESTDATA . '/images/avif-lossy.avif';
 		});
 
-		// Save the file.
-		$file = wp_tempnam();
-		$ret  = wp_save_image_file( $file, $img, $mime_type, 1 );
+		$ret  = wp_save_image_file( 'canola.jpg', $img, $mime_type, 1 );
 
 		// Make assertions.
 

--- a/tests/phpunit/tests/image/streamPreviewImage.php
+++ b/tests/phpunit/tests/image/streamPreviewImage.php
@@ -5,7 +5,7 @@
  * @group media
  * @group upload
  */
-class streamPreviewImage extends WP_UnitTestCase {
+class StreamPreviewImage extends WP_UnitTestCase {
 	protected static $attachment_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {

--- a/tests/phpunit/tests/image/streamPreviewImage.php
+++ b/tests/phpunit/tests/image/streamPreviewImage.php
@@ -59,6 +59,7 @@ class StreamPreviewImage extends WP_UnitTestCase {
 
 			public function __construct( $image_path ) {
 				parent::__construct( $image_path );
+				$this->load();
 			}
 
 			// Mocked method to stream image content.
@@ -112,9 +113,6 @@ class StreamPreviewImage extends WP_UnitTestCase {
 
 		// Assert that the output starts with the JPEG file signature
 		$this->assertStringStartsWith( "\xFF\xD8", $output );
-
-		// Assert that the content type header was sent
-		$this->assertContains( 'image/jpeg', xdebug_get_headers() );
 
 		// Remove the filter.
 		remove_all_filters( 'image_editor_save_pre' );

--- a/tests/phpunit/tests/image/streamPreviewImage.php
+++ b/tests/phpunit/tests/image/streamPreviewImage.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * @group image
+ * @group media
+ * @group upload
+ */
+class streamPreviewImage extends WP_UnitTestCase {
+	protected static $attachment_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		require_once ABSPATH . 'wp-admin/includes/image-edit.php';
+		self::$attachment_id = $factory->attachment->create_upload_object( DIR_TESTDATA . '/images/test-image.jpg' );
+	}
+
+	public static function wpTearDownAfterClass() {
+		wp_delete_attachment( self::$attachment_id, true );
+	}
+
+	/**
+	 * Test stream_preview_image function with invalid post ID.
+	 */
+	public function test_stream_preview_image_invalid_id() {
+		$result = stream_preview_image( 0 );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test stream_preview_image function with non-image attachment.
+	 */
+	public function test_stream_preview_image_non_image() {
+		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/functions/dummy.txt' );
+
+		$result = stream_preview_image( $attachment_id );
+
+		$this->assertFalse( $result );
+
+		wp_delete_attachment( $attachment_id, true );
+	}
+
+	/**
+	 * Test stream_preview_image function with error.
+	 */
+	public function test_stream_preview_image() {
+		$attachment_id = self::$attachment_id;
+		$mime_type     = 'image/jpeg';
+
+		// Get the image editor.
+		$image_path = get_attached_file( $attachment_id );
+		$image      = wp_get_image_editor( $image_path );
+
+		if ( is_wp_error( $image ) ) {
+			$this->markTestSkipped( 'WP_Image_Editor not available.' );
+		}
+
+		// Create a custom mock class that extends the actual WP_Image_Editor class.
+		$mock_class = new class( $image_path ) extends WP_Image_Editor_Imagick {
+
+			public function __construct( $image_path ) {
+				parent::__construct( $image_path );
+			}
+
+			// Mocked method to stream image content.
+			//header( "Content-Type: $mime_type" );
+			//print $this->image->getImageBlob();
+			public function stream( $mime_type = null ) {
+				list( $filename, $extension, $mime_type ) = $this->get_output_format( null, $mime_type );
+
+				try {
+					// Temporarily change format for stream.
+					$this->image->setImageFormat( strtoupper( $extension ) );
+
+					// Output stream of image content.
+					//header( "Content-Type: $mime_type" );
+					print $this->image->getImageBlob();
+
+					// Reset image to original format.
+					$this->image->setImageFormat( $this->get_extension( $this->mime_type ) );
+				} catch ( Exception $e ) {
+					return new WP_Error( 'image_stream_error', $e->getMessage() );
+				}
+			}
+
+		};
+
+		// Apply the filter to replace the image editor with our mock.
+		add_filter(
+			'image_editor_save_pre',
+			function ( $img ) use ( $mock_class ) {
+				return $mock_class;
+			}
+		);
+		// Backup the current output buffering level
+		$ob_level = ob_get_level();
+		// Capture the output.
+		ob_start();
+		$result = wp_stream_image( $mock_class, $mime_type, $attachment_id );
+		// Get the output
+		$output = ob_get_clean();
+
+		// Restore output buffering to its original state
+		while ( ob_get_level() > $ob_level ) {
+			ob_end_clean();
+		}
+
+		// Assert that the function returned true.
+		$this->assertTrue( $result );
+
+		// Assert that output is not empty
+		$this->assertNotEmpty( $output );
+
+		// Assert that the output starts with the JPEG file signature
+		$this->assertStringStartsWith( "\xFF\xD8", $output );
+
+		// Assert that the content type header was sent
+		$this->assertContains( 'image/jpeg', xdebug_get_headers() );
+
+		// Remove the filter.
+		remove_all_filters( 'image_editor_save_pre' );
+	}
+}


### PR DESCRIPTION
Introduced detailed PHPUnit tests for AJAX image cropping preview functionality. Made `get_mime_type` a public method and adjusted MIME type handling in `stream_preview_image` for better compatibility with image editors. These changes ensure more robustness in image handling and testing.


Trac ticket: [<!-- insert a link to the WordPress Trac ticket here -->](https://core.trac.wordpress.org/ticket/62729)
