### PR TITLE
Remove redundant escaping from the commit message that's passed to the Slack API

### DIFF
--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -135,6 +135,7 @@ jobs:
         with:
           retries: 2
           retry-exempt-status-codes: 418
+          result-encoding: string
           script: |
             const commit_details = await github.rest.repos.getCommit({
               owner: context.repo.owner,

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -147,7 +147,7 @@ jobs:
         id: commit-message
         run: |
           # shellcheck disable=SC2016
-          COMMIT_MESSAGE="$(echo "${COMMIT_MSG_RAW}" | awk 'NR==1' | sed 's/`/\\`/g' | sed 's/\"/\\\\\\"/g' | sed 's/\$/\\$/g')"
+          COMMIT_MESSAGE="$(echo "${COMMIT_MSG_RAW}" | awk 'NR==1')"
           echo "commit_message_escaped=${COMMIT_MESSAGE}" >> "$GITHUB_OUTPUT"
         env:
           COMMIT_MSG_RAW: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && fromJson( steps.current-commit-message.outputs.result ) || github.event.head_commit.message }}

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -143,18 +143,12 @@ jobs:
             });
             return commit_details.data.commit.message;
 
-      - name: Prepare commit message.
-        id: commit-message
-        run: |
-          # shellcheck disable=SC2016
-          COMMIT_MESSAGE="$(echo "${COMMIT_MSG_RAW}" | awk 'NR==1')"
-          echo "commit_message_escaped=${COMMIT_MESSAGE}" >> "$GITHUB_OUTPUT"
-        env:
-          COMMIT_MSG_RAW: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && fromJson( steps.current-commit-message.outputs.result ) || github.event.head_commit.message }}
-
       - name: Construct payload and store as an output
         id: create-payload
         run: |
+          # shellcheck disable=SC2016
+          COMMIT_MSG="$(echo "${COMMIT_MSG_RAW}" | awk 'NR==1')"
+
           PAYLOAD="$( jq \
             -n \
             --arg workflow_name "${GITHUB_WORKFLOW}" \
@@ -165,7 +159,7 @@ jobs:
           )"
           echo "payload=$PAYLOAD" >> "$GITHUB_OUTPUT"
         env:
-          COMMIT_MSG: ${{ steps.commit-message.outputs.commit_message_escaped }}
+          COMMIT_MSG_RAW: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && fromJson( steps.current-commit-message.outputs.result ) || github.event.head_commit.message }}
 
   # Posts notifications when a workflow fails.
   failure:

--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -146,9 +146,7 @@ jobs:
       - name: Construct payload and store as an output
         id: create-payload
         run: |
-          # shellcheck disable=SC2016
           COMMIT_MSG="$(echo "${COMMIT_MSG_RAW}" | awk 'NR==1')"
-
           PAYLOAD="$( jq \
             -n \
             --arg workflow_name "${GITHUB_WORKFLOW}" \


### PR DESCRIPTION
Prior to r59679 the commit message that was passed to the Slack API needed to be escaped so that backticks, double quotes, and dollar symbols were not interpreted by the shell within the GitHub Actions workflows. This was needed because the commit message was passed between jobs as output but used directly in the script using GitHub Actions expressions. In r59679 all instances of inline expressions were removed but the escaping was unnecessarily retained. This has resulted in backslashes preceding backticks, double quotes, and dollar symbols in messages sent to the Slack API and appearing in the test status messages that are shown in Slack.

This fixes that by eliminating everywhere that the commit message can be interpreted by the shell so it can be handled as a plain text string.

Trac ticket: https://core.trac.wordpress.org/ticket/62221