### PR TITLE
WP_Theme Revamp and Solving Report 63086

### DIFF
--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -328,6 +328,7 @@ final class WP_Theme implements ArrayAccess {
 			return;
 		} else {
 			$this->headers = get_file_data( $this->theme_root . '/' . $theme_file, self::$file_headers, 'theme' );
+
 			/*
 			 * Default themes always trump their pretenders.
 			 * Properly identify default themes that are inside a directory within wp-content/themes.
@@ -338,7 +339,7 @@ final class WP_Theme implements ArrayAccess {
 			}
 		}
 
-		// Check for circular reference
+		// Check for circular reference.
 		if ( ! $this->template && $this->stylesheet === $this->headers['Template'] ) {
 			$this->set_error(
 				'theme_child_invalid',
@@ -351,12 +352,12 @@ final class WP_Theme implements ArrayAccess {
 			return;
 		}
 
-		// (If template is set from cache [and there are no errors], we know it's good.)
+		// If template is set from cache [and there are no errors], we know it's good.
 		if ( ! $this->template ) {
 			$this->template = $this->headers['Template'];
 		}
 
-		// Handle missing template
+		// Handle missing template.
 		if ( ! $this->template ) {
 			$this->template = $this->stylesheet;
 			$theme_path     = $this->theme_root . '/' . $this->stylesheet;
@@ -380,6 +381,7 @@ final class WP_Theme implements ArrayAccess {
 		if ( ! is_array( $cache )
 			&& $this->template !== $this->stylesheet
 			&& ! file_exists( $this->theme_root . '/' . $this->template . '/index.php' )
+			&& ! $this->is_block_theme()
 		) {
 			/*
 			 * If we're in a directory of themes inside /themes, look for the parent nearby.
@@ -390,7 +392,8 @@ final class WP_Theme implements ArrayAccess {
 			$theme_root_template = null;
 
 			if ( '.' !== $parent_dir
-				&& file_exists( $this->theme_root . '/' . $parent_dir . '/' . $this->template . '/index.php' ) ) {
+				&& file_exists( $this->theme_root . '/' . $parent_dir . '/' . $this->template . '/index.php' )
+			) {
 				$this->template = $parent_dir . '/' . $this->template;
 			} elseif ( $directories && isset( $directories[ $this->template ] ) ) {
 				/*
@@ -400,10 +403,10 @@ final class WP_Theme implements ArrayAccess {
 				$theme_root_template = $directories[ $this->template ]['theme_root'];
 			} else {
 				// Parent theme is missing.
-				$this->errors = new WP_Error(
+				$this->set_error(
 					'theme_no_parent',
 					sprintf(
-						// translators: %s: Theme directory name.
+						/* translators: %s: Theme directory name. */
 						__( 'The parent theme is missing. Please install the "%s" parent theme.' ),
 						esc_html( $this->template )
 					)
@@ -447,7 +450,7 @@ final class WP_Theme implements ArrayAccess {
 			$this->parent      = new WP_Theme( $this->template, $parent_theme_root, $this );
 		}
 
-		// Check if theme is paused
+		// Check if theme is paused.
 		if ( wp_paused_themes()->get( $this->stylesheet ) && ( ! is_wp_error( $this->errors ) || ! isset( $this->errors->errors['theme_paused'] ) ) ) {
 			$this->errors = new WP_Error( 'theme_paused', __( 'This theme failed to load properly and was paused within the admin backend.' ) );
 		}
