### PR TITLE
Allow multiple `workflow_dispatch` runs.

### DIFF
--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -27,7 +27,7 @@ on:
 concurrency:
   # The concurrency group contains the workflow name and the branch name for pull requests
   # or the commit hash for any other events.
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  group: ${{ github.workflow }}-${{ inputs.new-version || github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
 # Disable permissions for all available scopes by default.


### PR DESCRIPTION
This updates the `concurrency:group` to differentiate between runs using different input values.

This prevents the previous one from being cancelled when running upgrade tests for multiple versions. For example, 6.7.2, 6.6.3, etc. Because the workflow runs from `trunk`, the current configuration would cancel all ongoing workflows when a new one is created.
 
Trac ticket: https://core.trac.wordpress.org/ticket/62221

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
