### PR TITLE
Adjust `top` value for screen reader shortcut in block editor at 782px

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -3908,6 +3908,10 @@ img {
 		top: -39px;
 	}
 
+	.block-editor-page .screen-reader-shortcut:focus {
+		top: 7px;
+	}
+
 	body {
 		min-width: 240px;
 		overflow-x: hidden;


### PR DESCRIPTION
Changes the `top` value to a positive 7 pixels at the `(max-width: 782px)` breakpoint within the block editor. With a negative value, it was mostly hidden.

I edited `common.css` instead of the `edit-post` styles because I did not want to redefine the negative value at `(min-width: 782px)`.

**Before** patch, with admin menu showing

![skip links hidden at 650 and 750 pixels](https://github.com/user-attachments/assets/1ac67689-2c4d-4960-a66b-8985b409c2ef)

**With** patch, with admin menu showing

![all skip links visible, but lower at 650, 750 and 782 pixels](https://github.com/user-attachments/assets/5117924c-fbd4-42c6-af48-a83d25d8e44d)

**Before** patch, in Fullscreen mode

![skip links hidden at 650 and 750 pixels and not available at 782 pixels or wider](https://github.com/user-attachments/assets/611b0628-1065-4b14-bae3-2927931b2708)

**With** patch, in Fullscreen mode

![skip links are visible at widths less than 782 pixels](https://github.com/user-attachments/assets/a54b2b46-6561-4445-a8b3-dff6c86a2e3c)

[Trac 63084](https://core.trac.wordpress.org/ticket/63084)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
