### PR TITLE
TwentyFourteen - Site Logo Support

### DIFF
--- a/src/wp-content/themes/twentyfourteen/functions.php
+++ b/src/wp-content/themes/twentyfourteen/functions.php
@@ -134,6 +134,16 @@ if ( ! function_exists( 'twentyfourteen_setup' ) ) :
 		// Add RSS feed links to <head> for posts and comments.
 		add_theme_support( 'automatic-feed-links' );
 
+		// Enable support for custom logo.
+		add_theme_support(
+			'custom-logo',
+			array(
+				'height'     => 40,
+				'width'      => 164,
+				'flex-width' => true,
+			)
+		);
+
 		// Enable support for Post Thumbnails, and declare two sizes.
 		add_theme_support( 'post-thumbnails' );
 		set_post_thumbnail_size( 672, 372, true );

--- a/src/wp-content/themes/twentyfourteen/header.php
+++ b/src/wp-content/themes/twentyfourteen/header.php
@@ -43,6 +43,9 @@
 
 	<header id="masthead" class="site-header">
 		<div class="header-main">
+			<?php if ( has_custom_logo() ) : ?>
+				<div id="site-logo"><?php echo get_custom_logo(); ?></div>
+			<?php endif; ?>
 			<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
 
 			<div class="search-toggle">

--- a/src/wp-content/themes/twentyfourteen/inc/customizer.php
+++ b/src/wp-content/themes/twentyfourteen/inc/customizer.php
@@ -37,6 +37,14 @@ function twentyfourteen_customize_register( $wp_customize ) {
 				'render_callback'     => 'twentyfourteen_customize_partial_blogdescription',
 			)
 		);
+		$wp_customize->selective_refresh->add_partial(
+			'custom_logo',
+			array(
+				'selector'            => '#site-logo',
+				'render_callback'     => 'twentyfourteen_customize_partial_site_logo',
+				'container_inclusive' => false,
+			)
+		);
 	}
 
 	// Rename the label to "Site Title Color" because this only affects the site title in this theme.
@@ -120,6 +128,14 @@ function twentyfourteen_customize_partial_blogdescription() {
 	bloginfo( 'description' );
 }
 
+/**
+ * Render the site logo for the selective refresh partial.
+ *
+ * Doing it this way so we don't have issues with `render_callback`'s arguments.
+ */
+function twentyfourteen_customize_partial_site_logo() {
+	echo get_custom_logo();
+}
 /**
  * Sanitize the Featured Content layout value.
  *

--- a/src/wp-content/themes/twentyfourteen/style.css
+++ b/src/wp-content/themes/twentyfourteen/style.css
@@ -903,7 +903,17 @@ span + .edit-link:before,
 	min-height: 48px;
 	padding: 0 10px;
 }
-
+#site-logo {
+	float: left;
+	margin: 4px 30px 0 0;
+	text-align: left;
+}
+#site-logo + .site-title {
+	clear: none;
+}
+#site-logo + .site-title + .site-description {
+	clear: none;
+}
 .site-title {
 	float: left;
 	font-size: 18px;


### PR DESCRIPTION
On the TwentyFourteen theme, this adds site logo support to provide users with the following options:
- Displays the site title and site description. (current standard)
- Display only the logo (if the user adds a logo)
- Display the logo, the site title and the description (if the user adds a logo and the header-text checkbox is ticked)

Trac ticket: https://core.trac.wordpress.org/ticket/61766

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
