### PR TITLE
Added condition to check if is an array() for $role_data['capabilities']

### DIFF
--- a/src/wp-includes/class-wp-user-query.php
+++ b/src/wp-includes/class-wp-user-query.php
@@ -482,7 +482,8 @@ class WP_User_Query {
 		$caps_with_roles = array();
 
 		foreach ( $available_roles as $role => $role_data ) {
-			$role_caps = array_keys( array_filter( $role_data['capabilities'] ) );
+
+			$role_caps = ( isset( $role_data['capabilities'] ) && is_array( $role_data['capabilities'] ) ) ? array_keys( array_filter( $role_data['capabilities'] ) ) : array();
 
 			foreach ( $capabilities as $cap ) {
 				if ( in_array( $cap, $role_caps, true ) ) {


### PR DESCRIPTION
Added condition to check if is an array() for $role_data['capabilities']. Even if  $role_data['capabilities'] set to false or true it will not give Fatal array for array_filter.

I've checked with unit tests from my end, but still need unit tests.
I've also fixed the PHPCS for patch attached to Core track issue. 

Trac ticket:  https://core.trac.wordpress.org/ticket/62600
