### PR TITLE
#62221 Don't run the build during unit test workflow

### DIFF
--- a/.github/workflows/reusable-phpunit-tests-v1.yml
+++ b/.github/workflows/reusable-phpunit-tests-v1.yml
@@ -109,9 +109,6 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Build WordPress
-        run: npm run build
-
       - name: Get composer cache directory
         if: ${{ env.COMPOSER_INSTALL == true }}
         id: composer-cache


### PR DESCRIPTION
What fails without this? Let's find out.

Trac ticket: https://core.trac.wordpress.org/ticket/62221