### PR TITLE
Add unit tests for hide comment bulk action dropdown based on user capability

### DIFF
--- a/src/wp-admin/includes/class-wp-comments-list-table.php
+++ b/src/wp-admin/includes/class-wp-comments-list-table.php
@@ -357,6 +357,10 @@ class WP_Comments_List_Table extends WP_List_Table {
 	protected function get_bulk_actions() {
 		global $comment_status;
 
+		if ( ! current_user_can( 'moderate_comments' ) ) {
+			return array(); // Return an empty array if the user doesn't have permission
+		}
+
 		$actions = array();
 
 		if ( in_array( $comment_status, array( 'all', 'approved' ), true ) ) {

--- a/tests/phpunit/tests/admin/wpCommentsListTable.php
+++ b/tests/phpunit/tests/admin/wpCommentsListTable.php
@@ -124,6 +124,53 @@ OPTIONS;
 	}
 
 	/**
+	 * @ticket 59440
+	 *
+	 * @covers WP_Comments_List_Table::bulk_actions
+	 */
+	public function test_bulk_action_menu_should_be_shown_if_user_has_capability() {
+		$u = self::factory()->user->create_and_get(
+			array(
+				'role' => 'administrator',
+			)
+		);
+
+		wp_set_current_user( $u );
+
+		$this->assertTrue( current_user_can( 'moderate_comments' ) );
+
+		ob_start();
+		$this->table->bulk_actions();
+		$output = ob_get_clean();
+
+		$this->assertNotEmpty( $output );
+		$this->assertStringContainsString( '<option value="-1">Bulk actions</option>', $output );
+	}
+
+	/**
+	 * @ticket 59440
+	 *
+	 * @covers WP_Comments_List_Table::bulk_actions
+	 */
+	public function test_bulk_action_menu_should_not_be_shown_if_user_has_no_capability() {
+		$u = self::factory()->user->create_and_get(
+			array(
+				'role' => 'subscriber',
+			)
+		);
+
+		wp_set_current_user( $u );
+
+		$this->assertFalse( current_user_can( 'moderate_comments' ) );
+
+		ob_start();
+		$this->table->bulk_actions();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+	}
+
+	/**
 	 * @ticket 45089
 	 *
 	 * @covers WP_Comments_List_Table::print_column_headers


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/59440

Added detailed PHPUnit tests to show bulk action drop-down menu for comments table list based on user capability.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
