### PR TITLE
Customizer: Move block theme check and getting the theme to `setup_theme`

### DIFF
--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -2450,8 +2450,10 @@ final class WP_Customize_Manager {
 			if ( ! current_user_can( get_post_type_object( 'customize_changeset' )->cap->create_posts ) ) {
 				wp_send_json_error( 'cannot_create_changeset_post' );
 			}
-		} elseif ( ! current_user_can( get_post_type_object( 'customize_changeset' )->cap->edit_post, $changeset_post_id ) ) {
+		} else {
+			if ( ! current_user_can( get_post_type_object( 'customize_changeset' )->cap->edit_post, $changeset_post_id ) ) {
 				wp_send_json_error( 'cannot_edit_changeset_post' );
+			}
 		}
 
 		if ( ! empty( $_POST['customize_changeset_data'] ) ) {

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -515,6 +515,7 @@ final class WP_Customize_Manager {
 			$this->components[] = 'widgets';
 		}
 
+		// Use the theme value stored during instantiation to get the WP_Theme object.
 		$this->theme = wp_get_theme( $this->theme );
 
 		// Check permissions for customize.php access since this method is called before customize.php can run any code.
@@ -2449,10 +2450,8 @@ final class WP_Customize_Manager {
 			if ( ! current_user_can( get_post_type_object( 'customize_changeset' )->cap->create_posts ) ) {
 				wp_send_json_error( 'cannot_create_changeset_post' );
 			}
-		} else {
-			if ( ! current_user_can( get_post_type_object( 'customize_changeset' )->cap->edit_post, $changeset_post_id ) ) {
+		} elseif ( ! current_user_can( get_post_type_object( 'customize_changeset' )->cap->edit_post, $changeset_post_id ) ) {
 				wp_send_json_error( 'cannot_edit_changeset_post' );
-			}
 		}
 
 		if ( ! empty( $_POST['customize_changeset_data'] ) ) {

--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -286,13 +286,8 @@ final class WP_Customize_Manager {
 			$args['messenger_channel'] = sanitize_key( wp_unslash( $_REQUEST['customize_messenger_channel'] ) );
 		}
 
-		// Do not load 'widgets' component if a block theme is activated.
-		if ( ! wp_is_block_theme() ) {
-			$this->components[] = 'widgets';
-		}
-
 		$this->original_stylesheet = get_stylesheet();
-		$this->theme               = wp_get_theme( 0 === validate_file( $args['theme'] ) ? $args['theme'] : null );
+		$this->theme               = 0 === validate_file( $args['theme'] ) ? $args['theme'] : null;
 		$this->messenger_channel   = $args['messenger_channel'];
 		$this->_changeset_uuid     = $args['changeset_uuid'];
 
@@ -514,6 +509,13 @@ final class WP_Customize_Manager {
 	 */
 	public function setup_theme() {
 		global $pagenow;
+
+		// Do not load 'widgets' component if a block theme is activated.
+		if ( ! wp_is_block_theme() ) {
+			$this->components[] = 'widgets';
+		}
+
+		$this->theme = wp_get_theme( $this->theme );
 
 		// Check permissions for customize.php access since this method is called before customize.php can run any code.
 		if ( 'customize.php' === $pagenow && ! current_user_can( 'customize' ) ) {


### PR DESCRIPTION
### Description

Trac ticket: https://core.trac.wordpress.org/ticket/63086

[This changeset](https://core.trac.wordpress.org/changeset/59968) introduced displaying a `_doing_it_wrong()` error if WP_Theme::is_block_theme is called too early. This caused the warnings to be displayed within `Customizer` where `wp_get_theme` and `wp_is_block_theme` were getting called before themes were set up.

This PR resolves the issue by calling them within the `setup_theme` hook.

### Testing Instructions

1. Navigate to `Appearance` -> `Customize`.
2. Confirm that no errors/warnings are displayed on the `Customizer` page.

### Screencast
#### Before
https://github.com/user-attachments/assets/deab34c7-e84a-4e1b-a54b-8223ee4b2cec

#### After
https://github.com/user-attachments/assets/c4ed1060-fab2-4e8c-acb6-288baf72c14e

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
