### PR TITLE
Twenty Nineteen: Make Mobile nav menu scrollable

### DIFF
--- a/src/wp-content/themes/twentynineteen/sass/navigation/_menu-main-navigation.scss
+++ b/src/wp-content/themes/twentynineteen/sass/navigation/_menu-main-navigation.scss
@@ -433,9 +433,13 @@
 			white-space: inherit;
 		}
 
+		&:not(:has(.sub-menu.expanded-true)) {
+			overflow-y: scroll;
+		}
+
 		&.expanded-true {
 
-			display: table;
+			display: block;
 			margin-top: 0;
 			opacity: 1;
 			padding-left: 0;

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -3271,8 +3271,12 @@ body.page .main-navigation {
   white-space: inherit;
 }
 
+.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu .expanded-true:not(:has(.sub-menu.expanded-true)) {
+  overflow-y: scroll;
+}
+
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true {
-  display: table;
+  display: block;
   margin-top: 0;
   opacity: 1;
   padding-right: 0;
@@ -3282,6 +3286,7 @@ body.page .main-navigation {
   left: 0;
   bottom: 0;
   position: fixed;
+  overflow: scroll;
   z-index: 100000;
   /* Make sure appears above mobile admin bar */
   width: 100vw;

--- a/src/wp-content/themes/twentynineteen/style-rtl.css
+++ b/src/wp-content/themes/twentynineteen/style-rtl.css
@@ -3271,7 +3271,7 @@ body.page .main-navigation {
   white-space: inherit;
 }
 
-.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu .expanded-true:not(:has(.sub-menu.expanded-true)) {
+.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu:not(:has(.sub-menu.expanded-true)) {
   overflow-y: scroll;
 }
 
@@ -3286,7 +3286,6 @@ body.page .main-navigation {
   left: 0;
   bottom: 0;
   position: fixed;
-  overflow: scroll;
   z-index: 100000;
   /* Make sure appears above mobile admin bar */
   width: 100vw;

--- a/src/wp-content/themes/twentynineteen/style.css
+++ b/src/wp-content/themes/twentynineteen/style.css
@@ -3271,8 +3271,12 @@ body.page .main-navigation {
   white-space: inherit;
 }
 
+.main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu:not(:has(.sub-menu.expanded-true)) {
+  overflow-y: scroll;
+}
+
 .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true {
-  display: table;
+  display: block;
   margin-top: 0;
   opacity: 1;
   padding-left: 0;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This PR solves the Trac issue ([#45902](https://core.trac.wordpress.org/ticket/45902)) by adding proper styles for making the mobile nav menu scrollable.

Trac ticket: [https://core.trac.wordpress.org/ticket/45902](https://core.trac.wordpress.org/ticket/45902)


#### Before

https://github.com/user-attachments/assets/2949484d-69d1-4700-84d6-dbc915ab56b0

#### After

https://github.com/user-attachments/assets/995f4cd0-d443-4d4f-b0dc-6bb29ae42bbd


