### PR TITLE
style: Align font-family of Calendar block in editor with front-end

### DIFF
--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -36,7 +36,7 @@ h6:lang(ar), figcaption:lang(ar),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(ar),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(ar), .wp-block-file:lang(ar), ul.wp-block-archives li > a:lang(ar),
 .wp-block-categories li > a:lang(ar),
-.wp-block-latest-posts li > a:lang(ar), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ar), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ar), .wp-caption dd:lang(ar), .wp-block-freeform blockquote cite:lang(ar) {
+.wp-block-latest-posts li > a:lang(ar), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ar), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ar), .wp-caption dd:lang(ar), .wp-block-freeform blockquote cite:lang(ar), .wp-calendar-table:lang(ar) {
   font-family: Tahoma, Arial, sans-serif;
 }
 
@@ -54,7 +54,7 @@ h6:lang(ary), figcaption:lang(ary),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(ary),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(ary), .wp-block-file:lang(ary), ul.wp-block-archives li > a:lang(ary),
 .wp-block-categories li > a:lang(ary),
-.wp-block-latest-posts li > a:lang(ary), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ary), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ary), .wp-caption dd:lang(ary), .wp-block-freeform blockquote cite:lang(ary) {
+.wp-block-latest-posts li > a:lang(ary), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ary), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ary), .wp-caption dd:lang(ary), .wp-block-freeform blockquote cite:lang(ary), .wp-calendar-table:lang(ary) {
   font-family: Tahoma, Arial, sans-serif;
 }
 
@@ -72,7 +72,7 @@ h6:lang(azb), figcaption:lang(azb),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(azb),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(azb), .wp-block-file:lang(azb), ul.wp-block-archives li > a:lang(azb),
 .wp-block-categories li > a:lang(azb),
-.wp-block-latest-posts li > a:lang(azb), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(azb), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(azb), .wp-caption dd:lang(azb), .wp-block-freeform blockquote cite:lang(azb) {
+.wp-block-latest-posts li > a:lang(azb), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(azb), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(azb), .wp-caption dd:lang(azb), .wp-block-freeform blockquote cite:lang(azb), .wp-calendar-table:lang(azb) {
   font-family: Tahoma, Arial, sans-serif;
 }
 
@@ -90,7 +90,7 @@ h6:lang(ckb), figcaption:lang(ckb),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(ckb),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(ckb), .wp-block-file:lang(ckb), ul.wp-block-archives li > a:lang(ckb),
 .wp-block-categories li > a:lang(ckb),
-.wp-block-latest-posts li > a:lang(ckb), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ckb), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ckb), .wp-caption dd:lang(ckb), .wp-block-freeform blockquote cite:lang(ckb) {
+.wp-block-latest-posts li > a:lang(ckb), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ckb), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ckb), .wp-caption dd:lang(ckb), .wp-block-freeform blockquote cite:lang(ckb), .wp-calendar-table:lang(ckb) {
   font-family: Tahoma, Arial, sans-serif;
 }
 
@@ -108,7 +108,7 @@ h6:lang(fa-IR), figcaption:lang(fa-IR),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(fa-IR),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(fa-IR), .wp-block-file:lang(fa-IR), ul.wp-block-archives li > a:lang(fa-IR),
 .wp-block-categories li > a:lang(fa-IR),
