### PR TITLE
Force npm install in  sync-gutenberg-packages script  to use .npmrc config

### DIFF
--- a/tools/release/sync-gutenberg-packages.js
+++ b/tools/release/sync-gutenberg-packages.js
@@ -5,6 +5,7 @@
 const fs = require( 'fs' );
 const spawn = require( 'cross-spawn' );
 const { zip, uniq, identity, groupBy } = require( 'lodash' );
+const path = require('path');
 
 /**
  * Constants
@@ -64,14 +65,24 @@ function readJSONFile( fileName ) {
  * @param {Array} packages List of tuples [packageName, version] to install.
  * @return {string} CLI output.
  */
-function installPackages( packages ) {
+function installPackages(packages) {
 	const packagesWithVersion = packages.map(
-		( [packageName, version] ) => `${ packageName }@${ version }`,
+	  ([packageName, version]) => `${packageName}@${version}`,
 	);
-	return spawn.sync( 'npm', ['install', ...packagesWithVersion, '--save'], {
-		stdio: 'inherit',
-	} );
-}
+	return spawn.sync(
+		"npm",
+		[
+			"install",
+			"--userconfig",
+			path.join(process.cwd(), ".npmrc"),
+			...packagesWithVersion,
+			"--save",
+		],
+	  	{
+			stdio: "inherit",
+	  	},
+	);
+  }
 
 /**
  * Computes which @wordpress packages are required by the Gutenberg
@@ -107,6 +118,13 @@ function getMismatchedNonWordPressDependencies() {
 	const currentPackages = getWordPressPackages( currentPackageJSON );
 
 	const packageLock = readJSONFile( "package-lock.json" );
+	console.log("JT   ->");
+	if (typeof packageLock !== 'object') {
+		
+		throw new Error("Parsed data is not a valid JSON object.");
+	}
+	console.log(packageLock);
+	process.exit(0);
 	const versionConflicts = Object.entries( packageLock.dependencies )
 		.filter( ( [packageName] ) => currentPackages.includes( packageName ) )
 		.flatMap( ( [, { dependencies }] ) => Object.entries( dependencies || {} ) )


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
`npm install` in `sync-gutenberg-packages` script is not respecting settings specified in `.npmrc` file. To troubleshoot, I ran `npm config list` from inside the sync-gutenberg-packages script and observed the following output.
```
; engine-strict = true ; overridden by env
; legacy-peer-deps = true ; overridden by env
; lockfile-version = "3" ; overridden by env
; prefer-dedupe = true ; overridden by env
; save-exact = true ; overridden by env
; save-prefix = "" ; overridden by env
```
This indicates `.npmrc` settings are being overridden by environment variables. This means the behavior might differ based on where script is ran. Made a change to explicitly use local `.npmrc` file while issuing `npm install` command.

I also observed the issue with parsing packageLock dependencies.
```
const versionConflicts = Object.entries( packageLock.dependencies )
TypeError: Cannot convert undefined or null to object
```
This is due to the fact that in generated `package-lock.json` file, `dependencies` are not a top level property/field, rather it is nested inside `packages` i.e each package. As a result, `packageLock.dependencies` is `undefined`. This needs some more investigation so I am hoping to raise a separate PR for that.

Trac ticket: https://core.trac.wordpress.org/ticket/62839

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
