### PR TITLE
44042 pre delete option filter

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1206,6 +1206,17 @@ function delete_option( $option ) {
 		$option = trim( $option );
 	}
 
+	/**
+	 * Filters the option name before the option gets deleted.
+	 *
+	 * Returning an empty string short circuits the function.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param string $option Option name.
+	 */
+	$option = trim( apply_filters( 'pre_delete_option', $option ) );
+
 	if ( empty( $option ) ) {
 		return false;
 	}

--- a/tests/phpunit/tests/option/option.php
+++ b/tests/phpunit/tests/option/option.php
@@ -613,4 +613,46 @@ class Tests_Option_Option extends WP_UnitTestCase {
 
 		return $stats['cmd_get'];
 	}
+
+	/**
+	 * @ticket 44042
+	 */
+	public function test_pre_delete_option_filter() {
+			add_filter(
+				'pre_delete_option',
+				function ( $option ) {
+					if ( 'test_option_test' === $option ) {
+						$option = 'test_option';
+					}
+
+					return $option;
+				}
+			);
+
+			add_option( 'test_option', '1' );
+			delete_option( 'test_option_test' );
+
+			$this->assertEquals( false, get_option( 'test_option' ) );
+	}
+
+	/**
+	 * Returning an empty string in `pre_delete_option` short circuits `delete_option()`.
+	 *
+	 * @ticket 44042
+	 */
+	public function test_pre_delete_option_short_circuit() {
+			add_filter(
+				'pre_delete_option',
+				function ( $option ) {
+					if ( 'test_option' === $option ) {
+						return '';
+					}
+				}
+			);
+
+			add_option( 'test_option', '5' );
+			delete_option( 'test_option' );
+
+			$this->assertEquals( '5', get_option( 'test_option' ) );
+	}
 }


### PR DESCRIPTION
Added a filter to modify the option name, which can prevent certain options from deleting.

Trac ticket: [WordPress Trac ticket 44042](https://core.trac.wordpress.org/ticket/44042)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
