### PR TITLE
Tests: Add test for post titles containing percentage followed by numbers

### DIFF
--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -756,4 +756,37 @@ class Tests_Post extends WP_UnitTestCase {
 		$this->assertTrue( use_block_editor_for_post( $restless_post_id ) );
 		remove_filter( 'use_block_editor_for_post', '__return_true' );
 	}
+
+	/**
+	 * Test that post title with %10 generates correct permalink.
+	 *
+	 * @ticket 3329
+	 * @covers ::get_permalink
+	 */
+	public function test_post_title_with_percentage_followed_by_numbers() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'  => 'Test Title %10',
+				'post_status' => 'publish',
+			)
+		);
+
+		$post = get_post( $post_id );
+
+		// Test slug generation
+		$this->assertSame( 'test-title-%10', $post->post_name );
+
+		// Test permalink generation
+		$permalink = get_permalink( $post_id );
+		$this->assertStringContainsString( 'test-title-%10', $permalink );
+
+		// Test that we can query this post
+		$query = new WP_Query( array( 'name' => $post->post_name ) );
+		$this->assertTrue( $query->have_posts() );
+		$this->assertEquals( $post_id, $query->post->ID );
+
+		$this->set_permalink_structure( '' );
+	}
 }


### PR DESCRIPTION
Trac Ticket: [#3329](https://core.trac.wordpress.org/ticket/3329)

This PR adds a unit test to verify that post titles containing percentage signs followed by numbers (e.g., %10) generate the correct permalinks. The test ensures that:

1. The post slug is generated correctly preserving the `%10`
2. The permalink contains the correct slug
3. The post can be queried using the generated slug

