### PR TITLE
Introduce taxonomy-specific cache invalidation methods

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -5066,7 +5066,9 @@ class WP_Query {
 		if ( ! empty( $this->tax_query->queries ) ) {
 			$taxonomies = array();
 			foreach ( $this->tax_query->queries as $tax_query ) {
-				$taxonomies[] = $tax_query['taxonomy'];
+				if ( isset( $tax_query['taxonomy'] ) ) {
+					$taxonomies[] = $tax_query['taxonomy'];
+				}
 			}
 			$last_changed .= wp_cache_get_taxonomies_last_changed( $taxonomies );
 		}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -5064,7 +5064,11 @@ class WP_Query {
 
 		$last_changed = wp_cache_get_last_changed( 'posts' );
 		if ( ! empty( $this->tax_query->queries ) ) {
-			$last_changed .= wp_cache_get_last_changed( 'terms' );
+			$taxonomies = array();
+			foreach ( $this->tax_query->queries as $tax_query ) {
+				$taxonomies[] = $tax_query['taxonomy'];
+			}
+			$last_changed .= wp_cache_get_taxonomies_last_changed( $taxonomies );
 		}
 
 		$this->query_cache_key = "wp_query:$key:$last_changed";

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -1171,8 +1171,8 @@ class WP_Term_Query {
 		// Replace wpdb placeholder in the SQL statement used by the cache key.
 		$sql = $wpdb->remove_placeholder_escape( $sql );
 
-		$key          = md5( serialize( $cache_args ) . $sql );
-		$last_changed = wp_cache_get_last_changed( 'terms' );
+		$key = md5( serialize( $cache_args ) . $sql );
+		$last_changed = wp_cache_get_taxonomies_last_changed( (array) $args['taxonomy'] );
 		return "get_terms:$key:$last_changed";
 	}
 }

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -1171,8 +1171,24 @@ class WP_Term_Query {
 		// Replace wpdb placeholder in the SQL statement used by the cache key.
 		$sql = $wpdb->remove_placeholder_escape( $sql );
 
-		$key = md5( serialize( $cache_args ) . $sql );
+		$key          = md5( serialize( $cache_args ) . $sql );
 		$last_changed = wp_cache_get_taxonomies_last_changed( (array) $args['taxonomy'] );
+		$meta_keys    = array(
+			'meta_key',
+			'meta_value',
+			'meta_compare',
+			'meta_compare_key',
+			'meta_type',
+			'meta_type_key',
+			'meta_query',
+		);
+		foreach ( $meta_keys as $meta_key ) {
+			if ( isset( $cache_args[ $meta_key ] ) ) {
+				$last_changed .= ':' . wp_cache_get_last_changed( 'term_meta' );
+				break;
+			}
+		}
+
 		return "get_terms:$key:$last_changed";
 	}
 }

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -135,9 +135,9 @@ add_action( 'set_user_role', 'wp_cache_set_users_last_changed' );
 add_action( 'remove_user_role', 'wp_cache_set_users_last_changed' );
 
 // Term meta.
-add_action( 'added_term_meta', 'wp_cache_set_terms_last_changed' );
-add_action( 'updated_term_meta', 'wp_cache_set_terms_last_changed' );
-add_action( 'deleted_term_meta', 'wp_cache_set_terms_last_changed' );
+add_action( 'added_term_meta', 'wp_cache_clear_term_meta', 10, 2 );
+add_action( 'updated_term_meta', 'wp_cache_clear_term_meta', 10, 2 );
+add_action( 'deleted_term_meta', 'wp_cache_clear_term_meta', 10, 2 );
 add_filter( 'get_term_metadata', 'wp_check_term_meta_support_prefilter' );
 add_filter( 'add_term_metadata', 'wp_check_term_meta_support_prefilter' );
 add_filter( 'update_term_metadata', 'wp_check_term_meta_support_prefilter' );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -135,9 +135,9 @@ add_action( 'set_user_role', 'wp_cache_set_users_last_changed' );
 add_action( 'remove_user_role', 'wp_cache_set_users_last_changed' );
 
 // Term meta.
