### PR TITLE
Permalink: Fix search pagination 404 error when using numbered pagination

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -4746,7 +4746,7 @@ function paginate_links( $args = '' ) {
 					$link = add_query_arg( $add_args, $link );
 				}
 				$link .= $args['add_fragment'];
-				$link  = get_option( 'permalink_structure' ) ? user_trailingslashit( $link, 'paged' ) : $link;
+				$link  = get_option( 'permalink_structure' ) && ! is_search() ? user_trailingslashit( $link, 'paged' ) : $link;
 
 				$page_links[] = sprintf(
 					'<a class="page-numbers" href="%s">%s</a>',


### PR DESCRIPTION


Trac ticket: https://core.trac.wordpress.org/ticket/63123

Fix pagination links for search results by preventing trailing slashes from being added to search query parameters. This change preserves the functionality from changeset [59966] while preventing 404 errors specifically on search result pages.

The issue occurred because trailing slashes were being added after search query parameters (e.g., `?s=post/`), causing malformed URLs. This change ensures numbered pagination works correctly on search pages while maintaining trailing slash consistency elsewhere like the categories page.

## Screencast

### Before:

https://github.com/user-attachments/assets/57231c79-5456-4759-ad09-fde5b196fff2




### After:

https://github.com/user-attachments/assets/37c2bada-86db-4204-bd6a-d535783c1ee0



