### PR TITLE
Support custom font sizes with Calendar block in Twenty Twelve

### DIFF
--- a/src/wp-content/themes/twentytwelve/css/blocks.css
+++ b/src/wp-content/themes/twentytwelve/css/blocks.css
@@ -401,6 +401,13 @@ pre.wp-block-code {
 	margin-bottom: 0;
 }
 
+/* Calendar */
+
+.wp-block-calendar:is([style*="font-size"], [class*="-font-size"]) *,
+.wp-block-calendar:is([style*="font-size"], [class*="-font-size"]) #wp-calendar {
+	font-size: 1em;
+}
+
 /*--------------------------------------------------------------
 6.0 Blocks - Colors
 --------------------------------------------------------------*/

--- a/src/wp-content/themes/twentytwelve/css/editor-blocks.css
+++ b/src/wp-content/themes/twentytwelve/css/editor-blocks.css
@@ -464,6 +464,12 @@ p.has-drop-cap:not(:focus)::first-letter {
 	padding-right: 0;
 }
 
+/* Calendar */
+
+.wp-block-calendar:is([style*="font-size"], [class*="-font-size"]) * {
+	font-size: 1em;
+}
+
 /*--------------------------------------------------------------
 7.0 Blocks - Colors
 --------------------------------------------------------------*/


### PR DESCRIPTION
When a user selects a font size in the Calendar block, this resets its inner elements to `1em` so they match the block's size.

On the front end, the selector needs a higher specificity on the `table` to override the font size assigned to `#wp-calendar` in `style.css`.

[Trac 62918](https://core.trac.wordpress.org/ticket/62918)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
