### PR TITLE
add check is capabilities key is set

### DIFF
--- a/src/wp-includes/class-wp-user-query.php
+++ b/src/wp-includes/class-wp-user-query.php
@@ -482,7 +482,11 @@ class WP_User_Query {
 		$caps_with_roles = array();
 
 		foreach ( $available_roles as $role => $role_data ) {
-			$role_caps = array_keys( array_filter( $role_data['capabilities'] ) );
+			$role_caps = array();
+
+			if ( isset( $role_data['capabilities'] ) ) {
+				$role_caps = array_keys( array_filter( $role_data['capabilities'] ) );
+			}
 
 			foreach ( $capabilities as $cap ) {
 				if ( in_array( $cap, $role_caps, true ) ) {


### PR DESCRIPTION
This PR addresses a fatal error in WP_User_Query that occurs when a user role is missing the capabilities key. This issue is typically caused by third-party plugins that create roles without properly setting capabilities. When such roles exist, calls to array_filter() on null trigger a fatal error.


Trac ticket: https://core.trac.wordpress.org/ticket/62600

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
