### PR TITLE
Fix canonical URL for attachment

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -4063,7 +4063,7 @@ function wp_get_canonical_url( $post = null ) {
 		return false;
 	}
 
-	if ( 'publish' !== $post->post_status ) {
+	if ( 'publish' !== get_post_status( $post ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
[#63041](https://core.trac.wordpress.org/ticket/63041)

## Description

This PR fixes an issue where `wp_get_canonical_url()` always returns false for attachments.

### Issue
Attachments have a post status of 'inherit' rather than 'publish'. The `wp_get_canonical_url()` function was directly checking `$post->post_status === 'publish'`, causing it to always return false for attachments.

### Fix
This PR changes the condition to use `get_post_status($post)` instead of directly accessing `$post->post_status`. The `get_post_status()` function properly handles the 'inherit' status for attachments.
