### PR TITLE
Add public visibility support to REST API settings endpoint

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2729,6 +2729,7 @@ function register_initial_settings() {
 			'show_in_rest' => array(
 				'name' => 'title',
 			),
+			'public'       => true,
 			'type'         => 'string',
 			'label'        => __( 'Title' ),
 			'description'  => __( 'Site title.' ),
@@ -2742,6 +2743,7 @@ function register_initial_settings() {
 			'show_in_rest' => array(
 				'name' => 'description',
 			),
+			'public'       => true,
 			'type'         => 'string',
 			'label'        => __( 'Tagline' ),
 			'description'  => __( 'Site tagline.' ),
@@ -2831,6 +2833,7 @@ function register_initial_settings() {
 			'show_in_rest' => array(
 				'name' => 'language',
 			),
+			'public'       => true,
 			'type'         => 'string',
 			'description'  => __( 'WordPress locale code.' ),
 			'default'      => 'en_US',
@@ -2884,6 +2887,7 @@ function register_initial_settings() {
 		'reading',
 		'show_on_front',
 		array(
+			'public'       => true,
 			'show_in_rest' => true,
 			'type'         => 'string',
 			'label'        => __( 'Show on front' ),
@@ -2895,6 +2899,7 @@ function register_initial_settings() {
 		'reading',
 		'page_on_front',
 		array(
+			'public'       => true,
 			'show_in_rest' => true,
 			'type'         => 'integer',
 			'label'        => __( 'Page on front' ),
@@ -2906,6 +2911,7 @@ function register_initial_settings() {
 		'reading',
 		'page_for_posts',
 		array(
+			'public'       => true,
 			'show_in_rest' => true,
 			'type'         => 'integer',
 			'description'  => __( 'The ID of the page that should display the latest posts' ),
@@ -2972,6 +2978,7 @@ function register_initial_settings() {
  *                                         When registering complex settings, this argument may optionally be an
  *                                         array with a 'schema' key.
  *     @type mixed      $default           Default value when calling `get_option()`.
+ *     @type bool      $public          Whether data associated with this setting should be considered public. Default false.
  * }
  */
 function register_setting( $option_group, $option_name, $args = array() ) {
@@ -2990,6 +2997,7 @@ function register_setting( $option_group, $option_name, $args = array() ) {
 		'description'       => '',
 		'sanitize_callback' => null,
 		'show_in_rest'      => false,
+		'public'            => false,
 	);
 
 	// Back-compat: old sanitize callback is added.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
@@ -42,7 +42,9 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_item' ),
-					'args'                => array(),
+					'args'                => array(
+						'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+					),
 					'permission_callback' => array( $this, 'get_item_permissions_check' ),
 				),
 				array(
@@ -65,7 +67,20 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 	 * @return bool True if the request has read access for the item, otherwise false.
 	 */
 	public function get_item_permissions_check( $request ) {
-		return current_user_can( 'manage_options' );
+		$can_manage_options = current_user_can( 'manage_options' );
+		if ( 'edit' === $request['context'] && ! $can_manage_options ) {
+			return false;
+		}
+
+		$options = $this->get_registered_options();
+
+		foreach ( $options as $name => $args ) {
+			if ( true === $args['schema']['public'] ) {
+				return true;
+			}
+		}
+
+		return $can_manage_options;
 	}
 
 	/**
@@ -77,10 +92,15 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 	 * @return array|WP_Error Array on success, or WP_Error object on failure.
 	 */
 	public function get_item( $request ) {
-		$options  = $this->get_registered_options();
-		$response = array();
+		$options            = $this->get_registered_options();
+		$response           = array();
+		$can_manage_options = current_user_can( 'manage_options' );
 
 		foreach ( $options as $name => $args ) {
+			if ( ! $can_manage_options && ! $args['schema']['public'] ) {
+				continue;
+			}
+
 			/**
 			 * Filters the value of a setting recognized by the REST API.
 			 *
@@ -240,6 +260,7 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 				'title'       => empty( $args['label'] ) ? '' : $args['label'],
 				'description' => empty( $args['description'] ) ? '' : $args['description'],
 				'default'     => isset( $args['default'] ) ? $args['default'] : null,
+				'public'      => isset( $args['public'] ) ? (bool) $args['public'] : false,
 			);
 
 			$rest_args['schema']      = array_merge( $default_schema, $rest_args['schema'] );

--- a/tests/phpunit/tests/rest-api/rest-settings-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-settings-controller.php
@@ -83,12 +83,59 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_get_item_is_not_public_not_authenticated() {
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/settings' );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertSame( 401, $response->get_status() );
+		$data     = $response->get_data();
+		$actual   = array_keys( $data );
+
+		$expected = array(
+			'description',
+			'language',
+			'page_for_posts',
+			'page_on_front',
+			'show_on_front',
+			'title',
+		);
+
+		sort( $expected );
+		sort( $actual );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $expected, $actual );
 	}
 
 	public function test_get_item_is_not_public_no_permission() {
 		wp_set_current_user( self::$author );
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/settings' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$actual   = array_keys( $data );
+
+		$expected = array(
+			'description',
+			'language',
+			'page_for_posts',
+			'page_on_front',
+			'show_on_front',
+			'title',
+		);
+
+		sort( $expected );
+		sort( $actual );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $expected, $actual );
+	}
+
+	public function test_get_item_is_not_public_not_authenticated_edit_context() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/settings' );
+		$request->set_param( 'context', 'edit' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	public function test_get_item_is_not_public_no_permission_edit_context() {
+		wp_set_current_user( self::$author );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/settings' );
+		$request->set_param( 'context', 'edit' );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertSame( 403, $response->get_status() );
 	}
@@ -176,6 +223,39 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$this->assertSame( 'validvalue2', $data['mycustomsettinginrest'] );
+	}
+
+	public function test_get_item_with_custom_setting_public() {
+		register_setting(
+			'somegroup',
+			'mycustomsettingpublic',
+			array(
+				'show_in_rest' => array(
+					'name'   => 'mycustomsettingpublicinrest',
+					'schema' => array(
+						'enum'    => array( 'validvalue1', 'validvalue2' ),
+						'default' => 'validvalue1',
+					),
+				),
+				'public'       => true,
+				'type'         => 'string',
+			)
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/settings' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertArrayHasKey( 'mycustomsettingpublicinrest', $data );
+		$this->assertSame( 'validvalue1', $data['mycustomsettingpublicinrest'] );
+
+		update_option( 'mycustomsettingpublic', 'validvalue2' );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/settings' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$this->assertSame( 'validvalue2', $data['mycustomsettingpublicinrest'] );
 	}
 
 	public function test_get_item_with_custom_array_setting() {

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -10834,7 +10834,14 @@ mockedApiResponse.Schema = {
                     "methods": [
                         "GET"
                     ],
-                    "args": []
+                    "args": {
+                        "context": {
+                            "description": "Scope under which the request is made; determines fields present in response.",
+                            "type": "string",
+                            "default": "view",
+                            "required": false
+                        }
+                    }
                 },
                 {
                     "methods": [


### PR DESCRIPTION
Introduce a `public` flag for registered settings, allowing settings to be accessible without manage_options capability. Update REST API Settings Controller to respect the `public` flag and customize response based on user permissions and context. Add relevant unit tests for new functionality.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/48885

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
