### PR TITLE
Block support: Add server-side processing for ariaLabel

### DIFF
--- a/src/wp-includes/block-supports/aria-label.php
+++ b/src/wp-includes/block-supports/aria-label.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Aria label block support flag.
+ *
+ * @package WordPress
+ * @since 6.8.0
+ */
+
+/**
+ * Registers the aria-label block attribute for block types that support it.
+ *
+ * @since 6.8.0
+ * @access private
+ *
+ * @param WP_Block_Type $block_type Block Type.
+ */
+function wp_register_aria_label_support( $block_type ) {
+	$has_aria_label_support = block_has_support( $block_type, array( 'ariaLabel' ), false );
+
+	if ( ! $has_aria_label_support ) {
+		return;
+	}
+
+	if ( ! $block_type->attributes ) {
+		$block_type->attributes = array();
+	}
+
+	if ( ! array_key_exists( 'ariaLabel', $block_type->attributes ) ) {
+		$block_type->attributes['ariaLabel'] = array(
+			'type' => 'string',
+		);
+	}
+}
+
+/**
+ * Add the aria-label to the output.
+ *
+ * @since 6.8.0
+ * @access private
+ *
+ * @param WP_Block_Type $block_type Block Type.
+ * @param array         $block_attributes Block attributes.
+ *
+ * @return array Block aria-label.
+ */
+function wp_apply_aria_label_support( $block_type, $block_attributes ) {
+	if ( ! $block_attributes ) {
+		return array();
+	}
+
+	$has_aria_label_support = block_has_support( $block_type, array( 'ariaLabel' ), false );
+	if ( ! $has_aria_label_support ) {
+		return array();
+	}
+
+	$has_aria_label = array_key_exists( 'ariaLabel', $block_attributes );
+	if ( ! $has_aria_label ) {
+		return array();
+	}
+	return array( 'aria-label' => $block_attributes['ariaLabel'] );
+}
+
+// Register the block support.
+WP_Block_Supports::get_instance()->register(
+	'aria-label',
+	array(
+		'register_attribute' => 'wp_register_aria_label_support',
+		'apply'              => 'wp_apply_aria_label_support',
+	)
+);

