### PR TITLE
Admin: Add search engine visibility test to Site Health

### DIFF
--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -17,6 +17,39 @@ if ( ! defined( 'WP_ADMIN' ) ) {
 }
 
 /**
+ * Display a persistent admin notice when “Discourage search engines from indexing this site” is enabled.
+ *
+ * @since 6.9
+ */
+add_action( 'admin_notices', 'wp_core_search_engine_visibility_notice' );
+
+function wp_core_search_engine_visibility_notice() {
+	if (
+		! is_network_admin()
+		&& ! is_user_admin()
+		&& current_user_can( 'manage_options' )
+		&& ! get_option( 'blog_public' )
+	) {
+		?>
+		<div class="notice notice-error is-dismissible">
+			<p>
+				<?php
+				echo wp_kses_post(
+					sprintf(
+						/* translators: %1$s open link, %2$s close link */
+						__( 'Search engines are <strong>discouraged</strong> from indexing your site. %1$sChange this setting%2$s.', 'default' ),
+						'<a href="' . esc_url( admin_url( 'options-reading.php#blog_public' ) ) . '">',
+						'</a>'
+					)
+				);
+				?>
+			</p>
+		</div>
+		<?php
+	}
+}
+
+/**
  * In case admin-header.php is included in a function.
  *
  * @global string    $title              The title of the current screen.

--- a/src/wp-admin/admin-header.php
+++ b/src/wp-admin/admin-header.php
@@ -17,39 +17,6 @@ if ( ! defined( 'WP_ADMIN' ) ) {
 }
 
 /**
- * Display a persistent admin notice when “Discourage search engines from indexing this site” is enabled.
- *
- * @since 6.9
- */
-add_action( 'admin_notices', 'wp_core_search_engine_visibility_notice' );
-
-function wp_core_search_engine_visibility_notice() {
-	if (
-		! is_network_admin()
-		&& ! is_user_admin()
-		&& current_user_can( 'manage_options' )
-		&& ! get_option( 'blog_public' )
-	) {
-		?>
-		<div class="notice notice-error is-dismissible">
-			<p>
-				<?php
-				echo wp_kses_post(
-					sprintf(
-						/* translators: %1$s open link, %2$s close link */
-						__( 'Search engines are <strong>discouraged</strong> from indexing your site. %1$sChange this setting%2$s.', 'default' ),
-						'<a href="' . esc_url( admin_url( 'options-reading.php#blog_public' ) ) . '">',
-						'</a>'
-					)
-				);
-				?>
-			</p>
-		</div>
-		<?php
-	}
-}
-
-/**
  * In case admin-header.php is included in a function.
  *
  * @global string    $title              The title of the current screen.

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -442,6 +442,7 @@
 
 #dashboard_right_now .search-engines-info:before {
 	content: "\f348";
+	color: #d63638;
 }
 
 /* Dashboard WordPress events */

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2688,6 +2688,49 @@ class WP_Site_Health {
 	}
 
 	/**
+	 * Tests whether search engine indexing is enabled.
+	 *
+	 * Surfaces as “good” if `blog_public === 1`, or “recommended” if `blog_public === 0`.
+	 *
+	 * @since 6.9
+	 *
+	 * @return array The test results.
+	 */
+	public function get_test_search_engine_visibility() {
+		$result = array(
+			'label'       => __( 'Search engine indexing is enabled.', 'default' ),
+			'status'      => 'good',
+			'badge'       => array(
+				'label' => __( 'Privacy', 'default' ),
+				'color' => 'blue',
+			),
+			'description' => sprintf(
+				'<p>%s</p>',
+				__( 'Search engines can crawl and index your site. No action needed.', 'default' )
+			),
+			'actions'     => sprintf(
+				'<p><a href="%1$s">%2$s</a></p>',
+				esc_url( admin_url( 'options-reading.php#blog_public' ) ),
+				__( 'Review your visibility settings', 'default' )
+			),
+			'test'        => 'search_engine_visibility',
+		);
+
+		// If indexing is discouraged, flip to “recommended”:
+		if ( ! get_option( 'blog_public' ) ) {
+			$result['status']         = 'recommended';
+			$result['label']          = __( 'Search engines are discouraged from indexing this site.', 'default' );
+			$result['badge']['color'] = 'blue';
+			$result['description']    = sprintf(
+				'<p>%s</p>',
+				__( 'Your site is hidden from search engines. Consider enabling indexing if this is a public site.', 'default' )
+			);
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Returns a set of tests that belong to the site status page.
 	 *
 	 * Each site status test is defined here, they may be `direct` tests, that run on page load, or `async` tests
@@ -2774,6 +2817,10 @@ class WP_Site_Health {
 				'autoloaded_options'           => array(
 					'label' => __( 'Autoloaded options' ),
 					'test'  => 'autoloaded_options',
+				),
+				'search_engine_visibility'     => array(
+					'label' => __( 'Search Engine Visibility' ),
+					'test'  => 'search_engine_visibility',
 				),
 			),
 			'async'  => array(


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63375

The "Discourage search engines" setting can be easily overlooked in the "**At A Glance widget**", potentially causing SEO issues during site launches. The Site Health report provides another visibility point for this critical setting.
This PR adds a new Site Health test to make site owners more aware when search engines are discouraged from indexing their sites.

Changes:
- Adds a new Site Health test under the "Privacy" category to check if search engines are discouraged
- Displays "recommended" status when search engines are discouraged, with clear messaging to review settings
- Provides a direct link to the Reading Settings page to change this option

