### PR TITLE
Added 'maybe_unserialize_allowed_classes' Filter for PHP Object Injection Prevention

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -647,13 +647,23 @@ function maybe_serialize( $data ) {
  * Unserializes data only if it was serialized.
  *
  * @since 2.0.0
+ * @since 6.8.0 Added 'maybe_unserialize_allowed_classes' filter for PHP Object Injection defense.
  *
  * @param string $data Data that might be unserialized.
  * @return mixed Unserialized data can be any type.
  */
 function maybe_unserialize( $data ) {
 	if ( is_serialized( $data ) ) { // Don't attempt to unserialize data that wasn't serialized going in.
-		return @unserialize( trim( $data ) );
+		/**
+		 * Filters the list of allowed classes that can be unserialized.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param bool|string[] $allowed_classes Whether to allow all classes (true), no classes (false),
+		 *                                       or specific classes (array of class names). Default true.
+		 */
+		$allowed_classes = apply_filters( 'maybe_unserialize_allowed_classes', true );
+		return @unserialize( trim( $data ), array( 'allowed_classes' => $allowed_classes ) );
 	}
 
 	return $data;

--- a/tests/phpunit/tests/functions/maybeSerialize.php
+++ b/tests/phpunit/tests/functions/maybeSerialize.php
@@ -244,4 +244,67 @@ class Tests_Functions_MaybeSerialize extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Tests that maybe_unserialize() allows all classes by default for backwards compatibility.
+	 *
+	 * @ticket 62970
+	 */
+	public function test_maybe_unserialize_allows_all_classes_by_default() {
+		$obj        = new stdClass();
+		$obj->foo   = 'bar';
+		$serialized = serialize( $obj );
+
+		$result = maybe_unserialize( $serialized );
+		$this->assertInstanceOf( 'stdClass', $result );
+		$this->assertEquals( 'bar', $result->foo );
+	}
+
+	/**
+	 * Tests that maybe_unserialize() blocks classes when filtered.
+	 *
+	 * @ticket 62970
+	 */
+	public function test_maybe_unserialize_blocks_filtered_classes() {
+		$obj        = new stdClass();
+		$obj->foo   = 'bar';
+		$serialized = serialize( $obj );
+
+		add_filter( 'maybe_unserialize_allowed_classes', '__return_false' );
+
+		$result = maybe_unserialize( $serialized );
+		$this->assertInstanceOf( '__PHP_Incomplete_Class', $result );
+		$this->assertNotInstanceOf( 'stdClass', $result );
+
+		remove_filter( 'maybe_unserialize_allowed_classes', '__return_false' );
+	}
+
+	/**
+	 * Tests that maybe_unserialize() allows specific classes when filtered.
+	 *
+	 * @ticket 62970
+	 */
+	public function test_maybe_unserialize_allows_filtered_classes() {
+		$obj        = new stdClass();
+		$obj->foo   = 'bar';
+		$serialized = serialize( $obj );
+
+		add_filter(
+			'maybe_unserialize_allowed_classes',
+			function () {
+				return array( 'stdClass' );
+			}
+		);
+
+		$result = maybe_unserialize( $serialized );
+		$this->assertInstanceOf( 'stdClass', $result );
+		$this->assertEquals( 'bar', $result->foo );
+
+		remove_filter(
+			'maybe_unserialize_allowed_classes',
+			function () {
+				return array( 'stdClass' );
+			}
+		);
+	}
 }


### PR DESCRIPTION
This pull request introduces the `maybe_unserialize_allowed_classes` filter to enhance security by providing control over which classes can be instantiated during unserialization. This helps to mitigate potential PHP Object Injection vulnerabilities.
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/62970

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
