### PR TITLE
Create git patch from saqibsarwar to resolve inner block issue

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1688,9 +1688,14 @@ function get_comment_delimited_block_content( $block_name, $block_attributes, $b
 function serialize_block( $block ) {
 	$block_content = '';
 
-	$index = 0;
 	foreach ( $block['innerContent'] as $chunk ) {
-		$block_content .= is_string( $chunk ) ? $chunk : serialize_block( $block['innerBlocks'][ $index++ ] );
+		if ( is_string( $chunk ) ) {
+			$block_content .= $chunk;
+		} else {
+			foreach ( $block['innerBlocks'] as $inner_block ) {
+				$block_content .= serialize_block( $inner_block );
+			}
+		}
 	}
 
 	if ( ! is_array( $block['attrs'] ) ) {


### PR DESCRIPTION
This PR introduces a fix provided by saqibsarwar 3 years ago or so, ticket attached to the PR. I've created a patch for this and am providing this PR as the issue has become dormant with no further input from the reporter however the solution itself is sound.

### Problem
The original serialize_block() function relied on index-based matching between innerContent and innerBlocks. This approach breaks when there are nested blocks within non-string innerContent elements, leading to incorrect or incomplete serialization of deeply nested structures.

### Solution
The updated serialize_block() function iterates over innerContent and dynamically processes nested innerBlocks without relying on positional indexing. For each non-string chunk in innerContent, it recursively serializes all child innerBlocks, ensuring accurate rendering and output for arbitrarily nested blocks.

### Benefits
Fixes serialization issues for complex/nested block layouts
Removes dependency on matching innerContent and innerBlocks indexes
Ensures consistent and correct block output, especially for custom blocks with dynamic inner structures

Trac ticket: https://core.trac.wordpress.org/ticket/56519

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
