### PR TITLE
Verify nonce docs correction

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2343,7 +2343,7 @@ if ( ! function_exists( 'wp_verify_nonce' ) ) :
 	/**
 	 * Verifies that a correct security nonce was used with time limit.
 	 *
-	 * A nonce is valid for 24 hours (by default).
+	 * A nonce is valid for between 12 and 24 hours (by default).
 	 *
 	 * @since 2.0.3
 	 *


### PR DESCRIPTION
Lifespans are still misleading in the auto-generated docs for `wp_verify_nonce()`. It has already been corrected elsewhere.

Trac ticket: [53236](https://core.trac.wordpress.org/ticket/53236)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
