### PR TITLE
Fix : Autocomplete Suggestions in File Editor

### DIFF
--- a/src/js/_enqueues/wp/code-editor.js
+++ b/src/js/_enqueues/wp/code-editor.js
@@ -306,6 +306,15 @@ if ( 'undefined' === typeof window.wp.codeEditor ) {
 					return;
 				}
 
+				// Don't trigger autocomplete on arrow keys for PHP files to prevent dropdown reset issue
+				if (
+					'php' === codemirror.options.mode &&
+					( event.keyCode === 38 || event.keyCode === 40 ) &&
+					codemirror.state.completionActive
+				) {
+					return;
+				}
+
 				// Prevent autocompletion in string literals or comments.
 				token = codemirror.getTokenAt( codemirror.getCursor() );
 				if ( 'string' === token.type || 'comment' === token.type ) {
@@ -339,6 +348,60 @@ if ( 'undefined' === typeof window.wp.codeEditor ) {
 
 		// Facilitate tabbing out of the editor.
 		configureTabbing( codemirror, settings );
+
+		// Fix for PHP autocompletion dropdown navigation issues
+		if ( 'php' === codemirror.options.mode ) {
+			// Create a wrapper for the showHint method that fixes PHP-specific issues
+			var originalShowHint = codemirror.showHint;
+			codemirror.showHint = function ( options ) {
+				// Call the original showHint method
+				var result = originalShowHint.call( this, options );
+
+				// Setup a keydown handler that will run before the normal CodeMirror handlers
+				if ( ! codemirror._phpAutocompleteFixAdded ) {
+					codemirror._phpAutocompleteFixAdded = true;
+
+					// Add event listener with high priority
+					codemirror.on( 'keydown', function ( cm, event ) {
+						// Only handle Up/Down keys when autocomplete is active
+						if (
+							( event.keyCode !== 38 && event.keyCode !== 40 ) ||
+							! codemirror.state.completionActive ||
+							! codemirror.state.completionActive.widget
+						) {
+							return;
+						}
+
+						var widget = codemirror.state.completionActive.widget;
+						var currentPos = widget.selectedHint;
+						var listLength = widget.data.list.length;
+
+						// For Up key at positions other than first item
+						if ( event.keyCode === 38 && currentPos > 0 ) {
+							// Manually change the active item and prevent default handling
+							widget.changeActive( currentPos - 1 );
+							event.preventDefault();
+							event.stopPropagation();
+							return;
+						}
+
+						// For Down key at positions other than last item
+						if (
+							event.keyCode === 40 &&
+							currentPos < listLength - 1
+						) {
+							// Manually change the active item and prevent default handling
+							widget.changeActive( currentPos + 1 );
+							event.preventDefault();
+							event.stopPropagation();
+							return;
+						}
+					} );
+				}
+
+				return result;
+			};
+		}
 
 		return instance;
 	};


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Fixed autocomplete dropdown navigation for PHP files : 
- Intercepting Up/Down arrow keys
- Manually handling hint selection to prevent the cursor resetting to the first item when navigating through suggestions.

Trac ticket: https://core.trac.wordpress.org/ticket/63161

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
