### PR TITLE
Fix WP Query::the_post for draft and autosave previews.

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3781,7 +3781,7 @@ class WP_Query {
 
 		// Ensure a full post object is available.
 		if ( $post instanceof stdClass ) {
-			// stdClass indicates that the full post object was not queried.
+			// stdClass indicates that a partial post object was queried.
 			$post = get_post( $post->ID );
 		} elseif ( is_numeric( $post ) ) {
 			// Numeric indicates that only post IDs were queried.

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3779,15 +3779,16 @@ class WP_Query {
 
 		$post = $this->next_post();
 
-		// Get the post ID.
-		if ( is_object( $post ) ) {
-			$global_post_id = $post->ID;
-		} else {
-			$global_post_id = $post;
+		// Ensure a full post object is available.
+		if ( $post instanceof stdClass ) {
+			// stdClass indicates that the full post object was not queried.
+			$post = get_post( $post->ID );
+		} elseif ( is_numeric( $post ) ) {
+			// Numeric indicates that only post IDs were queried.
+			$post = get_post( $post );
 		}
 
-		// Ensure the global $post is the full post object.
-		$post = get_post( $global_post_id );
+		// Set up the global post object for the loop.
 		$this->setup_postdata( $post );
 	}
 

--- a/tests/phpunit/tests/query/thePost.php
+++ b/tests/phpunit/tests/query/thePost.php
@@ -266,7 +266,15 @@ class Tests_Query_ThePost extends WP_UnitTestCase {
 		$query_args['preview_nonce'] = $nonce;
 		$post_preview_link           = get_preview_post_link( $published_post, $query_args );
 
-		// Set up the GET parameters for the preview link.
+		/*
+		 * Set up the GET parameters for the preview link.
+		 *
+		 * _show_post_preview() checks the $_GET super global for preview
+		 * and nonce parameters. It needs to run prior to the global query
+		 * being set up in WP_Query (via $this->go_to()), so the preview
+		 * parameters are created here to ensure _show_post_preview()
+		 * runs correctly.
+		 */
 		$_GET['preview_id']    = $published_post;
 		$_GET['preview_nonce'] = $nonce;
 		_show_post_preview();
@@ -293,7 +301,15 @@ class Tests_Query_ThePost extends WP_UnitTestCase {
 		$query_args['preview_nonce'] = $nonce;
 		$post_preview_link           = get_preview_post_link( $published_post, $query_args );
 
-		// Set up the GET parameters for the preview link.
+		/*
+		 * Set up the GET parameters for the preview link.
+		 *
+		 * _show_post_preview() checks the $_GET super global for preview
+		 * and nonce parameters. It needs to run prior to the global query
+		 * being set up in WP_Query (via $this->go_to()), so the preview
+		 * parameters are created here to ensure _show_post_preview()
+		 * runs correctly.
+		 */
 		$_GET['preview_id']    = $published_post;
 		$_GET['preview_nonce'] = $nonce;
 		_show_post_preview();

--- a/tests/phpunit/tests/query/thePost.php
+++ b/tests/phpunit/tests/query/thePost.php
@@ -217,26 +217,30 @@ class Tests_Query_ThePost extends WP_UnitTestCase {
 		// Ensure the global post is populated with the draft content for the preview link.
 		$this->go_to( get_preview_post_link( $draft_post ) );
 		if ( have_posts() ) {
-			the_post(); }
+			the_post();
+		}
 		$this->assertSame( 'ticket 56992', get_the_content(), 'Preview link should show draft content to logged in user' );
 
 		// Ensure the global post is populated with the draft content for the permalink.
 		$this->go_to( get_permalink( $draft_post ) );
 		if ( have_posts() ) {
-			the_post(); }
+			the_post();
+		}
 		$this->assertSame( 'ticket 56992', get_the_content(), 'Permalink should show draft content to logged in user' );
 
 		// Ensure the global post is not populated with the draft content for the preview link when logged out.
 		wp_set_current_user( 0 );
 		$this->go_to( get_preview_post_link( $draft_post ) );
 		if ( have_posts() ) {
-			the_post(); }
+			the_post();
+		}
 		$this->assertEmpty( get_the_content(), 'Preview link should not show draft content to logged out users' );
 
 		// Ensure the global post is not populated with the draft content for the permalink when logged out.
 		$this->go_to( get_permalink( $draft_post ) );
 		if ( have_posts() ) {
-			the_post(); }
+			the_post();
+		}
 		$this->assertEmpty( get_the_content(), 'Permalink should not show draft content to logged out users' );
 	}
 
@@ -274,13 +278,15 @@ class Tests_Query_ThePost extends WP_UnitTestCase {
 		// Ensure the global post is populated with the autosave content for the preview link.
 		$this->go_to( $post_preview_link );
 		if ( have_posts() ) {
-			the_post(); }
+			the_post();
+		}
 		$this->assertSame( 'ticket 56992 edited', get_the_content(), 'Preview link should show autosave content to logged in user' );
 
 		// Ensure the global post is populated with the published content for the permalink.
 		$this->go_to( get_permalink( $published_post ) );
 		if ( have_posts() ) {
-			the_post(); }
+			the_post();
+		}
 		$this->assertSame( 'ticket 56992', get_the_content(), 'Permalink should show published content to logged in user' );
 
 		wp_set_current_user( 0 );
