### PR TITLE
Fix: Handle presence of ; in CSS value while sanitizing inline styles

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2382,7 +2382,7 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 
 	$allowed_protocols = wp_allowed_protocols();
 
-	$css_array = explode( ';', trim( $css ) );
+	$css_array = preg_split( '/;(?![^()]*\)|[^"\']*["\'][^"\']*$)/', trim( $css ) );
 
 	/**
 	 * Filters the list of allowed CSS attributes.

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -939,6 +939,7 @@ EOF;
 	 * @ticket 56122
 	 * @ticket 58551
 	 * @ticket 60132
+	 * @ticket 63162
 	 *
 	 * @dataProvider data_safecss_filter_attr
 	 *
@@ -1358,6 +1359,15 @@ EOF;
 				'css'      => 'opacity: 10',
 				'expected' => 'opacity: 10',
 			),
+			// Test: Presence of `;` in the value.
+			array(
+				'css'      => '--wp-var-content: \'content; with:a;\';',
+				'expected' => '--wp-var-content: \'content; with:a;\'',
+			),
+			array(
+				'css'      => 'font-family: "My;Special:font";',
+				'expected' => 'font-family: "My;Special:font"',
+			),
 		);
 	}
 
@@ -1551,6 +1561,18 @@ EOF;
 				'background: red',
 			),
 
+			// Double quotes, URL with a semicolon.
+			array(
+				'background-image: url("/dir;/valid.gif");',
+				'background-image: url("/dir;/valid.gif")',
+			),
+
+			// Single quotes, URL with a semicolon.
+			array(
+				'background-image: url(\'/dir;/valid.gif\');',
+				'background-image: url(\'/dir;/valid.gif\')',
+			),
+
 			/*
 			 * Invalid use cases.
 			 */
@@ -1612,6 +1634,12 @@ EOF;
 			// Malformed, no closing `"`.
 			array(
 				'background-image: url( "http://example.com );',
+				'',
+			),
+
+			// Bad protocol, semi-colons in URL, data is not in default allowed protocols.
+			array(
+				'background-image: url("data:image/png;base64,base64encodeddata");',
 				'',
 			),
 		);


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

The PR handles the case when a semi-colon(;) is present in CSS value while splitting the styles while sanitizing inline-styles. 

Currently the CSS is split with `$css_array = explode( ';', trim( $css ) );` which results in unexpected sanitized inline-style if a CSS value has a `;` in it.

The PR refactors CSS string parsing to handle edge cases with semicolons inside functions or quoted strings.

Trac ticket: https://core.trac.wordpress.org/ticket/63162

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
