### PR TITLE
Update Twemoji to v16.0.1

### DIFF
--- a/src/js/_enqueues/vendor/twemoji.js
+++ b/src/js/_enqueues/vendor/twemoji.js
@@ -24,7 +24,7 @@ var twemoji = (function (
     /////////////////////////
 
       // default assets url, by default will be jsDelivr CDN
-      base: 'https://cdn.jsdelivr.net/gh/jdecked/twemoji@15.1.0/assets/',
+      base: 'https://cdn.jsdelivr.net/gh/jdecked/twemoji@16.0.1/assets/',
 
       // default assets file extensions, by default '.png'
       ext: '.png',


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63324

This PR updates the Twemoji library from `v15.1.0` to `v16.0.1`, adding support for Emoji `16.0`.