### PR TITLE
Bundled Theme: Remove fixed font size for table headers in Twenty Eleven

### DIFF
--- a/src/wp-content/themes/twentyeleven/editor-style.css
+++ b/src/wp-content/themes/twentyeleven/editor-style.css
@@ -218,6 +218,8 @@ table {
 tr th {
 	border: none !important;
 	color: #666;
+	font-size: 10px; /* Fallback for older browsers */
+	font-size: max(10px, 0.66666667em);
 	font-weight: 500;
 	letter-spacing: 0.1em;
 	line-height: 2.6em;

--- a/src/wp-content/themes/twentyeleven/editor-style.css
+++ b/src/wp-content/themes/twentyeleven/editor-style.css
@@ -218,7 +218,6 @@ table {
 tr th {
 	border: none !important;
 	color: #666;
-	font-size: 10px;
 	font-weight: 500;
 	letter-spacing: 0.1em;
 	line-height: 2.6em;

--- a/src/wp-content/themes/twentyeleven/style.css
+++ b/src/wp-content/themes/twentyeleven/style.css
@@ -817,6 +817,8 @@ a.assistive-text:focus,
 .entry-content th,
 .comment-content th {
 	color: #666;
+	font-size: 10px; /* Fallback for older browsers */
+	font-size: max(10px, 0.66666667em);
 	font-weight: 500;
 	letter-spacing: 0.1em;
 	line-height: 2.6em;

--- a/src/wp-content/themes/twentyeleven/style.css
+++ b/src/wp-content/themes/twentyeleven/style.css
@@ -817,7 +817,6 @@ a.assistive-text:focus,
 .entry-content th,
 .comment-content th {
 	color: #666;
-	font-size: 10px;
 	font-weight: 500;
 	letter-spacing: 0.1em;
 	line-height: 2.6em;


### PR DESCRIPTION
This PR removes the fixed font-size: 10px; rule applied to table header (<th>) elements in the Twenty Eleven theme. The issue caused table headers to ignore block editor font size settings, preventing proper scaling.

By removing this hardcoded font size from both editor-style.css and style.css, table headers will now inherit font sizes correctly based on block editor adjustments, improving theme flexibility and consistency.

Trac ticket: [#62983](https://core.trac.wordpress.org/ticket/62983)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
