### PR TITLE
Fix: Fixed CSS for Edit link outline on add new media. 

### DIFF
--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -115,10 +115,10 @@
 .media-item .attachment-tools {
 	display: flex;
 	align-items: center;
+	margin-top: 10px;
 }
 
 .media-item .edit-attachment {
-	padding: 14px 0;
 	display: block;
 	margin-right: 10px;
 }
@@ -168,7 +168,6 @@
 
 .media-item .filename {
 	padding: 14px 0;
-	overflow: hidden;
 	margin-left: 6px;
 }
 
@@ -1266,7 +1265,7 @@ audio, video {
 	.edit-attachment-frame textarea {
 		line-height: 1.5;
 	}
-	
+
 	.wp_attachment_details label[for="content"] {
 		font-size: 14px;
 		line-height: 1.5;


### PR DESCRIPTION
This PR fix the CSS for left outline for the Edit link for media item.
I've also removed extra spacing at bottom between attachment-tools container and media item container bottom.

Trac ticket: https://core.trac.wordpress.org/attachment/ticket/63602/

<img width="1114" alt="Screenshot 2025-06-20 at 1 41 58 PM" src="https://github.com/user-attachments/assets/452cceeb-07d6-4277-aa1c-038c5bf171d4" />
