### PR TITLE
Add filters for modifying plugin and theme editor documentation urls

### DIFF
--- a/src/wp-admin/plugin-editor.php
+++ b/src/wp-admin/plugin-editor.php
@@ -189,7 +189,6 @@ if ( str_ends_with( $real_file, '.php' ) ) {
 			 * @param string $plugin   Plugin file/directory name.
 			 */
 			$option_value = apply_filters( 'plugin_editor_documentation_url', $function, $file, $plugin );
-			
 			$docs_select .= '<option value="' . esc_attr( $option_value ) . '">' . esc_html( $function ) . '()</option>';
 		}
 
@@ -307,7 +306,7 @@ endif;
 		<div id="documentation" class="hide-if-no-js">
 			<label for="docs-list"><?php _e( 'Documentation:' ); ?></label>
 			<?php echo $docs_select; ?>
-			<input disabled id="docs-lookup" type="button" class="button" value="<?php esc_attr_e( 'Look Up' ); ?>" onclick="(() => { const v = jQuery('#docs-list').val(); if (!v) return; let url; if (v.startsWith('http://') || v.startsWith('https://')) { url = v; } else { try { new URL(v); url = v; } catch { url = `https://api.wordpress.org/core/handbook/1.0/?function=${escape(v)}&locale=<?php echo urlencode(get_user_locale()); ?>&version=<?php echo urlencode(get_bloginfo('version')); ?>&redirect=true`; } } window.open(url); })()" />
+			<input disabled id="docs-lookup" type="button" class="button" value="<?php esc_attr_e( 'Look Up' ); ?>" onclick="(() => { const v = jQuery('#docs-list').val(); if (!v) return; let url; if (v.startsWith('http://') || v.startsWith('https://')) { url = v; } else { try { new URL(v); url = v; } catch { url = `https://api.wordpress.org/core/handbook/1.0/?function=${escape(v)}&locale=<?php echo urlencode( get_user_locale() ); ?>&version=<?php echo urlencode( get_bloginfo( 'version' ) ); ?>&redirect=true`; } } window.open(url); })()" />
 		</div>
 	<?php endif; ?>
 

