### PR TITLE
Fix: WP_Font_Face: Font names that contain single quotes are not wrapped in double quotes

### DIFF
--- a/src/wp-includes/fonts/class-wp-font-face.php
+++ b/src/wp-includes/fonts/class-wp-font-face.php
@@ -346,6 +346,25 @@ class WP_Font_Face {
 
 		return $font_face;
 	}
+	/**
+	 * Wraps font-family in quotes if needed.
+	 *
+	 * @since 6.x.x
+	 *
+	 * @param string $item Font-family name.
+	 * @return string Quoted font-family if needed.
+	 */
+	
+	private function maybe_add_quotes( $item ) {
+		$regex = '/^(?!generic\([a-zA-Z\-]+\)$)(?!^[a-zA-Z\-]+$).+/';
+		$item  = trim( $item );
+		if ( preg_match( $regex, $item ) ) {
+			$item = trim( $item, "\"'" );
+			return '"' . $item . '"';
+		}
+		return $item;
+	}
+
 
 	/**
 	 * Builds the font-family's CSS.
@@ -362,13 +381,7 @@ class WP_Font_Face {
 		 * Wrap font-family in quotes if it contains spaces
 		 * and is not already wrapped in quotes.
 		 */
-		if (
-			str_contains( $font_face['font-family'], ' ' ) &&
-			! str_contains( $font_face['font-family'], '"' ) &&
-			! str_contains( $font_face['font-family'], "'" )
-		) {
-			$font_face['font-family'] = '"' . $font_face['font-family'] . '"';
-		}
+		$font_face['font-family'] = self::maybe_add_quotes( $font_face['font-family'] );
 
 		foreach ( $font_face as $key => $value ) {
 			// Compile the "src" parameter.

--- a/src/wp-includes/fonts/class-wp-font-face.php
+++ b/src/wp-includes/fonts/class-wp-font-face.php
@@ -346,24 +346,7 @@ class WP_Font_Face {
 
 		return $font_face;
 	}
-	/**
-	 * Wraps font-family in quotes if needed.
-	 *
-	 * @since 6.x.x
-	 *
-	 * @param string $item Font-family name.
-	 * @return string Quoted font-family if needed.
-	 */
-	private function maybe_add_quotes( $item ) {
-		$regex = '/^(?!generic\([a-zA-Z\-]+\)$)(?!^[a-zA-Z\-]+$).+/';
-		$item  = trim( $item );
-		if ( preg_match( $regex, $item ) ) {
-			$item = trim( $item, "\"'" );
-			return '"' . $item . '"';
-		}
-		return $item;
-	}
-
+	
 	/**
 	 * Builds the font-family's CSS.
 	 *
@@ -379,7 +362,7 @@ class WP_Font_Face {
 		 * Wrap font-family in quotes if it contains spaces
 		 * and is not already wrapped in quotes.
 		 */
-		$font_face['font-family'] = self::maybe_add_quotes( $font_face['font-family'] );
+		$font_face['font-family'] = WP_Font_Utils::maybe_add_quotes( $font_face['font-family'] );
 
 		foreach ( $font_face as $key => $value ) {
 			// Compile the "src" parameter.

--- a/src/wp-includes/fonts/class-wp-font-face.php
+++ b/src/wp-includes/fonts/class-wp-font-face.php
@@ -346,7 +346,7 @@ class WP_Font_Face {
 
 		return $font_face;
 	}
-	
+
 	/**
 	 * Builds the font-family's CSS.
 	 *
@@ -362,7 +362,7 @@ class WP_Font_Face {
 		 * Wrap font-family in quotes if it contains spaces
 		 * and is not already wrapped in quotes.
 		 */
-		$font_face['font-family'] = WP_Font_Utils::maybe_add_quotes( $font_face['font-family'] );
+		$font_face['font-family'] = WP_Font_Utils::normalize_css_font_family_name( $font_face['font-family'] );
 
 		foreach ( $font_face as $key => $value ) {
 			// Compile the "src" parameter.

--- a/src/wp-includes/fonts/class-wp-font-face.php
+++ b/src/wp-includes/fonts/class-wp-font-face.php
@@ -354,7 +354,6 @@ class WP_Font_Face {
 	 * @param string $item Font-family name.
 	 * @return string Quoted font-family if needed.
 	 */
-	
 	private function maybe_add_quotes( $item ) {
 		$regex = '/^(?!generic\([a-zA-Z\-]+\)$)(?!^[a-zA-Z\-]+$).+/';
 		$item  = trim( $item );
@@ -364,7 +363,6 @@ class WP_Font_Face {
 		}
 		return $item;
 	}
-
 
 	/**
 	 * Builds the font-family's CSS.

--- a/src/wp-includes/fonts/class-wp-font-face.php
+++ b/src/wp-includes/fonts/class-wp-font-face.php
@@ -362,7 +362,7 @@ class WP_Font_Face {
 		 * Wrap font-family in quotes if it contains spaces
 		 * and is not already wrapped in quotes.
 		 */
-		$font_face['font-family'] = WP_Font_Utils::normalize_quoted_font_family_name( $font_face['font-family'] );
+		$font_face['font-family'] = WP_Font_Utils::maybe_add_quotes( $font_face['font-family'] );
 
 		foreach ( $font_face as $key => $value ) {
 			// Compile the "src" parameter.

--- a/src/wp-includes/fonts/class-wp-font-face.php
+++ b/src/wp-includes/fonts/class-wp-font-face.php
@@ -362,7 +362,7 @@ class WP_Font_Face {
 		 * Wrap font-family in quotes if it contains spaces
 		 * and is not already wrapped in quotes.
 		 */
-		$font_face['font-family'] = WP_Font_Utils::maybe_add_quotes( $font_face['font-family'] );
+		$font_face['font-family'] = WP_Font_Utils::normalize_quoted_font_family_name( $font_face['font-family'] );
 
 		foreach ( $font_face as $key => $value ) {
 			// Compile the "src" parameter.

--- a/src/wp-includes/fonts/class-wp-font-utils.php
+++ b/src/wp-includes/fonts/class-wp-font-utils.php
@@ -29,7 +29,7 @@ class WP_Font_Utils {
 	 * @param string $item A font family name.
 	 * @return string The font family name with surrounding quotes, if necessary.
 	 */
-	private static function maybe_add_quotes( $item ) {
+	public static function maybe_add_quotes( $item ) {
 		// Matches strings that are not exclusively alphabetic characters or hyphens, and do not exactly follow the pattern generic(alphabetic characters or hyphens).
 		$regex = '/^(?!generic\([a-zA-Z\-]+\)$)(?!^[a-zA-Z\-]+$).+/';
 		$item  = trim( $item );

--- a/src/wp-includes/fonts/class-wp-font-utils.php
+++ b/src/wp-includes/fonts/class-wp-font-utils.php
@@ -29,7 +29,7 @@ class WP_Font_Utils {
 	 * @param string $item A font family name.
 	 * @return string The font family name with surrounding quotes, if necessary.
 	 */
-	public static function maybe_add_quotes( $item ) {
+	public static function normalize_css_font_family_name( $item ) {
 		// Matches strings that are not exclusively alphabetic characters or hyphens, and do not exactly follow the pattern generic(alphabetic characters or hyphens).
 		$regex = '/^(?!generic\([a-zA-Z\-]+\)$)(?!^[a-zA-Z\-]+$).+/';
 		$item  = trim( $item );
@@ -67,14 +67,14 @@ class WP_Font_Utils {
 		if ( str_contains( $output, ',' ) ) {
 			$items = explode( ',', $output );
 			foreach ( $items as $item ) {
-				$formatted_item = self::maybe_add_quotes( $item );
+				$formatted_item = self::normalize_css_font_family_name( $item );
 				if ( ! empty( $formatted_item ) ) {
 					$formatted_items[] = $formatted_item;
 				}
 			}
 			return implode( ', ', $formatted_items );
 		}
-		return self::maybe_add_quotes( $output );
+		return self::normalize_css_font_family_name( $output );
 	}
 
 	/**

--- a/src/wp-includes/fonts/class-wp-font-utils.php
+++ b/src/wp-includes/fonts/class-wp-font-utils.php
@@ -29,15 +29,12 @@ class WP_Font_Utils {
 	 * @param string $item A font family name.
 	 * @return string The font family name with surrounding quotes, if necessary.
 	 */
-	public static function normalize_quoted_font_family_name( $item ) {
+	public static function maybe_add_quotes( $item ) {
 		// Matches strings that are not exclusively alphabetic characters or hyphens, and do not exactly follow the pattern generic(alphabetic characters or hyphens).
 		$regex = '/^(?!generic\([a-zA-Z\-]+\)$)(?!^[a-zA-Z\-]+$).+/';
 		$item  = trim( $item );
 		if ( preg_match( $regex, $item ) ) {
 			$item = trim( $item, "\"'" );
-			$item = str_replace( [ "\r\n", "\r", "\n" ], '\\A', $item );
-			$item = str_replace( '\\', '\\\\', $item );
-			$item = str_replace( '"', '\\"', $item );
 			return '"' . $item . '"';
 		}
 		return $item;
@@ -70,14 +67,14 @@ class WP_Font_Utils {
 		if ( str_contains( $output, ',' ) ) {
 			$items = explode( ',', $output );
 			foreach ( $items as $item ) {
-				$formatted_item = self::normalize_quoted_font_family_name( $item );
+				$formatted_item = self::maybe_add_quotes( $item );
 				if ( ! empty( $formatted_item ) ) {
 					$formatted_items[] = $formatted_item;
 				}
 			}
 			return implode( ', ', $formatted_items );
 		}
-		return self::normalize_quoted_font_family_name( $output );
+		return self::maybe_add_quotes( $output );
 	}
 
 	/**

--- a/src/wp-includes/fonts/class-wp-font-utils.php
+++ b/src/wp-includes/fonts/class-wp-font-utils.php
@@ -29,12 +29,15 @@ class WP_Font_Utils {
 	 * @param string $item A font family name.
 	 * @return string The font family name with surrounding quotes, if necessary.
 	 */
-	public static function maybe_add_quotes( $item ) {
+	public static function normalize_quoted_font_family_name( $item ) {
 		// Matches strings that are not exclusively alphabetic characters or hyphens, and do not exactly follow the pattern generic(alphabetic characters or hyphens).
 		$regex = '/^(?!generic\([a-zA-Z\-]+\)$)(?!^[a-zA-Z\-]+$).+/';
 		$item  = trim( $item );
 		if ( preg_match( $regex, $item ) ) {
 			$item = trim( $item, "\"'" );
+			$item = str_replace( [ "\r\n", "\r", "\n" ], '\\A', $item );
+			$item = str_replace( '\\', '\\\\', $item );
+			$item = str_replace( '"', '\\"', $item );
 			return '"' . $item . '"';
 		}
 		return $item;
@@ -67,14 +70,14 @@ class WP_Font_Utils {
 		if ( str_contains( $output, ',' ) ) {
 			$items = explode( ',', $output );
 			foreach ( $items as $item ) {
-				$formatted_item = self::maybe_add_quotes( $item );
+				$formatted_item = self::normalize_quoted_font_family_name( $item );
 				if ( ! empty( $formatted_item ) ) {
 					$formatted_items[] = $formatted_item;
 				}
 			}
 			return implode( ', ', $formatted_items );
 		}
-		return self::maybe_add_quotes( $output );
+		return self::normalize_quoted_font_family_name( $output );
 	}
 
 	/**


### PR DESCRIPTION
I have created a patch for the following Trac ticket:
Trac ticket: https://core.trac.wordpress.org/ticket/63568

Details for the bug reproduction can be [found here](https://core.trac.wordpress.org/ticket/63568).

In this patch, the quotes are added by using the logic of `maybe_add_quotes `method in the `build_font_face_css `function.

The comparison of input and output before the patch and after the patch is:
![Patch comparison](https://github.com/user-attachments/assets/937a3473-9721-4e23-a04b-14ecb4ee01f7)

Here is the before patch (bug reproduction video):-
https://github.com/user-attachments/assets/d93736c0-d410-46da-84fa-38900f843471

After patch (test report video):-
https://github.com/user-attachments/assets/4a610657-5c09-4de1-92a2-f161c9910812

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
