### PR TITLE
feat: Added action 'maybe_serialize_data_is_serialized' to inform about double serialization.

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -637,6 +637,17 @@ function maybe_serialize( $data ) {
 	 * Also the world will end. See WP 3.6.1.
 	 */
 	if ( is_serialized( $data, false ) ) {
+		/**
+		 * Allows the developer to track double serialization in their projects.
+		 *
+		 * While not broken, double serialization increases the complexity of data structures, pose a performance
+		 * overhead and increases the cognitive load when reading code and data.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param string $data Already serialized data.
+		 */
+		do_action( 'maybe_serialize_data_is_serialized', $data );
 		return serialize( $data );
 	}
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -640,8 +640,8 @@ function maybe_serialize( $data ) {
 		/**
 		 * Allows the developer to track double serialization in their projects.
 		 *
-		 * While not broken, double serialization increases the complexity of data structures, pose a performance
-		 * overhead and increases the cognitive load when reading code and data.
+		 * While not broken, double serialization increases the complexity of data structures,
+		 * pose a performance overhead, and increases the cognitive load when reading code and data.
 		 *
 		 * @since 6.8.0
 		 *

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -679,8 +679,8 @@ function maybe_unserialize( $data ) {
  * @since 2.0.5
  * @since 6.1.0 Added Enum support.
  *
- * @param string $data   Value to check to see if was serialized.
- * @param bool   $strict Optional. Whether to be strict about the end of the string. Default true.
+ * @param mixed $data   Value to check to see if was serialized.
+ * @param bool  $strict Optional. Whether to be strict about the end of the string. Default true.
  * @return bool False if not serialized and true if it was.
  */
 function is_serialized( $data, $strict = true ) {


### PR DESCRIPTION
This is an alternative approach to take care of 62483. Instead of adding a `_doing_it_wrong()` like proposed in https://github.com/WordPress/wordpress-develop/pull/7847 this only adds an action, allowing professional developers and teams with a high requirement of standard and code quality to track double serialization.

Trac ticket: https://core.trac.wordpress.org/ticket/62483

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
