### PR TITLE
Accessibility: Make Customizer back button keyboard focusable

### DIFF
--- a/src/wp-includes/class-wp-customize-nav-menus.php
+++ b/src/wp-includes/class-wp-customize-nav-menus.php
@@ -1145,7 +1145,7 @@ final class WP_Customize_Nav_Menus {
 		?>
 		<div id="available-menu-items" class="accordion-container">
 			<div class="customize-section-title">
-				<button type="button" class="customize-section-back" tabindex="-1">
+				<button type="button" class="customize-section-back" type="button">
 					<span class="screen-reader-text">
 						<?php
 						/* translators: Hidden accessibility text. */

--- a/src/wp-includes/class-wp-customize-nav-menus.php
+++ b/src/wp-includes/class-wp-customize-nav-menus.php
@@ -1145,7 +1145,7 @@ final class WP_Customize_Nav_Menus {
 		?>
 		<div id="available-menu-items" class="accordion-container">
 			<div class="customize-section-title">
-				<button type="button" class="customize-section-back" type="button">
+				<button type="button" class="customize-section-back">
 					<span class="screen-reader-text">
 						<?php
 						/* translators: Hidden accessibility text. */

--- a/src/wp-includes/class-wp-customize-nav-menus.php
+++ b/src/wp-includes/class-wp-customize-nav-menus.php
@@ -1145,7 +1145,7 @@ final class WP_Customize_Nav_Menus {
 		?>
 		<div id="available-menu-items" class="accordion-container">
 			<div class="customize-section-title">
-				<button type="button" class="customize-section-back">
+				<button type="button" class="customize-section-back" tabindex="-1">
 					<span class="screen-reader-text">
 						<?php
 						/* translators: Hidden accessibility text. */

--- a/src/wp-includes/class-wp-customize-panel.php
+++ b/src/wp-includes/class-wp-customize-panel.php
@@ -374,7 +374,7 @@ class WP_Customize_Panel {
 	protected function content_template() {
 		?>
 		<li class="panel-meta customize-info accordion-section <# if ( ! data.description ) { #> cannot-expand<# } #>">
-			<button class="customize-panel-back" tabindex="-1"><span class="screen-reader-text">
+			<button class="customize-panel-back"><span class="screen-reader-text">
 				<?php
 				/* translators: Hidden accessibility text. */
 				_e( 'Back' );

--- a/src/wp-includes/class-wp-customize-panel.php
+++ b/src/wp-includes/class-wp-customize-panel.php
@@ -374,7 +374,7 @@ class WP_Customize_Panel {
 	protected function content_template() {
 		?>
 		<li class="panel-meta customize-info accordion-section <# if ( ! data.description ) { #> cannot-expand<# } #>">
-			<button class="customize-panel-back"><span class="screen-reader-text">
+			<button class="customize-panel-back" type="button"><span class="screen-reader-text">
 				<?php
 				/* translators: Hidden accessibility text. */
 				_e( 'Back' );

--- a/src/wp-includes/class-wp-customize-section.php
+++ b/src/wp-includes/class-wp-customize-section.php
@@ -363,7 +363,7 @@ class WP_Customize_Section {
 			<ul class="accordion-section-content" id="{{ data.id }}-content">
 				<li class="customize-section-description-container section-meta <# if ( data.description_hidden ) { #>customize-info<# } #>">
 					<div class="customize-section-title">
-						<button class="customize-section-back" tabindex="-1">
+						<button class="customize-section-back">
 							<span class="screen-reader-text">
 								<?php
 								/* translators: Hidden accessibility text. */

--- a/src/wp-includes/class-wp-customize-section.php
+++ b/src/wp-includes/class-wp-customize-section.php
@@ -363,7 +363,7 @@ class WP_Customize_Section {
 			<ul class="accordion-section-content" id="{{ data.id }}-content">
 				<li class="customize-section-description-container section-meta <# if ( data.description_hidden ) { #>customize-info<# } #>">
 					<div class="customize-section-title">
-						<button class="customize-section-back">
+						<button class="customize-section-back" type="button">
 							<span class="screen-reader-text">
 								<?php
 								/* translators: Hidden accessibility text. */

--- a/src/wp-includes/customize/class-wp-customize-nav-menus-panel.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menus-panel.php
@@ -68,7 +68,7 @@ class WP_Customize_Nav_Menus_Panel extends WP_Customize_Panel {
 	protected function content_template() {
 		?>
 		<li class="panel-meta customize-info accordion-section <# if ( ! data.description ) { #> cannot-expand<# } #>">
-			<button type="button" class="customize-panel-back" tabindex="-1">
+			<button type="button" class="customize-panel-back">
 				<span class="screen-reader-text">
 					<?php
 					/* translators: Hidden accessibility text. */


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63011

This PR fixes the accessibility issue where the Customizer back button was not keyboard-focusable. By removing the `tabindex="-1"` attribute from the back button in the Customizer section template, keyboard users can now navigate to and activate the back button.


Before - 




https://github.com/user-attachments/assets/0c4c595b-a921-4b96-ae51-54eb764dbd02





After - 


https://github.com/user-attachments/assets/281353ff-6fe4-42ab-b41a-095d8ae25e9a



