### PR TITLE
Multisite: Add missing closing backtick in inline comment

### DIFF
--- a/src/wp-includes/ms-settings.php
+++ b/src/wp-includes/ms-settings.php
@@ -77,7 +77,7 @@ if ( ! isset( $current_site ) || ! isset( $current_blog ) ) {
 	$bootstrap_result = ms_load_current_site_and_network( $domain, $path, is_subdomain_install() );
 
 	if ( true === $bootstrap_result ) {
-		// `$current_blog` and `$current_site are now populated.
+		// `$current_blog` and `$current_site` are now populated.
 	} elseif ( false === $bootstrap_result ) {
 		ms_not_installed( $domain, $path );
 	} else {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63410

Fixes a syntax error in a comment where the closing backtick for `$current_site` was missing. This ensures proper code documentation formatting in `ms-settings.php`.
