### PR TITLE
Twenty Twelve: Move skip link to be first focusable element

### DIFF
--- a/src/wp-content/themes/twentytwelve/header.php
+++ b/src/wp-content/themes/twentytwelve/header.php
@@ -33,8 +33,8 @@
 
 <body <?php body_class(); ?>>
 <?php wp_body_open(); ?>
-<a class="assistive-text" href="#content"><?php _e( 'Skip to content', 'twentytwelve' ); ?></a>
 <div id="page" class="hfeed site">
+	<a class="screen-reader-text skip-link" href="#content"><?php _e( 'Skip to content', 'twentytwelve' ); ?></a>
 	<header id="masthead" class="site-header">
 		<hgroup>
 			<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>

--- a/src/wp-content/themes/twentytwelve/header.php
+++ b/src/wp-content/themes/twentytwelve/header.php
@@ -33,6 +33,7 @@
 
 <body <?php body_class(); ?>>
 <?php wp_body_open(); ?>
+<a class="assistive-text" href="#content"><?php _e( 'Skip to content', 'twentytwelve' ); ?></a>
 <div id="page" class="hfeed site">
 	<header id="masthead" class="site-header">
 		<hgroup>
@@ -42,7 +43,6 @@
 
 		<nav id="site-navigation" class="main-navigation">
 			<button class="menu-toggle"><?php _e( 'Menu', 'twentytwelve' ); ?></button>
-			<a class="assistive-text" href="#content"><?php _e( 'Skip to content', 'twentytwelve' ); ?></a>
 			<?php
 			wp_nav_menu(
 				array(

--- a/src/wp-content/themes/twentytwelve/style.css
+++ b/src/wp-content/themes/twentytwelve/style.css
@@ -513,7 +513,7 @@ a:hover {
 	height: 1px;
 	width: 1px;
 }
-.main-navigation .assistive-text:focus,
+.assistive-text:focus,
 .site .screen-reader-text:hover,
 .site .screen-reader-text:active,
 .site .screen-reader-text:focus {

--- a/src/wp-content/themes/twentytwelve/style.css
+++ b/src/wp-content/themes/twentytwelve/style.css
@@ -513,7 +513,7 @@ a:hover {
 	height: 1px;
 	width: 1px;
 }
-.assistive-text:focus,
+.main-navigation .assistive-text:focus,
 .site .screen-reader-text:hover,
 .site .screen-reader-text:active,
 .site .screen-reader-text:focus {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/62967

This PR fixes an accessibility issue in the Twenty Twelve theme by moving the "Skip to content" link to be the first focusable element on the page. No changes to the link's functionality or styling.
