### PR TITLE
Remove leftover debug code from Box class

### DIFF
--- a/src/wp-includes/class-avif-info.php
+++ b/src/wp-includes/class-avif-info.php
@@ -305,7 +305,6 @@ class Box {
         $this->type = 'unknownversion';
       }
     }
-    // print_r( $this ); // Uncomment to print all boxes.
     return FOUND;
   }
 }


### PR DESCRIPTION
There is a commented-out debug statement `// print_r( $this ); // Uncomment to print all boxes.` in the `Box::parse()` method on the file `/wp-includes/class-box.php`

This appears to have been used during development for debugging purposes. While it's currently commented out and doesn't affect execution, it's generally a good practice to remove unused debug code from production files to keep the codebase clean and focused.

Removing this line would help improve readability and align with WordPress coding standards for maintainable code.

Trac ticket: https://core.trac.wordpress.org/ticket/63478

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
