### PR TITLE
Try: add icons to media type dropdowns

### DIFF
--- a/src/js/media/views/attachment-filters.js
+++ b/src/js/media/views/attachment-filters.js
@@ -39,6 +39,9 @@ AttachmentFilters = wp.media.View.extend(/** @lends wp.media.view.AttachmentFilt
 			};
 		}, this ).sortBy('priority').pluck('el').value() );
 
+		// Prepend the selectedelement.
+		this.$el.prepend( '<button><selectedcontent></selectedcontent></button>' );
+
 		this.listenTo( this.model, 'change', this.select );
 		this.select();
 	},

--- a/src/js/media/views/attachment-filters.js
+++ b/src/js/media/views/attachment-filters.js
@@ -28,8 +28,13 @@ AttachmentFilters = wp.media.View.extend(/** @lends wp.media.view.AttachmentFilt
 
 		// Build `<option>` elements.
 		this.$el.html( _.chain( this.filters ).map( function( filter, value ) {
+			// Potentially add an icon to the option.
+			var filterText = filter.text;
+			if ( filter.props.icon ) {
+				filterText = '<span class="dashicons dashicons-' + filter.props.icon + '"></span> ' + filter.text;
+			}
 			return {
-				el: $( '<option></option>' ).val( value ).html( filter.text )[0],
+				el: $( '<option></option>' ).val( value ).html( filterText )[0],
 				priority: filter.priority || 50
 			};
 		}, this ).sortBy('priority').pluck('el').value() );

--- a/src/js/media/views/attachment-filters/all.js
+++ b/src/js/media/views/attachment-filters/all.js
@@ -26,8 +26,9 @@ All = wp.media.view.AttachmentFilters.extend(/** @lends wp.media.view.Attachment
 					uploadedTo: null,
 					orderby: 'date',
 					order:   'DESC',
-					author:  null
-				}
+					author:  null,
+					icon: wp.media.view.settings.mimeIcons[key] || false
+				},
 			};
 		});
 
@@ -39,7 +40,8 @@ All = wp.media.view.AttachmentFilters.extend(/** @lends wp.media.view.Attachment
 				uploadedTo: null,
 				orderby: 'date',
 				order:   'DESC',
-				author:  null
+				author:  null,
+				icon: 'format-gallery'
 			},
 			priority: 10
 		};
@@ -53,7 +55,8 @@ All = wp.media.view.AttachmentFilters.extend(/** @lends wp.media.view.Attachment
 					uploadedTo: wp.media.view.settings.post.id,
 					orderby: 'menuOrder',
 					order:   'ASC',
-					author:  null
+					author:  null,
+					icon: 'upload'
 				},
 				priority: 20
 			};
@@ -67,7 +70,8 @@ All = wp.media.view.AttachmentFilters.extend(/** @lends wp.media.view.Attachment
 				type:       null,
 				orderby:    'menuOrder',
 				order:      'ASC',
-				author:     null
+				author:     null,
+				icon: 'no'
 			},
 			priority: 50
 		};
@@ -81,7 +85,8 @@ All = wp.media.view.AttachmentFilters.extend(/** @lends wp.media.view.Attachment
 					uploadedTo:	null,
 					orderby:	'date',
 					order:		'DESC',
-					author:		uid
+					author:		uid,
+					icon: 'admin-users'
 				},
 				priority: 50
 			};
@@ -98,7 +103,8 @@ All = wp.media.view.AttachmentFilters.extend(/** @lends wp.media.view.Attachment
 					type:       null,
 					orderby:    'date',
 					order:      'DESC',
-					author:     null
+					author:     null,
+					icon: 'trash'
 				},
 				priority: 50
 			};

--- a/src/js/media/views/attachment-filters/all.js
+++ b/src/js/media/views/attachment-filters/all.js
@@ -21,13 +21,13 @@ All = wp.media.view.AttachmentFilters.extend(/** @lends wp.media.view.Attachment
 			filters[ key ] = {
 				text: text,
 				props: {
-					status:  null,
-					type:    key,
+					status:     null,
+					type:       key,
 					uploadedTo: null,
-					orderby: 'date',
-					order:   'DESC',
-					author:  null,
-					icon: wp.media.view.settings.mimeIcons[key] || false
+					orderby:    'date',
+					order:      'DESC',
+					author:     null,
+					icon:       wp.media.view.settings.mimeIcons[key] || false
 				},
 			};
 		});
@@ -35,13 +35,13 @@ All = wp.media.view.AttachmentFilters.extend(/** @lends wp.media.view.Attachment
 		filters.all = {
 			text:  l10n.allMediaItems,
 			props: {
-				status:  null,
-				type:    null,
+				status:     null,
+				type:       null,
 				uploadedTo: null,
-				orderby: 'date',
-				order:   'DESC',
-				author:  null,
-				icon: 'format-gallery'
+				orderby:   'date',
+				order:     'DESC',
+				author:    null,
+				icon:      'format-gallery'
 			},
 			priority: 10
 		};
@@ -50,13 +50,13 @@ All = wp.media.view.AttachmentFilters.extend(/** @lends wp.media.view.Attachment
 			filters.uploaded = {
 				text:  l10n.uploadedToThisPost,
 				props: {
-					status:  null,
-					type:    null,
+					status:     null,
+					type:       null,
 					uploadedTo: wp.media.view.settings.post.id,
-					orderby: 'menuOrder',
-					order:   'ASC',
-					author:  null,
-					icon: 'upload'
+					orderby:   'menuOrder',
+					order:     'ASC',
+					author:    null,
+					icon:      'upload'
 				},
 				priority: 20
 			};
@@ -71,7 +71,7 @@ All = wp.media.view.AttachmentFilters.extend(/** @lends wp.media.view.Attachment
 				orderby:    'menuOrder',
 				order:      'ASC',
 				author:     null,
-				icon: 'no'
+				icon:       'no'
 			},
 			priority: 50
 		};
@@ -80,13 +80,13 @@ All = wp.media.view.AttachmentFilters.extend(/** @lends wp.media.view.Attachment
 			filters.mine = {
 				text:  l10n.mine,
 				props: {
-					status:		null,
-					type:		null,
-					uploadedTo:	null,
-					orderby:	'date',
-					order:		'DESC',
-					author:		uid,
-					icon: 'admin-users'
+					status:     null,
+					type:       null,
+					uploadedTo: null,
+					orderby:    'date',
+					order:      'DESC',
+					author:     uid,
+					icon:       'admin-users'
 				},
 				priority: 50
 			};
@@ -104,7 +104,7 @@ All = wp.media.view.AttachmentFilters.extend(/** @lends wp.media.view.Attachment
 					orderby:    'date',
 					order:      'DESC',
 					author:     null,
-					icon: 'trash'
+					icon:       'trash'
 				},
 				priority: 50
 			};

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -327,15 +327,6 @@ input[type="radio"].disabled:checked:before {
 	background-size: 16px 16px;
 	cursor: pointer;
 	vertical-align: middle;
-	appearance: base-select;
-}
-
-::picker(select) {
-  appearance: base-select;
-}
-
-.wp-core-ui select::picker-icon {
-  display: none;
 }
 
 .wp-core-ui select:hover {

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -327,6 +327,15 @@ input[type="radio"].disabled:checked:before {
 	background-size: 16px 16px;
 	cursor: pointer;
 	vertical-align: middle;
+	appearance: base-select;
+}
+
+::picker(select) {
+  appearance: base-select;
+}
+
+.wp-core-ui select::picker-icon {
+  display: none;
 }
 
 .wp-core-ui select:hover {

--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -445,6 +445,22 @@ border color while dragging a file over the uploader drop area */
 
 .post-type-attachment .wp-filter select {
 	margin: 0 6px 0 0;
+	appearance: base-select;
+}
+
+.post-type-attachment .wp-filter select::picker(select) {
+	appearance: base-select;
+}
+
+.post-type-attachment .wp-filter select selectedcontent,
+.media-modal-content .media-frame select.attachment-filters selectedcontent {
+	display: flex;
+	align-items: center;
+	gap: .5ch;
+}
+
+.post-type-attachment .wp-filter select::picker-icon {
+  display: none;
 }
 
 /**
@@ -1266,7 +1282,7 @@ audio, video {
 	.edit-attachment-frame textarea {
 		line-height: 1.5;
 	}
-	
+
 	.wp_attachment_details label[for="content"] {
 		font-size: 14px;
 		line-height: 1.5;

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -129,8 +129,9 @@ class WP_Media_List_Table extends WP_List_Table {
 		$filter = empty( $_GET['attachment-filter'] ) ? '' : $_GET['attachment-filter'];
 
 		$type_links['all'] = sprintf(
-			'<option value=""%s>%s</option>',
+			'<option value=""%s>%s%s</option>',
 			selected( $filter, true, false ),
+			'<span class="dashicons dashicons-format-gallery"></span> ',
 			__( 'All media items' )
 		);
 

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -291,6 +291,9 @@ class WP_Media_List_Table extends WP_List_Table {
 					?>
 				</label>
 				<select class="attachment-filters" name="attachment-filter" id="attachment-filter">
+					<button>
+						<selectedcontent></selectedcontent>
+					</button>
 					<?php
 					if ( ! empty( $views ) ) {
 						foreach ( $views as $class => $view ) {

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -146,11 +146,14 @@ class WP_Media_List_Table extends WP_List_Table {
 				false
 			);
 
+			$dashicon = ! empty( $label[3] ) ? "<span class='dashicons dashicons-format-$label[3]'></span> " : '';
+
 			$type_links[ $mime_type ] = sprintf(
-				'<option value="post_mime_type:%s"%s>%s</option>',
+				'<option value="post_mime_type:%s"%s>%s%s</option>',
 				esc_attr( $mime_type ),
 				$selected,
-				$label[0]
+				$label[0],
+				$dashicon
 			);
 		}
 

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -146,29 +146,31 @@ class WP_Media_List_Table extends WP_List_Table {
 				false
 			);
 
-			$dashicon = ! empty( $label[3] ) ? "<span class='dashicons dashicons-format-$label[3]'></span> " : '';
+			$dashicon = ! empty( $label[3] ) ? "<span class='dashicons dashicons-$label[3]'></span> " : '';
 
 			$type_links[ $mime_type ] = sprintf(
 				'<option value="post_mime_type:%s"%s>%s%s</option>',
 				esc_attr( $mime_type ),
 				$selected,
-				$label[0],
-				$dashicon
+				$dashicon,
+				$label[0]
 			);
 		}
 
-		$type_links['detached'] = '<option value="detached"' . ( $this->detached ? ' selected="selected"' : '' ) . '>' . _x( 'Unattached', 'media items' ) . '</option>';
+		$type_links['detached'] = '<option value="detached"' . ( $this->detached ? ' selected="selected"' : '' ) . '><span class="dashicons dashicons-no"></span> '. _x( 'Unattached', 'media items' ) . '</option>';
 
 		$type_links['mine'] = sprintf(
-			'<option value="mine"%s>%s</option>',
+			'<option value="mine"%s>%s%s</option>',
 			selected( 'mine' === $filter, true, false ),
+			'<span class="dashicons dashicons-admin-users"></span> ',
 			_x( 'Mine', 'media items' )
 		);
 
 		if ( $this->is_trash || ( defined( 'MEDIA_TRASH' ) && MEDIA_TRASH ) ) {
 			$type_links['trash'] = sprintf(
-				'<option value="trash"%s>%s</option>',
+				'<option value="trash"%s>%s%s</option>',
 				selected( 'trash' === $filter, true, false ),
+				'<span class="dashicons dashicons-trash"></span> ',
 				_x( 'Trash', 'attachment filter' )
 			);
 		}

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -158,7 +158,7 @@ class WP_Media_List_Table extends WP_List_Table {
 			);
 		}
 
-		$type_links['detached'] = '<option value="detached"' . ( $this->detached ? ' selected="selected"' : '' ) . '><span class="dashicons dashicons-no"></span> '. _x( 'Unattached', 'media items' ) . '</option>';
+		$type_links['detached'] = '<option value="detached"' . ( $this->detached ? ' selected="selected"' : '' ) . '><span class="dashicons dashicons-no"></span> ' . _x( 'Unattached', 'media items' ) . '</option>';
 
 		$type_links['mine'] = sprintf(
 			'<option value="mine"%s>%s%s</option>',

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -4899,6 +4899,7 @@ function wp_enqueue_media( $args = array() ) {
 		'tabs'              => $tabs,
 		'tabUrl'            => add_query_arg( array( 'chromeless' => true ), admin_url( 'media-upload.php' ) ),
 		'mimeTypes'         => wp_list_pluck( get_post_mime_types(), 0 ),
+		'mimeIcons'         => wp_list_pluck( get_post_mime_types(), 3, 0 ),
 		/** This filter is documented in wp-admin/includes/media.php */
 		'captions'          => ! apply_filters( 'disable_captions', '' ),
 		'nonce'             => array(

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3468,6 +3468,7 @@ function wp_count_attachments( $mime_type = '' ) {
  *
  * @since 2.9.0
  * @since 5.3.0 Added the 'Documents', 'Spreadsheets', and 'Archives' mime type groups.
+ * @since n.e.x.t. Added dashicon for each mime type.
  *
  * @return array List of post mime types.
  */
@@ -3481,6 +3482,7 @@ function get_post_mime_types() {
 				'Image <span class="count">(%s)</span>',
 				'Images <span class="count">(%s)</span>'
 			),
+			'image',
 		),
 		'audio'       => array(
 			_x( 'Audio', 'file type group' ),
@@ -3490,6 +3492,7 @@ function get_post_mime_types() {
 				'Audio <span class="count">(%s)</span>',
 				'Audio <span class="count">(%s)</span>'
 			),
+			'audio'
 		),
 		'video'       => array(
 			_x( 'Video', 'file type group' ),
@@ -3499,6 +3502,7 @@ function get_post_mime_types() {
 				'Video <span class="count">(%s)</span>',
 				'Video <span class="count">(%s)</span>'
 			),
+			'video',
 		),
 		'document'    => array(
 			__( 'Documents' ),
@@ -3508,6 +3512,7 @@ function get_post_mime_types() {
 				'Document <span class="count">(%s)</span>',
 				'Documents <span class="count">(%s)</span>'
 			),
+			'document'
 		),
 		'spreadsheet' => array(
 			__( 'Spreadsheets' ),
@@ -3517,6 +3522,7 @@ function get_post_mime_types() {
 				'Spreadsheet <span class="count">(%s)</span>',
 				'Spreadsheets <span class="count">(%s)</span>'
 			),
+			'spreadsheet'
 		),
 		'archive'     => array(
 			_x( 'Archives', 'file type group' ),
@@ -3526,6 +3532,7 @@ function get_post_mime_types() {
 				'Archive <span class="count">(%s)</span>',
 				'Archives <span class="count">(%s)</span>'
 			),
+			'archive'
 		),
 	);
 

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3492,7 +3492,7 @@ function get_post_mime_types() {
 				'Audio <span class="count">(%s)</span>',
 				'Audio <span class="count">(%s)</span>'
 			),
-			'format-audio'
+			'format-audio',
 		),
 		'video'       => array(
 			_x( 'Video', 'file type group' ),
@@ -3512,7 +3512,7 @@ function get_post_mime_types() {
 				'Document <span class="count">(%s)</span>',
 				'Documents <span class="count">(%s)</span>'
 			),
-			'media-document'
+			'media-document',
 		),
 		'spreadsheet' => array(
 			__( 'Spreadsheets' ),
@@ -3522,7 +3522,7 @@ function get_post_mime_types() {
 				'Spreadsheet <span class="count">(%s)</span>',
 				'Spreadsheets <span class="count">(%s)</span>'
 			),
-			'media-spreadsheet'
+			'media-spreadsheet',
 		),
 		'archive'     => array(
 			_x( 'Archives', 'file type group' ),
@@ -3532,7 +3532,7 @@ function get_post_mime_types() {
 				'Archive <span class="count">(%s)</span>',
 				'Archives <span class="count">(%s)</span>'
 			),
-			'archive'
+			'archive',
 		),
 	);
 

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3482,7 +3482,7 @@ function get_post_mime_types() {
 				'Image <span class="count">(%s)</span>',
 				'Images <span class="count">(%s)</span>'
 			),
