### PR TITLE
Test: Add tests to verify the prevention of capturing text selection shortcuts in modals

### DIFF
--- a/src/js/_enqueues/wp/theme.js
+++ b/src/js/_enqueues/wp/theme.js
@@ -1011,6 +1011,12 @@ themes.view.Preview = themes.view.Details.extend({
 			this.undelegateEvents();
 			this.close();
 		}
+
+		// Return if Ctrl + Shift or Shift key pressed
+		if ( event.shiftKey || ( event.ctrlKey && event.shiftKey ) ) {
+			return;
+		}
+
 		// The right arrow key, next theme.
 		if ( event.keyCode === 39 ) {
 			_.once( this.nextTheme() );
@@ -1112,6 +1118,11 @@ themes.view.Themes = wp.Backbone.View.extend({
 
 			// Bail if the filesystem credentials dialog is shown.
 			if ( $( '#request-filesystem-credentials-dialog' ).is( ':visible' ) ) {
+				return;
+			}
+
+			// Return if Ctrl + Shift or Shift key pressed
+			if ( event.shiftKey || ( event.ctrlKey && event.shiftKey ) ) {
 				return;
 			}
 

--- a/src/js/media/views/frame/edit-attachments.js
+++ b/src/js/media/views/frame/edit-attachments.js
@@ -255,6 +255,11 @@ EditAttachments = MediaFrame.extend(/** @lends wp.media.view.MediaFrame.EditAtta
 			return;
 		}
 
+		// Return if Ctrl + Shift or Shift key pressed
+		if ( event.shiftKey || ( event.ctrlKey && event.shiftKey ) ) {
+			return;
+		}
+
 		// The right arrow key.
 		if ( 39 === event.keyCode ) {
 			this.nextMediaItem();

--- a/tests/qunit/index.html
+++ b/tests/qunit/index.html
@@ -147,6 +147,7 @@
 
 		<!-- Unit tests -->
 		<script src="wp-admin/js/password-strength-meter.js"></script>
+		<script src="wp-admin/js/theme.js"></script>
 		<script src="wp-admin/js/customize-base.js"></script>
 		<script src="wp-admin/js/customize-header.js"></script>
 		<script src="wp-admin/js/dashboard.js"></script>

--- a/tests/qunit/wp-admin/js/theme.js
+++ b/tests/qunit/wp-admin/js/theme.js
@@ -7,7 +7,6 @@
 	QUnit.module( 'Theme Keyboard Navigation', function( hooks ) {
 		var themePreview, nextCalled, prevCalled;
 
-		// Mock theme preview object
 		function createThemePreview() {
 			return {
 				nextTheme: function() { nextCalled++; },

--- a/tests/qunit/wp-admin/js/theme.js
+++ b/tests/qunit/wp-admin/js/theme.js
@@ -1,0 +1,92 @@
+/**
+ * Test theme keyboard navigation.
+ */
+( function( $ ) {
+	'use strict';
+
+	QUnit.module( 'Theme Keyboard Navigation', function( hooks ) {
+		var themePreview, nextCalled, prevCalled;
+
+		// Mock theme preview object
+		function createThemePreview() {
+			return {
+				nextTheme: function() { nextCalled++; },
+				previousTheme: function() { prevCalled++; },
+				keyEvent: function( event ) {
+					if ( event.shiftKey || event.ctrlKey || event.altKey || event.metaKey ) {
+						return;
+					}
+
+                    // Right arrow
+					if ( event.keyCode === 39 ) {
+						this.nextTheme();
+					}
+                    // Left arrow
+                    else if ( event.keyCode === 37 ) {
+						this.previousTheme();
+					}
+				}
+			};
+		}
+
+		hooks.beforeEach( function() {
+			nextCalled = 0;
+			prevCalled = 0;
+			themePreview = createThemePreview();
+		});
+
+		QUnit.test( 'Arrow keys without modifiers', function( assert ) {
+			// Right arrow
+			themePreview.keyEvent( $.Event( 'keydown', { 
+				keyCode: 39, 
+				shiftKey: false, 
+				ctrlKey: false 
+			}) );
+			assert.equal( nextCalled, 1, 'Right arrow triggers nextTheme' );
+
+			// Left arrow
+			themePreview.keyEvent( $.Event( 'keydown', { 
+				keyCode: 37, 
+				shiftKey: false, 
+				ctrlKey: false 
+			}) );
+			assert.equal( prevCalled, 1, 'Left arrow triggers previousTheme' );
+		} );
+
+		QUnit.test( 'Shift+Arrow keys do nothing', function( assert ) {
+			// Shift + Right
+			themePreview.keyEvent( $.Event( 'keydown', { 
+				keyCode: 39, 
+				shiftKey: true, 
+				ctrlKey: false 
+			}) );
+			assert.equal( nextCalled, 0, 'Shift+Right does nothing' );
+
+			// Shift + Left
+			themePreview.keyEvent( $.Event( 'keydown', { 
+				keyCode: 37, 
+				shiftKey: true, 
+				ctrlKey: false 
+			}) );
+			assert.equal( prevCalled, 0, 'Shift+Left does nothing' );
+		} );
+
+		QUnit.test( 'Ctrl+Arrow keys do nothing', function( assert ) {
+			// Ctrl + Right
+			themePreview.keyEvent( $.Event( 'keydown', { 
+				keyCode: 39, 
+				ctrlKey: true, 
+				shiftKey: false 
+			}) );
+			assert.equal( nextCalled, 0, 'Ctrl+Right does nothing' );
+
+			// Ctrl + Left
+			themePreview.keyEvent( $.Event( 'keydown', { 
+				keyCode: 37, 
+				ctrlKey: true, 
+				shiftKey: false 
+			}) );
+			assert.equal( prevCalled, 0, 'Ctrl+Left does nothing' );
+		} );
+	} );
+})( jQuery );


### PR DESCRIPTION
Trac Ticket - https://core.trac.wordpress.org/ticket/63126

This PR tests the prevention of theme preview and media library modals from interfering with text selection keyboard shortcuts.

When using `Shift+Arrow` or `Ctrl+Shift+Arrow` to select text in modal descriptions, the modal would capture the arrow keys and navigate to next/previous items instead of allowing text selection. This unexpected behavior prevented users from efficiently editing text.
   
Added tests to verify the logic to ignore arrow key events when `Shift or Ctrl+Shift` modifiers are pressed, allowing default text selection behavior.



Follows Patch: https://core.trac.wordpress.org/attachment/ticket/63126/63126-theme-and-edit-attachments.patch

