### PR TITLE
#63167 Make more use of the example.com domain in tests

### DIFF
--- a/tests/e2e/specs/install.test.js
+++ b/tests/e2e/specs/install.test.js
@@ -58,7 +58,7 @@ test.describe( 'WordPress installation process', () => {
 		await page.getByLabel( 'Password', { exact: true } ).fill( '' );
 		await page.getByLabel( 'Password', { exact: true } ).fill( 'password' );
 		await page.getByLabel( /Confirm use of weak password/ ).check()
-		await page.getByLabel( 'Your Email' ).fill( 'test@test.com' );
+		await page.getByLabel( 'Your Email' ).fill( 'test@example.com' );
 
 		await page.getByRole( 'button', { name: 'Install WordPress' } ).click();
 

--- a/tests/phpunit/tests/admin/wpPluginsListTable.php
+++ b/tests/phpunit/tests/admin/wpPluginsListTable.php
@@ -57,7 +57,7 @@ class Tests_Admin_wpPluginsListTable extends WP_UnitTestCase {
 				'role'       => 'administrator',
 				'user_login' => 'test_wp_plugins_list_table',
 				'user_pass'  => 'password',
-				'user_email' => 'testadmin@test.com',
+				'user_email' => 'testadmin@example.com',
 			)
 		);
 		self::$original_s = $s;

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -21,7 +21,7 @@ class Tests_Comment extends WP_UnitTestCase {
 				'role'       => 'author',
 				'user_login' => 'test_wp_user_get',
 				'user_pass'  => 'password',
-				'user_email' => 'test@test.com',
+				'user_email' => 'author@example.com',
 			)
 		);
 
@@ -95,7 +95,7 @@ class Tests_Comment extends WP_UnitTestCase {
 				'comment_post_ID'      => self::$post_id,
 				'comment_author'       => 'Author',
 				'comment_author_url'   => 'http://example.localhost/',
-				'comment_author_email' => 'test@test.com',
+				'comment_author_email' => 'author@example.com',
 				'user_id'              => $admin_id_1,
 				'comment_content'      => 'This is a comment',
 			)
@@ -108,7 +108,7 @@ class Tests_Comment extends WP_UnitTestCase {
 				'role'       => 'administrator',
 				'user_login' => 'test_wp_admin_get',
 				'user_pass'  => 'password',
-				'user_email' => 'testadmin@test.com',
+				'user_email' => 'testadmin@example.com',
 			)
 		);
 
@@ -139,7 +139,7 @@ class Tests_Comment extends WP_UnitTestCase {
 				'comment_post_ID'      => self::$post_id,
 				'comment_author'       => 'Author',
 				'comment_author_url'   => 'http://example.localhost/',
-				'comment_author_email' => 'test@test.com',
+				'comment_author_email' => 'author@example.com',
 				'user_id'              => self::$user_id,
 				'comment_content'      => '<a href="http://example.localhost/something.html">click</a>',
 			)
@@ -152,7 +152,7 @@ class Tests_Comment extends WP_UnitTestCase {
 				'role'       => 'administrator',
 				'user_login' => 'test_wp_admin_get',
 				'user_pass'  => 'password',
-				'user_email' => 'testadmin@test.com',
+				'user_email' => 'testadmin@example.com',
 			)
 		);
 
