### PR TITLE
fix: explicitly return `''` in `get_the_block_template_html()`

### DIFF
--- a/src/wp-includes/block-template.php
+++ b/src/wp-includes/block-template.php
@@ -253,7 +253,7 @@ function get_the_block_template_html() {
 		if ( is_user_logged_in() ) {
 			return '<h1>' . esc_html__( 'No matching template found' ) . '</h1>';
 		}
-		return;
+		return '';
 	}
 
 	$content = $wp_embed->run_shortcode( $_wp_current_template_content );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR updates `get_the_block_template_html()` to return an empty string (`''`) if no template is found and the user is not logged in. This is instead of the current behavior of returning `void` (coerced to `null` ).

This is inline with both the function DocBlock and how the function is used throughout the codebase, and thus less disruptive than explicitly returning `null` and then casting the results back to an empty string wherever it's used.

While this issue was surfaced via PHPStan in https://github.com/WordPress/wordpress-develop/pull/7619 (trac: https://core.trac.wordpress.org/ticket/61175 ), it can be remediated independently of that ticket.

Trac ticket: https://core.trac.wordpress.org/ticket/63268

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
