### PR TITLE
Customizer: Fix input field widths and alignment for date-time controls

### DIFF
--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -362,16 +362,15 @@ body.trashing #publish-settings {
 .date-time-fields .date-input.day,
 .date-time-fields .date-input.hour,
 .date-time-fields .date-input.minute {
-	width: 52px;
+	width: 46px;
 }
 
-.wp-core-ui .date-time-fields .day-fields.clear select,
-.wp-core-ui .date-time-fields .time-fields.clear select {
+.customize-control-date_time select {
 	vertical-align: top;
 }
 
 .date-time-fields .date-input.year {
-	width: 70px;
+	width: 65px;
 }
 
 .date-time-fields .date-input.meridian {

--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -362,7 +362,12 @@ body.trashing #publish-settings {
 .date-time-fields .date-input.day,
 .date-time-fields .date-input.hour,
 .date-time-fields .date-input.minute {
-	width: 46px;
+	width: 52px;
+}
+
+.wp-core-ui .date-time-fields .day-fields.clear select,
+.wp-core-ui .date-time-fields .time-fields.clear select {
+	vertical-align: top;
 }
 
 .date-time-fields .date-input.year {

--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -371,7 +371,7 @@ body.trashing #publish-settings {
 }
 
 .date-time-fields .date-input.year {
-	width: 65px;
+	width: 70px;
 }
 
 .date-time-fields .date-input.meridian {

--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -366,7 +366,7 @@ body.trashing #publish-settings {
 }
 
 .customize-control-date_time select {
-	vertical-align: top ;
+	vertical-align: top;
 }
 
 .date-time-fields .date-input.year {

--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -366,7 +366,7 @@ body.trashing #publish-settings {
 }
 
 .customize-control-date_time select {
-	vertical-align: top;
+	vertical-align: top ;
 }
 
 .date-time-fields .date-input.year {

--- a/src/wp-includes/customize/class-wp-customize-date-time-control.php
+++ b/src/wp-includes/customize/class-wp-customize-date-time-control.php
@@ -154,7 +154,7 @@ class WP_Customize_Date_Time_Control extends WP_Customize_Control {
 						esc_html_e( 'Day' );
 						?>
 					</label>
-					<input id="{{ idPrefix }}date-time-day" type="number" size="2" autocomplete="off" class="date-input day" data-component="day" min="1" max="31" />
+					<input id="{{ idPrefix }}date-time-day" type="number" size="2" autocomplete="off" class="date-input day tiny-text" data-component="day" min="1" max="31" />
 					<?php $day_field = trim( ob_get_clean() ); ?>
 
 					<?php ob_start(); ?>
@@ -164,7 +164,7 @@ class WP_Customize_Date_Time_Control extends WP_Customize_Control {
 						esc_html_e( 'Year' );
 						?>
 					</label>
-					<input id="{{ idPrefix }}date-time-year" type="number" size="4" autocomplete="off" class="date-input year" data-component="year" min="{{ data.minYear }}" max="{{ data.maxYear }}">
+					<input id="{{ idPrefix }}date-time-year" type="number" size="4" autocomplete="off" class="date-input year tiny-text" data-component="year" min="{{ data.minYear }}" max="{{ data.maxYear }}">
 					<?php $year_field = trim( ob_get_clean() ); ?>
 
 					<?php printf( $date_format, $year_field, $month_field, $day_field ); ?>
@@ -182,7 +182,7 @@ class WP_Customize_Date_Time_Control extends WP_Customize_Control {
 						</label>
 						<# var maxHour = data.twelveHourFormat ? 12 : 23; #>
 						<# var minHour = data.twelveHourFormat ? 1 : 0; #>
-						<input id="{{ idPrefix }}date-time-hour" type="number" size="2" autocomplete="off" class="date-input hour" data-component="hour" min="{{ minHour }}" max="{{ maxHour }}">
+						<input id="{{ idPrefix }}date-time-hour" type="number" size="2" autocomplete="off" class="date-input hour tiny-text" data-component="hour" min="{{ minHour }}" max="{{ maxHour }}">
 						:
 						<label for="{{ idPrefix }}date-time-minute" class="screen-reader-text">
 							<?php
@@ -190,7 +190,7 @@ class WP_Customize_Date_Time_Control extends WP_Customize_Control {
 							esc_html_e( 'Minute' );
 							?>
 						</label>
-						<input id="{{ idPrefix }}date-time-minute" type="number" size="2" autocomplete="off" class="date-input minute" data-component="minute" min="0" max="59">
+						<input id="{{ idPrefix }}date-time-minute" type="number" size="2" autocomplete="off" class="date-input minute tiny-text" data-component="minute" min="0" max="59">
 						<# if ( data.twelveHourFormat ) { #>
 							<label for="{{ idPrefix }}date-time-meridian" class="screen-reader-text">
 								<?php


### PR DESCRIPTION
Trac ticket: [#51249](https://core.trac.wordpress.org/ticket/51249)

## What
- Increased the width of date-time input fields from 46px to 52px
- Added vertical alignment to select fields in day and time controls

## Why
- The previous width of 46px was causing text to be truncated
- Select fields were misaligned with neighboring elements, creating visual inconsistency

## How
- Updated width property in date-time input styles to accommodate longer text
- Added vertical align: top to select elements within day and time field groups

## Testing Instructions
1. Go to Customizer
2. Navigate to any panel with date-time controls
3. Verify date/time input fields show complete numbers without truncation
4. Check that select fields are properly aligned with neighboring inputs

## Screenshots
#### Before patch:
![image](https://github.com/user-attachments/assets/4379c751-49a0-4cfb-b43a-af4af3ed8a1e)

#### After Patch:
![image](https://github.com/user-attachments/assets/82608bce-8305-46ab-98b8-2607d8ee016f)

