### PR TITLE
Media: Add filter to disable months dropdown in media library

### DIFF
--- a/src/js/media/views/attachments/browser.js
+++ b/src/js/media/views/attachments/browser.js
@@ -1,5 +1,6 @@
 var View = wp.media.View,
 	mediaTrash = wp.media.view.settings.mediaTrash,
+	showMonths = wp.media.view.settings.showMonths,
 	l10n = wp.media.view.l10n,
 	$ = jQuery,
 	AttachmentsBrowser,
@@ -240,19 +241,21 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 				priority: -90
 			}).render() );
 
-			// DateFilter is a <select>, a visually hidden label element needs to be rendered before.
-			this.toolbar.set( 'dateFilterLabel', new wp.media.view.Label({
-				value: l10n.filterByDate,
-				attributes: {
-					'for': 'media-attachment-date-filters'
-				},
-				priority: -75
-			}).render() );
-			this.toolbar.set( 'dateFilter', new wp.media.view.DateFilter({
-				controller: this.controller,
-				model:      this.collection.props,
-				priority: -75
-			}).render() );
+			if ( showMonths ) {
+				// DateFilter is a <select>, a visually hidden label element needs to be rendered before.
+				this.toolbar.set( 'dateFilterLabel', new wp.media.view.Label({
+					value: l10n.filterByDate,
+					attributes: {
+						'for': 'media-attachment-date-filters'
+					},
+					priority: -75
+				}).render() );
+				this.toolbar.set( 'dateFilter', new wp.media.view.DateFilter({
+					controller: this.controller,
+					model:      this.collection.props,
+					priority: -75
+				}).render() );
+			}
 
 			// BulkSelection is a <div> with subviews, including screen reader text.
 			this.toolbar.set( 'selectModeToggleButton', new wp.media.view.SelectModeToggleButton({
@@ -361,7 +364,7 @@ AttachmentsBrowser = View.extend(/** @lends wp.media.view.AttachmentsBrowser.pro
 				}).render() );
 			}
 
-		} else if ( this.options.date ) {
+		} else if ( showMonths && this.options.date ) {
 			// DateFilter is a <select>, a visually hidden label element needs to be rendered before.
 			this.toolbar.set( 'dateFilterLabel', new wp.media.view.Label({
 				value: l10n.filterByDate,

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -4823,6 +4823,17 @@ function wp_enqueue_media( $args = array() ) {
 	}
 
 	/**
+	 * Filters whether to show the media library months dropdown.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @link https://core.trac.wordpress.org/ticket/41675
+	 *
+	 * @param bool $show Whether to show the media library months dropdown. Default true.
+	 */
+	$show_months_select = apply_filters( 'show_media_library_months_select', true );
+
+	/**
 	 * Allows overriding the list of months displayed in the media library.
 	 *
 	 * By default (if this filter does not return an array), a query will be
@@ -4838,24 +4849,27 @@ function wp_enqueue_media( $args = array() ) {
 	 *                                properties, or `null` for default behavior.
 	 */
 	$months = apply_filters( 'media_library_months_with_files', null );
-	if ( ! is_array( $months ) ) {
-		$months = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT DISTINCT YEAR( post_date ) AS year, MONTH( post_date ) AS month
-				FROM $wpdb->posts
-				WHERE post_type = %s
-				ORDER BY post_date DESC",
-				'attachment'
-			)
-		);
-	}
-	foreach ( $months as $month_year ) {
-		$month_year->text = sprintf(
-			/* translators: 1: Month, 2: Year. */
-			__( '%1$s %2$d' ),
-			$wp_locale->get_month( $month_year->month ),
-			$month_year->year
-		);
+
+	if ( true === $show_months_select ) {
+		if ( ! is_array( $months ) ) {
+			$months = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT DISTINCT YEAR( post_date ) AS year, MONTH( post_date ) AS month
+					FROM $wpdb->posts
+					WHERE post_type = %s
+					ORDER BY post_date DESC",
+					'attachment'
+				)
+			);
+		}
+		foreach ( $months as $month_year ) {
+			$month_year->text = sprintf(
+				/* translators: 1: Month, 2: Year. */
+				__( '%1$s %2$d' ),
+				$wp_locale->get_month( $month_year->month ),
+				$month_year->year
+			);
+		}
 	}
 
 	/**
@@ -4890,6 +4904,7 @@ function wp_enqueue_media( $args = array() ) {
 		'embedMimes'        => $ext_mimes,
 		'contentWidth'      => $content_width,
 		'months'            => $months,
+		'showMonths'        => $show_months_select,
 		'mediaTrash'        => MEDIA_TRASH ? 1 : 0,
 		'infiniteScrolling' => ( $infinite_scrolling ) ? 1 : 0,
 	);

--- a/tests/phpunit/tests/media/mediaMonthsFilter.php
+++ b/tests/phpunit/tests/media/mediaMonthsFilter.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Test WP_Media months filter functionality
+ *
+ * @group media
+ */
+class Tests_Media_MonthsFilter extends WP_UnitTestCase {
+
+	/**
+	 * Test that the show_media_library_months_select filter works
+	 *
+	 * @ticket 41675
+	 */
+	public function test_show_media_library_months_select_filter() {
+		$attachment1 = self::factory()->attachment->create_object(
+			array(
+				'file'           => 'test1.jpg',
+				'post_parent'    => 0,
+				'post_date'      => '2023-01-15 12:00:00',
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+
+		$attachment2 = self::factory()->attachment->create_object(
+			array(
+				'file'           => 'test2.jpg',
+				'post_parent'    => 0,
+				'post_date'      => '2023-02-15 12:00:00',
+				'post_type'      => 'attachment',
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+
+		$this->assertTrue( apply_filters( 'show_media_library_months_select', true ) );
+
+		add_filter( 'show_media_library_months_select', '__return_false' );
+		$this->assertFalse( apply_filters( 'show_media_library_months_select', true ) );
+
+		wp_delete_attachment( $attachment1, true );
+		wp_delete_attachment( $attachment2, true );
+	}
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/41675
Refresh for: https://github.com/WordPress/wordpress-develop/pull/2716

This adds a new filter `show_media_library_months_select` that allows disabling the months dropdown in the media library. Also added some related unit tests.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
