### PR TITLE
Fix: excessive vertical spacing in sidebar metadata on Edit Media screen (mobile view)

### DIFF
--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -1997,7 +1997,7 @@ table.links-table {
 	}
 
 	.misc-pub-section {
-		padding: 10px;
+		padding: 15px 10px;
 	}
 
 	#delete-action,

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -1997,7 +1997,7 @@ table.links-table {
 	}
 
 	.misc-pub-section {
-		padding: 10px 10px;
+		padding: 10px;
 	}
 
 	#delete-action,

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -1997,7 +1997,7 @@ table.links-table {
 	}
 
 	.misc-pub-section {
-		padding: 20px 10px;
+		padding: 10px 10px;
 	}
 
 	#delete-action,


### PR DESCRIPTION
Trac Ticket:

Core-63571

## Description

This PR addresses a UI issue in the WordPress admin area on the Edit Media screen (/wp-admin/post.php?post=<id>&action=edit), where the right-hand sidebar (.misc-pub-section) exhibits excessive and uneven vertical spacing between metadata items when viewed on smaller screen widths.

## Problem

- On mobile devices or narrow screens, .misc-pub-section items have a 20px vertical padding.

```
.misc-pub-section {
    padding: 20px 10px;
}
```
## Solution

- Reduced vertical padding for .misc-pub-section from 20px to 10px on mobile screen widths.

```
.misc-pub-section {
    padding: 10px 10px;
}
``` 

This aligns the vertical spacing with mobile UI best practices and ensures a more compact, user-friendly display on smaller screens.

## Screenshots

<table>
    <tr>
        <th>Before</th>
        <th>After</th>
    </tr>
    <tr>
        <td><img width="295" alt="Screenshot 2025-06-16 at 10 50 31 PM" src="https://github.com/user-attachments/assets/1089d16b-5af8-4535-bce5-246fcd220990" /></td>
        <td><img width="294" alt="Screenshot 2025-06-16 at 10 50 14 PM" src="https://github.com/user-attachments/assets/e13ed70a-f0e6-4065-b47f-1c483a197544" /></td>
    </tr>
</table>