### PR TITLE
Full setup for Xdebug and IDEs

### DIFF
--- a/tools/local-env/php-config.ini
+++ b/tools/local-env/php-config.ini
@@ -2,3 +2,4 @@ display_errors = On
 error_reporting = -1
 upload_max_filesize = 1G
 post_max_size = 1G
+xdebug.start_with_request=yes


### PR DESCRIPTION
This is a follow-up to this topic in 2025

Now that we are using XDebug 3, the original patches were deprecated.
https://xdebug.org/docs/upgrade_guide

Now the issues that @pento  was raising have been resolved since no `remote_enable` is needed anymore and the integration, is mostly straight forward. 

I'm submitting a new patch to enable the setup of Xdebug by default without requiring people to touch this file that is not ignored by .git by default. But Xdebug is not enabled by default since both `LOCAL_PHP_XDEBUG=true` and `LOCAL_PHP_XDEBUG_MODE=debug` are required for Xdebug to work, so in this regard, the user is "safe" by deafult.

But having to manually untrack the `tools/local-env/php-config.ini` file (in a development build, which theoretically Xdebug should be an staple for all developers), doesn't make any sense to me.

Pinging @desrosj as he introduced the latest changes in Xdebug `.env.` variables
@johnbillion and @whyisjake as they touch this report back in the day. 
Maybe it never progressed because of the concerns that @pento raised that are not valid any more.

Trac ticket: https://core.trac.wordpress.org/ticket/49953

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
