### PR TITLE
wp_mail() sets Content-Type header twice for multipart emails

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -481,13 +481,13 @@ if ( ! function_exists( 'wp_mail' ) ) :
 		 */
 		$phpmailer->CharSet = apply_filters( 'wp_mail_charset', $charset );
 
-		// Set mail's subject and body
+		// Set mail's subject and body.
 		$phpmailer->Subject = $subject;
 
 		if ( is_string( $message ) ) {
 			$phpmailer->Body = $message;
-			// Set Content-Type
-			// If we don't have a content-type from the input headers
+			// Set Content-Type.
+			// If we don't have a content-type from the input headers.
 			if ( ! isset( $content_type ) ) {
 				$content_type = 'text/plain';
 			}
@@ -501,13 +501,13 @@ if ( ! function_exists( 'wp_mail' ) ) :
 			*/
 			$content_type           = apply_filters( 'wp_mail_content_type', $content_type );
 			$phpmailer->ContentType = $content_type;
-			// Set whether it's plaintext, depending on $content_type
+			// Set whether it's plaintext, depending on $content_type.
 			if ( 'text/html' === $content_type ) {
 					$phpmailer->isHTML( true );
 			}
 
 			// For backwards compatibility, new multipart emails should use
-			// the array style $message. This never really worked well anyway
+			// the array style $message. This never really worked well anyway.
 			if ( false !== stripos( $content_type, 'multipart' ) && ! empty( $boundary ) ) {
 				$phpmailer->addCustomHeader( sprintf( 'Content-Type: %s; boundary="%s"', $content_type, $boundary ) );
 			}
@@ -525,13 +525,20 @@ if ( ! function_exists( 'wp_mail' ) ) :
 			}
 		}
 
-		// Set to use PHP's mail()
+		// Set to use PHP's mail().
 		$phpmailer->isMail();
 
-		// Set custom headers
+		// Set custom headers.
 		if ( ! empty( $headers ) ) {
 			foreach ( (array) $headers as $name => $content ) {
-				$phpmailer->addCustomHeader( sprintf( '%1$s: %2$s', $name, $content ) );
+				// Only add custom headers not added automatically by PHPMailer.
+				if ( ! in_array( $name, array( 'MIME-Version', 'X-Mailer' ), true ) ) {
+					try {
+						$phpmailer->addCustomHeader( sprintf( '%1$s: %2$s', $name, $content ) );
+					} catch ( PHPMailer\PHPMailer\Exception $e ) {
+						continue;
+					}
+				}
 			}
 		}
 

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -155,6 +155,11 @@ if ( ! function_exists( 'wp_mail' ) ) :
 	 * However, you can set the content type of the email by using the
 	 * {@see 'wp_mail_content_type'} filter.
 	 *
+	 * If $message is an array, the key of each is used to add as an attachment
+	 * with the value used as the body. The 'text/plain' element is used as the
+	 * text version of the body, with the 'text/html' element used as the HTML
+	 * version of the body. All other types are added as attachments.
+	 *
 	 * The default charset is based on the charset used on the blog. The charset can
 	 * be set using the {@see 'wp_mail_charset'} filter.
 	 *
@@ -166,7 +171,7 @@ if ( ! function_exists( 'wp_mail' ) ) :
 	 *
 	 * @param string|string[] $to          Array or comma-separated list of email addresses to send message.
 	 * @param string          $subject     Email subject.
-	 * @param string          $message     Message contents.
+	 * @param string|array $message     Message contents
 	 * @param string|string[] $headers     Optional. Additional headers.
 	 * @param string|string[] $attachments Optional. Paths to files to attach.
 	 * @return bool Whether the email was sent successfully.
@@ -318,6 +323,10 @@ if ( ! function_exists( 'wp_mail' ) ) :
 							}
 							break;
 						case 'content-type':
+							if ( is_array( $message ) ) {
+								// Multipart email, ignore the content-type header
+								break;
+							}
 							if ( str_contains( $content, ';' ) ) {
 								list( $type, $charset_content ) = explode( ';', $content );
 								$content_type                   = trim( $type );
@@ -417,10 +426,6 @@ if ( ! function_exists( 'wp_mail' ) ) :
 			return false;
 		}
 
-		// Set mail's subject and body.
-		$phpmailer->Subject = $subject;
-		$phpmailer->Body    = $message;
-
 		// Set destination addresses, using appropriate methods for handling addresses.
 		$address_headers = compact( 'to', 'cc', 'bcc', 'reply_to' );
 
@@ -461,32 +466,7 @@ if ( ! function_exists( 'wp_mail' ) ) :
 			}
 		}
 
