### PR TITLE
Remove the default `title` attribute from `the_shortlink()`

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -4247,11 +4247,12 @@ function wp_shortlink_header() {
  * Call like the_shortlink( __( 'Shortlinkage FTW' ) )
  *
  * @since 3.0.0
+ * @since 6.8.0 Removed default title attribute.
  *
- * @param string $text   Optional The link text or HTML to be displayed. Defaults to 'This is the short link.'
- * @param string $title  Optional The tooltip for the link. Must be sanitized. Defaults to the sanitized post title.
- * @param string $before Optional HTML to display before the link. Default empty.
- * @param string $after  Optional HTML to display after the link. Default empty.
+ * @param string $text   Optional. The link text or HTML to be displayed. Defaults to 'This is the short link.'
+ * @param string $title  Optional. The tooltip for the link. Must be sanitized. Defaults empty.
+ * @param string $before Optional. HTML to display before the link. Default empty.
+ * @param string $after  Optional. HTML to display after the link. Default empty.
  */
 function the_shortlink( $text = '', $title = '', $before = '', $after = '' ) {
 	$post = get_post();
@@ -4260,14 +4261,15 @@ function the_shortlink( $text = '', $title = '', $before = '', $after = '' ) {
 		$text = __( 'This is the short link.' );
 	}
 
-	if ( empty( $title ) ) {
-		$title = the_title_attribute( array( 'echo' => false ) );
-	}
-
 	$shortlink = wp_get_shortlink( $post->ID );
 
 	if ( ! empty( $shortlink ) ) {
-		$link = '<a rel="shortlink" href="' . esc_url( $shortlink ) . '" title="' . $title . '">' . $text . '</a>';
+		$link = sprintf(
+			'<a rel="shortlink" href="%1$s"%2$s>%3$s</a>',
+			esc_url( $shortlink ),
+			empty( $title ) ? '' : ' title="' . $title .'"',
+			$text
+		);
 
 		/**
 		 * Filters the short link anchor tag for a post.

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -4250,7 +4250,7 @@ function wp_shortlink_header() {
  * @since 6.8.0 Removed default title attribute.
  *
  * @param string $text   Optional. The link text or HTML to be displayed. Defaults to 'This is the short link.'
- * @param string $title  Optional. The tooltip for the link. Must be sanitized. Defaults empty.
+ * @param string $title  Optional. The tooltip for the link. Must be sanitized. Default empty.
  * @param string $before Optional. HTML to display before the link. Default empty.
  * @param string $after  Optional. HTML to display after the link. Default empty.
  */

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -4267,7 +4267,7 @@ function the_shortlink( $text = '', $title = '', $before = '', $after = '' ) {
 		$link = sprintf(
 			'<a rel="shortlink" href="%1$s"%2$s>%3$s</a>',
 			esc_url( $shortlink ),
-			empty( $title ) ? '' : ' title="' . $title .'"',
+			empty( $title ) ? '' : ' title="' . $title . '"',
 			$text
 		);
 


### PR DESCRIPTION
Option 2: Removes only the **default** `title` attribute from the shortlink.

[Trac 62838](https://core.trac.wordpress.org/ticket/62838)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
