### PR TITLE
Fix for uncaught error on some web browsers

### DIFF
--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -186,9 +186,9 @@ class WP_Script_Modules {
 	 */
 	public function add_hooks() {
 		$position = wp_is_block_theme() ? 'wp_head' : 'wp_footer';
-		add_action( $position, array( $this, 'print_import_map' ) );
-		add_action( $position, array( $this, 'print_enqueued_script_modules' ) );
-		add_action( $position, array( $this, 'print_script_module_preloads' ) );
+		add_action( $position, array( $this, 'print_import_map' ), 8 );
+		add_action( $position, array( $this, 'print_enqueued_script_modules' ), 8 );
+		add_action( $position, array( $this, 'print_script_module_preloads' ), 8 );
 
 		add_action( 'admin_print_footer_scripts', array( $this, 'print_import_map' ) );
 		add_action( 'admin_print_footer_scripts', array( $this, 'print_enqueued_script_modules' ) );


### PR DESCRIPTION
Some web browsers will ignore importmap script if a whole bunch of other javascript are listed before this:
`<script type="importmap" id="wp-importmap">`

Those web browsers will throw an error like this:
`Uncaught TypeError: The specifier “@wordpress/interactivity” was a bare specifier, but was not remapped to anything. Relative module specifiers must start with “./”, “../” or “/”.`

This is more likely to be an issue on WordPress sites with a lot of plugins installed.

When this happens, anything that relies on importmap wouldn't work. What I noticed on my site was the Twenty-Twenty-Two theme's mobile menu buttons not working.

Adding priority to these actions within the add_hooks function would make sure importmap script is listed before most other javascript.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
