### PR TITLE
[30691] Fix: Reset attachment post_parent when featured image is removed

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -8055,18 +8055,22 @@ function set_post_thumbnail( $post, $thumbnail_id ) {
 	$thumbnail_id = absint( $thumbnail_id );
 	if ( $post && $thumbnail_id && get_post( $thumbnail_id ) ) {
 		if ( wp_get_attachment_image( $thumbnail_id, 'thumbnail' ) ) {
+			// Set the thumbnail meta
 			$result = update_post_meta( $post->ID, '_thumbnail_id', $thumbnail_id );
-			
+
 			$attachment = get_post( $thumbnail_id );
 			if ( $attachment && 'attachment' === $attachment->post_type ) {
+				// Only update post_parent if it's not already set to this post
 				if ( (int) $attachment->post_parent !== (int) $post->ID ) {
-					wp_update_post( array(
-						'ID'          => $thumbnail_id,
-						'post_parent' => $post->ID
-					) );
+					wp_update_post(
+						array(
+							'ID'          => $thumbnail_id,
+							'post_parent' => $post->ID
+						)
+					);
 				}
 			}
-			
+
 			return $result;
 		} else {
 			return delete_post_meta( $post->ID, '_thumbnail_id' );
@@ -8087,19 +8091,21 @@ function delete_post_thumbnail( $post ) {
 	$post = get_post( $post );
 	if ( $post ) {
 		$thumbnail_id = get_post_thumbnail_id( $post->ID );
-		
+
 		$result = delete_post_meta( $post->ID, '_thumbnail_id' );
-		
+
 		if ( $result && $thumbnail_id ) {
 			$attachment = get_post( $thumbnail_id );
 			if ( $attachment && 'attachment' === $attachment->post_type && (int) $attachment->post_parent === (int) $post->ID ) {
-				wp_update_post( array(
-					'ID'          => $thumbnail_id,
-					'post_parent' => 0
-				) );
+				wp_update_post(
+					array(
+						'ID'          => $thumbnail_id,
+						'post_parent' => 0,
+					)
+				);
 			}
 		}
-		
+
 		return $result;
 	}
 	return false;

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -8055,7 +8055,19 @@ function set_post_thumbnail( $post, $thumbnail_id ) {
 	$thumbnail_id = absint( $thumbnail_id );
 	if ( $post && $thumbnail_id && get_post( $thumbnail_id ) ) {
 		if ( wp_get_attachment_image( $thumbnail_id, 'thumbnail' ) ) {
-			return update_post_meta( $post->ID, '_thumbnail_id', $thumbnail_id );
+			$result = update_post_meta( $post->ID, '_thumbnail_id', $thumbnail_id );
+			
+			$attachment = get_post( $thumbnail_id );
+			if ( $attachment && 'attachment' === $attachment->post_type ) {
+				if ( (int) $attachment->post_parent !== (int) $post->ID ) {
+					wp_update_post( array(
+						'ID'          => $thumbnail_id,
+						'post_parent' => $post->ID
+					) );
+				}
+			}
+			
+			return $result;
 		} else {
 			return delete_post_meta( $post->ID, '_thumbnail_id' );
 		}
@@ -8074,7 +8086,21 @@ function set_post_thumbnail( $post, $thumbnail_id ) {
 function delete_post_thumbnail( $post ) {
 	$post = get_post( $post );
 	if ( $post ) {
-		return delete_post_meta( $post->ID, '_thumbnail_id' );
+		$thumbnail_id = get_post_thumbnail_id( $post->ID );
+		
+		$result = delete_post_meta( $post->ID, '_thumbnail_id' );
+		
+		if ( $result && $thumbnail_id ) {
+			$attachment = get_post( $thumbnail_id );
+			if ( $attachment && 'attachment' === $attachment->post_type && (int) $attachment->post_parent === (int) $post->ID ) {
+				wp_update_post( array(
+					'ID'          => $thumbnail_id,
+					'post_parent' => 0
+				) );
+			}
+		}
+		
+		return $result;
 	}
 	return false;
 }

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -8065,7 +8065,7 @@ function set_post_thumbnail( $post, $thumbnail_id ) {
 					wp_update_post(
 						array(
 							'ID'          => $thumbnail_id,
-							'post_parent' => $post->ID
+							'post_parent' => $post->ID,
 						)
 					);
 				}


### PR DESCRIPTION
trac: https://core.trac.wordpress.org/ticket/30691

**Problem**
When a featured image is removed from a post, WordPress only deletes the _thumbnail_id meta field but doesn't reset the attachment's post_parent field back to 0. This creates orphaned relationships where attachments still reference deleted parent posts, causing incorrect results when using functions like get_children() and get_posts().

For Example:
Set image ID 123 as the featured image for post ID 456
Remove the featured image from post 456
Image 123 still has post_parent = 456 in wp_posts table
get_children(456) incorrectly returns image 123 as a child

**Root Cause**
The delete_post_thumbnail() function in wp-includes/post.php only removes the post meta. Additionally, set_post_thumbnail() doesn't properly establish the post_parent relationship when setting a featured image.

**Solution**
This PR enhances both functions to properly manage the post_parent relationship:

1. delete_post_thumbnail():
Retrieves the current thumbnail ID before deletion
Removes the _thumbnail_id meta field
Resets the attachment's post_parent to 0 if it was set to the current post

2. set_post_thumbnail():
Sets the _thumbnail_id meta field
Updates the attachment's post_parent to establish a proper relationship


