### PR TITLE
Fix minification with UglifyJS 3.18.0 and newer

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -774,7 +774,14 @@ module.exports = function(grunt) {
 		},
 		uglify: {
 			options: {
+				parse: {
+					module: false
+				},
+				compress: {
+					module: false
+				},
 				output: {
+					module: false,
 					ascii_only: true
 				}
 			},


### PR DESCRIPTION
The behavior of UglifyJS changed in version 3.18.0 to "process input as ES module by default".  This can cause issues for scripts which are not ES modules.

Trac ticket: https://core.trac.wordpress.org/ticket/62767

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
