### PR TITLE
#62221 The commit message passed to the Slack payload creation step is no longer JSON encoded

### DIFF
--- a/.github/workflows/slack-notifications.yml
+++ b/.github/workflows/slack-notifications.yml
@@ -158,7 +158,7 @@ jobs:
           )"
           echo "payload=$PAYLOAD" >> "$GITHUB_OUTPUT"
         env:
-          COMMIT_MSG_RAW: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && fromJson( steps.current-commit-message.outputs.result ) || github.event.head_commit.message }}
+          COMMIT_MSG_RAW: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && steps.current-commit-message.outputs.result || github.event.head_commit.message }}
 
   # Posts notifications when a workflow fails.
   failure:


### PR DESCRIPTION
Follow up to r59920. The commit message is now passed to this step as a plain string, not a JSON encoded string.

Trac ticket: https://core.trac.wordpress.org/ticket/62221