### PR TITLE
Posts: Preserve post_date when transitioning to future status in wp_update_post()

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -5129,8 +5129,11 @@ function wp_update_post( $postarr = array(), $wp_error = false, $fire_after_hook
 	}
 
 	// Drafts shouldn't be assigned a date unless explicitly done so by the user.
+	// Additionally, if the post_status is being updated to 'publish', 'future', or 'private',
+	// do not clear the date, as the provided date should take precedence.
 	if ( isset( $post['post_status'] )
 		&& in_array( $post['post_status'], array( 'draft', 'pending', 'auto-draft' ), true )
+		&& ( ! isset( $postarr['post_status'] ) || ! in_array( $postarr['post_status'], array( 'publish', 'future', 'private' ), true ) )
 		&& empty( $postarr['edit_date'] ) && ( '0000-00-00 00:00:00' === $post['post_date_gmt'] )
 	) {
 		$clear_date = true;

--- a/tests/phpunit/tests/post/wpUpdatePostDateStatus.php
+++ b/tests/phpunit/tests/post/wpUpdatePostDateStatus.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Test wp_update_post() date handling when changing post status
+ *
+ * @group post
+ * @covers ::wp_update_post
+ */
+class Tests_Post_wpUpdatePostDateStatus extends WP_UnitTestCase {
+
+	/**
+	 * Data provider for test_update_post_preserves_date
+	 *
+	 * @return array[] Test parameters
+	 */
+	public function data_post_status_transitions() {
+		return array(
+			'pending to future' => array(
+				'initial_status' => 'pending',
+			),
+			'draft to future'   => array(
+				'initial_status' => 'draft',
+			),
+		);
+	}
+
+	/**
+	 * Test that wp_update_post() preserves post_date when changing to future status
+	 *
+	 * @ticket 62468
+	 *
+	 * @dataProvider data_post_status_transitions
+	 * @covers ::wp_update_post
+	 *
+	 * @param string $initial_status Initial post status
+	 */
+	public function test_update_post_preserves_date( $initial_status ) {
+		$post_data = array(
+			'post_title'   => 'Test Post',
+			'post_content' => 'Test content',
+			'post_status'  => $initial_status,
+			'post_author'  => self::factory()->user->create( array( 'role' => 'editor' ) ),
+		);
+
+		$post_id = wp_insert_post( $post_data );
+		$this->assertIsInt( $post_id );
+
+		// Set future date (1 day from now)
+		$future_date     = gmdate( 'Y-m-d H:i:s', strtotime( '+1 day' ) );
+		$future_date_gmt = get_gmt_from_date( $future_date );
+
+		$update_data = array(
+			'ID'            => $post_id,
+			'post_status'   => 'future',
+			'post_date'     => $future_date,
+			'post_date_gmt' => $future_date_gmt,
+		);
+
+		$update_result = wp_update_post( $update_data );
+		$this->assertIsInt( $update_result );
+
+		$updated_post = get_post( $post_id );
+
+		$this->assertEquals( 'future', $updated_post->post_status );
+		$this->assertEquals( $future_date, $updated_post->post_date );
+		$this->assertEquals( $future_date_gmt, $updated_post->post_date_gmt );
+	}
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/62468

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
