### PR TITLE
Fix redirect comparison to account for port difference

### DIFF
--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -600,6 +600,10 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 	// www.example.com vs. example.com
 	$user_home = parse_url( home_url() );
 
+	if ( ! empty( $user_home['scheme'] ) ) {
+		$redirect['scheme'] = $user_home['scheme'];
+	}
+
 	if ( ! empty( $user_home['host'] ) ) {
 		$redirect['host'] = $user_home['host'];
 	}

--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -728,7 +728,7 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 		|| ( 'www.' . $original_host_low !== $redirect_host_low
 			&& 'www.' . $redirect_host_low !== $original_host_low )
 	) {
-		if ( strtolower( $original_port ) === strtolower( $redirect_port ) ) {
+		if ( $original_port === $redirect_port ) {
 			$redirect['host'] = $original['host'];
 		}
 	}

--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -716,16 +716,20 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 
 	$original_host_low = strtolower( $original['host'] );
 	$redirect_host_low = strtolower( $redirect['host'] );
+	$original_port = isset( $original['port'] ) ? strtolower( $original['port'] ) : '80';
+	$redirect_port = isset( $redirect['port'] ) ? strtolower( $redirect['port'] ) : '80';
 
 	/*
 	 * Ignore differences in host capitalization, as this can lead to infinite redirects.
 	 * Only redirect no-www <=> yes-www.
 	 */
 	if ( $original_host_low === $redirect_host_low
-		|| ( 'www.' . $original_host_low !== $redirect_host_low
-			&& 'www.' . $redirect_host_low !== $original_host_low )
+	     || ( 'www.' . $original_host_low !== $redirect_host_low
+	          && 'www.' . $redirect_host_low !== $original_host_low )
 	) {
-		$redirect['host'] = $original['host'];
+		if ( strtolower( $original_port ) === strtolower( $redirect_port ) ) {
+			$redirect['host'] = $original['host'];
+		}
 	}
 
 	$compare_original = array( $original['host'], $original['path'] );

--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -725,16 +725,22 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 	$redirect_port = isset( $redirect['port'] ) ? strtolower( $redirect['port'] ) : '80';
 
 	/*
-	 * Ignore differences in host capitalization, as this can lead to infinite redirects.
-	 * Only redirect no-www <=> yes-www.
+	 * Preserve original host casing if the hostnames are identical (ignoring case),
+	 * or differ in a way that is not just a www <=> non-www variation,
+	 * and the port is the same.
+	 *
+	 * This prevents unnecessary redirects and avoids redirect loops due to host casing,
+	 * but still allows canonical redirects between www and non-www variants.
 	 */
-	if ( $original_host_low === $redirect_host_low
-		|| ( 'www.' . $original_host_low !== $redirect_host_low
-			&& 'www.' . $redirect_host_low !== $original_host_low )
+	if (
+		$original_host_low === $redirect_host_low
+		|| (
+			'www.' . $original_host_low !== $redirect_host_low
+			&& 'www.' . $redirect_host_low !== $original_host_low
+			&& $original_port === $redirect_port
+		)
 	) {
-		if ( $original_port === $redirect_port ) {
-			$redirect['host'] = $original['host'];
-		}
+		$redirect['host'] = $original['host'];
 	}
 
 	$compare_original = array( $original['host'], $original['path'] );

--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -716,6 +716,7 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 
 	$original_host_low = strtolower( $original['host'] );
 	$redirect_host_low = strtolower( $redirect['host'] );
+
 	$original_port = isset( $original['port'] ) ? strtolower( $original['port'] ) : '80';
 	$redirect_port = isset( $redirect['port'] ) ? strtolower( $redirect['port'] ) : '80';
 
@@ -724,8 +725,8 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 	 * Only redirect no-www <=> yes-www.
 	 */
 	if ( $original_host_low === $redirect_host_low
-	     || ( 'www.' . $original_host_low !== $redirect_host_low
-	          && 'www.' . $redirect_host_low !== $original_host_low )
+		|| ( 'www.' . $original_host_low !== $redirect_host_low
+			&& 'www.' . $redirect_host_low !== $original_host_low )
 	) {
 		if ( strtolower( $original_port ) === strtolower( $redirect_port ) ) {
 			$redirect['host'] = $original['host'];

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -545,4 +545,29 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 			),
 		);
 	}
+	public function test_redirect_non_standard_localhost_port_to_canonical_domain() {
+		update_option( 'home', 'http://example.com' );
+		update_option( 'siteurl', 'http://example.com' );
+
+		// Simulate a request to a non-canonical domain
+		$_SERVER['HTTP_HOST'] = 'localhost:10020';
+		$_SERVER['REQUEST_URI'] = '/';
+
+		$redirect = redirect_canonical( 'http://localhost:10018/', false );
+
+		$this->assertSame( 'http://example.com/', $redirect );
+	}
+
+	public function test_redirect_non_standard_localhost_port_to_canonical_domain_with_ssl() {
+		update_option( 'home', 'https://example.com' );
+		update_option( 'siteurl', 'https://example.com' );
+
+		// Simulate a request to a non-canonical domain
+		$_SERVER['HTTP_HOST'] = 'localhost:10020';
+		$_SERVER['REQUEST_URI'] = '/';
+
+		$redirect = redirect_canonical( 'http://localhost:10018/', false );
+
+		$this->assertSame( 'https://example.com/', $redirect );
+	}
 }

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -584,6 +584,19 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 		$this->assertNull( $redirect );
 	}
 