@@ -1445,10 +1445,10 @@ class Tests_Comment extends WP_UnitTestCase {
 		// Post authors possibly notified when a comment is approved on their post.
 		wp_set_comment_status( $comment, 'approve' );
 
-		// Check to see if a notification email was sent to the post author `test@test.com`.
+		// Check to see if a notification email was sent to the post author `author@example.com`.
 		if ( isset( $GLOBALS['phpmailer']->mock_sent )
 			&& ! empty( $GLOBALS['phpmailer']->mock_sent )
-			&& 'test@test.com' === $GLOBALS['phpmailer']->mock_sent[0]['to'][0][0]
+			&& 'author@example.com' === $GLOBALS['phpmailer']->mock_sent[0]['to'][0][0]
 		) {
 			$email_sent_when_comment_approved = true;
 		} else {
@@ -1467,10 +1467,10 @@ class Tests_Comment extends WP_UnitTestCase {
 		);
 		wp_new_comment( $data );
 
-		// Check to see if a notification email was sent to the post author `test@test.com`.
+		// Check to see if a notification email was sent to the post author `author@example.com`.
 		if ( isset( $GLOBALS['phpmailer']->mock_sent ) &&
 			! empty( $GLOBALS['phpmailer']->mock_sent ) &&
-			'test@test.com' === $GLOBALS['phpmailer']->mock_sent[0]['to'][0][0] ) {
+			'author@example.com' === $GLOBALS['phpmailer']->mock_sent[0]['to'][0][0] ) {
 				$email_sent_when_comment_added = true;
 				reset_phpmailer_instance();
 		} else {

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -49,7 +49,7 @@ class Tests_User extends WP_UnitTestCase {
 		self::$user_ids[] = self::$admin_id;
 		self::$editor_id  = $factory->user->create(
 			array(
-				'user_email' => 'test@test.com',
+				'user_email' => 'test@example.com',
 				'role'       => 'editor',
 			)
 		);
@@ -820,7 +820,7 @@ class Tests_User extends WP_UnitTestCase {
 	 */
 	public function test_validate_username_string() {
 		$this->assertTrue( validate_username( 'johndoe' ) );
-		$this->assertTrue( validate_username( 'test@test.com' ) );
+		$this->assertTrue( validate_username( 'test@example.com' ) );
 	}
 
 	/**
@@ -1256,7 +1256,7 @@ class Tests_User extends WP_UnitTestCase {
 		// Alter the case of the email address (which stays the same).
 		$userdata = array(
 			'ID'         => self::$editor_id,
-			'user_email' => 'test@TEST.com',
+			'user_email' => 'test@EXAMPLE.com',
 		);
 		$update   = wp_update_user( $userdata );
 
@@ -1270,7 +1270,7 @@ class Tests_User extends WP_UnitTestCase {
 		// Change the email address.
 		$userdata = array(
 			'ID'         => self::$editor_id,
-			'user_email' => 'test2@test.com',
+			'user_email' => 'test2@example.com',
 		);
 		$update   = wp_update_user( $userdata );
 
@@ -1279,7 +1279,7 @@ class Tests_User extends WP_UnitTestCase {
 
 		// Verify that the email address has been updated.
 		$user = get_userdata( self::$editor_id );
-		$this->assertSame( $user->user_email, 'test2@test.com' );
+		$this->assertSame( $user->user_email, 'test2@example.com' );
 	}
 
 	/**
@@ -1978,7 +1978,7 @@ class Tests_User extends WP_UnitTestCase {
 	 * @ticket 43547
 	 */
 	public function test_wp_user_personal_data_exporter_no_user() {
-		$actual = wp_user_personal_data_exporter( 'not-a-user-email@test.com' );
+		$actual = wp_user_personal_data_exporter( 'not-a-user-email@example.com' );
 
 		$expected = array(
 			'data' => array(),

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -1035,7 +1035,7 @@ class Tests_User extends WP_UnitTestCase {
 		$u        = wp_insert_user(
 			array(
 				'user_login' => 'test',
-				'user_email' => 'test@example.com',
+				'user_email' => 'urltest@example.com',
 				'user_pass'  => 'password',
 				'user_url'   => $user_url,
 			)

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -42,7 +42,7 @@ wait_on( { resources: [ `tcp:localhost:${process.env.LOCAL_PORT}`] } )
 	.then( () => {
 		wp_cli( 'db reset --yes' );
 		const installCommand = process.env.LOCAL_MULTISITE === 'true'  ? 'multisite-install' : 'install';
-		wp_cli( `core ${ installCommand } --title="WordPress Develop" --admin_user=admin --admin_password=password --admin_email=test@test.com --skip-email --url=http://localhost:${process.env.LOCAL_PORT}` );
+		wp_cli( `core ${ installCommand } --title="WordPress Develop" --admin_user=admin --admin_password=password --admin_email=test@example.com --skip-email --url=http://localhost:${process.env.LOCAL_PORT}` );
 	} );
 
 /**


### PR DESCRIPTION
This replaces uses of `test.com` in tests with the more appropriate `example.com` which is intended for testing and examples.

Trac ticket: https://core.trac.wordpress.org/ticket/63167