### PR TITLE
Tests: Add REST API user creation email notification tests.

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -662,7 +662,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		 * This filter allows customization of the notification type when a new user is created via REST API.
 		 *
 		 * @param string $notify  Determines who gets notified. Accepts:
-		 *                        - 'admin' (default) or an empty string: Notify only the site administrator.
+		 *                        - 'admin': Notify only the site administrator. This is the default.
 		 *                        - 'user': Notify only the new user.
 		 *                        - 'both': Notify both admin and user.
 		 *                        - Any other value (e.g. `false`), no notification is sent.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -661,6 +661,8 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		 *
 		 * This filter allows customization of the notification type when a new user is created via REST API.
 		 *
+		 * @since 7.0.0
+		 *
 		 * @param string $notify  Determines who gets notified. Accepts:
 		 *                        - 'admin': Notify only the site administrator. This is the default.
 		 *                        - 'user': Notify only the new user.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -669,7 +669,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		 * @param int    $user_id User ID.
 		 */
 		$notify = apply_filters( 'rest_wp_user_created_notification', $notify = 'admin', $user_id );
-		if ( $notify && 'false' != $notify ) {
+		if ( $notify && 'false' !== $notify ) {
 			wp_new_user_notification( $user_id, null, $notify );
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -656,6 +656,23 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 			}
 		}
 
+		/**
+		 * Filters the type of notification sent upon new user registration.
+		 *
+		 * This filter allows customization of the notification type when a new user is created via REST API.
+		 *
+		 * @param string $notify  Determines who gets notified. Accepts:
+		 *                        - 'admin' (default) or an empty string: Notify only the site administrator.
+		 *                        - 'user': Notify only the new user.
+		 *                        - 'both': Notify both admin and user.
+		 *                        - 'false': Disable notifications entirely.
+		 * @param int    $user_id User ID.
+		 */
+		$notify = apply_filters( 'rest_wp_user_created_notification', $notify = 'admin', $user_id );
+		if ( $notify && 'false' != $notify ) {
+			wp_new_user_notification( $user_id, null, $notify );
+		}
+
 		$user = get_user_by( 'id', $user_id );
 
 		/**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -665,7 +665,7 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		 *                        - 'admin' (default) or an empty string: Notify only the site administrator.
 		 *                        - 'user': Notify only the new user.
 		 *                        - 'both': Notify both admin and user.
-		 *                        - 'false': Disable notifications entirely.
+		 *                        - false: Disable notifications entirely.
 		 * @param int    $user_id User ID.
 		 */
 		$notify = apply_filters( 'rest_wp_user_created_notification', 'admin', $user_id );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -665,11 +665,11 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		 *                        - 'admin' (default) or an empty string: Notify only the site administrator.
 		 *                        - 'user': Notify only the new user.
 		 *                        - 'both': Notify both admin and user.
-		 *                        - false: Disable notifications entirely.
+		 *                        - Any other value (e.g. `false`), no notification is sent.
 		 * @param int    $user_id User ID.
 		 */
 		$notify = apply_filters( 'rest_wp_user_created_notification', 'admin', $user_id );
