### PR TITLE
Fix: Default to UTF-8 for empty blog_charset values

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -297,6 +297,8 @@ foreach (
 // Misc filters.
 add_filter( 'wp_default_autoload_value', 'wp_filter_default_autoload_value_via_option_size', 5, 4 ); // Allow the value to be overridden at the default priority.
 add_filter( 'option_ping_sites', 'privacy_ping_filter' );
+
+add_filter( 'option_blog_charset', '_wp_ensure_blog_charset', 9 );
 add_filter( 'option_blog_charset', '_wp_specialchars' ); // IMPORTANT: This must not be wp_specialchars() or esc_html() or it'll cause an infinite loop.
 add_filter( 'option_blog_charset', '_canonical_charset' );
 add_filter( 'option_home', '_config_wp_home' );

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7567,12 +7567,12 @@ function get_tag_regex( $tag ) {
  */
 function is_utf8_charset( $blog_charset = null ) {
 	if ( empty( $blog_charset ) ) {
-        $blog_charset = 'UTF-8'; // Default to UTF-8 when empty
-    } else {
-        $blog_charset = $blog_charset ?? get_option( 'blog_charset', 'UTF-8' );
-    }
-    
-    return _is_utf8_charset( $blog_charset );
+		$blog_charset = 'UTF-8'; // Default to UTF-8 when empty
+	} else {
+		$blog_charset = $blog_charset ?? get_option( 'blog_charset', 'UTF-8' );
+	}
+
+	return _is_utf8_charset( $blog_charset );
 }
 
 /**
@@ -7588,9 +7588,9 @@ function is_utf8_charset( $blog_charset = null ) {
  * @return string The canonical form of the charset.
  */
 function _canonical_charset( $charset ) {
-    if ( empty( $charset ) ) {
-        return '';
-    }
+	if ( empty( $charset ) ) {
+		return '';
+	}
 
 	if ( is_utf8_charset( $charset ) ) {
 		return 'UTF-8';

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7566,10 +7566,10 @@ function get_tag_regex( $tag ) {
  * @return bool Whether the slug represents the UTF-8 encoding.
  */
 function is_utf8_charset( $blog_charset = null ) {
-	if ( empty( $blog_charset ) ) {
-		$blog_charset = 'UTF-8'; // Default to UTF-8 when empty
-	} else {
-		$blog_charset = $blog_charset ?? get_option( 'blog_charset', 'UTF-8' );
+	if ( null === $blog_charset ) {
+		$blog_charset = get_option( 'blog_charset', 'UTF-8' );
+	} elseif ( empty( $blog_charset ) ) {
+		return false;
 	}
 
 	return _is_utf8_charset( $blog_charset );

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7566,7 +7566,13 @@ function get_tag_regex( $tag ) {
  * @return bool Whether the slug represents the UTF-8 encoding.
  */
 function is_utf8_charset( $blog_charset = null ) {
-	return _is_utf8_charset( $blog_charset ?? get_option( 'blog_charset' ) );
+	if ( empty( $blog_charset ) ) {
+        $blog_charset = 'UTF-8'; // Default to UTF-8 when empty
+    } else {
+        $blog_charset = $blog_charset ?? get_option( 'blog_charset', 'UTF-8' );
+    }
+    
+    return _is_utf8_charset( $blog_charset );
 }
 
 /**
@@ -7582,6 +7588,10 @@ function is_utf8_charset( $blog_charset = null ) {
  * @return string The canonical form of the charset.
  */
 function _canonical_charset( $charset ) {
+    if ( empty( $charset ) ) {
+        return '';
+    }
+
 	if ( is_utf8_charset( $charset ) ) {
 		return 'UTF-8';
 	}

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -3238,3 +3238,15 @@ function wp_autoload_values_to_autoload() {
 
 	return array_intersect( $filtered_values, $autoload_values );
 }
+
+/**
+ * Ensures blog_charset has a value by defaulting to UTF-8 when empty.
+ *
+ * @since 6.8.0
+ *
+ * @param string|null $charset The character set from the option.
+ * @return string The character set, defaulting to UTF-8 when empty.
+ */
+function _wp_ensure_blog_charset( $charset ) {
+    return empty( $charset ) ? 'UTF-8' : $charset;
+}

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -3248,5 +3248,5 @@ function wp_autoload_values_to_autoload() {
  * @return string The character set, defaulting to UTF-8 when empty.
  */
 function _wp_ensure_blog_charset( $charset ) {
-    return empty( $charset ) ? 'UTF-8' : $charset;
+	return empty( $charset ) ? 'UTF-8' : $charset;
 }

--- a/tests/phpunit/tests/functions/ensureBlogCharset.php
+++ b/tests/phpunit/tests/functions/ensureBlogCharset.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Tests for the _wp_ensure_blog_charset() function.
+ *
+ * @group functions
+ * @group charset
+ *
+ * @covers ::_wp_ensure_blog_charset
+ */
+class Tests_Functions_EnsureBlogCharset extends WP_UnitTestCase {
+    /**
+     * Tests that _wp_ensure_blog_charset returns UTF-8 for empty or null values.
+     *
+     * @ticket 25693
+     *
+     * @dataProvider data_empty_charset_values
+     *
+     * @param mixed $empty_charset Empty or null charset value.
+     */
+    public function test_returns_utf8_for_empty_values( $empty_charset ) {
+        $this->assertSame(
+            'UTF-8',
+            _wp_ensure_blog_charset( $empty_charset ),
+            'Should return UTF-8 when the blog_charset value is empty'
+        );
+    }
+
+    /**
+     * Tests that _wp_ensure_blog_charset preserves valid charsets.
+     *
+     * @ticket 25693
+     *
+     * @dataProvider data_valid_charset_values
+     *
+     * @param string $valid_charset A valid charset.
+     */
+    public function test_preserves_valid_charset_values( $valid_charset ) {
+        $this->assertSame(
+            $valid_charset,
+            _wp_ensure_blog_charset( $valid_charset ),
+            'Should preserve the original charset when it is not empty'
+        );
+    }
+
+    /**
+     * Data provider for empty charset values.
+     *
+     * @return array[].
+     */
+    public static function data_empty_charset_values() {
+        return array(
+            array( null ),
+            array( '' ),
+            array( false ),
+            array( 0 ),
+            array( '0' ),
+        );
+    }
+
+    /**
+     * Data provider for valid charset values.
+     *
+     * @return array[].
+     */
+    public static function data_valid_charset_values() {
+        return array(
+            array( 'UTF-8' ),
+            array( 'ISO-8859-1' ),
+            array( 'ASCII' ),
+            array( 'Windows-1252' ),
+            array( 'EUC-JP' ),
+        );
+    }
+
+    /**
+     * Tests the integration of _wp_ensure_blog_charset with the option filter system.
+     *
+     * @ticket 25693
+     */
+    public function test_option_filter_integration() {
+        $original_charset = get_option( 'blog_charset' );
+
+        update_option( 'blog_charset', '' );
+        $this->assertSame( 'UTF-8', get_option( 'blog_charset' ), 'Filter should ensure UTF-8 when blog_charset is empty' );
+
+        update_option( 'blog_charset', 'ISO-8859-1' );
+        $this->assertSame( 'ISO-8859-1', get_option( 'blog_charset' ), 'Filter should preserve valid blog_charset' );
+
+        update_option( 'blog_charset', $original_charset );
+    }
+}

--- a/tests/phpunit/tests/functions/ensureBlogCharset.php
+++ b/tests/phpunit/tests/functions/ensureBlogCharset.php
@@ -8,84 +8,84 @@
  * @covers ::_wp_ensure_blog_charset
  */
 class Tests_Functions_EnsureBlogCharset extends WP_UnitTestCase {
-    /**
-     * Tests that _wp_ensure_blog_charset returns UTF-8 for empty or null values.
-     *
-     * @ticket 25693
-     *
-     * @dataProvider data_empty_charset_values
-     *
-     * @param mixed $empty_charset Empty or null charset value.
-     */
-    public function test_returns_utf8_for_empty_values( $empty_charset ) {
-        $this->assertSame(
-            'UTF-8',
-            _wp_ensure_blog_charset( $empty_charset ),
-            'Should return UTF-8 when the blog_charset value is empty'
-        );
-    }
+	/**
+	 * Tests that _wp_ensure_blog_charset returns UTF-8 for empty or null values.
+	 *
+	 * @ticket 25693
+	 *
+	 * @dataProvider data_empty_charset_values
+	 *
+	 * @param mixed $empty_charset Empty or null charset value.
+	 */
+	public function test_returns_utf8_for_empty_values( $empty_charset ) {
+		$this->assertSame(
+			'UTF-8',
+			_wp_ensure_blog_charset( $empty_charset ),
+			'Should return UTF-8 when the blog_charset value is empty'
+		);
+	}
 
-    /**
-     * Tests that _wp_ensure_blog_charset preserves valid charsets.
-     *
-     * @ticket 25693
-     *
-     * @dataProvider data_valid_charset_values
-     *
-     * @param string $valid_charset A valid charset.
-     */
-    public function test_preserves_valid_charset_values( $valid_charset ) {
-        $this->assertSame(
-            $valid_charset,
-            _wp_ensure_blog_charset( $valid_charset ),
-            'Should preserve the original charset when it is not empty'
-        );
-    }
+	/**
+	 * Tests that _wp_ensure_blog_charset preserves valid charsets.
+	 *
+	 * @ticket 25693
+	 *
+	 * @dataProvider data_valid_charset_values
+	 *
+	 * @param string $valid_charset A valid charset.
+	 */
+	public function test_preserves_valid_charset_values( $valid_charset ) {
+		$this->assertSame(
+			$valid_charset,
+			_wp_ensure_blog_charset( $valid_charset ),
+			'Should preserve the original charset when it is not empty'
+		);
+	}
 
-    /**
-     * Data provider for empty charset values.
-     *
-     * @return array[].
-     */
-    public static function data_empty_charset_values() {
-        return array(
-            array( null ),
-            array( '' ),
-            array( false ),
-            array( 0 ),
-            array( '0' ),
-        );
-    }
+	/**
+	 * Data provider for empty charset values.
+	 *
+	 * @return array[].
+	 */
+	public static function data_empty_charset_values() {
+		return array(
+			array( null ),
+			array( '' ),
+			array( false ),
+			array( 0 ),
+			array( '0' ),
+		);
+	}
 
-    /**
-     * Data provider for valid charset values.
-     *
-     * @return array[].
-     */
-    public static function data_valid_charset_values() {
-        return array(
-            array( 'UTF-8' ),
-            array( 'ISO-8859-1' ),
-            array( 'ASCII' ),
-            array( 'Windows-1252' ),
-            array( 'EUC-JP' ),
-        );
-    }
+	/**
+	 * Data provider for valid charset values.
+	 *
+	 * @return array[].
+	 */
+	public static function data_valid_charset_values() {
+		return array(
+			array( 'UTF-8' ),
+			array( 'ISO-8859-1' ),
+			array( 'ASCII' ),
+			array( 'Windows-1252' ),
+			array( 'EUC-JP' ),
+		);
+	}
 
-    /**
-     * Tests the integration of _wp_ensure_blog_charset with the option filter system.
-     *
-     * @ticket 25693
-     */
-    public function test_option_filter_integration() {
-        $original_charset = get_option( 'blog_charset' );
+	/**
+	 * Tests the integration of _wp_ensure_blog_charset with the option filter system.
+	 *
+	 * @ticket 25693
+	 */
+	public function test_option_filter_integration() {
+		$original_charset = get_option( 'blog_charset' );
 
-        update_option( 'blog_charset', '' );
-        $this->assertSame( 'UTF-8', get_option( 'blog_charset' ), 'Filter should ensure UTF-8 when blog_charset is empty' );
+		update_option( 'blog_charset', '' );
+		$this->assertSame( 'UTF-8', get_option( 'blog_charset' ), 'Filter should ensure UTF-8 when blog_charset is empty' );
 
-        update_option( 'blog_charset', 'ISO-8859-1' );
-        $this->assertSame( 'ISO-8859-1', get_option( 'blog_charset' ), 'Filter should preserve valid blog_charset' );
+		update_option( 'blog_charset', 'ISO-8859-1' );
+		$this->assertSame( 'ISO-8859-1', get_option( 'blog_charset' ), 'Filter should preserve valid blog_charset' );
 
-        update_option( 'blog_charset', $original_charset );
-    }
+		update_option( 'blog_charset', $original_charset );
+	}
 }

--- a/tests/phpunit/tests/functions/isUtf8Charset.php
+++ b/tests/phpunit/tests/functions/isUtf8Charset.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Tests for the is_utf8_charset() function.
+ *
+ * @group functions
+ * @group charset
+ *
+ * @covers ::is_utf8_charset
+ */
+class Tests_Functions_IsUtf8Charset extends WP_UnitTestCase {
+    /**
+     * Tests that is_utf8_charset correctly handles empty values.
+     *
+     * @ticket 25693
+     *
+     * @dataProvider data_empty_charset_values
+     *
+     * @param mixed $empty_charset Empty or null charset value.
+     */
+    public function test_handles_empty_values( $empty_charset ) {
+        $this->assertTrue(
+            is_utf8_charset( $empty_charset ),
+            'Should return true when the charset is empty (defaulting to UTF-8)'
+        );
+    }
+
+    /**
+     * Tests that is_utf8_charset correctly identifies UTF-8 variants.
+     *
+     * @ticket 25693
+     *
+     * @dataProvider data_utf8_charset_variants
+     *
+     * @param string $utf8_charset A UTF-8 charset variant.
+     */
+    public function test_identifies_utf8_variants( $utf8_charset ) {
+        $this->assertTrue(
+            is_utf8_charset( $utf8_charset ),
+            'Should identify valid UTF-8 charset variants'
+        );
+    }
+
+    /**
+     * Tests that is_utf8_charset correctly rejects non-UTF-8 charsets.
+     *
+     * @ticket 25693
+     *
+     * @dataProvider data_non_utf8_charset_values
+     *
+     * @param string $non_utf8_charset A non-UTF-8 charset.
+     */
+    public function test_rejects_non_utf8_charsets( $non_utf8_charset ) {
+        $this->assertFalse(
+            is_utf8_charset( $non_utf8_charset ),
+            'Should reject non-UTF-8 charsets'
+        );
+    }
+
+    /**
+     * Data provider for empty charset values.
+     *
+     * @return array[].
+     */
+    public static function data_empty_charset_values() {
+        return array(
+            array( null ),
+            array( '' ),
+            array( false ),
+            array( 0 ),
+            array( '0' ),
+        );
+    }
+
+    /**
+     * Data provider for UTF-8 charset variants.
+     *
+     * @return array[].
+     */
+    public static function data_utf8_charset_variants() {
+        return array(
+            array( 'UTF-8' ),
+            array( 'utf-8' ),
+            array( 'UTF8' ),
+            array( 'utf8' ),
+        );
+    }
+
+    /**
+     * Data provider for non-UTF-8 charset values.
+     *
+     * @return array[].
+     */
+    public static function data_non_utf8_charset_values() {
+        return array(
+            array( 'ISO-8859-1' ),
+            array( 'ASCII' ),
+            array( 'Windows-1252' ),
+            array( 'EUC-JP' ),
+            array( 'UTF-7' ),
+        );
+    }
+}

--- a/tests/phpunit/tests/functions/isUtf8Charset.php
+++ b/tests/phpunit/tests/functions/isUtf8Charset.php
@@ -8,95 +8,95 @@
  * @covers ::is_utf8_charset
  */
 class Tests_Functions_IsUtf8Charset extends WP_UnitTestCase {
-    /**
-     * Tests that is_utf8_charset correctly handles empty values.
-     *
-     * @ticket 25693
-     *
-     * @dataProvider data_empty_charset_values
-     *
-     * @param mixed $empty_charset Empty or null charset value.
-     */
-    public function test_handles_empty_values( $empty_charset ) {
-        $this->assertTrue(
-            is_utf8_charset( $empty_charset ),
-            'Should return true when the charset is empty (defaulting to UTF-8)'
-        );
-    }
+	/**
+	 * Tests that is_utf8_charset correctly handles empty values.
+	 *
+	 * @ticket 25693
+	 *
+	 * @dataProvider data_empty_charset_values
+	 *
+	 * @param mixed $empty_charset Empty or null charset value.
+	 */
+	public function test_handles_empty_values( $empty_charset ) {
+		$this->assertTrue(
+			is_utf8_charset( $empty_charset ),
+			'Should return true when the charset is empty (defaulting to UTF-8)'
+		);
+	}
 
-    /**
-     * Tests that is_utf8_charset correctly identifies UTF-8 variants.
-     *
-     * @ticket 25693
-     *
-     * @dataProvider data_utf8_charset_variants
-     *
-     * @param string $utf8_charset A UTF-8 charset variant.
-     */
-    public function test_identifies_utf8_variants( $utf8_charset ) {
-        $this->assertTrue(
-            is_utf8_charset( $utf8_charset ),
-            'Should identify valid UTF-8 charset variants'
-        );
-    }
+	/**
+	 * Tests that is_utf8_charset correctly identifies UTF-8 variants.
+	 *
+	 * @ticket 25693
+	 *
+	 * @dataProvider data_utf8_charset_variants
+	 *
+	 * @param string $utf8_charset A UTF-8 charset variant.
+	 */
+	public function test_identifies_utf8_variants( $utf8_charset ) {
+		$this->assertTrue(
+			is_utf8_charset( $utf8_charset ),
+			'Should identify valid UTF-8 charset variants'
+		);
+	}
 
-    /**
-     * Tests that is_utf8_charset correctly rejects non-UTF-8 charsets.
-     *
-     * @ticket 25693
-     *
-     * @dataProvider data_non_utf8_charset_values
-     *
-     * @param string $non_utf8_charset A non-UTF-8 charset.
-     */
-    public function test_rejects_non_utf8_charsets( $non_utf8_charset ) {
-        $this->assertFalse(
-            is_utf8_charset( $non_utf8_charset ),
-            'Should reject non-UTF-8 charsets'
-        );
-    }
+	/**
+	 * Tests that is_utf8_charset correctly rejects non-UTF-8 charsets.
+	 *
+	 * @ticket 25693
+	 *
+	 * @dataProvider data_non_utf8_charset_values
+	 *
+	 * @param string $non_utf8_charset A non-UTF-8 charset.
+	 */
+	public function test_rejects_non_utf8_charsets( $non_utf8_charset ) {
+		$this->assertFalse(
+			is_utf8_charset( $non_utf8_charset ),
+			'Should reject non-UTF-8 charsets'
+		);
+	}
 
-    /**
-     * Data provider for empty charset values.
-     *
-     * @return array[].
-     */
-    public static function data_empty_charset_values() {
-        return array(
-            array( null ),
-            array( '' ),
-            array( false ),
-            array( 0 ),
-            array( '0' ),
-        );
-    }
+	/**
+	 * Data provider for empty charset values.
+	 *
+	 * @return array[].
+	 */
+	public static function data_empty_charset_values() {
+		return array(
+			array( null ),
+			array( '' ),
+			array( false ),
+			array( 0 ),
+			array( '0' ),
+		);
+	}
 
-    /**
-     * Data provider for UTF-8 charset variants.
-     *
-     * @return array[].
-     */
-    public static function data_utf8_charset_variants() {
-        return array(
-            array( 'UTF-8' ),
-            array( 'utf-8' ),
-            array( 'UTF8' ),
-            array( 'utf8' ),
-        );
-    }
+	/**
+	 * Data provider for UTF-8 charset variants.
+	 *
+	 * @return array[].
+	 */
+	public static function data_utf8_charset_variants() {
+		return array(
+			array( 'UTF-8' ),
+			array( 'utf-8' ),
+			array( 'UTF8' ),
+			array( 'utf8' ),
+		);
+	}
 
-    /**
-     * Data provider for non-UTF-8 charset values.
-     *
-     * @return array[].
-     */
-    public static function data_non_utf8_charset_values() {
-        return array(
-            array( 'ISO-8859-1' ),
-            array( 'ASCII' ),
-            array( 'Windows-1252' ),
-            array( 'EUC-JP' ),
-            array( 'UTF-7' ),
-        );
-    }
+	/**
+	 * Data provider for non-UTF-8 charset values.
+	 *
+	 * @return array[].
+	 */
+	public static function data_non_utf8_charset_values() {
+		return array(
+			array( 'ISO-8859-1' ),
+			array( 'ASCII' ),
+			array( 'Windows-1252' ),
+			array( 'EUC-JP' ),
+			array( 'UTF-7' ),
+		);
+	}
 }

--- a/tests/phpunit/tests/functions/isUtf8Charset.php
+++ b/tests/phpunit/tests/functions/isUtf8Charset.php
@@ -9,7 +9,30 @@
  */
 class Tests_Functions_IsUtf8Charset extends WP_UnitTestCase {
 	/**
-	 * Tests that is_utf8_charset correctly handles empty values.
+	 * Tests that is_utf8_charset handles null by getting the blog_charset option.
+	 *
+	 * @ticket 25693
+	 */
+	public function test_handles_null_by_getting_option() {
+		$original_charset = get_option( 'blog_charset' );
+
+		update_option( 'blog_charset', 'UTF-8' );
+		$this->assertTrue(
+			is_utf8_charset( null ),
+			'Should return true when null is passed and blog_charset is UTF-8'
+		);
+
+		update_option( 'blog_charset', 'ISO-8859-1' );
+		$this->assertFalse(
+			is_utf8_charset( null ),
+			'Should return false when null is passed and blog_charset is not UTF-8'
+		);
+
+		update_option( 'blog_charset', $original_charset );
+	}
+
+	/**
+	 * Tests that is_utf8_charset returns false for empty values.
 	 *
 	 * @ticket 25693
 	 *
@@ -18,9 +41,9 @@ class Tests_Functions_IsUtf8Charset extends WP_UnitTestCase {
 	 * @param mixed $empty_charset Empty or null charset value.
 	 */
 	public function test_handles_empty_values( $empty_charset ) {
-		$this->assertTrue(
+		$this->assertFalse(
 			is_utf8_charset( $empty_charset ),
-			'Should return true when the charset is empty (defaulting to UTF-8)'
+			'Should return false when empty values are explicitly passed'
 		);
 	}
 
@@ -63,7 +86,6 @@ class Tests_Functions_IsUtf8Charset extends WP_UnitTestCase {
 	 */
 	public static function data_empty_charset_values() {
 		return array(
-			array( null ),
 			array( '' ),
 			array( false ),
 			array( 0 ),
@@ -80,8 +102,8 @@ class Tests_Functions_IsUtf8Charset extends WP_UnitTestCase {
 		return array(
 			array( 'UTF-8' ),
 			array( 'utf-8' ),
-			array( 'UTF8' ),
 			array( 'utf8' ),
+			array( 'UTF8' ),
 		);
 	}
 
@@ -93,10 +115,9 @@ class Tests_Functions_IsUtf8Charset extends WP_UnitTestCase {
 	public static function data_non_utf8_charset_values() {
 		return array(
 			array( 'ISO-8859-1' ),
-			array( 'ASCII' ),
 			array( 'Windows-1252' ),
+			array( 'ASCII' ),
 			array( 'EUC-JP' ),
-			array( 'UTF-7' ),
 		);
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/25693


Changes Made
- Added a new function `_wp_ensure_blog_charset` in `wp-includes/option.php` that returns 'UTF-8' when the charset is empty
- Registered this function as a filter on `'option_blog_charset'` with priority 9 in default-filters.php to ensure it runs before other charset-handling functions
- Modified `is_utf8_charset` and `_canonical_charset` functions in `functions.php` to properly handle empty values
- Added comprehensive unit tests to verify the changes

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
