### PR TITLE
Customizer: Add tooltips to responsive preview icons for improved usability

### DIFF
--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -618,6 +618,40 @@ body.trashing #publish-settings {
 	border-top: 1px solid #dcdcde;
 }
 
+/* CSS Tooltips */
+#customize-controls .tooltip {
+    position: relative;
+    overflow: visible;
+}
+
+#customize-controls .tooltip:after {
+    display: none;
+    position: absolute;
+    bottom: 100%;
+    right: 50%;
+    border: 1px solid #dcdcde;
+    margin-bottom: 5px;
+    padding: 5px 8px;
+    background: rgba(40, 40, 40, 0.9);
+    color: #fff;
+    content: attr(aria-label);
+    text-align: center;
+    transform: translateX(50%);
+    white-space: pre;
+    opacity: 0;
+    border-radius: 3px;
+    z-index: 10;
+    font-size: 13px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    transition: opacity 0.1s ease-in-out;
+}
+
+#customize-controls .tooltip:hover:after,
+#customize-controls .tooltip:focus:after {
+    display: inline-block;
+    opacity: 1;
+}
+
 .js .control-section:hover .accordion-section-title,
 .js .control-section .accordion-section-title:hover,
 .js .control-section.open .accordion-section-title,

--- a/src/wp-admin/customize.php
+++ b/src/wp-admin/customize.php
@@ -275,21 +275,21 @@ do_action( 'customize_controls_head' );
 			<?php if ( ! empty( $previewable_devices ) ) : ?>
 			<div class="devices-wrapper">
 				<div class="devices">
-					<?php foreach ( (array) $previewable_devices as $device => $settings ) : ?>
-						<?php
-						if ( empty( $settings['label'] ) ) {
-							continue;
-						}
-						$active = ! empty( $settings['default'] );
-						$class  = 'preview-' . $device;
-						if ( $active ) {
-							$class .= ' active';
-						}
-						?>
-						<button type="button" class="<?php echo esc_attr( $class ); ?>" aria-pressed="<?php echo esc_attr( $active ); ?>" data-device="<?php echo esc_attr( $device ); ?>">
-							<span class="screen-reader-text"><?php echo esc_html( $settings['label'] ); ?></span>
-						</button>
-					<?php endforeach; ?>
+				<?php foreach ( (array) $previewable_devices as $device => $settings ) : ?>
+					<?php
+					if ( empty( $settings['label'] ) ) {
+						continue;
+					}
+					$active = ! empty( $settings['default'] );
+					$class  = 'preview-' . $device . ' tooltip';
+					if ( $active ) {
+						$class .= ' active';
+					}
+					?>
+					<button type="button" class="<?php echo esc_attr( $class ); ?>" aria-pressed="<?php echo esc_attr( $active ); ?>" data-device="<?php echo esc_attr( $device ); ?>" aria-label="<?php echo esc_attr( $settings['label'] ); ?>">
+						<span class="screen-reader-text"><?php echo esc_html( $settings['label'] ); ?></span>
+					</button>
+				<?php endforeach; ?>
 				</div>
 			</div>
 			<?php endif; ?>


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/36447

This PR adds tooltip functionality to the responsive preview icons in the WordPress Customizer. By displaying tooltips on hover, users can now clearly identify the purpose of each device preview button before clicking them, enhancing usability and accessibility. 

The implementation:

- Uses `aria-label` attributes for tooltip content, which maintains accessibility
- Follows UI patterns similar to tooltip implementations elsewhere in the admin


### Before


https://github.com/user-attachments/assets/432bf2ec-3779-4e9e-ba77-cdbd2e77f04a



### After


https://github.com/user-attachments/assets/45085d9d-05a8-4eb9-90f8-0525a135d1e4


