### PR TITLE
Recovery Mode: Fix PHP warning when accessing plugin data

### DIFF
--- a/src/wp-includes/class-wp-recovery-mode-email-service.php
+++ b/src/wp-includes/class-wp-recovery-mode-email-service.php
@@ -360,7 +360,7 @@ When seeking help with this issue, you may be asked for some of the following in
 			),
 		);
 
-		if ( null !== $plugin ) {
+		if ( is_array( $plugin ) ) {
 			$debug['plugin'] = sprintf(
 				/* translators: 1: The failing plugins name. 2: The failing plugins version. */
 				__( 'Current plugin: %1$s (version %2$s)' ),


### PR DESCRIPTION
Trac ticket: [62816](https://core.trac.wordpress.org/ticket/62816)

This PR fixes a PHP warning that occurs in the Recovery Mode email service when accessing plugin data that doesn't exist.


Current behavior:

`WP_Recovery_Mode_Email_Service::get_plugin()` can return `false`
The code checks for `null !== $plugin` which passes even when `$plugin` is false
This leads to a PHP warning when trying to access the array offset on the `false` value

Fix:

Replace the condition `null !== $plugin` with `is_array( $plugin )` to ensure we only access array properties when we have valid plugin data. This prevents the PHP warning while maintaining the intended functionality