-.wp-block-latest-posts li > a:lang(fa-IR), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(fa-IR), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(fa-IR), .wp-caption dd:lang(fa-IR), .wp-block-freeform blockquote cite:lang(fa-IR) {
+.wp-block-latest-posts li > a:lang(fa-IR), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(fa-IR), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(fa-IR), .wp-caption dd:lang(fa-IR), .wp-block-freeform blockquote cite:lang(fa-IR), .wp-calendar-table:lang(fa-IR) {
   font-family: Tahoma, Arial, sans-serif;
 }
 
@@ -126,7 +126,7 @@ h6:lang(haz), figcaption:lang(haz),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(haz),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(haz), .wp-block-file:lang(haz), ul.wp-block-archives li > a:lang(haz),
 .wp-block-categories li > a:lang(haz),
-.wp-block-latest-posts li > a:lang(haz), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(haz), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(haz), .wp-caption dd:lang(haz), .wp-block-freeform blockquote cite:lang(haz) {
+.wp-block-latest-posts li > a:lang(haz), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(haz), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(haz), .wp-caption dd:lang(haz), .wp-block-freeform blockquote cite:lang(haz), .wp-calendar-table:lang(haz) {
   font-family: Tahoma, Arial, sans-serif;
 }
 
@@ -144,7 +144,7 @@ h6:lang(ps), figcaption:lang(ps),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(ps),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(ps), .wp-block-file:lang(ps), ul.wp-block-archives li > a:lang(ps),
 .wp-block-categories li > a:lang(ps),
-.wp-block-latest-posts li > a:lang(ps), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ps), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ps), .wp-caption dd:lang(ps), .wp-block-freeform blockquote cite:lang(ps) {
+.wp-block-latest-posts li > a:lang(ps), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ps), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ps), .wp-caption dd:lang(ps), .wp-block-freeform blockquote cite:lang(ps), .wp-calendar-table:lang(ps) {
   font-family: Tahoma, Arial, sans-serif;
 }
 
@@ -162,7 +162,7 @@ h6:lang(be), figcaption:lang(be),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(be),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(be), .wp-block-file:lang(be), ul.wp-block-archives li > a:lang(be),
 .wp-block-categories li > a:lang(be),
-.wp-block-latest-posts li > a:lang(be), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(be), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(be), .wp-caption dd:lang(be), .wp-block-freeform blockquote cite:lang(be) {
+.wp-block-latest-posts li > a:lang(be), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(be), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(be), .wp-caption dd:lang(be), .wp-block-freeform blockquote cite:lang(be), .wp-calendar-table:lang(be) {
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
 }
 
@@ -180,7 +180,7 @@ h6:lang(bg-BG), figcaption:lang(bg-BG),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(bg-BG),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(bg-BG), .wp-block-file:lang(bg-BG), ul.wp-block-archives li > a:lang(bg-BG),
 .wp-block-categories li > a:lang(bg-BG),
-.wp-block-latest-posts li > a:lang(bg-BG), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(bg-BG), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(bg-BG), .wp-caption dd:lang(bg-BG), .wp-block-freeform blockquote cite:lang(bg-BG) {
+.wp-block-latest-posts li > a:lang(bg-BG), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(bg-BG), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(bg-BG), .wp-caption dd:lang(bg-BG), .wp-block-freeform blockquote cite:lang(bg-BG), .wp-calendar-table:lang(bg-BG) {
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
 }
 
@@ -198,7 +198,7 @@ h6:lang(kk), figcaption:lang(kk),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(kk),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(kk), .wp-block-file:lang(kk), ul.wp-block-archives li > a:lang(kk),
 .wp-block-categories li > a:lang(kk),
-.wp-block-latest-posts li > a:lang(kk), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(kk), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(kk), .wp-caption dd:lang(kk), .wp-block-freeform blockquote cite:lang(kk) {
+.wp-block-latest-posts li > a:lang(kk), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(kk), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(kk), .wp-caption dd:lang(kk), .wp-block-freeform blockquote cite:lang(kk), .wp-calendar-table:lang(kk) {
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
 }
 
@@ -216,7 +216,7 @@ h6:lang(mk-MK), figcaption:lang(mk-MK),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(mk-MK),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(mk-MK), .wp-block-file:lang(mk-MK), ul.wp-block-archives li > a:lang(mk-MK),
 .wp-block-categories li > a:lang(mk-MK),
-.wp-block-latest-posts li > a:lang(mk-MK), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mk-MK), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mk-MK), .wp-caption dd:lang(mk-MK), .wp-block-freeform blockquote cite:lang(mk-MK) {
+.wp-block-latest-posts li > a:lang(mk-MK), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mk-MK), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mk-MK), .wp-caption dd:lang(mk-MK), .wp-block-freeform blockquote cite:lang(mk-MK), .wp-calendar-table:lang(mk-MK) {
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
 }
 
@@ -234,7 +234,7 @@ h6:lang(mn), figcaption:lang(mn),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(mn),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(mn), .wp-block-file:lang(mn), ul.wp-block-archives li > a:lang(mn),
 .wp-block-categories li > a:lang(mn),
