### PR TITLE
Administration: Improve alignment of comment actions in mobile view

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -2082,6 +2082,7 @@ div.action-links,
 
 	.row-actions span a,
 	.row-actions span .button-link {
+		font-size: 13px;
 		display: inline-block;
 		padding: 4px 16px 4px 0;
 		font-size: 13px;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR fixes an alignment issue in the admin tables row actions where list items were shifting right due to inconsistent padding. The solution sets consistent padding across action items while maintaining proper spacing between them, resulting in better visual alignment throughout the interface.

Before: 

![image](https://github.com/user-attachments/assets/a7c68afd-de63-48b7-976b-f33c5d20fed4)

After:

![image](https://github.com/user-attachments/assets/75a4da76-340b-4f64-ab2f-dc97c234b2cc)


Trac ticket: [#63277](https://core.trac.wordpress.org/ticket/63277)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