--- a/src/wp-includes/block-supports/aria-label.php
+++ b/src/wp-includes/block-supports/aria-label.php
@@ -38,7 +38,7 @@ function wp_register_aria_label_support( $block_type ) {
  * @since 6.8.0
  * @access private
  *
- * @param WP_Block_Type $block_type Block Type.
+ * @param WP_Block_Type $block_type       Block Type.
  * @param array         $block_attributes Block attributes.
  *
  * @return array Block aria-label.

--- a/src/wp-includes/class-wp-block-supports.php
+++ b/src/wp-includes/class-wp-block-supports.php
@@ -181,7 +181,7 @@ function get_block_wrapper_attributes( $extra_attributes = array() ) {
 
 	// This is hardcoded on purpose.
 	// We only support a fixed list of attributes.
-	$attributes_to_merge = array( 'style', 'class', 'id' );
+	$attributes_to_merge = array( 'style', 'class', 'id', 'aria-label' );
 	$attributes          = array();
 	foreach ( $attributes_to_merge as $attribute_name ) {
 		if ( empty( $new_attributes[ $attribute_name ] ) && empty( $extra_attributes[ $attribute_name ] ) ) {

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -386,6 +386,7 @@ require ABSPATH . WPINC . '/block-supports/duotone.php';
 require ABSPATH . WPINC . '/block-supports/shadow.php';
 require ABSPATH . WPINC . '/block-supports/background.php';
 require ABSPATH . WPINC . '/block-supports/block-style-variations.php';
+require ABSPATH . WPINC . '/block-supports/aria-label.php';
 require ABSPATH . WPINC . '/style-engine.php';
 require ABSPATH . WPINC . '/style-engine/class-wp-style-engine.php';
 require ABSPATH . WPINC . '/style-engine/class-wp-style-engine-css-declarations.php';

--- a/tests/phpunit/tests/block-supports/aria-label.php
+++ b/tests/phpunit/tests/block-supports/aria-label.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * @group block-supports
+ *
+ * @covers ::wp_apply_aria_label_support
+ */
+class Tests_Block_Supports_Aria_Label extends WP_UnitTestCase {
+	/**
+	 * @var string|null
+	 */
+	private $test_block_name;
+
+	public function set_up() {
+		parent::set_up();
+		$this->test_block_name = null;
+	}
+
+	public function tear_down() {
+		unregister_block_type( $this->test_block_name );
+		$this->test_block_name = null;
+		parent::tear_down();
+	}
+
+	/**
+	 * Registers a new block for testing aria-label support.
+	 *
+	 * @param string $block_name Name for the test block.
+	 * @param array  $supports   Array defining block support configuration.
+	 *
+	 * @return WP_Block_Type The block type for the newly registered test block.
+	 */
+	private function register_aria_label_block_with_support( $block_name, $supports = array() ) {
+		$this->test_block_name = $block_name;
+		register_block_type(
+			$this->test_block_name,
+			array(
+				'api_version' => 3,
+				'supports'    => $supports,
+			)
+		);
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		return $registry->get_registered( $this->test_block_name );
+	}
+
+	/**
+	 * Tests that position block support works as expected.
+	 *
+	 * @ticket 62919
+	 *
+	 * @dataProvider data_aria_label_block_support
+	 *
+	 * @param boolean|array $support Aria label block support configuration.
+	 * @param string        $value   Aria label value for attribute object.
+	 * @param array         $expected       Expected aria label block support styles.
+	 */
+	public function test_wp_apply_aria_label_support( $support, $value, $expected ) {
+		$block_type  = self::register_aria_label_block_with_support(
+			'test/aria-label-block',
+			array( 'ariaLabel' => $support )
+		);
+		$block_attrs = array( 'ariaLabel' => $value );
+		$actual      = wp_apply_aria_label_support( $block_type, $block_attrs );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_aria_label_block_support() {
+		return array(
+			'aria-label attribute is applied' => array(
+				'support'  => true,
+				'value'    => 'Label',
+				'expected' => array( 'aria-label' => 'Label' ),
+			),
+			'aria-label attribute is not applied if block does not support it' => array(
+				'support'  => false,
+				'value'    => 'Label',
+				'expected' => array(),
+			),
+		);
+	}
+}

--- a/tests/phpunit/tests/block-supports/aria-label.php
+++ b/tests/phpunit/tests/block-supports/aria-label.php
@@ -50,9 +50,9 @@ class Tests_Block_Supports_Aria_Label extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_aria_label_block_support
 	 *
-	 * @param boolean|array $support Aria label block support configuration.
-	 * @param string        $value   Aria label value for attribute object.
-	 * @param array         $expected       Expected aria label block support styles.
+	 * @param boolean|array $support  Aria label block support configuration.
+	 * @param string        $value    Aria label value for attribute object.
+	 * @param array         $expected Expected aria label block support styles.
 	 */
 	public function test_wp_apply_aria_label_support( $support, $value, $expected ) {
 		$block_type  = self::register_aria_label_block_with_support(

--- a/tests/phpunit/tests/blocks/supportedStyles.php
+++ b/tests/phpunit/tests/blocks/supportedStyles.php
@@ -152,6 +152,24 @@ class Tests_Blocks_SupportedStyles extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Runs assertions that the rendered output has expected content and aria-label attr.
+	 *
+	 * @param array  $block               Block to render.
+	 * @param string $expected_aria_label Expected output aria-label attr string.
+	 */
+	private function assert_content_and_aria_label_match( $block, $expected_aria_label ) {
+		$styled_block = $this->render_example_block( $block );
+		$content      = $this->get_content_from_block( $styled_block );
+
+		$this->assertSame( self::BLOCK_CONTENT, $content, 'Block content does not match expected content' );
+		$this->assertSame(
+			$expected_aria_label,
+			$this->get_attribute_from_block( 'aria-label', $styled_block ),
+			'Aria-label does not match expected aria-label'
+		);
+	}
+
+	/**
 	 * Tests color support for named color support for named colors.
 	 */
 	public function test_named_color_support() {
@@ -683,6 +701,31 @@ class Tests_Blocks_SupportedStyles extends WP_UnitTestCase {
 		$expected_classes = 'foo-bar-class';
 
 		$this->assert_content_and_styles_and_classes_match( $block, $expected_classes, $expected_styles );
+	}
+
+	/**
+	 * Tests aria-label server-side block support.
+	 */
+	public function test_aria_label_support() {
+		$block_type_settings = array(
+			'attributes' => array(),
+			'supports'   => array(
+				'ariaLabel' => true,
+			),
+		);
+		$this->register_block_type( 'core/example', $block_type_settings );
+
+		$block = array(
+			'blockName'    => 'core/example',
+			'attrs'        => array(
+				'ariaLabel' => 'Label',
+			),
+			'innerBlock'   => array(),
+			'innerContent' => array(),
+			'innerHTML'    => array(),
+		);
+
+		$this->assert_content_and_aria_label_match( $block, 'Label' );
 	}
 
 	/**


### PR DESCRIPTION
- Gutenberg PR: https://github.com/WordPress/gutenberg/pull/69096
- Trac ticket: https://core.trac.wordpress.org/ticket/62919

### Testing Instructions

See Gutenberg PR for reference.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
