### PR TITLE
Add path data for `style.css` in Twenty Twenty-Five theme

### DIFF
--- a/src/wp-content/themes/twentytwentyfive/functions.php
+++ b/src/wp-content/themes/twentytwentyfive/functions.php
@@ -55,6 +55,12 @@ if ( ! function_exists( 'twentytwentyfive_enqueue_styles' ) ) :
 			array(),
 			wp_get_theme()->get( 'Version' )
 		);
+
+		wp_style_add_data(
+			'twentytwentyfive-style',
+			'path',
+			get_parent_theme_file_path( 'style.css' )
+		);
 	}
 endif;
 add_action( 'wp_enqueue_scripts', 'twentytwentyfive_enqueue_styles' );


### PR DESCRIPTION
Trac Ticket: [#63007](https://core.trac.wordpress.org/ticket/63007)

## Description
Adds path data to the theme's `style.css` to enable inlining capabilities, which can improve the Largest Contentful Paint (LCP).

## Screenshot:

#### Before patch:
#### Network:
<img width="1014" alt="image" src="https://github.com/user-attachments/assets/ed34ed81-a653-4a25-86c2-f13eb7577a46" />


### After patch:
#### Network:
<img width="867" alt="image" src="https://github.com/user-attachments/assets/f191b83f-1f1b-46d1-aff3-456295932a53" />
