### PR TITLE
Refactor: add redirect support if referrer is missing

### DIFF
--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -1067,14 +1067,12 @@ function _wp_link_page( $i ) {
 
 	if ( 1 === $i ) {
 		$url = get_permalink();
-	} else {
-		if ( ! get_option( 'permalink_structure' ) || in_array( $post->post_status, array( 'draft', 'pending' ), true ) ) {
+	} elseif ( ! get_option( 'permalink_structure' ) || in_array( $post->post_status, array( 'draft', 'pending' ), true ) ) {
 			$url = add_query_arg( 'page', $i, get_permalink() );
-		} elseif ( 'page' === get_option( 'show_on_front' ) && (int) get_option( 'page_on_front' ) === $post->ID ) {
-			$url = trailingslashit( get_permalink() ) . user_trailingslashit( "$wp_rewrite->pagination_base/" . $i, 'single_paged' );
-		} else {
-			$url = trailingslashit( get_permalink() ) . user_trailingslashit( $i, 'single_paged' );
-		}
+	} elseif ( 'page' === get_option( 'show_on_front' ) && (int) get_option( 'page_on_front' ) === $post->ID ) {
+		$url = trailingslashit( get_permalink() ) . user_trailingslashit( "$wp_rewrite->pagination_base/" . $i, 'single_paged' );
+	} else {
+		$url = trailingslashit( get_permalink() ) . user_trailingslashit( $i, 'single_paged' );
 	}
 
 	if ( is_preview() ) {
@@ -1777,8 +1775,10 @@ function get_the_password_form( $post = 0 ) {
 	$post   = get_post( $post );
 	$label  = 'pwbox-' . ( empty( $post->ID ) ? rand() : $post->ID );
 	$output = '<form action="' . esc_url( site_url( 'wp-login.php?action=postpass', 'login_post' ) ) . '" class="post-password-form" method="post">
+	<input type="hidden" name="redirect_to" value="' . esc_url( get_permalink( $post ) ) . '" />
 	<p>' . __( 'This content is password protected. To view it please enter your password below:' ) . '</p>
-	<p><label for="' . $label . '">' . __( 'Password:' ) . ' <input name="post_password" id="' . $label . '" type="password" spellcheck="false" size="20" /></label> <input type="submit" name="Submit" value="' . esc_attr_x( 'Enter', 'post password form' ) . '" /></p></form>
+	<p><label for="' . $label . '">' . __( 'Password:' ) . ' <input name="post_password" id="' . $label . '" type="password" spellcheck="false" size="20" /></label> <input type="submit" name="Submit" value="' . esc_attr_x( 'Enter', 'post password form' ) . '" /></p>
+	</form>
 	';
 
 	/**

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -1798,10 +1798,13 @@ function get_the_password_form( $post = 0 ) {
 		$class                 = ' password-form-error';
 	}
 
-	$redirect_field = sprintf(
-		'<input type="hidden" name="redirect_to" value="%s" />',
-		esc_attr( get_permalink( $post ) )
-	);
+	$redirect_field = '';
+	if ( ! empty( $post->ID ) ) {
+		$redirect_field = sprintf(
+			'<input type="hidden" name="redirect_to" value="%s" />',
+			esc_attr( get_permalink( $post->ID ) )
+		);
+	}
 
 	$output = '<form action="' . esc_url( site_url( 'wp-login.php?action=postpass', 'login_post' ) ) . '" class="post-password-form' . $class . '" method="post">' . $redirect_field . $invalid_password_html . '
 	<p>' . __( 'This content is password protected. To view it please enter your password below:' ) . '</p>

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -1780,6 +1780,7 @@ function get_the_password_form( $post = 0 ) {
 	$invalid_password_html = '';
 	$aria                  = '';
 	$class                 = '';
+	$redirect_field        = '';
 
 	// If the referrer is the same as the current request, the user has entered an invalid password.
 	if ( ! empty( $post->ID ) && wp_get_raw_referer() === get_permalink( $post->ID ) && isset( $_COOKIE[ 'wp-postpass_' . COOKIEHASH ] ) ) {
@@ -1798,7 +1799,6 @@ function get_the_password_form( $post = 0 ) {
 		$class                 = ' password-form-error';
 	}
 
-	$redirect_field = '';
 	if ( ! empty( $post->ID ) ) {
 		$redirect_field = sprintf(
 			'<input type="hidden" name="redirect_to" value="%s" />',

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -1067,12 +1067,14 @@ function _wp_link_page( $i ) {
 
 	if ( 1 === $i ) {
 		$url = get_permalink();
-	} elseif ( ! get_option( 'permalink_structure' ) || in_array( $post->post_status, array( 'draft', 'pending' ), true ) ) {
-			$url = add_query_arg( 'page', $i, get_permalink() );
-	} elseif ( 'page' === get_option( 'show_on_front' ) && (int) get_option( 'page_on_front' ) === $post->ID ) {
-		$url = trailingslashit( get_permalink() ) . user_trailingslashit( "$wp_rewrite->pagination_base/" . $i, 'single_paged' );
 	} else {
-		$url = trailingslashit( get_permalink() ) . user_trailingslashit( $i, 'single_paged' );
+		if ( ! get_option( 'permalink_structure' ) || in_array( $post->post_status, array( 'draft', 'pending' ), true ) ) {
+			$url = add_query_arg( 'page', $i, get_permalink() );
+		} elseif ( 'page' === get_option( 'show_on_front' ) && (int) get_option( 'page_on_front' ) === $post->ID ) {
+			$url = trailingslashit( get_permalink() ) . user_trailingslashit( "$wp_rewrite->pagination_base/" . $i, 'single_paged' );
+		} else {
+			$url = trailingslashit( get_permalink() ) . user_trailingslashit( $i, 'single_paged' );
+		}
 	}
 
 	if ( is_preview() ) {

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -1796,7 +1796,12 @@ function get_the_password_form( $post = 0 ) {
 		$class                 = ' password-form-error';
 	}
 
-	$output = '<form action="' . esc_url( site_url( 'wp-login.php?action=postpass', 'login_post' ) ) . '" class="post-password-form' . $class . '" method="post">' . $invalid_password_html . '
+	$redirect_field = sprintf(
+		'<input type="hidden" name="redirect_to" value="%s" />',
+		esc_attr( get_permalink( $post ) )
+	);
+
+	$output = '<form action="' . esc_url( site_url( 'wp-login.php?action=postpass', 'login_post' ) ) . '" class="post-password-form' . $class . '" method="post">' . $redirect_field . $invalid_password_html . '
 	<p>' . __( 'This content is password protected. To view it please enter your password below:' ) . '</p>
 	<p><label for="' . $field_id . '">' . __( 'Password:' ) . ' <input name="post_password" id="' . $field_id . '" type="password" spellcheck="false" required size="20"' . $aria . ' /></label> <input type="submit" name="Submit" value="' . esc_attr_x( 'Enter', 'post password form' ) . '" /></p></form>
 	';

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -782,8 +782,9 @@ switch ( $action ) {
 		 *
 		 * @param int $expires The expiry time, as passed to setcookie().
 		 */
-		$expire  = apply_filters( 'post_password_expires', time() + 10 * DAY_IN_SECONDS );
-		$referer = wp_get_referer();
+		$expire      = apply_filters( 'post_password_expires', time() + 10 * DAY_IN_SECONDS );
+		$referer     = wp_get_referer();
+		$redirect_to = isset( $_POST['redirect_to'] ) ? $_POST['redirect_to'] : $referer;
 
 		if ( $referer ) {
 			$secure = ( 'https' === parse_url( $referer, PHP_URL_SCHEME ) );
@@ -793,7 +794,7 @@ switch ( $action ) {
 
 		setcookie( 'wp-postpass_' . COOKIEHASH, $hasher->HashPassword( wp_unslash( $_POST['post_password'] ) ), $expire, COOKIEPATH, COOKIE_DOMAIN, $secure );
 
-		wp_safe_redirect( wp_get_referer() );
+		wp_safe_redirect( $redirect_to );
 		exit;
 
 	case 'logout':

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -764,8 +764,7 @@ switch ( $action ) {
 		break;
 
 	case 'postpass':
-		$referer     = wp_get_referer();
-		$redirect_to = isset( $_POST['redirect_to'] ) ? $_POST['redirect_to'] : $referer;
+		$redirect_to = $_POST['redirect_to'] ?? wp_get_referer();
 
 		if ( ! isset( $_POST['post_password'] ) || ! is_string( $_POST['post_password'] ) ) {
 			wp_safe_redirect( $redirect_to );

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -787,8 +787,8 @@ switch ( $action ) {
 		 */
 		$expire = apply_filters( 'post_password_expires', time() + 10 * DAY_IN_SECONDS );
 
-		if ( $referer ) {
-			$secure = ( 'https' === parse_url( $referer, PHP_URL_SCHEME ) );
+		if ( $redirect_to ) {
+			$secure = ( 'https' === parse_url( $redirect_to, PHP_URL_SCHEME ) );
 		} else {
 			$secure = false;
 		}

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -785,7 +785,7 @@ switch ( $action ) {
 		 *
 		 * @param int $expires The expiry time, as passed to setcookie().
 		 */
-		$expire      = apply_filters( 'post_password_expires', time() + 10 * DAY_IN_SECONDS );
+		$expire = apply_filters( 'post_password_expires', time() + 10 * DAY_IN_SECONDS );
 
 		if ( $referer ) {
 			$secure = ( 'https' === parse_url( $referer, PHP_URL_SCHEME ) );

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -764,8 +764,11 @@ switch ( $action ) {
 		break;
 
 	case 'postpass':
+		$referer     = wp_get_referer();
+		$redirect_to = isset( $_POST['redirect_to'] ) ? $_POST['redirect_to'] : $referer;
+
 		if ( ! isset( $_POST['post_password'] ) || ! is_string( $_POST['post_password'] ) ) {
-			wp_safe_redirect( wp_get_referer() );
+			wp_safe_redirect( $redirect_to );
 			exit;
 		}
 
@@ -783,8 +786,6 @@ switch ( $action ) {
 		 * @param int $expires The expiry time, as passed to setcookie().
 		 */
 		$expire      = apply_filters( 'post_password_expires', time() + 10 * DAY_IN_SECONDS );
-		$referer     = wp_get_referer();
-		$redirect_to = isset( $_POST['redirect_to'] ) ? $_POST['redirect_to'] : $referer;
 
 		if ( $referer ) {
 			$secure = ( 'https' === parse_url( $referer, PHP_URL_SCHEME ) );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/62881

### Description

Adds a hidden `redirect_to` field to the password protection form to ensure proper redirection when Referrer-Policy is set to 'no-referrer'. This fixes the issue where users would see a white screen or get redirected to the homepage after entering a correct password.

Previously, the redirect relied solely on `wp_get_referer()` which fails when:
- Referrer-Policy is set to 'no-referrer'
- Direct URL access is used
- Coming from external domains

### Testing Instructions

> [!TIP] 
> `Nginx` users can add `add_header Referrer-Policy "no-referrer";` to set the referrer policy.

1. Create a password-protected post
2. Set Referrer-Policy to 'no-referrer' in your server config
3. Visit the protected post
4. Enter the correct password
5. Verify you're redirected back to the post

### Screencasts

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/ee4d981a-a492-4a1d-933f-a70105d73c1f)|![after](https://github.com/user-attachments/assets/e9ee65ff-746c-4106-abb2-f9612343f86a)|



---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
