### PR TITLE
Enhance `esc_html()` with`esc_br_html()` to Preserve Line Breaks

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4678,6 +4678,35 @@ function esc_html( $text ) {
 }
 
 /**
+ * Escapes text for HTML output while preserving line breaks.
+ *
+ * Converts newlines into `<br />` tags after escaping the text.
+ *
+ * @since 2.8.0
+ *
+ * @param string $text The text to be escaped.
+ * @return string The escaped text with preserved line breaks.
+ */
+function esc_br_html( $text ) {
+	$escaped_text_array     = array_map( 'esc_html', explode( "\n", $text ) );
+	$escaped_multiline_text = implode( '<br />', $escaped_text_array );
+
+	/**
+	 * Filters a string cleaned and escaped for output in HTML with line breaks.
+	 *
+	 * Text passed to esc_br_html() is escaped using esc_html() and newlines
+	 * are converted into `<br />` tags before output.
+	 *
+	 * @since 2.8.0
+	 *
+	 * @param string $escaped_multiline_text The text after it has been escaped and processed.
+	 * @param string $text                   The original text before escaping.
+	 */
+	return apply_filters( 'esc_br_html', $escaped_multiline_text, $text );
+}
+
+
+/**
  * Escaping for HTML attributes.
  *
  * @since 2.8.0

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -341,6 +341,24 @@ function esc_html__( $text, $domain = 'default' ) {
 }
 
 /**
+ * Retrieves the translation of $text and escapes it for safe use in HTML output with line breaks.
+ *
+ * If there is no translation, or the text domain isn't loaded, the original text
+ * is escaped and returned with newlines converted to `<br />` tags.
+ *
+ * @since 2.8.0
+ *
+ * @param string $text   Text to translate.
+ * @param string $domain Optional. Text domain. Unique identifier for retrieving translated strings.
+ *                       Default 'default'.
+ * @return string Translated and escaped text with line breaks.
+ */
+function esc_br_html__( $text, $domain = 'default' ) {
+	return esc_br_html( translate( $text, $domain ) );
+}
+
+
+/**
  * Displays translated text.
  *
  * @since 1.2.0
@@ -388,6 +406,25 @@ function esc_attr_e( $text, $domain = 'default' ) {
 function esc_html_e( $text, $domain = 'default' ) {
 	echo esc_html( translate( $text, $domain ) );
 }
+
+/**
+ * Displays translated text that has been escaped for safe use in HTML output with line breaks.
+ *
+ * If there is no translation, or the text domain isn't loaded, the original text
+ * is escaped and displayed with newlines converted to `<br />` tags.
+ *
+ * If you need the value for use in PHP, use esc_br_html__().
+ *
+ * @since 2.8.0
+ *
+ * @param string $text   Text to translate.
+ * @param string $domain Optional. Text domain. Unique identifier for retrieving translated strings.
+ *                       Default 'default'.
+ */
+function esc_br_html_e( $text, $domain = 'default' ) {
+	echo esc_br_html( translate( $text, $domain ) );
+}
+
 
 /**
  * Retrieves translated string with gettext context.
@@ -459,6 +496,25 @@ function esc_attr_x( $text, $context, $domain = 'default' ) {
 function esc_html_x( $text, $context, $domain = 'default' ) {
 	return esc_html( translate_with_gettext_context( $text, $context, $domain ) );
 }
+
+/**
+ * Translates string with gettext context, and escapes it for safe use in HTML output with line breaks.
+ *
+ * If there is no translation, or the text domain isn't loaded, the original text
+ * is escaped and returned with newlines converted to `<br />` tags.
+ *
+ * @since 2.9.0
+ *
+ * @param string $text    Text to translate.
+ * @param string $context Context information for the translators.
+ * @param string $domain  Optional. Text domain. Unique identifier for retrieving translated strings.
+ *                        Default 'default'.
+ * @return string Translated and escaped text with preserved line breaks.
+ */
+function esc_br_html_x( $text, $context, $domain = 'default' ) {
+	return esc_br_html( translate_with_gettext_context( $text, $context, $domain ) );
+}
+
 
 /**
  * Translates and retrieves the singular or plural form based on the supplied number.

--- a/tests/phpunit/tests/formatting/escBrHtml.php
+++ b/tests/phpunit/tests/formatting/escBrHtml.php
@@ -14,30 +14,30 @@ class Tests_Formatting_EscBrHtml extends WP_UnitTestCase {
 
 		// String with a single line break.
 		$html    = "The quick brown fox.\nJumps over the lazy dog.";
-		$escaped = "The quick brown fox.<br />Jumps over the lazy dog.";
+		$escaped = 'The quick brown fox.<br />Jumps over the lazy dog.';
 		$this->assertSame( $escaped, esc_br_html( $html ) );
 
 		// String with multiple line breaks.
 		$html    = "First line.\nSecond line.\nThird line.";
-		$escaped = "First line.<br />Second line.<br />Third line.";
+		$escaped = 'First line.<br />Second line.<br />Third line.';
 		$this->assertSame( $escaped, esc_br_html( $html ) );
 	}
 
 	public function test_escapes_ampersands_with_line_breaks() {
 		$html    = "penn & teller\nat&t";
-		$escaped = "penn &amp; teller<br />at&amp;t";
+		$escaped = 'penn &amp; teller<br />at&amp;t';
 		$this->assertSame( $escaped, esc_br_html( $html ) );
 	}
 
 	public function test_escapes_greater_and_less_than_with_line_breaks() {
 		$html    = "this > that\nthat <randomhtml />";
-		$escaped = "this &gt; that<br />that &lt;randomhtml /&gt;";
+		$escaped = 'this &gt; that<br />that &lt;randomhtml /&gt;';
 		$this->assertSame( $escaped, esc_br_html( $html ) );
 	}
 
 	public function test_preserves_existing_entities_with_line_breaks() {
 		$html    = "Line one: &#038;\nLine two: &#x00A3;\nLine three: &amp;";
-		$escaped = "Line one: &#038;<br />Line two: &#xA3;<br />Line three: &amp;";
+		$escaped = 'Line one: &#038;<br />Line two: &#xA3;<br />Line three: &amp;';
 		$this->assertSame( $escaped, esc_br_html( $html ) );
 	}
 
@@ -47,7 +47,7 @@ class Tests_Formatting_EscBrHtml extends WP_UnitTestCase {
 
 	public function test_handles_multiple_consecutive_line_breaks() {
 		$html    = "First line.\n\n\nSecond line.";
-		$escaped = "First line.<br /><br /><br />Second line.";
+		$escaped = 'First line.<br /><br /><br />Second line.';
 		$this->assertSame( $escaped, esc_br_html( $html ) );
 	}
 }

--- a/tests/phpunit/tests/formatting/escBrHtml.php
+++ b/tests/phpunit/tests/formatting/escBrHtml.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @group formatting
+ *
+ * @covers ::esc_br_html
+ */
+class Tests_Formatting_EscBrHtml extends WP_UnitTestCase {
+
+	public function test_esc_br_html_basics() {
+		// Simple string (no line breaks).
+		$html = 'The quick brown fox.';
+		$this->assertSame( $html, esc_br_html( $html ) );
+
+		// String with a single line break.
+		$html    = "The quick brown fox.\nJumps over the lazy dog.";
+		$escaped = "The quick brown fox.<br />Jumps over the lazy dog.";
+		$this->assertSame( $escaped, esc_br_html( $html ) );
+
+		// String with multiple line breaks.
+		$html    = "First line.\nSecond line.\nThird line.";
+		$escaped = "First line.<br />Second line.<br />Third line.";
+		$this->assertSame( $escaped, esc_br_html( $html ) );
+	}
+
+	public function test_escapes_ampersands_with_line_breaks() {
+		$html    = "penn & teller\nat&t";
+		$escaped = "penn &amp; teller<br />at&amp;t";
+		$this->assertSame( $escaped, esc_br_html( $html ) );
+	}
+
+	public function test_escapes_greater_and_less_than_with_line_breaks() {
+		$html    = "this > that\nthat <randomhtml />";
+		$escaped = "this &gt; that<br />that &lt;randomhtml /&gt;";
+		$this->assertSame( $escaped, esc_br_html( $html ) );
+	}
+
+	public function test_preserves_existing_entities_with_line_breaks() {
+		$html    = "Line one: &#038;\nLine two: &#x00A3;\nLine three: &amp;";
+		$escaped = "Line one: &#038;<br />Line two: &#xA3;<br />Line three: &amp;";
+		$this->assertSame( $escaped, esc_br_html( $html ) );
+	}
+
+	public function test_ignores_empty_strings() {
+		$this->assertSame( '', esc_br_html( '' ) );
+	}
+
+	public function test_handles_multiple_consecutive_line_breaks() {
+		$html    = "First line.\n\n\nSecond line.";
+		$escaped = "First line.<br /><br /><br />Second line.";
+		$this->assertSame( $escaped, esc_br_html( $html ) );
+	}
+}


### PR DESCRIPTION
This PR introduces `esc_br_html()`, an enhancement of `esc_html()` that escapes text for safe HTML output while preserving line breaks as `<br />` tags. Additionally, corresponding functions `esc_br_html__()`, `esc_br_html_x()`, and `esc_br_html_e()` are added to maintain consistency with WordPress Core escaping functions. Unit tests are included to validate functionality.

Trac ticket: https://core.trac.wordpress.org/ticket/46188

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
