### PR TITLE
Increase `body` font size in Twenty Ten editor styles

### DIFF
--- a/src/wp-content/themes/twentyten/editor-style.css
+++ b/src/wp-content/themes/twentyten/editor-style.css
@@ -33,8 +33,8 @@ code, code var {
 	font-family: Monaco, Consolas, "Andale Mono", "DejaVu Sans Mono", monospace;
 }
 body, input, textarea {
-	font-size: 12px;
-	line-height: 18px;
+	font-size: 16px;
+	line-height: 1.5;
 }
 hr {
 	background-color: #e7e7e7;


### PR DESCRIPTION
- Increases font size for `body`, `input` and `textarea` elements in the editor, to match the `#content` area on the front.
- Updates the `line-height` to a unitless value.

In the post content area, the `16px` font size also:
- Matches the front for elements that inherit the font size from `body`, such as `summary` in the Details block.
- Corrects `div` elements with relative font sizes, such as Button and File blocks.
- Corrects standard `div` elements within the Classic Editor.

Widget text is smaller than this on the front, but fixing that would be more complicated for little value (and it could be a follow-up effort _if_ it is worth doing).

[Trac 62965](https://core.trac.wordpress.org/ticket/62965)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
