### PR TITLE
Fix CodeMirror linting in CSS Editor (Customizer)

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -4266,7 +4266,17 @@ function wp_get_code_editor_settings( $args ) {
 		}
 	}
 
-	if ( in_array( $type, array( 'text/css', 'text/x-scss', 'text/x-less', 'text/x-sass' ), true ) ) {
+	if ( 'text/css' === $type ) {
+		$settings['codemirror'] = array_merge(
+			$settings['codemirror'],
+			array(
+				'mode'              => 'css',
+				'lint'              => true,
+				'autoCloseBrackets' => true,
+				'matchBrackets'     => true,
+			)
+		);
+	} elseif ( in_array( $type, array( 'text/x-scss', 'text/x-less', 'text/x-sass' ), true ) ) {
 		$settings['codemirror'] = array_merge(
 			$settings['codemirror'],
 			array(


### PR DESCRIPTION
The CodeMirror linting is not working in the Customizer > Additional CSS page.
It's also possible to save CSS that contains mistakes.
`lint` was set on `false`.

Trac ticket:
https://core.trac.wordpress.org/ticket/62927


![Additional CSS](https://github.com/user-attachments/assets/63e56141-43c7-4e8c-8971-3c58ee4855c5)

