### PR TITLE
Remove and replace title attributes from theme list tables

### DIFF
--- a/src/wp-admin/includes/class-wp-theme-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-theme-install-list-table.php
@@ -315,7 +315,7 @@ class WP_Theme_Install_List_Table extends WP_Themes_List_Table {
 		switch ( $status ) {
 			case 'update_available':
 				$actions[] = sprintf(
-					'<a class="install-now" href="%s" title="%s">%s</a>',
+					'<a class="install-now" href="%s" aria-label="%s">%s</a>',
 					esc_url( wp_nonce_url( $update_url, 'upgrade-theme_' . $theme->slug ) ),
 					/* translators: %s: Theme version. */
 					esc_attr( sprintf( __( 'Update to version %s' ), $theme->version ) ),
@@ -325,15 +325,14 @@ class WP_Theme_Install_List_Table extends WP_Themes_List_Table {
 			case 'newer_installed':
 			case 'latest_installed':
 				$actions[] = sprintf(
-					'<span class="install-now" title="%s">%s</span>',
-					esc_attr__( 'This theme is already installed and is up to date' ),
+					'<span class="install-now">%s</span>',
 					_x( 'Installed', 'theme' )
 				);
 				break;
 			case 'install':
 			default:
 				$actions[] = sprintf(
-					'<a class="install-now" href="%s" title="%s">%s</a>',
+					'<a class="install-now" href="%s" aria-label="%s">%s</a>',
 					esc_url( wp_nonce_url( $install_url, 'install-theme_' . $theme->slug ) ),
 					/* translators: %s: Theme name. */
 					esc_attr( sprintf( _x( 'Install %s', 'theme' ), $name ) ),
@@ -343,10 +342,9 @@ class WP_Theme_Install_List_Table extends WP_Themes_List_Table {
 		}
 
 		$actions[] = sprintf(
-			'<a class="install-theme-preview" href="%s" title="%s">%s</a>',
+			'<a class="install-theme-preview" href="%s" aria-label="%s">%s</a>',
 			esc_url( $preview_url ),
-			/* translators: %s: Theme name. */
-			esc_attr( sprintf( __( 'Preview %s' ), $name ) ),
+			esc_attr( $preview_title ),
 			__( 'Preview' )
 		);
 
@@ -363,7 +361,7 @@ class WP_Theme_Install_List_Table extends WP_Themes_List_Table {
 		$actions = apply_filters( 'theme_install_actions', $actions, $theme );
 
 		?>
-		<a class="screenshot install-theme-preview" href="<?php echo esc_url( $preview_url ); ?>" title="<?php echo esc_attr( $preview_title ); ?>">
+		<a class="screenshot install-theme-preview" href="<?php echo esc_url( $preview_url ); ?>" aria-label="<?php echo esc_attr( $preview_title ); ?>">
 			<img src="<?php echo esc_url( $theme->screenshot_url . '?ver=' . $theme->version ); ?>" width="150" alt="" />
 		</a>
 
@@ -474,7 +472,7 @@ class WP_Theme_Install_List_Table extends WP_Themes_List_Table {
 		switch ( $status ) {
 			case 'update_available':
 				printf(
-					'<a class="theme-install button button-primary" href="%s" title="%s">%s</a>',
+					'<a class="theme-install button button-primary" href="%s" aria-label="%s">%s</a>',
 					esc_url( wp_nonce_url( $update_url, 'upgrade-theme_' . $theme->slug ) ),
 					/* translators: %s: Theme version. */
 					esc_attr( sprintf( __( 'Update to version %s' ), $theme->version ) ),
@@ -484,8 +482,7 @@ class WP_Theme_Install_List_Table extends WP_Themes_List_Table {
 			case 'newer_installed':
 			case 'latest_installed':
 				printf(
-					'<span class="theme-install" title="%s">%s</span>',
-					esc_attr__( 'This theme is already installed and is up to date' ),
+					'<span class="theme-install">%s</span>',
 					_x( 'Installed', 'theme' )
 				);
 				break;

--- a/src/wp-admin/includes/class-wp-themes-list-table.php
+++ b/src/wp-admin/includes/class-wp-themes-list-table.php
@@ -211,7 +211,7 @@ class WP_Themes_List_Table extends WP_List_Table {
 
 			$actions             = array();
 			$actions['activate'] = sprintf(
-				'<a href="%s" class="activatelink" title="%s">%s</a>',
+				'<a href="%s" class="activatelink" aria-label="%s">%s</a>',
 				$activate_link,
 				/* translators: %s: Theme name. */
 				esc_attr( sprintf( _x( 'Activate &#8220;%s&#8221;', 'theme' ), $title ) ),


### PR DESCRIPTION
- Removes title attributes from `span` elements.
- Replaces `title` with `aria-label` for links whose visible text starts with the same word (in English). This is similar to links on the Add Plugins screen.
- Reuses the `$preview_title` variable to keep ARIA labels consistent for both Preview links.

[Trac 62834](https://core.trac.wordpress.org/ticket/62834)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
