### PR TITLE
62831 - remove grey background on top of the classic editor main textarea

### DIFF
--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -439,7 +439,6 @@ form#tags-filter {
 /* End TinyMCE native fullscreen mode override */
 
 #wp-content-editor-tools {
-	background-color: #f0f0f1;
 	padding-top: 20px;
 }
 


### PR DESCRIPTION
This brings more consistency with the white background.
Trac ticket: https://core.trac.wordpress.org/ticket/62831