### PR TITLE
Editor: Revert new default rendering mode for Pages

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -565,7 +565,6 @@ add_action( 'transition_post_status', '__clear_multi_author_cache' );
 
 // Post.
 add_action( 'init', 'create_initial_post_types', 0 ); // Highest priority.
-add_action( 'init', 'wp_set_editor_default_mode', 1 ); // Run after registering post types.
 add_action( 'admin_menu', '_add_post_type_submenus' );
 add_action( 'before_delete_post', '_reset_front_page_settings_for_post' );
 add_action( 'wp_trash_post', '_reset_front_page_settings_for_post' );

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -8524,14 +8524,3 @@ function wp_create_initial_post_meta() {
 		)
 	);
 }
-
-/**
- * Sets the default editor mode based on support for block templates.
- *
- * @since 6.8.0
- */
-function wp_set_editor_default_mode() {
-	if ( wp_is_block_theme() && current_theme_supports( 'block-templates' ) ) {
-		add_post_type_support( 'page', 'editor', array( 'default-mode' => 'template-locked' ) );
-	}
-}


### PR DESCRIPTION
> [!IMPORTANT]
> I want to highlight that limiting the ability to edit template parts in `template-locked` rendering mode is an intentional choice and isn't a bug.
>
> Unfortunately, this can make the new default rendering mode confusing in some instances and prevent users from editing a post/page title.

PR reverts the new default rendering mode for Pages ([WP-61811](https://core.trac.wordpress.org/ticket/61811)).

I'm not restoring the special case for the Site Editor, where the rendering mode was different from that of the Post Editor. Why?

* Consistency - The new default's goal was to make the page editing experience consistent between the post and site editors. There should be only one default rendering mode per post type across the editors.
* User preferences - The new persistent user preference allows users to set rendering mode based on their needs.
* More logic, more problems - I don't want to complicate the logic for deriving the default rendering mode.


Trac ticket: https://core.trac.wordpress.org/ticket/63139