### PR TITLE
#63166 Convert some `@internal` tags into inline tags.

### DIFF
--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2095,8 +2095,8 @@ function comment_id_fields( $post = null ) {
  *
  * Only affects users with JavaScript disabled.
  *
- * @internal The $comment global must be present to allow template tags access to the current
- *           comment. See https://core.trac.wordpress.org/changeset/36512.
+ * {@internal The $comment global must be present to allow template tags access to the current
+ *           comment. See https://core.trac.wordpress.org/changeset/36512.}
  *
  * @since 2.7.0
  * @since 6.2.0 Added the `$post` parameter.

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2551,6 +2551,11 @@ function balanceTags( $text, $force = false ) {  // phpcs:ignore WordPress.Namin
 /**
  * Balances tags of string using a modified stack.
  *
+ * {@internal Modified by Scott Reilly (coffee2code) 02 Aug 2004
+ *      1.1  Fixed handling of append/stack pop order of end text
+ *           Added Cleaning Hooks
+ *      1.0  First Version}
+ *
  * @since 2.0.4
  * @since 5.3.0 Improve accuracy and add support for custom element tags.
  *
@@ -2559,10 +2564,6 @@ function balanceTags( $text, $force = false ) {  // phpcs:ignore WordPress.Namin
  * @copyright November 4, 2001
  * @version 1.1
  * @todo Make better - change loop condition to $text in 1.2
- * @internal Modified by Scott Reilly (coffee2code) 02 Aug 2004
- *      1.1  Fixed handling of append/stack pop order of end text
- *           Added Cleaning Hooks
- *      1.0  First Version
  *
  * @param string $text Text to be balanced.
  * @return string Balanced text.

--- a/src/wp-includes/ms-load.php
+++ b/src/wp-includes/ms-load.php
@@ -129,9 +129,9 @@ function ms_site_check() {
 /**
  * Retrieves the closest matching network for a domain and path.
  *
- * @since 3.9.0
+ * {@internal In 4.4.0, converted to a wrapper for WP_Network::get_by_path()}
  *
- * @internal In 4.4.0, converted to a wrapper for WP_Network::get_by_path()
+ * @since 3.9.0
  *
  * @param string   $domain   Domain to check.
  * @param string   $path     Path to check.
@@ -552,11 +552,11 @@ function wpmu_current_site() {
 /**
  * Retrieves an object containing information about the requested network.
  *
+ * {@internal In 4.6.0, converted to use get_network()}
+ *
  * @since 3.9.0
  * @deprecated 4.7.0 Use get_network()
  * @see get_network()
- *
- * @internal In 4.6.0, converted to use get_network()
  *
  * @param object|int $network The network's database row or ID.
  * @return WP_Network|false Object containing network information if found, false if not.

--- a/src/wp-includes/rest-api/class-wp-rest-response.php
+++ b/src/wp-includes/rest-api/class-wp-rest-response.php
@@ -43,7 +43,7 @@ class WP_REST_Response extends WP_HTTP_Response {
 	/**
 	 * Adds a link to the response.
 	 *
-	 * @internal The $rel parameter is first, as this looks nicer when sending multiple.
+	 * {@internal The $rel parameter is first, as this looks nicer when sending multiple.}
 	 *
 	 * @since 4.4.0
 	 *
@@ -135,7 +135,7 @@ class WP_REST_Response extends WP_HTTP_Response {
 	/**
 	 * Sets a single link header.
 	 *
-	 * @internal The $rel parameter is first, as this looks nicer when sending multiple.
+	 * {@internal The $rel parameter is first, as this looks nicer when sending multiple.}
 	 *
 	 * @since 4.4.0
 	 *

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-controller.php
@@ -662,11 +662,11 @@ abstract class WP_REST_Controller {
 	/**
 	 * Sanitizes the slug value.
 	 *
-	 * @since 4.7.0
-	 *
-	 * @internal We can't use sanitize_title() directly, as the second
+	 * {@internal We can't use sanitize_title() directly, as the second
 	 * parameter is the fallback title, which would end up being set to the
-	 * request object.
+	 * request object.}
+	 *
+	 * @since 4.7.0
 	 *
 	 * @see https://github.com/WP-API/WP-API/issues/1585
 	 *

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -1292,6 +1292,8 @@ function get_term_to_edit( $id, $taxonomy ) {
  *
  * Prior to 4.5.0, taxonomy was passed as the first parameter of `get_terms()`.
  *
+ * {@internal The `$deprecated` parameter is parsed for backward compatibility only.}
+ *
  * @since 2.3.0
  * @since 4.2.0 Introduced 'name' and 'childless' parameters.
  * @since 4.4.0 Introduced the ability to pass 'term_id' as an alias of 'id' for the `orderby` parameter.
@@ -1300,8 +1302,6 @@ function get_term_to_edit( $id, $taxonomy ) {
  * @since 4.5.0 Changed the function signature so that the `$args` array can be provided as the first parameter.
  *              Introduced 'meta_key' and 'meta_value' parameters. Introduced the ability to order results by metadata.
  * @since 4.8.0 Introduced 'suppress_filter' parameter.
- *
- * @internal The `$deprecated` parameter is parsed for backward compatibility only.
  *
  * @param array|string $args       Optional. Array or string of arguments. See WP_Term_Query::__construct()
  *                                 for information on accepted arguments. Default empty array.
@@ -1927,10 +1927,10 @@ function sanitize_term_field( $field, $value, $term_id, $taxonomy, $context ) {
  *
  * Default $args is 'hide_empty' which can be 'hide_empty=true' or array('hide_empty' => true).
  *
+ * {@internal The `$deprecated` parameter is parsed for backward compatibility only.}
+ *
  * @since 2.3.0
  * @since 5.6.0 Changed the function signature so that the `$args` array can be provided as the first parameter.
- *
- * @internal The `$deprecated` parameter is parsed for backward compatibility only.
  *
  * @param array|string $args       Optional. Array or string of arguments. See WP_Term_Query::__construct()
  *                                 for information on accepted arguments. Default empty array.


### PR DESCRIPTION
The `@internal` tag is an odd one, it has a different meaning depending on whether it's used as a top-level tag or an inline tag. Quoting [the phpDocumentor docs](https://docs.phpdoc.org/guide/references/phpdoc/tags/internal.html):

> The `@internal` tag is used to denote that associated _Structural Elements_ are internal to the application or library. It may also be used inside a long description to insert a piece of text that is only applicable for the developers of the software.

So the former denotes that the symbol is for internal use only, and the latter denotes some internal documentation.

This PR fixes some instances of top level `@internal` tags that should be inline tags.

* Trac ticket: https://core.trac.wordpress.org/ticket/63166
* See https://github.com/php-stubs/wordpress-stubs/issues/287 CC @szepeviktor @jcvignoli.
