### PR TITLE
Perform permission_callback before validate_callback in REST API

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -1110,18 +1110,6 @@ class WP_REST_Server {
 			);
 		}
 
-		if ( ! is_wp_error( $error ) ) {
-			$check_required = $request->has_valid_params();
-			if ( is_wp_error( $check_required ) ) {
-				$error = $check_required;
-			} else {
-				$check_sanitized = $request->sanitize_params();
-				if ( is_wp_error( $check_sanitized ) ) {
-					$error = $check_sanitized;
-				}
-			}
-		}
-
 		$response = $this->respond_to_request( $request, $route, $handler, $error );
 		array_pop( $this->dispatching_requests );
 		return $response;
@@ -1266,6 +1254,18 @@ class WP_REST_Server {
 					__( 'Sorry, you are not allowed to do that.' ),
 					array( 'status' => rest_authorization_required_code() )
 				);
+			}
+		}
+
+		if ( ! is_wp_error( $response ) ) {
+			$check_required = $request->has_valid_params();
+			if ( is_wp_error( $check_required ) ) {
+				$response = $check_required;
+			} else {
+				$check_sanitized = $request->sanitize_params();
+				if ( is_wp_error( $check_sanitized ) ) {
+					$response = $check_sanitized;
+				}
 			}
 		}
 


### PR DESCRIPTION
 I am building a REST endpoint that goes like this `users/articles/{article_id}` while `{article_id}` can be validated with validate_callback on the $args parameter level.

In my validation, I check for the author of the article to match the currently logged-in user. If not, it should return a WP_Error of 404 status, assuming the user is logged in.

I expected a 403 permission error to come up for the guest from `permission_callback`, but it did not. Rather, it throws a 404 from `validate_callback` since the user is not logged in, and the ID does not match the author. Hence, `permission_callback` is not run.

Most of the `validate_callback` on the endpoint does some user authentication validations which expect `permission_callback` to have already been handled, but it is not

A better design will be permission_callback called first on each route before even running validations.

Trac ticket: https://core.trac.wordpress.org/ticket/62903