### PR TITLE
Fix: Twenty Twenty: Latest Posts, Latest comments, Categories block colors 

### DIFF
--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
@@ -458,6 +458,13 @@
 	margin: 5px 0 0 0;
 }
 
+.editor-styles-wrapper ul.wp-block-archives.has-text-color li,
+.editor-styles-wrapper ul.wp-block-categories.has-text-color li,
+.editor-styles-wrapper ul.wp-block-latest-posts.has-text-color li,
+.editor-styles-wrapper ul.wp-block-categories__list.has-text-color li {
+	color: inherit;
+}
+
 .editor-styles-wrapper ul.wp-block-archives li li,
 .editor-styles-wrapper ul.wp-block-categories li li,
 .editor-styles-wrapper ul.wp-block-categories__list li li,
@@ -497,6 +504,10 @@
 	margin-top: 0.15em;
 }
 
+.editor-styles-wrapper .wp-block-latest-comments.has-text-color time,
+.editor-styles-wrapper .wp-block-latest-posts.has-text-color time {
+	color: inherit;
+}
 
 /* Block: Table ------------------------------ */
 

--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
@@ -462,6 +462,13 @@
 	margin: 5px 0 0 0;
 }
 
+.editor-styles-wrapper ul.wp-block-archives.has-text-color li,
+.editor-styles-wrapper ul.wp-block-categories.has-text-color li,
+.editor-styles-wrapper ul.wp-block-latest-posts.has-text-color li,
+.editor-styles-wrapper ul.wp-block-categories__list.has-text-color li {
+	color: inherit;
+}
+
 .editor-styles-wrapper ul.wp-block-archives li li,
 .editor-styles-wrapper ul.wp-block-categories li li,
 .editor-styles-wrapper ul.wp-block-categories__list li li,
@@ -499,6 +506,11 @@
 	letter-spacing: normal;
 	line-height: 1.476;
 	margin-top: 0.15em;
+}
+
+.editor-styles-wrapper .wp-block-latest-comments.has-text-color time,
+.editor-styles-wrapper .wp-block-latest-posts.has-text-color time {
+	color: inherit;
 }
 
 

--- a/src/wp-content/themes/twentytwenty/style-rtl.css
+++ b/src/wp-content/themes/twentytwenty/style-rtl.css
@@ -2965,6 +2965,10 @@ ol.wp-block-latest-comments {
 	color: #6d6d6d;
 }
 
+.entry-content .wp-block-latest-posts.has-text-color li {
+	color: inherit;
+}
+
 .wp-block-archives a,
 .wp-block-categories a,
 .wp-block-latest-posts a,
@@ -2998,6 +3002,11 @@ ol.wp-block-latest-comments {
 	font-weight: 600;
 	letter-spacing: normal;
 	margin-top: 0.15em;
+}
+
+.wp-block-latest-comments.has-text-color .wp-block-latest-comments__comment-date,
+.wp-block-latest-posts.has-text-color .wp-block-latest-posts__post-date {
+	color: inherit;
 }
 
 

--- a/src/wp-content/themes/twentytwenty/style.css
+++ b/src/wp-content/themes/twentytwenty/style.css
@@ -2985,6 +2985,10 @@ ol.wp-block-latest-comments {
 	color: #6d6d6d;
 }
 
+.entry-content .wp-block-latest-posts.has-text-color li {
+	color: inherit;
+}
+
 .wp-block-archives a,
 .wp-block-categories a,
 .wp-block-latest-posts a,
@@ -3018,6 +3022,11 @@ ol.wp-block-latest-comments {
 	font-weight: 600;
 	letter-spacing: normal;
 	margin-top: 0.15em;
+}
+
+.wp-block-latest-comments.has-text-color .wp-block-latest-comments__comment-date,
+.wp-block-latest-posts.has-text-color .wp-block-latest-posts__post-date {
+	color: inherit;
 }
 
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/59706

This patch ensures that in twenty-twenty theme -

**In the block-editor:** 

1. the Latest Posts, Latest comments, Categories, Categories List blocks correctly apply the user-defined text color (has-text-color) in the block editor. Previously, hardcoded default styles (color: #6d6d6d) prevented selected text colors from rendering. This fix allows color: inherit when .has-text-color is present.
2. When users choose a custom text color for the Latest Comments and Latest Posts blocks, the <time> elements (post or comment dates) also reflect that color in the block editor. Without this, only links or titles change color while dates retain the default.

**In the frontend:**

1. The Latest Posts and Latest comments blocks correctly apply the user-defined text color (has-text-color) in the front end. Without this, only links or titles change color while dates retain the default. Since Categories, and Categories List blocks already have <a> links so they reflect color changes by default. 
2. In the frontend - Latest Posts and Latest comments blocks, the post and comment dates also reflect the user-defined color.

**Before patch - Latest posts block in backend and front end**
![image](https://github.com/user-attachments/assets/1d975eb8-645c-4b65-93ef-e909dc409398)

**After patch - Latest posts block in backend and front end**
![image(2)](https://github.com/user-attachments/assets/76d7bfd0-2b12-4f94-bbd3-cad0593df695)

**Before patch - Latest comment block in backend and front end**
![image(3)](https://github.com/user-attachments/assets/a69a3bc7-c502-4c92-bf9a-8829ed6ad94e)

**After patch - Latest comment block in backend and front end**
![image(4)](https://github.com/user-attachments/assets/fb725823-88ec-4b2e-8faf-b85461fc4acc)

**Test steps in the WordPress admin : -**
    Go to /wp-admin/ → activate twenty-twenty theme → create or edit a post.
    Insert a Latest Posts or Latest comments block.
    Set a custom text color.
    Preview/save and verify the color is applied correctly on:
        Editor side (backend)
        Front end of the site

Since padding is defined by `block-library` styles, so not changing that.