### PR TITLE
Twenty Fourteen: Move skip link to be first focusable element

### DIFF
--- a/src/wp-content/themes/twentyfourteen/header.php
+++ b/src/wp-content/themes/twentyfourteen/header.php
@@ -32,13 +32,13 @@
 
 <body <?php body_class(); ?>>
 <?php wp_body_open(); ?>
-<a class="screen-reader-text skip-link" href="#content">
-	<?php
-	/* translators: Hidden accessibility text. */
-	_e( 'Skip to content', 'twentyfourteen' );
-	?>
-</a>
 <div id="page" class="hfeed site">
+	<a class="screen-reader-text skip-link" href="#content">
+		<?php
+		/* translators: Hidden accessibility text. */
+		_e( 'Skip to content', 'twentyfourteen' );
+		?>
+	</a>
 	<?php if ( get_header_image() ) : ?>
 	<div id="site-header">
 		<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">

--- a/src/wp-content/themes/twentyfourteen/header.php
+++ b/src/wp-content/themes/twentyfourteen/header.php
@@ -32,6 +32,12 @@
 
 <body <?php body_class(); ?>>
 <?php wp_body_open(); ?>
+<a class="screen-reader-text skip-link" href="#content">
+	<?php
+	/* translators: Hidden accessibility text. */
+	_e( 'Skip to content', 'twentyfourteen' );
+	?>
+</a>
 <div id="page" class="hfeed site">
 	<?php if ( get_header_image() ) : ?>
 	<div id="site-header">
@@ -56,12 +62,6 @@
 
 			<nav id="primary-navigation" class="site-navigation primary-navigation">
 				<button class="menu-toggle"><?php _e( 'Primary Menu', 'twentyfourteen' ); ?></button>
-				<a class="screen-reader-text skip-link" href="#content">
-					<?php
-					/* translators: Hidden accessibility text. */
-					_e( 'Skip to content', 'twentyfourteen' );
-					?>
-				</a>
 				<?php
 				wp_nav_menu(
 					array(


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/62969

This PR fixes an accessibility issue in the Twenty Fourteen theme by moving the "Skip to content" link to be the first focusable element on the page. No changes to the link's functionality or styling.

