### PR TITLE
Update import.php

### DIFF
--- a/src/wp-admin/import.php
+++ b/src/wp-admin/import.php
@@ -30,7 +30,7 @@ get_current_screen()->add_help_tab(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 	'<p>' . __( '<a href="https://wordpress.org/documentation/article/tools-import-screen/">Documentation on Import</a>' ) . '</p>' .
-	'<p>' . __( '<a href="https://wordpress.org/support/forums">Support forums</a>' ) . '</p>'
+	'<p>' . __( '<a href="https://wordpress.org/support/forums/">Support forums</a>' ) . '</p>'
 );
 
 if ( current_user_can( 'install_plugins' ) ) {

--- a/src/wp-admin/import.php
+++ b/src/wp-admin/import.php
@@ -30,7 +30,7 @@ get_current_screen()->add_help_tab(
 get_current_screen()->set_help_sidebar(
 	'<p><strong>' . __( 'For more information:' ) . '</strong></p>' .
 	'<p>' . __( '<a href="https://wordpress.org/documentation/article/tools-import-screen/">Documentation on Import</a>' ) . '</p>' .
-	'<p>' . __( '<a href="https://wordpress.org/support/forums">Support</a>' ) . '</p>'
+	'<p>' . __( '<a href="https://wordpress.org/support/forums">Support forums</a>' ) . '</p>'
 );
 
 if ( current_user_can( 'install_plugins' ) ) {


### PR DESCRIPTION
Re the Help tab in dashboard.
Change the only instance of "Support" into "Support forums".
In all other Help tabs in dashboard there's a link with label "Support forums".

Edit by @audrasjb: https://core.trac.wordpress.org/ticket/63016