### PR TITLE
Menus: Remove redundant 'for' attribute from bulk select label.

### DIFF
--- a/src/wp-admin/nav-menus.php
+++ b/src/wp-admin/nav-menus.php
@@ -1123,7 +1123,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 								</div>
 
 								<div id="nav-menu-bulk-actions-top" class="bulk-actions" <?php echo $hide_style; ?>>
-									<label class="bulk-select-button" for="bulk-select-switcher-top">
+									<label class="bulk-select-button">
 										<input type="checkbox" id="bulk-select-switcher-top" name="bulk-select-switcher-top" class="bulk-select-switcher">
 										<span class="bulk-select-button-label"><?php _e( 'Bulk Select' ); ?></span>
 									</label>


### PR DESCRIPTION
This PR addresses a minor code improvement in the WordPress admin navigation menus. In `/wp-admin/nav-menus.php`, the `<label>` element for the bulk select checkbox contains a `for` attribute that is unnecessary because the associated `<input>` is nested within the `<label>`. Removing the `for` attribute simplifies the code without affecting functionality.

Trac ticket: [#62926](https://core.trac.wordpress.org/ticket/62926)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
