### PR TITLE
`is_object_in_term`: Honor object addition suspend and prevent memory leak

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -4892,7 +4892,7 @@ function is_object_in_term( $object_id, $taxonomy, $terms = null ) {
 			return $object_terms;
 		}
 
-		wp_cache_set( $object_id, wp_list_pluck( $object_terms, 'term_id' ), "{$taxonomy}_relationships" );
+		wp_cache_add( $object_id, wp_list_pluck( $object_terms, 'term_id' ), "{$taxonomy}_relationships" );
 	}
 
 	if ( is_wp_error( $object_terms ) ) {

--- a/tests/phpunit/tests/term/isObjectInTerm.php
+++ b/tests/phpunit/tests/term/isObjectInTerm.php
@@ -179,4 +179,32 @@ class Tests_IsObjectInTerm extends WP_UnitTestCase {
 	public function test_invalid_taxonomy_should_return_wp_error_object() {
 		$this->assertWPError( is_object_in_term( 12345, 'foo', 'bar' ) );
 	}
+
+	/**
+	 * @ticket 63618
+	 */
+	public function test_term_objects_should_not_be_added_to_cache_when_suspend_cache_addition() {
+		register_taxonomy( 'wptests_tax', 'post' );
+
+		$t = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax',
+				'slug'     => 'foo',
+			)
+		);
+
+		$object_id = 12345;
+		wp_cache_delete( $object_id, 'wptests_tax_relationships' );
+
+		$suspend = wp_suspend_cache_addition();
+		wp_suspend_cache_addition( true );
+
+		is_object_in_term( $object_id, 'wptests_tax', $t );
+
+		wp_suspend_cache_addition( $suspend );
+
+		$this->assertFalse( wp_cache_get( $object_id, 'wptests_tax_relationships' ) );
+
+		_unregister_taxonomy( 'wptests_tax', 'post' );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Use `wp_cache_add` instead of `wp_cache_set` to prevent cache additions when `wp_suspend_cache_addition` has been set to `true`.

Trac ticket: https://core.trac.wordpress.org/ticket/63618

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
