### PR TITLE
Strip query strings in wp_redirect_admin_locations.

### DIFF
--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -1034,6 +1034,9 @@ function wp_redirect_admin_locations() {
 		return;
 	}
 
+	// Strip query string from REQUEST_URI
+	$request_uri = untrailingslashit( preg_replace( '/\?.*$/', '', $_SERVER['REQUEST_URI'] ) );
+
 	$admins = array(
 		home_url( 'wp-admin', 'relative' ),
 		home_url( 'dashboard', 'relative' ),
@@ -1042,7 +1045,7 @@ function wp_redirect_admin_locations() {
 		site_url( 'admin', 'relative' ),
 	);
 
-	if ( in_array( untrailingslashit( $_SERVER['REQUEST_URI'] ), $admins, true ) ) {
+	if ( in_array( $request_uri, $admins, true ) ) {
 		wp_redirect( admin_url() );
 		exit;
 	}
@@ -1054,7 +1057,7 @@ function wp_redirect_admin_locations() {
 		site_url( 'login', 'relative' ),
 	);
 
-	if ( in_array( untrailingslashit( $_SERVER['REQUEST_URI'] ), $logins, true ) ) {
+	if ( in_array( $request_uri, $logins, true ) ) {
 		wp_redirect( wp_login_url() );
 		exit;
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

This fixes an issue where query parameters added by plugins (such as WooCommerce) 
would break admin and login redirects. The function now strips query strings from 
the request URI before comparing with admin/login URLs.

Trac ticket: https://core.trac.wordpress.org/ticket/63082

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
