### PR TITLE
Add tests for 55358

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -1628,7 +1628,10 @@ function term_exists( $term, $taxonomy = '', $parent_term = null ) {
 		if ( 0 === $term ) {
 			return 0;
 		}
-		$args  = wp_parse_args( array( 'include' => array( $term ) ), $defaults );
+		$args = wp_parse_args( array( 'include' => array( $term ) ), $defaults );
+		if ( ! empty( $taxonomy ) && is_numeric( $parent_term ) ) {
+			$args['parent'] = (int) $parent_term;
+		}
 		$terms = get_terms( $args );
 	} else {
 		$term = trim( wp_unslash( $term ) );

--- a/tests/phpunit/tests/term/termExists.php
+++ b/tests/phpunit/tests/term/termExists.php
@@ -401,4 +401,28 @@ class Tests_TermExists extends WP_UnitTestCase {
 		$this->assertNull( term_exists( '' ) );
 		$this->assertNull( term_exists( null ) );
 	}
+
+	/**
+	 * @ticket 55358
+	 * @covers ::term_exists()
+	 */
+	public function test_term_exists_with_term_id_should_acknowledge_parent_id() {
+		$parent_category = self::factory()->category->create();
+		$child_category  = self::factory()->category->create(
+			array(
+				'parent' => $parent_category,
+			)
+		);
+		$orphan_category = self::factory()->category->create();
+
+		$this->assertSame(
+			array(
+				'term_id'          => (string) $child_category,
+				'term_taxonomy_id' => (string) $child_category,
+			),
+			term_exists( $child_category, 'category', $parent_category ),
+			'Child category should be found with parent ID.'
+		);
+		$this->assertNull( term_exists( $orphan_category, 'category', $parent_category ), 'Orphan category should not be found with parent ID.' );
+	}
 }

--- a/tests/phpunit/tests/term/termExists.php
+++ b/tests/phpunit/tests/term/termExists.php
@@ -408,7 +408,7 @@ class Tests_TermExists extends WP_UnitTestCase {
 	 */
 	public function test_term_exists_with_term_id_should_acknowledge_parent_id() {
 		$parent_category = self::factory()->category->create();
-		$child_category  = self::factory()->category->create(
+		$child_category  = self::factory()->category->create_and_get(
 			array(
 				'parent' => $parent_category,
 			)
@@ -417,10 +417,10 @@ class Tests_TermExists extends WP_UnitTestCase {
 
 		$this->assertSame(
 			array(
-				'term_id'          => (string) $child_category,
-				'term_taxonomy_id' => (string) $child_category,
+				'term_id'          => (string) $child_category->term_id,
+				'term_taxonomy_id' => (string) $child_category->term_taxonomy_id,
 			),
-			term_exists( $child_category, 'category', $parent_category ),
+			term_exists( $child_category->term_id, 'category', $parent_category ),
 			'Child category should be found with parent ID.'
 		);
 		$this->assertNull( term_exists( $orphan_category, 'category', $parent_category ), 'Orphan category should not be found with parent ID.' );

--- a/tests/phpunit/tests/term/termExists.php
+++ b/tests/phpunit/tests/term/termExists.php
@@ -407,22 +407,22 @@ class Tests_TermExists extends WP_UnitTestCase {
 	 * @covers ::term_exists()
 	 */
 	public function test_term_exists_with_term_id_should_acknowledge_parent_id() {
-		$parent_category = self::factory()->category->create();
-		$child_category  = self::factory()->category->create_and_get(
+		$parent_category_id = self::factory()->category->create();
+		$child_category     = self::factory()->category->create_and_get(
 			array(
-				'parent' => $parent_category,
+				'parent' => $parent_category_id,
 			)
 		);
-		$orphan_category = self::factory()->category->create();
+		$orphan_category_id = self::factory()->category->create();
 
 		$this->assertSame(
 			array(
 				'term_id'          => (string) $child_category->term_id,
 				'term_taxonomy_id' => (string) $child_category->term_taxonomy_id,
 			),
-			term_exists( $child_category->term_id, 'category', $parent_category ),
+			term_exists( $child_category->term_id, 'category', $parent_category_id ),
 			'Child category should be found with parent ID.'
 		);
-		$this->assertNull( term_exists( $orphan_category, 'category', $parent_category ), 'Orphan category should not be found with parent ID.' );
+		$this->assertNull( term_exists( $orphan_category_id, 'category', $parent_category_id ), 'Orphan category should not be found with parent ID.' );
 	}
 }


### PR DESCRIPTION
Adds a PHPUnit tests for `term_exists()` with `$term` as integer and non null `$parent_term`.
Follows https://github.com/WordPress/wordpress-develop/pull/6790

Trac ticket: https://core.trac.wordpress.org/ticket/55358

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
