### PR TITLE
Customize: Respect reduced motion for controls close button

### DIFF
--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -834,11 +834,16 @@ h3.customize-section-title {
 	color: #3c434a;
 	text-align: left;
 	cursor: pointer;
-	transition:
+	box-sizing: content-box;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.customize-controls-close {
+		transition:
 		color .15s ease-in-out,
 		border-color .15s ease-in-out,
 		background .15s ease-in-out;
-	box-sizing: content-box;
+	}
 }
 
 .customize-panel-back,


### PR DESCRIPTION
Trac ticket: [#62806](https://core.trac.wordpress.org/ticket/62806)

This PR enhances accessibility in the Customizer by ensuring we properly respect users' motion preferences, particularly for those who may experience motion sensitivity or vestibular disorders.

Changes:
- Updates the customize-controls.css to apply consistent transition handling for the customize-controls-close button
- Aligns with existing prefers-reduced-motion implementations in the Customizer


Testing:
1. Enable "Reduce motion" in your system settings
2. Open the Customizer
3. Hover over the close button
4. Verify that transitions are appropriately minimized

## Screencast 


### Before


https://github.com/user-attachments/assets/5d8ce23c-ba8f-4220-9168-3c19a47aaaaa



### After


https://github.com/user-attachments/assets/89ce3a64-d457-49f6-9114-86b57bea4734


