### PR TITLE
Add `link_to_item` post type label

### DIFF
--- a/src/wp-includes/class-wp-post-type.php
+++ b/src/wp-includes/class-wp-post-type.php
@@ -1026,6 +1026,10 @@ final class WP_Post_Type {
 				_x( 'A link to a post.', 'navigation link block description' ),
 				_x( 'A link to a page.', 'navigation link block description' ),
 			),
+			'link_to_item'             => array(
+				_x( 'Link to post', 'editor control label' ),
+				_x( 'Link to page', 'editor control label' ),
+			),
 		);
 
 		return self::$default_labels;

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2110,6 +2110,7 @@ function _post_type_meta_capabilities( $capabilities = null ) {
  * @since 6.6.0 Added the `template_name` label.
  * @since 6.7.0 Restored pre-6.4.0 defaults for the `add_new` label and updated documentation.
  *              Updated core usage to reference `add_new_item`.
+ * @since x.y.z Added the `link_to_item` label.
  *
  * @access private
  *


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63534

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
