### PR TITLE
Fix: Resolves issue with `wp_rand()` function returning only `0` or `1` on `32-bit` PHP systems.

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2906,7 +2906,7 @@ if ( ! function_exists( 'wp_rand' ) ) :
 		 * Some misconfigured 32-bit environments (Entropy PHP, for example)
 		 * truncate integers larger than PHP_INT_MAX to PHP_INT_MAX rather than overflowing them to floats.
 		 */
-		$max_random_number = 3000000000 === 2147483647 ? (float) '4294967295' : 4294967295; // 4294967295 = 0xffffffff
+		$max_random_number = ( 4 === PHP_INT_SIZE ) ? PHP_INT_MAX : 4294967295; // Use PHP_INT_MAX for 32-bit systems.
 
 		if ( null === $min ) {
 			$min = 0;


### PR DESCRIPTION
Trac Ticket: Core-63099

## Problem

On 32-bit PHP systems, the wp_rand() function would incorrectly return only 0 or 1 when called without parameters due to an integer overflow. This occurred because the function sets $max_random_number to 4294967295, which overflows to -1 on 32-bit systems, leading to invalid arguments being passed to random_int().

## Solution

- Modified the calculation of $max_random_number to dynamically use PHP_INT_MAX for 32-bit systems (PHP_INT_SIZE === 4).

- For 64-bit systems, the previous behavior with 4294967295 remains unchanged.