### PR TITLE
Introduce workflow that automatically closes pull requests

### DIFF
--- a/.github/workflows/cleanup-pull-requests.yml
+++ b/.github/workflows/cleanup-pull-requests.yml
@@ -1,0 +1,122 @@
+# This workflow finds and closes any pull requests that are linked to Trac
+# tickets that are referenced as fixed in commit messages.
+#
+# More on using GitHub pull requests for contributing to WordPress: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/.
+name: Cleanup Pull Requests
+
+on:
+  push:
+    branches:
+      - trunk
+      - '4.[1-9]'
+      - '[5-9].[0-9]'
+
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
+jobs:
+  # Finds and closes pull requests referencing fixed Trac tickets in commit messages using the
+  # documented expected format
+  #
+  # Commit message format is documented in the Core handbook: https://make.wordpress.org/core/handbook/best-practices/commit-messages/.
+  #
+  # Performs the following steps:
+  # - Parse fixed ticket numbers from the commit message.
+  # - Parse the SVN revision from the commit message.
+  # - Searches for pull requests referencing any fixed tickets.
+  # - Leaves a comment on each PR before closing.
+  close-prs:
+    name: Clean up relevant pull requests
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: ${{ github.repository == 'WordPress/wordpress-develop' }}
+
+    steps:
+      - name: Find fixed ticket numbers
+        id: trac-tickets
+        run: |
+          COMMIT_MESSAGE=$(cat <<'EOF' | sed -n '/^Fixes #/,/\./p'
+          ${{ github.event.head_commit.message }}
+          EOF
+          )
+          echo "fixed_list=$(echo \"$COMMIT_MESSAGE\" | sed -n 's/.*Fixes #\([0-9]\+\).*/\1/p' | tr '\n' ' ')" >> $GITHUB_OUTPUT
+
+      - name: Get the SVN revision
+        id: git-svn-id
+        run: |
+          COMMIT_MESSAGE=$(cat <<'EOF' | sed -n '$p'
+          ${{ github.event.head_commit.message }}
+          EOF
+          )
+          echo "svn_revision_number=$(echo \"$COMMIT_MESSAGE\" | sed -n 's/.*git-svn-id: https:\/\/develop.svn.wordpress.org\/[^@]*@\([0-9]*\) .*/\1/p')" >> $GITHUB_OUTPUT
+
+      - name: Find pull requests
+        id: linked-prs
+        if: ${{ steps.trac-tickets.outputs.fixed_list != '' && steps.git-svn-id.outputs.svn_revision_number != '' }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fixedList = "${{ steps.trac-tickets.outputs.fixed_list }}".split(' ').filter(Boolean);
+
+            let prNumbers = [];
+
+            for (const ticket of fixedList) {
+              const query = 'is:pr is:open repo:' + context.repo.owner + '/' + context.repo.repo + ' in:body https://core.trac.wordpress.org/ticket/' + ticket;
+              const result = await github.rest.search.issuesAndPullRequests({ q: query });
+
+              prNumbers = prNumbers.concat(result.data.items.map(pr => pr.number));
+            }
+
+            return prNumbers;
+
+      - name: Comment and close pull requests
+        if: ${{ steps.trac-tickets.outputs.fixed_list != '' && steps.git-svn-id.outputs.svn_revision_number != '' }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const prNumbers = ${{ steps.linked-prs.outputs.result }};
+
+            const commentBody = `A commit was made that fixes the Trac ticket referenced in the description of this pull request.
+
+            SVN changeset: [${{ steps.git-svn-id.outputs.svn_revision_number }}](https://core.trac.wordpress.org/changeset/${{ steps.git-svn-id.outputs.svn_revision_number }})
+            GitHub changeset: ${{ github.sha }}
+
+            This PR will be closed, but please confirm the accuracy of this and reopen if there is more work to be done.`;
+
+            // Update all matched pull requests.
+            for (const prNumber of prNumbers) {
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+
+              if ( pr.data.state === 'closed' ) {
+                continue;
+              }
+
+              // Comment on the pull request with details.
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: commentBody
+              });
+
+              // Close the pull request.
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                state: 'closed'
+              });
+            }

--- a/.github/workflows/cleanup-pull-requests.yml
+++ b/.github/workflows/cleanup-pull-requests.yml
@@ -1,7 +1,3 @@
-# This workflow finds and closes any pull requests that are linked to Trac
-# tickets that are referenced as fixed in commit messages.
-#
-# More on using GitHub pull requests for contributing to WordPress: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/.
 name: Cleanup Pull Requests
 
 on:
@@ -23,100 +19,10 @@ concurrency:
 permissions: {}
 
 jobs:
