### PR TITLE
Only output debug info when in debug mode.

### DIFF
--- a/.github/workflows/reusable-check-built-files.yml
+++ b/.github/workflows/reusable-check-built-files.yml
@@ -59,6 +59,7 @@ jobs:
           custom-cache-suffix: ${{ steps.get-date.outputs.date }}
 
       - name: Log debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           npm --version
           node --version

--- a/.github/workflows/reusable-coding-standards-javascript.yml
+++ b/.github/workflows/reusable-coding-standards-javascript.yml
@@ -46,6 +46,7 @@ jobs:
           cache: npm
 
       - name: Log debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           npm --version
           node --version

--- a/.github/workflows/reusable-end-to-end-tests.yml
+++ b/.github/workflows/reusable-end-to-end-tests.yml
@@ -88,6 +88,7 @@ jobs:
           cache: npm
 
       - name: Log debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           npm --version
           node --version
@@ -113,6 +114,7 @@ jobs:
         run: docker ps -a
 
       - name: Docker debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           docker -v
           docker compose run --rm mysql mysql --version

--- a/.github/workflows/reusable-javascript-tests.yml
+++ b/.github/workflows/reusable-javascript-tests.yml
@@ -47,6 +47,7 @@ jobs:
           cache: npm
 
       - name: Log debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           npm --version
           node --version

--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -128,6 +128,7 @@ jobs:
           cache: npm
 
       - name: Log debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           npm --version
           node --version
@@ -193,6 +194,7 @@ jobs:
         run: docker ps -a
 
       - name: Docker debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           docker -v
           docker compose run --rm mysql mysql --version

--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -145,6 +145,7 @@ jobs:
           cache: npm
 
       - name: Log debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           npm --version
           node --version
@@ -172,6 +173,7 @@ jobs:
         run: docker ps -a
 
       - name: Docker debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           docker -v
           docker compose run --rm mysql mysql --version

--- a/.github/workflows/reusable-php-compatibility.yml
+++ b/.github/workflows/reusable-php-compatibility.yml
@@ -53,6 +53,7 @@ jobs:
           tools: cs2pr
 
       - name: Log debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           composer --version
 

--- a/.github/workflows/reusable-phpunit-tests-v1.yml
+++ b/.github/workflows/reusable-phpunit-tests-v1.yml
@@ -133,6 +133,7 @@ jobs:
           docker compose run --rm php composer install
 
       - name: Docker debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           docker -v
           docker compose -v
@@ -150,6 +151,7 @@ jobs:
           docker run --name memcached --net "${BASE}_wpdevnet" -d memcached
 
       - name: General debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           npm --version
           node --version
@@ -160,6 +162,7 @@ jobs:
         run: docker ps -a
 
       - name: WordPress Docker container debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           docker compose run --rm mysql mysql --version
           docker compose run --rm php php --version

--- a/.github/workflows/reusable-phpunit-tests-v2.yml
+++ b/.github/workflows/reusable-phpunit-tests-v2.yml
@@ -144,6 +144,7 @@ jobs:
           fi
 
       - name: Docker debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           docker -v
           docker compose -v
@@ -153,6 +154,7 @@ jobs:
           npm run env:start
 
       - name: General debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           npm --version
           node --version
@@ -163,6 +165,7 @@ jobs:
         run: docker ps -a
 
       - name: WordPress Docker container debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           docker compose run --rm mysql mysql --version
           docker compose run --rm php php --version

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -164,6 +164,7 @@ jobs:
         run: npm ci
 
       - name: General debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           npm --version
           node --version
@@ -173,6 +174,7 @@ jobs:
           locale -a
 
       - name: Docker debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           docker -v
 
@@ -184,6 +186,7 @@ jobs:
         run: docker ps -a
 
       - name: WordPress Docker container debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           docker compose run --rm mysql "${LOCAL_DB_CMD}" --version
           docker compose run --rm php php --version

--- a/.github/workflows/reusable-test-core-build-process.yml
+++ b/.github/workflows/reusable-test-core-build-process.yml
@@ -76,6 +76,7 @@ jobs:
           cache: npm
 
       - name: Log debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           npm --version
           node --version

--- a/.github/workflows/reusable-test-gutenberg-build-process.yml
+++ b/.github/workflows/reusable-test-gutenberg-build-process.yml
@@ -72,6 +72,7 @@ jobs:
             ${{ env.GUTENBERG_DIRECTORY }}/package-lock.json
 
       - name: Log debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           npm --version
           node --version

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -121,6 +121,7 @@ jobs:
         run: npm ci
 
       - name: General debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           npm --version
           node --version
@@ -130,6 +131,7 @@ jobs:
           locale -a
 
       - name: Docker debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           docker -v
 
@@ -141,6 +143,7 @@ jobs:
         run: docker ps -a
 
       - name: WordPress Docker container debug information
+        if: ${{ runner.debug == '1' }}
         run: |
           docker compose run --rm mysql "${LOCAL_DB_TYPE}" --version
           docker compose run --rm php php --version


### PR DESCRIPTION
This adds a conditional statement that checks for debug mode to be enabled before outputting debug information.

Trac ticket: Core-63170.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
