### PR TITLE
Adds in lighter font weight for settings labels

### DIFF
--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -859,7 +859,7 @@ ul#add-to-blog-users {
 	padding: 20px 10px 20px 0;
 	width: 200px;
 	line-height: 1.3;
-	font-weight: 600;
+	font-weight: 400;
 }
 
 .form-table th.th-full, /* Not used by core. Back-compat for pre-4.8 */


### PR DESCRIPTION
This lightens up the font weight from 600 to 400.

Trac ticket: https://core.trac.wordpress.org/ticket/62865.

---

This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. 
See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.