### PR TITLE
Simplify & Extend wp_resolve_numeric_slug_conflicts() early return.

### DIFF
--- a/src/wp-includes/rewrite.php
+++ b/src/wp-includes/rewrite.php
@@ -406,17 +406,13 @@ function wp_resolve_numeric_slug_conflicts( $query_vars = array() ) {
 		$compare = 'day';
 	}
 
-	if ( ! $compare ) {
+	if ( ! $compare || ! array_key_exists( $compare, $query_vars ) || ! is_scalar( $query_vars[ $compare ] ) ) {
 		return $query_vars;
 	}
 
 	// This is the potentially clashing slug.
-	$value = '';
-	if ( $compare && array_key_exists( $compare, $query_vars ) ) {
-		$value = $query_vars[ $compare ];
-	}
-
-	$post = get_page_by_path( $value, OBJECT, 'post' );
+	$value = $query_vars[ $compare ];
+	$post  = get_page_by_path( $value, OBJECT, 'post' );
 	if ( ! ( $post instanceof WP_Post ) ) {
 		return $query_vars;
 	}


### PR DESCRIPTION
This avoids invalid input from causing PHP Warnings & Fatals, such as when the `$compare` query field contains an array (which is not valid).

This also removes the duplicate check of `$compare` being set to a value.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/62828

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
