### PR TITLE
docs(get_category()): Changed PHPDoc for return and added more information

### DIFF
--- a/src/wp-includes/category.php
+++ b/src/wp-includes/category.php
@@ -86,7 +86,7 @@ function get_categories( $args = '' ) {
  *                             respectively. Default OBJECT.
  * @param string     $filter   Optional. How to sanitize category fields. Default 'raw'.
  * @return WP_Term|array|WP_Error|null Category data in type defined by $output parameter.
- *                                     WP_Term will come with backwards compatible property aliases filled in.
+ *                                     Returns a WP_Term object with backwards compatible property aliases filled in.
  *                                     WP_Error if $category is empty, null if it does not exist.
  */
 function get_category( $category, $output = OBJECT, $filter = 'raw' ) {

--- a/src/wp-includes/category.php
+++ b/src/wp-includes/category.php
@@ -85,8 +85,9 @@ function get_categories( $args = '' ) {
  *                             correspond to a WP_Term object, an associative array, or a numeric array,
  *                             respectively. Default OBJECT.
  * @param string     $filter   Optional. How to sanitize category fields. Default 'raw'.
- * @return object|array|WP_Error|null Category data in type defined by $output parameter.
- *                                    WP_Error if $category is empty, null if it does not exist.
+ * @return WP_Term|array|WP_Error|null Category data in type defined by $output parameter.
+ *                                     WP_Term will come with backwards compatible property aliases filled in.
+ *                                     WP_Error if $category is empty, null if it does not exist.
  */
 function get_category( $category, $output = OBJECT, $filter = 'raw' ) {
 	$category = get_term( $category, 'category', $output, $filter );


### PR DESCRIPTION
Added more details that WP_Term will have additional backwards compatible aliases for the era before WP 4.4 and 2.3


Trac ticket: https://core.trac.wordpress.org/ticket/62842#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
