### PR TITLE
Introduce the `wp_get_api_hostname()` function

### DIFF
--- a/src/js/_enqueues/wp/theme.js
+++ b/src/js/_enqueues/wp/theme.js
@@ -349,7 +349,7 @@ themes.Collection = Backbone.Collection.extend({
 		request: {}
 	},
 
-	// Send request to api.wordpress.org/themes.
+	// Send request to the `/themes` endpoint of the WordPress API.
 	apiCall: function( request, paginated ) {
 		return wp.ajax.send( 'query-themes', {
 			data: {
@@ -1605,8 +1605,8 @@ themes.view.InstallerSearch =  themes.view.Search.extend({
 		$( 'body' ).removeClass( 'show-filters filters-applied show-favorites-form' );
 		$( '.drawer-toggle' ).attr( 'aria-expanded', 'false' );
 
-		// Get the themes by sending Ajax POST request to api.wordpress.org/themes
-		// or searching the local cache.
+		// Get the themes by sending Ajax POST request to the `/themes` endpoint of
+		// the WordPress API, or searching the local cache.
 		this.collection.query( request );
 
 		// Set route.
@@ -1696,8 +1696,8 @@ themes.view.Installer = themes.view.Appearance.extend({
 		// Create a new collection with the proper theme data
 		// for each section.
 		if ( 'block-themes' === section ) {
-			// Get the themes by sending Ajax POST request to api.wordpress.org/themes
-			// or searching the local cache.
+			// Get the themes by sending Ajax POST request to the `/themes` endpoint
+			// of the WordPress API, or searching the local cache.
 			this.collection.query( { tag: 'full-site-editing' } );
 		} else {
 			this.collection.query( { browse: section } );
@@ -1775,8 +1775,8 @@ themes.view.Installer = themes.view.Appearance.extend({
 		filter = _.union( [ filter, this.filtersChecked() ] );
 		request = { tag: [ filter ] };
 
-		// Get the themes by sending Ajax POST request to api.wordpress.org/themes
-		// or searching the local cache.
+		// Get the themes by sending Ajax POST request to the `/themes` endpoint
+		// of the WordPress API, or searching the local cache.
 		this.collection.query( request );
 	},
 
@@ -1813,8 +1813,8 @@ themes.view.Installer = themes.view.Appearance.extend({
 			filteringBy.append( '<span class="tag">' + name + '</span>' );
 		});
 
-		// Get the themes by sending Ajax POST request to api.wordpress.org/themes
-		// or searching the local cache.
+		// Get the themes by sending Ajax POST request to the `/themes` endpoint
+		// of the WordPress API, or searching the local cache.
 		this.collection.query( request );
 	},
 
@@ -1840,8 +1840,8 @@ themes.view.Installer = themes.view.Appearance.extend({
 				username: username
 			},
 			success: function () {
-				// Get the themes by sending Ajax POST request to api.wordpress.org/themes
-				// or searching the local cache.
+				// Get the themes by sending Ajax POST request to the `/themes` endpoint
+				// of the WordPress API, or searching the local cache.
 				that.collection.query( request );
 			}
 		} );

--- a/src/js/_enqueues/wp/theme.js
+++ b/src/js/_enqueues/wp/theme.js
@@ -349,7 +349,7 @@ themes.Collection = Backbone.Collection.extend({
 		request: {}
 	},
 
-	// Send request to the `/themes` endpoint of the WordPress API.
+	// Send request to api.wordpress.org/themes.
 	apiCall: function( request, paginated ) {
 		return wp.ajax.send( 'query-themes', {
 			data: {

--- a/src/wp-admin/includes/class-wp-community-events.php
+++ b/src/wp-admin/includes/class-wp-community-events.php
@@ -10,7 +10,7 @@
 /**
  * Class WP_Community_Events.
  *
- * A client for the `/events` endpoint of the WordPress API.
+ * A client for api.wordpress.org/events.
  *
  * @since 4.8.0
  */

--- a/src/wp-admin/includes/class-wp-community-events.php
+++ b/src/wp-admin/includes/class-wp-community-events.php
@@ -10,7 +10,7 @@
 /**
  * Class WP_Community_Events.
  *
- * A client for api.wordpress.org/events.
+ * A client for the `/events` endpoint of the WordPress API.
  *
  * @since 4.8.0
  */
@@ -67,7 +67,7 @@ class WP_Community_Events {
 	 * with nearby events.
 	 *
 	 * The browser's request for events is proxied with this method, rather
-	 * than having the browser make the request directly to api.wordpress.org,
+	 * than having the browser make the request directly to the WordPress API (`api.wordpress.org` by default),
 	 * because it allows results to be cached server-side and shared with other
 	 * users and sites in the network. This makes the process more efficient,
 	 * since increasing the number of visits that get cached data means users
@@ -98,7 +98,7 @@ class WP_Community_Events {
 		// Include an unmodified $wp_version.
 		require ABSPATH . WPINC . '/version.php';
 
-		$api_url                    = 'http://api.wordpress.org/events/1.0/';
+		$api_url                    = wp_get_api_hostname() . '/events/1.0/';
 		$request_args               = $this->get_request_args( $location_search, $timezone );
 		$request_args['user-agent'] = 'WordPress/' . $wp_version . '; ' . home_url( '/' );
 

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -278,7 +278,7 @@ class WP_Debug_Data {
 			'value' => wp_get_api_hostname(),
 		);
 
-		$wp_dotorg = wp_remote_get( wp_get_api_hostname() , array( 'timeout' => 10 ) );
+		$wp_dotorg = wp_remote_get( wp_get_api_hostname(), array( 'timeout' => 10 ) );
 
 		if ( ! is_wp_error( $wp_dotorg ) ) {
 			$fields['dotorg_communication'] = array(

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -273,21 +273,26 @@ class WP_Debug_Data {
 		);
 
 		// WordPress features requiring processing.
-		$wp_dotorg = wp_remote_get( 'https://wordpress.org', array( 'timeout' => 10 ) );
+		$fields['dotorg_api_hostname'] = array(
+			'label' => __( 'WordPress API source used by this site' ),
+			'value' => wp_get_api_hostname(),
+		);
+
+		$wp_dotorg = wp_remote_get( wp_get_api_hostname() , array( 'timeout' => 10 ) );
 
 		if ( ! is_wp_error( $wp_dotorg ) ) {
 			$fields['dotorg_communication'] = array(
-				'label' => __( 'Communication with WordPress.org' ),
-				'value' => __( 'WordPress.org is reachable' ),
+				'label' => __( 'Communication with the WordPress API' ),
+				'value' => __( 'The WordPress API is reachable' ),
 				'debug' => 'true',
 			);
 		} else {
 			$fields['dotorg_communication'] = array(
-				'label' => __( 'Communication with WordPress.org' ),
+				'label' => __( 'Communication with the WordPress API' ),
 				'value' => sprintf(
-				/* translators: 1: The IP address WordPress.org resolves to. 2: The error returned by the lookup. */
-					__( 'Unable to reach WordPress.org at %1$s: %2$s' ),
-					gethostbyname( 'wordpress.org' ),
+					/* translators: 1: The IP address the WordPress API resolves to. 2: The error returned by the lookup. */
+					__( 'Unable to reach the WordPress API at %1$s: %2$s' ),
+					gethostbyname( wp_get_api_hostname() ),
 					$wp_dotorg->get_error_message()
 				),
 				'debug' => $wp_dotorg->get_error_message(),

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1319,6 +1319,16 @@ class WP_Site_Health {
 
 			$result['label'] = __( 'Could not reach the WordPress API' );
 
+			/*
+			 * By validating that the parsed URL does not return `null`,
+			 * we avoid a deprecation warning when running `gethostbyname()` later.
+			 */
+			$api_hostname    = wp_get_api_hostname();
+			$parsed_hostname = parse_url( $api_hostname, PHP_URL_HOST );
+			if ( null === $parsed_hostname ) {
+				$parsed_hostname = $api_hostname;
+			}
+
 			$result['description'] .= sprintf(
 				'<p>%s</p>',
 				sprintf(
@@ -1328,7 +1338,7 @@ class WP_Site_Health {
 					sprintf(
 						/* translators: 1: The IP address the WordPress API resolves to. 2: The error returned by the lookup. */
 						__( 'Your site is unable to reach the WordPress API at %1$s, and returned the error: %2$s' ),
-						gethostbyname( wp_get_api_hostname() ),
+						gethostbyname( $parsed_hostname ),
 						$wp_dotorg->get_error_message()
 					)
 				)

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1284,7 +1284,7 @@ class WP_Site_Health {
 	}
 
 	/**
-	 * Tests if the site can communicate with WordPress.org.
+	 * Tests if the site can communicate with the WordPress API.
 	 *
 	 * @since 5.2.0
 	 *
@@ -1292,7 +1292,7 @@ class WP_Site_Health {
 	 */
 	public function get_test_dotorg_communication() {
 		$result = array(
-			'label'       => __( 'Can communicate with WordPress.org' ),
+			'label'       => __( 'Can communicate with the WordPress API' ),
 			'status'      => '',
 			'badge'       => array(
 				'label' => __( 'Security' ),
@@ -1307,7 +1307,7 @@ class WP_Site_Health {
 		);
 
 		$wp_dotorg = wp_remote_get(
-			'https://api.wordpress.org',
+			wp_get_api_hostname(),
 			array(
 				'timeout' => 10,
 			)
@@ -1317,7 +1317,7 @@ class WP_Site_Health {
 		} else {
 			$result['status'] = 'critical';
 
-			$result['label'] = __( 'Could not reach WordPress.org' );
+			$result['label'] = __( 'Could not reach the WordPress API' );
 
 			$result['description'] .= sprintf(
 				'<p>%s</p>',
@@ -1326,9 +1326,9 @@ class WP_Site_Health {
 					/* translators: Hidden accessibility text. */
 					__( 'Error' ),
 					sprintf(
-						/* translators: 1: The IP address WordPress.org resolves to. 2: The error returned by the lookup. */
-						__( 'Your site is unable to reach WordPress.org at %1$s, and returned the error: %2$s' ),
-						gethostbyname( 'api.wordpress.org' ),
+						/* translators: 1: The IP address the WordPress API resolves to. 2: The error returned by the lookup. */
+						__( 'Your site is unable to reach the WordPress API at %1$s, and returned the error: %2$s' ),
+						gethostbyname( wp_get_api_hostname() ),
 						$wp_dotorg->get_error_message()
 					)
 				)

--- a/src/wp-admin/includes/credits.php
+++ b/src/wp-admin/includes/credits.php
@@ -32,7 +32,7 @@ function wp_credits( $version = '', $locale = '' ) {
 		|| str_contains( $version, '-' )
 		|| ( isset( $results['data']['version'] ) && ! str_starts_with( $version, $results['data']['version'] ) )
 	) {
-		$url     = wp_get_api_hostname() . "/core/credits/1.1/?version={$version}&locale={$locale}";
+		$url     = wp_get_api_hostname( true ) . "/core/credits/1.1/?version={$version}&locale={$locale}";
 		$options = array( 'user-agent' => 'WordPress/' . $version . '; ' . home_url( '/' ) );
 
 		if ( wp_http_supports( array( 'ssl' ) ) ) {

--- a/src/wp-admin/includes/credits.php
+++ b/src/wp-admin/includes/credits.php
@@ -32,7 +32,7 @@ function wp_credits( $version = '', $locale = '' ) {
 		|| str_contains( $version, '-' )
 		|| ( isset( $results['data']['version'] ) && ! str_starts_with( $version, $results['data']['version'] ) )
 	) {
-		$url     = "http://api.wordpress.org/core/credits/1.1/?version={$version}&locale={$locale}";
+		$url     = wp_get_api_hostname() . "/core/credits/1.1/?version={$version}&locale={$locale}";
 		$options = array( 'user-agent' => 'WordPress/' . $version . '; ' . home_url( '/' ) );
 
 		if ( wp_http_supports( array( 'ssl' ) ) ) {

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1811,7 +1811,7 @@ function wp_check_browser_version() {
 	$response = get_site_transient( 'browser_' . $key );
 
 	if ( false === $response ) {
-		$url     = wp_get_api_hostname() . '/core/browse-happy/1.1/';
+		$url     = wp_get_api_hostname( true ) . '/core/browse-happy/1.1/';
 		$options = array(
 			'body'       => array( 'useragent' => $_SERVER['HTTP_USER_AGENT'] ),
 			'user-agent' => 'WordPress/' . wp_get_wp_version() . '; ' . home_url( '/' ),

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1811,7 +1811,7 @@ function wp_check_browser_version() {
 	$response = get_site_transient( 'browser_' . $key );
 
 	if ( false === $response ) {
-		$url     = 'http://api.wordpress.org/core/browse-happy/1.1/';
+		$url     = wp_get_api_hostname() . '/core/browse-happy/1.1/';
 		$options = array(
 			'body'       => array( 'useragent' => $_SERVER['HTTP_USER_AGENT'] ),
 			'user-agent' => 'WordPress/' . wp_get_wp_version() . '; ' . home_url( '/' ),

--- a/src/wp-admin/includes/import.php
+++ b/src/wp-admin/includes/import.php
@@ -146,7 +146,7 @@ function wp_get_popular_importers() {
 				'locale'  => $locale,
 				'version' => wp_get_wp_version(),
 			),
-			wp_get_api_hostname() . '/core/importers/1.1/'
+			wp_get_api_hostname( true ) . '/core/importers/1.1/'
 		);
 		$options = array( 'user-agent' => 'WordPress/' . wp_get_wp_version() . '; ' . home_url( '/' ) );
 

--- a/src/wp-admin/includes/import.php
+++ b/src/wp-admin/includes/import.php
@@ -146,7 +146,7 @@ function wp_get_popular_importers() {
 				'locale'  => $locale,
 				'version' => wp_get_wp_version(),
 			),
-			'http://api.wordpress.org/core/importers/1.1/'
+			wp_get_api_hostname() . '/core/importers/1.1/'
 		);
 		$options = array( 'user-agent' => 'WordPress/' . wp_get_wp_version() . '; ' . home_url( '/' ) );
 

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1581,7 +1581,7 @@ function wp_check_php_version() {
 	$response = get_site_transient( 'php_check_' . $key );
 
 	if ( false === $response ) {
-		$url = 'http://api.wordpress.org/core/serve-happy/1.0/';
+		$url = wp_get_api_hostname() . '/core/serve-happy/1.0/';
 
 		if ( wp_http_supports( array( 'ssl' ) ) ) {
 			$url = set_url_scheme( $url, 'https' );

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1581,7 +1581,7 @@ function wp_check_php_version() {
 	$response = get_site_transient( 'php_check_' . $key );
 
 	if ( false === $response ) {
-		$url = wp_get_api_hostname() . '/core/serve-happy/1.0/';
+		$url = wp_get_api_hostname( true ) . '/core/serve-happy/1.0/';
 
 		if ( wp_http_supports( array( 'ssl' ) ) ) {
 			$url = set_url_scheme( $url, 'https' );

--- a/src/wp-admin/includes/network.php
+++ b/src/wp-admin/includes/network.php
@@ -554,7 +554,7 @@ define( 'BLOG_ID_CURRENT_SITE', 1 );
 
 		if ( ! empty( $keys_salts ) ) {
 			$keys_salts_str = '';
-			$from_api       = wp_remote_get( 'https://api.wordpress.org/secret-key/1.1/salt/' );
+			$from_api       = wp_remote_get( wp_get_api_hostname() . '/secret-key/1.1/salt/' );
 			if ( is_wp_error( $from_api ) ) {
 				foreach ( $keys_salts as $c => $v ) {
 					$keys_salts_str .= "\ndefine( '$c', '" . wp_generate_password( 64, true, true ) . "' );";

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -146,7 +146,7 @@ function plugins_api( $action, $args = array() ) {
 
 	if ( false === $res ) {
 
-		$url = wp_get_api_hostname() . '/plugins/info/1.2/';
+		$url = wp_get_api_hostname( true ) . '/plugins/info/1.2/';
 		$url = add_query_arg(
 			array(
 				'action'  => $action,

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -146,7 +146,7 @@ function plugins_api( $action, $args = array() ) {
 
 	if ( false === $res ) {
 
-		$url = 'http://api.wordpress.org/plugins/info/1.2/';
+		$url = wp_get_api_hostname() . '/plugins/info/1.2/';
 		$url = add_query_arg(
 			array(
 				'action'  => $action,

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -542,7 +542,7 @@ function themes_api( $action, $args = array() ) {
 	$res = apply_filters( 'themes_api', false, $action, $args );
 
 	if ( ! $res ) {
-		$url = wp_get_api_hostname() . '/themes/info/1.2/';
+		$url = wp_get_api_hostname( true ) . '/themes/info/1.2/';
 		$url = add_query_arg(
 			array(
 				'action'  => $action,

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -542,7 +542,7 @@ function themes_api( $action, $args = array() ) {
 	$res = apply_filters( 'themes_api', false, $action, $args );
 
 	if ( ! $res ) {
-		$url = 'http://api.wordpress.org/themes/info/1.2/';
+		$url = wp_get_api_hostname() . '/themes/info/1.2/';
 		$url = add_query_arg(
 			array(
 				'action'  => $action,

--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -50,7 +50,7 @@ function translations_api( $type, $args = null ) {
 	$res = apply_filters( 'translations_api', false, $type, $args );
 
 	if ( false === $res ) {
-		$url      = 'http://api.wordpress.org/translations/' . $type . '/1.0/';
+		$url      = wp_get_api_hostname() . '/translations/' . $type . '/1.0/';
 		$http_url = $url;
 		$ssl      = wp_http_supports( array( 'ssl' ) );
 		if ( $ssl ) {

--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -50,7 +50,7 @@ function translations_api( $type, $args = null ) {
 	$res = apply_filters( 'translations_api', false, $type, $args );
 
 	if ( false === $res ) {
-		$url      = wp_get_api_hostname() . '/translations/' . $type . '/1.0/';
+		$url      = wp_get_api_hostname( true ) . '/translations/' . $type . '/1.0/';
 		$http_url = $url;
 		$ssl      = wp_http_supports( array( 'ssl' ) );
 		if ( $ssl ) {

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -129,7 +129,7 @@ function find_core_auto_update() {
  * @return array|false An array of checksums on success, false on failure.
  */
 function get_core_checksums( $version, $locale ) {
-	$http_url = 'http://api.wordpress.org/core/checksums/1.0/?' . http_build_query( compact( 'version', 'locale' ), '', '&' );
+	$http_url = wp_get_api_hostname() . '/core/checksums/1.0/?' . http_build_query( compact( 'version', 'locale' ), '', '&' );
 	$url      = $http_url;
 
 	$ssl = wp_http_supports( array( 'ssl' ) );

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -129,7 +129,7 @@ function find_core_auto_update() {
  * @return array|false An array of checksums on success, false on failure.
  */
 function get_core_checksums( $version, $locale ) {
-	$http_url = wp_get_api_hostname() . '/core/checksums/1.0/?' . http_build_query( compact( 'version', 'locale' ), '', '&' );
+	$http_url = wp_get_api_hostname( true ) . '/core/checksums/1.0/?' . http_build_query( compact( 'version', 'locale' ), '', '&' );
 	$url      = $http_url;
 
 	$ssl = wp_http_supports( array( 'ssl' ) );

--- a/src/wp-admin/maint/repair.php
+++ b/src/wp-admin/maint/repair.php
@@ -82,7 +82,7 @@ if ( ! defined( 'WP_ALLOW_REPAIR' ) || ! WP_ALLOW_REPAIR ) {
 		'</h2>';
 
 		/* translators: 1: wp-config.php, 2: Secret key service URL. */
-		echo '<p>' . sprintf( __( 'While you are editing your %1$s file, take a moment to make sure you have all 8 keys and that they are unique. You can generate these using the <a href="%2$s">WordPress.org secret key service</a>.' ), '<code>wp-config.php</code>', 'https://api.wordpress.org/secret-key/1.1/salt/' ) . '</p>';
+		echo '<p>' . sprintf( __( 'While you are editing your %1$s file, take a moment to make sure you have all 8 keys and that they are unique. You can generate these using the <a href="%2$s">WordPress.org secret key service</a>.' ), '<code>wp-config.php</code>', wp_get_api_hostname() . '/secret-key/1.1/salt/' ) . '</p>';
 	}
 } elseif ( isset( $_GET['repair'] ) ) {
 

--- a/src/wp-admin/plugin-editor.php
+++ b/src/wp-admin/plugin-editor.php
@@ -295,7 +295,7 @@ endif;
 		<div id="documentation" class="hide-if-no-js">
 			<label for="docs-list"><?php _e( 'Documentation:' ); ?></label>
 			<?php echo $docs_select; ?>
-			<input disabled id="docs-lookup" type="button" class="button" value="<?php esc_attr_e( 'Look Up' ); ?>" onclick="if ( '' !== jQuery('#docs-list').val() ) { window.open( 'https://api.wordpress.org/core/handbook/1.0/?function=' + escape( jQuery( '#docs-list' ).val() ) + '&amp;locale=<?php echo urlencode( get_user_locale() ); ?>&amp;version=<?php echo urlencode( get_bloginfo( 'version' ) ); ?>&amp;redirect=true'); }" />
+			<input disabled id="docs-lookup" type="button" class="button" value="<?php esc_attr_e( 'Look Up' ); ?>" onclick="if ( '' !== jQuery('#docs-list').val() ) { window.open( '<?php echo wp_get_api_hostname() ?>/core/handbook/1.0/?function=' + escape( jQuery( '#docs-list' ).val() ) + '&amp;locale=<?php echo urlencode( get_user_locale() ); ?>&amp;version=<?php echo urlencode( get_bloginfo( 'version' ) ); ?>&amp;redirect=true'); }" />
 		</div>
 	<?php endif; ?>
 

--- a/src/wp-admin/plugin-editor.php
+++ b/src/wp-admin/plugin-editor.php
@@ -295,7 +295,7 @@ endif;
 		<div id="documentation" class="hide-if-no-js">
 			<label for="docs-list"><?php _e( 'Documentation:' ); ?></label>
 			<?php echo $docs_select; ?>
-			<input disabled id="docs-lookup" type="button" class="button" value="<?php esc_attr_e( 'Look Up' ); ?>" onclick="if ( '' !== jQuery('#docs-list').val() ) { window.open( '<?php echo wp_get_api_hostname() ?>/core/handbook/1.0/?function=' + escape( jQuery( '#docs-list' ).val() ) + '&amp;locale=<?php echo urlencode( get_user_locale() ); ?>&amp;version=<?php echo urlencode( get_bloginfo( 'version' ) ); ?>&amp;redirect=true'); }" />
+			<input disabled id="docs-lookup" type="button" class="button" value="<?php esc_attr_e( 'Look Up' ); ?>" onclick="if ( '' !== jQuery('#docs-list').val() ) { window.open( '<?php echo wp_get_api_hostname(); ?>/core/handbook/1.0/?function=' + escape( jQuery( '#docs-list' ).val() ) + '&amp;locale=<?php echo urlencode( get_user_locale() ); ?>&amp;version=<?php echo urlencode( get_bloginfo( 'version' ) ); ?>&amp;redirect=true'); }" />
 		</div>
 	<?php endif; ?>
 

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -358,7 +358,7 @@ switch ( $step ) {
 			$no_api = isset( $_POST['noapi'] );
 
 			if ( ! $no_api ) {
-				$secret_keys = wp_remote_get( 'https://api.wordpress.org/secret-key/1.1/salt/' );
+				$secret_keys = wp_remote_get( wp_get_api_hostname() . '/secret-key/1.1/salt/' );
 			}
 
 			if ( $no_api || is_wp_error( $secret_keys ) ) {

--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -324,7 +324,7 @@ else :
 			<div id="documentation" class="hide-if-no-js">
 				<label for="docs-list"><?php _e( 'Documentation:' ); ?></label>
 				<?php echo $docs_select; ?>
-				<input disabled id="docs-lookup" type="button" class="button" value="<?php esc_attr_e( 'Look Up' ); ?>" onclick="if ( '' !== jQuery('#docs-list').val() ) { window.open( 'https://api.wordpress.org/core/handbook/1.0/?function=' + escape( jQuery( '#docs-list' ).val() ) + '&amp;locale=<?php echo urlencode( get_user_locale() ); ?>&amp;version=<?php echo urlencode( get_bloginfo( 'version' ) ); ?>&amp;redirect=true'); }" />
+				<input disabled id="docs-lookup" type="button" class="button" value="<?php esc_attr_e( 'Look Up' ); ?>" onclick="if ( '' !== jQuery('#docs-list').val() ) { window.open( '<?php echo wp_get_api_hostname(); ?>/core/handbook/1.0/?function=' + escape( jQuery( '#docs-list' ).val() ) + '&amp;locale=<?php echo urlencode( get_user_locale() ); ?>&amp;version=<?php echo urlencode( get_bloginfo( 'version' ) ); ?>&amp;redirect=true'); }" />
 			</div>
 		<?php endif; ?>
 

--- a/src/wp-includes/class-wp-http.php
+++ b/src/wp-includes/class-wp-http.php
@@ -874,9 +874,8 @@ class WP_Http {
 	/**
 	 * Determines whether an HTTP API request to the given URL should be blocked.
 	 *
-	 * Those who are behind a proxy and want to prevent access to certain hosts may do so.
-	 * This will prevent plugins from working and core functionality,
-	 * if you don't include the WordPress API (`api.wordpress.org` by default).
+	 * Those who are behind a proxy and want to prevent access to certain hosts may do so. This will
+	 * prevent plugins from working and core functionality, if you don't include `api.wordpress.org`.
 	 *
 	 * You block external URL requests by defining `WP_HTTP_BLOCK_EXTERNAL` as true in your `wp-config.php`
 	 * file and this will only allow localhost and your site to make requests. The constant

--- a/src/wp-includes/class-wp-http.php
+++ b/src/wp-includes/class-wp-http.php
@@ -874,8 +874,9 @@ class WP_Http {
 	/**
 	 * Determines whether an HTTP API request to the given URL should be blocked.
 	 *
-	 * Those who are behind a proxy and want to prevent access to certain hosts may do so. This will
-	 * prevent plugins from working and core functionality, if you don't include `api.wordpress.org`.
+	 * Those who are behind a proxy and want to prevent access to certain hosts may do so.
+	 * This will prevent plugins from working and core functionality,
+	 * if you don't include the WordPress API (`api.wordpress.org` by default).
 	 *
 	 * You block external URL requests by defining `WP_HTTP_BLOCK_EXTERNAL` as true in your `wp-config.php`
 	 * file and this will only allow localhost and your site to make requests. The constant

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -378,13 +378,19 @@ function wp_is_development_mode( $mode ) {
  *
  * @since 6.8.0
  *
+ * @param bool $use_http Optional. Whether to use HTTP or HTTPS scheme for the default API endpoint. Default true.
  * @return string The current API hostname.
  */
-function wp_get_api_hostname() {
+function wp_get_api_hostname( $use_http = false ) {
 	static $current_hostname = '';
 
 	if ( defined( 'WP_RUN_CORE_TESTS' ) || '' === $current_hostname ) {
-		$current_hostname = 'https://api.wordpress.org';
+		/*
+		 * We only check the schema for the default API hostname, as anyone overriding it may
+		 * be doing so intentionally, for example an environment that relies on host aliases,
+		 * and are expected to know what they are doing.
+		 */
+		$current_hostname = ( $use_http ? 'http://' : 'https://' ) . 'api.wordpress.org';
 
 		// Check if the environment variable has been set, if `getenv` is available on the system.
 		if ( function_exists( 'getenv' ) ) {

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -371,6 +371,46 @@ function wp_is_development_mode( $mode ) {
 }
 
 /**
+ * Retrieves the current API hostname.
+ *
+ * The API hostname is used in requests for core, plugin, theme, and translation information,
+ * installation and updates.
+ *
+ * @since 6.8.0
+ *
+ * @return string The current API hostname.
+ */
+function wp_get_api_hostname() {
+	static $current_hostname = '';
+
+	if ( defined( 'WP_RUN_CORE_TESTS' ) || '' === $current_hostname ) {
+		$current_hostname = 'api.wordpress.org';
+
+		// Check if the environment variable has been set, if `getenv` is available on the system.
+		if ( function_exists( 'getenv' ) ) {
+			$has_env = getenv( 'WP_API_HOSTNAME' );
+			if ( false !== $has_env ) {
+				$current_hostname = $has_env;
+			}
+		}
+
+		// Fetch the hostname from a constant, this overrides the global system variable.
+		if ( defined( 'WP_API_HOSTNAME' ) && WP_API_HOSTNAME ) {
+			$current_hostname = WP_API_HOSTNAME;
+		}
+	}
+
+	/**
+	 * Filters the API hostname.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @param string $current_hostname The current hostname.
+	 */
+	return apply_filters( 'wp_api_hostname', $current_hostname );
+}
+
+/**
  * Ensures all of WordPress is not loaded when handling a favicon.ico request.
  *
  * Instead, send the headers for a zero-length favicon and bail.

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -384,7 +384,7 @@ function wp_get_api_hostname() {
 	static $current_hostname = '';
 
 	if ( defined( 'WP_RUN_CORE_TESTS' ) || '' === $current_hostname ) {
-		$current_hostname = 'api.wordpress.org';
+		$current_hostname = 'https://api.wordpress.org';
 
 		// Check if the environment variable has been set, if `getenv` is available on the system.
 		if ( function_exists( 'getenv' ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
@@ -11,7 +11,7 @@
  * Controller which provides REST endpoint for block patterns.
  *
  * This simply proxies the endpoint at http://api.wordpress.org/patterns/1.0/. That isn't necessary for
- * functionality, but is desired for privacy. It prevents the WordPress API from knowing the user's IP address.
+ * functionality, but is desired for privacy. It prevents api.wordpress.org from knowing the user's IP address.
  *
  * @since 5.8.0
  *
@@ -180,7 +180,7 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 	 * @since 5.8.0
 	 * @since 5.9.0 Renamed `$raw_pattern` to `$item` to match parent class for PHP 8 named parameter support.
 	 *
-	 * @param object          $item    Raw pattern from the WordPress API, before any changes.
+	 * @param object          $item    Raw pattern from api.wordpress.org, before any changes.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response
 	 */

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
@@ -114,7 +114,7 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 		$raw_patterns = get_site_transient( $transient_key );
 
 		if ( ! $raw_patterns ) {
-			$api_url = wp_get_api_hostname() . '/patterns/1.0/?' . build_query( $query_args );
+			$api_url = wp_get_api_hostname( true ) . '/patterns/1.0/?' . build_query( $query_args );
 			if ( wp_http_supports( array( 'ssl' ) ) ) {
 				$api_url = set_url_scheme( $api_url, 'https' );
 			}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
@@ -11,7 +11,7 @@
  * Controller which provides REST endpoint for block patterns.
  *
  * This simply proxies the endpoint at http://api.wordpress.org/patterns/1.0/. That isn't necessary for
- * functionality, but is desired for privacy. It prevents api.wordpress.org from knowing the user's IP address.
+ * functionality, but is desired for privacy. It prevents the WordPress API from knowing the user's IP address.
  *
  * @since 5.8.0
  *
@@ -114,7 +114,7 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 		$raw_patterns = get_site_transient( $transient_key );
 
 		if ( ! $raw_patterns ) {
-			$api_url = 'http://api.wordpress.org/patterns/1.0/?' . build_query( $query_args );
+			$api_url = wp_get_api_hostname() . '/patterns/1.0/?' . build_query( $query_args );
 			if ( wp_http_supports( array( 'ssl' ) ) ) {
 				$api_url = set_url_scheme( $api_url, 'https' );
 			}
@@ -180,7 +180,7 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 	 * @since 5.8.0
 	 * @since 5.9.0 Renamed `$raw_pattern` to `$item` to match parent class for PHP 8 named parameter support.
 	 *
-	 * @param object          $item    Raw pattern from api.wordpress.org, before any changes.
+	 * @param object          $item    Raw pattern from the WordPress API, before any changes.
 	 * @param WP_REST_Request $request Request object.
 	 * @return WP_REST_Response
 	 */

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * The WordPress version, PHP version, and locale is sent.
  *
- * Checks against the WordPress server at api.wordpress.org. Will only check
+ * Checks against the WordPress API server. Will only check
  * if WordPress isn't installing.
  *
  * @since 2.3.0
@@ -186,7 +186,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 		$query['channel'] = WP_AUTO_UPDATE_CORE;
 	}
 
-	$url      = 'http://api.wordpress.org/core/version-check/1.7/?' . http_build_query( $query, '', '&' );
+	$url      = wp_get_api_hostname() . '/core/version-check/1.7/?' . http_build_query( $query, '', '&' );
 	$http_url = $url;
 	$ssl      = wp_http_supports( array( 'ssl' ) );
 
@@ -308,7 +308,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
  *
  * A list of all plugins installed is sent to WP, along with the site locale.
  *
- * Checks against the WordPress server at api.wordpress.org. Will only check
+ * Checks against the WordPress API server. Will only check
  * if WordPress isn't installing.
  *
  * @since 2.3.0
@@ -434,7 +434,7 @@ function wp_update_plugins( $extra_stats = array() ) {
 		$options['body']['update_stats'] = wp_json_encode( $extra_stats );
 	}
 
-	$url      = 'http://api.wordpress.org/plugins/update-check/1.1/';
+	$url      = wp_get_api_hostname() . '/plugins/update-check/1.1/';
 	$http_url = $url;
 	$ssl      = wp_http_supports( array( 'ssl' ) );
 
@@ -580,7 +580,7 @@ function wp_update_plugins( $extra_stats = array() ) {
  *
  * A list of all themes installed is sent to WP, along with the site locale.
  *
- * Checks against the WordPress server at api.wordpress.org. Will only check
+ * Checks against the WordPress API server. Will only check
  * if WordPress isn't installing.
  *
  * @since 2.7.0
@@ -713,7 +713,7 @@ function wp_update_themes( $extra_stats = array() ) {
 		$options['body']['update_stats'] = wp_json_encode( $extra_stats );
 	}
 
-	$url      = 'http://api.wordpress.org/themes/update-check/1.1/';
+	$url      = wp_get_api_hostname() . '/themes/update-check/1.1/';
 	$http_url = $url;
 	$ssl      = wp_http_supports( array( 'ssl' ) );
 

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -186,7 +186,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 		$query['channel'] = WP_AUTO_UPDATE_CORE;
 	}
 
-	$url      = wp_get_api_hostname() . '/core/version-check/1.7/?' . http_build_query( $query, '', '&' );
+	$url      = wp_get_api_hostname( true ) . '/core/version-check/1.7/?' . http_build_query( $query, '', '&' );
 	$http_url = $url;
 	$ssl      = wp_http_supports( array( 'ssl' ) );
 
@@ -434,7 +434,7 @@ function wp_update_plugins( $extra_stats = array() ) {
 		$options['body']['update_stats'] = wp_json_encode( $extra_stats );
 	}
 
-	$url      = wp_get_api_hostname() . '/plugins/update-check/1.1/';
+	$url      = wp_get_api_hostname( true ) . '/plugins/update-check/1.1/';
 	$http_url = $url;
 	$ssl      = wp_http_supports( array( 'ssl' ) );
 
@@ -713,7 +713,7 @@ function wp_update_themes( $extra_stats = array() ) {
 		$options['body']['update_stats'] = wp_json_encode( $extra_stats );
 	}
 
-	$url      = wp_get_api_hostname() . '/themes/update-check/1.1/';
+	$url      = wp_get_api_hostname( true ) . '/themes/update-check/1.1/';
 	$http_url = $url;
 	$ssl      = wp_http_supports( array( 'ssl' ) );
 

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * The WordPress version, PHP version, and locale is sent.
  *
- * Checks against the WordPress API server. Will only check
+ * Checks against the WordPress server at api.wordpress.org. Will only check
  * if WordPress isn't installing.
  *
  * @since 2.3.0
@@ -308,7 +308,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
  *
  * A list of all plugins installed is sent to WP, along with the site locale.
  *
- * Checks against the WordPress API server. Will only check
+ * Checks against the WordPress server at api.wordpress.org. Will only check
  * if WordPress isn't installing.
  *
  * @since 2.3.0
@@ -580,7 +580,7 @@ function wp_update_plugins( $extra_stats = array() ) {
  *
  * A list of all themes installed is sent to WP, along with the site locale.
  *
- * Checks against the WordPress API server. Will only check
+ * Checks against the WordPress server at api.wordpress.org. Will only check
  * if WordPress isn't installing.
  *
  * @since 2.7.0

--- a/tests/phpunit/tests/load/wpGetApiHostname.php
+++ b/tests/phpunit/tests/load/wpGetApiHostname.php
@@ -19,6 +19,7 @@ class Test_WP_Get_API_Hostname extends WP_UnitTestCase {
 	 */
 	public function test_wp_get_api_hostname_returns_default_value() {
 		$this->assertSame( 'https://api.wordpress.org', wp_get_api_hostname() );
+		$this->assertSame( 'http://api.wordpress.org', wp_get_api_hostname( true ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/load/wpGetApiHostname.php
+++ b/tests/phpunit/tests/load/wpGetApiHostname.php
@@ -18,7 +18,7 @@ class Test_WP_Get_API_Hostname extends WP_UnitTestCase {
 	 * @ticket 62132
 	 */
 	public function test_wp_get_api_hostname_returns_default_value() {
-		$this->assertSame( 'api.wordpress.org', wp_get_api_hostname() );
+		$this->assertSame( 'https://api.wordpress.org', wp_get_api_hostname() );
 	}
 
 	/**

--- a/tests/phpunit/tests/load/wpGetApiHostname.php
+++ b/tests/phpunit/tests/load/wpGetApiHostname.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Unit tests for `wp_get_api_hostname()`.
+ *
+ * @package WordPress
+ * @subpackage UnitTests
+ * @since 6.8.0
+ *
+ * @group load
+ *
+ * @covers ::wp_get_api_hostname
+ */
+class Test_WP_Get_API_Hostname extends WP_UnitTestCase {
+
+	/**
+	 * Tests that `wp_get_api_hostname()` returns the default value.
+	 *
+	 * @ticket 62132
+	 */
+	public function test_wp_get_api_hostname_returns_default_value() {
+		$this->assertSame( 'api.wordpress.org', wp_get_api_hostname() );
+	}
+
+	/**
+	 * Tests that `wp_get_api_hostname()` returns the value of the `WP_API_HOSTNAME` environment variable.
+	 *
+	 * @ticket 62132
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_wp_get_api_hostname_returns_environment_variable_value() {
+		putenv( 'WP_API_HOSTNAME=env.api.org' );
+		$this->assertSame( 'env.api.org', wp_get_api_hostname() );
+	}
+
+	/**
+	 * Tests that `wp_get_api_hostname()` returns the value of the `WP_API_HOSTNAME` constant.
+	 *
+	 * @ticket 62132
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_wp_get_api_hostname_returns_constant_value() {
+		define( 'WP_API_HOSTNAME', 'constant.api.org' );
+		$this->assertSame( 'constant.api.org', wp_get_api_hostname() );
+	}
+
+	/**
+	 * Tests that `wp_get_api_hostname()` returns the value of the `'wp_api_hostname'` filter.
+	 *
+	 * @ticket 62132
+	 */
+	public function test_wp_get_api_hostname_returns_filter_value() {
+		add_filter(
+			'wp_api_hostname',
+			static function () {
+				return 'filter.api.org';
+			}
+		);
+		$this->assertSame( 'filter.api.org', wp_get_api_hostname() );
+	}
+
+	/**
+	 * Tests that `wp_get_api_hostname()` prioritizes the constant over the environment variable.
+	 *
+	 * @ticket 62132
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_wp_get_api_hostname_prioritizes_constant_over_environment_variable() {
+		putenv( 'WP_API_HOSTNAME=env.api.org' );
+		define( 'WP_API_HOSTNAME', 'constant.api.org' );
+		$this->assertSame( 'constant.api.org', wp_get_api_hostname() );
+	}
+
+	/**
+	 * Tests that `wp_get_api_hostname()` prioritizes the filter over the environment variable.
+	 *
+	 * @ticket 62132
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_wp_get_api_hostname_prioritizes_filter_over_environment_variable() {
+		putenv( 'WP_API_HOSTNAME=env.api.org' );
+		add_filter(
+			'wp_api_hostname',
+			static function () {
+				return 'filter.api.org';
+			}
+		);
+		$this->assertSame( 'filter.api.org', wp_get_api_hostname() );
+	}
+
+	/**
+	 * Tests that `wp_get_api_hostname()` prioritizes the filter over the constant.
+	 *
+	 * @ticket 62132
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_wp_get_api_hostname_prioritizes_filter_over_constant() {
+		define( 'WP_API_HOSTNAME', 'constant.api.org' );
+		add_filter(
+			'wp_api_hostname',
+			static function () {
+				return 'filter.api.org';
+			}
+		);
+		$this->assertSame( 'filter.api.org', wp_get_api_hostname() );
+	}
+}


### PR DESCRIPTION
The `wp_get_api_hostname()` function would allow hosters the ability to more easily set up local mirrors of the WordPress API.

This pull request summarizes some of the work already put into the ticket, and feedback from other communication platforms, so that all ideas are brought forth.

It introduces a new function, `wp_get_api_hostname()`, this is very directly named, as it relates to the base hostname used for API requests, and we wish to ensure its self evident what the intent of the function is.

It allows a hoster to define a `WP_API_HOSTNAME` environment variable, to pre-empt any installation steps, ensuring all requests are passed through their mirror from start to finish in the WP journey if need be.

It is also possible for a site to define the `WP_API_HOSTNAME` constant in their `wp-config.php` file, if they wish to diverge from the hosters predefined expectations.

And finally, there's the `wp_api_hostname` filter, for more fine grained control. Currently it does not pass any contexts, but it is easier to add to a filter later, than to take away from it, so this is a nice starting point for an initial implementation I think.

For more fine grained filtering control, the filters found within the WordPress HTTP API are better suited, but are not available to a site early enough in the flow to be usable for example during setup.

I've also simplified the Site Health outputs, instead of introducing extra checks, re-labeling the reference to "api.wordpress.org" to "the WordPress API" does the same, and by adding a field in the debug data section to reference what API host is returned, the information is still readily available if someone needs to look it up.

Trac ticket: https://core.trac.wordpress.org/ticket/62132

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
