### PR TITLE
Add WP_MAINTENANCE_FILE constant to make maintenance mode file location configurable

### DIFF
--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -1021,7 +1021,9 @@ class WP_Upgrader {
 			}
 		}
 
-		$file = $wp_filesystem->abspath() . '.maintenance';
+		// Check if a custom maintenance file location is defined.
+		$file = defined( 'WP_MAINTENANCE_FILE' ) ? WP_MAINTENANCE_FILE : $wp_filesystem->abspath() . '.maintenance';
+
 		if ( $enable ) {
 			if ( ! wp_doing_cron() ) {
 				$this->skin->feedback( 'maintenance_start' );

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -420,12 +420,16 @@ function wp_maintenance() {
 /**
  * Checks if maintenance mode is enabled.
  *
- * Checks for a file in the WordPress root directory named ".maintenance".
+ * Checks for a file named ".maintenance". By default, this file is located in the WordPress
+ * root directory (ABSPATH), but the location can be customized by defining the WP_MAINTENANCE_FILE
+ * constant in wp-config.php.
+ *
  * This file will contain the variable $upgrading, set to the time the file
  * was created. If the file was created less than 10 minutes ago, WordPress
  * is in maintenance mode.
  *
  * @since 5.5.0
+ * @since 6.9.0 Added support for the WP_MAINTENANCE_FILE constant.
  *
  * @global int $upgrading The Unix timestamp marking when upgrading WordPress began.
  *
@@ -434,11 +438,14 @@ function wp_maintenance() {
 function wp_is_maintenance_mode() {
 	global $upgrading;
 
-	if ( ! file_exists( ABSPATH . '.maintenance' ) || wp_installing() ) {
+	// Check if a custom maintenance file location is defined.
+	$maintenance_file = defined( 'WP_MAINTENANCE_FILE' ) ? WP_MAINTENANCE_FILE : ABSPATH . '.maintenance';
+
+	if ( ! file_exists( $maintenance_file ) || wp_installing() ) {
 		return false;
 	}
 
-	require ABSPATH . '.maintenance';
+	require $maintenance_file;
 
 	// If the $upgrading timestamp is older than 10 minutes, consider maintenance over.
 	if ( ( time() - $upgrading ) >= 10 * MINUTE_IN_SECONDS ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/62489

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
