### PR TITLE
[41604] Modified update_item() to read only POST body parameters thereby handling global query parameters

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
@@ -149,10 +149,10 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 		$params = array_diff_key( $params, $query_params );
 
 		if ( empty( $params ) || ! empty( array_diff_key( $params, $options ) ) ) {
-			$message = empty( $params ) 
+			$message = empty( $params )
 				? __( 'Request body cannot be empty.' )
 				: __( 'Invalid parameter(s) provided.' );
-			
+
 			return new WP_Error(
 				'rest_invalid_param',
 				$message,

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
@@ -145,15 +145,14 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 	public function update_item( $request ) {
 		$options = $this->get_registered_options();
 		$params = $request->get_params();
-		$url_params = $request->get_url_params();
 		$query_params = $request->get_query_params();
-		$params = array_diff_key( $params, $url_params, $query_params );
+		$params = array_diff_key( $params, $query_params );
 
 		if ( empty( $params ) || ! empty( array_diff_key( $params, $options ) ) ) {
-			$message = empty( $params )
+			$message = empty( $params ) 
 				? __( 'Request body cannot be empty.' )
 				: __( 'Invalid parameter(s) provided.' );
-
+			
 			return new WP_Error(
 				'rest_invalid_param',
 				$message,

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
@@ -145,7 +145,7 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 	public function update_item( $request ) {
 		$options = $this->get_registered_options();
 
-		$params = $request->get_params();
+		$params = $request->get_body_params();
 
 		if ( empty( $params ) || ! empty( array_diff_key( $params, $options ) ) ) {
 			$message = empty( $params )

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
@@ -144,14 +144,16 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 	 */
 	public function update_item( $request ) {
 		$options = $this->get_registered_options();
-
-		$params = $request->get_body_params();
+		$params = $request->get_params();
+		$url_params = $request->get_url_params();
+		$query_params = $request->get_query_params();
+		$params = array_diff_key( $params, $url_params, $query_params );
 
 		if ( empty( $params ) || ! empty( array_diff_key( $params, $options ) ) ) {
-			$message = empty( $params )
+			$message = empty( $params ) 
 				? __( 'Request body cannot be empty.' )
 				: __( 'Invalid parameter(s) provided.' );
-
+			
 			return new WP_Error(
 				'rest_invalid_param',
 				$message,

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-settings-controller.php
@@ -150,10 +150,10 @@ class WP_REST_Settings_Controller extends WP_REST_Controller {
 		$params = array_diff_key( $params, $url_params, $query_params );
 
 		if ( empty( $params ) || ! empty( array_diff_key( $params, $options ) ) ) {
-			$message = empty( $params ) 
+			$message = empty( $params )
 				? __( 'Request body cannot be empty.' )
 				: __( 'Invalid parameter(s) provided.' );
-			
+
 			return new WP_Error(
 				'rest_invalid_param',
 				$message,

--- a/tests/phpunit/tests/rest-api/rest-settings-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-settings-controller.php
@@ -397,6 +397,9 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertSame( 400, $response->get_status() );
 	}
 
+	/**
+	 * @ticket 41604
+	 */
 	public function test_update_item() {
 		wp_set_current_user( self::$administrator );
 
@@ -410,6 +413,39 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertSame( get_option( 'blogname' ), $data['title'] );
 	}
 
+	/**
+	 * @ticket 41604
+	 */
+	public function test_update_item_with_global_parameters_present() {
+		wp_set_current_user( self::$administrator );
+
+		$request = new WP_REST_Request( 'PUT', '/wp/v2/settings' );
+		$request->set_param( 'title', 'The new title!' );
+		$request->set_param( '_locale', 'user' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'The new title!', $data['title'] );
+		$this->assertSame( get_option( 'blogname' ), $data['title'] );
+	}
+
+	/**
+	 * @ticket 41604
+	 */
+	public function test_update_item_with_empty_body() {
+		wp_set_current_user( self::$administrator );
+
+		$request  = new WP_REST_Request( 'PUT', '/wp/v2/settings' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * @ticket 41604
+	 */
 	public function test_update_nonexistent_item() {
 		wp_set_current_user( self::$administrator );
 
@@ -420,6 +456,9 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertSame( 400, $response->get_status() );
 	}
 
+	/**
+	 * @ticket 41604
+	 */
 	public function test_update_partially_valid_items() {
 		wp_set_current_user( self::$administrator );
 

--- a/tests/phpunit/tests/rest-api/rest-settings-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-settings-controller.php
@@ -421,7 +421,7 @@ class WP_Test_REST_Settings_Controller extends WP_Test_REST_Controller_Testcase 
 
 		$request = new WP_REST_Request( 'PUT', '/wp/v2/settings' );
 		$request->set_param( 'title', 'The new title!' );
-		$request->set_param( '_locale', 'user' );
+		$request->set_url_params( array( '_locale' => 'user' ) );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/41604

This PR fixes the issue pointed out by @Mamaduka i.e., the API can contain global query parameters, such as _locale, which fail to pass. This is fixed by replacing the $request->get_params(); by  $request->get_body_params()

