### PR TITLE
fix: update pingomatic URL to use HTTPS

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -446,7 +446,7 @@ function populate_options( array $options = array() ) {
 		'moderation_keys'                 => '',
 		'active_plugins'                  => array(),
 		'category_base'                   => '',
-		'ping_sites'                      => 'http://rpc.pingomatic.com/',
+		'ping_sites'                      => 'https://rpc.pingomatic.com/',
 		'comment_max_links'               => 2,
 		'gmt_offset'                      => $gmt_offset,
 

--- a/tests/phpunit/tests/option/sanitizeOption.php
+++ b/tests/phpunit/tests/option/sanitizeOption.php
@@ -42,7 +42,7 @@ class Tests_Option_SanitizeOption extends WP_UnitTestCase {
 			array( 'blog_public', -2, '-2' ),
 			array( 'date_format', 'F j, Y', 'F j, Y' ),
 			array( 'date_format', 'F j, Y', 'F j, <strong>Y</strong>' ),
-			array( 'ping_sites', 'http://rpc.pingomatic.com/', 'http://rpc.pingomatic.com/' ),
+			array( 'ping_sites', 'https://rpc.pingomatic.com/', 'https://rpc.pingomatic.com/' ),
 			array( 'ping_sites', "http://www.example.com\nhttp://example.org", "www.example.com \n\texample.org\n\n" ),
 			array( 'gmt_offset', '0', 0 ),
 			array( 'gmt_offset', '1.5', '1.5' ),


### PR DESCRIPTION
> Replaced the pingomatic URL in settings and related tests to use HTTPS instead of HTTP for improved security and consistency. This ensures communication with pingomatic occurs over a secure connection.
>
> (This commit message was AI-generated.)

Trac ticket: [#62979](https://core.trac.wordpress.org/ticket/62979)