### PR TITLE
is_front_page incorrectly returns false

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4374,9 +4374,7 @@ class WP_Query {
 	 * @return bool Whether the query is for the front page of the site.
 	 */
 	public function is_front_page() {
-		$show_on_front  = get_option( 'show_on_front' );
-		$page_on_front  = get_option( 'page_on_front' );
-		$page_for_posts = get_option( 'page_for_posts' );
+		$show_on_front = get_option( 'show_on_front' );
 
 		// If Your Latest Posts is selected.
 		if ( 'posts' === $show_on_front && $this->is_home() ) {
@@ -4384,13 +4382,16 @@ class WP_Query {
 		}
 
 		if ( 'page' === $show_on_front ) {
+			$page_on_front = get_option( 'page_on_front' );
+			$page_for_posts = get_option( 'page_for_posts' );
+
 			// If a static homepage is set and we're on that page.
 			if ( $page_on_front && $this->is_page( $page_on_front ) ) {
 				return true;
 			}
 
 			// Edge case where a posts page has been selected but a homepage is not set.
-			if ( $page_for_posts && ! $page_on_front && $this->is_home() ) {
+			if ( $page_for_posts && ! $page_on_front && get_queried_object_id() !== (int) $page_for_posts ) {
 				return true;
 			}
 		}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4374,8 +4374,8 @@ class WP_Query {
 	 * @return bool Whether the query is for the front page of the site.
 	 */
 	public function is_front_page() {
-		$show_on_front = get_option( 'show_on_front' );
-		$page_on_front = get_option( 'page_on_front' );
+		$show_on_front  = get_option( 'show_on_front' );
+		$page_on_front  = get_option( 'page_on_front' );
 		$page_for_posts = get_option( 'page_for_posts' );
 
 		// Most likely case.

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4374,22 +4374,27 @@ class WP_Query {
 	 * @return bool Whether the query is for the front page of the site.
 	 */
 	public function is_front_page() {
+		$show_on_front = get_option( 'show_on_front' );
+		$page_on_front = get_option( 'page_on_front' );
+		$page_for_posts = get_option( 'page_for_posts' );
+
 		// Most likely case.
-		if ( 'posts' === get_option( 'show_on_front' ) && $this->is_home() ) {
+		if ( 'posts' === $show_on_front && $this->is_home() ) {
 			return true;
-		} elseif ( 'page' === get_option( 'show_on_front' ) && get_option( 'page_on_front' )
-			&& $this->is_page( get_option( 'page_on_front' ) )
-		) {
-			return true;
-		} elseif ( 'page' === get_option( 'show_on_front' ) && get_option( 'page_for_posts' )
-			&& ! get_option( 'page_on_front' )
-			&& $this->is_home()
-		) {
-			// Edge case where the Reading settings has a posts page set but not a static homepage.
-			return true;
-		} else {
-			return false;
 		}
+
+		if ( 'page' === $show_on_front ) {
+			if ( $page_on_front && $this->is_page( $page_on_front ) ) {
+				return true;
+			}
+
+			// Edge case where the Reading settings has a posts page set but not a static homepage.
+			if ( $page_for_posts && ! $page_on_front && $this->is_home() ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4391,7 +4391,7 @@ class WP_Query {
 			}
 
 			// Edge case where a posts page has been selected but a homepage is not set.
-			if ( $page_for_posts && ! $page_on_front && get_queried_object_id() !== (int) $page_for_posts ) {
+			if ( $page_for_posts && is_home() && ( (int) $page_for_posts !== get_queried_object_id() ) ) {
 				return true;
 			}
 		}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4378,17 +4378,18 @@ class WP_Query {
 		$page_on_front  = get_option( 'page_on_front' );
 		$page_for_posts = get_option( 'page_for_posts' );
 
-		// Most likely case.
+		// If Your Latest Posts is selected.
 		if ( 'posts' === $show_on_front && $this->is_home() ) {
 			return true;
 		}
 
 		if ( 'page' === $show_on_front ) {
+			// If a static homepage is set and we're on that page.
 			if ( $page_on_front && $this->is_page( $page_on_front ) ) {
 				return true;
 			}
 
-			// Edge case where the Reading settings has a posts page set but not a static homepage.
+			// Edge case where a posts page has been selected but a homepage is not set.
 			if ( $page_for_posts && ! $page_on_front && $this->is_home() ) {
 				return true;
 			}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4391,7 +4391,7 @@ class WP_Query {
 			}
 
 			// Edge case where a posts page has been selected but a homepage is not set.
-			if ( $page_for_posts && is_home() && ( (int) $page_for_posts !== get_queried_object_id() ) ) {
+			if ( $page_for_posts && is_home() && ( get_queried_object_id() !== (int) $page_for_posts ) ) {
 				return true;
 			}
 		}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4381,6 +4381,12 @@ class WP_Query {
 			&& $this->is_page( get_option( 'page_on_front' ) )
 		) {
 			return true;
+		} elseif ( 'page' === get_option( 'show_on_front' ) && get_option( 'page_for_posts' )
+			&& ! get_option( 'page_on_front' )
+			&& $this->is_home()
+		) {
+			// Edge case where the Reading settings has a posts page set but not a static homepage.
+			return true;
 		} else {
 			return false;
 		}


### PR DESCRIPTION
When the Reading settings have a posts page set but a homepage is not set, is_front_page incorrectly returns false when a front end user visits the front page of the site.

Trac ticket: https://core.trac.wordpress.org/ticket/59252 

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
