### PR TITLE
Media: Prevent long user display names from overflowing in media modal

### DIFF
--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -1810,6 +1810,10 @@
 	word-wrap: break-word;
 }
 
+.attachment-info .uploaded-by {
+    word-wrap: break-word;
+}
+
 .attachment-info .thumbnail {
 	position: relative;
 	float: left;


### PR DESCRIPTION
Fixes a layout issue in the media modal where long, unbroken user display names can overflow the "Uploaded by" field. This applies `word-wrap: break-word;` to `.attachment-info .uploaded-by` to ensure the layout remains intact.

Trac ticket: [#63260](https://core.trac.wordpress.org/ticket/63260)

Before:
<img width="1470" alt="Screenshot 2025-04-10 at 5 39 43 PM" src="https://github.com/user-attachments/assets/368c40de-57fd-4c9f-9d78-730672aca2fc" />

After:
<img width="1470" alt="Screenshot 2025-04-10 at 5 41 57 PM" src="https://github.com/user-attachments/assets/6d5067db-8a94-4a05-abba-10fa31664f83" />

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
