### PR TITLE
Add hash handling to site health infos accordions

### DIFF
--- a/src/js/_enqueues/admin/site-health.js
+++ b/src/js/_enqueues/admin/site-health.js
@@ -44,6 +44,8 @@ jQuery( function( $ ) {
 	$( '.health-check-accordion' ).on( 'click', '.health-check-accordion-trigger', function() {
 		var isExpanded = ( 'true' === $( this ).attr( 'aria-expanded' ) );
 
+		window.location.hash = $( this ).attr( 'id' );
+
 		if ( isExpanded ) {
 			$( this ).attr( 'aria-expanded', 'false' );
 			$( '#' + $( this ).attr( 'aria-controls' ) ).attr( 'hidden', true );
@@ -53,8 +55,19 @@ jQuery( function( $ ) {
 		}
 	} );
 
-	// Site Health test handling.
+	// Get hash from query string and open the related accordion.
+	$( window ).on( 'load', function() {
+		var hash = window.location.hash;
+		if ( hash ) {
+			var requestedPanel = $( hash );
+			if ( requestedPanel.length ) {
+				$( requestedPanel ).attr( 'aria-expanded', 'true' );
+				$( '#' + requestedPanel.attr( 'aria-controls' ) ).attr( 'hidden', false );
+			}
+		}
+	} );
 
+	// Site Health test handling.
 	$( '.site-health-view-passed' ).on( 'click', function() {
 		var goodIssuesWrapper = $( '#health-check-issues-good' );
 

--- a/src/js/_enqueues/admin/site-health.js
+++ b/src/js/_enqueues/admin/site-health.js
@@ -61,7 +61,7 @@ jQuery( function( $ ) {
 		if ( hash ) {
 			var requestedPanel = $( hash );
 			if ( requestedPanel.length ) {
-				$( requestedPanel ).attr( 'aria-expanded', 'true' );
+				requestedPanel.attr('aria-expanded', 'true');
 				$( '#' + requestedPanel.attr( 'aria-controls' ) ).attr( 'hidden', false );
 			}
 		}

--- a/src/wp-admin/site-health-info.php
+++ b/src/wp-admin/site-health-info.php
@@ -73,7 +73,7 @@ wp_admin_notice(
 
 			?>
 			<h3 class="health-check-accordion-heading">
-				<button aria-expanded="false" class="health-check-accordion-trigger" aria-controls="health-check-accordion-block-<?php echo esc_attr( $section ); ?>" type="button">
+				<button id="health-check-section-<?php echo esc_attr( $section ); ?>" aria-expanded="false" class="health-check-accordion-trigger" aria-controls="health-check-accordion-block-<?php echo esc_attr( $section ); ?>" type="button">
 					<span class="title">
 						<?php echo esc_html( $details['label'] ); ?>
 						<?php


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/62846

This PR does the following changes:
- Add an ID to each accordion button
- On page load, get the hash and open the related accordion
- Update the URL hash each time an accordion button is clicked

This way, people can use the URL of the page to share a direct link to the site health info section they want.
Note: As a first iteration, this changeset doesn't add any UI button.