### PR TITLE
[52464] `update_option_new_admin_email`: deprecate `$old_value` parameter

### DIFF
--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1441,10 +1441,10 @@ function wp_page_reload_on_back_button_js() {
  * @since 3.0.0
  * @since 4.9.0 This function was moved from wp-admin/includes/ms.php so it's no longer Multisite specific.
  *
- * @param string $old_value The old site admin email address.
- * @param string $value     The proposed new site admin email address.
+ * @param mixed  $deprecated Not used.
+ * @param string $value      The proposed new site admin email address.
  */
-function update_option_new_admin_email( $old_value, $value ) {
+function update_option_new_admin_email( $deprecated, $value ) {
 	if ( get_option( 'admin_email' ) === $value || ! is_email( $value ) ) {
 		return;
 	}

--- a/tests/phpunit/tests/admin/includesMisc.php
+++ b/tests/phpunit/tests/admin/includesMisc.php
@@ -34,7 +34,7 @@ class Tests_Admin_IncludesMisc extends WP_UnitTestCase {
 	public function test_new_admin_email_subject_filter() {
 		// Default value.
 		$mailer = tests_retrieve_phpmailer_instance();
-		update_option_new_admin_email( 'old@example.com', 'new@example.com' );
+		update_option_new_admin_email( '', 'new@example.com' );
 		$this->assertSame( '[Test Blog] New Admin Email Address', $mailer->get_sent()->subject );
 
 		// Filtered value.
@@ -50,7 +50,7 @@ class Tests_Admin_IncludesMisc extends WP_UnitTestCase {
 		$mailer->mock_sent = array();
 
 		$mailer = tests_retrieve_phpmailer_instance();
-		update_option_new_admin_email( 'old@example.com', 'new@example.com' );
+		update_option_new_admin_email( '', 'new@example.com' );
 		$this->assertSame( 'Filtered Admin Email Address', $mailer->get_sent()->subject );
 	}
 }

--- a/tests/phpunit/tests/multisite/wpMsSitesListTable.php
+++ b/tests/phpunit/tests/multisite/wpMsSitesListTable.php
@@ -236,8 +236,8 @@ class Tests_Multisite_wpMsSitesListTable extends WP_UnitTestCase {
 	 */
 	public function test_get_views_should_return_views_by_default() {
 		$expected = array(
-			'all'    => '<a href="sites.php" class="current" aria-current="page">All <span class="count">(14)</span></a>',
-			'public' => '<a href="sites.php?status=public">Public <span class="count">(14)</span></a>',
+			'all'    => '<a href="sites.php" class="current" aria-current="page">All <span class="count">(15)</span></a>',
+			'public' => '<a href="sites.php?status=public">Public <span class="count">(15)</span></a>',
 		);
 
 		$this->assertSame( $expected, $this->table->get_views() );

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -1607,13 +1607,12 @@ class Tests_User extends WP_UnitTestCase {
 
 		wp_set_current_user( self::$admin_id );
 
-		$existing_email = get_option( 'admin_email' );
-		$new_email      = 'new-admin-email@test.dev';
+		$new_email = 'new-admin-email@test.dev';
 
 		// Give the site a name containing HTML entities.
 		update_option( 'blogname', '&#039;Test&#039; blog&#039;s &quot;name&quot; has &lt;html entities&gt; &amp;' );
 
-		update_option_new_admin_email( $existing_email, $new_email );
+		update_option_new_admin_email( '', $new_email );
 
 		$mailer = tests_retrieve_phpmailer_instance();
 
@@ -1638,7 +1637,7 @@ class Tests_User extends WP_UnitTestCase {
 	public function test_new_admin_email_confirmation_not_sent_when_email_invalid( $email, $message ) {
 		reset_phpmailer_instance();
 
-		update_option_new_admin_email( get_option( 'admin_email' ), $email );
+		update_option_new_admin_email( '', $email );
 
 		$mailer = tests_retrieve_phpmailer_instance();
 


### PR DESCRIPTION
Change the parameter `$old_value` to `$deprecated`, because it is not used in the function

Trac ticket: https://core.trac.wordpress.org/ticket/52464

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