--- a/src/wp-admin/plugin-editor.php
+++ b/src/wp-admin/plugin-editor.php
@@ -178,7 +178,19 @@ if ( str_ends_with( $real_file, '.php' ) ) {
 		$docs_select .= '<option value="">' . esc_html__( 'Function Name&hellip;' ) . '</option>';
 
 		foreach ( $functions as $function ) {
-			$docs_select .= '<option value="' . esc_attr( $function ) . '">' . esc_html( $function ) . '()</option>';
+
+			/**
+			 * Allows the documentation URL to be filtered for the Plugin Editor.
+			 *
+			 * @since x
+			 *
+			 * @param string $function Name of the selected function.
+			 * @param string $file     Path to the file being edited.
+			 * @param string $plugin   Plugin file/directory name.
+			 */
+			$option_value = apply_filters( 'plugin_editor_documentation_url', $function, $file, $plugin );
+			
+			$docs_select .= '<option value="' . esc_attr( $option_value ) . '">' . esc_html( $function ) . '()</option>';
 		}
 
 		$docs_select .= '</select>';
@@ -295,7 +307,7 @@ endif;
 		<div id="documentation" class="hide-if-no-js">
 			<label for="docs-list"><?php _e( 'Documentation:' ); ?></label>
 			<?php echo $docs_select; ?>
-			<input disabled id="docs-lookup" type="button" class="button" value="<?php esc_attr_e( 'Look Up' ); ?>" onclick="if ( '' !== jQuery('#docs-list').val() ) { window.open( 'https://api.wordpress.org/core/handbook/1.0/?function=' + escape( jQuery( '#docs-list' ).val() ) + '&amp;locale=<?php echo urlencode( get_user_locale() ); ?>&amp;version=<?php echo urlencode( get_bloginfo( 'version' ) ); ?>&amp;redirect=true'); }" />
+			<input disabled id="docs-lookup" type="button" class="button" value="<?php esc_attr_e( 'Look Up' ); ?>" onclick="(() => { const v = jQuery('#docs-list').val(); if (!v) return; let url; if (v.startsWith('http://') || v.startsWith('https://')) { url = v; } else { try { new URL(v); url = v; } catch { url = `https://api.wordpress.org/core/handbook/1.0/?function=${escape(v)}&locale=<?php echo urlencode(get_user_locale()); ?>&version=<?php echo urlencode(get_bloginfo('version')); ?>&redirect=true`; } } window.open(url); })()" />
 		</div>
 	<?php endif; ?>
 

--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -336,7 +336,7 @@ else :
 			<div id="documentation" class="hide-if-no-js">
 				<label for="docs-list"><?php _e( 'Documentation:' ); ?></label>
 				<?php echo $docs_select; ?>
-				<input disabled id="docs-lookup" type="button" class="button" value="<?php esc_attr_e( 'Look Up' ); ?>" onclick="(() => { const v = jQuery('#docs-list').val(); if (!v) return; let url; if (v.startsWith('http://') || v.startsWith('https://')) { url = v; } else { try { new URL(v); url = v; } catch { url = `https://api.wordpress.org/core/handbook/1.0/?function=${escape(v)}&locale=<?php echo urlencode(get_user_locale()); ?>&version=<?php echo urlencode(get_bloginfo('version')); ?>&redirect=true`; } } window.open(url); })()" />
+				<input disabled id="docs-lookup" type="button" class="button" value="<?php esc_attr_e( 'Look Up' ); ?>" onclick="(() => { const v = jQuery('#docs-list').val(); if (!v) return; let url; if (v.startsWith('http://') || v.startsWith('https://')) { url = v; } else { try { new URL(v); url = v; } catch { url = `https://api.wordpress.org/core/handbook/1.0/?function=${escape(v)}&locale=<?php echo urlencode( get_user_locale() ); ?>&version=<?php echo urlencode( get_bloginfo( 'version' ) ); ?>&redirect=true`; } } window.open(url); })()" />
 			</div>
 		<?php endif; ?>
 

--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -172,7 +172,19 @@ if ( ! empty( $posted_content ) ) {
 			$docs_select .= '<option value="">' . esc_html__( 'Function Name&hellip;' ) . '</option>';
 
 			foreach ( $functions as $function ) {
-				$docs_select .= '<option value="' . esc_attr( $function ) . '">' . esc_html( $function ) . '()</option>';
+
+				/**
+				 * Allows the documentation URL to be filtered for the Theme Editor.
+				 *
+				 * @since x
+				 *
+				 * @param string $function Name of the selected function.
+				 * @param string $file     Path to the file being edited.
+				 * @param string $theme    Directory name of the theme being edited.
+				 */
+				$option_value = apply_filters( 'theme_editor_documentation_url', $function, $file, $theme->get_stylesheet() );
+
+				$docs_select .= '<option value="' . esc_attr( $option_value ) . '">' . esc_html( $function ) . '()</option>';
 			}
 
 			$docs_select .= '</select>';
@@ -324,7 +336,7 @@ else :
 			<div id="documentation" class="hide-if-no-js">
 				<label for="docs-list"><?php _e( 'Documentation:' ); ?></label>
 				<?php echo $docs_select; ?>
-				<input disabled id="docs-lookup" type="button" class="button" value="<?php esc_attr_e( 'Look Up' ); ?>" onclick="if ( '' !== jQuery('#docs-list').val() ) { window.open( 'https://api.wordpress.org/core/handbook/1.0/?function=' + escape( jQuery( '#docs-list' ).val() ) + '&amp;locale=<?php echo urlencode( get_user_locale() ); ?>&amp;version=<?php echo urlencode( get_bloginfo( 'version' ) ); ?>&amp;redirect=true'); }" />
+				<input disabled id="docs-lookup" type="button" class="button" value="<?php esc_attr_e( 'Look Up' ); ?>" onclick="(() => { const v = jQuery('#docs-list').val(); if (!v) return; let url; if (v.startsWith('http://') || v.startsWith('https://')) { url = v; } else { try { new URL(v); url = v; } catch { url = `https://api.wordpress.org/core/handbook/1.0/?function=${escape(v)}&locale=<?php echo urlencode(get_user_locale()); ?>&version=<?php echo urlencode(get_bloginfo('version')); ?>&redirect=true`; } } window.open(url); })()" />
 			</div>
 		<?php endif; ?>
 


### PR DESCRIPTION
As per the Trac ticket, I've refactored a previous approach to allow for documentation URL's to be overridden within the theme and plugin editor. The previous approach had some limitations, this approach provides two new filters (one for theme, another for plugins) that allow documentation links to be overridden by theme, plugin, file or individual function.

Trac ticket: https://core.trac.wordpress.org/ticket/14808

```php
<?php
/**
 * Filter the function documentation URL in either the theme or plugin editor.
 *
 * @param string $function Name of the selected function.
 * @param string $file Full path of the file being edited.
 * @param string $theme Director name of the theme being edited.
 * @return string
 */
function override_theme_documentation_links( $function, $file, $theme ) {

        // Ignore for anything but our test theme.
        if ( 'test-theme' !== $theme ) {
                return $function;
        }

        // Example 1: Override documentation URL's for specific functions.
        if ( 'get_header' === $function ) {
                return 'https://mysite.com/different-docs?function=' . $function;
        }

        // Example 2: Override documentation URL's for all functions within a specific file.
        if ( str_contains( $file, 'header.php' ) ) {
                return 'https://mysite.com/header-docs?function=' . $function;
        }

        // Example 3: Override documentation URL's for all functions for theme.
        return 'https://mysite.com/docs?function=' . $function;
}

add_filter( 'theme_editor_documentation_url', 'override_theme_documentation_links', 10, 3 );

/**
 * Filter the function documentation URL in the plugin editor.
 *
 * @param string $function Name of the selected function.
 * @param string $file Full path of the file being edited.
 * @param string $name Name of the plugin being edited.
 * @return string
 */
function override_plugin_documentation_links( $function, $file, $plugin ) {

        // Ignore for anything but our test plugin.
        if ( 'hello.php' !== $plugin ) {
                return $function;
        }

        // Example 1: Override documentation URL's for all functions for plugin.
        return 'https://mysite.com/plugin-docs?function=' . $function;
}

add_filter( 'plugin_editor_documentation_url', 'override_plugin_documentation_links', 10, 3 );
``` 
