### PR TITLE
Fix: Remove `recovery_mode_clean_expired_keys` cron event on Populate Network.

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -1018,6 +1018,11 @@ function populate_network( $network_id = 1, $domain = '', $email = '', $site_nam
 		return $errors;
 	}
 
+	// Remove the cron event since Recovery Mode is not used in Multisite.
+	if ( wp_next_scheduled( 'recovery_mode_clean_expired_keys' ) ) {
+		wp_clear_scheduled_hook( 'recovery_mode_clean_expired_keys' );
+	}
+
 	if ( 1 === $network_id ) {
 		$wpdb->insert(
 			$wpdb->site,
@@ -1046,6 +1051,11 @@ function populate_network( $network_id = 1, $domain = '', $email = '', $site_nam
 			'subdomain_install' => $subdomain_install,
 		)
 	);
+
+	// Remove the cron event since Recovery Mode is not used in Multisite.
+	if ( wp_next_scheduled( 'recovery_mode_clean_expired_keys' ) ) {
+		wp_clear_scheduled_hook( 'recovery_mode_clean_expired_keys' );
+	}
 
 	/*
 	 * When upgrading from single to multisite, assume the current site will

--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -1018,11 +1018,6 @@ function populate_network( $network_id = 1, $domain = '', $email = '', $site_nam
 		return $errors;
 	}
 
-	// Remove the cron event since Recovery Mode is not used in Multisite.
-	if ( wp_next_scheduled( 'recovery_mode_clean_expired_keys' ) ) {
-		wp_clear_scheduled_hook( 'recovery_mode_clean_expired_keys' );
-	}
-
 	if ( 1 === $network_id ) {
 		$wpdb->insert(
 			$wpdb->site,


### PR DESCRIPTION
Trac Ticket: Core-61450

## Description

- This update adds functionality inside the `populate_network()` function to remove the `recovery_mode_clean_expired_keys` cron event. Since Recovery Mode is not used in a Multisite environment, this cron event is no longer necessary. Removing it ensures that unnecessary scheduled tasks are not running.

## Changes

- Cron Event Removal: The following code has been added inside the `populate_network()` function to clear the `recovery_mode_clean_expired_keys` cron event if it's scheduled.

## Why This Is Necessary

The `recovery_mode_clean_expired_keys` cron event is intended for cleaning expired recovery keys in single-site installations. It is not required in a Multisite environment, and clearing it ensures that unnecessary cron jobs are not scheduled, thus improving overall performance.