### PR TITLE
Set registry paths before loading plugin/theme

### DIFF
--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -525,6 +525,17 @@ require_once ABSPATH . 'wp-admin/includes/plugin.php';
 foreach ( wp_get_active_and_valid_plugins() as $plugin ) {
 	wp_register_plugin_realpath( $plugin );
 
+	$plugin_data = get_plugin_data( $plugin, false, false );
+
+	$textdomain = $plugin_data['TextDomain'];
+	if ( $textdomain ) {
+		if ( $plugin_data['DomainPath'] ) {
+			$GLOBALS['wp_textdomain_registry']->set_custom_path( $textdomain, dirname( $plugin ) . $plugin_data['DomainPath'] );
+		} else {
+			$GLOBALS['wp_textdomain_registry']->set_custom_path( $textdomain, dirname( $plugin ) );
+		}
+	}
+
 	$_wp_plugin_file = $plugin;
 	include_once $plugin;
 	$plugin = $_wp_plugin_file; // Avoid stomping of the $plugin variable in a plugin.
@@ -537,17 +548,6 @@ foreach ( wp_get_active_and_valid_plugins() as $plugin ) {
 	 * @param string $plugin Full path to the plugin's main file.
 	 */
 	do_action( 'plugin_loaded', $plugin );
-
-	$plugin_data = get_plugin_data( $plugin, false, false );
-
-	$textdomain = $plugin_data['TextDomain'];
-	if ( $textdomain ) {
-		if ( $plugin_data['DomainPath'] ) {
-			$GLOBALS['wp_textdomain_registry']->set_custom_path( $textdomain, dirname( $plugin ) . $plugin_data['DomainPath'] );
-		} else {
-			$GLOBALS['wp_textdomain_registry']->set_custom_path( $textdomain, dirname( $plugin ) );
-		}
-	}
 }
 unset( $plugin, $_wp_plugin_file, $plugin_data, $textdomain );
 
@@ -684,11 +684,11 @@ $GLOBALS['wp_locale_switcher']->init();
 foreach ( wp_get_active_and_valid_themes() as $theme ) {
 	$wp_theme = wp_get_theme( basename( $theme ) );
 
+	$wp_theme->load_textdomain();
+
 	if ( file_exists( $theme . '/functions.php' ) ) {
 		include $theme . '/functions.php';
 	}
-
-	$wp_theme->load_textdomain();
 }
 unset( $theme, $wp_theme );
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

This is a follow-up to the original implementation.

```
I18N: Set textdomain registry information before loading plugins/theme.

This way, warnings for early translation calls can be emitted that aren't attached to any hook.

Follow-up to [59461].

Props swissspidy.
Fixes #62244. See #44937.
```

Trac ticket: https://core.trac.wordpress.org/ticket/62244

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
