### PR TITLE
Run performance testing on PHP 8.4

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -106,6 +106,7 @@ jobs:
       multisite: ${{ matrix.multisite }}
       subject: ${{ matrix.subject }}
       TARGET_SHA: ${{ needs.determine-matrix.outputs.target_sha }}
+      php-version: '8.4'
 
   compare:
     name: ${{ matrix.label }}

--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -68,7 +68,6 @@ env:
   LOCAL_PHP_MEMCACHED: ${{ inputs.memcached }}
   LOCAL_PHP: ${{ inputs.php-version }}${{ 'latest' != inputs.php-version && '-fpm' || '' }}
   LOCAL_MULTISITE: ${{ inputs.multisite }}
-  LOCAL_DB_VERSION: '9.2'
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.

--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -68,6 +68,7 @@ env:
   LOCAL_PHP_MEMCACHED: ${{ inputs.memcached }}
   LOCAL_PHP: ${{ inputs.php-version }}${{ 'latest' != inputs.php-version && '-fpm' || '' }}
   LOCAL_MULTISITE: ${{ inputs.multisite }}
+  LOCAL_DB_VERSION: '9.2'
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.


### PR DESCRIPTION
The PHPUnit test suite when run on PHP 8.4 with MySQL 8.4 seems to be taking 2-3x the amount of time as all other jobs. This switches the performance testing workflow to use PHP 8.4 to see if there is a noticeable change in measured performance. 

[See Slack conversation](https://wordpress.slack.com/archives/C08D0Q6BHNY/p1740590291554779).

Trac ticket: https://core.trac.wordpress.org/ticket/63026

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
