### PR TITLE
Ensure block editor preloading middleware JSON is correctly escaped

### DIFF
--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -762,11 +762,16 @@ function block_editor_rest_api_preload( array $preload_paths, $block_editor_cont
 	$wp_scripts = $backup_wp_scripts;
 	$wp_styles  = $backup_wp_styles;
 
+	$json_encode_flags = JSON_HEX_TAG | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS;
+	if ( ! is_utf8_charset() ) {
+		$json_encode_flags = JSON_HEX_TAG | JSON_UNESCAPED_SLASHES;
+	}
+
 	wp_add_inline_script(
 		'wp-api-fetch',
 		sprintf(
 			'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );',
-			wp_json_encode( $preload_data )
+			wp_json_encode( $preload_data, $json_encode_flags )
 		),
 		'after'
 	);

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -762,11 +762,16 @@ function block_editor_rest_api_preload( array $preload_paths, $block_editor_cont
 	$wp_scripts = $backup_wp_scripts;
 	$wp_styles  = $backup_wp_styles;
 
+	$json_encode_flags = JSON_HEX_TAG | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS;
+	if ( ! is_utf8_charset() ) {
+		$json_encode_flags = JSON_HEX_TAG | JSON_UNESCAPED_SLASHES;
+	}
+
 	wp_add_inline_script(
 		'wp-api-fetch',
 		sprintf(
 			'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );',
-			wp_json_encode( $preload_data, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
+			wp_json_encode( $preload_data, $json_encode_flags )
 		),
 		'after'
 	);

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -762,16 +762,11 @@ function block_editor_rest_api_preload( array $preload_paths, $block_editor_cont
 	$wp_scripts = $backup_wp_scripts;
 	$wp_styles  = $backup_wp_styles;
 
-	$json_encode_flags = JSON_HEX_TAG | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS;
-	if ( ! is_utf8_charset() ) {
-		$json_encode_flags = JSON_HEX_TAG | JSON_UNESCAPED_SLASHES;
-	}
-
 	wp_add_inline_script(
 		'wp-api-fetch',
 		sprintf(
 			'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );',
-			wp_json_encode( $preload_data, $json_encode_flags )
+			wp_json_encode( $preload_data, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
 		),
 		'after'
 	);

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -762,16 +762,11 @@ function block_editor_rest_api_preload( array $preload_paths, $block_editor_cont
 	$wp_scripts = $backup_wp_scripts;
 	$wp_styles  = $backup_wp_styles;
 
-	$json_encode_flags = JSON_HEX_TAG | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS;
-	if ( ! is_utf8_charset() ) {
-		$json_encode_flags = JSON_HEX_TAG | JSON_UNESCAPED_SLASHES;
-	}
-
 	wp_add_inline_script(
 		'wp-api-fetch',
 		sprintf(
 			'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );',
-			wp_json_encode( $preload_data, $json_encode_flags )
+			wp_json_encode( $preload_data )
 		),
 		'after'
 	);

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -727,8 +727,8 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 	 * @covers ::block_editor_rest_api_preload
 	 *
 	 * Some valid JSON-encoded data is dangerous to embed in HTML without appropriate
-	 * escaping. This test includes prints an example of such data that would prevent
-	 * the enclosing `<script>` from closing on its apparent closer and remain open.
+	 * escaping. This test includes an example of data that would prevent the enclosing
+	 * `<script></script>` tag from closing on its apparent closer and remain open.
 	 */
 	public function test_ensure_preload_data_script_tag_closes() {
 		add_theme_support( 'html5', array( 'script' ) );

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -738,7 +738,7 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 			array(
 				'methods'             => 'GET',
 				'callback'            => function () {
-					return '<!-- unclosed comment and a script tag <script></script>';
+					return 'Unclosed comment and a script open tag <!--<script>';
 				},
 				'permission_callback' => '__return_true',
 			)
@@ -761,7 +761,7 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 		$expected = <<<HTML
 <script src="{$baseurl}/wp-includes/js/dist/api-fetch.min.js?ver=test" id="wp-api-fetch-js"></script>
 <script id="wp-api-fetch-js-after">
-wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( {"/test/v0/test-62797":{"body":["\\u003C!-- unclosed comment and a script tag \\u003Cscript\\u003E\\u003C/script\\u003E"],"headers":{"Allow":"GET"}}} ) );
+wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( {"/test/v0/test-62797":{"body":["Unclosed comment and a script open tag \\u003C!--\\u003Cscript\\u003E"],"headers":{"Allow":"GET"}}} ) );
 </script>
 
 HTML;

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -744,11 +744,9 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 			)
 		);
 
-		// Need set up rest requests with some data like `<!-- <script>`...
-		wp_scripts()->registered['wp-api-fetch']->extra['after'] = array();
+		// Prevent a bunch of noisy or unstable data from being included in the test output.
 		wp_scripts()->registered['wp-api-fetch']->ver            = 'test';
-		$src = includes_url( '/test-src/api-fetch.js' );
-		wp_scripts()->registered['wp-api-fetch']->src = $src;
+		wp_scripts()->registered['wp-api-fetch']->extra['after'] = array();
 
 		block_editor_rest_api_preload(
 			array( '/test/v0/test-62797' ),
@@ -759,7 +757,7 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 		wp_scripts()->do_item( 'wp-api-fetch' );
 		$output   = ob_get_clean();
 		$expected = <<<HTML
-<script src="{$src}?ver=test" id="wp-api-fetch-js"></script>
+<script src="http://example.org/wp-includes/js/dist/api-fetch.min.js?ver=test" id="wp-api-fetch-js"></script>
 <script id="wp-api-fetch-js-after">
 wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( {"/test/v0/test-62797":{"body":["\\u003C!-- unclosed comment and a script tag \\u003Cscript\\u003E\\u003C/script\\u003E"],"headers":{"Allow":"GET"}}} ) );
 </script>

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -725,16 +725,19 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 	 * @ticket 62797
 	 *
 	 * @covers ::block_editor_rest_api_preload
+	 *
+	 * Some valid JSON-encoded data is dangerous to embed in HTML without appropriate
+	 * escaping. This test includes prints an example of such data that would prevent
+	 * the enclosing `<script>` from closing on its apparent closer and remain open.
 	 */
-	public function test_preload_closes_script_tag() {
+	public function test_ensure_preload_data_script_tag_closes() {
 		add_theme_support( 'html5', array( 'script' ) );
-
 		register_rest_route(
 			'test/v0',
 			'test-62797',
 			array(
 				'methods'             => 'GET',
-				'callback'            => function ( WP_REST_Request $request ) {
+				'callback'            => function () {
 					return '<!-- unclosed comment and a script tag <script></script>';
 				},
 				'permission_callback' => '__return_true',

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -9,7 +9,6 @@
  * @group blocks
  */
 class Tests_Blocks_Editor extends WP_UnitTestCase {
-
 	/**
 	 * Sets up each test method.
 	 */
@@ -720,5 +719,49 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 				'expected'      => '\/?context=edit',
 			),
 		);
+	}
+
+	/**
+	 * @ticket 62797
+	 *
+	 * @covers ::block_editor_rest_api_preload
+	 */
+	public function test_preload_closes_script_tag() {
+		add_theme_support( 'html5', array( 'script' ) );
+
+		register_rest_route(
+			'test/v0',
+			'test-62797',
+			array(
+				'methods'             => 'GET',
+				'callback'            => function ( WP_REST_Request $request ) {
+					return '<!-- unclosed comment and a script tag <script></script>';
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+
+		// Need set up rest requests with some data like `<!-- <script>`...
+		wp_scripts()->registered['wp-api-fetch']->extra['after'] = array();
+		wp_scripts()->registered['wp-api-fetch']->ver            = 'test';
+		$src = includes_url( '/test-src/api-fetch.js' );
+		wp_scripts()->registered['wp-api-fetch']->src = $src;
+
+		block_editor_rest_api_preload(
+			array( '/test/v0/test-62797' ),
+			new WP_Block_Editor_Context()
+		);
+
+		ob_start();
+		wp_scripts()->do_item( 'wp-api-fetch' );
+		$output   = ob_get_clean();
+		$expected = <<<HTML
+<script src="{$src}?ver=test" id="wp-api-fetch-js"></script>
+<script id="wp-api-fetch-js-after">
+wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( {"/test/v0/test-62797":{"body":["\\u003C!-- unclosed comment and a script tag \\u003Cscript\\u003E\\u003C/script\\u003E"],"headers":{"Allow":"GET"}}} ) );
+</script>
+
+HTML;
+		$this->assertEqualHTML( $expected, $output );
 	}
 }

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -755,9 +755,11 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 
 		ob_start();
 		wp_scripts()->do_item( 'wp-api-fetch' );
-		$output   = ob_get_clean();
+		$output = ob_get_clean();
+
+		$baseurl  = site_url();
 		$expected = <<<HTML
-<script src="http://example.org/wp-includes/js/dist/api-fetch.min.js?ver=test" id="wp-api-fetch-js"></script>
+<script src="{$baseurl}/wp-includes/js/dist/api-fetch.min.js?ver=test" id="wp-api-fetch-js"></script>
 <script id="wp-api-fetch-js-after">
 wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( {"/test/v0/test-62797":{"body":["\\u003C!-- unclosed comment and a script tag \\u003Cscript\\u003E\\u003C/script\\u003E"],"headers":{"Allow":"GET"}}} ) );
 </script>

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -636,7 +636,7 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 54558
-	 * @dataProvider data_block_editor_rest_api_preload_does_not_add_redundant_leading_slash
+	 * @dataProvider data_block_editor_rest_api_preload_adds_missing_leading_slash
 	 *
 	 * @covers ::block_editor_rest_api_preload
 	 *
@@ -692,7 +692,7 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 	 *
 	 * @return array
 	 */
-	public function data_block_editor_rest_api_preload_does_not_add_redundant_leading_slash() {
+	public function data_block_editor_rest_api_preload_adds_missing_leading_slash() {
 		return array(
 			'a string without a slash'               => array(
 				'preload_paths' => array( 'wp/v2/blocks' ),

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -630,13 +630,13 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 
 		$after = implode( '', wp_scripts()->registered['wp-api-fetch']->extra['after'] );
 		$this->assertStringContainsString( 'wp.apiFetch.createPreloadingMiddleware', $after );
-		$this->assertStringContainsString( '"\/wp\/v2\/blocks"', $after );
-		$this->assertStringContainsString( '"\/wp\/v2\/types"', $after );
+		$this->assertStringContainsString( '"/wp/v2/blocks"', $after );
+		$this->assertStringContainsString( '"/wp/v2/types"', $after );
 	}
 
 	/**
 	 * @ticket 54558
-	 * @dataProvider data_block_editor_rest_api_preload_adds_missing_leading_slash
+	 * @dataProvider data_block_editor_rest_api_preload_does_not_add_redundant_leading_slash
 	 *
 	 * @covers ::block_editor_rest_api_preload
 	 *
@@ -692,15 +692,15 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 	 *
 	 * @return array
 	 */
-	public function data_block_editor_rest_api_preload_adds_missing_leading_slash() {
+	public function data_block_editor_rest_api_preload_does_not_add_redundant_leading_slash() {
 		return array(
 			'a string without a slash'               => array(
 				'preload_paths' => array( 'wp/v2/blocks' ),
-				'expected'      => '\/wp\/v2\/blocks',
+				'expected'      => '/wp/v2/blocks',
 			),
 			'a string with a slash'                  => array(
 				'preload_paths' => array( '/wp/v2/blocks' ),
-				'expected'      => '\/wp\/v2\/blocks',
+				'expected'      => '/wp/v2/blocks',
 			),
 			'a string starting with a question mark' => array(
 				'preload_paths' => array( '?context=edit' ),
@@ -708,15 +708,15 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 			),
 			'an array with a string without a slash' => array(
 				'preload_paths' => array( array( 'wp/v2/blocks', 'OPTIONS' ) ),
-				'expected'      => '\/wp\/v2\/blocks',
+				'expected'      => '/wp/v2/blocks',
 			),
 			'an array with a string with a slash'    => array(
 				'preload_paths' => array( array( '/wp/v2/blocks', 'OPTIONS' ) ),
-				'expected'      => '\/wp\/v2\/blocks',
+				'expected'      => '/wp/v2/blocks',
 			),
 			'an array with a string starting with a question mark' => array(
 				'preload_paths' => array( array( '?context=edit', 'OPTIONS' ) ),
-				'expected'      => '\/?context=edit',
+				'expected'      => '/?context=edit',
 			),
 		);
 	}


### PR DESCRIPTION
Fixes [#62797](https://core.trac.wordpress.org/ticket/62797) by correctly escaping JSON included inside JavaScript in a `script` tag.

`wp_add_inline_script` will correctly escape closing script tags `</script>` which prevents script contents from breaking out of the script, it does not handle cases where some content may enter the HTML [script data double escaped state](https://html.spec.whatwg.org/multipage/parsing.html#script-data-double-escaped-state) and prevent the real script closing tag from closing the script tag as expected, leading to a broken document where the script tag remains open.

This can be tested by applying the patch and following the reproduction steps in [#62797](https://core.trac.wordpress.org/ticket/62797).

Trac ticket: https://core.trac.wordpress.org/ticket/62797

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
