### PR TITLE
Editor: Update REST API preloaded paths for 6.8

### DIFF
--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -93,8 +93,6 @@ $preload_paths = array(
 			'site_icon_url',
 			'site_logo',
 			'timezone_string',
-			'default_template_part_areas',
-			'default_template_types',
 			'url',
 			'page_for_posts',
 			'page_on_front',

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -79,6 +79,28 @@ $preload_paths = array(
 	 * Please ensure that the equivalent check is kept in sync with this preload path.
 	 */
 	'/wp/v2/global-styles/' . WP_Theme_JSON_Resolver::get_user_global_styles_post_id() . '?context=' . $global_styles_endpoint_context,
+	// Used by getBlockPatternCategories in useBlockEditorSettings.
+	'/wp/v2/block-patterns/categories',
+	// @see packages/core-data/src/entities.js
+	'/?_fields=' . implode(
+		',',
+		array(
+			'description',
+			'gmt_offset',
+			'home',
+			'name',
+			'site_icon',
+			'site_icon_url',
+			'site_logo',
+			'timezone_string',
+			'default_template_part_areas',
+			'default_template_types',
+			'url',
+			'page_for_posts',
+			'page_on_front',
+			'show_on_front',
+		)
+	),
 );
 
 block_editor_rest_api_preload( $preload_paths, $block_editor_context );

--- a/src/wp-admin/edit-form-blocks.php
+++ b/src/wp-admin/edit-form-blocks.php
@@ -53,6 +53,10 @@ $rest_path = rest_get_route_for_post( $post );
 
 $active_theme                   = get_stylesheet();
 $global_styles_endpoint_context = current_user_can( 'edit_theme_options' ) ? 'edit' : 'view';
+$template_lookup_slug           = 'page' === $post->post_type ? 'page' : 'single-' . $post->post_type;
+if ( ! empty( $post->post_name ) ) {
+	$template_lookup_slug .= '-' . $post->post_name;
+}
 // Preload common data.
 $preload_paths = array(
 	'/wp/v2/types?context=view',
@@ -98,6 +102,12 @@ $preload_paths = array(
 			'page_on_front',
 			'show_on_front',
 		)
+	),
+	$paths[] = add_query_arg(
+		'slug',
+		// @see https://github.com/WordPress/gutenberg/blob/e093fefd041eb6cc4a4e7f67b92ab54fd75c8858/packages/core-data/src/private-selectors.ts#L244-L254
+		$template_lookup_slug,
+		'/wp/v2/templates/lookup'
 	),
 );
 

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -223,8 +223,6 @@ $preload_paths = array(
 			'site_icon_url',
 			'site_logo',
 			'timezone_string',
-			'default_template_part_areas',
-			'default_template_types',
 			'url',
 			'page_for_posts',
 			'page_on_front',

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -199,6 +199,32 @@ $preload_paths = array(
 		),
 		'GET',
 	),
+	'/wp/v2/settings',
+	array( '/wp/v2/settings', 'OPTIONS' ),
+	'/wp/v2/templates/lookup?slug=front-page',
+	'/wp/v2/templates/lookup?slug=home',
+	// Used by getBlockPatternCategories in useBlockEditorSettings.
+	'/wp/v2/block-patterns/categories',
+	// @see packages/core-data/src/entities.js
+	'/?_fields=' . implode(
+		',',
+		array(
+			'description',
+			'gmt_offset',
+			'home',
+			'name',
+			'site_icon',
+			'site_icon_url',
+			'site_logo',
+			'timezone_string',
+			'default_template_part_areas',
+			'default_template_types',
+			'url',
+			'page_for_posts',
+			'page_on_front',
+			'show_on_front',
+		)
+	),
 );
 
 block_editor_rest_api_preload( $preload_paths, $block_editor_context );

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -139,7 +139,15 @@ foreach ( get_default_block_template_types() as $slug => $template_type ) {
 	$indexed_template_types[] = $template_type;
 }
 
-$block_editor_context = new WP_Block_Editor_Context( array( 'name' => 'core/edit-site' ) );
+$context_settings = array( 'name' => 'core/edit-site' );
+
+if ( ! empty( $_GET['postId'] ) && is_numeric( $_GET['postId'] ) ) {
+	$context_settings['post'] = get_post( (int) $_GET['postId'] );
+} elseif ( isset( $_GET['p'] ) && preg_match( '/^\/page\/(\d+)$/', $_GET['p'], $matches ) ) {
+	$context_settings['post'] = get_post( (int) $matches[1] );
+}
+
+$block_editor_context = new WP_Block_Editor_Context( $context_settings );
 $custom_settings      = array(
 	'siteUrl'                   => site_url(),
 	'postsPerPage'              => get_option( 'posts_per_page' ),
@@ -201,8 +209,6 @@ $preload_paths = array(
 	),
 	'/wp/v2/settings',
 	array( '/wp/v2/settings', 'OPTIONS' ),
-	'/wp/v2/templates/lookup?slug=front-page',
-	'/wp/v2/templates/lookup?slug=home',
 	// Used by getBlockPatternCategories in useBlockEditorSettings.
 	'/wp/v2/block-patterns/categories',
 	// @see packages/core-data/src/entities.js
@@ -226,6 +232,24 @@ $preload_paths = array(
 		)
 	),
 );
+
+if ( $block_editor_context->post ) {
+	$route_for_post = rest_get_route_for_post( $block_editor_context->post );
+	if ( $route_for_post ) {
+		$preload_paths[] = add_query_arg( 'context', 'edit', $route_for_post );
+		if ( 'page' === $block_editor_context->post->post_type ) {
+			$preload_paths[] = add_query_arg(
+				'slug',
+				// @see https://github.com/WordPress/gutenberg/blob/e093fefd041eb6cc4a4e7f67b92ab54fd75c8858/packages/core-data/src/private-selectors.ts#L244-L254
+				'page-' . $block_editor_context->post->post_name,
+				'/wp/v2/templates/lookup'
+			);
+		}
+	}
+} else {
+	$preload_paths[] = '/wp/v2/templates/lookup?slug=front-page';
+	$preload_paths[] = '/wp/v2/templates/lookup?slug=home';
+}
 
 block_editor_rest_api_preload( $preload_paths, $block_editor_context );
 

--- a/src/wp-admin/site-editor.php
+++ b/src/wp-admin/site-editor.php
@@ -241,7 +241,7 @@ if ( $block_editor_context->post ) {
 			$preload_paths[] = add_query_arg(
 				'slug',
 				// @see https://github.com/WordPress/gutenberg/blob/e093fefd041eb6cc4a4e7f67b92ab54fd75c8858/packages/core-data/src/private-selectors.ts#L244-L254
-				'page-' . $block_editor_context->post->post_name,
+				empty( $block_editor_context->post->post_name ) ? 'page' : 'page-' . $post->post_name,
 				'/wp/v2/templates/lookup'
 			);
 		}


### PR DESCRIPTION
Combines the following core sync PRs: #7687 and #7695.

Gutenberg PRs:

* https://github.com/WordPress/gutenberg/pull/66488
* https://github.com/WordPress/gutenberg/pull/67497
* https://github.com/WordPress/gutenberg/pull/66631
* https://github.com/WordPress/gutenberg/pull/67465
* https://github.com/WordPress/gutenberg/pull/66579
* https://github.com/WordPress/gutenberg/pull/66654
* https://github.com/WordPress/gutenberg/pull/67518
* https://github.com/WordPress/gutenberg/pull/69400
* https://github.com/WordPress/gutenberg/pull/69454

Trac ticket: https://core.trac.wordpress.org/ticket/63050

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
