### PR TITLE
Update functions.php to fix deprecated warnings

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -2192,7 +2192,7 @@ function wp_normalize_path( $path ) {
 	}
 
 	// Standardize all paths to use '/'.
-	$path = str_replace( '\\', '/', $path );
+	$path = str_replace('\\', '/', $path ?? '');
 
 	// Replace multiple slashes down to a singular, allowing for network shares having two slashes.
 	$path = preg_replace( '|(?<=.)/+|', '/', $path );
@@ -7357,7 +7357,7 @@ function _device_can_upload() {
  * @return bool True if the path is a stream URL.
  */
 function wp_is_stream( $path ) {
-	$scheme_separator = strpos( $path, '://' );
+	$scheme_separator = strpos($path ?? '', '://');
 
 	if ( false === $scheme_separator ) {
 		// $path isn't a stream.


### PR DESCRIPTION
Fixed two pieces of code that were generating deprecated warnings: 

-- Backtrace from warning 'strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated' at /wp-includes/functions.php 7329: this was the code causing the error: $scheme_separator = strpos( $path, '://' );

-- Backtrace from warning 'str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated' at /wp-includes/functions.php 2189:
this was the code causing the error: $path = str_replace( '\\', '/', $path );

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
around line 2189, changed the code to: `$path = str_replace('\\', '/', $path ?? '');`
The ?? '' operator ensures that if $path is null, it is replaced with an empty string ('') before being processed by str_replace().

around line 7329, changed the code to: `$scheme_separator = strpos($path ?? '', '://');`
The ?? '' operator ensures that if $path is null, it is replaced with an empty string ('') before being passed to strpos(). 


Trac ticket: https://core.trac.wordpress.org/ticket/63107

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
