### PR TITLE
Administration: Allow filtering of bulk action fields

### DIFF
--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -1321,8 +1321,8 @@ $( function() {
 
 		// Observe submissions from posts lists for 'bulk_action' or users lists for 'new_role'.
 		var bulkFieldRelations = {
-			'bulk_action' : 'action',
-			'changeit' : 'new_role'
+			'bulk_action' : window.bulkFieldRelations.bulk_action,
+			'changeit' : window.bulkFieldRelations.changeit
 		};
 		if ( ! Object.keys( bulkFieldRelations ).includes( submitterName ) ) {
 			return;

--- a/src/js/_enqueues/admin/common.js
+++ b/src/js/_enqueues/admin/common.js
@@ -1321,8 +1321,8 @@ $( function() {
 
 		// Observe submissions from posts lists for 'bulk_action' or users lists for 'new_role'.
 		var bulkFieldRelations = {
-			'bulk_action' : window.bulkFieldRelations.bulk_action,
-			'changeit' : window.bulkFieldRelations.changeit
+			'bulk_action' : window.bulkActionObserverIds.bulk_action,
+			'changeit' : window.bulkActionObserverIds.changeit
 		};
 		if ( ! Object.keys( bulkFieldRelations ).includes( submitterName ) ) {
 			return;

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -765,12 +765,12 @@ function wp_default_scripts( $scripts ) {
 		'common',
 		'bulkActionObserverIds',
 		/**
-		 * Filters the array of field relations for the bulk actions.
+		 * Filters the array of field name attributes for bulk actions.
 		 *
 		 * @since 6.8.1
 		 *
 		 * @param array $bulk_action_observer_ids {
-		 *      An array of field IDs for the bulk actions.
+		 *      An array of field name attributes for bulk actions.
 		 *
 		 *      @type string $bulk_action The bulk action field name. Default 'action'.
 		 *      @type string $changeit    The new role field name. Default 'new_role'.

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -776,7 +776,7 @@ function wp_default_scripts( $scripts ) {
 		 *      @type string $changeit    The new role field name. Default 'new_role'.
 		 * }
 		 */
-		apply_filters( 'buld_field_relations', $bulk_field_relations )
+		apply_filters( 'bulk_field_relations', $bulk_field_relations )
 	);
 
 	$scripts->add( 'wp-sanitize', "/wp-includes/js/wp-sanitize$suffix.js", array(), false, 1 );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -757,6 +757,28 @@ function wp_default_scripts( $scripts ) {
 	$scripts->add( 'common', "/wp-admin/js/common$suffix.js", array( 'jquery', 'hoverIntent', 'utils', 'wp-a11y' ), false, 1 );
 	$scripts->set_translations( 'common' );
 
+	$bulk_field_relations = array(
+		'bulk_action' => 'action',
+		'changeit'    => 'new_role',
+	);
+	did_action( 'init' ) && $scripts->localize(
+		'common',
+		'bulkFieldRelations',
+		/**
+		 * Filters the array of field relations for the bulk actions.
+		 *
+		 * @since 6.7.3
+		 *
+		 * @param array $bulk_field_relations {
+		 * 		An array of field relations for the bulk actions.
+		 *
+		 *  	@type string $bulk_action The bulk action field name. Default 'action'.
+		 * 		@type string $changeit    The new role field name. Default 'new_role'.
+		 * }
+		 */
+		apply_filters( 'buld_field_relations', $bulk_field_relations )
+	);
+
 	$scripts->add( 'wp-sanitize', "/wp-includes/js/wp-sanitize$suffix.js", array(), false, 1 );
 
 	$scripts->add( 'sack', "/wp-includes/js/tw-sack$suffix.js", array(), '1.6.1', 1 );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -757,26 +757,26 @@ function wp_default_scripts( $scripts ) {
 	$scripts->add( 'common', "/wp-admin/js/common$suffix.js", array( 'jquery', 'hoverIntent', 'utils', 'wp-a11y' ), false, 1 );
 	$scripts->set_translations( 'common' );
 
-	$bulk_field_relations = array(
+	$bulk_action_observer_ids = array(
 		'bulk_action' => 'action',
 		'changeit'    => 'new_role',
 	);
 	did_action( 'init' ) && $scripts->localize(
 		'common',
-		'bulkFieldRelations',
+		'bulkActionObserverIds',
 		/**
 		 * Filters the array of field relations for the bulk actions.
 		 *
-		 * @since 6.7.3
+		 * @since 6.8.1
 		 *
-		 * @param array $bulk_field_relations {
-		 *      An array of field relations for the bulk actions.
+		 * @param array $bulk_action_observer_ids {
+		 *      An array of field IDs for the bulk actions.
 		 *
 		 *      @type string $bulk_action The bulk action field name. Default 'action'.
 		 *      @type string $changeit    The new role field name. Default 'new_role'.
 		 * }
 		 */
-		apply_filters( 'bulk_field_relations', $bulk_field_relations )
+		apply_filters( 'bulk_action_observer_ids', $bulk_action_observer_ids )
 	);
 
 	$scripts->add( 'wp-sanitize', "/wp-includes/js/wp-sanitize$suffix.js", array(), false, 1 );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -770,10 +770,10 @@ function wp_default_scripts( $scripts ) {
 		 * @since 6.7.3
 		 *
 		 * @param array $bulk_field_relations {
-		 * 		An array of field relations for the bulk actions.
+		 *      An array of field relations for the bulk actions.
 		 *
-		 *  	@type string $bulk_action The bulk action field name. Default 'action'.
-		 * 		@type string $changeit    The new role field name. Default 'new_role'.
+		 *      @type string $bulk_action The bulk action field name. Default 'action'.
+		 *      @type string $changeit    The new role field name. Default 'new_role'.
 		 * }
 		 */
 		apply_filters( 'buld_field_relations', $bulk_field_relations )


### PR DESCRIPTION
This updates the patch from @ethitter to include inline documentation and a single filter

https://core.trac.wordpress.org/ticket/63005