-  # Finds and closes pull requests referencing fixed Trac tickets in commit messages using the
-  # documented expected format
-  #
-  # Commit message format is documented in the Core handbook: https://make.wordpress.org/core/handbook/best-practices/commit-messages/.
-  #
-  # Performs the following steps:
-  # - Parse fixed ticket numbers from the commit message.
-  # - Parse the SVN revision from the commit message.
-  # - Searches for pull requests referencing any fixed tickets.
-  # - Leaves a comment on each PR before closing.
+  # Runs pull request cleanup.
   close-prs:
-    name: Clean up relevant pull requests
-    runs-on: ubuntu-latest
+    name: Clean up pull requests
     permissions:
       pull-requests: write
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
-
-    steps:
-      - name: Find fixed ticket numbers
-        id: trac-tickets
-        run: |
-          COMMIT_MESSAGE=$(cat <<'EOF' | sed -n '/^Fixes #/,/\./p'
-          ${{ github.event.head_commit.message }}
-          EOF
-          )
-          echo "fixed_list=$(echo \"$COMMIT_MESSAGE\" | sed -n 's/.*Fixes #\([0-9]\+\).*/\1/p' | tr '\n' ' ')" >> $GITHUB_OUTPUT
-
-      - name: Get the SVN revision
-        id: git-svn-id
-        run: |
-          COMMIT_MESSAGE=$(cat <<'EOF' | sed -n '$p'
-          ${{ github.event.head_commit.message }}
-          EOF
-          )
-          echo "svn_revision_number=$(echo \"$COMMIT_MESSAGE\" | sed -n 's/.*git-svn-id: https:\/\/develop.svn.wordpress.org\/[^@]*@\([0-9]*\) .*/\1/p')" >> $GITHUB_OUTPUT
-
-      - name: Find pull requests
-        id: linked-prs
-        if: ${{ steps.trac-tickets.outputs.fixed_list != '' && steps.git-svn-id.outputs.svn_revision_number != '' }}
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          script: |
-            const fixedList = "${{ steps.trac-tickets.outputs.fixed_list }}".split(' ').filter(Boolean);
-
-            let prNumbers = [];
-
-            for (const ticket of fixedList) {
-              const query = 'is:pr is:open repo:' + context.repo.owner + '/' + context.repo.repo + ' in:body https://core.trac.wordpress.org/ticket/' + ticket;
-              const result = await github.rest.search.issuesAndPullRequests({ q: query });
-
-              prNumbers = prNumbers.concat(result.data.items.map(pr => pr.number));
-            }
-
-            return prNumbers;
-
-      - name: Comment and close pull requests
-        if: ${{ steps.trac-tickets.outputs.fixed_list != '' && steps.git-svn-id.outputs.svn_revision_number != '' }}
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          script: |
-            const prNumbers = ${{ steps.linked-prs.outputs.result }};
-
-            const commentBody = `A commit was made that fixes the Trac ticket referenced in the description of this pull request.
-
-            SVN changeset: [${{ steps.git-svn-id.outputs.svn_revision_number }}](https://core.trac.wordpress.org/changeset/${{ steps.git-svn-id.outputs.svn_revision_number }})
-            GitHub changeset: ${{ github.sha }}
-
-            This PR will be closed, but please confirm the accuracy of this and reopen if there is more work to be done.`;
-
-            // Update all matched pull requests.
-            for (const prNumber of prNumbers) {
-              const pr = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber
-              });
-
-              if ( pr.data.state === 'closed' ) {
-                continue;
-              }
-
-              // Comment on the pull request with details.
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body: commentBody
-              });
-
-              // Close the pull request.
-              await github.rest.pulls.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber,
-                state: 'closed'
-              });
-            }
+    uses: ./.github/workflows/reusable-cleanup-pull-requests.yml

--- a/.github/workflows/reusable-cleanup-pull-requests.yml
+++ b/.github/workflows/reusable-cleanup-pull-requests.yml
@@ -74,7 +74,7 @@ jobs:
             const commentBody = `A commit was made that fixes the Trac ticket referenced in the description of this pull request.
 
             SVN changeset: [${{ steps.git-svn-id.outputs.svn_revision_number }}](https://core.trac.wordpress.org/changeset/${{ steps.git-svn-id.outputs.svn_revision_number }})
-            GitHub changeset: ${{ github.sha }}
+            GitHub commit: https://github.com/WordPress/wordpress-develop/commit/${{ github.sha }}
 
             This PR will be closed, but please confirm the accuracy of this and reopen if there is more work to be done.`;
 

--- a/.github/workflows/reusable-cleanup-pull-requests.yml
+++ b/.github/workflows/reusable-cleanup-pull-requests.yml
@@ -21,11 +21,10 @@ jobs:
   # - Searches for pull requests referencing any fixed tickets.
   # - Leaves a comment on each PR before closing.
   close-prs:
-    name: Clean up relevant pull requests
+    name: Find and close PRs
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: ${{ github.repository == 'WordPress/wordpress-develop' }}
 
     steps:
       - name: Find fixed ticket numbers

