### PR TITLE
Canonical redirects disallow tag named comments. Refresh for 39535.diff

### DIFF
--- a/src/wp-includes/canonical.php
+++ b/src/wp-includes/canonical.php
@@ -445,10 +445,15 @@ function redirect_canonical( $requested_url = null, $do_redirect = true ) {
 			) {
 				// Strip off any existing paging.
 				$redirect['path'] = preg_replace( "#/$wp_rewrite->pagination_base/?[0-9]+?(/+)?$#", '/', $redirect['path'] );
-				// Strip off feed endings.
-				$redirect['path'] = preg_replace( '#/(comments/?)?(feed|rss2?|rdf|atom)(/+|$)#', '/', $redirect['path'] );
 				// Strip off any existing comment paging.
 				$redirect['path'] = preg_replace( "#/{$wp_rewrite->comments_pagination_base}-[0-9]+?(/+)?$#", '/', $redirect['path'] );
+				// Only strip comments/ from comment feed on site
+				if ( $redirect['path'] == preg_replace( '#(https?:)?//[^/]+#', '', get_feed_link( 'comments_rss2' ) ) ) {
+					$redirect['path'] = preg_replace( '#/(comments/)(feed|rss2?|rdf|atom)(/+|$)#', '/', $redirect['path'] );
+				} else {
+					// Strip off feed endings
+					$redirect['path'] = preg_replace( '#/(feed|rss2?|rdf|atom)(/+|$)#', '/', $redirect['path'] );
+				}
 			}
 
 			$addl_path    = '';

--- a/tests/phpunit/tests/canonical/feeds.php
+++ b/tests/phpunit/tests/canonical/feeds.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @group canonical
+ */
+class Tests_Canonical_Feeds extends WP_Canonical_UnitTestCase {
+	public $structure = '/%postname%/';
+
+	public static $posts = array();
+
+	public static function wpSetUpBeforeClass( $factory ) {
+
+		self::$posts[0] = $factory->post->create( array( 'post_name' => 'post0' ) );
+
+		$c1 = self::factory()->tag->create_and_get(
+			array(
+				'name' => 'Comments',
+				'slug' => 'comments',
+			)
+		);
+
+		$c2 = self::factory()->tag->create_and_get(
+			array(
+				'name' => 'Test Tag',
+				'slug' => 'test',
+			)
+		);
+
+		wp_set_object_terms( self::$posts[0], array( $c1->slug, $c2->slug ), 'post_tag' );
+	}
+
+	/**
+	 * @ticket 39535
+	 *
+	 * @dataProvider data_canonical_feed
+	 */
+	public function test_canonical_feed( $test_url, $expected, $ticket = 0, $expected_doing_it_wrong = array() ) {
+		global $wp;
+		if ( $ticket ) {
+			$this->knownWPBug( $ticket );
+		}
+
+		$this->go_to( $test_url );
+
+		$query_vars = array_diff( $wp->query_vars, $wp->extra_query_vars );
+
+		$this->assertEquals( $expected, $query_vars );
+	}
+
+	public function data_canonical_feed() {
+		/* Data format:
+		 * [0]: Test URL.
+		 * [1]: array( expected query vars to be set )
+		 * [2]: (optional) The ticket the test refers to, Can be skipped if unknown.
+		 */
+
+		return array(
+			// posts feed for tag 'comments'
+			array(
+				'/tag/comments/feed/',
+				array(
+					'tag'  => 'comments',
+					'feed' => 'feed',
+				),
+				39535,
+			),
+
+			// posts feed for tag 'test'
+			array(
+				'/tag/test/feed/',
+				array(
+					'tag'  => 'test',
+					'feed' => 'feed',
+				),
+			),
+
+			// comments feed entire site
+			array(
+				'/comments/feed/',
+				array(
+					'withcomments' => '1',
+					'feed'         => 'feed',
+				),
+			),
+
+		);
+	}
+}


### PR DESCRIPTION
This patch is not working. Unit Tests not passing. Needs more work.

Trac ticket: https://core.trac.wordpress.org/ticket/39535

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
