### PR TITLE
REST API: Add has_theme_json field in the Themes REST API response

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -332,6 +332,10 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 			$data['is_block_theme'] = $theme->is_block_theme();
 		}
 
+		if ( rest_is_field_included( 'has_theme_json', $fields ) ) {
+			$data['has_theme_json'] = wp_theme_has_theme_json();
+		}
+
 		if ( rest_is_field_included( 'stylesheet_uri', $fields ) ) {
 			if ( $this->is_same_theme( $theme, $current_theme ) ) {
 				$data['stylesheet_uri'] = get_stylesheet_directory_uri();
@@ -543,6 +547,11 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 				),
 				'is_block_theme'              => array(
 					'description' => __( 'Whether the theme is a block-based theme.' ),
+					'type'        => 'boolean',
+					'readonly'    => true,
+				),
+				'has_theme_json'              => array(
+					'description' => __( 'Whether the theme has a theme.json file.' ),
 					'type'        => 'boolean',
 					'readonly'    => true,
 				),

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -365,7 +365,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$response   = self::perform_active_theme_request( 'OPTIONS' );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertCount( 20, $properties );
+		$this->assertCount( 21, $properties );
 
 		$this->assertArrayHasKey( 'author', $properties );
 		$this->assertArrayHasKey( 'raw', $properties['author']['properties'] );

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -180,6 +180,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 			'default_template_types',
 			'description',
 			'is_block_theme',
+			'has_theme_json',
 			'name',
 			'requires_php',
 			'requires_wp',
@@ -222,6 +223,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 			'author_uri',
 			'description',
 			'is_block_theme',
+			'has_theme_json',
 			'name',
 			'requires_php',
 			'requires_wp',
@@ -381,6 +383,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'default_template_types', $properties );
 
 		$this->assertArrayHasKey( 'is_block_theme', $properties );
+		$this->assertArrayHasKey( 'has_theme_json', $properties );
 
 		$this->assertArrayHasKey( 'name', $properties );
 		$this->assertArrayHasKey( 'raw', $properties['name']['properties'] );
@@ -544,6 +547,27 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 
 		$this->assertArrayHasKey( 'is_block_theme', $result[0] );
 		$this->assertTrue( $result[0]['is_block_theme'] );
+	}
+
+	/**
+	 * @ticket 63253
+	 * @covers WP_REST_Themes_Controller::prepare_item_for_response
+	 */
+	public function test_theme_has_theme_json() {
+		// Test classic theme (Theme without theme.json).
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+
+		$this->assertArrayHasKey( 'has_theme_json', $result[0] );
+		$this->assertFalse( $result[0]['has_theme_json'] );
+
+		// Test block theme (Theme with theme.json).
+		switch_theme( 'block-theme' );
+		$response = self::perform_active_theme_request();
+		$result   = $response->get_data();
+
+		$this->assertArrayHasKey( 'has_theme_json', $result[0] );
+		$this->assertTrue( $result[0]['has_theme_json'] );
 	}
 
 	/**
@@ -1372,6 +1396,7 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 			'author_uri',
 			'description',
 			'is_block_theme',
+			'has_theme_json',
 			'name',
 			'requires_php',
 			'requires_wp',


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63253

Gutenberg PR: https://github.com/WordPress/gutenberg/pull/69857

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
