### PR TITLE
Twenty Fourteen: Exclude Content Sidebar from Latest Comments link color

### DIFF
--- a/src/wp-content/themes/twentyfourteen/css/blocks.css
+++ b/src/wp-content/themes/twentyfourteen/css/blocks.css
@@ -368,7 +368,7 @@ p.has-drop-cap:not(:focus)::first-letter {
 	color: #41a62a;
 }
 
-.widget-area .wp-block-latest-comments__comment-meta a {
+.widget-area:where(:not(.content-sidebar)) .wp-block-latest-comments__comment-meta a {
 	color: #fff;
 }
 


### PR DESCRIPTION
Avoids adding white link text where the background color is white.

[Trac 63520](https://core.trac.wordpress.org/ticket/63520)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
