### PR TITLE
Add `get_pages_args` filter to allow full control of original arguments in `get_pages()`

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6387,7 +6387,7 @@ function get_pages( $args = array() ) {
 	 * @param array $defaults Array of default arguments.
 	 */
 	$args = apply_filters( 'get_pages_args', $args, $defaults );
-	
+
 	$parsed_args = wp_parse_args( $args, $defaults );
 
 	$number       = (int) $parsed_args['number'];

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6378,6 +6378,16 @@ function get_pages( $args = array() ) {
 		'post_status'  => 'publish',
 	);
 
+	/**
+	 * Filters arguments passed to get_pages to maintain correspondence with get_pages_query_args filter for WP_Query.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param array $args  Array of arguments passed to get_pages.
+	 * @param array $defaults Array of default arguments.
+	 */
+	$args = apply_filters( 'get_pages_args', $args, $defaults );
+	
 	$parsed_args = wp_parse_args( $args, $defaults );
 
 	$number       = (int) $parsed_args['number'];


### PR DESCRIPTION
Adds a new `get_pages_args` filter before `wp_parse_args()` in `get_pages()`.

This allows developers to modify values such as `child_of`, `number`, `offset`, `parent`, and others that are not handled via the `get_pages_query_args` filter.

Trac ticket: https://core.trac.wordpress.org/ticket/63600
