### PR TITLE
Site Health: Mark `WP_Debug_Data::get_sizes()` as deprecated in WordPress 5.6.0

### DIFF
--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -1866,6 +1866,8 @@ class WP_Debug_Data {
 	 * @return array The sizes of the directories, also the database size and total installation size.
 	 */
 	public static function get_sizes() {
+		_deprecated_function( __METHOD__, '5.6.0', 'WP_REST_Site_Health_Controller::get_directory_sizes()' );
+		
 		$size_db    = self::get_database_size();
 		$upload_dir = wp_get_upload_dir();
 

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -1867,7 +1867,7 @@ class WP_Debug_Data {
 	 */
 	public static function get_sizes() {
 		_deprecated_function( __METHOD__, '5.6.0', 'WP_REST_Site_Health_Controller::get_directory_sizes()' );
-		
+
 		$size_db    = self::get_database_size();
 		$upload_dir = wp_get_upload_dir();
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: [63516](https://core.trac.wordpress.org/ticket/63516)
---

This PR explicitly deprecates `WP_Debug_Data::get_sizes()` function according to suggestions in trac ticket (unused in core)
