### PR TITLE
Script Loader: Remove compression constants and related code

### DIFF
--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -1464,24 +1464,6 @@ class WP_Debug_Data {
 			$concatenate_scripts_debug = 'undefined';
 		}
 
-		// Check COMPRESS_SCRIPTS.
-		if ( defined( 'COMPRESS_SCRIPTS' ) ) {
-			$compress_scripts       = COMPRESS_SCRIPTS ? __( 'Enabled' ) : __( 'Disabled' );
-			$compress_scripts_debug = COMPRESS_SCRIPTS ? 'true' : 'false';
-		} else {
-			$compress_scripts       = __( 'Undefined' );
-			$compress_scripts_debug = 'undefined';
-		}
-
-		// Check COMPRESS_CSS.
-		if ( defined( 'COMPRESS_CSS' ) ) {
-			$compress_css       = COMPRESS_CSS ? __( 'Enabled' ) : __( 'Disabled' );
-			$compress_css_debug = COMPRESS_CSS ? 'true' : 'false';
-		} else {
-			$compress_css       = __( 'Undefined' );
-			$compress_css_debug = 'undefined';
-		}
-
 		// Check WP_ENVIRONMENT_TYPE.
 		if ( defined( 'WP_ENVIRONMENT_TYPE' ) ) {
 			$wp_environment_type       = WP_ENVIRONMENT_TYPE ? WP_ENVIRONMENT_TYPE : __( 'Empty value' );
@@ -1561,16 +1543,6 @@ class WP_Debug_Data {
 				'label' => 'CONCATENATE_SCRIPTS',
 				'value' => $concatenate_scripts,
 				'debug' => $concatenate_scripts_debug,
-			),
-			'COMPRESS_SCRIPTS'    => array(
-				'label' => 'COMPRESS_SCRIPTS',
-				'value' => $compress_scripts,
-				'debug' => $compress_scripts_debug,
-			),
-			'COMPRESS_CSS'        => array(
-				'label' => 'COMPRESS_CSS',
-				'value' => $compress_css,
-				'debug' => $compress_css_debug,
 			),
 			'WP_ENVIRONMENT_TYPE' => array(
 				'label' => 'WP_ENVIRONMENT_TYPE',

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2395,15 +2395,25 @@ function _print_styles() {
  * @since 2.8.0
  *
  * @global bool $concatenate_scripts
+ * @global bool $compress_scripts
+ * @global bool $compress_css
  */
 function script_concat_settings() {
-	global $concatenate_scripts;
+	global $concatenate_scripts, $compress_scripts, $compress_css;
 
 	if ( ! isset( $concatenate_scripts ) ) {
 		$concatenate_scripts = defined( 'CONCATENATE_SCRIPTS' ) ? CONCATENATE_SCRIPTS : true;
 		if ( ( ! is_admin() && ! did_action( 'login_init' ) ) || ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ) {
 			$concatenate_scripts = false;
 		}
+	}
+
+	if ( ! isset( $compress_scripts ) ) {
+		$compress_scripts = true;
+	}
+
+	if ( ! isset( $compress_css ) ) {
+		$compress_css = true;
 	}
 }
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -5,9 +5,6 @@
  * Several constants are used to manage the loading, concatenating and compression of scripts and CSS:
  * define('SCRIPT_DEBUG', true); loads the development (non-minified) versions of all scripts and CSS, and disables compression and concatenation,
  * define('CONCATENATE_SCRIPTS', false); disables compression and concatenation of scripts and CSS,
- * define('COMPRESS_SCRIPTS', false); disables compression of scripts,
- * define('COMPRESS_CSS', false); disables compression of CSS,
- * define('ENFORCE_GZIP', true); forces gzip for compression (default is deflate).
  *
  * The globals $concatenate_scripts, $compress_scripts and $compress_css can be set by plugins
  * to temporarily override the above settings. Also a compression test is run once and the result is saved
@@ -2185,42 +2182,36 @@ function print_footer_scripts() {
  * @ignore
  *
  * @global WP_Scripts $wp_scripts
- * @global bool       $compress_scripts
  */
 function _print_scripts() {
-	global $wp_scripts, $compress_scripts;
+    global $wp_scripts;
 
-	$zip = $compress_scripts ? 1 : 0;
-	if ( $zip && defined( 'ENFORCE_GZIP' ) && ENFORCE_GZIP ) {
-		$zip = 'gzip';
-	}
+    $concat    = trim( $wp_scripts->concat, ', ' );
+    $type_attr = current_theme_supports( 'html5', 'script' ) ? '' : " type='text/javascript'";
 
-	$concat    = trim( $wp_scripts->concat, ', ' );
-	$type_attr = current_theme_supports( 'html5', 'script' ) ? '' : " type='text/javascript'";
+    if ( $concat ) {
+        if ( ! empty( $wp_scripts->print_code ) ) {
+            echo "\n<script{$type_attr}>\n";
+            echo "/* <![CDATA[ */\n"; // Not needed in HTML 5.
+            echo $wp_scripts->print_code;
+            echo "/* ]]> */\n";
+            echo "</script>\n";
+        }
 
-	if ( $concat ) {
-		if ( ! empty( $wp_scripts->print_code ) ) {
-			echo "\n<script{$type_attr}>\n";
-			echo "/* <![CDATA[ */\n"; // Not needed in HTML 5.
-			echo $wp_scripts->print_code;
-			echo "/* ]]> */\n";
-			echo "</script>\n";
-		}
+        $concat       = str_split( $concat, 128 );
+        $concatenated = '';
 
-		$concat       = str_split( $concat, 128 );
-		$concatenated = '';
+        foreach ( $concat as $key => $chunk ) {
+            $concatenated .= "&load%5Bchunk_{$key}%5D={$chunk}";
+        }
 
-		foreach ( $concat as $key => $chunk ) {
-			$concatenated .= "&load%5Bchunk_{$key}%5D={$chunk}";
-		}
+        $src = $wp_scripts->base_url . "/wp-admin/load-scripts.php?" . ltrim( $concatenated, '&' ) . '&ver=' . $wp_scripts->default_version;
+        echo "<script{$type_attr} src='" . esc_attr( $src ) . "'></script>\n";
+    }
 
-		$src = $wp_scripts->base_url . "/wp-admin/load-scripts.php?c={$zip}" . $concatenated . '&ver=' . $wp_scripts->default_version;
-		echo "<script{$type_attr} src='" . esc_attr( $src ) . "'></script>\n";
-	}
-
-	if ( ! empty( $wp_scripts->print_html ) ) {
-		echo $wp_scripts->print_html;
-	}
+    if ( ! empty( $wp_scripts->print_html ) ) {
+        echo $wp_scripts->print_html;
+    }
 }
 
 /**
@@ -2365,84 +2356,55 @@ function print_late_styles() {
  *
  * @ignore
  * @since 3.3.0
- *
- * @global bool $compress_css
  */
 function _print_styles() {
-	global $compress_css;
+    $wp_styles = wp_styles();
 
-	$wp_styles = wp_styles();
+    $concat    = trim( $wp_styles->concat, ', ' );
+    $type_attr = current_theme_supports( 'html5', 'style' ) ? '' : ' type="text/css"';
 
-	$zip = $compress_css ? 1 : 0;
-	if ( $zip && defined( 'ENFORCE_GZIP' ) && ENFORCE_GZIP ) {
-		$zip = 'gzip';
-	}
+    if ( $concat ) {
+        $dir = $wp_styles->text_direction;
+        $ver = $wp_styles->default_version;
 
-	$concat    = trim( $wp_styles->concat, ', ' );
-	$type_attr = current_theme_supports( 'html5', 'style' ) ? '' : ' type="text/css"';
+        $concat       = str_split( $concat, 128 );
+        $concatenated = '';
 
-	if ( $concat ) {
-		$dir = $wp_styles->text_direction;
-		$ver = $wp_styles->default_version;
+        foreach ( $concat as $key => $chunk ) {
+            $concatenated .= "&load%5Bchunk_{$key}%5D={$chunk}";
+        }
 
-		$concat       = str_split( $concat, 128 );
-		$concatenated = '';
+        $href = $wp_styles->base_url . "/wp-admin/load-styles.php?dir={$dir}" . $concatenated . '&ver=' . $ver;
+        echo "<link rel='stylesheet' href='" . esc_attr( $href ) . "'{$type_attr} media='all' />\n";
 
-		foreach ( $concat as $key => $chunk ) {
-			$concatenated .= "&load%5Bchunk_{$key}%5D={$chunk}";
-		}
+        if ( ! empty( $wp_styles->print_code ) ) {
+            echo "<style{$type_attr}>\n";
+            echo $wp_styles->print_code;
+            echo "\n</style>\n";
+        }
+    }
 
-		$href = $wp_styles->base_url . "/wp-admin/load-styles.php?c={$zip}&dir={$dir}" . $concatenated . '&ver=' . $ver;
-		echo "<link rel='stylesheet' href='" . esc_attr( $href ) . "'{$type_attr} media='all' />\n";
-
-		if ( ! empty( $wp_styles->print_code ) ) {
-			echo "<style{$type_attr}>\n";
-			echo $wp_styles->print_code;
-			echo "\n</style>\n";
-		}
-	}
-
-	if ( ! empty( $wp_styles->print_html ) ) {
-		echo $wp_styles->print_html;
-	}
+    if ( ! empty( $wp_styles->print_html ) ) {
+        echo $wp_styles->print_html;
+    }
 }
 
 /**
- * Determines the concatenation and compression settings for scripts and styles.
+ * Determines the concatenation settings for scripts and styles.
  *
  * @since 2.8.0
  *
  * @global bool $concatenate_scripts
- * @global bool $compress_scripts
- * @global bool $compress_css
  */
 function script_concat_settings() {
-	global $concatenate_scripts, $compress_scripts, $compress_css;
+    global $concatenate_scripts;
 
-	$compressed_output = ( ini_get( 'zlib.output_compression' ) || 'ob_gzhandler' === ini_get( 'output_handler' ) );
-
-	$can_compress_scripts = ! wp_installing() && get_site_option( 'can_compress_scripts' );
-
-	if ( ! isset( $concatenate_scripts ) ) {
-		$concatenate_scripts = defined( 'CONCATENATE_SCRIPTS' ) ? CONCATENATE_SCRIPTS : true;
-		if ( ( ! is_admin() && ! did_action( 'login_init' ) ) || ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ) {
-			$concatenate_scripts = false;
-		}
-	}
-
-	if ( ! isset( $compress_scripts ) ) {
-		$compress_scripts = defined( 'COMPRESS_SCRIPTS' ) ? COMPRESS_SCRIPTS : true;
-		if ( $compress_scripts && ( ! $can_compress_scripts || $compressed_output ) ) {
-			$compress_scripts = false;
-		}
-	}
-
-	if ( ! isset( $compress_css ) ) {
-		$compress_css = defined( 'COMPRESS_CSS' ) ? COMPRESS_CSS : true;
-		if ( $compress_css && ( ! $can_compress_scripts || $compressed_output ) ) {
-			$compress_css = false;
-		}
-	}
+    if ( ! isset( $concatenate_scripts ) ) {
+        $concatenate_scripts = defined( 'CONCATENATE_SCRIPTS' ) ? CONCATENATE_SCRIPTS : true;
+        if ( ( ! is_admin() && ! did_action( 'login_init' ) ) || ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ) {
+            $concatenate_scripts = false;
+        }
+    }
 }
 
 /**

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2184,34 +2184,34 @@ function print_footer_scripts() {
  * @global WP_Scripts $wp_scripts
  */
 function _print_scripts() {
-    global $wp_scripts;
+	global $wp_scripts;
 
-    $concat    = trim( $wp_scripts->concat, ', ' );
-    $type_attr = current_theme_supports( 'html5', 'script' ) ? '' : " type='text/javascript'";
+	$concat    = trim( $wp_scripts->concat, ', ' );
+	$type_attr = current_theme_supports( 'html5', 'script' ) ? '' : " type='text/javascript'";
 
-    if ( $concat ) {
-        if ( ! empty( $wp_scripts->print_code ) ) {
-            echo "\n<script{$type_attr}>\n";
-            echo "/* <![CDATA[ */\n"; // Not needed in HTML 5.
-            echo $wp_scripts->print_code;
-            echo "/* ]]> */\n";
-            echo "</script>\n";
-        }
+	if ( $concat ) {
+		if ( ! empty( $wp_scripts->print_code ) ) {
+			echo "\n<script{$type_attr}>\n";
+			echo "/* <![CDATA[ */\n"; // Not needed in HTML 5.
+			echo $wp_scripts->print_code;
+			echo "/* ]]> */\n";
+			echo "</script>\n";
+		}
 
-        $concat       = str_split( $concat, 128 );
-        $concatenated = '';
+		$concat       = str_split( $concat, 128 );
+		$concatenated = '';
 
-        foreach ( $concat as $key => $chunk ) {
-            $concatenated .= "&load%5Bchunk_{$key}%5D={$chunk}";
-        }
+		foreach ( $concat as $key => $chunk ) {
+			$concatenated .= "&load%5Bchunk_{$key}%5D={$chunk}";
+		}
 
-        $src = $wp_scripts->base_url . "/wp-admin/load-scripts.php?" . ltrim( $concatenated, '&' ) . '&ver=' . $wp_scripts->default_version;
-        echo "<script{$type_attr} src='" . esc_attr( $src ) . "'></script>\n";
-    }
+		$src = $wp_scripts->base_url . '/wp-admin/load-scripts.php?' . ltrim( $concatenated, '&' ) . '&ver=' . $wp_scripts->default_version;
+		echo "<script{$type_attr} src='" . esc_attr( $src ) . "'></script>\n";
+	}
 
-    if ( ! empty( $wp_scripts->print_html ) ) {
-        echo $wp_scripts->print_html;
-    }
+	if ( ! empty( $wp_scripts->print_html ) ) {
+		echo $wp_scripts->print_html;
+	}
 }
 
 /**
@@ -2358,35 +2358,35 @@ function print_late_styles() {
  * @since 3.3.0
  */
 function _print_styles() {
-    $wp_styles = wp_styles();
+	$wp_styles = wp_styles();
 
-    $concat    = trim( $wp_styles->concat, ', ' );
-    $type_attr = current_theme_supports( 'html5', 'style' ) ? '' : ' type="text/css"';
+	$concat    = trim( $wp_styles->concat, ', ' );
+	$type_attr = current_theme_supports( 'html5', 'style' ) ? '' : ' type="text/css"';
 
-    if ( $concat ) {
-        $dir = $wp_styles->text_direction;
-        $ver = $wp_styles->default_version;
+	if ( $concat ) {
+		$dir = $wp_styles->text_direction;
+		$ver = $wp_styles->default_version;
 
-        $concat       = str_split( $concat, 128 );
-        $concatenated = '';
+		$concat       = str_split( $concat, 128 );
+		$concatenated = '';
 
-        foreach ( $concat as $key => $chunk ) {
-            $concatenated .= "&load%5Bchunk_{$key}%5D={$chunk}";
-        }
+		foreach ( $concat as $key => $chunk ) {
+			$concatenated .= "&load%5Bchunk_{$key}%5D={$chunk}";
+		}
 
-        $href = $wp_styles->base_url . "/wp-admin/load-styles.php?dir={$dir}" . $concatenated . '&ver=' . $ver;
-        echo "<link rel='stylesheet' href='" . esc_attr( $href ) . "'{$type_attr} media='all' />\n";
+		$href = $wp_styles->base_url . "/wp-admin/load-styles.php?dir={$dir}" . $concatenated . '&ver=' . $ver;
+		echo "<link rel='stylesheet' href='" . esc_attr( $href ) . "'{$type_attr} media='all' />\n";
 
-        if ( ! empty( $wp_styles->print_code ) ) {
-            echo "<style{$type_attr}>\n";
-            echo $wp_styles->print_code;
-            echo "\n</style>\n";
-        }
-    }
+		if ( ! empty( $wp_styles->print_code ) ) {
+			echo "<style{$type_attr}>\n";
+			echo $wp_styles->print_code;
+			echo "\n</style>\n";
+		}
+	}
 
-    if ( ! empty( $wp_styles->print_html ) ) {
-        echo $wp_styles->print_html;
-    }
+	if ( ! empty( $wp_styles->print_html ) ) {
+		echo $wp_styles->print_html;
+	}
 }
 
 /**
@@ -2397,14 +2397,14 @@ function _print_styles() {
  * @global bool $concatenate_scripts
  */
 function script_concat_settings() {
-    global $concatenate_scripts;
+	global $concatenate_scripts;
 
-    if ( ! isset( $concatenate_scripts ) ) {
-        $concatenate_scripts = defined( 'CONCATENATE_SCRIPTS' ) ? CONCATENATE_SCRIPTS : true;
-        if ( ( ! is_admin() && ! did_action( 'login_init' ) ) || ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ) {
-            $concatenate_scripts = false;
-        }
-    }
+	if ( ! isset( $concatenate_scripts ) ) {
+		$concatenate_scripts = defined( 'CONCATENATE_SCRIPTS' ) ? CONCATENATE_SCRIPTS : true;
+		if ( ( ! is_admin() && ! did_action( 'login_init' ) ) || ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ) {
+			$concatenate_scripts = false;
+		}
+	}
 }
 
 /**

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2,13 +2,13 @@
 /**
  * WordPress scripts and styles default loader.
  *
- * Several constants are used to manage the loading, concatenating and compression of scripts and CSS:
+ * These constants are used to manage the loading and concatenating of scripts and CSS:
  * define('SCRIPT_DEBUG', true); loads the development (non-minified) versions of all scripts and CSS, and disables compression and concatenation,
  * define('CONCATENATE_SCRIPTS', false); disables compression and concatenation of scripts and CSS,
  *
- * The globals $concatenate_scripts, $compress_scripts and $compress_css can be set by plugins
- * to temporarily override the above settings. Also a compression test is run once and the result is saved
- * as option 'can_compress_scripts' (0/1). The test will run again if that option is deleted.
+ * The global $concatenate_scripts can be set by plugins to temporarily override the above settings.
+ * Also a compression test is run once and the result is saved as option 'can_compress_scripts' (0/1).
+ * The test will run again if that option is deleted.
  *
  * @package WordPress
  */

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -1445,7 +1445,7 @@ HTML
 		// Reset global before asserting.
 		$concatenate_scripts = $old_value;
 
-		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep,two-concat-dep,three-concat-dep&amp;ver={$wp_version}'></script>\n";
+		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?load%5Bchunk_0%5D=one-concat-dep,two-concat-dep,three-concat-dep&amp;ver={$wp_version}'></script>\n";
 		$expected .= "<script type='text/javascript' src='/main-script.js' id='main-defer-script-js' defer='defer' data-wp-strategy='defer'></script>\n";
 
 		$this->assertEqualHTML( $expected, $print_scripts, '<body>', 'Scripts are being incorrectly concatenated when a main script is registered with a "defer" loading strategy. Deferred scripts should not be part of the script concat loading query.' );
@@ -1480,7 +1480,7 @@ HTML
 		// Reset global before asserting.
 		$concatenate_scripts = $old_value;
 
-		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep-1,two-concat-dep-1,three-concat-dep-1&amp;ver={$wp_version}'></script>\n";
+		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?load%5Bchunk_0%5D=one-concat-dep-1,two-concat-dep-1,three-concat-dep-1&amp;ver={$wp_version}'></script>\n";
 		$expected .= "<script type='text/javascript' src='/main-script.js' id='main-async-script-1-js' async='async' data-wp-strategy='async'></script>\n";
 
 		$this->assertEqualHTML( $expected, $print_scripts, '<body>', 'Scripts are being incorrectly concatenated when a main script is registered with an "async" loading strategy. Async scripts should not be part of the script concat loading query.' );
@@ -1519,7 +1519,7 @@ HTML
 		// Reset global before asserting.
 		$concatenate_scripts = $old_value;
 
-		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep-2,two-concat-dep-2,three-concat-dep-2,four-concat-dep-2,five-concat-dep-2,six-concat-dep-2&amp;ver={$wp_version}'></script>\n";
+		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?load%5Bchunk_0%5D=one-concat-dep-2,two-concat-dep-2,three-concat-dep-2,four-concat-dep-2,five-concat-dep-2,six-concat-dep-2&amp;ver={$wp_version}'></script>\n";
 		$expected .= "<script type='text/javascript' src='/main-script.js' id='deferred-script-2-js' defer='defer' data-wp-strategy='defer'></script>\n";
 
 		$this->assertEqualHTML( $expected, $print_scripts, '<body>', 'Scripts are being incorrectly concatenated when a main script is registered as deferred after other blocking scripts are registered. Deferred scripts should not be part of the script concat loader query string. ' );
@@ -1604,7 +1604,7 @@ HTML
 		wp_print_scripts();
 		$print_scripts = get_echo( '_print_scripts' );
 
-		$expected = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one,two,three&amp;ver={$wp_version}'></script>\n";
+		$expected = "<script type='text/javascript' src='/wp-admin/load-scripts.php?load%5Bchunk_0%5D=one,two,three&amp;ver={$wp_version}'></script>\n";
 
 		$this->assertSame( $expected, $print_scripts );
 	}
@@ -2062,7 +2062,7 @@ HTML;
 		wp_add_inline_script( 'two', 'console.log("after two");' );
 		wp_add_inline_script( 'three', 'console.log("after three");' );
 
-		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one&amp;ver={$wp_version}'></script>\n";
+		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?load%5Bchunk_0%5D=one&amp;ver={$wp_version}'></script>\n";
 		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}two.js?ver={$wp_version}' id='two-js'></script>\n";
 		$expected .= "<script type='text/javascript' id='two-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after two\");\n/* ]]> */\n</script>\n";
 		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}three.js?ver={$wp_version}' id='three-js'></script>\n";
@@ -2115,7 +2115,7 @@ HTML;
 		$wp_scripts->base_url  = '';
 		$wp_scripts->do_concat = true;
 
-		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core,jquery-migrate&amp;ver={$wp_version}'></script>\n";
+		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?load%5Bchunk_0%5D=jquery-core,jquery-migrate&amp;ver={$wp_version}'></script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
 		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n/* ]]> */\n</script>\n";
 
@@ -2139,7 +2139,7 @@ HTML;
 		$wp_scripts->base_url  = '';
 		$wp_scripts->do_concat = true;
 
-		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core,jquery-migrate&amp;ver={$wp_version}'></script>\n";
+		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?load%5Bchunk_0%5D=jquery-core,jquery-migrate&amp;ver={$wp_version}'></script>\n";
 		$expected .= "<!--[if gte IE 9]>\n";
 		$expected .= "<script type=\"text/javascript\" src=\"http://example.com\" id=\"test-example-js\"></script>\n";
 		$expected .= "<script type=\"text/javascript\" id=\"test-example-js-after\">\n/* <![CDATA[ */\nconsole.log(\"after\");\n/* ]]> */\n</script>\n";
@@ -2167,7 +2167,7 @@ HTML;
 		$wp_scripts->base_url  = '';
 		$wp_scripts->do_concat = true;
 
-		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core,jquery-migrate&amp;ver={$wp_version}'></script>\n";
+		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?load%5Bchunk_0%5D=jquery-core,jquery-migrate&amp;ver={$wp_version}'></script>\n";
 		$expected .= "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n/* ]]> */\n</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
 
@@ -2192,7 +2192,7 @@ HTML;
 		$wp_scripts->base_url  = '';
 		$wp_scripts->do_concat = true;
 
-		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core,jquery-migrate,wp-dom-ready,wp-hooks&amp;ver={$wp_version}'></script>\n";
+		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?load%5Bchunk_0%5D=jquery-core,jquery-migrate,wp-dom-ready,wp-hooks&amp;ver={$wp_version}'></script>\n";
 		$expected .= "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n/* ]]> */\n</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
 		$expected .= "<script type='text/javascript' src='/wp-includes/js/dist/i18n.min.js' id='wp-i18n-js'></script>\n";
@@ -2306,7 +2306,7 @@ HTML;
 		wp_add_inline_script( 'three', 'console.log("before three");', 'before' );
 		wp_enqueue_script( 'four', '/wp-includes/js/script4.js' );
 
-		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one,two&amp;ver={$wp_version}'></script>\n";
+		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?load%5Bchunk_0%5D=one,two&amp;ver={$wp_version}'></script>\n";
 		$expected .= "<script type='text/javascript' id='three-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before three\");\n/* ]]> */\n</script>\n";
 		$expected .= "<script type='text/javascript' src='/wp-includes/js/script3.js?ver={$wp_version}' id='three-js'></script>\n";
 		$expected .= "<script type='text/javascript' src='/wp-includes/js/script4.js?ver={$wp_version}' id='four-js'></script>\n";
@@ -3063,7 +3063,7 @@ HTML;
 		);
 
 		// The non-default script should end concatenation and maintain order.
-		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core&amp;ver={$wp_version}'></script>\n";
+		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?load%5Bchunk_0%5D=jquery-core&amp;ver={$wp_version}'></script>\n";
 		$expected .= "<script type='text/javascript' src='/plugins/wp-i18n.js' id='wp-i18n-js'></script>\n";
 		$expected .= "<script type='text/javascript' src='/default/common.js' id='common-js'></script>\n";
 


### PR DESCRIPTION
Remove legacy compression constants (COMPRESS_SCRIPTS, COMPRESS_CSS, ENFORCE_GZIP) and related code.

Before:
<img width="496" alt="Screenshot 2025-02-26 at 12 07 02 PM" src="https://github.com/user-attachments/assets/3a26f657-8b4e-4eb6-98cf-9cd146d4d75e" />

After:
<img width="517" alt="Screenshot 2025-02-26 at 12 06 03 PM" src="https://github.com/user-attachments/assets/6f7c43af-d85e-449e-8264-738d2f73f3f7" />

Trac ticket: [#63017](https://core.trac.wordpress.org/ticket/63017)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
