### PR TITLE
Allow removing title attributes from author archive links and author website links

### DIFF
--- a/src/wp-includes/author-template.php
+++ b/src/wp-includes/author-template.php
@@ -224,24 +224,28 @@ function the_author_meta( $field = '', $user_id = false ) {
  * the author's name.
  *
  * @since 3.0.0
+ * @since 6.8.0 Added `$use_title_attr` parameter.
  *
  * @global WP_User $authordata The current author's data.
  *
+ * @param bool $use_title_attr Optional. Whether to add a title attribute.
+ *                             Default true.
  * @return string An HTML link if the author's URL exists in user meta,
  *                otherwise the result of get_the_author().
  */
-function get_the_author_link() {
+function get_the_author_link( $use_title_attr = true ) {
 	if ( get_the_author_meta( 'url' ) ) {
 		global $authordata;
 
 		$author_url          = get_the_author_meta( 'url' );
 		$author_display_name = get_the_author();
+		/* translators: %s: Author's display name. */
+		$author_title        = sprintf( __( 'Visit %s&#8217;s website' ), $author_display_name );
 
 		$link = sprintf(
-			'<a href="%1$s" title="%2$s" rel="author external">%3$s</a>',
+			'<a href="%1$s"%2$s rel="author external">%3$s</a>',
 			esc_url( $author_url ),
-			/* translators: %s: Author's display name. */
-			esc_attr( sprintf( __( 'Visit %s&#8217;s website' ), $author_display_name ) ),
+			$use_title_attr ? ' title="' . esc_attr( $author_title ) . '"' : '',
 			$author_display_name
 		);
 
@@ -269,9 +273,13 @@ function get_the_author_link() {
  * @link https://developer.wordpress.org/reference/functions/the_author_link/
  *
  * @since 2.1.0
+ * @since 6.8.0 Added `$use_title_attr` parameter.
+ *
+ * @param bool $use_title_attr Optional. Whether to add a title attribute.
+ *                             Default true.
  */
-function the_author_link() {
-	echo get_the_author_link();
+function the_author_link( $use_title_attr = true ) {
+	echo get_the_author_link( $use_title_attr );
 }
 
 /**
@@ -305,23 +313,27 @@ function the_author_posts() {
  * Returns an HTML-formatted link using get_author_posts_url().
  *
  * @since 4.4.0
+ * @since 6.8.0 Added `$use_title_attr` parameter.
  *
  * @global WP_User $authordata The current author's data.
  *
+ * @param bool $use_title_attr Optional. Whether to add a title attribute. Default true.
  * @return string An HTML link to the author page, or an empty string if $authordata is not set.
  */
-function get_the_author_posts_link() {
+function get_the_author_posts_link( $use_title_attr = true ) {
 	global $authordata;
 
 	if ( ! is_object( $authordata ) ) {
 		return '';
 	}
 
+	/* translators: %s: Author's display name. */
+	$author_title = sprintf( __( 'Posts by %s' ), get_the_author() );
+
 	$link = sprintf(
-		'<a href="%1$s" title="%2$s" rel="author">%3$s</a>',
+		'<a href="%1$s"%2$s rel="author">%3$s</a>',
 		esc_url( get_author_posts_url( $authordata->ID, $authordata->user_nicename ) ),
-		/* translators: %s: Author's display name. */
-		esc_attr( sprintf( __( 'Posts by %s' ), get_the_author() ) ),
+		$use_title_attr ? ' title="' . esc_attr( $author_title ) . '"' : '',
 		get_the_author()
 	);
 
@@ -339,15 +351,18 @@ function get_the_author_posts_link() {
  * Displays an HTML link to the author page of the current post's author.
  *
  * @since 1.2.0
- * @since 4.4.0 Converted into a wrapper for get_the_author_posts_link()
+ * @since 4.4.0 Converted into a wrapper for get_the_author_posts_link().
+ * @since 6.8.0 Added `$use_title_attr` parameter.
  *
- * @param string $deprecated Unused.
+ * @param bool $use_title_attr Optional. Whether to add a title attribute. Default true.
  */
-function the_author_posts_link( $deprecated = '' ) {
-	if ( ! empty( $deprecated ) ) {
-		_deprecated_argument( __FUNCTION__, '2.1.0' );
+function the_author_posts_link( $use_title_attr = true ) {
+	// Avoid conflict from deprecated `$idmode` string parameter.
+	if ( false !== $use_title_attr ) {
+		$use_title_attr = true;
 	}
-	echo get_the_author_posts_link();
+
+	echo get_the_author_posts_link( $use_title_attr );
 }
 
 /**
@@ -407,27 +422,28 @@ function get_author_posts_url( $author_id, $author_nicename = '' ) {
  * @param string|array $args {
  *     Optional. Array or string of default arguments.
  *
- *     @type string       $orderby       How to sort the authors. Accepts 'nicename', 'email', 'url', 'registered',
- *                                       'user_nicename', 'user_email', 'user_url', 'user_registered', 'name',
- *                                       'display_name', 'post_count', 'ID', 'meta_value', 'user_login'. Default 'name'.
- *     @type string       $order         Sorting direction for $orderby. Accepts 'ASC', 'DESC'. Default 'ASC'.
- *     @type int          $number        Maximum authors to return or display. Default empty (all authors).
- *     @type bool         $optioncount   Show the count in parenthesis next to the author's name. Default false.
- *     @type bool         $exclude_admin Whether to exclude the 'admin' account, if it exists. Default true.
- *     @type bool         $show_fullname Whether to show the author's full name. Default false.
- *     @type bool         $hide_empty    Whether to hide any authors with no posts. Default true.
- *     @type string       $feed          If not empty, show a link to the author's feed and use this text as the alt
- *                                       parameter of the link. Default empty.
- *     @type string       $feed_image    If not empty, show a link to the author's feed and use this image URL as
- *                                       clickable anchor. Default empty.
- *     @type string       $feed_type     The feed type to link to. Possible values include 'rss2', 'atom'.
- *                                       Default is the value of get_default_feed().
- *     @type bool         $echo          Whether to output the result or instead return it. Default true.
- *     @type string       $style         If 'list', each author is wrapped in an `<li>` element, otherwise the authors
- *                                       will be separated by commas.
- *     @type bool         $html          Whether to list the items in HTML form or plaintext. Default true.
- *     @type int[]|string $exclude       Array or comma/space-separated list of author IDs to exclude. Default empty.
- *     @type int[]|string $include       Array or comma/space-separated list of author IDs to include. Default empty.
+ *     @type string       $orderby        How to sort the authors. Accepts 'nicename', 'email', 'url', 'registered',
+ *                                        'user_nicename', 'user_email', 'user_url', 'user_registered', 'name',
+ *                                        'display_name', 'post_count', 'ID', 'meta_value', 'user_login'. Default 'name'.
+ *     @type string       $order          Sorting direction for $orderby. Accepts 'ASC', 'DESC'. Default 'ASC'.
+ *     @type int          $number         Maximum authors to return or display. Default empty (all authors).
+ *     @type bool         $optioncount    Show the count in parenthesis next to the author's name. Default false.
+ *     @type bool         $exclude_admin  Whether to exclude the 'admin' account, if it exists. Default true.
+ *     @type bool         $show_fullname  Whether to show the author's full name. Default false.
+ *     @type bool         $hide_empty     Whether to hide any authors with no posts. Default true.
+ *     @type string       $feed           If not empty, show a link to the author's feed and use this text as the alt
+ *                                        parameter of the link. Default empty.
+ *     @type string       $feed_image     If not empty, show a link to the author's feed and use this image URL as
+ *                                        clickable anchor. Default empty.
+ *     @type string       $feed_type      The feed type to link to. Possible values include 'rss2', 'atom'.
+ *                                        Default is the value of get_default_feed().
+ *     @type bool         $echo           Whether to output the result or instead return it. Default true.
+ *     @type string       $style          If 'list', each author is wrapped in an `<li>` element, otherwise the authors
+ *                                        will be separated by commas.
+ *     @type bool         $html           Whether to list the items in HTML form or plaintext. Default true.
+ *     @type int[]|string $exclude        Array or comma/space-separated list of author IDs to exclude. Default empty.
+ *     @type int[]|string $include        Array or comma/space-separated list of author IDs to include. Default empty.
+ *     @type bool         $use_title_attr Whether to add a title attribute. Default true.
  * }
  * @return void|string Void if 'echo' argument is true, list of authors if 'echo' is false.
  */
@@ -435,21 +451,22 @@ function wp_list_authors( $args = '' ) {
 	global $wpdb;
 
 	$defaults = array(
-		'orderby'       => 'name',
-		'order'         => 'ASC',
-		'number'        => '',
-		'optioncount'   => false,
-		'exclude_admin' => true,
-		'show_fullname' => false,
-		'hide_empty'    => true,
-		'feed'          => '',
-		'feed_image'    => '',
-		'feed_type'     => '',
-		'echo'          => true,
-		'style'         => 'list',
-		'html'          => true,
-		'exclude'       => '',
-		'include'       => '',
+		'orderby'        => 'name',
+		'order'          => 'ASC',
+		'number'         => '',
+		'optioncount'    => false,
+		'exclude_admin'  => true,
+		'show_fullname'  => false,
+		'hide_empty'     => true,
+		'feed'           => '',
+		'feed_image'     => '',
+		'feed_type'      => '',
+		'echo'           => true,
+		'style'          => 'list',
+		'html'           => true,
+		'exclude'        => '',
+		'include'        => '',
+		'use_title_attr' => true,
 	);
 
 	$parsed_args = wp_parse_args( $args, $defaults );
@@ -530,11 +547,13 @@ function wp_list_authors( $args = '' ) {
 			$return .= '<li>';
 		}
 
+		/* translators: %s: Author's display name. */
+		$author_title = sprintf( __( 'Posts by %s' ), $author->display_name );
+
 		$link = sprintf(
-			'<a href="%1$s" title="%2$s">%3$s</a>',
+			'<a href="%1$s"%2$s>%3$s</a>',
 			esc_url( get_author_posts_url( $author->ID, $author->user_nicename ) ),
-			/* translators: %s: Author's display name. */
-			esc_attr( sprintf( __( 'Posts by %s' ), $author->display_name ) ),
+			$parsed_args['use_title_attr'] ? ' title="' . esc_attr( $author_title ) . '"' : '',
 			$name
 		);
 

--- a/tests/phpunit/tests/user/wpListAuthors.php
+++ b/tests/phpunit/tests/user/wpListAuthors.php
@@ -340,4 +340,24 @@ class Tests_User_wpListAuthors extends WP_UnitTestCase {
 			)
 		);
 	}
+
+	/**
+	 * @ticket 62835
+	 */
+	public function test_wp_list_authors_remove_title_attributes() {
+		$expected['use_title_attr'] =
+			'<li><a href="' . self::$user_urls[1] . '">bob</a></li>' .
+			'<li><a href="' . self::$user_urls[2] . '">paul</a></li>' .
+			'<li><a href="' . self::$user_urls[0] . '">zack</a></li>';
+
+		$this->assertSame(
+			$expected['use_title_attr'],
+			wp_list_authors(
+				array(
+					'echo'           => false,
+					'use_title_attr' => false,
+				)
+			)
+		);
+	}
 }


### PR DESCRIPTION
Option 3:
Creates a new `$use_title_attr` argument for each of the author link functions.

By default, this should not change the output of these functions.

[Trac 62835](https://core.trac.wordpress.org/ticket/62835)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
