### PR TITLE
REST API: Return empty meta field as object in view context

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
@@ -58,8 +58,17 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 		unset( $data['content']['rendered'] );
 
 		// Add the core wp_pattern_sync_status meta as top level property to the response.
-		$data['wp_pattern_sync_status'] = isset( $data['meta']['wp_pattern_sync_status'] ) ? $data['meta']['wp_pattern_sync_status'] : '';
-		unset( $data['meta']['wp_pattern_sync_status'] );
+		$sync_status = '';
+		if ( isset( $data['meta'] ) ) {
+			if ( is_array( $data['meta'] ) && isset( $data['meta']['wp_pattern_sync_status'] ) ) {
+				$sync_status = $data['meta']['wp_pattern_sync_status'];
+				unset( $data['meta']['wp_pattern_sync_status'] );
+			} elseif ( is_object( $data['meta'] ) && isset( $data['meta']->wp_pattern_sync_status ) ) {
+				$sync_status = $data['meta']->wp_pattern_sync_status;
+				unset( $data['meta']->wp_pattern_sync_status );
+			}
+		}
+		$data['wp_pattern_sync_status'] = $sync_status;
 		return $data;
 	}
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -2054,7 +2054,18 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		}
 
 		if ( rest_is_field_included( 'meta', $fields ) ) {
-			$data['meta'] = $this->meta->get_value( $post->ID, $request );
+			$meta_value = $this->meta->get_value( $post->ID, $request );
+
+			// Ensure empty meta value is returned as an object {} if the schema expects an object
+			// and the context is 'view'. For 'edit' context, it should remain an empty array
+			// to ensure PUT requests expecting an array function correctly.
+			if ( 'view' === $request['context'] && empty( $meta_value ) && is_array( $meta_value ) ) {
+				$schema = $this->get_item_schema();
+				if ( isset( $schema['properties']['meta']['type'] ) && 'object' === $schema['properties']['meta']['type'] ) {
+					$meta_value = (object) array();
+				}
+			}
+			$data['meta'] = $meta_value;
 		}
 
 		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), array( 'show_in_rest' => true ) );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR addresses an inconsistency in the WordPress REST API where an empty meta field was returned as `[]` (empty array), while the API schema specifies it should be `{}` (empty object). This primarily affects clients consuming the API in the default `'view'` context.


The `WP_REST_Posts_Controller::prepare_item_for_response()` method now checks the request context. It only converts an empty meta array (`[]`) to an empty object (`{}`) if `$request['context'] === 'view'`. For the `'edit'` context, it remains `[]`.
The `WP_REST_Blocks_Controller::filter_response_by_context()` method has been updated to safely access the `wp_pattern_sync_status` key/property regardless of whether `$data['meta']` is an array or an object.

Trac ticket: https://core.trac.wordpress.org/ticket/54484

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
