### PR TITLE
Hide the Node.js error message when a Docker command produces a non-zero exit code

### DIFF
--- a/tools/local-env/scripts/docker.js
+++ b/tools/local-env/scripts/docker.js
@@ -12,5 +12,10 @@ if (process.argv.includes('--coverage-html')) {
 	process.env.LOCAL_PHP_XDEBUG_MODE = 'coverage';
 }
 
-// Execute any docker compose command passed to this script.
-execSync( 'docker compose ' + composeFiles + ' ' + process.argv.slice( 2 ).join( ' ' ), { stdio: 'inherit' } );
+// This try-catch prevents the superfluous Node.js debugging information from being shown if the command fails
+try {
+	// Execute any docker compose command passed to this script.
+	execSync( 'docker compose ' + composeFiles + ' ' + process.argv.slice( 2 ).join( ' ' ), { stdio: 'inherit' } );
+} catch ( error ) {
+	process.exit( 1 );
+}

--- a/tools/local-env/scripts/docker.js
+++ b/tools/local-env/scripts/docker.js
@@ -12,9 +12,9 @@ if (process.argv.includes('--coverage-html')) {
 	process.env.LOCAL_PHP_XDEBUG_MODE = 'coverage';
 }
 
-// This try-catch prevents the superfluous Node.js debugging information from being shown if the command fails
+// This try-catch prevents the superfluous Node.js debugging information from being shown if the command fails.
 try {
-	// Execute any docker compose command passed to this script.
+	// Execute any Docker compose command passed to this script.
 	execSync( 'docker compose ' + composeFiles + ' ' + process.argv.slice( 2 ).join( ' ' ), { stdio: 'inherit' } );
 } catch ( error ) {
 	process.exit( 1 );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/62814

## Screenshots

### Before

<img width="817" alt="" src="https://github.com/user-attachments/assets/f899e4a2-3cde-4366-afda-be32bc05bfb8" />

### After

<img width="819" alt="" src="https://github.com/user-attachments/assets/6768b087-9b56-4ea4-8026-226bc892828f" />
