### PR TITLE
Workflow: Add support for `Core-{n}` format in PR Cleanup Action

### DIFF
--- a/.github/workflows/reusable-cleanup-pull-requests.yml
+++ b/.github/workflows/reusable-cleanup-pull-requests.yml
@@ -54,7 +54,9 @@ jobs:
             let prNumbers = [];
 
             for (const ticket of fixedList) {
-              const query = 'is:pr is:open repo:' + context.repo.owner + '/' + context.repo.repo + ' in:body https://core.trac.wordpress.org/ticket/' + ticket;
+              const tracUrlFormat = `https://core.trac.wordpress.org/ticket/${ ticket }`;
+              const corePrefix = `Core-${ ticket }`;
+              const query = `is:pr is:open repo:${ context.repo.owner }/${ context.repo.repo } in:body ${ tracUrlFormat } OR ${ corePrefix }`;
               const result = await github.rest.search.issuesAndPullRequests({ q: query });
 
               prNumbers = prNumbers.concat(result.data.items.map(pr => pr.number));


### PR DESCRIPTION
### Description

Trac ticket: Core-63081

This PR enhances the search query by enabling support for `Core-{n}`, improving the filtering of PRs.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
