### PR TITLE
Feature: Pass object_id to `prepare_value_for_response`

### DIFF
--- a/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
+++ b/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
@@ -84,6 +84,8 @@ abstract class WP_REST_Meta_Fields {
 			$name       = $args['name'];
 			$all_values = get_metadata( $this->get_meta_type(), $object_id, $meta_key, false );
 
+			$args['object_id'] = $object_id;
+
 			if ( $args['single'] ) {
 				if ( empty( $all_values ) ) {
 					$value = $args['schema']['default'];


### PR DESCRIPTION
Trac Ticket: Core-62855

## Summary

- Currently, the `WP_REST_Meta_Fields::prepare_value_for_response()` method accepts three parameters: `$value`, `$request`, and `$args`. However, it does not include information about the current item (e.g., post or term) being retrieved, which leads to issues when preparing data for terms. Specifically, when using the prepare_callback function, it's impossible to access the current term's data, particularly when making requests like `/wp-json/v2/wp/categories`.

- This issue does not occur for posts, as WordPress automatically sets the global `$post` object, allowing functions like `get_post()` to retrieve the current post. However, there is no equivalent for terms, which causes the gap in data handling for terms.

## Solution

- This PR addresses the issue by setting the object_id (the term ID, for example) inside `$args` and passing it to `prepare_value_for_response()`. This allows developers to access the current term (or post) within the callback, ensuring that the correct data is returned, especially for taxonomies like categories.

## Changes

- Added object_id to `$args` in the call to prepare_value_for_response().

- Updated all relevant function calls to pass object_id.

## Why

- Fixes the issue where term data is inaccessible in callbacks.

- Provides a consistent way to access the current term, similar to how post data is handled.

- Ensures accurate data retrieval when querying for terms (e.g., categories).
