### PR TITLE
Pin specific runner image versions.

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -80,7 +80,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ phpcs, jshint, slack-notifications ]

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -67,7 +67,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ e2e-tests, slack-notifications ]

--- a/.github/workflows/failed-workflow.yml
+++ b/.github/workflows/failed-workflow.yml
@@ -23,7 +23,7 @@ jobs:
   # - Restarts all failed jobs when the workflow fails or is cancelled for the first time.
   failed-workflow:
     name: Rerun a workflow
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     timeout-minutes: 30

--- a/.github/workflows/install-testing.yml
+++ b/.github/workflows/install-testing.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-24.04 ]
         php: ${{ fromJSON( needs.build-test-matrix.outputs.php-versions ) }}
         db-type: [ 'mysql' ]
         db-version: ${{ fromJSON( needs.build-test-matrix.outputs.mysql-versions ) }}
@@ -152,7 +152,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -70,7 +70,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -82,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-24.04 ]
         memcached: [ false, true ]
         php: ${{ fromJSON( needs.build-test-matrix.outputs.php-versions ) }}
         db-version: ${{ fromJSON( needs.build-test-matrix.outputs.mysql-versions ) }}
@@ -123,7 +123,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ build-test-matrix, environment-tests-mysql, slack-notifications ]

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -66,7 +66,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -67,7 +67,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-24.04 ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4' ]
@@ -54,14 +54,14 @@ jobs:
 
         include:
           # Include jobs that test with memcached.
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             php: '8.3'
             db-type: 'mysql'
             db-version: '8.4'
             tests-domain: 'example.org'
             multisite: false
             memcached: true
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             php: '8.3'
             db-type: 'mysql'
             db-version: '8.4'
@@ -69,14 +69,14 @@ jobs:
             multisite: true
             memcached: true
           # Include jobs with a port on the test domain for both single and multisite.
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             php: '8.4'
             db-type: 'mysql'
             db-version: '8.4'
             tests-domain: 'example.org:8889'
             multisite: false
             memcached: false
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             php: '8.4'
             db-type: 'mysql'
             db-version: '8.4'
@@ -84,7 +84,7 @@ jobs:
             multisite: true
             memcached: false
           # Report test results to the Host Test Results.
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             db-type: 'mysql'
             db-version: '8.4'
             tests-domain: 'example.org'
@@ -115,7 +115,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-24.04 ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         db-type: [ 'mariadb' ]
         db-version: [ '5.5', '10.3', '10.4', '10.5', '10.6', '10.11', '11.4' ]
@@ -124,13 +124,13 @@ jobs:
 
         include:
         # Include jobs that test with memcached.
-        - os: ubuntu-latest
+        - os: ubuntu-24.04
           php: '8.3'
           db-type: 'mariadb'
           db-version: '11.4'
           multisite: false
           memcached: true
-        - os: ubuntu-latest
+        - os: ubuntu-24.04
           php: '8.3'
           db-type: 'mariadb'
           db-version: '11.4'
@@ -165,7 +165,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-24.04 ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         db-type: [ 'mysql', 'mariadb' ]
         db-version: [ '9.1', '11.6' ]
@@ -236,7 +236,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -48,7 +48,7 @@ jobs:
   # - Removes the props-bot label, if necessary.
   props-bot:
     name: Generate a list of props
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       # The action needs permission `write` permission for PRs in order to add a comment.
       pull-requests: write

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -22,7 +22,7 @@ permissions: {}
 jobs:
   # Comments on a pull request when the author is a first time contributor.
   post-welcome-message:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
       pull-requests: write
@@ -80,7 +80,7 @@ jobs:
   # Leaves a comment on a pull request with a link to test the changes in a WordPress Playground instance.
   playground-details:
     name: Comment on a pull request with Playground details
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
       pull-requests: write
@@ -170,7 +170,7 @@ jobs:
   # Manages comments reminding contributors to include a Trac ticket link when opening a pull request.
   trac-ticket-check:
     name: Manage Trac ticket reminders for pull requests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/reusable-cleanup-pull-requests.yml
+++ b/.github/workflows/reusable-cleanup-pull-requests.yml
@@ -22,7 +22,7 @@ jobs:
   # - Leaves a comment on each PR before closing.
   close-prs:
     name: Find and close PRs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
 

--- a/.github/workflows/reusable-coding-standards-javascript.yml
+++ b/.github/workflows/reusable-coding-standards-javascript.yml
@@ -27,7 +27,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   jshint:
     name: Run coding standards checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     timeout-minutes: 20

--- a/.github/workflows/reusable-coding-standards-php.yml
+++ b/.github/workflows/reusable-coding-standards-php.yml
@@ -39,7 +39,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   phpcs:
     name: Run coding standards checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     timeout-minutes: 20

