### PR TITLE
Add CSS to fix emoji and plugin title rendering

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1380,6 +1380,13 @@ ul.cat-checklist input[name="post_category[]"]:indeterminate::before {
 	margin: 0.5em 0;
 }
 
+.plugin-title a {
+    white-space: nowrap;
+    word-break: normal;
+    display: inline-flex;
+    align-items: center;
+}
+
 .plugins .plugin-description a,
 .plugins .plugin-update a,
 .updates-table .plugin-title a {


### PR DESCRIPTION
Fixes [#63120](https://core.trac.wordpress.org/ticket/63120).

This changeset updates the plugin title styling in the WordPress Admin Plugin List Table.

- Applied `white-space: nowrap`, `word-break: normal`, and `inline-flex` display to `.plugin-title a`.
- Ensures that emojis in plugin titles render correctly without breaking text layout.
- Fixes visual misalignment issues when plugin names start with emoji characters.

Trac ticket: https://core.trac.wordpress.org/ticket/63120
