### PR TITLE
Update formatting.php untrailingslashit rtrim call cast value to string

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2816,7 +2816,7 @@ function trailingslashit( $value ) {
  * @return string String without the trailing slashes.
  */
 function untrailingslashit( $value ) {
-	return rtrim( $value, '/\\' );
+	return rtrim( strval( $value ), '/\\' );
 }
 
 /**


### PR DESCRIPTION
Fixes errors like the following:
Deprecated: rtrim(): Passing null to parameter 1 ($string) of type string is deprecated in /wp-includes/formatting.php on line 2819

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

The untrailingslashit function in formatting.php passes the $value param directly into the PHP rtrim function, which only takes Strings. Anything else trows a "Deprecated" warning (example below).

In my personal case, Yoast SEO was the culprit in the stacktrace, but this untrailingslashit should at least validate and/or cast the $value param to String with strval before calling rtrim.

Incoming updated version:
```
function untrailingslashit( $value ) {
        return rtrim( strval( $value ), '/\\' ); // <-- Cast $value to String with strval()
}
```
Previous unvalidated version:
```
function untrailingslashit( $value ) {
        return rtrim( $value, '/\\' );
}
```

Fixes these types of errors:
**Deprecated: rtrim(): Passing null to parameter [#1](https://core.trac.wordpress.org/ticket/1) ($string) of type string is deprecated in /wp-includes/formatting.php on line 2819**

Trac ticket: [63379 Fix for deprecated rtrim passing null to parameter](https://core.trac.wordpress.org/ticket/63379#ticket)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
