### PR TITLE
Checks for Registered Assets Issue 63109

### DIFF
--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -313,8 +313,8 @@ function _wp_get_iframed_editor_assets() {
 	 * Register all currently registered styles and scripts. The actions that
 	 * follow enqueue assets, but don't necessarily register them.
 	 */
-	$wp_styles->registered  = $current_wp_styles->registered;
-	$wp_scripts->registered = $current_wp_scripts->registered;
+	$wp_styles->registered  = isset( $current_wp_styles->registered ) ? $current_wp_styles->registered : array();
+	$wp_scripts->registered = isset( $current_wp_scripts->registered ) ? $current_wp_scripts->registered : array();
 
 	/*
 	 * We generally do not need reset styles for the iframed editor.

--- a/src/wp-includes/block-editor.php
+++ b/src/wp-includes/block-editor.php
@@ -313,8 +313,8 @@ function _wp_get_iframed_editor_assets() {
 	 * Register all currently registered styles and scripts. The actions that
 	 * follow enqueue assets, but don't necessarily register them.
 	 */
-	$wp_styles->registered  = isset( $current_wp_styles->registered ) ? $current_wp_styles->registered : array();
-	$wp_scripts->registered = isset( $current_wp_scripts->registered ) ? $current_wp_scripts->registered : array();
+	$wp_styles->registered  = $current_wp_styles->registered ?? array();
+	$wp_scripts->registered = $current_wp_scripts->registered ?? array();
 
 	/*
 	 * We generally do not need reset styles for the iframed editor.


### PR DESCRIPTION
The issue comes from a not registered script for this specific unit test `test_get_block_editor_settings_theme_json_settings` making to fail because of an early error. With this patch, the test is passing.

Trac ticket: https://core.trac.wordpress.org/ticket/63109

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
