### PR TITLE
fix: Duplicate Custom Fielda are created in new Post.

### DIFF
--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -446,8 +446,6 @@ function edit_post( $post_data = null ) {
 		}
 	}
 
-	add_meta( $post_id );
-
 	update_post_meta( $post_id, '_edit_last', get_current_user_id() );
 
 	$success = wp_update_post( $translated );


### PR DESCRIPTION
This PR solves the issue of duplicate custom fields are added for new post. This [comment](https://github.com/WordPress/gutenberg/issues/69281#issuecomment-2678491228) explains the reason behind this bug.

To fix this issue, I've removed the duplicate call to `add_meta` from `edit_post` function. The reason:
1. Custom fields are handled via AJAX with proper error handling. Hence, we don't need to worry about them being saved.
2. There's no error handling for `add_meta` inside `edit_post`. Hence, if for some reason, `add_meta` failed to save the custom field then the user won't be aware.

Trac ticket: https://core.trac.wordpress.org/ticket/47576

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
