### PR TITLE
Fix taxonomy URLs without path component in canonical redirection.

### DIFF
--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -378,9 +378,11 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 								// Taxonomy accessible via ?taxonomy=...&term=... or any custom query var.
 								parse_str( $tax_url['query'], $query_vars );
 								$redirect['query'] = add_query_arg( $query_vars, $redirect['query'] );
-							} else {
+							} elseif ( isset( $tax_url['path'] ) ) {
 								// Taxonomy is accessible via a "pretty URL".
 								$redirect['path'] = $tax_url['path'];
+							} else {
+								$redirect['path'] = '';
 							}
 						} else {
 							// Some query vars are set via $_GET. Unset those from $_GET that exist via the rewrite.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR fixes an issue in the `redirect_canonical()` function in `wp-includes/canonical.php` where URLs without a path component would cause PHP warnings.

The fix adds an explicit check for the existence of the 'path' key before trying to access it and provides a fallback empty path when it's missing.

Trac ticket: https://core.trac.wordpress.org/ticket/63252

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
