### PR TITLE
Add `theme_mods_{$stylesheet}` option during `populate_options()`

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -574,6 +574,9 @@ function populate_options( array $options = array() ) {
 
 	$options = wp_parse_args( $options, $defaults );
 
+	// 6.8.0
+	$options[ 'theme_mods_' . $options['stylesheet'] ] = array();
+
 	// Set autoload to no for these options.
 	$fat_options = array(
 		'moderation_keys',

--- a/tests/phpunit/tests/theme.php
+++ b/tests/phpunit/tests/theme.php
@@ -471,6 +471,17 @@ class Tests_Theme extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that installation added a "theme_mods_" option for the default theme.
+	 *
+	 * @ticket 33600
+	 */
+	public function test_populate_options_theme_mod() {
+		$stylesheet = get_option( 'stylesheet' );
+		$this->assertSame( WP_DEFAULT_THEME, $stylesheet );
+		$this->assertSame( array(), get_option( "theme_mods_{$stylesheet}" ) );
+	}
+
+	/**
 	 * Test _wp_keep_alive_customize_changeset_dependent_auto_drafts.
 	 *
 	 * @covers ::_wp_keep_alive_customize_changeset_dependent_auto_drafts


### PR DESCRIPTION
Adapted a 10-year-old ticket by dlh 

Trac ticket: https://core.trac.wordpress.org/ticket/33600

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
