### PR TITLE
Fixed: Dashboard has accessibility issue regarding insufficient contrast ratio.

### DIFF
--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -591,11 +591,17 @@
 }
 
 .community-events-footer {
+	float: none;
 	margin-top: 0;
 	margin-bottom: 0;
 	padding: 12px;
 	border-top: 1px solid #f0f0f1;
 	color: #dcdcde;
+}
+
+.community-events-footer .dashicons {
+	position: relative;
+	top: 4px;
 }
 
 /* Safari 10 + VoiceOver specific: without this, the hidden text gets read out before the link. */

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1304,42 +1304,44 @@ function wp_dashboard_events_news() {
 		<?php wp_dashboard_primary(); ?>
 	</div>
 
-	<p class="community-events-footer">
-		<?php
-			printf(
-				'<a href="%1$s" target="_blank">%2$s <span class="screen-reader-text"> %3$s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a>',
-				'https://make.wordpress.org/community/meetups-landing-page',
-				__( 'Meetups' ),
-				/* translators: Hidden accessibility text. */
-				__( '(opens in a new tab)' )
-			);
-		?>
-
-		|
-
-		<?php
-			printf(
-				'<a href="%1$s" target="_blank">%2$s <span class="screen-reader-text"> %3$s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a>',
-				'https://central.wordcamp.org/schedule/',
-				__( 'WordCamps' ),
-				/* translators: Hidden accessibility text. */
-				__( '(opens in a new tab)' )
-			);
-		?>
-
-		|
-
-		<?php
-			printf(
-				'<a href="%1$s" target="_blank">%2$s <span class="screen-reader-text"> %3$s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a>',
-				/* translators: If a Rosetta site exists (e.g. https://es.wordpress.org/news/), then use that. Otherwise, leave untranslated. */
-				esc_url( _x( 'https://wordpress.org/news/', 'Events and News dashboard widget' ) ),
-				__( 'News' ),
-				/* translators: Hidden accessibility text. */
-				__( '(opens in a new tab)' )
-			);
-		?>
-	</p>
+	<ul class="subsubsub community-events-footer">
+		<li>
+			<?php
+				printf(
+					'<a href="%1$s" target="_blank">%2$s <span class="screen-reader-text"> %3$s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a>',
+					'https://make.wordpress.org/community/meetups-landing-page',
+					__( 'Meetups' ),
+					/* translators: Hidden accessibility text. */
+					__( '(opens in a new tab)' )
+				);
+			?>
+			|
+		</li>
+		<li>
+			<?php
+				printf(
+					'<a href="%1$s" target="_blank">%2$s <span class="screen-reader-text"> %3$s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a>',
+					'https://central.wordcamp.org/schedule/',
+					__( 'WordCamps' ),
+					/* translators: Hidden accessibility text. */
+					__( '(opens in a new tab)' )
+				);
+			?>
+			|
+		</li>
+		<li>
+			<?php
+				printf(
+					'<a href="%1$s" target="_blank">%2$s <span class="screen-reader-text"> %3$s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a>',
+					/* translators: If a Rosetta site exists (e.g. https://es.wordpress.org/news/), then use that. Otherwise, leave untranslated. */
+					esc_url( _x( 'https://wordpress.org/news/', 'Events and News dashboard widget' ) ),
+					__( 'News' ),
+					/* translators: Hidden accessibility text. */
+					__( '(opens in a new tab)' )
+				);
+			?>
+		</li>
+	</ul>
 
 	<?php
 }


### PR DESCRIPTION
On dashboard, While I am checking the accessibility issues, I found that There is insufficient contrast ratio on the WordPress Events and News section.

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63540

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
