### PR TITLE
Twenty Twenty-Five: Update text strings

### DIFF
--- a/src/wp-content/themes/twentytwentyfive/patterns/banner-intro-image.php
+++ b/src/wp-content/themes/twentytwentyfive/patterns/banner-intro-image.php
@@ -39,7 +39,7 @@
 			<div class="wp-block-buttons">
 				<!-- wp:button -->
 				<div class="wp-block-button">
-					<a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'Learn More', 'Button text of intro section.', 'twentytwentyfive' ); ?></a>
+					<a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Learn more', 'twentytwentyfive' ); ?></a>
 				</div>
 				<!-- /wp:button -->
 			</div>

--- a/src/wp-content/themes/twentytwentyfive/patterns/header-centered.php
+++ b/src/wp-content/themes/twentytwentyfive/patterns/header-centered.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Title: Centered header
+ * Title: Centered site header
  * Slug: twentytwentyfive/header-centered
  * Categories: header
  * Block Types: core/template-part/header
- * Description: Header with centered site title and navigation.
+ * Description: Site header with centered site title and navigation.
  *
  * @package WordPress
  * @subpackage Twenty_Twenty_Five

--- a/src/wp-content/themes/twentytwentyfive/patterns/header-columns.php
+++ b/src/wp-content/themes/twentytwentyfive/patterns/header-columns.php
@@ -4,7 +4,7 @@
  * Slug: twentytwentyfive/header-columns
  * Categories: header
  * Block Types: core/template-part/header
- * Description: Header with site title and navigation in columns.
+ * Description: Site header with site title and navigation in columns.
  *
  * @package WordPress
  * @subpackage Twenty_Twenty_Five

--- a/src/wp-content/themes/twentytwentyfive/patterns/header-large-title.php
+++ b/src/wp-content/themes/twentytwentyfive/patterns/header-large-title.php
@@ -4,7 +4,7 @@
  * Slug: twentytwentyfive/header-large-title
  * Categories: header
  * Block Types: core/template-part/header
- * Description: Header with large site title and right-aligned navigation.
+ * Description: Site header with large site title and right-aligned navigation.
  *
  * @package WordPress
  * @subpackage Twenty_Twenty_Five

--- a/src/wp-content/themes/twentytwentyfive/patterns/header.php
+++ b/src/wp-content/themes/twentytwentyfive/patterns/header.php
@@ -4,7 +4,7 @@
  * Slug: twentytwentyfive/header
  * Categories: header
  * Block Types: core/template-part/header
- * Description: Header with site title and navigation.
+ * Description: Site header with site title and navigation.
  *
  * @package WordPress
  * @subpackage Twenty_Twenty_Five

--- a/src/wp-content/themes/twentytwentyfive/patterns/hero-full-width-image.php
+++ b/src/wp-content/themes/twentytwentyfive/patterns/hero-full-width-image.php
@@ -30,7 +30,7 @@
 			<!-- wp:buttons -->
 			<div class="wp-block-buttons">
 				<!-- wp:button -->
-				<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php echo esc_html_x( 'Learn More', 'Sample hero button', 'twentytwentyfive' ); ?></a></div>
+				<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Learn more', 'twentytwentyfive' ); ?></a></div>
 				<!-- /wp:button -->
 			</div>
 			<!-- /wp:buttons -->

--- a/src/wp-content/themes/twentytwentyfive/patterns/template-404-vertical-header-blog.php
+++ b/src/wp-content/themes/twentytwentyfive/patterns/template-404-vertical-header-blog.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Right-aligned blog, 404
+ * Title: Right-aligned 404
  * Slug: twentytwentyfive/template-404-vertical-header-blog
  * Template Types: 404
  * Viewport width: 1400

--- a/src/wp-content/themes/twentytwentyfive/patterns/template-archive-text-blog.php
+++ b/src/wp-content/themes/twentytwentyfive/patterns/template-archive-text-blog.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Text-only blog, archive
+ * Title: Text blog archive
  * Slug: twentytwentyfive/template-archive-text-blog
  * Template Types: archive
  * Viewport width: 1400

