### PR TITLE
Add input to skip playwright browsers

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -33,7 +33,7 @@ on:
       - 'tests/e2e/**'
       # Confirm any changes to relevant workflow files.
       - '.github/workflows/end-to-end-tests.yml'
-      - '.github/workflows/reusable-end-to-end-tests-*.yml'
+      - '.github/workflows/reusable-end-to-end-tests*.yml'
   workflow_dispatch:
 
 # Cancels all previous workflow runs for pull requests that have not completed.

--- a/.github/workflows/reusable-end-to-end-tests.yml
+++ b/.github/workflows/reusable-end-to-end-tests.yml
@@ -28,6 +28,11 @@ on:
         description: 'A specific version of Gutenberg to install.'
         required: false
         type: 'string'
+      install-playwright:
+        description: 'Whether to install Playwright browsers.'
+        required: false
+        type: 'boolean'
+        default: true
 
 env:
   LOCAL_DIR: build
@@ -94,6 +99,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright browsers
+        if: ${{ inputs.install-playwright }}
         run: npx playwright install --with-deps
 
       - name: Build WordPress


### PR DESCRIPTION
In 6.4, the E2E tests switched to using Playwright. Earlier branches continue to utilize Puppeteer.

Recently, the E2E testing workflow in 6.3 and earlier has started to fail. The cause is coming from the `npx install playwright --with-deps` command. This step is not necessary for older branches because Playwright is not even used.

This adds an input to the reusable workflow to allow this step to be easily skipped for older branches.

Trac ticket: https://core.trac.wordpress.org/ticket/63117

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
