### PR TITLE
Request for Feature Enhancement: Make "Create a New Menu" a Clear CTA/Button.

### DIFF
--- a/src/wp-admin/nav-menus.php
+++ b/src/wp-admin/nav-menus.php
@@ -954,9 +954,14 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 		<span class="add-edit-menu-action">
 			<?php
 			printf(
-				/* translators: %s: URL to create a new menu. */
-				__( 'Edit your menu below, or <a href="%s">create a new menu</a>. Do not forget to save your changes!' ),
-				esc_url(
+				/* translators: No placeholders needed now */
+				__( 'Edit your menu below with necessary details. To create a new menu, click the button below. Don\'t forget to save your changes!' )
+			);
+			?>
+			<br>
+			<a href="
+				<?php
+				print esc_url(
 					add_query_arg(
 						array(
 							'action' => 'edit',
@@ -964,9 +969,11 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 						),
 						admin_url( 'nav-menus.php' )
 					)
-				)
-			);
-			?>
+				);
+				?>
+			" class="button button-primary" style="margin-top: 10px; display: inline-block;">
+				<?php _e( 'Create a new menu' ); ?>
+			</a>
 			<span class="screen-reader-text">
 				<?php
 				/* translators: Hidden accessibility text. */


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63010

This PR addresses ticket [#63010](https://core.trac.wordpress.org/ticket/63010) by enhancing the visibility of the "Create a new menu" option in the WordPress admin navigation menu interface. The change converts what was previously an inline text link into a clearly visible button, improving usability and accessibility.

<img width="921" alt="Screenshot 2025-02-27 at 10 56 08 PM" src="https://github.com/user-attachments/assets/dc08e64a-2e54-4a8e-8c47-f6bd446056a3" />

---

**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
