### PR TITLE
Relax allowed path restrictions for block metadata collections and make the allowed root list filterable

### DIFF
--- a/src/wp-includes/class-wp-block-metadata-registry.php
+++ b/src/wp-includes/class-wp-block-metadata-registry.php
@@ -40,7 +40,7 @@ class WP_Block_Metadata_Registry {
 	/**
 	 * Stores the default allowed collection root paths.
 	 *
-	 * @since 6.8.0
+	 * @since 6.7.2
 	 * @var string[]|null
 	 */
 	private static $default_collection_roots = null;
@@ -103,7 +103,7 @@ class WP_Block_Metadata_Registry {
 		 * contain symlinked plugins, so that these root directories cannot be used themselves for a block metadata
 		 * collection either.
 		 *
-		 * @since 6.8.0
+		 * @since 6.7.2
 		 *
 		 * @param string[] $collection_roots List of allowed metadata collection root paths.
 		 */
@@ -127,7 +127,7 @@ class WP_Block_Metadata_Registry {
 					__( 'Block metadata collections cannot be registered as one of the following directories or their parent directories: %s' ),
 					esc_html( implode( wp_get_list_item_separator(), $collection_roots ) )
 				),
-				'6.8.0'
+				'6.7.2'
 			);
 			return false;
 		}
