### PR TITLE
Bump the recommended MariaDB version to 10.6

### DIFF
--- a/src/readme.html
+++ b/src/readme.html
@@ -59,7 +59,7 @@
 <h3>Recommendations</h3>
 <ul>
 	<li><a href="https://www.php.net/">PHP</a> version <strong>7.4</strong> or greater.</li>
-	<li><a href="https://www.mysql.com/">MySQL</a> version <strong>8.0</strong> or greater OR <a href="https://mariadb.org/">MariaDB</a> version <strong>10.5</strong> or greater.</li>
+	<li><a href="https://www.mysql.com/">MySQL</a> version <strong>8.0</strong> or greater OR <a href="https://mariadb.org/">MariaDB</a> version <strong>10.6</strong> or greater.</li>
 	<li>The <a href="https://httpd.apache.org/docs/2.2/mod/mod_rewrite.html">mod_rewrite</a> Apache module.</li>
 	<li><a href="https://wordpress.org/news/2016/12/moving-toward-ssl/">HTTPS</a> support.</li>
 	<li>A link to <a href="https://wordpress.org/">wordpress.org</a> on your site.</li>

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -18,7 +18,7 @@ class WP_Site_Health {
 	private $mysql_server_version        = '';
 	private $mysql_required_version      = '5.5';
 	private $mysql_recommended_version   = '8.0';
-	private $mariadb_recommended_version = '10.5';
+	private $mariadb_recommended_version = '10.6';
 
 	public $php_memory_limit;
 


### PR DESCRIPTION
MariaDB 10.5 will reach the end of life on [24 June 2025](https://mariadb.org/about/#maintenance-policy).

To ensure WordPress is recommending a supported version of the software, the recommended version should be updated to 10.6 or greater.

Core Trac Ticket: https://core.trac.wordpress.org/ticket/63587