### PR TITLE
Add sanitization to WP_Locale::get_month()

### DIFF
--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -312,13 +312,19 @@ class WP_Locale {
 	 * You can use an integer instead and it will add the
 	 * '0' before the numbers less than 10 for you.
 	 *
+	 * If the month number is not found, an empty string is returned.
+	 *
 	 * @since 2.1.0
 	 *
 	 * @param string|int $month_number '01' through '12'.
 	 * @return string Translated full month name.
 	 */
 	public function get_month( $month_number ) {
-		return $this->month[ zeroise( $month_number, 2 ) ];
+		$month_number = zeroise( $month_number, 2 );
+		if ( ! isset( $this->month[ $month_number ] ) ) {
+			return '';
+		}
+		return $this->month[ $month_number ];
 	}
 
 	/**

--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -312,12 +312,10 @@ class WP_Locale {
 	 * You can use an integer instead and it will add the
 	 * '0' before the numbers less than 10 for you.
 	 *
-	 * If the month number is not found, an empty string is returned.
-	 *
 	 * @since 2.1.0
 	 *
 	 * @param string|int $month_number '01' through '12'.
-	 * @return string Translated full month name.
+	 * @return string Translated full month name. If the month number is not found, an empty string is returned.
 	 */
 	public function get_month( $month_number ) {
 		$month_number = zeroise( $month_number, 2 );


### PR DESCRIPTION
refactor(class-wp-locale.php): Added sanitization to WP_Locale::get_month()

This prevents a Warning: Undefined array key "00"

Co-authored-by: xateman

Refs: #62824

Trac ticket: https://core.trac.wordpress.org/ticket/62824#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
