### PR TITLE
Hide toolbar shortcut when admin menu is hidden

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -3912,6 +3912,10 @@ img {
 		top: 7px;
 	}
 
+	.screen-reader-shortcut[href="#wp-toolbar"] {
+		display: none;
+	}
+
 	body {
 		min-width: 240px;
 		overflow-x: hidden;


### PR DESCRIPTION
Hides "Skip to Toolbar" link when it has nothing to skip past.

[Trac 63118](https://core.trac.wordpress.org/ticket/63118)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
