### PR TITLE
Default Post Format in Quick Press Issue

### DIFF
--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -603,6 +603,11 @@ function wp_dashboard_quick_press( $error_msg = false ) {
 			<input type="hidden" name="action" id="quickpost-action" value="post-quickdraft-save" />
 			<input type="hidden" name="post_ID" value="<?php echo $post_ID; ?>" />
 			<input type="hidden" name="post_type" value="post" />
+			<?php
+			if ( current_theme_supports( 'post-formats' ) && post_type_supports( 'post', 'post-formats' ) && get_option( 'default_post_format' ) ) {
+				echo '<input type="hidden" name="post_format" value="' . esc_attr( get_option( 'default_post_format' ) ) . '" />';
+			}
+			?>
 			<?php wp_nonce_field( 'add-post' ); ?>
 			<?php submit_button( __( 'Save Draft' ), 'primary', 'save', false, array( 'id' => 'save-post' ) ); ?>
 			<br class="clear" />

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -605,7 +605,15 @@ function wp_dashboard_quick_press( $error_msg = false ) {
 			<input type="hidden" name="post_type" value="post" />
 			<?php
 			if ( current_theme_supports( 'post-formats' ) && post_type_supports( 'post', 'post-formats' ) && get_option( 'default_post_format' ) ) {
-				echo '<input type="hidden" name="post_format" value="' . esc_attr( get_option( 'default_post_format' ) ) . '" />';
+				/**
+				* Filters the post format for quick draft posts.
+				*
+				* @since 6.9.0
+				*
+				* @param string $post_format The post format to use. Default is the site's default post format.
+				*/
+				$post_format = apply_filters( 'quick_draft_post_format', get_option( 'default_post_format' ) );
+				echo '<input type="hidden" name="post_format" value="' . esc_attr( $post_format ) . '" />';
 			}
 			?>
 			<?php wp_nonce_field( 'add-post' ); ?>

--- a/tests/e2e/specs/dashboard.test.js
+++ b/tests/e2e/specs/dashboard.test.js
@@ -8,10 +8,16 @@ test.describe( 'Quick Draft', () => {
 		await requestUtils.deleteAllPosts();
 	} );
 
-	test( 'Allows draft to be created with Title and Content', async ( {
+	test( 'Allows draft to be created with Title and Content and check default post format', async ( {
 	   admin,
-	   page
+	   page,
+	   requestUtils
 	} ) => {
+		// First set the default post format to Quote.
+		await admin.visitAdminPage( 'options-writing.php' );
+		await page.selectOption( '#default_post_format', 'quote' );
+		await page.getByRole( 'button', { name: 'Save Changes' } ).click();
+
 		await admin.visitAdminPage( '/' );
 
 		// Wait for Quick Draft title field to appear.
@@ -36,6 +42,17 @@ test.describe( 'Quick Draft', () => {
 		await expect(
 			page.locator( '.drafts .draft-title' ).first().getByRole( 'link' )
 		).toHaveText( 'Test Draft Title' );
+
+		// Get the post ID from the URL of the first draft.
+		const draftLink = page.locator( '.drafts .draft-title' ).first().getByRole( 'link' );
+		const draftUrl = await draftLink.getAttribute( 'href' );
+		const draftId = draftUrl.match( /post=(\d+)/ )[ 1 ];
+
+		// Verify the post format is set to quote using the REST API.
+		const response = await requestUtils.rest( {
+			path: `/wp/v2/posts/${draftId}`,
+		} );
+		expect( response.format ).toBe( 'quote' );
 
 		// Check that new draft appears in Posts page
 		await admin.visitAdminPage( '/edit.php' );
@@ -70,53 +87,5 @@ test.describe( 'Quick Draft', () => {
 		await expect(
 			page.locator( '.type-post.status-draft .title' ).first()
 		).toContainText( 'Untitled' );
-	} );
-
-	test( 'Applies default post format to Quick Draft', async ( {
-		admin,
-		page,
-		requestUtils
-	} ) => {
-		// First set the default post format to Quote.
-		await admin.visitAdminPage( 'options-writing.php' );
-		await page.selectOption( '#default_post_format', 'quote' );
-		await page.getByRole( 'button', { name: 'Save Changes' } ).click();
-
-		// Now create a draft using Quick Draft.
-		await admin.visitAdminPage( '/' );
-
-		// Wait for Quick Draft title field to appear.
-		const draftTitleField = page.locator(
-			'#quick-press'
-		).getByRole( 'textbox', { name: 'Title' } );
-
-		await expect( draftTitleField ).toBeVisible();
-
-		// Focus and fill in a title.
-		await draftTitleField.fill( 'Test Quote Draft' );
-
-		// Navigate to content field and type in some content
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.type( 'Test Quote Content' );
-
-		// Navigate to Save Draft button and press it.
-		await page.keyboard.press( 'Tab' );
-		await page.keyboard.press( 'Enter' );
-
-		// Wait for new draft to appear in Your Recent Drafts section.
-		await expect(
-			page.locator( '.drafts .draft-title' ).first().getByRole( 'link' )
-		).toHaveText( 'Test Quote Draft' );
-
-		// Get the post ID from the URL of the first draft.
-		const draftLink = page.locator( '.drafts .draft-title' ).first().getByRole( 'link' );
-		const draftUrl = await draftLink.getAttribute( 'href' );
-		const draftId = draftUrl.match( /post=(\d+)/ )[ 1 ];
-
-		// Verify the post format is set to quote using the REST API.
-		const response = await requestUtils.rest( {
-			path: `/wp/v2/posts/${draftId}`,
-		} );
-		expect( response.format ).toBe( 'quote' );
 	} );
 } );

--- a/tests/e2e/specs/dashboard.test.js
+++ b/tests/e2e/specs/dashboard.test.js
@@ -71,4 +71,52 @@ test.describe( 'Quick Draft', () => {
 			page.locator( '.type-post.status-draft .title' ).first()
 		).toContainText( 'Untitled' );
 	} );
+
+	test( 'Applies default post format to Quick Draft', async ( {
+		admin,
+		page,
+		requestUtils
+	} ) => {
+		// First set the default post format to Quote.
+		await admin.visitAdminPage( 'options-writing.php' );
+		await page.selectOption( '#default_post_format', 'quote' );
+		await page.getByRole( 'button', { name: 'Save Changes' } ).click();
+
+		// Now create a draft using Quick Draft.
+		await admin.visitAdminPage( '/' );
+
+		// Wait for Quick Draft title field to appear.
+		const draftTitleField = page.locator(
+			'#quick-press'
+		).getByRole( 'textbox', { name: 'Title' } );
+
+		await expect( draftTitleField ).toBeVisible();
+
+		// Focus and fill in a title.
+		await draftTitleField.fill( 'Test Quote Draft' );
+
+		// Navigate to content field and type in some content
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.type( 'Test Quote Content' );
+
+		// Navigate to Save Draft button and press it.
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Enter' );
+
+		// Wait for new draft to appear in Your Recent Drafts section.
+		await expect(
+			page.locator( '.drafts .draft-title' ).first().getByRole( 'link' )
+		).toHaveText( 'Test Quote Draft' );
+
+		// Get the post ID from the URL of the first draft.
+		const draftLink = page.locator( '.drafts .draft-title' ).first().getByRole( 'link' );
+		const draftUrl = await draftLink.getAttribute( 'href' );
+		const draftId = draftUrl.match( /post=(\d+)/ )[ 1 ];
+
+		// Verify the post format is set to quote using the REST API.
+		const response = await requestUtils.rest( {
+			path: `/wp/v2/posts/${draftId}`,
+		} );
+		expect( response.format ).toBe( 'quote' );
+	} );
 } );

--- a/tests/phpunit/tests/admin/includesDashboard.php
+++ b/tests/phpunit/tests/admin/includesDashboard.php
@@ -54,5 +54,9 @@ class Tests_Admin_IncludesDashboard extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'name="post_format"', $output );
 		$this->assertStringContainsString( 'value="quote"', $output );
+
+		// Clean up or there will be a collision with other tests.
+		delete_option( 'default_post_format' );
+		remove_theme_support( 'post-formats' );
 	}
 }

--- a/tests/phpunit/tests/admin/includesDashboard.php
+++ b/tests/phpunit/tests/admin/includesDashboard.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Tests for admin dashboard functionality.
+ *
+ * @group admin
+ * @group dashboard
+ *
+ * @package Tests\Admin
+ */
+
+/**
+ * Class Tests_Admin_IncludesDashboard
+ */
+class Tests_Admin_IncludesDashboard extends WP_UnitTestCase {
+
+	/**
+	 * Set up the test environment with the dashboard functions.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		if ( ! function_exists( 'wp_dashboard_quick_press' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/dashboard.php';
+		}
+	}
+
+	/**
+	 * Tear down the test environment:
+	 * Delete last post id option to avoid collisions with other tests.
+	 */
+	public function tear_down() {
+		delete_user_option( get_current_user_id(), 'dashboard_quick_press_last_post_id' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Test that wp_dashboard_quick_press includes default post format hidden field.
+	 *
+	 * @ticket 42910
+	 * @covers ::wp_dashboard_quick_press
+	 */
+	public function test_wp_dashboard_quick_press_default_post_format_applied_to_draft() {
+		$user_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+
+		add_theme_support( 'post-formats', array( 'aside', 'gallery', 'quote' ) );
+		update_option( 'default_post_format', 'quote' );
+
+		set_current_screen( 'dashboard' );
+
+		ob_start();
+		wp_dashboard_quick_press();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'name="post_format"', $output );
+		$this->assertStringContainsString( 'value="quote"', $output );
+	}
+}


### PR DESCRIPTION
The `post_type` was never been set in during the `wp_dashboard_quick_press` but in that function, there is a mechanism that replicates all the information from the last post, this was the reason it was not set during the initial creation but set during the second

I've added a new patch that more adequately solves this problem within where it should actually be (in the `wp_dashboard_quick_press`) including some unit testing coverage to check if the wp_dashboard_quick_press is displaying what it should be displaying.

@sandeepdahiya if you can test this new patch version again, it would be great.

Trac ticket: https://core.trac.wordpress.org/ticket/42910

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
