### PR TITLE
The loop changes: perf follow up.

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2067,9 +2067,17 @@ class WP_Query {
 			case 'id=>parent':
 				$fields = "{$wpdb->posts}.ID, {$wpdb->posts}.post_parent";
 				break;
+			case '':
+				/*
+				 * Set the default to 'all'.
+				 *
+				 * This is used in `WP_Query::the_post` to determine if the
+				 * entire post object has been queried.
+				 */
+				$q['fields'] = 'all';
+				// Falls through.
 			default:
-				$q['fields'] = 'all'; // Ensure that the default is 'all'.
-				$fields      = "{$wpdb->posts}.*";
+				$fields = "{$wpdb->posts}.*";
 		}
 
 		if ( '' !== $q['menu_order'] ) {

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3748,7 +3748,7 @@ class WP_Query {
 		global $post;
 
 		if ( ! $this->in_the_loop ) {
-			if ( $this->posts[0] instanceof WP_Post ) {
+			if ( 'all' === $this->query_vars['fields'] ) {
 				// Full post objects queried.
 				$post_objects = $this->posts;
 			} else {
@@ -3792,12 +3792,17 @@ class WP_Query {
 		$post = $this->next_post();
 
 		// Ensure a full post object is available.
-		if ( ! $post instanceof WP_Post ) {
+		if ( 'all' !== $this->query_vars['fields'] ) {
 			if ( 'ids' === $this->query_vars['fields'] ) {
 				// Post IDs queried.
 				$post = get_post( $post );
 			} elseif ( isset( $post->ID ) ) {
-				// Partial object (stdClass) queried.
+				/*
+				 * Partial objecct queried.
+				 *
+				 * The post object was queried with a partial set of
+				 * fields, populate the entire object for the loop.
+				 */
 				$post = get_post( $post->ID );
 			}
 		}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2068,7 +2068,8 @@ class WP_Query {
 				$fields = "{$wpdb->posts}.ID, {$wpdb->posts}.post_parent";
 				break;
 			default:
-				$fields = "{$wpdb->posts}.*";
+				$q['fields'] = 'all'; // Ensure that the default is 'all'.
+				$fields      = "{$wpdb->posts}.*";
 		}
 
 		if ( '' !== $q['menu_order'] ) {
@@ -3739,28 +3740,30 @@ class WP_Query {
 		global $post;
 
 		if ( ! $this->in_the_loop ) {
-			// Get post IDs to prime incomplete post objects.
-			$post_ids = array_reduce(
-				$this->posts,
-				function ( $carry, $post ) {
-					if ( is_numeric( $post ) && $post > 0 ) {
-						// Query for post ID.
-						$carry[] = $post;
-					}
+			if ( $this->posts[0] instanceof WP_Post ) {
+				// Full post objects queried.
+				$post_objects = $this->posts;
+			} else {
+				if ( 'ids' === $this->query_vars['fields'] ) {
+					// Post IDs queried.
+					$post_ids = $this->posts;
+				} else {
+					// Only partial objects queried, need to prime the cache for the loop.
+					$post_ids = array_reduce(
+						$this->posts,
+						function ( $carry, $post ) {
+							if ( isset( $post->ID ) ) {
+								$carry[] = $post->ID;
+							}
 
-					if ( is_object( $post ) && isset( $post->ID ) ) {
-						// Query for object, either WP_Post or stdClass.
-						$carry[] = $post->ID;
-					}
-
-					return $carry;
-				},
-				array()
-			);
-			if ( $post_ids ) {
+							return $carry;
+						},
+						array()
+					);
+				}
 				_prime_post_caches( $post_ids, $this->query_vars['update_post_term_cache'], $this->query_vars['update_post_meta_cache'] );
+				$post_objects = array_map( 'get_post', $post_ids );
 			}
-			$post_objects = array_map( 'get_post', $post_ids );
 			update_post_author_caches( $post_objects );
 		}
 
@@ -3781,12 +3784,14 @@ class WP_Query {
 		$post = $this->next_post();
 
 		// Ensure a full post object is available.
-		if ( $post instanceof stdClass ) {
-			// stdClass indicates that a partial post object was queried.
-			$post = get_post( $post->ID );
-		} elseif ( is_numeric( $post ) ) {
-			// Numeric indicates that only post IDs were queried.
-			$post = get_post( $post );
+		if ( ! $post instanceof WP_Post ) {
+			if ( 'ids' === $this->query_vars['fields'] ) {
+				// Post IDs queried.
+				$post = get_post( $post );
+			} elseif ( isset( $post->ID ) ) {
+				// Partial object (stdClass) queried.
+				$post = get_post( $post->ID );
+			}
 		}
 
 		// Set up the global post object for the loop.

--- a/tests/phpunit/tests/query/thePost.php
+++ b/tests/phpunit/tests/query/thePost.php
@@ -79,8 +79,8 @@ class Tests_Query_ThePost extends WP_UnitTestCase {
 		);
 
 		$this->assertNotEmpty( $query->posts, 'The query is expected to return results' );
-		$this->assertSame( $query->get( 'fields' ), 'custom', 'The query is expected to use the custom fields value' );
-		$this->assertStringContainsString( "$wpdb->posts.ID,$wpdb->posts.post_author", $query->request, 'The query is expected to use the custom fields value' );
+		$this->assertSame( $query->get( 'fields' ), 'custom', 'The WP_Query class is expected to use the custom fields value' );
+		$this->assertStringContainsString( "$wpdb->posts.ID,$wpdb->posts.post_author", $query->request, 'The database query is expected to use the custom fields value' );
 	}
 
 	/**

--- a/tests/phpunit/tests/query/thePost.php
+++ b/tests/phpunit/tests/query/thePost.php
@@ -121,11 +121,11 @@ class Tests_Query_ThePost extends WP_UnitTestCase {
 		$global_post   = get_post();
 		$specific_post = get_post( self::$page_child_ids[0], ARRAY_A );
 
+		$this->assertSameSetsWithIndex( $specific_post, $global_post->to_array(), 'The global post is expected to be fully populated.' );
+
 		$this->assertNotEmpty( get_the_title(), 'The title is expected to be populated.' );
 		$this->assertNotEmpty( get_the_content(), 'The content is expected to be populated.' );
 		$this->assertNotEmpty( get_the_excerpt(), 'The excerpt is expected to be populated.' );
-
-		$this->assertSameSetsWithIndex( $specific_post, $global_post->to_array(), 'The global post is expected to be fully populated.' );
 	}
 
 	/**
@@ -155,11 +155,11 @@ class Tests_Query_ThePost extends WP_UnitTestCase {
 		$global_post   = get_post();
 		$specific_post = get_post( self::$page_child_ids[0], ARRAY_A );
 
+		$this->assertSameSetsWithIndex( $specific_post, $global_post->to_array(), 'The global post is expected to be fully populated.' );
+
 		$this->assertNotEmpty( get_the_title(), 'The title is expected to be populated.' );
 		$this->assertNotEmpty( get_the_content(), 'The content is expected to be populated.' );
 		$this->assertNotEmpty( get_the_excerpt(), 'The excerpt is expected to be populated.' );
-
-		$this->assertSameSetsWithIndex( $specific_post, $global_post->to_array(), 'The global post is expected to be fully populated.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/query/thePost.php
+++ b/tests/phpunit/tests/query/thePost.php
@@ -84,6 +84,51 @@ class Tests_Query_ThePost extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure custom 'fields' populates the global post in the loop.
+	 *
+	 * @ticket 56992
+	 */
+	public function test_wp_query_with_custom_fields_value_populates_the_global_post() {
+		global $wpdb;
+		add_filter(
+			'posts_fields',
+			function ( $fields, $query ) {
+				global $wpdb;
+
+				if ( $query->get( 'fields' ) === 'custom' ) {
+					$fields = "$wpdb->posts.ID,$wpdb->posts.post_author";
+				}
+
+				return $fields;
+			},
+			10,
+			2
+		);
+
+		$query = new WP_Query(
+			array(
+				'fields'    => 'custom',
+				'post_type' => 'page',
+				'post__in'  => self::$page_child_ids,
+				'orderby'   => 'id',
+				'order'     => 'ASC',
+			)
+		);
+
+		$query->the_post();
+
+		// Get the global post and specific post.
+		$global_post   = get_post();
+		$specific_post = get_post( self::$page_child_ids[0], ARRAY_A );
+
+		$this->assertNotEmpty( get_the_title(), 'The title is expected to be populated.' );
+		$this->assertNotEmpty( get_the_content(), 'The content is expected to be populated.' );
+		$this->assertNotEmpty( get_the_excerpt(), 'The excerpt is expected to be populated.' );
+
+		$this->assertSameSetsWithIndex( $specific_post, $global_post->to_array(), 'The global post is expected to be fully populated.' );
+	}
+
+	/**
 	 * Ensure that a secondary loop populates the global post completely regardless of the fields parameter.
 	 *
 	 * @ticket 56992

--- a/tests/phpunit/tests/query/thePost.php
+++ b/tests/phpunit/tests/query/thePost.php
@@ -49,6 +49,41 @@ class Tests_Query_ThePost extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure custom 'fields' values are respected.
+	 *
+	 * @ticket 56992
+	 */
+	public function test_wp_query_respects_custom_fields_values() {
+		global $wpdb;
+		add_filter(
+			'posts_fields',
+			function ( $fields, $query ) {
+				global $wpdb;
+
+				if ( $query->get( 'fields' ) === 'custom' ) {
+					$fields = "$wpdb->posts.ID,$wpdb->posts.post_author";
+				}
+
+				return $fields;
+			},
+			10,
+			2
+		);
+
+		$query = new WP_Query(
+			array(
+				'fields'    => 'custom',
+				'post_type' => 'page',
+				'post__in'  => self::$page_child_ids,
+			)
+		);
+
+		$this->assertNotEmpty( $query->posts, 'The query is expected to return results' );
+		$this->assertSame( $query->get( 'fields' ), 'custom', 'The query is expected to use the custom fields value' );
+		$this->assertStringContainsString( "$wpdb->posts.ID,$wpdb->posts.post_author", $query->request, 'The query is expected to use the custom fields value' );
+	}
+
+	/**
 	 * Ensure that a secondary loop populates the global post completely regardless of the fields parameter.
 	 *
 	 * @ticket 56992


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/56992

Fixes a performance regression with `fields => all` by avoiding looping through the `WP_Posts::$posts` values if it's known that they will either be full objects be numeric values.

For partial queries the, custom or using `parent, id`, the objects are traversed for cache priming.


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
