### PR TITLE
Improve env:install command with better configurability and error handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,7 @@ services:
       PHP_FPM_UID: ${PHP_FPM_UID-1000}
       PHP_FPM_GID: ${PHP_FPM_GID-1000}
       HOST_PATH: ${PWD-}/${LOCAL_DIR-src}
+      WP_CONFIG_PATH: ${WP_CONFIG_PATH-/var/www/wp-config.php}
 
     volumes:
       - ./:/var/www

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ services:
       PHP_FPM_UID: ${PHP_FPM_UID-1000}
       PHP_FPM_GID: ${PHP_FPM_GID-1000}
       HOST_PATH: ${PWD-}/${LOCAL_DIR-src}
-      WP_CONFIG_PATH: ${WP_CONFIG_PATH-/var/www/wp-config.php}
+      WP_CONFIG_PATH: /var/www/wp-config.php
 
     volumes:
       - ./:/var/www

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -36,11 +36,23 @@ const testConfig = readFileSync( 'wp-tests-config-sample.php', 'utf8' )
 writeFileSync( 'wp-tests-config.php', testConfig );
 
 // Once the site is available, install WordPress!
-wait_on( { resources: [ `tcp:localhost:${process.env.LOCAL_PORT}`] } )
+wait_on( {
+	resources: [ `tcp:localhost:${process.env.LOCAL_PORT}`],
+	timeout: 3000,
+} )
+	.catch( err => {
+		console.error( `Error: It appears the development environment has not been started. Message: ${ err.message }` );
+		console.error( `Did you forget to do 'npm run env:start'?` );
+		process.exit( 1 );
+	} )
 	.then( () => {
 		wp_cli( 'db reset --yes' );
 		const installCommand = process.env.LOCAL_MULTISITE === 'true'  ? 'multisite-install' : 'install';
 		wp_cli( `core ${ installCommand } --title="WordPress Develop" --admin_user=admin --admin_password=password --admin_email=test@example.com --skip-email --url=http://localhost:${process.env.LOCAL_PORT}` );
+	} )
+	.catch( err => {
+		console.error( `Error: Unable to reset DB and install WordPress. Message: ${ err.message }` );
+		process.exit( 1 );
 	} );
 
 /**

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -1,3 +1,5 @@
+/* jshint node:true */
+
 const dotenv       = require( 'dotenv' );
 const dotenvExpand = require( 'dotenv-expand' );
 const wait_on = require( 'wait-on' );
@@ -28,8 +30,8 @@ const testConfig = readFileSync( 'wp-tests-config-sample.php', 'utf8' )
 	.replace( 'yourusernamehere', 'root' )
 	.replace( 'yourpasswordhere', 'password' )
 	.replace( 'localhost', 'mysql' )
-	.replace( "'WP_TESTS_DOMAIN', 'example.org'", `'WP_TESTS_DOMAIN', '${process.env.LOCAL_WP_TESTS_DOMAIN}'` )
-	.concat( "\ndefine( 'FS_METHOD', 'direct' );\n" );
+	.replace( `'WP_TESTS_DOMAIN', 'example.org'`, `'WP_TESTS_DOMAIN', '${process.env.LOCAL_WP_TESTS_DOMAIN}'` )
+	.concat( `\ndefine( 'FS_METHOD', 'direct' );\n` );
 
 writeFileSync( 'wp-tests-config.php', testConfig );
 

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -2,7 +2,7 @@ const dotenv       = require( 'dotenv' );
 const dotenvExpand = require( 'dotenv-expand' );
 const wait_on = require( 'wait-on' );
 const { execSync } = require( 'child_process' );
-const { renameSync, readFileSync, writeFileSync } = require( 'fs' );
+const { readFileSync, writeFileSync } = require( 'fs' );
 const local_env_utils = require( './utils' );
 
 dotenvExpand.expand( dotenv.config() );
@@ -11,7 +11,7 @@ dotenvExpand.expand( dotenv.config() );
 local_env_utils.determine_auth_option();
 
 // Create wp-config.php.
-wp_cli( 'config create --dbname=wordpress_develop --dbuser=root --dbpass=password --dbhost=mysql --force' );
+wp_cli( `config create --dbname=wordpress_develop --dbuser=root --dbpass=password --dbhost=mysql --force --config-file=${process.env.LOCAL_DIR}/../wp-config.php` );
 
 // Add the debug settings to wp-config.php.
 // Windows requires this to be done as an additional step, rather than using the --extra-php option in the previous step.
@@ -21,9 +21,6 @@ wp_cli( `config set WP_DEBUG_DISPLAY ${process.env.LOCAL_WP_DEBUG_DISPLAY} --raw
 wp_cli( `config set SCRIPT_DEBUG ${process.env.LOCAL_SCRIPT_DEBUG} --raw --type=constant` );
 wp_cli( `config set WP_ENVIRONMENT_TYPE ${process.env.LOCAL_WP_ENVIRONMENT_TYPE} --type=constant` );
 wp_cli( `config set WP_DEVELOPMENT_MODE ${process.env.LOCAL_WP_DEVELOPMENT_MODE} --type=constant` );
-
-// Move wp-config.php to the base directory, so it doesn't get mixed up in the src or build directories.
-renameSync( `${process.env.LOCAL_DIR}/wp-config.php`, 'wp-config.php' );
 
 // Read in wp-tests-config-sample.php, edit it to work with our config, then write it to wp-tests-config.php.
 const testConfig = readFileSync( 'wp-tests-config-sample.php', 'utf8' )


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63543

* Force WP-CLI to use the the `wp-config.php` in the directory above the `src` directory via the `WP_CONFIG_PATH` environment variable [read by WP-CLI](https://github.com/wp-cli/wp-cli/blob/2800ad0a66747a826ae4221b2f022f1df6779cb6/php/utils.php#L328-L329) in the `wp_locate_config()` function.
* Update the `env:install` command to write out the config at the repo root instead of writing it inside of the `ABSPATH` only then to move it one directory up.
* Fix JSHint issues.
* Add error handling to when `npm run env:install` is executed without having first done `npm run env:start` (which has tripped me up multiple times), in which case the script will end with an exit code of 1 and emit:
```
Error: It appears the development environment has not been started. Message: Timed out waiting for: tcp:localhost:8000
Did you forget to do 'npm run env:start'?
```

# Commit Message

Build/Test Tools: Improve `env:install` command with better configurability and error handling.

* Force WP-CLI to use the the `wp-config.php` in the directory above the `src` directory via the `WP_CONFIG_PATH` environment variable [read by WP-CLI](https://github.com/wp-cli/wp-cli/blob/2800ad0a66747a826ae4221b2f022f1df6779cb6/php/utils.php#L328-L329) in the `wp_locate_config()` function.
* Update the `env:install` command to write out the config at the repo root instead of writing it inside of the `ABSPATH` only then to move it one directory up.
* Fix JSHint issues.
* Add error handling to when `npm run env:install` is executed without having first done `npm run env:start` (which has tripped me up multiple times), in which case the script will end with an exit code of 1 and emit:

> Error: It appears the development environment has not been started. Message: Timed out waiting for: tcp:localhost:8000
> Did you forget to do 'npm run env:start'?

Fixes #63543.
Props westonruter, jorbin, SirLouen.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
