### PR TITLE
Add delete_private_posts capability when deleting own private posts

### DIFF
--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -148,9 +148,13 @@ function map_meta_cap( $cap, $user_id, ...$args ) {
 					$status = get_post_meta( $post->ID, '_wp_trash_meta_status', true );
 					if ( in_array( $status, array( 'publish', 'future' ), true ) ) {
 						$caps[] = $post_type->cap->delete_published_posts;
+					} elseif ( 'private' === $status ) {
+						$caps[] = $post_type->cap->delete_private_posts;
 					} else {
 						$caps[] = $post_type->cap->delete_posts;
 					}
+				} elseif ( 'private' === $post->post_status ) {
+					$caps[] = $post_type->cap->delete_private_posts;
 				} else {
 					// If the post is draft...
 					$caps[] = $post_type->cap->delete_posts;
@@ -254,6 +258,8 @@ function map_meta_cap( $cap, $user_id, ...$args ) {
 					} else {
 						$caps[] = $post_type->cap->edit_posts;
 					}
+				} elseif ( 'private' === $post->post_status ) {
+					$caps[] = $post_type->cap->edit_private_posts;
 				} else {
 					// If the post is draft...
 					$caps[] = $post_type->cap->edit_posts;

--- a/tests/phpunit/tests/user/mapMetaCap.php
+++ b/tests/phpunit/tests/user/mapMetaCap.php
@@ -457,4 +457,43 @@ class Tests_User_MapMetaCap extends WP_UnitTestCase {
 			array( 'assign_term' ),
 		);
 	}
+
+	/**
+	 * Test that delete_private_posts capability is required for author's own private posts.
+	 *
+	 * @ticket 38997
+	 */
+	public function test_delete_private_posts_required_for_own_posts() {
+		register_post_type(
+			self::$post_type,
+			array(
+				'capability_type' => 'post',
+				'map_meta_cap'    => true,
+			)
+		);
+
+		$own_private_post_id = self::factory()->post->create(
+			array(
+				'post_type'   => self::$post_type,
+				'post_status' => 'private',
+				'post_author' => self::$user_id,
+			)
+		);
+
+		$required_caps = map_meta_cap( 'delete_post', self::$user_id, $own_private_post_id );
+		$this->assertContains( 'delete_private_posts', $required_caps, 'delete_private_posts capability should be required to delete own private posts' );
+
+		$trashed_private_post_id = self::factory()->post->create(
+			array(
+				'post_type'   => self::$post_type,
+				'post_status' => 'trash',
+				'post_author' => self::$user_id,
+			)
+		);
+
+		update_post_meta( $trashed_private_post_id, '_wp_trash_meta_status', 'private' );
+
+		$required_caps = map_meta_cap( 'delete_post', self::$user_id, $trashed_private_post_id );
+		$this->assertContains( 'delete_private_posts', $required_caps, 'delete_private_posts capability should be required to delete own trashed private posts' );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/38997

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
