### PR TITLE
Editor: Change hook for 'wp_set_editor_default_mode'

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -562,6 +562,7 @@ add_action( 'transition_post_status', '__clear_multi_author_cache' );
 
 // Post.
 add_action( 'init', 'create_initial_post_types', 0 ); // Highest priority.
+add_action( 'init', 'wp_set_editor_default_mode', 1 ); // Run after registering post types.
 add_action( 'admin_menu', '_add_post_type_submenus' );
 add_action( 'before_delete_post', '_reset_front_page_settings_for_post' );
 add_action( 'wp_trash_post', '_reset_front_page_settings_for_post' );
@@ -737,7 +738,6 @@ add_action( 'save_post_wp_template_part', 'wp_set_unique_slug_on_create_template
 add_action( 'wp_enqueue_scripts', 'wp_enqueue_block_template_skip_link' );
 add_action( 'wp_footer', 'the_block_template_skip_link' ); // Retained for backwards-compatibility. Unhooked by wp_enqueue_block_template_skip_link().
 add_action( 'after_setup_theme', 'wp_enable_block_templates', 1 );
-add_action( 'after_setup_theme', 'wp_set_editor_default_mode', 2 ); // Run after enabling block templates.
 add_action( 'wp_loaded', '_add_template_loader_filters' );
 
 // wp_navigation post type.


### PR DESCRIPTION
## Why

The `wp_set_editor_default_mode` should run after `create_initial_post_types`. This ensures that post types are already registered and that initial registration doesn't override the new default support.

## Testing Instructions
1. Create a new editor or admin user.
2. Switch to this user.
3. Create a page.
4. Confirm that it loads with `template-locked` as the default rendering mode.

Trac ticket: https://core.trac.wordpress.org/ticket/61811#comment:25

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
