### PR TITLE
Fix: Failing `wp_timezone_override_offset()` Test Due to DST

### DIFF
--- a/tests/phpunit/tests/functions/wpTimezoneOverrideOffset.php
+++ b/tests/phpunit/tests/functions/wpTimezoneOverrideOffset.php
@@ -33,7 +33,22 @@ class Tests_Functions_wpTimezoneOverrideOffset extends WP_UnitTestCase {
 			'bad option set'                => array( 'BAD_TIME_ZONE', false ),
 			'UTC option set'                => array( 'UTC', 0.0 ),
 			'EST option set'                => array( 'EST', -5.0 ),
-			'NST option set'                => array( 'America/St_Johns', -3.5 ),
+			'NST option set'                => array( 'America/St_Johns', $this->get_expected_offset( 'America/St_Johns' ) ),
 		);
+	}
+
+	/**
+	 * Gets the expected timezone offset in hours for a given timezone.
+	 *
+	 * This function determines the current offset (including daylight saving time adjustments)
+	 * for the provided timezone string.
+	 *
+	 * @param string $timezone_string The timezone identifier (e.g., 'America/St_Johns').
+	 * @return float The current timezone offset in hours.
+	 */
+	private function get_expected_offset( $timezone_string ) {
+		$timezone = new DateTimeZone( $timezone_string );
+		$datetime = new DateTime( 'now', $timezone );
+		return $timezone->getOffset( $datetime ) / 3600;
 	}
 }

--- a/tests/phpunit/tests/functions/wpTimezoneOverrideOffset.php
+++ b/tests/phpunit/tests/functions/wpTimezoneOverrideOffset.php
@@ -44,7 +44,6 @@ class Tests_Functions_wpTimezoneOverrideOffset extends WP_UnitTestCase {
 	 * and returns the corresponding offset in hours.
 	 *
 	 * @param string $timezone_string The timezone identifier (e.g., 'America/St_Johns').
-	 *
 	 * @return float The timezone offset in hours (-3.5 for standard time, -2.5 for DST).
 	 */
 	private function get_timezone_offset_based_on_dst( $timezone_string ) {

--- a/tests/phpunit/tests/functions/wpTimezoneOverrideOffset.php
+++ b/tests/phpunit/tests/functions/wpTimezoneOverrideOffset.php
@@ -33,22 +33,28 @@ class Tests_Functions_wpTimezoneOverrideOffset extends WP_UnitTestCase {
 			'bad option set'                => array( 'BAD_TIME_ZONE', false ),
 			'UTC option set'                => array( 'UTC', 0.0 ),
 			'EST option set'                => array( 'EST', -5.0 ),
-			'NST option set'                => array( 'America/St_Johns', $this->get_expected_offset( 'America/St_Johns' ) ),
+			'NST option set'                => array( 'America/St_Johns', $this->get_timezone_offset_based_on_dst( 'America/St_Johns' ) ),
 		);
 	}
 
 	/**
-	 * Gets the expected timezone offset in hours for a given timezone.
+	 * Determines the current timezone offset based on daylight saving time (DST).
 	 *
-	 * This function determines the current offset (including daylight saving time adjustments)
-	 * for the provided timezone string.
+	 * This function checks if the provided timezone is currently observing DST
+	 * and returns the corresponding offset in hours.
 	 *
 	 * @param string $timezone_string The timezone identifier (e.g., 'America/St_Johns').
-	 * @return float The current timezone offset in hours.
+	 * @return float The timezone offset in hours (-3.5 for standard time, -2.5 for DST).
 	 */
-	private function get_expected_offset( $timezone_string ) {
+	private function get_timezone_offset_based_on_dst( $timezone_string ) {
 		$timezone = new DateTimeZone( $timezone_string );
-		$datetime = new DateTime( 'now', $timezone );
-		return $timezone->getOffset( $datetime ) / 3600;
+		$timestamp = time();
+		$transitions = $timezone->getTransitions( $timestamp, $timestamp );
+
+		if ( false === $transitions || ! is_array( $transitions ) || ! isset( $transitions[0]['isdst'] ) ) {
+			return -3.5;
+		}
+
+		return $transitions[0]['isdst'] ? -2.5 : -3.5;
 	}
 }

--- a/tests/phpunit/tests/functions/wpTimezoneOverrideOffset.php
+++ b/tests/phpunit/tests/functions/wpTimezoneOverrideOffset.php
@@ -33,29 +33,25 @@ class Tests_Functions_wpTimezoneOverrideOffset extends WP_UnitTestCase {
 			'bad option set'                => array( 'BAD_TIME_ZONE', false ),
 			'UTC option set'                => array( 'UTC', 0.0 ),
 			'EST option set'                => array( 'EST', -5.0 ),
-			'NST option set'                => array( 'America/St_Johns', $this->get_timezone_offset_based_on_dst( 'America/St_Johns' ) ),
+			'NST option set'                => array( 'America/St_Johns', $this->is_timezone_in_dst( 'America/St_Johns' ) ? -2.5 : -3.5 ),
 		);
 	}
 
 	/**
-	 * Determines the current timezone offset based on daylight saving time (DST).
-	 *
-	 * This function checks if the provided timezone is currently observing DST
-	 * and returns the corresponding offset in hours.
+	 * Determines whether the current timezone offset is observing daylight saving time (DST).
 	 *
 	 * @param string $timezone_string The timezone identifier (e.g., 'America/St_Johns').
-	 *
-	 * @return float The timezone offset in hours (-3.5 for standard time, -2.5 for DST).
+	 * @return bool Whether the timezone is observing DST.
 	 */
