### PR TITLE
Error prevention checks for delete and mkdir in FTPext

### DIFF
--- a/src/wp-admin/includes/class-wp-filesystem-ftpext.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpext.php
@@ -392,7 +392,7 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 	 * @return bool True on success, false on failure.
 	 */
 	public function delete( $file, $recursive = false, $type = false ) {
-		if ( empty( $file ) ) {
+		if ( empty( $file ) || ! $this->exists( $file ) ) {
 			return false;
 		}
 
@@ -573,7 +573,7 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 	public function mkdir( $path, $chmod = false, $chown = false, $chgrp = false ) {
 		$path = untrailingslashit( $path );
 
-		if ( empty( $path ) ) {
+		if ( empty( $path ) || $this->exists( $path ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
This patch introduces two little little checks for file/dir existence, one in mkdir and one in rmdir. 

Generally mkdir and delete/rmdir functions introduce an error control operator to filter out the `exists` checks that are generally implicit in both functions (both to check if already exist, or if the directory doesn't exist, respectively). 

This introduces two problems: This is against WordPress CS, and when debugging with `track_errors` enabled this is a pain in the stomach. For this reason, ideally the error control operator should avoided whenever possible and handle the special cases orderly. This said, the current state of functions were not even using this error control operator, so they were generating a ton of Warnings.

Trac ticket: https://core.trac.wordpress.org/ticket/63197

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