+	public function test_different_host_casing_with_port_redirect_without_host_change() {
+		update_option( 'home', 'http://example.com:8080' );
+		update_option( 'siteurl', 'http://example.com:8080' );
+
+		// Simulate a request to a non-canonical domain
+		$_SERVER['HTTP_HOST']   = 'Example.com:10200';
+		$_SERVER['REQUEST_URI'] = '/';
+
+		$redirect = redirect_canonical( 'http://Example.com:10200/', false );
+
+		$this->assertSame( 'http://Example.com:8080/', $redirect );
+	}
+
 	public function test_redirect_www_to_non_www() {
 		update_option( 'home', 'http://example.com' );
 		update_option( 'siteurl', 'http://example.com' );
@@ -608,5 +621,18 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 		$redirect = redirect_canonical( 'http://example.com/', false );
 
 		$this->assertSame( 'http://www.example.com/', $redirect );
+	}
+
+	public function test_redirect_port_for_same_host() {
+		update_option( 'home', 'http://example.com:8080' );
+		update_option( 'siteurl', 'http://example.com:8080' );
+
+		// Simulate a request to a non-canonical domain
+		$_SERVER['HTTP_HOST']   = 'example.com:10200';
+		$_SERVER['REQUEST_URI'] = '/';
+
+		$redirect = redirect_canonical( 'http://example.com:10200/', false );
+
+		$this->assertSame( 'http://example.com:8080/', $redirect );
 	}
 }

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -556,18 +556,13 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 	 *
 	 * @param string $home_url      The home URL to set.
 	 * @param string $site_url      The site URL to set.
-	 * @param string $request_host  The HTTP_HOST to simulate.
 	 * @param string $request_url   The URL to test redirection for.
 	 * @param string $expected_url  The expected redirect URL, or null if no redirect.
 	 * @param string $failure_msg   The message to display on test failure.
 	 */
