### PR TITLE
Admin Menu: Make expand admin menu button easily discoverable

### DIFF
--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -469,8 +469,25 @@ ul#adminmenu > li.current > a.current:after {
 	cursor: pointer;
 }
 
+.collapse-button-icon::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  z-index: -1;
+}
+
 #collapse-button:hover {
 	color: #72aee6;
+}
+
+#collapse-button:hover .collapse-button-icon:before {
+  box-shadow: 0 0 0 2px #2271b1;
+  outline: 2px solid transparent;
 }
 
 #collapse-button:focus {

--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -28,7 +28,7 @@
 #adminmenu {
 	clear: left;
 	margin: 12px 0;
-	padding: 0;
+	padding-bottom: 2rem;
 	list-style: none;
 }
 
@@ -458,10 +458,14 @@ ul#adminmenu > li.current > a.current:after {
 	margin: 0;
 	border: none;
 	padding: 0;
-	position: relative;
+	position: fixed;
+	bottom: 0;
+	left: 0;
+	width: 160px;
 	overflow: visible;
 	background: none;
 	color: #a7aaad;
+	background-color: #1d2327;
 	cursor: pointer;
 }
 

--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -489,7 +489,8 @@ ul#adminmenu > li.current > a.current:after {
 	color: #72aee6;
 }
 
-#collapse-button:hover .collapse-button-icon:before {
+#collapse-button:hover .collapse-button-icon:before,
+#collapse-button:focus .collapse-button-icon:before {
   box-shadow: 0 0 0 2px #2271b1;
   outline: 2px solid transparent;
 }

--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -469,6 +469,10 @@ ul#adminmenu > li.current > a.current:after {
 	cursor: pointer;
 }
 
+.folded #collapse-button {
+	width: 36px;
+}
+
 .collapse-button-icon::before {
   content: "";
   position: absolute;

--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -491,7 +491,7 @@ ul#adminmenu > li.current > a.current:after {
 
 #collapse-button:hover .collapse-button-icon:before,
 #collapse-button:focus .collapse-button-icon:before {
-  box-shadow: 0 0 0 2px #2271b1;
+  box-shadow: 0 0 0 2px #72aee6;
   outline: 2px solid transparent;
 }
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/50423

## What
This PR increases discoverability of expand/collapse admin menu button

Suggestions from design team discussion have been incorporated into this fix
Ref: https://core.trac.wordpress.org/ticket/50423#comment:5

## How
1. The collapse button has been moved towards the bottom for separation with the rest of the menu items
2. An additional ring indicator has been added for hover & focus states similar to the button found in customizer panel

Additionally, to incorporate cases where there isn't sufficient height for all menu items & it scrolls, the button stays at the bottom with background color applied to be easily visible, extra padding has been added to menu list at the bottom for separation in overflow state

## Screenshots

Folded state

![image](https://github.com/user-attachments/assets/a2461407-6e3e-4481-ac04-c800d6890233)

Open state

![image](https://github.com/user-attachments/assets/c1b9d853-2f0c-49c1-974f-cb931cb078a9)

Focus/Hover indicator

![image](https://github.com/user-attachments/assets/61648836-2bfc-4854-8d72-a5977dcbd014)
