### PR TITLE
Administration: Avoid rendering empty bottom tablenav container when pagination is hidden

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -693,6 +693,10 @@ th.sorted a span {
 	margin: 0 0 9px;
 }
 
+.tablenav.bottom:has(> .tablenav-pages.no-pages) {
+	display: none;
+}
+
 .tablenav .no-pages,
 .tablenav .one-page .pagination-links {
 	display: none;

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -693,10 +693,6 @@ th.sorted a span {
 	margin: 0 0 9px;
 }
 
-.tablenav.bottom:has(> .tablenav-pages.no-pages) {
-	display: none;
-}
-
 .tablenav .no-pages,
 .tablenav .one-page .pagination-links {
 	display: none;

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -1021,7 +1021,7 @@ class WP_List_Table {
 	 * @param string $which The location of the pagination: Either 'top' or 'bottom'.
 	 */
 	protected function pagination( $which ) {
-		if ( empty( $this->_pagination_args ) ) {
+		if ( empty( $this->_pagination_args['total_items'] ) ) {
 			return;
 		}
 
@@ -1669,6 +1669,9 @@ class WP_List_Table {
 	 * @param string $which The location of the navigation: Either 'top' or 'bottom'.
 	 */
 	protected function display_tablenav( $which ) {
+		if ( 'bottom' === $which && ! $this->has_items() ) {
+			return;
+		}
 		if ( 'top' === $which ) {
 			wp_nonce_field( 'bulk-' . $this->_args['plural'] );
 		}


### PR DESCRIPTION
Hides the bottom tablenav container on taxonomy term list screens when it contains a hidden .tablenav-pages.no-pages element. This prevents unnecessary vertical spacing when no tags exist and improves layout consistency in the admin UI.

Before:

![image](https://github.com/user-attachments/assets/dcb2d809-47c0-4886-a87f-c7d84316a5a9)

After:

<img width="1470" alt="Screenshot 2025-04-29 at 3 14 35 PM" src="https://github.com/user-attachments/assets/bf6bab77-53ac-4f36-8af2-7c332064b5c3" />

Trac ticket: [#63369](https://core.trac.wordpress.org/ticket/63369)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
