### PR TITLE
Use quiet pulls during local environment installation and WP-CLI commands

### DIFF
--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -55,7 +55,7 @@ wait_on( { resources: [ `tcp:localhost:${process.env.LOCAL_PORT}`] } )
 function wp_cli( cmd ) {
 	const composeFiles = local_env_utils.get_compose_files();
 
-	execSync( `docker compose ${composeFiles} run --rm cli ${cmd}`, { stdio: 'inherit' } );
+	execSync( `docker compose ${composeFiles} run --quiet-pull --rm cli ${cmd}`, { stdio: 'inherit' } );
 }
 
 /**

--- a/tools/local-env/scripts/start.js
+++ b/tools/local-env/scripts/start.js
@@ -31,7 +31,7 @@ try {
 const containers = ( process.env.LOCAL_PHP_MEMCACHED === 'true' )
 	? 'wordpress-develop memcached'
 	: 'wordpress-develop';
-execSync( `docker compose ${composeFiles} up -d ${containers}`, { stdio: 'inherit' } );
+execSync( `docker compose ${composeFiles} up --quiet-pull -d ${containers}`, { stdio: 'inherit' } );
 
 // If Docker Toolbox is being used, we need to manually forward LOCAL_PORT to the Docker VM.
 if ( process.env.DOCKER_TOOLBOX_INSTALL_PATH ) {


### PR DESCRIPTION
This reduces the noise of the output -- both locally and on CI -- when first pulling containers during local environment installation and the first time the `cli` container is pulled for WP-CLI commands.

Trac ticket: https://core.trac.wordpress.org/ticket/62280