### PR TITLE
Fix auth cookie documentation and remove unnecessary filter in `wp_set_auth_cookie()`

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -971,7 +971,7 @@ if ( ! function_exists( 'wp_set_auth_cookie' ) ) :
 	 * Sets the authentication cookies based on user ID.
 	 *
 	 * The $remember parameter determines if the cookie will persist beyond the session.
-	 * When $remember is true, the cookie is kept for 14 days (two weeks). 
+	 * When $remember is true, the cookie is kept for 14 days (two weeks).
 	 * When $remember is false, the cookie is a session cookie and expires when the browser is closed.
 	 *
 	 * @since 2.5.0

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -984,6 +984,9 @@ if ( ! function_exists( 'wp_set_auth_cookie' ) ) :
 	 * @param string      $token    Optional. User's session token to use for this cookie.
 	 */
 	function wp_set_auth_cookie( $user_id, $remember = false, $secure = '', $token = '' ) {
+		$expire     = 0;
+		$expiration = time() + ( 2 * DAY_IN_SECONDS );
+
 		if ( $remember ) {
 			/**
 			 * Filters the duration of the authentication cookie expiration period.
@@ -1001,9 +1004,6 @@ if ( ! function_exists( 'wp_set_auth_cookie' ) ) :
 			 * Needed for the login grace period in wp_validate_auth_cookie().
 			 */
 			$expire = $expiration + ( 12 * HOUR_IN_SECONDS );
-		} else {
-			$expiration = time() + ( 2 * DAY_IN_SECONDS );
-			$expire     = 0;
 		}
 
 		if ( '' === $secure ) {

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -970,9 +970,9 @@ if ( ! function_exists( 'wp_set_auth_cookie' ) ) :
 	/**
 	 * Sets the authentication cookies based on user ID.
 	 *
-	 * The $remember parameter increases the time that the cookie will be kept. The
-	 * default the cookie is kept without remembering is two days. When $remember is
-	 * set, the cookies will be kept for 14 days or two weeks.
+	 * The $remember parameter determines if the cookie will persist beyond the session.
+	 * When $remember is true, the cookie is kept for 14 days (two weeks). 
+	 * When $remember is false, the cookie is a session cookie and expires when the browser is closed.
 	 *
 	 * @since 2.5.0
 	 * @since 4.3.0 Added the `$token` parameter.
@@ -1002,8 +1002,7 @@ if ( ! function_exists( 'wp_set_auth_cookie' ) ) :
 			 */
 			$expire = $expiration + ( 12 * HOUR_IN_SECONDS );
 		} else {
-			/** This filter is documented in wp-includes/pluggable.php */
-			$expiration = time() + apply_filters( 'auth_cookie_expiration', 2 * DAY_IN_SECONDS, $user_id, $remember );
+			$expiration = time() + ( 2 * DAY_IN_SECONDS );
 			$expire     = 0;
 		}
 


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/63230


The documentation for `wp_set_auth_cookie()` incorrectly stated that non-"Remember me" logins expire in two days. In reality, they are session cookies (they expire on the browser's close). Additionally, the `auth_cookie_expiration` filter was redundantly applied for non-persistent logins.  

This PR - 

- Updates the docblock to clarify session cookie behavior.  
- Removes the `auth_cookie_expiration` filter call when `$remember` is false, as the browser ignores the filtered expiration time in this case.  


