### PR TITLE
Block Hooks: Fix child insertion next to Classic block

### DIFF
--- a/tests/phpunit/tests/blocks/applyBlockHooksToContent.php
+++ b/tests/phpunit/tests/blocks/applyBlockHooksToContent.php
@@ -68,6 +68,7 @@ class Tests_Blocks_ApplyBlockHooksToContent extends WP_UnitTestCase {
 		$registry = WP_Block_Type_Registry::get_instance();
 
 		$registry->unregister( 'tests/hooked-block' );
+		$registry->unregister( 'tests/hooked-block-as-last-child' );
 		$registry->unregister( 'tests/hooked-block-with-multiple-false' );
 		$registry->unregister( 'tests/dynamically-hooked-block-with-multiple-false' );
 	}
@@ -104,6 +105,21 @@ class Tests_Blocks_ApplyBlockHooksToContent extends WP_UnitTestCase {
 		$block_opener  = '<!-- wp:tests/anchor-block-for-child-insertion -->';
 		$block_closer  = '<!-- /wp:tests/anchor-block-for-child-insertion -->';
 		$sibling_block = '<!-- wp:tests/sibling /-->';
+
+		$context          = new WP_Block_Template();
+		$context->content = $block_opener . $sibling_block . $block_closer;
+
+		$actual = apply_block_hooks_to_content( $context->content, $context, 'insert_hooked_blocks' );
+		$this->assertSame(
+			$block_opener . $sibling_block . '<!-- wp:tests/hooked-block-as-last-child /-->' . $block_closer,
+			$actual
+		);
+	}
+
+	public function test_apply_block_hooks_to_content_inserts_hooked_block_as_last_child_if_sibling_is_classic_block() {
+		$block_opener  = '<!-- wp:tests/anchor-block-for-child-insertion -->';
+		$block_closer  = '<!-- /wp:tests/anchor-block-for-child-insertion -->';
+		$sibling_block = '<h2>Hello World!</h2>';
 
 		$context          = new WP_Block_Template();
 		$context->content = $block_opener . $sibling_block . $block_closer;

--- a/tests/phpunit/tests/blocks/applyBlockHooksToContent.php
+++ b/tests/phpunit/tests/blocks/applyBlockHooksToContent.php
@@ -29,6 +29,15 @@ class Tests_Blocks_ApplyBlockHooksToContent extends WP_UnitTestCase {
 		);
 
 		register_block_type(
+			'tests/hooked-block-as-last-child',
+			array(
+				'block_hooks' => array(
+					'tests/anchor-block-for-child-insertion' => 'last_child',
+				),
+			)
+		);
+
+		register_block_type(
 			'tests/hooked-block-with-multiple-false',
 			array(
 				'block_hooks' => array(
@@ -87,6 +96,21 @@ class Tests_Blocks_ApplyBlockHooksToContent extends WP_UnitTestCase {
 		$actual = apply_block_hooks_to_content( $context->content, $context, 'insert_hooked_blocks' );
 		$this->assertSame(
 			'<!-- wp:tests/anchor-block /--><!-- wp:tests/hooked-block /-->',
+			$actual
+		);
+	}
+
+	public function test_apply_block_hooks_to_content_inserts_hooked_block_as_last_child_if_sibling_is_present() {
+		$block_opener  = '<!-- wp:tests/anchor-block-for-child-insertion -->';
+		$block_closer  = '<!-- /wp:tests/anchor-block-for-child-insertion -->';
+		$sibling_block = '<!-- wp:tests/sibling /-->';
+
+		$context          = new WP_Block_Template();
+		$context->content = $block_opener . $sibling_block . $block_closer;
+
+		$actual = apply_block_hooks_to_content( $context->content, $context, 'insert_hooked_blocks' );
+		$this->assertSame(
+			$block_opener . $sibling_block . '<!-- wp:tests/hooked-block-as-last-child /-->' . $block_closer,
 			$actual
 		);
 	}


### PR DESCRIPTION
WIP. More details to follow.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
