### PR TITLE
Robots: Use `admin_url()` to dynamically retrieve the url

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -1717,8 +1717,10 @@ function do_robots() {
 	$public = (bool) get_option( 'blog_public' );
 
 	$admin_path = wp_make_link_relative( admin_url() );
-	$output    .= sprintf( "Disallow: %s\n", $admin_path );
-	$output    .= sprintf( "Allow: %s\n", $admin_path . 'admin-ajax.php' );
+	$output    .= sprintf( 'Disallow: %1$s%2$s', $admin_path, PHP_EOL );
+	$output    .= sprintf( 
+		'Allow: %1$s%2$s', $admin_path . 'admin-ajax.php', PHP_EOL 
+	);
 
 	/**
 	 * Filters the robots.txt output.

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -1718,9 +1718,7 @@ function do_robots() {
 
 	$admin_path = wp_make_link_relative( admin_url() );
 	$output    .= sprintf( 'Disallow: %1$s%2$s', $admin_path, PHP_EOL );
-	$output    .= sprintf( 
-		'Allow: %1$s%2$s', $admin_path . 'admin-ajax.php', PHP_EOL 
-	);
+	$output    .= sprintf( 'Allow: %1$s%2$s', $admin_path . 'admin-ajax.php', PHP_EOL );
 
 	/**
 	 * Filters the robots.txt output.

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -1717,8 +1717,8 @@ function do_robots() {
 	$public = (bool) get_option( 'blog_public' );
 
 	$admin_path = wp_make_link_relative( admin_url() );
-	$output .= sprintf( "Disallow: %s\n", $admin_path );
-	$output .= sprintf( "Allow: %s\n", $admin_path . 'admin-ajax.php' );
+	$output    .= sprintf( "Disallow: %s\n", $admin_path );
+	$output    .= sprintf( "Allow: %s\n", $admin_path . 'admin-ajax.php' );
 
 	/**
 	 * Filters the robots.txt output.

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -1716,10 +1716,9 @@ function do_robots() {
 	$output = "User-agent: *\n";
 	$public = (bool) get_option( 'blog_public' );
 
-	$site_url = parse_url( site_url() );
-	$path     = ( ! empty( $site_url['path'] ) ) ? $site_url['path'] : '';
-	$output  .= "Disallow: $path/wp-admin/\n";
-	$output  .= "Allow: $path/wp-admin/admin-ajax.php\n";
+	$admin_path = wp_make_link_relative( admin_url() );
+	$output .= sprintf( "Disallow: %s\n", $admin_path );
+	$output .= sprintf( "Allow: %s\n", $admin_path . 'admin-ajax.php' );
 
 	/**
 	 * Filters the robots.txt output.


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63467

### Description

This PR introduces the use of the `admin_url()` function to dynamically retrieve the admin URL, replacing previously hardcoded values.

### Screenshots

|Site|Before|After|
|-|-|-|
|Single-site|![single-site-before](https://github.com/user-attachments/assets/ba7120a7-b553-4d10-a3db-92c8e5d9db42)|![single-site](https://github.com/user-attachments/assets/7213c20b-b523-40d5-ae87-abed445fae6c)|
|Multisite|![multi-site-before](https://github.com/user-attachments/assets/1ff15b2b-20f9-42d3-bcbd-6c0a6ee7b34f)|![multisite](https://github.com/user-attachments/assets/239f5a9b-9e33-4188-9957-a4ec34d342bc)|


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
