### PR TITLE
Twenty Eleven: Ensure font weight in table cells matches editor styles

### DIFF
--- a/src/wp-content/themes/twentyeleven/style.css
+++ b/src/wp-content/themes/twentyeleven/style.css
@@ -50,7 +50,6 @@ table {/* tables still need 'cellspacing="0"' in the markup */
 	border-spacing: 0;
 }
 caption, th, td {
-	font-weight: normal;
 	text-align: left;
 }
 blockquote:before, blockquote:after,


### PR DESCRIPTION
Trac ticket: [#63034](https://core.trac.wordpress.org/ticket/63034)

Removes `font-weight: normal;` from `caption, th, td` in style.css to ensure font weight set in the editor is correctly applied on the frontend.

Before:

https://github.com/user-attachments/assets/374c5cf1-835a-4bc2-9afb-72705bb96a6c

After:

https://github.com/user-attachments/assets/5fcdd072-4fa2-403e-a91b-39bfb4c5c8fd

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
