### PR TITLE
Fix: Correct Display Name Behavior When First and Last Name Fields Are Cleared

### DIFF
--- a/src/js/_enqueues/admin/user-profile.js
+++ b/src/js/_enqueues/admin/user-profile.js
@@ -428,6 +428,10 @@
 
 				greeting.text( display_name );
 			} );
+
+			if ( greeting.text() !== current_name ) {
+				select.trigger( 'change' );
+			}
 		}
 
 		$colorpicker = $( '#color-picker' );

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -510,24 +510,26 @@ switch ( $action ) {
 									$public_display['display_nickname'] = $profile_user->nickname;
 									$public_display['display_username'] = $profile_user->user_login;
 
-								if ( ! empty( $profile_user->first_name ) ) {
-									$public_display['display_firstname'] = $profile_user->first_name;
-								}
+									$public_display['display_firstname'] = ! empty( $profile_user->first_name ) ? $profile_user->first_name : '';
+									$public_display['display_lastname']  = ! empty( $profile_user->last_name ) ? $profile_user->last_name : '';
+									$public_display['display_firstlast'] = ! empty( $profile_user->first_name ) && ! empty( $profile_user->last_name ) ? $profile_user->first_name . ' ' . $profile_user->last_name : '';
+									$public_display['display_lastfirst'] = ! empty( $profile_user->first_name ) && ! empty( $profile_user->last_name ) ? $profile_user->last_name . ' ' . $profile_user->first_name : '';
 
-								if ( ! empty( $profile_user->last_name ) ) {
-									$public_display['display_lastname'] = $profile_user->last_name;
-								}
 
-								if ( ! empty( $profile_user->first_name ) && ! empty( $profile_user->last_name ) ) {
-									$public_display['display_firstlast'] = $profile_user->first_name . ' ' . $profile_user->last_name;
-									$public_display['display_lastfirst'] = $profile_user->last_name . ' ' . $profile_user->first_name;
-								}
-
-								if ( ! in_array( $profile_user->display_name, $public_display, true ) ) { // Only add this if it isn't duplicated elsewhere.
+								if ( // Only add this if it isn't duplicated elsewhere.
+										( ! in_array( $profile_user->display_name, $public_display, true ) ) &&
+										// This check ensures that the display name is only added if it matches the user login or nickname,
+										// preventing the display name from retaining an outdated value if the first name or last name were modified.
+										(
+											$profile_user->display_name === $profile_user->user_login ||
+											$profile_user->display_name === $profile_user->nickname
+										)
+									) {
 									$public_display = array( 'display_displayname' => $profile_user->display_name ) + $public_display;
 								}
 
 								$public_display = array_map( 'trim', $public_display );
+								$public_display = array_filter( $public_display );
 								$public_display = array_unique( $public_display );
 
 								?>

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -529,9 +529,6 @@ switch ( $action ) {
 								$public_display = array_filter( $public_display );
 								$public_display = array_unique( $public_display );
 
-								error_log( print_r( $public_display, true ) );
-								error_log( print_r( $profile_user->display_name, true ) );
-
 								?>
 								<?php foreach ( $public_display as $id => $item ) : ?>
 									<option <?php selected( $profile_user->display_name, $item ); ?>><?php echo $item; ?></option>

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -515,22 +515,22 @@ switch ( $action ) {
 									$public_display['display_firstlast'] = ! empty( $profile_user->first_name ) && ! empty( $profile_user->last_name ) ? $profile_user->first_name . ' ' . $profile_user->last_name : '';
 									$public_display['display_lastfirst'] = ! empty( $profile_user->first_name ) && ! empty( $profile_user->last_name ) ? $profile_user->last_name . ' ' . $profile_user->first_name : '';
 
-
-								if ( // Only add this if it isn't duplicated elsewhere.
-										( ! in_array( $profile_user->display_name, $public_display, true ) ) &&
-										// This check ensures that the display name is only added if it matches the user login or nickname,
-										// preventing the display name from retaining an outdated value if the first name or last name were modified.
-										(
-											$profile_user->display_name === $profile_user->user_login ||
-											$profile_user->display_name === $profile_user->nickname
-										)
-									) {
-									$public_display = array( 'display_displayname' => $profile_user->display_name ) + $public_display;
+								if ( ! in_array( $profile_user->display_name, $public_display, true ) ) { // Only add this if it isn't duplicated elsewhere.
+									// This check ensures that the display name is only added if it matches the user login or nickname,
+									// preventing the display name from retaining an outdated value if the first name or last name were modified.
+									if ( $profile_user->display_name === $profile_user->user_login || $profile_user->display_name === $profile_user->nickname ) {
+										$public_display = array( 'display_displayname' => $profile_user->display_name ) + $public_display;
+									} else {
+										$profile_user->display_name = $profile_user->user_login; // Fallback.
+									}
 								}
 
 								$public_display = array_map( 'trim', $public_display );
 								$public_display = array_filter( $public_display );
 								$public_display = array_unique( $public_display );
+
+								error_log( print_r( $public_display, true ) );
+								error_log( print_r( $profile_user->display_name, true ) );
 
 								?>
 								<?php foreach ( $public_display as $id => $item ) : ?>


### PR DESCRIPTION
Trac Ticket: https://core.trac.wordpress.org/ticket/61469

This pull request addresses the issue where the display name does not correctly update when the "First Name" and "Last Name" fields are cleared in the user profile. The behavior was inconsistent, and the display name would still show the previously entered first and last names unless the "Display name publicly as" field was manually modified.

### Problem:
- When users enter a first and last name and select a display name option that includes those values, the display name updates as expected.
- However, when the user clears the "First Name" and "Last Name" fields, the display name still reflects the previously entered names.
- The display name only updates correctly if the user manually changes the "Display name publicly as" field.

### Solution:
- Updated the logic in the user profile form to automatically update the display name based on the current values in the "First Name" and "Last Name" fields.
- Added a fallback mechanism where the display name will revert to the user login if the first and last names are removed or empty.
- Implemented dynamic changes to the display name dropdown, ensuring it updates when the "First Name" or "Last Name" fields are modified or cleared.

### Changes:
- Modified the PHP logic that handles the display name options to ensure that when the first and last name fields are cleared, the display name correctly reflects the changes without needing to manually adjust the "Display name publicly as" field.
- Adjusted JavaScript to ensure the admin toolbar greeting (Howdy, * in the admin bar) is updated dynamically based on changes made to the display name in the profile form.
  
### Expected Behavior:
- When a user clears the "First Name" and "Last Name" fields, the display name should update automatically to reflect these changes without needing any further interaction with the "Display name publicly as" dropdown.
- The admin toolbar greeting ("Howdy, *") will also update accordingly when the display name is changed.

This change ensures a smoother user experience when editing the profile, especially when clearing first and last name fields.

Let me know if you need anything further!


https://github.com/user-attachments/assets/045c97de-2a85-4737-8aed-2073b42ddaf6