### PR TITLE
Show sidebar's description below its name in Customizer Widgets sidebar list

### DIFF
--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -733,7 +733,10 @@ final class WP_Customize_Widgets {
 				<p class="description">{description}</p>
 				<ul class="widget-area-select">
 					<% _.each( sidebars, function ( sidebar ){ %>
-						<li class="" data-id="<%- sidebar.id %>" title="<%- sidebar.description %>" tabindex="0"><%- sidebar.name %></li>
+						<li class="" data-id="<%- sidebar.id %>" tabindex="0">
+							<div><strong><%- sidebar.name %></strong></div>
+							<div><%- sidebar.description %></div>
+						</li>
 					<% }); %>
 				</ul>
 				<div class="move-widget-actions">


### PR DESCRIPTION
Option 1: Show sidebar name and description, and remove the `title` attribute.

![Name and description as visible text](https://github.com/user-attachments/assets/37875c76-d2f9-455b-a994-f40c7e681389)

[Trac 62836](https://core.trac.wordpress.org/ticket/62836)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