-.wp-block-latest-posts li > a:lang(mn), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mn), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mn), .wp-caption dd:lang(mn), .wp-block-freeform blockquote cite:lang(mn) {
+.wp-block-latest-posts li > a:lang(mn), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mn), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mn), .wp-caption dd:lang(mn), .wp-block-freeform blockquote cite:lang(mn), .wp-calendar-table:lang(mn) {
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
 }
 
@@ -252,7 +252,7 @@ h6:lang(ru-RU), figcaption:lang(ru-RU),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(ru-RU),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(ru-RU), .wp-block-file:lang(ru-RU), ul.wp-block-archives li > a:lang(ru-RU),
 .wp-block-categories li > a:lang(ru-RU),
-.wp-block-latest-posts li > a:lang(ru-RU), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ru-RU), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ru-RU), .wp-caption dd:lang(ru-RU), .wp-block-freeform blockquote cite:lang(ru-RU) {
+.wp-block-latest-posts li > a:lang(ru-RU), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ru-RU), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ru-RU), .wp-caption dd:lang(ru-RU), .wp-block-freeform blockquote cite:lang(ru-RU), .wp-calendar-table:lang(ru-RU) {
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
 }
 
@@ -270,7 +270,7 @@ h6:lang(sah), figcaption:lang(sah),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(sah),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(sah), .wp-block-file:lang(sah), ul.wp-block-archives li > a:lang(sah),
 .wp-block-categories li > a:lang(sah),
-.wp-block-latest-posts li > a:lang(sah), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(sah), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(sah), .wp-caption dd:lang(sah), .wp-block-freeform blockquote cite:lang(sah) {
+.wp-block-latest-posts li > a:lang(sah), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(sah), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(sah), .wp-caption dd:lang(sah), .wp-block-freeform blockquote cite:lang(sah), .wp-calendar-table:lang(sah) {
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
 }
 
@@ -288,7 +288,7 @@ h6:lang(sr-RS), figcaption:lang(sr-RS),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(sr-RS),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(sr-RS), .wp-block-file:lang(sr-RS), ul.wp-block-archives li > a:lang(sr-RS),
 .wp-block-categories li > a:lang(sr-RS),
-.wp-block-latest-posts li > a:lang(sr-RS), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(sr-RS), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(sr-RS), .wp-caption dd:lang(sr-RS), .wp-block-freeform blockquote cite:lang(sr-RS) {
+.wp-block-latest-posts li > a:lang(sr-RS), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(sr-RS), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(sr-RS), .wp-caption dd:lang(sr-RS), .wp-block-freeform blockquote cite:lang(sr-RS), .wp-calendar-table:lang(sr-RS) {
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
 }
 
@@ -306,7 +306,7 @@ h6:lang(tt-RU), figcaption:lang(tt-RU),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(tt-RU),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(tt-RU), .wp-block-file:lang(tt-RU), ul.wp-block-archives li > a:lang(tt-RU),
 .wp-block-categories li > a:lang(tt-RU),
-.wp-block-latest-posts li > a:lang(tt-RU), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(tt-RU), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(tt-RU), .wp-caption dd:lang(tt-RU), .wp-block-freeform blockquote cite:lang(tt-RU) {
+.wp-block-latest-posts li > a:lang(tt-RU), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(tt-RU), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(tt-RU), .wp-caption dd:lang(tt-RU), .wp-block-freeform blockquote cite:lang(tt-RU), .wp-calendar-table:lang(tt-RU) {
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
 }
 
@@ -324,7 +324,7 @@ h6:lang(uk), figcaption:lang(uk),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(uk),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(uk), .wp-block-file:lang(uk), ul.wp-block-archives li > a:lang(uk),
 .wp-block-categories li > a:lang(uk),
-.wp-block-latest-posts li > a:lang(uk), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(uk), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(uk), .wp-caption dd:lang(uk), .wp-block-freeform blockquote cite:lang(uk) {
+.wp-block-latest-posts li > a:lang(uk), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(uk), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(uk), .wp-caption dd:lang(uk), .wp-block-freeform blockquote cite:lang(uk), .wp-calendar-table:lang(uk) {
   font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, sans-serif;
 }
 
@@ -342,7 +342,7 @@ h6:lang(zh-HK), figcaption:lang(zh-HK),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(zh-HK),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(zh-HK), .wp-block-file:lang(zh-HK), ul.wp-block-archives li > a:lang(zh-HK),
 .wp-block-categories li > a:lang(zh-HK),
-.wp-block-latest-posts li > a:lang(zh-HK), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-HK), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-HK), .wp-caption dd:lang(zh-HK), .wp-block-freeform blockquote cite:lang(zh-HK) {
+.wp-block-latest-posts li > a:lang(zh-HK), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-HK), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-HK), .wp-caption dd:lang(zh-HK), .wp-block-freeform blockquote cite:lang(zh-HK), .wp-calendar-table:lang(zh-HK) {
   font-family: -apple-system, BlinkMacSystemFont, "PingFang HK", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
 }
 
@@ -360,7 +360,7 @@ h6:lang(zh-TW), figcaption:lang(zh-TW),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(zh-TW),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(zh-TW), .wp-block-file:lang(zh-TW), ul.wp-block-archives li > a:lang(zh-TW),
 .wp-block-categories li > a:lang(zh-TW),
-.wp-block-latest-posts li > a:lang(zh-TW), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-TW), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-TW), .wp-caption dd:lang(zh-TW), .wp-block-freeform blockquote cite:lang(zh-TW) {
+.wp-block-latest-posts li > a:lang(zh-TW), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-TW), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-TW), .wp-caption dd:lang(zh-TW), .wp-block-freeform blockquote cite:lang(zh-TW), .wp-calendar-table:lang(zh-TW) {
   font-family: -apple-system, BlinkMacSystemFont, "PingFang TC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
 }
 
