### PR TITLE
Tests: Add unit test for empty comment tags in export

### DIFF
--- a/src/wp-admin/includes/export.php
+++ b/src/wp-admin/includes/export.php
@@ -685,7 +685,7 @@ function export_wp( $args = array() ) {
 	endforeach;
 
 				$_comments = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->comments WHERE comment_post_ID = %d AND comment_approved <> 'spam'", $post->ID ) );
-				$comments = array_filter( array_map( 'get_comment', $_comments ) );
+				$comments  = array_filter( array_map( 'get_comment', $_comments ) );
 				foreach ( $comments as $c ) :
 					?>
 		<wp:comment>

--- a/src/wp-admin/includes/export.php
+++ b/src/wp-admin/includes/export.php
@@ -685,7 +685,7 @@ function export_wp( $args = array() ) {
 	endforeach;
 
 				$_comments = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->comments WHERE comment_post_ID = %d AND comment_approved <> 'spam'", $post->ID ) );
-				$comments  = array_map( 'get_comment', $_comments );
+				$comments = array_filter( array_map( 'get_comment', $_comments ) );
 				foreach ( $comments as $c ) :
 					?>
 		<wp:comment>

--- a/src/wp-admin/includes/export.php
+++ b/src/wp-admin/includes/export.php
@@ -685,7 +685,12 @@ function export_wp( $args = array() ) {
 	endforeach;
 
 				$_comments = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $wpdb->comments WHERE comment_post_ID = %d AND comment_approved <> 'spam'", $post->ID ) );
-				$comments  = array_filter( array_map( 'get_comment', $_comments ) );
+				$comments  = array_filter(
+					array_map( 'get_comment', $_comments ),
+					static function ( $comment ) {
+						return $comment instanceof WP_Comment;
+					}
+				);
 				foreach ( $comments as $c ) :
 					?>
 		<wp:comment>

--- a/src/wp-includes/comment.php
+++ b/src/wp-includes/comment.php
@@ -240,9 +240,12 @@ function get_comment( $comment = null, $output = OBJECT ) {
 	 *
 	 * @since 2.3.0
 	 *
-	 * @param WP_Comment $_comment Comment data.
+	 * @param WP_Comment|null $_comment Comment data.
 	 */
 	$_comment = apply_filters( 'get_comment', $_comment );
+	if ( ! ( $_comment instanceof WP_Comment ) ) {
+		return null;
+	}
 
 	if ( OBJECT === $output ) {
 		return $_comment;

--- a/tests/phpunit/tests/admin/exportWp.php
+++ b/tests/phpunit/tests/admin/exportWp.php
@@ -290,4 +290,55 @@ class Tests_Admin_ExportWp extends WP_UnitTestCase {
 		$post_ids_key   = $expected_ids[0];
 		$args['author'] = self::$post_ids[ $post_ids_key ]['post_author'];
 	}
+
+	/**
+	 * @ticket 61244
+	 * @covers ::export_wp
+	 */
+	public function test_export_wp_should_not_include_empty_comments_when_filtered() {
+		$post_id = self::factory()->post->create( array( 'post_title' => 'Test Post' ) );
+		self::factory()->comment->create_post_comments( $post_id, 3 );
+
+		// Add filter to make get_comment return false.
+		add_action(
+			'export_wp',
+			function () {
+				add_filter( 'get_comment', '__return_false' );
+			}
+		);
+
+		ob_start();
+		export_wp();
+		$xml = ob_get_clean();
+
+		$xml_obj = simplexml_load_string( $xml );
+
+		// Convert all <wp:comment> tags to string for easier checking.
+		$comment_tags = $xml_obj->xpath( '//wp:comment' );
+
+		// Verify there are no comment tags in the export.
+		$this->assertEmpty( $comment_tags, 'No <wp:comment> tags should be present when comments are filtered out.' );
+	}
+
+	/**
+	 * @ticket 61244
+	 * @covers ::export_wp
+	 */
+	public function test_export_wp_includes_comments_when_not_filtered() {
+		$post_id       = self::factory()->post->create( array( 'post_title' => 'Test Post' ) );
+		$comment_count = 3;
+		self::factory()->comment->create_post_comments( $post_id, $comment_count );
+
+		ob_start();
+		export_wp();
+		$xml = ob_get_clean();
+
+		$xml_obj = simplexml_load_string( $xml );
+
+		// Count <wp:comment> tags.
+		$comment_tags = $xml_obj->xpath( '//wp:comment' );
+
+		// Verify the correct number of comment tags are present.
+		$this->assertCount( $comment_count, $comment_tags, 'Export should include all comments when not filtered.' );
+	}
 }

--- a/tests/phpunit/tests/admin/exportWp.php
+++ b/tests/phpunit/tests/admin/exportWp.php
@@ -307,16 +307,10 @@ class Tests_Admin_ExportWp extends WP_UnitTestCase {
 			}
 		);
 
-		ob_start();
-		export_wp();
-		$xml = ob_get_clean();
+		$xml_obj = $this->get_the_export( array() );
 
-		$xml_obj = simplexml_load_string( $xml );
-
-		// Convert all <wp:comment> tags to string for easier checking.
 		$comment_tags = $xml_obj->xpath( '//wp:comment' );
 
-		// Verify there are no comment tags in the export.
 		$this->assertEmpty( $comment_tags, 'No <wp:comment> tags should be present when comments are filtered out.' );
 	}
 
@@ -329,16 +323,10 @@ class Tests_Admin_ExportWp extends WP_UnitTestCase {
 		$comment_count = 3;
 		self::factory()->comment->create_post_comments( $post_id, $comment_count );
 
-		ob_start();
-		export_wp();
-		$xml = ob_get_clean();
+		$xml_obj = $this->get_the_export( array() );
 
-		$xml_obj = simplexml_load_string( $xml );
-
-		// Count <wp:comment> tags.
 		$comment_tags = $xml_obj->xpath( '//wp:comment' );
 
-		// Verify the correct number of comment tags are present.
 		$this->assertCount( $comment_count, $comment_tags, 'Export should include all comments when not filtered.' );
 	}
 }

--- a/tests/phpunit/tests/admin/exportWp.php
+++ b/tests/phpunit/tests/admin/exportWp.php
@@ -308,7 +308,7 @@ class Tests_Admin_ExportWp extends WP_UnitTestCase {
 
 		$xml_obj      = $this->get_the_export( array() );
 		$comment_tags = $xml_obj->xpath( '//wp:comment' );
-		$this->assertEmpty( $comment_tags, 'No <wp:comment> tags should be present when comments are filtered out.' );
+		$this->assertCount( 0, $comment_tags, 'No <wp:comment> tags should be present when comments are filtered out.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/admin/exportWp.php
+++ b/tests/phpunit/tests/admin/exportWp.php
@@ -293,7 +293,6 @@ class Tests_Admin_ExportWp extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 61244
-	 * @covers ::export_wp
 	 */
 	public function test_export_wp_should_not_include_empty_comments_when_filtered() {
 		$post_id = self::factory()->post->create( array( 'post_title' => 'Test Post' ) );
@@ -307,24 +306,20 @@ class Tests_Admin_ExportWp extends WP_UnitTestCase {
 			}
 		);
 
-		$xml_obj = $this->get_the_export( array() );
-
+		$xml_obj      = $this->get_the_export( array() );
 		$comment_tags = $xml_obj->xpath( '//wp:comment' );
-
 		$this->assertEmpty( $comment_tags, 'No <wp:comment> tags should be present when comments are filtered out.' );
 	}
 
 	/**
 	 * @ticket 61244
-	 * @covers ::export_wp
 	 */
 	public function test_export_wp_includes_comments_when_not_filtered() {
 		$post_id       = self::factory()->post->create( array( 'post_title' => 'Test Post' ) );
 		$comment_count = 3;
 		self::factory()->comment->create_post_comments( $post_id, $comment_count );
 
-		$xml_obj = $this->get_the_export( array() );
-
+		$xml_obj      = $this->get_the_export( array() );
 		$comment_tags = $xml_obj->xpath( '//wp:comment' );
 
 		$this->assertCount( $comment_count, $comment_tags, 'Export should include all comments when not filtered.' );

--- a/tests/phpunit/tests/admin/exportWp.php
+++ b/tests/phpunit/tests/admin/exportWp.php
@@ -321,7 +321,6 @@ class Tests_Admin_ExportWp extends WP_UnitTestCase {
 
 		$xml_obj      = $this->get_the_export( array() );
 		$comment_tags = $xml_obj->xpath( '//wp:comment' );
-
 		$this->assertCount( $comment_count, $comment_tags, 'Export should include all comments when not filtered.' );
 	}
 }

--- a/tests/phpunit/tests/admin/exportWp.php
+++ b/tests/phpunit/tests/admin/exportWp.php
@@ -299,11 +299,11 @@ class Tests_Admin_ExportWp extends WP_UnitTestCase {
 		$post_id = self::factory()->post->create( array( 'post_title' => 'Test Post' ) );
 		self::factory()->comment->create_post_comments( $post_id, 3 );
 
-		// Add filter to make get_comment return false.
+		// Add filter to make get_comment return null.
 		add_action(
 			'export_wp',
 			function () {
-				add_filter( 'get_comment', '__return_false' );
+				add_filter( 'get_comment', '__return_null' );
 			}
 		);
 

--- a/tests/phpunit/tests/admin/exportWp.php
+++ b/tests/phpunit/tests/admin/exportWp.php
@@ -302,7 +302,7 @@ class Tests_Admin_ExportWp extends WP_UnitTestCase {
 		// Add filter to make get_comment return null.
 		add_action(
 			'export_wp',
-			function () {
+			static function () {
 				add_filter( 'get_comment', '__return_null' );
 			}
 		);

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -1896,4 +1896,20 @@ class Tests_Comment extends WP_UnitTestCase {
 		// Verify the sibling note is NOT trashed (no cascade since child is not top-level).
 		$this->assertSame( '1', get_comment( $sibling_note )->comment_approved );
 	}
+
+	/**
+	 * @ticket 61244
+	 *
+	 * @covers ::get_comment
+	 */
+	public function test_get_comment_filter() {
+		$comment_id = self::factory()->comment->create( array( 'comment_post_ID' => self::$post_id ) );
+
+		$comment = get_comment( $comment_id );
+		$this->assertInstanceOf( WP_Comment::class, $comment );
+		$this->assertSame( $comment_id, (int) $comment->comment_ID, 'Expected the same comment.' );
+
+		add_filter( 'get_comment', '__return_null' );
+		$this->assertNull( get_comment( $comment_id ), 'Expected get_comment() to return null when get_comment filter returns null.' );
+	}
 }


### PR DESCRIPTION


Trac ticket: https://core.trac.wordpress.org/ticket/61244

This PR adds unit tests for the patch present to verify the behavior of comment filtering during exports.

The new test ensures that when comments are filtered out using `get_comment` filter, no empty `<wp:comment>` tags appear in the export XML.




Run the tests: 

```bash

npm run test:php -- --filter=Tests_Admin_ExportWp 

```

