### PR TITLE
Add `noindex` meta tag to `readme.html`

### DIFF
--- a/src/readme.html
+++ b/src/readme.html
@@ -3,6 +3,7 @@
 <head>
 	<meta name="viewport" content="width=device-width" />
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+	<meta name="robots" content="noindex,nofollow" />
 	<title>WordPress &#8250; ReadMe</title>
 	<link rel="stylesheet" href="wp-admin/css/install.css?ver=20100228" type="text/css" />
 </head>


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63069

Add `noindex` meta tag to `readme.html` to prevent search engines from indexing this file. This addresses SEO issues where WordPress installation files are appearing in search results, affecting both site owners and the official documentation's search rankings.


