### PR TITLE
Add post type support to get_calendar() function

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2259,10 +2259,10 @@ function get_calendar( $args = array() ) {
 		'display'   => true,
 		'post_type' => 'post',
 	);
-	
+
 	$original_args = func_get_args();
-	$args = array();
-	
+	$args          = array();
+
 	if ( ! empty( $original_args ) ) {
 		if ( ! is_array( $original_args[0] ) ) {
 			if ( isset( $original_args[0] ) && is_bool( $original_args[0] ) ) {

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2259,16 +2259,20 @@ function get_calendar( $args = array() ) {
 		'display'   => true,
 		'post_type' => 'post',
 	);
-
-	if ( ! is_array( $args ) ) {
-		$backwards_compatible_args = func_get_args();
-
-		if ( isset( $backwards_compatible_args[0] ) && is_bool( $backwards_compatible_args[0] ) ) {
-			$defaults['initial'] = $backwards_compatible_args[0];
-		}
-
-		if ( isset( $backwards_compatible_args[1] ) && is_bool( $backwards_compatible_args[1] ) ) {
-			$defaults['display'] = $backwards_compatible_args[1];
+	
+	$original_args = func_get_args();
+	$args = array();
+	
+	if ( ! empty( $original_args ) ) {
+		if ( ! is_array( $original_args[0] ) ) {
+			if ( isset( $original_args[0] ) && is_bool( $original_args[0] ) ) {
+				$defaults['initial'] = $original_args[0];
+			}
+			if ( isset( $original_args[1] ) && is_bool( $original_args[1] ) ) {
+				$defaults['display'] = $original_args[1];
+			}
+		} else {
+			$args = $original_args[0];
 		}
 	}
 

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2233,6 +2233,7 @@ function calendar_week_mod( $num ) {
  * no posts for the month, then it will not be displayed.
  *
  * @since 1.0.0
+ * @since 6.8.0 New argument $args added.
  *
  * @global wpdb      $wpdb      WordPress database abstraction object.
  * @global int       $m
@@ -2241,21 +2242,60 @@ function calendar_week_mod( $num ) {
  * @global WP_Locale $wp_locale WordPress date and time locale object.
  * @global array     $posts
  *
- * @param bool $initial Optional. Whether to use initial calendar names. Default true.
- * @param bool $display Optional. Whether to display the calendar output. Default true.
+ * @param array $args {
+ *     Optional. Arguments for the `get_calendar` function.
+ *
+ *     @type bool $initial   Whether to use initial calendar names. Default true.
+ *     @type bool $display   Whether to display the calendar output. Default true.
+ *     @type string $post_type Optional. Post type. Default 'post'.
+ * }
  * @return void|string Void if `$display` argument is true, calendar HTML if `$display` is false.
  */
-function get_calendar( $initial = true, $display = true ) {
+function get_calendar( $args = array() ) {
 	global $wpdb, $m, $monthnum, $year, $wp_locale, $posts;
+
+	$defaults = array(
+		'initial'   => true,
+		'display'   => true,
+		'post_type' => 'post',
+	);
+
+	if ( ! is_array( $args ) ) {
+		$backwards_compatible_args = func_get_args();
+
+		if ( isset( $backwards_compatible_args[0] ) && is_bool( $backwards_compatible_args[0] ) ) {
+			$defaults['initial'] = $backwards_compatible_args[0];
+		}
+
+		if ( isset( $backwards_compatible_args[1] ) && is_bool( $backwards_compatible_args[1] ) ) {
+			$defaults['display'] = $backwards_compatible_args[1];
+		}
+	}
+
+	/**
+	 * Filter the `get_calendar` function arguments before they are used.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @param array $args {
+	 *     Optional. Arguments for the `get_calendar` function.
+	 *
+	 *     @type bool $initial   Whether to use initial calendar names. Default true.
+	 *     @type bool $display   Whether to display the calendar output. Default true.
+	 *     @type string $post_type Optional. Post type. Default 'post'.
+	 * }
+	 * @return array The arguments for the `get_calendar` function.
+	 */
+	$args = apply_filters( 'get_calendar_args', wp_parse_args( $args, $defaults ) );
 
 	$key   = md5( $m . $monthnum . $year );
 	$cache = wp_cache_get( 'get_calendar', 'calendar' );
 
 	if ( $cache && is_array( $cache ) && isset( $cache[ $key ] ) ) {
 		/** This filter is documented in wp-includes/general-template.php */
-		$output = apply_filters( 'get_calendar', $cache[ $key ] );
+		$output = apply_filters( 'get_calendar', $cache[ $key ], $args );
 
-		if ( $display ) {
+		if ( $args['display'] ) {
 			echo $output;
 			return;
 		}
@@ -2267,9 +2307,15 @@ function get_calendar( $initial = true, $display = true ) {
 		$cache = array();
 	}
 
+	$post_type = $args['post_type'];
+	if ( ! post_type_exists( $post_type ) ) {
+		$post_type = 'post';
+	}
+
 	// Quick check. If we have no posts at all, abort!
 	if ( ! $posts ) {
-		$gotsome = $wpdb->get_var( "SELECT 1 as test FROM $wpdb->posts WHERE post_type = 'post' AND post_status = 'publish' LIMIT 1" );
+		$prepared_query = $wpdb->prepare( "SELECT 1 as test FROM $wpdb->posts WHERE post_type = %s AND post_status = 'publish' LIMIT 1", $post_type );
+		$gotsome        = $wpdb->get_var( $prepared_query );
 		if ( ! $gotsome ) {
 			$cache[ $key ] = '';
 			wp_cache_set( 'get_calendar', $cache, 'calendar' );
@@ -2309,22 +2355,27 @@ function get_calendar( $initial = true, $display = true ) {
 	$last_day  = gmdate( 't', $unixmonth );
 
 	// Get the next and previous month and year with at least one post.
-	$previous = $wpdb->get_row(
+	$previous_prepared_query = $wpdb->prepare(
 		"SELECT MONTH(post_date) AS month, YEAR(post_date) AS year
 		FROM $wpdb->posts
 		WHERE post_date < '$thisyear-$thismonth-01'
-		AND post_type = 'post' AND post_status = 'publish'
+		AND post_type = %s AND post_status = 'publish'
 		ORDER BY post_date DESC
-		LIMIT 1"
+		LIMIT 1",
+		$post_type
 	);
-	$next     = $wpdb->get_row(
+	$previous                = $wpdb->get_row( $previous_prepared_query );
+
+	$next_prepared_query = $wpdb->prepare(
 		"SELECT MONTH(post_date) AS month, YEAR(post_date) AS year
 		FROM $wpdb->posts
 		WHERE post_date > '$thisyear-$thismonth-{$last_day} 23:59:59'
-		AND post_type = 'post' AND post_status = 'publish'
+		AND post_type = %s AND post_status = 'publish'
 		ORDER BY post_date ASC
-		LIMIT 1"
+		LIMIT 1",
+		$post_type
 	);
+	$next                = $wpdb->get_row( $next_prepared_query );
 
 	/* translators: Calendar caption: 1: Month name, 2: 4-digit year. */
 	$calendar_caption = _x( '%1$s %2$s', 'calendar caption' );
@@ -2344,7 +2395,7 @@ function get_calendar( $initial = true, $display = true ) {
 	}
 
 	foreach ( $myweek as $wd ) {
-		$day_name         = $initial ? $wp_locale->get_weekday_initial( $wd ) : $wp_locale->get_weekday_abbrev( $wd );
+		$day_name         = $args['initial'] ? $wp_locale->get_weekday_initial( $wd ) : $wp_locale->get_weekday_abbrev( $wd );
 		$wd               = esc_attr( $wd );
 		$calendar_output .= "\n\t\t<th scope=\"col\" aria-label=\"$wd\">$day_name</th>";
 	}
@@ -2358,14 +2409,14 @@ function get_calendar( $initial = true, $display = true ) {
 	$daywithpost = array();
 
 	// Get days with posts.
-	$dayswithposts = $wpdb->get_results(
+	$dayswithposts_prepared_query = $wpdb->prepare(
 		"SELECT DISTINCT DAYOFMONTH(post_date)
 		FROM $wpdb->posts WHERE post_date >= '{$thisyear}-{$thismonth}-01 00:00:00'
-		AND post_type = 'post' AND post_status = 'publish'
+		AND post_type = %s AND post_status = 'publish'
 		AND post_date <= '{$thisyear}-{$thismonth}-{$last_day} 23:59:59'",
-		ARRAY_N
+		$post_type
 	);
-
+	$dayswithposts                = $wpdb->get_results( $dayswithposts_prepared_query, ARRAY_N );
 	if ( $dayswithposts ) {
 		foreach ( (array) $dayswithposts as $daywith ) {
 			$daywithpost[] = (int) $daywith[0];
@@ -2452,19 +2503,29 @@ function get_calendar( $initial = true, $display = true ) {
 	$cache[ $key ] = $calendar_output;
 	wp_cache_set( 'get_calendar', $cache, 'calendar' );
 
-	if ( $display ) {
-		/**
-		 * Filters the HTML calendar output.
-		 *
-		 * @since 3.0.0
-		 *
-		 * @param string $calendar_output HTML output of the calendar.
-		 */
-		echo apply_filters( 'get_calendar', $calendar_output );
+	/**
+	 * Filters the HTML calendar output.
+	 *
+	 * @since 3.0.0
+	 * @since 6.8.0 New argument $args added.
+	 *
+	 * @param string $calendar_output HTML output of the calendar.
+	 * @param array  $args {
+	 *     Optional. Array of display arguments.
+	 *
+	 *     @type bool $initial   Whether to use initial calendar names. Default true.
+	 *     @type bool $display   Whether to display the calendar output. Default true.
+	 *     @type string $post_type Optional. Post type. Default 'post'.
+	 * }
+	 */
+	$calendar_output = apply_filters( 'get_calendar', $calendar_output, $args );
+
+	if ( $args['display'] ) {
+		echo $calendar_output;
 		return;
 	}
-	/** This filter is documented in wp-includes/general-template.php */
-	return apply_filters( 'get_calendar', $calendar_output );
+
+	return $calendar_output;
 }
 
 /**

--- a/tests/phpunit/tests/functions/getCalendar.php
+++ b/tests/phpunit/tests/functions/getCalendar.php
@@ -39,9 +39,7 @@ class Tests_Get_Calendar extends WP_UnitTestCase {
 	 */
 	public function test_get_calendar_display() {
 		$expected = '<table id="wp-calendar"';
-		ob_start();
-		get_calendar( array( 'display' => true ) );
-		$actual = ob_get_clean();
+		$actual   = get_echo( 'get_calendar', array( array( 'display' => true ) ) );
 		$this->assertStringContainsString( $expected, $actual );
 	}
 
@@ -66,9 +64,7 @@ class Tests_Get_Calendar extends WP_UnitTestCase {
 			}
 		);
 
-		ob_start();
-		get_calendar();
-		$calendar_html = ob_get_clean();
+		$calendar_html = get_echo( 'get_calendar' );
 
 		remove_all_filters( 'get_calendar_args' );
 
@@ -83,9 +79,7 @@ class Tests_Get_Calendar extends WP_UnitTestCase {
 	 * @ticket 34093
 	 */
 	public function test_get_calendar_backwards_compatibility() {
-		ob_start();
-		get_calendar( false );
-		$first_calendar_html = ob_get_clean();
+		$first_calendar_html = get_echo( 'get_calendar', array( false ) );
 
 		wp_cache_delete( 'get_calendar', 'calendar' );
 

--- a/tests/phpunit/tests/functions/getCalendar.php
+++ b/tests/phpunit/tests/functions/getCalendar.php
@@ -86,11 +86,11 @@ class Tests_Get_Calendar extends WP_UnitTestCase {
 		ob_start();
 		get_calendar( false );
 		$first_calendar_html = ob_get_clean();
-	
+
 		wp_cache_delete( 'get_calendar', 'calendar' );
 
 		$second_calendar_html = get_calendar( false, false );
-	
+
 		$this->assertStringContainsString( '<th scope="col" aria-label="Monday">Mon</th>', $first_calendar_html );
 		$this->assertStringContainsString( 'February 2025', $first_calendar_html );
 		$this->assertStringContainsString( '<table id="wp-calendar"', $second_calendar_html );

--- a/tests/phpunit/tests/functions/getCalendar.php
+++ b/tests/phpunit/tests/functions/getCalendar.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Tests for the get_calendar() function.
+ *
+ * @since 6.8.0
+ *
+ * @group functions
+ * @group calendar
+ *
+ * @covers ::get_calendar
+ */
+class Tests_Get_Calendar extends WP_UnitTestCase {
+
+	/**
+	 * Array of post IDs for testing.
+	 *
+	 * @var int[]
+	 */
+	protected static $post_ids;
+
+	/**
+	 * Set up before class.
+	 *
+	 * @param WP_UnitTest_Factory $factory Test factory.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$post_ids = $factory->post->create_many(
+			3,
+			array(
+				'post_date' => '2025-02-01 12:00:00',
+			)
+		);
+	}
+
+	/**
+	 * Clean up test data after class.
+	 */
+	public static function wpTearDownAfterClass() {
+		foreach ( self::$post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+	}
+
+	/**
+	 * Test that get_calendar() displays output when display is true.
+	 *
+	 * @ticket 34093
+	 */
+	public function test_get_calendar_display() {
+		$expected = '<table id="wp-calendar"';
+		ob_start();
+		get_calendar( array( 'display' => true ) );
+		$actual = ob_get_clean();
+		$this->assertStringContainsString( $expected, $actual );
+	}
+
+	/**
+	 * Test that get_calendar() respects the get_calendar_args filter.
+	 *
+	 * @ticket 34093
+	 */
+	public function test_get_calendar_args_filter() {
+		$page_id = self::factory()->post->create(
+			array(
+				'post_type' => 'page',
+				'post_date' => '2025-02-03 12:00:00',
+			)
+		);
+
+		add_filter(
+			'get_calendar_args',
+			function ( $args ) {
+				$args['post_type'] = 'page';
+				return $args;
+			}
+		);
+
+		ob_start();
+		get_calendar();
+		$calendar_html = ob_get_clean();
+
+		$this->assertStringContainsString( '<table id="wp-calendar"', $calendar_html );
+		$this->assertStringContainsString( 'Posts published on February 3, 2025', $calendar_html );
+		$this->assertStringContainsString( 'February 2025', $calendar_html );
+
+		wp_delete_post( $page_id, true );
+		remove_all_filters( 'get_calendar_args' );
+	}
+
+	/**
+	 * Test that get_calendar() maintains backwards compatibility with old parameter format.
+	 *
+	 * @ticket 34093
+	 */
+	public function test_get_calendar_backwards_compatibility() {
+		ob_start();
+		get_calendar( false );
+		$calendar_html = ob_get_clean();
+
+		$this->assertStringContainsString( '<th scope="col" aria-label="Monday">Mon</th>', $calendar_html );
+		$this->assertStringContainsString( 'February 2025', $calendar_html );
+
+		wp_cache_delete( 'get_calendar', 'calendar' );
+
+		$calendar_html = get_calendar( false, false );
+
+		$this->assertStringContainsString( '<table id="wp-calendar"', $calendar_html );
+		$this->assertStringContainsString( '<th scope="col" aria-label="Monday">Mon</th>', $calendar_html );
+	}
+}

--- a/tests/phpunit/tests/functions/getCalendar.php
+++ b/tests/phpunit/tests/functions/getCalendar.php
@@ -12,11 +12,11 @@
 class Tests_Get_Calendar extends WP_UnitTestCase {
 
 	/**
-	 * Array of post IDs for testing.
+	 * Array of post IDs.
 	 *
 	 * @var int[]
 	 */
-	protected static $post_ids;
+	protected static $post_ids = array();
 
 	/**
 	 * Set up before class.
@@ -30,15 +30,6 @@ class Tests_Get_Calendar extends WP_UnitTestCase {
 				'post_date' => '2025-02-01 12:00:00',
 			)
 		);
-	}
-
-	/**
-	 * Clean up test data after class.
-	 */
-	public static function wpTearDownAfterClass() {
-		foreach ( self::$post_ids as $post_id ) {
-			wp_delete_post( $post_id, true );
-		}
 	}
 
 	/**
@@ -79,12 +70,11 @@ class Tests_Get_Calendar extends WP_UnitTestCase {
 		get_calendar();
 		$calendar_html = ob_get_clean();
 
+		remove_all_filters( 'get_calendar_args' );
+
 		$this->assertStringContainsString( '<table id="wp-calendar"', $calendar_html );
 		$this->assertStringContainsString( 'Posts published on February 3, 2025', $calendar_html );
 		$this->assertStringContainsString( 'February 2025', $calendar_html );
-
-		wp_delete_post( $page_id, true );
-		remove_all_filters( 'get_calendar_args' );
 	}
 
 	/**
@@ -95,16 +85,15 @@ class Tests_Get_Calendar extends WP_UnitTestCase {
 	public function test_get_calendar_backwards_compatibility() {
 		ob_start();
 		get_calendar( false );
-		$calendar_html = ob_get_clean();
-
-		$this->assertStringContainsString( '<th scope="col" aria-label="Monday">Mon</th>', $calendar_html );
-		$this->assertStringContainsString( 'February 2025', $calendar_html );
-
+		$first_calendar_html = ob_get_clean();
+	
 		wp_cache_delete( 'get_calendar', 'calendar' );
 
-		$calendar_html = get_calendar( false, false );
-
-		$this->assertStringContainsString( '<table id="wp-calendar"', $calendar_html );
-		$this->assertStringContainsString( '<th scope="col" aria-label="Monday">Mon</th>', $calendar_html );
+		$second_calendar_html = get_calendar( false, false );
+	
+		$this->assertStringContainsString( '<th scope="col" aria-label="Monday">Mon</th>', $first_calendar_html );
+		$this->assertStringContainsString( 'February 2025', $first_calendar_html );
+		$this->assertStringContainsString( '<table id="wp-calendar"', $second_calendar_html );
+		$this->assertStringContainsString( '<th scope="col" aria-label="Monday">Mon</th>', $second_calendar_html );
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/34093
Patch Refresh for: https://core.trac.wordpress.org/attachment/ticket/34093/34093-7.diff

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