-	private function get_timezone_offset_based_on_dst( $timezone_string ) {
+	private function is_timezone_in_dst( $timezone_string ) {
 		$timezone    = new DateTimeZone( $timezone_string );
 		$timestamp   = time();
 		$transitions = $timezone->getTransitions( $timestamp, $timestamp );
 
 		if ( false === $transitions || ! is_array( $transitions ) || ! isset( $transitions[0]['isdst'] ) ) {
-			return -3.5;
+			return false;
 		}
 
-		return $transitions[0]['isdst'] ? -2.5 : -3.5;
+		return $transitions[0]['isdst'];
 	}
 }

--- a/tests/phpunit/tests/functions/wpTimezoneOverrideOffset.php
+++ b/tests/phpunit/tests/functions/wpTimezoneOverrideOffset.php
@@ -44,11 +44,12 @@ class Tests_Functions_wpTimezoneOverrideOffset extends WP_UnitTestCase {
 	 * and returns the corresponding offset in hours.
 	 *
 	 * @param string $timezone_string The timezone identifier (e.g., 'America/St_Johns').
+	 *
 	 * @return float The timezone offset in hours (-3.5 for standard time, -2.5 for DST).
 	 */
 	private function get_timezone_offset_based_on_dst( $timezone_string ) {
-		$timezone = new DateTimeZone( $timezone_string );
-		$timestamp = time();
+		$timezone    = new DateTimeZone( $timezone_string );
+		$timestamp   = time();
 		$transitions = $timezone->getTransitions( $timestamp, $timestamp );
 
 		if ( false === $transitions || ! is_array( $transitions ) || ! isset( $transitions[0]['isdst'] ) ) {


### PR DESCRIPTION
Trac Ticke: Core-63079

### Summary

- This PR fixes the failing test for `wp_timezone_override_offset()`, which was caused by **Daylight Saving Time (DST) adjustments** in **`America/St_Johns`**. The test previously expected a static offset of **`-3.5`**, but during DST, the actual offset changes to **`-2.5`**, leading to test failures.

### Changes

- Introduced `get_timezone_offset_based_on_dst()` to determine the correct offset based on whether DST is active.
- Updated the test data provider to use this function instead of a hardcoded value.
- The function now returns **`-2.5`** when DST is active and **`-3.5`** otherwise.
