### PR TITLE
Removing FTP Class Exclusion for PHPCS

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -46,7 +46,6 @@
 	<exclude-pattern>/node_modules/*</exclude-pattern>
 	<exclude-pattern>/vendor/*</exclude-pattern>
 
-	<exclude-pattern>/src/wp-admin/includes/class-ftp*</exclude-pattern>
 	<exclude-pattern>/src/wp-admin/includes/class-pclzip\.php</exclude-pattern>
 	<exclude-pattern>/src/wp-admin/includes/deprecated\.php</exclude-pattern>
 	<exclude-pattern>/src/wp-admin/includes/ms-deprecated\.php</exclude-pattern>


### PR DESCRIPTION
Time to open FTP Classes for PHPCS?
Nothing to test here.

Trac ticket: https://core.trac.wordpress.org/ticket/63436

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
