### PR TITLE
Fix #59602: Update table and figcaption styles in Twenty Fifteen theme

### DIFF
--- a/src/wp-content/themes/twentyfifteen/css/editor-blocks.css
+++ b/src/wp-content/themes/twentyfifteen/css/editor-blocks.css
@@ -418,7 +418,7 @@ div.editor-styles-wrapper .wp-block-list:where(.has-background) {
 
 /* Captions */
 
-[class^="wp-block-"] figcaption {
+figure[class*="wp-block-"] > figcaption {
 	color: #707070;
 	font-family: "Noto Sans", sans-serif;
 	font-size: 12px;
@@ -426,36 +426,36 @@ div.editor-styles-wrapper .wp-block-list:where(.has-background) {
 	padding: 0.5em 0;
 }
 
-.editor-block-list__block [class^="wp-block-"] figcaption {
+.editor-styles-wrapper figure[class*="wp-block-"] > figcaption {
 	line-height: 1.5;
 }
 
 @media screen and (min-width: 46.25em) {
-	[class^="wp-block-"] figcaption {
+	figure[class*="wp-block-"] > figcaption {
 		font-size: 14px;
 	}
 }
 
 @media screen and (min-width: 55em) {
-	[class^="wp-block-"] figcaption {
+	figure[class*="wp-block-"] > figcaption {
 		font-size: 16px;
 	}
 }
 
 @media screen and (min-width: 59.6875em) {
-	[class^="wp-block-"] figcaption {
+	figure[class*="wp-block-"] > figcaption {
 		font-size: 12px;
 	}
 }
 
 @media screen and (min-width: 68.75em) {
-	[class^="wp-block-"] figcaption {
+	figure[class*="wp-block-"] > figcaption {
 		font-size: 14px;
 	}
 }
 
 @media screen and (min-width: 77.5em) {
-	[class^="wp-block-"] figcaption {
+	figure[class*="wp-block-"] > figcaption {
 		font-size: 16px;
 	}
 }

--- a/src/wp-content/themes/twentyfifteen/css/editor-style.css
+++ b/src/wp-content/themes/twentyfifteen/css/editor-style.css
@@ -298,9 +298,12 @@ table td,
 .mce-item-table td {
 	border-width: 0 1px 1px 0;
 	font-family: "Noto Serif", serif;
-	font-size: 17px;
 	padding: 7px;
 	vertical-align: baseline;
+}
+
+table caption {
+	font-weight: normal;
 }
 
 img {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/59602

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

This PR fixes issue trac#59602 by:
     1. Updating figcaption selectors to use `figure[class*="wp-block-"] >` instead of `[class^="wp-block-"]` for better specificity
     2. Removing font-size from table elements in editor-style.css
     3. Adding font-weight: normal to table caption elements

Also, this effectively ports [59602.3.patch](https://core.trac.wordpress.org/attachment/ticket/59602/59602.3.patch) by sabernhardt to GitHub to try and get a WP Playground link for testing purposes.