### PR TITLE
Test: Add test for update time and date format on locale change

### DIFF
--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -264,18 +264,24 @@ if ( 'update' === $action ) { // We are saving settings sent from a settings pag
 		$options = $allowed_options[ $option_page ];
 	}
 
+	$using_locales_default_date_format = false;
+	$using_locales_default_time_format = false;
 	if ( 'general' === $option_page ) {
 		// Handle custom date/time formats.
 		if ( ! empty( $_POST['date_format'] ) && isset( $_POST['date_format_custom'] )
 			&& '\c\u\s\t\o\m' === wp_unslash( $_POST['date_format'] )
 		) {
 			$_POST['date_format'] = $_POST['date_format_custom'];
+		} elseif ( __( 'F j, Y' ) === $_POST['date_format'] ) {
+			$using_locales_default_date_format = true;
 		}
 
 		if ( ! empty( $_POST['time_format'] ) && isset( $_POST['time_format_custom'] )
 			&& '\c\u\s\t\o\m' === wp_unslash( $_POST['time_format'] )
 		) {
 			$_POST['time_format'] = $_POST['time_format_custom'];
+		} elseif ( __( 'g:i a' ) === $_POST['time_format'] ) {
+			$using_locales_default_time_format = true;
 		}
 
 		// Map UTC+- timezones to gmt_offsets and set timezone_string to empty.
@@ -353,6 +359,16 @@ if ( 'update' === $action ) { // We are saving settings sent from a settings pag
 		$user_language_new = get_user_locale();
 		if ( $user_language_old !== $user_language_new ) {
 			load_default_textdomain( $user_language_new );
+
+			// Set date/time formats to the new locale's defaults if the
+			// old locale's defaults were used before the update.
+			if ( $using_locales_default_date_format ) {
+				update_option( 'date_format', __( 'F j, Y' ) );
+			}
+
+			if ( $using_locales_default_time_format ) {
+				update_option( 'time_format', __( 'g:i a' ) );
+			}
 		}
 	} else {
 		add_settings_error( 'general', 'settings_updated', __( 'Settings save failed.' ), 'error' );

--- a/tests/phpunit/tests/l10n/switchingLocaleUpdatesDateTimeFormats.php
+++ b/tests/phpunit/tests/l10n/switchingLocaleUpdatesDateTimeFormats.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * @ticket 36259
+ * @group l10n
+ * @group i18n
+ */
+class Tests_I18n_SwitchingLocaleUpdatesDateTimeFormats extends WP_UnitTestCase {
+	/**
+	 * Original locale before tests.
+	 *
+	 * @var string
+	 */
+	private $orig_locale;
+
+	/**
+	 * Original date format.
+	 *
+	 * @var string
+	 */
+	private $orig_date_format;
+
+	/**
+	 * Original time format.
+	 *
+	 * @var string
+	 */
+	private $orig_time_format;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->orig_locale      = get_locale();
+		$this->orig_date_format = get_option( 'date_format' );
+		$this->orig_time_format = get_option( 'time_format' );
+
+		if ( 'en_US' !== $this->orig_locale ) {
+			switch_to_locale( 'en_US' );
+		}
+
+		update_option( 'date_format', 'F j, Y' );
+		update_option( 'time_format', 'g:i a' );
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		switch_to_locale( $this->orig_locale );
+		update_option( 'date_format', $this->orig_date_format );
+		update_option( 'time_format', $this->orig_time_format );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Mock the translation function for testing.
+	 *
+	 * @param string $locale The locale to mock translations for.
+	 */
+	private function mock_translations_for_locale( $locale ) {
+		global $l10n;
+
+		$translations = new MO();
+
+		if ( 'en_GB' === $locale ) {
+			$translations->add_entry(
+				new Translation_Entry(
+					array(
+						'singular'     => 'F j, Y',
+						'translations' => array( 'j F Y' ),
+					)
+				)
+			);
+			$translations->add_entry(
+				new Translation_Entry(
+					array(
+						'singular'     => 'g:i a',
+						'translations' => array( 'H:i' ),
+					)
+				)
+			);
+		}
+
+		$l10n['default'] = &$translations;
+	}
+
+	/**
+	 * @covers ::update_date_time_formats_on_locale_change
+	 */
+	public function test_switching_language_updates_date_time_formats() {
+		$user_language_old = get_locale();
+
+		$using_locales_default_date_format = ( __( 'F j, Y' ) === get_option( 'date_format' ) );
+		$using_locales_default_time_format = ( __( 'g:i a' ) === get_option( 'time_format' ) );
+
+		// Switch to British English and mock translations
+		$locale = 'en_GB';
+		switch_to_locale( $locale );
+		$this->mock_translations_for_locale( $locale );
+
+		$user_language_new = get_locale();
+		$this->assertSame( $locale, $user_language_new, 'Locale should have changed to ' . $locale );
+
+		$this->assertSame( 'j F Y', __( 'F j, Y' ) );
+		$this->assertSame( 'H:i', __( 'g:i a' ) );
+
+		// Simulate the date and time formats being updated
+		if ( $user_language_old !== $user_language_new ) {
+			if ( $using_locales_default_date_format ) {
+				update_option( 'date_format', __( 'F j, Y' ) );
+			}
+
+			if ( $using_locales_default_time_format ) {
+				update_option( 'time_format', __( 'g:i a' ) );
+			}
+		}
+
+		$this->assertSame( 'j F Y', get_option( 'date_format' ), 'Date format was not updated to British English default' );
+		$this->assertSame( 'H:i', get_option( 'time_format' ), 'Time format was not updated to British English default' );
+	}
+}


### PR DESCRIPTION
Trac ticket: [#36259](https://core.trac.wordpress.org/ticket/36259)

Patch used: https://core.trac.wordpress.org/attachment/ticket/36259/36259.diff

## Description:

Added a unit test that verifies date and time formats are updated when switching locale.

## Testing Instruction:
Run following command to verify the test:

```
npm run test:php -- --filter=Tests_I18n_SwitchingLocaleUpdatesDateTimeFormats
```