### PR TITLE
Improving ftpext exists function

### DIFF
--- a/src/wp-admin/includes/class-wp-filesystem-ftpext.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpext.php
@@ -426,13 +426,19 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 	 * @return bool Whether $path exists or not.
 	 */
 	public function exists( $path ) {
+		// @63173 Special case for root directory.
+		if ( '/' === $path ) {
+			return true;
+		}
+
 		$parent_dir = dirname( $path );
 		$filename   = basename( $path );
-		$list       = ftp_rawlist( $this->link, $parent_dir );
+		$list       = ftp_rawlist( $this->link, '-al ' . $parent_dir );
 
 		if ( ! empty( $list ) ) {
 			foreach ( $list as $ftp_listing_line ) {
-				if ( str_contains( $ftp_listing_line, $filename ) ) {
+				$entry = $this->parselisting( $ftp_listing_line );
+				if ( ! empty( $entry ) && $entry['name'] === $filename ) {
 					return true;
 				}
 			}

--- a/src/wp-admin/includes/class-wp-filesystem-ftpext.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpext.php
@@ -435,6 +435,23 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 			return false;
 		}
 
+		// For deeper paths (2), better use ftp_rawlist() instead of ftp_nlist()
+		$path_depth = substr_count( $path, '/' );
+		if ( $path_depth > 2 ) {
+			$parent_dir = dirname( $path );
+			$filename   = basename( $path );
+			$list       = ftp_rawlist( $this->link, $parent_dir );
+
+			if ( ! empty( $list ) ) {
+				foreach ( $list as $line ) {
+					if ( strpos( $line, $filename ) !== false ) {
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+
 		$list = ftp_nlist( $this->link, $path );
 
 		if ( empty( $list ) && $this->is_dir( $path ) ) {

--- a/src/wp-admin/includes/class-wp-filesystem-ftpext.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpext.php
@@ -420,46 +420,26 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 	 *
 	 * @since 2.5.0
 	 * @since 6.3.0 Returns false for an empty path.
+	 * @since 6.8.0 Switching to ftp_rawlist() for better compatibility with long paths.
 	 *
 	 * @param string $path Path to file or directory.
 	 * @return bool Whether $path exists or not.
 	 */
 	public function exists( $path ) {
-		/*
-		 * Check for empty path. If ftp_nlist() receives an empty path,
-		 * it checks the current working directory and may return true.
-		 *
-		 * See https://core.trac.wordpress.org/ticket/33058.
-		 */
-		if ( '' === $path ) {
-			return false;
-		}
+		$parent_dir = dirname( $path );
+		$filename   = basename( $path );
+		$list       = ftp_rawlist( $this->link, $parent_dir );
 
-		// For deeper paths (2), better use ftp_rawlist() instead of ftp_nlist()
-		$path_depth = substr_count( $path, '/' );
-		if ( $path_depth > 2 ) {
-			$parent_dir = dirname( $path );
-			$filename   = basename( $path );
-			$list       = ftp_rawlist( $this->link, $parent_dir );
-
-			if ( ! empty( $list ) ) {
-				foreach ( $list as $line ) {
-					if ( strpos( $line, $filename ) !== false ) {
-						return true;
-					}
+		if ( ! empty( $list ) ) {
+			foreach ( $list as $ftp_listing_line ) {
+				if ( str_contains( $ftp_listing_line, $filename ) ) {
+					return true;
 				}
 			}
-			return false;
 		}
-
-		$list = ftp_nlist( $this->link, $path );
-
-		if ( empty( $list ) && $this->is_dir( $path ) ) {
-			return true; // File is an empty directory.
-		}
-
-		return ! empty( $list ); // Empty list = no file, so invert.
+		return false;
 	}
+
 
 	/**
 	 * Checks if resource is a file.

--- a/src/wp-admin/includes/class-wp-filesystem-ftpext.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpext.php
@@ -426,7 +426,11 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 	 * @return bool Whether $path exists or not.
 	 */
 	public function exists( $path ) {
-		// @63173 Special case for root directory.
+		/*
+		 * Special case for root directory if the path is '/'.
+		 *
+		 * See https://core.trac.wordpress.org/ticket/63173.
+		 */
 		if ( '/' === $path ) {
 			return true;
 		}


### PR DESCRIPTION
This patch is very tricky to test, here I'm going to provide some info and instructions.

The error comes when the FTP path is extremely long. This happens for example on core updates (with nightly versions), it creates a folder with a very long name, and then a full wordpress structure inside `wp-content/upgrades`

The simplest way to test this is the following:
1. Set an FTP in the server
2. Set up the FS_METHOD to ftpext (`wp-config.php`) with the FTP credentials
3. Install a WordPress nightly version but not the latest (go with the previous one so it will trigger an update)

You can also do these steps: https://core.trac.wordpress.org/ticket/62718#comment:20 to setup your own docker environment using the `wordpress-develop` env

Once you have everything set-up:
4. Go to the Admin area, then Dashboard > Updates
5. Update to latest nightly button 
6. Without the patch it should throw an error: `The update could not be unpacked`
7. With the patch it might throw other errors unrelated to this particular report, but it will end updating.

Trac ticket: https://core.trac.wordpress.org/ticket/63173

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
