### PR TITLE
Fixed use is_wp_error() instead of instanceof WP_Error in class-wp-customize-custom-css-setting.php

### DIFF
--- a/src/wp-includes/customize/class-wp-customize-custom-css-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-custom-css-setting.php
@@ -197,7 +197,7 @@ final class WP_Customize_Custom_CSS_Setting extends WP_Customize_Setting {
 			)
 		);
 
-		if ( $r instanceof WP_Error ) {
+		if ( is_wp_error( $r ) ) {
 			return false;
 		}
 		$post_id = $r->ID;


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63363