### PR TITLE
Right margin removed from admin menu dropdown

### DIFF
--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -429,7 +429,6 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 #wpadminbar #wp-admin-bar-user-actions > li {
 	margin-left: 16px;
-	margin-right: 16px;
 }
 
 #wpadminbar #wp-admin-bar-user-actions.ab-submenu {


### PR DESCRIPTION
Fixes [#62991](https://core.trac.wordpress.org/ticket/62991)

Removes the right margin from the admin profile dropdown to make area clickable.