### PR TITLE
Consider moving skip link before `#page` in Twenty Fourteen

### DIFF
--- a/src/wp-content/themes/twentyfourteen/header.php
+++ b/src/wp-content/themes/twentyfourteen/header.php
@@ -32,13 +32,13 @@
 
 <body <?php body_class(); ?>>
 <?php wp_body_open(); ?>
+<a class="screen-reader-text skip-link" href="#content">
+	<?php
+	/* translators: Hidden accessibility text. */
+	_e( 'Skip to content', 'twentyfourteen' );
+	?>
+</a>
 <div id="page" class="hfeed site">
-	<a class="screen-reader-text skip-link" href="#content">
-		<?php
-		/* translators: Hidden accessibility text. */
-		_e( 'Skip to content', 'twentyfourteen' );
-		?>
-	</a>
 	<?php $is_front = ! is_paged() && ( is_front_page() || ( is_home() && ( (int) get_option( 'page_for_posts' ) !== get_queried_object_id() ) ) ); ?>
 	<?php if ( get_header_image() ) : ?>
 	<div id="site-header">


### PR DESCRIPTION
Moves skip link between `wp_body_open()` and `<div id="page">`, as @himanshupathak95 originally had in the first pull request.

With this, the link would appear consistently in the top corner.

![screenshots with proposed change](https://github.com/user-attachments/assets/69286722-5d7f-4d67-9583-4afa5c118bf8)

[Trac 62969](https://core.trac.wordpress.org/ticket/62969)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
