### PR TITLE
Fix: Add type check to hash before passing it to has_equals to prevent warning

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2672,7 +2672,13 @@ if ( ! function_exists( 'wp_check_password' ) ) :
 
 		// If the hash is still md5...
 		if ( strlen( $hash ) <= 32 ) {
-			$check = hash_equals( $hash, md5( $password ) );
+			// Ensure both $hash and the md5 of $password are strings before passing them to `hash_equals()`.
+			if ( is_string( $hash ) && is_string( md5( $password ) ) ) {
+				$check = hash_equals( $hash, md5( $password ) );
+			} else {
+				$check = false;
+			}
+
 			if ( $check && $user_id ) {
 				// Rehash using new hash.
 				wp_set_password( $password, $user_id );
@@ -2702,7 +2708,12 @@ if ( ! function_exists( 'wp_check_password' ) ) :
 			$wp_hasher = new PasswordHash( 8, true );
 		}
 
-		$check = $wp_hasher->CheckPassword( $password, $hash );
+		// Ensure that both $password and $hash are strings before passing them to `CheckPassword()`
+		if ( is_string( $password ) && is_string( $hash ) ) {
+			$check = $wp_hasher->CheckPassword( $password, $hash );
+		} else {
+			$check = false;
+		}
 
 		/** This filter is documented in wp-includes/pluggable.php */
 		return apply_filters( 'check_password', $check, $password, $hash, $user_id );


### PR DESCRIPTION
Trac Ticket: Core-59824

## Summary

- This pull request addresses a bug where the `hash_equals()` function in the `wp_check_password()` function would throw an error when it received a null value as one of its arguments. This issue occurs when the hash comparison logic inadvertently passes null, causing PHP to raise a TypeError in certain edge cases, especially when a hacker attempts to pass null values in an attack. The fix ensures that both the hash and the plaintext password are properly validated as strings before calling `hash_equals()` and `CheckPassword()`.

## Changes

- Added type checks before invoking the hash_equals() function to ensure both the `$hash` and the result of `md5($password)` are valid strings.

- Similarly, added type checks before calling `$wp_hasher->CheckPassword()` to ensure both `$password` and `$hash` are strings.

- The function now gracefully handles invalid or unexpected input (such as null values) by returning false instead of causing a fatal error.

## Why is this important?

- This change ensures that the wp_check_password() function will:

    - Avoid throwing errors when invalid inputs (like null) are provided, especially in cases of malicious requests.

    - Improve the robustness of the password-checking process, making it more secure and resilient to unexpected input.

    - Provide greater compatibility with PHP versions that support hash_equals() and newer password hashing protocols.