### PR TITLE
New Update for Local XDebug Compliance

### DIFF
--- a/tools/local-env/php-config.ini
+++ b/tools/local-env/php-config.ini
@@ -2,3 +2,4 @@ display_errors = On
 error_reporting = -1
 upload_max_filesize = 1G
 post_max_size = 1G
+xdebug.start_with_request=yes

--- a/tools/local-env/php-config.ini
+++ b/tools/local-env/php-config.ini
@@ -2,4 +2,4 @@ display_errors = On
 error_reporting = -1
 upload_max_filesize = 1G
 post_max_size = 1G
-xdebug.start_with_request=yes
+xdebug.start_with_request=trigger


### PR DESCRIPTION
I've commited a new patch version, switching to `trigger` instead of `yes`:
https://xdebug.org/docs/all_settings#start_with_request

The problem is that since we are setting mode to `debug` it will start xdebug during the github tests
 
With `trigger` it will only will be executed on trigger (for example, via browser extension to listen to breakpoints, or with `xdebug_break`). Its less comfy but it should work well with Github Actions.

Trac ticket: https://core.trac.wordpress.org/ticket/49953
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
