### PR TITLE
Add: MAIL_ENVELOP_FROM constant for flexible email Sender header mana…

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -406,6 +406,11 @@ if ( ! function_exists( 'wp_mail' ) ) :
 		$from_name = apply_filters( 'wp_mail_from_name', $from_name );
 
 		try {
+			// Configure envelop-from via MAIL_ENVELOP_FROM if defined.
+			if ( defined( 'MAIL_ENVELOP_FROM' ) && MAIL_ENVELOP_FROM ) {
+				$phpmailer->Sender = MAIL_ENVELOP_FROM;
+			}
+
 			$phpmailer->setFrom( $from_email, $from_name, false );
 		} catch ( PHPMailer\PHPMailer\Exception $e ) {
 			$mail_error_data                             = compact( 'to', 'subject', 'message', 'headers', 'attachments' );

--- a/tests/phpunit/tests/pluggable/wpMail.php
+++ b/tests/phpunit/tests/pluggable/wpMail.php
@@ -554,4 +554,34 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 		$phpmailer = $GLOBALS['phpmailer'];
 		$this->assertNotSame( 'user1', $phpmailer->AltBody );
 	}
+
+	/**
+	 * Test wp_mail without MAIL_ENVELOP_FROM definition.
+	 */
+	public function test_wp_mail_without_mail_envelop_from() {
+		if ( defined( 'MAIL_ENVELOP_FROM' ) ) {
+			$this->markTestSkipped( 'MAIL_ENVELOP_FROM is defined, cannot test without it.' );
+		}
+
+		wp_mail( 'test@example.localhost', 'Subject', 'Content' );
+
+		$mailer = tests_retrieve_phpmailer_instance();
+
+		$this->assertEmpty( $mailer->Sender, 'Sender field should be empty when MAIL_ENVELOP_FROM is not defined.' );
+	}
+
+	/**
+	 * Test the MAIL_ENVELOP_FROM functionality in wp_mail.
+	 */
+	public function test_wp_mail_with_mail_envelop_from() {
+		if ( ! defined( 'MAIL_ENVELOP_FROM' ) ) {
+			define( 'MAIL_ENVELOP_FROM', 'no-reply@example.localhost' );
+		}
+
+		wp_mail( 'test@example.localhost', 'Subject', 'Content' );
+
+		$mailer = tests_retrieve_phpmailer_instance();
+
+		$this->assertSame( 'no-reply@example.localhost', $mailer->Sender, 'MAIL_ENVELOP_FROM should correctly set the Sender field.' );
+	}
 }


### PR DESCRIPTION
#### Summary
This pull request introduces a new `MAIL_ENVELOP_FROM` constant to allow better control of the "Sender" header in outgoing emails.

Why is this important ?
Using a properly configured sender email is essential for meeting SPF / DKIM requirements, improving deliverability, and avoiding spoofing issues.

To adopt this feature, users can define the `MAIL_ENVELOP_FROM` constant in `wp-config.php`.This configuration is especially beneficial in multisite environments, where dynamic Sender values may be needed.

#### Changes
Core logic changes
Updated`wp-includes/pluggable.php` to set PHPMailer’s `Sender` property based on the `MAIL_ENVELOP_FROM` constant(if defined).
Added tests to cover cases where `MAIL_ENVELOP_FROM` is defined and where it is not.

#### Why
The "Sender" header is critical for the following reasons:
- SPF and DKIM Authentication
Ensures emails are not flagged as spoofed by third parties.Accurate and consistent Sender addresses are necessary to meet the requirements for SPF and DKIM authentication.

- Flexible Control
Site - specific email addresses can be used for better brand consistency, or notification emails can be configured to meet the requirements of particular domain forwarding servers.

#### Usage
##### Single Sites
For most single - site configurations, the`MAIL_ENVELOP_FROM` constant can be defined in `wp-config.php` as follows:
```php
/**
 * Envelope-from email address for outgoing WordPress emails.
 * Example: Replace no-reply@yourdomain.com with a real email address
 * that has SPF/DKIM properly configured for your domain.
 */
define('MAIL_ENVELOP_FROM', 'no-reply@yourdomain.com');
```
##### Multisite Configurations
```php
if (str_contains($_SERVER['HTTP_HOST'], 'site1.com')) {
	define('MAIL_ENVELOP_FROM', 'no-reply@site1.com');
} elseif(str_contains($_SERVER['HTTP_HOST'], 'site2.com')) {
	define('MAIL_ENVELOP_FROM', 'no-reply@site2.com');
} else {
	define('MAIL_ENVELOP_FROM', 'no-reply@example.com');
}
```
This setup allows you to handle different sender addresses based on the site or subdomain.

#### Impact
This change enables more flexible management of the sender email address, making it easier to improve email delivery reliability and SPF / DKIM authentication success rates.This is particularly useful for multisite or complex email environments, as it helps address challenges with sender configuration.