### PR TITLE
Add plugin update message hook support to Dashboard > Updates page

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1329,6 +1329,26 @@ ul.cat-checklist input[name="post_category[]"]:indeterminate::before {
 	color: #c3c4c7;
 }
 
+.plugins .plugin-title .update-message .dashicons {
+	float: none;
+	padding: 0;
+	width: auto;
+	height: auto;
+	font-size: 16px;
+	background-color: transparent;
+	box-shadow: none;
+	color: inherit;
+	display: inline;
+	vertical-align: middle;
+}
+.plugins .plugin-title .update-message .dashicons:before {
+	padding: 0;
+	background-color: transparent;
+	box-shadow: none;
+	font-size: 16px;
+	color: inherit;
+}
+
 #update-themes-table .plugin-title img,
 #update-themes-table .plugin-title .dashicons {
 	width: 85px;

--- a/src/wp-admin/update-core.php
+++ b/src/wp-admin/update-core.php
@@ -612,6 +612,50 @@ function list_plugin_updates() {
 
 			echo $upgrade_notice;
 			?>
+		</p>
+
+		<?php
+		ob_start();
+
+		/**
+		 * Fires at the end of the update message container in each
+		 * row of the plugins list table.
+		 *
+		 * The dynamic portion of the hook name, `$plugin_file`, refers to the path
+		 * of the plugin's primary file relative to the plugins directory.
+		 *
+		 * @since 2.8.0
+		 *
+		 * @param array  $plugin_data An array of plugin metadata. See get_plugin_data()
+		 *                            and the {@see 'plugin_row_meta'} filter for the list
+		 *                            of possible values.
+		 * @param object $response {
+		 *     An object of metadata about the available plugin update.
+		 *
+		 *     @type string   $id           Plugin ID, e.g. `w.org/plugins/[plugin-name]`.
+		 *     @type string   $slug         Plugin slug.
+		 *     @type string   $plugin       Plugin basename.
+		 *     @type string   $new_version  New plugin version.
+		 *     @type string   $url          Plugin URL.
+		 *     @type string   $package      Plugin update package URL.
+		 *     @type string[] $icons        An array of plugin icon URLs.
+		 *     @type string[] $banners      An array of plugin banner URLs.
+		 *     @type string[] $banners_rtl  An array of plugin RTL banner URLs.
+		 *     @type string   $requires     The version of WordPress which the plugin requires.
+		 *     @type string   $tested       The version of WordPress the plugin is tested against.
+		 *     @type string   $requires_php The version of PHP which the plugin requires.
+		 * }
+		 */
+		do_action( "in_plugin_update_message-{$plugin_file}", (array) $plugin_data, $plugin_data->update ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+
+		$custom_message = ob_get_clean();
+
+		if ( ! empty( trim( $custom_message ) ) ) {
+			echo '<div class="update-message notice inline notice-warning notice-alt">';
+			echo '<p>' . $custom_message . '</p>';
+			echo '</div>';
+		}
+		?>
 		</p></td>
 	</tr>
 			<?php


### PR DESCRIPTION
Trac Ticket: https://core.trac.wordpress.org/ticket/62543

This PR adds the `in_plugin_update_message-{$file}` hook to `list_plugin_updates()` function in update-core.php
- Custom plugin messages now display in properly styled notice boxes matching WordPress admin patterns
- Added CSS overrides to fix Dashicons display conflicts with existing list-tables.css styles
- Custom plugin warning messages now appear consistently on both plugin management interfaces

### Plugins > Installed Plugins section
<img width="1462" alt="plugin installation" src="https://github.com/user-attachments/assets/2bf29993-1b60-4248-8f92-9a7c552a3f25" />

### Dashboard > Updates page
<img width="1464" alt="Dashboard Update" src="https://github.com/user-attachments/assets/17d6fef0-c330-425c-93fd-840c0cdd669b" />

