### PR TITLE
Add regression test for `wp_option` theme data corruption bug

### DIFF
--- a/tests/phpunit/tests/option/option.php
+++ b/tests/phpunit/tests/option/option.php
@@ -613,4 +613,36 @@ class Tests_Option_Option extends WP_UnitTestCase {
 
 		return $stats['cmd_get'];
 	}
+
+	/**
+	 * Test that updating an option doesn't corrupt other options, particularly theme options.
+	 *
+	 * @ticket 53520
+	 *
+	 * @covers ::update_option
+	 */
+	public function test_update_option_does_not_corrupt_theme_options() {
+		// Switch to a specific theme for testing
+		$original_theme = get_stylesheet();
+		$test_theme     = 'twentytwentyone';
+
+		switch_theme( $test_theme );
+
+		// Record theme options before update
+		$stylesheet_before = get_option( 'stylesheet' );
+		$template_before   = get_option( 'template' );
+
+		// Update an unrelated option
+		$this->assertTrue( update_option( 'blogname', 'Test Site Theme Corruption Test' ) );
+
+		// Verify theme options remain unchanged
+		$this->assertSame( $stylesheet_before, get_option( 'stylesheet' ) );
+		$this->assertSame( $template_before, get_option( 'template' ) );
+		$this->assertSame( $test_theme, get_stylesheet() );
+
+		// Restore original theme
+		if ( $original_theme !== $test_theme ) {
+			switch_theme( $original_theme );
+		}
+	}
 }


### PR DESCRIPTION
Trac ticket: [53520](https://core.trac.wordpress.org/ticket/53520)


This PR adds a regression test for the bug fixed in Gutenberg v10.7.4 where updating options in `options-general.php` would corrupt theme-related `wp_options`.

The bug caused themes to break and revert to default themes after updating any setting in the Settings or Customizer pages. This was tracked in wp-calypso issues [#53447](https://github.com/Automattic/wp-calypso/issues/53447) and [#53431](https://github.com/Automattic/wp-calypso/issues/53431) and fixed in Gutenberg PR [#32797](https://github.com/WordPress/gutenberg/pull/32797).

This test ensures that updating an unrelated option doesn't corrupt theme-related options like 'stylesheet' and 'template', preventing this serious issue from recurring in the future.


See: https://github.com/WordPress/gutenberg/pull/32797