### PR TITLE
Twenty Fourteen: use css-only carousel

### DIFF
--- a/src/wp-content/themes/twentyfourteen/content-featured-post.php
+++ b/src/wp-content/themes/twentyfourteen/content-featured-post.php
@@ -9,7 +9,7 @@
 
 ?>
 
-<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?> data-index="<?php echo esc_attr( $GLOBALS['index'] ); ?>">
 	<a class="post-thumbnail" href="<?php the_permalink(); ?>">
 	<?php
 	// Output the featured image.

--- a/src/wp-content/themes/twentyfourteen/featured-content.php
+++ b/src/wp-content/themes/twentyfourteen/featured-content.php
@@ -10,7 +10,7 @@
 ?>
 
 <div id="featured-content" class="featured-content">
-	<div class="featured-content-inner">
+	<div class="featured-content-inner" data-prev="<?php esc_attr_e( 'Previous', 'twentyfourteen' ); ?>" data-next="<?php esc_attr_e( 'Next', 'twentyfourteen' ); ?>">
 	<?php
 		/**
 		 * Fires before the Twenty Fourteen featured content.
@@ -20,12 +20,17 @@
 		do_action( 'twentyfourteen_featured_posts_before' );
 
 		$featured_posts = twentyfourteen_get_featured_posts();
+
+	$GLOBALS['index'] = 1;
 	foreach ( (array) $featured_posts as $order => $post ) :
 		setup_postdata( $post );
 
 		// Include the featured content template.
 		get_template_part( 'content', 'featured-post' );
-		endforeach;
+
+		++$GLOBALS['index'];
+	endforeach;
+	unset( $GLOBALS['index'] );
 
 		/**
 		 * Fires after the Twenty Fourteen featured content.

--- a/src/wp-content/themes/twentyfourteen/functions.php
+++ b/src/wp-content/themes/twentyfourteen/functions.php
@@ -366,12 +366,14 @@ function twentyfourteen_scripts() {
 		wp_enqueue_script( 'jquery-masonry' );
 	}
 
+	$slider_script_ver = '20150120';
+
 	if ( is_front_page() && 'slider' === get_theme_mod( 'featured_content_layout' ) ) {
-		wp_enqueue_script(
+		wp_register_script(
 			'twentyfourteen-slider',
 			get_template_directory_uri() . '/js/slider.js',
 			array( 'jquery' ),
-			'20150120',
+			$slider_script_ver,
 			array(
 				'in_footer' => false, // Because involves header.
 				'strategy'  => 'defer',
@@ -391,12 +393,27 @@ function twentyfourteen_scripts() {
 		'twentyfourteen-script',
 		get_template_directory_uri() . '/js/functions.js',
 		array( 'jquery' ),
-		'20230526',
+		random_int( 1, 1000 ),
 		array(
 			'in_footer' => false, // Because involves header.
 			'strategy'  => 'defer',
 		)
 	);
+
+	if ( is_front_page() && 'slider' === get_theme_mod( 'featured_content_layout' ) ) {
+		wp_localize_script(
+			'twentyfourteen-script',
+			'twentyfourteenScriptVars',
+			array(
+				'sliderScriptUrl'        => get_template_directory_uri() . '/js/slider.js?ver' . $slider_script_ver,
+				'sliderScriptId'         => 'twentyfourteen-slider-js',
+				'featuredSliderDefaults' => array(
+					'prevText' => __( 'Previous', 'twentyfourteen' ),
+					'nextText' => __( 'Next', 'twentyfourteen' ),
+				),
+			)
+		);
+	}
 }
 add_action( 'wp_enqueue_scripts', 'twentyfourteen_scripts' );
 

--- a/src/wp-content/themes/twentyfourteen/js/functions.js
+++ b/src/wp-content/themes/twentyfourteen/js/functions.js
@@ -5,6 +5,7 @@
  * footer widgets and Featured Content slider.
  *
  */
