### PR TITLE
Text color removed from wriiten by from single post template

### DIFF
--- a/src/wp-content/themes/twentytwentyfive/patterns/hidden-written-by.php
+++ b/src/wp-content/themes/twentytwentyfive/patterns/hidden-written-by.php
@@ -11,7 +11,7 @@
 
 ?>
 <!-- wp:group {"style":{"spacing":{"blockGap":"0.2em","margin":{"bottom":"var:preset|spacing|60"}}},"fontSize":"small","layout":{"type":"flex","flexWrap":"wrap"}} -->
-<div class="wp-block-group  has-text-color has-link-color has-small-font-size" style="margin-bottom:var(--wp--preset--spacing--60)">
+<div class="wp-block-group has-small-font-size" style="margin-bottom:var(--wp--preset--spacing--60)">
 	<!-- wp:paragraph -->
 	<p><?php esc_html_e( 'Written by ', 'twentytwentyfive' ); ?></p>
 	<!-- /wp:paragraph -->

--- a/src/wp-content/themes/twentytwentyfive/patterns/hidden-written-by.php
+++ b/src/wp-content/themes/twentytwentyfive/patterns/hidden-written-by.php
@@ -10,8 +10,8 @@
  */
 
 ?>
-<!-- wp:group {"style":{"spacing":{"blockGap":"0.2em","margin":{"bottom":"var:preset|spacing|60"}}},"textColor":"accent-4","fontSize":"small","layout":{"type":"flex","flexWrap":"wrap"}} -->
-<div class="wp-block-group has-accent-4-color has-text-color has-link-color has-small-font-size" style="margin-bottom:var(--wp--preset--spacing--60)">
+<!-- wp:group {"style":{"spacing":{"blockGap":"0.2em","margin":{"bottom":"var:preset|spacing|60"}}},"fontSize":"small","layout":{"type":"flex","flexWrap":"wrap"}} -->
+<div class="wp-block-group  has-text-color has-link-color has-small-font-size" style="margin-bottom:var(--wp--preset--spacing--60)">
 	<!-- wp:paragraph -->
 	<p><?php esc_html_e( 'Written by ', 'twentytwentyfive' ); ?></p>
 	<!-- /wp:paragraph -->


### PR DESCRIPTION
Fixes [#62982](https://core.trac.wordpress.org/ticket/62982)

### Testing instructions:

1. Activate Twenty Twenty-Five.
2. Edit the single posts template.
3. Select the main group block, or, the first group block that is inside the main.
4. Open the Styles tab in the block settings.
5. Apply Styles 1 to 5, one by one, and observe the color of the text
6. "Written by author in categories" that is below the featured image.

| Before |
<img width="1438" alt="before-patch" src="https://github.com/user-attachments/assets/6f6866ea-1d48-4029-a74a-d014c9873607" /> 

| After |
<img width="1438" alt="after-patch" src="https://github.com/user-attachments/assets/61246b15-3f06-4b26-887a-939ad98a4a91" />
