### PR TITLE
Fix: Update return doc to String|False for current_filter() and current_action()

### DIFF
--- a/src/wp-includes/plugin.php
+++ b/src/wp-includes/plugin.php
@@ -359,7 +359,7 @@ function remove_all_filters( $hook_name, $priority = false ) {
  *
  * @global string[] $wp_current_filter Stores the list of current filters with the current one last
  *
- * @return string Hook name of the current filter.
+ * @return string|false Hook name of the current filter.
  */
 function current_filter() {
 	global $wp_current_filter;
@@ -632,7 +632,7 @@ function remove_all_actions( $hook_name, $priority = false ) {
  *
  * @since 3.9.0
  *
- * @return string Hook name of the current action.
+ * @return string|false Hook name of the current action.
  */
 function current_action() {
 	return current_filter();

--- a/src/wp-includes/plugin.php
+++ b/src/wp-includes/plugin.php
@@ -359,7 +359,7 @@ function remove_all_filters( $hook_name, $priority = false ) {
  *
  * @global string[] $wp_current_filter Stores the list of current filters with the current one last
  *
- * @return string|false Hook name of the current filter.
+ * @return string|false Hook name of the current filter, false if no filter running.
  */
 function current_filter() {
 	global $wp_current_filter;
@@ -632,7 +632,7 @@ function remove_all_actions( $hook_name, $priority = false ) {
  *
  * @since 3.9.0
  *
- * @return string|false Hook name of the current action.
+ * @return string|false Hook name of the current action, false if no action running.
  */
 function current_action() {
 	return current_filter();


### PR DESCRIPTION
Trac Ticket: Core-63479

## Problem
The @return annotations for current_action() and current_filter() are currently defined as string, but both functions can return false when called outside the context of any action or filter. This can occur in specific scenarios such as:

- Within an exception handler after a fatal or uncaught exception.

- When WordPress is manually loaded (e.g., via wp-load.php) and code is executed before any hooks have been triggered.

This mismatch between the documented return type and actual behavior can lead to incorrect assumptions and potential runtime issues.

## Solution

Update the @return annotations for both current_action() and current_filter() to string|false.