-			'image',
+			'format-image',
 		),
 		'audio'       => array(
 			_x( 'Audio', 'file type group' ),
@@ -3492,7 +3492,7 @@ function get_post_mime_types() {
 				'Audio <span class="count">(%s)</span>',
 				'Audio <span class="count">(%s)</span>'
 			),
-			'audio'
+			'format-audio'
 		),
 		'video'       => array(
 			_x( 'Video', 'file type group' ),
@@ -3502,7 +3502,7 @@ function get_post_mime_types() {
 				'Video <span class="count">(%s)</span>',
 				'Video <span class="count">(%s)</span>'
 			),
-			'video',
+			'format-video',
 		),
 		'document'    => array(
 			__( 'Documents' ),
@@ -3512,7 +3512,7 @@ function get_post_mime_types() {
 				'Document <span class="count">(%s)</span>',
 				'Documents <span class="count">(%s)</span>'
 			),
-			'document'
+			'media-document'
 		),
 		'spreadsheet' => array(
 			__( 'Spreadsheets' ),
@@ -3522,7 +3522,7 @@ function get_post_mime_types() {
 				'Spreadsheet <span class="count">(%s)</span>',
 				'Spreadsheets <span class="count">(%s)</span>'
 			),
-			'spreadsheet'
+			'media-spreadsheet'
 		),
 		'archive'     => array(
 			_x( 'Archives', 'file type group' ),

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3467,8 +3467,8 @@ function wp_count_attachments( $mime_type = '' ) {
  * Gets default post mime types.
  *
  * @since 2.9.0
- * @since 5.3.0 Added the 'Documents', 'Spreadsheets', and 'Archives' mime type groups.
- * @since n.e.x.t. Added dashicon for each mime type.
+ * @since 5.3.0    Added the 'Documents', 'Spreadsheets', and 'Archives' mime type groups.
+ * @since n.e.x.t. Added dashicon strings for each mime type.
  *
  * @return array List of post mime types.
  */


### PR DESCRIPTION
# Description
The new [Customizable Select API](https://developer.chrome.com/blog/rfc-customizable-select) enables HTML select elements that can include images to make select elements more helpful for users. 

This PR uses this new feature to add icons next to the media type dropdown in the media library.

# Screenshots
## Before PR
Before this PR, the media filter looks like this:

### Grid view
![current media filter - grid](https://github.com/user-attachments/assets/4e094494-40d2-4aa8-a72f-65995ca7a17e)

### List view
![current media filter list view](https://github.com/user-attachments/assets/abffd55d-7295-4861-bf1d-24debeeb81b9)

## After PR

### Grid view
![fixed grid](https://github.com/user-attachments/assets/31d2990a-62cf-40bc-82a3-72c3b3d3c416)


### List view
![fixed 1](https://github.com/user-attachments/assets/b7265007-e617-4575-bb64-c10b233088dd)


## Notes
* Uses existing core dashicons for all images.
* Non-supporting browsers show the standard select element, ignoring the icons.
* Still works exactly like a regular select element
* I only added minimal styling, we probably want to have the background match other dropdowns.
* Issue: after selecting a filter, the selected item shown at the top does not include the icon, possibly because we are manually setting this value?
![icon missing](https://github.com/user-attachments/assets/bb3edada-8db7-4c01-af0e-095484752a30)


Trac ticket: None: this is an experiment so far.

<!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
