### PR TITLE
Adds alt row background color change for table

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -700,7 +700,7 @@ div#widgets-right .widget-top:hover,
 .striped > tbody > :nth-child(odd),
 ul.striped > :nth-child(odd),
 .alternate {
-	background-color: #f6f7f7;
+	background-color: #f8f8f8;
 }
 
 .bar {

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -529,7 +529,7 @@
 }
 
 .community-events ul {
-	background-color: #f6f7f7;
+	background-color: #f8f8f8;
 	padding-left: 0;
 	padding-right: 0;
 	padding-bottom: 0;
@@ -912,7 +912,7 @@ body #dashboard-widgets .postbox form .submit {
 
 #future-posts li:nth-child(odd),
 #published-posts li:nth-child(odd) {
-	background-color: #f6f7f7;
+	background-color: #f8f8f8;
 }
 
 .activity-block {
@@ -941,7 +941,7 @@ body #dashboard-widgets .postbox form .submit {
 }
 
 #activity-widget #the-comment-list .comment-item {
-	background: #f6f7f7;
+	background: #f8f8f8;
 	padding: 12px;
 	position: relative;
 }


### PR DESCRIPTION
This changes the background color to be consistent with the one used on hover in dataViews.
What this does is reduce number of grays which are getting out of control a bit again.

Trac ticket: https://core.trac.wordpress.org/ticket/62866.

---

This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request.
See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.