### PR TITLE
FEAT: Add support to print script modules in the footer.

### DIFF
--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -215,7 +215,7 @@ class WP_Script_Modules {
 		foreach ( $this->get_marked_for_enqueue() as $id => $script_module ) {
 
 			// If the script module is marked for printing in the footer, skip it.
-			if( isset( $script_module[ 'in_footer' ] ) && true === $script_module[ 'in_footer']){
+			if ( isset( $script_module['in_footer'] ) && true === $script_module['in_footer'] ) {
 				continue;
 			}
 

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -47,32 +47,33 @@ class WP_Script_Modules {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param string            $id       The identifier of the script module. Should be unique. It will be used in the
-	 *                                    final import map.
-	 * @param string            $src      Optional. Full URL of the script module, or path of the script module relative
-	 *                                    to the WordPress root directory. If it is provided and the script module has
-	 *                                    not been registered yet, it will be registered.
-	 * @param array             $deps     {
-	 *                                        Optional. List of dependencies.
+	 * @param string            $id        The identifier of the script module. Should be unique. It will be used in the
+	 *                                     final import map.
+	 * @param string            $src       Optional. Full URL of the script module, or path of the script module relative
+	 *                                     to the WordPress root directory. If it is provided and the script module has
+	 *                                     not been registered yet, it will be registered.
+	 * @param array             $deps      {
+	 *                                         Optional. List of dependencies.
 	 *
-	 *                                        @type string|array ...$0 {
-	 *                                            An array of script module identifiers of the dependencies of this script
-	 *                                            module. The dependencies can be strings or arrays. If they are arrays,
-	 *                                            they need an `id` key with the script module identifier, and can contain
-	 *                                            an `import` key with either `static` or `dynamic`. By default,
-	 *                                            dependencies that don't contain an `import` key are considered static.
+	 *                                         @type string|array ...$0 {
+	 *                                             An array of script module identifiers of the dependencies of this script
+	 *                                             module. The dependencies can be strings or arrays. If they are arrays,
+	 *                                             they need an `id` key with the script module identifier, and can contain
+	 *                                             an `import` key with either `static` or `dynamic`. By default,
+	 *                                             dependencies that don't contain an `import` key are considered static.
 	 *
-	 *                                            @type string $id     The script module identifier.
-	 *                                            @type string $import Optional. Import type. May be either `static` or
-	 *                                                                 `dynamic`. Defaults to `static`.
-	 *                                        }
-	 *                                    }
-	 * @param string|false|null $version  Optional. String specifying the script module version number. Defaults to false.
-	 *                                    It is added to the URL as a query string for cache busting purposes. If $version
-	 *                                    is set to false, the version number is the currently installed WordPress version.
-	 *                                    If $version is set to null, no version is added.
+	 *                                             @type string $id     The script module identifier.
+	 *                                             @type string $import Optional. Import type. May be either `static` or
+	 *                                                                  `dynamic`. Defaults to `static`.
+	 *                                         }
+	 *                                     }
+	 * @param string|false|null $version   Optional. String specifying the script module version number. Defaults to false.
+	 *                                     It is added to the URL as a query string for cache busting purposes. If $version
+	 *                                     is set to false, the version number is the currently installed WordPress version.
+	 *                                     If $version is set to null, no version is added.
+	 * @param bool              $in_footer Optional. Whether to enqueue the script module in the footer. Defaults to false.
 	 */
-	public function register( string $id, string $src, array $deps = array(), $version = false ) {
+	public function register( string $id, string $src, array $deps = array(), $version = false, bool $in_footer = false ) {
 		if ( ! isset( $this->registered[ $id ] ) ) {
 			$dependencies = array();
 			foreach ( $deps as $dependency ) {
@@ -100,6 +101,7 @@ class WP_Script_Modules {
 				'version'      => $version,
 				'enqueue'      => isset( $this->enqueued_before_registered[ $id ] ),
 				'dependencies' => $dependencies,
+				'in_footer'    => $in_footer,
 			);
 		}
 	}
@@ -112,36 +114,37 @@ class WP_Script_Modules {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @param string            $id       The identifier of the script module. Should be unique. It will be used in the
-	 *                                    final import map.
-	 * @param string            $src      Optional. Full URL of the script module, or path of the script module relative
-	 *                                    to the WordPress root directory. If it is provided and the script module has
-	 *                                    not been registered yet, it will be registered.
-	 * @param array             $deps     {
-	 *                                        Optional. List of dependencies.
+	 * @param string            $id        The identifier of the script module. Should be unique. It will be used in the
+	 *                                     final import map.
+	 * @param string            $src       Optional. Full URL of the script module, or path of the script module relative
+	 *                                     to the WordPress root directory. If it is provided and the script module has
+	 *                                     not been registered yet, it will be registered.
+	 * @param array             $deps      {
+	 *                                         Optional. List of dependencies.
 	 *
-	 *                                        @type string|array ...$0 {
-	 *                                            An array of script module identifiers of the dependencies of this script
-	 *                                            module. The dependencies can be strings or arrays. If they are arrays,
-	 *                                            they need an `id` key with the script module identifier, and can contain
-	 *                                            an `import` key with either `static` or `dynamic`. By default,
-	 *                                            dependencies that don't contain an `import` key are considered static.
+	 *                                         @type string|array ...$0 {
+	 *                                             An array of script module identifiers of the dependencies of this script
+	 *                                             module. The dependencies can be strings or arrays. If they are arrays,
+	 *                                             they need an `id` key with the script module identifier, and can contain
+	 *                                             an `import` key with either `static` or `dynamic`. By default,
+	 *                                             dependencies that don't contain an `import` key are considered static.
 	 *
-	 *                                            @type string $id     The script module identifier.
-	 *                                            @type string $import Optional. Import type. May be either `static` or
-	 *                                                                 `dynamic`. Defaults to `static`.
-	 *                                        }
-	 *                                    }
-	 * @param string|false|null $version  Optional. String specifying the script module version number. Defaults to false.
-	 *                                    It is added to the URL as a query string for cache busting purposes. If $version
-	 *                                    is set to false, the version number is the currently installed WordPress version.
-	 *                                    If $version is set to null, no version is added.
+	 *                                             @type string $id     The script module identifier.
+	 *                                             @type string $import Optional. Import type. May be either `static` or
+	 *                                                                  `dynamic`. Defaults to `static`.
+	 *                                         }
+	 *                                     }
+	 * @param string|false|null $version   Optional. String specifying the script module version number. Defaults to false.
+	 *                                     It is added to the URL as a query string for cache busting purposes. If $version
+	 *                                     is set to false, the version number is the currently installed WordPress version.
+	 *                                     If $version is set to null, no version is added.
+	 * @param bool              $in_footer Optional. Whether to enqueue the script module in the footer. Defaults to false.
 	 */
-	public function enqueue( string $id, string $src = '', array $deps = array(), $version = false ) {
+	public function enqueue( string $id, string $src = '', array $deps = array(), $version = false, bool $in_footer = false ) {
 		if ( isset( $this->registered[ $id ] ) ) {
 			$this->registered[ $id ]['enqueue'] = true;
 		} elseif ( $src ) {
-			$this->register( $id, $src, $deps, $version );
+			$this->register( $id, $src, $deps, $version, $in_footer );
 			$this->registered[ $id ]['enqueue'] = true;
 		} else {
 			$this->enqueued_before_registered[ $id ] = true;
@@ -190,6 +193,8 @@ class WP_Script_Modules {
 		add_action( $position, array( $this, 'print_enqueued_script_modules' ) );
 		add_action( $position, array( $this, 'print_script_module_preloads' ) );
 
+		add_action( 'wp_footer', array( $this, 'print_footer_enqueued_script_modules' ) );
+
 		add_action( 'admin_print_footer_scripts', array( $this, 'print_import_map' ) );
 		add_action( 'admin_print_footer_scripts', array( $this, 'print_enqueued_script_modules' ) );
 		add_action( 'admin_print_footer_scripts', array( $this, 'print_script_module_preloads' ) );
@@ -201,13 +206,43 @@ class WP_Script_Modules {
 	}
 
 	/**
-	 * Prints the enqueued script modules using script tags with type="module"
+	 * Prints the header enqueued script modules using script tags with type="module"
 	 * attributes.
 	 *
 	 * @since 6.5.0
 	 */
 	public function print_enqueued_script_modules() {
 		foreach ( $this->get_marked_for_enqueue() as $id => $script_module ) {
+
+			// If the script module is marked for printing in the footer, skip it.
+			if( isset( $script_module[ 'in_footer' ] ) && true === $script_module[ 'in_footer']){
+				continue;
+			}
+
+			wp_print_script_tag(
+				array(
+					'type' => 'module',
+					'src'  => $this->get_src( $id ),
+					'id'   => $id . '-js-module',
+				)
+			);
+		}
+	}
+
+	/**
+	 * Prints the footer enqueued script modules using script tags with type="module"
+	 * attributes.
+	 *
+	 * @since 6.5.0
+	 */
+	public function print_footer_enqueued_script_modules() {
+		foreach ( $this->get_marked_for_enqueue() as $id => $script_module ) {
+
+			// Process only those scripts which are marked for printing in footer.
+			if ( ! isset( $script_module['in_footer'] ) || true !== $script_module['in_footer'] ) {
+				continue;
+			}
+
 			wp_print_script_tag(
 				array(
 					'type' => 'module',

--- a/src/wp-includes/script-modules.php
+++ b/src/wp-includes/script-modules.php
@@ -36,33 +36,34 @@ function wp_script_modules(): WP_Script_Modules {
  *
  * @since 6.5.0
  *
- * @param string            $id      The identifier of the script module. Should be unique. It will be used in the
- *                                   final import map.
- * @param string            $src     Optional. Full URL of the script module, or path of the script module relative
- *                                   to the WordPress root directory. If it is provided and the script module has
- *                                   not been registered yet, it will be registered.
- * @param array             $deps    {
- *                                       Optional. List of dependencies.
+ * @param string            $id        The identifier of the script module. Should be unique. It will be used in the
+ *                                     final import map.
+ * @param string            $src       Optional. Full URL of the script module, or path of the script module relative
+ *                                     to the WordPress root directory. If it is provided and the script module has
+ *                                     not been registered yet, it will be registered.
+ * @param array             $deps      {
+ *                                         Optional. List of dependencies.
  *
- *                                       @type string|array ...$0 {
- *                                           An array of script module identifiers of the dependencies of this script
- *                                           module. The dependencies can be strings or arrays. If they are arrays,
- *                                           they need an `id` key with the script module identifier, and can contain
- *                                           an `import` key with either `static` or `dynamic`. By default,
- *                                           dependencies that don't contain an `import` key are considered static.
+ *                                         @type string|array ...$0 {
+ *                                             An array of script module identifiers of the dependencies of this script
+ *                                             module. The dependencies can be strings or arrays. If they are arrays,
+ *                                             they need an `id` key with the script module identifier, and can contain
+ *                                             an `import` key with either `static` or `dynamic`. By default,
+ *                                             dependencies that don't contain an `import` key are considered static.
  *
- *                                           @type string $id     The script module identifier.
- *                                           @type string $import Optional. Import type. May be either `static` or
- *                                                                `dynamic`. Defaults to `static`.
- *                                       }
- *                                   }
- * @param string|false|null $version Optional. String specifying the script module version number. Defaults to false.
- *                                   It is added to the URL as a query string for cache busting purposes. If $version
- *                                   is set to false, the version number is the currently installed WordPress version.
- *                                   If $version is set to null, no version is added.
+ *                                             @type string $id     The script module identifier.
+ *                                             @type string $import Optional. Import type. May be either `static` or
+ *                                                                  `dynamic`. Defaults to `static`.
+ *                                         }
+ *                                     }
+ * @param string|false|null $version   Optional. String specifying the script module version number. Defaults to false.
+ *                                     It is added to the URL as a query string for cache busting purposes. If $version
+ *                                     is set to false, the version number is the currently installed WordPress version.
+ *                                     If $version is set to null, no version is added.
+ * @param bool              $in_footer Optional. Whether to enqueue the script module in the footer. Defaults to false.
  */
-function wp_register_script_module( string $id, string $src, array $deps = array(), $version = false ) {
-	wp_script_modules()->register( $id, $src, $deps, $version );
+function wp_register_script_module( string $id, string $src, array $deps = array(), $version = false, bool $in_footer = false ) {
+	wp_script_modules()->register( $id, $src, $deps, $version, $in_footer );
 }
 
 /**
@@ -73,33 +74,34 @@ function wp_register_script_module( string $id, string $src, array $deps = array
  *
  * @since 6.5.0
  *
- * @param string            $id      The identifier of the script module. Should be unique. It will be used in the
- *                                   final import map.
- * @param string            $src     Optional. Full URL of the script module, or path of the script module relative
- *                                   to the WordPress root directory. If it is provided and the script module has
- *                                   not been registered yet, it will be registered.
- * @param array             $deps    {
- *                                       Optional. List of dependencies.
+ * @param string            $id        The identifier of the script module. Should be unique. It will be used in the
+ *                                     final import map.
+ * @param string            $src       Optional. Full URL of the script module, or path of the script module relative
+ *                                     to the WordPress root directory. If it is provided and the script module has
+ *                                     not been registered yet, it will be registered.
+ * @param array             $deps      {
+ *                                         Optional. List of dependencies.
  *
- *                                       @type string|array ...$0 {
- *                                           An array of script module identifiers of the dependencies of this script
- *                                           module. The dependencies can be strings or arrays. If they are arrays,
- *                                           they need an `id` key with the script module identifier, and can contain
- *                                           an `import` key with either `static` or `dynamic`. By default,
- *                                           dependencies that don't contain an `import` key are considered static.
+ *                                         @type string|array ...$0 {
+ *                                             An array of script module identifiers of the dependencies of this script
+ *                                             module. The dependencies can be strings or arrays. If they are arrays,
+ *                                             they need an `id` key with the script module identifier, and can contain
+ *                                             an `import` key with either `static` or `dynamic`. By default,
+ *                                             dependencies that don't contain an `import` key are considered static.
  *
- *                                           @type string $id     The script module identifier.
- *                                           @type string $import Optional. Import type. May be either `static` or
- *                                                                `dynamic`. Defaults to `static`.
- *                                       }
- *                                   }
- * @param string|false|null $version Optional. String specifying the script module version number. Defaults to false.
- *                                   It is added to the URL as a query string for cache busting purposes. If $version
- *                                   is set to false, the version number is the currently installed WordPress version.
- *                                   If $version is set to null, no version is added.
+ *                                             @type string $id     The script module identifier.
+ *                                             @type string $import Optional. Import type. May be either `static` or
+ *                                                                  `dynamic`. Defaults to `static`.
+ *                                         }
+ *                                     }
+ * @param string|false|null $version   Optional. String specifying the script module version number. Defaults to false.
+ *                                     It is added to the URL as a query string for cache busting purposes. If $version
+ *                                     is set to false, the version number is the currently installed WordPress version.
+ *                                     If $version is set to null, no version is added.
+ * @param bool              $in_footer Optional. Whether to enqueue the script module in the footer. Defaults to false.
  */
-function wp_enqueue_script_module( string $id, string $src = '', array $deps = array(), $version = false ) {
-	wp_script_modules()->enqueue( $id, $src, $deps, $version );
+function wp_enqueue_script_module( string $id, string $src = '', array $deps = array(), $version = false, bool $in_footer = false ) {
+	wp_script_modules()->enqueue( $id, $src, $deps, $version, $in_footer );
 }
 
 /**
@@ -142,6 +144,8 @@ function wp_default_script_modules() {
 	$assets = include ABSPATH . WPINC . "/assets/script-modules-packages{$suffix}.php";
 
 	foreach ( $assets as $file_name => $script_module_data ) {
+		$in_footer = false;
+
 		/*
 		 * Build the WordPress Script Module ID from the file name.
 		 * Prepend `@wordpress/` and remove extensions and `/index` if present:
@@ -170,6 +174,6 @@ function wp_default_script_modules() {
 		}
 
 		$path = includes_url( "js/dist/script-modules/{$file_name}" );
-		wp_register_script_module( $script_module_id, $path, $script_module_data['dependencies'], $script_module_data['version'] );
+		wp_register_script_module( $script_module_id, $path, $script_module_data['dependencies'], $script_module_data['version'], $in_footer );
 	}
 }


### PR DESCRIPTION
## Summary
This PR adds support for printing script modules in the footer.
It also works with `premap` loaded in the header.

### Changes Made
- Added a parameter `$in_footer` to the `wp_register_script_module` function.
- The printing of default scripts using `wp_default_script_modules` remains unchanged to avoid any potential breakage. If needed, we can conditionally set `$in_footer` to `true` to print specific scripts in the footer.

### Why
- This change supports the ongoing effort to print the `Interactivity API` module in the footer.


Trac ticket: https://core.trac.wordpress.org/ticket/63486


