### PR TITLE
Adapted Patch 39699: Filter to check XML-RPC data before any DB insertion

### DIFF
--- a/src/wp-includes/class-wp-xmlrpc-server.php
+++ b/src/wp-includes/class-wp-xmlrpc-server.php
@@ -1540,6 +1540,22 @@ class wp_xmlrpc_server extends IXR_Server {
 			$post_data['edit_date'] = true;
 		}
 
+		/**
+		 * Filter XML-RPC data to be added/updated via XML-RPC before any DB insertion
+		 *
+		 * @since 4.8
+		 *
+		 * @param array   $post_data       Parsed array of post data.
+		 * @param array   $content_struct  Post data array.
+		 * @param WP_User $user            WP_User object.
+		 * 
+		 * @return array|IXR_Error
+		 */
+		$post_data = apply_filters( 'xmlrpc_before_insert_post', $post_data, $content_struct, $user );
+		if ( $post_data instanceof IXR_Error ) {
+			return $post_data;
+		}
+
 		if ( ! isset( $post_data['ID'] ) ) {
 			$post_data['ID'] = get_default_post_to_edit( $post_data['post_type'], true )->ID;
 		}

--- a/tests/phpunit/tests/xmlrpc/wp/editPost.php
+++ b/tests/phpunit/tests/xmlrpc/wp/editPost.php
@@ -528,4 +528,41 @@ class Tests_XMLRPC_wp_editPost extends WP_XMLRPC_UnitTestCase {
 		$after = get_post( $post_id );
 		$this->assertSame( '0000-00-00 00:00:00', $after->post_date_gmt );
 	}
+
+	/**
+	 * @ticket 39699
+	 */
+	public function test_xmlrpc_before_insert_post() {
+		$this->make_user_by_role( 'editor' );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Post title',
+				'post_content' => 'Post edited',
+				'post_status'  => 'draft',
+				'post_type'    => 'post',
+			)
+		);
+
+		// Add filter
+		add_filter( 'xmlrpc_before_insert_post', array( $this, 'filter_xmlrpc_before_insert_post' ), 10, 3 );
+
+		$result = $this->myxmlrpcserver->wp_editPost( array( 1, 'editor', 'editor', $post_id, array( 'post_title' => 'Too short' ) ) );
+		$this->assertInstanceOf( 'IXR_Error', $result );
+		$this->assertEquals( 500, $result->code );
+		$this->assertEquals( 'Post title too short.', $result->message );
+
+		$result       = $this->myxmlrpcserver->wp_editPost( array( 1, 'editor', 'editor', $post_id, array( 'post_title' => 'Right title' ) ) );
+		$fetched_post = get_post( $post_id );
+		$this->assertNotInstanceOf( 'IXR_Error', $result );
+		$this->assertTrue( $result );
+		$this->assertEquals( 'Right title', $fetched_post->post_title );
+	}
+
+	public function filter_xmlrpc_before_insert_post( $post_data, $content_struct, $user ) {
+		if ( strlen( $post_data['post_title'] ) < 10 ) {
+			return new \IXR_Error( 500, 'Post title too short.' );
+		}
+		return $post_data;
+	}
 }

--- a/tests/phpunit/tests/xmlrpc/wp/newPost.php
+++ b/tests/phpunit/tests/xmlrpc/wp/newPost.php
@@ -445,4 +445,62 @@ class Tests_XMLRPC_wp_newPost extends WP_XMLRPC_UnitTestCase {
 		$this->assertStringMatchesFormat( '%d', $result );
 		$this->assertSame( $date_string, $fetched_post->post_date_gmt );
 	}
+
+	/**
+	 * @ticket 39699
+	 */
+	public function test_xmlrpc_before_insert_post() {
+		$this->make_user_by_role( 'editor' );
+
+		// Add filter
+		add_filter( 'xmlrpc_before_insert_post', array( $this, 'filter_xmlrpc_before_insert_post' ), 10, 3 );
+
+		$result = $this->myxmlrpcserver->wp_newPost(
+			array(
+				1,
+				'editor',
+				'editor',
+				array(
+					'post_title'    => 'Too short',
+					'custom_fields' => array(
+						array(
+							'key'   => 'custom_field_to_create',
+							'value' => '123456789',
+						),
+					),
+				),
+			)
+		);
+		$this->assertInstanceOf( 'IXR_Error', $result );
+		$this->assertEquals( 500, $result->code );
+		$this->assertEquals( 'Post title too short.', $result->message );
+
+		$result       = $this->myxmlrpcserver->wp_newPost(
+			array(
+				1,
+				'editor',
+				'editor',
+				array(
+					'post_title'    => 'Right title',
+					'custom_fields' => array(
+						array(
+							'key'   => 'custom_field_to_create',
+							'value' => '123456789',
+						),
+					),
+				),
+			)
+		);
+		$fetched_post = get_post( $result );
+		$this->assertStringMatchesFormat( '%d', $result );
+		$this->assertEquals( 'Right title', $fetched_post->post_title );
+	}
+
+	public function filter_xmlrpc_before_insert_post( $post_data, $content_struct, $user ) {
+
+		if ( strlen( $post_data['post_title'] ) < 10 ) {
+			return new \IXR_Error( 500, 'Post title too short.' );
+		}
+		return $post_data;
+	}
 }


### PR DESCRIPTION
This patch is an adaptation of the original patch made 8 years ago in the ticket
It adds some corrections + sorting of PHPCS issues.

More info about this patch in Trac.

Trac ticket: https://core.trac.wordpress.org/ticket/39699

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
