### PR TITLE
Fix: Correct Parsing of Final Shortcode Attribute Without Trailing Space

### DIFF
--- a/src/wp-includes/shortcodes.php
+++ b/src/wp-includes/shortcodes.php
@@ -591,7 +591,7 @@ function unescape_invalid_shortcodes( $content ) {
  * @return string The shortcode attribute regular expression.
  */
 function get_shortcode_atts_regex() {
-	return '/([\w-]+)\s*=\s*"([^"]*)"(?:\s|$)|([\w-]+)\s*=\s*\'([^\']*)\'(?:\s|$)|([\w-]+)\s*=\s*([^\s\'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|\'([^\']*)\'(?:\s|$)|(\S+)(?:\s|$)/';
+	return '/([\w-]+)\s*=\s*"([^"]*)"|([\w-]+)\s*=\s*\'([^\']*)\'|([\w-]+)\s*=\s*([^\s\'"\]]+)|"([^"]*)"|\'([^\']*)\'|(\S+)/';
 }
 
 /**


### PR DESCRIPTION
Trac Ticket: https://core.trac.wordpress.org/ticket/57790

### **Fix: Correct Parsing of Final Shortcode Attribute Without Trailing Space**  

#### **Issue Summary**  
The `shortcode_parse_atts()` function, which uses `get_shortcode_atts_regex()`, fails to correctly parse the last attribute of a shortcode when there is **no space** between the final attribute’s closing quote and the closing bracket `]`.  

#### **Steps to Reproduce**  

##### **Current Behavior (Bug)**  
```php
shortcode_parse_atts('[shortcode-name category="banana-stand" money="yes"]'); // No space
```
**Output:**
```php
Array(
    [0] => [shortcode-name
    [category] => banana-stand
    [1] => money="yes"]
)
```
The last attribute (`money="yes"`) is incorrectly treated as a separate entry instead of being parsed as a key-value pair.  

##### **Expected Behavior**  
When a space is included before the closing `]`, the function behaves correctly:  
```php
shortcode_parse_atts('[shortcode-name category="banana-stand" money="yes" ]'); // Has space
```
**Output:**
```php
Array(
    [0] => [shortcode-name
    [category] => banana-stand
    [money] => yes
    [1] => ]
)
```

#### **Root Cause**  
The issue stems from the `get_shortcode_atts_regex()` pattern, where the final attribute pair is not properly matched if there is **no space** before `]`. The previous regex enforced a space (`\s`) or end-of-string (`$`) after an attribute, causing the last attribute to be misinterpreted.  

#### **Proposed Fix**  
The updated regex removes unnecessary lookaheads and ensures correct parsing regardless of whether a space exists before `]`.  

##### **Old Code:**
```php
return '/([\w-]+)\s*=\s*"([^"]*)"(?:\s|$)|([\w-]+)\s*=\s*\'([^\']*)\'(?:\s|$)|([\w-]+)\s*=\s*([^\s\'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|\'([^\']*)\'(?:\s|$)|(\S+)(?:\s|$)/';
```

##### **New Code:**
```php
return '/([\w-]+)\s*=\s*"([^"]*)"|([\w-]+)\s*=\s*\'([^\']*)\'|([\w-]+)\s*=\s*([^\s\'"\]]+)|"([^"]*)"|\'([^\']*)\'|(\S+)/';
```

#### **Test Results**  
After applying the fix, both cases now produce the expected output:  
```php
Array(
    [0] => [shortcode-name
    [category] => banana-stand
    [money] => yes
    [1] => ]
)
```
Ensuring that the last attribute is parsed correctly, regardless of spacing.

#### **Impact & Compatibility**  
- This fix improves accuracy without affecting existing correctly formatted shortcodes.  
- Fully backward-compatible with previous WordPress versions.  
- Ensures `shortcode_parse_atts()` is more robust when handling shortcode attributes.  