### PR TITLE
Twenty Thirteen: Move skip link to be first focusable element

### DIFF
--- a/src/wp-content/themes/twentythirteen/header.php
+++ b/src/wp-content/themes/twentythirteen/header.php
@@ -21,13 +21,13 @@
 
 <body <?php body_class(); ?>>
 	<?php wp_body_open(); ?>
-	<a class="screen-reader-text skip-link" href="#content">
-		<?php
-		/* translators: Hidden accessibility text. */
-		_e( 'Skip to content', 'twentythirteen' );
-		?>
-	</a>
 	<div id="page" class="hfeed site">
+		<a class="screen-reader-text skip-link" href="#content">
+			<?php
+			/* translators: Hidden accessibility text. */
+			_e( 'Skip to content', 'twentythirteen' );
+			?>
+		</a>
 		<header id="masthead" class="site-header">
 			<a class="home-link" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
 				<h1 class="site-title"><?php bloginfo( 'name' ); ?></h1>

--- a/src/wp-content/themes/twentythirteen/header.php
+++ b/src/wp-content/themes/twentythirteen/header.php
@@ -21,6 +21,12 @@
 
 <body <?php body_class(); ?>>
 	<?php wp_body_open(); ?>
+	<a class="screen-reader-text skip-link" href="#content">
+		<?php
+		/* translators: Hidden accessibility text. */
+		_e( 'Skip to content', 'twentythirteen' );
+		?>
+	</a>
 	<div id="page" class="hfeed site">
 		<header id="masthead" class="site-header">
 			<a class="home-link" href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
@@ -31,12 +37,6 @@
 			<div id="navbar" class="navbar">
 				<nav id="site-navigation" class="navigation main-navigation">
 					<button class="menu-toggle"><?php _e( 'Menu', 'twentythirteen' ); ?></button>
-					<a class="screen-reader-text skip-link" href="#content">
-						<?php
-						/* translators: Hidden accessibility text. */
-						_e( 'Skip to content', 'twentythirteen' );
-						?>
-					</a>
 					<?php
 					wp_nav_menu(
 						array(


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/62968


This PR fixes an accessibility issue in the Twenty Thirteen theme by moving the "Skip to content" link to be the first focusable element on the page. No changes to the link's functionality or styling.
