### PR TITLE
code quality: remove useless `empty()` checks in `map_meta_cap()`

### DIFF
--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -470,7 +470,7 @@ function map_meta_cap( $cap, $user_id, ...$args ) {
 			if ( $meta_key ) {
 				$allowed = ! is_protected_meta( $meta_key, $object_type );
 
-				if ( ! empty( $object_subtype ) && has_filter( "auth_{$object_type}_meta_{$meta_key}_for_{$object_subtype}" ) ) {
+				if ( has_filter( "auth_{$object_type}_meta_{$meta_key}_for_{$object_subtype}" ) ) {
 
 					/**
 					 * Filters whether the user is allowed to edit a specific meta key of a specific object type and subtype.
@@ -512,36 +512,33 @@ function map_meta_cap( $cap, $user_id, ...$args ) {
 					$allowed = apply_filters( "auth_{$object_type}_meta_{$meta_key}", $allowed, $meta_key, $object_id, $user_id, $cap, $caps );
 				}
 
-				if ( ! empty( $object_subtype ) ) {
-
-					/**
-					 * Filters whether the user is allowed to edit meta for specific object types/subtypes.
-					 *
-					 * Return true to have the mapped meta caps from `edit_{$object_type}` apply.
-					 *
-					 * The dynamic portion of the hook name, `$object_type` refers to the object type being filtered.
-					 * The dynamic portion of the hook name, `$object_subtype` refers to the object subtype being filtered.
-					 * The dynamic portion of the hook name, `$meta_key`, refers to the meta key passed to map_meta_cap().
-					 *
-					 * @since 4.6.0 As `auth_post_{$post_type}_meta_{$meta_key}`.
-					 * @since 4.7.0 Renamed from `auth_post_{$post_type}_meta_{$meta_key}` to
-					 *              `auth_{$object_type}_{$object_subtype}_meta_{$meta_key}`.
-					 * @deprecated 4.9.8 Use {@see 'auth_{$object_type}_meta_{$meta_key}_for_{$object_subtype}'} instead.
-					 *
-					 * @param bool     $allowed   Whether the user can add the object meta. Default false.
-					 * @param string   $meta_key  The meta key.
-					 * @param int      $object_id Object ID.
-					 * @param int      $user_id   User ID.
-					 * @param string   $cap       Capability name.
-					 * @param string[] $caps      Array of the user's capabilities.
-					 */
-					$allowed = apply_filters_deprecated(
-						"auth_{$object_type}_{$object_subtype}_meta_{$meta_key}",
-						array( $allowed, $meta_key, $object_id, $user_id, $cap, $caps ),
-						'4.9.8',
-						"auth_{$object_type}_meta_{$meta_key}_for_{$object_subtype}"
-					);
-				}
+				/**
+				 * Filters whether the user is allowed to edit meta for specific object types/subtypes.
+				 *
+				 * Return true to have the mapped meta caps from `edit_{$object_type}` apply.
+				 *
+				 * The dynamic portion of the hook name, `$object_type` refers to the object type being filtered.
+				 * The dynamic portion of the hook name, `$object_subtype` refers to the object subtype being filtered.
+				 * The dynamic portion of the hook name, `$meta_key`, refers to the meta key passed to map_meta_cap().
+				 *
+				 * @since 4.6.0 As `auth_post_{$post_type}_meta_{$meta_key}`.
+				 * @since 4.7.0 Renamed from `auth_post_{$post_type}_meta_{$meta_key}` to
+				 *              `auth_{$object_type}_{$object_subtype}_meta_{$meta_key}`.
+				 * @deprecated 4.9.8 Use {@see 'auth_{$object_type}_meta_{$meta_key}_for_{$object_subtype}'} instead.
+				 *
+				 * @param bool     $allowed   Whether the user can add the object meta. Default false.
+				 * @param string   $meta_key  The meta key.
+				 * @param int      $object_id Object ID.
+				 * @param int      $user_id   User ID.
+				 * @param string   $cap       Capability name.
+				 * @param string[] $caps      Array of the user's capabilities.
+				 */
+				$allowed = apply_filters_deprecated(
+					"auth_{$object_type}_{$object_subtype}_meta_{$meta_key}",
+					array( $allowed, $meta_key, $object_id, $user_id, $cap, $caps ),
+					'4.9.8',
+					"auth_{$object_type}_meta_{$meta_key}_for_{$object_subtype}"
+				);
 
 				if ( ! $allowed ) {
 					$caps[] = $cap;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR removes two unnecessary `empty( $object_subtype )` checks from `map_meta_cap()`, as it causes the currently `case` to break in the conditional preceding this one: 
- https://github.com/justlevine/wordpress-develop/blob/dbad7732e342f1795a536817e5c5c86c802f84b2/src/wp-includes/capabilities.php#L461-L464

While this issue was surfaced via PHPStan in https://github.com/WordPress/wordpress-develop/pull/7619 (trac: https://core.trac.wordpress.org/ticket/61175 ), it can be remediated independently of that ticket.

Trac ticket: https://core.trac.wordpress.org/ticket/63268

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
