### PR TITLE
Build/Test Tools: Improve dev environment's CLI in speed, non-interactive usage, and argument handling

### DIFF
--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -155,7 +155,7 @@ jobs:
         run: npm run env:restart
 
       - name: Test a CLI command
-        run: npm run env:cli wp option get siteurl
+        run: npm run env:cli option get siteurl
 
       - name: Test logs command
         run: npm run env:logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,9 @@ services:
     volumes:
       - ./:/var/www
 
+    # Keeps the service alive.
+    command: 'sleep infinity'
+
     # The init directive ensures the command runs with a PID > 1, so Ctrl+C works correctly.
     init: true
 

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
 		"env:clean": "node ./tools/local-env/scripts/docker.js down -v --remove-orphans",
 		"env:reset": "node ./tools/local-env/scripts/docker.js down --rmi all -v --remove-orphans",
 		"env:install": "node ./tools/local-env/scripts/install.js",
-		"env:cli": "node ./tools/local-env/scripts/docker.js run --rm cli",
+		"env:cli": "node ./tools/local-env/scripts/docker.js exec cli wp --allow-root",
 		"env:logs": "node ./tools/local-env/scripts/docker.js logs",
 		"env:pull": "node ./tools/local-env/scripts/docker.js pull",
 		"test:performance": "wp-scripts test-playwright --config tests/performance/playwright.config.js",

--- a/tools/local-env/scripts/docker.js
+++ b/tools/local-env/scripts/docker.js
@@ -2,7 +2,7 @@
 
 const dotenv       = require( 'dotenv' );
 const dotenvExpand = require( 'dotenv-expand' );
-const { execSync } = require( 'child_process' );
+const { spawnSync } = require( 'child_process' );
 const local_env_utils = require( './utils' );
 
 dotenvExpand.expand( dotenv.config() );
