### PR TITLE
docs: add missing `null` to `_wp_get_current_user()` return type

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -3708,7 +3708,7 @@ function wp_get_users_with_no_role( $site_id = null ) {
  * @see wp_get_current_user()
  * @global WP_User $current_user Checks if the current user is set.
  *
- * @return WP_User Current WP_User instance.
+ * @return WP_User|null Current WP_User instance or null if no user is logged in.
  */
 function _wp_get_current_user() {
 	global $current_user;

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -3708,7 +3708,7 @@ function wp_get_users_with_no_role( $site_id = null ) {
  * @see wp_get_current_user()
  * @global WP_User $current_user Checks if the current user is set.
  *
- * @return WP_User|null Current WP_User instance or null if no user is logged in.
+ * @return WP_User|null Current WP_User instance if user is logged in, null otherwise.
  */
 function _wp_get_current_user() {
 	global $current_user;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

This PR updates the `@return` type for `_wp_get_current_user()` to correctly reflect that it can return a `null` value if no user is logged in.

While this issue was surfaced via PHPStan in https://github.com/WordPress/wordpress-develop/pull/7619 (trac: https://core.trac.wordpress.org/ticket/61175 ), it can be remediated independently of that ticket.

Trac ticket: https://core.trac.wordpress.org/ticket/63268

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
