### PR TITLE
[40736]: Deprecate `get_blog_count` and rename it to `get_site_count`

### DIFF
--- a/src/wp-admin/admin.php
+++ b/src/wp-admin/admin.php
@@ -72,7 +72,7 @@ if ( get_option( 'db_upgraded' ) ) {
 	 * @param bool $do_mu_upgrade Whether to perform the Multisite upgrade routine. Default true.
 	 */
 	if ( apply_filters( 'do_mu_upgrade', true ) ) {
-		$c = get_blog_count();
+		$c = get_site_count();
 
 		/*
 		 * If there are 50 or fewer sites, run every time. Otherwise, throttle to reduce load:

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -253,7 +253,7 @@ class WP_Debug_Data {
 
 			$site_count = 0;
 			foreach ( $network_ids as $network_id ) {
-				$site_count += get_blog_count( $network_id );
+				$site_count += get_site_count( $network_id );
 			}
 
 			$fields['site_count'] = array(

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -455,7 +455,7 @@ function wp_network_dashboard_right_now() {
 	}
 
 	$c_users = get_user_count();
-	$c_blogs = get_blog_count();
+	$c_blogs = get_site_count();
 
 	/* translators: %s: Number of users on the network. */
 	$user_text = sprintf( _n( '%s user', '%s users', $c_users ), number_format_i18n( $c_users ) );

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -462,7 +462,7 @@ final class WP_Interactivity_API {
 							// segments. It excludes underscore intentionally to prevent confusion.
 							// E.g., "custom-directive".
 							'([a-z0-9]+(?:-[a-z0-9]+)*)' .
-							// (Optional) Match '--' followed by any alphanumeric charachters. It
+							// (Optional) Match '--' followed by any alphanumeric characters. It
 							// excludes underscore intentionally to prevent confusion, but it can
 							// contain multiple hyphens. E.g., "--custom-prefix--with-more-info".
 							'(?:--([a-z0-9_-]+))?$' .

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -462,7 +462,7 @@ final class WP_Interactivity_API {
 							// segments. It excludes underscore intentionally to prevent confusion.
 							// E.g., "custom-directive".
 							'([a-z0-9]+(?:-[a-z0-9]+)*)' .
-							// (Optional) Match '--' followed by any alphanumeric characters. It
+							// (Optional) Match '--' followed by any alphanumeric charachters. It
 							// excludes underscore intentionally to prevent confusion, but it can
 							// contain multiple hyphens. E.g., "--custom-prefix--with-more-info".
 							'(?:--([a-z0-9_-]+))?$' .

--- a/src/wp-includes/ms-deprecated.php
+++ b/src/wp-includes/ms-deprecated.php
@@ -749,3 +749,24 @@ function global_terms( $term_id, $deprecated = '' ) {
 
 	return $term_id;
 }
+
+/**
+ * The number of active sites on your installation.
+ *
+ * The count is cached and updated twice daily. This is not a live count.
+ *
+ * @since MU 1.0
+ *
+ * @deprecated 6.9.0 Use get_site_count()
+ * @see get_site_count()
+ *
+ * @since 3.7.0 The $network_id parameter has been deprecated.
+ * @since 4.9.0 The $network_id parameter is now being used.
+ *
+ * @param int|null $network_id ID of the network. Default is the current network.
+ * @return int Number of active sites on the network.
+ */
+function get_blog_count( $network_id = null ) {
+    _deprecated_function( __FUNCTION__, '6.9', 'get_site_count()' );
+    return get_site_count( $network_id  );
+}

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -21,7 +21,7 @@
  */
 function get_sitestats() {
 	$stats = array(
-		'blogs' => get_blog_count(),
+		'blogs' => get_site_count(),
 		'users' => get_user_count(),
 	);
 
@@ -114,15 +114,13 @@ function get_active_blog_for_user( $user_id ) {
  *
  * The count is cached and updated twice daily. This is not a live count.
  *
- * @since MU (3.0.0)
- * @since 3.7.0 The `$network_id` parameter has been deprecated.
- * @since 4.8.0 The `$network_id` parameter is now being used.
+ * @since 6.9.0
  *
  * @param int|null $network_id ID of the network. Default is the current network.
  * @return int Number of active sites on the network.
  */
-function get_blog_count( $network_id = null ) {
-	return get_network_option( $network_id, 'blog_count' );
+function get_site_count( $network_id = null ) {
+	return (int) get_network_option( $network_id, 'blog_count' );
 }
 
 /**
@@ -2729,7 +2727,7 @@ function wp_is_large_network( $using = 'sites', $network_id = null ) {
 		return apply_filters( 'wp_is_large_network', $is_large_network, 'users', $count, $network_id );
 	}
 
-	$count = get_blog_count( $network_id );
+	$count = get_site_count( $network_id );
 
 	/** This filter is documented in wp-includes/ms-functions.php */
 	return apply_filters( 'wp_is_large_network', $count > 10000, 'sites', $count, $network_id );

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -86,7 +86,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 	}
 
 	if ( is_multisite() ) {
-		$num_blogs         = get_blog_count();
+		$num_blogs         = get_site_count();
 		$wp_install        = network_site_url();
 		$multisite_enabled = 1;
 	} else {

--- a/tests/phpunit/tests/multisite/network.php
+++ b/tests/phpunit/tests/multisite/network.php
@@ -202,12 +202,12 @@ class Tests_Multisite_Network extends WP_UnitTestCase {
 	/**
 	 * @ticket 22917
 	 */
-	public function test_get_blog_count_no_filter_applied() {
+	public function test_get_site_count_no_filter_applied() {
 		wp_update_network_counts();
-		$site_count_start = get_blog_count();
+		$site_count_start = get_site_count();
 
 		$site_ids = self::factory()->blog->create_many( 1 );
-		$actual   = (int) get_blog_count(); // Count only updated when cron runs, so should be unchanged.
+		$actual   = get_site_count(); // Count only updated when cron runs, so should be unchanged.
 
 		foreach ( $site_ids as $site_id ) {
 			wp_delete_site( $site_id );
@@ -220,13 +220,13 @@ class Tests_Multisite_Network extends WP_UnitTestCase {
 	/**
 	 * @ticket 22917
 	 */
-	public function test_get_blog_count_enable_live_network_counts_false() {
+	public function test_get_site_count_enable_live_network_counts_false() {
 		wp_update_network_counts();
-		$site_count_start = get_blog_count();
+		$site_count_start = get_site_count();
 
 		add_filter( 'enable_live_network_counts', '__return_false' );
 		$site_ids = self::factory()->blog->create_many( 1 );
-		$actual   = (int) get_blog_count(); // Count only updated when cron runs, so should be unchanged.
+		$actual   = get_site_count(); // Count only updated when cron runs, so should be unchanged.
 		remove_filter( 'enable_live_network_counts', '__return_false' );
 
 		foreach ( $site_ids as $site_id ) {
@@ -240,13 +240,13 @@ class Tests_Multisite_Network extends WP_UnitTestCase {
 	/**
 	 * @ticket 22917
 	 */
-	public function test_get_blog_count_enabled_live_network_counts_true() {
+	public function test_get_site_count_enabled_live_network_counts_true() {
 		wp_update_network_counts();
-		$site_count_start = get_blog_count();
+		$site_count_start = get_site_count();
 
 		add_filter( 'enable_live_network_counts', '__return_true' );
 		$site_ids = self::factory()->blog->create_many( 1 );
-		$actual   = get_blog_count();
+		$actual   = get_site_count();
 		remove_filter( 'enable_live_network_counts', '__return_true' );
 
 		foreach ( $site_ids as $site_id ) {
@@ -260,10 +260,10 @@ class Tests_Multisite_Network extends WP_UnitTestCase {
 	/**
 	 * @ticket 37865
 	 */
-	public function test_get_blog_count_on_different_network() {
+	public function test_get_site_count_on_different_network() {
 		wp_update_network_site_counts( self::$different_network_id );
 
-		$site_count = get_blog_count( self::$different_network_id );
+		$site_count = get_site_count( self::$different_network_id );
 
 		$this->assertEquals( count( self::$different_site_ids ), $site_count );
 	}
@@ -378,7 +378,7 @@ class Tests_Multisite_Network extends WP_UnitTestCase {
 
 		wp_update_network_site_counts();
 
-		$result = get_blog_count();
+		$result = get_site_count();
 		$this->assertSame( $expected, $result );
 	}
 
@@ -390,7 +390,7 @@ class Tests_Multisite_Network extends WP_UnitTestCase {
 
 		wp_update_network_site_counts( self::$different_network_id );
 
-		$result = get_blog_count( self::$different_network_id );
+		$result = get_site_count( self::$different_network_id );
 		$this->assertSame( 3, $result );
 	}
 
@@ -435,8 +435,8 @@ class Tests_Multisite_Network extends WP_UnitTestCase {
 
 		wp_update_network_counts();
 
-		$site_count = (int) get_blog_count();
-		$user_count = (int) get_user_count();
+		$site_count = get_site_count();
+		$user_count = get_user_count();
 
 		$this->assertGreaterThan( 0, $site_count );
 		$this->assertGreaterThan( 0, $user_count );
@@ -451,8 +451,8 @@ class Tests_Multisite_Network extends WP_UnitTestCase {
 
 		wp_update_network_counts( self::$different_network_id );
 
-		$site_count = (int) get_blog_count( self::$different_network_id );
-		$user_count = (int) get_user_count( self::$different_network_id );
+		$site_count = get_site_count( self::$different_network_id );
+		$user_count = get_user_count( self::$different_network_id );
 
 		$this->assertGreaterThan( 0, $site_count );
 		$this->assertGreaterThan( 0, $user_count );
@@ -627,13 +627,13 @@ class Tests_Multisite_Network extends WP_UnitTestCase {
 	public function test_wpmu_create_blog_updates_correct_network_site_count() {
 		global $wpdb;
 
-		$original_count = get_blog_count( self::$different_network_id );
+		$original_count = get_site_count( self::$different_network_id );
 
 		$suppress = $wpdb->suppress_errors();
 		$site_id  = wpmu_create_blog( 'example.org', '/', '', 1, array(), self::$different_network_id );
 		$wpdb->suppress_errors( $suppress );
 
-		$result = get_blog_count( self::$different_network_id );
+		$result = get_site_count( self::$different_network_id );
 
 		wpmu_delete_blog( $site_id, true );
 

--- a/tests/phpunit/tests/multisite/site.php
+++ b/tests/phpunit/tests/multisite/site.php
@@ -186,9 +186,9 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 			}
 		}
 
-		// Update the blog count cache to use get_blog_count().
+		// Update the blog count cache to use get_site_count().
 		wp_update_network_counts();
-		$this->assertSame( 2, (int) get_blog_count() );
+		$this->assertSame( 2, get_site_count() );
 	}
 
 	public function test_site_caches_should_invalidate_when_invalidation_is_not_suspended() {
@@ -349,9 +349,9 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 		// Delete the site without forcing a table drop.
 		wpmu_delete_blog( $blog_id, false );
 
-		// Update the blog count cache to use get_blog_count().
+		// Update the blog count cache to use get_site_count().
 		wp_update_network_counts();
-		$this->assertSame( 1, get_blog_count() );
+		$this->assertSame( 1, get_site_count() );
 	}
 
 	/**
@@ -363,9 +363,9 @@ class Tests_Multisite_Site extends WP_UnitTestCase {
 		// Delete the site and force a table drop.
 		wpmu_delete_blog( $blog_id, true );
 
-		// Update the blog count cache to use get_blog_count().
+		// Update the blog count cache to use get_site_count().
 		wp_update_network_counts();
-		$this->assertSame( 1, get_blog_count() );
+		$this->assertSame( 1, get_site_count() );
 	}
 
 	/**


### PR DESCRIPTION
Deprecate `get_blog_count` and rename it to `get_site_count`. Ensure that `get_site_count()` return an integer.

Trac ticket: https://core.trac.wordpress.org/ticket/40736

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
