### PR TITLE
chore: fix incorrect casing for `PHPMailer::addCC` and `::addBCC` calls

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -446,10 +446,10 @@ if ( ! function_exists( 'wp_mail' ) ) :
 							$phpmailer->addAddress( $address, $recipient_name );
 							break;
 						case 'cc':
-							$phpmailer->addCc( $address, $recipient_name );
+							$phpmailer->addCC( $address, $recipient_name );
 							break;
 						case 'bcc':
-							$phpmailer->addBcc( $address, $recipient_name );
+							$phpmailer->addBCC( $address, $recipient_name );
 							break;
 						case 'reply_to':
 							$phpmailer->addReplyTo( $address, $recipient_name );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

This PR fixes the casing of calls to `PHPMailer::addCC` (from `::addCc` - lowercase `c` ) and `PHPMailer::addBCC` (from `::addBcc`, - lowercase `cc` ) in `wp_mail()`.

While this issue was surfaced via PHPStan in https://github.com/WordPress/wordpress-develop/pull/7619 (trac: https://core.trac.wordpress.org/ticket/61175 ), it can be remediated independently of that ticket.

Trac ticket: https://core.trac.wordpress.org/ticket/63268

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
