### PR TITLE
Fix missing white space between comment reply title and cancel comment reply link

### DIFF
--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2657,7 +2657,7 @@ function comment_form( $args = array(), $post = null ) {
 		'title_reply_to'       => __( 'Leave a Reply to %s' ),
 		'title_reply_before'   => '<h3 id="reply-title" class="comment-reply-title">',
 		'title_reply_after'    => '</h3>',
-		'cancel_reply_before'  => ' <small>',
+		'cancel_reply_before'  => ' <small> ',
 		'cancel_reply_after'   => '</small>',
 		'cancel_reply_link'    => __( 'Cancel reply' ),
 		'label_submit'         => __( 'Post Comment' ),


### PR DESCRIPTION
Fix missing white space between comment reply title and cancel comment reply link.
Currently all themes use CSS to fix this.

There's a single white space added, but that's ignored: `' <small>'` 
When adding white space before ánd after the tag it will display properly: `' <small> '`

As mentioned in [this trac ticket](https://core.trac.wordpress.org/ticket/51589).

![Cancel reply](https://github.com/user-attachments/assets/cbca27dd-5c20-4533-b059-dfae6216e9c0)

