### PR TITLE
Coding Standards: Check for an empty $old_email first in wp_site_admin_email_change_notification()

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -8123,7 +8123,7 @@ function wp_site_admin_email_change_notification( $old_email, $new_email, $optio
 	$send = true;
 
 	// Don't send the notification to the default 'admin_email' value or an empty value.
-	if ( 'you@example.com' === $old_email || empty( $old_email ) ) {
+	if ( empty( $old_email ) || 'you@example.com' === $old_email ) {
 		$send = false;
 	}
 

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -2870,7 +2870,7 @@ function wp_network_admin_email_change_notification( $option_name, $new_email, $
 	$send = true;
 
 	// Don't send the notification to the default 'admin_email' value or an empty value.
-	if ( 'you@example.com' === $old_email || empty( $old_email ) ) {
+	if ( empty( $old_email ) || 'you@example.com' === $old_email ) {
 		$send = false;
 	}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63267