### PR TITLE
Admin bar: Update the Edit Site link

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -458,21 +458,19 @@ function wp_admin_bar_site_menu( $wp_admin_bar ) {
  * @since 5.9.0
  * @since 6.3.0 Added `$_wp_current_template_id` global for editing of current template directly from the admin bar.
  * @since 6.6.0 Added the `canvas` query arg to the Site Editor link.
- *
- * @global string $_wp_current_template_id
+ * @since 6.8.0 Removed the query args to ensure that the link opens the starting screen of the Site Editor.
  *
  * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
  */
 function wp_admin_bar_edit_site_menu( $wp_admin_bar ) {
-	global $_wp_current_template_id;
 
 	// Don't show if a block theme is not activated.
 	if ( ! wp_is_block_theme() ) {
 		return;
 	}
 
-	// Don't show for users who can't edit theme options or when in the admin.
-	if ( ! current_user_can( 'edit_theme_options' ) || is_admin() ) {
+	// Don't show for users who can't edit theme options.
+	if ( ! current_user_can( 'edit_theme_options' ) ) {
 		return;
 	}
 
@@ -480,14 +478,7 @@ function wp_admin_bar_edit_site_menu( $wp_admin_bar ) {
 		array(
 			'id'    => 'site-editor',
 			'title' => __( 'Edit Site' ),
-			'href'  => add_query_arg(
-				array(
-					'postType' => 'wp_template',
-					'postId'   => $_wp_current_template_id,
-					'canvas'   => 'edit',
-				),
-				admin_url( 'site-editor.php' )
-			),
+			'href'  => admin_url( 'site-editor.php' ),
 		)
 	);
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->https://core.trac.wordpress.org/ticket/62368

This is the backport of https://github.com/WordPress/gutenberg/pull/69271

This PR changes the Edit Site link in the admin bar to point to the top level (the "home") of the Site Editor, instead of opening the current template.

Based on feedback in https://core.trac.wordpress.org/ticket/62368, the Edit Site link also shows in the admin area.
Showing the link while in the admin area makes the admin bar more consistent and makes it easier to use, since you can use your muscle memory.

**Testing Instructions**
Activate a block theme.
Confirm that the Edit Site link shows in the admin bar, and that it leads to the Site Editor, without opening a specific template.
Activate a classic theme and confirm that the link does not show.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
