### PR TITLE
Fixed stylings issues on the posts quick edit section for auchor and date part.

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1040,8 +1040,10 @@ tr.inline-edit-row td {
 	line-height: 2.3;
 }
 
-fieldset.inline-edit-date .timestamp-wrap label {
-	margin-bottom: 0.2em;
+@media screen and (min-width: 782px) {
+	fieldset.inline-edit-date .timestamp-wrap label {
+		margin-bottom: 0.2em;
+	}
 }
 
 .inline-edit-row fieldset .inline-edit-author {

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1037,7 +1037,15 @@ tr.inline-edit-row td {
 	display: block;
 	float: left;
 	width: 6em;
-	line-height: 2.5;
+	line-height: 2.3;
+}
+
+fieldset.inline-edit-date .timestamp-wrap label {
+	margin-bottom: 0.2em;
+}
+
+.inline-edit-row fieldset .inline-edit-author {
+	width: max-content;
 }
 
 #posts-filter fieldset.inline-edit-date legend {


### PR DESCRIPTION


<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This PR fixes the following things:

- In the Post list page, and inside the quick edit, the time in the date part doesn't have the appropriate space in responsive.

- Also when we hover even outside part of the Author part still the dropdown get focused.

Trac ticket: https://core.trac.wordpress.org/ticket/63198

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
