### PR TITLE
Editor: Add option to ignore sticky posts in Query block

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2489,8 +2489,14 @@ function build_query_vars_from_query_block( $block, $page ) {
 				 */
 				$query['post__in']            = ! empty( $sticky ) ? $sticky : array( 0 );
 				$query['ignore_sticky_posts'] = 1;
-			} else {
+			}
+
+			if ( 'exclude' === $block->context['query']['sticky'] ) {
 				$query['post__not_in'] = array_merge( $query['post__not_in'], $sticky );
+			}
+
+			if ( 'ignore' === $block->context['query']['sticky'] ) {
+				$query['ignore_sticky_posts'] = 1;
 			}
 		}
 		if ( ! empty( $block->context['query']['exclude'] ) ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2489,13 +2489,9 @@ function build_query_vars_from_query_block( $block, $page ) {
 				 */
 				$query['post__in']            = ! empty( $sticky ) ? $sticky : array( 0 );
 				$query['ignore_sticky_posts'] = 1;
-			}
-
-			if ( 'exclude' === $block->context['query']['sticky'] ) {
+			} elseif ( 'exclude' === $block->context['query']['sticky'] ) {
 				$query['post__not_in'] = array_merge( $query['post__not_in'], $sticky );
-			}
-
-			if ( 'ignore' === $block->context['query']['sticky'] ) {
+			} elseif ( 'ignore' === $block->context['query']['sticky'] ) {
 				$query['ignore_sticky_posts'] = 1;
 			}
 		}


### PR DESCRIPTION
Introduce a new `ignore` value for the `sticky` query argument. When this value is used, the query will not prepend sticky posts at the top but display them in the natural order.

Related: https://github.com/WordPress/wordpress-develop/pull/8228
Gutenberg PR: https://github.com/WordPress/gutenberg/pull/69057
Trac ticket: https://core.trac.wordpress.org/ticket/62908#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
