### PR TITLE
Fix: Displayed Important pages at top in the Most Recent tab pages in classic menu

### DIFF
--- a/src/wp-admin/includes/nav-menu.php
+++ b/src/wp-admin/includes/nav-menu.php
@@ -620,6 +620,9 @@ function wp_nav_menu_item_post_type_meta_box( $data_object, $box ) {
 				);
 				$most_recent = $get_posts->query( $recent_args );
 
+				// Added important pages in Most recent tab at top.
+				$most_recent = array_merge( $important_pages, $most_recent );
+
 				$args['walker'] = $walker;
 
 				/**


### PR DESCRIPTION
This PR resolve the most recent tab in classic menu is not showing Important pages issue.

Trac ticket: https://core.trac.wordpress.org/ticket/63473

This PR tested on :
WordPress: 6.8.1
PHP: 8.4.7
Server: nginx/1.27.5
Browser: Latest Chrome and Firefox
Theme: Twenty Twenty
