### PR TITLE
Add and manage loaded objects in metadata lazyloader

### DIFF
--- a/src/wp-includes/class-wp-metadata-lazyloader.php
+++ b/src/wp-includes/class-wp-metadata-lazyloader.php
@@ -39,6 +39,14 @@ class WP_Metadata_Lazyloader {
 	protected $pending_objects;
 
 	/**
+	 * Loaded objects queue.
+	 *
+	 * @since x.x.x
+	 * @var array
+	 */
+	protected $loaded_objects;
+
+	/**
 	 * Settings for supported object types.
 	 *
 	 * @since 4.5.0
@@ -185,6 +193,11 @@ class WP_Metadata_Lazyloader {
 			return $check;
 		}
 
+		$loaded_ids = array_keys( $this->loaded_objects[ $meta_type ] );
+		if ( $object_id && in_array( $object_id, $loaded_ids, true ) ) {
+			return $check;
+		}
+
 		$object_ids = array_keys( $this->pending_objects[ $meta_type ] );
 		if ( $object_id && ! in_array( $object_id, $object_ids, true ) ) {
 			$object_ids[] = $object_id;
@@ -196,5 +209,50 @@ class WP_Metadata_Lazyloader {
 		$this->reset_queue( $meta_type );
 
 		return $check;
+	}
+
+	/**
+	 * Adds specified IDs to the list of loaded objects for the given meta type.
+	 *
+	 * This method updates the internal "loaded_objects" property with the provided IDs for
+	 * the specified meta type. If the meta type is not initialized in the settings or loaded_objects,
+	 * the method ensures that a structure is created for it.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $meta_type The type of meta data being added (e.g., 'post', 'comment', etc.).
+	 * @param array $ids An array of IDs to add to the loaded objects for the given meta type.
+	 */
+	public function add_to_loaded( $meta_type, array $ids ) {
+		if ( ! isset( $this->settings[ $meta_type ] ) ) {
+			return;
+		}
+		if ( ! isset( $this->loaded_objects[ $meta_type ] ) ) {
+			$this->loaded_objects[ $meta_type ] = array();
+		}
+
+		$this->loaded_objects[ $meta_type ] = array_unique( array_merge( $this->loaded_objects[ $meta_type ], $ids ) );
+		var_dump( $this->loaded_objects );
+	}
+
+	/**
+	 * Resets the loaded objects for a specific object type.
+	 *
+	 * Clears the loaded objects list for the specified object type. If the object type is not recognized,
+	 * an error is returned.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $object_type The type of object whose loaded objects should be reset.
+	 * @return true|WP_Error True on success, or WP_Error if the object type is invalid.
+	 */
+	public function reset_loaded_objects( $object_type ) {
+		if ( ! isset( $this->settings[ $object_type ] ) ) {
+			return new WP_Error( 'invalid_object_type', __( 'Invalid object type.' ) );
+		}
+
+		$this->loaded_objects[ $object_type ] = array();
+
+		return true;
 	}
 }

--- a/src/wp-includes/meta.php
+++ b/src/wp-includes/meta.php
@@ -1216,6 +1216,9 @@ function update_meta_cache( $meta_type, $object_ids ) {
 	}
 	wp_cache_add_multiple( $data, $cache_group );
 
+	$wp_metadata_lazyloader = wp_metadata_lazyloader();
+	$wp_metadata_lazyloader->add_to_loaded( $meta_type, $non_cached_ids );
+
 	return $cache;
 }
 

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -288,6 +288,9 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 		$lazyloader->reset_queue( 'term' );
 		$lazyloader->reset_queue( 'comment' );
 		$lazyloader->reset_queue( 'blog' );
+		$lazyloader->reset_loaded_objects( 'term' );
+		$lazyloader->reset_loaded_objects( 'comment' );
+		$lazyloader->reset_loaded_objects( 'blog' );
 	}
 
 	/**


### PR DESCRIPTION
Introduce the `loaded_objects` property to track loaded metadata objects. Add `add_to_loaded` and `reset_loaded_objects` methods to manage these objects for specific meta types. Update caching logic and tests to utilize these enhancements, improving metadata loading efficiency.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
