### PR TITLE
Fix the rest api special characters

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -1908,7 +1908,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			add_filter( 'protected_title_format', array( $this, 'protected_title_format' ) );
 			add_filter( 'private_title_format', array( $this, 'protected_title_format' ) );
 
-			$data['title']['rendered'] = get_the_title( $post->ID );
+			$data['title']['rendered'] = wp_kses_decode_entities( get_the_title( $post->ID ) );
 
 			remove_filter( 'protected_title_format', array( $this, 'protected_title_format' ) );
 			remove_filter( 'private_title_format', array( $this, 'protected_title_format' ) );


### PR DESCRIPTION
**Description**
get_the_title( $post->ID ) retrieves the post title.
`wp_kses_decode_entities()` will decode any HTML entities (like &#038; → &) in the title.
This change will ensure that any special characters in the title, like &, are properly decoded before being returned in the REST API response.
Now, the title.rendered field in the REST API response will return the decoded title with the correct characters like &, instead of the Unicode entities.

Trac ticket: [https://core.trac.wordpress.org/ticket/53860](https://core.trac.wordpress.org/ticket/53860)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
