### PR TITLE
Administration: Reduce vertical spacing between dashboard widgets on mobile

### DIFF
--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -1249,6 +1249,7 @@ a.rsswidget {
 
 	#dashboard-widgets .meta-box-sortables {
 		min-height: 0;
+		margin-bottom: 0;
 	}
 
 	.is-dragging-metaboxes #dashboard-widgets .meta-box-sortables {


### PR DESCRIPTION
 PR reduces vertical spacing between stacked dashboard widgets on smaller screens by setting margin-bottom: 0 on .meta-box-sortables, resulting in a more compact and consistent mobile layout.

Trac ticket: [#63337](https://core.trac.wordpress.org/ticket/63337)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