-		// Set to use PHP's mail().
-		$phpmailer->isMail();
-
-		// Set Content-Type and charset.
-
-		// If we don't have a Content-Type from the input headers.
-		if ( ! isset( $content_type ) ) {
-			$content_type = 'text/plain';
-		}
-
-		/**
-		 * Filters the wp_mail() content type.
-		 *
-		 * @since 2.3.0
-		 *
-		 * @param string $content_type Default wp_mail() content type.
-		 */
-		$content_type = apply_filters( 'wp_mail_content_type', $content_type );
-
-		$phpmailer->ContentType = $content_type;
-
-		// Set whether it's plaintext, depending on $content_type.
-		if ( 'text/html' === $content_type ) {
-			$phpmailer->isHTML( true );
-		}
-
+		//Set a charset.
 		// If we don't have a charset from the input headers.
 		if ( ! isset( $charset ) ) {
 			$charset = get_bloginfo( 'charset' );
@@ -501,21 +481,57 @@ if ( ! function_exists( 'wp_mail' ) ) :
 		 */
 		$phpmailer->CharSet = apply_filters( 'wp_mail_charset', $charset );
 
-		// Set custom headers.
-		if ( ! empty( $headers ) ) {
-			foreach ( (array) $headers as $name => $content ) {
-				// Only add custom headers not added automatically by PHPMailer.
-				if ( ! in_array( $name, array( 'MIME-Version', 'X-Mailer' ), true ) ) {
-					try {
-						$phpmailer->addCustomHeader( sprintf( '%1$s: %2$s', $name, $content ) );
-					} catch ( PHPMailer\PHPMailer\Exception $e ) {
-						continue;
+		// Set mail's subject and body
+		$phpmailer->Subject = $subject;
+
+		if ( is_string( $message ) ) {
+			$phpmailer->Body = $message;
+			// Set Content-Type
+			// If we don't have a content-type from the input headers
+			if ( ! isset( $content_type ) ) {
+				$content_type = 'text/plain';
+			}
+
+			/**
+			* Filters the wp_mail() content type.
+			*
+			* @since 2.3.0
+			*
+			* @param string $content_type Default wp_mail() content type.
+			*/
+			$content_type           = apply_filters( 'wp_mail_content_type', $content_type );
+			$phpmailer->ContentType = $content_type;
+			// Set whether it's plaintext, depending on $content_type
+			if ( 'text/html' === $content_type ) {
+					$phpmailer->isHTML( true );
+			}
+
+			// For backwards compatibility, new multipart emails should use
+			// the array style $message. This never really worked well anyway
+			if ( false !== stripos( $content_type, 'multipart' ) && ! empty( $boundary ) ) {
+				$phpmailer->addCustomHeader( sprintf( 'Content-Type: %s; boundary="%s"', $content_type, $boundary ) );
+			}
+		} elseif ( is_array( $message ) ) {
+			foreach ( $message as $type => $bodies ) {
+				foreach ( (array) $bodies as $body ) {
+					if ( 'text/html' === $type ) {
+						$phpmailer->Body = $body;
+					} elseif ( 'text/plain' === $type ) {
+						$phpmailer->AltBody = $body;
+					} else {
+						$phpmailer->addAttachment( $body, '', 'base64', $type );
 					}
 				}
 			}
+		}
 
-			if ( false !== stripos( $content_type, 'multipart' ) && ! empty( $boundary ) ) {
-				$phpmailer->addCustomHeader( sprintf( 'Content-Type: %s; boundary="%s"', $content_type, $boundary ) );
+		// Set to use PHP's mail()
+		$phpmailer->isMail();
+
+		// Set custom headers
+		if ( ! empty( $headers ) ) {
+			foreach ( (array) $headers as $name => $content ) {
+				$phpmailer->addCustomHeader( sprintf( '%1$s: %2$s', $name, $content ) );
 			}
 		}
 

--- a/tests/phpunit/tests/pluggable/wpMail.php
+++ b/tests/phpunit/tests/pluggable/wpMail.php
@@ -569,38 +569,29 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 		);
 
 		wp_mail( $to, $subject, $messages );
+		$mailer = tests_retrieve_phpmailer_instance();
 
-		preg_match( '/boundary="(.*)"/', $GLOBALS['phpmailer']->mock_sent[0]['header'], $matches );
+		preg_match( '/boundary="(.*)"/', $mailer->get_sent()->header, $matches );
 		$boundary = $matches[1];
-		$body     = '--' . $boundary . "\r\n";
-		$body    .= 'Content-Type: text/plain; charset=us-ascii' . "\r\n";
-		$body    .= "\r\n";
-		$body    .= 'Here is some plain text.' . "\r\n";
-		$body    .= "\r\n";
-		$body    .= '--' . $boundary . "\r\n";
-		$body    .= 'Content-Type: text/html; charset=UTF-8' . "\r\n";
-		$body    .= 'Content-Transfer-Encoding: 8bit' . "\r\n";
-		$body    .= "\r\n";
-		$body    .= '<html><head></head><body>Here is the HTML with UTF-8 γειά σου Κόσμε;-)<body></html>' . "\r\n";
-		$body    .= "\r\n";
-		$body    .= "\r\n";
-		$body    .= '--' . $boundary . '--' . "\r\n";
+		$body     = '--' . $boundary . "\n";
+		$body    .= 'Content-Type: text/plain; charset=us-ascii' . "\n";
+		$body    .= "\n";
+		$body    .= 'Here is some plain text.' . "\n";
+		$body    .= "\n";
+		$body    .= '--' . $boundary . "\n";
+		$body    .= 'Content-Type: text/html; charset=UTF-8' . "\n";
+		$body    .= 'Content-Transfer-Encoding: 8bit' . "\n";
+		$body    .= "\n";
+		$body    .= '<html><head></head><body>Here is the HTML with UTF-8 γειά σου Κόσμε;-)<body></html>' . "\n";
+		$body    .= "\n";
+		$body    .= "\n";
+		$body    .= '--' . $boundary . '--' . "\n";
 
-		// We need some better assertions here but these test the behaviour for now.
-		$this->assertEquals(
-			str_replace( "\r\n", "\n", $body ),
-			str_replace( "\r\n", "\n", $GLOBALS['phpmailer']->mock_sent[0]['body'] ),
-			'The body is not as expected.'
-		);
-		$this->assertSame(
-			1,
-			substr_count( $GLOBALS['phpmailer']->mock_sent[0]['header'], 'Content-Type: multipart/alternative;' ),
-			'The multipart / alternative header is not present.'
-		);
-		$this->assertSame(
-			1,
-			substr_count( $GLOBALS['phpmailer']->mock_sent[0]['header'], 'Content-Type:' ),
-			'The Content-Type header is not present.'
+		$this->assertSameIgnoreEOL( $body, $mailer->get_sent()->body, 'The body is not as expected.' );
+		$this->assertStringContainsString(
+			'Content-Type: multipart/alternative;',
+			$mailer->get_sent()->header,
+			'The multipart/alternative header is not present.'
 		);
 	}
 
@@ -625,10 +616,22 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 		wp_mail( $to, $subject, $message );
 		remove_action( 'phpmailer_init', array( $this, 'wp_mail_set_alt_body' ) );
 
-		$this->assertSame( 1, substr_count( $GLOBALS['phpmailer']->mock_sent[0]['header'], 'Content-Type: multipart/alternative;' ) );
-		$this->assertSame( 1, substr_count( $GLOBALS['phpmailer']->mock_sent[0]['header'], 'Content-Type:' ) );
-		$this->assertSame( 1, substr_count( $GLOBALS['phpmailer']->mock_sent[0]['body'], 'Content-Type: text/plain; charset=UTF-8' ) );
-		$this->assertSame( 1, substr_count( $GLOBALS['phpmailer']->mock_sent[0]['body'], 'Content-Type: text/html; charset=UTF-8' ) );
-		$this->assertSame( 2, substr_count( $GLOBALS['phpmailer']->mock_sent[0]['body'], 'Content-Type:' ) );
+		$mailer = tests_retrieve_phpmailer_instance();
+
+		$this->assertStringContainsString(
+			'Content-Type: multipart/alternative;',
+			$mailer->get_sent()->header,
+			'The multipart/alternative header is not present.'
+		);
+		$this->assertStringContainsString(
+			'Content-Type: text/plain; charset=UTF-8',
+			$mailer->get_sent()->body,
+			'The text/plain Content-Type header is not present.'
+		);
+		$this->assertStringContainsString(
+			'Content-Type: text/html; charset=UTF-8',
+			$mailer->get_sent()->body,
+			'The text/html Content-Type header is not present.'
+		);
 	}
 }

--- a/tests/phpunit/tests/pluggable/wpMail.php
+++ b/tests/phpunit/tests/pluggable/wpMail.php
@@ -572,19 +572,19 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 
 		preg_match( '/boundary="(.*)"/', $GLOBALS['phpmailer']->mock_sent[0]['header'], $matches );
 		$boundary = $matches[1];
-		$body     = '--' . $boundary . "\n";
-		$body    .= 'Content-Type: text/plain; charset=us-ascii' . "\n";
-		$body    .= "\n";
-		$body    .= 'Here is some plain text.' . "\n";
-		$body    .= "\n";
-		$body    .= '--' . $boundary . "\n";
-		$body    .= 'Content-Type: text/html; charset=UTF-8' . "\n";
-		$body    .= 'Content-Transfer-Encoding: 8bit' . "\n";
-		$body    .= "\n";
-		$body    .= '<html><head></head><body>Here is the HTML with UTF-8 γειά σου Κόσμε;-)<body></html>' . "\n";
-		$body    .= "\n";
-		$body    .= "\n";
-		$body    .= '--' . $boundary . '--' . "\n";
+		$body     = '--' . $boundary . "\r\n";
+		$body    .= 'Content-Type: text/plain; charset=us-ascii' . "\r\n";
+		$body    .= "\r\n";
+		$body    .= 'Here is some plain text.' . "\r\n";
+		$body    .= "\r\n";
+		$body    .= '--' . $boundary . "\r\n";
+		$body    .= 'Content-Type: text/html; charset=UTF-8' . "\r\n";
+		$body    .= 'Content-Transfer-Encoding: 8bit' . "\r\n";
+		$body    .= "\r\n";
+		$body    .= '<html><head></head><body>Here is the HTML with UTF-8 γειά σου Κόσμε;-)<body></html>' . "\r\n";
+		$body    .= "\r\n";
+		$body    .= "\r\n";
+		$body    .= '--' . $boundary . '--' . "\r\n";
 
 		// We need some better assertions here but these test the behaviour for now.
 		$this->assertEquals( $body, $GLOBALS['phpmailer']->mock_sent[0]['body'], 'The body is not as expected.' );

--- a/tests/phpunit/tests/pluggable/wpMail.php
+++ b/tests/phpunit/tests/pluggable/wpMail.php
@@ -587,7 +587,11 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 		$body    .= '--' . $boundary . '--' . "\r\n";
 
 		// We need some better assertions here but these test the behaviour for now.
-		$this->assertEquals( $body, $GLOBALS['phpmailer']->mock_sent[0]['body'], 'The body is not as expected.' );
+		$this->assertEquals(
+			str_replace( "\r\n", "\n", $body ),
+			str_replace( "\r\n", "\n", $GLOBALS['phpmailer']->mock_sent[0]['body'] ),
+			'The body is not as expected.'
+		);
 		$this->assertSame(
 			1,
 			substr_count( $GLOBALS['phpmailer']->mock_sent[0]['header'], 'Content-Type: multipart/alternative;' ),

--- a/tests/phpunit/tests/pluggable/wpMail.php
+++ b/tests/phpunit/tests/pluggable/wpMail.php
@@ -554,4 +554,77 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 		$phpmailer = $GLOBALS['phpmailer'];
 		$this->assertNotSame( 'user1', $phpmailer->AltBody );
 	}
+
+	/**
+	 * Test that wp_mail() can send a multipart/alternative email with plain text and html versions.
+	 *
+	 * @ticket 15448
+	 */
+	public function test_wp_mail_plain_and_html() {
+		$to       = 'user@example.com';
+		$subject  = 'Test email with plain text and html versions';
+		$messages = array(
+			'text/plain' => 'Here is some plain text.',
+			'text/html'  => '<html><head></head><body>Here is the HTML with UTF-8 γειά σου Κόσμε;-)<body></html>',
+		);
+
+		wp_mail( $to, $subject, $messages );
+
+		preg_match( '/boundary="(.*)"/', $GLOBALS['phpmailer']->mock_sent[0]['header'], $matches );
+		$boundary = $matches[1];
+		$body     = '--' . $boundary . "\r\n";
+		$body    .= 'Content-Type: text/plain; charset=us-ascii' . "\r\n";
+		$body    .= "\r\n";
+		$body    .= 'Here is some plain text.' . "\r\n";
+		$body    .= "\r\n";
+		$body    .= '--' . $boundary . "\r\n";
+		$body    .= 'Content-Type: text/html; charset=UTF-8' . "\r\n";
+		$body    .= 'Content-Transfer-Encoding: 8bit' . "\r\n";
+		$body    .= "\r\n";
+		$body    .= '<html><head></head><body>Here is the HTML with UTF-8 γειά σου Κόσμε;-)<body></html>' . "\r\n";
+		$body    .= "\r\n";
+		$body    .= "\r\n";
+		$body    .= '--' . $boundary . '--' . "\r\n";
+
+		// We need some better assertions here but these test the behaviour for now.
+		$this->assertEquals( $body, $GLOBALS['phpmailer']->mock_sent[0]['body'], 'The body is not as expected.' );
+		$this->assertSame(
+			1,
+			substr_count( $GLOBALS['phpmailer']->mock_sent[0]['header'], 'Content-Type: multipart/alternative;' ),
+			'The multipart / alternative header is not present.'
+		);
+		$this->assertSame(
+			1,
+			substr_count( $GLOBALS['phpmailer']->mock_sent[0]['header'], 'Content-Type:' ),
+			'The Content-Type header is not present.'
+		);
+	}
+
+	/*
+	 * 'phpmailer_init' action for test_wp_mail_plain_and_html_workaround().
+	 */
+	public function wp_mail_set_alt_body( $mailer ) {
+		$mailer->AltBody = strip_tags( $mailer->Body );
+	}
+
+	/**
+	 * Check workarounds using phpmailer_init still work around.
+	 *
+	 * @ticket 15448
+	 */
+	public function test_wp_mail_plain_and_html_workaround() {
+		$to      = 'user@example.com';
+		$subject = 'Test email with plain text derived from html version';
+		$message = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /></head><body><p>Hello World! γειά σου Κόσμε</p></body></html>';
+
+		add_action( 'phpmailer_init', array( $this, 'wp_mail_set_alt_body' ) );
+		wp_mail( $to, $subject, $message );
+		remove_action( 'phpmailer_init', array( $this, 'wp_mail_set_alt_body' ) );
+
+		$this->assertSame( 1, substr_count( $GLOBALS['phpmailer']->mock_sent[0]['header'], 'Content-Type: multipart/alternative;' ) );
+		$this->assertSame( 1, substr_count( $GLOBALS['phpmailer']->mock_sent[0]['header'], 'Content-Type:' ) );
+		$this->assertSame( 1, substr_count( $GLOBALS['phpmailer']->mock_sent[0]['body'], 'Content-Type: text/plain; charset=UTF-8' ) );
+		$this->assertSame( 1, substr_count( $GLOBALS['phpmailer']->mock_sent[0]['body'], 'Content-Type: text/html; charset=UTF-8' ) );
+		$this->assertSame( 2, substr_count( $GLOBALS['phpmailer']->mock_sent[0]['body'], 'Content-Type:' ) );
+	}
 }

--- a/tests/phpunit/tests/pluggable/wpMail.php
+++ b/tests/phpunit/tests/pluggable/wpMail.php
@@ -572,19 +572,19 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 
 		preg_match( '/boundary="(.*)"/', $GLOBALS['phpmailer']->mock_sent[0]['header'], $matches );
 		$boundary = $matches[1];
-		$body     = '--' . $boundary . "\r\n";
-		$body    .= 'Content-Type: text/plain; charset=us-ascii' . "\r\n";
-		$body    .= "\r\n";
-		$body    .= 'Here is some plain text.' . "\r\n";
-		$body    .= "\r\n";
-		$body    .= '--' . $boundary . "\r\n";
-		$body    .= 'Content-Type: text/html; charset=UTF-8' . "\r\n";
-		$body    .= 'Content-Transfer-Encoding: 8bit' . "\r\n";
-		$body    .= "\r\n";
-		$body    .= '<html><head></head><body>Here is the HTML with UTF-8 γειά σου Κόσμε;-)<body></html>' . "\r\n";
-		$body    .= "\r\n";
-		$body    .= "\r\n";
-		$body    .= '--' . $boundary . '--' . "\r\n";
+		$body     = '--' . $boundary . "\n";
+		$body    .= 'Content-Type: text/plain; charset=us-ascii' . "\n";
+		$body    .= "\n";
+		$body    .= 'Here is some plain text.' . "\n";
+		$body    .= "\n";
+		$body    .= '--' . $boundary . "\n";
+		$body    .= 'Content-Type: text/html; charset=UTF-8' . "\n";
+		$body    .= 'Content-Transfer-Encoding: 8bit' . "\n";
+		$body    .= "\n";
+		$body    .= '<html><head></head><body>Here is the HTML with UTF-8 γειά σου Κόσμε;-)<body></html>' . "\n";
+		$body    .= "\n";
+		$body    .= "\n";
+		$body    .= '--' . $boundary . '--' . "\n";
 
 		// We need some better assertions here but these test the behaviour for now.
 		$this->assertEquals( $body, $GLOBALS['phpmailer']->mock_sent[0]['body'], 'The body is not as expected.' );


### PR DESCRIPTION
This is a refresh of 15448_Sep2019.11.diff
Creating this PR to pass the GH CI protocol
Check for further testing after this

Trac ticket: https://core.trac.wordpress.org/ticket/15448

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
