### PR TITLE
Remove screencast.com oembed provider.

### DIFF
--- a/src/wp-includes/class-wp-oembed.php
+++ b/src/wp-includes/class-wp-oembed.php
@@ -89,7 +89,6 @@ class WP_oEmbed {
 			'#https?://videopress\.com/v/.*#'              => array( 'https://public-api.wordpress.com/oembed/?for=' . $host, true ),
 			'#https?://(www\.)?reddit\.com/r/[^/]+/comments/.*#i' => array( 'https://www.reddit.com/oembed', true ),
 			'#https?://(www\.)?speakerdeck\.com/.*#i'      => array( 'https://speakerdeck.com/oembed.{format}', true ),
-			'#https?://(www\.)?screencast\.com/.*#i'       => array( 'https://api.screencast.com/external/oembed', true ),
 			'#https?://([a-z0-9-]+\.)?amazon\.(com|com\.mx|com\.br|ca)/.*#i' => array( 'https://read.amazon.com/kp/api/oembed', true ),
 			'#https?://([a-z0-9-]+\.)?amazon\.(co\.uk|de|fr|it|es|in|nl|ru)/.*#i' => array( 'https://read.amazon.co.uk/kp/api/oembed', true ),
 			'#https?://([a-z0-9-]+\.)?amazon\.(co\.jp|com\.au)/.*#i' => array( 'https://read.amazon.com.au/kp/api/oembed', true ),
@@ -216,6 +215,7 @@ class WP_oEmbed {
 		 * | Meetup.com   | meetup.com           | 3.9.0     | 6.0.1     |
 		 * | Meetup.com   | meetu.ps             | 3.9.0     | 6.0.1     |
 		 * | SlideShare   | slideshare.net       | 3.5.0     | 6.6.0     |
+		 * | Screencast   | screencast.com       | 4.8.0     | 6.9.0     |
 		 *
 		 * @see wp_oembed_add_provider()
 		 *

--- a/src/wp-includes/class-wp-oembed.php
+++ b/src/wp-includes/class-wp-oembed.php
@@ -215,7 +215,7 @@ class WP_oEmbed {
 		 * | Meetup.com   | meetup.com           | 3.9.0     | 6.0.1     |
 		 * | Meetup.com   | meetu.ps             | 3.9.0     | 6.0.1     |
 		 * | SlideShare   | slideshare.net       | 3.5.0     | 6.6.0     |
-		 * | Screencast   | screencast.com       | 4.8.0     | 6.9.0     |
+		 * | Screencast   | screencast.com       | 4.8.0     | 6.8.2     |
 		 *
 		 * @see wp_oembed_add_provider()
 		 *


### PR DESCRIPTION
A refactor of systems at screencast.com has broken existing embeds and removed the existing oembed endpoint.

`https://api.screencast.com/external/oembed` now returns a `410 Gone` response.

See the lengthy discussion on the ticket from [comment 35 onwards](https://core.trac.wordpress.org/ticket/61941#comment:35). 

Trac ticket: https://core.trac.wordpress.org/ticket/61941
Follow up to r40574 / https://github.com/wordPress/wordpress-develop/commit/9a2188dd560fe0e2f756c114939fdf7a099032ed

<img width="533" alt="Screenshot 2025-06-20 at 8 11 13 am" src="https://github.com/user-attachments/assets/68ebdeff-d68c-4066-9ad8-a3e3d4b228fd" />

