### PR TITLE
63444 | Add a Markdown version of the README to ensure proper rendering in GitHub interface.

### DIFF
--- a/issue file
+++ b/issue file
@@ -1,0 +1,1 @@
+I just created this to be able to do the issue


### PR DESCRIPTION
Add README.md for proper GitHub rendering of WordPress repository

Add a Markdown version of the README to ensure proper rendering in the main WordPress GitHub repository (https://github.com/WordPress/WordPress).

The current README.html file in the main WordPress repository (https://github.com/WordPress/WordPress) displays as raw HTML code when viewed on GitHub, affecting readability and accessibility of WordPress documentation for developers. This PR adds a README.md file in Markdown format while maintaining the original README.html for backward compatibility.

Changes:
- Convert HTML content to equivalent Markdown formatting
- Preserve all links, structure, and information from the original
- Maintain backward compatibility by keeping README.html

This improvement helps developers browsing the repository on GitHub to read the documentation more easily without having to download or view the raw HTML file.

Tested on Chrome, Firefox, and OperaGX browsers.

Props KerubinDev.
Fixes https://core.trac.wordpress.org/ticket/63444
[README.MD](https://github.com/user-attachments/files/20197314/README.MD)