@@ -378,7 +378,7 @@ h6:lang(zh-CN), figcaption:lang(zh-CN),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(zh-CN),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(zh-CN), .wp-block-file:lang(zh-CN), ul.wp-block-archives li > a:lang(zh-CN),
 .wp-block-categories li > a:lang(zh-CN),
-.wp-block-latest-posts li > a:lang(zh-CN), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-CN), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-CN), .wp-caption dd:lang(zh-CN), .wp-block-freeform blockquote cite:lang(zh-CN) {
+.wp-block-latest-posts li > a:lang(zh-CN), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(zh-CN), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(zh-CN), .wp-caption dd:lang(zh-CN), .wp-block-freeform blockquote cite:lang(zh-CN), .wp-calendar-table:lang(zh-CN) {
   font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", "Microsoft YaHei New", STHeiti Light, sans-serif;
 }
 
@@ -396,7 +396,7 @@ h6:lang(bn-BD), figcaption:lang(bn-BD),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(bn-BD),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(bn-BD), .wp-block-file:lang(bn-BD), ul.wp-block-archives li > a:lang(bn-BD),
 .wp-block-categories li > a:lang(bn-BD),
-.wp-block-latest-posts li > a:lang(bn-BD), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(bn-BD), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(bn-BD), .wp-caption dd:lang(bn-BD), .wp-block-freeform blockquote cite:lang(bn-BD) {
+.wp-block-latest-posts li > a:lang(bn-BD), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(bn-BD), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(bn-BD), .wp-caption dd:lang(bn-BD), .wp-block-freeform blockquote cite:lang(bn-BD), .wp-calendar-table:lang(bn-BD) {
   font-family: Arial, sans-serif;
 }
 
@@ -414,7 +414,7 @@ h6:lang(hi-IN), figcaption:lang(hi-IN),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(hi-IN),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(hi-IN), .wp-block-file:lang(hi-IN), ul.wp-block-archives li > a:lang(hi-IN),
 .wp-block-categories li > a:lang(hi-IN),
-.wp-block-latest-posts li > a:lang(hi-IN), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(hi-IN), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(hi-IN), .wp-caption dd:lang(hi-IN), .wp-block-freeform blockquote cite:lang(hi-IN) {
+.wp-block-latest-posts li > a:lang(hi-IN), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(hi-IN), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(hi-IN), .wp-caption dd:lang(hi-IN), .wp-block-freeform blockquote cite:lang(hi-IN), .wp-calendar-table:lang(hi-IN) {
   font-family: Arial, sans-serif;
 }
 
@@ -432,7 +432,7 @@ h6:lang(mr), figcaption:lang(mr),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(mr),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(mr), .wp-block-file:lang(mr), ul.wp-block-archives li > a:lang(mr),
 .wp-block-categories li > a:lang(mr),
-.wp-block-latest-posts li > a:lang(mr), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mr), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mr), .wp-caption dd:lang(mr), .wp-block-freeform blockquote cite:lang(mr) {
+.wp-block-latest-posts li > a:lang(mr), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(mr), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(mr), .wp-caption dd:lang(mr), .wp-block-freeform blockquote cite:lang(mr), .wp-calendar-table:lang(mr) {
   font-family: Arial, sans-serif;
 }
 
@@ -450,7 +450,7 @@ h6:lang(ne-NP), figcaption:lang(ne-NP),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(ne-NP),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(ne-NP), .wp-block-file:lang(ne-NP), ul.wp-block-archives li > a:lang(ne-NP),
 .wp-block-categories li > a:lang(ne-NP),
-.wp-block-latest-posts li > a:lang(ne-NP), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ne-NP), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ne-NP), .wp-caption dd:lang(ne-NP), .wp-block-freeform blockquote cite:lang(ne-NP) {
+.wp-block-latest-posts li > a:lang(ne-NP), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ne-NP), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ne-NP), .wp-caption dd:lang(ne-NP), .wp-block-freeform blockquote cite:lang(ne-NP), .wp-calendar-table:lang(ne-NP) {
   font-family: Arial, sans-serif;
 }
 
