### PR TITLE
Upgrade/Install: Better error message when uploading theme as plugin and vice versa.

### DIFF
--- a/src/wp-admin/includes/class-plugin-upgrader.php
+++ b/src/wp-admin/includes/class-plugin-upgrader.php
@@ -487,6 +487,13 @@ class Plugin_Upgrader extends WP_Upgrader {
 		}
 
 		if ( empty( $this->new_plugin_data ) ) {
+			if ( file_exists( $working_directory . 'style.css' ) ) {
+				return new WP_Error(
+					'incompatible_archive_theme_detected',
+					$this->strings['incompatible_archive'],
+					__( 'The uploaded package appears to be a theme. Please upload it in the Appearance > Themes menu.' )
+				);
+			}
 			return new WP_Error( 'incompatible_archive_no_plugins', $this->strings['incompatible_archive'], __( 'No valid plugins were found.' ) );
 		}
 

--- a/src/wp-admin/includes/class-theme-upgrader.php
+++ b/src/wp-admin/includes/class-theme-upgrader.php
@@ -577,6 +577,21 @@ class Theme_Upgrader extends WP_Upgrader {
 
 		// A proper archive should have a style.css file in the single subdirectory.
 		if ( ! file_exists( $working_directory . 'style.css' ) ) {
+			// Check if the package is a plugin.
+			$plugin_files = glob( $working_directory . '*.php' );
+			if ( $plugin_files ) {
+				foreach ( $plugin_files as $file ) {
+					$plugin_data = get_plugin_data( $file, false, false );
+					if ( ! empty( $plugin_data['Name'] ) ) {
+						return new WP_Error(
+							'incompatible_archive_plugin_detected',
+							$this->strings['incompatible_archive'],
+							__( 'The uploaded package appears to be a plugin. Please upload it in the Plugins menu.' )
+						);
+					}
+				}
+			}
+
 			return new WP_Error(
 				'incompatible_archive_theme_no_style',
 				$this->strings['incompatible_archive'],


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/28845

The PR updates error messages to indicate if a theme is uploaded as a plugin and vice versa.

Uploading Plugin in place of theme

| Before | After |
|--------|--------|
| <img width="1467" alt="image" src="https://github.com/user-attachments/assets/d535436d-d74e-4d15-86f0-35ea32dc863d" />| <img width="1467" alt="image" src="https://github.com/user-attachments/assets/9e39b338-8832-49ec-abcb-3972ba57b063" /> |

Uploading Theme in place of plugin

| Before | After |
|--------|--------|
| <img width="1467" alt="image" src="https://github.com/user-attachments/assets/7c9ad42d-06be-4931-a24e-aeafc056c5e3" /> | <img width="1467" alt="image" src="https://github.com/user-attachments/assets/a29340be-9475-43ad-9e00-1bda12edfccb" /> |

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
