### PR TITLE
Refactor alloptions cache handling for non-external caches

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -618,7 +618,15 @@ function wp_load_alloptions( $force_cache = false ) {
 	}
 
 	if ( ! wp_installing() || ! is_multisite() ) {
-		$alloptions = wp_cache_get( 'alloptions', 'options', $force_cache );
+		if ( wp_using_ext_object_cache() ) {
+			$alloptions = wp_cache_get( 'alloptions', 'options', $force_cache );
+		} else {
+			$alloptionskeys = wp_cache_get( 'alloptionskeys', 'options', $force_cache );
+			$alloptions     = false;
+			if ( is_array( $alloptionskeys ) ) {
+				$alloptions = wp_cache_get_multiple( $alloptionskeys, 'options' );
+			}
+		}
 	} else {
 		$alloptions = false;
 	}
@@ -647,7 +655,12 @@ function wp_load_alloptions( $force_cache = false ) {
 			 */
 			$alloptions = apply_filters( 'pre_cache_alloptions', $alloptions );
 
-			wp_cache_add( 'alloptions', $alloptions, 'options' );
+			if ( wp_using_ext_object_cache() ) {
+				wp_cache_add( 'alloptions', $alloptions, 'options' );
+			} else {
+				wp_cache_set_multiple( $alloptions, '', 'options' );
+				wp_cache_set( 'alloptionskeys', array_keys( $alloptions ), 'options' );
+			}
 		}
 	}
 


### PR DESCRIPTION
Introduce separate logic for handling alloptions when not using an external object cache. This includes retrieving keys and setting multiple cache entries individually, improving compatibility and efficiency for internal caching mechanisms.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/32452

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
