### PR TITLE
Accessibility: Add aria-live attribute support to `settings_errors()`

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1859,11 +1859,11 @@ function do_settings_fields( $page, $section ) {
  * @param string $setting  Slug title of the setting to which this error applies.
  * @param string $code     Slug-name to identify the error. Used as part of 'id' attribute in HTML output.
  * @param string $message  The formatted message text to display to the user (will be shown inside styled
- *                        `<div>` and `<p>` tags).
- * @param string $type    Optional. Message type, controls HTML class. Possible values include 'error',
- *                        'success', 'warning', 'info'. Default 'error'.
+ *                         `<div>` and `<p>` tags).
+ * @param string $type     Optional. Message type, controls HTML class. Possible values include 'error',
+ *                         'success', 'warning', 'info'. Default 'error'.
  * @param string $aria_live Optional. The ARIA live attribute value. Possible values include 'off', 'polite',
- *                        'assertive'. Default empty string which doesn't add the attribute.
+ *                         'assertive'. Default empty string which doesn't add the attribute.
  */
 function add_settings_error( $setting, $code, $message, $type = 'error', $aria_live = '' ) {
 	global $wp_settings_errors;
@@ -2014,7 +2014,7 @@ function settings_errors( $setting = '', $sanitize = false, $hide_on_update = fa
 		);
 
 		$aria_live_attr = '';
-		if ( ! empty( $details['aria_live'] ) && in_array( $details['aria_live'], array( 'off', 'polite', 'assertive' ), true ) ) {
+		if ( in_array( $details['aria_live'], array( 'off', 'polite', 'assertive' ), true ) ) {
 			$aria_live_attr = sprintf( ' aria-live="%s"', esc_attr( $details['aria_live'] ) );
 		}
 

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -1852,24 +1852,28 @@ function do_settings_fields( $page, $section ) {
  *
  * @since 3.0.0
  * @since 5.3.0 Added `warning` and `info` as possible values for `$type`.
+ * @since 6.9.0 Added `$aria_live` parameter to control the screen reader announcement.
  *
  * @global array[] $wp_settings_errors Storage array of errors registered during this pageload
  *
- * @param string $setting Slug title of the setting to which this error applies.
- * @param string $code    Slug-name to identify the error. Used as part of 'id' attribute in HTML output.
- * @param string $message The formatted message text to display to the user (will be shown inside styled
+ * @param string $setting  Slug title of the setting to which this error applies.
+ * @param string $code     Slug-name to identify the error. Used as part of 'id' attribute in HTML output.
+ * @param string $message  The formatted message text to display to the user (will be shown inside styled
  *                        `<div>` and `<p>` tags).
  * @param string $type    Optional. Message type, controls HTML class. Possible values include 'error',
  *                        'success', 'warning', 'info'. Default 'error'.
+ * @param string $aria_live Optional. The ARIA live attribute value. Possible values include 'off', 'polite',
+ *                        'assertive'. Default empty string which doesn't add the attribute.
  */
-function add_settings_error( $setting, $code, $message, $type = 'error' ) {
+function add_settings_error( $setting, $code, $message, $type = 'error', $aria_live = '' ) {
 	global $wp_settings_errors;
 
 	$wp_settings_errors[] = array(
-		'setting' => $setting,
-		'code'    => $code,
-		'message' => $message,
-		'type'    => $type,
+		'setting'   => $setting,
+		'code'      => $code,
+		'message'   => $message,
+		'type'      => $type,
+		'aria_live' => $aria_live,
 	);
 }
 
@@ -2009,7 +2013,12 @@ function settings_errors( $setting = '', $sanitize = false, $hide_on_update = fa
 			esc_attr( $details['type'] )
 		);
 
-		$output .= "<div id='$css_id' class='$css_class'> \n";
+		$aria_live_attr = '';
+		if ( ! empty( $details['aria_live'] ) && in_array( $details['aria_live'], array( 'off', 'polite', 'assertive' ), true ) ) {
+			$aria_live_attr = sprintf( ' aria-live="%s"', esc_attr( $details['aria_live'] ) );
+		}
+
+		$output .= "<div id='$css_id' class='$css_class'$aria_live_attr> \n";
 		$output .= "<p><strong>{$details['message']}</strong></p>";
 		$output .= "</div> \n";
 	}

--- a/tests/phpunit/tests/admin/includesTemplate.php
+++ b/tests/phpunit/tests/admin/includesTemplate.php
@@ -404,6 +404,7 @@ class Tests_Admin_IncludesTemplate extends WP_UnitTestCase {
 			'code'    => 'blogdescription',
 			'message' => 'Too short',
 			'type'    => 'error',
+			'aria_live' => '',
 		);
 
 		$wp_settings_errors = null;

--- a/tests/phpunit/tests/admin/includesTemplate.php
+++ b/tests/phpunit/tests/admin/includesTemplate.php
@@ -400,10 +400,10 @@ class Tests_Admin_IncludesTemplate extends WP_UnitTestCase {
 			'type'    => 'error',
 		);
 		$blogdescription_error = array(
-			'setting' => 'blogdescription',
-			'code'    => 'blogdescription',
-			'message' => 'Too short',
-			'type'    => 'error',
+			'setting'   => 'blogdescription',
+			'code'      => 'blogdescription',
+			'message'   => 'Too short',
+			'type'      => 'error',
 			'aria_live' => '',
 		);
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63199

This PR enhances the accessibility of admin notices by adding support for the aria-live attribute in the `settings_errors()` function. This also adds the ability to control the aria-live attribute, which helps direct screen reader users' attention to these notices with appropriate urgency levels.

- Added an optional 'aria_live' parameter to `add_settings_error()`
- Updated `settings_errors()` to output the aria-live attribute when provided

