### PR TITLE
Uploads: Fix media uploader styling issue for long filenames

### DIFF
--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -1421,6 +1421,7 @@
 
 .upload-errors .upload-error-filename {
 	font-weight: 600;
+	word-break: break-all;
 }
 
 .upload-errors .upload-error-message {


### PR DESCRIPTION
This PR resolves an issue where long filenames in the media uploader popup would overflow. By adding word-break: break-all;to the .upload-error-filename class, filenames will now properly break into multiple lines to avoid UI issues.

Before: 
<img width="1469" alt="Screenshot 2025-02-18 at 1 18 54 AM" src="https://github.com/user-attachments/assets/07515aa4-de0e-4cc5-85bb-2b9850248279" />

After:
<img width="1470" alt="Screenshot 2025-02-18 at 1 11 18 AM" src="https://github.com/user-attachments/assets/5adf085e-f9f7-4376-a8db-12519df4ede3" />

Trac ticket:[#62980](https://core.trac.wordpress.org/ticket/62980)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
