### PR TITLE
Administration: Fix inconsistent form field widths in taxonomy screens on mobile

### DIFF
--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -2049,4 +2049,20 @@ table.links-table {
 	.privacy-text-section .return-to-top {
 		margin: 2em 0 0;
 	}
+
+	.form-field input[type="text"],
+	.form-field input[type="password"],
+	.form-field input[type="email"],
+	.form-field input[type="number"],
+	.form-field input[type="search"],
+	.form-field input[type="tel"],
+	.form-field input[type="url"],
+	.form-field textarea,
+	.form-field select {
+		width: 100%;
+	}
+
+	.form-field select {
+		max-width: 100%;
+	}
 }


### PR DESCRIPTION
This PR improves visual consistency in the mobile view of taxonomy screens (e.g., Categories, Tags) by updating form field widths in the “Add New” section. Inputs, textareas, and selects now use width: 100% instead of 95%, aligning them with the search input and table layout.

Trac ticket: [#63418](https://core.trac.wordpress.org/ticket/63418)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
