### PR TITLE
Bundled Theme: Remove inconsistent top border from table cells in editor

### DIFF
--- a/src/wp-content/themes/twentytwelve/editor-style.css
+++ b/src/wp-content/themes/twentytwelve/editor-style.css
@@ -280,7 +280,6 @@ tr th {
 	text-transform: uppercase;
 }
 td {
-	border-top: 1px solid #ededed !important;
 	color: inherit;
 	font-size: inherit;
 	font-weight: normal;


### PR DESCRIPTION
Trac ticket: [#58077](https://core.trac.wordpress.org/ticket/58077)

Fixes the inconsistent top border in the Twenty Twelve theme’s table block within the editor. The top border appeared too light, making it seem missing. This update removes the unnecessary border style to maintain consistency with the rest of the 
table.

Before:

<img width="804" alt="Screenshot 2025-03-06 at 8 02 57 PM" src="https://github.com/user-attachments/assets/6e1153dd-8c2e-4eb8-a598-6d4ddc19208a" />

After:

<img width="799" alt="Screenshot 2025-03-06 at 8 02 21 PM" src="https://github.com/user-attachments/assets/b337a800-ec37-4fd3-b8ce-276fc6e92a89" />

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
