### PR TITLE
Build/Test Tools: Update wp-prettier to 3.0.3 and refine ESLint ignore patterns

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,8 @@
 # Files and folders related to build/test tools
-/build
-/node_modules
+build
+build-module
+build-types
+node_modules
 /tests
 /vendor
 /tools
@@ -9,7 +11,8 @@
 /src/js/_enqueues/vendor
 
 # Webpack built files
-/src/wp-includes/js/media-*
+/src/wp-includes/js/
+*.min.js
 
 # Themes
 src/wp-content/themes/

--- a/.eslintignore
+++ b/.eslintignore
@@ -6,13 +6,26 @@ node_modules
 /tests
 /vendor
 /tools
+/jsdoc
+/artifacts
+/coverage
+/.cache
+/src/wp-includes/blocks/**/*.js
+/src/wp-includes/blocks/**/*.js.map
+/src/wp-admin/js
 
 # Excluded files and folders based on `jsdoc.conf.json` exclusions
 /src/js/_enqueues/vendor
 
 # Webpack built files
-/src/wp-includes/js/
+/src/wp-includes/js
 *.min.js
 
 # Themes
-src/wp-content/themes/
+src/wp-content/themes
+
+# Files and folders that get created in wp-content
+/src/wp-content/plugins
+/src/wp-content/mu-plugins
+/src/wp-content/upgrade
+/src/wp-content/uploads

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,15 +1,13 @@
 # Files and folders related to build/test tools
-build
-build-module
-build-types
-node_modules
+/build
+/node_modules
 /tests
 /vendor
 /tools
 /jsdoc
 /artifacts
 /coverage
-/.cache
+.cache/*
 /src/wp-includes/blocks/**/*.js
 /src/wp-includes/blocks/**/*.js.map
 /src/wp-admin/js
@@ -19,7 +17,6 @@ node_modules
 
 # Webpack built files
 /src/wp-includes/js
-*.min.js
 
 # Themes
 src/wp-content/themes

--- a/package-lock.json
+++ b/package-lock.json
@@ -142,7 +142,7 @@
 				"install-changed": "1.1.0",
 				"matchdep": "~2.0.0",
 				"postcss": "8.4.49",
-				"prettier": "npm:wp-prettier@2.6.2",
+				"prettier": "npm:wp-prettier@3.0.3",
 				"qunit": "~2.23.1",
 				"react-refresh": "0.14.0",
 				"sass": "1.83.4",
@@ -9448,22 +9448,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.4.31"
-			}
-		},
-		"node_modules/@wordpress/scripts/node_modules/prettier": {
-			"name": "wp-prettier",
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3.tgz",
-			"integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
-			"dev": true,
-			"bin": {
-				"prettier": "bin/prettier.cjs"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
 		"node_modules/@wordpress/scripts/node_modules/read-pkg-up": {
@@ -28903,10 +28887,20 @@
 		},
 		"node_modules/prettier": {
 			"name": "wp-prettier",
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.6.2.tgz",
-			"integrity": "sha512-AV33EzqiFJ3fj+mPlKABN59YFPReLkDxQnj067Z3uEOeRQf3g05WprL0RDuqM7UBhSRo9W1rMSC2KvZmjE5UOA==",
-			"dev": true
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3.tgz",
+			"integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"prettier": "bin/prettier.cjs"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
+			}
 		},
 		"node_modules/prettier-linter-helpers": {
 			"version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"install-changed": "1.1.0",
 		"matchdep": "~2.0.0",
 		"postcss": "8.4.49",
-		"prettier": "npm:wp-prettier@2.6.2",
+		"prettier": "npm:wp-prettier@3.0.3",
 		"qunit": "~2.23.1",
 		"react-refresh": "0.14.0",
 		"sass": "1.83.4",


### PR DESCRIPTION
Trac ticket: [#62935](https://core.trac.wordpress.org/ticket/62935)

## Description
This PR updates the wp-prettier dependency from version 2.6.2 to 3.0.3 and refines the ESLint ignore patterns for better build management. The changes aim to fix the issues with `lint:jsdoc` and `lint:jsdoc:fix` scripts.

## Changes proposed in this Pull Request
- Upgrade wp-prettier from 2.6.2 to 3.0.3 to resolve JS linting issues
- Update .eslintignore patterns to be more specific:
  - Add `build-module` and `build-types` directories
  - Replace `/build` with `build` for consistency
  - Add `*.min.js` pattern to ignore minified files
  - Update wp-includes JS ignore pattern

## Testing Instructions
1. Run `npm install` to update dependencies
3. Run `npm run lint:jsdoc` to verify linting works
4. Run `npm run lint:jsdoc:fix` to verify auto-fixing works
5. Verify that build directories are properly ignored

## Screenshots
![image](https://github.com/user-attachments/assets/524ed431-1fff-4b58-a5e4-9837fe91defd)