--- a/.github/workflows/reusable-end-to-end-tests.yml
+++ b/.github/workflows/reusable-end-to-end-tests.yml
@@ -59,7 +59,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   e2e-tests:
     name: Run E2E tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     timeout-minutes: 20

--- a/.github/workflows/reusable-javascript-tests.yml
+++ b/.github/workflows/reusable-javascript-tests.yml
@@ -28,7 +28,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   test-js:
     name: Run QUnit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     timeout-minutes: 20

--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -115,7 +115,7 @@ jobs:
   # - Ensure version-controlled files are not modified or deleted.
   performance:
     name: ${{ inputs.multisite && 'Multisite' || 'Single site' }} / ${{ inputs.memcached && 'Memcached' || 'Default' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     if: ${{ ! contains( github.event.before, '00000000' ) }}

--- a/.github/workflows/reusable-php-compatibility.yml
+++ b/.github/workflows/reusable-php-compatibility.yml
@@ -33,7 +33,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   php-compatibility:
     name: Run compatibility checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     timeout-minutes: 20

--- a/.github/workflows/reusable-phpunit-tests-v1.yml
+++ b/.github/workflows/reusable-phpunit-tests-v1.yml
@@ -14,7 +14,7 @@ on:
         description: 'Operating system to run tests on'
         required: false
         type: 'string'
-        default: 'ubuntu-latest'
+        default: 'ubuntu-24.04'
       php:
         description: 'The version of PHP to use, in the format of X.Y'
         required: true

--- a/.github/workflows/reusable-phpunit-tests-v2.yml
+++ b/.github/workflows/reusable-phpunit-tests-v2.yml
@@ -14,7 +14,7 @@ on:
         description: 'Operating system to run tests on'
         required: false
         type: 'string'
-        default: 'ubuntu-latest'
+        default: 'ubuntu-24.04'
       php:
         description: 'The version of PHP to use, in the format of X.Y'
         required: true

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -12,7 +12,7 @@ on:
         description: 'Operating system to run tests on'
         required: false
         type: 'string'
-        default: 'ubuntu-latest'
+        default: 'ubuntu-24.04'
       php:
         description: 'The version of PHP to use, in the format of X.Y'
         required: true

--- a/.github/workflows/reusable-support-json-reader-v1.yml
+++ b/.github/workflows/reusable-support-json-reader-v1.yml
@@ -42,7 +42,7 @@ jobs:
     name: Determine major WordPress version
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
       version: ${{ steps.major-wp-version.outputs.version }}
@@ -78,7 +78,7 @@ jobs:
     name: Determine PHP versions
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [ major-wp-version ]
     timeout-minutes: 5
     outputs:
@@ -121,7 +121,7 @@ jobs:
     name: Determine MySQL versions
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [ major-wp-version ]
     timeout-minutes: 5
     outputs:

--- a/.github/workflows/reusable-test-core-build-process.yml
+++ b/.github/workflows/reusable-test-core-build-process.yml
@@ -10,7 +10,7 @@ on:
         description: 'Operating system to run tests on'
         required: false
         type: 'string'
-        default: 'ubuntu-latest'
+        default: 'ubuntu-24.04'
       directory:
         description: 'Directory to run WordPress from. Valid values are `src` or `build`'
         required: false
@@ -98,7 +98,7 @@ jobs:
         run: git diff --exit-code
 
       - name: Create ZIP of built files
-        if: ${{ inputs.directory == 'build' && 'ubuntu-latest' == inputs.os }}
+        if: ${{ inputs.directory == 'build' && 'ubuntu-24.04' == inputs.os }}
         run: zip -r wordpress.zip build/.
 
       - name: Clean after building to run from ${{ inputs.directory }}

--- a/.github/workflows/reusable-test-gutenberg-build-process.yml
+++ b/.github/workflows/reusable-test-gutenberg-build-process.yml
@@ -10,7 +10,7 @@ on:
         description: 'Operating system to run tests on'
         required: false
         type: 'string'
-        default: 'ubuntu-latest'
+        default: 'ubuntu-24.04'
       directory:
         description: 'Directory to run WordPress from. Valid values are `src` or `build`'
         required: false

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -12,7 +12,7 @@ on:
         description: 'Operating system to test'
         required: false
         type: 'string'
-        default: 'ubuntu-latest'
+        default: 'ubuntu-24.04'
       php:
         description: 'The version of PHP to use, in the format of X.Y'
         required: false

--- a/.github/workflows/reusable-upgrade-testing.yml
+++ b/.github/workflows/reusable-upgrade-testing.yml
@@ -8,7 +8,7 @@ on:
         description: 'Operating system to run tests on.'
         required: false
         type: 'string'
-        default: 'ubuntu-latest'
+        default: 'ubuntu-24.04'
       wp:
         description: 'The version of WordPress to start with.'
         required: true

--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -15,7 +15,7 @@ jobs:
   # - Runs actionlint.
   actionlint:
     name: Run actionlint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     timeout-minutes: 5

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -47,7 +47,7 @@ jobs:
   # - Constructs and stores a message payload as an output.
   prepare:
     name: Prepare notifications
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read
@@ -171,7 +171,7 @@ jobs:
   failure:
     name: Failure notifications
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [ prepare ]
     if: ${{ needs.prepare.outputs.previous_conclusion != 'first-failure' && inputs.calling_status == 'failure' || failure() }}
@@ -188,7 +188,7 @@ jobs:
   fixed:
     name: Fixed notifications
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [ prepare ]
     if: ${{ contains( fromJson( '["failure", "cancelled", "none"]' ), needs.prepare.outputs.previous_conclusion ) && inputs.calling_status == 'success' && success() }}
@@ -205,7 +205,7 @@ jobs:
   success:
     name: Success notifications
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [ prepare ]
     if: ${{ inputs.calling_status == 'success' && success() }}
@@ -222,7 +222,7 @@ jobs:
   cancelled:
     name: Cancelled notifications
     permissions: {}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     needs: [ prepare ]
     if: ${{ inputs.calling_status == 'cancelled' || cancelled() }}

--- a/.github/workflows/test-and-zip-default-themes.yml
+++ b/.github/workflows/test-and-zip-default-themes.yml
@@ -59,7 +59,7 @@ jobs:
   # - Checks for zero-byte (empty) files.
   check-for-empty-files:
     name: ${{ matrix.theme }} empty file check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     timeout-minutes: 10
@@ -109,7 +109,7 @@ jobs:
   # - Ensures version-controlled files are not modified or deleted.
   test-build-scripts:
     name: Test ${{ matrix.theme }} build script
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     timeout-minutes: 10
@@ -158,7 +158,7 @@ jobs:
   # - Uploads the theme files as a workflow artifact (files uploaded as an artifact are automatically zipped).
   bundle-theme:
     name: Create ${{ matrix.theme }} ZIP file
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     needs: [ check-for-empty-files, test-build-scripts ]
@@ -219,7 +219,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -38,11 +38,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-24.04, windows-2022 ]
         directory: [ 'src', 'build' ]
         include:
           # Only prepare artifacts for Playground once.
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             directory: 'build'
             save-build: true
             prepare-playground: ${{ github.event_name == 'pull_request' && true || '' }}
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest ]
+        os: [ macos-14 ]
         directory: [ 'src', 'build' ]
     with:
       os: ${{ matrix.os }}
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-24.04, windows-2022 ]
         directory: [ 'src', 'build' ]
     with:
       os: ${{ matrix.os }}