@@ -259,7 +259,7 @@ class WP_Block_Metadata_Registry {
 	/**
 	 * Checks whether the given block metadata collection path is valid against the list of collection roots.
 	 *
-	 * @since 6.8.0
+	 * @since 6.7.2
 	 *
 	 * @param string   $path             Block metadata collection path, without trailing slash.
 	 * @param string[] $collection_roots List of collection root paths, without trailing slashes.
@@ -284,7 +284,7 @@ class WP_Block_Metadata_Registry {
 	/**
 	 * Gets the default collection root directory paths.
 	 *
-	 * @since 6.8.0
+	 * @since 6.7.2
 	 *
 	 * @return string[] List of directory paths within which metadata collections are allowed.
 	 */

--- a/src/wp-includes/class-wp-block-metadata-registry.php
+++ b/src/wp-includes/class-wp-block-metadata-registry.php
@@ -103,11 +103,13 @@ class WP_Block_Metadata_Registry {
 		 */
 		$allowed_collection_roots = apply_filters( 'wp_allowed_block_metadata_collection_roots', $allowed_collection_roots );
 
-		$allowed_collection_roots = array_map(
-			static function ( $allowed_root ) {
-				return rtrim( $allowed_root, '/' );
-			},
-			$allowed_collection_roots
+		$allowed_collection_roots = array_unique(
+			array_map(
+				static function ( $allowed_root ) {
+					return rtrim( $allowed_root, '/' );
+				},
+				$allowed_collection_roots
+			)
 		);
 
 		// Check if the path is valid:
@@ -266,7 +268,7 @@ class WP_Block_Metadata_Registry {
 			}
 
 			// Otherwise, if the path is within any of the allowed roots, it is valid.
-			if ( str_starts_with( $allowed_root, $path ) ) {
+			if ( str_starts_with( $path, $allowed_root ) ) {
 				$matching_root_found = true;
 			}
 		}
@@ -300,7 +302,7 @@ class WP_Block_Metadata_Registry {
 			$allowed_collection_roots[] = trailingslashit( wp_normalize_path( WP_CONTENT_DIR ) ) . ltrim( wp_normalize_path( $theme_root ), '/' );
 		}
 
-		self::$default_allowed_collection_roots = $allowed_collection_roots;
+		self::$default_allowed_collection_roots = array_unique( $allowed_collection_roots );
 		return self::$default_allowed_collection_roots;
 	}
 }

--- a/src/wp-includes/class-wp-block-metadata-registry.php
+++ b/src/wp-includes/class-wp-block-metadata-registry.php
@@ -117,6 +117,7 @@ class WP_Block_Metadata_Registry {
 			_doing_it_wrong(
 				__METHOD__,
 				sprintf(
+					/* translators: %s: list of allowed collection roots */
 					__( 'Block metadata collections can only be registered within one of the following directories: %s' ),
 					esc_html( implode( wp_get_list_item_separator(), $allowed_collection_roots ) )
 				),

--- a/src/wp-includes/class-wp-block-metadata-registry.php
+++ b/src/wp-includes/class-wp-block-metadata-registry.php
@@ -124,7 +124,7 @@ class WP_Block_Metadata_Registry {
 				__METHOD__,
 				sprintf(
 					/* translators: %s: list of allowed collection roots */
-					__( 'Block metadata collections can only be registered within one of the following directories: %s' ),
+					__( 'Block metadata collections cannot be registered as one of the following directories or their parent directories: %s' ),
 					esc_html( implode( wp_get_list_item_separator(), $collection_roots ) )
 				),
 				'6.8.0'

--- a/tests/phpunit/tests/blocks/wpBlockMetadataRegistry.php
+++ b/tests/phpunit/tests/blocks/wpBlockMetadataRegistry.php
@@ -80,12 +80,18 @@ class Tests_Blocks_WpBlockMetadataRegistry extends WP_UnitTestCase {
 		$this->assertFalse( $result, 'Invalid plugin path should not be registered' );
 	}
 
+	/**
+	 * @ticket 62140
+	 */
 	public function test_register_collection_with_valid_muplugin_path() {
 		$plugin_path = WPMU_PLUGIN_DIR . '/my-plugin/blocks';
 		$result      = WP_Block_Metadata_Registry::register_collection( $plugin_path, $this->temp_manifest_file );
 		$this->assertTrue( $result, 'Valid must-use plugin path should be registered successfully' );
 	}
 
+	/**
+	 * @ticket 62140
+	 */
 	public function test_register_collection_with_invalid_muplugin_path() {
 		$invalid_plugin_path = WPMU_PLUGIN_DIR;
 
@@ -95,12 +101,18 @@ class Tests_Blocks_WpBlockMetadataRegistry extends WP_UnitTestCase {
 		$this->assertFalse( $result, 'Invalid must-use plugin path should not be registered' );
 	}
 
+	/**
+	 * @ticket 62140
+	 */
 	public function test_register_collection_with_valid_theme_path() {
 		$theme_path = WP_CONTENT_DIR . '/themes/my-theme/blocks';
 		$result     = WP_Block_Metadata_Registry::register_collection( $theme_path, $this->temp_manifest_file );
 		$this->assertTrue( $result, 'Valid theme path should be registered successfully' );
 	}
 
+	/**
+	 * @ticket 62140
+	 */
 	public function test_register_collection_with_invalid_theme_path() {
 		$invalid_theme_path = WP_CONTENT_DIR . '/themes';
 
@@ -110,12 +122,18 @@ class Tests_Blocks_WpBlockMetadataRegistry extends WP_UnitTestCase {
 		$this->assertFalse( $result, 'Invalid theme path should not be registered' );
 	}
 
+	/**
+	 * @ticket 62140
+	 */
 	public function test_register_collection_with_arbitrary_path() {
 		$arbitrary_path = '/var/arbitrary/path';
 		$result         = WP_Block_Metadata_Registry::register_collection( $arbitrary_path, $this->temp_manifest_file );
 		$this->assertTrue( $result, 'Arbitrary path should be registered successfully' );
 	}
 
+	/**
+	 * @ticket 62140
+	 */
 	public function test_register_collection_with_arbitrary_path_and_collection_roots_filter() {
 		$arbitrary_path = '/var/arbitrary/path';
 		add_filter(
@@ -138,6 +156,9 @@ class Tests_Blocks_WpBlockMetadataRegistry extends WP_UnitTestCase {
 		$this->assertTrue( $result, 'Arbitrary path should be registered successfully if it is within a collection root' );
 	}
 
+	/**
+	 * @ticket 62140
+	 */
 	public function test_register_collection_with_wp_content_parent_directory_path() {
 		$invalid_path = dirname( WP_CONTENT_DIR );
 
@@ -147,6 +168,9 @@ class Tests_Blocks_WpBlockMetadataRegistry extends WP_UnitTestCase {
 		$this->assertFalse( $result, 'Invalid path (parent directory of "wp-content") should not be registered' );
 	}
 
+	/**
+	 * @ticket 62140
+	 */
 	public function test_register_collection_with_wp_includes_parent_directory_path() {
 		$invalid_path = ABSPATH;
 

--- a/tests/phpunit/tests/blocks/wpBlockMetadataRegistry.php
+++ b/tests/phpunit/tests/blocks/wpBlockMetadataRegistry.php
@@ -80,12 +80,88 @@ class Tests_Blocks_WpBlockMetadataRegistry extends WP_UnitTestCase {
 		$this->assertFalse( $result, 'Invalid plugin path should not be registered' );
 	}
 
-	public function test_register_collection_with_non_existent_path() {
-		$non_existent_path = '/path/that/does/not/exist';
+	public function test_register_collection_with_valid_muplugin_path() {
+		$plugin_path = WPMU_PLUGIN_DIR . '/my-plugin/blocks';
+		$result      = WP_Block_Metadata_Registry::register_collection( $plugin_path, $this->temp_manifest_file );
+		$this->assertTrue( $result, 'Valid must-use plugin path should be registered successfully' );
+	}
+
+	public function test_register_collection_with_invalid_muplugin_path() {
+		$invalid_plugin_path = WPMU_PLUGIN_DIR;
 
 		$this->setExpectedIncorrectUsage( 'WP_Block_Metadata_Registry::register_collection' );
 
-		$result = WP_Block_Metadata_Registry::register_collection( $non_existent_path, $this->temp_manifest_file );
-		$this->assertFalse( $result, 'Non-existent path should not be registered' );
+		$result = WP_Block_Metadata_Registry::register_collection( $invalid_plugin_path, $this->temp_manifest_file );
+		$this->assertFalse( $result, 'Invalid must-use plugin path should not be registered' );
+	}
+
+	public function test_register_collection_with_valid_theme_path() {
+		$theme_path = WP_CONTENT_DIR . '/themes/my-theme/blocks';
+		$result     = WP_Block_Metadata_Registry::register_collection( $theme_path, $this->temp_manifest_file );
+		$this->assertTrue( $result, 'Valid theme path should be registered successfully' );
+	}
+
+	public function test_register_collection_with_invalid_theme_path() {
+		$invalid_theme_path = WP_CONTENT_DIR . '/themes';
+
+		$this->setExpectedIncorrectUsage( 'WP_Block_Metadata_Registry::register_collection' );
+
+		$result = WP_Block_Metadata_Registry::register_collection( $invalid_theme_path, $this->temp_manifest_file );
+		$this->assertFalse( $result, 'Invalid theme path should not be registered' );
+	}
+
+	public function test_register_collection_with_arbitrary_path() {
+		$arbitrary_path = '/var/arbitrary/path';
+		$result         = WP_Block_Metadata_Registry::register_collection( $arbitrary_path, $this->temp_manifest_file );
+		$this->assertTrue( $result, 'Arbitrary path should be registered successfully' );
+	}
+
+	public function test_register_collection_with_arbitrary_path_and_collection_roots_filter() {
+		$arbitrary_path = '/var/arbitrary/path';
+		add_filter(
+			'wp_allowed_block_metadata_collection_roots',
+			static function ( $paths ) use ( $arbitrary_path ) {
+				$paths[] = $arbitrary_path;
+				return $paths;
+			}
+		);
+
+		$this->setExpectedIncorrectUsage( 'WP_Block_Metadata_Registry::register_collection' );
+
+		$result = WP_Block_Metadata_Registry::register_collection( $arbitrary_path, $this->temp_manifest_file );
+		$this->assertFalse( $result, 'Arbitrary path should not be registered if it matches a collection root' );
+
+		$result = WP_Block_Metadata_Registry::register_collection( dirname( $arbitrary_path ), $this->temp_manifest_file );
+		$this->assertFalse( $result, 'Arbitrary path should not be registered if it is a parent directory of a collection root' );
+
+		$result = WP_Block_Metadata_Registry::register_collection( $arbitrary_path . '/my-plugin/blocks', $this->temp_manifest_file );
+		$this->assertTrue( $result, 'Arbitrary path should be registered successfully if it is within a collection root' );
+	}
+
+	public function test_register_collection_with_wp_content_parent_directory_path() {
+		$invalid_path = dirname( WP_CONTENT_DIR );
+
+		$this->setExpectedIncorrectUsage( 'WP_Block_Metadata_Registry::register_collection' );
+
+		$result = WP_Block_Metadata_Registry::register_collection( $invalid_path, $this->temp_manifest_file );
+		$this->assertFalse( $result, 'Invalid path (parent directory of "wp-content") should not be registered' );
+	}
+
+	public function test_register_collection_with_wp_includes_parent_directory_path() {
+		$invalid_path = ABSPATH;
+
+		$this->setExpectedIncorrectUsage( 'WP_Block_Metadata_Registry::register_collection' );
+
+		$result = WP_Block_Metadata_Registry::register_collection( $invalid_path, $this->temp_manifest_file );
+		$this->assertFalse( $result, 'Invalid path (parent directory of "wp-includes") should not be registered' );
+	}
+
+	public function test_register_collection_with_non_existent_manifest() {
+		$non_existent_manifest = '/path/that/does/not/exist/block-manifest.php';
+
+		$this->setExpectedIncorrectUsage( 'WP_Block_Metadata_Registry::register_collection' );
+
+		$result = WP_Block_Metadata_Registry::register_collection( '/var/arbitrary/path', $non_existent_manifest );
+		$this->assertFalse( $result, 'Non-existent manifest should not be registered' );
 	}
 }


### PR DESCRIPTION
This PR implements a solution to allow block metadata collections in additional directories, based on the ideas from the Trac ticket:
* By default, it allows block metadata collections _within_ the `wp-includes` directory, as well as the root directories for plugins, must-use plugins, and themes.
* The list of allowed root directories can be expanded via a new filter `wp_allowed_block_metadata_collection_roots`.
* Note: Block metadata collections paths must never exactly match one of the root directories or their parent directories. Otherwise it would be possible to e.g. register a collection for the entire `wp-content/plugins` directory (or `wp-content`, or the root directory of WordPress etc.), which then would conflict with other collections within that directory.

Trac ticket: https://core.trac.wordpress.org/ticket/62140

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
