### PR TITLE
Bundled Theme: Fix scroll jump when closing modals in Twenty Twenty.

### DIFF
--- a/src/wp-content/themes/twentytwenty/assets/js/index.js
+++ b/src/wp-content/themes/twentytwenty/assets/js/index.js
@@ -257,7 +257,10 @@ twentytwenty.coverModals = {
 						clickedEl = false;
 					}
 
-					_win.scrollTo( 0, Math.abs( _win.twentytwenty.scrolled + getAdminBarHeight() ) );
+					_win.scrollTo({
+						top: Math.abs( _win.twentytwenty.scrolled + getAdminBarHeight() ),
+						behavior: 'instant'
+					});
 
 					_win.twentytwenty.scrolled = 0;
 				}, 500 );


### PR DESCRIPTION
This PR addresses an issue where closing search modal (e.g., mobile menu or search) causes the page to briefly jump to the top and scroll back. The fix ensures smooth scroll restoration by:

- Using `behavior: 'instant'` in `scrollTo` for instant position restoration

Trac ticket: [#52116](https://core.trac.wordpress.org/ticket/52116)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