-		if ( false !== $notify ) {
+		if ( in_array( $notify, array( 'admin', 'user', 'both' ), true ) ) {
 			wp_new_user_notification( $user_id, null, $notify );
 		}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-users-controller.php
@@ -668,8 +668,8 @@ class WP_REST_Users_Controller extends WP_REST_Controller {
 		 *                        - 'false': Disable notifications entirely.
 		 * @param int    $user_id User ID.
 		 */
-		$notify = apply_filters( 'rest_wp_user_created_notification', $notify = 'admin', $user_id );
-		if ( $notify && 'false' !== $notify ) {
+		$notify = apply_filters( 'rest_wp_user_created_notification', 'admin', $user_id );
+		if ( false !== $notify ) {
 			wp_new_user_notification( $user_id, null, $notify );
 		}
 

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -1390,7 +1390,7 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertSame( 201, $response->get_status() );
-		
+
 		$mailer = tests_retrieve_phpmailer_instance();
 		$this->assertNotEmpty( $mailer->mock_sent, 'No emails were sent' );
 		$this->assertSame( get_option( 'admin_email' ), $mailer->mock_sent[0]['to'][0][0] );
@@ -1401,14 +1401,17 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	 */
 	public function test_create_user_notification_respects_filter() {
 		wp_set_current_user( self::$user );
-		add_filter( 'rest_wp_user_created_notification', function() {
-			return 'both';
-		});
+		add_filter(
+			'rest_wp_user_created_notification',
+			function () {
+				return 'both';
+			}
+		);
 
 		reset_phpmailer_instance();
 
 		$user_email = 'testuser2@example.com';
-		$request = new WP_REST_Request( 'POST', '/wp/v2/users' );
+		$request    = new WP_REST_Request( 'POST', '/wp/v2/users' );
 		$request->set_param( 'username', 'testuser2' );
 		$request->set_param( 'email', $user_email );
 		$request->set_param( 'password', 'testpassword2' );

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -1380,6 +1380,10 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	 * @ticket 40477
 	 */
 	public function test_create_user_sends_admin_notification() {
+		if ( is_multisite() ) {
+			grant_super_admin( self::$user );
+		}
+
 		wp_set_current_user( self::$user );
 		reset_phpmailer_instance();
 
@@ -1400,6 +1404,10 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 	 * @ticket 40477
 	 */
 	public function test_create_user_notification_respects_filter() {
+		if ( is_multisite() ) {
+			grant_super_admin( self::$user );
+		}
+
 		wp_set_current_user( self::$user );
 		add_filter(
 			'rest_wp_user_created_notification',

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -1397,7 +1397,20 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 
 		$mailer = tests_retrieve_phpmailer_instance();
 		$this->assertNotEmpty( $mailer->mock_sent, 'No emails were sent' );
-		$this->assertSame( get_option( 'admin_email' ), $mailer->mock_sent[0]['to'][0][0] );
+
+		// Check that at least one email was sent to the admin.
+		$admin_email    = get_option( 'admin_email' );
+		$recipients     = array_column( $mailer->mock_sent, 'to' );
+		$admin_notified = false;
+
+		foreach ( $recipients as $recipient_list ) {
+			if ( isset( $recipient_list[0][0] ) && $recipient_list[0][0] === $admin_email ) {
+				$admin_notified = true;
+				break;
+			}
+		}
+
+		$this->assertTrue( $admin_notified, 'Admin email notification was not sent' );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -1439,9 +1439,27 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		rest_get_server()->dispatch( $request );
 
 		$mailer = tests_retrieve_phpmailer_instance();
-		$this->assertCount( 2, $mailer->mock_sent, 'Expected 2 emails (admin + user)' );
-		$this->assertSame( get_option( 'admin_email' ), $mailer->mock_sent[0]['to'][0][0] );
-		$this->assertSame( $user_email, $mailer->mock_sent[1]['to'][0][0] );
+		$this->assertGreaterThanOrEqual( 2, count( $mailer->mock_sent ), 'Expected at least 2 emails (admin + user)' );
+
+		// Verify both admin and user received notifications.
+		$admin_email    = get_option( 'admin_email' );
+		$recipients     = array_column( $mailer->mock_sent, 'to' );
+		$admin_notified = false;
+		$user_notified  = false;
+
+		foreach ( $recipients as $recipient_list ) {
+			if ( isset( $recipient_list[0][0] ) ) {
+				if ( $recipient_list[0][0] === $admin_email ) {
+					$admin_notified = true;
+				}
+				if ( $recipient_list[0][0] === $user_email ) {
+					$user_notified = true;
+				}
+			}
+		}
+
+		$this->assertTrue( $admin_notified, 'Admin email notification was not sent' );
+		$this->assertTrue( $user_notified, 'User email notification was not sent' );
 
 		remove_all_filters( 'rest_wp_user_created_notification' );
 	}

--- a/tests/phpunit/tests/rest-api/rest-users-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-users-controller.php
@@ -1376,6 +1376,52 @@ class WP_Test_REST_Users_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->check_add_edit_user_response( $response );
 	}
 
+	/**
+	 * @ticket 40477
+	 */
+	public function test_create_user_sends_admin_notification() {
+		wp_set_current_user( self::$user );
+		reset_phpmailer_instance();
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/users' );
+		$request->set_param( 'username', 'testuser' );
+		$request->set_param( 'email', 'testuser@example.com' );
+		$request->set_param( 'password', 'testpassword' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 201, $response->get_status() );
+		
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertNotEmpty( $mailer->mock_sent, 'No emails were sent' );
+		$this->assertSame( get_option( 'admin_email' ), $mailer->mock_sent[0]['to'][0][0] );
+	}
+
+	/**
+	 * @ticket 40477
+	 */
+	public function test_create_user_notification_respects_filter() {
+		wp_set_current_user( self::$user );
+		add_filter( 'rest_wp_user_created_notification', function() {
+			return 'both';
+		});
+
+		reset_phpmailer_instance();
+
+		$user_email = 'testuser2@example.com';
+		$request = new WP_REST_Request( 'POST', '/wp/v2/users' );
+		$request->set_param( 'username', 'testuser2' );
+		$request->set_param( 'email', $user_email );
+		$request->set_param( 'password', 'testpassword2' );
+		rest_get_server()->dispatch( $request );
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertCount( 2, $mailer->mock_sent, 'Expected 2 emails (admin + user)' );
+		$this->assertSame( get_option( 'admin_email' ), $mailer->mock_sent[0]['to'][0][0] );
+		$this->assertSame( $user_email, $mailer->mock_sent[1]['to'][0][0] );
+
+		remove_all_filters( 'rest_wp_user_created_notification' );
+	}
+
 	public function test_create_item_invalid_username() {
 		$this->allow_user_to_manage_multisite();
 


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/40477



This PR adds unit tests verifying email notifications are sent when creating users through the REST API. Tests cover:

- Default admin notification behavior
- Filter override capability via `rest_wp_user_created_notification`
- Multi-recipient notifications when using 'both' parameter

Follows the implementation from https://github.com/WordPress/wordpress-develop/pull/8572 by @nikunj8866. 


