### PR TITLE
Add quick/bulk edit status icons, matching block editor

### DIFF
--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -327,6 +327,15 @@ input[type="radio"].disabled:checked:before {
 	background-size: 16px 16px;
 	cursor: pointer;
 	vertical-align: middle;
+	appearance: base-select; /*Customizable select support.*/
+}
+
+::picker(select) {
+  appearance: base-select;
+}
+
+.wp-core-ui select::picker-icon {
+  display: none;
 }
 
 .wp-core-ui select:hover {

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1992,15 +1992,28 @@ class WP_Posts_List_Table extends WP_List_Table {
 								<?php endif; // $bulk ?>
 
 								<?php if ( $can_publish ) : // Contributors only get "Unpublished" and "Pending Review". ?>
-									<option value="publish"><?php _e( 'Published' ); ?></option>
-									<option value="future"><?php _e( 'Scheduled' ); ?></option>
+									<option value="publish">
+										<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 18.5a6.5 6.5 0 1 1 0-13 6.5 6.5 0 0 1 0 13ZM4 12a8 8 0 1 1 16 0 8 8 0 0 1-16 0Zm11.53-1.47-1.06-1.06L11 12.94l-1.47-1.47-1.06 1.06L11 15.06l4.53-4.53Z"></path></svg>
+										<?php _e( 'Published' ); ?>
+									</option>
+									<option value="future">
+										<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 18.5a6.5 6.5 0 1 1 0-13 6.5 6.5 0 0 1 0 13ZM4 12a8 8 0 1 1 16 0 8 8 0 0 1-16 0Zm9 1V8h-1.5v3.5h-2V13H13Z"></path></svg>
+										<?php _e( 'Scheduled' ); ?>
+									</option>
 									<?php if ( $bulk ) : ?>
-										<option value="private"><?php _e( 'Private' ); ?></option>
+										<option value="private">
+											<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 18.5A6.5 6.5 0 0 1 6.93 7.931l9.139 9.138A6.473 6.473 0 0 1 12 18.5Zm5.123-2.498a6.5 6.5 0 0 0-9.124-9.124l9.124 9.124ZM4 12a8 8 0 1 1 16 0 8 8 0 0 1-16 0Z"></path></svg>
+											<?php _e( 'Private' ); ?>
+										</option>
 									<?php endif; // $bulk ?>
 								<?php endif; ?>
-
-								<option value="pending"><?php _e( 'Pending Review' ); ?></option>
-								<option value="draft"><?php _e( 'Draft' ); ?></option>
+								<option value="pending">
+									<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 18.5a6.5 6.5 0 1 1 0-13 6.5 6.5 0 0 1 0 13ZM4 12a8 8 0 1 1 16 0 8 8 0 0 1-16 0Zm8 4a4 4 0 0 1-4-4h4V8a4 4 0 0 1 0 8Z"></path></svg>
+									<?php _e( 'Pending Review' ); ?></option>
+								<option value="draft">
+									<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false"><path fill-rule="evenodd" clip-rule="evenodd" d="M12 18.5a6.5 6.5 0 1 1 0-13 6.5 6.5 0 0 1 0 13ZM4 12a8 8 0 1 1 16 0 8 8 0 0 1-16 0Zm8 4a4 4 0 0 0 4-4H8a4 4 0 0 0 4 4Z"></path></svg>
+									<?php _e( 'Draft' ); ?>
+								</option>
 							</select>
 						</label>
 


### PR DESCRIPTION
# Description
This PR adds status icons to the bulk edit and quick edit select elements. The svgs in the code are from the block editor which already shows a status icon next to each status, for example:

![image](https://github.com/user-attachments/assets/b6bf85ca-c838-4b34-89b8-2a5351c1c185)

This PR adds those status icons to the status selector on the quick edit screen and bilk edit screen which currently look like this:

## Quick edit:
![image](https://github.com/user-attachments/assets/f0fa046a-14f2-4215-bc07-b53cc1bb7a8d)

## Select detail:
![image](https://github.com/user-attachments/assets/e82242b1-2390-440b-8961-5252e7186c43)


## Bulk edit:
![image](https://github.com/user-attachments/assets/d870c9ac-d548-455f-b697-f2591f7eb999)

## Select detail:
![image](https://github.com/user-attachments/assets/60fbddc8-ff12-4e6d-8e31-2af2aa9ff6c8)

# After PR
After this PR, the select elements opt into the new Customizable Select API which enables HTML select elements. It then adds the svg icons from the editor to the selects. After the PR they look like this:

## Quick edit:
![status on quick edit](https://github.com/user-attachments/assets/6806661d-0a0d-4ded-bff5-55c04c27a056)

## Bulk edit:
![status on bulk edit](https://github.com/user-attachments/assets/173b306a-ab67-458d-b1ee-c449572fa78b)



Trac ticket: No ticket yet, this is purely experimental.

<!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