@@ -17,7 +17,15 @@ if (process.argv.includes('--coverage-html')) {
 // This try-catch prevents the superfluous Node.js debugging information from being shown if the command fails.
 try {
 	// Execute any Docker compose command passed to this script.
-	execSync( 'docker compose ' + composeFiles + ' ' + process.argv.slice( 2 ).join( ' ' ), { stdio: 'inherit' } );
+	spawnSync(
+		'docker',
+		[
+			'compose',
+			...composeFiles.map( ( composeFile ) => [ '-f', composeFile ] ).flat(),
+			...process.argv.slice( 2 )
+		],
+		{ stdio: 'inherit' }
+	);
 } catch ( error ) {
 	process.exit( 1 );
 }

--- a/tools/local-env/scripts/docker.js
+++ b/tools/local-env/scripts/docker.js
@@ -14,20 +14,17 @@ if ( process.argv.includes( '--coverage-html' ) ) {
 	process.env.LOCAL_PHP_XDEBUG_MODE = 'coverage';
 }
 
-// This try-catch prevents the superfluous Node.js debugging information from being shown if the command fails.
-try {
-	// Execute any Docker compose command passed to this script.
-	spawnSync(
-		'docker',
-		[
-			'compose',
-			...composeFiles
-				.map( ( composeFile ) => [ '-f', composeFile ] )
-				.flat(),
-			...process.argv.slice( 2 ),
-		],
-		{ stdio: 'inherit' }
-	);
-} catch ( error ) {
-	process.exit( 1 );
-}
+// Execute any Docker compose command passed to this script.
+const returns = spawnSync(
+	'docker',
+	[
+		'compose',
+		...composeFiles
+			.map( ( composeFile ) => [ '-f', composeFile ] )
+			.flat(),
+		...process.argv.slice( 2 ),
+	],
+	{ stdio: 'inherit' }
+);
+
+process.exit( returns.status );

--- a/tools/local-env/scripts/docker.js
+++ b/tools/local-env/scripts/docker.js
@@ -14,6 +14,12 @@ if ( process.argv.includes( '--coverage-html' ) ) {
 	process.env.LOCAL_PHP_XDEBUG_MODE = 'coverage';
 }
 
+// Add --no-TTY (-T) arg after exec and run commands when STDIN is not a TTY.
+const dockerCommand = process.argv.slice( 2 );
+if ( [ 'exec', 'run' ].includes( dockerCommand[0] ) && ! process.stdin.isTTY ) {
+	dockerCommand.splice( 1, 0, '--no-TTY' );
+}
+
 // Execute any Docker compose command passed to this script.
 const returns = spawnSync(
 	'docker',
@@ -22,7 +28,7 @@ const returns = spawnSync(
 		...composeFiles
 			.map( ( composeFile ) => [ '-f', composeFile ] )
 			.flat(),
-		...process.argv.slice( 2 ),
+		...dockerCommand,
 	],
 	{ stdio: 'inherit' }
 );

--- a/tools/local-env/scripts/docker.js
+++ b/tools/local-env/scripts/docker.js
@@ -1,3 +1,5 @@
+/* jshint node:true */
+
 const dotenv       = require( 'dotenv' );
 const dotenvExpand = require( 'dotenv-expand' );
 const { execSync } = require( 'child_process' );

--- a/tools/local-env/scripts/docker.js
+++ b/tools/local-env/scripts/docker.js
@@ -1,6 +1,6 @@
 /* jshint node:true */
 
-const dotenv       = require( 'dotenv' );
+const dotenv = require( 'dotenv' );
 const dotenvExpand = require( 'dotenv-expand' );
 const { spawnSync } = require( 'child_process' );
 const local_env_utils = require( './utils' );
@@ -9,7 +9,7 @@ dotenvExpand.expand( dotenv.config() );
 
 const composeFiles = local_env_utils.get_compose_files();
 
-if (process.argv.includes('--coverage-html')) {
+if ( process.argv.includes( '--coverage-html' ) ) {
 	process.env.LOCAL_PHP_XDEBUG = 'true';
 	process.env.LOCAL_PHP_XDEBUG_MODE = 'coverage';
 }
@@ -21,8 +21,10 @@ try {
 		'docker',
 		[
 			'compose',
-			...composeFiles.map( ( composeFile ) => [ '-f', composeFile ] ).flat(),
-			...process.argv.slice( 2 )
+			...composeFiles
+				.map( ( composeFile ) => [ '-f', composeFile ] )
+				.flat(),
+			...process.argv.slice( 2 ),
 		],
 		{ stdio: 'inherit' }
 	);

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -15,9 +15,6 @@ local_env_utils.determine_auth_option();
 // Create wp-config.php.
 wp_cli( `config create --dbname=wordpress_develop --dbuser=root --dbpass=password --dbhost=mysql --force --config-file="wp-config.php"` );
 
-// Since WP-CLI runs as root, the wp-config.php created above will be read-only. This needs to be writable for the sake of E2E tests.
-execSync( 'node ./tools/local-env/scripts/docker.js exec cli chmod 666 wp-config.php' );
-
 // Add the debug settings to wp-config.php.
 // Windows requires this to be done as an additional step, rather than using the --extra-php option in the previous step.
 wp_cli( `config set WP_DEBUG ${process.env.LOCAL_WP_DEBUG} --raw --type=constant` );

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -61,7 +61,5 @@ wait_on( {
  * @param {string} cmd The WP-CLI command to run.
  */
 function wp_cli( cmd ) {
-	const composeFiles = local_env_utils.get_compose_files();
-
-	execSync( `docker compose ${composeFiles} exec cli wp --allow-root ${cmd} --path=/var/www/${process.env.LOCAL_DIR}`, { stdio: 'inherit' } );
+	execSync( `npm --silent run env:cli -- ${cmd} --path=/var/www/${process.env.LOCAL_DIR}`, { stdio: 'inherit' } );
 }

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -63,5 +63,5 @@ wait_on( {
 function wp_cli( cmd ) {
 	const composeFiles = local_env_utils.get_compose_files();
 
-	execSync( `docker compose ${composeFiles} run --quiet-pull --rm cli ${cmd} --path=/var/www/${process.env.LOCAL_DIR}`, { stdio: 'inherit' } );
+	execSync( `docker compose ${composeFiles} exec cli wp --allow-root ${cmd} --path=/var/www/${process.env.LOCAL_DIR}`, { stdio: 'inherit' } );
 }

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -6,7 +6,6 @@ const wait_on = require( 'wait-on' );
 const { execSync } = require( 'child_process' );
 const { readFileSync, writeFileSync } = require( 'fs' );
 const local_env_utils = require( './utils' );
-const fs = require('fs');
 
 dotenvExpand.expand( dotenv.config() );
 
@@ -16,8 +15,8 @@ local_env_utils.determine_auth_option();
 // Create wp-config.php.
 wp_cli( `config create --dbname=wordpress_develop --dbuser=root --dbpass=password --dbhost=mysql --force --config-file="wp-config.php"` );
 
-// Make sure wp-config.php is writable for the sake of E2E tests.
-fs.chmodSync( 'wp-config.php', 0o666 );
+// Since WP-CLI runs as root, the wp-config.php created above will be read-only. This needs to be writable for the sake of E2E tests.
+execSync( 'node ./tools/local-env/scripts/docker.js exec cli chmod 666 wp-config.php' );
 
 // Add the debug settings to wp-config.php.
 // Windows requires this to be done as an additional step, rather than using the --extra-php option in the previous step.

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -6,6 +6,7 @@ const wait_on = require( 'wait-on' );
 const { execSync } = require( 'child_process' );
 const { readFileSync, writeFileSync } = require( 'fs' );
 const local_env_utils = require( './utils' );
+const fs = require('fs');
 
 dotenvExpand.expand( dotenv.config() );
 
@@ -13,7 +14,10 @@ dotenvExpand.expand( dotenv.config() );
 local_env_utils.determine_auth_option();
 
 // Create wp-config.php.
-wp_cli( `config create --dbname=wordpress_develop --dbuser=root --dbpass=password --dbhost=mysql --force --config-file=${process.env.LOCAL_DIR}/../wp-config.php` );
+wp_cli( `config create --dbname=wordpress_develop --dbuser=root --dbpass=password --dbhost=mysql --force --config-file="wp-config.php"` );
+
+// Make sure wp-config.php is writable for the sake of E2E tests.
+fs.chmodSync( 'wp-config.php', 0o666 );
 
 // Add the debug settings to wp-config.php.
 // Windows requires this to be done as an additional step, rather than using the --extra-php option in the previous step.

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -61,5 +61,7 @@ wait_on( {
  * @param {string} cmd The WP-CLI command to run.
  */
 function wp_cli( cmd ) {
-	execSync( `npm --silent run env:cli -- ${cmd} --path=/var/www/${process.env.LOCAL_DIR}`, { stdio: 'inherit' } );
+	const composeFiles = local_env_utils.get_compose_files();
+
+	execSync( `docker compose ${composeFiles} run --quiet-pull --rm cli ${cmd} --path=/var/www/${process.env.LOCAL_DIR}`, { stdio: 'inherit' } );
 }

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -61,7 +61,5 @@ wait_on( {
  * @param {string} cmd The WP-CLI command to run.
  */
 function wp_cli( cmd ) {
-	const composeFiles = local_env_utils.get_compose_files();
-
-	execSync( `docker compose ${composeFiles} run --quiet-pull --rm cli ${cmd} --path=/var/www/${process.env.LOCAL_DIR}`, { stdio: 'inherit' } );
+	execSync( `npm --silent run env:cli -- ${cmd} --path=/var/www/${process.env.LOCAL_DIR}`, { stdio: 'inherit' } );
 }

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -15,6 +15,9 @@ local_env_utils.determine_auth_option();
 // Create wp-config.php.
 wp_cli( `config create --dbname=wordpress_develop --dbuser=root --dbpass=password --dbhost=mysql --force --config-file="wp-config.php"` );
 
+// Since WP-CLI runs as root, the wp-config.php created above will be read-only. This needs to be writable for the sake of E2E tests.
+execSync( 'node ./tools/local-env/scripts/docker.js exec cli chmod 666 wp-config.php' );
+
 // Add the debug settings to wp-config.php.
 // Windows requires this to be done as an additional step, rather than using the --extra-php option in the previous step.
 wp_cli( `config set WP_DEBUG ${process.env.LOCAL_WP_DEBUG} --raw --type=constant` );

--- a/tools/local-env/scripts/start.js
+++ b/tools/local-env/scripts/start.js
@@ -30,7 +30,7 @@ try {
 }
 
 // Start the local-env containers.
-const containers = [ 'wordpress-develop' ];
+const containers = [ 'wordpress-develop', 'cli' ];
 if ( process.env.LOCAL_PHP_MEMCACHED === 'true' ) {
 	containers.push( 'memcached' );
 }

--- a/tools/local-env/scripts/start.js
+++ b/tools/local-env/scripts/start.js
@@ -1,3 +1,5 @@
+/* jshint node:true */
+
 const dotenv       = require( 'dotenv' );
 const dotenvExpand = require( 'dotenv-expand' );
 const { execSync } = require( 'child_process' );
@@ -5,7 +7,7 @@ const local_env_utils = require( './utils' );
 const { constants, copyFile } = require( 'node:fs' );
 
 // Copy the default .env file when one is not present.
-copyFile( '.env.example', '.env', constants.COPYFILE_EXCL, (e) => {
+copyFile( '.env.example', '.env', constants.COPYFILE_EXCL, () => {
 	console.log( '.env file already exists. .env.example was not copied.' );
 });
 
@@ -28,15 +30,16 @@ try {
 }
 
 // Start the local-env containers.
-const containers = ( process.env.LOCAL_PHP_MEMCACHED === 'true' )
-	? 'wordpress-develop memcached'
-	: 'wordpress-develop';
-execSync( `docker compose ${composeFiles} up --quiet-pull -d ${containers}`, { stdio: 'inherit' } );
+const containers = [ 'wordpress-develop' ];
+if ( process.env.LOCAL_PHP_MEMCACHED === 'true' ) {
+	containers.push( 'memcached' );
+}
+execSync( `docker compose ${composeFiles} up --quiet-pull -d ${containers.join( ' ' )}`, { stdio: 'inherit' } );
 
 // If Docker Toolbox is being used, we need to manually forward LOCAL_PORT to the Docker VM.
 if ( process.env.DOCKER_TOOLBOX_INSTALL_PATH ) {
 	// VBoxManage is added to the PATH on every platform except Windows.
-	const vboxmanage = process.env.VBOX_MSI_INSTALL_PATH ? `${ process.env.VBOX_MSI_INSTALL_PATH }/VBoxManage` : 'VBoxManage'
+	const vboxmanage = process.env.VBOX_MSI_INSTALL_PATH ? `${ process.env.VBOX_MSI_INSTALL_PATH }/VBoxManage` : 'VBoxManage';
 
 	// Check if the port forwarding is already configured for this port.
 	const vminfoBuffer = execSync( `"${ vboxmanage }" showvminfo "${ process.env.DOCKER_MACHINE_NAME }" --machinereadable` );

--- a/tools/local-env/scripts/start.js
+++ b/tools/local-env/scripts/start.js
@@ -2,7 +2,7 @@
 
 const dotenv       = require( 'dotenv' );
 const dotenvExpand = require( 'dotenv-expand' );
-const { execSync } = require( 'child_process' );
+const { execSync, spawnSync } = require( 'child_process' );
 const local_env_utils = require( './utils' );
 const { constants, copyFile } = require( 'node:fs' );
 
@@ -34,7 +34,19 @@ const containers = [ 'wordpress-develop', 'cli' ];
 if ( process.env.LOCAL_PHP_MEMCACHED === 'true' ) {
 	containers.push( 'memcached' );
 }
-execSync( `docker compose ${composeFiles} up --quiet-pull -d ${containers.join( ' ' )}`, { stdio: 'inherit' } );
+
+spawnSync(
+	'docker',
+	[
+		'compose',
+		...composeFiles.map( ( composeFile ) => [ '-f', composeFile ] ).flat(),
+		'up',
+		'--quiet-pull',
+		'-d',
+		...containers,
+	],
+	{ stdio: 'inherit' }
+);
 
 // If Docker Toolbox is being used, we need to manually forward LOCAL_PORT to the Docker VM.
 if ( process.env.DOCKER_TOOLBOX_INSTALL_PATH ) {
@@ -42,7 +54,14 @@ if ( process.env.DOCKER_TOOLBOX_INSTALL_PATH ) {
 	const vboxmanage = process.env.VBOX_MSI_INSTALL_PATH ? `${ process.env.VBOX_MSI_INSTALL_PATH }/VBoxManage` : 'VBoxManage';
 
 	// Check if the port forwarding is already configured for this port.
-	const vminfoBuffer = execSync( `"${ vboxmanage }" showvminfo "${ process.env.DOCKER_MACHINE_NAME }" --machinereadable` );
+	const vminfoBuffer = spawnSync(
+		vboxmanage,
+		[
+			'showvminfo',
+			process.env.DOCKER_MACHINE_NAME,
+			'--machinereadable'
+		]
+	).stdout;
 	const vminfo = vminfoBuffer.toString().split( /[\r\n]+/ );
 
 	vminfo.forEach( ( info ) => {
@@ -56,10 +75,29 @@ if ( process.env.DOCKER_TOOLBOX_INSTALL_PATH ) {
 
 		// Delete rules that are using the port we need.
 		if ( rule[ 3 ] === process.env.LOCAL_PORT || rule[ 5 ] === process.env.LOCAL_PORT ) {
-			execSync( `"${ vboxmanage }" controlvm "${ process.env.DOCKER_MACHINE_NAME }" natpf1 delete ${ rule[ 0 ] }`, { stdio: 'inherit' } );
+			spawnSync(
+				vboxmanage,
+				[
+					'controlvm',
+					process.env.DOCKER_MACHINE_NAME,
+					'natpf1',
+					'delete',
+					rule[ 0 ]
+				],
+				{ stdio: 'inherit' }
+			);
 		}
 	} );
 
 	// Add our port forwarding rule.
-	execSync( `"${ vboxmanage }" controlvm "${ process.env.DOCKER_MACHINE_NAME }" natpf1 "tcp-port${ process.env.LOCAL_PORT },tcp,127.0.0.1,${ process.env.LOCAL_PORT },,${ process.env.LOCAL_PORT }"`, { stdio: 'inherit' } );
+	spawnSync(
+		vboxmanage,
+		[
+			'controlvm',
+			process.env.DOCKER_MACHINE_NAME,
+			'natpf1',
+			`tcp-port${ process.env.LOCAL_PORT },tcp,127.0.0.1,${ process.env.LOCAL_PORT },,${ process.env.LOCAL_PORT }`
+		],
+		{ stdio: 'inherit' }
+	);
 }

--- a/tools/local-env/scripts/utils.js
+++ b/tools/local-env/scripts/utils.js
@@ -1,3 +1,5 @@
+/* jshint node:true */
+
 const { existsSync } = require( 'node:fs' );
 
 const local_env_utils = {

--- a/tools/local-env/scripts/utils.js
+++ b/tools/local-env/scripts/utils.js
@@ -12,12 +12,14 @@ const local_env_utils = {
 	 *
 	 * When PHP 7.2 or 7.3 is used in combination with MySQL 8.4, an override file will also be returned to ensure
 	 * that the mysql_native_password plugin authentication plugin is on and available for use.
+	 *
+	 * @return {string[]} Compose files.
 	 */
 	get_compose_files: function() {
-		var composeFiles = '-f docker-compose.yml';
+		const composeFiles = [ 'docker-compose.yml' ];
 
 		if ( existsSync( 'docker-compose.override.yml' ) ) {
-			composeFiles = composeFiles + ' -f docker-compose.override.yml';
+			composeFiles.push( 'docker-compose.override.yml' );
 		}
 
 		if ( process.env.LOCAL_DB_TYPE !== 'mysql' ) {
@@ -30,7 +32,7 @@ const local_env_utils = {
 
 		// PHP 7.2/7.3 in combination with MySQL 8.4 requires additional configuration to function properly.
 		if ( process.env.LOCAL_DB_VERSION === '8.4' ) {
-			composeFiles = composeFiles + ' -f tools/local-env/old-php-mysql-84.override.yml';
+			composeFiles.push( 'tools/local-env/old-php-mysql-84.override.yml' );
 		}
 
 		return composeFiles;


### PR DESCRIPTION
Build/Test Tools: Improve dev environment's CLI in speed, non-interactive usage, and argument handling.

* Start `cli` container when running `env:start`. This greatly speeds up calls to WP-CLI since the container is already running rather than having to start up for each call. 
* Facilitate calls to `env:cli` in non-interactive context (non-TTY) to allow piping content into commands or use in shell scripts.
* Fix passing arguments to WP-CLI from `env:cli` so that arguments with spaces are passed as expected.
* Fix JSHint issues.

This aligns the wordpress-develop environment closer to wp-env. See https://github.com/WordPress/gutenberg/pull/50007.

Props westonruter, jorbin, SirLouen, sandeepdahiya.
Fixes #63564.

----

Trac ticket: https://core.trac.wordpress.org/ticket/63564

# Running `env:install`

## Before

```
$ time npm run env:install

> WordPress@6.9.0 env:install
> node ./tools/local-env/scripts/install.js

[+] Creating 2/2
 ✔ Container wordpress-develop-mysql-1  Running                                                                                                                                0.0s 
 ✔ Container wordpress-develop-php-1    Running                                                                                                                                0.0s 
Success: Generated 'wp-config.php' file.
[+] Creating 2/2
 ✔ Container wordpress-develop-php-1    Running                                                                                                                                0.0s 
 ✔ Container wordpress-develop-mysql-1  Running                                                                                                                                0.0s 
Success: Updated the constant 'WP_DEBUG' in the 'wp-config.php' file with the raw value 'true'.
[+] Creating 2/2
 ✔ Container wordpress-develop-php-1    Running                                                                                                                                0.0s 
 ✔ Container wordpress-develop-mysql-1  Running                                                                                                                                0.0s 
Success: Added the constant 'WP_DEBUG_LOG' to the 'wp-config.php' file with the raw value 'true'.
[+] Creating 2/2
 ✔ Container wordpress-develop-mysql-1  Running                                                                                                                                0.0s 
 ✔ Container wordpress-develop-php-1    Running                                                                                                                                0.0s 
Success: Added the constant 'WP_DEBUG_DISPLAY' to the 'wp-config.php' file with the raw value 'true'.
[+] Creating 2/2
 ✔ Container wordpress-develop-mysql-1  Running                                                                                                                                0.0s 
 ✔ Container wordpress-develop-php-1    Running                                                                                                                                0.0s 
Success: Added the constant 'SCRIPT_DEBUG' to the 'wp-config.php' file with the raw value 'true'.
[+] Creating 2/2
 ✔ Container wordpress-develop-mysql-1  Running                                                                                                                                0.0s 
 ✔ Container wordpress-develop-php-1    Running                                                                                                                                0.0s 
Success: Added the constant 'WP_ENVIRONMENT_TYPE' to the 'wp-config.php' file with the value 'local'.
[+] Creating 2/2
 ✔ Container wordpress-develop-php-1    Running                                                                                                                                0.0s 
 ✔ Container wordpress-develop-mysql-1  Running                                                                                                                                0.0s 
Success: Added the constant 'WP_DEVELOPMENT_MODE' to the 'wp-config.php' file with the value 'core'.
[+] Creating 2/2
 ✔ Container wordpress-develop-mysql-1  Running                                                                                                                                0.0s 
 ✔ Container wordpress-develop-php-1    Running                                                                                                                                0.0s 
Success: Database reset.
[+] Creating 2/2
 ✔ Container wordpress-develop-php-1    Running                                                                                                                                0.0s 
 ✔ Container wordpress-develop-mysql-1  Running                                                                                                                                0.0s 
Success: WordPress installed successfully.

real    0m14.993s
user    0m0.681s
sys     0m0.399s
```

## After

```
$ time npm run env:install

> WordPress@6.9.0 env:install
> node ./tools/local-env/scripts/install.js

Success: Generated 'wp-config.php' file.
Success: Updated the constant 'WP_DEBUG' in the 'wp-config.php' file with the raw value 'true'.
Success: Added the constant 'WP_DEBUG_LOG' to the 'wp-config.php' file with the raw value 'true'.
Success: Added the constant 'WP_DEBUG_DISPLAY' to the 'wp-config.php' file with the raw value 'true'.
Success: Added the constant 'SCRIPT_DEBUG' to the 'wp-config.php' file with the raw value 'true'.
Success: Added the constant 'WP_ENVIRONMENT_TYPE' to the 'wp-config.php' file with the value 'local'.
Success: Added the constant 'WP_DEVELOPMENT_MODE' to the 'wp-config.php' file with the value 'core'.
Success: Database reset.
Success: WordPress installed successfully.

real    0m4.018s
user    0m0.598s
sys     0m0.334s
```

# Running a single WP-CLI command

## Before

```
$ time npm run env:cli post list

> WordPress@6.9.0 env:cli
> node ./tools/local-env/scripts/docker.js run --rm cli post list

[+] Creating 2/2
 ✔ Container wordpress-develop-php-1    Running                                                                                                                                0.0s 
 ✔ Container wordpress-develop-mysql-1  Running                                                                                                                                0.0s 
+----+--------------+-------------+---------------------+-------------+
| ID | post_title   | post_name   | post_date           | post_status |
+----+--------------+-------------+---------------------+-------------+
| 1  | Hello world! | hello-world | 2025-06-09 22:03:24 | publish     |
+----+--------------+-------------+---------------------+-------------+

real    0m2.074s
user    0m0.125s
sys     0m0.108s
```

## After

```
$ time npm run env:cli post list

> WordPress@6.9.0 env:cli
> node ./tools/local-env/scripts/docker.js exec cli wp --allow-root post list

+----+--------------+-------------+---------------------+-------------+
| ID | post_title   | post_name   | post_date           | post_status |
+----+--------------+-------------+---------------------+-------------+
| 1  | Hello world! | hello-world | 2025-06-09 22:03:24 | publish     |
+----+--------------+-------------+---------------------+-------------+

real    0m0.682s
user    0m0.126s
sys     0m0.059s
```

# Passing an argument with spaces to WP-CLI

## Before

```
$ time npm --silent run env:cli option set blogname "WordPress Develop"
[+] Creating 2/2
 ✔ Container wordpress-develop-php-1    Running                                                                                                                                0.0s 
 ✔ Container wordpress-develop-mysql-1  Running                                                                                                                                0.0s 
Error: Too many positional arguments: Develop


real    0m1.818s
user    0m0.137s
sys     0m0.071s
```

## After

```
$ time npm --silent run env:cli option set blogname "WordPress Develop"
Success: Value passed for 'blogname' option is unchanged.

real    0m0.773s
user    0m0.117s
sys     0m0.095s
```

# Passing data to WP-CLI via STDIN

## Before

```
$ echo "WP Develop" | time npm --silent run env:cli -- option set blogname 
[+] Creating 2/2
 ✔ Container wordpress-develop-mysql-1  Running                                                                                                                                0.0s 
 ✔ Container wordpress-develop-php-1    Running                                                                                                                                0.0s 
the input device is not a TTY
        0.22 real         0.12 user         0.05 sys
```

## After

```
$ echo "WP Develop" | time npm --silent run env:cli -- option set blogname
Success: Updated 'blogname' option.
        0.81 real         0.11 user         0.09 sys
```

# Calling WP-CLI from shell script

Given a `watch.sh` script that runs PHP unit tests for the `comment` group whenever a couple of the comments PHP files are modified:

```bash
fswatch tests/phpunit/tests/comment/commentForm.php src/wp-includes/comment-template.php | while read -r modified_file; do
	clear
	echo "Modified file: $modified_file"
	npm --silent run test:php -- --group=comment
done
```

## Before

```
$ ./watch.sh
Modified file: /Users/westonruter/repos/wordpress-develop/tests/phpunit/tests/comment/commentForm.php
the input device is not a TTY
```

## After


```
$ ./watch.sh
Modified file: /Users/westonruter/repos/wordpress-develop/tests/phpunit/tests/comment/commentForm.php
Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.
PHPUnit 9.6.23 by Sebastian Bergmann and contributors.

Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

...............................................................  63 / 510 ( 12%)
............................................................... 126 / 510 ( 24%)
............................................................... 189 / 510 ( 37%)
............................................................... 252 / 510 ( 49%)
............................................................... 315 / 510 ( 61%)
............................................................... 378 / 510 ( 74%)
............................................................... 441 / 510 ( 86%)
............................................................... 504 / 510 ( 98%)
......                                                          510 / 510 (100%)

Time: 00:03.489, Memory: 195.00 MB

OK (510 tests, 1260 assertions)
```



---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
