### PR TITLE
Twenty Nineteen: increase specificity for Table blocks' cell border color in the editor

### DIFF
--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -1272,7 +1272,7 @@ figcaption,
 }
 
 /** === Table === */
-.wp-block-table td, .wp-block-table th {
+body .wp-block-table td, body .wp-block-table th {
   border-color: #767676;
 }
 

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -669,7 +669,7 @@ figcaption,
 
 /** === Table === */
 
-.wp-block-table {
+body .wp-block-table {
 
 	td, th {
 		border-color: $color__text-light;


### PR DESCRIPTION
Adds the `body` element to the selector in **editor** styles to show the theme's border color, even with the Stripes style. With older versions of WordPress, `body` is changed to `.editor-styles-wrapper`.

[Trac 63469](https://core.trac.wordpress.org/ticket/63469)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
