### PR TITLE
Fix : Posts tagged with complex Emoji can't be found

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2326,7 +2326,6 @@ function sanitize_title_with_dashes( $title, $raw_title = '', $context = 'displa
 				// Non-visible characters that display without a width.
 				'%e2%80%8b', // Zero width space.
 				'%e2%80%8c', // Zero width non-joiner.
-				'%e2%80%8d', // Zero width joiner.
 				'%e2%80%8e', // Left-to-right mark.
 				'%e2%80%8f', // Right-to-left mark.
 				'%e2%80%aa', // Left-to-right embedding.


### PR DESCRIPTION
Allowed ZERO WIDTH JOINER in function  sanitize_title_with_dashes [src/wp-includes/formatting.php :2328] to support complex emojis. Complex Emoji's need Zero Width Joiner which tells rendering engine to join two emojis to create a complex one
for example 👨‍💻 is created by 👨 + ZWJ (U+200D) + 💻
Trac ticket: [62948](https://core.trac.wordpress.org/ticket/62948)