### PR TITLE
docs: fixed parameter type for embed_oembed_html filter in WP_Embed::shortcode()

### DIFF
--- a/src/wp-includes/class-wp-embed.php
+++ b/src/wp-includes/class-wp-embed.php
@@ -283,10 +283,10 @@ class WP_Embed {
 				 *
 				 * @see WP_Embed::shortcode()
 				 *
-				 * @param string|false $cache   The cached HTML result, stored in post meta.
-				 * @param string       $url     The attempted embed URL.
-				 * @param array        $attr    An array of shortcode attributes.
-				 * @param int          $post_id Post ID.
+				 * @param string $cache   The cached HTML result, stored in post meta.
+				 * @param string $url     The attempted embed URL.
+				 * @param array  $attr    An array of shortcode attributes.
+				 * @param int    $post_id Post ID.
 				 */
 				return apply_filters( 'embed_oembed_html', $cache, $url, $attr, $post_id );
 			}

--- a/src/wp-includes/class-wp-embed.php
+++ b/src/wp-includes/class-wp-embed.php
@@ -283,7 +283,7 @@ class WP_Embed {
 				 *
 				 * @see WP_Embed::shortcode()
 				 *
-				 * @param string $cache   The cached HTML result, stored in post meta.
+				 * @param string $cache   The cached HTML result, loaded from post meta.
 				 * @param string $url     The attempted embed URL.
 				 * @param array  $attr    An array of shortcode attributes.
 				 * @param int    $post_id Post ID.


### PR DESCRIPTION
As described in the trac ticket, the PHPdoc for `embed_oembed_html` is misleading. This fixes this issue.
 
Trac ticket: https://core.trac.wordpress.org/ticket/63220#ticket
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
