### PR TITLE
npm run dev: Warning: Maximum call stack size exceeded

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1247,7 +1247,7 @@ module.exports = function(grunt) {
 					'!' + SOURCE_DIR + 'js/**/*.js',
 					// Ignore version control directories.
 					'!' + SOURCE_DIR + '**/.{svn,git}/**',
-					'!' + SOURCE_DIR + 'wp-content/plugins/**/node_modules/**'
+					'!' + SOURCE_DIR + 'wp-content/plugins/**'
 				],
 				tasks: ['clean:dynamic', 'copy:dynamic'],
 				options: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1251,6 +1251,7 @@ module.exports = function(grunt) {
 					'!' + SOURCE_DIR + 'js/**/*.js',
 					// Ignore version control directories.
 					'!' + SOURCE_DIR + '**/.{svn,git}/**',
+					// Maximum call stack size exceeded. See #63606
 					'!' + SOURCE_DIR + 'wp-content/plugins/**',
 					SOURCE_DIR + 'wp-content/plugins/akismet/**'
 				],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -260,8 +260,12 @@ module.exports = function(grunt) {
 						dest: BUILD_DIR
 					},
 					{
-						[BUILD_DIR + 'index.php']: ['src/_index.php'],
-						[BUILD_DIR + 'wp-admin/index.php']: ['src/wp-admin/_index.php']
+						src: 'src/_index.php',
+						dest: BUILD_DIR + 'index.php'
+					},
+					{
+						src: 'src/wp-admin/_index.php',
+						dest: BUILD_DIR + 'wp-admin/index.php'
 					}
 				]
 			},
@@ -1247,7 +1251,8 @@ module.exports = function(grunt) {
 					'!' + SOURCE_DIR + 'js/**/*.js',
 					// Ignore version control directories.
 					'!' + SOURCE_DIR + '**/.{svn,git}/**',
-					'!' + SOURCE_DIR + 'wp-content/plugins/**'
+					'!' + SOURCE_DIR + 'wp-content/plugins/**',
+					SOURCE_DIR + 'wp-content/plugins/akismet/**'
 				],
 				tasks: ['clean:dynamic', 'copy:dynamic'],
 				options: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1246,7 +1246,8 @@ module.exports = function(grunt) {
 					SOURCE_DIR + '**',
 					'!' + SOURCE_DIR + 'js/**/*.js',
 					// Ignore version control directories.
-					'!' + SOURCE_DIR + '**/.{svn,git}/**'
+					'!' + SOURCE_DIR + '**/.{svn,git}/**',
+					'!' + SOURCE_DIR + 'wp-content/plugins/**'
 				],
 				tasks: ['clean:dynamic', 'copy:dynamic'],
 				options: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1247,7 +1247,7 @@ module.exports = function(grunt) {
 					'!' + SOURCE_DIR + 'js/**/*.js',
 					// Ignore version control directories.
 					'!' + SOURCE_DIR + '**/.{svn,git}/**',
-					'!' + SOURCE_DIR + 'wp-content/plugins/**'
+					'!' + SOURCE_DIR + 'wp-content/plugins/**/node_modules/**'
 				],
 				tasks: ['clean:dynamic', 'copy:dynamic'],
 				options: {


### PR DESCRIPTION
== Testing & Reproduction Instructions

1. Install a ton of plugins. The thing is that if you install block plugins with a zillion `node_modules` files it will be easier to reproduce. The more files in the plugins directory, the better to reproduce this
2. Run `npm run dev`
3. Check the logs and see if you can spot the `Warning: Maximum call stack size exceeded`

With the patch, this should be gone

Trac ticket: https://core.trac.wordpress.org/ticket/63606

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
