### PR TITLE
Twenty Nineteen - Aria attributes on a Primary Menu Submenu

### DIFF
--- a/src/wp-content/themes/twentynineteen/inc/template-functions.php
+++ b/src/wp-content/themes/twentynineteen/inc/template-functions.php
@@ -138,10 +138,10 @@ function twentynineteen_add_ellipses_to_nav( $nav_menu, $args ) {
 				<ul class="main-menu">
 					<li class="menu-item menu-item-has-children">
 						<button class="submenu-expand main-menu-more-toggle is-empty" tabindex="-1"
-							aria-label="' . esc_attr__( 'More', 'twentynineteen' ) . '" aria-haspopup="true" aria-expanded="false">' .
+							aria-label="' . esc_attr__( 'More', 'twentynineteen' ) . '" aria-expanded="false" aria-controls="sub-menu-more">' .
 							twentynineteen_get_icon_svg( 'arrow_drop_down_ellipsis' ) . '
 						</button>
-						<ul class="sub-menu hidden-links">
+						<ul class="sub-menu hidden-links" id="sub-menu-more">
 							<li class="mobile-parent-nav-menu-item">
 								<button class="menu-item-link-return">' .
 									twentynineteen_get_icon_svg( 'chevron_left' ) .
@@ -181,10 +181,9 @@ add_filter( 'wp_nav_menu', 'twentynineteen_add_ellipses_to_nav', 10, 2 );
  */
 function twentynineteen_nav_menu_link_attributes( $atts, $item ) {
 
-	// Add [aria-haspopup] and [aria-expanded] to menu items that have children.
+	// Add [aria-expanded] to menu items that have children.
 	$item_has_children = in_array( 'menu-item-has-children', $item->classes, true );
 	if ( $item_has_children ) {
-		$atts['aria-haspopup'] = 'true';
 		$atts['aria-expanded'] = 'false';
 	}
 

--- a/src/wp-content/themes/twentynineteen/js/touch-keyboard-navigation.js
+++ b/src/wp-content/themes/twentynineteen/js/touch-keyboard-navigation.js
@@ -98,6 +98,24 @@
 		ariaItem.setAttribute('aria-expanded', ariaState);
 	}
 
+	function toggleAriaExpandedOnHover() {
+		document.querySelectorAll('.main-navigation li.menu-item-has-children').forEach(function(li) {
+			['mouseenter', 'mouseleave'].forEach(function(event) {
+				li.addEventListener(event, function() {
+					var expanded = event === 'mouseenter' ? 'true' : 'false';
+					var anchor = li.querySelector('a');
+					var button = li.querySelector('button.main-menu-more-toggle');
+					if (anchor) {
+						anchor.setAttribute('aria-expanded', expanded);
+					}
+					if (button) {
+						button.setAttribute('aria-expanded', expanded);
+					}
+				});
+			});
+		});
+	}
+
 	/**
 	 * Open sub-menu.
 	 *
@@ -318,11 +336,28 @@
 		}, false);
 	}
 
+	// Add unique ID to each .sub-menu and aria-controls to parent links
+	function addUniqueIDToSubMenus() {
+		var subMenus = document.querySelectorAll( '.main-navigation .sub-menu' );
+		subMenus.forEach( function( subMenu, index ) {
+			var parentLi = subMenu.closest( 'li.menu-item-has-children' );
+			subMenu.id = 'sub-menu-' + (index + 1);
+			if ( parentLi ) {
+				var parentLink = parentLi.querySelector( 'a' );
+				if ( parentLink ) {
+					parentLink.setAttribute( 'aria-controls', subMenu.id );
+				}
+			}
+		} );
+	}
+
 	/**
 	 * Run our sub-menu function as soon as the document is `ready`.
 	 */
 	document.addEventListener( 'DOMContentLoaded', function() {
 		toggleSubmenuDisplay();
+		addUniqueIDToSubMenus();
+		toggleAriaExpandedOnHover();
 	});
 
 	/**


### PR DESCRIPTION
This updates a primary menu submenu with the following changes:
- removes aria haspopup
- fixes the aria-expanded attribute to update on hover 
- adds a unique ID to a submenu that is setup in the primary menu
- adds aria-controls using the same ID of the submenu 
- adds aria-controls and an ID to the automated dropdown menu that gets generated 

Trac ticket: https://core.trac.wordpress.org/ticket/47051 

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
