### PR TITLE
Script Loader: Document special case for `colors` style registration

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1584,7 +1584,12 @@ function wp_default_styles( $styles ) {
 	}
 
 	// Register a stylesheet for the selected admin color scheme.
-	$styles->add( 'colors', false, array( 'wp-admin', 'buttons' ) );
+
+	// This is a special case where 'true' is used as a placeholder.
+	// The actual URL will be determined dynamically via wp_style_loader_src.
+	// While 'true' doesn't match the string|false type expectation for $src,
+	// changing it breaks admin color scheme functionality.
+	$styles->add( 'colors', true, array( 'wp-admin', 'buttons' ) );
 
 	$suffix = SCRIPT_DEBUG ? '' : '.min';
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1584,7 +1584,7 @@ function wp_default_styles( $styles ) {
 	}
 
 	// Register a stylesheet for the selected admin color scheme.
-	$styles->add( 'colors', true, array( 'wp-admin', 'buttons' ) );
+	$styles->add( 'colors', false, array( 'wp-admin', 'buttons' ) );
 
 	$suffix = SCRIPT_DEBUG ? '' : '.min';
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63043

This PR adds documentation to clarify a special case in style registration for the 'colors' handle in `wp_default_styles()`.

The code uses `true` as the `src` parameter, while `WP_Styles::add()` typically expects a `string` URL or `false`. However, testing confirms that changing this value breaks the admin color scheme functionality.

The added comment explains that this is a special case where [`wp_style_loader_src()`](https://github.com/WordPress/wordpress-develop/blob/b4f0fc916ef58c0285f119e24f56e90831fcfc48/src/wp-includes/script-loader.php#L2070) expects a truthy value to properly replace it with the actual color scheme URL based on user preferences.

