### PR TITLE
#62221 Fix the previous conclusion value

### DIFF
--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           retries: 2
           retry-exempt-status-codes: 418
+          result-encoding: string
           script: |
             const workflow_run = await github.rest.actions.getWorkflowRun({
               owner: context.repo.owner,


### PR DESCRIPTION
## Why is this needed?

The output of the `previous-attempt-result` job is a JSON encoded string because [`actions/github-script` encodes output as JSON by default](https://github.com/actions/github-script?tab=readme-ov-file#result-encoding). This means the output is a string wrapped in double quotes, for example: `"first-failure"`.

This can be seen in a workflow run that has debugging enabled, for example [this workflow run](https://github.com/WordPress/wordpress-develop/actions/runs/12915574397/job/36018724686):

```
##[debug]Set output result = "failure"
```

Compare that to a job that uses `actions/github-script` to return an object:

```
##[debug]Set output payload = {"workflow_name":"Upgrade Tests" ...
```

Prior to [r59679](https://core.trac.wordpress.org/changeset/59679#file27) this was fine because the value was echoed to an output which means its surrounding double quotes lost their significance:

```
echo "previous_conclusion=${{ steps.previous-attempt-result.outputs.result }}" >> $GITHUB_OUTPUT
```

The change in [r59679](https://core.trac.wordpress.org/changeset/59679#file27) means the return value of the `previous-attempt-result` job is used directly in the `previous_conclusion` output, thus retaining its surrounding double quotes. Conditions in subsequent jobs such as `if: ${{ needs.prepare.outputs.previous_conclusion != 'first-failure'` are now broken because the `previous_conclusion` value is unexpectedly wrapped in double quotes and therefore don't match the conditions as expected.

This change fixes that so the conditions for the Slack notification jobs now work as expected again.

Trac ticket: https://core.trac.wordpress.org/ticket/62221