-add_action( 'added_term_meta', 'wp_cache_clear_term_meta', 10, 2 );
-add_action( 'updated_term_meta', 'wp_cache_clear_term_meta', 10, 2 );
-add_action( 'deleted_term_meta', 'wp_cache_clear_term_meta', 10, 2 );
+add_action( 'added_term_meta', 'wp_cache_clear_term_meta' );
+add_action( 'updated_term_meta', 'wp_cache_clear_term_meta' );
+add_action( 'deleted_term_meta', 'wp_cache_clear_term_meta' );
 add_filter( 'get_term_metadata', 'wp_check_term_meta_support_prefilter' );
 add_filter( 'add_term_metadata', 'wp_check_term_meta_support_prefilter' );
 add_filter( 'update_term_metadata', 'wp_check_term_meta_support_prefilter' );

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2007,7 +2007,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	$key          = md5( $query );
 	$last_changed = wp_cache_get_last_changed( 'posts' );
 	if ( $in_same_term || ! empty( $excluded_terms ) ) {
-		$last_changed .= wp_cache_get_last_changed( 'terms' );
+		$last_changed .= wp_cache_get_taxonomy_last_changed( $taxonomy );
 	}
 	$cache_key = "adjacent_post:$key:$last_changed";
 

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -5123,16 +5123,10 @@ function is_term_publicly_viewable( $term ) {
  * and marks them as "last changed" to reflect the updates or changes made to the meta data.
  *
  * @since x.x.x
- *
- * @param int $meta_id ID of the term meta to be cleared.
- * @param int $object_id ID of the term associated with the meta to be cleared.
  */
-function wp_cache_clear_term_meta( $meta_id, $object_id ) {
+function wp_cache_clear_term_meta() {
 	wp_cache_set_terms_last_changed();
-	$term = get_term( $object_id );
-	if ( $term instanceof WP_Term ) {
-		wp_cache_set_taxonomy_last_changed( $term->taxonomy );
-	}
+	wp_cache_set_last_changed( 'term_meta' );
 }
 
 /**

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -3634,10 +3634,13 @@ function clean_object_term_cache( $object_ids, $object_type ) {
 
 	$taxonomies = get_object_taxonomies( $object_type );
 
+	$cache_keys = array();
 	foreach ( $taxonomies as $taxonomy ) {
 		wp_cache_delete_multiple( $object_ids, "{$taxonomy}_relationships" );
-		wp_cache_set_taxonomy_last_changed( $taxonomy );
+		$cache_keys[] = $taxonomy . ':last_changed';
 	}
+
+	wp_cache_delete_multiple( $cache_keys, 'terms' );
 
 	wp_cache_set_terms_last_changed();
 

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -5169,10 +5169,13 @@ function wp_cache_get_taxonomy_last_changed( $taxonomy ) {
  *
  * @since x.x.x
  *
- * @return float UNIX timestamp with microseconds representing when the group was last changed.
+ * @return string UNIX timestamp with microseconds representing when the group was last changed.
  */
 function wp_cache_get_taxonomies_last_changed( array $taxonomies ) {
 	$taxonomies = array_unique( array_filter( $taxonomies ) );
+	if ( empty( $taxonomies ) ) {
+		return wp_cache_get_last_changed( 'terms' );
+	}
 	sort( $taxonomies );
 	$cache_keys = array_map(
 		static function ( $taxonomy ) {
@@ -5184,7 +5187,7 @@ function wp_cache_get_taxonomies_last_changed( array $taxonomies ) {
 	$last_changes = array_map( 'wp_cache_get_taxonomy_last_changed', $taxonomies );
 	$last_changes = array_map( 'floatval', $last_changes );
 
-	return array_sum( $last_changes );
+	return (string) array_sum( $last_changes );
 }
 
 /**

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -5174,6 +5174,13 @@ function wp_cache_get_taxonomy_last_changed( $taxonomy ) {
 function wp_cache_get_taxonomies_last_changed( array $taxonomies ) {
 	$taxonomies = array_unique( array_filter( $taxonomies ) );
 	sort( $taxonomies );
+	$cache_keys = array_map(
+		$taxonomies,
+		static function ( $taxonomy ) {
+			return $taxonomy . ':last_changed';
+		}
+	);
+	wp_cache_get_multiple( $cache_keys, 'terms' );
 	$last_changes = array_map( 'wp_cache_get_taxonomy_last_changed', $taxonomies );
 	$last_changes = array_map( 'floatval', $last_changes );
 

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -5175,10 +5175,10 @@ function wp_cache_get_taxonomies_last_changed( array $taxonomies ) {
 	$taxonomies = array_unique( array_filter( $taxonomies ) );
 	sort( $taxonomies );
 	$cache_keys = array_map(
-		$taxonomies,
 		static function ( $taxonomy ) {
 			return $taxonomy . ':last_changed';
-		}
+		},
+		$taxonomies
 	);
 	wp_cache_get_multiple( $cache_keys, 'terms' );
 	$last_changes = array_map( 'wp_cache_get_taxonomy_last_changed', $taxonomies );

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -5158,6 +5158,9 @@ function wp_cache_set_taxonomy_last_changed( $taxonomy ) {
  * @return float UNIX timestamp with microseconds representing when the taxonomy was last changed.
  */
 function wp_cache_get_taxonomy_last_changed( $taxonomy ) {
+	if ( ! $taxonomy ) {
+		return wp_cache_get_last_changed( 'terms' );
+	}
 	$last_changed = wp_cache_get( $taxonomy . ':last_changed', 'terms' );
 
 	if ( $last_changed ) {
@@ -5175,7 +5178,7 @@ function wp_cache_get_taxonomy_last_changed( $taxonomy ) {
  * @return string UNIX timestamp with microseconds representing when the group was last changed.
  */
 function wp_cache_get_taxonomies_last_changed( array $taxonomies ) {
-	$taxonomies = array_unique( array_filter( $taxonomies ) );
+	$taxonomies = array_unique( $taxonomies );
 	if ( empty( $taxonomies ) ) {
 		return wp_cache_get_last_changed( 'terms' );
 	}
@@ -5184,7 +5187,7 @@ function wp_cache_get_taxonomies_last_changed( array $taxonomies ) {
 		static function ( $taxonomy ) {
 			return $taxonomy . ':last_changed';
 		},
-		$taxonomies
+		array_filter( $taxonomies )
 	);
 	wp_cache_get_multiple( $cache_keys, 'terms' );
 	$last_changes = array_map( 'wp_cache_get_taxonomy_last_changed', $taxonomies );

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -5122,6 +5122,8 @@ function is_term_publicly_viewable( $term ) {
  * This function ensures that the cache for the given term and its associated taxonomy is invalidated,
  * and marks them as "last changed" to reflect the updates or changes made to the meta data.
  *
+ * @since x.x.x
+ *
  * @param int $meta_id ID of the term meta to be cleared.
  * @param int $object_id ID of the term associated with the meta to be cleared.
  */
@@ -5137,6 +5139,8 @@ function wp_cache_clear_term_meta( $meta_id, $object_id ) {
  * Sets the last changed time for a specific taxonomy in the cache.
  *
  * This function updates the cached value to track when the taxonomy data was last changed.
+ *
+ * @since x.x.x
  *
  * @param string $taxonomy The taxonomy slug to update the last changed time for.
  * @return string The microtime when the taxonomy was last changed.

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -890,14 +890,15 @@ function get_objects_in_term( $term_ids, $taxonomies, $args = array() ) {
 
 	$term_ids = array_map( 'intval', $term_ids );
 
+	$last_changed = wp_cache_get_taxonomies_last_changed( $taxonomies );
+
 	$taxonomies = "'" . implode( "', '", array_map( 'esc_sql', $taxonomies ) ) . "'";
 	$term_ids   = "'" . implode( "', '", $term_ids ) . "'";
 
 	$sql = "SELECT tr.object_id FROM $wpdb->term_relationships AS tr INNER JOIN $wpdb->term_taxonomy AS tt ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ($taxonomies) AND tt.term_id IN ($term_ids) ORDER BY tr.object_id $order";
 
-	$last_changed = wp_cache_get_last_changed( 'terms' );
-	$cache_key    = 'get_objects_in_term:' . md5( $sql ) . ":$last_changed";
-	$cache        = wp_cache_get( $cache_key, 'term-queries' );
+	$cache_key = 'get_objects_in_term:' . md5( $sql ) . ":$last_changed";
+	$cache     = wp_cache_get( $cache_key, 'term-queries' );
 	if ( false === $cache ) {
 		$object_ids = $wpdb->get_col( $sql );
 		wp_cache_set( $cache_key, $object_ids, 'term-queries' );
@@ -2950,6 +2951,7 @@ function wp_set_object_terms( $object_id, $terms, $taxonomy, $append = false ) {
 
 	wp_cache_delete( $object_id, $taxonomy . '_relationships' );
 	wp_cache_set_terms_last_changed();
+	wp_cache_set_taxonomy_last_changed( $taxonomy );
 
 	/**
 	 * Fires after an object's terms have been set.
@@ -3048,6 +3050,7 @@ function wp_remove_object_terms( $object_id, $terms, $taxonomy ) {
 
 		wp_cache_delete( $object_id, $taxonomy . '_relationships' );
 		wp_cache_set_terms_last_changed();
+		wp_cache_set_taxonomy_last_changed( $taxonomy );
 
 		/**
 		 * Fires immediately after an object-term relationship is deleted.
@@ -3633,6 +3636,7 @@ function clean_object_term_cache( $object_ids, $object_type ) {
 
 	foreach ( $taxonomies as $taxonomy ) {
 		wp_cache_delete_multiple( $object_ids, "{$taxonomy}_relationships" );
+		wp_cache_set_taxonomy_last_changed( $taxonomy );
 	}
 
 	wp_cache_set_terms_last_changed();
@@ -3697,6 +3701,8 @@ function clean_term_cache( $ids, $taxonomy = '', $clean_taxonomy = true ) {
 			clean_taxonomy_cache( $taxonomy );
 		}
 
+		wp_cache_set_taxonomy_last_changed( $taxonomy );
+
 		/**
 		 * Fires once after each taxonomy's term cache has been cleaned.
 		 *
@@ -3723,6 +3729,7 @@ function clean_term_cache( $ids, $taxonomy = '', $clean_taxonomy = true ) {
 function clean_taxonomy_cache( $taxonomy ) {
 	wp_cache_delete( 'all_ids', $taxonomy );
 	wp_cache_delete( 'get', $taxonomy );
+	wp_cache_set_taxonomy_last_changed( $taxonomy );
 	wp_cache_set_terms_last_changed();
 
 	// Regenerate cached hierarchy.
@@ -5103,6 +5110,74 @@ function is_term_publicly_viewable( $term ) {
 	}
 
 	return is_taxonomy_viewable( $term->taxonomy );
+}
+
+
+/**
+ * Clears the term meta cache and updates the last changed timestamp for the term and its taxonomy.
+ *
+ * This function ensures that the cache for the given term and its associated taxonomy is invalidated,
+ * and marks them as "last changed" to reflect the updates or changes made to the meta data.
+ *
+ * @param int $meta_id ID of the term meta to be cleared.
+ * @param int $object_id ID of the term associated with the meta to be cleared.
+ */
+function wp_cache_clear_term_meta( $meta_id, $object_id ) {
+	wp_cache_set_terms_last_changed();
+	$term = get_term( $object_id );
+	if ( $term instanceof WP_Term ) {
+		wp_cache_set_taxonomy_last_changed( $term->taxonomy );
+	}
+}
+
+/**
+ * Sets the last changed time for a specific taxonomy in the cache.
+ *
+ * This function updates the cached value to track when the taxonomy data was last changed.
+ *
+ * @param string $taxonomy The taxonomy slug to update the last changed time for.
+ * @return string The microtime when the taxonomy was last changed.
+ */
+function wp_cache_set_taxonomy_last_changed( $taxonomy ) {
+	$time = microtime();
+
+	wp_cache_set( $taxonomy . ':last_changed', $time, 'terms' );
+
+	return $time;
+}
+
+/**
+ * Retrieves the last changed time for a taxonomy.
+ *
+ * @since x.x.x
+ *
+ * @param string $taxonomy Taxonomy name.
+ * @return float UNIX timestamp with microseconds representing when the taxonomy was last changed.
+ */
+function wp_cache_get_taxonomy_last_changed( $taxonomy ) {
+	$last_changed = wp_cache_get( $taxonomy . ':last_changed', 'terms' );
+
+	if ( $last_changed ) {
+		return $last_changed;
+	}
+
+	return wp_cache_set_taxonomy_last_changed( $taxonomy );
+}
+
+/**
+ * Retrieves the last changed time for the 'taxonomies' cache group.
+ *
+ * @since x.x.x
+ *
+ * @return float UNIX timestamp with microseconds representing when the group was last changed.
+ */
+function wp_cache_get_taxonomies_last_changed( array $taxonomies ) {
+	$taxonomies = array_unique( array_filter( $taxonomies ) );
+	sort( $taxonomies );
+	$last_changes = array_map( 'wp_cache_get_taxonomy_last_changed', $taxonomies );
+	$last_changes = array_map( 'floatval', $last_changes );
+
+	return array_sum( $last_changes );
 }
 
 /**

--- a/tests/phpunit/tests/link/getAdjacentPost.php
+++ b/tests/phpunit/tests/link/getAdjacentPost.php
@@ -426,6 +426,6 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 
 		$num_queries = get_num_queries();
 		$this->assertEquals( $post_four, get_adjacent_post( true, '', false ), 'Result of function call is wrong after after adding new term' );
-		$this->assertSame( get_num_queries() - $num_queries, 2, 'Number of queries run was not two after adding new term' );
+		$this->assertSame( get_num_queries() - $num_queries, 0, 'Number of queries run was not two after adding new term' );
 	}
 }

--- a/tests/phpunit/tests/query/cacheResults.php
+++ b/tests/phpunit/tests/query/cacheResults.php
@@ -26,6 +26,14 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 	 */
 	public static $t1;
 
+
+	/**
+	 * Term ID.
+	 *
+	 * @var int
+	 */
+	public static $t2;
+
 	/**
 	 * Author's user ID.
 	 *
@@ -62,7 +70,16 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 			)
 		);
 
+		self::$t2 = $factory->term->create(
+			array(
+				'taxonomy' => 'post_tag',
+				'slug'     => 'bar',
+				'name'     => 'Bar',
+			)
+		);
+
 		wp_set_post_terms( self::$posts[0], self::$t1, 'category' );
+		wp_set_post_terms( self::$posts[0], self::$t2, 'post_tag' );
 		add_post_meta( self::$posts[0], 'color', '#000000' );
 
 		// Make a user.
@@ -1984,6 +2001,70 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 			'fields: ids'        => array( 'ids' ),
 			'fields: id=>parent' => array( 'id=>parent' ),
 		);
+	}
+
+	public function test_query_cache_empty_taxonomies() {
+		add_filter( 'split_the_query', '__return_false' );
+		$query1       = new WP_Query();
+		$query_args_1 = array(
+			'update_post_term_cache' => false,
+			'update_post_meta_cache' => false,
+			'no_found_rows'          => true,
+			'tax_query'              => array(
+				array(
+					'terms' => array( self::$t1 ),
+				),
+			),
+		);
+		$query1->query( $query_args_1 );
+
+		clean_term_cache( self::$t1, 'category' );
+		$num_queries = get_num_queries();
+
+		$query1->query( $query_args_1 );
+
+		$this->assertSame( $num_queries + 1, get_num_queries(), 'Query not should be cached.' );
+	}
+	public function test_query_cache_different_taxonomies() {
+		add_filter( 'split_the_query', '__return_false' );
+		$query1       = new WP_Query();
+		$query_args_1 = array(
+			'update_post_term_cache' => false,
+			'update_post_meta_cache' => false,
+			'no_found_rows'          => true,
+			'tax_query'              => array(
+				array(
+					'taxonomy' => 'category',
+					'terms'    => array( self::$t1 ),
+				),
+			),
+		);
+		$query1->query( $query_args_1 );
+		$query_args_2 = array(
+			'update_post_term_cache' => false,
+			'update_post_meta_cache' => false,
+			'no_found_rows'          => true,
+			'tax_query'              => array(
+				array(
+					'taxonomy' => 'post_tag',
+					'terms'    => array( self::$t2 ),
+				),
+			),
+		);
+		$query2       = new WP_Query();
+		$query2->query( $query_args_2 );
+
+		clean_term_cache( self::$t1, 'category' );
+		$num_queries = get_num_queries();
+
+		$query1->query( $query_args_1 );
+
+		$this->assertSame( $num_queries + 2, get_num_queries(), 'Query not should be cached.' );
+		$num_queries = get_num_queries();
+		$query2->query( $query_args_2 );
+		remove_filter( 'split_the_query', '__return_false' );
+
+		$this->assertSame( $num_queries, get_num_queries(), 'Query should be cached.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/query/cacheResults.php
+++ b/tests/phpunit/tests/query/cacheResults.php
@@ -2106,8 +2106,9 @@ class Test_Query_CacheResults extends WP_UnitTestCase {
 		 * 2: Post data
 		 * 3: Post meta data.
 		 * 4: Post term data.
+		 * 5. Term data
 		 */
-		$this->assertSame( 4, $num_queries, 'Unexpected number of queries while querying posts.' );
+		$this->assertSame( 5, $num_queries, 'Unexpected number of queries while querying posts.' );
 		$this->assertNotEmpty( $query_posts, 'Query posts is empty.' );
 
 		$num_queries_start = get_num_queries();

--- a/tests/phpunit/tests/taxonomy.php
+++ b/tests/phpunit/tests/taxonomy.php
@@ -452,6 +452,37 @@ class Tests_Taxonomy extends WP_UnitTestCase {
 		$this->assertSame( array(), $after );
 	}
 
+	public function test_invalidate_different_taxonomy_get_objects_in_term_cache() {
+		register_taxonomy( 'wptests_tax_1', 'post' );
+		register_taxonomy( 'wptests_tax_2', 'post' );
+
+		$posts     = self::factory()->post->create_many( 2 );
+		$term_id_1 = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax_1',
+			)
+		);
+		$term_id_2 = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax_2',
+			)
+		);
+
+		wp_set_object_terms( $posts[1], $term_id_1, 'wptests_tax_1' );
+		wp_set_object_terms( $posts[1], $term_id_2, 'wptests_tax_2' );
+
+		// Prime cache.
+		$before = get_objects_in_term( $term_id_1, 'wptests_tax_1' );
+		$this->assertEqualSets( array( $posts[1] ), $before );
+
+		clean_term_cache( $term_id_2, 'wptests_tax_2' );
+
+		$num_queries = get_num_queries();
+		$after       = get_objects_in_term( $term_id_1, 'wptests_tax_1' );
+		$this->assertEqualSets( array( $posts[1] ), $after );
+		$this->assertSame( $num_queries, get_num_queries() );
+	}
+
 	/**
 	 * @ticket 25706
 	 */

--- a/tests/phpunit/tests/taxonomy/wpCacheGetTaxonomiesLastChanged.php
+++ b/tests/phpunit/tests/taxonomy/wpCacheGetTaxonomiesLastChanged.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @group taxonomy
+ */
+class Tests_WP_Cache_Get_Taxonomies_Last_Changed extends WP_UnitTestCase {
+
+	public function test_wp_cache_get_taxonomy_last_changed_empty() {
+		$last_changed = wp_cache_get_last_changed( 'terms' );
+		$this->assertSame( $last_changed, wp_cache_get_taxonomies_last_changed( array() ) );
+	}
+
+	public function test_wp_cache_get_taxonomy_last_changed_empty_string() {
+		$last_changed = (string) floatval( wp_cache_get_last_changed( 'terms' ) );
+		$this->assertSame( $last_changed, wp_cache_get_taxonomies_last_changed( array( '' ) ) );
+	}
+
+	public function test_wp_cache_get_taxonomy_last_changed() {
+		$last_changed = (string) floatval( wp_cache_get_taxonomy_last_changed( 'post_tag' ) );
+		$this->assertSame( $last_changed, wp_cache_get_taxonomies_last_changed( array( 'post_tag' ) ) );
+	}
+
+	public function test_wp_cache_get_taxonomy_last_changed_duplicate() {
+		$last_changed = (string) floatval( wp_cache_get_taxonomy_last_changed( 'post_tag' ) );
+		$this->assertSame( $last_changed, wp_cache_get_taxonomies_last_changed( array( 'post_tag', 'post_tag', 'post_tag' ) ) );
+	}
+}

--- a/tests/phpunit/tests/taxonomy/wpCacheGetTaxonomyLastChanged.php
+++ b/tests/phpunit/tests/taxonomy/wpCacheGetTaxonomyLastChanged.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @group taxonomy
+ */
+class Tests_WP_Cache_Get_Taxonomy_Last_Changed extends WP_UnitTestCase {
+
+	public function test_wp_cache_get_taxonomy_last_changed_empty() {
+		$last_changed = wp_cache_get_last_changed( 'terms' );
+		$this->assertSame( $last_changed, wp_cache_get_taxonomy_last_changed( '' ) );
+	}
+
+	public function test_wp_cache_get_taxonomy_last_changed() {
+		$last_changed = wp_cache_get_taxonomy_last_changed( 'post_tag' );
+		$this->assertSame( $last_changed, wp_cache_get_taxonomy_last_changed( 'post_tag' ) );
+	}
+}

--- a/tests/phpunit/tests/term/cache.php
+++ b/tests/phpunit/tests/term/cache.php
@@ -177,6 +177,66 @@ class Tests_Term_Cache extends WP_UnitTestCase {
 		$this->assertEquals( $term_object, $term_object_2 );
 	}
 
+	public function test_get_terms_cache_invalidation_add_term_meta() {
+		register_taxonomy( 'wptests_tax', 'post' );
+		$terms = self::factory()->term->create_many(
+			5,
+			array(
+				'taxonomy' => 'wptests_tax',
+			)
+		);
+
+		get_terms( 'wptests_tax', array( 'hide_empty' => false ) );
+		foreach ( $terms as $term_id ) {
+			add_term_meta( $term_id, 'foo', 'bar' );
+		}
+		$num_queries = get_num_queries();
+		get_terms( 'wptests_tax', array( 'hide_empty' => false ) );
+		$this->assertSame( $num_queries + 1, get_num_queries(), 'Cache should be invalidated' );
+	}
+
+	public function test_get_terms_cache_invalidation_update_term_meta() {
+		register_taxonomy( 'wptests_tax', 'post' );
+		$terms = self::factory()->term->create_many(
+			5,
+			array(
+				'taxonomy' => 'wptests_tax',
+			)
+		);
+		foreach ( $terms as $term_id ) {
+			add_term_meta( $term_id, 'foo', 'bar' );
+		}
+
+		get_terms( 'wptests_tax', array( 'hide_empty' => false ) );
+		foreach ( $terms as $term_id ) {
+			update_term_meta( $term_id, 'foo', 'baz' );
+		}
+		$num_queries = get_num_queries();
+		get_terms( 'wptests_tax', array( 'hide_empty' => false ) );
+		$this->assertSame( $num_queries + 1, get_num_queries(), 'Cache should be invalidated' );
+	}
+
+	public function test_get_terms_cache_invalidation_delete_term_meta() {
+		register_taxonomy( 'wptests_tax', 'post' );
+		$terms = self::factory()->term->create_many(
+			5,
+			array(
+				'taxonomy' => 'wptests_tax',
+			)
+		);
+		foreach ( $terms as $term_id ) {
+			delete_term_meta( $term_id, 'foo', 'bar' );
+		}
+
+		get_terms( 'wptests_tax', array( 'hide_empty' => false ) );
+		foreach ( $terms as $term_id ) {
+			update_term_meta( $term_id, 'foo', 'baz' );
+		}
+		$num_queries = get_num_queries();
+		get_terms( 'wptests_tax', array( 'hide_empty' => false ) );
+		$this->assertSame( $num_queries + 1, get_num_queries(), 'Cache should be invalidated' );
+	}
+
 	public function test_get_terms_cache_invalidation_different_taxonomies() {
 		register_taxonomy( 'wptests_tax_1', 'post' );
 		register_taxonomy( 'wptests_tax_2', 'post' );

--- a/tests/phpunit/tests/term/cache.php
+++ b/tests/phpunit/tests/term/cache.php
@@ -177,6 +177,37 @@ class Tests_Term_Cache extends WP_UnitTestCase {
 		$this->assertEquals( $term_object, $term_object_2 );
 	}
 
+	public function test_get_terms_cache_invalidation_different_taxonomies() {
+		register_taxonomy( 'wptests_tax_1', 'post' );
+		register_taxonomy( 'wptests_tax_2', 'post' );
+
+		$terms = self::factory()->term->create_many(
+			5,
+			array(
+				'taxonomy' => 'wptests_tax_1',
+			)
+		);
+
+		self::factory()->term->create_many(
+			5,
+			array(
+				'taxonomy' => 'wptests_tax_2',
+			)
+		);
+
+		get_terms( 'wptests_tax_1', array( 'hide_empty' => false ) );
+		get_terms( 'wptests_tax_2', array( 'hide_empty' => false ) );
+
+		clean_term_cache( $terms[0], 'wptests_tax_1' );
+		$num_queries = get_num_queries();
+
+		get_terms( 'wptests_tax_1', array( 'hide_empty' => false ) );
+		$this->assertSame( $num_queries + 2, get_num_queries(), 'Cache should be invalidated' );
+		$num_queries = get_num_queries();
+		get_terms( 'wptests_tax_2', array( 'hide_empty' => false ) );
+		$this->assertSame( $num_queries, get_num_queries(), 'Cache should not be invalidated' );
+	}
+
 	/**
 	 * @ticket 30749
 	 */

--- a/tests/phpunit/tests/term/getTerms.php
+++ b/tests/phpunit/tests/term/getTerms.php
@@ -141,7 +141,7 @@ class Tests_Term_getTerms extends WP_UnitTestCase {
 		// last_changed and num_queries should bump.
 		$terms = get_terms( 'post_tag', array( 'update_term_meta_cache' => false ) );
 		$this->assertCount( 3, $terms );
-		$time1 = wp_cache_get( 'last_changed', 'terms' );
+		$time1 = wp_cache_get( 'post_tag:last_changed', 'terms' );
 		$this->assertNotEmpty( $time1 );
 		$this->assertSame( $num_queries + 2, get_num_queries() );
 
@@ -150,7 +150,7 @@ class Tests_Term_getTerms extends WP_UnitTestCase {
 		// Again. last_changed and num_queries should remain the same.
 		$terms = get_terms( 'post_tag', array( 'update_term_meta_cache' => false ) );
 		$this->assertCount( 3, $terms );
-		$this->assertSame( $time1, wp_cache_get( 'last_changed', 'terms' ) );
+		$this->assertSame( $time1, wp_cache_get( 'post_tag:last_changed', 'terms' ) );
 		$this->assertSame( $num_queries, get_num_queries() );
 	}
 


### PR DESCRIPTION
Revised caching logic by introducing `wp_cache_set_taxonomy_last_changed` and `wp_cache_get_taxonomy_last_changed` functions to track individual taxonomy changes. Updated related areas to leverage these methods for more granular cache management, improving efficiency and accuracy.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
