### PR TITLE
Canonical URL Tests for Attachments

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -4063,7 +4063,7 @@ function wp_get_canonical_url( $post = null ) {
 		return false;
 	}
 
-	if ( 'publish' !== $post->post_status ) {
+	if ( 'publish' !== get_post_status( $post ) ) {
 		return false;
 	}
 

--- a/tests/phpunit/tests/link/wpGetCanonicalUrl.php
+++ b/tests/phpunit/tests/link/wpGetCanonicalUrl.php
@@ -1,18 +1,52 @@
 <?php
+/**
+ * Tests for the Get Canonical Url function.
+ *
+ * @package WordPress
+ * @subpackage Link
+ */
 
 /**
+ * Class for Testing the Get Canonical Url function.
+ *
  * @group link
  * @group canonical
  * @covers ::wp_get_canonical_url
  */
-class Tests_Link_wpGetCanonicalUrl extends WP_UnitTestCase {
+class Tests_Link_WpGetCanonicalUrl extends WP_UnitTestCase {
+
+	/**
+	 * The ID of the post.
+	 *
+	 * @var int
+	 */
 	public static $post_id;
 
+	/**
+	 * The ID of the attachment.
+	 *
+	 * @var int
+	 */
+	public static $attachment_id;
+
+	/**
+	 * Sets up the test environment before any tests are run.
+	 *
+	 * @param WP_UnitTest_Factory $factory The factory object.
+	 */
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$post_id = $factory->post->create(
 			array(
 				'post_content' => 'Page 1 <!--nextpage--> Page 2 <!--nextpage--> Page 3',
 				'post_status'  => 'publish',
+			)
+		);
+
+		self::$attachment_id = $factory->attachment->create_object(
+			array(
+				'file'        => DIR_TESTDATA . '/images/canola.jpg',
+				'post_parent' => self::$post_id,
+				'post_status' => 'inherit',
 			)
 		);
 	}
@@ -138,6 +172,19 @@ class Tests_Link_wpGetCanonicalUrl extends WP_UnitTestCase {
 		$expected = user_trailingslashit( trailingslashit( get_permalink( self::$post_id ) ) . $wp_rewrite->comments_pagination_base . '-' . $cpage, 'commentpaged' ) . '#comments';
 
 		$this->assertSame( $expected, wp_get_canonical_url( self::$post_id ) );
+	}
+
+	/**
+	 * This test ensures that attachments with 'inherit' status properly receive a canonical URL.
+	 *
+	 * @ticket 63041
+	 */
+	public function test_attachment_canonical_url() {
+		$this->go_to( get_attachment_link( self::$attachment_id ) );
+		$canonical_url = wp_get_canonical_url( self::$attachment_id );
+
+		$this->assertNotFalse( $canonical_url, 'Attachment should have a canonical URL' );
+		$this->assertSame( get_attachment_link( self::$attachment_id ), $canonical_url, 'Canonical URL should match the attachment permalink' );
 	}
 
 	/**


### PR DESCRIPTION
## Combined Test Report and Unit Tests Patch 
### Description
This report validates that the indicated patch works as expected.

Patch tested: https://github.com/WordPress/wordpress-develop/pull/8435.diff

### Environment
- WordPress: 6.8-beta3-60042-src
- PHP: 8.2.28
- Server: nginx/1.27.4
- Database: mysqli (Server: 8.4.4 / Client: mysqlnd 8.2.28)
- Browser: Chrome 134.0.0.0
- OS: Windows 10/11
- Theme: My Twenty Twenty Child Theme 1.0
- MU Plugins: None activated
- Plugins:
  * Test Reports 1.2.0

### Testing Instructions without the Patch
1. Enable `wp_attachment_pages_enabled`in the `wp_options` table (change 0 to 1)
2. Upload an image to Media > Add Media File
3. Click on Edit and then click on the Media Permalink
4. Check the source code for a canonical tag.

### Expected result
The canonical tag is in the code

### Results without the Patch
1. 🐞 Bug occurs.
### Results with the Patch
1.  ✅ Issue resolved with patch.

### Additional Notes
I have also sorted all the PHPCS issues in the `wpGetCanonicalUrl.php` file (only missing comments)

Props to [@Infinite-Null](https://profiles.wordpress.org/ankitkumarshah/) for the patch https://github.com/WordPress/wordpress-develop/pull/8435
Also Props to [@othernoel](https://profiles.wordpress.org/othernoel) who clearly hinted the patch solution in the report.

Trac ticket: https://core.trac.wordpress.org/ticket/63041

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