@@ -299,13 +305,15 @@ class Tests_Query_ThePost extends WP_UnitTestCase {
 		// Ensure the global post is not populated with the draft content for the preview link when logged out.
 		$this->go_to( $post_preview_link );
 		if ( have_posts() ) {
-			the_post(); }
+			the_post();
+		}
 		$this->assertSame( 'ticket 56992', get_the_content(), 'Preview link should show published to logged out users' );
 
 		// Ensure the global post is not populated with the draft content for the permalink when logged out.
 		$this->go_to( get_permalink( $published_post ) );
 		if ( have_posts() ) {
-			the_post(); }
+			the_post();
+		}
 		$this->assertSame( 'ticket 56992', get_the_content(), 'Permalink should show published content to logged out users' );
 	}
 }

--- a/tests/phpunit/tests/query/thePost.php
+++ b/tests/phpunit/tests/query/thePost.php
@@ -319,7 +319,7 @@ class Tests_Query_ThePost extends WP_UnitTestCase {
 		if ( have_posts() ) {
 			the_post();
 		}
-		$this->assertSame( 'ticket 56992', get_the_content(), 'Preview link should show published to logged out users' );
+		$this->assertSame( 'ticket 56992', get_the_content(), 'Preview link should show published content to logged out users' );
 
 		// Ensure the global post is not populated with the draft content for the permalink when logged out.
 		$this->go_to( get_permalink( $published_post ) );

--- a/tests/phpunit/tests/query/thePost.php
+++ b/tests/phpunit/tests/query/thePost.php
@@ -28,13 +28,6 @@ class Tests_Query_ThePost extends WP_UnitTestCase {
 	public static $page_child_ids = array();
 
 	/**
-	 * Editor user ID.
-	 *
-	 * @var int
-	 */
-	public static $editor_user_id = 0;
-
-	/**
 	 * Create the shared fixtures.
 	 *
 	 * @param WP_UnitTest_Factory $factory Factory object.
@@ -42,7 +35,6 @@ class Tests_Query_ThePost extends WP_UnitTestCase {
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$author_ids     = $factory->user->create_many( 5, array( 'role' => 'author' ) );
 		self::$page_parent_id = $factory->post->create( array( 'post_type' => 'page' ) );
-		self::$editor_user_id = $factory->user->create( array( 'role' => 'editor' ) );
 
 		// Create child pages.
 		foreach ( self::$author_ids as $author_id ) {

--- a/tests/phpunit/tests/query/thePost.php
+++ b/tests/phpunit/tests/query/thePost.php
@@ -201,6 +201,8 @@ class Tests_Query_ThePost extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure draft content is shown for post previews and permalinks for logged in users.
+	 *
 	 * @ticket 56992
 	 */
 	public function test_post_preview_links_draft_posts() {
@@ -245,6 +247,8 @@ class Tests_Query_ThePost extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure autosave content is shown for post previews.
+	 *
 	 * @ticket 56992
 	 */
 	public function test_post_preview_links_autosaves() {

--- a/tests/phpunit/tests/query/thePost.php
+++ b/tests/phpunit/tests/query/thePost.php
@@ -28,6 +28,13 @@ class Tests_Query_ThePost extends WP_UnitTestCase {
 	public static $page_child_ids = array();
 
 	/**
+	 * Editor user ID.
+	 *
+	 * @var int
+	 */
+	public static $editor_user_id = 0;
+
+	/**
 	 * Create the shared fixtures.
 	 *
 	 * @param WP_UnitTest_Factory $factory Factory object.
@@ -35,6 +42,7 @@ class Tests_Query_ThePost extends WP_UnitTestCase {
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$author_ids     = $factory->user->create_many( 5, array( 'role' => 'author' ) );
 		self::$page_parent_id = $factory->post->create( array( 'post_type' => 'page' ) );
+		self::$editor_user_id = $factory->user->create( array( 'role' => 'editor' ) );
 
 		// Create child pages.
 		foreach ( self::$author_ids as $author_id ) {
@@ -190,5 +198,114 @@ class Tests_Query_ThePost extends WP_UnitTestCase {
 			'post IDs'                  => array( 'ids', 4 ),
 			'post ids and parent'       => array( 'id=>parent', 4 ),
 		);
+	}
+
+	/**
+	 * @ticket 56992
+	 */
+	public function test_post_preview_links_draft_posts() {
+		$user_id = self::$author_ids[0];
+		wp_set_current_user( $user_id );
+		$draft_post = $this->factory()->post->create(
+			array(
+				'post_status'  => 'draft',
+				'post_author'  => $user_id,
+				'post_content' => 'ticket 56992',
+			)
+		);
+
+		// Ensure the global post is populated with the draft content for the preview link.
+		$this->go_to( get_preview_post_link( $draft_post ) );
+		if ( have_posts() ) {
+			the_post(); }
+		$this->assertSame( 'ticket 56992', get_the_content(), 'Preview link should show draft content to logged in user' );
+
+		// Ensure the global post is populated with the draft content for the permalink.
+		$this->go_to( get_permalink( $draft_post ) );
+		if ( have_posts() ) {
+			the_post(); }
+		$this->assertSame( 'ticket 56992', get_the_content(), 'Permalink should show draft content to logged in user' );
+
+		// Ensure the global post is not populated with the draft content for the preview link when logged out.
+		wp_set_current_user( 0 );
+		$this->go_to( get_preview_post_link( $draft_post ) );
+		if ( have_posts() ) {
+			the_post(); }
+		$this->assertEmpty( get_the_content(), 'Preview link should not show draft content to logged out users' );
+
+		// Ensure the global post is not populated with the draft content for the permalink when logged out.
+		$this->go_to( get_permalink( $draft_post ) );
+		if ( have_posts() ) {
+			the_post(); }
+		$this->assertEmpty( get_the_content(), 'Permalink should not show draft content to logged out users' );
+	}
+
+	/**
+	 * @ticket 56992
+	 */
+	public function test_post_preview_links_autosaves() {
+		$user_id = self::$author_ids[0];
+		wp_set_current_user( $user_id );
+		$published_post = $this->factory()->post->create(
+			array(
+				'post_status'  => 'publish',
+				'post_author'  => $user_id,
+				'post_content' => 'ticket 56992',
+			)
+		);
+
+		// Create an autosave for the published post.
+		$autosave                 = get_post( $published_post, ARRAY_A );
+		$autosave['post_ID']      = $published_post;
+		$autosave['post_content'] = 'ticket 56992 edited';
+		wp_create_post_autosave( $autosave );
+
+		// Set up the preview $_GET parameters.
+		$nonce                       = wp_create_nonce( 'post_preview_' . $published_post );
+		$query_args['preview_id']    = $published_post;
+		$query_args['preview_nonce'] = $nonce;
+		$post_preview_link           = get_preview_post_link( $published_post, $query_args );
+
+		// Set up the GET parameters for the preview link.
+		$_GET['preview_id']    = $published_post;
+		$_GET['preview_nonce'] = $nonce;
+		_show_post_preview();
+
+		// Ensure the global post is populated with the autosave content for the preview link.
+		$this->go_to( $post_preview_link );
+		if ( have_posts() ) {
+			the_post(); }
+		$this->assertSame( 'ticket 56992 edited', get_the_content(), 'Preview link should show autosave content to logged in user' );
+
+		// Ensure the global post is populated with the published content for the permalink.
+		$this->go_to( get_permalink( $published_post ) );
+		if ( have_posts() ) {
+			the_post(); }
+		$this->assertSame( 'ticket 56992', get_the_content(), 'Permalink should show published content to logged in user' );
+
+		wp_set_current_user( 0 );
+
+		// New user, new nonce; set up the preview $_GET parameters.
+		$nonce                       = wp_create_nonce( 'post_preview_' . $published_post );
+		$query_args['preview_id']    = $published_post;
+		$query_args['preview_nonce'] = $nonce;
+		$post_preview_link           = get_preview_post_link( $published_post, $query_args );
+
+		// Set up the GET parameters for the preview link.
+		$_GET['preview_id']    = $published_post;
+		$_GET['preview_nonce'] = $nonce;
+		_show_post_preview();
+
+		// Ensure the global post is not populated with the draft content for the preview link when logged out.
+		$this->go_to( $post_preview_link );
+		if ( have_posts() ) {
+			the_post(); }
+		$this->assertSame( 'ticket 56992', get_the_content(), 'Preview link should show published to logged out users' );
+
+		// Ensure the global post is not populated with the draft content for the permalink when logged out.
+		$this->go_to( get_permalink( $published_post ) );
+		if ( have_posts() ) {
+			the_post(); }
+		$this->assertSame( 'ticket 56992', get_the_content(), 'Permalink should show published content to logged out users' );
 	}
 }


### PR DESCRIPTION
Follow up to earlier commit after it broke preview of autosaves, see [Core-56992 (comment)](https://core.trac.wordpress.org/ticket/56992#comment:22)

This modifies `WP_Query::the_post()` to only call `get_post()` if `WP_Query::$posts` does not `WP_Post` objects. Other data types (`stdClass` or numeric) indicates partial data was queired, a `WP_Post` object indicates the full data was queried and populated.

Trac ticket: https://core.trac.wordpress.org/ticket/56992

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
