### PR TITLE
Insufficient color contrast between background and foreground in site icon description

### DIFF
--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -1377,6 +1377,7 @@ span.description,
 
 p.description code {
 	font-style: normal;
+	color: #3c434a;
 }
 
 .form-wrap .form-field {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63236