### PR TITLE
Twenty Seventeen: Fix search block input padding in editor

### DIFF
--- a/src/wp-content/themes/twentyseventeen/assets/css/editor-blocks.css
+++ b/src/wp-content/themes/twentyseventeen/assets/css/editor-blocks.css
@@ -831,3 +831,8 @@ table.wp-block-table td:last-child {
 	font-weight: 800;
 	line-height: 1.5;
 }
+
+.wp-block-search .wp-block-search__input {
+	padding: 0.7em;
+	line-height: 1.5;
+}


### PR DESCRIPTION
Adjust padding of search block input in the editor to match frontend styles. Improves visual consistency between editor and frontend in the Twenty Seventeen theme.

After Fix:
![image](https://github.com/user-attachments/assets/f2b39964-9f91-4d3f-8aae-5bb704489698)


Trac ticket: [#63344](https://core.trac.wordpress.org/ticket/63344)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
