### PR TITLE
Adding FTP Support for Docker/Env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,9 @@ LOCAL_PHP_XDEBUG_MODE=develop,debug
 # Whether or not to enable Memcached.
 LOCAL_PHP_MEMCACHED=false
 
+# Whether or not to enable FTP.
+LOCAL_FTP=false
+
 ##
 # The database software to use.
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM wordpressdevelop/php:latest
+
+# Install the FTP extension
+RUN docker-php-ext-install ftp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,0 @@
-FROM wordpressdevelop/php:latest
-
-# Install the FTP extension
-RUN docker-php-ext-install ftp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,9 @@ services:
   # The PHP container.
   ##
   php:
-    image: wordpressdevelop/php:${LOCAL_PHP-latest}
+    build:
+      context: .
+      dockerfile: Dockerfile
 
     networks:
       - wpdevnet
@@ -137,6 +139,27 @@ services:
     depends_on:
       php:
         condition: service_started
+
+  ##
+  # The FTP container.
+  ##
+  ftp:
+    image: 'garethflowers/ftp-server:latest'
+
+    networks:
+      - wpdevnet
+
+    ports:
+      - '20-21:20-21/tcp'
+      - '40000-40009:40000-40009/tcp'
+
+    volumes:
+      - ./src/:/home/admin/
+
+    environment:
+      FTP_USER: admin
+      FTP_PASS: password
+      PUBLIC_IP: ${SERVICE_NAME:-ftp}
 
 volumes:
   # So that sites aren't wiped every time containers are restarted, MySQL uses a persistent volume.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,9 +32,7 @@ services:
   # The PHP container.
   ##
   php:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: wordpressdevelop/php:${LOCAL_PHP-latest}
 
     networks:
       - wpdevnet

--- a/tools/local-env/scripts/start.js
+++ b/tools/local-env/scripts/start.js
@@ -35,7 +35,7 @@ if ( process.env.LOCAL_PHP_MEMCACHED === 'true' ) {
 }
 
 if ( process.env.LOCAL_FTP === 'true' ) {
-	containers += 'ftp';
+	containers += ' ftp';
 }
 execSync( `docker compose ${composeFiles} up --quiet-pull -d ${containers}`, { stdio: 'inherit' } );
 

--- a/tools/local-env/scripts/start.js
+++ b/tools/local-env/scripts/start.js
@@ -28,9 +28,15 @@ try {
 }
 
 // Start the local-env containers.
-const containers = ( process.env.LOCAL_PHP_MEMCACHED === 'true' )
-	? 'wordpress-develop memcached'
-	: 'wordpress-develop';
+let containers = 'wordpress-develop';
+
+if ( process.env.LOCAL_PHP_MEMCACHED === 'true' ) {
+	containers += ' memcached';
+}
+
+if ( process.env.LOCAL_FTP === 'true' ) {
+	containers += 'ftp';
+}
 execSync( `docker compose ${composeFiles} up --quiet-pull -d ${containers}`, { stdio: 'inherit' } );
 
 // If Docker Toolbox is being used, we need to manually forward LOCAL_PORT to the Docker VM.


### PR DESCRIPTION
In my quest of trying to add some features for testing/debugging in env/docker, here I'm providing a simple setup for an FTP server than it's used in a couple of elements in WP sites.

For now, I'm not going to add instructions because, contrarily to the Mailhog patch that I think it's 100% complete, I feel that this one needs a little more polish and I need more ideas. For now, it's a working version. I might use for testing and debugging on top of certain tickets that need FTP and then rebasing to wipe this commit.

Trac ticket: https://core.trac.wordpress.org/ticket/63172

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
