### PR TITLE
About Page: Improve documentation and reduce copy

### DIFF
--- a/src/js/_enqueues/vendor/twemoji.js
+++ b/src/js/_enqueues/vendor/twemoji.js
@@ -26,7 +26,6 @@ var twemoji = (function (
       // default assets url, by default will be jsDelivr CDN
       base: 'https://cdn.jsdelivr.net/gh/jdecked/twemoji@15.1.0/assets/',
 
-
       // default assets file extensions, by default '.png'
       ext: '.png',
 

--- a/src/js/_enqueues/vendor/twemoji.js
+++ b/src/js/_enqueues/vendor/twemoji.js
@@ -26,6 +26,7 @@ var twemoji = (function (
       // default assets url, by default will be jsDelivr CDN
       base: 'https://cdn.jsdelivr.net/gh/jdecked/twemoji@15.1.0/assets/',
 
+
       // default assets file extensions, by default '.png'
       ext: '.png',
 

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -59,8 +59,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 				<h2><?php _e( 'A release polished to a high sheen.' ); ?></h2>
 				<p class="is-subheading"><?php _e( 'WordPress 6.8 polishes and refines the tools you use every day, making your site faster, more secure, and easier to manage.' ); ?></p>
 				<p><?php _e( 'The Style Book now has a structured layout and works with Classic themes, giving you more control over global styles.' ); ?></p>
-				<p><?php _e( 'Speculative loading speeds up navigation by preloading links before users navigate to them, while bcrypt hashing strengthens password security automatically.' ); ?></p>
-				<p><?php _e( 'Behind the scenes, database optimizations improve performance, and a new security warning system helps prevent vulnerabilities before they become a problem.' ); ?></p>
+				<p><?php _e( 'Speculative loading speeds up navigation by preloading links before users navigate to them, bcrypt hashing strengthens password security automatically, and database optimizations improve performance.' ); ?></p>
 			</div>
 		</div>
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63323

Fix copy on WordPress 6.8 - About page 


Updates the "A release polished to a high sheen" section to remove the security warning system reference and consolidate the remaining features into a single, streamlined sentence.