@@ -468,7 +468,7 @@ h6:lang(el), figcaption:lang(el),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(el),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(el), .wp-block-file:lang(el), ul.wp-block-archives li > a:lang(el),
 .wp-block-categories li > a:lang(el),
-.wp-block-latest-posts li > a:lang(el), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(el), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(el), .wp-caption dd:lang(el), .wp-block-freeform blockquote cite:lang(el) {
+.wp-block-latest-posts li > a:lang(el), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(el), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(el), .wp-caption dd:lang(el), .wp-block-freeform blockquote cite:lang(el), .wp-calendar-table:lang(el) {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
@@ -486,7 +486,7 @@ h6:lang(gu), figcaption:lang(gu),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(gu),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(gu), .wp-block-file:lang(gu), ul.wp-block-archives li > a:lang(gu),
 .wp-block-categories li > a:lang(gu),
-.wp-block-latest-posts li > a:lang(gu), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(gu), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(gu), .wp-caption dd:lang(gu), .wp-block-freeform blockquote cite:lang(gu) {
+.wp-block-latest-posts li > a:lang(gu), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(gu), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(gu), .wp-caption dd:lang(gu), .wp-block-freeform blockquote cite:lang(gu), .wp-calendar-table:lang(gu) {
   font-family: Arial, sans-serif;
 }
 
@@ -504,7 +504,7 @@ h6:lang(he-IL), figcaption:lang(he-IL),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(he-IL),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(he-IL), .wp-block-file:lang(he-IL), ul.wp-block-archives li > a:lang(he-IL),
 .wp-block-categories li > a:lang(he-IL),
-.wp-block-latest-posts li > a:lang(he-IL), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(he-IL), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(he-IL), .wp-caption dd:lang(he-IL), .wp-block-freeform blockquote cite:lang(he-IL) {
+.wp-block-latest-posts li > a:lang(he-IL), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(he-IL), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(he-IL), .wp-caption dd:lang(he-IL), .wp-block-freeform blockquote cite:lang(he-IL), .wp-calendar-table:lang(he-IL) {
   font-family: "Arial Hebrew", Arial, sans-serif;
 }
 
@@ -522,7 +522,7 @@ h6:lang(ja), figcaption:lang(ja),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(ja),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(ja), .wp-block-file:lang(ja), ul.wp-block-archives li > a:lang(ja),
 .wp-block-categories li > a:lang(ja),
-.wp-block-latest-posts li > a:lang(ja), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ja), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ja), .wp-caption dd:lang(ja), .wp-block-freeform blockquote cite:lang(ja) {
+.wp-block-latest-posts li > a:lang(ja), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ja), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ja), .wp-caption dd:lang(ja), .wp-block-freeform blockquote cite:lang(ja), .wp-calendar-table:lang(ja) {
   font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", Meiryo, "Helvetica Neue", sans-serif;
 }
 
@@ -540,7 +540,7 @@ h6:lang(ko-KR), figcaption:lang(ko-KR),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(ko-KR),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(ko-KR), .wp-block-file:lang(ko-KR), ul.wp-block-archives li > a:lang(ko-KR),
 .wp-block-categories li > a:lang(ko-KR),
-.wp-block-latest-posts li > a:lang(ko-KR), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ko-KR), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ko-KR), .wp-caption dd:lang(ko-KR), .wp-block-freeform blockquote cite:lang(ko-KR) {
+.wp-block-latest-posts li > a:lang(ko-KR), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(ko-KR), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(ko-KR), .wp-caption dd:lang(ko-KR), .wp-block-freeform blockquote cite:lang(ko-KR), .wp-calendar-table:lang(ko-KR) {
   font-family: "Apple SD Gothic Neo", "Malgun Gothic", "Nanum Gothic", Dotum, sans-serif;
 }
 
@@ -558,7 +558,7 @@ h6:lang(th), figcaption:lang(th),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(th),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(th), .wp-block-file:lang(th), ul.wp-block-archives li > a:lang(th),
 .wp-block-categories li > a:lang(th),
-.wp-block-latest-posts li > a:lang(th), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(th), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(th), .wp-caption dd:lang(th), .wp-block-freeform blockquote cite:lang(th) {
+.wp-block-latest-posts li > a:lang(th), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(th), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(th), .wp-caption dd:lang(th), .wp-block-freeform blockquote cite:lang(th), .wp-calendar-table:lang(th) {
   font-family: "Sukhumvit Set", "Helvetica Neue", helvetica, arial, sans-serif;
 }
 
@@ -576,7 +576,7 @@ h6:lang(vi), figcaption:lang(vi),
 .wp-block[data-type="core/pullquote"][data-align="left"] .wp-block-pullquote__citation:lang(vi),
 .wp-block[data-type="core/pullquote"][data-align="right"] .wp-block-pullquote__citation:lang(vi), .wp-block-file:lang(vi), ul.wp-block-archives li > a:lang(vi),
 .wp-block-categories li > a:lang(vi),
-.wp-block-latest-posts li > a:lang(vi), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(vi), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(vi), .wp-caption dd:lang(vi), .wp-block-freeform blockquote cite:lang(vi) {
+.wp-block-latest-posts li > a:lang(vi), .wp-block-latest-posts .wp-block-latest-posts__post-date:lang(vi), .wp-block-latest-comments .wp-block-latest-comments__comment-meta:lang(vi), .wp-caption dd:lang(vi), .wp-block-freeform blockquote cite:lang(vi), .wp-calendar-table:lang(vi) {
   font-family: "Libre Franklin", sans-serif;
 }
 
@@ -1632,4 +1632,9 @@ ul.wp-block-archives li ul,
 .avatar,
 .wp-block-post-author__avatar img {
   border-radius: 100%;
+}
+
+/** === Calendar Block === */
+.wp-calendar-table {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -1079,3 +1079,9 @@ $group-block-background__padding: $font__size_base;
 .wp-block-post-author__avatar img {
 	border-radius: 100%;
 }
+
+/** === Calendar Block === */
+
+.wp-calendar-table {
+	@include font-family( $font__heading );
+}


### PR DESCRIPTION
This PR addresses a visual inconsistency in the Twenty Nineteen theme where the Calendar block (`.wp-calendar-table`) displays a different font-family in the block editor compared to the front-end.

### Changes:
- Adds a font-family rule to `.wp-calendar-table` in `style-editor.scss` using the existing `$font__heading` variable and `font-family()` mixin.
- Ensures consistent typography between front-end and editor.
- Rebuilds `style-editor.css` and `style-editor-rtl.css` with the updated styles.

Trac ticket: https://core.trac.wordpress.org/ticket/63331

### Before
https://github.com/user-attachments/assets/9fcf90d2-ae5a-4f10-be7a-dae6fc550184

### After
https://github.com/user-attachments/assets/a1f6c218-cb2a-4354-82ed-17b27fd2f917