### PR TITLE
Update: Add 6px Left right padding for Admin Bar Link

### DIFF
--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -140,7 +140,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 #wpadminbar .quicklinks > ul > li > a {
-	padding: 0 8px 0 7px;
+	padding: 0 6px;
 }
 
 #wpadminbar .menupop .ab-sub-wrapper,


### PR DESCRIPTION
Trac Ticket: Core-63033

This PR sets the left and right padding of the WordPress admin bar links to 6px, ensuring consistent padding on both sides from the user's perspective.

