### PR TITLE
Twenty Twenty: "Add citation" text font-weight issue in Quote block

### DIFF
--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
@@ -670,6 +670,14 @@ hr.wp-block-separator.is-style-dots::before {
 	line-height: 1.25;
 }
 
+.editor-styles-wrapper .wp-block-quote cite em {
+	font-weight: bolder;
+}
+
+.editor-styles-wrapper .wp-block-quote cite strong {
+	font-weight: 700;
+}
+
 .editor-styles-wrapper .wp-block-quote cite {
 	font-style: normal;
 }

--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
@@ -674,6 +674,14 @@ hr.wp-block-separator.is-style-dots::before {
 	line-height: 1.25;
 }
 
+.editor-styles-wrapper .wp-block-quote cite em {
+	font-weight: bolder;
+}
+
+.editor-styles-wrapper .wp-block-quote cite strong {
+	font-weight: 700;
+}
+
 .editor-styles-wrapper .wp-block-quote cite {
 	font-style: normal;
 }


### PR DESCRIPTION
In Twenty Twenty Theme, when italic formatting is applied to citation text in the Quote block's "Add citation" field, the editor and frontend display different font-weight styles. While the editor shows the italic text with normal font-weight, the frontend displays it with bolder font-weight, creating an inconsistency in the visual representation. The inconsistency also exist with bold font styles.

**Steps to replicate:**
1. Activate the Twenty Twenty Theme
2. Add Quote block
3. Add text in "Add citation" section  
4. Select the added text and make it italic
5. Save Page/Post
6. View the page/post on frontend

**Expected behavior:** Editor should match frontend styling for italic citations

**Solution:** Added CSS rule to ensure italic citations display with bolder font-weight in the editor, matching the frontend appearance.

Trac ticket: [#55934](https://core.trac.wordpress.org/ticket/55934)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more