### PR TITLE
Administration: Fix low color contrast for <code> elements

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -420,6 +420,7 @@ code {
 
 kbd,
 code {
+	color: #44464B;
 	padding: 3px 5px 2px;
 	margin: 0 1px;
 	background: #f0f0f1;

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -420,7 +420,6 @@ code {
 
 kbd,
 code {
-	color: #44464B;
 	padding: 3px 5px 2px;
 	margin: 0 1px;
 	background: #f0f0f1;

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -1379,6 +1379,11 @@ p.description code {
 	font-style: normal;
 }
 
+p.description code,
+.form-wrap p code {
+	color: #50575e;
+}
+
 .form-wrap .form-field {
 	margin: 1em 0;
 	padding: 0;


### PR DESCRIPTION
This PR fixes a low color contrast issue for `<code>` and `<kbd>` elements in the WordPress admin by setting a default text color `#44464B` to ensure compliance with WCAG 2.1 standards. Previously, these elements had a fixed light background but inherited text color, which in some contexts (e.g., the Site Icon description on the General Settings page) led to insufficient contrast flagged by accessibility tools like Lighthouse and WebAIM.

Trac ticket: [#63449](https://core.trac.wordpress.org/ticket/63449)

![image](https://github.com/user-attachments/assets/ca6839d6-fd4c-4098-ae7f-d617656554d3)


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
