### PR TITLE
Menus: Fix performance issue with tons of duplicated queries

### DIFF
--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -42,7 +42,7 @@ class Walker_Nav_Menu extends Walker {
 	/**
 	 * The URL to the privacy policy page.
 	 *
-	 * @since 6.7.2
+	 * @since 6.2.0
 	 * @var string
 	 */
 	private static $privacy_policy_url = null;
@@ -52,15 +52,15 @@ class Walker_Nav_Menu extends Walker {
 	 * This method caches the URL to avoid multiple database queries and shared the URL between all instances of the class.
 	 * Single query is performed on the first call to this method.
 	 *
-	 * @since 6.7.2
+	 * @since 6.8.0
 	 *
 	 * @return string The URL to the privacy policy page.
 	 */
-	public static function check_privacy_policy_url() {
+	private static function get_privacy_policy_url() {
 		if ( null === self::$privacy_policy_url ) {
-			self::$privacy_policy_url = get_privacy_policy_url();
+			static::$privacy_policy_url = get_privacy_policy_url();
 		}
-		return self::$privacy_policy_url;
+		return static::$privacy_policy_url;
 	}
 
 	/**
@@ -260,7 +260,7 @@ class Walker_Nav_Menu extends Walker {
 		$atts['rel']    = ! empty( $menu_item->xfn ) ? $menu_item->xfn : '';
 
 		if ( ! empty( $menu_item->url ) ) {
-			if ( static::check_privacy_policy_url() === $menu_item->url ) {
+			if ( static::get_privacy_policy_url() === $menu_item->url ) {
 				$atts['rel'] = empty( $atts['rel'] ) ? 'privacy-policy' : $atts['rel'] . ' privacy-policy';
 			}
 

--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -42,7 +42,7 @@ class Walker_Nav_Menu extends Walker {
 	/**
 	 * The URL to the privacy policy page.
 	 *
-	 * @since 6.2.0
+	 * @since 6.8.0
 	 * @var string
 	 */
 	private $privacy_policy_url;

--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -39,29 +39,29 @@ class Walker_Nav_Menu extends Walker {
 		'id'     => 'db_id',
 	);
 
-    /**
-     * The URL to the privacy policy page.
-     *
-     * @since 6.7.2
-     * @var string
-     */
-    private static $privacy_policy_url = null;
+	/**
+	 * The URL to the privacy policy page.
+	 *
+	 * @since 6.7.2
+	 * @var string
+	 */
+	private static $privacy_policy_url = null;
 
-    /**
-     * Get the URL to the privacy policy page.
-     * This method caches the URL to avoid multiple database queries and shared the URL between all instances of the class.
-     * Single query is performed on the first call to this method.
-     *
-     * @since 6.7.2
-     *
-     * @return string The URL to the privacy policy page.
-     */
-    public static function check_privacy_policy_url() {
-        if (null === self::$privacy_policy_url) {
-            self::$privacy_policy_url = get_privacy_policy_url();
-        }
-        return self::$privacy_policy_url;
-    }
+	/**
+	 * Get the URL to the privacy policy page.
+	 * This method caches the URL to avoid multiple database queries and shared the URL between all instances of the class.
+	 * Single query is performed on the first call to this method.
+	 *
+	 * @since 6.7.2
+	 *
+	 * @return string The URL to the privacy policy page.
+	 */
+	public static function check_privacy_policy_url() {
+		if ( null === self::$privacy_policy_url ) {
+			self::$privacy_policy_url = get_privacy_policy_url();
+		}
+		return self::$privacy_policy_url;
+	}
 
 	/**
 	 * Starts the list before the elements are added.

--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -39,6 +39,30 @@ class Walker_Nav_Menu extends Walker {
 		'id'     => 'db_id',
 	);
 
+    /**
+     * The URL to the privacy policy page.
+     *
+     * @since 6.7.2
+     * @var string
+     */
+    private static $privacy_policy_url = null;
+
+    /**
+     * Get the URL to the privacy policy page.
+     * This method caches the URL to avoid multiple database queries and shared the URL between all instances of the class.
+     * Single query is performed on the first call to this method.
+     *
+     * @since 6.7.2
+     *
+     * @return string The URL to the privacy policy page.
+     */
+    public static function check_privacy_policy_url() {
+        if (null === self::$privacy_policy_url) {
+            self::$privacy_policy_url = get_privacy_policy_url();
+        }
+        return self::$privacy_policy_url;
+    }
+
 	/**
 	 * Starts the list before the elements are added.
 	 *
@@ -236,7 +260,7 @@ class Walker_Nav_Menu extends Walker {
 		$atts['rel']    = ! empty( $menu_item->xfn ) ? $menu_item->xfn : '';
 
 		if ( ! empty( $menu_item->url ) ) {
-			if ( get_privacy_policy_url() === $menu_item->url ) {
+			if ( static::check_privacy_policy_url() === $menu_item->url ) {
 				$atts['rel'] = empty( $atts['rel'] ) ? 'privacy-policy' : $atts['rel'] . ' privacy-policy';
 			}
 

--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -45,22 +45,13 @@ class Walker_Nav_Menu extends Walker {
 	 * @since 6.2.0
 	 * @var string
 	 */
-	private static $privacy_policy_url = null;
+	private $privacy_policy_url = null;
 
 	/**
-	 * Get the URL to the privacy policy page.
-	 * This method caches the URL to avoid multiple database queries and shared the URL between all instances of the class.
-	 * Single query is performed on the first call to this method.
-	 *
-	 * @since 6.8.0
-	 *
-	 * @return string The URL to the privacy policy page.
+	 * Constructor.
 	 */
-	private static function get_privacy_policy_url() {
-		if ( null === self::$privacy_policy_url ) {
-			static::$privacy_policy_url = get_privacy_policy_url();
-		}
-		return static::$privacy_policy_url;
+	public function __construct() {
+		$this->privacy_policy_url = get_privacy_policy_url();
 	}
 
 	/**
@@ -260,7 +251,7 @@ class Walker_Nav_Menu extends Walker {
 		$atts['rel']    = ! empty( $menu_item->xfn ) ? $menu_item->xfn : '';
 
 		if ( ! empty( $menu_item->url ) ) {
-			if ( static::get_privacy_policy_url() === $menu_item->url ) {
+			if ( $this->privacy_policy_url === $menu_item->url ) {
 				$atts['rel'] = empty( $atts['rel'] ) ? 'privacy-policy' : $atts['rel'] . ' privacy-policy';
 			}
 

--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -49,6 +49,8 @@ class Walker_Nav_Menu extends Walker {
 
 	/**
 	 * Constructor.
+	 *
+	 * @since 6.8.0
 	 */
 	public function __construct() {
 		$this->privacy_policy_url = get_privacy_policy_url();

--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -45,7 +45,7 @@ class Walker_Nav_Menu extends Walker {
 	 * @since 6.2.0
 	 * @var string
 	 */
-	private $privacy_policy_url = null;
+	private $privacy_policy_url;
 
 	/**
 	 * Constructor.

--- a/tests/phpunit/tests/menu/walker-nav-menu.php
+++ b/tests/phpunit/tests/menu/walker-nav-menu.php
@@ -16,6 +16,30 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 	 * @var int
 	 */
 	private $orig_wp_nav_menu_max_depth;
+	/**
+	 * The privacy policy page ID.
+	 *
+	 * @var int
+	 */
+	protected static $privacy_policy_id;
+
+	/**
+	 * Set up before class.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_title'  => 'Test Privacy Policy',
+				'post_status' => 'publish',
+			)
+		);
+
+		update_option( 'wp_page_for_privacy_policy', $post_id );
+		self::$privacy_policy_id = (int) get_option( 'wp_page_for_privacy_policy' );
+	}
 
 	/**
 	 * Setup.
@@ -40,6 +64,18 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 
 		$_wp_nav_menu_max_depth = $this->orig_wp_nav_menu_max_depth;
 		parent::tear_down();
+	}
+
+	/**
+	 * Tear down after class.
+	 */
+	public static function tear_down_after_class() {
+		if ( self::$privacy_policy_id ) {
+			wp_delete_post( self::$privacy_policy_id, true );
+			update_option( 'wp_page_for_privacy_policy', 0 );
+		}
+
+		parent::tear_down_after_class();
 	}
 
 	/**
@@ -136,23 +172,12 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 	 * @param string $target   Optional. The target value. Default empty string.
 	 */
 	public function test_walker_nav_menu_start_el_should_add_rel_privacy_policy_to_privacy_policy_url( $expected, $xfn = '', $target = '' ) {
-		$post_id = self::factory()->post->create(
-			array(
-				'post_type'   => 'page',
-				'post_title'  => 'Test Privacy Policy',
-				'post_status' => 'publish',
-			)
-		);
-
-		// Set the privacy policy page.
-		update_option( 'wp_page_for_privacy_policy', $post_id );
-		$privacy_policy_id = (int) get_option( 'wp_page_for_privacy_policy' );
 
 		$output = '';
 
 		$item = array(
-			'ID'        => $privacy_policy_id,
-			'object_id' => $privacy_policy_id,
+			'ID'        => self::$privacy_policy_id,
+			'object_id' => self::$privacy_policy_id,
 			'title'     => 'Privacy Policy',
 			'target'    => $target,
 			'xfn'       => $xfn,
@@ -217,6 +242,7 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 		);
 
 		// Do not set the privacy policy page.
+		update_option( 'wp_page_for_privacy_policy', 0 );
 
 		$output = '';
 
@@ -251,23 +277,12 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 	 * @covers Walker_Nav_Menu::start_el
 	 */
 	public function test_walker_nav_menu_start_el_should_not_add_rel_privacy_policy_when_no_url_is_passed() {
-		$post_id = self::factory()->post->create(
-			array(
-				'post_type'   => 'page',
-				'post_title'  => 'Test Privacy Policy',
-				'post_status' => 'publish',
-			)
-		);
-
-		// Set the privacy policy page.
-		update_option( 'wp_page_for_privacy_policy', $post_id );
-		$privacy_policy_id = (int) get_option( 'wp_page_for_privacy_policy' );
 
 		$output = '';
 
 		$item = array(
-			'ID'        => $privacy_policy_id,
-			'object_id' => $privacy_policy_id,
+			'ID'        => self::$privacy_policy_id,
+			'object_id' => self::$privacy_policy_id,
 			'title'     => 'Privacy Policy',
 			'target'    => '',
 			'xfn'       => '',
@@ -296,22 +311,10 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 	 * @covers Walker_Nav_Menu::start_el
 	 */
 	public function test_walker_nav_menu_start_el_should_add_rel_privacy_policy_when_id_does_not_match_but_url_does() {
-		$post_id = self::factory()->post->create(
-			array(
-				'post_type'   => 'page',
-				'post_title'  => 'Test Privacy Policy',
-				'post_status' => 'publish',
-			)
-		);
-
-		// Set the privacy policy page.
-		update_option( 'wp_page_for_privacy_policy', $post_id );
-		$privacy_policy_id = (int) get_option( 'wp_page_for_privacy_policy' );
-
 		$output = '';
 
 		// Ensure the ID does not match the privacy policy.
-		$not_privacy_policy_id = $privacy_policy_id - 1;
+		$not_privacy_policy_id = self::$privacy_policy_id - 1;
 
 		$item = array(
 			'ID'        => $not_privacy_policy_id,
@@ -415,6 +418,46 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that get_privacy_policy_url() returns the correct URL.
+	 */
+	public function test_get_privacy_policy_url_returns_correct_url() {
+		$expected_url = get_privacy_policy_url();
+		$actual_url   = $this->invoke_private_method( 'get_privacy_policy_url' );
+
+		$this->assertSame( $expected_url, $actual_url, 'The URL should match the privacy policy URL set in the option.' );
+	}
+
+	/**
+	 * Test that get_privacy_policy_url() updates after cache reset.
+	 */
+	public function test_get_privacy_policy_url_updates_after_reset() {
+		// Set initial privacy policy URL.
+		$first_url = $this->invoke_private_method( 'get_privacy_policy_url' );
+
+		// Change the privacy policy option.
+		$new_policy_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_title'  => 'New Privacy Policy',
+				'post_status' => 'publish',
+			)
+		);
+		update_option( 'wp_page_for_privacy_policy', $new_policy_id );
+
+		// Reset the cache by setting the static property to null.
+		$reflection = new ReflectionClass( 'Walker_Nav_Menu' );
+		$property   = $reflection->getProperty( 'privacy_policy_url' );
+		$property->setAccessible( true );
+		$property->setValue( null );
+
+		// Fetch the new URL.
+		$new_url = $this->invoke_private_method( 'get_privacy_policy_url' );
+
+		$this->assertNotSame( $first_url, $new_url, 'The URL should update after the cache is reset.' );
+	}
+
+
+	/**
 	 * Data provider.
 	 *
 	 * @return array[]
@@ -446,5 +489,16 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 				'expected' => ' id="hello&amp;goodbye"',
 			),
 		);
+	}
+
+	/**
+	 * Helper method to call private methods.
+	 */
+	private function invoke_private_method( $method_name ) {
+		$reflection = new ReflectionClass( 'Walker_Nav_Menu' );
+		$method     = $reflection->getMethod( $method_name );
+		$method->setAccessible( true );
+
+		return $method->invoke( null );
 	}
 }


### PR DESCRIPTION
The `start_el()` method in Walker_Nav_Menu currently calls `get_privacy_policy_url()` for every menu item when building menus. This results in redundant queries, particularly for menus with many items. This patch initialize the get_privacy_policy_url() result in the Walker constructor, improving performance while maintaining existing functionality.

Trac ticket: https://core.trac.wordpress.org/ticket/62818

### How to Test
	1.	Install and activate the [Query Monitor](https://en-ca.wordpress.org/plugins/query-monitor/) plugin.
	2.	Create a menu with multiple items (20+ for better observation).
	3.	Assign the menu to a theme location that uses wp_nav_menu() to render it.
	4.	Enable the privacy policy page under Settings > Privacy to ensure get_privacy_policy_url() returns a value.
	5.	Load a page where the menu is rendered.

### Before applying the patch:
	* Use Query Monitor to observe database queries.
	* Notice multiple redundant calls to get_privacy_policy_url() for each menu item.

### After applying the patch:
	* Reload the same page and monitor queries using Query Monitor.
	* Confirm that get_privacy_policy_url() is only called once, even with many menu items.


----

# Commit Message

Menus: Improve performance by calling `get_privacy_policy_url()` once per `Walker_Nav_Menu` instance rather than for every nav menu item.

The `start_el()` method in `Walker_Nav_Menu` was calling `get_privacy_policy_url()` for every menu item when building menus. This resulted in redundant queries, particularly for menus with many items. This patch obtains the `get_privacy_policy_url()` value in the constructor for reuse in the `start_el()` method to improve performance.

Redundant code to construct the privacy policy page is also refactored into the `set_up` method during tests.

Props arzola, swissspidy, westonruter, mukesh27.
Fixes #62818.
