### PR TITLE
Fix: Normalize ABSPATH concatenation patterns in core

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1886,7 +1886,7 @@ class WP_Site_Health {
 		);
 
 		if ( ! function_exists( 'WP_Filesystem' ) ) {
-			require_once ABSPATH . '/wp-admin/includes/file.php';
+			require_once ABSPATH . 'wp-admin/includes/file.php';
 		}
 
 		ob_start();

--- a/src/wp-includes/class-wp-plugin-dependencies.php
+++ b/src/wp-includes/class-wp-plugin-dependencies.php
@@ -159,7 +159,7 @@ class WP_Plugin_Dependencies {
 	 * @return bool Whether the plugin has active dependents.
 	 */
 	public static function has_active_dependents( $plugin_file ) {
-		require_once ABSPATH . '/wp-admin/includes/plugin.php';
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 		$dependents = self::get_dependents( self::convert_to_slug( $plugin_file ) );
 		foreach ( $dependents as $dependent ) {
@@ -235,7 +235,7 @@ class WP_Plugin_Dependencies {
 			return false;
 		}
 
-		require_once ABSPATH . '/wp-admin/includes/plugin.php';
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 		foreach ( self::$dependencies[ $plugin_file ] as $dependency ) {
 			$dependency_filepath = self::get_dependency_filepath( $dependency );
@@ -495,7 +495,7 @@ class WP_Plugin_Dependencies {
 			wp_send_json_success( $status );
 		}
 
-		require_once ABSPATH . '/wp-admin/includes/plugin.php';
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 		$inactive_dependencies = array();
 		foreach ( $dependencies as $dependency ) {
@@ -544,7 +544,7 @@ class WP_Plugin_Dependencies {
 			return self::$plugins;
 		}
 
-		require_once ABSPATH . '/wp-admin/includes/plugin.php';
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		self::$plugins = get_plugins();
 
 		return self::$plugins;

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -1121,7 +1121,7 @@ function _wp_delete_all_temp_backups() {
 	global $wp_filesystem;
 
 	if ( ! function_exists( 'WP_Filesystem' ) ) {
-		require_once ABSPATH . '/wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/file.php';
 	}
 
 	ob_start();


### PR DESCRIPTION


This PR removes the leading slash from paths that are concatenated with ABSPATH. Since ABSPATH already includes a trailing slash, adding another slash creates unnecessary double slashes and is inconsistent with most of the WordPress core.


Trac ticket: https://core.trac.wordpress.org/ticket/63102

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
