### PR TITLE
Modified CSS for admin bar menu items

### DIFF
--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -175,6 +175,13 @@ html:lang(he-il) .rtl #wpadminbar * {
 	float: none;
 }
 
+#wpadminbar .quicklinks .menupop.hover ul li{
+    min-width: 140px;
+    padding: 0 10px;
+}
+#wpadminbar .quicklinks .menupop.hover ul li .ab-item{
+    width: max-content;
+}
 #wpadminbar .quicklinks .menupop ul li a strong {
 	font-weight: 600;
 }
@@ -187,7 +194,6 @@ html:lang(he-il) .rtl #wpadminbar * {
 	line-height: 2;
 	height: 26px;
 	white-space: nowrap;
-	min-width: 140px;
 }
 
 #wpadminbar .shortlink-input {


### PR DESCRIPTION
Fixes [#62989](https://core.trac.wordpress.org/ticket/62989)

### Testing Instructions

- Log in to any WordPress site.
- Locate your profile details in the top-right corner.
- Hover over your profile name to trigger the dropdown menu.
- Move the cursor over the text inside the dropdown menu—the text colour changes as expected.
- Slowly move the cursor toward the right edge of the text (but still within the clickable area).
- Notice that the text colour changed only when hovering over text only.