### PR TITLE
E2E tests: Ensure logged in before visiting admin pages.

### DIFF
--- a/tests/e2e/specs/dashboard.test.js
+++ b/tests/e2e/specs/dashboard.test.js
@@ -5,6 +5,7 @@ import { test, expect } from '@wordpress/e2e-test-utils-playwright';
 
 test.describe( 'Quick Draft', () => {
 	test.beforeEach( async ({ requestUtils }) => {
+		await requestUtils.login();
 		await requestUtils.deleteAllPosts();
 	} );
 

--- a/tests/e2e/specs/dashboard.test.js
+++ b/tests/e2e/specs/dashboard.test.js
@@ -4,8 +4,9 @@
 import { test, expect } from '@wordpress/e2e-test-utils-playwright';
 
 test.describe( 'Quick Draft', () => {
-	test.beforeEach( async ({ requestUtils }) => {
+	test.beforeEach( async ({ requestUtils, page }) => {
 		await requestUtils.login();
+		await page.waitForLoadState( 'networkidle' );
 		await requestUtils.deleteAllPosts();
 	} );
 

--- a/tests/e2e/specs/edit-posts.test.js
+++ b/tests/e2e/specs/edit-posts.test.js
@@ -4,8 +4,9 @@
 import { test, expect } from '@wordpress/e2e-test-utils-playwright';
 
 test.describe( 'Edit Posts', () => {
-	test.beforeEach( async ( { requestUtils }) => {
+	test.beforeEach( async ( { requestUtils, page }) => {
 		await requestUtils.login();
+		await page.waitForLoadState( 'networkidle' );
 		await requestUtils.deleteAllPosts();
 	} );
 

--- a/tests/e2e/specs/edit-posts.test.js
+++ b/tests/e2e/specs/edit-posts.test.js
@@ -5,6 +5,7 @@ import { test, expect } from '@wordpress/e2e-test-utils-playwright';
 
 test.describe( 'Edit Posts', () => {
 	test.beforeEach( async ( { requestUtils }) => {
+		await requestUtils.login();
 		await requestUtils.deleteAllPosts();
 	} );
 

--- a/tests/e2e/specs/empty-trash-restore-trashed-posts.test.js
+++ b/tests/e2e/specs/empty-trash-restore-trashed-posts.test.js
@@ -7,6 +7,7 @@ const POST_TITLE = 'Test Title';
 
 test.describe( 'Empty Trash', () => {
 	test.beforeEach( async ( { requestUtils } ) => {
+		await requestUtils.login();
 		await requestUtils.deleteAllPosts();
 	});
 

--- a/tests/e2e/specs/empty-trash-restore-trashed-posts.test.js
+++ b/tests/e2e/specs/empty-trash-restore-trashed-posts.test.js
@@ -6,8 +6,9 @@ import { test, expect } from '@wordpress/e2e-test-utils-playwright';
 const POST_TITLE = 'Test Title';
 
 test.describe( 'Empty Trash', () => {
-	test.beforeEach( async ( { requestUtils } ) => {
+	test.beforeEach( async ( { requestUtils, page } ) => {
 		await requestUtils.login();
+		await page.waitForLoadState( 'networkidle' );
 		await requestUtils.deleteAllPosts();
 	});
 

--- a/tests/e2e/specs/general-settings-invalid-timezone.test.js
+++ b/tests/e2e/specs/general-settings-invalid-timezone.test.js
@@ -4,7 +4,8 @@ test.describe( 'Settings -> General', () => {
 	const invalidTimezones = [ '', '0', 'Barry/Gary' ];
 
 	for ( const invalidTimezone of invalidTimezones ) {
-		test( `Does not allow saving an invalid timezone string with "${invalidTimezone}"`, async ( { admin, page } ) => {
+		test( `Does not allow saving an invalid timezone string with "${invalidTimezone}"`, async ( { admin, page, requestUtils } ) => {
+			await requestUtils.login();
 			await admin.visitAdminPage( '/options-general.php' );
 
 			// Set the timezone to a valid value.

--- a/tests/e2e/specs/general-settings-invalid-timezone.test.js
+++ b/tests/e2e/specs/general-settings-invalid-timezone.test.js
@@ -6,6 +6,7 @@ test.describe( 'Settings -> General', () => {
 	for ( const invalidTimezone of invalidTimezones ) {
 		test( `Does not allow saving an invalid timezone string with "${invalidTimezone}"`, async ( { admin, page, requestUtils } ) => {
 			await requestUtils.login();
+			await page.waitForLoadState( 'networkidle' );
 			await admin.visitAdminPage( '/options-general.php' );
 
 			// Set the timezone to a valid value.

--- a/tests/e2e/specs/hello.test.js
+++ b/tests/e2e/specs/hello.test.js
@@ -4,7 +4,8 @@
 import { test, expect } from '@wordpress/e2e-test-utils-playwright';
 
 test.describe( 'Hello World', () => {
-	test( 'Should load properly', async ( { admin, page }) => {
+	test( 'Should load properly', async ( { admin, page, requestUtils }) => {
+		await requestUtils.login();
 		await admin.visitAdminPage( '/' );
 		await expect(
 			page.getByRole('heading', { name: 'Welcome to WordPress', level: 2 })

--- a/tests/e2e/specs/hello.test.js
+++ b/tests/e2e/specs/hello.test.js
@@ -6,6 +6,7 @@ import { test, expect } from '@wordpress/e2e-test-utils-playwright';
 test.describe( 'Hello World', () => {
 	test( 'Should load properly', async ( { admin, page, requestUtils }) => {
 		await requestUtils.login();
+		await page.waitForLoadState( 'networkidle' );
 		await admin.visitAdminPage( '/' );
 		await expect(
 			page.getByRole('heading', { name: 'Welcome to WordPress', level: 2 })

--- a/tests/e2e/specs/profile/applications-passwords.test.js
+++ b/tests/e2e/specs/profile/applications-passwords.test.js
@@ -95,6 +95,8 @@ class ApplicationPasswords {
 	}
 
 	async create(applicationName = TEST_APPLICATION_NAME) {
+		// Log in before visiting admin page.
+		await this.requestUtils.login();
 		await this.admin.visitAdminPage( '/profile.php' );
 
 		const newPasswordField = this.page.getByRole( 'textbox', { name: 'New Application Password Name' } );

--- a/tests/e2e/specs/profile/applications-passwords.test.js
+++ b/tests/e2e/specs/profile/applications-passwords.test.js
@@ -97,6 +97,7 @@ class ApplicationPasswords {
 	async create(applicationName = TEST_APPLICATION_NAME) {
 		// Log in before visiting admin page.
 		await this.requestUtils.login();
+		await this.page.waitForLoadState( 'networkidle' );
 		await this.admin.visitAdminPage( '/profile.php' );
 
 		const newPasswordField = this.page.getByRole( 'textbox', { name: 'New Application Password Name' } );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

`admin.visitAdminPage()` requires users be logged in to prevent it from throwing an error. For some tests this is causing misbehaviour depending on the order in which the tests run.

Trac ticket: https://core.trac.wordpress.org/ticket/62280

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
