### PR TITLE
Post: Fix `wp_list_pages()` to correctly honor `exclude` with `depth` parameter

### DIFF
--- a/src/wp-includes/class-wp-walker.php
+++ b/src/wp-includes/class-wp-walker.php
@@ -252,13 +252,23 @@ class Walker {
 			$this->display_element( $e, $children_elements, $max_depth, 0, $args, $output );
 		}
 
+		$has_excluded_parents = false;
+
+		if ( $max_depth > 0 ) {
+			if ( is_array( $args[0] ) && ! empty( $args[0]['exclude'] ) ) {
+				$has_excluded_parents = true;
+			} elseif ( is_object( $args[0] ) && ! empty( $args[0]->exclude ) ) {
+				$has_excluded_parents = true;
+			}
+		}
+
 		/*
-		* If we are displaying all levels (depth=0),
+		* If we are displaying all levels (depth = 0),
 		* OR if specific parents were excluded with limited depth,
 		* we may have got orphans, which should be displayed regardless.
 		*/
-		if ( 0 === $max_depth || ( $max_depth > 0 && ! empty( $args[0]->exclude ) ) ) {
-			if ( count( $children_elements ) > 0 ) {
+		if ( 0 === $max_depth || $has_excluded_parents ) {
+			if ( ! empty( $children_elements ) ) {
 				$empty_array = array();
 				foreach ( $children_elements as $orphans ) {
 					foreach ( $orphans as $op ) {

--- a/src/wp-includes/class-wp-walker.php
+++ b/src/wp-includes/class-wp-walker.php
@@ -257,7 +257,7 @@ class Walker {
 		* OR if specific parents were excluded with limited depth,
 		* we may have got orphans, which should be displayed regardless.
 		*/
-		if ( 0 === $max_depth || ( $max_depth > 0 && ! empty( $args[0]['exclude'] ) ) ) {
+		if ( 0 === $max_depth || ( $max_depth > 0 && ! empty( $args[0]->exclude ) ) ) {
 			if ( count( $children_elements ) > 0 ) {
 				$empty_array = array();
 				foreach ( $children_elements as $orphans ) {

--- a/src/wp-includes/class-wp-walker.php
+++ b/src/wp-includes/class-wp-walker.php
@@ -254,7 +254,7 @@ class Walker {
 
 		$has_excluded_parents = false;
 
-		if ( $max_depth > 0 ) {
+		if ( $max_depth > 0 && isset( $args[0] ) ) {
 			if ( is_array( $args[0] ) && ! empty( $args[0]['exclude'] ) ) {
 				$has_excluded_parents = true;
 			} elseif ( is_object( $args[0] ) && ! empty( $args[0]->exclude ) ) {

--- a/src/wp-includes/class-wp-walker.php
+++ b/src/wp-includes/class-wp-walker.php
@@ -253,14 +253,17 @@ class Walker {
 		}
 
 		/*
-		 * If we are displaying all levels, and remaining children_elements is not empty,
-		 * then we got orphans, which should be displayed regardless.
-		 */
-		if ( ( 0 === $max_depth ) && count( $children_elements ) > 0 ) {
-			$empty_array = array();
-			foreach ( $children_elements as $orphans ) {
-				foreach ( $orphans as $op ) {
-					$this->display_element( $op, $empty_array, 1, 0, $args, $output );
+		* If we are displaying all levels (depth=0),
+		* OR if specific parents were excluded with limited depth,
+		* we may have got orphans, which should be displayed regardless.
+		*/
+		if ( 0 === $max_depth || ( $max_depth > 0 && ! empty( $args[0]['exclude'] ) ) ) {
+			if ( count( $children_elements ) > 0 ) {
+				$empty_array = array();
+				foreach ( $children_elements as $orphans ) {
+					foreach ( $orphans as $op ) {
+						$this->display_element( $op, $empty_array, 1, 0, $args, $output );
+					}
 				}
 			}
 		}

--- a/tests/phpunit/tests/post/wpListPages.php
+++ b/tests/phpunit/tests/post/wpListPages.php
@@ -540,4 +540,36 @@ class Tests_Post_wpListPages extends WP_UnitTestCase {
 			'The output should contain exactly one "current_page_item" class.'
 		);
 	}
+
+	/**
+	 * @ticket 27326
+	 */
+	public function test_wp_list_page_combo_exclude_depth() {
+		$args = array(
+			'echo'    => false,
+			'exclude' => self::$parent_3,
+			'depth'   => 3,
+		);
+
+		$expected = '<li class="pagenav">Pages<ul><li class="page_item page-item-' . self::$parent_1 . ' page_item_has_children"><a href="' . get_permalink( self::$parent_1 ) . '">Parent 1</a>
+<ul class=\'children\'>
+	<li class="page_item page-item-' . self::$children[ self::$parent_1 ][0] . '"><a href="' . get_permalink( self::$children[ self::$parent_1 ][0] ) . '">Child 1</a></li>
+	<li class="page_item page-item-' . self::$children[ self::$parent_1 ][1] . '"><a href="' . get_permalink( self::$children[ self::$parent_1 ][1] ) . '">Child 2</a></li>
+	<li class="page_item page-item-' . self::$children[ self::$parent_1 ][2] . '"><a href="' . get_permalink( self::$children[ self::$parent_1 ][2] ) . '">Child 3</a></li>
+</ul>
+</li>
+<li class="page_item page-item-' . self::$parent_2 . ' page_item_has_children"><a href="' . get_permalink( self::$parent_2 ) . '">Parent 2</a>
+<ul class=\'children\'>
+	<li class="page_item page-item-' . self::$children[ self::$parent_2 ][0] . '"><a href="' . get_permalink( self::$children[ self::$parent_2 ][0] ) . '">Child 1</a></li>
+	<li class="page_item page-item-' . self::$children[ self::$parent_2 ][1] . '"><a href="' . get_permalink( self::$children[ self::$parent_2 ][1] ) . '">Child 2</a></li>
+	<li class="page_item page-item-' . self::$children[ self::$parent_2 ][2] . '"><a href="' . get_permalink( self::$children[ self::$parent_2 ][2] ) . '">Child 3</a></li>
+</ul>
+</li>
+<li class="page_item page-item-' . self::$children[ self::$parent_3 ][0] . '"><a href="' . get_permalink( self::$children[ self::$parent_3 ][0] ) . '">Child 1</a></li>
+<li class="page_item page-item-' . self::$children[ self::$parent_3 ][1] . '"><a href="' . get_permalink( self::$children[ self::$parent_3 ][1] ) . '">Child 2</a></li>
+<li class="page_item page-item-' . self::$children[ self::$parent_3 ][2] . '"><a href="' . get_permalink( self::$children[ self::$parent_3 ][2] ) . '">Child 3</a></li>
+</ul></li>';
+
+		$this->assertSameIgnoreEOL( $expected, wp_list_pages( $args ) );
+	}
 }


### PR DESCRIPTION
Fixes unexpected behavior when using wp_list_pages() with both depth and exclude parameters.

Previously, excluded parent pages would also exclude their children if depth > 0, making exclude behave like exclude_tree. This change updates the walker logic to ensure orphaned children of excluded parents are still displayed when depth is limited, consistent with how exclude works without depth.

A follow-up commit will add unit test coverage for this behavior.

Trac ticket: [#27326](https://core.trac.wordpress.org/ticket/27326)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
