### PR TITLE
fix/62797 encode lt in inline scripts

### DIFF
--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -521,7 +521,7 @@ class WP_Scripts extends WP_Dependencies {
 			return '';
 		}
 
-		return trim( implode( "\n", $data ), "\n" );
+		return trim( implode( "\n", str_replace( '<', '&lt;', $data ) ), "\n" );
 	}
 
 	/**


### PR DESCRIPTION

Consider a fix for [#62797](https://core.trac.wordpress.org/ticket/62797) that encodes `<` in inline script tags.

Trac ticket: [#62797](https://core.trac.wordpress.org/ticket/62797)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
