### PR TITLE
Remove any `title` attribute from `the_shortlink()`

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -4247,11 +4247,12 @@ function wp_shortlink_header() {
  * Call like the_shortlink( __( 'Shortlinkage FTW' ) )
  *
  * @since 3.0.0
+ * @since 6.8.0 Removed title attribute.
  *
- * @param string $text   Optional The link text or HTML to be displayed. Defaults to 'This is the short link.'
- * @param string $title  Optional The tooltip for the link. Must be sanitized. Defaults to the sanitized post title.
- * @param string $before Optional HTML to display before the link. Default empty.
- * @param string $after  Optional HTML to display after the link. Default empty.
+ * @param string $text   Optional. The link text or HTML to be displayed. Defaults to 'This is the short link.'
+ * @param string $title  Unused.
+ * @param string $before Optional. HTML to display before the link. Default empty.
+ * @param string $after  Optional. HTML to display after the link. Default empty.
  */
 function the_shortlink( $text = '', $title = '', $before = '', $after = '' ) {
 	$post = get_post();
@@ -4260,14 +4261,10 @@ function the_shortlink( $text = '', $title = '', $before = '', $after = '' ) {
 		$text = __( 'This is the short link.' );
 	}
 
-	if ( empty( $title ) ) {
-		$title = the_title_attribute( array( 'echo' => false ) );
-	}
-
 	$shortlink = wp_get_shortlink( $post->ID );
 
 	if ( ! empty( $shortlink ) ) {
-		$link = '<a rel="shortlink" href="' . esc_url( $shortlink ) . '" title="' . $title . '">' . $text . '</a>';
+		$link = '<a rel="shortlink" href="' . esc_url( $shortlink ) . '">' . $text . '</a>';
 
 		/**
 		 * Filters the short link anchor tag for a post.
@@ -4277,7 +4274,7 @@ function the_shortlink( $text = '', $title = '', $before = '', $after = '' ) {
 		 * @param string $link      Shortlink anchor tag.
 		 * @param string $shortlink Shortlink URL.
 		 * @param string $text      Shortlink's text.
-		 * @param string $title     Shortlink's title attribute.
+		 * @param string $title     Shortlink's title attribute. Unused.
 		 */
 		$link = apply_filters( 'the_shortlink', $link, $shortlink, $text, $title );
 		echo $before, $link, $after;

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -4270,11 +4270,12 @@ function the_shortlink( $text = '', $title = '', $before = '', $after = '' ) {
 		 * Filters the short link anchor tag for a post.
 		 *
 		 * @since 3.0.0
+		 * @since 6.8.0 Removed title attribute.
 		 *
 		 * @param string $link      Shortlink anchor tag.
 		 * @param string $shortlink Shortlink URL.
 		 * @param string $text      Shortlink's text.
-		 * @param string $title     Shortlink's title attribute. Unused.
+		 * @param string $title     Unused.
 		 */
 		$link = apply_filters( 'the_shortlink', $link, $shortlink, $text, $title );
 		echo $before, $link, $after;

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -4270,12 +4270,11 @@ function the_shortlink( $text = '', $title = '', $before = '', $after = '' ) {
 		 * Filters the short link anchor tag for a post.
 		 *
 		 * @since 3.0.0
-		 * @since 6.8.0 Removed title attribute.
 		 *
 		 * @param string $link      Shortlink anchor tag.
 		 * @param string $shortlink Shortlink URL.
 		 * @param string $text      Shortlink's text.
-		 * @param string $title     Unused.
+		 * @param string $title     Shortlink's title attribute. Unused.
 		 */
 		$link = apply_filters( 'the_shortlink', $link, $shortlink, $text, $title );
 		echo $before, $link, $after;


### PR DESCRIPTION
Option 1: Removes **any** `title` attribute from the shortlink output, and updates documentation.

[Trac 62838](https://core.trac.wordpress.org/ticket/62838)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
