### PR TITLE
#63203 Correct the fallback behaviour for application passwords that don't use a generic hash

### DIFF
--- a/src/wp-includes/class-wp-application-passwords.php
+++ b/src/wp-includes/class-wp-application-passwords.php
@@ -502,6 +502,12 @@ class WP_Application_Passwords {
 		string $password,
 		string $hash
 	): bool {
+		if ( ! str_starts_with( $hash, '$generic$' ) ) {
+			// If the hash doesn't start with `$generic$`, it is a hash created with `wp_hash_password()`.
+			// This is the case for application passwords created before 6.8.0.
+			return wp_check_password( $password, $hash );
+		}
+
 		return wp_verify_fast_hash( $password, $hash );
 	}
 }

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -9150,8 +9150,8 @@ function wp_fast_hash(
  * Checks whether a plaintext message matches the hashed value. Used to verify values hashed via wp_fast_hash().
  *
  * The function uses Sodium to hash the message and compare it to the hashed value. If the hash is not a generic hash,
- * the hash is treated as a phpass portable hash in order to provide backward compatibility for application passwords
- * which were hashed using phpass prior to WordPress 6.8.0.
+ * the hash is treated as a phpass portable hash in order to provide backward compatibility for passwords and security
+ * keys which were hashed using phpass prior to WordPress 6.8.0.
  *
  * @since 6.8.0
  *

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -1615,6 +1615,19 @@ class Tests_Auth extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 21022
+	 * @ticket 63203
+	 */
+	public function test_application_password_is_hashed_with_fast_hash() {
+		$user_id = self::factory()->user->create();
+
+		// Create a new app-only password.
+		list( $_, $item ) = WP_Application_Passwords::create_new_application_password( $user_id, array( 'name' => 'phpunit' ) );
+
+		$this->assertStringStartsWith( '$generic$', $item['password'] );
+	}
+
+	/**
 	 * @ticket 42790
 	 */
 	public function test_authenticate_application_password_respects_existing_user() {

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -1619,10 +1619,8 @@ class Tests_Auth extends WP_UnitTestCase {
 	 * @ticket 63203
 	 */
 	public function test_application_password_is_hashed_with_fast_hash() {
-		$user_id = self::factory()->user->create();
-
 		// Create a new app-only password.
-		list( $_, $item ) = WP_Application_Passwords::create_new_application_password( $user_id, array( 'name' => 'phpunit' ) );
+		list( $_, $item ) = WP_Application_Passwords::create_new_application_password( self::$user_id, array( 'name' => 'phpunit' ) );
 
 		$this->assertStringStartsWith( '$generic$', $item['password'] );
 	}

--- a/tests/phpunit/tests/auth.php
+++ b/tests/phpunit/tests/auth.php
@@ -1135,6 +1135,29 @@ class Tests_Auth extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 21022
+	 * @ticket 63203
+	 */
+	public function test_plain_bcrypt_application_password_is_accepted() {
+		add_filter( 'application_password_is_api_request', '__return_true' );
+		add_filter( 'wp_is_application_passwords_available', '__return_true' );
+
+		$password = 'password';
+
+		// Set an application password with plain bcrypt, which mimics a password that was hashed with
+		// a custom `wp_hash_password()` in use.
+		$uuid = self::set_application_password_with_plain_bcrypt( $password, self::$user_id );
+
+		// Authenticate.
+		$user = wp_authenticate_application_password( null, self::USER_LOGIN, $password );
+
+		// Verify that the plain bcrypt hash for the application password was valid.
+		$this->assertNotWPError( $user );
+		$this->assertInstanceOf( 'WP_User', $user );
+		$this->assertSame( self::$user_id, $user->ID );
+	}
+
+	/**
 	 * @dataProvider data_usernames
 	 *
 	 * @ticket 21022
@@ -1966,6 +1989,27 @@ class Tests_Auth extends WP_UnitTestCase {
 	/**
 	 * Test the tests
 	 *
+	 * @covers Tests_Auth::set_application_password_with_plain_bcrypt
+	 *
+	 * @ticket 21022
+	 * @ticket 63203
+	 */
+	public function test_set_application_password_with_plain_bcrypt() {
+		// Set an application password with the plain_bcrypt algorithm.
+		$uuid = self::set_application_password_with_plain_bcrypt( 'password', self::$user_id );
+
+		// Ensure the password is hashed with plain_bcrypt.
+		$hash = WP_Application_Passwords::get_user_application_password( self::$user_id, $uuid )['password'];
+		$this->assertStringStartsWith( '$2y$', $hash );
+	}
+
+	private static function set_application_password_with_plain_bcrypt( string $password, int $user_id ) {
+		return self::set_application_password( password_hash( $password, PASSWORD_BCRYPT ), $user_id );
+	}
+
+	/**
+	 * Test the tests
+	 *
 	 * @covers Tests_Auth::set_application_password_with_phpass
 	 *
 	 * @ticket 21022
@@ -1980,12 +2024,16 @@ class Tests_Auth extends WP_UnitTestCase {
 	}
 
 	private static function set_application_password_with_phpass( string $password, int $user_id ) {
+		return self::set_application_password( self::$wp_hasher->HashPassword( $password ), $user_id );
+	}
+
+	private static function set_application_password( string $hash, int $user_id ) {
 		$uuid = wp_generate_uuid4();
 		$item = array(
 			'uuid'      => $uuid,
 			'app_id'    => '',
 			'name'      => 'Test',
-			'password'  => self::$wp_hasher->HashPassword( $password ),
+			'password'  => $hash,
 			'created'   => time(),
 			'last_used' => null,
 			'last_ip'   => null,


### PR DESCRIPTION
This change adjusts the back-compat behaviour for application passwords.

Prior to 6.8 application password were hashed using `wp_hash_password()`. Since 6.8 they are hashed with `wp_fast_hash()`. The existing back-compat layer inside `wp_verify_fast_hash ()` isn't entirely accurate because it provides back-compat for phpass portable hashes, but `wp_hash_password()` is pluggable which means application passwords prior to 6.8 might have been hashed using another algorithm if the function was overridden.

For fully accurate back-compat support, `wp_check_password()` needs to be used instead of a direct call to phpass.

The existing back-compat inside `wp_verify_fast_hash()` that calls phpass directly should remain in place because this provides the back-compat for password reset keys, user request keys, and the recovery mode key, all of which used phpass directly prior to 6.8.

---

Trac ticket: https://core.trac.wordpress.org/ticket/63203