### PR TITLE
White background + welcome widget border

### DIFF
--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -352,7 +352,7 @@ ul#adminmenu > li.current > a.current:after {
 	width: 0;
 	position: absolute;
 	pointer-events: none;
-	border-right-color: #f0f0f1;
+	border-right-color: #fff;
 	top: 50%;
 	margin-top: -8px;
 }

--- a/src/wp-admin/css/colors/_variables.scss
+++ b/src/wp-admin/css/colors/_variables.scss
@@ -15,7 +15,7 @@ $notification-color: #d54e21 !default;
 
 // global
 
-$body-background: #f1f1f1 !default;
+$body-background: #fff !default;
 
 $link: #0073aa !default;
 $link-focus: color.adjust($link, $lightness: 10%) !default;

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -220,7 +220,6 @@ body {
 }
 
 body {
-	background: #f0f0f1;
 	color: #3c434a;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	font-size: 13px;

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -242,7 +242,6 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
-	border: 1px solid #151515;
 }
 
 .welcome-panel-header {

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -242,6 +242,7 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
+	border: 1px solid #151515;
 }
 
 .welcome-panel-header {


### PR DESCRIPTION
This is related to https://core.trac.wordpress.org/ticket/62831.

I noticed that the white background was removing the background difference between the welcome panel (the section with a white background).

![1-welcome-without-border](https://github.com/user-attachments/assets/e47f3274-59f7-4042-acc0-dafb58656a41)

While it doesn't look shocking to me, this PR also adds a border to the welcome widget.

![2-welcome-with-black-border](https://github.com/user-attachments/assets/5cbd7466-39b0-432b-9795-299001d8e777)

This is the only issue I found while testing this changeset.
More tests are welcome!