### PR TITLE
Fix some build tool warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
 	"name": "wordpress/wordpress",
+	"version": "6.9.0",
 	"license": "GPL-2.0-or-later",
 	"description": "WordPress is open source software you can use to create a beautiful website, blog, or app.",
 	"homepage": "https://wordpress.org",


### PR DESCRIPTION
There are a few errors happening when running `npm run env:start`:

```
The repository at "/var/www" does not have the correct ownership and git refuses to use it:

fatal: detected dubious ownership in repository at '/var/www'
To add an exception for this directory, call:

        git config --global --add safe.directory /var/www

Composer could not detect the root package (wordpress/wordpress) version, defaulting to '1.0.0'. See https://getcomposer.org/root-version
```

It appears that adding a `version` to the `composer.json` file fixes both of these errors.

Props @SirLouen for noticing this.

Trac ticket: https://core.trac.wordpress.org/ticket/63167

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
