### PR TITLE
Widget: Fix color contrast in widget

### DIFF
--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -595,7 +595,7 @@
 	margin-bottom: 0;
 	padding: 12px;
 	border-top: 1px solid #f0f0f1;
-	color: #dcdcde;
+	color: #73777D;
 }
 
 /* Safari 10 + VoiceOver specific: without this, the hidden text gets read out before the link. */
@@ -927,7 +927,7 @@ body #dashboard-widgets .postbox form .submit {
 }
 
 .activity-block .subsubsub li {
-	color: #dcdcde;
+	color: #73777D;
 }
 
 /* Dashboard activity widget - Comments */


### PR DESCRIPTION
This PR improves accessibility in the WordPress Dashboard by updating the color of the vertical separator `|` used in the footer of the “WordPress Events and News” widget.

Previously, the separator used the color #dcdcde, which fails the WCAG 2.1 AA contrast requirement against a white background. The new color `#73777D` ensures a minimum contrast ratio of 4.54:1, meeting accessibility standards for normal text.

Trac Ticket: [#63447](https://core.trac.wordpress.org/ticket/63447)