### PR TITLE
Remove dashboard link from `sample page` content

### DIFF
--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -322,11 +322,7 @@ Commenter avatars come from <a href="%s">Gravatar</a>.'
 			$first_page .= "</p></blockquote>\n<!-- /wp:quote -->\n\n";
 
 			$first_page .= "<!-- wp:paragraph -->\n<p>";
-			$first_page .= sprintf(
-				/* translators: First page content. %s: Site admin URL. */
-				__( 'As a new WordPress user, you should go to <a href="%s">your dashboard</a> to delete this page and create new pages for your content. Have fun!' ),
-				admin_url()
-			);
+			$first_page .= __( 'As a new WordPress user, you should go to your dashboard to delete this page and create new pages for your content. Have fun!' );
 			$first_page .= "</p>\n<!-- /wp:paragraph -->";
 		}
 


### PR DESCRIPTION

Trac ticket: [#62929](https://core.trac.wordpress.org/ticket/62929)

## Description
This PR removes the dashboard link from the sample page content in `upgrade.php`. Previously, the link was using `admin_url()` which caused issues in environments like WordPress Playground where the URL might not be accessible.

## Testing Instructions
1. Create a fresh WordPress installation 
2. Check the sample page content
3. Verify that the text "your dashboard" appears without a hyperlink

## Screenshots (if applicable)
### Before:
![image](https://github.com/user-attachments/assets/ae91edb2-f3b8-43bb-b90d-03c88830d9c2)

### After:
![image](https://github.com/user-attachments/assets/957f8846-e8bd-4c80-8b1f-cea3dc895088)
