### PR TITLE
Login and Registration: Add filters for changing labels in login, registration, lostpassword forms

### DIFF
--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -900,7 +900,7 @@ switch ( $action ) {
 		 *
 		 * @param string $lostpasswordform_user_login_label The label for the username or email address field.
 		 */
-		$lostpasswordform_user_login_label = apply_filters( 'lostpasswordform_user_login_label', __( 'Username or Email Address' ) );
+		$lostpasswordform_user_login_label = apply_filters( 'lostpasswordform_user_login_label', __( 'Username or Email Address ' ) );
 		?>
 
 		<form name="lostpasswordform" id="lostpasswordform" action="<?php echo esc_url( network_site_url( 'wp-login.php?action=lostpassword', 'login_post' ) ); ?>" method="post">

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -900,7 +900,7 @@ switch ( $action ) {
 		 *
 		 * @param string $lostpasswordform_user_login_label The label for the username or email address field.
 		 */
-		$lostpasswordform_user_login_label = apply_filters( 'lostpasswordform_user_login_label', __( 'Username or Email Address ' ) );
+		$lostpasswordform_user_login_label = apply_filters( 'lostpasswordform_user_login_label', __( 'Username or Email Address' ) );
 		?>
 
 		<form name="lostpasswordform" id="lostpasswordform" action="<?php echo esc_url( network_site_url( 'wp-login.php?action=lostpassword', 'login_post' ) ); ?>" method="post">

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -893,11 +893,11 @@ switch ( $action ) {
 
 		/**
 		 * Filters the label for the username or email address field on the lost password form.
-		 * 
+		 *
 		 * Default is 'Username or Email Address'.
-		 * 
-		 * @since 5.7.0
-		 * 
+		 *
+		 * @since 6.8.0
+		 *
 		 * @param string $lostpasswordform_user_login_label The label for the username or email address field.
 		 */
 		$lostpasswordform_user_login_label = apply_filters( 'lostpasswordform_user_login_label', __( 'Username or Email Address' ) );
@@ -1174,19 +1174,24 @@ switch ( $action ) {
 		);
 
 		/**
-		 * Filters the labels for the registration form fields.
-		 * 
-		 * Default is 'Username' and 'Email'.
-		 * 
-		 * @param array $registerform_labels An array of labels for the registration form fields.
+		 * Filters the label for the username or email address field on the lost password form.
+		 *
+		 * Default is 'Username or Email Address'.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param string $lostpasswordform_user_login_label The label for the username or email address field.
 		 */
-		$registerform_labels = apply_filters( 'registerform_labels', [
-			'registerform_user_login_label' => __( 'Username' ),
-			'registerform_user_email_label' => __( 'Email' ),
-		]);
+		$registerform_labels = apply_filters(
+			'registerform_labels',
+			array(
+				'registerform_user_login_label' => __( 'Username' ),
+				'registerform_user_email_label' => __( 'Email' ),
+			)
+		);
 
 		$registerform_user_login_label = $registerform_labels['registerform_user_login_label'];
-		$registerform_user_email_label = $registerform_labels['registerform_user_email_label'];		
+		$registerform_user_email_label = $registerform_labels['registerform_user_email_label'];
 		?>
 		<form name="registerform" id="registerform" action="<?php echo esc_url( site_url( 'wp-login.php?action=register', 'login_post' ) ); ?>" method="post" novalidate="novalidate">
 			<p>
@@ -1533,9 +1538,11 @@ switch ( $action ) {
 
 		/**
 		 * Filters the label for the username or email address field on the login form.
-		 * 
+		 *
 		 * Default is 'Username or Email Address'.
-		 * 
+		 *
+		 * @since 6.8.0
+		 *
 		 * @param string $loginform_user_login_label The label for the username or email address field.
 		 */
 		$loginform_user_login_label = apply_filters( 'loginform_user_login_label', __( 'Username or Email Address' ) );

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -891,11 +891,21 @@ switch ( $action ) {
 			$user_login = wp_unslash( $_POST['user_login'] );
 		}
 
+		/**
+		 * Filters the label for the username or email address field on the lost password form.
+		 * 
+		 * Default is 'Username or Email Address'.
+		 * 
+		 * @since 5.7.0
+		 * 
+		 * @param string $lostpasswordform_user_login_label The label for the username or email address field.
+		 */
+		$lostpasswordform_user_login_label = apply_filters( 'lostpasswordform_user_login_label', __( 'Username or Email Address' ) );
 		?>
 
 		<form name="lostpasswordform" id="lostpasswordform" action="<?php echo esc_url( network_site_url( 'wp-login.php?action=lostpassword', 'login_post' ) ); ?>" method="post">
 			<p>
-				<label for="user_login"><?php _e( 'Username or Email Address' ); ?></label>
+				<label for="user_login"><?php echo esc_html( $lostpasswordform_user_login_label ); ?></label>
 				<input type="text" name="user_login" id="user_login" class="input" value="<?php echo esc_attr( $user_login ); ?>" size="20" autocapitalize="off" autocomplete="username" required="required" />
 			</p>
 			<?php
@@ -1163,14 +1173,28 @@ switch ( $action ) {
 			$errors
 		);
 
+		/**
+		 * Filters the labels for the registration form fields.
+		 * 
+		 * Default is 'Username' and 'Email'.
+		 * 
+		 * @param array $registerform_labels An array of labels for the registration form fields.
+		 */
+		$registerform_labels = apply_filters( 'registerform_labels', [
+			'registerform_user_login_label' => __( 'Username' ),
+			'registerform_user_email_label' => __( 'Email' ),
+		]);
+
+		$registerform_user_login_label = $registerform_labels['registerform_user_login_label'];
+		$registerform_user_email_label = $registerform_labels['registerform_user_email_label'];		
 		?>
 		<form name="registerform" id="registerform" action="<?php echo esc_url( site_url( 'wp-login.php?action=register', 'login_post' ) ); ?>" method="post" novalidate="novalidate">
 			<p>
-				<label for="user_login"><?php _e( 'Username' ); ?></label>
+				<label for="user_login"><?php echo esc_html( $registerform_user_login_label ); ?></label>
 				<input type="text" name="user_login" id="user_login" class="input" value="<?php echo esc_attr( $user_login ); ?>" size="20" autocapitalize="off" autocomplete="username" required="required" />
 			</p>
 			<p>
-				<label for="user_email"><?php _e( 'Email' ); ?></label>
+				<label for="user_email"><?php echo esc_html( $registerform_user_email_label ); ?></label>
 				<input type="email" name="user_email" id="user_email" class="input" value="<?php echo esc_attr( $user_email ); ?>" size="25" autocomplete="email" required="required" />
 			</p>
 			<?php
@@ -1506,11 +1530,20 @@ switch ( $action ) {
 		}
 
 		wp_enqueue_script( 'user-profile' );
+
+		/**
+		 * Filters the label for the username or email address field on the login form.
+		 * 
+		 * Default is 'Username or Email Address'.
+		 * 
+		 * @param string $loginform_user_login_label The label for the username or email address field.
+		 */
+		$loginform_user_login_label = apply_filters( 'loginform_user_login_label', __( 'Username or Email Address' ) );
 		?>
 
 		<form name="loginform" id="loginform" action="<?php echo esc_url( site_url( 'wp-login.php', 'login_post' ) ); ?>" method="post">
 			<p>
-				<label for="user_login"><?php _e( 'Username or Email Address' ); ?></label>
+				<label for="user_login"><?php echo esc_html( $loginform_user_login_label ); ?></label>
 				<input type="text" name="log" id="user_login"<?php echo $aria_describedby; ?> class="input" value="<?php echo esc_attr( $user_login ); ?>" size="20" autocapitalize="off" autocomplete="username" required="required" />
 			</p>
 


### PR DESCRIPTION
Added custom filters to modify form labels dynamically:  
- `loginform_user_login_label`: Customize the username/email field label on the login form.  
- `lostpasswordform_user_login_label`: Change the username/email field label on the lost password form.  
- `registerform_labels`: Modify multiple labels in the registration form, including username and email fields.  

These filters allow greater flexibility in customizing authentication-related forms without modifying core files.

Trac ticket: https://core.trac.wordpress.org/ticket/62837