@@ -474,7 +477,7 @@ final class WP_Theme implements ArrayAccess {
 	/**
 	 * Cache the theme data.
 	 *
-	 * since 6.8.0
+	 * @since 6.8.0
 	 *
 	 * @param array $additional_data Additional data to cache.
 	 * @return void
@@ -499,7 +502,7 @@ final class WP_Theme implements ArrayAccess {
 	/**
 	 * Set an error for the theme.
 	 *
-	 * since 6.8.0
+	 * @since 6.8.0
 	 *
 	 * @param string $code The error code.
 	 * @param string $message The error message.
@@ -508,7 +511,6 @@ final class WP_Theme implements ArrayAccess {
 	private function set_error( $code, $message ) {
 		$this->errors = new WP_Error( $code, $message );
 		$this->cache_theme_data();
-		return;
 	}
 
 	/**

--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -297,9 +297,13 @@ final class WP_Theme implements ArrayAccess {
 				$theme_root_template = $cache['theme_root_template'];
 			}
 		} elseif ( ! file_exists( $this->theme_root . '/' . $theme_file ) ) {
-			$this->headers['Name'] = $this->stylesheet;
+			$this->headers['Name']        = $this->stylesheet;
+			$this->template               = $this->stylesheet;
+			$this->block_theme            = false;
+			$this->block_template_folders = $this->default_template_folders;
+
 			if ( ! file_exists( $this->theme_root . '/' . $this->stylesheet ) ) {
-				$this->errors = new WP_Error(
+				$this->set_error(
 					'theme_not_found',
 					sprintf(
 						/* translators: %s: Theme directory name. */
@@ -308,43 +312,19 @@ final class WP_Theme implements ArrayAccess {
 					)
 				);
 			} else {
-				$this->errors = new WP_Error( 'theme_no_stylesheet', __( 'Stylesheet is missing.' ) );
+				$this->set_error( 'theme_no_stylesheet', __( 'Stylesheet is missing.' ) );
 			}
