### PR TITLE
Use `number` type for post `menu_order` inputs

### DIFF
--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1868,7 +1868,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 
 						<label>
 							<span class="title"><?php _e( 'Order' ); ?></span>
-							<span class="input-text-wrap"><input type="text" name="menu_order" class="inline-edit-menu-order-input" value="<?php echo $post->menu_order; ?>" /></span>
+							<span class="input-text-wrap"><input type="number" name="menu_order" class="tiny-text inline-edit-menu-order-input" value="<?php echo $post->menu_order; ?>" /></span>
 						</label>
 
 					<?php endif; // ! $bulk ?>

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -1068,7 +1068,7 @@ function page_attributes_meta_box( $post ) {
 <?php endif; ?>
 	<?php if ( post_type_supports( $post->post_type, 'page-attributes' ) ) : ?>
 <p class="post-attributes-label-wrapper menu-order-label-wrapper"><label class="post-attributes-label" for="menu_order"><?php _e( 'Order' ); ?></label></p>
-<input name="menu_order" type="text" size="4" id="menu_order" value="<?php echo esc_attr( $post->menu_order ); ?>" />
+<input name="menu_order" type="number" id="menu_order" class="small-text" value="<?php echo esc_attr( $post->menu_order ); ?>" />
 		<?php
 		/**
 		 * Fires before the help hint text in the 'Page Attributes' meta box.


### PR DESCRIPTION
In Quick Edit, this:
- Switches the Order field to a `number` input.
- Adds the `tiny-text` class to remove (right) side padding, without changing the width of `6em`.

In the Classic Editor's meta box, this:
- Switches the Order field to a `number` input.
- Removes `size` attribute.
- Adds the `small-text` class to remove the side padding and to define the width (fixed at `65px` on large screens, or `auto`—up to `4.375em`—on narrow screens).

[Trac 44103](https://core.trac.wordpress.org/ticket/44103)

Before:
![text inputs before patch](https://github.com/user-attachments/assets/f9df99c2-4f0d-442c-a696-2b5272f2f906)

With patch:
![number inputs with patch](https://github.com/user-attachments/assets/93595258-d5df-44ba-9e74-f7da01f03dc8)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
