### PR TITLE
Feat/add support uri header

### DIFF
--- a/src/wp-admin/includes/class-wp-ms-themes-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-themes-list-table.php
@@ -751,6 +751,18 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 			);
 		}
 
+		if ( $theme->get( 'SupportURI') ) {
+			/* translators: %s: Theme name. */
+			$aria_label = sprintf( __( 'Visit support site for %s' ), $theme->display( 'Name' ) );
+
+			$theme_meta[] = sprintf(
+				'<a href="%s" aria-label="%s">%s</a>',
+				$theme->display( 'SupportURI' ),
+				esc_attr( $aria_label ),
+				__( 'Visit Support Site' )
+			);
+		}
+
 		if ( $theme->parent() ) {
 			$theme_meta[] = sprintf(
 				/* translators: %s: Theme name. */

--- a/src/wp-admin/includes/class-wp-ms-themes-list-table.php
+++ b/src/wp-admin/includes/class-wp-ms-themes-list-table.php
@@ -751,7 +751,7 @@ class WP_MS_Themes_List_Table extends WP_List_Table {
 			);
 		}
 
-		if ( $theme->get( 'SupportURI') ) {
+		if ( $theme->get( 'SupportURI' ) ) {
 			/* translators: %s: Theme name. */
 			$aria_label = sprintf( __( 'Visit support site for %s' ), $theme->display( 'Name' ) );
 

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1210,6 +1210,18 @@ class WP_Plugins_List_Table extends WP_List_Table {
 						);
 					}
 
+					if ( ! empty( $plugin_data['SupportURI'] ) ) {
+						/* translators: %s: Plugin name. */
+						$aria_label = sprintf( __( 'Visit support forums for %s' ), $plugin_name );
+
+						$plugin_meta[] = sprintf(
+							'<a href="%s" aria-label="%s">%s</a>',
+							esc_url( $plugin_data['SupportURI'] ),
+							esc_attr( $aria_label ),
+							__( 'Visit support forums' )
+						);
+					}
+
 					/**
 					 * Filters the array of row meta for each plugin in the Plugins list table.
 					 *
@@ -1237,6 +1249,7 @@ class WP_Plugins_List_Table extends WP_List_Table {
 					 *     @type bool     $update-supported Whether the plugin supports updates.
 					 *     @type string   $Name             The human-readable name of the plugin.
 					 *     @type string   $PluginURI        Plugin URI.
+					 *     @type string   $SupportURI       Plugin support URI.
 					 *     @type string   $Version          Plugin version.
 					 *     @type string   $Description      Plugin description.
 					 *     @type string   $Author           Plugin author.

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -193,9 +193,9 @@ function _get_plugin_data_markup_translate( $plugin_file, $plugin_data, $markup 
 	$plugin_data['Description'] = wp_kses( $plugin_data['Description'], $allowed_tags );
 	$plugin_data['Version']     = wp_kses( $plugin_data['Version'], $allowed_tags );
 
-	$plugin_data['PluginURI'] = esc_url( $plugin_data['PluginURI'] );
+	$plugin_data['PluginURI']  = esc_url( $plugin_data['PluginURI'] );
 	$plugin_data['SupportURI'] = esc_url( $plugin_data['SupportURI'] );
-	$plugin_data['AuthorURI'] = esc_url( $plugin_data['AuthorURI'] );
+	$plugin_data['AuthorURI']  = esc_url( $plugin_data['AuthorURI'] );
 
 	$plugin_data['Title']      = $plugin_data['Name'];
 	$plugin_data['AuthorName'] = $plugin_data['Author'];

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -56,6 +56,7 @@
  *
  *     @type string $Name            Name of the plugin. Should be unique.
  *     @type string $PluginURI       Plugin URI.
+ *     @type string $SupportURI      Plugin Support URI.
  *     @type string $Version         Plugin version.
  *     @type string $Description     Plugin description.
  *     @type string $Author          Plugin author's name.
@@ -76,6 +77,7 @@ function get_plugin_data( $plugin_file, $markup = true, $translate = true ) {
 	$default_headers = array(
 		'Name'            => 'Plugin Name',
 		'PluginURI'       => 'Plugin URI',
+		'SupportURI'      => 'Support URI',
 		'Version'         => 'Version',
 		'Description'     => 'Description',
 		'Author'          => 'Author',
@@ -157,7 +159,7 @@ function _get_plugin_data_markup_translate( $plugin_file, $plugin_data, $markup 
 			$textdomain = 'default';
 		}
 		if ( $textdomain ) {
-			foreach ( array( 'Name', 'PluginURI', 'Description', 'Author', 'AuthorURI', 'Version' ) as $field ) {
+			foreach ( array( 'Name', 'PluginURI', 'SupportURI', 'Description', 'Author', 'AuthorURI', 'Version' ) as $field ) {
 				if ( ! empty( $plugin_data[ $field ] ) ) {
 					// phpcs:ignore WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText,WordPress.WP.I18n.NonSingularStringLiteralDomain
 					$plugin_data[ $field ] = translate( $plugin_data[ $field ], $textdomain );
@@ -192,6 +194,7 @@ function _get_plugin_data_markup_translate( $plugin_file, $plugin_data, $markup 
 	$plugin_data['Version']     = wp_kses( $plugin_data['Version'], $allowed_tags );
 
 	$plugin_data['PluginURI'] = esc_url( $plugin_data['PluginURI'] );
+	$plugin_data['SupportURI'] = esc_url( $plugin_data['SupportURI'] );
 	$plugin_data['AuthorURI'] = esc_url( $plugin_data['AuthorURI'] );
 
 	$plugin_data['Title']      = $plugin_data['Name'];

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -769,6 +769,7 @@ function wp_prepare_themes_for_js( $themes = null ) {
 			'description'    => $theme->display( 'Description' ),
 			'author'         => $theme->display( 'Author', false, true ),
 			'authorAndUri'   => $theme->display( 'Author' ),
+			'supportUri'     => $theme->display( 'SupportURI' ),
 			'tags'           => $theme->display( 'Tags' ),
 			'version'        => $theme->get( 'Version' ),
 			'compatibleWP'   => is_wp_version_compatible( $theme->get( 'RequiresWP' ) ),

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -1245,6 +1245,12 @@ function wp_theme_auto_update_setting_template() {
 					</p>
 				<# } #>
 
+				<# if ( data.supportUri) { #>
+					<p>
+						<a href="{{{ data.supportUri }}}" class="button button-secondary" target="_blank"><?php _e( 'Need help?' ); ?></a>
+					</p>
+				<# } #>
+
 				<# if ( data.tags ) { #>
 					<p class="theme-tags"><span><?php _e( 'Tags:' ); ?></span> {{{ data.tags }}}</p>
 				<# } #>

--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -30,6 +30,7 @@ final class WP_Theme implements ArrayAccess {
 	private static $file_headers = array(
 		'Name'        => 'Theme Name',
 		'ThemeURI'    => 'Theme URI',
+		'SupportURI'  => 'Support URI',
 		'Description' => 'Description',
 		'Author'      => 'Author',
 		'AuthorURI'   => 'Author URI',
@@ -936,7 +937,7 @@ final class WP_Theme implements ArrayAccess {
 	 * @since 6.1.0 Added support for `Update URI` header.
 	 *
 	 * @param string $header Theme header. Accepts 'Name', 'Description', 'Author', 'Version',
-	 *                       'ThemeURI', 'AuthorURI', 'Status', 'Tags', 'RequiresWP', 'RequiresPHP',
+	 *                       'ThemeURI', SupportURI, 'AuthorURI', 'Status', 'Tags', 'RequiresWP', 'RequiresPHP',
 	 *                       'UpdateURI'.
 	 * @param string $value  Value to sanitize.
 	 * @return string|array An array for Tags header, string otherwise.
@@ -978,6 +979,7 @@ final class WP_Theme implements ArrayAccess {
 				$value = wp_kses( $value, $header_tags_with_a );
 				break;
 			case 'ThemeURI':
+			case 'SupportURI':
 			case 'AuthorURI':
 				$value = sanitize_url( $value );
 				break;
@@ -1000,7 +1002,7 @@ final class WP_Theme implements ArrayAccess {
 	 *
 	 * @since 3.4.0
 	 *
-	 * @param string       $header    Theme header. Name, Description, Author, Version, ThemeURI, AuthorURI, Status, Tags.
+	 * @param string       $header    Theme header. Name, Description, Author, Version, ThemeURI, SupportURI, AuthorURI, Status, Tags.
 	 * @param string|array $value     Value to mark up. An array for Tags header, string otherwise.
 	 * @param string       $translate Whether the header has been translated.
 	 * @return string Value, marked up.
@@ -1030,6 +1032,7 @@ final class WP_Theme implements ArrayAccess {
 				$value = implode( $comma, $value );
 				break;
 			case 'ThemeURI':
+			case 'SupportURI':
 			case 'AuthorURI':
 				$value = esc_url( $value );
 				break;

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-plugins-controller.php
@@ -586,6 +586,7 @@ class WP_REST_Plugins_Controller extends WP_REST_Controller {
 			'status'       => $this->get_plugin_status( $item['_file'] ),
 			'name'         => $item['Name'],
 			'plugin_uri'   => $item['PluginURI'],
+			'support_uri'  => $item['SupportURI'],
 			'author'       => $item['Author'],
 			'author_uri'   => $item['AuthorURI'],
 			'description'  => array(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -276,6 +276,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 			'name'        => 'Name',
 			'tags'        => 'Tags',
 			'theme_uri'   => 'ThemeURI',
+			'support_uri' => 'SupportURI',
 		);
 
 		foreach ( $rich_field_mappings as $field => $header ) {

--- a/tests/phpunit/data/themedir1/default/style.css
+++ b/tests/phpunit/data/themedir1/default/style.css
@@ -1,6 +1,7 @@
 /*  
 Theme Name: WordPress Default
 Theme URI: http://wordpress.org/
+Support URI: http://wordpress.org/support/
 Description: The default WordPress theme based on the famous <a href="http://binarybonsai.com/kubrick/">Kubrick</a>.
 Version: 1.6
 Author: Michael Heilemann

--- a/tests/phpunit/tests/admin/wpPluginsListTable.php
+++ b/tests/phpunit/tests/admin/wpPluginsListTable.php
@@ -36,6 +36,7 @@ class Tests_Admin_wpPluginsListTable extends WP_UnitTestCase {
 			'Description' => 'A fake plugin for testing.',
 			'Author'      => 'WordPress',
 			'AuthorURI'   => 'https://wordpress.org/',
+			'SupportURI'  => 'https://wordpress.org/support/plugin/fake-plugin',
 			'TextDomain'  => 'fake-plugin',
 			'DomainPath'  => '/languages',
 			'Network'     => false,

--- a/tests/phpunit/tests/file.php
+++ b/tests/phpunit/tests/file.php
@@ -23,6 +23,7 @@ class Tests_File extends WP_UnitTestCase {
 		$theme_headers = array(
 			'Name'        => 'Theme Name',
 			'ThemeURI'    => 'Theme URI',
+			'SupportURI'  => 'Support URI',
 			'Description' => 'Description',
 			'Version'     => 'Version',
 			'Author'      => 'Author',
@@ -34,6 +35,7 @@ class Tests_File extends WP_UnitTestCase {
 		$expected = array(
 			'Name'        => 'WordPress Default',
 			'ThemeURI'    => 'http://wordpress.org/',
+			'SupportURI'  => 'http://wordpress.org/support/',
 			'Description' => 'The default WordPress theme based on the famous <a href="http://binarybonsai.com/kubrick/">Kubrick</a>.',
 			'Version'     => '1.6',
 			'Author'      => 'Michael Heilemann',


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Trac ticket: https://core.trac.wordpress.org/ticket/45949

This PR add support for `SupportURI` header as discussed in Trac ticket.

**Plugin's preview**
<img width="1198" alt="Screenshot 2025-03-26 at 9 09 14 PM" src="https://github.com/user-attachments/assets/07d306ce-adae-459a-b202-83dc18070bb9" />

**Theme's preview**
<img width="1192" alt="Screenshot 2025-03-26 at 9 11 09 PM" src="https://github.com/user-attachments/assets/f1be2b38-9951-4f96-9c84-db7ec0240c76" />


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
