### PR TITLE
Add E2E test for privacy settings

### DIFF
--- a/tests/e2e/assets/expected_text.txt
+++ b/tests/e2e/assets/expected_text.txt
@@ -1,0 +1,38 @@
+Who we are
+Our website address is: http://localhost:8889.
+
+Comments
+When visitors leave comments on the site we collect the data shown in the comments form, and also the visitor’s IP address and browser user agent string to help spam detection.
+
+An anonymized string created from your email address (also called a hash) may be provided to the Gravatar service to see if you are using it. The Gravatar service privacy policy is available here: https://automattic.com/privacy/. After approval of your comment, your profile picture is visible to the public in the context of your comment.
+
+Media
+If you upload images to the website, you should avoid uploading images with embedded location data (EXIF GPS) included. Visitors to the website can download and extract any location data from images on the website.
+
+Cookies
+If you leave a comment on our site you may opt-in to saving your name, email address and website in cookies. These are for your convenience so that you do not have to fill in your details again when you leave another comment. These cookies will last for one year.
+
+If you visit our login page, we will set a temporary cookie to determine if your browser accepts cookies. This cookie contains no personal data and is discarded when you close your browser.
+
+When you log in, we will also set up several cookies to save your login information and your screen display choices. Login cookies last for two days, and screen options cookies last for a year. If you select "Remember Me", your login will persist for two weeks. If you log out of your account, the login cookies will be removed.
+
+If you edit or publish an article, an additional cookie will be saved in your browser. This cookie includes no personal data and simply indicates the post ID of the article you just edited. It expires after 1 day.
+
+Embedded content from other websites
+Articles on this site may include embedded content (e.g. videos, images, articles, etc.). Embedded content from other websites behaves in the exact same way as if the visitor has visited the other website.
+
+These websites may collect data about you, use cookies, embed additional third-party tracking, and monitor your interaction with that embedded content, including tracking your interaction with the embedded content if you have an account and are logged in to that website.
+
+Who we share your data with
+If you request a password reset, your IP address will be included in the reset email.
+
+How long we retain your data
+If you leave a comment, the comment and its metadata are retained indefinitely. This is so we can recognize and approve any follow-up comments automatically instead of holding them in a moderation queue.
+
+For users that register on our website (if any), we also store the personal information they provide in their user profile. All users can see, edit, or delete their personal information at any time (except they cannot change their username). Website administrators can also see and edit that information.
+
+What rights you have over your data
+If you have an account on this site, or have left comments, you can request to receive an exported file of the personal data we hold about you, including any data you have provided to us. You can also request that we erase any personal data we hold about you. This does not include any data we are obliged to keep for administrative, legal, or security purposes.
+
+Where your data is sent
+Visitor comments may be checked through an automated spam detection service.

--- a/tests/e2e/specs/settings/privacy.test.js
+++ b/tests/e2e/specs/settings/privacy.test.js
@@ -1,0 +1,95 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Privacy Settings', () => {
+	const postTitle = 'Privacy Policy Test';
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.createPage( {
+			title: postTitle,
+			status: 'publish',
+		} );
+	} );
+	test.beforeEach( async ( { admin } ) => {
+		// Navigate to Privacy Settings page before each test
+		await admin.visitAdminPage( 'options-privacy.php' );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllPages();
+	} );
+
+	test( 'creates the privacy page', async ( { page, editor, admin } ) => {
+		// Assert the title of the Privacy Settings page
+		await expect(
+			page.locator( "div[class='privacy-settings-title-section'] h1" )
+		).toHaveText( 'Privacy' );
+		await page.locator( '#create-page' ).click();
+
+        await page.locator('button.components-button.is-small.has-icon:has-text("Close")').click();
+		// Verify the specific text inside the 'Editor content' region
+		const guideText =
+			'Need help putting together your new Privacy Policy page? Check out our guide for';
+		await expect(
+			page
+				.getByRole( 'region', { name: 'Editor content' } )
+				.getByText( guideText )
+		).toBeVisible();
+		await page.keyboard.press( 'Escape' );
+		await editor.publishPost();
+		await admin.visitAdminPage( 'options-privacy.php' );
+
+		const privacyPolicyDropdown = page.locator(
+			'select#page_for_privacy_policy'
+		);
+
+		// Get the selected option's text
+		const selectedValue = await privacyPolicyDropdown
+			.locator( 'option:checked' )
+			.textContent();
+
+		// Verify the selected option is "Privacy Policy"
+		await expect( selectedValue.trim() ).toBe( 'Privacy Policy' );
+	} );
+
+	test( 'changes the Privacy Policy Page', async ( { page } ) => {
+		// Locate the dropdown and set the value by visible text
+		await page
+			.locator( 'select#page_for_privacy_policy' )
+			.selectOption( { label: postTitle } );
+
+		// Click the "Use This Page" button to set the privacy page
+		await page.click( 'role=button[name="Use This Page"i]' );
+
+		// Verify success message
+		await expect(
+			page.locator( '#setting-error-page_for_privacy_policy' )
+		).toHaveText(
+			/Privacy Policy page setting updated successfully. Remember to update your menus!/
+		);
+	} );
+
+	test( 'validates the Privacy Policy Guide Title', async ( { page } ) => {
+		// Navigate to the Privacy Policy Guide tab
+		await page.click( "a[class='privacy-settings-tab']" );
+
+		// Verify the header text in the Privacy Policy Guide section
+		await expect(
+			page.locator( 'text=Privacy Policy Guide' ).first()
+		).toHaveText( 'Privacy Policy Guide' );
+	} );
+
+	test( 'copies WordPress text to clipboard', async ( { page } ) => {
+		// Navigate to the Privacy Policy Guide tab
+		await page.click( "a[class='privacy-settings-tab']" );
+		await page.click(
+			'.privacy-settings-accordion-trigger:has-text("WordPress")'
+		);
+
+		// Verify the header text in the Privacy Policy Guide section
+		await expect(
+			page.locator( 'text=Privacy Policy Guide' ).first()
+		).toHaveText( 'Privacy Policy Guide' );
+	} );
+} );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/52895

This PR has test to
- create privacy page
- changes the Privacy Policy Page
- validates the Privacy Policy Guide Title
- copies WordPress text to clipboard 
To make the "copies WordPress text to clipboard" test work, in Playwright config, this needs to be added 

`permissions: ['clipboard-read', 'clipboard-write'], // Allows clipboard read and write access`