### PR TITLE
Try: improve hierarchical display of category parent select

### DIFF
--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -1055,88 +1055,6 @@ form#tags-filter {
 	}
 }
 
-/* Hierarchical Category Select Styling */
-
-.wp-core-ui select.category-parent-hierarchical-select {
-  &, &::picker(select) {
-    appearance: base-select;
-  }
-  &::picker-icon {
-	display: none;
-  }
-}
-
-.category-parent-hierarchical-select option {
-    position: relative;
-    padding-left: 10px; /* Base padding for level 0 */
-}
-
-/* Indentation based on depth (Levels 1-10) */
-.category-parent-hierarchical-select option.level-1  { padding-left: 30px; } /* 10 + 20*1 */
-.category-parent-hierarchical-select option.level-2  { padding-left: 50px; } /* 10 + 20*2 */
-.category-parent-hierarchical-select option.level-3  { padding-left: 70px; } /* 10 + 20*3 */
-.category-parent-hierarchical-select option.level-4  { padding-left: 90px; } /* 10 + 20*4 */
-.category-parent-hierarchical-select option.level-5  { padding-left: 110px; } /* 10 + 20*5 */
-.category-parent-hierarchical-select option.level-6  { padding-left: 130px; } /* 10 + 20*6 */
-.category-parent-hierarchical-select option.level-7  { padding-left: 150px; } /* 10 + 20*7 */
-.category-parent-hierarchical-select option.level-8  { padding-left: 170px; } /* 10 + 20*8 */
-.category-parent-hierarchical-select option.level-9  { padding-left: 190px; } /* 10 + 20*9 */
-.category-parent-hierarchical-select option.level-10 { padding-left: 210px; } /* 10 + 20*10 */
-
-/* --- Line Drawing (Revised Attempt) --- */
-/* Vertical line segment */
-.category-parent-hierarchical-select option:not(.level-0)::before {
-    content: '';
-    position: absolute;
-    /* Extend vertically to connect options */
-    top: -1em; /* Start slightly above the option */
-    bottom: 1em; /* End slightly below the option */
-    width: 1px;
-    background-color: #ccc; /* Line color */
-    z-index: 0; /* Behind text */
-    /* Left positioning is handled per level below */
-}
-
-/* Horizontal line segment */
-.category-parent-hierarchical-select option:not(.level-0)::after {
-    content: '';
-    position: absolute;
-    top: 1em; /* Center vertically */
-    width: 18px; /* Adjusted horizontal line length */
-    height: 1px;
-    background-color: #ccc; /* Line color */
-    z-index: 0; /* Behind text */
-     /* Left positioning is handled per level below */
-}
-
-/* --- Line Positioning per depth (Levels 1-10) --- */
-/* Apply left offset to both pseudo-elements */
-.category-parent-hierarchical-select option.level-1::before,
-.category-parent-hierarchical-select option.level-1::after { left: 20px; }
-
-.category-parent-hierarchical-select option.level-2::before,
-.category-parent-hierarchical-select option.level-2::after { left: 40px; }
-
-.category-parent-hierarchical-select option.level-3::before,
-.category-parent-hierarchical-select option.level-3::after { left: 60px; }
-
-.category-parent-hierarchical-select option.level-4::before,
-.category-parent-hierarchical-select option.level-4::after { left: 80px; }
-
-.category-parent-hierarchical-select option.level-5::before,
-.category-parent-hierarchical-select option.level-5::after { left: 100px; }
-
-
-/* TODO: Add rules for last-child elements if possible/needed for line termination */
-/* --- End Line Drawing --- */
-
-.category-parent-hierarchical-select option.level-1::after { width: 38px; }
-.category-parent-hierarchical-select option.level-2::after { width: 48px; }
-.category-parent-hierarchical-select option.level-3::after { width: 60px; }
-.category-parent-hierarchical-select option.level-4::after { width: 70px; }
-.category-parent-hierarchical-select option.level-5::after { width: 83px; }
-
-
 @media only screen and (max-width: 1004px) {
 
 	.privacy-settings-body,
@@ -2132,3 +2050,71 @@ table.links-table {
 		margin: 2em 0 0;
 	}
 }
