### PR TITLE
Prevent password field from getting focus on installation page

### DIFF
--- a/src/js/_enqueues/admin/user-profile.js
+++ b/src/js/_enqueues/admin/user-profile.js
@@ -57,7 +57,7 @@
 		$( '#pw-weak-text-label' ).text( __( 'Confirm use of weak password' ) );
 
 		// Focus the password field.
-		if ( 'mailserver_pass' !== $pass1.prop('id' ) ) {
+		if ( 'mailserver_pass' !== $pass1.prop('id' ) && !$('#weblog_title').length ) {
 			$( $pass1 ).trigger( 'focus' );
 		}
 	}


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/63281

This PR addresses an issue where the password field incorrectly receives focus during WordPress installation instead of the first field (site title).

This change adds a condition to check if we're on the installation page by looking for the `#weblog_title element`, and if so, prevents the automatic focus on the password field.


Testing:

1. Start a fresh WordPress installation
2. Proceed to the final setup page
3. Verify that the focus is positioned in the site title field (first field) 

