### PR TITLE
Removing PHP notice for non pattern definition files

### DIFF
--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -1902,6 +1902,10 @@ final class WP_Theme implements ArrayAccess {
 		foreach ( $files as $file ) {
 			$pattern = get_file_data( $file, $default_headers );
 
+			if ( empty( $pattern['slug'] ) && empty( $pattern['title'] ) ) {
+				continue;
+			}
+
 			if ( empty( $pattern['slug'] ) ) {
 				_doing_it_wrong(
 					__FUNCTION__,

--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -1863,12 +1863,12 @@ final class WP_Theme implements ArrayAccess {
 		/**
 		 * Filters list of block pattern files for a theme.
 		 *
-		 * @since 6.8
+		 * @since 6.8.0
 		 *
 		 * @param array  $files   Array of theme files found within `patterns` directory.
 		 * @param string $dirpath Path of theme `patterns` directory being scanned.
 		 */
-		$files = (array) apply_filters( 'get_block_patterns_files', $files, $dirpath );
+		$files = apply_filters( 'theme_block_pattern_files', $files, $dirpath );
 
 		$dirpath = trailingslashit( $dirpath );
 
@@ -1902,10 +1902,6 @@ final class WP_Theme implements ArrayAccess {
 
 		foreach ( $files as $file ) {
 			$pattern = get_file_data( $file, $default_headers );
-
-			if ( empty( $pattern['slug'] ) && empty( $pattern['title'] ) ) {
-				continue;
-			}
 
 			if ( empty( $pattern['slug'] ) ) {
 				_doing_it_wrong(

--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -1894,15 +1894,7 @@ final class WP_Theme implements ArrayAccess {
 			$pattern = get_file_data( $file, $default_headers );
 
 			if ( empty( $pattern['slug'] ) ) {
-				_doing_it_wrong(
-					__FUNCTION__,
-					sprintf(
-						/* translators: 1: file name. */
-						__( 'Could not register file "%s" as a block pattern ("Slug" field missing)' ),
-						$file
-					),
-					'6.0.0'
-				);
+				// Skip any file without pattern slug definition.
 				continue;
 			}
 

--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -1860,6 +1860,15 @@ final class WP_Theme implements ArrayAccess {
 
 		$files = (array) self::scandir( $dirpath, 'php', -1 );
 
+		/**
+		 * Filters list of block pattern files for a theme.
+		 *
+		 * @since 6.8
+		 *
+		 * @param array $files Array of theme files found within `patterns` directory.
+		 */
+		$files = (array) apply_filters( 'get_block_patterns_files', $files );
+
 		$dirpath = trailingslashit( $dirpath );
 
 		if ( ! $files ) {
@@ -1894,7 +1903,15 @@ final class WP_Theme implements ArrayAccess {
 			$pattern = get_file_data( $file, $default_headers );
 
 			if ( empty( $pattern['slug'] ) ) {
-				// Skip any file without pattern slug definition.
+				_doing_it_wrong(
+					__FUNCTION__,
+					sprintf(
+						/* translators: 1: file name. */
+						__( 'Could not register file "%s" as a block pattern ("Slug" field missing)' ),
+						$file
+					),
+					'6.0.0'
+				);
 				continue;
 			}
 

--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -1865,9 +1865,10 @@ final class WP_Theme implements ArrayAccess {
 		 *
 		 * @since 6.8
 		 *
-		 * @param array $files Array of theme files found within `patterns` directory.
+		 * @param array  $files   Array of theme files found within `patterns` directory.
+		 * @param string $dirpath Path of theme `patterns` directory being scanned.
 		 */
-		$files = (array) apply_filters( 'get_block_patterns_files', $files );
+		$files = (array) apply_filters( 'get_block_patterns_files', $files, $dirpath );
 
 		$dirpath = trailingslashit( $dirpath );
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Skipping non-pattern-definition PHP files within `theme-slug/patterns` folder during block pattern registration.
This allows using helper PHP files within `theme-slug/patterns` folder, keeping pattern related code in the theme together.

Trac ticket: https://core.trac.wordpress.org/ticket/63212

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
