### PR TITLE
Fix wp-settings- and wp-settings-time- cookie getting set repeatedly …

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1735,6 +1735,10 @@ function wp_user_settings() {
 		}
 	}
 
+	if ( '' === $settings ) {
+		$settings = ' ';
+	}
+
 	// The cookie is not set in the current browser or the saved value is newer.
 	$secure = ( 'https' === parse_url( admin_url(), PHP_URL_SCHEME ) );
 	setcookie( 'wp-settings-' . $user_id, $settings, time() + YEAR_IN_SECONDS, SITECOOKIEPATH, '', $secure );


### PR DESCRIPTION
…on every request, if settings are empty

Trac ticket: https://core.trac.wordpress.org/ticket/63280

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
