### PR TITLE
get_post_galleries() : Avoid a PHP Warning when an image block doesn't contain an ID.

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5298,12 +5298,17 @@ function get_post_galleries( $post, $html = true ) {
 			// New Gallery block format as an array.
 			if ( $has_inner_blocks ) {
 				$attrs = wp_list_pluck( $block['innerBlocks'], 'attrs' );
-				$ids   = wp_list_pluck( $attrs, 'id' );
 
-				foreach ( $ids as $id ) {
-					$url = wp_get_attachment_url( $id );
+				$ids = array();
+				foreach ( $attrs as $attr ) {
+					if ( isset( $attr['id'] ) ) {
+						continue;
+					}
 
-					if ( is_string( $url ) && ! in_array( $url, $srcs, true ) ) {
+					$ids[] = $attr['id'];
+					$url   = wp_get_attachment_url( $attr['id'] );
+
+					if ( $url && ! in_array( $url, $srcs, true ) ) {
 						$srcs[] = $url;
 					}
 				}

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5301,7 +5301,7 @@ function get_post_galleries( $post, $html = true ) {
 
 				$ids = array();
 				foreach ( $attrs as $attr ) {
-					if ( isset( $attr['id'] ) ) {
+					if ( ! isset( $attr['id'] ) ) {
 						continue;
 					}
 


### PR DESCRIPTION

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63577 <!-- insert a link to the WordPress Trac ticket here --> 

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
