### PR TITLE
Allow admin submenu accessible when theme details model open

### DIFF
--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -65,7 +65,7 @@
 #adminmenuwrap {
 	position: relative;
 	float: left;
-	z-index: 9990;
+	z-index: 19990; /* Above theme model and below the admin toolbar */
 }
 
 /* side admin menu */


### PR DESCRIPTION
<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/62911

## Problem:
The left admin submenu is unresponsive and cannot be accessed while the Theme Details modal is active.

## Expected Behavior:
The left admin submenu should remain accessible and functional even when the Theme Details modal is open.

## Solution: 
- set z-index for `#adminmenuwrap` in between 10000 (`.theme-overlay`) to 99999 (`#wpadminbar`), which puts admin submenu above theme model and below the admin toolbar.

### Before:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/2ce414cf-9e54-4c90-8930-183cc650fb40" />

### After
<img width="500" alt="image" src="https://github.com/user-attachments/assets/bb58c8d7-872d-4279-9ce9-fb995dc7dc21" />

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
