### PR TITLE
36428 - Update default link category id

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -471,7 +471,7 @@ function populate_options( array $options = array() ) {
 
 		// 2.1.0
 		'blog_public'                     => '1',
-		'default_link_category'           => 2,
+		'default_link_category'           => 0,
 		'show_on_front'                   => 'posts',
 
 		// 2.2.0


### PR DESCRIPTION
**Changes:**
---------- 
- Update the default link category to be populated as **0**, not as **2**, as when WordPress is installed, there will not be any default link categories added, unlike the Category taxonomy.
- The above change makes sense to me, as the link feature is not widely used in many WordPress sites and is not default-enabled.

Trac ticket: https://core.trac.wordpress.org/ticket/36428