### PR TITLE
fix: Ensure proper closing of li element in plugin-editor.php

### DIFF
--- a/src/wp-admin/plugin-editor.php
+++ b/src/wp-admin/plugin-editor.php
@@ -288,6 +288,7 @@ printf(
 		<ul role="group">
 			<?php wp_print_plugin_file_tree( wp_make_plugin_file_tree( $plugin_editable_files ) ); ?>
 		</ul>
+	</li>
 	</ul>
 </div>
 


### PR DESCRIPTION

This commit ensures that the list item element in the plugin file tree navigation is closed adequately with a </li> tag. The HTML structure in plugin-editor.php now correctly nests the tree structure with proper opening and closing tags.

This improves HTML validity and accessibility compliance for screen readers and other assistive technologies that rely on proper DOM structure, especially important for elements using ARIA roles like "treeitem" and "group".

Trac ticket: https://core.trac.wordpress.org/ticket/63546

Props dkarfa

