### PR TITLE
REST API: Capitalize "REST" in error message

### DIFF
--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -434,7 +434,7 @@ function rest_api_loaded() {
 	if ( ! is_string( $GLOBALS['wp']->query_vars['rest_route'] ) ) {
 		$rest_type_error = new WP_Error(
 			'rest_path_invalid_type',
-			__( 'The rest route parameter must be a string.' ),
+			__( 'The REST route parameter must be a string.' ),
 			array( 'status' => 400 )
 		);
 		wp_die( $rest_type_error );

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -440,7 +440,6 @@ function rest_api_loaded() {
 		wp_die( $rest_type_error );
 	}
 
-
 	/**
 	 * Whether this is a REST Request.
 	 *

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -440,6 +440,7 @@ function rest_api_loaded() {
 		wp_die( $rest_type_error );
 	}
 
+
 	/**
 	 * Whether this is a REST Request.
 	 *

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -2577,7 +2577,7 @@ class Tests_REST_API extends WP_UnitTestCase {
 			rest_api_loaded();
 		} catch ( WPDieException $e ) {
 			$this->assertStringContainsString(
-				'The rest route parameter must be a string.',
+				'The REST route parameter must be a string.',
 				$e->getMessage()
 			);
 			throw $e; // Re-throw to satisfy expectException

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -2580,6 +2580,7 @@ class Tests_REST_API extends WP_UnitTestCase {
 				'The REST route parameter must be a string.',
 				$e->getMessage()
 			);
+			
 			throw $e; // Re-throw to satisfy expectException
 		}
 	}

--- a/tests/phpunit/tests/rest-api.php
+++ b/tests/phpunit/tests/rest-api.php
@@ -2580,7 +2580,6 @@ class Tests_REST_API extends WP_UnitTestCase {
 				'The REST route parameter must be a string.',
 				$e->getMessage()
 			);
-			
 			throw $e; // Re-throw to satisfy expectException
 		}
 	}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63193


This PR fixes the capitalization of "REST" in an error message and its corresponding test.
Previously, the error message was using "rest" (lowercase) instead of the proper acronym "REST" (uppercase). 
The changes are reflected in the test files as well.
