### PR TITLE
KSES and semicolons

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2379,6 +2379,7 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 
 	$css = wp_kses_no_null( $css );
 	$css = str_replace( array( "\n", "\r", "\t" ), '', $css );
+	$css = html_entity_decode( $css );
 
 	$allowed_protocols = wp_allowed_protocols();
 

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -1509,6 +1509,18 @@ EOF;
 				"background-image: url( 'http://example.com/valid.gif' )",
 			),
 
+			// URL with query parameters
+			array(
+				"background-image: url( 'http://example.com/valid.gif?width=100&height=100' );",
+				"background-image: url( 'http://example.com/valid.gif?width=100&height=100' )",
+			),
+
+			// URL with encoded ampersands
+			array(
+				"background-image: url( 'http://example.com/valid.gif?width=100&amp;height=100' );",
+				"background-image: url( 'http://example.com/valid.gif?width=100&height=100' )",
+			),
+
 			// No quotes.
 			array(
 				'background-image: url( http://example.com/valid.gif );',


### PR DESCRIPTION
Coming from this report:
https://core.trac.wordpress.org/ticket/55452

I've figured out that possibly this patch could solve, on an inner level the issues behind HTML encoded characters when sanitizing.
Not sure if this patch may sort this issue, because I still feel that problem with SVG could go beyond (the XSS problem). So I have no tested against this specific scenario, but I think I could bring this patch for attention.

Trac ticket: https://core.trac.wordpress.org/ticket/63149

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
