### PR TITLE
If a setting is defined in wp-config.php, disable the respective field on options.php.

### DIFF
--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -416,6 +416,11 @@ foreach ( (array) $options as $option ) :
 			$class    = 'all-options disabled';
 		}
 	} else {
+		if ( in_array( $option->option_name, [ 'siteurl', 'home' ], true ) && defined( 'WP_' . strtoupper( $option->option_name ) ) ) {
+			// If a setting is defined in wp-config.php, disable the respective field.
+			$disabled = true;
+		}
+
 		$value               = $option->option_value;
 		$options_to_update[] = $option->option_name;
 		$class               = 'all-options';

--- a/src/wp-admin/options.php
+++ b/src/wp-admin/options.php
@@ -416,7 +416,7 @@ foreach ( (array) $options as $option ) :
 			$class    = 'all-options disabled';
 		}
 	} else {
-		if ( in_array( $option->option_name, [ 'siteurl', 'home' ], true ) && defined( 'WP_' . strtoupper( $option->option_name ) ) ) {
+		if ( in_array( $option->option_name, array( 'siteurl', 'home' ), true ) && defined( 'WP_' . strtoupper( $option->option_name ) ) ) {
 			// If a setting is defined in wp-config.php, disable the respective field.
 			$disabled = true;
 		}


### PR DESCRIPTION
If a setting is defined in wp-config.php, disable the respective field.

Trac ticket: [63341](https://core.trac.wordpress.org/ticket/63341)
