### PR TITLE
get_boundary_post Only works from a single page - get_boundary_post.diff Refresh

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2191,11 +2191,11 @@ function prev_post_rel_link( $title = '%title', $in_same_term = false, $excluded
  * @return array|null Array containing the boundary post object if successful, null otherwise.
  */
 function get_boundary_post( $in_same_term = false, $excluded_terms = '', $start = true, $taxonomy = 'category' ) {
-	$post = get_post();
-
 	if ( ! taxonomy_exists( $taxonomy ) ) {
 		return null;
 	}
+
+	$post = get_post();
 
 	$query_args = array(
 		'posts_per_page'         => 1,

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -2193,7 +2193,7 @@ function prev_post_rel_link( $title = '%title', $in_same_term = false, $excluded
 function get_boundary_post( $in_same_term = false, $excluded_terms = '', $start = true, $taxonomy = 'category' ) {
 	$post = get_post();
 
-	if ( ! $post || ! is_single() || is_attachment() || ! taxonomy_exists( $taxonomy ) ) {
+	if ( ! taxonomy_exists( $taxonomy ) ) {
 		return null;
 	}
 


### PR DESCRIPTION
Refreshing patch 

Trac ticket: https://core.trac.wordpress.org/ticket/22957

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
