### PR TITLE
Add site logo support to TwentyThirteen

### DIFF
--- a/src/wp-content/themes/twentythirteen/functions.php
+++ b/src/wp-content/themes/twentythirteen/functions.php
@@ -245,6 +245,17 @@ function twentythirteen_setup() {
 	// This theme uses wp_nav_menu() in one location.
 	register_nav_menu( 'primary', __( 'Navigation Menu', 'twentythirteen' ) );
 
+	// Enable support for custom logo.
+	add_theme_support(
+		'custom-logo',
+		array(
+			'height'               => 100,
+			'width'                => 300,
+			'flex-width'           => true,
+			'unlink-homepage-logo' => true,
+		)
+	);
+
 	/*
 	 * This theme uses a custom image size for featured images, displayed on
 	 * "standard" posts and pages.
@@ -817,6 +828,14 @@ function twentythirteen_customize_register( $wp_customize ) {
 				'render_callback'     => 'twentythirteen_customize_partial_blogdescription',
 			)
 		);
+		$wp_customize->selective_refresh->add_partial(
+			'custom_logo',
+			array(
+				'selector'            => '.site-logo',
+				'render_callback'     => 'twentythirteen_customize_partial_site_logo',
+				'container_inclusive' => false,
+			)
+		);
 	}
 }
 add_action( 'customize_register', 'twentythirteen_customize_register' );
@@ -845,6 +864,15 @@ function twentythirteen_customize_partial_blogname() {
  */
 function twentythirteen_customize_partial_blogdescription() {
 	bloginfo( 'description' );
+}
+
+/**
+ * Render the site logo for the selective refresh partial.
+ *
+ * Doing it this way so we don't have issues with `render_callback`'s arguments.
+ */
+function twentythirteen_customize_partial_site_logo() {
+	echo get_custom_logo();
 }
 
 /**

--- a/src/wp-content/themes/twentythirteen/header.php
+++ b/src/wp-content/themes/twentythirteen/header.php
@@ -24,6 +24,9 @@
 	<div id="page" class="hfeed site">
 		<header id="masthead" class="site-header">
 			<a class="home-link" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
+				<?php if ( has_custom_logo() ) : ?>
+					<span class="site-logo"><?php echo get_custom_logo(); ?></span>
+				<?php endif; ?>
 				<h1 class="site-title"><?php bloginfo( 'name' ); ?></h1>
 				<h2 class="site-description"><?php bloginfo( 'description' ); ?></h2>
 			</a>

--- a/src/wp-content/themes/twentythirteen/inc/custom-header.php
+++ b/src/wp-content/themes/twentythirteen/inc/custom-header.php
@@ -106,7 +106,7 @@ function twentythirteen_header_style() {
 	}
 	@media (max-width: 767px) {
 		.site-header {
-			background-size: 768px auto;
+			background-size: auto 220px;
 		}
 	}
 	@media (max-width: 359px) {

--- a/src/wp-content/themes/twentythirteen/style.css
+++ b/src/wp-content/themes/twentythirteen/style.css
@@ -2945,7 +2945,7 @@ footer.entry-meta {
 		width: auto;
 	}
 	.site-header .home-link {
-		min-height: 0;
+		min-height: 85px;
 	}
 	.site-title {
 		font-size: 36px;
@@ -2979,7 +2979,6 @@ footer.entry-meta {
 	}
 	.site-logo img {
 		margin: 8px 0 0;
-		max-height: 100px;
 	}
 	.site-logo .custom-logo-link {
 		padding: 0;

--- a/src/wp-content/themes/twentythirteen/style.css
+++ b/src/wp-content/themes/twentythirteen/style.css
@@ -838,7 +838,22 @@ img.wp-smiley,
 .site-header {
 	position: relative;
 }
-
+.site-logo {
+	float:left;
+	padding: 58px 0 10px;
+}
+.site-logo {
+	max-width: 100%;
+}
+.site-logo + .site-title {
+	clear: none;
+}
+.site-logo + .site-title + .site-description {
+	clear: none;
+}
+.site-logo .custom-logo-link {
+	padding: 0 20px;
+}
 .site-header .home-link {
 	color: #141412;
 	display: block;
@@ -2922,6 +2937,13 @@ footer.entry-meta {
 
 /* Collapse oversized image and pulled images after iPad breakpoint. */
 @media (max-width: 767px) {
+	.site-logo {
+		padding: 8px 0 10px;
+	}
+	.site-logo img {
+  		max-height: 70px;
+		width: auto;
+	}
 	.site-header .home-link {
 		min-height: 0;
 	}
@@ -2952,6 +2974,16 @@ footer.entry-meta {
 }
 
 @media (max-width: 643px) {
+	.site-logo {
+		float: none;
+	}
+	.site-logo img {
+		margin: 8px 0 0;
+		max-height: 100px;
+	}
+	.site-logo .custom-logo-link {
+		padding: 0;
+	}
 	.site-title {
 		font-size: 30px;
 	}


### PR DESCRIPTION
On the TwentyThirteen theme, this adds site logo support to provide users with the following options:
- Displays the site title and site description. (current standard)
- Display only the logo (if the user adds a logo)
- Display the logo, the site title and the description (if the user adds a logo and the header-text checkbox is ticked)

Trac ticket: https://core.trac.wordpress.org/ticket/61766

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
