### PR TITLE
Fix: remove `_doing_it_wrong` notice and early return in `WP_Theme:is_block_theme`

### DIFF
--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -1576,11 +1576,6 @@ final class WP_Theme implements ArrayAccess {
 	 * @return bool
 	 */
 	public function is_block_theme() {
-		if ( ! did_action( 'setup_theme' ) ) {
-			_doing_it_wrong( __METHOD__, __( 'This method should not be called before themes are set up.' ), '6.8.0' );
-			return false;
-		}
-
 		if ( isset( $this->block_theme ) ) {
 			return $this->block_theme;
 		}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

This PR partially reverts https://core.trac.wordpress.org/changeset/59968 by removing the ~warning~ notice and early return in `WP_Theme::is_block_theme()`, which causes issues if active plugins call `wp_is_block_theme()` early. It's safe for plugins to call `wp_is_block_theme()` anytime so the early return and notice should be removed.

* `wp_is_block_theme` doesn't need to be called after `after_theme_setup`, it just needs to be called after theme directories [have been registered](https://github.com/WordPress/wordpress-develop/blob/32fe6af9c36e2b80e79a664fc6ae53d9c5cd3f9a/src/wp-settings.php#L519).
* The initial issue with the child theme is caused by calling that function after [creating post types](https://github.com/WordPress/wordpress-develop/blob/32fe6af9c36e2b80e79a664fc6ae53d9c5cd3f9a/src/wp-settings.php#L514), which is before the theme directories registration.
* Moving that logic to `after_theme_setup`, as we did in https://core.trac.wordpress.org/changeset/59968, is enough to solve the issue.
* Plugins can never break the theme resolution because they are loaded [after](https://github.com/WordPress/wordpress-develop/blob/32fe6af9c36e2b80e79a664fc6ae53d9c5cd3f9a/src/wp-settings.php#L529-L557) theme directories registration.

Trac ticket: https://core.trac.wordpress.org/ticket/63086

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
