### PR TITLE
Administration: Respect color scheme for selected Media Library items

### DIFF
--- a/src/wp-admin/css/colors/_admin.scss
+++ b/src/wp-admin/css/colors/_admin.scss
@@ -563,15 +563,35 @@ ul#adminmenu > li.current > a.current:after {
 	background-color: variables.$highlight-color;
 }
 
-.details.attachment {
+.wp-core-ui .details.attachment {
 	box-shadow:
 		inset 0 0 0 3px #fff,
 		inset 0 0 0 7px variables.$highlight-color;
 }
 
-.attachment.details .check {
+.wp-core-ui .attachment.details .check {
 	background-color: variables.$highlight-color;
 	box-shadow: 0 0 0 1px #fff, 0 0 0 2px variables.$highlight-color;
+}
+
+.wp-core-ui .attachment:focus,
+.wp-core-ui .selected.attachment:focus,
+.wp-core-ui .attachment.details:focus {
+	box-shadow:
+		inset 0 0 2px 3px #fff,
+		inset 0 0 0 7px variables.$highlight-color;
+	/* Only visible in Windows High Contrast mode */
+	outline: 2px solid transparent;
+	outline-offset: -6px;
+}
+
+.wp-core-ui .attachment.details .check,
+.wp-core-ui .attachment.selected .check:focus,
+.wp-core-ui .media-frame.mode-grid .attachment.selected .check {
+	background-color: variables.$highlight-color;
+	box-shadow:
+		0 0 0 1px #fff,
+		0 0 0 2px variables.$highlight-color;
 }
 
 .media-selection .attachment.selection.details .thumbnail {

--- a/src/wp-admin/css/colors/_admin.scss
+++ b/src/wp-admin/css/colors/_admin.scss
@@ -80,27 +80,28 @@ input[type=radio]:checked::before {
 	color: variables.$link-focus;
 }
 
-input[type="text"]:focus,
-input[type="password"]:focus,
-input[type="color"]:focus,
-input[type="date"]:focus,
-input[type="datetime"]:focus,
-input[type="datetime-local"]:focus,
-input[type="email"]:focus,
-input[type="month"]:focus,
-input[type="number"]:focus,
-input[type="search"]:focus,
-input[type="tel"]:focus,
-input[type="text"]:focus,
-input[type="time"]:focus,
-input[type="url"]:focus,
-input[type="week"]:focus,
-input[type="checkbox"]:focus,
-input[type="radio"]:focus,
-select:focus,
-textarea:focus {
-	border-color: variables.$highlight-color;
-	box-shadow: 0 0 0 1px variables.$highlight-color;
+.wp-core-ui {
+	input[type="text"]:focus,
+	input[type="password"]:focus,
+	input[type="color"]:focus,
+	input[type="date"]:focus,
+	input[type="datetime"]:focus,
+	input[type="datetime-local"]:focus,
+	input[type="email"]:focus,
+	input[type="month"]:focus,
+	input[type="number"]:focus,
+	input[type="search"]:focus,
+	input[type="tel"]:focus,
+	input[type="time"]:focus,
+	input[type="url"]:focus,
+	input[type="week"]:focus,
+	input[type="checkbox"]:focus,
+	input[type="radio"]:focus,
+	select:focus,
+	textarea:focus {
+		border-color: variables.$highlight-color;
+		box-shadow: 0 0 0 1px variables.$highlight-color;
+	}
 }
 
 
@@ -563,25 +564,27 @@ ul#adminmenu > li.current > a.current:after {
 	background-color: variables.$highlight-color;
 }
 
-.wp-core-ui .details.attachment {
-	box-shadow:
-		inset 0 0 0 3px #fff,
-		inset 0 0 0 7px variables.$highlight-color;
-}
+.wp-core-ui {
+	.attachment.details {
+		box-shadow:
+			inset 0 0 0 3px #fff,
+			inset 0 0 0 7px variables.$highlight-color;
+	}
 
-.wp-core-ui .attachment.details .check,
-.wp-core-ui .attachment.selected .check:focus,
-.wp-core-ui .media-frame.mode-grid .attachment.selected .check {
-	background-color: variables.$highlight-color;
-	box-shadow: 0 0 0 1px #fff, 0 0 0 2px variables.$highlight-color;
-}
+	.attachment.details .check,
+	.attachment.selected .check:focus,
+	.media-frame.mode-grid .attachment.selected .check {
+		background-color: variables.$highlight-color;
+		box-shadow: 0 0 0 1px #fff, 0 0 0 2px variables.$highlight-color;
+	}
 
-.wp-core-ui .attachment:focus,
-.wp-core-ui .selected.attachment:focus,
-.wp-core-ui .attachment.details:focus {
-	box-shadow:
-		inset 0 0 2px 3px #fff,
-		inset 0 0 0 7px variables.$highlight-color;
+	.attachment:focus,
+	.selected.attachment:focus,
+	.attachment.details:focus {
+		box-shadow:
+			inset 0 0 2px 3px #fff,
+			inset 0 0 0 7px variables.$highlight-color;
+	}
 }
 
 .media-selection .attachment.selection.details .thumbnail {

--- a/src/wp-admin/css/colors/_admin.scss
+++ b/src/wp-admin/css/colors/_admin.scss
@@ -569,7 +569,9 @@ ul#adminmenu > li.current > a.current:after {
 		inset 0 0 0 7px variables.$highlight-color;
 }
 
-.wp-core-ui .attachment.details .check {
+.wp-core-ui .attachment.details .check,
+.wp-core-ui .attachment.selected .check:focus,
+.wp-core-ui .media-frame.mode-grid .attachment.selected .check {
 	background-color: variables.$highlight-color;
 	box-shadow: 0 0 0 1px #fff, 0 0 0 2px variables.$highlight-color;
 }
@@ -580,18 +582,6 @@ ul#adminmenu > li.current > a.current:after {
 	box-shadow:
 		inset 0 0 2px 3px #fff,
 		inset 0 0 0 7px variables.$highlight-color;
-	/* Only visible in Windows High Contrast mode */
-	outline: 2px solid transparent;
-	outline-offset: -6px;
-}
-
-.wp-core-ui .attachment.details .check,
-.wp-core-ui .attachment.selected .check:focus,
-.wp-core-ui .media-frame.mode-grid .attachment.selected .check {
-	background-color: variables.$highlight-color;
-	box-shadow:
-		0 0 0 1px #fff,
-		0 0 0 2px variables.$highlight-color;
 }
 
 .media-selection .attachment.selection.details .thumbnail {


### PR DESCRIPTION
### Description

This PR ensures that the selected admin color scheme is correctly applied to individual attachments within the `Select or Upload Media` dialog. Previously, due to CSS specificity issues, custom color schemes were overridden, leading to inconsistent styling.

Trac ticket: https://core.trac.wordpress.org/ticket/63553

### Screenshots

|Before|After|
|-|-|
|![css-specificity](https://github.com/user-attachments/assets/e70c9b65-e59f-44de-a11c-9f1b1bc0a76f)|![specificity-after](https://github.com/user-attachments/assets/07d29910-0e26-4c29-bbf1-90bf279dd427)|
|![admin-color-theme](https://github.com/user-attachments/assets/40cf22af-8976-4c1f-8137-fce542b1c658)|![after](https://github.com/user-attachments/assets/678a5fe4-b406-4416-b751-855dc83ce50d)|


## Use of AI Tools

AI assistance: No

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