@@ -109,7 +109,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest ]
+        os: [ macos-14 ]
         directory: [ 'src', 'build' ]
     with:
       os: ${{ matrix.os }}
@@ -133,7 +133,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -83,7 +83,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ slack-notifications ]

--- a/.github/workflows/test-old-branches.yml
+++ b/.github/workflows/test-old-branches.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   dispatch-workflows-for-old-branches:
     name: ${{ matrix.workflow }} for ${{ matrix.branch }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     timeout-minutes: 20

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest' ]
+        os: [ 'ubuntu-24.04' ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4', '9.1' ]
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest' ]
+        os: [ 'ubuntu-24.04' ]
         php: [ '7.2', '7.4', '8.0', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.4' ]
@@ -125,7 +125,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest' ]
+        os: [ 'ubuntu-24.04' ]
         php: [ '7.2', '7.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.4' ]
@@ -157,7 +157,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest' ]
+        os: [ 'ubuntu-24.04' ]
         php: [ '8.0', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.4' ]
@@ -182,7 +182,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest' ]
+        os: [ 'ubuntu-24.04' ]
         php: [ '7.2', '7.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.4' ]
@@ -216,7 +216,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest' ]
+        os: [ 'ubuntu-24.04' ]
         php: [ '8.0', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.4' ]
@@ -240,7 +240,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest' ]
+        os: [ 'ubuntu-24.04' ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.0', '8.4', '9.1' ]
@@ -285,7 +285,7 @@ jobs:
 
   failed-workflow:
     name: Failed workflow tasks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     needs: [ slack-notifications ]


### PR DESCRIPTION
While it would be nice to always use `*-latest` images, it's proven to be problematic enough to consider pinning specific versions of runner images.

- Because images are deployed over week long (sometimes month long) periods, it's not uncommon for workflows to have warning notices that GH adds for awareness that do not have any impact on the workflow's result. This makes it hard to separate legitimate failures/problems from these warnings.
- As images slowly roll out, things can suddenly start to fail. See [Core-62843](https://core.trac.wordpress.org/ticket/62843) and [Core-62808](https://core.trac.wordpress.org/ticket/62808) as examples.

Trac ticket: https://core.trac.wordpress.org/ticket/62221

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
