### PR TITLE
Add __toString() method to WP_Term class and related unit test

### DIFF
--- a/src/wp-includes/class-wp-term.php
+++ b/src/wp-includes/class-wp-term.php
@@ -242,4 +242,15 @@ final class WP_Term {
 				return sanitize_term( $data, $data->taxonomy, 'raw' );
 		}
 	}
+
+	/**
+	 * Return string value.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @return string The term's name.
+	 */
+	public function __toString() {
+		return $this->name;
+	}
 }

--- a/tests/phpunit/tests/term/wpTerm.php
+++ b/tests/phpunit/tests/term/wpTerm.php
@@ -89,4 +89,12 @@ class Tests_Term_WpTerm extends WP_UnitTestCase {
 		$found = WP_Term::get_instance( self::$term_id, 'wptests_tax2' );
 		$this->assertFalse( $found );
 	}
+
+	/**
+	 * @ticket 36641
+	 */
+	public function test_to_string_should_return_term_name() {
+		$term = get_term( self::$term_id );
+		$this->assertSame( $term->name, (string) $term );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/36641
Refresh for: https://core.trac.wordpress.org/attachment/ticket/36641/36641.patch

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
