### PR TITLE
REST API: Add default templates and template part areas data to index

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1263,7 +1263,7 @@ function rest_add_application_passwords_to_index( $response ) {
  * @param WP_REST_Response $response REST API response.
  * @return WP_REST_Response Modified REST API response.
  */
-function rest_add_templates_default_data_to_index( WP_REST_Response $response ) {
+function rest_add_templates_default_data_to_index( $response ) {
 	if ( ! is_user_logged_in() ) {
 		return $response;
 	}

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -255,6 +255,7 @@ function rest_api_default_filters() {
 
 	add_filter( 'rest_pre_dispatch', 'rest_handle_options_request', 10, 3 );
 	add_filter( 'rest_index', 'rest_add_application_passwords_to_index' );
+	add_filter( 'rest_index', 'rest_add_templates_default_data_to_index' );
 }
 
 /**
@@ -1250,6 +1251,31 @@ function rest_add_application_passwords_to_index( $response ) {
 			'authorization' => admin_url( 'authorize-application.php' ),
 		),
 	);
+
+	return $response;
+}
+
+/**
+ * Adds the default template types and template part areas to the REST API index.
+ *
+ * @since 6.8.0
+ *
+ * @param WP_REST_Response $response REST API response.
+ * @return WP_REST_Response Modified REST API response.
+ */
+function rest_add_templates_default_data_to_index( WP_REST_Response $response ) {
+	if ( ! is_user_logged_in() ) {
+		return $response;
+	}
+
+	$default_template_types = array();
+	foreach ( (array) get_default_block_template_types() as $slug => $template_type ) {
+		$template_type['slug']    = (string) $slug;
+		$default_template_types[] = $template_type;
+	}
+
+	$response->data['default_template_part_areas'] = get_allowed_block_template_part_areas();
+	$response->data['default_template_types']      = $default_template_types;
 
 	return $response;
 }

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -1264,7 +1264,17 @@ function rest_add_application_passwords_to_index( $response ) {
  * @return WP_REST_Response Modified REST API response.
  */
 function rest_add_templates_default_data_to_index( $response ) {
-	if ( ! is_user_logged_in() ) {
+	$can_edit_posts = current_user_can( 'edit_posts' );
+	if ( ! $can_edit_posts ) {
+		foreach ( get_post_types( array( 'show_in_rest' => true ), 'objects' ) as $post_type ) {
+			if ( current_user_can( $post_type->cap->edit_posts ) ) {
+				$can_edit_posts = true;
+				break;
+			}
+		}
+	}
+
+	if ( ! $can_edit_posts ) {
 		return $response;
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -2587,29 +2587,30 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 
 	/**
 	 * @ticket 62574
+	 *
+	 * @dataProvider data_rest_index_template_and_template_part_default
+	 *
+	 * @param string $user_id     The test user role.
+	 * @param bool   $has_values Is data returned by REST index endpoint.
 	 */
-	public function test_populates_templates_default_data_for_logged_in_user() {
-		wp_set_current_user( self::$admin_id );
+	public function test_template_and_template_part_area_defaults( $role, $has_values ) {
+		if ( $role ) {
+			$user_id = self::factory()->user->create( array( 'role' => $role ) );
+			wp_set_current_user( $user_id );
+		}
+
 		$server  = new WP_REST_Server();
 		$request = new WP_REST_Request( 'GET', '/' );
 		$index   = $server->dispatch( $request );
 		$data    = $index->get_data();
 
-		$this->assertArrayHasKey( 'default_template_part_areas', $data );
-		$this->assertArrayHasKey( 'default_template_types', $data );
-	}
-
-	/**
-	 * @ticket 62574
-	 */
-	public function test_does_not_populate_templates_default_data_for_logged_out_user() {
-		$server  = new WP_REST_Server();
-		$request = new WP_REST_Request( 'GET', '/' );
-		$index   = $server->dispatch( $request );
-		$data    = $index->get_data();
-
-		$this->assertArrayNotHasKey( 'default_template_part_areas', $data );
-		$this->assertArrayNotHasKey( 'default_template_types', $data );
+		if ( $has_values ) {
+			$this->assertArrayHasKey( 'default_template_part_areas', $data );
+			$this->assertArrayHasKey( 'default_template_types', $data );
+		} else {
+			$this->assertArrayNotHasKey( 'default_template_part_areas', $data );
+			$this->assertArrayNotHasKey( 'default_template_types', $data );
+		}
 	}
 
 	public function _validate_as_integer_123( $value, $request, $key ) {
@@ -2642,6 +2643,22 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 			array( true, false ),
 			array( false, true ),
 			array( false, false ),
+		);
+	}
+
+	/**
+	 * @return array {
+	 *     @type array {
+	 *         @type string $role       The test user role.
+	 *         @type bool   $has_values Is data returned by REST index endpoint.
+	 *     }
+	 * }
+	 */
+	public function data_rest_index_template_and_template_part_default() {
+		return array(
+			array( 'subscriber', false ),
+			array( 'contributor', true ),
+			array( 'editor', true ),
 		);
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-server.php
+++ b/tests/phpunit/tests/rest-api/rest-server.php
@@ -2585,6 +2585,33 @@ class Tests_REST_Server extends WP_Test_REST_TestCase {
 		$this->assertSame( array( 'GET', 'PUT' ), $link['targetHints']['allow'] );
 	}
 
+	/**
+	 * @ticket 62574
+	 */
+	public function test_populates_templates_default_data_for_logged_in_user() {
+		wp_set_current_user( self::$admin_id );
+		$server  = new WP_REST_Server();
+		$request = new WP_REST_Request( 'GET', '/' );
+		$index   = $server->dispatch( $request );
+		$data    = $index->get_data();
+
+		$this->assertArrayHasKey( 'default_template_part_areas', $data );
+		$this->assertArrayHasKey( 'default_template_types', $data );
+	}
+
+	/**
+	 * @ticket 62574
+	 */
+	public function test_does_not_populate_templates_default_data_for_logged_out_user() {
+		$server  = new WP_REST_Server();
+		$request = new WP_REST_Request( 'GET', '/' );
+		$index   = $server->dispatch( $request );
+		$data    = $index->get_data();
+
+		$this->assertArrayNotHasKey( 'default_template_part_areas', $data );
+		$this->assertArrayNotHasKey( 'default_template_types', $data );
+	}
+
 	public function _validate_as_integer_123( $value, $request, $key ) {
 		if ( ! is_int( $value ) ) {
 			return new WP_Error( 'some-error', 'This is not valid!' );

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -12231,7 +12231,162 @@ mockedApiResponse.Schema = {
     },
     "site_logo": 0,
     "site_icon": 0,
-    "site_icon_url": ""
+    "site_icon_url": "",
+    "default_template_part_areas": [
+        {
+            "area": "uncategorized",
+            "label": "General",
+            "description": "General templates often perform a specific role like displaying post content, and are not tied to any particular area.",
+            "icon": "layout",
+            "area_tag": "div"
+        },
+        {
+            "area": "header",
+            "label": "Header",
+            "description": "The Header template defines a page area that typically contains a title, logo, and main navigation.",
+            "icon": "header",
+            "area_tag": "header"
+        },
+        {
+            "area": "footer",
+            "label": "Footer",
+            "description": "The Footer template defines a page area that typically contains site credits, social links, or any other combination of blocks.",
+            "icon": "footer",
+            "area_tag": "footer"
+        }
+    ],
+    "default_template_types": [
+        {
+            "title": "Index",
+            "description": "Used as a fallback template for all pages when a more specific template is not defined.",
+            "slug": "index"
+        },
+        {
+            "title": "Blog Home",
+            "description": "Displays the latest posts as either the site homepage or as the \"Posts page\" as defined under reading settings. If it exists, the Front Page template overrides this template when posts are shown on the homepage.",
+            "slug": "home"
+        },
+        {
+            "title": "Front Page",
+            "description": "Displays your site's homepage, whether it is set to display latest posts or a static page. The Front Page template takes precedence over all templates.",
+            "slug": "front-page"
+        },
+        {
+            "title": "Single Entries",
+            "description": "Displays any single entry, such as a post or a page. This template will serve as a fallback when a more specific template (e.g. Single Post, Page, or Attachment) cannot be found.",
+            "slug": "singular"
+        },
+        {
+            "title": "Single Posts",
+            "description": "Displays a single post on your website unless a custom template has been applied to that post or a dedicated template exists.",
+            "slug": "single"
+        },
+        {
+            "title": "Pages",
+            "description": "Displays a static page unless a custom template has been applied to that page or a dedicated template exists.",
+            "slug": "page"
+        },
+        {
+            "title": "All Archives",
+            "description": "Displays any archive, including posts by a single author, category, tag, taxonomy, custom post type, and date. This template will serve as a fallback when more specific templates (e.g. Category or Tag) cannot be found.",
+            "slug": "archive"
+        },
+        {
+            "title": "Author Archives",
+            "description": "Displays a single author's post archive. This template will serve as a fallback when a more specific template (e.g. Author: Admin) cannot be found.",
+            "slug": "author"
+        },
+        {
+            "title": "Category Archives",
+            "description": "Displays a post category archive. This template will serve as a fallback when a more specific template (e.g. Category: Recipes) cannot be found.",
+            "slug": "category"
+        },
+        {
+            "title": "Taxonomy",
+            "description": "Displays a custom taxonomy archive. Like categories and tags, taxonomies have terms which you use to classify things. For example: a taxonomy named \"Art\" can have multiple terms, such as \"Modern\" and \"18th Century.\" This template will serve as a fallback when a more specific template (e.g. Taxonomy: Art) cannot be found.",
+            "slug": "taxonomy"
+        },
+        {
+            "title": "Date Archives",
+            "description": "Displays a post archive when a specific date is visited (e.g., example.com/2023/).",
+            "slug": "date"
+        },
+        {
+            "title": "Tag Archives",
+            "description": "Displays a post tag archive. This template will serve as a fallback when a more specific template (e.g. Tag: Pizza) cannot be found.",
+            "slug": "tag"
+        },
+        {
+            "title": "Attachment Pages",
+            "description": "Displays when a visitor views the dedicated page that exists for any media attachment.",
+            "slug": "attachment"
+        },
+        {
+            "title": "Search Results",
+            "description": "Displays when a visitor performs a search on your website.",
+            "slug": "search"
+        },
+        {
+            "title": "Privacy Policy",
+            "description": "Displays your site's Privacy Policy page.",
+            "slug": "privacy-policy"
+        },
+        {
+            "title": "Page: 404",
+            "description": "Displays when a visitor views a non-existent page, such as a dead link or a mistyped URL.",
+            "slug": "404"
+        },
+        {
+            "title": "Post Format: Standard",
+            "description": "Displays the Standard post format archive.",
+            "slug": "taxonomy-post_format-post-format-standard"
+        },
+        {
+            "title": "Post Format: Aside",
+            "description": "Displays the Aside post format archive.",
+            "slug": "taxonomy-post_format-post-format-aside"
+        },
+        {
+            "title": "Post Format: Chat",
+            "description": "Displays the Chat post format archive.",
+            "slug": "taxonomy-post_format-post-format-chat"
+        },
+        {
+            "title": "Post Format: Gallery",
+            "description": "Displays the Gallery post format archive.",
+            "slug": "taxonomy-post_format-post-format-gallery"
+        },
+        {
+            "title": "Post Format: Link",
+            "description": "Displays the Link post format archive.",
+            "slug": "taxonomy-post_format-post-format-link"
+        },
+        {
+            "title": "Post Format: Image",
+            "description": "Displays the Image post format archive.",
+            "slug": "taxonomy-post_format-post-format-image"
+        },
+        {
+            "title": "Post Format: Quote",
+            "description": "Displays the Quote post format archive.",
+            "slug": "taxonomy-post_format-post-format-quote"
+        },
+        {
+            "title": "Post Format: Status",
+            "description": "Displays the Status post format archive.",
+            "slug": "taxonomy-post_format-post-format-status"
+        },
+        {
+            "title": "Post Format: Video",
+            "description": "Displays the Video post format archive.",
+            "slug": "taxonomy-post_format-post-format-video"
+        },
+        {
+            "title": "Post Format: Audio",
+            "description": "Displays the Audio post format archive.",
+            "slug": "taxonomy-post_format-post-format-audio"
+        }
+    ]
 };
 
 mockedApiResponse.oembed = {


### PR DESCRIPTION
Alternative to #7895.

Limits access to the `default_template_part_areas` and `default_template_types` values. They are now only available to logged-in users viathe  REST index.

Gutenberg PR: https://github.com/WordPress/gutenberg/pull/69346
Trac ticket: https://core.trac.wordpress.org/ticket/62574

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
