### PR TITLE
Fix wpautop() generating invalid HTML with empty paragraph tags

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -591,6 +591,15 @@ function wpautop( $text, $br = true ) {
 	$text = preg_replace( '!<br />(\s*</?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)[^>]*>)!', '$1', $text );
 	$text = preg_replace( "|\n</p>$|", '</p>', $text );
 
+	// If two closing paragraph tags are adjacent, remove the second.
+	$text = preg_replace( "|</p>\s*</p>|", '</p>', $text );
+
+	// If a block element is followed by a closing paragraph tag, remove it.
+	$text = preg_replace( '!(</?' . $allblocks . '[^>]*>)\s*</p>!', '$1', $text );
+
+	// Remove empty paragraphs.
+	$text = preg_replace( '|<p>\s*</p>|', '', $text );
+
 	// Replace placeholder <pre> tags with their original content.
 	if ( ! empty( $pre_tags ) ) {
 		$text = str_replace( array_keys( $pre_tags ), array_values( $pre_tags ), $text );

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -592,7 +592,7 @@ function wpautop( $text, $br = true ) {
 	$text = preg_replace( "|\n</p>$|", '</p>', $text );
 
 	// If two closing paragraph tags are adjacent, remove the second.
-	$text = preg_replace( "|</p>\s*</p>|", '</p>', $text );
+	$text = preg_replace( '|</p>\s*</p>|', '</p>', $text );
 
 	// If a block element is followed by a closing paragraph tag, remove it.
 	$text = preg_replace( '!(</?' . $allblocks . '[^>]*>)\s*</p>!', '$1', $text );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63148

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
