### PR TITLE
Re-render Attachment View if there are changes other than the current setting

### DIFF
--- a/src/js/media/views/attachment.js
+++ b/src/js/media/views/attachment.js
@@ -579,12 +579,18 @@ _.each({
 		}
 
 		/*
+		 * Re-render if attributes other than the current setting have also changed.
+		 * This ensures all model changes are reflected in the view.
+		 */
+		var otherChanges = _.difference( _.keys( model.changedAttributes() ), [ setting ] );
+
+		/*
 		 * If the updated value is in sync with the value in the DOM, there
 		 * is no need to re-render. If we're currently editing the value,
 		 * it will automatically be in sync, suppressing the re-render for
 		 * the view we're editing, while updating any others.
 		 */
-		if ( value === $setting.find('input, textarea, select, [value]').val() ) {
+		if ( _.isEmpty( otherChanges ) && value === $setting.find('input, textarea, select, [value]').val() ) {
 			return this;
 		}
 


### PR DESCRIPTION
Trac ticket: [#62902](https://core.trac.wordpress.org/ticket/62902)

### Description

https://github.com/WordPress/wordpress-develop/blob/7d10dd7b0fde2a782395887c2d66439481440f9b/src/js/media/views/attachment.js#L587-L589

This code bails out early when the updated value matches the DOM, but the model starts with defaults (e.g., an empty title), and AJAX delays can leave values uninitialized. This can block re-renders, especially when the data becomes available post the AJAX call. 

While the early return prevents unnecessary updates, it shouldn't apply when multiple changes occur simultaneously during initialization. Instead, bailing out only when a single change occurs—and it matches the DOM—ensures proper hydration and fixes the bug.

### Screencast

https://github.com/user-attachments/assets/5f3b33c3-cdd7-4e26-adef-aaf8d263ac02

## Use of AI Tools

AI assistance: No

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
