### PR TITLE
Fix: Added style for wp-activate.php and wp-signup.php for gap between header/footer and screen.

### DIFF
--- a/src/wp-activate.php
+++ b/src/wp-activate.php
@@ -97,6 +97,28 @@ function do_activate_header() {
 }
 add_action( 'wp_head', 'do_activate_header' );
 
+// Add body class for wp-activate page.
+add_filter( 'body_class', 'wp_activate_body_class' );
+
+/**
+ * Add body class for wp-signup.php
+ *
+ * @param array $body_class array of body classes
+ *
+ * @return array
+ */
+function wp_activate_body_class( $body_class ) {
+
+	if ( is_array( $body_class ) ) {
+		array_push( $body_class, 'wp-activate-page' );
+	} else {
+		$body_class = array();
+		array_push( $body_class, 'wp-activate-page' );
+	}
+
+	return $body_class;
+}
+
 /**
  * Loads styles specific to this page.
  *
@@ -111,6 +133,7 @@ function wpmu_activate_stylesheet() {
 		#language { margin-top: 0.5em; }
 		.wp-activate-container .error { background: #f66; color: #333; }
 		span.h3 { padding: 0 8px; font-size: 1.3em; font-weight: 600; }
+		.wp-activate-page #header, .wp-activate-page #footer{ max-width: 90%; margin: 0 auto }
 	</style>
 	<?php
 }

--- a/src/wp-signup.php
+++ b/src/wp-signup.php
@@ -12,6 +12,29 @@ require __DIR__ . '/wp-load.php';
 
 add_filter( 'wp_robots', 'wp_robots_no_robots' );
 
+// Add body class for wp-signup page.
+add_filter( 'body_class', 'wp_signup_body_class' );
+
+/**
+ * Add body class for wp-signup.php
+ *
+ * @param array $body_class array of body classes
+ *
+ * @return array
+ */
+function wp_signup_body_class( $body_class ) {
+
+	if ( is_array( $body_class ) ) {
+		array_push( $body_class, 'wp-signup-page' );
+	} else {
+		$body_class = array();
+		array_push( $body_class, 'wp-signup-page' );
+	}
+
+	return $body_class;
+
+}
+
 require __DIR__ . '/wp-blog-header.php';
 
 nocache_headers();
@@ -88,6 +111,7 @@ function wpmu_signup_stylesheet() {
 		.mu_register .signup-options .wp-signup-radio-button { display: block; }
 		.mu_register .privacy-intro .wp-signup-radio-button { margin-right: 0.5em; }
 		.rtl .mu_register .wp-signup-blogname { direction: ltr; text-align: right; }
+		.wp-signup-page #header, .wp-signup-page #footer { max-width: 90%; margin: 0 auto }
 	</style>
 	<?php
 }


### PR DESCRIPTION
- I've enabled Network site settings for Both site and user registration on multisite WordPress.
- There are no space between screen and header/footer.
- The issue is coming for all FSE themes 2022, 2023, 2024, 2025. It looks find theme 2021 and before.
- I've added filter for body classes for both the pages. and added style by using those new classes in this PR.
- We have handle this CSS in theme, there are more chance for improvement for UI on both these pages

(Trac #63499)