### PR TITLE
Posts, Post Types: Add pre_post_insert action hook before inserting a new post

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -4851,7 +4851,7 @@ function wp_insert_post( $postarr, $wp_error = false, $fire_after_hooks = true )
 		/**
 		 * Fires immediately before a new post is inserted in the database.
 		 *
-		 * @since 6.8
+		 * @since 6.9.0
 		 *
 		 * @param array $data Array of unslashed post data.
 		 */

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -4848,6 +4848,15 @@ function wp_insert_post( $postarr, $wp_error = false, $fire_after_hooks = true )
 			}
 		}
 
+		/**
+		 * Fires immediately before a new post is inserted in the database.
+		 *
+		 * @since 6.8
+		 *
+		 * @param array $data Array of unslashed post data.
+		 */
+		do_action( 'pre_post_insert', $data );
+
 		if ( false === $wpdb->insert( $wpdb->posts, $data ) ) {
 			if ( $wp_error ) {
 				if ( 'attachment' === $post_type ) {


### PR DESCRIPTION
This PR introduces the pre_post_insert hook, allowing developers to modify or inspect post data before insertion, similar to pre_post_update. This enhances flexibility for use cases like duplicate content detection.

Trac ticket: [#63115](https://core.trac.wordpress.org/ticket/63115)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
