### PR TITLE
Serialize: Respect attribute type for empty arrays

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1595,6 +1595,7 @@ function make_after_block_visitor( $hooked_blocks, $context, $callback = 'insert
  * to ensure consistent operation between PHP and JavaScript.
  *
  * @since 5.3.1
+ * @since 6.8.2 Add $block_name parameter.
  *
  * @param array       $block_attributes Attributes object.
  * @param string|null $block_name       Block name. Null if the block name is unknown. Optional.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1601,14 +1601,22 @@ function make_after_block_visitor( $hooked_blocks, $context, $callback = 'insert
  * @return string Serialized attributes.
  */
 function serialize_block_attributes( $block_attributes, $block_name = null ) {
+	$attribute_definitions = null;
 	foreach ( $block_attributes as $attribute => $value ) {
 		if ( is_array( $value ) && empty( $value ) ) {
 			// An empty `array()` is encoded as `[]` in JSON. However, it's possible
 			// that the attribute type is really an object (associative array in PHP),
 			// so we need to check for that.
-			$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
-			if ( $block_type && isset( $block_type->attributes[ $attribute ] ) ) {
-				$attribute_type = $block_type->attributes[ $attribute ]['type'];
+			if ( null === $attribute_definitions ) {
+				$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
+				if ( $block_type && isset( $block_type->attributes ) ) {
+					$attribute_definitions = $block_type->attributes;
+				} else {
+					$attribute_definitions = array();
+				}
+			}
+			if ( ! empty( $attribute_definitions ) ) {
+				$attribute_type = $attribute_definitions[ $attribute ]['type'];
 				if ( 'object' === $attribute_type ) {
 					$block_attributes[ $attribute ] = new stdClass();
 				}

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1596,10 +1596,26 @@ function make_after_block_visitor( $hooked_blocks, $context, $callback = 'insert
  *
  * @since 5.3.1
  *
- * @param array $block_attributes Attributes object.
+ * @param array       $block_attributes Attributes object.
+ * @param string|null $block_name       Block name. Null if the block name is unknown. Optional.
  * @return string Serialized attributes.
  */
-function serialize_block_attributes( $block_attributes ) {
+function serialize_block_attributes( $block_attributes, $block_name = null ) {
+	foreach ( $block_attributes as $attribute => $value ) {
+		if ( is_array( $value ) && empty( $value ) ) {
+			// An empty `array()` is encoded as `[]` in JSON. However, it's possible
+			// that the attribute type is really an object (associative array in PHP),
+			// so we need to check for that.
+			$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
+			if ( $block_type && isset( $block_type->attributes[ $attribute ] ) ) {
+				$attribute_type = $block_type->attributes[ $attribute ]['type'];
+				if ( 'object' === $attribute_type ) {
+					$block_attributes[ $attribute ] = new stdClass();
+				}
+			}
+		}
+	}
+
 	$encoded_attributes = wp_json_encode( $block_attributes, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 	$encoded_attributes = preg_replace( '/--/', '\\u002d\\u002d', $encoded_attributes );
 	$encoded_attributes = preg_replace( '/</', '\\u003c', $encoded_attributes );
@@ -1646,7 +1662,7 @@ function get_comment_delimited_block_content( $block_name, $block_attributes, $b
 	}
 
 	$serialized_block_name = strip_core_block_namespace( $block_name );
-	$serialized_attributes = empty( $block_attributes ) ? '' : serialize_block_attributes( $block_attributes ) . ' ';
+	$serialized_attributes = empty( $block_attributes ) ? '' : serialize_block_attributes( $block_attributes, $block_name ) . ' ';
 
 	if ( empty( $block_content ) ) {
 		return sprintf( '<!-- wp:%s %s/-->', $serialized_block_name, $serialized_attributes );

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1615,7 +1615,7 @@ function serialize_block_attributes( $block_attributes, $block_name = null ) {
 					$attribute_definitions = array();
 				}
 			}
-			if ( ! empty( $attribute_definitions ) ) {
+			if ( ! empty( $attribute_definitions ) && isset( $attribute_definitions[ $attribute ]['type'] ) ) {
 				$attribute_type = $attribute_definitions[ $attribute ]['type'];
 				if ( 'object' === $attribute_type ) {
 					$block_attributes[ $attribute ] = new stdClass();

--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -78,10 +78,10 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 			// Block with attribute values that should not be escaped.
 			array( '<!-- wp:attributes {"key":"€1.00 / 3 for €2.00"} /-->' ),
 
-			// Block with attribute values that have array keys.
+			// Block with empty array attribute value.
 			array( '<!-- wp:attributes {"array":[]} /-->' ),
 
-			// Block with attribute values that have empty keys.
+			// Block with empty object attribute value.
 			array( '<!-- wp:attributes {"object":{}} /-->' ),
 		);
 	}

--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -10,6 +10,37 @@
  * @group blocks
  */
 class Tests_Blocks_Serialize extends WP_UnitTestCase {
+	/**
+	 * Set up.
+	 *
+	 * @ticket 63325.
+	 */
+	public static function wpSetUpBeforeClass() {
+		register_block_type(
+			'core/attributes',
+			array(
+				'attributes' => array(
+					'array'  => array(
+						'type' => 'array',
+					),
+					'object' => array(
+						'type' => 'object',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Tear down.
+	 *
+	 * @ticket 63325.
+	 */
+	public static function wpTearDownAfterClass() {
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		$registry->unregister( 'core/attributes' );
+	}
 
 	/**
 	 * @dataProvider data_serialize_identity_from_parsed
@@ -46,6 +77,12 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 
 			// Block with attribute values that should not be escaped.
 			array( '<!-- wp:attributes {"key":"€1.00 / 3 for €2.00"} /-->' ),
+
+			// Block with attribute values that have array keys.
+			array( '<!-- wp:attributes {"array":[]} /-->' ),
+
+			// Block with attribute values that have empty keys.
+			array( '<!-- wp:attributes {"object":{}} /-->' ),
 		);
 	}
 


### PR DESCRIPTION
In `serialize_attributes`, if the value of an attribute is an empty `array()`, it will always be JSON-encoded into `[]` even though it could be an associative array (which should be encoded into `{}`) — but that distinction just doesn’t exist for _empty_ arrays in PHP. In other words, PHP simply doesn’t have enough (meta) information to know what it should encode an empty `array()` into.

So our best bet is to infer the attribute type from the block definition. This isn't great, since `serialize_attributes` is a low-level function that was previously able to operate without any knowledge about higher-level block semantics, but alas.

Note that this also violates function signature parity of `serialize_attributes` (PHP) and `serializeAttributes` (JS), as the PHP version needs to know the block name in order to look up its block definition. Maybe the violation is permissible here, but I’d like to hear @dmsnell’s optionion before proceeding. Alternatively, we can move the logic I’m introducing here one level up, i.e. into `get_comment_delimited_block_content`. This should still be sufficient for all practical purposes; it is also currently the only callsite of `serialize_attributes` in the entire Core codebase.

Trac ticket: https://core.trac.wordpress.org/ticket/63325
Gutenberg issue: https://github.com/WordPress/gutenberg/issues/69959
Prior art: https://github.com/WordPress/wordpress-develop/pull/8735 h/t @margolisj

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
