### PR TITLE
Warning with New Classic Theme Without Widgets

### DIFF
--- a/src/wp-includes/class-wp-customize-widgets.php
+++ b/src/wp-includes/class-wp-customize-widgets.php
@@ -922,8 +922,10 @@ final class WP_Customize_Widgets {
 				<h3>
 					<span class="customize-action">
 					<?php
+						$panel       = $this->manager->get_panel( 'widgets' );
+						$panel_title = $panel && isset( $panel->title ) ? $panel->title : __( 'Widgets' );
 						/* translators: &#9656; is the unicode right-pointing triangle. %s: Section title in the Customizer. */
-						printf( __( 'Customizing &#9656; %s' ), esc_html( $this->manager->get_panel( 'widgets' )->title ) );
+						printf( __( 'Customizing &#9656; %s' ), esc_html( $panel_title ) );
 					?>
 					</span>
 					<?php _e( 'Add a Widget' ); ?>

--- a/tests/phpunit/tests/customize/widgets.php
+++ b/tests/phpunit/tests/customize/widgets.php
@@ -890,7 +890,7 @@ class Tests_WP_Customize_Widgets extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'Notice', $output );
 		$this->assertStringNotContainsString( 'Error', $output );
 
-		// Check that the output contains expected widget controls HTML
+		// Check that the output contains expected widget controls HTML.
 		$this->assertStringContainsString( 'id="widgets-left"', $output );
 		$this->assertStringContainsString( 'id="available-widgets"', $output );
 		$this->assertStringNotContainsString( 'id="accordion-panel-widgets"', $output );

--- a/tests/phpunit/tests/customize/widgets.php
+++ b/tests/phpunit/tests/customize/widgets.php
@@ -886,13 +886,13 @@ class Tests_WP_Customize_Widgets extends WP_UnitTestCase {
 		$output                 = ob_get_clean();
 		$wp_registered_sidebars = $original_sidebars;
 
-		$this->assertStringNotContainsString( 'Warning', $output );
-		$this->assertStringNotContainsString( 'Notice', $output );
-		$this->assertStringNotContainsString( 'Error', $output );
+		$this->assertStringNotContainsString( 'Warning', $output, 'Failed asserting that the output does not contain "Warning".' );
+		$this->assertStringNotContainsString( 'Notice', $output, 'Failed asserting that the output does not contain "Notice".' );
+		$this->assertStringNotContainsString( 'Error', $output, 'Failed asserting that the output does not contain "Error".' );
 
 		// Check that the output contains expected widget controls HTML.
-		$this->assertStringContainsString( 'id="widgets-left"', $output );
-		$this->assertStringContainsString( 'id="available-widgets"', $output );
-		$this->assertStringNotContainsString( 'id="accordion-panel-widgets"', $output );
+		$this->assertStringContainsString( 'id="widgets-left"', $output, 'Failed asserting that the output contains "id=widgets-left".' );
+		$this->assertStringContainsString( 'id="available-widgets"', $output, 'Failed asserting that the output contains "id=available-widgets".' );
+		$this->assertStringNotContainsString( 'id="accordion-panel-widgets"', $output, 'Failed asserting that the output does not contain "id=accordion-panel-widgets".' );
 	}
 }

--- a/tests/phpunit/tests/customize/widgets.php
+++ b/tests/phpunit/tests/customize/widgets.php
@@ -857,4 +857,42 @@ class Tests_WP_Customize_Widgets extends WP_UnitTestCase {
 		$this->manager->widgets->prepreview_added_widget_instance();
 		$this->manager->widgets->remove_prepreview_filters();
 	}
+
+	/**
+	 * Test that output_widget_control_templates() works without sidebars.
+	 * This test verifies that the fix for accessing panel title works correctly
+	 * when no sidebars are registered or the widgets panel doesn't exist.
+	 *
+	 * @ticket 63151
+	 *
+	 * @covers WP_Customize_Widgets::output_widget_control_templates
+	 */
+	public function test_output_widget_control_templates_without_sidebars() {
+		global $wp_registered_sidebars;
+
+		$original_sidebars      = $wp_registered_sidebars;
+		$wp_registered_sidebars = array();
+		$manager                = new WP_Customize_Manager();
+		$widgets                = new WP_Customize_Widgets( $manager );
+
+		if ( $manager->get_panel( 'widgets' ) ) {
+			$manager->remove_panel( 'widgets' );
+		}
+
+		ob_start();
+
+		$widgets->output_widget_control_templates();
+
+		$output                 = ob_get_clean();
+		$wp_registered_sidebars = $original_sidebars;
+
+		$this->assertStringNotContainsString( 'Warning', $output );
+		$this->assertStringNotContainsString( 'Notice', $output );
+		$this->assertStringNotContainsString( 'Error', $output );
+
+		// Check that the output contains expected widget controls HTML
+		$this->assertStringContainsString( 'id="widgets-left"', $output );
+		$this->assertStringContainsString( 'id="available-widgets"', $output );
+		$this->assertStringNotContainsString( 'id="accordion-panel-widgets"', $output );
+	}
 }


### PR DESCRIPTION
After some discussion in Slack I'm going to bring some context to this topic:

I never realized that a theme could have no sidebars but @audrasjb brough this:
> This may be something we can improve  on Core, or at least something that should be documented.

And the use-case of ArtZ91:
> how I see it from my side: my goal as a developer is to create some templates based on a specific design. There are no sidebars, so I don't think I need to implement the widgets feature if it's not going to be used. Any another developer, I think, do the same for local business, and they sometimes not used widgets.

So basically, here I provide a patch to avoid the requirement of a widget sidebar area. 

Testing Instructions:
1. Create a basic classic theme with only `style.css` and `index.php`, can follow these two files provided in docs instructions: https://developer.wordpress.org/themes/classic-themes/your-first-theme/#classic-theme
2. Activate such theme
3. Go to the theme Customizer
4. Check server `debug.log`
5. Before patch, a warning should appear. After patch warning should be sorted.

Trac ticket: https://core.trac.wordpress.org/ticket/63151

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
