### PR TITLE
Fix: Apply text color to table borders when custom text color is set

### DIFF
--- a/src/wp-content/themes/twentysixteen/style.css
+++ b/src/wp-content/themes/twentysixteen/style.css
@@ -527,6 +527,12 @@ td {
 	border: 1px solid #d1d1d1;
 }
 
+table.has-text-color,
+table.has-text-color td,
+table.has-text-color th {
+  border-color: currentColor;
+}
+
 table {
 	border-collapse: separate;
 	border-spacing: 0;


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/60336

Tables with custom text color now have matching borders on the frontend— by aligning border-color with currentColor. This creates a more cohesive and visually consistent block editor experience while preserving the default #d1d1d1 fallback when no custom color is set.

**After patch when color is applied to text - backend and front end**
![image](https://github.com/user-attachments/assets/1721fd2d-1b96-4b6a-95a9-3870ee3b6138)

**After patch when no color is applied to text - border color is theme default color #d1d1d1 **
![image(1)](https://github.com/user-attachments/assets/9b74cd20-2831-4e04-97f5-2a39a1e53e65)
