### PR TITLE
Update Playwright - 6.6 branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -103,7 +103,7 @@
 			},
 			"devDependencies": {
 				"@lodder/grunt-postcss": "^3.1.1",
-				"@playwright/test": "1.45.0",
+				"@playwright/test": "1.49.1",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.15",
 				"@wordpress/babel-preset-default": "8.0.1",
 				"@wordpress/dependency-extraction-webpack-plugin": "6.0.2",
@@ -3648,12 +3648,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.0.tgz",
-			"integrity": "sha512-TVYsfMlGAaxeUllNkywbwek67Ncf8FRGn8ZlRdO291OL3NjG9oMbfVhyP82HQF0CZLMrYsvesqoUekxdWuF9Qw==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
+			"integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.45.0"
+				"playwright": "1.49.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -26917,12 +26918,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.0.tgz",
-			"integrity": "sha512-4z3ac3plDfYzGB6r0Q3LF8POPR20Z8D0aXcxbJvmfMgSSq1hkcgvFRXJk9rUq5H/MJ0Ktal869hhOdI/zUTeLA==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+			"integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.45.0"
+				"playwright-core": "1.49.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -26935,10 +26937,11 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.0.tgz",
-			"integrity": "sha512-lZmHlFQ0VYSpAs43dRq1/nJ9G/6SiTI7VPqidld9TDefL9tX87bTKExWZZUF5PeRyqtXqd8fQi2qmfIedkwsNQ==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+			"integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"playwright-core": "cli.js"
 			},
@@ -36872,12 +36875,12 @@
 			"dev": true
 		},
 		"@playwright/test": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.0.tgz",
-			"integrity": "sha512-TVYsfMlGAaxeUllNkywbwek67Ncf8FRGn8ZlRdO291OL3NjG9oMbfVhyP82HQF0CZLMrYsvesqoUekxdWuF9Qw==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
+			"integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
 			"dev": true,
 			"requires": {
-				"playwright": "1.45.0"
+				"playwright": "1.49.1"
 			}
 		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
@@ -54380,19 +54383,19 @@
 			}
 		},
 		"playwright": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.0.tgz",
-			"integrity": "sha512-4z3ac3plDfYzGB6r0Q3LF8POPR20Z8D0aXcxbJvmfMgSSq1hkcgvFRXJk9rUq5H/MJ0Ktal869hhOdI/zUTeLA==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+			"integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
 			"dev": true,
 			"requires": {
 				"fsevents": "2.3.2",
-				"playwright-core": "1.45.0"
+				"playwright-core": "1.49.1"
 			}
 		},
 		"playwright-core": {
-			"version": "1.45.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.0.tgz",
-			"integrity": "sha512-lZmHlFQ0VYSpAs43dRq1/nJ9G/6SiTI7VPqidld9TDefL9tX87bTKExWZZUF5PeRyqtXqd8fQi2qmfIedkwsNQ==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+			"integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
 			"dev": true
 		},
 		"plur": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	],
 	"devDependencies": {
 		"@lodder/grunt-postcss": "^3.1.1",
-		"@playwright/test": "1.49.0",
+		"@playwright/test": "1.49.1",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.15",
 		"@wordpress/babel-preset-default": "8.0.1",
 		"@wordpress/dependency-extraction-webpack-plugin": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	],
 	"devDependencies": {
 		"@lodder/grunt-postcss": "^3.1.1",
-		"@playwright/test": "1.45.0",
+		"@playwright/test": "1.49.1",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.15",
 		"@wordpress/babel-preset-default": "8.0.1",
 		"@wordpress/dependency-extraction-webpack-plugin": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	],
 	"devDependencies": {
 		"@lodder/grunt-postcss": "^3.1.1",
-		"@playwright/test": "1.49.1",
+		"@playwright/test": "1.49.0",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.15",
 		"@wordpress/babel-preset-default": "8.0.1",
 		"@wordpress/dependency-extraction-webpack-plugin": "6.0.2",


### PR DESCRIPTION
The E2E and Performance testing workflows have started failing recently for branches using Playwright. This seems to be due to the change for `ubuntu-latest` to now point to `ubuntu-24` instead of `ubuntu-22`.

Updating Playwright to the latest version seems to fix the issue with no obvious side effects. Since this only effects build tooling and not the built software, this seems like a reasonable change to make in a somewhat older branch.

This updates the 6.6 branch so that older versions are not more up to date.

Trac ticket: https://core.trac.wordpress.org/ticket/62843

See also #8169, #8163, #8164, #8171.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
