### PR TITLE
TwentyTwentyOne: add aria-controls attributes to a primary sub-menu

### DIFF
--- a/src/wp-content/themes/twentytwentyone/assets/js/primary-navigation.js
+++ b/src/wp-content/themes/twentytwentyone/assets/js/primary-navigation.js
@@ -120,6 +120,18 @@ function twentytwentyoneExpandSubMenu( el ) { // jshint ignore:line
 			};
 		}
 
+		var subMenus = document.querySelectorAll( '.primary-menu-container .sub-menu' );
+		subMenus.forEach( function( subMenu, index ) {
+			var parentLi = subMenu.closest( 'li.menu-item-has-children' );
+			subMenu.id = 'sub-menu-' + (index + 1);
+			if ( parentLi ) {
+				var parentLink = parentLi.querySelector( 'button' );
+				if ( parentLink ) {
+					parentLink.setAttribute( 'aria-controls', subMenu.id );
+				}
+			}
+		} );
+
 		/**
 		 * Trap keyboard navigation in the menu modal.
 		 * Adapted from Twenty Twenty.


### PR DESCRIPTION
On the twentytwentyone theme, this adds the aria-controls attribute to sub-menu buttons and the id to the sub-menu wrapper for added context on what is being expanded.

Trac ticket: https://core.trac.wordpress.org/ticket/62973 

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
