### PR TITLE
This diff introduces a subtle but important shift in how WordPress ha…

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2517,7 +2517,7 @@ function the_date_xml() {
 }
 
 /**
- * Displays or retrieves the date the current post was written (once per date)
+ * Displays or retrieves the date of the post (once per date)
  *
  * Will only output the date if the current post's date is different from the
  * previous one output.
@@ -2550,7 +2550,7 @@ function the_date( $format = '', $before = '', $after = '', $display = true ) {
 	}
 
 	/**
-	 * Filters the date a post was published for display.
+	 * Filters the date of the post for display.
 	 *
 	 * @since 0.71
 	 *
@@ -2569,7 +2569,7 @@ function the_date( $format = '', $before = '', $after = '', $display = true ) {
 }
 
 /**
- * Retrieves the date on which the post was written.
+ * Retrieves the date of the post.
  *
  * Unlike the_date() this function will always return the date.
  * Modify output with the {@see 'get_the_date'} filter.
@@ -2592,7 +2592,7 @@ function get_the_date( $format = '', $post = null ) {
 	$the_date = get_post_time( $_format, false, $post, true );
 
 	/**
-	 * Filters the date a post was published.
+	 * Filters the date of the post.
 	 *
 	 * @since 3.0.0
 	 *
@@ -2672,7 +2672,7 @@ function get_the_modified_date( $format = '', $post = null ) {
 }
 
 /**
- * Displays the time at which the post was written.
+ * Displays the date of the post.
  *
  * @since 0.71
  *
@@ -2682,7 +2682,7 @@ function get_the_modified_date( $format = '', $post = null ) {
  */
 function the_time( $format = '' ) {
 	/**
-	 * Filters the time a post was written for display.
+	 * Filters the date of the post display.
 	 *
 	 * @since 0.71
 	 *
@@ -2694,7 +2694,7 @@ function the_time( $format = '' ) {
 }
 
 /**
- * Retrieves the time at which the post was written.
+ * Retrieves the date of the post.
  *
  * @since 1.5.0
  *
@@ -2717,7 +2717,7 @@ function get_the_time( $format = '', $post = null ) {
 	$the_time = get_post_time( $_format, false, $post, true );
 
 	/**
-	 * Filters the time a post was written.
+	 * Filters the date of the post.
 	 *
 	 * @since 1.5.0
 	 *
@@ -2730,12 +2730,12 @@ function get_the_time( $format = '', $post = null ) {
 }
 
 /**
- * Retrieves the time at which the post was written.
+ * Retrieves the localized date of the post.
  *
  * @since 2.0.0
  *
- * @param string      $format    Optional. Format to use for retrieving the time the post
- *                               was written. Accepts 'G', 'U', or PHP date format. Default 'U'.
+ * @param string      $format    Optional. Format to use for retrieving the time the post.
+ *                               Accepts 'G', 'U', or PHP date format. Default 'U'.
  * @param bool        $gmt       Optional. Whether to retrieve the GMT time. Default false.
  * @param int|WP_Post $post      Post ID or post object. Default is global `$post` object.
  * @param bool        $translate Whether to translate the time string. Default false.
@@ -2774,12 +2774,12 @@ function get_post_time( $format = 'U', $gmt = false, $post = null, $translate = 
 	}
 
 	/**
-	 * Filters the localized time a post was written.
+	 * Filters the localized date of the post.
 	 *
 	 * @since 2.6.0
 	 *
 	 * @param string|int $time   Formatted date string or Unix timestamp if `$format` is 'U' or 'G'.
-	 * @param string     $format Format to use for retrieving the time the post was written.
+	 * @param string     $format Format to use for retrieving the time the post.
 	 *                           Accepts 'G', 'U', or PHP date format.
 	 * @param bool       $gmt    Whether to retrieve the GMT time.
 	 */
@@ -2976,7 +2976,7 @@ function get_post_modified_time( $format = 'U', $gmt = false, $post = null, $tra
 }
 
 /**
- * Displays the weekday on which the post was written.
+ * Displays the weekday for the post.
  *
  * @since 0.71
  *
@@ -2994,7 +2994,7 @@ function the_weekday() {
 	$the_weekday = $wp_locale->get_weekday( get_post_time( 'w', false, $post ) );
 
 	/**
-	 * Filters the weekday on which the post was written, for display.
+	 * Filters the weekday of the post, for display.
 	 *
 	 * @since 0.71
 	 *
@@ -3004,19 +3004,20 @@ function the_weekday() {
 }
 
 /**
- * Displays the weekday on which the post was written.
+ * Displays the localized weekday date for the post
  *
  * Will only output the weekday if the current post's weekday is different from
  * the previous one output.
  *
  * @since 0.71
  *
- * @global WP_Locale $wp_locale       WordPress date and time locale object.
- * @global string    $currentday      The day of the current post in the loop.
- * @global string    $previousweekday The day of the previous post in the loop.
- *
  * @param string $before Optional. Output before the date. Default empty.
  * @param string $after  Optional. Output after the date. Default empty.
+ *
+ *@global string    $previousweekday The day of the previous post in the loop.
+ *
+ * @global WP_Locale $wp_locale       WordPress date and time locale object.
+ * @global string    $currentday      The day of the current post in the loop.
  */
 function the_weekday_date( $before = '', $after = '' ) {
 	global $wp_locale, $currentday, $previousweekday;
@@ -3037,7 +3038,7 @@ function the_weekday_date( $before = '', $after = '' ) {
 	}
 
 	/**
-	 * Filters the localized date on which the post was written, for display.
+	 * Filters the localized weekday date of the post, for display.
 	 *
 	 * @since 0.71
 	 *

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2517,7 +2517,7 @@ function the_date_xml() {
 }
 
 /**
- * Displays or retrieves the date of the post (once per date)
+ * Displays or retrieves the date of the post (once per date).
  *
  * Will only output the date if the current post's date is different from the
  * previous one output.
@@ -2734,7 +2734,7 @@ function get_the_time( $format = '', $post = null ) {
  *
  * @since 2.0.0
  *
- * @param string      $format    Optional. Format to use for retrieving the time the post.
+ * @param string      $format    Optional. Format to use for retrieving the localized date of the post.
  *                               Accepts 'G', 'U', or PHP date format. Default 'U'.
  * @param bool        $gmt       Optional. Whether to retrieve the GMT time. Default false.
  * @param int|WP_Post $post      Post ID or post object. Default is global `$post` object.
@@ -3014,7 +3014,7 @@ function the_weekday() {
  * @param string $before Optional. Output before the date. Default empty.
  * @param string $after  Optional. Output after the date. Default empty.
  *
- *@global string    $previousweekday The day of the previous post in the loop.
+ * @global string $previousweekday The day of the previous post in the loop.
  *
  * @global WP_Locale $wp_locale       WordPress date and time locale object.
  * @global string    $currentday      The day of the current post in the loop.


### PR DESCRIPTION
…ndles dates and times associated with posts.  Instead of referring to the "date the post was written," the functions and filter descriptions now refer to the "date of the post."  This change likely reflects a move towards greater flexibility in how dates are used, accommodating scenarios where the displayed date might not strictly correspond to the writing date (e.g., scheduled posts, backdated posts, or content where the "date" represents something other than creation).

Here's a breakdown of the changes:

* **Function and Filter Descriptions:** Docblocks for `the_date()`, `get_the_date()`, `the_time()`, `get_the_time()`, `get_post_time()`, `the_weekday()`, and `the_weekday_date()` have been updated to reflect the new "date of the post" language.  The filters associated with these functions have also received corresponding updates.  This change is primarily semantic.

* **`get_post_time()` Docblock Update:**  The description for `get_post_time()` is also updated, clarifying that the `$format` parameter accepts standard PHP date formats or 'G' (Unix timestamp) or 'U' (seconds since the Unix Epoch).  The wording emphasizes that this function retrieves the *localized* date of the post.

The changes don't introduce new functionality or modify existing behavior.  They clarify the purpose of these functions and make the documentation more accurate and flexible.  The shift to "date of the post" acknowledges that the displayed date might have different meanings depending on the context.

Trac ticket: https://core.trac.wordpress.org/ticket/51289