### PR TITLE
Block Hooks: Suppress insertion of hooked blocks in before/after position into post object content

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1264,7 +1264,7 @@ function apply_block_hooks_to_content_from_post_object( $content, $post = null, 
 	};
 
 	// Apply Block Hooks.
-	add_filter( 'hooked_block_types', $suppress_blocks_from_insertion_before_and_after_wrapper_block, PHP_INT_MAX , 3);
+	add_filter( 'hooked_block_types', $suppress_blocks_from_insertion_before_and_after_wrapper_block, PHP_INT_MAX, 3);
 	$content = apply_block_hooks_to_content( $content, $post, $callback );
 	remove_filter( 'hooked_block_types', $suppress_blocks_from_insertion_before_and_after_wrapper_block, PHP_INT_MAX );
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1126,10 +1126,10 @@ function apply_block_hooks_to_content( $content, $context = null, $callback = 'i
 	}
 
 	/*
-	 * We also need to cover the case where a hooked block with `multiple: false` is not
-	 * present in `$content` at first and we're allowed to insert it once -- but not again.
+	 * We also need to cover the case where the hooked block is not present in
+	 * `$content` at first and we're allowed to insert it once -- but not again.
 	 */
-	$suppress_single_instance_blocks = static function ( $hooked_block_types ) use ( &$block_allows_multiple_instances, $content, $context ) {
+	$suppress_single_instance_blocks = static function ( $hooked_block_types ) use ( &$block_allows_multiple_instances, $content ) {
 		static $single_instance_blocks_present_in_content = array();
 		foreach ( $hooked_block_types as $index => $hooked_block_type ) {
 			if ( ! isset( $block_allows_multiple_instances[ $hooked_block_type ] ) ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1264,7 +1264,7 @@ function apply_block_hooks_to_content_from_post_object( $content, $post = null, 
 	};
 
 	// Apply Block Hooks.
-	add_filter( 'hooked_block_types', $suppress_blocks_from_insertion_before_and_after_wrapper_block, PHP_INT_MAX, 3);
+	add_filter( 'hooked_block_types', $suppress_blocks_from_insertion_before_and_after_wrapper_block, PHP_INT_MAX, 3 );
 	$content = apply_block_hooks_to_content( $content, $post, $callback );
 	remove_filter( 'hooked_block_types', $suppress_blocks_from_insertion_before_and_after_wrapper_block, PHP_INT_MAX );
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1129,9 +1129,25 @@ function apply_block_hooks_to_content( $content, $context = null, $callback = 'i
 	 * We also need to cover the case where the hooked block is not present in
 	 * `$content` at first and we're allowed to insert it once -- but not again.
 	 */
-	$suppress_single_instance_blocks = static function ( $hooked_block_types ) use ( &$block_allows_multiple_instances, $content ) {
+	$suppress_single_instance_blocks = static function ( $hooked_block_types, $relative_position, $anchor_block_type ) use ( &$block_allows_multiple_instances, $content, $context ) {
 		static $single_instance_blocks_present_in_content = array();
 		foreach ( $hooked_block_types as $index => $hooked_block_type ) {
+			if ( $context instanceof WP_Post ) {
+				$wrapper_block_type = 'core/post-content';
+				if ( 'wp_navigation' === $context->post_type ) {
+					$wrapper_block_type = 'core/navigation';
+				} elseif ( 'wp_block' === $context->post_type ) {
+					$wrapper_block_type = 'core/block';
+				}
+
+				if (
+					$wrapper_block_type === $anchor_block_type &&
+					in_array( $relative_position, array( 'before', 'after' ), true )
+				) {
+					$hooked_block_types = array();
+				}
+			}
+
 			if ( ! isset( $block_allows_multiple_instances[ $hooked_block_type ] ) ) {
 				$hooked_block_type_definition =
 					WP_Block_Type_Registry::get_instance()->get_registered( $hooked_block_type );
@@ -1157,7 +1173,7 @@ function apply_block_hooks_to_content( $content, $context = null, $callback = 'i
 		}
 		return $hooked_block_types;
 	};
-	add_filter( 'hooked_block_types', $suppress_single_instance_blocks, PHP_INT_MAX );
+	add_filter( 'hooked_block_types', $suppress_single_instance_blocks, PHP_INT_MAX, 3 );
 	$content = traverse_and_serialize_blocks(
 		parse_blocks( $content ),
 		$before_block_visitor,

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1125,7 +1125,7 @@ function apply_block_hooks_to_content( $content, $context = null, $callback = 'i
 		}
 	}
 
-	$suppress_single_instance_blocks = static function ( $hooked_block_types, $relative_position, $anchor_block_type ) use ( &$block_allows_multiple_instances, $content, $context ) {
+	$suppress_blocks_from_insertion = static function ( $hooked_block_types, $relative_position, $anchor_block_type ) use ( &$block_allows_multiple_instances, $content, $context ) {
 		static $single_instance_blocks_present_in_content = array();
 
 		/*
@@ -1179,13 +1179,13 @@ function apply_block_hooks_to_content( $content, $context = null, $callback = 'i
 		}
 		return $hooked_block_types;
 	};
-	add_filter( 'hooked_block_types', $suppress_single_instance_blocks, PHP_INT_MAX, 3 );
+	add_filter( 'hooked_block_types', $suppress_blocks_from_insertion, PHP_INT_MAX, 3 );
 	$content = traverse_and_serialize_blocks(
 		parse_blocks( $content ),
 		$before_block_visitor,
 		$after_block_visitor
 	);
-	remove_filter( 'hooked_block_types', $suppress_single_instance_blocks, PHP_INT_MAX );
+	remove_filter( 'hooked_block_types', $suppress_blocks_from_insertion, PHP_INT_MAX );
 
 	return $content;
 }

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1125,34 +1125,12 @@ function apply_block_hooks_to_content( $content, $context = null, $callback = 'i
 		}
 	}
 
-	$suppress_blocks_from_insertion = static function ( $hooked_block_types, $relative_position, $anchor_block_type ) use ( &$block_allows_multiple_instances, $content, $context ) {
+	/*
+	 * We also need to cover the case where a hooked block with `multiple: false` is not
+	 * present in `$content` at first and we're allowed to insert it once -- but not again.
+	 */
+	$suppress_single_instance_blocks = static function ( $hooked_block_types ) use ( &$block_allows_multiple_instances, $content, $context ) {
 		static $single_instance_blocks_present_in_content = array();
-
-		/*
-		 * If the context is a post object, we need to avoid inserting any blocks hooked into the
-		 * `before` and `after` positions of the temporary wrapper block that we create to wrap the content.
-		 * See https://core.trac.wordpress.org/ticket/63287 for more details.
-		 */
-		if ( $context instanceof WP_Post ) {
-			$wrapper_block_type = 'core/post-content';
-			if ( 'wp_navigation' === $context->post_type ) {
-				$wrapper_block_type = 'core/navigation';
-			} elseif ( 'wp_block' === $context->post_type ) {
-				$wrapper_block_type = 'core/block';
-			}
-
-			if (
-				$wrapper_block_type === $anchor_block_type &&
-				in_array( $relative_position, array( 'before', 'after' ), true )
-			) {
-				return array();
-			}
-		}
-
-		/*
-		 * We also need to cover the case where a hooked block with `multiple: false` is not
-		 * present in `$content` at first and we're allowed to insert it once -- but not again.
-		 */
 		foreach ( $hooked_block_types as $index => $hooked_block_type ) {
 			if ( ! isset( $block_allows_multiple_instances[ $hooked_block_type ] ) ) {
 				$hooked_block_type_definition =
@@ -1179,13 +1157,13 @@ function apply_block_hooks_to_content( $content, $context = null, $callback = 'i
 		}
 		return $hooked_block_types;
 	};
-	add_filter( 'hooked_block_types', $suppress_blocks_from_insertion, PHP_INT_MAX, 3 );
+	add_filter( 'hooked_block_types', $suppress_single_instance_blocks, PHP_INT_MAX );
 	$content = traverse_and_serialize_blocks(
 		parse_blocks( $content ),
 		$before_block_visitor,
 		$after_block_visitor
 	);
-	remove_filter( 'hooked_block_types', $suppress_blocks_from_insertion, PHP_INT_MAX );
+	remove_filter( 'hooked_block_types', $suppress_single_instance_blocks, PHP_INT_MAX );
 
 	return $content;
 }
@@ -1270,8 +1248,25 @@ function apply_block_hooks_to_content_from_post_object( $content, $post = null, 
 		$content
 	);
 
+	/*
+	 * We need to avoid inserting any blocks hooked into the `before` and `after` positions
+	 * of the temporary wrapper block that we create to wrap the content.
+	 * See https://core.trac.wordpress.org/ticket/63287 for more details.
+	 */
+	$suppress_blocks_from_insertion_before_and_after_wrapper_block = static function ( $hooked_block_types, $relative_position, $anchor_block_type ) use ( $wrapper_block_type ) {
+		if (
+			$wrapper_block_type === $anchor_block_type &&
+			in_array( $relative_position, array( 'before', 'after' ), true )
+		) {
+			return array();
+		}
+		return $hooked_block_types;
+	};
+
 	// Apply Block Hooks.
+	add_filter( 'hooked_block_types', $suppress_blocks_from_insertion_before_and_after_wrapper_block, PHP_INT_MAX , 3);
 	$content = apply_block_hooks_to_content( $content, $post, $callback );
+	remove_filter( 'hooked_block_types', $suppress_blocks_from_insertion_before_and_after_wrapper_block, PHP_INT_MAX );
 
 	// Finally, we need to remove the temporary wrapper block.
 	$content = remove_serialized_parent_block( $content );

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1125,11 +1125,12 @@ function apply_block_hooks_to_content( $content, $context = null, $callback = 'i
 		}
 	}
 
-	/*
-	 * We also need to cover the case where the hooked block is not present in
-	 * `$content` at first and we're allowed to insert it once -- but not again.
-	 */
 	$suppress_single_instance_blocks = static function ( $hooked_block_types, $relative_position, $anchor_block_type ) use ( &$block_allows_multiple_instances, $content, $context ) {
+		/*
+		 * If the context is a post object, we need to avoid inserting any blocks hooked into the
+		 * `before` and `after` positions of the temporary wrapper block that we create to wrap the content.
+		 * See https://core.trac.wordpress.org/ticket/63287 for more details.
+		 */
 		if ( $context instanceof WP_Post ) {
 			$wrapper_block_type = 'core/post-content';
 			if ( 'wp_navigation' === $context->post_type ) {
@@ -1146,6 +1147,10 @@ function apply_block_hooks_to_content( $content, $context = null, $callback = 'i
 			}
 		}
 
+		/*
+		 * We also need to cover the case where a hooked block with `multiple: false` is not
+		 * present in `$content` at first and we're allowed to insert it once -- but not again.
+		 */
 		static $single_instance_blocks_present_in_content = array();
 		foreach ( $hooked_block_types as $index => $hooked_block_type ) {
 			if ( ! isset( $block_allows_multiple_instances[ $hooked_block_type ] ) ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1130,24 +1130,24 @@ function apply_block_hooks_to_content( $content, $context = null, $callback = 'i
 	 * `$content` at first and we're allowed to insert it once -- but not again.
 	 */
 	$suppress_single_instance_blocks = static function ( $hooked_block_types, $relative_position, $anchor_block_type ) use ( &$block_allows_multiple_instances, $content, $context ) {
-		static $single_instance_blocks_present_in_content = array();
-		foreach ( $hooked_block_types as $index => $hooked_block_type ) {
-			if ( $context instanceof WP_Post ) {
-				$wrapper_block_type = 'core/post-content';
-				if ( 'wp_navigation' === $context->post_type ) {
-					$wrapper_block_type = 'core/navigation';
-				} elseif ( 'wp_block' === $context->post_type ) {
-					$wrapper_block_type = 'core/block';
-				}
-
-				if (
-					$wrapper_block_type === $anchor_block_type &&
-					in_array( $relative_position, array( 'before', 'after' ), true )
-				) {
-					$hooked_block_types = array();
-				}
+		if ( $context instanceof WP_Post ) {
+			$wrapper_block_type = 'core/post-content';
+			if ( 'wp_navigation' === $context->post_type ) {
+				$wrapper_block_type = 'core/navigation';
+			} elseif ( 'wp_block' === $context->post_type ) {
+				$wrapper_block_type = 'core/block';
 			}
 
+			if (
+				$wrapper_block_type === $anchor_block_type &&
+				in_array( $relative_position, array( 'before', 'after' ), true )
+			) {
+				return array();
+			}
+		}
+
+		static $single_instance_blocks_present_in_content = array();
+		foreach ( $hooked_block_types as $index => $hooked_block_type ) {
 			if ( ! isset( $block_allows_multiple_instances[ $hooked_block_type ] ) ) {
 				$hooked_block_type_definition =
 					WP_Block_Type_Registry::get_instance()->get_registered( $hooked_block_type );

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1126,6 +1126,8 @@ function apply_block_hooks_to_content( $content, $context = null, $callback = 'i
 	}
 
 	$suppress_single_instance_blocks = static function ( $hooked_block_types, $relative_position, $anchor_block_type ) use ( &$block_allows_multiple_instances, $content, $context ) {
+		static $single_instance_blocks_present_in_content = array();
+
 		/*
 		 * If the context is a post object, we need to avoid inserting any blocks hooked into the
 		 * `before` and `after` positions of the temporary wrapper block that we create to wrap the content.
@@ -1151,7 +1153,6 @@ function apply_block_hooks_to_content( $content, $context = null, $callback = 'i
 		 * We also need to cover the case where a hooked block with `multiple: false` is not
 		 * present in `$content` at first and we're allowed to insert it once -- but not again.
 		 */
-		static $single_instance_blocks_present_in_content = array();
 		foreach ( $hooked_block_types as $index => $hooked_block_type ) {
 			if ( ! isset( $block_allows_multiple_instances[ $hooked_block_type ] ) ) {
 				$hooked_block_type_definition =

--- a/tests/phpunit/tests/blocks/applyBlockHooksToContent.php
+++ b/tests/phpunit/tests/blocks/applyBlockHooksToContent.php
@@ -17,13 +17,14 @@ class Tests_Blocks_ApplyBlockHooksToContent extends WP_UnitTestCase {
 	 * Set up.
 	 *
 	 * @ticket 61902.
+	 * @ticket 63287.
 	 */
 	public static function wpSetUpBeforeClass() {
 		register_block_type(
 			'tests/hooked-block',
 			array(
 				'block_hooks' => array(
-					'tests/anchor-block' => 'after',
+					'core/post-content' => 'after',
 				),
 			)
 		);
@@ -79,23 +80,25 @@ class Tests_Blocks_ApplyBlockHooksToContent extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 61902
+	 * @ticket 63287
 	 */
 	public function test_apply_block_hooks_to_content_inserts_hooked_block() {
 		$context          = new WP_Block_Template();
-		$context->content = '<!-- wp:tests/anchor-block /-->';
+		$context->content = '<!-- wp:post-content /-->';
 
 		$actual = apply_block_hooks_to_content( $context->content, $context, 'insert_hooked_blocks' );
 		$this->assertSame(
-			'<!-- wp:tests/anchor-block /--><!-- wp:tests/hooked-block /-->',
+			'<!-- wp:post-content /--><!-- wp:tests/hooked-block /-->',
 			$actual
 		);
 	}
 
 	/**
 	 * @ticket 61074
+	 * @ticket 63287
 	 */
 	public function test_apply_block_hooks_to_content_with_context_set_to_null() {
-		$content = '<!-- wp:tests/anchor-block /-->';
+		$content = '<!-- wp:post-content /-->';
 
 		/*
 		 * apply_block_hooks_to_content() will fall back to the global $post object (via get_post())
@@ -106,7 +109,7 @@ class Tests_Blocks_ApplyBlockHooksToContent extends WP_UnitTestCase {
 
 		$actual = apply_block_hooks_to_content( $content, null, 'insert_hooked_blocks' );
 		$this->assertSame(
-			'<!-- wp:tests/anchor-block /--><!-- wp:tests/hooked-block /-->',
+			'<!-- wp:post-content /--><!-- wp:tests/hooked-block /-->',
 			$actual
 		);
 	}

--- a/tests/phpunit/tests/blocks/applyBlockHooksToContentFromPostObject.php
+++ b/tests/phpunit/tests/blocks/applyBlockHooksToContentFromPostObject.php
@@ -97,6 +97,8 @@ class Tests_Blocks_ApplyBlockHooksToContentFromPostObject extends WP_UnitTestCas
 				),
 			)
 		);
+
+		register_block_type( 'tests/dynamically-hooked-block-before-post-content' );
 	}
 
 	/**
@@ -110,6 +112,7 @@ class Tests_Blocks_ApplyBlockHooksToContentFromPostObject extends WP_UnitTestCas
 		$registry->unregister( 'tests/hooked-block' );
 		$registry->unregister( 'tests/hooked-block-first-child' );
 		$registry->unregister( 'tests/hooked-block-after-post-content' );
+		$registry->unregister( 'tests/dynamically-hooked-block-before-post-content' );
 	}
 
 	/**

--- a/tests/phpunit/tests/blocks/applyBlockHooksToContentFromPostObject.php
+++ b/tests/phpunit/tests/blocks/applyBlockHooksToContentFromPostObject.php
@@ -109,6 +109,7 @@ class Tests_Blocks_ApplyBlockHooksToContentFromPostObject extends WP_UnitTestCas
 
 		$registry->unregister( 'tests/hooked-block' );
 		$registry->unregister( 'tests/hooked-block-first-child' );
+		$registry->unregister( 'tests/other-hooked-block' );
 	}
 
 	/**

--- a/tests/phpunit/tests/blocks/applyBlockHooksToContentFromPostObject.php
+++ b/tests/phpunit/tests/blocks/applyBlockHooksToContentFromPostObject.php
@@ -88,6 +88,15 @@ class Tests_Blocks_ApplyBlockHooksToContentFromPostObject extends WP_UnitTestCas
 				),
 			)
 		);
+
+		register_block_type(
+			'tests/other-hooked-block',
+			array(
+				'block_hooks' => array(
+					'core/post-content' => 'after',
+				),
+			)
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/blocks/applyBlockHooksToContentFromPostObject.php
+++ b/tests/phpunit/tests/blocks/applyBlockHooksToContentFromPostObject.php
@@ -141,6 +141,33 @@ class Tests_Blocks_ApplyBlockHooksToContentFromPostObject extends WP_UnitTestCas
 	}
 
 	/**
+	 * @ticket 63287
+	 */
+	public function test_apply_block_hooks_to_content_from_post_object_does_not_insert_hooked_block_before_container_block() {
+		$filter = function ( $hooked_block_types, $relative_position, $anchor_block_type ) {
+			if ( 'core/post-content' === $anchor_block_type && 'before' === $relative_position ) {
+				$hooked_block_types[] = 'tests/dynamically-hooked-block-before-post-content';
+			}
+
+			return $hooked_block_types;
+		};
+
+		$expected = '<!-- wp:tests/hooked-block-first-child /-->' .
+			self::$post->post_content .
+			'<!-- wp:tests/hooked-block /-->';
+
+		add_filter( 'hooked_block_types', $filter, 10, 3 );
+		$actual = apply_block_hooks_to_content_from_post_object(
+			self::$post->post_content,
+			self::$post,
+			'insert_hooked_blocks'
+		);
+		remove_filter( 'hooked_block_types', $filter, 10 );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
 	 * @ticket 62716
 	 */
 	public function test_apply_block_hooks_to_content_from_post_object_inserts_hooked_block_if_content_contains_no_blocks() {

--- a/tests/phpunit/tests/blocks/applyBlockHooksToContentFromPostObject.php
+++ b/tests/phpunit/tests/blocks/applyBlockHooksToContentFromPostObject.php
@@ -90,7 +90,7 @@ class Tests_Blocks_ApplyBlockHooksToContentFromPostObject extends WP_UnitTestCas
 		);
 
 		register_block_type(
-			'tests/other-hooked-block',
+			'tests/hooked-block-after-post-content',
 			array(
 				'block_hooks' => array(
 					'core/post-content' => 'after',
@@ -109,7 +109,7 @@ class Tests_Blocks_ApplyBlockHooksToContentFromPostObject extends WP_UnitTestCas
 
 		$registry->unregister( 'tests/hooked-block' );
 		$registry->unregister( 'tests/hooked-block-first-child' );
-		$registry->unregister( 'tests/other-hooked-block' );
+		$registry->unregister( 'tests/hooked-block-after-post-content' );
 	}
 
 	/**


### PR DESCRIPTION
As of WordPress 6.8, Block Hooks are also applied to post content. In order to allow for first/last child insertion of a hooked block into the Post Content block, we wrap the block's post content (as obtained from the DB) in a temporary `<!-- wp:post-content -->` wrapper block, run the `apply_block_hooks_to_content_from_post_object` function on the resulting markup, and remove the wrapper block.

In [`#63287`](https://core.trac.wordpress.org/ticket/63287), @obenland reported that there was a problem when using Block Hooks to insert a block _before_ or _after_ a Post Content block. See that ticket for more details about how the bug manifested itself.

After some thought, I believe that we need to exempt hooked blocks that are meant to be inserted `before` or `after` a Post Content block from the `apply_block_hooks_to_content_from_post_object` algorithm when it is run on a post object's content wrapped in a temporary wrapper block. Arguably, a block that is supposed to be _before_ or _after_ a given block should not be absorbed into the latter's content; instead, it should remain _outside_. (This is in contrast to first/last child insertion, where it makes sense to absorb the child block _inside_ of the anchor block.)

(Instead, if a block is supposed to be inserted before or after a Post Content block, it should be the job of the containing markup entity -- typically a template -- to absorb it.)

The present PR implements this idea by adding logic to a pre-existing filter that is run with "latest" priority on the `hooked_block_types` hook. Specifically, that logic checks if the given context is a post object, and if so, verifies that the anchor block matches the post object's corresponding block type. (This means that it isn't limited to the Post Content block, but also applies to the Synced Pattern and Navigation blocks.)

---

Includes test coverage for the following scenarios:

- Hooked block inserted before/after Post Content block via block registration. https://github.com/WordPress/wordpress-develop/pull/8700/commits/34c64939bc30066b7639d49237e6a06849e9a7c7 _This is the case that led to the bug being detected, see [`#63287`](https://core.trac.wordpress.org/ticket/63287)._
- Hooked block inserted before/after Post Content block via `hooked_block_types` filter. 6e12f44b25
- Hooked block inserted in before/after position _inside_ of Post Content block. _Already covered by [pre-existing](https://github.com/WordPress/wordpress-develop/blob/9063e30f6f34d313ecdc3394f45ca63283732b24/tests/phpunit/tests/blocks/applyBlockHooksToContentFromPostObject.php#L74-L81) [test](https://github.com/WordPress/wordpress-develop/blob/9063e30f6f34d313ecdc3394f45ca63283732b24/tests/phpunit/tests/blocks/applyBlockHooksToContentFromPostObject.php#L105-L117)._
- Hooked block inserted before/after Post Content block contained in other context (e.g. inside a template). https://github.com/WordPress/wordpress-develop/pull/8700/commits/8f53c8b2cb92f8ecd4bf35afc72ffe9367d77e0b _This modifies an existing test case to use the Post Content block as anchor block._

Props @obenland @aaronjorbin @gziolo.

Trac ticket: https://core.trac.wordpress.org/ticket/63287

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
