### PR TITLE
Twenty Eleven: Fix quote block editor styles to match front end styles

### DIFF
--- a/src/wp-content/themes/twentyeleven/editor-blocks.css
+++ b/src/wp-content/themes/twentyeleven/editor-blocks.css
@@ -272,6 +272,10 @@ p.has-drop-cap:not(:focus)::first-letter {
 	padding: 0;
 }
 
+.wp-block-quote em, .wp-block-quote i, .wp-block-quote cite {
+	font-style: normal;
+}
+
 .edit-post-visual-editor .editor-block-list__block .wp-block-quote p,
 .editor-styles-wrapper .wp-block-quote p {
 	font-family: Georgia, "Bitstream Charter", serif;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: [https://core.trac.wordpress.org/ticket/55063](https://core.trac.wordpress.org/ticket/55063)

Match Editor and Frontend style when Italicizing text in quote block.

### Before:

![Screenshot 2025-06-16 at 2 18 17 PM](https://github.com/user-attachments/assets/3a595f32-20fc-4108-b696-d82818b91313)

### After: 

![Screenshot 2025-06-16 at 2 18 05 PM](https://github.com/user-attachments/assets/fe738ec9-ffd3-4ce5-b891-a3838be5145d)

