### PR TITLE
Validate locale before outputting HTML lang attribute

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -4507,6 +4507,14 @@ function get_language_attributes( $doctype = 'html' ) {
 
 	$lang = get_bloginfo( 'language' );
 	if ( $lang ) {
+		$locale = str_replace( '-', '_', $lang );
+
+		if ( 'en_US' !== $locale ) {
+			if ( ! function_exists( 'has_translation' ) || ! has_translation( 'html_lang_attribute', 'default', $locale ) ) {
+				$lang = 'en-US';
+			}
+		}
+
 		if ( 'text/html' === get_option( 'html_type' ) || 'html' === $doctype ) {
 			$attributes[] = 'lang="' . esc_attr( $lang ) . '"';
 		}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/47546

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

## Testing Instructions
### Test Case 1: Default Locale (en_US)
- Set WordPress to use English (United States)
- In wp-admin, go to Settings → General
- Set "Site Language" to "English (United States)"
- Save changes
- View the page source of any front-end page
- Verify the HTML tag contains lang="en-US"
### Test Case 2: Valid Non-Default Locale
- Install a language pack (e.g., French)
- In wp-admin, go to Settings → General
- Set "Site Language" to "Français"
- Save changes
- View the page source
- Verify the HTML tag contains lang="fr-FR"
### Test Case 3: Invalid/Missing Locale
- Manually set an invalid locale in the database:
```sql
UPDATE wp_options SET option_value = 'xx_XX' WHERE option_name = 'WPLANG';
```
Or using WP-CLI:
```bash
wp option update WPLANG xx_XX
```
- View the page source
- Verify the HTML tag falls back to lang="en-US"
