### PR TITLE
Refine cache handling invalidation in count_user_posts

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -7423,7 +7423,7 @@ function get_posts_by_author_sql( $post_type, $full = true, $post_author = null,
 
 	$sql = '( ' . implode( ' OR ', $post_type_clauses ) . ' )';
 
-	if ( null !== $post_author ) {
+	if ( is_numeric( $post_author ) ) {
 		$sql .= $wpdb->prepare( ' AND post_author = %d', $post_author );
 	}
 
@@ -7673,6 +7673,7 @@ function clean_post_cache( $post ) {
 	}
 
 	wp_cache_set_posts_last_changed();
+	wp_cache_set_last_changed( 'post_author:' . $post->post_author );
 }
 
 /**

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -4980,6 +4980,7 @@ function wp_insert_post( $postarr, $wp_error = false, $fire_after_hooks = true )
 	clean_post_cache( $post_id );
 
 	$post = get_post( $post_id );
+	clean_post_author_cache( $post->post_author );
 
 	if ( ! empty( $postarr['page_template'] ) ) {
 		$post->page_template = $postarr['page_template'];
@@ -7673,7 +7674,18 @@ function clean_post_cache( $post ) {
 	}
 
 	wp_cache_set_posts_last_changed();
-	wp_cache_set_last_changed( 'post_author:' . $post->post_author );
+	clean_post_author_cache( $post->post_author );
+}
+
+/**
+ * Will clean the post author in the cache.
+ *
+ * @since 6.8.0
+ *
+ * @param int $user_id User ID.
+ */
+function clean_post_author_cache( $user_id ) {
+	wp_cache_delete( 'last_changed', 'post_author:' . $user_id );
 }
 
 /**

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2016,7 +2016,7 @@ function clean_user_cache( $user ) {
 	wp_cache_delete( $user->ID, 'users' );
 	wp_cache_delete( $user->user_login, 'userlogins' );
 	wp_cache_delete( $user->user_nicename, 'userslugs' );
-	wp_cache_delete( 'last_changed', 'post_author:' . $user->ID );
+	clean_post_author_cache( $user->ID );
 
 	if ( ! empty( $user->user_email ) ) {
 		wp_cache_delete( $user->user_email, 'useremail' );

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -622,7 +622,8 @@ function count_user_posts( $userid, $post_type = 'post', $public_only = false ) 
 	$where = get_posts_by_author_sql( $post_type, true, $userid, $public_only );
 	$query = "SELECT COUNT(*) FROM $wpdb->posts $where";
 
-	$last_changed = wp_cache_get_last_changed( 'posts' );
+	$cache_group  = ! is_numeric( $userid ) ? 'posts' : 'post_author:' . $userid;
+	$last_changed = wp_cache_get_last_changed( $cache_group );
 	$cache_key    = 'count_user_posts:' . md5( $query ) . ':' . $last_changed;
 	$count        = wp_cache_get( $cache_key, 'post-queries' );
 	if ( false === $count ) {
@@ -2015,6 +2016,7 @@ function clean_user_cache( $user ) {
 	wp_cache_delete( $user->ID, 'users' );
 	wp_cache_delete( $user->user_login, 'userlogins' );
 	wp_cache_delete( $user->user_nicename, 'userslugs' );
+	wp_cache_delete( 'last_changed', 'post_author:' . $user->ID );
 
 	if ( ! empty( $user->user_email ) ) {
 		wp_cache_delete( $user->user_email, 'useremail' );

--- a/tests/phpunit/tests/user/countUserPosts.php
+++ b/tests/phpunit/tests/user/countUserPosts.php
@@ -227,6 +227,46 @@ class Tests_User_CountUserPosts extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Post count should be correct after different user update a post via a database query.
+	 *
+	 * @ticket 39242
+	 */
+	public function test_invalidate_cache_different_users_post_update_db() {
+		global $wpdb;
+
+		// Create new user.
+		$new_user_id = self::factory()->user->create(
+			array(
+				'role' => 'author',
+			)
+		);
+
+		// Assign post to next user.
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => $new_user_id,
+				'post_type'   => 'post',
+			)
+		);
+
+		// Prior to reassigning posts.
+		$this->assertSame( '4', count_user_posts( self::$user_id ), 'Original user is expected to have a count of four posts prior to reassignment.' );
+		$this->assertSame( '1', count_user_posts( $new_user_id ), 'New user is expected to have a count of zero posts prior to reassignment.' );
+
+		$wpdb->update( $wpdb->posts, array( 'post_author' => self::$user_id ), array( 'ID' => $post_id ) );
+		clean_post_cache( $post_id );
+		clean_post_author_cache( self::$user_id );
+
+		// After reassigning posts.
+		$query_num_start = get_num_queries();
+		$this->assertSame( '5', count_user_posts( self::$user_id ), 'Original user is expected to have a count of zero posts following reassignment.' );
+		$this->assertSame( $query_num_start + 1, get_num_queries(), 'Cache should as another users has been updated' );
+		$query_num_start = get_num_queries();
+		$this->assertSame( '0', count_user_posts( $new_user_id ), 'New user is expected to have a count of four posts following reassignment.' );
+		$this->assertSame( $query_num_start + 1, get_num_queries(), 'Cache not be hit as this user has created a post' );
+	}
+
+	/**
 	 * Post count should be correct after deleting user without reassigning posts.
 	 *
 	 * @ticket 39242

--- a/tests/phpunit/tests/user/countUserPosts.php
+++ b/tests/phpunit/tests/user/countUserPosts.php
@@ -116,6 +116,76 @@ class Tests_User_CountUserPosts extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Post count should be correct after different user creates a post.
+	 *
+	 * @ticket 39242
+	 */
+	public function test_invalidate_cache_different_users() {
+		// Create new user.
+		$new_user_id = self::factory()->user->create(
+			array(
+				'role' => 'author',
+			)
+		);
+
+		// Prior to reassigning posts.
+		$this->assertSame( '4', count_user_posts( self::$user_id ), 'Original user is expected to have a count of four posts prior to reassignment.' );
+		$this->assertSame( '0', count_user_posts( $new_user_id ), 'New user is expected to have a count of zero posts prior to reassignment.' );
+
+		// Assign post to next user.
+		self::factory()->post->create(
+			array(
+				'post_author' => $new_user_id,
+				'post_type'   => 'post',
+			)
+		);
+
+		// After reassigning posts.
+		$query_num_start = get_num_queries();
+		$this->assertSame( '4', count_user_posts( self::$user_id ), 'Original user is expected to have a count of zero posts following reassignment.' );
+		$this->assertSame( $query_num_start, get_num_queries(), 'Cache should as another users has been updated' );
+		$query_num_start = get_num_queries();
+		$this->assertSame( '1', count_user_posts( $new_user_id ), 'New user is expected to have a count of four posts following reassignment.' );
+		$this->assertSame( $query_num_start + 1, get_num_queries(), 'Cache not be hit as this user has created a post' );
+	}
+
+	/**
+	 * Post count should be correct after different user delete a post.
+	 *
+	 * @ticket 39242
+	 */
+	public function test_invalidate_cache_different_users_post_delete() {
+		// Create new user.
+		$new_user_id = self::factory()->user->create(
+			array(
+				'role' => 'author',
+			)
+		);
+
+		// Assign post to next user.
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => $new_user_id,
+				'post_type'   => 'post',
+			)
+		);
+
+		// Prior to reassigning posts.
+		$this->assertSame( '4', count_user_posts( self::$user_id ), 'Original user is expected to have a count of four posts prior to reassignment.' );
+		$this->assertSame( '1', count_user_posts( $new_user_id ), 'New user is expected to have a count of zero posts prior to reassignment.' );
+
+		wp_delete_post( $post_id, true );
+
+		// After reassigning posts.
+		$query_num_start = get_num_queries();
+		$this->assertSame( '4', count_user_posts( self::$user_id ), 'Original user is expected to have a count of zero posts following reassignment.' );
+		$this->assertSame( $query_num_start, get_num_queries(), 'Cache should as another users has been updated' );
+		$query_num_start = get_num_queries();
+		$this->assertSame( '0', count_user_posts( $new_user_id ), 'New user is expected to have a count of four posts following reassignment.' );
+		$this->assertSame( $query_num_start + 1, get_num_queries(), 'Cache not be hit as this user has created a post' );
+	}
+
+	/**
 	 * Post count should be correct after deleting user without reassigning posts.
 	 *
 	 * @ticket 39242
@@ -210,6 +280,36 @@ class Tests_User_CountUserPosts extends WP_UnitTestCase {
 		$total_queries = get_num_queries() - $query_num_start;
 
 		$this->assertSame( 0, $total_queries, 'Cache should be hit for string and array equivalent post types.' );
+	}
+
+	/**
+	 * @ticket 39242
+	 * @dataProvider data_user_id_values
+	 */
+	public function test_cache_should_be_hit_for_values( $user_value ) {
+		// Prime cache.
+		count_user_posts( $user_value, 'post' );
+
+		$query_num_start = get_num_queries();
+		count_user_posts( $user_value, array( 'post' ) );
+		$total_queries = get_num_queries() - $query_num_start;
+
+		$this->assertSame( 0, $total_queries, 'Cache should be hit for string and array equivalent post types.' );
+	}
+
+	/**
+	 * Data provider for test_cache_should_be_hit_for_values
+	 *
+	 * @return array
+	 */
+	public function data_user_id_values() {
+		return array(
+			'null value'   => array( null ),
+			'false value'  => array( false ),
+			'zero value'   => array( 0 ),
+			'string value' => array( 'foo' ),
+			'float value'  => array( 1.0 ),
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/user/countUserPosts.php
+++ b/tests/phpunit/tests/user/countUserPosts.php
@@ -186,6 +186,47 @@ class Tests_User_CountUserPosts extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Post count should be correct after different user update a post.
+	 *
+	 * @ticket 39242
+	 */
+	public function test_invalidate_cache_different_users_post_update() {
+		// Create new user.
+		$new_user_id = self::factory()->user->create(
+			array(
+				'role' => 'author',
+			)
+		);
+
+		// Assign post to next user.
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => $new_user_id,
+				'post_type'   => 'post',
+			)
+		);
+
+		// Prior to reassigning posts.
+		$this->assertSame( '4', count_user_posts( self::$user_id ), 'Original user is expected to have a count of four posts prior to reassignment.' );
+		$this->assertSame( '1', count_user_posts( $new_user_id ), 'New user is expected to have a count of zero posts prior to reassignment.' );
+
+		wp_update_post(
+			array(
+				'ID'          => $post_id,
+				'post_author' => self::$user_id,
+			)
+		);
+
+		// After reassigning posts.
+		$query_num_start = get_num_queries();
+		$this->assertSame( '5', count_user_posts( self::$user_id ), 'Original user is expected to have a count of zero posts following reassignment.' );
+		$this->assertSame( $query_num_start + 1, get_num_queries(), 'Cache should as another users has been updated' );
+		$query_num_start = get_num_queries();
+		$this->assertSame( '0', count_user_posts( $new_user_id ), 'New user is expected to have a count of four posts following reassignment.' );
+		$this->assertSame( $query_num_start + 1, get_num_queries(), 'Cache not be hit as this user has created a post' );
+	}
+
+	/**
 	 * Post count should be correct after deleting user without reassigning posts.
 	 *
 	 * @ticket 39242


### PR DESCRIPTION
Updated caching logic to use user-specific cache groups for post queries, improving granularity and efficiency. Ensured proper cache invalidation for `post_author` when relevant user data changes. Adjusted author-based SQL checks to ensure compatibility with cache updates.

Added tests for null, zero, false and float values, as was not tested before. 

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/39242
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
