### PR TITLE
#63008 Use a large, primary, right-aligned button on every screen during setup and installation

### DIFF
--- a/src/wp-admin/css/install.css
+++ b/src/wp-admin/css/install.css
@@ -100,9 +100,6 @@ fieldset {
 	text-align: left;
 	padding: 0;
 }
-.language-chooser.wp-core-ui .step .button.button-large {
-	font-size: 14px;
-}
 textarea {
 	border: 1px solid #dcdcde;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
@@ -342,8 +339,8 @@ body.language-chooser {
 	color: #0a4b78;
 }
 
-.language-chooser .step {
-	text-align: right;
+.step {
+	text-align: end;
 }
 
 .screen-reader-input,

--- a/src/wp-admin/install.php
+++ b/src/wp-admin/install.php
@@ -214,7 +214,7 @@ function display_setup_form( $error = null ) {
 			</td>
 		</tr>
 	</table>
-	<p class="step"><?php submit_button( __( 'Install WordPress' ), 'large', 'Submit', false, array( 'id' => 'submit' ) ); ?></p>
+	<p class="step"><?php submit_button( __( 'Install WordPress' ), 'primary large', 'Submit', false, array( 'id' => 'submit' ) ); ?></p>
 	<input type="hidden" name="language" value="<?php echo isset( $_REQUEST['language'] ) ? esc_attr( $_REQUEST['language'] ) : ''; ?>" />
 </form>
 	<?php
@@ -226,7 +226,7 @@ if ( is_blog_installed() ) {
 	die(
 		'<h1>' . __( 'Already Installed' ) . '</h1>' .
 		'<p>' . __( 'You appear to have already installed WordPress. To reinstall please clear your old database tables first.' ) . '</p>' .
-		'<p class="step"><a href="' . esc_url( wp_login_url() ) . '">' . __( 'Log In' ) . '</a></p>' .
+		'<p class="step"><a href="' . esc_url( wp_login_url() ) . '" class="button button-primary button-large">' . __( 'Log In' ) . '</a></p>' .
 		'</body></html>'
 	);
 }
@@ -469,7 +469,7 @@ switch ( $step ) {
 	</tr>
 </table>
 
-<p class="step"><a href="<?php echo esc_url( wp_login_url() ); ?>"><?php _e( 'Log In' ); ?></a></p>
+<p class="step"><a href="<?php echo esc_url( wp_login_url() ); ?>" class="button button-primary button-large"><?php _e( 'Log In' ); ?></a></p>
 
 			<?php
 		}

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -204,7 +204,7 @@ switch ( $step ) {
 </p>
 <p><?php _e( 'In all likelihood, these items were supplied to you by your web host. If you do not have this information, then you will need to contact them before you can continue. If you are ready&hellip;' ); ?></p>
 
-<p class="step"><a href="<?php echo $step_1; ?>" class="button button-large"><?php _e( 'Let&#8217;s go!' ); ?></a></p>
+<p class="step"><a href="<?php echo $step_1; ?>" class="button button-primary button-large"><?php _e( 'Let&#8217;s go!' ); ?></a></p>
 		<?php
 		break;
 
@@ -269,7 +269,7 @@ switch ( $step ) {
 			?>
 <input name="noapi" type="hidden" value="1" /><?php } ?>
 	<input type="hidden" name="language" value="<?php echo esc_attr( $language ); ?>" />
-	<p class="step"><input name="submit" type="submit" value="<?php echo htmlspecialchars( __( 'Submit' ), ENT_QUOTES ); ?>" class="button button-large" /></p>
+	<p class="step"><input name="submit" type="submit" value="<?php echo htmlspecialchars( __( 'Submit' ), ENT_QUOTES ); ?>" class="button button-primary button-large" /></p>
 </form>
 		<?php
 		wp_print_scripts( 'password-toggle' );
@@ -298,7 +298,7 @@ switch ( $step ) {
 			$install .= '?language=en_US';
 		}
 
-		$tryagain_link = '</p><p class="step"><a href="' . $step_1 . '" onclick="javascript:history.go(-1);return false;" class="button button-large">' . __( 'Try Again' ) . '</a>';
+		$tryagain_link = '</p><p class="step"><a href="' . $step_1 . '" onclick="javascript:history.go(-1);return false;" class="button button-primary button-large">' . __( 'Try Again' ) . '</a>';
 
 		if ( empty( $prefix ) ) {
 			wp_die( __( '<strong>Error:</strong> "Table Prefix" must not be empty.' ) . $tryagain_link );
@@ -443,7 +443,7 @@ switch ( $step ) {
 	</label></p>
 <textarea id="wp-config" cols="98" rows="15" class="code" readonly="readonly" aria-describedby="wp-config-description"><?php echo $config_text; ?></textarea>
 <p><?php _e( 'After you&#8217;ve done that, click &#8220;Run the installation&#8221;.' ); ?></p>
-<p class="step"><a href="<?php echo $install; ?>" class="button button-large"><?php _e( 'Run the installation' ); ?></a></p>
+<p class="step"><a href="<?php echo $install; ?>" class="button button-primary button-large"><?php _e( 'Run the installation' ); ?></a></p>
 <script>
 (function(){
 if ( ! /iPad|iPod|iPhone/.test( navigator.userAgent ) ) {
@@ -508,7 +508,7 @@ if ( ! /iPad|iPod|iPhone/.test( navigator.userAgent ) ) {
 </h1>
 <p><?php _e( 'All right, sparky! You&#8217;ve made it through this part of the installation. WordPress can now communicate with your database. If you are ready, time now to&hellip;' ); ?></p>
 
-<p class="step"><a href="<?php echo $install; ?>" class="button button-large"><?php _e( 'Run the installation' ); ?></a></p>
+<p class="step"><a href="<?php echo $install; ?>" class="button button-primary button-large"><?php _e( 'Run the installation' ); ?></a></p>
 				<?php
 			else :
 				printf( '<p>%s</p>', $error_message );

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3999,6 +3999,19 @@ function _default_wp_die_handler( $message, $title = '', $args = array() ) {
 			background: #f1f1f1;
 		}
 
+		.button.button-primary {
+			background: #2271b1;
+			border-color: #2271b1;
+			color: #fff;
+		}
+
+		.button.button-primary:hover,
+		.button.button-primary:focus {
+			background: #135e96;
+			border-color: #135e96;
+			color: #fff;
+		}
+
 		.button:focus {
 			background: #f3f5f6;
 			border-color: #007cba;


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63008

Before and after screenshots are on the Trac ticket.

## Steps to test

Warning: these steps are destructive, only test this on a testing site.

1. Clear out your database, for example via `wp db reset`
2. Delete `wp-config.php`
3. Visit /wp-admin and follow the testing steps
4. Confirm all buttons and links that take you to the next screen are consistently styled, sized, and placed
5. Repeat the steps but choose an RTL language on the first step, and confirm all buttons are placed to the left instead of the right

You may need to clear your browser cache to get the changes in `install.css` to show up (this file is cache-busted according to the WordPress version number).