### PR TITLE
Only skip full size PNG generation when output format is also PNG

### DIFF
--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -261,8 +261,10 @@ function wp_create_image_subsizes( $file, $attachment_id ) {
 		$image_meta['image_meta'] = $exif_meta;
 	}
 
+	$output_format = wp_get_image_editor_output_format( $file, $imagesize['mime'] );
+
 	// Do not scale (large) PNG images. May result in sub-sizes that have greater file size than the original. See #48736.
-	if ( 'image/png' !== $imagesize['mime'] ) {
+	if ( 'image/png' !== $imagesize['mime'] || 'image/png' !== $output_format ) {
 
 		/**
 		 * Filters the "BIG image" threshold value.
@@ -298,9 +300,6 @@ function wp_create_image_subsizes( $file, $attachment_id ) {
 			// The image will be converted if needed on saving.
 			$scale_down = true;
 		} else {
-			// The image may need to be converted regardless of its dimensions.
-			$output_format = wp_get_image_editor_output_format( $file, $imagesize['mime'] );
-
 			if (
 				is_array( $output_format ) &&
 				array_key_exists( $imagesize['mime'], $output_format ) &&


### PR DESCRIPTION
Fix an issue where PNG uploads failed to create full sized images when outputting in an alternate format (eg. WebP or AVIF). 

Trac ticket: https://core.trac.wordpress.org/ticket/62900


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
