### PR TITLE
Adding non resizable formats for SVG uploading issue in block editor

### DIFF
--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -71,20 +71,6 @@ function wp_initial_constants() {
 		ini_set( 'memory_limit', WP_MEMORY_LIMIT );
 	}
 
-	/**
-	 * Define mime types that cannot be resized
-	 *
-	 * @since 6.8.0
-	 */
-	if ( ! defined( 'NON_RESIZABLE_FORMATS' ) ) {
-		define(
-			'NON_RESIZABLE_FORMATS',
-			array(
-				'image/svg+xml',
-			)
-		);
-	}
-
 	if ( ! isset( $blog_id ) ) {
 		$blog_id = 1;
 	}

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -71,6 +71,20 @@ function wp_initial_constants() {
 		ini_set( 'memory_limit', WP_MEMORY_LIMIT );
 	}
 
+	/**
+	 * Define mime types that cannot be resized
+	 *
+	 * @since 6.8.0
+	 */
+	if ( ! defined( 'NON_RESIZABLE_FORMATS' ) ) {
+		define(
+			'NON_RESIZABLE_FORMATS',
+			array(
+				'image/svg+xml',
+			)
+		);
+	}
+
 	if ( ! isset( $blog_id ) ) {
 		$blog_id = 1;
 	}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -156,13 +156,13 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			str_starts_with( $files['file']['type'], 'image/' )
 		) {
 			// List of non-resizable image formats.
-			$non_editor_resizable_formats = array(
+			$editor_non_resizable_formats = array(
 				'image/svg+xml',
 			);
 
 			// Check if the image editor supports the type or ignore if it isn't a format resizable by an editor.
 			if (
-				! in_array( $files['file']['type'], $non_editor_resizable_formats, true ) &&
+				! in_array( $files['file']['type'], $editor_non_resizable_formats, true ) &&
 				! wp_image_editor_supports( array( 'mime_type' => $files['file']['type'] ) )
 			) {
 				return new WP_Error(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -155,9 +155,14 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			isset( $files['file']['type'] ) &&
 			str_starts_with( $files['file']['type'], 'image/' )
 		) {
-			// Check if the image editor supports the type or if it's a non-resizable format.
+			// List of non-resizable image formats.
+			$non_editor_resizable_formats = array(
+				'image/svg+xml',
+			);
+
+			// Check if the image editor supports the type or ignore if it isn't a format resizable by an editor.
 			if (
-				! in_array( $files['file']['type'], NON_RESIZABLE_FORMATS, true ) &&
+				! in_array( $files['file']['type'], $non_editor_resizable_formats, true ) &&
 				! wp_image_editor_supports( array( 'mime_type' => $files['file']['type'] ) )
 			) {
 				return new WP_Error(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -155,8 +155,11 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			isset( $files['file']['type'] ) &&
 			str_starts_with( $files['file']['type'], 'image/' )
 		) {
-			// Check if the image editor supports the type.
-			if ( ! wp_image_editor_supports( array( 'mime_type' => $files['file']['type'] ) ) ) {
+			// Check if the image editor supports the type or if it's a non-resizable format.
+			if (
+				! in_array( $files['file']['type'], NON_RESIZABLE_FORMATS, true ) &&
+				! wp_image_editor_supports( array( 'mime_type' => $files['file']['type'] ) )
+			) {
 				return new WP_Error(
 					'rest_upload_image_type_not_supported',
 					__( 'The web server cannot generate responsive image sizes for this image. Convert it to JPEG or PNG before uploading.' ),

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -2631,12 +2631,12 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 					'name'     => 'video-play.svg',
 					'size'     => filesize( self::$test_svg_file ),
 					'tmp_name' => self::$test_svg_file,
-					'type'     => 'image/svg+xml'
+					'type'     => 'image/svg+xml',
 				),
 			)
 		);
 		$rest_controller = new WP_REST_Attachments_Controller( 'attachment' );
-		$result = $rest_controller->create_item_permissions_check( $request );
+		$result          = $rest_controller->create_item_permissions_check( $request );
 
 		$this->assertTrue( $result );
 	}

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -33,6 +33,11 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	private static $test_avif_file;
 
 	/**
+	 * @var string The path to the SVG test image.
+	 */
+	private static $test_svg_file;
+
+	/**
 	 * @var array The recorded posts query clauses.
 	 */
 	protected $posts_clauses;
@@ -113,6 +118,12 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		self::$test_avif_file = get_temp_dir() . 'avif-lossy.avif';
 		if ( ! file_exists( self::$test_avif_file ) ) {
 			copy( $orig_avif_file, self::$test_avif_file );
+		}
+
+		$test_svg_file       = DIR_TESTDATA . '/uploads/video-play.svg';
+		self::$test_svg_file = get_temp_dir() . 'video-play.svg';
+		if ( ! file_exists( self::$test_svg_file ) ) {
+			copy( $test_svg_file, self::$test_svg_file );
 		}
 
 		add_filter( 'rest_pre_dispatch', array( $this, 'wpSetUpBeforeRequest' ), 10, 3 );
@@ -2602,5 +2613,31 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertSame( 201, $response->get_status() );
+	}
+
+	/**
+	 * Test that uploading an SVG image doesn't throw a `rest_upload_image_type_not_supported` error.
+	 *
+	 * @ticket 63302
+	 */
+	public function test_upload_svg_image() {
+		wp_set_current_user( self::$editor_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
+		$request->set_header( 'Content-Type', 'image/svg+xml' );
+		$request->set_file_params(
+			array(
+				'file' => array(
+					'file'     => file_get_contents( self::$test_svg_file ),
+					'name'     => 'video-play.svg',
+					'size'     => filesize( self::$test_svg_file ),
+					'tmp_name' => self::$test_svg_file,
+					'type'     => 'image/svg+xml'
+				),
+			)
+		);
+		$rest_controller = new WP_REST_Attachments_Controller( 'attachment' );
+		$result = $rest_controller->create_item_permissions_check( $request );
+
+		$this->assertTrue( $result );
 	}
 }


### PR DESCRIPTION
Rethinking on the idea by @pbiron of providing some sort of filtering to provide access to SVG uploads in block editor after 
https://core.trac.wordpress.org/changeset/60084

The thing is that I believe that forcing users to add more hooks (over the hooks that have to be already added for SVG compatibility), is something undesirable. Maybe hard-coding `image/svg+xml` could be a little hard for future debugging or  extensibility, or proofing in general. So the idea here is to provide some sort of descriptive term, that actually describes the faulting scenario: "If non-resizable formats are not considered, they won't be able to be uploaded in the block editor", by using some global constant. 

Not gonna lie, I have not figured out where to best put this global const, so I've decided to place it a little at random and leave it to better criterion.

Trac ticket: https://core.trac.wordpress.org/ticket/63302

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
