### PR TITLE
docs: `WP_Block_*::get_registered()` methods can return `null`

### DIFF
--- a/src/wp-includes/class-wp-block-pattern-categories-registry.php
+++ b/src/wp-includes/class-wp-block-pattern-categories-registry.php
@@ -107,7 +107,7 @@ final class WP_Block_Pattern_Categories_Registry {
 	 * @since 5.5.0
 	 *
 	 * @param string $category_name Pattern category name including namespace.
-	 * @return array Registered pattern properties.
+	 * @return array|null Registered pattern properties, or `null` if the pattern category is not registered.
 	 */
 	public function get_registered( $category_name ) {
 		if ( ! $this->is_registered( $category_name ) ) {

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -188,7 +188,7 @@ final class WP_Block_Patterns_Registry {
 	 * @since 5.5.0
 	 *
 	 * @param string $pattern_name Block pattern name including namespace.
-	 * @return array Registered pattern properties.
+	 * @return array|null Registered pattern properties or `null` if the pattern is not registered.
 	 */
 	public function get_registered( $pattern_name ) {
 		if ( ! $this->is_registered( $pattern_name ) ) {

--- a/src/wp-includes/class-wp-block-styles-registry.php
+++ b/src/wp-includes/class-wp-block-styles-registry.php
@@ -140,7 +140,7 @@ final class WP_Block_Styles_Registry {
 	 *
 	 * @param string $block_name       Block type name including namespace.
 	 * @param string $block_style_name Block style name.
-	 * @return array Registered block style properties.
+	 * @return array|null Registered block style properties or `null` if the block style is not registered.
 	 */
 	public function get_registered( $block_name, $block_style_name ) {
 		if ( ! $this->is_registered( $block_name, $block_style_name ) ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

This PR fixes the `@return` annotation for the `get_registered()` methods in the following classes to correctly indicate they can return `null` if no item is registered:

- `WP_Block_Pattern_Categories_Registry::get_registered()`
- `WP_Block_Patterns_Registry::get_registered()`
- `WP_Block_Styles_Registry::get_registered()`

While this issue was surfaced via PHPStan in https://github.com/WordPress/wordpress-develop/pull/7619 (trac: https://core.trac.wordpress.org/ticket/61175 ), it can be remediated independently of that ticket.

Trac ticket: https://core.trac.wordpress.org/ticket/63268

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
