### PR TITLE
Fix image quality degradation caused by quantizeImage on resized PNG assets (Trac #63448)

### DIFF
--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -506,7 +506,14 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 							$current_colors = $this->image->getImageColors();
 							$max_colors     = min( $max_colors, $current_colors );
 						}
-						$this->image->quantizeImage( $max_colors, $this->image->getColorspace(), 0, false, false );
+
+						/*
+						 * Only apply color quantization under safe conditions
+						 * such as if max_colors is set low to avoid image degradation.
+						 */
+						if ( $max_colors < 256 ) {
+							$this->image->quantizeImage( $max_colors, $this->image->getColorspace(), 0, false, false );
+						}
 
 						/**
 						 * If the colorspace is 'gray', use the png8 format to ensure it stays indexed.

--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -485,32 +485,33 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 				$this->image->setOption( 'png:compression-level', '9' );
 				$this->image->setOption( 'png:compression-strategy', '1' );
 
-				// Check for an alpha channel.
+				// Handle alpha chunk inclusion or exclusion.
 				if (
-					is_callable( array( $this->image, 'getImageAlphaChannel' ) )
-					&& $this->image->getImageAlphaChannel()
+					is_callable( array( $this->image, 'getImageAlphaChannel' ) ) &&
+					$this->image->getImageAlphaChannel()
 				) {
 					$this->image->setOption( 'png:include-chunk', 'tRNS' );
 				} else {
 					$this->image->setOption( 'png:exclude-chunk', 'all' );
 				}
 
-				// Reduce colors in the image only if it's an indexed PNG with <= 256 colors.
+				// Only apply quantization to actual indexed PNGs.
 				if (
 					is_callable( array( $this->image, 'getImageColors' ) ) &&
+					is_callable( array( $this->image, 'getImageDepth' ) ) &&
 					is_callable( array( $this->image, 'getImageProperty' ) )
 				) {
 					$current_colors = $this->image->getImageColors();
-					$color_type     = $this->image->getImageProperty( 'png:IHDR.color_type' );
+					$bit_depth      = $this->image->getImageDepth();
+					$max_colors     = pow( 2, $bit_depth );
+					$color_type     = $this->image->getImageProperty( 'png:IHDR.color-type-orig' );
 
-					if ( $current_colors <= 256 && '3' === $color_type ) {
+					if ( $current_colors <= $max_colors && '3' === $color_type ) {
 						$this->image->quantizeImage( $current_colors, $this->image->getColorspace(), 0, false, false );
 					}
 				}
 
-				/**
-				 * If the colorspace is 'gray', use the png8 format to ensure it stays indexed.
-				 */
+				// If grayscale, ensure format is png8 to retain index palette.
 				if ( Imagick::COLORSPACE_GRAY === $this->image->getImageColorspace() ) {
 					$this->image->setOption( 'png:format', 'png8' );
 				}

--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -484,44 +484,35 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 				$this->image->setOption( 'png:compression-filter', '5' );
 				$this->image->setOption( 'png:compression-level', '9' );
 				$this->image->setOption( 'png:compression-strategy', '1' );
-				// Check to see if a PNG is indexed, and find the pixel depth.
-				if ( is_callable( array( $this->image, 'getImageDepth' ) ) ) {
-					$indexed_pixel_depth = $this->image->getImageDepth();
 
-					// Indexed PNG files get some additional handling.
-					if ( 0 < $indexed_pixel_depth && 8 >= $indexed_pixel_depth ) {
-						// Check for an alpha channel.
-						if (
-							is_callable( array( $this->image, 'getImageAlphaChannel' ) )
-							&& $this->image->getImageAlphaChannel()
-						) {
-							$this->image->setOption( 'png:include-chunk', 'tRNS' );
-						} else {
-							$this->image->setOption( 'png:exclude-chunk', 'all' );
-						}
+				// Check for an alpha channel.
+				if (
+					is_callable( array( $this->image, 'getImageAlphaChannel' ) )
+					&& $this->image->getImageAlphaChannel()
+				) {
+					$this->image->setOption( 'png:include-chunk', 'tRNS' );
+				} else {
+					$this->image->setOption( 'png:exclude-chunk', 'all' );
+				}
 
-						// Reduce colors in the images to maximum needed, using the global colorspace.
-						$max_colors = pow( 2, $indexed_pixel_depth );
-						if ( is_callable( array( $this->image, 'getImageColors' ) ) ) {
-							$current_colors = $this->image->getImageColors();
-							$max_colors     = min( $max_colors, $current_colors );
-						}
+				// Reduce colors in the image only if it's an indexed PNG with <= 256 colors.
+				if (
+					is_callable( array( $this->image, 'getImageColors' ) ) &&
+					is_callable( array( $this->image, 'getImageProperty' ) )
+				) {
+					$current_colors = $this->image->getImageColors();
+					$color_type     = $this->image->getImageProperty( 'png:IHDR.color_type' );
 
-						/*
-						 * Only apply color quantization under safe conditions
-						 * such as if max_colors is set low to avoid image degradation.
-						 */
-						if ( $max_colors < 256 ) {
-							$this->image->quantizeImage( $max_colors, $this->image->getColorspace(), 0, false, false );
-						}
-
-						/**
-						 * If the colorspace is 'gray', use the png8 format to ensure it stays indexed.
-						 */
-						if ( Imagick::COLORSPACE_GRAY === $this->image->getImageColorspace() ) {
-							$this->image->setOption( 'png:format', 'png8' );
-						}
+					if ( $current_colors <= 256 && '3' === $color_type ) {
+						$this->image->quantizeImage( $current_colors, $this->image->getColorspace(), 0, false, false );
 					}
+				}
+
+				/**
+				 * If the colorspace is 'gray', use the png8 format to ensure it stays indexed.
+				 */
+				if ( Imagick::COLORSPACE_GRAY === $this->image->getImageColorspace() ) {
+					$this->image->setOption( 'png:format', 'png8' );
 				}
 			}
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR addresses a regression introduced in WordPress 6.8 via [[59589](https://core.trac.wordpress.org/changeset/59589)], where use of `Imagick::quantizeImage()` during image resizing causes visible quality loss, especially for:

- PNGs with transparency
- Images with soft gradients or color transitions

**Observed Effects**
- Banding and posterization in gradients
- Loss of clarity in high-fidelity illustrations
- Artifacts in resized images generated via upload or `wp media regenerate`

**Updated Fix**
Instead of relying on `getImageDepth()` (which inaccurately represents image color depth), this updated approach:

- Uses `getImageColors()` to check if the image has **256 colors or fewer**
- Uses `getImageProperty( 'png:IHDR.color_type' )` to verify if it's an **indexed PNG (color_type = 3)**

Only when **both** conditions are met does `quantizeImage()` run. This prevents quantization from being applied to high-color or truecolor images, preserving fidelity.

Grayscale PNGs still receive the `png8` treatment, and alpha chunk logic is retained.

Trac ticket: https://core.trac.wordpress.org/ticket/63448

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
