### PR TITLE
Bump `esversion` from 6 to 10 in JSHint config

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -3,7 +3,7 @@
 	"curly": true,
 	"eqeqeq": true,
 	"eqnull": true,
-	"esversion": 6,
+	"esversion": 10,
 	"expr": true,
 	"immed": true,
 	"noarg": true,


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63077

This bumps the `esversion` config in `.jshintrc` to version 10. This includes support for the following features:

> 7 - To enable language features introduced by [ECMAScript 7](https://www.ecma-international.org/ecma-262/7.0/index.html). Notable additions: the exponentiation operator.
> 8 - To enable language features introduced by [ECMAScript 8](https://www.ecma-international.org/ecma-262/8.0/index.html). Notable additions: async functions, shared memory, and atomics
> 9 - To enable language features introduced by [ECMAScript 9](https://www.ecma-international.org/ecma-262/9.0/index.html). Notable additions: asynchronous iteration, rest/spread properties, and various RegExp extensions
> 10 - To enable language features introduced by [ECMAScript 10](https://www.ecma-international.org/ecma-262/10.0/index.html). Notable additions: optional catch bindings.

Note that for ES10 the notable addition is optional catch bindings. According to caniuse, this is [supported by >95% of users](https://caniuse.com/mdn-javascript_statements_try_catch_optional_catch_binding) globally. The feature was implemented in Chrome 66, Safari 11.1, and Firefox 58--all of which were released in 2018.

# Commit Message

Bump `esversion` from 6 to 10 in JSHint config.

The current `esversion` 6 corresponds to an ECMAScript version from a decade ago (2015). Updating from 6 to 10 allows the following features to be used in Core JS: the exponentiation operator, async functions, shared memory, atomics, asynchronous iteration, rest/spread properties, various RegExp extensions, and optional catch bindings. These features have been supported by all browsers (except for IE11) well beyond WordPress's browser support policy. This also brings Core's allowed ES version closer in line with Gutenberg which is currently using features like async functions.

Props westonruter, swissspidy, mukesh27.
Fixes #63077.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
