### PR TITLE
#62221 Fix some path handling when installing the local environment from the build directory

### DIFF
--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -12,7 +12,7 @@ dotenvExpand.expand( dotenv.config() );
 local_env_utils.determine_auth_option();
 
 // Create wp-config.php.
-wp_cli( 'config create --dbname=wordpress_develop --dbuser=root --dbpass=password --dbhost=mysql --path=/var/www/src --force' );
+wp_cli( 'config create --dbname=wordpress_develop --dbuser=root --dbpass=password --dbhost=mysql --force' );
 
 // Add the debug settings to wp-config.php.
 // Windows requires this to be done as an additional step, rather than using the --extra-php option in the previous step.
@@ -24,7 +24,7 @@ wp_cli( `config set WP_ENVIRONMENT_TYPE ${process.env.LOCAL_WP_ENVIRONMENT_TYPE}
 wp_cli( `config set WP_DEVELOPMENT_MODE ${process.env.LOCAL_WP_DEVELOPMENT_MODE} --type=constant` );
 
 // Move wp-config.php to the base directory, so it doesn't get mixed up in the src or build directories.
-renameSync( 'src/wp-config.php', 'wp-config.php' );
+renameSync( `${process.env.LOCAL_DIR}/wp-config.php`, 'wp-config.php' );
 
 install_wp_importer();
 
@@ -55,7 +55,7 @@ wait_on( { resources: [ `tcp:localhost:${process.env.LOCAL_PORT}`] } )
 function wp_cli( cmd ) {
 	const composeFiles = local_env_utils.get_compose_files();
 
-	execSync( `docker compose ${composeFiles} run --quiet-pull --rm cli ${cmd}`, { stdio: 'inherit' } );
+	execSync( `docker compose ${composeFiles} run --quiet-pull --rm cli ${cmd} --path=/var/www/${process.env.LOCAL_DIR}`, { stdio: 'inherit' } );
 }
 
 /**


### PR DESCRIPTION
The `npm run env:install` command runs the install using the code in `src` regardless of whether `LOCAL_DIR` is set to `build`. 99% of the time this isn't a problem because the two codebases are usually functionally identical, but in the case of the performance tests on GitHub Actions the installation needs to run from the `build` directory because a different version of WordPress is downloaded into `build`.

This has always been the case but the effect was not noticed until the performance tests were split up in [[59749]](https://core.trac.wordpress.org/changeset/59749). This bug is preventing the performance tests for #7333 from running correctly.

Trac ticket: https://core.trac.wordpress.org/ticket/62221
Trac ticket: https://core.trac.wordpress.org/ticket/21022