### PR TITLE
Do not rely on the config file to boot

### DIFF
--- a/src/wp-load.php
+++ b/src/wp-load.php
@@ -103,3 +103,6 @@ if ( file_exists( ABSPATH . 'wp-config.php' ) ) {
 
 	wp_die( $die, __( 'WordPress &rsaquo; Error' ) );
 }
+
+/** Sets up WordPress vars and included files. */
+require_once ABSPATH . 'wp-settings.php';

--- a/wp-config-sample.php
+++ b/wp-config-sample.php
@@ -92,11 +92,3 @@ define( 'WP_DEBUG', false );
 
 
 /* That's all, stop editing! Happy publishing. */
-
-/** Absolute path to the WordPress directory. */
-if ( ! defined( 'ABSPATH' ) ) {
-	define( 'ABSPATH', __DIR__ . '/' );
-}
-
-/** Sets up WordPress vars and included files. */
-require_once ABSPATH . 'wp-settings.php';


### PR DESCRIPTION
Allow installations' main config files to used or analysed by external tools, by simple inclusion, without booting WP.

Trac ticket: https://core.trac.wordpress.org/ticket/5276

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
