### PR TITLE
Embeds: Resolve conflicts and add oEmbed filter tests

### DIFF
--- a/src/wp-includes/embed.php
+++ b/src/wp-includes/embed.php
@@ -931,6 +931,7 @@ function wp_filter_oembed_result( $result, $data, $url ) {
 		'a'          => array(
 			'href' => true,
 		),
+		'p'          => array(),
 		'blockquote' => array(),
 		'iframe'     => array(
 			'src'          => true,
@@ -947,36 +948,36 @@ function wp_filter_oembed_result( $result, $data, $url ) {
 	$html = wp_kses( $result, $allowed_html );
 
 	preg_match( '|(<blockquote>.*?</blockquote>)?.*(<iframe.*?></iframe>)|ms', $html, $content );
+
 	// We require at least the iframe to exist.
-	if ( empty( $content[2] ) ) {
-		return false;
+	if ( ! empty( $content[2] ) ) {
+		$html = $content[1] . $content[2];
+
+		preg_match( '/ src=([\'"])(.*?)\1/', $html, $results );
+
+		if ( ! empty( $results ) ) {
+			$secret = wp_generate_password( 10, false );
+
+			$url = esc_url( "{$results[2]}#?secret=$secret" );
+			$q   = $results[1];
+
+			$html = str_replace( $results[0], ' src=' . $q . $url . $q . ' data-secret=' . $q . $secret . $q, $html );
+			$html = str_replace( '<blockquote', "<blockquote data-secret=\"$secret\"", $html );
+		}
+
+		$allowed_html['blockquote']['data-secret'] = true;
+		$allowed_html['iframe']['data-secret']     = true;
+
+		$html = wp_kses( $html, $allowed_html );
+
+		if ( ! empty( $content[1] ) ) {
+			// We have a blockquote to fall back on. Hide the iframe by default.
+			$html = str_replace( '<iframe', '<iframe style="position: absolute; visibility: hidden;"', $html );
+			$html = str_replace( '<blockquote', '<blockquote class="wp-embedded-content"', $html );
+		}
+
+		$html = str_ireplace( '<iframe', '<iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted"', $html );
 	}
-	$html = $content[1] . $content[2];
-
-	preg_match( '/ src=([\'"])(.*?)\1/', $html, $results );
-
-	if ( ! empty( $results ) ) {
-		$secret = wp_generate_password( 10, false );
-
-		$url = esc_url( "{$results[2]}#?secret=$secret" );
-		$q   = $results[1];
-
-		$html = str_replace( $results[0], ' src=' . $q . $url . $q . ' data-secret=' . $q . $secret . $q, $html );
-		$html = str_replace( '<blockquote', "<blockquote data-secret=\"$secret\"", $html );
-	}
-
-	$allowed_html['blockquote']['data-secret'] = true;
-	$allowed_html['iframe']['data-secret']     = true;
-
-	$html = wp_kses( $html, $allowed_html );
-
-	if ( ! empty( $content[1] ) ) {
-		// We have a blockquote to fall back on. Hide the iframe by default.
-		$html = str_replace( '<iframe', '<iframe style="position: absolute; visibility: hidden;"', $html );
-		$html = str_replace( '<blockquote', '<blockquote class="wp-embedded-content"', $html );
-	}
-
-	$html = str_ireplace( '<iframe', '<iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted"', $html );
 
 	return $html;
 }

--- a/tests/phpunit/tests/oembed/controller.php
+++ b/tests/phpunit/tests/oembed/controller.php
@@ -790,7 +790,8 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 		$this->assertSame( 'Untrusted', $data->provider_name );
 		$this->assertSame( self::UNTRUSTED_PROVIDER_URL, $data->provider_url );
 		$this->assertSame( 'rich', $data->type );
-		$this->assertFalse( $data->html );
+		$this->assertNotFalse( $data->html );
+		$this->assertSame( 'Filtered<a href="">Unfiltered</a>', $data->html );
 	}
 
 	/**

--- a/tests/phpunit/tests/oembed/filterResult.php
+++ b/tests/phpunit/tests/oembed/filterResult.php
@@ -48,12 +48,12 @@ EOD;
 		$html   = '<span>Hello</span><p>World</p>';
 		$actual = wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), '' );
 
-		$this->assertFalse( $actual );
+		$this->assertSame( 'Hello<p>World</p>' ,$actual );
 
 		$html   = '<div><p></p></div><script></script>';
 		$actual = wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), '' );
 
-		$this->assertFalse( $actual );
+		$this->assertSame( '<p></p>' , $actual );
 	}
 
 	public function test_filter_oembed_result_secret_param_available() {
@@ -76,7 +76,7 @@ EOD;
 
 	public function test_filter_oembed_result_invalid_result() {
 		$this->assertFalse( wp_filter_oembed_result( false, (object) array( 'type' => 'rich' ), '' ) );
-		$this->assertFalse( wp_filter_oembed_result( '', (object) array( 'type' => 'rich' ), '' ) );
+		$this->assertSame( '', wp_filter_oembed_result( '', (object) array( 'type' => 'rich' ), '' ) );
 	}
 
 	public function test_filter_oembed_result_blockquote_adds_style_to_iframe() {
@@ -135,5 +135,35 @@ EOD;
 		$actual = _oembed_filter_feed_content( wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), '' ) );
 
 		$this->assertSame( '<blockquote class="wp-embedded-content"></blockquote><iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted" ></iframe>', $actual );
+	}
+
+	/**
+	 * Test standalone blockquote with paragraph tag is allowed.
+	 */
+	public function test_filter_oembed_result_standalone_blockquote_paragraph() {
+		$html   = '<blockquote><p>Test content</p></blockquote>';
+		$actual = wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), '' );
+
+		$this->assertSame( '<blockquote><p>Test content</p></blockquote>', $actual );
+	}
+
+	/**
+	 * Test multiple paragraph tags within blockquote are preserved.
+	 */
+	public function test_filter_oembed_result_multiple_paragraphs() {
+		$html   = '<blockquote><p>First paragraph</p><p>Second paragraph</p></blockquote>';
+		$actual = wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), '' );
+
+		$this->assertSame( '<blockquote><p>First paragraph</p><p>Second paragraph</p></blockquote>', $actual );
+	}
+
+	/**
+	 * Test blockquote with paragraph and link tags.
+	 */
+	public function test_filter_oembed_result_paragraph_with_link() {
+		$html   = '<blockquote><p>Text with <a href="https://example.com">link</a></p></blockquote>';
+		$actual = wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), '' );
+
+		$this->assertSame( '<blockquote><p>Text with <a href="https://example.com">link</a></p></blockquote>', $actual );
 	}
 }

