### PR TITLE
Fixed skip array_map() in get_terms() if object_ids is not set

### DIFF
--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -593,7 +593,7 @@ class WP_Term_Query {
 			);
 		}
 
-		if ( '' === $args['object_ids'] ) {
+		if ( empty( $args['object_ids'] ) ) {
 			$args['object_ids'] = array();
 		} else {
 			$args['object_ids'] = array_map( 'intval', (array) $args['object_ids'] );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63256