+/* global twentyfourteenScriptVars */
 ( function( $ ) {
 	var body    = $( 'body' ),
 		_window = $( window ),
@@ -174,11 +175,19 @@
 		}
 
 		// Initialize Featured Content slider.
-		if ( body.is( '.slider' ) ) {
-			$( '.featured-content' ).featuredslider( {
-				selector: '.featured-content-inner > article',
-				controlsContainer: '.featured-content'
-			} );
+		if (body.is('.slider') && ! CSS.supports( 'scroll-marker-group: after' ) ) {
+			var slider = document.createElement( 'script' );
+			slider.src = twentyfourteenScriptVars.sliderScriptUrl;
+			slider.id = twentyfourteenScriptVars.sliderScriptId;
+			window.featuredSliderDefaults = twentyfourteenScriptVars.featuredSliderDefaults;
+			slider.onload = function() {
+				$('.featured-content').featuredslider({
+					selector: '.featured-content-inner > article',
+					controlsContainer: '.featured-content'
+				});
+			};
+
+			document.body.appendChild(slider);
 		}
 	} );
 } )( jQuery );

--- a/src/wp-content/themes/twentyfourteen/style.css
+++ b/src/wp-content/themes/twentyfourteen/style.css
@@ -3184,6 +3184,92 @@ a.post-thumbnail:hover {
 	display: none;
 }
 
+@supports (scroll-marker-group: after) {
+	.slider .featured-content {
+	}
+
+	.slider .featured-content-inner {
+		display: grid;
+		grid-auto-columns: 100%;
+		grid-auto-flow: column;
+
+		scroll-behavior: smooth;
+
+		scrollbar-width: none;
+		anchor-name: --carousel;
+		overflow-x: auto;
+		overscroll-behavior-x: contain;
+		scroll-snap-type: x mandatory;
+
+		/* Dot Navigation */
+		scroll-marker-group: after;
+	}
+
+	/* The scroll-marker-group is actually a *sibling* */
+	.slider .featured-content-inner::scroll-marker-group {
+		position: absolute;
+		bottom: 0;
+		left: calc(222px + 24px + 6px);
+		z-index: 5;
+	}
+
+	.slider .featured-content .hentry::scroll-marker {
+		display: block;
+		content: '' / attr(data-index);
+		width: 12px;
+		height: 12px;
+		background: #4d4d4d;
+		float: left;
+		margin: 18px 24px 18px 0;
+		cursor: pointer;
+	}
+
+	.slider .featured-content .hentry::scroll-marker:target-current {
+		background: #24890d;
+	}
+
+	.slider .featured-content .hentry {
+		display: block;
+		container-type: scroll-state;
+		scroll-snap-align: center;
+	}
+
+	.slider .featured-content-inner::scroll-button(*) {
+		font: normal 32px/46px Genericons;
+		position: absolute;
+		bottom: 0;
+		right: 0;
+		height: 48px;
+		aspect-ratio: 1;
+		background: #000;
+		color: #fff;
+		cursor: pointer;
+		border: none;
+		z-index: 5;
+	}
+
+	@media screen and (min-width: 673px) {
+		.slider .featured-content-inner::scroll-button(*) {
+			line-height: 48px;
+		}
+	}
+
+	.slider .featured-content-inner::scroll-button(*):disabled {
+
+	}
+	.slider .featured-content-inner::scroll-button(*):hover {
+		background: #24890d;
+	}
+
+	.slider .featured-content-inner::scroll-button(left) {
+		content: "\f430" / attr(data-prev);
+		right: 48px;
+	}
+
+	.slider .featured-content-inner::scroll-button(right) {
+		content: "\f429" / attr(data-next);
+	}
+}
 
 /**
  * 10.0 Multisite


### PR DESCRIPTION
In supporting browsers, the carousel is built using CSS only. The `slider.js` script (19 KB) is **not** loaded. This saves some bandwidth.

If the browser doesn't support the feature, the `slider.js` script is loaded on demand.

Not implemented in the CSS version: cyclic/infinite carousel. This currently requires some JavaScript still, but I think this could be just as well omitted as it doesn't seem critical for this feature.

Demo:

https://github.com/user-attachments/assets/4d9aee53-1c97-4099-9e04-6c190d840feb


Trac ticket: https://core.trac.wordpress.org/ticket/63251

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
