### PR TITLE
Feat: Allow `int` type for version in `_WP_Dependency` chain

### DIFF
--- a/src/wp-includes/class-wp-dependencies.php
+++ b/src/wp-includes/class-wp-dependencies.php
@@ -238,19 +238,19 @@ class WP_Dependencies {
 	 * @since 2.1.0
 	 * @since 2.6.0 Moved from `WP_Scripts`.
 	 *
-	 * @param string           $handle Name of the item. Should be unique.
-	 * @param string|false     $src    Full URL of the item, or path of the item relative
-	 *                                 to the WordPress root directory. If source is set to false,
-	 *                                 the item is an alias of other items it depends on.
-	 * @param string[]         $deps   Optional. An array of registered item handles this item depends on.
-	 *                                 Default empty array.
-	 * @param string|bool|null $ver    Optional. String specifying item version number, if it has one,
-	 *                                 which is added to the URL as a query string for cache busting purposes.
-	 *                                 If version is set to false, a version number is automatically added
-	 *                                 equal to current installed WordPress version.
-	 *                                 If set to null, no version is added.
-	 * @param mixed            $args   Optional. Custom property of the item. NOT the class property $args.
-	 *                                 Examples: $media, $in_footer.
+	 * @param string               $handle Name of the item. Should be unique.
+	 * @param string|false         $src    Full URL of the item, or path of the item relative
+	 *                                     to the WordPress root directory. If source is set to false,
+	 *                                     the item is an alias of other items it depends on.
+	 * @param string[]             $deps   Optional. An array of registered item handles this item depends on.
+	 *                                     Default empty array.
+	 * @param string|int|bool|null $ver    Optional. String or Integer specifying item version number, if it has one,
+	 *                                     which is added to the URL as a query string for cache busting purposes.
+	 *                                     If version is set to false, a version number is automatically added
+	 *                                     equal to current installed WordPress version.
+	 *                                     If set to null, no version is added.
+	 * @param mixed                $args   Optional. Custom property of the item. NOT the class property $args.
+	 *                                     Examples: $media, $in_footer.
 	 * @return bool Whether the item has been registered. True on success, false on failure.
 	 */
 	public function add( $handle, $src, $deps = array(), $ver = false, $args = null ) {

--- a/src/wp-includes/class-wp-dependency.php
+++ b/src/wp-includes/class-wp-dependency.php
@@ -50,7 +50,7 @@ class _WP_Dependency {
 	 * Used for cache-busting.
 	 *
 	 * @since 2.6.0
-	 * @var bool|string
+	 * @var bool|string|int
 	 */
 	public $ver = false;
 

--- a/src/wp-includes/functions.wp-scripts.php
+++ b/src/wp-includes/functions.wp-scripts.php
@@ -159,15 +159,18 @@ function wp_add_inline_script( $handle, $data, $position = 'after' ) {
  * @since 4.3.0 A return value was added.
  * @since 6.3.0 The $in_footer parameter of type boolean was overloaded to be an $args parameter of type array.
  *
- * @param string           $handle    Name of the script. Should be unique.
- * @param string|false     $src       Full URL of the script, or path of the script relative to the WordPress root directory.
- *                                    If source is set to false, script is an alias of other scripts it depends on.
- * @param string[]         $deps      Optional. An array of registered script handles this script depends on. Default empty array.
- * @param string|bool|null $ver       Optional. String specifying script version number, if it has one, which is added to the URL
- *                                    as a query string for cache busting purposes. If version is set to false, a version
- *                                    number is automatically added equal to current installed WordPress version.
- *                                    If set to null, no version is added.
- * @param array|bool       $args     {
+ * @param string               $handle    Name of the script. Should be unique.
+ * @param string|false         $src       Full URL of the script, or path of the script relative to the WordPress
+ *                                        root directory.
+ *                                        If source is set to false, script is an alias of other scripts it depends on.
+ * @param string[]             $deps      Optional. An array of registered script handles this script depends on.
+ *                                        Default empty array.
+ * @param string|int|bool|null $ver       Optional. String or Integer specifying script version number, if it has one, which is
+ *                                        added to the URL as a query string for cache busting purposes. If version
+ *                                        is set to false, a version number is automatically added equal to current
+ *                                        installed WordPress version.
+ *                                        If set to null, no version is added.
+ * @param array|bool           $args      {
  *     Optional. An array of additional script loading strategies. Default empty array.
  *     Otherwise, it may be a boolean in which case it determines whether the script is printed in the footer. Default false.
  *
@@ -340,17 +343,20 @@ function wp_deregister_script( $handle ) {
  * @since 2.1.0
  * @since 6.3.0 The $in_footer parameter of type boolean was overloaded to be an $args parameter of type array.
  *
- * @param string           $handle    Name of the script. Should be unique.
- * @param string           $src       Full URL of the script, or path of the script relative to the WordPress root directory.
- *                                    Default empty.
- * @param string[]         $deps      Optional. An array of registered script handles this script depends on. Default empty array.
- * @param string|bool|null $ver       Optional. String specifying script version number, if it has one, which is added to the URL
- *                                    as a query string for cache busting purposes. If version is set to false, a version
- *                                    number is automatically added equal to current installed WordPress version.
- *                                    If set to null, no version is added.
- * @param array|bool       $args     {
+ * @param string               $handle    Name of the script. Should be unique.
+ * @param string               $src       Full URL of the script, or path of the script relative to the WordPress
+ *                                        root directory.
+ *                                        Default empty.
+ * @param string[]             $deps      Optional. An array of registered script handles this script depends on.
+ *                                        Default empty array.
+ * @param string|int|bool|null $ver       Optional. String or Integer specifying script version number, if it has one,
+ *                                        which is added to the URL as a query string for cache busting purposes.
+ *                                        If version is set to false, a version number is automatically added equal
+ *                                        to current installed WordPress version.
+ *                                        If set to null, no version is added.
+ * @param array|bool           $args      {
  *     Optional. An array of additional script loading strategies. Default empty array.
- *     Otherwise, it may be a boolean in which case it determines whether the script is printed in the footer. Default false.
+ *     Otherwise, it may be a boolean in which case it determines whether the script is printed in the footer.Default false.
  *
  *     @type string    $strategy     Optional. If provided, may be either 'defer' or 'async'.
  *     @type bool      $in_footer    Optional. Whether to print the script in the footer. Default 'false'.

--- a/src/wp-includes/functions.wp-styles.php
+++ b/src/wp-includes/functions.wp-styles.php
@@ -113,17 +113,21 @@ function wp_add_inline_style( $handle, $data ) {
  * @since 2.6.0
  * @since 4.3.0 A return value was added.
  *
- * @param string           $handle Name of the stylesheet. Should be unique.
- * @param string|false     $src    Full URL of the stylesheet, or path of the stylesheet relative to the WordPress root directory.
- *                                 If source is set to false, stylesheet is an alias of other stylesheets it depends on.
- * @param string[]         $deps   Optional. An array of registered stylesheet handles this stylesheet depends on. Default empty array.
- * @param string|bool|null $ver    Optional. String specifying stylesheet version number, if it has one, which is added to the URL
- *                                 as a query string for cache busting purposes. If version is set to false, a version
- *                                 number is automatically added equal to current installed WordPress version.
- *                                 If set to null, no version is added.
- * @param string           $media  Optional. The media for which this stylesheet has been defined.
- *                                 Default 'all'. Accepts media types like 'all', 'print' and 'screen', or media queries like
- *                                 '(orientation: portrait)' and '(max-width: 640px)'.
+ * @param string               $handle Name of the stylesheet. Should be unique.
+ * @param string|false         $src    Full URL of the stylesheet, or path of the stylesheet relative to the WordPress
+ *                                     root directory.
+ *                                     If source is set to false, stylesheet is an alias of other stylesheets it
+ *                                     depends on.
+ * @param string[]             $deps   Optional. An array of registered stylesheet handles this stylesheet depends on.
+ *                                     Default empty array.
+ * @param string|int|bool|null $ver    Optional. String or Integer specifying stylesheet version number, if it has
+ *                                     one, which is added to the URL as a query string for cache busting purposes.
+ *                                     If version is set to false, a version number is automatically added
+ *                                     equal to current installed WordPress version.
+ *                                     If set to null, no version is added.
+ * @param string               $media  Optional. The media for which this stylesheet has been defined.
+ *                                     Default 'all'. Accepts media types like 'all', 'print' and 'screen', or media
+ *                                     queries like '(orientation: portrait)' and '(max-width: 640px)'.
  * @return bool Whether the style has been registered. True on success, false on failure.
  */
 function wp_register_style( $handle, $src, $deps = array(), $ver = false, $media = 'all' ) {
@@ -158,17 +162,19 @@ function wp_deregister_style( $handle ) {
  *
  * @since 2.6.0
  *
- * @param string           $handle Name of the stylesheet. Should be unique.
- * @param string           $src    Full URL of the stylesheet, or path of the stylesheet relative to the WordPress root directory.
- *                                 Default empty.
- * @param string[]         $deps   Optional. An array of registered stylesheet handles this stylesheet depends on. Default empty array.
- * @param string|bool|null $ver    Optional. String specifying stylesheet version number, if it has one, which is added to the URL
- *                                 as a query string for cache busting purposes. If version is set to false, a version
- *                                 number is automatically added equal to current installed WordPress version.
- *                                 If set to null, no version is added.
- * @param string           $media  Optional. The media for which this stylesheet has been defined.
- *                                 Default 'all'. Accepts media types like 'all', 'print' and 'screen', or media queries like
- *                                 '(orientation: portrait)' and '(max-width: 640px)'.
+ * @param string               $handle Name of the stylesheet. Should be unique.
+ * @param string               $src    Full URL of the stylesheet, or path of the stylesheet relative to the
+ *                                     WordPress root directory. Default empty.
+ * @param string[]             $deps   Optional. An array of registered stylesheet handles this stylesheet depends on.
+ *                                     Default empty array.
+ * @param string|int|bool|null $ver    Optional. String or Integer specifying stylesheet version number, if it has
+ *                                     one, which is added to the URL as a query string for cache busting purposes.
+ *                                     If version is set to false, a version number is automatically added equal
+ *                                     to current installed WordPress version.
+ *                                     If set to null, no version is added.
+ * @param string               $media  Optional. The media for which this stylesheet has been defined.
+ *                                     Default 'all'. Accepts media types like 'all', 'print' and 'screen', or media
+ *                                     queries like '(orientation: portrait)' and '(max-width: 640px)'.
  */
 function wp_enqueue_style( $handle, $src = '', $deps = array(), $ver = false, $media = 'all' ) {
 	_wp_scripts_maybe_doing_it_wrong( __FUNCTION__, $handle );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63563

- Updated the function doc, to add support for `int` type on `WP_Dependency, WP_Dependencies` classes and `wp_enqueue_script, wp_enqueue_style, wp_register_script, wp_register_style` function.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
