### PR TITLE
 Update playwright - 6.5 branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -103,7 +103,7 @@
 			},
 			"devDependencies": {
 				"@lodder/grunt-postcss": "^3.1.1",
-				"@playwright/test": "1.32.0",
+				"@playwright/test": "1.49.1",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@wordpress/babel-preset-default": "7.35.1",
 				"@wordpress/dependency-extraction-webpack-plugin": "5.2.1",
@@ -3663,22 +3663,19 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.0.tgz",
-			"integrity": "sha512-zOdGloaF0jeec7hqoLqM5S3L2rR4WxMJs6lgiAeR70JlH7Ml54ZPoIIf3X7cvnKde3Q9jJ/gaxkFh8fYI9s1rg==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
+			"integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@types/node": "*",
-				"playwright-core": "1.32.0"
+				"playwright": "1.49.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=14"
-			},
-			"optionalDependencies": {
-				"fsevents": "2.3.2"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -26023,16 +26020,36 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/playwright-core": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.0.tgz",
-			"integrity": "sha512-Z9Ij17X5Z3bjpp6XKujGBp9Gv4eViESac9aDmwgQFUEJBW0K80T21m/Z+XJQlu4cNsvPygw33b6V1Va6Bda5zQ==",
+		"node_modules/playwright": {
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+			"integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
 			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.49.1"
+			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+			"integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/plur": {
@@ -35778,14 +35795,12 @@
 			"dev": true
 		},
 		"@playwright/test": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.0.tgz",
-			"integrity": "sha512-zOdGloaF0jeec7hqoLqM5S3L2rR4WxMJs6lgiAeR70JlH7Ml54ZPoIIf3X7cvnKde3Q9jJ/gaxkFh8fYI9s1rg==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
+			"integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
 			"dev": true,
 			"requires": {
-				"@types/node": "*",
-				"fsevents": "2.3.2",
-				"playwright-core": "1.32.0"
+				"playwright": "1.49.1"
 			}
 		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
@@ -52728,10 +52743,20 @@
 				}
 			}
 		},
+		"playwright": {
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+			"integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+			"dev": true,
+			"requires": {
+				"fsevents": "2.3.2",
+				"playwright-core": "1.49.1"
+			}
+		},
 		"playwright-core": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.0.tgz",
-			"integrity": "sha512-Z9Ij17X5Z3bjpp6XKujGBp9Gv4eViESac9aDmwgQFUEJBW0K80T21m/Z+XJQlu4cNsvPygw33b6V1Va6Bda5zQ==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+			"integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
 			"dev": true
 		},
 		"plur": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	],
 	"devDependencies": {
 		"@lodder/grunt-postcss": "^3.1.1",
-		"@playwright/test": "1.32.0",
+		"@playwright/test": "1.49.1",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@wordpress/babel-preset-default": "7.35.1",
 		"@wordpress/dependency-extraction-webpack-plugin": "5.2.1",


### PR DESCRIPTION
The E2E and Performance testing workflows have started failing recently for branches using Playwright. This seems to be due to the change for `ubuntu-latest` to now point to `ubuntu-24` instead of `ubuntu-22`.

Updating Playwright to the latest version seems to fix the issue with no obvious side effects. Since this only effects build tooling and not the built software, this seems like a reasonable change to make in a somewhat older branch.

- [6.5 branch failing E2E workflow](https://github.com/WordPress/wordpress-develop/actions/runs/12890525253/attempts/2)
- [6.5 failing performance workflow](https://github.com/WordPress/wordpress-develop/actions/runs/12890525300/attempts/2)

See also #8169, #8164, #8164, #8171.

Trac ticket: https://core.trac.wordpress.org/ticket/62843

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
