### PR TITLE
Enhance super admin functions to accept network ID parameter and rela…

### DIFF
--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -1133,16 +1133,13 @@ function remove_role( $role ) {
  *
  * @global array $super_admins
  *
+ * @param int|null $network_id Optional. ID of the network. Default is the current network ID.
  * @return string[] List of super admin logins.
  */
-function get_super_admins() {
+function get_super_admins($network_id = null) {
 	global $super_admins;
 
-	if ( isset( $super_admins ) ) {
-		return $super_admins;
-	} else {
-		return get_site_option( 'site_admins', array( 'admin' ) );
-	}
+	return $super_admins ?? get_network_option($network_id ?? get_current_network_id(), 'site_admins', array('admin'));
 }
 
 /**
@@ -1151,9 +1148,10 @@ function get_super_admins() {
  * @since 3.0.0
  *
  * @param int|false $user_id Optional. The ID of a user. Defaults to false, to check the current user.
+ * @param int|null  $network_id Optional. ID of the network. Default is the current network ID.
  * @return bool Whether the user is a site admin.
  */
-function is_super_admin( $user_id = false ) {
+function is_super_admin( $user_id = false, $network_id = null ) {
 	if ( ! $user_id ) {
 		$user = wp_get_current_user();
 	} else {
@@ -1165,7 +1163,7 @@ function is_super_admin( $user_id = false ) {
 	}
 
 	if ( is_multisite() ) {
-		$super_admins = get_super_admins();
+		$super_admins = get_super_admins($network_id);
 		if ( is_array( $super_admins ) && in_array( $user->user_login, $super_admins, true ) ) {
 			return true;
 		}
@@ -1184,12 +1182,33 @@ function is_super_admin( $user_id = false ) {
  * @global array $super_admins
  *
  * @param int $user_id ID of the user to be granted Super Admin privileges.
+ * @param int $network_id Optional. ID of the network. Default is the current network ID.
  * @return bool True on success, false on failure. This can fail when the user is
  *              already a super admin or when the `$super_admins` global is defined.
  */
-function grant_super_admin( $user_id ) {
+function grant_super_admin( $user_id, $network_id = null ) {
 	// If global super_admins override is defined, there is nothing to do here.
 	if ( isset( $GLOBALS['super_admins'] ) || ! is_multisite() ) {
+		return false;
+	}
+
+	if (null === $network_id ) {
+		$network_id = get_current_network_id();
+	}
+
+	if(! get_network($network_id)) {
+		return false;
+	}
+
+	/**
+	 * Filters the user ID of the user to be granted Super Admin privileges.
+	 * Allows filters to prevent granting access.
+	 *
+	 * @param int $user_id ID of the user to be granted Super Admin privileges.
+	 * @param int $network_id ID of the network.
+	 */
+	$user_id = apply_filters( 'pre_grant_super_admin', $user_id, $network_id );
+	if (! $user_id) {
 		return false;
 	}
 
@@ -1199,28 +1218,35 @@ function grant_super_admin( $user_id ) {
 	 * @since 3.0.0
 	 *
 	 * @param int $user_id ID of the user that is about to be granted Super Admin privileges.
+	 * @param int $network_id ID of the network.
 	 */
-	do_action( 'grant_super_admin', $user_id );
+	do_action( 'grant_super_admin', $user_id, $network_id );
 
 	// Directly fetch site_admins instead of using get_super_admins().
-	$super_admins = get_site_option( 'site_admins', array( 'admin' ) );
+	$super_admins = get_network_option( $network_id, 'site_admins', array( 'admin' ) );
 
 	$user = get_userdata( $user_id );
-	if ( $user && ! in_array( $user->user_login, $super_admins, true ) ) {
-		$super_admins[] = $user->user_login;
-		update_site_option( 'site_admins', $super_admins );
-
-		/**
-		 * Fires after the user is granted Super Admin privileges.
-		 *
-		 * @since 3.0.0
-		 *
-		 * @param int $user_id ID of the user that was granted Super Admin privileges.
-		 */
-		do_action( 'granted_super_admin', $user_id );
-		return true;
+	if ( ! $user || in_array( $user->user_login, $super_admins, true ) ) {
+		return false;
 	}
-	return false;
+
+	$super_admins[] = $user->user_login;
+	if ( ! update_network_option( $network_id, 'site_admins', $super_admins ) ) {
+		return false;
+	}
+
+	/**
+	 * Fires after the user is granted Super Admin privileges.
+	 *
+	 * @param int $user_id ID of the user that was granted Super Admin privileges.
+	 * @param int $network_id ID of the network.
+	 *
+	 * @since 3.0.0
+	 *
+	 */
+	do_action( 'granted_super_admin', $user_id, $network_id );
+
+	return true;
 }
 
 /**
@@ -1231,46 +1257,73 @@ function grant_super_admin( $user_id ) {
  * @global array $super_admins
  *
  * @param int $user_id ID of the user Super Admin privileges to be revoked from.
+ * @param int $network_id Optional. ID of the network. Default is the current network ID.
  * @return bool True on success, false on failure. This can fail when the user's email
  *              is the network admin email or when the `$super_admins` global is defined.
  */
-function revoke_super_admin( $user_id ) {
+function revoke_super_admin( $user_id, $network_id = null ) {
 	// If global super_admins override is defined, there is nothing to do here.
 	if ( isset( $GLOBALS['super_admins'] ) || ! is_multisite() ) {
+		return false;
+	}
+
+	if( null === $network_id ) {
+		$network_id = get_current_network_id();
+	}
+
+	/**
+	 * Filters the user ID of the user to be revoked Super Admin privileges.
+	 * Allows filters to prevent revoking access.
+	 *
+	 * @param int $user_id ID of the user to be revoked Super Admin privileges.
+	 * @param int $network_id ID of the network.
+	 */
+	$user_id = apply_filters( 'pre_revoke_super_admin', $user_id, $network_id );
+	if ( ! $user_id ) {
 		return false;
 	}
 
 	/**
 	 * Fires before the user's Super Admin privileges are revoked.
 	 *
+	 * @param int $user_id ID of the user Super Admin privileges are being revoked from.
+	 * @param int $network_id ID of the network.
+	 *
 	 * @since 3.0.0
 	 *
-	 * @param int $user_id ID of the user Super Admin privileges are being revoked from.
 	 */
-	do_action( 'revoke_super_admin', $user_id );
+	do_action( 'revoke_super_admin', $user_id, $network_id );
 
 	// Directly fetch site_admins instead of using get_super_admins().
-	$super_admins = get_site_option( 'site_admins', array( 'admin' ) );
+	$super_admins = get_network_option( $network_id, 'site_admins', array( 'admin' ) );
 
 	$user = get_userdata( $user_id );
-	if ( $user && 0 !== strcasecmp( $user->user_email, get_site_option( 'admin_email' ) ) ) {
-		$key = array_search( $user->user_login, $super_admins, true );
-		if ( false !== $key ) {
-			unset( $super_admins[ $key ] );
-			update_site_option( 'site_admins', $super_admins );
-
-			/**
-			 * Fires after the user's Super Admin privileges are revoked.
-			 *
-			 * @since 3.0.0
-			 *
-			 * @param int $user_id ID of the user Super Admin privileges were revoked from.
-			 */
-			do_action( 'revoked_super_admin', $user_id );
-			return true;
-		}
+	if ( ! $user || 0 === strcasecmp( $user->user_email, get_site_option( 'admin_email' ) ) ) {
+		return false;
 	}
-	return false;
+
+	$key = array_search( $user->user_login, $super_admins, true );
+	if ( false === $key ) {
+		return false;
+	}
+
+	unset( $super_admins[ $key ] );
+	if ( ! update_network_option( $network_id, 'site_admins', $super_admins ) ) {
+		return false;
+	}
+
+	/**
+	 * Fires after the user's Super Admin privileges are revoked.
+	 *
+	 * @param int $user_id ID of the user Super Admin privileges were revoked from.
+	 * @param int $network_id ID of the network.
+	 *
+	 * @since 3.0.0
+	 *
+	 */
+	do_action( 'revoked_super_admin', $user_id, $network_id );
+
+	return true;
 }
 
 /**

--- a/tests/phpunit/tests/user/Tests_User_Multinetwork.php
+++ b/tests/phpunit/tests/user/Tests_User_Multinetwork.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace phpunit\tests\user;
+
+/**
+ * Tests specific to users in multinetwork.
+ *
+ * @group user
+ * @group ms-required
+ * @group ms-user
+ * @group multisite
+ * @group multinetwork
+ */
+class Tests_User_Multinetwork extends \WP_UnitTestCase {
+
+	public function test_super_admin_privileges() {
+		[$network1_id, $network2_id] = self::factory()->network->create_many( 2 );
+
+		// Test that the first network has the default super admin.
+		$network1_admins = get_super_admins( $network1_id );
+		$this->assertIsArray( $network1_admins, 'Network one should have an array of super admins.' );
+		$this->assertContains( 'admin', $network1_admins, 'Network one should have the super admin "admin".' );
+		$this->assertCount( 1, $network1_admins, 'Network one should have only one super admin.' );
+
+		// Test that the second network has the default super admin.
+		$network2_admins = get_super_admins( $network2_id );
+		$this->assertIsArray( $network2_admins, 'Network two should have an array of super admins.' );
+		$this->assertContains( 'admin', $network2_admins, 'Network two should have the super admin "admin".' );
+		$this->assertCount( 1, $network2_admins, 'Network two should have only one super admin.' );
+
+		// Test that the new user not a super admin on either network.
+		$user1 = self::factory()->user->create_and_get();
+		$this->assertFalse( is_super_admin( $user1->ID, $network1_id ), 'User one should not be a super admin of network one' );
+		$this->assertFalse( is_super_admin( $user1->ID, $network2_id ), 'User one should not be a super admin of network two' );
+
+		// Grant and revoke super admin privileges for user one on network one.
+		$this->assertTrue( grant_super_admin( $user1->ID, $network1_id ), 'User one should be granted super admin privileges on network one.' );
+		$this->assertTrue( is_super_admin( $user1->ID, $network1_id ), 'User one should be a super admin of network one' );
+		$this->assertFalse( is_super_admin( $user1->ID, $network2_id ), 'User one should not be a super admin of network two' );
+		$this->assertTrue( revoke_super_admin( $user1->ID, $network1_id ), 'User one should have super admin privileges revoked on network one.' );
+		$this->assertFalse( is_super_admin( $user1->ID, $network1_id ), 'User one should not be a super admin of network one' );
+
+		// Test that new user two is not a super admin on either network.
+		$user2 = self::factory()->user->create_and_get();
+		$this->assertFalse( is_super_admin( $user2->ID, $network1_id ), 'User two should not be a super admin of network one' );
+		$this->assertFalse( is_super_admin( $user2->ID, $network2_id ), 'User two should not be a super admin of network two' );
+
+		// Grant and revoke super admin privileges for user two on network two.
+		$this->assertTrue( grant_super_admin( $user2->ID, $network2_id ), 'User two should be granted super admin privileges on network two.' );
+		$this->assertFalse( is_super_admin( $user2->ID, $network1_id ), 'User two should not be a super admin of network one' );
+		$this->assertTrue( is_super_admin( $user2->ID, $network2_id ), 'User two should be a super admin of network two' );
+		$this->assertTrue( revoke_super_admin( $user2->ID, $network2_id ), 'User two should have super admin privileges revoked on network two.' );
+		$this->assertFalse( is_super_admin( $user2->ID, $network2_id ), 'User two should not be a super admin of network two' );
+	}
+
+}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63536#ticket

Multisite installs that host multiple networks currently treat all super-admin functions as being tied to the primary network. This limits enterprise-scale setups (e.g., SaaS platforms that shard customers into separate networks)

The patch introduces first-class, backward-compatible support for a $network_id argument in four super-admin helpers, allowing each network to maintain an independent site_admins list while preserving legacy behavior.

Scope of Code Changes
The four helpers—get_super_admins(), is_super_admin(), grant_super_admin(), and revoke_super_admin()—now accept an optional $network_id parameter.
They now call get_network_option() / update_network_option() when a network ID is supplied; otherwise they keep using the current network (maintaining old behaviour).
Early returns and the global $super_admins override are preserved exactly as before.

Design and Back-Compatibility
Calling without $network_id still works exactly as today.
Calling with a specific $network_id now targets that network’s site_admins row.
If $GLOBALSsuper_admins? is defined, it still overrides everything and the new code short-circuits.
Plugin hooks (grant_super_admin, granted_super_admin, revoke_super_admin, revoked_super_admin) now receive $network_id as a second argument, but positional callbacks remain compatible.

All DocBlocks have been updated to describe the new parameter.
Hook signatures are extended but remain backward-compatible.
The change is fully transparent unless developers opt into the new argument.
Created new tests to test functionality.