--- a/tests/phpunit/tests/oembed/filterResult.php
+++ b/tests/phpunit/tests/oembed/filterResult.php
@@ -48,12 +48,12 @@ EOD;
 		$html   = '<span>Hello</span><p>World</p>';
 		$actual = wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), '' );
 
-		$this->assertSame( 'Hello<p>World</p>' ,$actual );
+		$this->assertSame( 'Hello<p>World</p>', $actual );
 
 		$html   = '<div><p></p></div><script></script>';
 		$actual = wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), '' );
 
-		$this->assertSame( '<p></p>' , $actual );
+		$this->assertSame( '<p></p>', $actual );
 	}
 
 	public function test_filter_oembed_result_secret_param_available() {


### PR DESCRIPTION
### Summary
This PR resolves conflicts from [PR #6484](https://github.com/WordPress/wordpress-develop/pull/6484) and adds unit tests to ensure proper behavior of `wp_filter_oembed_result()`.

### Changes
- Resolved merge conflicts from the previous PR.
- Added test cases to verify:
  - Paragraphs inside blockquotes are preserved.
  - Multiple paragraphs within blockquotes render correctly.
  - Inline elements (e.g., links) remain intact.

### Testing Instructions
1. Run PHPUnit tests:  
```
 npm run test:php -- --filter=Tests_Filter_oEmbed_Result 
```
3. Ensure all tests pass successfully.

Trac Ticket: [#61127](https://core.trac.wordpress.org/ticket/61127)
