### PR TITLE
Restore typehint but make it nullable

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1160,7 +1160,7 @@ function apply_block_hooks_to_content( $content, $context = null, $callback = 'i
  *                               Default: 'insert_hooked_blocks'.
  * @return string The serialized markup.
  */
-function apply_block_hooks_to_content_from_post_object( $content, $post = null, $callback = 'insert_hooked_blocks' ) {
+function apply_block_hooks_to_content_from_post_object( $content, ?WP_Post $post = null, $callback = 'insert_hooked_blocks' ) {
 	// Default to the current post if no context is provided.
 	if ( null === $post ) {
 		$post = get_post();


### PR DESCRIPTION
We can still get the benefit of the type hint by making it nullable instead of removing it all together. This will work down to php7.1 which is below the minimum WP version.

See https://3v4l.org/1Mdrl for the deprecation and https://3v4l.org/o764l for the nullable version

Originally added in https://core.trac.wordpress.org/changeset/59838 Removed in https://core.trac.wordpress.org/changeset/59839

Trac Ticket: https://core.trac.wordpress.org/ticket/62716

