### PR TITLE
Sorting Notices due to early calls to is_block_theme

### DIFF
--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -286,10 +286,10 @@ final class WP_Customize_Manager {
 			$args['messenger_channel'] = sanitize_key( wp_unslash( $_REQUEST['customize_messenger_channel'] ) );
 		}
 
-		// Do not load 'widgets' component if a block theme is activated.
-		if ( ! wp_is_block_theme() ) {
-			$this->components[] = 'widgets';
-		}
+		// Revert the conditional, is problematic. See #63086
+		$this->components[] = 'widgets';
+
+		add_action( 'after_setup_theme', array( $this, 'maybe_remove_widgets_component' ) );
 
 		$this->original_stylesheet = get_stylesheet();
 		$this->theme               = wp_get_theme( 0 === validate_file( $args['theme'] ) ? $args['theme'] : null );
@@ -6159,5 +6159,18 @@ final class WP_Customize_Manager {
 	 */
 	public function _render_custom_logo_partial() {
 		return get_custom_logo();
+	}
+
+	/**
+	 * Maybe remove the 'widgets' component if a block theme is active.
+	 *
+	 * @see Ticket #63086
+	 *
+	 * @since 6.8.0
+	 */
+	public function maybe_remove_widgets_component() {
+		if ( wp_is_block_theme() ) {
+			$this->components = array_diff( $this->components, array( 'widgets' ) );
+		}
 	}
 }

--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -392,37 +392,16 @@ final class WP_Theme implements ArrayAccess {
 			$this->template = $this->stylesheet;
 			$theme_path     = $this->theme_root . '/' . $this->stylesheet;
 
-			if ( ! $this->is_block_theme() && ! file_exists( $theme_path . '/index.php' ) ) {
-				$error_message = sprintf(
-					/* translators: 1: templates/index.html, 2: index.php, 3: Documentation URL, 4: Template, 5: style.css */
-					__( 'Template is missing. Standalone themes need to have a %1$s or %2$s template file. <a href="%3$s">Child themes</a> need to have a %4$s header in the %5$s stylesheet.' ),
-					'<code>templates/index.html</code>',
-					'<code>index.php</code>',
-					__( 'https://developer.wordpress.org/themes/advanced-topics/child-themes/' ),
-					'<code>Template</code>',
-					'<code>style.css</code>'
-				);
-				$this->errors = new WP_Error( 'theme_no_index', $error_message );
-				$this->cache_add(
-					'theme',
-					array(
-						'block_template_folders' => $this->get_block_template_folders(),
-						'block_theme'            => $this->block_theme,
-						'headers'                => $this->headers,
-						'errors'                 => $this->errors,
-						'stylesheet'             => $this->stylesheet,
-						'template'               => $this->template,
-					)
-				);
-				return;
+			if ( ! file_exists( $theme_path . '/index.php' ) ) {
+				add_action( 'after_setup_theme', array( $this, '_handle_missing_template' ) );
 			}
 		}
 
-		// If we got our data from cache, we can assume that 'template' is pointing to the right place.
+			// If we got our data from cache, we can assume that 'template' is pointing to the right place.
 		if ( ! is_array( $cache )
 			&& $this->template !== $this->stylesheet
 			&& ! file_exists( $this->theme_root . '/' . $this->template . '/index.php' )
-		) {
+			) {
 			/*
 			 * If we're in a directory of themes inside /themes, look for the parent nearby.
 			 * wp-content/themes/directory-of-themes/*
@@ -431,7 +410,7 @@ final class WP_Theme implements ArrayAccess {
 			$directories = search_theme_directories();
 
 			if ( '.' !== $parent_dir
-				&& file_exists( $this->theme_root . '/' . $parent_dir . '/' . $this->template . '/index.php' )
+			&& file_exists( $this->theme_root . '/' . $parent_dir . '/' . $this->template . '/index.php' )
 			) {
 				$this->template = $parent_dir . '/' . $this->template;
 			} elseif ( $directories && isset( $directories[ $this->template ] ) ) {
@@ -445,7 +424,7 @@ final class WP_Theme implements ArrayAccess {
 				$this->errors = new WP_Error(
 					'theme_no_parent',
 					sprintf(
-						/* translators: %s: Theme directory name. */
+					/* translators: %s: Theme directory name. */
 						__( 'The parent theme is missing. Please install the "%s" parent theme.' ),
 						esc_html( $this->template )
 					)
@@ -466,7 +445,7 @@ final class WP_Theme implements ArrayAccess {
 			}
 		}
 