+
+/* Hierarchical Category Select Styling */
+
+.wp-core-ui select.category-parent-hierarchical-select {
+	&, &::picker(select) {
+		appearance: base-select;
+	}
+	&::picker-icon {
+		display: none;
+	}
+}
+
+.category-parent-hierarchical-select option {
+	position: relative;
+	padding-left: 10px;
+}
+
+.category-parent-hierarchical-select option.level-1  { padding-left: 30px; }
+.category-parent-hierarchical-select option.level-2  { padding-left: 50px; }
+.category-parent-hierarchical-select option.level-3  { padding-left: 70px; }
+.category-parent-hierarchical-select option.level-4  { padding-left: 90px; }
+.category-parent-hierarchical-select option.level-5  { padding-left: 110px; }
+
+
+/* Vertical line segment */
+.category-parent-hierarchical-select option:not(.level-0)::before {
+	content: '';
+	position: absolute;
+	top: -1em;
+	bottom: 1em;
+	width: 1px;
+	background-color: #ccc;
+	z-index: 0;
+}
+
+/* Horizontal line segment */
+.category-parent-hierarchical-select option:not(.level-0)::after {
+	content: '';
+	position: absolute;
+	top: 1em;
+	width: 18px;
+	height: 1px;
+	background-color: #ccc;
+	z-index: 0;
+}
+
+/* Apply left offset to both pseudo-elements */
+.category-parent-hierarchical-select option.level-1::before,
+.category-parent-hierarchical-select option.level-1::after { left: 20px; }
+
+.category-parent-hierarchical-select option.level-2::before,
+.category-parent-hierarchical-select option.level-2::after { left: 40px; }
+
+.category-parent-hierarchical-select option.level-3::before,
+.category-parent-hierarchical-select option.level-3::after { left: 60px; }
+
+.category-parent-hierarchical-select option.level-4::before,
+.category-parent-hierarchical-select option.level-4::after { left: 80px; }
+
+.category-parent-hierarchical-select option.level-5::before,
+.category-parent-hierarchical-select option.level-5::after { left: 100px; }
+
+
+.category-parent-hierarchical-select option.level-1::after { width: 38px; }
+.category-parent-hierarchical-select option.level-2::after { width: 48px; }
+.category-parent-hierarchical-select option.level-3::after { width: 60px; }
+.category-parent-hierarchical-select option.level-4::after { width: 70px; }
+.category-parent-hierarchical-select option.level-5::after { width: 83px; }

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -1055,6 +1055,88 @@ form#tags-filter {
 	}
 }
 
