### PR TITLE
Query: Add `is_home_page()` method to test if viewing the site home page

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -4503,6 +4503,31 @@ class WP_Query {
 	}
 
 	/**
+	 * Determines whether the query is for the site's actual home page.
+	 *
+	 * This is true when:
+	 * - Not viewing a paged version of the site
+	 * - AND either:
+	 *   - The current page is set as the static front page
+	 *   - OR the current page is the posts page but NOT the dedicated "page for posts"
+	 *
+	 * This is different from both is_front_page() and is_home(), as it identifies
+	 * the true "home" view of the site regardless of WordPress configuration.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @return bool Whether the query is for the site's actual home page.
+	 */
+	public function is_home_page() {
+		return ! $this->is_paged() &&
+		( $this->is_front_page() ||
+			( $this->is_home() &&
+			( (int) get_option( 'page_for_posts' ) !== $this->get_queried_object_id() )
+			)
+		);
+	}
+
+	/**
 	 * Determines whether the query is for the Privacy Policy page.
 	 *
 	 * This is the page which shows the Privacy Policy content of your site.

--- a/src/wp-includes/query.php
+++ b/src/wp-includes/query.php
@@ -508,6 +508,33 @@ function is_home() {
 }
 
 /**
+ * Determines whether the query is for the site's actual home page.
+ *
+ * This is different from both is_front_page() and is_home(), as it identifies
+ * the true "home" view of the site regardless of WordPress configuration.
+ *
+ * For more information on this and similar theme functions, check out
+ * the {@link https://developer.wordpress.org/themes/basics/conditional-tags/
+ * Conditional Tags} article in the Theme Developer Handbook.
+ *
+ * @since 6.8.0
+ *
+ * @global WP_Query $wp_query WordPress Query object.
+ *
+ * @return bool Whether the query is for the site's actual home page.
+ */
+function is_home_page() {
+	global $wp_query;
+
+	if ( ! isset( $wp_query ) ) {
+		_doing_it_wrong( __FUNCTION__, __( 'Conditional query tags do not work before the query is run. Before then, they always return false.' ), '3.1.0' );
+		return false;
+	}
+
+	return $wp_query->is_home_page();
+}
+
+/**
  * Determines whether the query is for the Privacy Policy page.
  *
  * The Privacy Policy page is the page that shows the Privacy Policy content of the site.

--- a/tests/phpunit/tests/query/conditionals.php
+++ b/tests/phpunit/tests/query/conditionals.php
@@ -56,6 +56,86 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 		delete_option( 'page_for_posts' );
 	}
 
+	/**
+	 * @ticket 63044
+	 */
+	public function test_is_home_page_with_posts_on_front() {
+		// Default setup: posts page is the front page
+		$this->go_to( '/' );
+		$this->assertQueryTrue( 'is_home', 'is_front_page' );
+		$this->assertTrue( is_home_page() );
+
+		// Visit front page with pagination
+		update_option( 'posts_per_page', 2 );
+		self::factory()->post->create_many( 3 );
+		$this->go_to( '/page/2/' );
+		$this->assertQueryTrue( 'is_home', 'is_front_page', 'is_paged' );
+		$this->assertFalse( is_home_page() );
+	}
+
+	/**
+	 * @ticket 63044
+	 */
+	public function test_is_home_page_with_page_on_front() {
+		$page_on_front  = self::factory()->post->create(
+			array(
+				'post_type' => 'page',
+			)
+		);
+		$page_for_posts = self::factory()->post->create(
+			array(
+				'post_type' => 'page',
+			)
+		);
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_on_front', $page_on_front );
+		update_option( 'page_for_posts', $page_for_posts );
+
+		// Visit the front page
+		$this->go_to( '/' );
+		$this->assertQueryTrue( 'is_front_page', 'is_page', 'is_singular' );
+		$this->assertTrue( is_home_page() );
+
+		// Visit the posts page
+		$this->go_to( get_permalink( $page_for_posts ) );
+		$this->assertQueryTrue( 'is_home', 'is_posts_page' );
+		$this->assertFalse( is_home_page() );
+
+		update_option( 'show_on_front', 'posts' );
+		delete_option( 'page_on_front' );
+		delete_option( 'page_for_posts' );
+	}
+
+	/**
+	 * @ticket 63044
+	 */
+	public function test_is_home_page_with_paginated_static_front() {
+		$page_on_front = self::factory()->post->create(
+			array(
+				'post_type'    => 'page',
+				'post_title'   => 'Static Front Page',
+				'post_content' => 'Page 1 <!--nextpage--> Page 2',
+			)
+		);
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_on_front', $page_on_front );
+
+		// Visit the front page
+		$this->go_to( '/' );
+		$this->assertQueryTrue( 'is_front_page', 'is_page', 'is_singular' );
+		$this->assertTrue( is_home_page() );
+
+		// Visit page 2 of the front page
+		$permalink = get_permalink( $page_on_front );
+		$this->go_to( $permalink . 'page/2/' );
+		
+		$this->assertTrue( is_paged() );
+		$this->assertFalse( is_home_page() );
+
+		update_option( 'show_on_front', 'posts' );
+		delete_option( 'page_on_front' );
+	}
+
 	public function test_404() {
 		$this->go_to( '/notapage' );
 		$this->assertQueryTrue( 'is_404' );

--- a/tests/phpunit/tests/query/conditionals.php
+++ b/tests/phpunit/tests/query/conditionals.php
@@ -128,7 +128,7 @@ class Tests_Query_Conditionals extends WP_UnitTestCase {
 		// Visit page 2 of the front page
 		$permalink = get_permalink( $page_on_front );
 		$this->go_to( $permalink . 'page/2/' );
-		
+
 		$this->assertTrue( is_paged() );
 		$this->assertFalse( is_home_page() );
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63044


This PR adds a new `is_home_page()` method to `WP_Query` that makes it easier to test whether the current page is truly the site's home page.

The method addresses the confusion between `is_front_page()` and `is_home()`, creating a single reliable method to identify the site's actual home view. It returns `true` only when the current page is the non-paginated view of either the static front page or the blog index (when not set as `page_for_posts`).

