### PR TITLE
#63052 Unblock the upgrade pre-flight check on WordPress < 5.1

### DIFF
--- a/.github/workflows/upgrade-develop-testing.yml
+++ b/.github/workflows/upgrade-develop-testing.yml
@@ -63,7 +63,7 @@ jobs:
         php: [ '7.2', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.4' ]
-        wp: [ '6.5', '6.6', '6.7' ]
+        wp: [ '5.0', '6.5', '6.6', '6.7' ]
         multisite: [ false, true ]
 
         exclude:

--- a/.github/workflows/upgrade-develop-testing.yml
+++ b/.github/workflows/upgrade-develop-testing.yml
@@ -63,16 +63,17 @@ jobs:
         php: [ '7.2', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.4' ]
-        wp: [ '5.0', '6.5', '6.6', '6.7' ]
+        # WordPress 4.9 is the oldest version that supports PHP 7.2.
+        wp: [ '4.9', '6.5', '6.6', '6.7' ]
         multisite: [ false, true ]
 
         exclude:
           # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
           - php: '7.2'
             db-version: '8.4'
-          # WordPress 5.0 does not support PHP 8.4.
+          # WordPress 4.9 does not support PHP 8.4.
           - php: '8.4'
-            wp: '5.0'
+            wp: '4.9'
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}

--- a/.github/workflows/upgrade-develop-testing.yml
+++ b/.github/workflows/upgrade-develop-testing.yml
@@ -70,6 +70,9 @@ jobs:
           # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
           - php: '7.2'
             db-version: '8.4'
+          # WordPress 5.0 does not support PHP 8.4.
+          - php: '8.4'
+            wp: '5.0'
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}

--- a/src/wp-admin/includes/update-core.php
+++ b/src/wp-admin/includes/update-core.php
@@ -1199,7 +1199,7 @@ function update_core( $from, $to ) {
 		}
 
 		// Add a warning when required PHP extensions are missing.
-		if ( $missing_extensions->has_errors() ) {
+		if ( ! empty( $missing_extensions->errors ) ) {
 			return $missing_extensions;
 		}
 	}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63052

The `WP_Error::has_errors()` method was introduced in 5.1, so it can't be used in `update_core()` which is in the `wp-admin/includes/update-core.php` file that gets copied into place over the existing one during the pre-upgrade prep.

This PR replaces usage of that method with the same check for the public `errors` property that the method uses.

I've added an upgrade test from WordPress 4.9, which is [the oldest branch that supports PHP 7.2](https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/#older-wordpress-versions). If we want to test further back than this then we'll need to make some more changes to PHP version usage in the workflow file that I think can happen in a follow-up ticket.