### PR TITLE
Admin: Standardize padding in menu item source accordions

### DIFF
--- a/src/wp-admin/css/customize-nav-menus.css
+++ b/src/wp-admin/css/customize-nav-menus.css
@@ -583,7 +583,7 @@
 
 #available-menu-items .accordion-section-content .available-menu-items-list {
 	margin: 0 0 64px;
-	padding: 1px 15px 15px;
+	padding: 15px;
 }
 
 #available-menu-items .accordion-section-content .available-menu-items-list:only-child { /* Types that do not support new items for the current user */
@@ -591,7 +591,7 @@
 }
 
 #new-custom-menu-item .accordion-section-content {
-	padding: 0 15px 15px;
+	padding: 15px;
 }
 
 #available-menu-items .menu-item-tpl {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63438


This PR addresses CSS padding inconsistencies within the  Customizer accordion sections. Specifically, it standardizes the padding for lists of available items (Pages, Posts, etc.) and the "Custom Links" section.

Updates the `padding` property for the affected selectors in both `wp-admin/css/nav-menus.css` and `wp-admin/css/customize-nav-menus.css` to a uniform `15px` on all sides. This enhances visual consistency and improves the user experience in these core menu management interfaces.





## Screencast

### Before 


https://github.com/user-attachments/assets/7445402a-8483-43c9-b613-ccd260d225de








### After


https://github.com/user-attachments/assets/820fbd79-60c4-4bc7-b0e7-abb197830e9b
