### PR TITLE
REST API: Respect `per_page` parameter when handling sticky posts

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -305,10 +305,6 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		// Ensure our per_page parameter overrides any provided posts_per_page filter.
 		if ( isset( $registered['per_page'] ) ) {
 			$args['posts_per_page'] = $request['per_page'];
-
-			if ( ! isset( $request['sticky'] ) ) {
-				$args['ignore_sticky_posts'] = true;
-			}
 		}
 
 		if ( isset( $registered['sticky'], $request['sticky'] ) ) {
@@ -450,6 +446,16 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 
 		$posts_query  = new WP_Query();
 		$query_result = $posts_query->query( $query_args );
+
+		$limit = (int) $posts_query->query_vars['posts_per_page'];
+		if (
+			$limit > 0 &&
+			! isset( $request['sticky'] ) &&
+			! $posts_query->query_vars['ignore_sticky_posts'] &&
+			count( $query_result ) > $limit
+		) {
+			$query_result = array_slice( $query_result, 0, $limit );
+		}
 
 		// Allow access to all password protected posts if the context is edit.
 		if ( 'edit' === $request['context'] ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -305,6 +305,10 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		// Ensure our per_page parameter overrides any provided posts_per_page filter.
 		if ( isset( $registered['per_page'] ) ) {
 			$args['posts_per_page'] = $request['per_page'];
+
+			if ( ! isset( $request['sticky'] ) ) {
+				$args['ignore_sticky_posts'] = true;
+			}
 		}
 
 		if ( isset( $registered['sticky'], $request['sticky'] ) ) {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63339

This PR fixes an issue in the REST API where the `per_page` parameter is not respected when retrieving posts that include sticky posts. In 6.8, calling `/wp-json/wp/v2/posts?per_page=2` would return all sticky posts with the requested number of regular posts, potentially returning many more items than expected.

The fix ensures that when a user specifies a `per_page` parameter without explicitly setting the `sticky` parameter, it ignores the special sticky post behavior and respects the pagination limit.

- If a user explicitly sets sticky=true, they'll get only sticky posts
- If a user explicitly sets sticky=false, they'll get no sticky posts
- If a user doesn't specify sticky but sets per_page, they'll get a properly paginated result with no special handling for sticky posts
- The default behavior when no parameters are specified remains unchanged