### PR TITLE
Bundled Theme: Fix inconsistent table caption spacing between editor and frontend

### DIFF
--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -896,6 +896,10 @@ figcaption,
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
+:where(.editor-styles-wrapper table:not(:last-child)) {
+  margin-bottom: 1.375rem;
+}
+
 /** === Cover === */
 .wp-block-cover h2,
 .wp-block-cover .wp-block-cover-text {
@@ -1272,10 +1276,6 @@ figcaption,
 }
 
 /** === Table === */
-.wp-block-table table {
-	margin-bottom: 1.375rem;
-}
-
 .wp-block-table td, .wp-block-table th {
   border-color: #767676;
 }

--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -1272,6 +1272,10 @@ figcaption,
 }
 
 /** === Table === */
+.wp-block-table table {
+	margin-bottom: 1.375rem;
+}
+
 .wp-block-table td, .wp-block-table th {
   border-color: #767676;
 }

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -280,6 +280,10 @@ figcaption,
 	@include font-family( $font__heading );
 }
 
+:where(.editor-styles-wrapper table:not(:last-child)) {
+	margin-bottom: 1.375rem;
+}
+
 /** === Cover === */
 
 .wp-block-cover {


### PR DESCRIPTION
This PR addresses the issue of inconsistent spacing between the table caption and the table in the Twenty Nineteen theme. The spacing differs between the editor and the frontend.
- Added a bottom margin to the table in the editor (style-editor.css) to match the frontend display.


Before:
![image](https://github.com/user-attachments/assets/33718360-abb7-422b-b224-03815ddae1c6)


After:
<img width="1920" alt="after-fix" src="https://github.com/user-attachments/assets/265aa687-6269-49ba-a9f4-06b0b1a1e977" />


Trac ticket: [#63143](https://core.trac.wordpress.org/ticket/63143)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
