### PR TITLE
Backport: add support for selects on the elements API

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -629,11 +629,13 @@ class WP_Theme_JSON {
 		// The block classes are necessary to target older content that won't use the new class names.
 		'caption' => '.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption',
 		'cite'    => 'cite',
+		'select'  => '.wp-element-select',
 	);
 
 	const __EXPERIMENTAL_ELEMENT_CLASS_NAMES = array(
 		'button'  => 'wp-element-button',
 		'caption' => 'wp-element-caption',
+		'select'  => 'wp-element-select',
 	);
 
 	/**

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -629,13 +629,12 @@ class WP_Theme_JSON {
 		// The block classes are necessary to target older content that won't use the new class names.
 		'caption' => '.wp-element-caption, .wp-block-audio figcaption, .wp-block-embed figcaption, .wp-block-gallery figcaption, .wp-block-image figcaption, .wp-block-table figcaption, .wp-block-video figcaption',
 		'cite'    => 'cite',
-		'select'  => '.wp-element-select',
+		'select'  => 'select',
 	);
 
 	const __EXPERIMENTAL_ELEMENT_CLASS_NAMES = array(
 		'button'  => 'wp-element-button',
 		'caption' => 'wp-element-caption',
-		'select'  => 'wp-element-select',
 	);
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Backport for https://github.com/WordPress/gutenberg/pull/70379

Trac ticket: https://core.trac.wordpress.org/ticket/63555


## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of https://github.com/WordPress/gutenberg/issues/34198

This PR adds support for the select element which can be used by themers and extenders to style selects or dropdown elements. Right now the experimental form block doesn't have dropdowns in it, but many extenders do, so I wanted to cover them too in line with the work being done at #70378
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

So a theme can style consistently how forms should look like regardless of the plugins installed (if they opt in this new API)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We are targeting the select HTML element instead of adding a class, more context in this [comment](https://github.com/WordPress/gutenberg/pull/70378#issuecomment-2963401440) about the reasoning. In any case, this PR adds no extra styling unless a theme opts in to use this and the specificity of any generated CSS with the element would be 0.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

This one is a little hard to test without having a native block that has a dropdown in it that doesn't overly style it. What I did was:
1. added the following to my theme.json file:

```
"elements": {
			"select": {
				"color": {
					"text": "red",
					"background": "blue"
				}
			},
}
```

2. With WooCommerce active I checked any selects added by the plugin that don't have styles for text or background. 

<img width="543" alt="Screenshot 2025-06-10 at 16 32 33" src="https://github.com/user-attachments/assets/01b20184-92c8-455b-8299-bc8c5e3fc990" />



Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

https://core.trac.wordpress.org/ticket/63555

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
