### PR TITLE
Docs: Add missing @param tags for SetLanguage() method in WP_PHPMailer class

### DIFF
--- a/src/wp-includes/class-wp-phpmailer.php
+++ b/src/wp-includes/class-wp-phpmailer.php
@@ -32,6 +32,9 @@ class WP_PHPMailer extends PHPMailer\PHPMailer\PHPMailer {
 	 *
 	 * @since 6.8.0
 	 *
+	 * @param string $langcode  Optional. Language code to set (e.g: 'en', 'fr', etc.). Default 'en'.
+	 * @param string $lang_path Optional. Path to the language files. Default empty string.
+	 *
 	 * @return true Always returns true.
 	 */
 	public function SetLanguage( $langcode = 'en', $lang_path = '' ) {

--- a/src/wp-includes/class-wp-phpmailer.php
+++ b/src/wp-includes/class-wp-phpmailer.php
@@ -34,7 +34,6 @@ class WP_PHPMailer extends PHPMailer\PHPMailer\PHPMailer {
 	 *
 	 * @param string $langcode  Optional. Language code to set (e.g: 'en', 'fr', etc.). Default 'en'.
 	 * @param string $lang_path Optional. Path to the language files. Default empty string.
-	 *
 	 * @return true Always returns true.
 	 */
 	public function SetLanguage( $langcode = 'en', $lang_path = '' ) {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63368