### PR TITLE
Site health: Add warning for ms files

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2775,6 +2775,10 @@ class WP_Site_Health {
 					'label' => __( 'Autoloaded options' ),
 					'test'  => 'autoloaded_options',
 				),
+				'ms_files_deprecated'          => array(
+					'label' => __( 'MS Files Upload Handler' ),
+					'test'  => 'ms_files_deprecated',
+				),
 			),
 			'async'  => array(
 				'dotorg_communication' => array(
@@ -3622,5 +3626,51 @@ class WP_Site_Health {
 		 * @param string[] $services The list of available persistent object cache services.
 		 */
 		return apply_filters( 'site_status_available_object_cache_services', $services );
+	}
+
+	/**
+	 * Test if site is using the deprecated ms-files.php handler.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @return array The test results.
+	 */
+	public function get_test_ms_files_deprecated() {
+		$result = array(
+			'label'       => __( 'Your site is not using the deprecated ms-files.php handler' ),
+			'status'      => 'good',
+			'badge'       => array(
+				'label' => __( 'Security' ),
+				'color' => 'blue',
+			),
+			'description' => sprintf(
+				'<p>%s</p>',
+				__( 'Your multisite network is using the current upload system.' )
+			),
+			'actions'     => '',
+			'test'        => 'ms_files_deprecated',
+		);
+
+		// Skip this test if not in a multisite environment
+		if ( ! is_multisite() ) {
+			return $result;
+		}
+
+		// Check if site is using ms-files
+		if ( defined( 'BLOGUPLOADDIR' ) ) {
+			$result['status']      = 'critical';
+			$result['label']       = __( 'Your site is using the deprecated ms-files.php handler' );
+			$result['description'] = sprintf(
+				'<p>%s</p>',
+				__( 'Your multisite network is using the legacy ms-files.php file handler which has been deprecated since WordPress 3.5.0.' ),
+			);
+			$result['actions']     = sprintf(
+				'<p><a href="%s" target="_blank" rel="noopener">%s</a></p>',
+				'https://halfelf.org/2012/dumping-ms-files/',
+				__( 'Learn how to migrate from ms-files.php' ),
+			);
+		}
+
+		return $result;
 	}
 }

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -3662,12 +3662,12 @@ class WP_Site_Health {
 			$result['label']       = __( 'Your site is using the deprecated ms-files.php handler' );
 			$result['description'] = sprintf(
 				'<p>%s</p>',
-				__( 'Your multisite network is using the legacy ms-files.php file handler which has been deprecated since WordPress 3.5.0.' ),
+				__( 'Your multisite network is using the legacy ms-files.php file handler which has been deprecated since WordPress 3.5.0.' )
 			);
 			$result['actions']     = sprintf(
 				'<p><a href="%s" target="_blank" rel="noopener">%s</a></p>',
 				'https://halfelf.org/2012/dumping-ms-files/',
-				__( 'Learn how to migrate from ms-files.php' ),
+				__( 'Learn how to migrate from ms-files.php' )
 			);
 		}
 

--- a/src/wp-includes/ms-files.php
+++ b/src/wp-includes/ms-files.php
@@ -6,6 +6,15 @@
  *
  * @package WordPress
  * @subpackage Multisite
+ *
+ * WARNING: This is a legacy file handler that has been deprecated since WordPress 3.5.0.
+ * It is maintained only for backward compatibility with older multisite installations.
+ *
+ * IMPORTANT NOTICE FOR CONTRIBUTORS:
+ * - This file is in maintenance mode only
+ * - Only PHP compatibility and security-related changes should be made to this file
+ * - No new features should be added
+ * - Site administrators should migrate to the new upload system
  */
 
 define( 'MS_FILES_REQUEST', true );

--- a/src/wp-includes/ms-files.php
+++ b/src/wp-includes/ms-files.php
@@ -15,6 +15,7 @@
  * - Only PHP compatibility and security-related changes should be made to this file
  * - No new features should be added
  * - Site administrators should migrate to the new upload system
+ * - See https://halfelf.org/2012/dumping-ms-files/ for migration guidance
  */
 
 define( 'MS_FILES_REQUEST', true );


### PR DESCRIPTION
[#63397](https://core.trac.wordpress.org/ticket/63397)

This PR implements a stronger deprecation for the legacy `ms-files.php` file handler in WordPress Multisite.

This change adds a new Site Health check that will alert site administrators if they are still using this legacy file handler, providing them with information about its deprecated status and resources for migration to the new upload system. Also this PR added developer focused documentation comment.

### Screenshot:
![image](https://github.com/user-attachments/assets/2e45057c-f2bc-4a2c-815d-281b19fea485)