### PR TITLE
Enhancement: Allow template application to all public post types when 'any' is specified

### DIFF
--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -1337,6 +1337,11 @@ final class WP_Theme implements ArrayAccess {
 				$types = array( 'page' );
 				if ( preg_match( '|Template Post Type:(.*)$|mi', file_get_contents( $full_path ), $type ) ) {
 					$types = explode( ',', _cleanup_header_comment( $type[1] ) );
+
+					// If 'any' is specified, apply the template to all public post types
+					if ( in_array( 'any', $types, true ) ) {
+						$types = get_post_types( array( 'public' => true ) ); // Get all public post types
+					}
 				}
 
 				foreach ( $types as $type ) {


### PR DESCRIPTION
Trac Ticket: https://core.trac.wordpress.org/ticket/41773

---

This patch enhances the flexibility of custom templates in WordPress themes by allowing developers to specify `Template Post Type: any` in the template file header. This addition automatically registers the template for **all public post types**, removing the need to explicitly enumerate them.

**Why this change was needed:**

Prior to this patch, template files using the `Template Name:` header would only be available for the `page` post type by default. If developers wanted to assign a template to additional post types, they had to use the `Template Post Type:` header and list each post type explicitly:

```php
/*
Template Name: My Template
Template Post Type: post, page, book, movie
*/
```

However, this approach does not scale well when working with themes or plugins that need the same template across many or dynamically registered post types. Maintaining a hard-coded list becomes tedious and error-prone.

By supporting:

```php
/*
Template Name: My Template
Template Post Type: any
*/
```

template authors can now register the file for **all public post types** without redundancy or extra logic.

**Implementation Details:**

The change occurs within the `WP_Theme::get_post_templates()` method. The following logic was added:

```php
if ( in_array( 'any', $types, true ) ) {
    $types = get_post_types( array( 'public' => true ) );
}
```

This check occurs after parsing the `Template Post Type:` header. If `any` is found in the list, it dynamically replaces `$types` with all current public post types retrieved via `get_post_types()`.

The rest of the logic remains unchanged and continues to associate templates with the relevant post types by sanitizing and mapping them into the `$post_templates` array.