### PR TITLE
Fix #62920 - Prevent redirect of query URLs with commas

### DIFF
--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -65,6 +65,11 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 		return;
 	}
 
+	// Don't redirect URLs with commas in query parameters (Bug #62920)
+	if ( isset( $_SERVER['QUERY_STRING'] ) && strpos( $_SERVER['QUERY_STRING'], ',' ) !== false ) {
+		return false;
+	}
+
 	if ( ! $requested_url && isset( $_SERVER['HTTP_HOST'] ) ) {
 		// Build the URL in the address bar.
 		$requested_url  = is_ssl() ? 'https://' : 'http://';

--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -65,7 +65,7 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 		return;
 	}
 
-	// Don't redirect URLs with commas in query parameters (Bug #62920)
+	// Don't redirect URLs with commas in query parameters (Bug #62920).
 	if ( isset( $_SERVER['QUERY_STRING'] ) && strpos( $_SERVER['QUERY_STRING'], ',' ) !== false ) {
 		return false;
 	}


### PR DESCRIPTION
Referencing pull request: #8346
Fixed the comment formatting according to standard.

Trac ticket: https://core.trac.wordpress.org/ticket/62920

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
