### PR TITLE
Fix: Restore Local Request Handling for SSL Verification for `https_local_ssl_verify` filter

### DIFF
--- a/src/wp-includes/class-wp-http-curl.php
+++ b/src/wp-includes/class-wp-http-curl.php
@@ -115,7 +115,10 @@ class WP_Http_Curl {
 			}
 		}
 
-		$is_local   = isset( $parsed_args['local'] ) && $parsed_args['local'];
+		$is_local = ( isset( $parsed_args['local'] ) && $parsed_args['local'] )
+		|| ( isset( $_SERVER['REMOTE_ADDR'] ) && in_array( $_SERVER['REMOTE_ADDR'], [ '127.0.0.1', '::1' ], true ) )
+		|| ( isset( $_SERVER['HTTP_HOST'] ) && in_array( $_SERVER['HTTP_HOST'], [ 'localhost', '127.0.0.1' ], true ) );
+
 		$ssl_verify = isset( $parsed_args['sslverify'] ) && $parsed_args['sslverify'];
 		if ( $is_local ) {
 			/** This filter is documented in wp-includes/class-wp-http-streams.php */

--- a/src/wp-includes/class-wp-http-curl.php
+++ b/src/wp-includes/class-wp-http-curl.php
@@ -116,8 +116,8 @@ class WP_Http_Curl {
 		}
 
 		$is_local = ( isset( $parsed_args['local'] ) && $parsed_args['local'] )
-		|| ( isset( $_SERVER['REMOTE_ADDR'] ) && in_array( $_SERVER['REMOTE_ADDR'], [ '127.0.0.1', '::1' ], true ) )
-		|| ( isset( $_SERVER['HTTP_HOST'] ) && in_array( $_SERVER['HTTP_HOST'], [ 'localhost', '127.0.0.1' ], true ) );
+		|| ( isset( $_SERVER['REMOTE_ADDR'] ) && in_array( $_SERVER['REMOTE_ADDR'], array( '127.0.0.1', '::1' ), true ) )
+		|| ( isset( $_SERVER['HTTP_HOST'] ) && in_array( $_SERVER['HTTP_HOST'], array( 'localhost', '127.0.0.1' ), true ) );
 
 		$ssl_verify = isset( $parsed_args['sslverify'] ) && $parsed_args['sslverify'];
 		if ( $is_local ) {

--- a/src/wp-includes/class-wp-http-streams.php
+++ b/src/wp-includes/class-wp-http-streams.php
@@ -96,7 +96,10 @@ class WP_Http_Streams {
 
 		$connect_host = $secure_transport ? 'ssl://' . $connect_host : 'tcp://' . $connect_host;
 
-		$is_local   = isset( $parsed_args['local'] ) && $parsed_args['local'];
+		$is_local = ( isset( $parsed_args['local'] ) && $parsed_args['local'] )
+		|| ( isset( $_SERVER['REMOTE_ADDR'] ) && in_array( $_SERVER['REMOTE_ADDR'], [ '127.0.0.1', '::1' ], true ) )
+		|| ( isset( $_SERVER['HTTP_HOST'] ) && in_array( $_SERVER['HTTP_HOST'], [ 'localhost', '127.0.0.1' ], true ) );
+
 		$ssl_verify = isset( $parsed_args['sslverify'] ) && $parsed_args['sslverify'];
 
 		if ( $is_local ) {

--- a/src/wp-includes/class-wp-http-streams.php
+++ b/src/wp-includes/class-wp-http-streams.php
@@ -97,8 +97,8 @@ class WP_Http_Streams {
 		$connect_host = $secure_transport ? 'ssl://' . $connect_host : 'tcp://' . $connect_host;
 
 		$is_local = ( isset( $parsed_args['local'] ) && $parsed_args['local'] )
-		|| ( isset( $_SERVER['REMOTE_ADDR'] ) && in_array( $_SERVER['REMOTE_ADDR'], [ '127.0.0.1', '::1' ], true ) )
-		|| ( isset( $_SERVER['HTTP_HOST'] ) && in_array( $_SERVER['HTTP_HOST'], [ 'localhost', '127.0.0.1' ], true ) );
+		|| ( isset( $_SERVER['REMOTE_ADDR'] ) && in_array( $_SERVER['REMOTE_ADDR'], array( '127.0.0.1', '::1' ), true ) )
+		|| ( isset( $_SERVER['HTTP_HOST'] ) && in_array( $_SERVER['HTTP_HOST'], array( 'localhost', '127.0.0.1' ), true ) );
 
 		$ssl_verify = isset( $parsed_args['sslverify'] ) && $parsed_args['sslverify'];
 


### PR DESCRIPTION
Trac Ticket: Core-51767

## Issue

In WordPress 4.6, the `$args['local']` element was removed from HTTP API requests, which caused the https_local_ssl_verify filter to malfunction.

## Solution

This update restores the expected behaviour by checking if a request is local using:

- The REMOTE_ADDR (127.0.0.1, ::1).

- The HTTP_HOST (localhost, 127.0.0.1).