### PR TITLE
Administration: Fix text overflow in Activity widget for long post titles.

### DIFF
--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -45,6 +45,7 @@
 
 #dashboard-widgets .postbox .inside {
 	margin-bottom: 0;
+	word-break: break-word;
 }
 
 #dashboard-widgets .meta-box-sortables {
@@ -1030,7 +1031,6 @@ body #dashboard-widgets .postbox form .submit {
 #dashboard-widgets .button-link,
 .community-events-footer a {
 	text-decoration: none;
-	word-break: break-word;
 }
 
 #dashboard-widgets h2 a {

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -1030,6 +1030,7 @@ body #dashboard-widgets .postbox form .submit {
 #dashboard-widgets .button-link,
 .community-events-footer a {
 	text-decoration: none;
+	word-break: break-word;
 }
 
 #dashboard-widgets h2 a {


### PR DESCRIPTION
Trac ticket: [#36081](https://core.trac.wordpress.org/ticket/36081)

 Fixes an issue where long, unbroken post titles overflow the Dashboard Activity widget by applying word-break: break-word; to relevant links.

Chrome: 

<img width="1470" alt="Screenshot 2025-04-08 at 8 50 48 AM" src="https://github.com/user-attachments/assets/1991d0bb-dab2-4444-bfc5-d7ab4b8462ec" />


Firefox:

<img width="1470" alt="Screenshot 2025-04-08 at 8 50 38 AM" src="https://github.com/user-attachments/assets/4a2cc3a7-e146-4505-8aeb-04cd0a339ca6" />

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
