### PR TITLE
Tests: Update assertions in AtomParser_Parse_Test to allow for greater than or equal checks

### DIFF
--- a/tests/phpunit/tests/atomlib/AtomParser_Parse_Test.php
+++ b/tests/phpunit/tests/atomlib/AtomParser_Parse_Test.php
@@ -68,8 +68,8 @@ final class AtomParser_Parse_Test extends WP_UnitTestCase {
 		$this->assertSame( 28, $atom->start_element_call_counter, sprintf( $msg, 'start_element' ) );
 		$this->assertSame( 28, $atom->end_element_call_counter, sprintf( $msg, 'end_element' ) );
 		$this->assertSame( 2, $atom->start_ns_call_counter, sprintf( $msg, 'start_ns' ) );
-		$this->assertSame( 0, $atom->end_ns_call_counter, sprintf( $msg, 'end_ns' ) );
-		$this->assertSame( 57, $atom->cdata_call_counter, sprintf( $msg, 'cdata' ) );
-		$this->assertSame( 2, $atom->default_call_counter, sprintf( $msg, '_default' ) );
+		$this->assertGreaterThanOrEqual( 0, $atom->end_ns_call_counter, sprintf( $msg, 'end_ns' ) );
+		$this->assertGreaterThanOrEqual( 57, $atom->cdata_call_counter, sprintf( $msg, 'cdata' ) );
+		$this->assertGreaterThanOrEqual( 2, $atom->default_call_counter, sprintf( $msg, '_default' ) );
 	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/62110

### Description

The `AtomParser_Parse_Test::test_parse_sets_handlers` test fails for the last three assertions. It was agreed that this is a tests-only issue, and a patch should be created to fix the test cases by using `assertGreaterThan` instead of `assertSame` as the test intends to verify that the handlers are being called, not to validate their functionality.  

Additionally, some hosting environments are experiencing test failures due to the same issue. Relevant references can be found [here](https://make.wordpress.org/hosting/test-results/r59527/).

### Screenshots

![Screenshot 2025-01-30 at 3 42 13 PM](https://github.com/user-attachments/assets/e1be1c5d-25c9-4d09-b939-f2519f097645)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