-		// Set the parent, if we're a child theme.
+			// Set the parent, if we're a child theme.
 		if ( $this->template !== $this->stylesheet ) {
 			// If we are a parent, then there is a problem. Only two generations allowed! Cancel things out.
 			if ( $_child instanceof WP_Theme && $_child->template === $this->stylesheet ) {
@@ -474,7 +453,7 @@ final class WP_Theme implements ArrayAccess {
 				$_child->errors = new WP_Error(
 					'theme_parent_invalid',
 					sprintf(
-						/* translators: %s: Theme directory name. */
+					/* translators: %s: Theme directory name. */
 						__( 'The "%s" theme is not a valid parent theme.' ),
 						esc_html( $_child->template )
 					)
@@ -495,7 +474,7 @@ final class WP_Theme implements ArrayAccess {
 					$this->errors = new WP_Error(
 						'theme_parent_invalid',
 						sprintf(
-							/* translators: %s: Theme directory name. */
+						/* translators: %s: Theme directory name. */
 							__( 'The "%s" theme is not a valid parent theme.' ),
 							esc_html( $this->template )
 						)
@@ -522,10 +501,10 @@ final class WP_Theme implements ArrayAccess {
 			$this->errors = new WP_Error( 'theme_paused', __( 'This theme failed to load properly and was paused within the admin backend.' ) );
 		}
 
-		// We're good. If we didn't retrieve from cache, set it.
+			// We're good. If we didn't retrieve from cache, set it.
 		if ( ! is_array( $cache ) ) {
 			$cache = array(
-				'block_theme'            => $this->is_block_theme(),
+				'block_theme'            => false, // See #63086
 				'block_template_folders' => $this->get_block_template_folders(),
 				'headers'                => $this->headers,
 				'errors'                 => $this->errors,
@@ -537,28 +516,30 @@ final class WP_Theme implements ArrayAccess {
 				$cache['theme_root_template'] = $theme_root_template;
 			}
 			$this->cache_add( 'theme', $cache );
+
+			add_action( 'after_setup_theme', array( $this, '_update_cached_block_theme' ) );
 		}
 	}
 
-	/**
-	 * When converting the object to a string, the theme name is returned.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @return string Theme name, ready for display (translated)
-	 */
+		/**
+		 * When converting the object to a string, the theme name is returned.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @return string Theme name, ready for display (translated)
+		 */
 	public function __toString() {
 		return (string) $this->display( 'Name' );
 	}
 
-	/**
-	 * __isset() magic method for properties formerly returned by current_theme_info()
-	 *
-	 * @since 3.4.0
-	 *
-	 * @param string $offset Property to check if set.
-	 * @return bool Whether the given property is set.
-	 */
+		/**
+		 * __isset() magic method for properties formerly returned by current_theme_info()
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param string $offset Property to check if set.
+		 * @return bool Whether the given property is set.
+		 */
 	public function __isset( $offset ) {
 		static $properties = array(
 			'name',
@@ -580,14 +561,14 @@ final class WP_Theme implements ArrayAccess {
 		return in_array( $offset, $properties, true );
 	}
 
-	/**
-	 * __get() magic method for properties formerly returned by current_theme_info()
-	 *
-	 * @since 3.4.0
-	 *
-	 * @param string $offset Property to get.
-	 * @return mixed Property value.
-	 */
+		/**
+		 * __get() magic method for properties formerly returned by current_theme_info()
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param string $offset Property to get.
+		 * @return mixed Property value.
+		 */
 	public function __get( $offset ) {
 		switch ( $offset ) {
 			case 'name':
@@ -624,36 +605,36 @@ final class WP_Theme implements ArrayAccess {
 		}
 	}
 
-	/**
-	 * Method to implement ArrayAccess for keys formerly returned by get_themes()
-	 *
-	 * @since 3.4.0
-	 *
-	 * @param mixed $offset
-	 * @param mixed $value
-	 */
-	#[ReturnTypeWillChange]
+		/**
+		 * Method to implement ArrayAccess for keys formerly returned by get_themes()
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param mixed $offset
+		 * @param mixed $value
+		 */
+		#[ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {}
 
-	/**
-	 * Method to implement ArrayAccess for keys formerly returned by get_themes()
-	 *
-	 * @since 3.4.0
-	 *
-	 * @param mixed $offset
-	 */
-	#[ReturnTypeWillChange]
+		/**
+		 * Method to implement ArrayAccess for keys formerly returned by get_themes()
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param mixed $offset
+		 */
+		#[ReturnTypeWillChange]
 	public function offsetUnset( $offset ) {}
 
-	/**
-	 * Method to implement ArrayAccess for keys formerly returned by get_themes()
-	 *
-	 * @since 3.4.0
-	 *
-	 * @param mixed $offset
-	 * @return bool
-	 */
-	#[ReturnTypeWillChange]
+		/**
+		 * Method to implement ArrayAccess for keys formerly returned by get_themes()
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param mixed $offset
+		 * @return bool
+		 */
+		#[ReturnTypeWillChange]
 	public function offsetExists( $offset ) {
 		static $keys = array(
 			'Name',
@@ -680,22 +661,22 @@ final class WP_Theme implements ArrayAccess {
 		return in_array( $offset, $keys, true );
 	}
 
-	/**
-	 * Method to implement ArrayAccess for keys formerly returned by get_themes().
-	 *
-	 * Author, Author Name, Author URI, and Description did not previously return
-	 * translated data. We are doing so now as it is safe to do. However, as
-	 * Name and Title could have been used as the key for get_themes(), both remain
-	 * untranslated for back compatibility. This means that ['Name'] is not ideal,
-	 * and care should be taken to use `$theme::display( 'Name' )` to get a properly
-	 * translated header.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @param mixed $offset
-	 * @return mixed
-	 */
-	#[ReturnTypeWillChange]
+		/**
+		 * Method to implement ArrayAccess for keys formerly returned by get_themes().
+		 *
+		 * Author, Author Name, Author URI, and Description did not previously return
+		 * translated data. We are doing so now as it is safe to do. However, as
+		 * Name and Title could have been used as the key for get_themes(), both remain
+		 * untranslated for back compatibility. This means that ['Name'] is not ideal,
+		 * and care should be taken to use `$theme::display( 'Name' )` to get a properly
+		 * translated header.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param mixed $offset
+		 * @return mixed
+		 */
+		#[ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
 		switch ( $offset ) {
 			case 'Name':
@@ -743,47 +724,47 @@ final class WP_Theme implements ArrayAccess {
 		}
 	}
 
-	/**
-	 * Returns errors property.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @return WP_Error|false WP_Error if there are errors, or false.
-	 */
+		/**
+		 * Returns errors property.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @return WP_Error|false WP_Error if there are errors, or false.
+		 */
 	public function errors() {
 		return is_wp_error( $this->errors ) ? $this->errors : false;
 	}
 
-	/**
-	 * Determines whether the theme exists.
-	 *
-	 * A theme with errors exists. A theme with the error of 'theme_not_found',
-	 * meaning that the theme's directory was not found, does not exist.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @return bool Whether the theme exists.
-	 */
+		/**
+		 * Determines whether the theme exists.
+		 *
+		 * A theme with errors exists. A theme with the error of 'theme_not_found',
+		 * meaning that the theme's directory was not found, does not exist.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @return bool Whether the theme exists.
+		 */
 	public function exists() {
 		return ! ( $this->errors() && in_array( 'theme_not_found', $this->errors()->get_error_codes(), true ) );
 	}
 
-	/**
-	 * Returns reference to the parent theme.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @return WP_Theme|false Parent theme, or false if the active theme is not a child theme.
-	 */
+		/**
+		 * Returns reference to the parent theme.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @return WP_Theme|false Parent theme, or false if the active theme is not a child theme.
+		 */
 	public function parent() {
 		return isset( $this->parent ) ? $this->parent : false;
 	}
 
-	/**
-	 * Perform reinitialization tasks.
-	 *
-	 * Prevents a callback from being injected during unserialization of an object.
-	 */
+		/**
+		 * Perform reinitialization tasks.
+		 *
+		 * Prevents a callback from being injected during unserialization of an object.
+		 */
 	public function __wakeup() {
 		if ( $this->parent && ! $this->parent instanceof self ) {
 			throw new UnexpectedValueException();
@@ -799,40 +780,40 @@ final class WP_Theme implements ArrayAccess {
 		$this->headers_sanitized = array();
 	}
 
-	/**
-	 * Adds theme data to cache.
-	 *
-	 * Cache entries keyed by the theme and the type of data.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @param string       $key  Type of data to store (theme, screenshot, headers, post_templates)
-	 * @param array|string $data Data to store
-	 * @return bool Return value from wp_cache_add()
-	 */
+		/**
+		 * Adds theme data to cache.
+		 *
+		 * Cache entries keyed by the theme and the type of data.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param string       $key  Type of data to store (theme, screenshot, headers, post_templates)
+		 * @param array|string $data Data to store
+		 * @return bool Return value from wp_cache_add()
+		 */
 	private function cache_add( $key, $data ) {
 		return wp_cache_add( $key . '-' . $this->cache_hash, $data, 'themes', self::$cache_expiration );
 	}
 
-	/**
-	 * Gets theme data from cache.
-	 *
-	 * Cache entries are keyed by the theme and the type of data.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @param string $key Type of data to retrieve (theme, screenshot, headers, post_templates)
-	 * @return mixed Retrieved data
-	 */
+		/**
+		 * Gets theme data from cache.
+		 *
+		 * Cache entries are keyed by the theme and the type of data.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param string $key Type of data to retrieve (theme, screenshot, headers, post_templates)
+		 * @return mixed Retrieved data
+		 */
 	private function cache_get( $key ) {
 		return wp_cache_get( $key . '-' . $this->cache_hash, 'themes' );
 	}
 
-	/**
-	 * Clears the cache for the theme.
-	 *
-	 * @since 3.4.0
-	 */
+		/**
+		 * Clears the cache for the theme.
+		 *
+		 * @since 3.4.0
+		 */
 	public function cache_delete() {
 		foreach ( array( 'theme', 'screenshot', 'headers', 'post_templates' ) as $key ) {
 			wp_cache_delete( $key . '-' . $this->cache_hash, 'themes' );
@@ -851,22 +832,22 @@ final class WP_Theme implements ArrayAccess {
 		$this->delete_pattern_cache();
 	}
 
-	/**
-	 * Gets a raw, unformatted theme header.
-	 *
-	 * The header is sanitized, but is not translated, and is not marked up for display.
-	 * To get a theme header for display, use the display() method.
-	 *
-	 * Use the get_template() method, not the 'Template' header, for finding the template.
-	 * The 'Template' header is only good for what was written in the style.css, while
-	 * get_template() takes into account where WordPress actually located the theme and
-	 * whether it is actually valid.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @param string $header Theme header. Name, Description, Author, Version, ThemeURI, AuthorURI, Status, Tags.
-	 * @return string|array|false String or array (for Tags header) on success, false on failure.
-	 */
+		/**
+		 * Gets a raw, unformatted theme header.
+		 *
+		 * The header is sanitized, but is not translated, and is not marked up for display.
+		 * To get a theme header for display, use the display() method.
+		 *
+		 * Use the get_template() method, not the 'Template' header, for finding the template.
+		 * The 'Template' header is only good for what was written in the style.css, while
+		 * get_template() takes into account where WordPress actually located the theme and
+		 * whether it is actually valid.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param string $header Theme header. Name, Description, Author, Version, ThemeURI, AuthorURI, Status, Tags.
+		 * @return string|array|false String or array (for Tags header) on success, false on failure.
+		 */
 	public function get( $header ) {
 		if ( ! isset( $this->headers[ $header ] ) ) {
 			return false;
@@ -896,17 +877,17 @@ final class WP_Theme implements ArrayAccess {
 		return $this->headers_sanitized[ $header ];
 	}
 
-	/**
-	 * Gets a theme header, formatted and translated for display.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @param string $header    Theme header. Name, Description, Author, Version, ThemeURI, AuthorURI, Status, Tags.
-	 * @param bool   $markup    Optional. Whether to mark up the header. Defaults to true.
-	 * @param bool   $translate Optional. Whether to translate the header. Defaults to true.
-	 * @return string|array|false Processed header. An array for Tags if `$markup` is false, string otherwise.
-	 *                            False on failure.
-	 */
+		/**
+		 * Gets a theme header, formatted and translated for display.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param string $header    Theme header. Name, Description, Author, Version, ThemeURI, AuthorURI, Status, Tags.
+		 * @param bool   $markup    Optional. Whether to mark up the header. Defaults to true.
+		 * @param bool   $translate Optional. Whether to translate the header. Defaults to true.
+		 * @return string|array|false Processed header. An array for Tags if `$markup` is false, string otherwise.
+		 *                            False on failure.
+		 */
 	public function display( $header, $markup = true, $translate = true ) {
 		$value = $this->get( $header );
 		if ( false === $value ) {
@@ -928,19 +909,19 @@ final class WP_Theme implements ArrayAccess {
 		return $value;
 	}
 
-	/**
-	 * Sanitizes a theme header.
-	 *
-	 * @since 3.4.0
-	 * @since 5.4.0 Added support for `Requires at least` and `Requires PHP` headers.
-	 * @since 6.1.0 Added support for `Update URI` header.
-	 *
-	 * @param string $header Theme header. Accepts 'Name', 'Description', 'Author', 'Version',
-	 *                       'ThemeURI', 'AuthorURI', 'Status', 'Tags', 'RequiresWP', 'RequiresPHP',
-	 *                       'UpdateURI'.
-	 * @param string $value  Value to sanitize.
-	 * @return string|array An array for Tags header, string otherwise.
-	 */
+		/**
+		 * Sanitizes a theme header.
+		 *
+		 * @since 3.4.0
+		 * @since 5.4.0 Added support for `Requires at least` and `Requires PHP` headers.
+		 * @since 6.1.0 Added support for `Update URI` header.
+		 *
+		 * @param string $header Theme header. Accepts 'Name', 'Description', 'Author', 'Version',
+		 *                       'ThemeURI', 'AuthorURI', 'Status', 'Tags', 'RequiresWP', 'RequiresPHP',
+		 *                       'UpdateURI'.
+		 * @param string $value  Value to sanitize.
+		 * @return string|array An array for Tags header, string otherwise.
+		 */
 	private function sanitize_header( $header, $value ) {
 		switch ( $header ) {
 			case 'Status':
@@ -995,16 +976,16 @@ final class WP_Theme implements ArrayAccess {
 		return $value;
 	}
 
-	/**
-	 * Marks up a theme header.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @param string       $header    Theme header. Name, Description, Author, Version, ThemeURI, AuthorURI, Status, Tags.
-	 * @param string|array $value     Value to mark up. An array for Tags header, string otherwise.
-	 * @param string       $translate Whether the header has been translated.
-	 * @return string Value, marked up.
-	 */
+		/**
+		 * Marks up a theme header.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param string       $header    Theme header. Name, Description, Author, Version, ThemeURI, AuthorURI, Status, Tags.
+		 * @param string|array $value     Value to mark up. An array for Tags header, string otherwise.
+		 * @param string       $translate Whether the header has been translated.
+		 * @return string Value, marked up.
+		 */
 	private function markup_header( $header, $value, $translate ) {
 		switch ( $header ) {
 			case 'Name':
@@ -1038,15 +1019,15 @@ final class WP_Theme implements ArrayAccess {
 		return $value;
 	}
 
-	/**
-	 * Translates a theme header.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @param string       $header Theme header. Name, Description, Author, Version, ThemeURI, AuthorURI, Status, Tags.
-	 * @param string|array $value  Value to translate. An array for Tags header, string otherwise.
-	 * @return string|array Translated value. An array for Tags header, string otherwise.
-	 */
+		/**
+		 * Translates a theme header.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param string       $header Theme header. Name, Description, Author, Version, ThemeURI, AuthorURI, Status, Tags.
+		 * @param string|array $value  Value to translate. An array for Tags header, string otherwise.
+		 * @return string|array Translated value. An array for Tags header, string otherwise.
+		 */
 	private function translate_header( $header, $value ) {
 		switch ( $header ) {
 			case 'Name':
@@ -1115,44 +1096,44 @@ final class WP_Theme implements ArrayAccess {
 		return $value;
 	}
 
-	/**
-	 * Returns the directory name of the theme's "stylesheet" files, inside the theme root.
-	 *
-	 * In the case of a child theme, this is directory name of the child theme.
-	 * Otherwise, get_stylesheet() is the same as get_template().
-	 *
-	 * @since 3.4.0
-	 *
-	 * @return string Stylesheet
-	 */
+		/**
+		 * Returns the directory name of the theme's "stylesheet" files, inside the theme root.
+		 *
+		 * In the case of a child theme, this is directory name of the child theme.
+		 * Otherwise, get_stylesheet() is the same as get_template().
+		 *
+		 * @since 3.4.0
+		 *
+		 * @return string Stylesheet
+		 */
 	public function get_stylesheet() {
 		return $this->stylesheet;
 	}
 
-	/**
-	 * Returns the directory name of the theme's "template" files, inside the theme root.
-	 *
-	 * In the case of a child theme, this is the directory name of the parent theme.
-	 * Otherwise, the get_template() is the same as get_stylesheet().
-	 *
-	 * @since 3.4.0
-	 *
-	 * @return string Template
-	 */
+		/**
+		 * Returns the directory name of the theme's "template" files, inside the theme root.
+		 *
+		 * In the case of a child theme, this is the directory name of the parent theme.
+		 * Otherwise, the get_template() is the same as get_stylesheet().
+		 *
+		 * @since 3.4.0
+		 *
+		 * @return string Template
+		 */
 	public function get_template() {
 		return $this->template;
 	}
 
-	/**
-	 * Returns the absolute path to the directory of a theme's "stylesheet" files.
-	 *
-	 * In the case of a child theme, this is the absolute path to the directory
-	 * of the child theme's files.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @return string Absolute path of the stylesheet directory.
-	 */
+		/**
+		 * Returns the absolute path to the directory of a theme's "stylesheet" files.
+		 *
+		 * In the case of a child theme, this is the absolute path to the directory
+		 * of the child theme's files.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @return string Absolute path of the stylesheet directory.
+		 */
 	public function get_stylesheet_directory() {
 		if ( $this->errors() && in_array( 'theme_root_missing', $this->errors()->get_error_codes(), true ) ) {
 			return '';
@@ -1161,16 +1142,16 @@ final class WP_Theme implements ArrayAccess {
 		return $this->theme_root . '/' . $this->stylesheet;
 	}
 
-	/**
-	 * Returns the absolute path to the directory of a theme's "template" files.
-	 *
-	 * In the case of a child theme, this is the absolute path to the directory
-	 * of the parent theme's files.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @return string Absolute path of the template directory.
-	 */
+		/**
+		 * Returns the absolute path to the directory of a theme's "template" files.
+		 *
+		 * In the case of a child theme, this is the absolute path to the directory
+		 * of the parent theme's files.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @return string Absolute path of the template directory.
+		 */
 	public function get_template_directory() {
 		if ( $this->parent() ) {
 			$theme_root = $this->parent()->theme_root;
@@ -1181,30 +1162,30 @@ final class WP_Theme implements ArrayAccess {
 		return $theme_root . '/' . $this->template;
 	}
 
-	/**
-	 * Returns the URL to the directory of a theme's "stylesheet" files.
-	 *
-	 * In the case of a child theme, this is the URL to the directory of the
-	 * child theme's files.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @return string URL to the stylesheet directory.
-	 */
+		/**
+		 * Returns the URL to the directory of a theme's "stylesheet" files.
+		 *
+		 * In the case of a child theme, this is the URL to the directory of the
+		 * child theme's files.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @return string URL to the stylesheet directory.
+		 */
 	public function get_stylesheet_directory_uri() {
 		return $this->get_theme_root_uri() . '/' . str_replace( '%2F', '/', rawurlencode( $this->stylesheet ) );
 	}
 
-	/**
-	 * Returns the URL to the directory of a theme's "template" files.
-	 *
-	 * In the case of a child theme, this is the URL to the directory of the
-	 * parent theme's files.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @return string URL to the template directory.
-	 */
+		/**
+		 * Returns the URL to the directory of a theme's "template" files.
+		 *
+		 * In the case of a child theme, this is the URL to the directory of the
+		 * parent theme's files.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @return string URL to the template directory.
+		 */
 	public function get_template_directory_uri() {
 		if ( $this->parent() ) {
 			$theme_root_uri = $this->parent()->get_theme_root_uri();
@@ -1215,30 +1196,30 @@ final class WP_Theme implements ArrayAccess {
 		return $theme_root_uri . '/' . str_replace( '%2F', '/', rawurlencode( $this->template ) );
 	}
 
-	/**
-	 * Returns the absolute path to the directory of the theme root.
-	 *
-	 * This is typically the absolute path to wp-content/themes.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @return string Theme root.
-	 */
+		/**
+		 * Returns the absolute path to the directory of the theme root.
+		 *
+		 * This is typically the absolute path to wp-content/themes.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @return string Theme root.
+		 */
 	public function get_theme_root() {
 		return $this->theme_root;
 	}
 
-	/**
-	 * Returns the URL to the directory of the theme root.
-	 *
-	 * This is typically the absolute URL to wp-content/themes. This forms the basis
-	 * for all other URLs returned by WP_Theme, so we pass it to the public function
-	 * get_theme_root_uri() and allow it to run the {@see 'theme_root_uri'} filter.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @return string Theme root URI.
-	 */
+		/**
+		 * Returns the URL to the directory of the theme root.
+		 *
+		 * This is typically the absolute URL to wp-content/themes. This forms the basis
+		 * for all other URLs returned by WP_Theme, so we pass it to the public function
+		 * get_theme_root_uri() and allow it to run the {@see 'theme_root_uri'} filter.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @return string Theme root URI.
+		 */
 	public function get_theme_root_uri() {
 		if ( ! isset( $this->theme_root_uri ) ) {
 			$this->theme_root_uri = get_theme_root_uri( $this->stylesheet, $this->theme_root );
@@ -1246,19 +1227,19 @@ final class WP_Theme implements ArrayAccess {
 		return $this->theme_root_uri;
 	}
 
-	/**
-	 * Returns the main screenshot file for the theme.
-	 *
-	 * The main screenshot is called screenshot.png. gif and jpg extensions are also allowed.
-	 *
-	 * Screenshots for a theme must be in the stylesheet directory. (In the case of child
-	 * themes, parent theme screenshots are not inherited.)
-	 *
-	 * @since 3.4.0
-	 *
-	 * @param string $uri Type of URL to return, either 'relative' or an absolute URI. Defaults to absolute URI.
-	 * @return string|false Screenshot file. False if the theme does not have a screenshot.
-	 */
+		/**
+		 * Returns the main screenshot file for the theme.
+		 *
+		 * The main screenshot is called screenshot.png. gif and jpg extensions are also allowed.
+		 *
+		 * Screenshots for a theme must be in the stylesheet directory. (In the case of child
+		 * themes, parent theme screenshots are not inherited.)
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param string $uri Type of URL to return, either 'relative' or an absolute URI. Defaults to absolute URI.
+		 * @return string|false Screenshot file. False if the theme does not have a screenshot.
+		 */
 	public function get_screenshot( $uri = 'uri' ) {
 		$screenshot = $this->cache_get( 'screenshot' );
 		if ( $screenshot ) {
@@ -1284,19 +1265,19 @@ final class WP_Theme implements ArrayAccess {
 		return false;
 	}
 
-	/**
-	 * Returns files in the theme's directory.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @param string[]|string $type          Optional. Array of extensions to find, string of a single extension,
-	 *                                       or null for all extensions. Default null.
-	 * @param int             $depth         Optional. How deep to search for files. Defaults to a flat scan (0 depth).
-	 *                                       -1 depth is infinite.
-	 * @param bool            $search_parent Optional. Whether to return parent files. Default false.
-	 * @return string[] Array of files, keyed by the path to the file relative to the theme's directory, with the values
-	 *                  being absolute paths.
-	 */
+		/**
+		 * Returns files in the theme's directory.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param string[]|string $type          Optional. Array of extensions to find, string of a single extension,
+		 *                                       or null for all extensions. Default null.
+		 * @param int             $depth         Optional. How deep to search for files. Defaults to a flat scan (0 depth).
+		 *                                       -1 depth is infinite.
+		 * @param bool            $search_parent Optional. Whether to return parent files. Default false.
+		 * @return string[] Array of files, keyed by the path to the file relative to the theme's directory, with the values
+		 *                  being absolute paths.
+		 */
 	public function get_files( $type = null, $depth = 0, $search_parent = false ) {
 		$files = (array) self::scandir( $this->get_stylesheet_directory(), $type, $depth );
 
@@ -1307,15 +1288,15 @@ final class WP_Theme implements ArrayAccess {
 		return array_filter( $files );
 	}
 
-	/**
-	 * Returns the theme's post templates.
-	 *
-	 * @since 4.7.0
-	 * @since 5.8.0 Include block templates.
-	 *
-	 * @return array[] Array of page template arrays, keyed by post type and filename,
-	 *                 with the value of the translated header name.
-	 */
+		/**
+		 * Returns the theme's post templates.
+		 *
+		 * @since 4.7.0
+		 * @since 5.8.0 Include block templates.
+		 *
+		 * @return array[] Array of page template arrays, keyed by post type and filename,
+		 *                 with the value of the translated header name.
+		 */
 	public function get_post_templates() {
 		// If you screw up your active theme and we invalidate your parent, most things still work. Let it slide.
 		if ( $this->errors() && $this->errors()->get_error_codes() !== array( 'theme_parent_invalid' ) ) {
@@ -1380,17 +1361,17 @@ final class WP_Theme implements ArrayAccess {
 		return $post_templates;
 	}
 
-	/**
-	 * Returns the theme's post templates for a given post type.
-	 *
-	 * @since 3.4.0
-	 * @since 4.7.0 Added the `$post_type` parameter.
-	 *
-	 * @param WP_Post|null $post      Optional. The post being edited, provided for context.
-	 * @param string       $post_type Optional. Post type to get the templates for. Default 'page'.
-	 *                                If a post is provided, its post type is used.
-	 * @return string[] Array of template header names keyed by the template file name.
-	 */
+		/**
+		 * Returns the theme's post templates for a given post type.
+		 *
+		 * @since 3.4.0
+		 * @since 4.7.0 Added the `$post_type` parameter.
+		 *
+		 * @param WP_Post|null $post      Optional. The post being edited, provided for context.
+		 * @param string       $post_type Optional. Post type to get the templates for. Default 'page'.
+		 *                                If a post is provided, its post type is used.
+		 * @return string[] Array of template header names keyed by the template file name.
+		 */
 	public function get_page_templates( $post = null, $post_type = 'page' ) {
 		if ( $post ) {
 			$post_type = get_post_type( $post );
@@ -1436,22 +1417,22 @@ final class WP_Theme implements ArrayAccess {
 		return $post_templates;
 	}
 
-	/**
-	 * Scans a directory for files of a certain extension.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @param string            $path          Absolute path to search.
-	 * @param array|string|null $extensions    Optional. Array of extensions to find, string of a single extension,
-	 *                                         or null for all extensions. Default null.
-	 * @param int               $depth         Optional. How many levels deep to search for files. Accepts 0, 1+, or
-	 *                                         -1 (infinite depth). Default 0.
-	 * @param string            $relative_path Optional. The basename of the absolute path. Used to control the
-	 *                                         returned path for the found files, particularly when this function
-	 *                                         recurses to lower depths. Default empty.
-	 * @return string[]|false Array of files, keyed by the path to the file relative to the `$path` directory prepended
-	 *                        with `$relative_path`, with the values being absolute paths. False otherwise.
-	 */
+		/**
+		 * Scans a directory for files of a certain extension.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param string            $path          Absolute path to search.
+		 * @param array|string|null $extensions    Optional. Array of extensions to find, string of a single extension,
+		 *                                         or null for all extensions. Default null.
+		 * @param int               $depth         Optional. How many levels deep to search for files. Accepts 0, 1+, or
+		 *                                         -1 (infinite depth). Default 0.
+		 * @param string            $relative_path Optional. The basename of the absolute path. Used to control the
+		 *                                         returned path for the found files, particularly when this function
+		 *                                         recurses to lower depths. Default empty.
+		 * @return string[]|false Array of files, keyed by the path to the file relative to the `$path` directory prepended
+		 *                        with `$relative_path`, with the values being absolute paths. False otherwise.
+		 */
 	private static function scandir( $path, $extensions = null, $depth = 0, $relative_path = '' ) {
 		if ( ! is_dir( $path ) ) {
 			return false;
@@ -1497,17 +1478,17 @@ final class WP_Theme implements ArrayAccess {
 		return $files;
 	}
 
-	/**
-	 * Loads the theme's textdomain.
-	 *
-	 * Translation files are not inherited from the parent theme. TODO: If this fails for the
-	 * child theme, it should probably try to load the parent theme's translations.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @return bool True if the textdomain was successfully loaded or has already been loaded.
-	 *  False if no textdomain was specified in the file headers, or if the domain could not be loaded.
-	 */
+		/**
+		 * Loads the theme's textdomain.
+		 *
+		 * Translation files are not inherited from the parent theme. TODO: If this fails for the
+		 * child theme, it should probably try to load the parent theme's translations.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @return bool True if the textdomain was successfully loaded or has already been loaded.
+		 *  False if no textdomain was specified in the file headers, or if the domain could not be loaded.
+		 */
 	public function load_textdomain() {
 		if ( isset( $this->textdomain_loaded ) ) {
 			return $this->textdomain_loaded;
@@ -1536,16 +1517,16 @@ final class WP_Theme implements ArrayAccess {
 		return $this->textdomain_loaded;
 	}
 
-	/**
-	 * Determines whether the theme is allowed (multisite only).
-	 *
-	 * @since 3.4.0
-	 *
-	 * @param string $check   Optional. Whether to check only the 'network'-wide settings, the 'site'
-	 *                        settings, or 'both'. Defaults to 'both'.
-	 * @param int    $blog_id Optional. Ignored if only network-wide settings are checked. Defaults to current site.
-	 * @return bool Whether the theme is allowed for the network. Returns true in single-site.
-	 */
+		/**
+		 * Determines whether the theme is allowed (multisite only).
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param string $check   Optional. Whether to check only the 'network'-wide settings, the 'site'
+		 *                        settings, or 'both'. Defaults to 'both'.
+		 * @param int    $blog_id Optional. Ignored if only network-wide settings are checked. Defaults to current site.
+		 * @return bool Whether the theme is allowed for the network. Returns true in single-site.
+		 */
 	public function is_allowed( $check = 'both', $blog_id = null ) {
 		if ( ! is_multisite() ) {
 			return true;
@@ -1568,13 +1549,13 @@ final class WP_Theme implements ArrayAccess {
 		return false;
 	}
 
-	/**
-	 * Returns whether this theme is a block-based theme or not.
-	 *
-	 * @since 5.9.0
-	 *
-	 * @return bool
-	 */
+		/**
+		 * Returns whether this theme is a block-based theme or not.
+		 *
+		 * @since 5.9.0
+		 *
+		 * @return bool
+		 */
 	public function is_block_theme() {
 		if ( ! did_action( 'setup_theme' ) ) {
 			_doing_it_wrong( __METHOD__, __( 'This method should not be called before themes are set up.' ), '6.8.0' );
@@ -1602,17 +1583,17 @@ final class WP_Theme implements ArrayAccess {
 		return $this->block_theme;
 	}
 
-	/**
-	 * Retrieves the path of a file in the theme.
-	 *
-	 * Searches in the stylesheet directory before the template directory so themes
-	 * which inherit from a parent theme can just override one file.
-	 *
-	 * @since 5.9.0
-	 *
-	 * @param string $file Optional. File to search for in the stylesheet directory.
-	 * @return string The path of the file.
-	 */
+		/**
+		 * Retrieves the path of a file in the theme.
+		 *
+		 * Searches in the stylesheet directory before the template directory so themes
+		 * which inherit from a parent theme can just override one file.
+		 *
+		 * @since 5.9.0
+		 *
+		 * @param string $file Optional. File to search for in the stylesheet directory.
+		 * @return string The path of the file.
+		 */
 	public function get_file_path( $file = '' ) {
 		$file = ltrim( $file, '/' );
 
@@ -1631,15 +1612,15 @@ final class WP_Theme implements ArrayAccess {
 		return apply_filters( 'theme_file_path', $path, $file );
 	}
 
-	/**
-	 * Determines the latest WordPress default theme that is installed.
-	 *
-	 * This hits the filesystem.
-	 *
-	 * @since 4.4.0
-	 *
-	 * @return WP_Theme|false Object, or false if no theme is installed, which would be bad.
-	 */
+		/**
+		 * Determines the latest WordPress default theme that is installed.
+		 *
+		 * This hits the filesystem.
+		 *
+		 * @since 4.4.0
+		 *
+		 * @return WP_Theme|false Object, or false if no theme is installed, which would be bad.
+		 */
 	public static function get_core_default_theme() {
 		foreach ( array_reverse( self::$default_themes ) as $slug => $name ) {
 			$theme = wp_get_theme( $slug );
@@ -1650,14 +1631,14 @@ final class WP_Theme implements ArrayAccess {
 		return false;
 	}
 
-	/**
-	 * Returns array of stylesheet names of themes allowed on the site or network.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @param int $blog_id Optional. ID of the site. Defaults to the current site.
-	 * @return string[] Array of stylesheet names.
-	 */
+		/**
+		 * Returns array of stylesheet names of themes allowed on the site or network.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param int $blog_id Optional. ID of the site. Defaults to the current site.
+		 * @return string[] Array of stylesheet names.
+		 */
 	public static function get_allowed( $blog_id = null ) {
 		/**
 		 * Filters the array of themes allowed on the network.
@@ -1674,13 +1655,13 @@ final class WP_Theme implements ArrayAccess {
 		return $network + self::get_allowed_on_site( $blog_id );
 	}
 
-	/**
-	 * Returns array of stylesheet names of themes allowed on the network.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @return string[] Array of stylesheet names.
-	 */
+		/**
+		 * Returns array of stylesheet names of themes allowed on the network.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @return string[] Array of stylesheet names.
+		 */
 	public static function get_allowed_on_network() {
 		static $allowed_themes;
 		if ( ! isset( $allowed_themes ) ) {
@@ -1699,14 +1680,14 @@ final class WP_Theme implements ArrayAccess {
 		return $allowed_themes;
 	}
 
-	/**
-	 * Returns array of stylesheet names of themes allowed on the site.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @param int $blog_id Optional. ID of the site. Defaults to the current site.
-	 * @return string[] Array of stylesheet names.
-	 */
+		/**
+		 * Returns array of stylesheet names of themes allowed on the site.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param int $blog_id Optional. ID of the site. Defaults to the current site.
+		 * @return string[] Array of stylesheet names.
+		 */
 	public static function get_allowed_on_site( $blog_id = null ) {
 		static $allowed_themes = array();
 
@@ -1779,18 +1760,18 @@ final class WP_Theme implements ArrayAccess {
 		return (array) apply_filters( 'site_allowed_themes', $allowed_themes[ $blog_id ], $blog_id );
 	}
 
-	/**
-	 * Returns the folder names of the block template directories.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @return string[] {
-	 *     Folder names used by block themes.
-	 *
-	 *     @type string $wp_template      Theme-relative directory name for block templates.
-	 *     @type string $wp_template_part Theme-relative directory name for block template parts.
-	 * }
-	 */
+		/**
+		 * Returns the folder names of the block template directories.
+		 *
+		 * @since 6.4.0
+		 *
+		 * @return string[] {
+		 *     Folder names used by block themes.
+		 *
+		 *     @type string $wp_template      Theme-relative directory name for block templates.
+		 *     @type string $wp_template_part Theme-relative directory name for block template parts.
+		 * }
+		 */
 	public function get_block_template_folders() {
 		// Return set/cached value if available.
 		if ( isset( $this->block_template_folders ) ) {
@@ -1810,37 +1791,37 @@ final class WP_Theme implements ArrayAccess {
 		return $this->block_template_folders;
 	}
 
-	/**
-	 * Gets block pattern data for a specified theme.
-	 * Each pattern is defined as a PHP file and defines
-	 * its metadata using plugin-style headers. The minimum required definition is:
-	 *
-	 *     /**
-	 *      * Title: My Pattern
-	 *      * Slug: my-theme/my-pattern
-	 *      *
-	 *
-	 * The output of the PHP source corresponds to the content of the pattern, e.g.:
-	 *
-	 *     <main><p><?php echo "Hello"; ?></p></main>
-	 *
-	 * If applicable, this will collect from both parent and child theme.
-	 *
-	 * Other settable fields include:
-	 *
-	 *     - Description
-	 *     - Viewport Width
-	 *     - Inserter         (yes/no)
-	 *     - Categories       (comma-separated values)
-	 *     - Keywords         (comma-separated values)
-	 *     - Block Types      (comma-separated values)
-	 *     - Post Types       (comma-separated values)
-	 *     - Template Types   (comma-separated values)
-	 *
-	 * @since 6.4.0
-	 *
-	 * @return array Block pattern data.
-	 */
+		/**
+		 * Gets block pattern data for a specified theme.
+		 * Each pattern is defined as a PHP file and defines
+		 * its metadata using plugin-style headers. The minimum required definition is:
+		 *
+		 *     /**
+		 *      * Title: My Pattern
+		 *      * Slug: my-theme/my-pattern
+		 *      *
+		 *
+		 * The output of the PHP source corresponds to the content of the pattern, e.g.:
+		 *
+		 *     <main><p><?php echo "Hello"; ?></p></main>
+		 *
+		 * If applicable, this will collect from both parent and child theme.
+		 *
+		 * Other settable fields include:
+		 *
+		 *     - Description
+		 *     - Viewport Width
+		 *     - Inserter         (yes/no)
+		 *     - Categories       (comma-separated values)
+		 *     - Keywords         (comma-separated values)
+		 *     - Block Types      (comma-separated values)
+		 *     - Post Types       (comma-separated values)
+		 *     - Template Types   (comma-separated values)
+		 *
+		 * @since 6.4.0
+		 *
+		 * @return array Block pattern data.
+		 */
 	public function get_block_patterns() {
 		$can_use_cached = ! wp_is_development_mode( 'theme' );
 
@@ -1902,7 +1883,7 @@ final class WP_Theme implements ArrayAccess {
 				_doing_it_wrong(
 					__FUNCTION__,
 					sprintf(
-						/* translators: 1: file name. */
+					/* translators: 1: file name. */
 						__( 'Could not register file "%s" as a block pattern ("Slug" field missing)' ),
 						$file
 					),
@@ -1915,7 +1896,7 @@ final class WP_Theme implements ArrayAccess {
 				_doing_it_wrong(
 					__FUNCTION__,
 					sprintf(
-						/* translators: 1: file name; 2: slug value found. */
+					/* translators: 1: file name; 2: slug value found. */
 						__( 'Could not register file "%1$s" as a block pattern (invalid slug "%2$s")' ),
 						$file,
 						$pattern['slug']
@@ -1929,7 +1910,7 @@ final class WP_Theme implements ArrayAccess {
 				_doing_it_wrong(
 					__FUNCTION__,
 					sprintf(
-						/* translators: 1: file name. */
+					/* translators: 1: file name. */
 						__( 'Could not register file "%s" as a block pattern ("Title" field missing)' ),
 						$file
 					),
@@ -1979,14 +1960,14 @@ final class WP_Theme implements ArrayAccess {
 		return $pattern_data;
 	}
 
-	/**
-	 * Gets block pattern cache.
-	 *
-	 * @since 6.4.0
-	 * @since 6.6.0 Uses transients to cache regardless of site environment.
-	 *
-	 * @return array|false Returns an array of patterns if cache is found, otherwise false.
-	 */
+		/**
+		 * Gets block pattern cache.
+		 *
+		 * @since 6.4.0
+		 * @since 6.6.0 Uses transients to cache regardless of site environment.
+		 *
+		 * @return array|false Returns an array of patterns if cache is found, otherwise false.
+		 */
 	private function get_pattern_cache() {
 		if ( ! $this->exists() ) {
 			return false;
@@ -2000,14 +1981,14 @@ final class WP_Theme implements ArrayAccess {
 		return false;
 	}
 
-	/**
-	 * Sets block pattern cache.
-	 *
-	 * @since 6.4.0
-	 * @since 6.6.0 Uses transients to cache regardless of site environment.
-	 *
-	 * @param array $patterns Block patterns data to set in cache.
-	 */
+		/**
+		 * Sets block pattern cache.
+		 *
+		 * @since 6.4.0
+		 * @since 6.6.0 Uses transients to cache regardless of site environment.
+		 *
+		 * @param array $patterns Block patterns data to set in cache.
+		 */
 	private function set_pattern_cache( array $patterns ) {
 		$pattern_data = array(
 			'version'  => $this->get( 'Version' ),
@@ -2029,7 +2010,7 @@ final class WP_Theme implements ArrayAccess {
 			_doing_it_wrong(
 				__METHOD__,
 				sprintf(
-					/* translators: %1$s: The filter name.*/
+				/* translators: %1$s: The filter name.*/
 					__( 'The %1$s filter must return an integer value greater than 0.' ),
 					'<code>wp_theme_files_cache_ttl</code>'
 				),
@@ -2042,23 +2023,23 @@ final class WP_Theme implements ArrayAccess {
 		set_site_transient( 'wp_theme_files_patterns-' . $this->cache_hash, $pattern_data, $cache_expiration );
 	}
 
-	/**
-	 * Clears block pattern cache.
-	 *
-	 * @since 6.4.0
-	 * @since 6.6.0 Uses transients to cache regardless of site environment.
-	 */
+		/**
+		 * Clears block pattern cache.
+		 *
+		 * @since 6.4.0
+		 * @since 6.6.0 Uses transients to cache regardless of site environment.
+		 */
 	public function delete_pattern_cache() {
 		delete_site_transient( 'wp_theme_files_patterns-' . $this->cache_hash );
 	}
 
-	/**
-	 * Enables a theme for all sites on the current network.
-	 *
-	 * @since 4.6.0
-	 *
-	 * @param string|string[] $stylesheets Stylesheet name or array of stylesheet names.
-	 */
+		/**
+		 * Enables a theme for all sites on the current network.
+		 *
+		 * @since 4.6.0
+		 *
+		 * @param string|string[] $stylesheets Stylesheet name or array of stylesheet names.
+		 */
 	public static function network_enable_theme( $stylesheets ) {
 		if ( ! is_multisite() ) {
 			return;
@@ -2076,13 +2057,13 @@ final class WP_Theme implements ArrayAccess {
 		update_site_option( 'allowedthemes', $allowed_themes );
 	}
 
-	/**
-	 * Disables a theme for all sites on the current network.
-	 *
-	 * @since 4.6.0
-	 *
-	 * @param string|string[] $stylesheets Stylesheet name or array of stylesheet names.
-	 */
+		/**
+		 * Disables a theme for all sites on the current network.
+		 *
+		 * @since 4.6.0
+		 *
+		 * @param string|string[] $stylesheets Stylesheet name or array of stylesheet names.
+		 */
 	public static function network_disable_theme( $stylesheets ) {
 		if ( ! is_multisite() ) {
 			return;
@@ -2102,13 +2083,13 @@ final class WP_Theme implements ArrayAccess {
 		update_site_option( 'allowedthemes', $allowed_themes );
 	}
 
-	/**
-	 * Sorts themes by name.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @param WP_Theme[] $themes Array of theme objects to sort (passed by reference).
-	 */
+		/**
+		 * Sorts themes by name.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param WP_Theme[] $themes Array of theme objects to sort (passed by reference).
+		 */
 	public static function sort_by_name( &$themes ) {
 		if ( str_starts_with( get_user_locale(), 'en_' ) ) {
 			uasort( $themes, array( 'WP_Theme', '_name_sort' ) );
@@ -2120,33 +2101,33 @@ final class WP_Theme implements ArrayAccess {
 		}
 	}
 
-	/**
-	 * Callback function for usort() to naturally sort themes by name.
-	 *
-	 * Accesses the Name header directly from the class for maximum speed.
-	 * Would choke on HTML but we don't care enough to slow it down with strip_tags().
-	 *
-	 * @since 3.4.0
-	 *
-	 * @param WP_Theme $a First theme.
-	 * @param WP_Theme $b Second theme.
-	 * @return int Negative if `$a` falls lower in the natural order than `$b`. Zero if they fall equally.
-	 *             Greater than 0 if `$a` falls higher in the natural order than `$b`. Used with usort().
-	 */
+		/**
+		 * Callback function for usort() to naturally sort themes by name.
+		 *
+		 * Accesses the Name header directly from the class for maximum speed.
+		 * Would choke on HTML but we don't care enough to slow it down with strip_tags().
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param WP_Theme $a First theme.
+		 * @param WP_Theme $b Second theme.
+		 * @return int Negative if `$a` falls lower in the natural order than `$b`. Zero if they fall equally.
+		 *             Greater than 0 if `$a` falls higher in the natural order than `$b`. Used with usort().
+		 */
 	private static function _name_sort( $a, $b ) {
 		return strnatcasecmp( $a->headers['Name'], $b->headers['Name'] );
 	}
 
-	/**
-	 * Callback function for usort() to naturally sort themes by translated name.
-	 *
-	 * @since 3.4.0
-	 *
-	 * @param WP_Theme $a First theme.
-	 * @param WP_Theme $b Second theme.
-	 * @return int Negative if `$a` falls lower in the natural order than `$b`. Zero if they fall equally.
-	 *             Greater than 0 if `$a` falls higher in the natural order than `$b`. Used with usort().
-	 */
+		/**
+		 * Callback function for usort() to naturally sort themes by translated name.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param WP_Theme $a First theme.
+		 * @param WP_Theme $b Second theme.
+		 * @return int Negative if `$a` falls lower in the natural order than `$b`. Zero if they fall equally.
+		 *             Greater than 0 if `$a` falls higher in the natural order than `$b`. Used with usort().
+		 */
 	private static function _name_sort_i18n( $a, $b ) {
 		return strnatcasecmp( $a->name_translated, $b->name_translated );
 	}
@@ -2161,5 +2142,55 @@ final class WP_Theme implements ArrayAccess {
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * Handles the case where a theme is missing a template file.
+	 * It's moved after setup theme to handle the block_theme check
+	 *
+	 * @see Ticket #63086
+	 *
+	 * @since 6.8.0
+	 */
+	public function _handle_missing_template() {
+		$error_message = sprintf(
+		/* translators: 1: templates/index.html, 2: index.php, 3: Documentation URL, 4: Template, 5: style.css */
+			__( 'Template is missing. Standalone themes need to have a %1$s or %2$s template file. <a href="%3$s">Child themes</a> need to have a %4$s header in the %5$s stylesheet.' ),
+			'<code>templates/index.html</code>',
+			'<code>index.php</code>',
+			__( 'https://developer.wordpress.org/themes/advanced-topics/child-themes/' ),
+			'<code>Template</code>',
+			'<code>style.css</code>'
+		);
+		$this->errors = new WP_Error( 'theme_no_index', $error_message );
+		$this->cache_add(
+			'theme',
+			array(
+				'block_template_folders' => $this->get_block_template_folders(),
+				'block_theme'            => $this->block_theme,
+				'headers'                => $this->headers,
+				'errors'                 => $this->errors,
+				'stylesheet'             => $this->stylesheet,
+				'template'               => $this->template,
+			)
+		);
+		return;
+	}
+
+	/**
+	 * Updates the cached value with the correct block_theme status.
+	 * It's moved after setup theme to handle the block_theme check
+	 *
+	 * @see Ticket #63086
+	 *
+	 * @since 6.8.0
+	 */
+	public function _update_cached_block_theme() {
+		// Update the cached value with the correct block_theme status
+		$cache = $this->cache_get( 'theme' );
+		if ( is_array( $cache ) ) {
+			$cache['block_theme'] = $this->is_block_theme();
+			$this->cache_add( 'theme', $cache );
+		}
 	}
 }

--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -401,7 +401,7 @@ final class WP_Theme implements ArrayAccess {
 		if ( ! is_array( $cache )
 			&& $this->template !== $this->stylesheet
 			&& ! file_exists( $this->theme_root . '/' . $this->template . '/index.php' )
-			) {
+		) {
 			/*
 			 * If we're in a directory of themes inside /themes, look for the parent nearby.
 			 * wp-content/themes/directory-of-themes/*
@@ -410,7 +410,7 @@ final class WP_Theme implements ArrayAccess {
 			$directories = search_theme_directories();
 
 			if ( '.' !== $parent_dir
-			&& file_exists( $this->theme_root . '/' . $parent_dir . '/' . $this->template . '/index.php' )
+				&& file_exists( $this->theme_root . '/' . $parent_dir . '/' . $this->template . '/index.php' )
 			) {
 				$this->template = $parent_dir . '/' . $this->template;
 			} elseif ( $directories && isset( $directories[ $this->template ] ) ) {
@@ -424,7 +424,7 @@ final class WP_Theme implements ArrayAccess {
 				$this->errors = new WP_Error(
 					'theme_no_parent',
 					sprintf(
-					/* translators: %s: Theme directory name. */
+						/* translators: %s: Theme directory name. */
 						__( 'The parent theme is missing. Please install the "%s" parent theme.' ),
 						esc_html( $this->template )
 					)
@@ -445,7 +445,7 @@ final class WP_Theme implements ArrayAccess {
 			}
 		}
 
-			// Set the parent, if we're a child theme.
+		// Set the parent, if we're a child theme.
 		if ( $this->template !== $this->stylesheet ) {
 			// If we are a parent, then there is a problem. Only two generations allowed! Cancel things out.
 			if ( $_child instanceof WP_Theme && $_child->template === $this->stylesheet ) {
@@ -453,7 +453,7 @@ final class WP_Theme implements ArrayAccess {
 				$_child->errors = new WP_Error(
 					'theme_parent_invalid',
 					sprintf(
-					/* translators: %s: Theme directory name. */
+						/* translators: %s: Theme directory name. */
 						__( 'The "%s" theme is not a valid parent theme.' ),
 						esc_html( $_child->template )
 					)
@@ -474,7 +474,7 @@ final class WP_Theme implements ArrayAccess {
 					$this->errors = new WP_Error(
 						'theme_parent_invalid',
 						sprintf(
-						/* translators: %s: Theme directory name. */
+							/* translators: %s: Theme directory name. */
 							__( 'The "%s" theme is not a valid parent theme.' ),
 							esc_html( $this->template )
 						)
@@ -501,7 +501,7 @@ final class WP_Theme implements ArrayAccess {
 			$this->errors = new WP_Error( 'theme_paused', __( 'This theme failed to load properly and was paused within the admin backend.' ) );
 		}
 
-			// We're good. If we didn't retrieve from cache, set it.
+		// We're good. If we didn't retrieve from cache, set it.
 		if ( ! is_array( $cache ) ) {
 			$cache = array(
 				'block_theme'            => false, // See #63086
@@ -521,25 +521,25 @@ final class WP_Theme implements ArrayAccess {
 		}
 	}
 
-		/**
-		 * When converting the object to a string, the theme name is returned.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @return string Theme name, ready for display (translated)
-		 */
+	/**
+	 * When converting the object to a string, the theme name is returned.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @return string Theme name, ready for display (translated)
+	 */
 	public function __toString() {
 		return (string) $this->display( 'Name' );
 	}
 
-		/**
-		 * __isset() magic method for properties formerly returned by current_theme_info()
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param string $offset Property to check if set.
-		 * @return bool Whether the given property is set.
-		 */
+	/**
+	 * __isset() magic method for properties formerly returned by current_theme_info()
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param string $offset Property to check if set.
+	 * @return bool Whether the given property is set.
+	 */
 	public function __isset( $offset ) {
 		static $properties = array(
 			'name',
@@ -561,14 +561,14 @@ final class WP_Theme implements ArrayAccess {
 		return in_array( $offset, $properties, true );
 	}
 
-		/**
-		 * __get() magic method for properties formerly returned by current_theme_info()
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param string $offset Property to get.
-		 * @return mixed Property value.
-		 */
+	/**
+	 * __get() magic method for properties formerly returned by current_theme_info()
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param string $offset Property to get.
+	 * @return mixed Property value.
+	 */
 	public function __get( $offset ) {
 		switch ( $offset ) {
 			case 'name':
@@ -605,36 +605,36 @@ final class WP_Theme implements ArrayAccess {
 		}
 	}
 
-		/**
-		 * Method to implement ArrayAccess for keys formerly returned by get_themes()
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param mixed $offset
-		 * @param mixed $value
-		 */
-		#[ReturnTypeWillChange]
+	/**
+	 * Method to implement ArrayAccess for keys formerly returned by get_themes()
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param mixed $offset
+	 * @param mixed $value
+	 */
+	#[ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {}
 
-		/**
-		 * Method to implement ArrayAccess for keys formerly returned by get_themes()
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param mixed $offset
-		 */
-		#[ReturnTypeWillChange]
+	/**
+	 * Method to implement ArrayAccess for keys formerly returned by get_themes()
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param mixed $offset
+	 */
+	#[ReturnTypeWillChange]
 	public function offsetUnset( $offset ) {}
 
-		/**
-		 * Method to implement ArrayAccess for keys formerly returned by get_themes()
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param mixed $offset
-		 * @return bool
-		 */
-		#[ReturnTypeWillChange]
+	/**
+	 * Method to implement ArrayAccess for keys formerly returned by get_themes()
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param mixed $offset
+	 * @return bool
+	 */
+	#[ReturnTypeWillChange]
 	public function offsetExists( $offset ) {
 		static $keys = array(
 			'Name',
@@ -661,22 +661,22 @@ final class WP_Theme implements ArrayAccess {
 		return in_array( $offset, $keys, true );
 	}
 
-		/**
-		 * Method to implement ArrayAccess for keys formerly returned by get_themes().
-		 *
-		 * Author, Author Name, Author URI, and Description did not previously return
-		 * translated data. We are doing so now as it is safe to do. However, as
-		 * Name and Title could have been used as the key for get_themes(), both remain
-		 * untranslated for back compatibility. This means that ['Name'] is not ideal,
-		 * and care should be taken to use `$theme::display( 'Name' )` to get a properly
-		 * translated header.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param mixed $offset
-		 * @return mixed
-		 */
-		#[ReturnTypeWillChange]
+	/**
+	 * Method to implement ArrayAccess for keys formerly returned by get_themes().
+	 *
+	 * Author, Author Name, Author URI, and Description did not previously return
+	 * translated data. We are doing so now as it is safe to do. However, as
+	 * Name and Title could have been used as the key for get_themes(), both remain
+	 * untranslated for back compatibility. This means that ['Name'] is not ideal,
+	 * and care should be taken to use `$theme::display( 'Name' )` to get a properly
+	 * translated header.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param mixed $offset
+	 * @return mixed
+	 */
+	#[ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
 		switch ( $offset ) {
 			case 'Name':
@@ -724,47 +724,47 @@ final class WP_Theme implements ArrayAccess {
 		}
 	}
 
-		/**
-		 * Returns errors property.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @return WP_Error|false WP_Error if there are errors, or false.
-		 */
+	/**
+	 * Returns errors property.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @return WP_Error|false WP_Error if there are errors, or false.
+	 */
 	public function errors() {
 		return is_wp_error( $this->errors ) ? $this->errors : false;
 	}
 
-		/**
-		 * Determines whether the theme exists.
-		 *
-		 * A theme with errors exists. A theme with the error of 'theme_not_found',
-		 * meaning that the theme's directory was not found, does not exist.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @return bool Whether the theme exists.
-		 */
+	/**
+	 * Determines whether the theme exists.
+	 *
+	 * A theme with errors exists. A theme with the error of 'theme_not_found',
+	 * meaning that the theme's directory was not found, does not exist.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @return bool Whether the theme exists.
+	 */
 	public function exists() {
 		return ! ( $this->errors() && in_array( 'theme_not_found', $this->errors()->get_error_codes(), true ) );
 	}
 
-		/**
-		 * Returns reference to the parent theme.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @return WP_Theme|false Parent theme, or false if the active theme is not a child theme.
-		 */
+	/**
+	 * Returns reference to the parent theme.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @return WP_Theme|false Parent theme, or false if the active theme is not a child theme.
+	 */
 	public function parent() {
 		return isset( $this->parent ) ? $this->parent : false;
 	}
 
-		/**
-		 * Perform reinitialization tasks.
-		 *
-		 * Prevents a callback from being injected during unserialization of an object.
-		 */
+	/**
+	 * Perform reinitialization tasks.
+	 *
+	 * Prevents a callback from being injected during unserialization of an object.
+	 */
 	public function __wakeup() {
 		if ( $this->parent && ! $this->parent instanceof self ) {
 			throw new UnexpectedValueException();
@@ -780,40 +780,40 @@ final class WP_Theme implements ArrayAccess {
 		$this->headers_sanitized = array();
 	}
 
-		/**
-		 * Adds theme data to cache.
-		 *
-		 * Cache entries keyed by the theme and the type of data.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param string       $key  Type of data to store (theme, screenshot, headers, post_templates)
-		 * @param array|string $data Data to store
-		 * @return bool Return value from wp_cache_add()
-		 */
+	/**
+	 * Adds theme data to cache.
+	 *
+	 * Cache entries keyed by the theme and the type of data.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param string       $key  Type of data to store (theme, screenshot, headers, post_templates)
+	 * @param array|string $data Data to store
+	 * @return bool Return value from wp_cache_add()
+	 */
 	private function cache_add( $key, $data ) {
 		return wp_cache_add( $key . '-' . $this->cache_hash, $data, 'themes', self::$cache_expiration );
 	}
 
-		/**
-		 * Gets theme data from cache.
-		 *
-		 * Cache entries are keyed by the theme and the type of data.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param string $key Type of data to retrieve (theme, screenshot, headers, post_templates)
-		 * @return mixed Retrieved data
-		 */
+	/**
+	 * Gets theme data from cache.
+	 *
+	 * Cache entries are keyed by the theme and the type of data.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param string $key Type of data to retrieve (theme, screenshot, headers, post_templates)
+	 * @return mixed Retrieved data
+	 */
 	private function cache_get( $key ) {
 		return wp_cache_get( $key . '-' . $this->cache_hash, 'themes' );
 	}
 
-		/**
-		 * Clears the cache for the theme.
-		 *
-		 * @since 3.4.0
-		 */
+	/**
+	 * Clears the cache for the theme.
+	 *
+	 * @since 3.4.0
+	 */
 	public function cache_delete() {
 		foreach ( array( 'theme', 'screenshot', 'headers', 'post_templates' ) as $key ) {
 			wp_cache_delete( $key . '-' . $this->cache_hash, 'themes' );
@@ -832,22 +832,22 @@ final class WP_Theme implements ArrayAccess {
 		$this->delete_pattern_cache();
 	}
 
-		/**
-		 * Gets a raw, unformatted theme header.
-		 *
-		 * The header is sanitized, but is not translated, and is not marked up for display.
-		 * To get a theme header for display, use the display() method.
-		 *
-		 * Use the get_template() method, not the 'Template' header, for finding the template.
-		 * The 'Template' header is only good for what was written in the style.css, while
-		 * get_template() takes into account where WordPress actually located the theme and
-		 * whether it is actually valid.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param string $header Theme header. Name, Description, Author, Version, ThemeURI, AuthorURI, Status, Tags.
-		 * @return string|array|false String or array (for Tags header) on success, false on failure.
-		 */
+	/**
+	 * Gets a raw, unformatted theme header.
+	 *
+	 * The header is sanitized, but is not translated, and is not marked up for display.
+	 * To get a theme header for display, use the display() method.
+	 *
+	 * Use the get_template() method, not the 'Template' header, for finding the template.
+	 * The 'Template' header is only good for what was written in the style.css, while
+	 * get_template() takes into account where WordPress actually located the theme and
+	 * whether it is actually valid.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param string $header Theme header. Name, Description, Author, Version, ThemeURI, AuthorURI, Status, Tags.
+	 * @return string|array|false String or array (for Tags header) on success, false on failure.
+	 */
 	public function get( $header ) {
 		if ( ! isset( $this->headers[ $header ] ) ) {
 			return false;
@@ -877,17 +877,17 @@ final class WP_Theme implements ArrayAccess {
 		return $this->headers_sanitized[ $header ];
 	}
 
-		/**
-		 * Gets a theme header, formatted and translated for display.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param string $header    Theme header. Name, Description, Author, Version, ThemeURI, AuthorURI, Status, Tags.
-		 * @param bool   $markup    Optional. Whether to mark up the header. Defaults to true.
-		 * @param bool   $translate Optional. Whether to translate the header. Defaults to true.
-		 * @return string|array|false Processed header. An array for Tags if `$markup` is false, string otherwise.
-		 *                            False on failure.
-		 */
+	/**
+	 * Gets a theme header, formatted and translated for display.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param string $header    Theme header. Name, Description, Author, Version, ThemeURI, AuthorURI, Status, Tags.
+	 * @param bool   $markup    Optional. Whether to mark up the header. Defaults to true.
+	 * @param bool   $translate Optional. Whether to translate the header. Defaults to true.
+	 * @return string|array|false Processed header. An array for Tags if `$markup` is false, string otherwise.
+	 *                            False on failure.
+	 */
 	public function display( $header, $markup = true, $translate = true ) {
 		$value = $this->get( $header );
 		if ( false === $value ) {
@@ -909,19 +909,19 @@ final class WP_Theme implements ArrayAccess {
 		return $value;
 	}
 
-		/**
-		 * Sanitizes a theme header.
-		 *
-		 * @since 3.4.0
-		 * @since 5.4.0 Added support for `Requires at least` and `Requires PHP` headers.
-		 * @since 6.1.0 Added support for `Update URI` header.
-		 *
-		 * @param string $header Theme header. Accepts 'Name', 'Description', 'Author', 'Version',
-		 *                       'ThemeURI', 'AuthorURI', 'Status', 'Tags', 'RequiresWP', 'RequiresPHP',
-		 *                       'UpdateURI'.
-		 * @param string $value  Value to sanitize.
-		 * @return string|array An array for Tags header, string otherwise.
-		 */
+	/**
+	 * Sanitizes a theme header.
+	 *
+	 * @since 3.4.0
+	 * @since 5.4.0 Added support for `Requires at least` and `Requires PHP` headers.
+	 * @since 6.1.0 Added support for `Update URI` header.
+	 *
+	 * @param string $header Theme header. Accepts 'Name', 'Description', 'Author', 'Version',
+	 *                       'ThemeURI', 'AuthorURI', 'Status', 'Tags', 'RequiresWP', 'RequiresPHP',
+	 *                       'UpdateURI'.
+	 * @param string $value  Value to sanitize.
+	 * @return string|array An array for Tags header, string otherwise.
+	 */
 	private function sanitize_header( $header, $value ) {
 		switch ( $header ) {
 			case 'Status':
@@ -976,16 +976,16 @@ final class WP_Theme implements ArrayAccess {
 		return $value;
 	}
 
-		/**
-		 * Marks up a theme header.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param string       $header    Theme header. Name, Description, Author, Version, ThemeURI, AuthorURI, Status, Tags.
-		 * @param string|array $value     Value to mark up. An array for Tags header, string otherwise.
-		 * @param string       $translate Whether the header has been translated.
-		 * @return string Value, marked up.
-		 */
+	/**
+	 * Marks up a theme header.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param string       $header    Theme header. Name, Description, Author, Version, ThemeURI, AuthorURI, Status, Tags.
+	 * @param string|array $value     Value to mark up. An array for Tags header, string otherwise.
+	 * @param string       $translate Whether the header has been translated.
+	 * @return string Value, marked up.
+	 */
 	private function markup_header( $header, $value, $translate ) {
 		switch ( $header ) {
 			case 'Name':
@@ -1019,15 +1019,15 @@ final class WP_Theme implements ArrayAccess {
 		return $value;
 	}
 
-		/**
-		 * Translates a theme header.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param string       $header Theme header. Name, Description, Author, Version, ThemeURI, AuthorURI, Status, Tags.
-		 * @param string|array $value  Value to translate. An array for Tags header, string otherwise.
-		 * @return string|array Translated value. An array for Tags header, string otherwise.
-		 */
+	/**
+	 * Translates a theme header.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param string       $header Theme header. Name, Description, Author, Version, ThemeURI, AuthorURI, Status, Tags.
+	 * @param string|array $value  Value to translate. An array for Tags header, string otherwise.
+	 * @return string|array Translated value. An array for Tags header, string otherwise.
+	 */
 	private function translate_header( $header, $value ) {
 		switch ( $header ) {
 			case 'Name':
@@ -1096,44 +1096,44 @@ final class WP_Theme implements ArrayAccess {
 		return $value;
 	}
 
-		/**
-		 * Returns the directory name of the theme's "stylesheet" files, inside the theme root.
-		 *
-		 * In the case of a child theme, this is directory name of the child theme.
-		 * Otherwise, get_stylesheet() is the same as get_template().
-		 *
-		 * @since 3.4.0
-		 *
-		 * @return string Stylesheet
-		 */
+	/**
+	 * Returns the directory name of the theme's "stylesheet" files, inside the theme root.
+	 *
+	 * In the case of a child theme, this is directory name of the child theme.
+	 * Otherwise, get_stylesheet() is the same as get_template().
+	 *
+	 * @since 3.4.0
+	 *
+	 * @return string Stylesheet
+	 */
 	public function get_stylesheet() {
 		return $this->stylesheet;
 	}
 
-		/**
-		 * Returns the directory name of the theme's "template" files, inside the theme root.
-		 *
-		 * In the case of a child theme, this is the directory name of the parent theme.
-		 * Otherwise, the get_template() is the same as get_stylesheet().
-		 *
-		 * @since 3.4.0
-		 *
-		 * @return string Template
-		 */
+	/**
+	 * Returns the directory name of the theme's "template" files, inside the theme root.
+	 *
+	 * In the case of a child theme, this is the directory name of the parent theme.
+	 * Otherwise, the get_template() is the same as get_stylesheet().
+	 *
+	 * @since 3.4.0
+	 *
+	 * @return string Template
+	 */
 	public function get_template() {
 		return $this->template;
 	}
 
-		/**
-		 * Returns the absolute path to the directory of a theme's "stylesheet" files.
-		 *
-		 * In the case of a child theme, this is the absolute path to the directory
-		 * of the child theme's files.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @return string Absolute path of the stylesheet directory.
-		 */
+	/**
+	 * Returns the absolute path to the directory of a theme's "stylesheet" files.
+	 *
+	 * In the case of a child theme, this is the absolute path to the directory
+	 * of the child theme's files.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @return string Absolute path of the stylesheet directory.
+	 */
 	public function get_stylesheet_directory() {
 		if ( $this->errors() && in_array( 'theme_root_missing', $this->errors()->get_error_codes(), true ) ) {
 			return '';
@@ -1142,16 +1142,16 @@ final class WP_Theme implements ArrayAccess {
 		return $this->theme_root . '/' . $this->stylesheet;
 	}
 
-		/**
-		 * Returns the absolute path to the directory of a theme's "template" files.
-		 *
-		 * In the case of a child theme, this is the absolute path to the directory
-		 * of the parent theme's files.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @return string Absolute path of the template directory.
-		 */
+	/**
+	 * Returns the absolute path to the directory of a theme's "template" files.
+	 *
+	 * In the case of a child theme, this is the absolute path to the directory
+	 * of the parent theme's files.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @return string Absolute path of the template directory.
+	 */
 	public function get_template_directory() {
 		if ( $this->parent() ) {
 			$theme_root = $this->parent()->theme_root;
@@ -1162,30 +1162,30 @@ final class WP_Theme implements ArrayAccess {
 		return $theme_root . '/' . $this->template;
 	}
 
-		/**
-		 * Returns the URL to the directory of a theme's "stylesheet" files.
-		 *
-		 * In the case of a child theme, this is the URL to the directory of the
-		 * child theme's files.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @return string URL to the stylesheet directory.
-		 */
+	/**
+	 * Returns the URL to the directory of a theme's "stylesheet" files.
+	 *
+	 * In the case of a child theme, this is the URL to the directory of the
+	 * child theme's files.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @return string URL to the stylesheet directory.
+	 */
 	public function get_stylesheet_directory_uri() {
 		return $this->get_theme_root_uri() . '/' . str_replace( '%2F', '/', rawurlencode( $this->stylesheet ) );
 	}
 
-		/**
-		 * Returns the URL to the directory of a theme's "template" files.
-		 *
-		 * In the case of a child theme, this is the URL to the directory of the
-		 * parent theme's files.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @return string URL to the template directory.
-		 */
+	/**
+	 * Returns the URL to the directory of a theme's "template" files.
+	 *
+	 * In the case of a child theme, this is the URL to the directory of the
+	 * parent theme's files.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @return string URL to the template directory.
+	 */
 	public function get_template_directory_uri() {
 		if ( $this->parent() ) {
 			$theme_root_uri = $this->parent()->get_theme_root_uri();
@@ -1196,30 +1196,30 @@ final class WP_Theme implements ArrayAccess {
 		return $theme_root_uri . '/' . str_replace( '%2F', '/', rawurlencode( $this->template ) );
 	}
 
-		/**
-		 * Returns the absolute path to the directory of the theme root.
-		 *
-		 * This is typically the absolute path to wp-content/themes.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @return string Theme root.
-		 */
+	/**
+	 * Returns the absolute path to the directory of the theme root.
+	 *
+	 * This is typically the absolute path to wp-content/themes.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @return string Theme root.
+	 */
 	public function get_theme_root() {
 		return $this->theme_root;
 	}
 
-		/**
-		 * Returns the URL to the directory of the theme root.
-		 *
-		 * This is typically the absolute URL to wp-content/themes. This forms the basis
-		 * for all other URLs returned by WP_Theme, so we pass it to the public function
-		 * get_theme_root_uri() and allow it to run the {@see 'theme_root_uri'} filter.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @return string Theme root URI.
-		 */
+	/**
+	 * Returns the URL to the directory of the theme root.
+	 *
+	 * This is typically the absolute URL to wp-content/themes. This forms the basis
+	 * for all other URLs returned by WP_Theme, so we pass it to the public function
+	 * get_theme_root_uri() and allow it to run the {@see 'theme_root_uri'} filter.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @return string Theme root URI.
+	 */
 	public function get_theme_root_uri() {
 		if ( ! isset( $this->theme_root_uri ) ) {
 			$this->theme_root_uri = get_theme_root_uri( $this->stylesheet, $this->theme_root );
@@ -1227,19 +1227,19 @@ final class WP_Theme implements ArrayAccess {
 		return $this->theme_root_uri;
 	}
 
-		/**
-		 * Returns the main screenshot file for the theme.
-		 *
-		 * The main screenshot is called screenshot.png. gif and jpg extensions are also allowed.
-		 *
-		 * Screenshots for a theme must be in the stylesheet directory. (In the case of child
-		 * themes, parent theme screenshots are not inherited.)
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param string $uri Type of URL to return, either 'relative' or an absolute URI. Defaults to absolute URI.
-		 * @return string|false Screenshot file. False if the theme does not have a screenshot.
-		 */
+	/**
+	 * Returns the main screenshot file for the theme.
+	 *
+	 * The main screenshot is called screenshot.png. gif and jpg extensions are also allowed.
+	 *
+	 * Screenshots for a theme must be in the stylesheet directory. (In the case of child
+	 * themes, parent theme screenshots are not inherited.)
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param string $uri Type of URL to return, either 'relative' or an absolute URI. Defaults to absolute URI.
+	 * @return string|false Screenshot file. False if the theme does not have a screenshot.
+	 */
 	public function get_screenshot( $uri = 'uri' ) {
 		$screenshot = $this->cache_get( 'screenshot' );
 		if ( $screenshot ) {
@@ -1265,19 +1265,19 @@ final class WP_Theme implements ArrayAccess {
 		return false;
 	}
 
-		/**
-		 * Returns files in the theme's directory.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param string[]|string $type          Optional. Array of extensions to find, string of a single extension,
-		 *                                       or null for all extensions. Default null.
-		 * @param int             $depth         Optional. How deep to search for files. Defaults to a flat scan (0 depth).
-		 *                                       -1 depth is infinite.
-		 * @param bool            $search_parent Optional. Whether to return parent files. Default false.
-		 * @return string[] Array of files, keyed by the path to the file relative to the theme's directory, with the values
-		 *                  being absolute paths.
-		 */
+	/**
+	 * Returns files in the theme's directory.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param string[]|string $type          Optional. Array of extensions to find, string of a single extension,
+	 *                                       or null for all extensions. Default null.
+	 * @param int             $depth         Optional. How deep to search for files. Defaults to a flat scan (0 depth).
+	 *                                       -1 depth is infinite.
+	 * @param bool            $search_parent Optional. Whether to return parent files. Default false.
+	 * @return string[] Array of files, keyed by the path to the file relative to the theme's directory, with the values
+	 *                  being absolute paths.
+	 */
 	public function get_files( $type = null, $depth = 0, $search_parent = false ) {
 		$files = (array) self::scandir( $this->get_stylesheet_directory(), $type, $depth );
 
@@ -1288,15 +1288,15 @@ final class WP_Theme implements ArrayAccess {
 		return array_filter( $files );
 	}
 
-		/**
-		 * Returns the theme's post templates.
-		 *
-		 * @since 4.7.0
-		 * @since 5.8.0 Include block templates.
-		 *
-		 * @return array[] Array of page template arrays, keyed by post type and filename,
-		 *                 with the value of the translated header name.
-		 */
+	/**
+	 * Returns the theme's post templates.
+	 *
+	 * @since 4.7.0
+	 * @since 5.8.0 Include block templates.
+	 *
+	 * @return array[] Array of page template arrays, keyed by post type and filename,
+	 *                 with the value of the translated header name.
+	 */
 	public function get_post_templates() {
 		// If you screw up your active theme and we invalidate your parent, most things still work. Let it slide.
 		if ( $this->errors() && $this->errors()->get_error_codes() !== array( 'theme_parent_invalid' ) ) {
@@ -1361,17 +1361,17 @@ final class WP_Theme implements ArrayAccess {
 		return $post_templates;
 	}
 
-		/**
-		 * Returns the theme's post templates for a given post type.
-		 *
-		 * @since 3.4.0
-		 * @since 4.7.0 Added the `$post_type` parameter.
-		 *
-		 * @param WP_Post|null $post      Optional. The post being edited, provided for context.
-		 * @param string       $post_type Optional. Post type to get the templates for. Default 'page'.
-		 *                                If a post is provided, its post type is used.
-		 * @return string[] Array of template header names keyed by the template file name.
-		 */
+	/**
+	 * Returns the theme's post templates for a given post type.
+	 *
+	 * @since 3.4.0
+	 * @since 4.7.0 Added the `$post_type` parameter.
+	 *
+	 * @param WP_Post|null $post      Optional. The post being edited, provided for context.
+	 * @param string       $post_type Optional. Post type to get the templates for. Default 'page'.
+	 *                                If a post is provided, its post type is used.
+	 * @return string[] Array of template header names keyed by the template file name.
+	 */
 	public function get_page_templates( $post = null, $post_type = 'page' ) {
 		if ( $post ) {
 			$post_type = get_post_type( $post );
@@ -1417,22 +1417,22 @@ final class WP_Theme implements ArrayAccess {
 		return $post_templates;
 	}
 
-		/**
-		 * Scans a directory for files of a certain extension.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param string            $path          Absolute path to search.
-		 * @param array|string|null $extensions    Optional. Array of extensions to find, string of a single extension,
-		 *                                         or null for all extensions. Default null.
-		 * @param int               $depth         Optional. How many levels deep to search for files. Accepts 0, 1+, or
-		 *                                         -1 (infinite depth). Default 0.
-		 * @param string            $relative_path Optional. The basename of the absolute path. Used to control the
-		 *                                         returned path for the found files, particularly when this function
-		 *                                         recurses to lower depths. Default empty.
-		 * @return string[]|false Array of files, keyed by the path to the file relative to the `$path` directory prepended
-		 *                        with `$relative_path`, with the values being absolute paths. False otherwise.
-		 */
+	/**
+	 * Scans a directory for files of a certain extension.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param string            $path          Absolute path to search.
+	 * @param array|string|null $extensions    Optional. Array of extensions to find, string of a single extension,
+	 *                                         or null for all extensions. Default null.
+	 * @param int               $depth         Optional. How many levels deep to search for files. Accepts 0, 1+, or
+	 *                                         -1 (infinite depth). Default 0.
+	 * @param string            $relative_path Optional. The basename of the absolute path. Used to control the
+	 *                                         returned path for the found files, particularly when this function
+	 *                                         recurses to lower depths. Default empty.
+	 * @return string[]|false Array of files, keyed by the path to the file relative to the `$path` directory prepended
+	 *                        with `$relative_path`, with the values being absolute paths. False otherwise.
+	 */
 	private static function scandir( $path, $extensions = null, $depth = 0, $relative_path = '' ) {
 		if ( ! is_dir( $path ) ) {
 			return false;
@@ -1478,17 +1478,17 @@ final class WP_Theme implements ArrayAccess {
 		return $files;
 	}
 
-		/**
-		 * Loads the theme's textdomain.
-		 *
-		 * Translation files are not inherited from the parent theme. TODO: If this fails for the
-		 * child theme, it should probably try to load the parent theme's translations.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @return bool True if the textdomain was successfully loaded or has already been loaded.
-		 *  False if no textdomain was specified in the file headers, or if the domain could not be loaded.
-		 */
+	/**
+	 * Loads the theme's textdomain.
+	 *
+	 * Translation files are not inherited from the parent theme. TODO: If this fails for the
+	 * child theme, it should probably try to load the parent theme's translations.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @return bool True if the textdomain was successfully loaded or has already been loaded.
+	 *  False if no textdomain was specified in the file headers, or if the domain could not be loaded.
+	 */
 	public function load_textdomain() {
 		if ( isset( $this->textdomain_loaded ) ) {
 			return $this->textdomain_loaded;
@@ -1517,16 +1517,16 @@ final class WP_Theme implements ArrayAccess {
 		return $this->textdomain_loaded;
 	}
 
-		/**
-		 * Determines whether the theme is allowed (multisite only).
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param string $check   Optional. Whether to check only the 'network'-wide settings, the 'site'
-		 *                        settings, or 'both'. Defaults to 'both'.
-		 * @param int    $blog_id Optional. Ignored if only network-wide settings are checked. Defaults to current site.
-		 * @return bool Whether the theme is allowed for the network. Returns true in single-site.
-		 */
+	/**
+	 * Determines whether the theme is allowed (multisite only).
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param string $check   Optional. Whether to check only the 'network'-wide settings, the 'site'
+	 *                        settings, or 'both'. Defaults to 'both'.
+	 * @param int    $blog_id Optional. Ignored if only network-wide settings are checked. Defaults to current site.
+	 * @return bool Whether the theme is allowed for the network. Returns true in single-site.
+	 */
 	public function is_allowed( $check = 'both', $blog_id = null ) {
 		if ( ! is_multisite() ) {
 			return true;
@@ -1549,13 +1549,13 @@ final class WP_Theme implements ArrayAccess {
 		return false;
 	}
 
-		/**
-		 * Returns whether this theme is a block-based theme or not.
-		 *
-		 * @since 5.9.0
-		 *
-		 * @return bool
-		 */
+	/**
+	 * Returns whether this theme is a block-based theme or not.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @return bool
+	 */
 	public function is_block_theme() {
 		if ( ! did_action( 'setup_theme' ) ) {
 			_doing_it_wrong( __METHOD__, __( 'This method should not be called before themes are set up.' ), '6.8.0' );
@@ -1583,17 +1583,17 @@ final class WP_Theme implements ArrayAccess {
 		return $this->block_theme;
 	}
 
-		/**
-		 * Retrieves the path of a file in the theme.
-		 *
-		 * Searches in the stylesheet directory before the template directory so themes
-		 * which inherit from a parent theme can just override one file.
-		 *
-		 * @since 5.9.0
-		 *
-		 * @param string $file Optional. File to search for in the stylesheet directory.
-		 * @return string The path of the file.
-		 */
+	/**
+	 * Retrieves the path of a file in the theme.
+	 *
+	 * Searches in the stylesheet directory before the template directory so themes
+	 * which inherit from a parent theme can just override one file.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param string $file Optional. File to search for in the stylesheet directory.
+	 * @return string The path of the file.
+	 */
 	public function get_file_path( $file = '' ) {
 		$file = ltrim( $file, '/' );
 
@@ -1612,15 +1612,15 @@ final class WP_Theme implements ArrayAccess {
 		return apply_filters( 'theme_file_path', $path, $file );
 	}
 
-		/**
-		 * Determines the latest WordPress default theme that is installed.
-		 *
-		 * This hits the filesystem.
-		 *
-		 * @since 4.4.0
-		 *
-		 * @return WP_Theme|false Object, or false if no theme is installed, which would be bad.
-		 */
+	/**
+	 * Determines the latest WordPress default theme that is installed.
+	 *
+	 * This hits the filesystem.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @return WP_Theme|false Object, or false if no theme is installed, which would be bad.
+	 */
 	public static function get_core_default_theme() {
 		foreach ( array_reverse( self::$default_themes ) as $slug => $name ) {
 			$theme = wp_get_theme( $slug );
@@ -1631,14 +1631,14 @@ final class WP_Theme implements ArrayAccess {
 		return false;
 	}
 
-		/**
-		 * Returns array of stylesheet names of themes allowed on the site or network.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param int $blog_id Optional. ID of the site. Defaults to the current site.
-		 * @return string[] Array of stylesheet names.
-		 */
+	/**
+	 * Returns array of stylesheet names of themes allowed on the site or network.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param int $blog_id Optional. ID of the site. Defaults to the current site.
+	 * @return string[] Array of stylesheet names.
+	 */
 	public static function get_allowed( $blog_id = null ) {
 		/**
 		 * Filters the array of themes allowed on the network.
@@ -1655,13 +1655,13 @@ final class WP_Theme implements ArrayAccess {
 		return $network + self::get_allowed_on_site( $blog_id );
 	}
 
-		/**
-		 * Returns array of stylesheet names of themes allowed on the network.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @return string[] Array of stylesheet names.
-		 */
+	/**
+	 * Returns array of stylesheet names of themes allowed on the network.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @return string[] Array of stylesheet names.
+	 */
 	public static function get_allowed_on_network() {
 		static $allowed_themes;
 		if ( ! isset( $allowed_themes ) ) {
@@ -1680,14 +1680,14 @@ final class WP_Theme implements ArrayAccess {
 		return $allowed_themes;
 	}
 
-		/**
-		 * Returns array of stylesheet names of themes allowed on the site.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param int $blog_id Optional. ID of the site. Defaults to the current site.
-		 * @return string[] Array of stylesheet names.
-		 */
+	/**
+	 * Returns array of stylesheet names of themes allowed on the site.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param int $blog_id Optional. ID of the site. Defaults to the current site.
+	 * @return string[] Array of stylesheet names.
+	 */
 	public static function get_allowed_on_site( $blog_id = null ) {
 		static $allowed_themes = array();
 
@@ -1760,18 +1760,18 @@ final class WP_Theme implements ArrayAccess {
 		return (array) apply_filters( 'site_allowed_themes', $allowed_themes[ $blog_id ], $blog_id );
 	}
 
-		/**
-		 * Returns the folder names of the block template directories.
-		 *
-		 * @since 6.4.0
-		 *
-		 * @return string[] {
-		 *     Folder names used by block themes.
-		 *
-		 *     @type string $wp_template      Theme-relative directory name for block templates.
-		 *     @type string $wp_template_part Theme-relative directory name for block template parts.
-		 * }
-		 */
+	/**
+	 * Returns the folder names of the block template directories.
+	 *
+	 * @since 6.4.0
+	 *
+	 * @return string[] {
+	 *     Folder names used by block themes.
+	 *
+	 *     @type string $wp_template      Theme-relative directory name for block templates.
+	 *     @type string $wp_template_part Theme-relative directory name for block template parts.
+	 * }
+	 */
 	public function get_block_template_folders() {
 		// Return set/cached value if available.
 		if ( isset( $this->block_template_folders ) ) {
@@ -1791,37 +1791,37 @@ final class WP_Theme implements ArrayAccess {
 		return $this->block_template_folders;
 	}
 
-		/**
-		 * Gets block pattern data for a specified theme.
-		 * Each pattern is defined as a PHP file and defines
-		 * its metadata using plugin-style headers. The minimum required definition is:
-		 *
-		 *     /**
-		 *      * Title: My Pattern
-		 *      * Slug: my-theme/my-pattern
-		 *      *
-		 *
-		 * The output of the PHP source corresponds to the content of the pattern, e.g.:
-		 *
-		 *     <main><p><?php echo "Hello"; ?></p></main>
-		 *
-		 * If applicable, this will collect from both parent and child theme.
-		 *
-		 * Other settable fields include:
-		 *
-		 *     - Description
-		 *     - Viewport Width
-		 *     - Inserter         (yes/no)
-		 *     - Categories       (comma-separated values)
-		 *     - Keywords         (comma-separated values)
-		 *     - Block Types      (comma-separated values)
-		 *     - Post Types       (comma-separated values)
-		 *     - Template Types   (comma-separated values)
-		 *
-		 * @since 6.4.0
-		 *
-		 * @return array Block pattern data.
-		 */
+	/**
+	 * Gets block pattern data for a specified theme.
+	 * Each pattern is defined as a PHP file and defines
+	 * its metadata using plugin-style headers. The minimum required definition is:
+	 *
+	 *     /**
+	 *      * Title: My Pattern
+	 *      * Slug: my-theme/my-pattern
+	 *      *
+	 *
+	 * The output of the PHP source corresponds to the content of the pattern, e.g.:
+	 *
+	 *     <main><p><?php echo "Hello"; ?></p></main>
+	 *
+	 * If applicable, this will collect from both parent and child theme.
+	 *
+	 * Other settable fields include:
+	 *
+	 *     - Description
+	 *     - Viewport Width
+	 *     - Inserter         (yes/no)
+	 *     - Categories       (comma-separated values)
+	 *     - Keywords         (comma-separated values)
+	 *     - Block Types      (comma-separated values)
+	 *     - Post Types       (comma-separated values)
+	 *     - Template Types   (comma-separated values)
+	 *
+	 * @since 6.4.0
+	 *
+	 * @return array Block pattern data.
+	 */
 	public function get_block_patterns() {
 		$can_use_cached = ! wp_is_development_mode( 'theme' );
 
@@ -1883,7 +1883,7 @@ final class WP_Theme implements ArrayAccess {
 				_doing_it_wrong(
 					__FUNCTION__,
 					sprintf(
-					/* translators: 1: file name. */
+						/* translators: 1: file name. */
 						__( 'Could not register file "%s" as a block pattern ("Slug" field missing)' ),
 						$file
 					),
@@ -1896,7 +1896,7 @@ final class WP_Theme implements ArrayAccess {
 				_doing_it_wrong(
 					__FUNCTION__,
 					sprintf(
-					/* translators: 1: file name; 2: slug value found. */
+						/* translators: 1: file name; 2: slug value found. */
 						__( 'Could not register file "%1$s" as a block pattern (invalid slug "%2$s")' ),
 						$file,
 						$pattern['slug']
@@ -1910,7 +1910,7 @@ final class WP_Theme implements ArrayAccess {
 				_doing_it_wrong(
 					__FUNCTION__,
 					sprintf(
-					/* translators: 1: file name. */
+						/* translators: 1: file name. */
 						__( 'Could not register file "%s" as a block pattern ("Title" field missing)' ),
 						$file
 					),
@@ -1960,14 +1960,14 @@ final class WP_Theme implements ArrayAccess {
 		return $pattern_data;
 	}
 
-		/**
-		 * Gets block pattern cache.
-		 *
-		 * @since 6.4.0
-		 * @since 6.6.0 Uses transients to cache regardless of site environment.
-		 *
-		 * @return array|false Returns an array of patterns if cache is found, otherwise false.
-		 */
+	/**
+	 * Gets block pattern cache.
+	 *
+	 * @since 6.4.0
+	 * @since 6.6.0 Uses transients to cache regardless of site environment.
+	 *
+	 * @return array|false Returns an array of patterns if cache is found, otherwise false.
+	 */
 	private function get_pattern_cache() {
 		if ( ! $this->exists() ) {
 			return false;
@@ -1981,14 +1981,14 @@ final class WP_Theme implements ArrayAccess {
 		return false;
 	}
 
-		/**
-		 * Sets block pattern cache.
-		 *
-		 * @since 6.4.0
-		 * @since 6.6.0 Uses transients to cache regardless of site environment.
-		 *
-		 * @param array $patterns Block patterns data to set in cache.
-		 */
+	/**
+	 * Sets block pattern cache.
+	 *
+	 * @since 6.4.0
+	 * @since 6.6.0 Uses transients to cache regardless of site environment.
+	 *
+	 * @param array $patterns Block patterns data to set in cache.
+	 */
 	private function set_pattern_cache( array $patterns ) {
 		$pattern_data = array(
 			'version'  => $this->get( 'Version' ),
@@ -2010,7 +2010,7 @@ final class WP_Theme implements ArrayAccess {
 			_doing_it_wrong(
 				__METHOD__,
 				sprintf(
-				/* translators: %1$s: The filter name.*/
+					/* translators: %1$s: The filter name.*/
 					__( 'The %1$s filter must return an integer value greater than 0.' ),
 					'<code>wp_theme_files_cache_ttl</code>'
 				),
@@ -2023,23 +2023,23 @@ final class WP_Theme implements ArrayAccess {
 		set_site_transient( 'wp_theme_files_patterns-' . $this->cache_hash, $pattern_data, $cache_expiration );
 	}
 
-		/**
-		 * Clears block pattern cache.
-		 *
-		 * @since 6.4.0
-		 * @since 6.6.0 Uses transients to cache regardless of site environment.
-		 */
+	/**
+	 * Clears block pattern cache.
+	 *
+	 * @since 6.4.0
+	 * @since 6.6.0 Uses transients to cache regardless of site environment.
+	 */
 	public function delete_pattern_cache() {
 		delete_site_transient( 'wp_theme_files_patterns-' . $this->cache_hash );
 	}
 
-		/**
-		 * Enables a theme for all sites on the current network.
-		 *
-		 * @since 4.6.0
-		 *
-		 * @param string|string[] $stylesheets Stylesheet name or array of stylesheet names.
-		 */
+	/**
+	 * Enables a theme for all sites on the current network.
+	 *
+	 * @since 4.6.0
+	 *
+	 * @param string|string[] $stylesheets Stylesheet name or array of stylesheet names.
+	 */
 	public static function network_enable_theme( $stylesheets ) {
 		if ( ! is_multisite() ) {
 			return;
@@ -2057,13 +2057,13 @@ final class WP_Theme implements ArrayAccess {
 		update_site_option( 'allowedthemes', $allowed_themes );
 	}
 
-		/**
-		 * Disables a theme for all sites on the current network.
-		 *
-		 * @since 4.6.0
-		 *
-		 * @param string|string[] $stylesheets Stylesheet name or array of stylesheet names.
-		 */
+	/**
+	 * Disables a theme for all sites on the current network.
+	 *
+	 * @since 4.6.0
+	 *
+	 * @param string|string[] $stylesheets Stylesheet name or array of stylesheet names.
+	 */
 	public static function network_disable_theme( $stylesheets ) {
 		if ( ! is_multisite() ) {
 			return;
@@ -2083,13 +2083,13 @@ final class WP_Theme implements ArrayAccess {
 		update_site_option( 'allowedthemes', $allowed_themes );
 	}
 
-		/**
-		 * Sorts themes by name.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param WP_Theme[] $themes Array of theme objects to sort (passed by reference).
-		 */
+	/**
+	 * Sorts themes by name.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param WP_Theme[] $themes Array of theme objects to sort (passed by reference).
+	 */
 	public static function sort_by_name( &$themes ) {
 		if ( str_starts_with( get_user_locale(), 'en_' ) ) {
 			uasort( $themes, array( 'WP_Theme', '_name_sort' ) );
@@ -2101,33 +2101,33 @@ final class WP_Theme implements ArrayAccess {
 		}
 	}
 
-		/**
-		 * Callback function for usort() to naturally sort themes by name.
-		 *
-		 * Accesses the Name header directly from the class for maximum speed.
-		 * Would choke on HTML but we don't care enough to slow it down with strip_tags().
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param WP_Theme $a First theme.
-		 * @param WP_Theme $b Second theme.
-		 * @return int Negative if `$a` falls lower in the natural order than `$b`. Zero if they fall equally.
-		 *             Greater than 0 if `$a` falls higher in the natural order than `$b`. Used with usort().
-		 */
+	/**
+	 * Callback function for usort() to naturally sort themes by name.
+	 *
+	 * Accesses the Name header directly from the class for maximum speed.
+	 * Would choke on HTML but we don't care enough to slow it down with strip_tags().
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param WP_Theme $a First theme.
+	 * @param WP_Theme $b Second theme.
+	 * @return int Negative if `$a` falls lower in the natural order than `$b`. Zero if they fall equally.
+	 *             Greater than 0 if `$a` falls higher in the natural order than `$b`. Used with usort().
+	 */
 	private static function _name_sort( $a, $b ) {
 		return strnatcasecmp( $a->headers['Name'], $b->headers['Name'] );
 	}
 
-		/**
-		 * Callback function for usort() to naturally sort themes by translated name.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param WP_Theme $a First theme.
-		 * @param WP_Theme $b Second theme.
-		 * @return int Negative if `$a` falls lower in the natural order than `$b`. Zero if they fall equally.
-		 *             Greater than 0 if `$a` falls higher in the natural order than `$b`. Used with usort().
-		 */
+	/**
+	 * Callback function for usort() to naturally sort themes by translated name.
+	 *
+	 * @since 3.4.0
+	 *
+	 * @param WP_Theme $a First theme.
+	 * @param WP_Theme $b Second theme.
+	 * @return int Negative if `$a` falls lower in the natural order than `$b`. Zero if they fall equally.
+	 *             Greater than 0 if `$a` falls higher in the natural order than `$b`. Used with usort().
+	 */
 	private static function _name_sort_i18n( $a, $b ) {
 		return strnatcasecmp( $a->name_translated, $b->name_translated );
 	}

--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -397,7 +397,7 @@ final class WP_Theme implements ArrayAccess {
 			}
 		}
 
-			// If we got our data from cache, we can assume that 'template' is pointing to the right place.
+		// If we got our data from cache, we can assume that 'template' is pointing to the right place.
 		if ( ! is_array( $cache )
 			&& $this->template !== $this->stylesheet
 			&& ! file_exists( $this->theme_root . '/' . $this->template . '/index.php' )

--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -504,7 +504,6 @@ final class WP_Theme implements ArrayAccess {
 		// We're good. If we didn't retrieve from cache, set it.
 		if ( ! is_array( $cache ) ) {
 			$cache = array(
-				'block_theme'            => false, // See #63086
 				'block_template_folders' => $this->get_block_template_folders(),
 				'headers'                => $this->headers,
 				'errors'                 => $this->errors,
@@ -2186,7 +2185,6 @@ final class WP_Theme implements ArrayAccess {
 	 * @since 6.8.0
 	 */
 	public function _update_cached_block_theme() {
-		// Update the cached value with the correct block_theme status
 		$cache = $this->cache_get( 'theme' );
 		if ( is_array( $cache ) ) {
 			$cache['block_theme'] = $this->is_block_theme();

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -4352,7 +4352,14 @@ function create_initial_theme_features() {
  * @return bool Whether the active theme is a block-based theme or not.
  */
 function wp_is_block_theme() {
-	return wp_get_theme()->is_block_theme();
+	/**
+	 * Filters whether the active theme is a block-based theme or not.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @return bool $is_block_theme Whether the active theme is a block-based theme or not.
+	 */
+	return apply_filters( 'wp_is_block_theme', wp_get_theme()->is_block_theme() );
 }
 
 /**

--- a/tests/phpunit/tests/customize/manager.php
+++ b/tests/phpunit/tests/customize/manager.php
@@ -3680,6 +3680,9 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 	 * Test that widgets component is properly handled with block themes.
 	 *
 	 * @ticket #63086
+	 *
+	 * @group is_block_theme
+	 *
 	 * @covers WP_Customize_Manager::__construct
 	 * @covers WP_Customize_Manager::maybe_remove_widgets_component
 	 */
@@ -3701,6 +3704,9 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 	 * Test that widgets component remains for non-block themes.
 	 *
 	 * @ticket #63086
+	 *
+	 * @group is_block_theme
+	 *
 	 * @covers WP_Customize_Manager::__construct
 	 * @covers WP_Customize_Manager::maybe_remove_widgets_component
 	 */

--- a/tests/phpunit/tests/customize/manager.php
+++ b/tests/phpunit/tests/customize/manager.php
@@ -3675,6 +3675,64 @@ class Tests_WP_Customize_Manager extends WP_UnitTestCase {
 			$this->assertSame( $video_url, $sanitized );
 		}
 	}
+
+	/**
+	 * Test that widgets component is properly handled with block themes.
+	 *
+	 * @ticket #63086
+	 * @covers WP_Customize_Manager::__construct
+	 * @covers WP_Customize_Manager::maybe_remove_widgets_component
+	 */
+	public function test_widgets_component_with_block_theme() {
+		// Mock a wp_is_block_theme() to return true
+		add_filter( 'wp_is_block_theme', '__return_true' );
+
+		$manager = new WP_Customize_Manager();
+		$this->assertContains( 'widgets', $this->get_property( 'components', $manager ) );
+
+		do_action( 'after_setup_theme' );
+		$this->assertNotContains( 'widgets', $this->get_property( 'components', $manager ) );
+
+		// Clean up
+		remove_filter( 'wp_is_block_theme', '__return_true' );
+	}
+
+	/**
+	 * Test that widgets component remains for non-block themes.
+	 *
+	 * @ticket #63086
+	 * @covers WP_Customize_Manager::__construct
+	 * @covers WP_Customize_Manager::maybe_remove_widgets_component
+	 */
+	public function test_widgets_component_with_non_block_theme() {
+		// Mock a wp_is_block_theme() to return false
+		add_filter( 'wp_is_block_theme', '__return_false' );
+
+		$manager = new WP_Customize_Manager();
+		$this->assertContains( 'widgets', $this->get_property( 'components', $manager ) );
+
+		do_action( 'after_setup_theme' );
+		$this->assertContains( 'widgets', $this->get_property( 'components', $manager ) );
+
+		// Clean up
+		remove_filter( 'wp_is_block_theme', '__return_false' );
+	}
+
+	/**
+	 * Helper method to access protected properties in
+	 * test_widgets_component_with_block_theme and
+	 * test_widgets_component_with_non_block_theme.
+	 *
+	 * @param string $name      Property name.
+	 * @param object $instance  Object instance.
+	 * @return mixed Property value.
+	 */
+	private function get_property( $name, $instance ) {
+		$reflection = new ReflectionClass( get_class( $instance ) );
+		$property   = $reflection->getProperty( $name );
+		$property->setAccessible( true );
+		return $property->getValue( $instance );
+	}
 }
 
 require_once ABSPATH . WPINC . '/class-wp-customize-setting.php';

--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -1458,4 +1458,108 @@ class Tests_Theme extends WP_UnitTestCase {
 
 		$this->assertSame( $template_path, $new_template_path, 'Switching blogs switches the template path' );
 	}
+
+	/**
+	 * Test that is_block_theme() returns correct value when called after setup_theme.
+	 *
+	 * @ticket 63086
+	 *
+	 * @group is_block_theme
+	 *
+	 * @covers ::is_block_theme
+	 */
+	public function test_is_block_theme_after_setup() {
+		global $wp_theme_directories;
+		$theme = new WP_Theme( 'block-theme', $wp_theme_directories[1] );
+
+		$this->mock_block_theme();
+
+		$this->assertFalse( $theme->is_block_theme() );
+
+		do_action( 'setup_theme' );
+		$theme->cache_delete(); // Clear the cache to force re-evaluation
+		$this->assertTrue( $theme->is_block_theme() );
+	}
+
+	/**
+	 * Test that is_block_theme() returns false for non-block themes.
+	 *
+	 * @ticket 63086
+	 *
+	 * @group is_block_theme
+	 *
+	 * @covers ::is_block_theme
+	 */
+	public function test_is_block_theme_returns_false_for_non_block_theme() {
+		global $wp_theme_directories;
+		$theme = new WP_Theme( 'default', $this->orig_theme_dir[1] );
+
+		// No templates/index.html should exist
+		add_filter(
+			'theme_file_path',
+			function ( $path, $file ) {
+				if ( '/templates/index.html' === $file || '/block-templates/index.html' === $file ) {
+					return '/path/that/does/not/exist';
+				}
+				return $path;
+			},
+			10,
+			2
+		);
+		$this->assertFalse( $theme->is_block_theme() );
+
+		do_action( 'setup_theme' );
+		$theme->cache_delete(); // Clear the cache to force re-evaluation
+		$this->assertFalse( $theme->is_block_theme() );
+	}
+
+	/**
+	 * Tests that _update_cached_block_theme updates the cache with the correct block theme status.
+	 *
+	 * @ticket 63086
+	 *
+	 * @group is_block_theme
+	 *
+	 * @covers WP_Theme::_update_cached_block_theme
+	 */
+	public function test_update_cached_block_theme() {
+		global $wp_theme_directories;
+		$theme = new WP_Theme( 'block-theme', $wp_theme_directories[1] );
+		$this->mock_block_theme();
+
+		// Initially, block_theme should be false
+		$this->assertFalse( $theme->is_block_theme(), 'Theme should not be identified as a block theme yet' );
+
+		do_action( 'setup_theme' );
+		$theme->_update_cached_block_theme();
+
+		$reflection = new ReflectionClass( $theme );
+		$property   = $reflection->getProperty( 'block_theme' );
+		$property->setAccessible( true );
+		$property->setValue( $theme, null );
+
+		$this->assertTrue( $theme->is_block_theme(), 'Theme should be identified as a block theme after cache update' );
+	}
+
+	/*
+	 * Mock a block theme by creating a temporary file in the theme directory.
+	 *
+	 * @ticket 63086
+	 */
+	public function mock_block_theme() {
+
+		add_filter(
+			'theme_file_path',
+			function ( $path, $file ) {
+				if ( '/templates/index.html' === $file ) {
+					$temp_file = wp_tempnam( 'block-theme-test' );
+					file_put_contents( $temp_file, 'test' );
+					return $temp_file;
+				}
+				return $path;
+			},
+			10,
+			2
+		);
+	}
 }


### PR DESCRIPTION
After some debugging, I've found that this issue is three-folded: There are 3 points in the current code that are generating the notice because there is a check that avoids using `is_block_theme()` calls too early. 

In this first commit, I'm sorting the first one, but I have to do some "extra" edits (like a filter in `wp_is_block_theme`) and added some tests taking advantage of these edits 

I would like some dev feedback (maybe @joemcgill that was involved in the introduction of this check in the ticket 63062), to see if it's ok to continue with this line and sort the other two notices in a similar fashion.

Trac ticket: https://core.trac.wordpress.org/ticket/63086

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
