### PR TITLE
Add an action hook at the end of the Import screen

### DIFF
--- a/src/wp-admin/import.php
+++ b/src/wp-admin/import.php
@@ -237,6 +237,15 @@ if ( current_user_can( 'install_plugins' ) ) {
 }
 ?>
 
+<?php
+/**
+ * Fires at the end of the Import screen.
+ *
+ * @since 6.8.0
+ */
+do_action( 'import_filters' );
+?>
+
 </div>
 
 <?php


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/54419

This PR adds an action hook at the end of the import screen, consistently with other admin screens.

Note `import_filters` action hook name doesn't appear to conflict with existing plugins: https://wpdirectory.net/search/01JJBSRW4CYR37K9E9XFHJHACG