+/* Hierarchical Category Select Styling */
+
+.wp-core-ui select.category-parent-hierarchical-select {
+  &, &::picker(select) {
+    appearance: base-select;
+  }
+  &::picker-icon {
+	display: none;
+  }
+}
+
+.category-parent-hierarchical-select option {
+    position: relative;
+    padding-left: 10px; /* Base padding for level 0 */
+}
+
+/* Indentation based on depth (Levels 1-10) */
+.category-parent-hierarchical-select option.level-1  { padding-left: 30px; } /* 10 + 20*1 */
+.category-parent-hierarchical-select option.level-2  { padding-left: 50px; } /* 10 + 20*2 */
+.category-parent-hierarchical-select option.level-3  { padding-left: 70px; } /* 10 + 20*3 */
+.category-parent-hierarchical-select option.level-4  { padding-left: 90px; } /* 10 + 20*4 */
+.category-parent-hierarchical-select option.level-5  { padding-left: 110px; } /* 10 + 20*5 */
+.category-parent-hierarchical-select option.level-6  { padding-left: 130px; } /* 10 + 20*6 */
+.category-parent-hierarchical-select option.level-7  { padding-left: 150px; } /* 10 + 20*7 */
+.category-parent-hierarchical-select option.level-8  { padding-left: 170px; } /* 10 + 20*8 */
+.category-parent-hierarchical-select option.level-9  { padding-left: 190px; } /* 10 + 20*9 */
+.category-parent-hierarchical-select option.level-10 { padding-left: 210px; } /* 10 + 20*10 */
+
+/* --- Line Drawing (Revised Attempt) --- */
+/* Vertical line segment */
+.category-parent-hierarchical-select option:not(.level-0)::before {
+    content: '';
+    position: absolute;
+    /* Extend vertically to connect options */
+    top: -1em; /* Start slightly above the option */
+    bottom: 1em; /* End slightly below the option */
+    width: 1px;
+    background-color: #ccc; /* Line color */
+    z-index: 0; /* Behind text */
+    /* Left positioning is handled per level below */
+}
+
+/* Horizontal line segment */
+.category-parent-hierarchical-select option:not(.level-0)::after {
+    content: '';
+    position: absolute;
+    top: 1em; /* Center vertically */
+    width: 18px; /* Adjusted horizontal line length */
+    height: 1px;
+    background-color: #ccc; /* Line color */
+    z-index: 0; /* Behind text */
+     /* Left positioning is handled per level below */
+}
+
+/* --- Line Positioning per depth (Levels 1-10) --- */
+/* Apply left offset to both pseudo-elements */
+.category-parent-hierarchical-select option.level-1::before,
+.category-parent-hierarchical-select option.level-1::after { left: 20px; }
+
+.category-parent-hierarchical-select option.level-2::before,
+.category-parent-hierarchical-select option.level-2::after { left: 40px; }
+
+.category-parent-hierarchical-select option.level-3::before,
+.category-parent-hierarchical-select option.level-3::after { left: 60px; }
+
+.category-parent-hierarchical-select option.level-4::before,
+.category-parent-hierarchical-select option.level-4::after { left: 80px; }
+
+.category-parent-hierarchical-select option.level-5::before,
+.category-parent-hierarchical-select option.level-5::after { left: 100px; }
+
+
+/* TODO: Add rules for last-child elements if possible/needed for line termination */
+/* --- End Line Drawing --- */
+
+.category-parent-hierarchical-select option.level-1::after { width: 38px; }
+.category-parent-hierarchical-select option.level-2::after { width: 48px; }
+.category-parent-hierarchical-select option.level-3::after { width: 60px; }
+.category-parent-hierarchical-select option.level-4::after { width: 70px; }
+.category-parent-hierarchical-select option.level-5::after { width: 83px; }
+
+
 @media only screen and (max-width: 1004px) {
 
 	.privacy-settings-body,

--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -410,6 +410,11 @@ function wp_dropdown_categories( $args = '' ) {
 	$id       = $parsed_args['id'] ? esc_attr( $parsed_args['id'] ) : $name;
 	$required = $parsed_args['required'] ? 'required' : '';
 
+	// Add custom class for hierarchical dropdowns.
+	if ( ! empty( $parsed_args['hierarchical'] ) ) {
+		$class .= ' category-parent-hierarchical-select';
+	}
+
 	$aria_describedby_attribute = $parsed_args['aria_describedby'] ? ' aria-describedby="' . esc_attr( $parsed_args['aria_describedby'] ) . '"' : '';
 
 	if ( ! $parsed_args['hide_if_empty'] || ! empty( $categories ) ) {

--- a/tests/phpunit/tests/category/wpDropdownCategories.php
+++ b/tests/phpunit/tests/category/wpDropdownCategories.php
@@ -255,4 +255,84 @@ class Tests_Category_WpDropdownCategories extends WP_UnitTestCase {
 		// Test to see if it contains the "required" attribute.
 		$this->assertDoesNotMatchRegularExpression( '/<select[^>]+required/', $dropdown_categories );
 	}
+
+	/**
+	 * @ticket 60910
+	 */
+	public function test_wp_dropdown_categories_hierarchical_should_have_level_classes() {
+		$parent = self::factory()->category->create( array( 'name' => 'Parent' ) );
+		$child  = self::factory()->category->create(
+			array(
+				'name'   => 'Child',
+				'parent' => $parent,
+			)
+		);
+		$grandchild = self::factory()->category->create(
+			array(
+				'name'   => 'Grandchild',
+				'parent' => $child,
+			)
+		);
+
+		$found = wp_dropdown_categories(
+			array(
+				'echo'         => 0,
+				'hide_empty'   => 0,
+				'hierarchical' => 1,
+				'orderby'      => 'name', // Ensure consistent order for testing.
+				'order'        => 'ASC',
+			)
+		);
+
+		// Check for level classes at different depths.
+		$this->assertStringContainsString( 'class="level-0"', $found, 'Level 0 class missing.' );
+		$this->assertStringContainsString( 'class="level-1"', $found, 'Level 1 class missing.' );
+		$this->assertStringContainsString( 'class="level-2"', $found, 'Level 2 class missing.' );
+
+		// Check specific options.
+		$this->assertMatchesRegularExpression( '/<option[^>]+class="level-0"[^>]*value="' . $parent . '"/', $found, 'Parent level class incorrect.' );
+		$this->assertMatchesRegularExpression( '/<option[^>]+class="level-1"[^>]*value="' . $child . '"/', $found, 'Child level class incorrect.' );
+		$this->assertMatchesRegularExpression( '/<option[^>]+class="level-2"[^>]*value="' . $grandchild . '"/', $found, 'Grandchild level class incorrect.' );
+	}
+
+	/**
+	 * @ticket 60910
+	 */
+	public function test_wp_dropdown_categories_hierarchical_should_have_custom_select_class() {
+		self::factory()->category->create(); // Ensure there's at least one category.
+
+		$found = wp_dropdown_categories(
+			array(
+				'echo'         => 0,
+				'hide_empty'   => 0,
+				'hierarchical' => 1,
+				'class'        => 'some-other-class', // Test appending.
+			)
+		);
+
+		// Check that the select tag contains the specific hierarchical class along with any others.
+		$this->assertMatchesRegularExpression( '/<select[^>]+class="[^"]*some-other-class[^"]*category-parent-hierarchical-select[^"]*"/', $found );
+	}
+
+	/**
+	 * @ticket 60910
+	 */
+	public function test_wp_dropdown_categories_non_hierarchical_should_not_have_custom_select_class() {
+		self::factory()->category->create(); // Ensure there's at least one category.
+
+		$found = wp_dropdown_categories(
+			array(
+				'echo'         => 0,
+				'hide_empty'   => 0,
+				'hierarchical' => 0, // Explicitly non-hierarchical.
+				'class'        => 'postform some-other-class',
+			)
+		);
+
+		// Check that the select tag does NOT contain the specific hierarchical class.
+		$this->assertStringNotContainsString( 'category-parent-hierarchical-select', $found );
+		// Check that other classes are still present.
+		$this->assertMatchesRegularExpression( '/<select[^>]+class="[^"]*postform[^"]*"/', $found );
+		$this->assertMatchesRegularExpression( '/<select[^>]+class="[^"]*some-other-class[^"]*"/', $found );
+	}
 }

--- a/tests/phpunit/tests/category/wpDropdownCategories.php
+++ b/tests/phpunit/tests/category/wpDropdownCategories.php
@@ -257,6 +257,8 @@ class Tests_Category_WpDropdownCategories extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the category dropdown is generated correctly, including the level classes.
+	 *
 	 * @ticket 60910
 	 */
 	public function test_wp_dropdown_categories_hierarchical_should_have_level_classes() {


### PR DESCRIPTION
## Adding a visual Hierarchy
The category parent selector currently indicates the parent/child relationship in the dropdown by indenting entries. Actual indentation levels are difficult to discern. Now that select elements can be fully styled HTML, this PR aims to improve the select with a graphical treatment that leverages CSS to display the "tree" structure of the hierarchy. 

Here is what I have so far:

### Before:
(this is how the select looks in non-supporting browsers as well)
![image](https://github.com/user-attachments/assets/df13e78d-186c-418e-86cf-7629a41ef94b)

### After:
(could use a little polish to remove extra lines and reduce indents slightly)
![graphical heirarchy](https://github.com/user-attachments/assets/e7f1870a-46de-4b7f-9c51-6affe6f212ba)



Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
