### PR TITLE
Editor: Add cache-busting for block styles during development

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -328,8 +328,9 @@ function register_block_style_handle( $metadata, $field_name, $index = 0 ) {
 	$style_path_norm = wp_normalize_path( realpath( dirname( $metadata['file'] ) . '/' . $style_path ) );
 	$style_uri       = get_block_asset_url( $style_path_norm );
 
-	$version = ! $is_core_block && isset( $metadata['version'] ) ? $metadata['version'] : false;
-	$result  = wp_register_style(
+	$block_version = ! $is_core_block && isset( $metadata['version'] ) ? $metadata['version'] : false;
+	$version       = $style_path_norm && defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? filemtime( $style_path_norm ) : $block_version;
+	$result        = wp_register_style(
 		$style_handle_name,
 		$style_uri,
 		array(),


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63254

This PR introduces a development mode for block editor styles. When `SCRIPT_DEBUG` is enabled, block editor styles will now use the file modification time as their version, ensuring cache busting during development. This matches the behavior that already exists for block scripts.

Previously, block editor styles would only use the version from `block.json`, which doesn't change during development, causing styles to be cached even after changes.


