### PR TITLE
Fix: Update `wp_verify_fast_hash` to use `wp_check_password` for backward compatibility

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -9168,8 +9168,8 @@ function wp_verify_fast_hash(
 ): bool {
 	if ( ! str_starts_with( $hash, '$generic$' ) ) {
 		// Back-compat for old phpass hashes.
-		require_once ABSPATH . WPINC . '/class-phpass.php';
-		return ( new PasswordHash( 8, true ) )->CheckPassword( $message, $hash );
+		return wp_check_password( $message, $hash );
+
 	}
 
 	return hash_equals( $hash, wp_fast_hash( $message ) );


### PR DESCRIPTION
Trac Ticket: Core-63203