### PR TITLE
Remove title attribute from Customizer widget area selection list

### DIFF
--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -733,7 +733,7 @@ final class WP_Customize_Widgets {
 				<p class="description">{description}</p>
 				<ul class="widget-area-select">
 					<% _.each( sidebars, function ( sidebar ){ %>
-						<li class="" data-id="<%- sidebar.id %>" title="<%- sidebar.description %>" tabindex="0"><%- sidebar.name %></li>
+						<li class="" data-id="<%- sidebar.id %>" tabindex="0"><%- sidebar.name %></li>
 					<% }); %>
 				</ul>
 				<div class="move-widget-actions">


### PR DESCRIPTION
Option 2: Remove the `title` attribute with sidebar description, and then the option only shows the sidebar name.

![Sidebar name only](https://github.com/user-attachments/assets/39e041fa-08d9-46b2-9755-38394037ab70)

[Trac 62836](https://core.trac.wordpress.org/ticket/62836)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
