### PR TITLE
Restrict "Default Post Format" Options to Formats Supported by the Active Theme

### DIFF
--- a/src/wp-admin/options-writing.php
+++ b/src/wp-admin/options-writing.php
@@ -99,8 +99,12 @@ wp_dropdown_categories(
 </td>
 </tr>
 <?php
-$post_formats = get_post_format_strings();
-unset( $post_formats['standard'] );
+$supported_formats = get_theme_support( 'post-formats' );
+if ( is_array( $supported_formats ) && isset( $supported_formats[0] ) ) {
+	$post_formats = array_intersect_key( get_post_format_strings(), array_flip( $supported_formats[0] ) );
+} else {
+	$post_formats = array();
+}
 ?>
 <tr>
 <th scope="row"><label for="default_post_format"><?php _e( 'Default Post Format' ); ?></label></th>


### PR DESCRIPTION
This PR updates the `options-writing.php` admin screen to ensure that the **"Default Post Format"** dropdown only displays post formats explicitly supported by the currently active theme. Previously, this dropdown listed **all core post formats**, regardless of whether the theme declared support via `add_theme_support( 'post-formats', [...] )`.

This behavior led to possible misconfiguration, user confusion, and inconsistent behavior between the settings screen and the post editor (which already hides unsupported formats).

#### Previous Logic

The dropdown was populated using:

```php
$post_formats = get_post_format_strings();
unset( $post_formats['standard'] );
```

This included all formats regardless of theme support.

#### New Logic

Replaced with:

```php
$supported_formats = get_theme_support( 'post-formats' );

if ( is_array( $supported_formats ) && isset( $supported_formats[0] ) ) {
    $post_formats = array_intersect_key( get_post_format_strings(), array_flip( $supported_formats[0] ) );
} else {
    $post_formats = array();
}
```

This ensures only the intersection of supported formats and registered format strings is used. The `standard` format remains available separately, as it is treated as the fallback/default.

### Why This Matters

* Prevents the admin UI from offering unsupported options.
* Aligns admin settings with front-end and post editor behavior.
* Avoids storing invalid default values in `default_post_format` which have no effect on post rendering.
* Reduces user confusion by not listing formats that won’t have any visible impact.

### Edge Cases Handled

* If the theme supports no formats, only the `standard` option is shown.
* If the theme supports all formats, the dropdown behavior remains unchanged.
* Backward compatibility is preserved, as the underlying storage and post format API remains the same.

Trac Link: https://core.trac.wordpress.org/ticket/43613