### PR TITLE
Fix missing MIME type in Atom feed

### DIFF
--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -542,7 +542,7 @@ function atom_enclosure() {
 					if ( isset( $enclosure[ $i ] ) ) {
 						if ( is_numeric( $enclosure[ $i ] ) ) {
 							$length = trim( $enclosure[ $i ] );
-						} elseif ( in_array( $enclosure[ $i ], $mimes, true ) ) {
+						} elseif ( in_array( trim( $enclosure[ $i ] ), $mimes, true ) ) {
 							$type = trim( $enclosure[ $i ] );
 						}
 					}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

The atom_enclosure doesn't always pick up MIME types correctly. This PR ensures consistency with rss_enclosure.

Trac ticket: https://core.trac.wordpress.org/ticket/63292

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
