### PR TITLE
#62221 Ensure `context.runId` is always coerced to a string

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -107,6 +107,6 @@ jobs:
               workflow_id: 'failed-workflow.yml',
               ref: 'trunk',
               inputs: {
-                run_id: context.runId,
+                run_id: `${context.runId}`,
               }
             });

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -93,6 +93,6 @@ jobs:
               workflow_id: 'failed-workflow.yml',
               ref: 'trunk',
               inputs: {
-                run_id: context.runId,
+                run_id: `${context.runId}`,
               }
             });

--- a/.github/workflows/install-testing.yml
+++ b/.github/workflows/install-testing.yml
@@ -179,6 +179,6 @@ jobs:
               workflow_id: 'failed-workflow.yml',
               ref: 'trunk',
               inputs: {
-                run_id: context.runId,
+                run_id: `${context.runId}`,
               }
             });

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -97,6 +97,6 @@ jobs:
               workflow_id: 'failed-workflow.yml',
               ref: 'trunk',
               inputs: {
-                run_id: context.runId,
+                run_id: `${context.runId}`,
               }
             });

--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -150,6 +150,6 @@ jobs:
               workflow_id: 'failed-workflow.yml',
               ref: 'trunk',
               inputs: {
-                run_id: context.runId,
+                run_id: `${context.runId}`,
               }
             });

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -93,6 +93,6 @@ jobs:
               workflow_id: 'failed-workflow.yml',
               ref: 'trunk',
               inputs: {
-                run_id: context.runId,
+                run_id: `${context.runId}`,
               }
             });

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -94,6 +94,6 @@ jobs:
               workflow_id: 'failed-workflow.yml',
               ref: 'trunk',
               inputs: {
-                run_id: context.runId,
+                run_id: `${context.runId}`,
               }
             });

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -263,6 +263,6 @@ jobs:
               workflow_id: 'failed-workflow.yml',
               ref: 'trunk',
               inputs: {
-                run_id: context.runId,
+                run_id: `${context.runId}`,
               }
             });

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -68,7 +68,7 @@ jobs:
             const workflow_run = await github.rest.actions.getWorkflowRun({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              run_id: context.runId,
+              run_id: `${context.runId}`,
             });
 
             if ( process.env.CALLING_STATUS == 'failure' && workflow_run.data.run_attempt == 1 ) {
@@ -82,7 +82,7 @@ jobs:
               const previous_run = await github.rest.actions.getWorkflowRunAttempt({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                run_id: context.runId,
+                run_id: `${context.runId}`,
                 attempt_number: workflow_run.data.run_attempt - 1
               });
 

--- a/.github/workflows/test-and-zip-default-themes.yml
+++ b/.github/workflows/test-and-zip-default-themes.yml
@@ -246,6 +246,6 @@ jobs:
               workflow_id: 'failed-workflow.yml',
               ref: 'trunk',
               inputs: {
-                run_id: '${{ github.run_id }}'
+                run_id: `${context.runId}`,
               }
             });

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -160,6 +160,6 @@ jobs:
               workflow_id: 'failed-workflow.yml',
               ref: 'trunk',
               inputs: {
-                run_id: '${{ github.run_id }}'
+                run_id: `${context.runId}`,
               }
             });

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -110,6 +110,6 @@ jobs:
               workflow_id: 'failed-workflow.yml',
               ref: 'trunk',
               inputs: {
-                run_id: '${{ github.run_id }}'
+                run_id: `${context.runId}`,
               }
             });

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -312,6 +312,6 @@ jobs:
               workflow_id: 'failed-workflow.yml',
               ref: 'trunk',
               inputs: {
-                run_id: '${{ github.run_id }}'
+                run_id: `${context.runId}`,
               }
             });


### PR DESCRIPTION
`context.runId` is an integer, which doesn't seem to be accepted for the `run_id` input in the `failed-workflow.yml` workflow. This fixes that, and also updates two missed instances of inline expressions.

Trac ticket: https://core.trac.wordpress.org/ticket/62221