### PR TITLE
Change ignore sticky default for rest API

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -346,8 +346,6 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			unset( $args['ignore_sticky_posts'] );
 		}
 
-
-
 		if (
 			isset( $registered['search_semantics'], $request['search_semantics'] )
 			&& 'exact' === $request['search_semantics']

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -346,6 +346,8 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			unset( $args['ignore_sticky_posts'] );
 		}
 
+
+
 		if (
 			isset( $registered['search_semantics'], $request['search_semantics'] )
 			&& 'exact' === $request['search_semantics']
@@ -3075,7 +3077,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			$query_params['ignore_sticky'] = array(
 				'description' => __( 'Whether to ignore sticky posts or not.' ),
 				'type'        => 'boolean',
-				'default'     => false,
+				'default'     => true,
 			);
 		}
 

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -5983,10 +5983,35 @@ Shankle pork chop prosciutto ribeye ham hock pastrami. T-bone shank brisket baco
 	 * Test the REST API support for `ignore_sticky_posts`.
 	 *
 	 * @ticket 35907
+	 * @ticket 63307
 	 *
 	 * @covers WP_REST_Posts_Controller::get_items
 	 */
-	public function test_get_posts_ignore_sticky_default_prepends_sticky_posts() {
+	public function test_get_posts_ignore_sticky_true_prepends_sticky_posts() {
+		$id1 = self::$post_id;
+		// Create more recent post to avoid automatically placing other at the top.
+		$id2 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		update_option( 'sticky_posts', array( $id1 ) );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_param( 'ignore_sticky', false );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( $data[0]['id'], $id1, 'Response has no sticky post at the top.' );
+		$this->assertSame( $data[1]['id'], $id2, 'It is followed by the sticky post chronologically.' );
+	}
+
+	/**
+	 * Test the REST API doesn't prioritize sticky posts by default.
+	 *
+	 * @ticket 35907
+	 * @ticket 63307
+	 *
+	 * @covers WP_REST_Posts_Controller::get_items
+	 */
+	public function test_get_posts_ignore_sticky_default_false_prepends_sticky_posts() {
 		$id1 = self::$post_id;
 		// Create more recent post to avoid automatically placing other at the top.
 		$id2 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
@@ -5997,14 +6022,14 @@ Shankle pork chop prosciutto ribeye ham hock pastrami. T-bone shank brisket baco
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertSame( $data[0]['id'], $id1, 'Response has sticky post at the top.' );
-		$this->assertSame( $data[1]['id'], $id2, 'It is followed by most recent post.' );
+		$this->assertSame( $data[0]['id'], $id2, 'Response has no sticky post at the top.' );
 	}
 
 	/**
 	 * Test the REST API support for `ignore_sticky_posts`.
 	 *
 	 * @ticket 35907
+	 * @ticket 63307
 	 *
 	 * @covers WP_REST_Posts_Controller::get_items
 	 */
@@ -6015,37 +6040,10 @@ Shankle pork chop prosciutto ribeye ham hock pastrami. T-bone shank brisket baco
 		update_option( 'sticky_posts', array( $id1 ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
-		$request->set_param( 'ignore_sticky', true );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
 		$this->assertSame( $data[0]['id'], $id2, 'Response has no sticky post at the top.' );
-	}
-
-	/**
-	 * Test the REST API support for `ignore_sticky_posts`.
-	 * Adding more tests for the `include` parameter with sticky posts.
-	 *
-	 * @ticket 35907
-	 * @ticket 63307
-	 *
-	 * @covers WP_REST_Posts_Controller::get_items
-	 */
-	public function test_get_posts_ignore_sticky_honors_include() {
-		$id1 = self::$post_id;
-		$id2 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
-		$id3 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
-
-		update_option( 'sticky_posts', array( $id1, $id3 ) );
-
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
-		$request->set_param( 'include', array( $id2, $id3 ) );
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-
-		$this->assertCount( 2, $data, 'Only two posts are expected to be returned.' );
-		$this->assertSame( $data[0]['id'], $id3, 'Return the sticky post first.' );
-		$this->assertSame( $data[1]['id'], $id2, 'Return the included post second.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -5994,7 +5994,7 @@ Shankle pork chop prosciutto ribeye ham hock pastrami. T-bone shank brisket baco
 
 		update_option( 'sticky_posts', array( $id1 ) );
 
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$request->set_param( 'ignore_sticky', false );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
@@ -6039,7 +6039,7 @@ Shankle pork chop prosciutto ribeye ham hock pastrami. T-bone shank brisket baco
 
 		update_option( 'sticky_posts', array( $id1 ) );
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -333,18 +333,14 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	/**
 	 * @dataProvider data_readable_http_methods
 	 * @ticket 56481
-	 * @ticket 63307
 	 *
 	 * @param string $method The HTTP method to use.
 	 */
 	public function test_get_items_author_query( $method ) {
 		self::factory()->post->create( array( 'post_author' => self::$editor_id ) );
-		$sticked_post = self::factory()->post->create( array( 'post_author' => self::$author_id ) );
 		self::factory()->post->create( array( 'post_author' => self::$author_id ) );
 
-		update_option( 'sticky_posts', array( $sticked_post ) );
-
-		$total_posts = self::$total_posts + 3;
+		$total_posts = self::$total_posts + 2;
 
 		// All posts in the database.
 		$request = new WP_REST_Request( $method, '/wp/v2/posts' );
@@ -367,13 +363,12 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertSame( 200, $response->get_status() );
 		$data = $response->get_data();
 		if ( $request->is_method( 'get' ) ) {
-			$this->assertCount( 3, $data );
-			// Sticky post should be first.
-			$this->assertSameSets( array( self::$author_id, self::$editor_id, self::$author_id ), wp_list_pluck( $data, 'author' ) );
+			$this->assertCount( 2, $data );
+			$this->assertSameSets( array( self::$editor_id, self::$author_id ), wp_list_pluck( $data, 'author' ) );
 		} else {
 			$this->assertSame( array(), $data, 'Failed asserting that response data is null for HEAD request.' );
 			$headers = $response->get_headers();
-			$this->assertSame( 3, $headers['X-WP-Total'], 'Failed asserting that X-WP-Total header is 3.' );
+			$this->assertSame( 2, $headers['X-WP-Total'], 'Failed asserting that X-WP-Total header is 2.' );
 		}
 
 		// Limit to editor.

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -5975,6 +5975,33 @@ Shankle pork chop prosciutto ribeye ham hock pastrami. T-bone shank brisket baco
 	}
 
 	/**
+	 * Test the REST API doesn't prioritize sticky posts by default.
+	 *
+	 * @ticket 35907
+	 * @ticket 63307
+	 *
+	 * @covers WP_REST_Posts_Controller::get_items
+	 */
+	public function test_get_posts_ignore_sticky_by_default() {
+		$id1 = self::$post_id;
+		// Create more recent post to avoid automatically placing other at the top.
+		$id2 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		update_option( 'sticky_posts', array( $id1 ) );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		$rest_ids = wp_list_pluck( $data, 'id' );
+
+		$this->assertSame( $data[0]['id'], $id2, 'Response has no sticky post at the top.' );
+
+		$posts_query = new WP_Query( array( 'ignore_sticky_posts' => true ) );
+		$post_ids   = wp_list_pluck( $posts_query->get_posts(), 'ID' );
+		$this->assertSame( $rest_ids, $post_ids, 'Response is same as WP_Query with ignore_sticky_posts=true.' );
+	}
+
+	/**
 	 * Test the REST API support for `ignore_sticky_posts`.
 	 *
 	 * @ticket 35907
@@ -5982,7 +6009,7 @@ Shankle pork chop prosciutto ribeye ham hock pastrami. T-bone shank brisket baco
 	 *
 	 * @covers WP_REST_Posts_Controller::get_items
 	 */
-	public function test_get_posts_ignore_sticky_true_prepends_sticky_posts() {
+	public function test_get_posts_ignore_sticky_false_prepends_sticky_posts() {
 		$id1 = self::$post_id;
 		// Create more recent post to avoid automatically placing other at the top.
 		$id2 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
@@ -5993,31 +6020,14 @@ Shankle pork chop prosciutto ribeye ham hock pastrami. T-bone shank brisket baco
 		$request->set_param( 'ignore_sticky', false );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
+		$rest_ids = wp_list_pluck( $data, 'id' );
 
-		$this->assertSame( $data[0]['id'], $id1, 'Response has no sticky post at the top.' );
-		$this->assertSame( $data[1]['id'], $id2, 'It is followed by the sticky post chronologically.' );
-	}
+		$this->assertSame( $data[0]['id'], $id1, 'Response has sticky post at the top.' );
+		$this->assertSame( $data[1]['id'], $id2, 'It is followed by most recent post.' );
 
-	/**
-	 * Test the REST API doesn't prioritize sticky posts by default.
-	 *
-	 * @ticket 35907
-	 * @ticket 63307
-	 *
-	 * @covers WP_REST_Posts_Controller::get_items
-	 */
-	public function test_get_posts_ignore_sticky_default_false_prepends_sticky_posts() {
-		$id1 = self::$post_id;
-		// Create more recent post to avoid automatically placing other at the top.
-		$id2 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
-
-		update_option( 'sticky_posts', array( $id1 ) );
-
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts' );
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-
-		$this->assertSame( $data[0]['id'], $id2, 'Response has no sticky post at the top.' );
+		$posts_query = new WP_Query();
+		$post_ids   = wp_list_pluck( $posts_query->get_posts(), 'ID' );
+		$this->assertSame( $rest_ids, $post_ids, 'Response is same as WP_Query with ignore_sticky_posts=false.' );
 	}
 
 	/**
@@ -6028,17 +6038,25 @@ Shankle pork chop prosciutto ribeye ham hock pastrami. T-bone shank brisket baco
 	 *
 	 * @covers WP_REST_Posts_Controller::get_items
 	 */
-	public function test_get_posts_ignore_sticky_ignores_post_stickiness() {
+	public function test_get_posts_ignore_sticky_honors_include() {
+
 		$id1 = self::$post_id;
 		$id2 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
 
 		update_option( 'sticky_posts', array( $id1 ) );
 
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request->set_param( 'include', array( $id2 ) );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
+		$rest_ids = wp_list_pluck( $data, 'id' );
 
-		$this->assertSame( $data[0]['id'], $id2, 'Response has no sticky post at the top.' );
+		$this->assertCount( 1, $data, 'Only one post is expected to be returned.' );
+		$this->assertSame( $data[0]['id'], $id2, 'Returns the included post.' );
+
+		$posts_query = new WP_Query( array( 'post__in' => array( $id2 ), 'ignore_sticky_posts' => true ) );
+		$post_ids   = wp_list_pluck( $posts_query->get_posts(), 'ID' );
+		$this->assertSame( $rest_ids, $post_ids, 'Response is same as WP_Query with ignore_sticky_posts=truehas no sticky post at the top.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -5989,7 +5989,7 @@ Shankle pork chop prosciutto ribeye ham hock pastrami. T-bone shank brisket baco
 
 		update_option( 'sticky_posts', array( $id1 ) );
 
-		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 		$rest_ids = wp_list_pluck( $data, 'id' );
@@ -5997,7 +5997,7 @@ Shankle pork chop prosciutto ribeye ham hock pastrami. T-bone shank brisket baco
 		$this->assertSame( $data[0]['id'], $id2, 'Response has no sticky post at the top.' );
 
 		$posts_query = new WP_Query( array( 'ignore_sticky_posts' => true ) );
-		$post_ids   = wp_list_pluck( $posts_query->get_posts(), 'ID' );
+		$post_ids    = wp_list_pluck( $posts_query->get_posts(), 'ID' );
 		$this->assertSame( $rest_ids, $post_ids, 'Response is same as WP_Query with ignore_sticky_posts=true.' );
 	}
 
@@ -6026,7 +6026,7 @@ Shankle pork chop prosciutto ribeye ham hock pastrami. T-bone shank brisket baco
 		$this->assertSame( $data[1]['id'], $id2, 'It is followed by most recent post.' );
 
 		$posts_query = new WP_Query();
-		$post_ids   = wp_list_pluck( $posts_query->get_posts(), 'ID' );
+		$post_ids    = wp_list_pluck( $posts_query->get_posts(), 'ID' );
 		$this->assertSame( $rest_ids, $post_ids, 'Response is same as WP_Query with ignore_sticky_posts=false.' );
 	}
 
@@ -6054,8 +6054,13 @@ Shankle pork chop prosciutto ribeye ham hock pastrami. T-bone shank brisket baco
 		$this->assertCount( 1, $data, 'Only one post is expected to be returned.' );
 		$this->assertSame( $data[0]['id'], $id2, 'Returns the included post.' );
 
-		$posts_query = new WP_Query( array( 'post__in' => array( $id2 ), 'ignore_sticky_posts' => true ) );
-		$post_ids   = wp_list_pluck( $posts_query->get_posts(), 'ID' );
+		$posts_query = new WP_Query(
+			array(
+				'post__in'            => array( $id2 ),
+				'ignore_sticky_posts' => true,
+			)
+		);
+		$post_ids    = wp_list_pluck( $posts_query->get_posts(), 'ID' );
 		$this->assertSame( $rest_ids, $post_ids, 'Response is same as WP_Query with ignore_sticky_posts=truehas no sticky post at the top.' );
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-posts-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-posts-controller.php
@@ -333,14 +333,18 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 	/**
 	 * @dataProvider data_readable_http_methods
 	 * @ticket 56481
+	 * @ticket 63307
 	 *
 	 * @param string $method The HTTP method to use.
 	 */
 	public function test_get_items_author_query( $method ) {
 		self::factory()->post->create( array( 'post_author' => self::$editor_id ) );
+		$sticked_post = self::factory()->post->create( array( 'post_author' => self::$author_id ) );
 		self::factory()->post->create( array( 'post_author' => self::$author_id ) );
 
-		$total_posts = self::$total_posts + 2;
+		update_option( 'sticky_posts', array( $sticked_post ) );
+
+		$total_posts = self::$total_posts + 3;
 
 		// All posts in the database.
 		$request = new WP_REST_Request( $method, '/wp/v2/posts' );
@@ -363,12 +367,13 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertSame( 200, $response->get_status() );
 		$data = $response->get_data();
 		if ( $request->is_method( 'get' ) ) {
-			$this->assertCount( 2, $data );
-			$this->assertSameSets( array( self::$editor_id, self::$author_id ), wp_list_pluck( $data, 'author' ) );
+			$this->assertCount( 3, $data );
+			// Sticky post should be first.
+			$this->assertSameSets( array( self::$author_id, self::$editor_id, self::$author_id ), wp_list_pluck( $data, 'author' ) );
 		} else {
 			$this->assertSame( array(), $data, 'Failed asserting that response data is null for HEAD request.' );
 			$headers = $response->get_headers();
-			$this->assertSame( 2, $headers['X-WP-Total'], 'Failed asserting that X-WP-Total header is 2.' );
+			$this->assertSame( 3, $headers['X-WP-Total'], 'Failed asserting that X-WP-Total header is 3.' );
 		}
 
 		// Limit to editor.
@@ -661,19 +666,24 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertSame( 'Search Result', $data[0]['title']['rendered'] );
 	}
 
+	/**
+	 * @ticket 63307
+	 */
 	public function test_get_items_slug_query() {
-		self::factory()->post->create(
+		$id1 = self::factory()->post->create(
 			array(
 				'post_title'  => 'Apple',
 				'post_status' => 'publish',
 			)
 		);
-		self::factory()->post->create(
+		$id2 = self::factory()->post->create(
 			array(
 				'post_title'  => 'Banana',
 				'post_status' => 'publish',
 			)
 		);
+
+		update_option( 'sticky_posts', array( $id2 ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
 		$request->set_param( 'slug', 'apple' );
@@ -681,7 +691,7 @@ class WP_Test_REST_Posts_Controller extends WP_Test_REST_Post_Type_Controller_Te
 		$this->assertSame( 200, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertCount( 1, $data );
-		$this->assertSame( 'Apple', $data[0]['title']['rendered'] );
+		$this->assertSame( 'Apple', $data[0]['title']['rendered'], 'Return the post with the given slug' );
 	}
 
 	public function test_get_items_multiple_slugs_array_query() {
@@ -6014,24 +6024,28 @@ Shankle pork chop prosciutto ribeye ham hock pastrami. T-bone shank brisket baco
 
 	/**
 	 * Test the REST API support for `ignore_sticky_posts`.
+	 * Adding more tests for the `include` parameter with sticky posts.
 	 *
 	 * @ticket 35907
+	 * @ticket 63307
 	 *
 	 * @covers WP_REST_Posts_Controller::get_items
 	 */
 	public function test_get_posts_ignore_sticky_honors_include() {
 		$id1 = self::$post_id;
 		$id2 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$id3 = self::factory()->post->create( array( 'post_status' => 'publish' ) );
 
-		update_option( 'sticky_posts', array( $id1 ) );
+		update_option( 'sticky_posts', array( $id1, $id3 ) );
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/posts' );
-		$request->set_param( 'include', array( $id2 ) );
+		$request->set_param( 'include', array( $id2, $id3 ) );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertCount( 1, $data, 'Only one post is expected to be returned.' );
-		$this->assertSame( $data[0]['id'], $id2, 'Returns the included post.' );
+		$this->assertCount( 2, $data, 'Only two posts are expected to be returned.' );
+		$this->assertSame( $data[0]['id'], $id3, 'Return the sticky post first.' );
+		$this->assertSame( $data[1]['id'], $id2, 'Return the included post second.' );
 	}
 
 	/**

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -633,7 +633,7 @@ mockedApiResponse.Schema = {
                         "ignore_sticky": {
                             "description": "Whether to ignore sticky posts or not.",
                             "type": "boolean",
-                            "default": false,
+                            "default": true,
                             "required": false
                         },
                         "format": {


### PR DESCRIPTION
This builds off the work in #8713 and #8731. 

Core Trac: https://core.trac.wordpress.org/ticket/63307