### PR TITLE
Thumbnails Resize Imagick Filtering

### DIFF
--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -400,7 +400,7 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 	 * @param bool   $strip_meta  Optional. Strip all profiles, excluding color profiles, from the image. Default true.
 	 * @return void|WP_Error
 	 */
-	protected function thumbnail_image( $dst_w, $dst_h, $filter_name = 'FILTER_TRIANGLE', $strip_meta = true ) {
+	public function thumbnail_image( $dst_w, $dst_h, $filter_name = 'FILTER_TRIANGLE', $strip_meta = true ) {
 		$allowed_filters = array(
 			'FILTER_POINT',
 			'FILTER_BOX',
@@ -418,6 +418,17 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 			'FILTER_BESSEL',
 			'FILTER_SINC',
 		);
+
+		/**
+		 * Filters the choice of Imagick resizing filter used.
+		 *
+		 * This filter only applies when resizing using the Imagick editor.
+		 *
+		 * @since 6.9
+		 *
+		 * @param string $filter_name Imagick resize filter constant.
+		 */
+		$filter_name = apply_filters( 'imagick_resize_filter', $filter_name );
 
 		/**
 		 * Set the filter value if '$filter_name' name is in the allowed list and the related

--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -396,11 +396,11 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 	 *
 	 * @param int    $dst_w       The destination width.
 	 * @param int    $dst_h       The destination height.
-	 * @param string $filter_name Optional. The Imagick filter to use when resizing. Default 'FILTER_TRIANGLE'.
+	 * @param string $filter_name Optional. The Imagick filter to use when resizing. Default 'FILTER_LANCZOS'.
 	 * @param bool   $strip_meta  Optional. Strip all profiles, excluding color profiles, from the image. Default true.
 	 * @return void|WP_Error
 	 */
-	public function thumbnail_image( $dst_w, $dst_h, $filter_name = 'FILTER_TRIANGLE', $strip_meta = true ) {
+	public function thumbnail_image( $dst_w, $dst_h, $filter_name = 'FILTER_LANCZOS', $strip_meta = true ) {
 		$allowed_filters = array(
 			'FILTER_POINT',
 			'FILTER_BOX',
@@ -437,7 +437,7 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 		if ( in_array( $filter_name, $allowed_filters, true ) && defined( 'Imagick::' . $filter_name ) ) {
 			$filter = constant( 'Imagick::' . $filter_name );
 		} else {
-			$filter = defined( 'Imagick::FILTER_TRIANGLE' ) ? Imagick::FILTER_TRIANGLE : false;
+			$filter = defined( 'Imagick::FILTER_LANCZOS' ) ? Imagick::FILTER_LANCZOS : false;
 		}
 
 		/**
@@ -485,7 +485,7 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 			// Set appropriate quality settings after resizing.
 			if ( 'image/jpeg' === $this->mime_type ) {
 				if ( is_callable( array( $this->image, 'unsharpMaskImage' ) ) ) {
-					$this->image->unsharpMaskImage( 0.25, 0.25, 8, 0.065 );
+					$this->image->unsharpMaskImage( 1, 0.45, 3, 0 );
 				}
 
 				$this->image->setOption( 'jpeg:fancy-upsampling', 'off' );


### PR DESCRIPTION
I've been playing around a ton lately with the `Image_Editor_Imagick` class in #63448, and I was a little confused on why `thumbnail_image` method was using this `filter_name` defined parameter if It's never actually used anywhere else and basically perma-defaulting to `FILTER TRIANGLE`, plus all those "allowed_filters" array as if any of them could be actually used (or ever actually used). I understood that could be simply a future proofing strategy, which it's always adequate.

Moreover, the target of `$filter_name` is to set `$filter` and there is a forced conditional in the case that `$filter_name` doesn't even exist, to again, default to `FILTER_TRIANGLE`, so feels redundant and unnecessary (again, only one call and forced assignation, which happens to be the problem discussed here). 

Doesn't make more sense, to simply remove default to `thumbnail_image`, pass it to the real function, `resize` that semantically actually needs it (which happens to be public), in the end you are passing the arguments that are actually needed for the resize (i.e. size and resizing method), and given that its public, anyone could simply instantiate and the `Image_Editor_Imagick` and define whatever they want?

And if you want to add a redundant hook just for those users that simply would like to stick to the standard flow without instantiations, why not? All in! 

For example, as a use-case, WPML in `src/wp-content/plugins/sitepress-multilingual-cms/classes/ajax/endpoints/Upload.php` L40 instantiates a `Image_Editor_Imagick` calling to resize. In this case, if they wanted some extra "quality" they could have simply added the extra paremeter, without having to deal with a cumbersome hook.

Trac ticket: https://core.trac.wordpress.org/ticket/40415

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
