### PR TITLE
fix: Update legacy 'error' CSS class to 'notice notice-error'

### DIFF
--- a/src/js/_enqueues/admin/tags.js
+++ b/src/js/_enqueues/admin/tags.js
@@ -55,11 +55,11 @@ jQuery( function($) {
 					$('a.tag-link-' + data.match(/tag_ID=(\d+)/)[1]).remove();
 
 				} else if ( '-1' == r ) {
-					$('#ajax-response').empty().append('<div class="error"><p>' + wp.i18n.__( 'Sorry, you are not allowed to do that.' ) + '</p></div>');
+					$('#ajax-response').empty().append('<div class="notice notice-error"><p>' + wp.i18n.__( 'Sorry, you are not allowed to do that.' ) + '</p></div>');
 					tr.children().css('backgroundColor', '');
 
 				} else {
-					$('#ajax-response').empty().append('<div class="error"><p>' + wp.i18n.__( 'An error occurred while processing your request. Please try again later.' ) + '</p></div>');
+					$('#ajax-response').empty().append('<div class="notice notice-error"><p>' + wp.i18n.__( 'An error occurred while processing your request. Please try again later.' ) + '</p></div>');
 					tr.children().css('backgroundColor', '');
 				}
 			});

--- a/src/js/_enqueues/vendor/plupload/handlers.js
+++ b/src/js/_enqueues/vendor/plupload/handlers.js
@@ -204,7 +204,7 @@ function prepareMediaItemInit( fileObj ) {
 
 // Generic error message.
 function wpQueueError( message ) {
-	jQuery( '#media-upload-error' ).show().html( '<div class="error"><p>' + message + '</p></div>' );
+	jQuery( '#media-upload-error' ).show().html( '<div class="notice notice-error"><p>' + message + '</p></div>' );
 }
 
 // File-specific error messages.

--- a/src/js/_enqueues/wp/theme.js
+++ b/src/js/_enqueues/wp/theme.js
@@ -1665,7 +1665,7 @@ themes.view.Installer = themes.view.Appearance.extend({
 		this.listenTo( this.collection, 'query:fail', function() {
 			$( 'body' ).removeClass( 'loading-content' );
 			$( '.theme-browser' ).find( 'div.error' ).remove();
-			$( '.theme-browser' ).find( 'div.themes' ).before( '<div class="error"><p>' + l10n.error + '</p><p><button class="button try-again">' + l10n.tryAgain + '</button></p></div>' );
+			$( '.theme-browser' ).find( 'div.themes' ).before( '<div class="notice notice-error"><p>' + l10n.error + '</p><p><button class="button try-again">' + l10n.tryAgain + '</button></p></div>' );
 			$( '.theme-browser .error .try-again' ).on( 'click', function( e ) {
 				e.preventDefault();
 				$( 'input.wp-filter-search' ).trigger( 'input' );

--- a/src/wp-signup.php
+++ b/src/wp-signup.php
@@ -131,7 +131,7 @@ function show_blog_form( $blogname = '', $blog_title = '', $errors = '' ) {
 	$errmsg_blogname_aria = '';
 	if ( $errmsg_blogname ) {
 		$errmsg_blogname_aria = 'wp-signup-blogname-error ';
-		echo '<p class="error" id="wp-signup-blogname-error">' . $errmsg_blogname . '</p>';
+		echo '<p class="notice notice-error" id="wp-signup-blogname-error">' . $errmsg_blogname . '</p>';
 	}
 
 	if ( ! is_subdomain_install() ) {
@@ -164,7 +164,7 @@ function show_blog_form( $blogname = '', $blog_title = '', $errors = '' ) {
 	$errmsg_blog_title_aria = '';
 	if ( $errmsg_blog_title ) {
 		$errmsg_blog_title_aria = ' aria-describedby="wp-signup-blog-title-error"';
-		echo '<p class="error" id="wp-signup-blog-title-error">' . $errmsg_blog_title . '</p>';
+		echo '<p class="notice notice-error" id="wp-signup-blog-title-error">' . $errmsg_blog_title . '</p>';
 	}
 	echo '<input name="blog_title" type="text" id="blog_title" value="' . esc_attr( $blog_title ) . '" required="required" autocomplete="off"' . $errmsg_blog_title_aria . ' />';
 	?>
@@ -280,7 +280,7 @@ function show_user_form( $user_name = '', $user_email = '', $errors = '' ) {
 	$errmsg_username_aria = '';
 	if ( $errmsg_username ) {
 		$errmsg_username_aria = 'wp-signup-username-error ';
-		echo '<p class="error" id="wp-signup-username-error">' . $errmsg_username . '</p>';
+		echo '<p class="notice notice-error" id="wp-signup-username-error">' . $errmsg_username . '</p>';
 	}
 	?>
 	<input name="user_name" type="text" id="user_name" value="<?php echo esc_attr( $user_name ); ?>" autocapitalize="none" autocorrect="off" maxlength="60" autocomplete="username" required="required" aria-describedby="<?php echo $errmsg_username_aria; ?>wp-signup-username-description" />
@@ -293,7 +293,7 @@ function show_user_form( $user_name = '', $user_email = '', $errors = '' ) {
 	$errmsg_email_aria = '';
 	if ( $errmsg_email ) {
 		$errmsg_email_aria = 'wp-signup-email-error ';
-		echo '<p class="error" id="wp-signup-email-error">' . $errmsg_email . '</p>';
+		echo '<p class="notice notice-error" id="wp-signup-email-error">' . $errmsg_email . '</p>';
 	}
 	?>
 	<input name="user_email" type="email" id="user_email" value="<?php echo esc_attr( $user_email ); ?>" maxlength="200" autocomplete="email" required="required" aria-describedby="<?php echo $errmsg_email_aria; ?>wp-signup-email-description" />
@@ -303,7 +303,7 @@ function show_user_form( $user_name = '', $user_email = '', $errors = '' ) {
 	// Extra fields.
 	$errmsg_generic = $errors->get_error_message( 'generic' );
 	if ( $errmsg_generic ) {
-		echo '<p class="error" id="wp-signup-generic-error">' . $errmsg_generic . '</p>';
+		echo '<p class="notice notice-error" id="wp-signup-generic-error">' . $errmsg_generic . '</p>';
 	}
 	/**
 	 * Fires at the end of the new user account registration form.


### PR DESCRIPTION
# Remove `<strong>` tags from admin error notices by adding new CSS class `notice notice-error`

## Description

This PR addresses the inconsistent use of bold formatting in admin error notices. Currently, many error messages are wrapped entirely in `<strong>` tags, making the whole message bold. This PR aims to remove these unnecessary `<strong>` tags, improving readability and consistency with other admin notices.

## Changes proposed in this Pull Request:
- Remove `<strong>` tags that wrap entire error messages
- Retain bold formatting only for specific terms that require emphasis within messages
- Update the legacy CSS class `error` to the more modern `notice notice-error`


Trac ticket: https://core.trac.wordpress.org/ticket/50402

Props dkarfa, audrasjb, joedolson.
