### PR TITLE
Allow speculative loading exclusion classes to be specified on parent element

### DIFF
--- a/src/wp-includes/speculative-loading.php
+++ b/src/wp-includes/speculative-loading.php
@@ -190,19 +190,19 @@ function wp_get_speculation_rules(): ?WP_Speculation_Rules {
 				'selector_matches' => 'a[rel~="nofollow"]',
 			),
 		),
-		// Also exclude links that are explicitly marked to opt out.
+		// Also exclude links that are explicitly marked to opt out, either directly or via a parent element.
 		array(
 			'not' => array(
-				'selector_matches' => ".no-{$mode}",
+				'selector_matches' => ".no-{$mode}, .no-{$mode} a",
 			),
 		),
 	);
 
-	// If using 'prerender', also exclude links that opt-out of 'prefetch' because it's part of 'prerender'.
+	// If using 'prerender', also exclude links that opt out of 'prefetch' because it's part of 'prerender'.
 	if ( 'prerender' === $mode ) {
 		$main_rule_conditions[] = array(
 			'not' => array(
-				'selector_matches' => '.no-prefetch',
+				'selector_matches' => '.no-prefetch, .no-prefetch a',
 			),
 		);
 	}

--- a/tests/phpunit/tests/speculative-loading/wpGetSpeculationRules.php
+++ b/tests/phpunit/tests/speculative-loading/wpGetSpeculationRules.php
@@ -139,7 +139,7 @@ class Tests_Speculative_Loading_wpGetSpeculationRules extends WP_UnitTestCase {
 		$this->assertCount( 4, $rules['prefetch'][0]['where']['and'] );
 		$this->assertArrayHasKey( 'not', $rules['prefetch'][0]['where']['and'][3] );
 		$this->assertArrayHasKey( 'selector_matches', $rules['prefetch'][0]['where']['and'][3]['not'] );
-		$this->assertSame( '.no-prefetch', $rules['prefetch'][0]['where']['and'][3]['not']['selector_matches'] );
+		$this->assertSame( '.no-prefetch, .no-prefetch a', $rules['prefetch'][0]['where']['and'][3]['not']['selector_matches'] );
 	}
 
 	/**
@@ -164,10 +164,10 @@ class Tests_Speculative_Loading_wpGetSpeculationRules extends WP_UnitTestCase {
 		$this->assertCount( 5, $rules['prerender'][0]['where']['and'] );
 		$this->assertArrayHasKey( 'not', $rules['prerender'][0]['where']['and'][3] );
 		$this->assertArrayHasKey( 'selector_matches', $rules['prerender'][0]['where']['and'][3]['not'] );
-		$this->assertSame( '.no-prerender', $rules['prerender'][0]['where']['and'][3]['not']['selector_matches'] );
+		$this->assertSame( '.no-prerender, .no-prerender a', $rules['prerender'][0]['where']['and'][3]['not']['selector_matches'] );
 		$this->assertArrayHasKey( 'not', $rules['prerender'][0]['where']['and'][4] );
 		$this->assertArrayHasKey( 'selector_matches', $rules['prerender'][0]['where']['and'][4]['not'] );
-		$this->assertSame( '.no-prefetch', $rules['prerender'][0]['where']['and'][4]['not']['selector_matches'] );
+		$this->assertSame( '.no-prefetch, .no-prefetch a', $rules['prerender'][0]['where']['and'][4]['not']['selector_matches'] );
 	}
 
 	/**


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63032

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
