### PR TITLE
Fixed remove unnecessary type casting in wp-links-opml.php

### DIFF
--- a/src/wp-links-opml.php
+++ b/src/wp-links-opml.php
@@ -19,7 +19,7 @@ $link_cat = '';
 if ( ! empty( $_GET['link_cat'] ) ) {
 	$link_cat = $_GET['link_cat'];
 	if ( ! in_array( $link_cat, array( 'all', '0' ), true ) ) {
-		$link_cat = absint( (string) urldecode( $link_cat ) );
+		$link_cat = absint( urldecode( $link_cat ) );
 	}
 }
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63367
