### PR TITLE
Fixed: deprecated warning in wp_parse_list() when passing null value

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -4964,7 +4964,7 @@ function wp_parse_args( $args, $defaults = array() ) {
  */
 function wp_parse_list( $input_list ) {
 	if ( ! is_array( $input_list ) ) {
-		return preg_split( '/[\s,]+/', $input_list, -1, PREG_SPLIT_NO_EMPTY );
+		return preg_split( '/[\s,]+/', (string) $input_list, -1, PREG_SPLIT_NO_EMPTY );
 	}
 
 	// Validate all entries of the list are scalar.


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63221