--- a/src/wp-content/themes/twentytwentyfive/patterns/template-archive-vertical-header-blog.php
+++ b/src/wp-content/themes/twentytwentyfive/patterns/template-archive-vertical-header-blog.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Archive for the right-aligned blog
+ * Title: Right-aligned archive
  * Slug: twentytwentyfive/template-archive-vertical-header-blog
  * Template Types: archive
  * Viewport width: 1400

--- a/src/wp-content/themes/twentytwentyfive/patterns/template-home-text-blog.php
+++ b/src/wp-content/themes/twentytwentyfive/patterns/template-home-text-blog.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Text-only blog, home
+ * Title: Text blog home
  * Slug: twentytwentyfive/template-home-text-blog
  * Template Types: front-page, home
  * Viewport width: 1400

--- a/src/wp-content/themes/twentytwentyfive/patterns/template-home-vertical-header-blog.php
+++ b/src/wp-content/themes/twentytwentyfive/patterns/template-home-vertical-header-blog.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Homepage for right-aligned blog
+ * Title: Right-aligned home
  * Slug: twentytwentyfive/template-home-vertical-header-blog
  * Template Types: front-page, index, home
  * Viewport width: 1400

--- a/src/wp-content/themes/twentytwentyfive/patterns/template-page-vertical-header-blog.php
+++ b/src/wp-content/themes/twentytwentyfive/patterns/template-page-vertical-header-blog.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Page template for the right-aligned blog
+ * Title: Right-aligned page
  * Slug: twentytwentyfive/template-page-vertical-header-blog
  * Template Types: page
  * Viewport width: 1400

--- a/src/wp-content/themes/twentytwentyfive/patterns/template-query-loop-text-blog.php
+++ b/src/wp-content/themes/twentytwentyfive/patterns/template-query-loop-text-blog.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Text-only blog, posts
+ * Title: Text blog query loop
  * Slug: twentytwentyfive/template-query-loop-text-blog
  * Inserter: no
  *

--- a/src/wp-content/themes/twentytwentyfive/patterns/template-query-loop-vertical-header-blog.php
+++ b/src/wp-content/themes/twentytwentyfive/patterns/template-query-loop-vertical-header-blog.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Right-aligned posts
+ * Title: Right-aligned query loop
  * Slug: twentytwentyfive/template-query-loop-vertical-header-blog
  * Inserter: no
  *

--- a/src/wp-content/themes/twentytwentyfive/patterns/template-search-text-blog.php
+++ b/src/wp-content/themes/twentytwentyfive/patterns/template-search-text-blog.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Text-only blog, search
+ * Title: Text blog search results
  * Slug: twentytwentyfive/template-search-text-blog
  * Template Types: search
  * Viewport width: 1400

--- a/src/wp-content/themes/twentytwentyfive/patterns/template-single-text-blog.php
+++ b/src/wp-content/themes/twentytwentyfive/patterns/template-single-text-blog.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Text-only blog, single post
+ * Title: Text blog single post
  * Slug: twentytwentyfive/template-single-text-blog
  * Template Types: posts, single
  * Viewport width: 1400

--- a/src/wp-content/themes/twentytwentyfive/patterns/vertical-header.php
+++ b/src/wp-content/themes/twentytwentyfive/patterns/vertical-header.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Title: Vertical header
+ * Title: Vertical site header
  * Slug: twentytwentyfive/vertical-header
  * Categories: header
  * Block Types: core/template-part/vertical-header
- * Description: Vertical Header with site title and navigation
+ * Description: Vertical site header with site title and navigation.
  * Viewport width: 300
  *
  * @package WordPress

--- a/src/wp-content/themes/twentytwentyfive/theme.json
+++ b/src/wp-content/themes/twentytwentyfive/theme.json
@@ -694,7 +694,7 @@
 		{
 			"area": "header",
 			"name": "vertical-header",
-			"title": "Vertical Header"
+			"title": "Vertical site header"
 		},
 		{
 			"area": "header",


### PR DESCRIPTION
In Twenty Twenty-Five:

Remove the unnecessary context from some text strings where the translatable text was the same but the context was different. This reduces the number of strings a translator needs to work with.

Update the name of headers, to make it easier for translators to understand that they are site headers not headings.
Update the name of templates to make the naming more consistent.
Example:
`Title: Text-only blog, home` is now `Title: Text blog home` to match `Title: News blog home` etc.

Trac ticket: https://core.trac.wordpress.org/ticket/62482

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