-			$this->template               = $this->stylesheet;
-			$this->block_theme            = false;
-			$this->block_template_folders = $this->default_template_folders;
-			$this->cache_add(
-				'theme',
-				array(
-					'block_template_folders' => $this->block_template_folders,
-					'block_theme'            => $this->block_theme,
-					'headers'                => $this->headers,
-					'errors'                 => $this->errors,
-					'stylesheet'             => $this->stylesheet,
-					'template'               => $this->template,
-				)
-			);
+
 			if ( ! file_exists( $this->theme_root ) ) { // Don't cache this one.
 				$this->errors->add( 'theme_root_missing', __( '<strong>Error:</strong> The themes directory is either empty or does not exist. Please check your installation.' ) );
 			}
 			return;
 		} elseif ( ! is_readable( $this->theme_root . '/' . $theme_file ) ) {
 			$this->headers['Name']        = $this->stylesheet;
-			$this->errors                 = new WP_Error( 'theme_stylesheet_not_readable', __( 'Stylesheet is not readable.' ) );
 			$this->template               = $this->stylesheet;
 			$this->block_theme            = false;
 			$this->block_template_folders = $this->default_template_folders;
-			$this->cache_add(
-				'theme',
-				array(
-					'block_template_folders' => $this->block_template_folders,
-					'block_theme'            => $this->block_theme,
-					'headers'                => $this->headers,
-					'errors'                 => $this->errors,
-					'stylesheet'             => $this->stylesheet,
-					'template'               => $this->template,
-				)
-			);
+			$this->set_error( 'theme_stylesheet_not_readable', __( 'Stylesheet is not readable.' ) );
 			return;
 		} else {
 			$this->headers = get_file_data( $this->theme_root . '/' . $theme_file, self::$file_headers, 'theme' );
@@ -353,15 +333,14 @@ final class WP_Theme implements ArrayAccess {
 			 * Properly identify default themes that are inside a directory within wp-content/themes.
 			 */
 			$default_theme_slug = array_search( $this->headers['Name'], self::$default_themes, true );
-			if ( $default_theme_slug ) {
-				if ( basename( $this->stylesheet ) !== $default_theme_slug ) {
-					$this->headers['Name'] .= '/' . $this->stylesheet;
-				}
+			if ( $default_theme_slug && basename( $this->stylesheet ) !== $default_theme_slug ) {
+				$this->headers['Name'] .= '/' . $this->stylesheet;
 			}
 		}
 
+		// Check for circular reference
 		if ( ! $this->template && $this->stylesheet === $this->headers['Template'] ) {
-			$this->errors = new WP_Error(
+			$this->set_error(
 				'theme_child_invalid',
 				sprintf(
 					/* translators: %s: Template. */
@@ -369,17 +348,6 @@ final class WP_Theme implements ArrayAccess {
 					'<code>Template</code>'
 				)
 			);
-			$this->cache_add(
-				'theme',
-				array(
-					'block_template_folders' => $this->get_block_template_folders(),
-					'block_theme'            => $this->is_block_theme(),
-					'headers'                => $this->headers,
-					'errors'                 => $this->errors,
-					'stylesheet'             => $this->stylesheet,
-				)
-			);
-
 			return;
 		}
 
@@ -388,6 +356,7 @@ final class WP_Theme implements ArrayAccess {
 			$this->template = $this->headers['Template'];
 		}
 
+		// Handle missing template
 		if ( ! $this->template ) {
 			$this->template = $this->stylesheet;
 			$theme_path     = $this->theme_root . '/' . $this->stylesheet;
@@ -402,18 +371,7 @@ final class WP_Theme implements ArrayAccess {
 					'<code>Template</code>',
 					'<code>style.css</code>'
 				);
-				$this->errors = new WP_Error( 'theme_no_index', $error_message );
-				$this->cache_add(
-					'theme',
-					array(
-						'block_template_folders' => $this->get_block_template_folders(),
-						'block_theme'            => $this->block_theme,
-						'headers'                => $this->headers,
-						'errors'                 => $this->errors,
-						'stylesheet'             => $this->stylesheet,
-						'template'               => $this->template,
-					)
-				);
+				$this->set_error( 'theme_no_index', $error_message );
 				return;
 			}
 		}
@@ -427,12 +385,12 @@ final class WP_Theme implements ArrayAccess {
 			 * If we're in a directory of themes inside /themes, look for the parent nearby.
 			 * wp-content/themes/directory-of-themes/*
 			 */
-			$parent_dir  = dirname( $this->stylesheet );
-			$directories = search_theme_directories();
+			$parent_dir          = dirname( $this->stylesheet );
+			$directories         = search_theme_directories();
+			$theme_root_template = null;
 
 			if ( '.' !== $parent_dir
-				&& file_exists( $this->theme_root . '/' . $parent_dir . '/' . $this->template . '/index.php' )
-			) {
+				&& file_exists( $this->theme_root . '/' . $parent_dir . '/' . $this->template . '/index.php' ) ) {
 				$this->template = $parent_dir . '/' . $this->template;
 			} elseif ( $directories && isset( $directories[ $this->template ] ) ) {
 				/*
@@ -445,20 +403,9 @@ final class WP_Theme implements ArrayAccess {
 				$this->errors = new WP_Error(
 					'theme_no_parent',
 					sprintf(
-						/* translators: %s: Theme directory name. */
+						// translators: %s: Theme directory name.
 						__( 'The parent theme is missing. Please install the "%s" parent theme.' ),
 						esc_html( $this->template )
-					)
-				);
-				$this->cache_add(
-					'theme',
-					array(
-						'block_template_folders' => $this->get_block_template_folders(),
-						'block_theme'            => $this->is_block_theme(),
-						'headers'                => $this->headers,
-						'errors'                 => $this->errors,
-						'stylesheet'             => $this->stylesheet,
-						'template'               => $this->template,
 					)
 				);
 				$this->parent = new WP_Theme( $this->template, $this->theme_root, $this );
@@ -471,7 +418,7 @@ final class WP_Theme implements ArrayAccess {
 			// If we are a parent, then there is a problem. Only two generations allowed! Cancel things out.
 			if ( $_child instanceof WP_Theme && $_child->template === $this->stylesheet ) {
 				$_child->parent = null;
-				$_child->errors = new WP_Error(
+				$_child->set_error(
 					'theme_parent_invalid',
 					sprintf(
 						/* translators: %s: Theme directory name. */
@@ -479,20 +426,11 @@ final class WP_Theme implements ArrayAccess {
 						esc_html( $_child->template )
 					)
 				);
-				$_child->cache_add(
-					'theme',
-					array(
-						'block_template_folders' => $_child->get_block_template_folders(),
-						'block_theme'            => $_child->is_block_theme(),
-						'headers'                => $_child->headers,
-						'errors'                 => $_child->errors,
-						'stylesheet'             => $_child->stylesheet,
-						'template'               => $_child->template,
-					)
-				);
+
+				// Check for circular reference
 				// The two themes actually reference each other with the Template header.
 				if ( $_child->stylesheet === $this->template ) {
-					$this->errors = new WP_Error(
+					$this->set_error(
 						'theme_parent_invalid',
 						sprintf(
 							/* translators: %s: Theme directory name. */
@@ -500,31 +438,23 @@ final class WP_Theme implements ArrayAccess {
 							esc_html( $this->template )
 						)
 					);
-					$this->cache_add(
-						'theme',
-						array(
-							'block_template_folders' => $this->get_block_template_folders(),
-							'block_theme'            => $this->is_block_theme(),
-							'headers'                => $this->headers,
-							'errors'                 => $this->errors,
-							'stylesheet'             => $this->stylesheet,
-							'template'               => $this->template,
-						)
-					);
 				}
 				return;
 			}
+
 			// Set the parent. Pass the current instance so we can do the checks above and assess errors.
-			$this->parent = new WP_Theme( $this->template, isset( $theme_root_template ) ? $theme_root_template : $this->theme_root, $this );
+			$parent_theme_root = isset( $theme_root_template ) ? $theme_root_template : $this->theme_root;
+			$this->parent      = new WP_Theme( $this->template, $parent_theme_root, $this );
 		}
 
+		// Check if theme is paused
 		if ( wp_paused_themes()->get( $this->stylesheet ) && ( ! is_wp_error( $this->errors ) || ! isset( $this->errors->errors['theme_paused'] ) ) ) {
 			$this->errors = new WP_Error( 'theme_paused', __( 'This theme failed to load properly and was paused within the admin backend.' ) );
 		}
 
 		// We're good. If we didn't retrieve from cache, set it.
 		if ( ! is_array( $cache ) ) {
-			$cache = array(
+			$cache_data = array(
 				'block_theme'            => $this->is_block_theme(),
 				'block_template_folders' => $this->get_block_template_folders(),
 				'headers'                => $this->headers,
@@ -534,10 +464,51 @@ final class WP_Theme implements ArrayAccess {
 			);
 			// If the parent theme is in another root, we'll want to cache this. Avoids an entire branch of filesystem calls above.
 			if ( isset( $theme_root_template ) ) {
-				$cache['theme_root_template'] = $theme_root_template;
+				$cache_data['theme_root_template'] = $theme_root_template;
 			}
-			$this->cache_add( 'theme', $cache );
+
+			$this->cache_add( 'theme', $cache_data );
 		}
+	}
+
+	/**
+	 * Cache the theme data.
+	 *
+	 * since 6.8.0
+	 *
+	 * @param array $additional_data Additional data to cache.
+	 * @return void
+	 */
+	private function cache_theme_data( $additional_data = array() ) {
+		$cache_data = array(
+			'block_template_folders' => $this->get_block_template_folders(),
+			'block_theme'            => $this->is_block_theme(),
+			'headers'                => $this->headers,
+			'errors'                 => $this->errors,
+			'stylesheet'             => $this->stylesheet,
+			'template'               => $this->template,
+		);
+
+		if ( ! empty( $additional_data ) ) {
+			$cache_data = array_merge( $cache_data, $additional_data );
+		}
+
+		$this->cache_add( 'theme', $cache_data );
+	}
+
+	/**
+	 * Set an error for the theme.
+	 *
+	 * since 6.8.0
+	 *
+	 * @param string $code The error code.
+	 * @param string $message The error message.
+	 * @return void
+	 */
+	private function set_error( $code, $message ) {
+		$this->errors = new WP_Error( $code, $message );
+		$this->cache_theme_data();
+		return;
 	}
 
 	/**

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -4352,11 +4352,6 @@ function create_initial_theme_features() {
  * @return bool Whether the active theme is a block-based theme or not.
  */
 function wp_is_block_theme() {
-	if ( empty( $GLOBALS['wp_theme_directories'] ) ) {
-		_doing_it_wrong( __FUNCTION__, __( 'This function should not be called before the theme directory is registered.' ), '6.8.0' );
-		return false;
-	}
-
 	return wp_get_theme()->is_block_theme();
 }
 


### PR DESCRIPTION
I was going crazy with so many repetitions of the same code in the `WP_Theme` class. Extremely difficult to understand the constructor and to track down the problems. But still, I think that comments are not very self-explanatory. 

This patch partially refactors the constructor and sorts this issue (that is mostly caused because of the current convoluted state of such constructor). And still, I'm not 100% sure that this is the best solution.

Apart from this, here are the testing instructions for this patch:

1. I have created an [adhoc plugin](https://github.com/SirLouen/simple-block-theme-detection/archive/refs/tags/1.0.0.zip) that checks the result of wp_is_block_theme() function in each step
2. Install this plugin as a mu-plugin
3. Install this [Child theme](https://core.trac.wordpress.org/attachment/ticket/63062/child.zip) and activate it
4. Make sure you have TwentyTwentyFive also installed
5. Theme should be loading without issues.
6. Activate a non-block theme -> Go to customizer, check there are no notices there
7. Add the shortcode [block_theme_detection] to a post and check if its passing in all the actions hooks

Trac ticket: https://core.trac.wordpress.org/ticket/63086

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
