### PR TITLE
Update playwright - 6.4 branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,7 @@
 			},
 			"devDependencies": {
 				"@lodder/grunt-postcss": "^3.1.1",
-				"@playwright/test": "1.32.0",
+				"@playwright/test": "1.49.1",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.5",
 				"@wordpress/babel-preset-default": "7.26.13",
 				"@wordpress/dependency-extraction-webpack-plugin": "4.25.13",
@@ -3741,22 +3741,19 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.0.tgz",
-			"integrity": "sha512-zOdGloaF0jeec7hqoLqM5S3L2rR4WxMJs6lgiAeR70JlH7Ml54ZPoIIf3X7cvnKde3Q9jJ/gaxkFh8fYI9s1rg==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
+			"integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@types/node": "*",
-				"playwright-core": "1.32.0"
+				"playwright": "1.49.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
 			},
 			"engines": {
-				"node": ">=14"
-			},
-			"optionalDependencies": {
-				"fsevents": "2.3.2"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -26652,6 +26649,25 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/playwright": {
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+			"integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.49.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
 		"node_modules/playwright-core": {
 			"version": "1.32.0",
 			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.0.tgz",
@@ -26662,6 +26678,19 @@
 			},
 			"engines": {
 				"node": ">=14"
+			}
+		},
+		"node_modules/playwright/node_modules/playwright-core": {
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+			"integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/plur": {
@@ -36734,14 +36763,12 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.32.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.0.tgz",
-			"integrity": "sha512-zOdGloaF0jeec7hqoLqM5S3L2rR4WxMJs6lgiAeR70JlH7Ml54ZPoIIf3X7cvnKde3Q9jJ/gaxkFh8fYI9s1rg==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
+			"integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
 			"dev": true,
 			"requires": {
-				"@types/node": "*",
-				"fsevents": "2.3.2",
-				"playwright-core": "1.32.0"
+				"playwright": "1.49.1"
 			}
 		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
@@ -54084,6 +54111,24 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				}
+			}
+		},
+		"playwright": {
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+			"integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+			"dev": true,
+			"requires": {
+				"fsevents": "2.3.2",
+				"playwright-core": "1.49.1"
+			},
+			"dependencies": {
+				"playwright-core": {
+					"version": "1.49.1",
+					"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+					"integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
 					"dev": true
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	],
 	"devDependencies": {
 		"@lodder/grunt-postcss": "^3.1.1",
-		"@playwright/test": "1.32.0",
+		"@playwright/test": "1.49.1",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.5",
 		"@wordpress/babel-preset-default": "7.26.13",
 		"@wordpress/dependency-extraction-webpack-plugin": "4.25.13",


### PR DESCRIPTION
The E2E and Performance testing workflows have started failing recently for branches using Playwright. This seems to be due to the change for `ubuntu-latest` to now point to `ubuntu-24` instead of `ubuntu-22`.

Updating Playwright to the latest version seems to fix the issue with no obvious side effects. Since this only effects build tooling and not the built software, this seems like a reasonable change to make in a somewhat older branch.

- [6.4 branch failing E2E workflow](https://github.com/WordPress/wordpress-develop/actions/runs/12890525150/attempts/2)
- [6.4 failing performance workflow](https://github.com/WordPress/wordpress-develop/actions/runs/12890525256/attempts/2)

See also #8169, #8163, #8170, #8171.

Trac ticket: https://core.trac.wordpress.org/ticket/62843

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
