### PR TITLE
Remove redundant access tags from DocBlocks

### DIFF
--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -1543,7 +1543,6 @@ class WP_List_Table {
 	 * should be provided via get_sortable_columns().
 	 *
 	 * @since 6.3.0
-	 * @access public
 	 */
 	public function print_table_description() {
 		list( $columns, $hidden, $sortable ) = $this->get_column_info();

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -36,7 +36,6 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 	 * installed plugins.
 	 *
 	 * @since 4.9.0
-	 * @access protected
 	 *
 	 * @return array
 	 */

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -496,7 +496,6 @@ class WP_Posts_List_Table extends WP_List_Table {
 	 * Displays a formats drop-down for filtering items.
 	 *
 	 * @since 5.2.0
-	 * @access protected
 	 *
 	 * @param string $post_type Post type slug.
 	 */

--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -402,7 +402,6 @@ class WP_Upgrader {
 	 * Flattens the results of WP_Filesystem_Base::dirlist() for iterating over.
 	 *
 	 * @since 4.9.0
-	 * @access protected
 	 *
 	 * @param array  $nested_files Array of files as returned by WP_Filesystem_Base::dirlist().
 	 * @param string $path         Relative path to prepend to child nodes. Optional.

--- a/src/wp-includes/class-wp-block-list.php
+++ b/src/wp-includes/class-wp-block-list.php
@@ -19,7 +19,6 @@ class WP_Block_List implements Iterator, ArrayAccess, Countable {
 	 *
 	 * @since 5.5.0
 	 * @var array[]|WP_Block[]
-	 * @access protected
 	 */
 	protected $blocks;
 
@@ -28,7 +27,6 @@ class WP_Block_List implements Iterator, ArrayAccess, Countable {
 	 *
 	 * @since 5.5.0
 	 * @var array
-	 * @access protected
 	 */
 	protected $available_context;
 
@@ -37,7 +35,6 @@ class WP_Block_List implements Iterator, ArrayAccess, Countable {
 	 *
 	 * @since 5.5.0
 	 * @var WP_Block_Type_Registry
-	 * @access protected
 	 */
 	protected $registry;
 

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -54,7 +54,6 @@ class WP_Block {
 	 *
 	 * @since 5.5.0
 	 * @var array
-	 * @access protected
 	 */
 	protected $available_context;
 
@@ -63,7 +62,6 @@ class WP_Block {
 	 *
 	 * @since 5.9.0
 	 * @var WP_Block_Type_Registry
-	 * @access protected
 	 */
 	protected $registry;
 

--- a/src/wp-includes/class-wp-classic-to-block-menu-converter.php
+++ b/src/wp-includes/class-wp-classic-to-block-menu-converter.php
@@ -10,7 +10,6 @@
  * Converts a Classic Menu to Block Menu blocks.
  *
  * @since 6.3.0
- * @access public
  */
 class WP_Classic_To_Block_Menu_Converter {
 

--- a/src/wp-includes/class-wp-navigation-fallback.php
+++ b/src/wp-includes/class-wp-navigation-fallback.php
@@ -12,7 +12,6 @@
 /**
  * Manages fallback behavior for Navigation menus.
  *
- * @access public
  * @since 6.3.0
  */
 class WP_Navigation_Fallback {

--- a/src/wp-includes/widgets/class-wp-widget-media-gallery.php
+++ b/src/wp-includes/widgets/class-wp-widget-media-gallery.php
@@ -240,7 +240,6 @@ class WP_Widget_Media_Gallery extends WP_Widget_Media {
 	 * Whether the widget has content to show.
 	 *
 	 * @since 4.9.0
-	 * @access protected
 	 *
 	 * @param array $instance Widget instance props.
 	 * @return bool Whether widget has content.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This patch removes `@access` tags from DocBlocks when the visibility is already defined in the method declaration. In such cases, the tags are redundant and do not provide additional value. This change is consistent with the WordPress PHP documentation standards.

This patch does not modify affected methods in `WP_User_Search` (which is deprecated), or in `SimplePie_Decode_HTML_Entities`, `SimplePie\Parse\Date`, and `SimplePie\XML\Declaration\Parser`.

Trac ticket: https://core.trac.wordpress.org/ticket/63272

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
