### PR TITLE
Add filter for post statuses in quickedit - Refreshing 36237.patch

### DIFF
--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1995,6 +1995,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 								if ( $can_publish ) {
 									$inline_edit_statuses['publish'] = __( 'Published' );
 									$inline_edit_statuses['future']  = __( 'Scheduled' );
+									// There is already a checkbox for Private in Single Post Quick Edit. See #63612.
 									if ( $bulk ) {
 										$inline_edit_statuses['private'] = __( 'Private' );
 									}

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1984,22 +1984,46 @@ class WP_Posts_List_Table extends WP_List_Table {
 					<div class="inline-edit-group wp-clearfix">
 
 						<label class="inline-edit-status alignleft">
-							<span class="title"><?php _e( 'Status' ); ?></span>
+							<span class="title"><?php __( 'Status' ); ?></span>
 							<select name="_status">
-								<?php if ( $bulk ) : ?>
-									<option value="-1"><?php _e( '&mdash; No Change &mdash;' ); ?></option>
-								<?php endif; // $bulk ?>
+								<?php
+								$inline_edit_statuses = array();
+								if ( $bulk ) {
+									$inline_edit_statuses['-1'] = __( '&mdash; No Change &mdash;' );
+								}
+								// Contributors only get "Unpublished" and "Pending Review".
+								if ( $can_publish ) {
+									$inline_edit_statuses['publish'] = __( 'Published' );
+									$inline_edit_statuses['future']  = __( 'Scheduled' );
+									if ( $bulk ) {
+										$inline_edit_statuses['private'] = __( 'Private' );
+									}
+								}
 
-								<?php if ( $can_publish ) : // Contributors only get "Unpublished" and "Pending Review". ?>
-									<option value="publish"><?php _e( 'Published' ); ?></option>
-									<option value="future"><?php _e( 'Scheduled' ); ?></option>
-									<?php if ( $bulk ) : ?>
-										<option value="private"><?php _e( 'Private' ); ?></option>
-									<?php endif; // $bulk ?>
-								<?php endif; ?>
+								$inline_edit_statuses['pending'] = __( 'Pending Review' );
+								$inline_edit_statuses['draft']   = __( 'Draft' );
+								/**
+								 * Filters the statuses available in the Quick Edit UI.
+								 *
+								 * @since 6.9.0
+								 *
+								 * @param array $inline_edit_statuses An array of statuses available in the Quick Edit UI.
+								 * @param string $screen->post_type The post type slug.
+								 * @param bool $bulk A flag to denote if it's a bulk action.
+								 * @param bool $can_publish A flag to denote if the user can publish posts.
+								 *
+								 * @return array $inline_edit_statuses An array of statuses available in the Quick Edit UI.
+								 */
+								$inline_edit_statuses = apply_filters( 'quick_edit_statuses', $inline_edit_statuses, $screen->post_type, $bulk, $can_publish );
 
-								<option value="pending"><?php _e( 'Pending Review' ); ?></option>
-								<option value="draft"><?php _e( 'Draft' ); ?></option>
+								if ( is_array( $inline_edit_statuses ) ) :
+									foreach ( $inline_edit_statuses as $inline_status_value => $inline_status_text ) :
+										?>
+										<option value="<?php echo esc_attr( $inline_status_value ); ?>"><?php echo esc_attr( $inline_status_text ); ?></option>		
+										<?php
+									endforeach;
+								endif;
+								?>
 							</select>
 						</label>
 

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1984,7 +1984,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 					<div class="inline-edit-group wp-clearfix">
 
 						<label class="inline-edit-status alignleft">
-							<span class="title"><?php __( 'Status' ); ?></span>
+							<span class="title"><?php _e( 'Status' ); ?></span>
 							<select name="_status">
 								<?php
 								$inline_edit_statuses = array();


### PR DESCRIPTION
Refreshing and Improving 36237.patch
I've code reviewed it and compared to the original version, there was a little difference on the conditionals (adding Private status type too early). 
I am not sure if this was implemented by the original author on purpose @kakomap because there doesn't seem to be an explanation on this.

Apart from this, everything looks good, a nice DRY refactor, meant to include the filter accordingly.

I will be posting a test to this refresh
Automated could be done through Playwright. But I would leave this for further iterations. If anyone wants to add this feel free.
Trac ticket: https://core.trac.wordpress.org/ticket/36237

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
