### PR TITLE
GH Actions: Update deprecated search API in `reusable-cleanup-pull-requests`

### DIFF
--- a/.github/workflows/reusable-cleanup-pull-requests.yml
+++ b/.github/workflows/reusable-cleanup-pull-requests.yml
@@ -57,7 +57,7 @@ jobs:
               const tracTicketUrl = `https://core.trac.wordpress.org/ticket/${ ticket }`;
               const corePrefix = `Core-${ ticket }`;
               const query = `is:pr is:open repo:${ context.repo.owner }/${ context.repo.repo } in:body ${ tracTicketUrl } OR ${ corePrefix }`;
-              const result = await github.rest.search.issuesAndPullRequests({ q: query });
+              const result = await github.rest.search.issues({ q: query });
 
               prNumbers = prNumbers.concat(result.data.items.map(pr => pr.number));
             }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63278



This PR updates the `reusable-cleanup-pull-requests.yml` workflow to use the [`github.rest.search.issues`](https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#search-issues-and-pull-requests) method instead of the deprecated `github.rest.search.issuesAndPullRequests` method for finding related pull requests.


The `issuesAndPullRequests` search method is [deprecated by GitHub](https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more/) and scheduled for removal in September 2025. This change ensures the workflow continues to function correctly after the deprecated method is removed. The `search.issues` method can achieve the same results when used with the existing `is:pr` filter in the query.

