### PR TITLE
Enhance site title validation: add required attribute and error handling for empty input

### DIFF
--- a/src/wp-admin/includes/options.php
+++ b/src/wp-admin/includes/options.php
@@ -3,7 +3,7 @@
  * WordPress Options Administration API.
  *
  * @package WordPress
- * @subpackage Administratio
+ * @subpackage Administration
  * @since 4.4.0
  */
 

--- a/src/wp-admin/includes/options.php
+++ b/src/wp-admin/includes/options.php
@@ -3,7 +3,7 @@
  * WordPress Options Administration API.
  *
  * @package WordPress
- * @subpackage Administration
+ * @subpackage Administratio
  * @since 4.4.0
  */
 

--- a/src/wp-admin/includes/options.php
+++ b/src/wp-admin/includes/options.php
@@ -51,6 +51,47 @@ function options_general_add_js() {
 			$siteIconPreview.text( title );
 		});
 
+		// Site name validation.
+		$( 'form' ).on( 'submit', function(e) {
+			var $blogname = $( '#blogname' );
+			var siteTitle = $.trim( $blogname.val() );
+			
+			// Remove any existing error messages.
+			$( '.site-title-error' ).remove();
+			$blogname.removeClass( 'form-invalid' );
+			
+			// Check if site title is empty.
+			if ( ! siteTitle ) {
+				e.preventDefault();
+				
+				// Add error styling.
+				$blogname.addClass( 'form-invalid' );
+				
+				// Add error message.
+				$blogname.closest( 'td' ).append( 
+					'<p class="site-title-error" style="color: #d63638; margin-top: 5px;">' +
+					'<?php esc_html_e( 'Site title is required and cannot be empty.' ); ?>' +
+					'</p>' 
+				);
+
+				// Focus on the field.
+				$blogname.focus();
+
+				// Scroll to the field.
+				$( 'html, body' ).animate({
+					scrollTop: $blogname.offset().top - 100
+				}, 500);
+				
+				return false;
+			}
+		});
+
+		// Remove error message when user starts typing.
+		$( '#blogname' ).on( 'input', function() {
+			$( '.site-title-error' ).remove();
+			$( this ).removeClass( 'form-invalid' );
+		});
+
 		$( 'input[name="date_format"]' ).on( 'click', function() {
 			if ( 'date_format_custom_radio' !== $(this).attr( 'id' ) )
 				$( 'input[name="date_format_custom"]' ).val( $( this ).val() ).closest( 'fieldset' ).find( '.example' ).text( $( this ).parent( 'label' ).children( '.format-i18n' ).text() );

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -74,7 +74,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 
 <tr>
 <th scope="row"><label for="blogname"><?php _e( 'Site Title' ); ?></label></th>
-<td><input name="blogname" type="text" id="blogname" value="<?php form_option( 'blogname' ); ?>" class="regular-text" /></td>
+<td><input required name="blogname" type="text" id="blogname" value="<?php form_option( 'blogname' ); ?>" class="regular-text" /></td>
 </tr>
 
 <?php


### PR DESCRIPTION
Trac Ticket: https://core.trac.wordpress.org/ticket/63548

---

This PR introduces a **client-side validation mechanism** for the **Site Title (Blog Name)** field on the WordPress General Settings screen (`options-general.php`). The goal is to ensure that site administrators do not leave the field empty, as this has serious implications for:

* SEO performance
* Accessibility (screen readers rely on a proper site name)
* Theme compatibility and proper display
* General user experience

Despite the importance of this field, no validation or instructional guidance currently exists.

### Changes Introduced

#### 1. **HTML Attribute Update in `options-general.php`**

Added the `required` attribute to the `<input>` element for the Site Title field:

```php
<input required name="blogname" type="text" id="blogname" value="<?php form_option( 'blogname' ); ?>" class="regular-text" />
```

This ensures modern browsers offer native validation out of the box.

#### 2. **Custom JavaScript Validation in `options.php`**

Hooked into `admin_head` via:

```php
add_action( 'admin_head', 'options_general_add_js' );
```

Then added jQuery-based validation script to provide enhanced UX and fallback behavior.

**Key logic implemented:**

* Prevent form submission if Site Title is blank.
* Append custom error message styled in red under the field.
* Scroll and focus to the invalid field.
* Remove error state as soon as the user starts typing.

**Validation JS snippet:**

```js
$('form').on('submit', function(e) {
    var $blogname = $('#blogname');
    var siteTitle = $.trim($blogname.val());

    $('.site-title-error').remove();
    $blogname.removeClass('form-invalid');

    if (!siteTitle) {
        e.preventDefault();
        $blogname.addClass('form-invalid');
        $blogname.closest('td').append(
            '<p class="site-title-error" style="color: #d63638; margin-top: 5px;">' +
            '<?php esc_html_e( 'Site title is required and cannot be empty.' ); ?>' +
            '</p>'
        );
        $blogname.focus();
        $('html, body').animate({ scrollTop: $blogname.offset().top - 100 }, 500);
        return false;
    }
});

$('#blogname').on('input', function() {
    $('.site-title-error').remove();
    $(this).removeClass('form-invalid');
});
```

### Why This Is Important

* **No existing warning** or guidance is provided for an empty Site Title.
* The **Tagline** field includes a descriptive example, but Site Title—being more critical—is left unchecked.
* The Site Title is a key component in how search engines and screen readers understand and display your site.
* Misconfigured or empty titles degrade theme outputs and can confuse users.