### PR TITLE
Administration: Add iframe support in plugin installation and adjust CSS

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -2842,6 +2842,10 @@ div.action-links {
 	margin: 16px 0;
 }
 
+#section-holder iframe {
+	width: 100%;
+}
+
 #plugin-information .fyi {
 	float: right;
 	position: relative;

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -569,6 +569,11 @@ function install_plugin_information() {
 			'alt'   => array(),
 		),
 		'blockquote' => array( 'cite' => true ),
+		'iframe'     => array(
+			'src'    => array(),
+			'height' => array(),
+			'width'  => array(),
+		),
 	);
 
 	$plugins_section_titles = array(


### PR DESCRIPTION
Track ticket: https://core.trac.wordpress.org/ticket/45853

This PR addresses an issue where embedded videos in a plugin’s `readme.txt` file do not load when searching for plugins within a WordPress install or when viewing the plugin details modal.  

- Videos embedded in a plugin’s `readme.txt` file display correctly on WordPress.org but do not appear within the WP-Admin plugin search or the "View Details" modal.  
- Inspecting the element showed an empty `<span class="embed-youtube"></span>`, indicating that the embedded video was stripped during sanitization.  

#### **Root Cause**  
- In `plugin-install.php`, the function `install_plugin_information()` sanitizes the plugin data using `wp_kses()`.  
- The `$plugins_allowedtags` array, which defines the permitted HTML tags, **did not include support for `<iframe>`**, causing the embedded video to be removed.  

#### **Proposed Solution**  
- Added support for the `<iframe>` tag within `$plugins_allowedtags`, allowing embedded videos from sources like YouTube and Vimeo to be retained.  
- Applied CSS rules to ensure iframes are properly sized within the plugin details view for better UI consistency.  