### PR TITLE
Fix: Refactor deprecated function call in `WP_Community_Events::format_event_data_time()`

### DIFF
--- a/src/wp-admin/includes/class-wp-community-events.php
+++ b/src/wp-admin/includes/class-wp-community-events.php
@@ -381,10 +381,10 @@ class WP_Community_Events {
 	 * @return array The response with dates and times formatted.
 	 */
 	protected function format_event_data_time( $response_body ) {
-		_deprecated_function(
+		_doing_it_wrong(
 			__METHOD__,
-			'5.5.2',
-			'This is no longer used by core, and only kept for backward compatibility.'
+			__( 'This is no longer used by core, and only kept for backward compatibility.' ),
+			'5.5.2'
 		);
 
 		if ( isset( $response_body['events'] ) ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

In this PR Refactored the deprecated function call to use _doing_it_wrong() for better clarity and compatibility in `WP_Community_Events::format_event_data_time()`

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63511

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