--- a/.github/workflows/reusable-cleanup-pull-requests.yml
+++ b/.github/workflows/reusable-cleanup-pull-requests.yml
@@ -1,0 +1,109 @@
+##
+# A reusable workflow that finds and closes any pull requests that are linked to Trac
+# tickets that are referenced as fixed in commit messages.
+#
+# More info about using GitHub pull requests for contributing to WordPress can be found in the handbook: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/.
+##
+name: Run pull request cleanup
+
+on:
+  workflow_call:
+
+jobs:
+  # Finds and closes pull requests referencing fixed Trac tickets in commit messages using the
+  # documented expected format
+  #
+  # Commit message format is documented in the Core handbook: https://make.wordpress.org/core/handbook/best-practices/commit-messages/.
+  #
+  # Performs the following steps:
+  # - Parse fixed ticket numbers from the commit message.
+  # - Parse the SVN revision from the commit message.
+  # - Searches for pull requests referencing any fixed tickets.
+  # - Leaves a comment on each PR before closing.
+  close-prs:
+    name: Clean up relevant pull requests
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: ${{ github.repository == 'WordPress/wordpress-develop' }}
+
+    steps:
+      - name: Find fixed ticket numbers
+        id: trac-tickets
+        run: |
+          COMMIT_MESSAGE=$(cat <<'EOF' | sed -n '/^Fixes #/,/\./p'
+          ${{ github.event.head_commit.message }}
+          EOF
+          )
+          echo "fixed_list=$(echo \"$COMMIT_MESSAGE\" | sed -n 's/.*Fixes #\([0-9]\+\).*/\1/p' | tr '\n' ' ')" >> $GITHUB_OUTPUT
+
+      - name: Get the SVN revision
+        id: git-svn-id
+        run: |
+          COMMIT_MESSAGE=$(cat <<'EOF' | sed -n '$p'
+          ${{ github.event.head_commit.message }}
+          EOF
+          )
+          echo "svn_revision_number=$(echo \"$COMMIT_MESSAGE\" | sed -n 's/.*git-svn-id: https:\/\/develop.svn.wordpress.org\/[^@]*@\([0-9]*\) .*/\1/p')" >> $GITHUB_OUTPUT
+
+      - name: Find pull requests
+        id: linked-prs
+        if: ${{ steps.trac-tickets.outputs.fixed_list != '' && steps.git-svn-id.outputs.svn_revision_number != '' }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fixedList = "${{ steps.trac-tickets.outputs.fixed_list }}".split(' ').filter(Boolean);
+
+            let prNumbers = [];
+
+            for (const ticket of fixedList) {
+              const query = 'is:pr is:open repo:' + context.repo.owner + '/' + context.repo.repo + ' in:body https://core.trac.wordpress.org/ticket/' + ticket;
+              const result = await github.rest.search.issuesAndPullRequests({ q: query });
+
+              prNumbers = prNumbers.concat(result.data.items.map(pr => pr.number));
+            }
+
+            return prNumbers;
+
+      - name: Comment and close pull requests
+        if: ${{ steps.trac-tickets.outputs.fixed_list != '' && steps.git-svn-id.outputs.svn_revision_number != '' }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const prNumbers = ${{ steps.linked-prs.outputs.result }};
+
+            const commentBody = `A commit was made that fixes the Trac ticket referenced in the description of this pull request.
+
+            SVN changeset: [${{ steps.git-svn-id.outputs.svn_revision_number }}](https://core.trac.wordpress.org/changeset/${{ steps.git-svn-id.outputs.svn_revision_number }})
+            GitHub changeset: ${{ github.sha }}
+
+            This PR will be closed, but please confirm the accuracy of this and reopen if there is more work to be done.`;
+
+            // Update all matched pull requests.
+            for (const prNumber of prNumbers) {
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+
+              if ( pr.data.state === 'closed' ) {
+                continue;
+              }
+
+              // Comment on the pull request with details.
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: commentBody
+              });
+
+              // Close the pull request.
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                state: 'closed'
+              });
+            }

--- a/.github/workflows/reusable-cleanup-pull-requests.yml
+++ b/.github/workflows/reusable-cleanup-pull-requests.yml
@@ -80,16 +80,6 @@ jobs:
 
             // Update all matched pull requests.
             for (const prNumber of prNumbers) {
-              const pr = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber
-              });
-
-              if ( pr.data.state === 'closed' ) {
-                continue;
-              }
-
               // Comment on the pull request with details.
               await github.rest.issues.createComment({
                 owner: context.repo.owner,


### PR DESCRIPTION
This introduces a workflow that finds pull requests referencing any fixed tickets in commit messages.

Trac ticket: https://core.trac.wordpress.org/ticket/62817

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