-	public function test_domain_and_port_redirections( $home_url, $site_url, $request_host, $request_url, $expected_url, $failure_msg ) {
+	public function test_domain_and_port_redirections( $home_url, $site_url, $request_url, $expected_url, $failure_msg ) {
 		update_option( 'home', $home_url );
 		update_option( 'siteurl', $site_url );
-
-		// Simulate a request to a non-canonical domain.
-		$_SERVER['HTTP_HOST']   = $request_host;
-		$_SERVER['REQUEST_URI'] = '/';
 
 		$redirect = redirect_canonical( $request_url, false );
 
@@ -580,7 +575,6 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 	 * @return array[] {
 	 *     @type string $home_url      The home URL to set.
 	 *     @type string $site_url      The site URL to set.
-	 *     @type string $request_host  The HTTP_HOST to simulate.
 	 *     @type string $request_url   The URL to test redirection for.
 	 *     @type string $expected_url  The expected redirect URL, or null if no redirect.
 	 *     @type string $failure_msg   The message to display on test failure.
@@ -591,7 +585,6 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 			'non-standard localhost port to canonical domain' => array(
 				'home_url'     => 'http://example.com',
 				'site_url'     => 'http://example.com',
-				'request_host' => 'localhost:10020',
 				'request_url'  => 'http://localhost:10020/',
 				'expected_url' => 'http://example.com/',
 				'failure_msg'  => 'Failed to redirect non-standard localhost port to canonical domain',
@@ -599,7 +592,6 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 			'non-standard localhost port to canonical domain with SSL' => array(
 				'home_url'     => 'https://example.com',
 				'site_url'     => 'https://example.com',
-				'request_host' => 'localhost:10020',
 				'request_url'  => 'http://localhost:10020/',
 				'expected_url' => 'https://example.com/',
 				'failure_msg'  => 'Failed to redirect non-standard localhost port to canonical domain with SSL',
@@ -607,7 +599,6 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 			'different host casing do not redirect' => array(
 				'home_url'     => 'http://example.com',
 				'site_url'     => 'http://example.com',
-				'request_host' => 'Example.com',
 				'request_url'  => 'http://Example.com/',
 				'expected_url' => null,
 				'failure_msg'  => 'Should not redirect when only host casing differs',
@@ -615,7 +606,6 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 			'different host casing with port redirect without host change' => array(
 				'home_url'     => 'http://example.com:8080',
 				'site_url'     => 'http://example.com:8080',
-				'request_host' => 'Example.com:10200',
 				'request_url'  => 'http://Example.com:10200/',
 				'expected_url' => 'http://Example.com:8080/',
 				'failure_msg'  => 'Failed to redirect to correct port while preserving host casing',
@@ -623,7 +613,6 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 			'www to non-www'                        => array(
 				'home_url'     => 'http://example.com',
 				'site_url'     => 'http://example.com',
-				'request_host' => 'www.example.com',
 				'request_url'  => 'http://www.example.com/',
 				'expected_url' => 'http://example.com/',
 				'failure_msg'  => 'Failed to redirect www to non-www domain',
@@ -631,7 +620,6 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 			'non-www to www'                        => array(
 				'home_url'     => 'http://www.example.com',
 				'site_url'     => 'http://www.example.com',
-				'request_host' => 'example.com',
 				'request_url'  => 'http://example.com/',
 				'expected_url' => 'http://www.example.com/',
 				'failure_msg'  => 'Failed to redirect non-www to www domain',
@@ -639,7 +627,6 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 			'port for same host'                    => array(
 				'home_url'     => 'http://example.com:8080',
 				'site_url'     => 'http://example.com:8080',
-				'request_host' => 'example.com:10200',
 				'request_url'  => 'http://example.com:10200/',
 				'expected_url' => 'http://example.com:8080/',
 				'failure_msg'  => 'Failed to redirect to correct port for same host',

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -570,4 +570,43 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 
 		$this->assertSame( 'https://example.com/', $redirect );
 	}
+
+	public function test_different_host_casing_do_not_redirect() {
+		update_option( 'home', 'http://example.com' );
+		update_option( 'siteurl', 'http://example.com' );
+
+		// Simulate a request to a non-canonical domain
+		$_SERVER['HTTP_HOST']   = 'Example.com';
+		$_SERVER['REQUEST_URI'] = '/';
+
+		$redirect = redirect_canonical( 'http://Example.com/', false );
+
+		$this->assertNull( $redirect );
+	}
+
+	public function test_redirect_www_to_non_www() {
+		update_option( 'home', 'http://example.com' );
+		update_option( 'siteurl', 'http://example.com' );
+
+		// Simulate a request to a non-canonical domain
+		$_SERVER['HTTP_HOST']   = 'www.example.com';
+		$_SERVER['REQUEST_URI'] = '/';
+
+		$redirect = redirect_canonical( 'http://www.example.com/', false );
+
+		$this->assertSame( 'http://example.com/', $redirect );
+	}
+
+	public function test_redirect_non_www_to_www() {
+		update_option( 'home', 'http://www.example.com' );
+		update_option( 'siteurl', 'http://www.example.com' );
+
+		// Simulate a request to a non-canonical domain
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['REQUEST_URI'] = '/';
+
+		$redirect = redirect_canonical( 'http://example.com/', false );
+
+		$this->assertSame( 'http://www.example.com/', $redirect );
+	}
 }

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -545,94 +545,105 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 			),
 		);
 	}
-	public function test_redirect_non_standard_localhost_port_to_canonical_domain() {
-		update_option( 'home', 'http://example.com' );
-		update_option( 'siteurl', 'http://example.com' );
 
-		// Simulate a request to a non-canonical domain
-		$_SERVER['HTTP_HOST']   = 'localhost:10020';
+	/**
+	 * Test domain and port redirections.
+	 *
+	 * @ticket 33821
+	 * @dataProvider data_domain_and_port_redirections
+	 *
+	 * @covers ::redirect_canonical
+	 *
+	 * @param string $home_url      The home URL to set.
+	 * @param string $site_url      The site URL to set.
+	 * @param string $request_host  The HTTP_HOST to simulate.
+	 * @param string $request_url   The URL to test redirection for.
+	 * @param string $expected_url  The expected redirect URL, or null if no redirect.
+	 * @param string $failure_msg   The message to display on test failure.
+	 */
+	public function test_domain_and_port_redirections( $home_url, $site_url, $request_host, $request_url, $expected_url, $failure_msg ) {
+		update_option( 'home', $home_url );
+		update_option( 'siteurl', $site_url );
+
+		// Simulate a request to a non-canonical domain.
+		$_SERVER['HTTP_HOST']   = $request_host;
 		$_SERVER['REQUEST_URI'] = '/';
 
-		$redirect = redirect_canonical( 'http://localhost:10018/', false );
+		$redirect = redirect_canonical( $request_url, false );
 
-		$this->assertSame( 'http://example.com/', $redirect );
+		$this->assertSame( $expected_url, $redirect, $failure_msg );
 	}
 
-	public function test_redirect_non_standard_localhost_port_to_canonical_domain_with_ssl() {
-		update_option( 'home', 'https://example.com' );
-		update_option( 'siteurl', 'https://example.com' );
-
-		// Simulate a request to a non-canonical domain
-		$_SERVER['HTTP_HOST']   = 'localhost:10020';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$redirect = redirect_canonical( 'http://localhost:10018/', false );
-
-		$this->assertSame( 'https://example.com/', $redirect );
-	}
-
-	public function test_different_host_casing_do_not_redirect() {
-		update_option( 'home', 'http://example.com' );
-		update_option( 'siteurl', 'http://example.com' );
-
-		// Simulate a request to a non-canonical domain
-		$_SERVER['HTTP_HOST']   = 'Example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$redirect = redirect_canonical( 'http://Example.com/', false );
-
-		$this->assertNull( $redirect );
-	}
-
-	public function test_different_host_casing_with_port_redirect_without_host_change() {
-		update_option( 'home', 'http://example.com:8080' );
-		update_option( 'siteurl', 'http://example.com:8080' );
-
-		// Simulate a request to a non-canonical domain
-		$_SERVER['HTTP_HOST']   = 'Example.com:10200';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$redirect = redirect_canonical( 'http://Example.com:10200/', false );
-
-		$this->assertSame( 'http://Example.com:8080/', $redirect );
-	}
-
-	public function test_redirect_www_to_non_www() {
-		update_option( 'home', 'http://example.com' );
-		update_option( 'siteurl', 'http://example.com' );
-
-		// Simulate a request to a non-canonical domain
-		$_SERVER['HTTP_HOST']   = 'www.example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$redirect = redirect_canonical( 'http://www.example.com/', false );
-
-		$this->assertSame( 'http://example.com/', $redirect );
-	}
-
-	public function test_redirect_non_www_to_www() {
-		update_option( 'home', 'http://www.example.com' );
-		update_option( 'siteurl', 'http://www.example.com' );
-
-		// Simulate a request to a non-canonical domain
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$redirect = redirect_canonical( 'http://example.com/', false );
-
-		$this->assertSame( 'http://www.example.com/', $redirect );
-	}
-
-	public function test_redirect_port_for_same_host() {
-		update_option( 'home', 'http://example.com:8080' );
-		update_option( 'siteurl', 'http://example.com:8080' );
-
-		// Simulate a request to a non-canonical domain
-		$_SERVER['HTTP_HOST']   = 'example.com:10200';
-		$_SERVER['REQUEST_URI'] = '/';
-
-		$redirect = redirect_canonical( 'http://example.com:10200/', false );
-
-		$this->assertSame( 'http://example.com:8080/', $redirect );
+	/**
+	 * Data provider for test_domain_and_port_redirections().
+	 *
+	 * @return array[] {
+	 *     @type string $home_url      The home URL to set.
+	 *     @type string $site_url      The site URL to set.
+	 *     @type string $request_host  The HTTP_HOST to simulate.
+	 *     @type string $request_url   The URL to test redirection for.
+	 *     @type string $expected_url  The expected redirect URL, or null if no redirect.
+	 *     @type string $failure_msg   The message to display on test failure.
+	 * }
+	 */
+	public function data_domain_and_port_redirections() {
+		return array(
+			'non-standard localhost port to canonical domain' => array(
+				'home_url'     => 'http://example.com',
+				'site_url'     => 'http://example.com',
+				'request_host' => 'localhost:10020',
+				'request_url'  => 'http://localhost:10020/',
+				'expected_url' => 'http://example.com/',
+				'failure_msg'  => 'Failed to redirect non-standard localhost port to canonical domain',
+			),
+			'non-standard localhost port to canonical domain with SSL' => array(
+				'home_url'     => 'https://example.com',
+				'site_url'     => 'https://example.com',
+				'request_host' => 'localhost:10020',
+				'request_url'  => 'http://localhost:10020/',
+				'expected_url' => 'https://example.com/',
+				'failure_msg'  => 'Failed to redirect non-standard localhost port to canonical domain with SSL',
+			),
+			'different host casing do not redirect' => array(
+				'home_url'     => 'http://example.com',
+				'site_url'     => 'http://example.com',
+				'request_host' => 'Example.com',
+				'request_url'  => 'http://Example.com/',
+				'expected_url' => null,
+				'failure_msg'  => 'Should not redirect when only host casing differs',
+			),
+			'different host casing with port redirect without host change' => array(
+				'home_url'     => 'http://example.com:8080',
+				'site_url'     => 'http://example.com:8080',
+				'request_host' => 'Example.com:10200',
+				'request_url'  => 'http://Example.com:10200/',
+				'expected_url' => 'http://Example.com:8080/',
+				'failure_msg'  => 'Failed to redirect to correct port while preserving host casing',
+			),
+			'www to non-www'                        => array(
+				'home_url'     => 'http://example.com',
+				'site_url'     => 'http://example.com',
+				'request_host' => 'www.example.com',
+				'request_url'  => 'http://www.example.com/',
+				'expected_url' => 'http://example.com/',
+				'failure_msg'  => 'Failed to redirect www to non-www domain',
+			),
+			'non-www to www'                        => array(
+				'home_url'     => 'http://www.example.com',
+				'site_url'     => 'http://www.example.com',
+				'request_host' => 'example.com',
+				'request_url'  => 'http://example.com/',
+				'expected_url' => 'http://www.example.com/',
+				'failure_msg'  => 'Failed to redirect non-www to www domain',
+			),
+			'port for same host'                    => array(
+				'home_url'     => 'http://example.com:8080',
+				'site_url'     => 'http://example.com:8080',
+				'request_host' => 'example.com:10200',
+				'request_url'  => 'http://example.com:10200/',
+				'expected_url' => 'http://example.com:8080/',
+				'failure_msg'  => 'Failed to redirect to correct port for same host',
+			),
+		);
 	}
 }

--- a/tests/phpunit/tests/canonical.php
+++ b/tests/phpunit/tests/canonical.php
@@ -550,7 +550,7 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 		update_option( 'siteurl', 'http://example.com' );
 
 		// Simulate a request to a non-canonical domain
-		$_SERVER['HTTP_HOST'] = 'localhost:10020';
+		$_SERVER['HTTP_HOST']   = 'localhost:10020';
 		$_SERVER['REQUEST_URI'] = '/';
 
 		$redirect = redirect_canonical( 'http://localhost:10018/', false );
@@ -563,7 +563,7 @@ class Tests_Canonical extends WP_Canonical_UnitTestCase {
 		update_option( 'siteurl', 'https://example.com' );
 
 		// Simulate a request to a non-canonical domain
-		$_SERVER['HTTP_HOST'] = 'localhost:10020';
+		$_SERVER['HTTP_HOST']   = 'localhost:10020';
 		$_SERVER['REQUEST_URI'] = '/';
 
 		$redirect = redirect_canonical( 'http://localhost:10018/', false );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Fix redirect comparison to account for port difference to ensure redirects from a requested URL that uses port to a canonical URL that doesn't use port work correctly.

Trac ticket: https://core.trac.wordpress.org/ticket/33821

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
