### PR TITLE
Accessibility: Add screen reader announcements for upload image errors

### DIFF
--- a/src/js/media/views/uploader/status.js
+++ b/src/js/media/views/uploader/status.js
@@ -124,8 +124,11 @@ UploaderStatus = View.extend(/** @lends wp.media.view.UploaderStatus.prototype *
 		this.views.add( '.upload-errors', statusError, { at: 0 } );
 		_.delay( function() {
 			buttonClose.trigger( 'focus' );
-			wp.a11y.speak( error.get( 'message' ), 'assertive' );
 		}, 1000 );
+
+		_.delay( function() {
+			wp.a11y.speak( error.get( 'message' ) );
+		}, 1500 );
 	},
 
 	dismiss: function() {
@@ -135,6 +138,7 @@ UploaderStatus = View.extend(/** @lends wp.media.view.UploaderStatus.prototype *
 			_.invoke( errors, 'remove' );
 		}
 		wp.Uploader.errors.reset();
+		wp.a11y.speak( wp.i18n.__( 'Error dismissed.' ) );
 		// Move focus to the modal after the dismiss button gets removed from the DOM.
 		if ( this.controller.modal ) {
 			this.controller.modal.focusManager.focus();

--- a/src/wp-admin/async-upload.php
+++ b/src/wp-admin/async-upload.php
@@ -112,12 +112,14 @@ if ( isset( $_REQUEST['post_id'] ) ) {
 
 $id = media_handle_upload( 'async-upload', $post_id );
 if ( is_wp_error( $id ) ) {
-	$button_unique_id = uniqid( 'dismiss-' );
-	$message          = sprintf(
+	$button_unique_id     = uniqid( 'dismiss-' );
+	$error_description_id = uniqid( 'error-description-' );
+	$message              = sprintf(
 		'%s <strong>%s</strong><br />%s',
 		sprintf(
-			'<button type="button" id="%s" class="dismiss button-link">%s</button>',
+			'<button type="button" id="%1$s" class="dismiss button-link" aria-describedby="%2$s">%3$s</button>',
 			esc_attr( $button_unique_id ),
+			esc_attr( $error_description_id ),
 			__( 'Dismiss' )
 		),
 		sprintf(
@@ -127,14 +129,23 @@ if ( is_wp_error( $id ) ) {
 		),
 		esc_html( $id->get_error_message() )
 	);
+
 	wp_admin_notice(
 		$message,
 		array(
+			'id'                 => $error_description_id,
 			'additional_classes' => array( 'error-div', 'error' ),
 			'paragraph_wrap'     => false,
 		)
 	);
-	echo "<script>jQuery( 'button#{$button_unique_id}' ).on( 'click', function() {jQuery(this).parents('div.media-item').slideUp(200, function(){jQuery(this).remove();})});</script>\n";
+
+	$speak_message = sprintf(
+		/* translators: %s: Name of the file that failed to upload. */
+		__( '%s has failed to upload.' ),
+		esc_js( $_FILES['async-upload']['name'] )
+	);
+
+	echo "<script>_.delay(function() {wp.a11y.speak('{$speak_message}');}, 1500);jQuery( 'button#{$button_unique_id}' ).on( 'click', function() {jQuery(this).parents('div.media-item').slideUp(200, function(){jQuery(this).remove();wp.a11y.speak( wp.i18n.__( 'Error dismissed.' ) );jQuery( '#plupload-browse-button' ).trigger( 'focus' );})});</script>\n";
 	exit;
 }
 

--- a/src/wp-admin/async-upload.php
+++ b/src/wp-admin/async-upload.php
@@ -145,7 +145,7 @@ if ( is_wp_error( $id ) ) {
 		esc_js( $_FILES['async-upload']['name'] )
 	);
 
-	echo "<script>_.delay(function() {wp.a11y.speak('{$speak_message}');}, 1500);jQuery( 'button#{$button_unique_id}' ).on( 'click', function() {jQuery(this).parents('div.media-item').slideUp(200, function(){jQuery(this).remove();wp.a11y.speak( wp.i18n.__( 'Error dismissed.' ) );jQuery( '#plupload-browse-button' ).trigger( 'focus' );})});</script>\n";
+	echo "<script>_.delay(function() {wp.a11y.speak('" . esc_js( $speak_message ) . "');}, 1500);jQuery( 'button#{$button_unique_id}' ).on( 'click', function() {jQuery(this).parents('div.media-item').slideUp(200, function(){jQuery(this).remove();wp.a11y.speak( wp.i18n.__( 'Error dismissed.' ) );jQuery( '#plupload-browse-button' ).trigger( 'focus' );})});</script>\n";
 	exit;
 }
 


### PR DESCRIPTION
### Description

This PR adds screen reader announcements for upload image failures and dismiss interaction.

Trac ticket: https://core.trac.wordpress.org/ticket/63114

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
