### PR TITLE
Docs: Clarify add_editor_style() applies to both TinyMCE and block editor

### DIFF
--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -737,7 +737,7 @@ p.search-box {
 .tablenav .search-plugins input[name="s"],
 .tagsdiv .newtag {
 	float: left;
-	margin: 0;
+	margin: 0 4px 0 0;
 }
 
 .js.plugins-php .search-box .wp-filter-search {

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -737,7 +737,7 @@ p.search-box {
 .tablenav .search-plugins input[name="s"],
 .tagsdiv .newtag {
 	float: left;
-	margin: 0 4px 0 0;
+	margin: 0;
 }
 
 .js.plugins-php .search-box .wp-filter-search {

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -2158,20 +2158,15 @@ function wp_update_custom_css_post( $css, $args = array() ) {
 }
 
 /**
- * Registers stylesheets for use in the visual editor.
+ * Adds callback for editor stylesheets.
  *
- * This function allows themes to add custom CSS to the visual editor, ensuring
- * a consistent appearance between the editor and the front end of the site.
- *
- * It supports both the classic TinyMCE editor and the block editor (Gutenberg).
- * For block themes, these styles are also applied to the block editor iframe.
- *
- * The parameter $stylesheet is the name of the stylesheet, relative to
- * the theme root. It also accepts an array of stylesheets.
- * It is optional and defaults to 'editor-style.css'.
+ * This function allows you to add custom stylesheets to the editor.
+ * It works for both the classic editor (TinyMCE) and the block editor (Gutenberg).
+ * The parameter $stylesheet can accept a single stylesheet filename (relative to the theme root),
+ * or an array of stylesheets. If no parameter is provided, the default 'editor-style.css' is used.
  *
  * This function automatically adds another stylesheet with -rtl prefix, e.g. editor-style-rtl.css.
- * If that file doesn't exist, it is removed before adding the stylesheet(s) to TinyMCE.
+ * If that file doesn't exist, it is removed before adding the stylesheet(s) to editor.
  * If an array of stylesheets is passed to add_editor_style(),
  * RTL is only added for the first stylesheet.
  *
@@ -2183,7 +2178,7 @@ function wp_update_custom_css_post( $css, $args = array() ) {
  * @global array $editor_styles
  *
  * @param array|string $stylesheet Optional. Stylesheet name or array thereof, relative to theme root.
- *                                 Defaults to 'editor-style.css'
+ *                                 Defaults to 'editor-style.css'.
  */
 function add_editor_style( $stylesheet = 'editor-style.css' ) {
 	global $editor_styles;

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -2158,7 +2158,13 @@ function wp_update_custom_css_post( $css, $args = array() ) {
 }
 
 /**
- * Adds callback for custom TinyMCE editor stylesheets.
+ * Registers stylesheets for use in the visual editor.
+ *
+ * This function allows themes to add custom CSS to the visual editor, ensuring
+ * a consistent appearance between the editor and the front end of the site.
+ *
+ * It supports both the classic TinyMCE editor and the block editor (Gutenberg).
+ * For block themes, these styles are also applied to the block editor iframe.
  *
  * The parameter $stylesheet is the name of the stylesheet, relative to
  * the theme root. It also accepts an array of stylesheets.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
Docs: Clarify add_editor_style() applies to both TinyMCE and block editor

Trac ticket: https://core.trac.wordpress.org/ticket/63411

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
