### PR TITLE
Youtube oEmbed Test is not loading scripts

### DIFF
--- a/tests/phpunit/tests/oembed/controller.php
+++ b/tests/phpunit/tests/oembed/controller.php
@@ -604,6 +604,7 @@ class Test_oEmbed_Controller extends WP_UnitTestCase {
 	 * @see wp_maybe_load_embeds()
 	 */
 	public function test_proxy_with_classic_embed_provider() {
+		wp_scripts()->registered['wp-embed'];
 		wp_set_current_user( self::$editor );
 		$request = new WP_REST_Request( 'GET', '/oembed/1.0/proxy' );
 		$request->set_param( 'url', 'https://www.youtube.com/embed/' . self::YOUTUBE_VIDEO_ID );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63590

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
