### PR TITLE
Themes: Allow add_theme_support( 'html5' ) to accept true for all features

### DIFF
--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -2738,7 +2738,7 @@ function add_theme_support( $feature, ...$args ) {
 				'style',
 			);
 
-			if ( isset($args[0]) && true === $args[0] ) {
+			if ( isset( $args[0] ) && true === $args[0] ) {
 				$args = array( 0 => $feature_areas );
 			}
 

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -2728,7 +2728,7 @@ function add_theme_support( $feature, ...$args ) {
 			break;
 
 		case 'html5':
-			$defaults = array(
+			$feature_areas = array(
 				'search-form',
 				'comment-form',
 				'comment-list',
@@ -2738,8 +2738,8 @@ function add_theme_support( $feature, ...$args ) {
 				'style',
 			);
 
-			if ( true === $args[0] ) {
-				$args = array( 0 => $defaults );
+			if ( isset($args[0]) && true === $args[0] ) {
+				$args = array( 0 => $feature_areas );
 			}
 
 			// You can't just pass 'html5', you need to pass an array of types.

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -2728,6 +2728,20 @@ function add_theme_support( $feature, ...$args ) {
 			break;
 
 		case 'html5':
+			$defaults = array(
+				'search-form',
+				'comment-form',
+				'comment-list',
+				'gallery',
+				'caption',
+				'script',
+				'style',
+			);
+
+			if ( true === $args[0] ) {
+				$args = array( 0 => $defaults );
+			}
+
 			// You can't just pass 'html5', you need to pass an array of types.
 			if ( empty( $args[0] ) || ! is_array( $args[0] ) ) {
 				_doing_it_wrong(


### PR DESCRIPTION
This PR enhances `add_theme_support( 'html5' )` by allowing true as a shorthand to enable all HTML5-supported features. Previously, themes had to explicitly list each feature. This update simplifies adoption while maintaining backward compatibility.

Trac ticket: [#63060](https://core.trac.wordpress.org/ticket/63060)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
