### PR TITLE
Try: Ensure tests from PR #8789 pass on 6.7

### DIFF
--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -10,6 +10,37 @@
  * @group blocks
  */
 class Tests_Blocks_Serialize extends WP_UnitTestCase {
+	/**
+	 * Set up.
+	 *
+	 * @ticket 63325.
+	 */
+	public static function wpSetUpBeforeClass() {
+		register_block_type(
+			'core/attributes',
+			array(
+				'attributes' => array(
+					'array'  => array(
+						'type' => 'array',
+					),
+					'object' => array(
+						'type' => 'object',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Tear down.
+	 *
+	 * @ticket 63325.
+	 */
+	public static function wpTearDownAfterClass() {
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		$registry->unregister( 'core/attributes' );
+	}
 
 	/**
 	 * @dataProvider data_serialize_identity_from_parsed
@@ -46,6 +77,12 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 
 			// Block with attribute values that should not be escaped.
 			array( '<!-- wp:attributes {"key":"€1.00 / 3 for €2.00"} /-->' ),
+
+			// Block with empty array attribute value.
+			array( '<!-- wp:attributes {"array":[]} /-->' ),
+
+			// Block with empty object attribute value.
+			array( '<!-- wp:attributes {"object":{}} /-->' ),
 		);
 	}
 


### PR DESCRIPTION
Run the new tests added in https://github.com/WordPress/wordpress-develop/pull/8789/ on 6.7 branch to ensure backwards compatibility is restored from 6.7 -> 6.8

Trac ticket: https://core.trac.wordpress.org/ticket/63325


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
