### PR TITLE
feat(WP_Term): added getter and setter for backwards compatibility

### DIFF
--- a/src/wp-includes/class-wp-term.php
+++ b/src/wp-includes/class-wp-term.php
@@ -226,6 +226,7 @@ final class WP_Term {
 	 * Getter.
 	 *
 	 * @since 4.4.0
+	 * @since 6.8.0 Added backwards compatibility aliases.
 	 *
 	 * @param string $key Property to get.
 	 * @return mixed Property value.
@@ -240,6 +241,52 @@ final class WP_Term {
 				}
 
 				return sanitize_term( $data, $data->taxonomy, 'raw' );
+
+				// Backwards compatibility aliases.
+				case 'cat_ID':
+					return $this->term_id;
+				case 'category_count':
+					return $this->count;
+				case 'category_description':
+					return $this->description;
+				case 'cat_name':
+					return $this->name;
+				case 'category_nicename':
+					return $this->slug;
+				case 'category_parent':
+					return $this->parent;
+		}
+	}
+
+	/**
+	 * Setter.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @param string $key   Property to set.
+	 * @param mixed  $value Property value.
+	 */
+	public function __set( $key, $value ) {
+		switch ( $key ) {
+			// Backwards compatibility aliases.
+			case 'cat_ID':
+				$this->term_id = $value;
+				break;
+			case 'category_count':
+				$this->count = $value;
+				break;
+			case 'category_description':
+				$this->description = $value;
+				break;
+			case 'cat_name':
+				$this->name = $value;
+				break;
+			case 'category_nicename':
+				$this->slug = $value;
+				break;
+			case 'category_parent':
+				$this->parent = $value;
+				break;
 		}
 	}
 }

--- a/src/wp-includes/class-wp-term.php
+++ b/src/wp-includes/class-wp-term.php
@@ -242,19 +242,19 @@ final class WP_Term {
 
 				return sanitize_term( $data, $data->taxonomy, 'raw' );
 
-				// Backwards compatibility aliases.
-				case 'cat_ID':
-					return $this->term_id;
-				case 'category_count':
-					return $this->count;
-				case 'category_description':
-					return $this->description;
-				case 'cat_name':
-					return $this->name;
-				case 'category_nicename':
-					return $this->slug;
-				case 'category_parent':
-					return $this->parent;
+			// Backwards compatibility aliases.
+			case 'cat_ID':
+				return $this->term_id;
+			case 'category_count':
+				return $this->count;
+			case 'category_description':
+				return $this->description;
+			case 'cat_name':
+				return $this->name;
+			case 'category_nicename':
+				return $this->slug;
+			case 'category_parent':
+				return $this->parent;
 		}
 	}
 


### PR DESCRIPTION
This proposes a replacement of dynamic properties as in `_make_cat_compat()`

Refs: #62863

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/62863#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
