### PR TITLE
FIX: Ensure `upgrader_process_complete` fires for bulk updates

### DIFF
--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -952,40 +952,39 @@ class WP_Upgrader {
 			add_action( 'shutdown', array( $this, 'delete_temp_backup' ), 100, 0 );
 		}
 
+		/**
+		* Fires when the upgrader process is complete.
+		*
+		* See also {@see 'upgrader_package_options'}.
+		*
+		* @since 3.6.0
+		* @since 3.7.0 Added to WP_Upgrader::run().
+		* @since 4.6.0 `$translations` was added as a possible argument to `$hook_extra`.
+		*
+		* @param WP_Upgrader $upgrader   WP_Upgrader instance. In other contexts this might be a
+		*                                Theme_Upgrader, Plugin_Upgrader, Core_Upgrade, or Language_Pack_Upgrader instance.
+		* @param array       $hook_extra {
+		*     Array of bulk item update data.
+		*
+		*     @type string $action       Type of action. Default 'update'.
+		*     @type string $type         Type of update process. Accepts 'plugin', 'theme', 'translation', or 'core'.
+		*     @type bool   $bulk         Whether the update process is a bulk update. Default true.
+		*     @type array  $plugins      Array of the basename paths of the plugins' main files.
+		*     @type array  $themes       The theme slugs.
+		*     @type array  $translations {
+		*         Array of translations update data.
+		*
+		*         @type string $language The locale the translation is for.
+		*         @type string $type     Type of translation. Accepts 'plugin', 'theme', or 'core'.
+		*         @type string $slug     Text domain the translation is for. The slug of a theme/plugin or
+		*                                'default' for core translations.
+		*         @type string $version  The version of a theme, plugin, or core.
+		*     }
+		* }
+		*/
+		do_action( 'upgrader_process_complete', $this, $options['hook_extra'] );
+
 		if ( ! $options['is_multi'] ) {
-
-			/**
-			 * Fires when the upgrader process is complete.
-			 *
-			 * See also {@see 'upgrader_package_options'}.
-			 *
-			 * @since 3.6.0
-			 * @since 3.7.0 Added to WP_Upgrader::run().
-			 * @since 4.6.0 `$translations` was added as a possible argument to `$hook_extra`.
-			 *
-			 * @param WP_Upgrader $upgrader   WP_Upgrader instance. In other contexts this might be a
-			 *                                Theme_Upgrader, Plugin_Upgrader, Core_Upgrade, or Language_Pack_Upgrader instance.
-			 * @param array       $hook_extra {
-			 *     Array of bulk item update data.
-			 *
-			 *     @type string $action       Type of action. Default 'update'.
-			 *     @type string $type         Type of update process. Accepts 'plugin', 'theme', 'translation', or 'core'.
-			 *     @type bool   $bulk         Whether the update process is a bulk update. Default true.
-			 *     @type array  $plugins      Array of the basename paths of the plugins' main files.
-			 *     @type array  $themes       The theme slugs.
-			 *     @type array  $translations {
-			 *         Array of translations update data.
-			 *
-			 *         @type string $language The locale the translation is for.
-			 *         @type string $type     Type of translation. Accepts 'plugin', 'theme', or 'core'.
-			 *         @type string $slug     Text domain the translation is for. The slug of a theme/plugin or
-			 *                                'default' for core translations.
-			 *         @type string $version  The version of a theme, plugin, or core.
-			 *     }
-			 * }
-			 */
-			do_action( 'upgrader_process_complete', $this, $options['hook_extra'] );
-
 			$this->skin->footer();
 		}
 


### PR DESCRIPTION
## Summary
The `upgrader_process_complete` hook currently only fires for individual plugin updates but is skipped during bulk operations due to an `is_multi` condition check. This inconsistency breaks plugins that rely on post-upgrade actions like cache clearing, security scans, and configuration updates.

### Changes Made
- Move the `upgrader_process_complete` hook from the `is_multi` condition in WP_Upgrader::run()
- Keep the is_multi check only for $this->skin->footer() calls
- Maintain existing bulk upgrade hooks in Plugin_Upgrader and Theme_Upgrader for backward compatibility

Trac ticket: https://core.trac.wordpress.org/ticket/63596
