### PR TITLE
Unify timestamps of query cache keys

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2882,7 +2882,7 @@ class WP_Query {
 			$comments_request = "SELECT $distinct {$wpdb->comments}.comment_ID FROM {$wpdb->comments} $cjoin $cwhere $cgroupby $corderby $climits";
 
 			$key          = md5( $comments_request );
-			$last_changed = wp_cache_get_last_changed( 'posts' ) . '+' . wp_cache_get_last_changed( 'comment' );
+			$last_changed = wp_cache_get_last_changed( 'comment' ) . '+' . wp_cache_get_last_changed( 'posts' );
 
 			$cache_key   = "comment_feed:$key:$last_changed";
 			$comment_ids = wp_cache_get( $cache_key, 'comment-queries' );

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -5064,7 +5064,7 @@ class WP_Query {
 
 		$last_changed = wp_cache_get_last_changed( 'posts' );
 		if ( ! empty( $this->tax_query->queries ) ) {
-			$last_changed = wp_cache_get_last_changed( 'terms' ) . "+" . $last_changed;
+			$last_changed = wp_cache_get_last_changed( 'terms' ) . '+' . $last_changed;
 		}
 
 		$this->query_cache_key = "wp_query:$key:$last_changed";

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -5064,7 +5064,7 @@ class WP_Query {
 
 		$last_changed = wp_cache_get_last_changed( 'posts' );
 		if ( ! empty( $this->tax_query->queries ) ) {
-			$last_changed .= wp_cache_get_last_changed( 'terms' );
+			$last_changed = wp_cache_get_last_changed( 'terms' ) . "+" . $last_changed;
 		}
 
 		$this->query_cache_key = "wp_query:$key:$last_changed";

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2882,7 +2882,7 @@ class WP_Query {
 			$comments_request = "SELECT $distinct {$wpdb->comments}.comment_ID FROM {$wpdb->comments} $cjoin $cwhere $cgroupby $corderby $climits";
 
 			$key          = md5( $comments_request );
-			$last_changed = wp_cache_get_last_changed( 'comment' ) . '+' . wp_cache_get_last_changed( 'posts' );
+			$last_changed = wp_cache_get_last_changed( 'posts' ) . '+' . wp_cache_get_last_changed( 'comment' );
 
 			$cache_key   = "comment_feed:$key:$last_changed";
 			$comment_ids = wp_cache_get( $cache_key, 'comment-queries' );
@@ -5064,7 +5064,7 @@ class WP_Query {
 
 		$last_changed = wp_cache_get_last_changed( 'posts' );
 		if ( ! empty( $this->tax_query->queries ) ) {
-			$last_changed = wp_cache_get_last_changed( 'terms' ) . '+' . $last_changed;
+			$last_changed .= '+' . wp_cache_get_last_changed( 'terms' );
 		}
 
 		$this->query_cache_key = "wp_query:$key:$last_changed";

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2882,7 +2882,7 @@ class WP_Query {
 			$comments_request = "SELECT $distinct {$wpdb->comments}.comment_ID FROM {$wpdb->comments} $cjoin $cwhere $cgroupby $corderby $climits";
 
 			$key          = md5( $comments_request );
-			$last_changed = wp_cache_get_last_changed( 'comment' ) . ':' . wp_cache_get_last_changed( 'posts' );
+			$last_changed = wp_cache_get_last_changed( 'comment' ) . '+' . wp_cache_get_last_changed( 'posts' );
 
 			$cache_key   = "comment_feed:$key:$last_changed";
 			$comment_ids = wp_cache_get( $cache_key, 'comment-queries' );

--- a/src/wp-includes/class-wp-user-query.php
+++ b/src/wp-includes/class-wp-user-query.php
@@ -1080,7 +1080,7 @@ class WP_User_Query {
 				switch_to_blog( $blog_id );
 			}
 
-			$last_changed .= wp_cache_get_last_changed( 'posts' );
+			$last_changed = wp_cache_get_last_changed( 'posts' ) . '+' . $last_changed;
 
 			if ( $switch ) {
 				restore_current_blog();

--- a/src/wp-includes/class-wp-user-query.php
+++ b/src/wp-includes/class-wp-user-query.php
@@ -1080,7 +1080,7 @@ class WP_User_Query {
 				switch_to_blog( $blog_id );
 			}
 
-			$last_changed = wp_cache_get_last_changed( 'posts' ) . '+' . $last_changed;
+			$last_changed .= '+' . wp_cache_get_last_changed( 'posts' );
 
 			if ( $switch ) {
 				restore_current_blog();

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2007,7 +2007,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	$key          = md5( $query );
 	$last_changed = wp_cache_get_last_changed( 'posts' );
 	if ( $in_same_term || ! empty( $excluded_terms ) ) {
-		$last_changed = wp_cache_get_last_changed( 'terms' ) . '+' . $last_changed;
+		$last_changed .= '+' . wp_cache_get_last_changed( 'terms' );
 	}
 	$cache_key = "adjacent_post:$key:$last_changed";
 

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2007,7 +2007,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	$key          = md5( $query );
 	$last_changed = wp_cache_get_last_changed( 'posts' );
 	if ( $in_same_term || ! empty( $excluded_terms ) ) {
-		$last_changed .= wp_cache_get_last_changed( 'terms' );
+		$last_changed = wp_cache_get_last_changed( 'terms' ) . '+' . $last_changed;
 	}
 	$cache_key = "adjacent_post:$key:$last_changed";
 


### PR DESCRIPTION
This is a followup to #8615. Currently query cache keys are un-parseable and they should be unified. 

```
<hash>:0.91192600-1743003204:0.90454100-1743003204
<hash>:0.91192600-17430032040.90454100-1743003204
<hash>:0.90454100-1743003204
```

I propose this new format, where the primary cache group is always last:

```
<hash>:<2nd-group>+<group>
<hash>:<group>

<hash>:0.91192600-1743003204+0.90454100-1743003204
<hash>:0.90454100-1743003204
```

Trac ticket: https://core.trac.wordpress.org/ticket/63195

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
