### PR TITLE
fix: Fixes the error that getchmod() can cause a fatal error

### DIFF
--- a/src/wp-admin/includes/class-wp-filesystem-ftpext.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpext.php
@@ -313,7 +313,11 @@ class WP_Filesystem_FTPext extends WP_Filesystem_Base {
 	public function getchmod( $file ) {
 		$dir = $this->dirlist( $file );
 
-		return $dir[ $file ]['permsn'];
+		if ( ! empty( $dir[ $file ]['permsn'] ) ) {
+			return $dir[ $file ]['permsn'];
+		}
+
+		return '';
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
+++ b/src/wp-admin/includes/class-wp-filesystem-ftpsockets.php
@@ -323,7 +323,11 @@ class WP_Filesystem_ftpsockets extends WP_Filesystem_Base {
 	public function getchmod( $file ) {
 		$dir = $this->dirlist( $file );
 
-		return $dir[ $file ]['permsn'];
+		if ( ! empty( $dir[ $file ]['permsn'] ) ) {
+			return $dir[ $file ]['permsn'];
+		}
+
+		return '';
 	}
 
 	/**


### PR DESCRIPTION
Co-authored-by: @zaphir
Ref: https://core.trac.wordpress.org/ticket/63474#ticket

Fixes 63474 in the way suggested in the ticket.

Trac ticket: https://core.trac.wordpress.org/ticket/63474#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
