### PR TITLE
Enhance export XML filename to include args

### DIFF
--- a/src/wp-admin/includes/export.php
+++ b/src/wp-admin/includes/export.php
@@ -81,7 +81,45 @@ function export_wp( $args = array() ) {
 		$sitename .= '.';
 	}
 	$date        = gmdate( 'Y-m-d' );
-	$wp_filename = $sitename . 'WordPress.' . $date . '.xml';
+	$wp_filename = $sitename . 'WordPress.' . $date;
+
+	// Append content type.
+	if ( isset( $args['content'] ) ) {
+		$wp_filename .= '.' . sanitize_key( $args['content'] );
+	}
+
+	// Append category if available.
+	if ( isset( $args['category'] ) ) {
+		$category = get_term( $args['category'], 'category' );
+		if ( $category && ! is_wp_error( $category ) ) {
+			$wp_filename .= '.' . sanitize_key( $category->slug );
+		}
+	}
+
+	// Append author if available.
+	if ( isset( $args['author'] ) ) {
+		$author = get_user_by( 'id', $args['author'] );
+		if ( $author ) {
+			$wp_filename .= '.' . sanitize_key( $author->user_nicename );
+		}
+	}
+
+	// Append start and end date if available.
+	if ( isset( $args['start_date'] ) ) {
+		$wp_filename .= '.' . sanitize_key( $args['start_date'] );
+	}
+	if ( isset( $args['end_date'] ) ) {
+		$wp_filename .= '.' . sanitize_key( $args['end_date'] );
+	}
+
+	// Append post status if available.
+	if ( isset( $args['status'] ) ) {
+		$wp_filename .= '.' . sanitize_key( $args['status'] );
+	}
+
+	$wp_filename .= '.xml';
+
+	$wp_filename = sanitize_file_name( $wp_filename );
 	/**
 	 * Filters the export filename.
 	 *


### PR DESCRIPTION
This PR enhances the export XML filename generation in WordPress by appending relevant details such as content type, category, author, date range, and post status. This improvement helps users easily differentiate multiple exported files.



<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/55762

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
