### PR TITLE
Remove translator comment when the hidden text is also visible next to it

### DIFF
--- a/src/wp-admin/includes/class-custom-background.php
+++ b/src/wp-admin/includes/class-custom-background.php
@@ -430,12 +430,7 @@ class Custom_Background {
 			?>
 <tr>
 <th scope="row"><?php _e( 'Image Position' ); ?></th>
-<td><fieldset><legend class="screen-reader-text"><span>
-			<?php
-			/* translators: Hidden accessibility text. */
-			_e( 'Image Position' );
-			?>
-</span></legend>
+<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Image Position' ); ?></span></legend>
 <div class="background-position-control">
 			<?php foreach ( $background_position_options as $group ) : ?>
 	<div class="button-group">
@@ -454,12 +449,7 @@ class Custom_Background {
 
 <tr>
 <th scope="row"><label for="background-size"><?php _e( 'Image Size' ); ?></label></th>
-<td><fieldset><legend class="screen-reader-text"><span>
-			<?php
-			/* translators: Hidden accessibility text. */
-			_e( 'Image Size' );
-			?>
-</span></legend>
+<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Image Size' ); ?></span></legend>
 <select id="background-size" name="background-size">
 <option value="auto"<?php selected( 'auto', get_theme_mod( 'background_size', get_theme_support( 'custom-background', 'default-size' ) ) ); ?>><?php _ex( 'Original', 'Original Size' ); ?></option>
 <option value="contain"<?php selected( 'contain', get_theme_mod( 'background_size', get_theme_support( 'custom-background', 'default-size' ) ) ); ?>><?php _e( 'Fit to Screen' ); ?></option>
@@ -470,12 +460,7 @@ class Custom_Background {
 
 <tr>
 <th scope="row"><?php _ex( 'Repeat', 'Background Repeat' ); ?></th>
-<td><fieldset><legend class="screen-reader-text"><span>
-			<?php
-			/* translators: Hidden accessibility text. */
-			_ex( 'Repeat', 'Background Repeat' );
-			?>
-</span></legend>
+<td><fieldset><legend class="screen-reader-text"><span><?php _ex( 'Repeat', 'Background Repeat' ); ?></span></legend>
 <input name="background-repeat" type="hidden" value="no-repeat">
 <label><input type="checkbox" name="background-repeat" value="repeat"<?php checked( 'repeat', get_theme_mod( 'background_repeat', get_theme_support( 'custom-background', 'default-repeat' ) ) ); ?>> <?php _e( 'Repeat Background Image' ); ?></label>
 </fieldset></td>
@@ -483,12 +468,7 @@ class Custom_Background {
 
 <tr>
 <th scope="row"><?php _ex( 'Scroll', 'Background Scroll' ); ?></th>
-<td><fieldset><legend class="screen-reader-text"><span>
-			<?php
-			/* translators: Hidden accessibility text. */
-			_ex( 'Scroll', 'Background Scroll' );
-			?>
-</span></legend>
+<td><fieldset><legend class="screen-reader-text"><span><?php _ex( 'Scroll', 'Background Scroll' ); ?></span></legend>
 <input name="background-attachment" type="hidden" value="fixed">
 <label><input name="background-attachment" type="checkbox" value="scroll" <?php checked( 'scroll', get_theme_mod( 'background_attachment', get_theme_support( 'custom-background', 'default-attachment' ) ) ); ?>> <?php _e( 'Scroll with Page' ); ?></label>
 </fieldset></td>
@@ -496,12 +476,7 @@ class Custom_Background {
 <?php endif; // get_background_image() ?>
 <tr>
 <th scope="row"><?php _e( 'Background Color' ); ?></th>
-<td><fieldset><legend class="screen-reader-text"><span>
-		<?php
-		/* translators: Hidden accessibility text. */
-		_e( 'Background Color' );
-		?>
-</span></legend>
+<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Background Color' ); ?></span></legend>
 		<?php
 		$default_color = '';
 		if ( current_theme_supports( 'custom-background', 'default-color' ) ) {

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -1228,12 +1228,7 @@ function link_categories_meta_box( $link ) {
 function link_target_meta_box( $link ) {
 
 	?>
-<fieldset><legend class="screen-reader-text"><span>
-	<?php
-	/* translators: Hidden accessibility text. */
-	_e( 'Target' );
-	?>
-</span></legend>
+<fieldset><legend class="screen-reader-text"><span><?php _e( 'Target' ); ?></span></legend>
 <p><label for="link_target_blank" class="selectit">
 <input id="link_target_blank" type="radio" name="link_target" value="_blank" <?php echo ( isset( $link->link_target ) && ( '_blank' === $link->link_target ) ? 'checked="checked"' : '' ); ?> />
 	<?php _e( '<code>_blank</code> &mdash; new window or tab.' ); ?></label></p>
@@ -1324,12 +1319,7 @@ function link_xfn_meta_box( $link ) {
 	<tr>
 		<th scope="row"><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'identity' ); ?></th>
 		<td><fieldset>
-			<legend class="screen-reader-text"><span>
-				<?php
-				/* translators: Hidden accessibility text. xfn: https://gmpg.org/xfn/ */
-				_e( 'identity' );
-				?>
-			</span></legend>
+			<legend class="screen-reader-text"><span><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'identity' ); ?></span></legend>
 			<label for="me">
 			<input type="checkbox" name="identity" value="me" id="me" <?php xfn_check( 'identity', 'me' ); ?> />
 			<?php _e( 'another web address of mine' ); ?></label>
@@ -1338,12 +1328,7 @@ function link_xfn_meta_box( $link ) {
 	<tr>
 		<th scope="row"><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'friendship' ); ?></th>
 		<td><fieldset>
-			<legend class="screen-reader-text"><span>
-				<?php
-				/* translators: Hidden accessibility text. xfn: https://gmpg.org/xfn/ */
-				_e( 'friendship' );
-				?>
-			</span></legend>
+			<legend class="screen-reader-text"><span><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'friendship' ); ?></span></legend>
 			<label for="contact">
 			<input class="valinp" type="radio" name="friendship" value="contact" id="contact" <?php xfn_check( 'friendship', 'contact' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'contact' ); ?>
 			</label>
@@ -1361,12 +1346,7 @@ function link_xfn_meta_box( $link ) {
 	<tr>
 		<th scope="row"> <?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'physical' ); ?> </th>
 		<td><fieldset>
-			<legend class="screen-reader-text"><span>
-				<?php
-				/* translators: Hidden accessibility text. xfn: https://gmpg.org/xfn/ */
-				_e( 'physical' );
-				?>
-			</span></legend>
+			<legend class="screen-reader-text"><span><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'physical' ); ?></span></legend>
 			<label for="met">
 			<input class="valinp" type="checkbox" name="physical" value="met" id="met" <?php xfn_check( 'physical', 'met' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'met' ); ?>
 			</label>
@@ -1375,12 +1355,7 @@ function link_xfn_meta_box( $link ) {
 	<tr>
 		<th scope="row"> <?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'professional' ); ?> </th>
 		<td><fieldset>
-			<legend class="screen-reader-text"><span>
-				<?php
-				/* translators: Hidden accessibility text. xfn: https://gmpg.org/xfn/ */
-				_e( 'professional' );
-				?>
-			</span></legend>
+			<legend class="screen-reader-text"><span><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'professional' ); ?></span></legend>
 			<label for="co-worker">
 			<input class="valinp" type="checkbox" name="professional" value="co-worker" id="co-worker" <?php xfn_check( 'professional', 'co-worker' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'co-worker' ); ?>
 			</label>
@@ -1392,12 +1367,7 @@ function link_xfn_meta_box( $link ) {
 	<tr>
 		<th scope="row"><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'geographical' ); ?></th>
 		<td><fieldset>
-			<legend class="screen-reader-text"><span>
-				<?php
-				/* translators: Hidden accessibility text. xfn: https://gmpg.org/xfn/ */
-				_e( 'geographical' );
-				?>
-			</span></legend>
+			<legend class="screen-reader-text"><span><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'geographical' ); ?></span></legend>
 			<label for="co-resident">
 			<input class="valinp" type="radio" name="geographical" value="co-resident" id="co-resident" <?php xfn_check( 'geographical', 'co-resident' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'co-resident' ); ?>
 			</label>
@@ -1412,12 +1382,7 @@ function link_xfn_meta_box( $link ) {
 	<tr>
 		<th scope="row"><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'family' ); ?></th>
 		<td><fieldset>
-			<legend class="screen-reader-text"><span>
-				<?php
-				/* translators: Hidden accessibility text. xfn: https://gmpg.org/xfn/ */
-				_e( 'family' );
-				?>
-			</span></legend>
+			<legend class="screen-reader-text"><span><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'family' ); ?></span></legend>
 			<label for="child">
 			<input class="valinp" type="radio" name="family" value="child" id="child" <?php xfn_check( 'family', 'child' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'child' ); ?>
 			</label>
@@ -1441,12 +1406,7 @@ function link_xfn_meta_box( $link ) {
 	<tr>
 		<th scope="row"><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'romantic' ); ?></th>
 		<td><fieldset>
-			<legend class="screen-reader-text"><span>
-				<?php
-				/* translators: Hidden accessibility text. xfn: https://gmpg.org/xfn/ */
-				_e( 'romantic' );
-				?>
-			</span></legend>
+			<legend class="screen-reader-text"><span><?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'romantic' ); ?></span></legend>
 			<label for="muse">
 			<input class="valinp" type="checkbox" name="romantic" value="muse" id="muse" <?php xfn_check( 'romantic', 'muse' ); ?> />&nbsp;<?php /* translators: xfn: https://gmpg.org/xfn/ */ _e( 'muse' ); ?>
 			</label>

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1022,12 +1022,7 @@ function admin_color_scheme_picker( $user_id ) {
 	}
 	?>
 	<fieldset id="color-picker" class="scheme-list">
-		<legend class="screen-reader-text"><span>
-			<?php
-			/* translators: Hidden accessibility text. */
-			_e( 'Administration Color Scheme' );
-			?>
-		</span></legend>
+		<legend class="screen-reader-text"><span><?php _e( 'Administration Color Scheme' ); ?></span></legend>
 		<?php
 		wp_nonce_field( 'save-color-scheme', 'color-nonce', false );
 		foreach ( $_wp_admin_css_colors as $color => $color_info ) :

--- a/src/wp-admin/install.php
+++ b/src/wp-admin/install.php
@@ -184,15 +184,7 @@ function display_setup_form( $error = null ) {
 			<th scope="row"><?php has_action( 'blog_privacy_selector' ) ? _e( 'Site visibility' ) : _e( 'Search engine visibility' ); ?></th>
 			<td>
 				<fieldset>
-					<legend class="screen-reader-text"><span>
-						<?php
-						has_action( 'blog_privacy_selector' )
-							/* translators: Hidden accessibility text. */
-							? _e( 'Site visibility' )
-							/* translators: Hidden accessibility text. */
-							: _e( 'Search engine visibility' );
-						?>
-					</span></legend>
+					<legend class="screen-reader-text"><span><?php has_action( 'blog_privacy_selector' ) ? _e( 'Site visibility' ) : _e( 'Search engine visibility' ); ?></span></legend>
 					<?php
 					if ( has_action( 'blog_privacy_selector' ) ) {
 						?>

--- a/src/wp-admin/network/settings.php
+++ b/src/wp-admin/network/settings.php
@@ -209,12 +209,7 @@ if ( isset( $_GET['updated'] ) ) {
 				?>
 				<td>
 					<fieldset>
-					<legend class="screen-reader-text">
-						<?php
-						/* translators: Hidden accessibility text. */
-						_e( 'New registrations settings' );
-						?>
-					</legend>
+					<legend class="screen-reader-text"><?php _e( 'Allow new registrations' ); ?></legend>
 					<label><input name="registration" type="radio" id="registration1" value="none"<?php checked( $reg, 'none' ); ?> /> <?php _e( 'Registration is disabled' ); ?></label><br />
 					<label><input name="registration" type="radio" id="registration2" value="user"<?php checked( $reg, 'user' ); ?> /> <?php _e( 'User accounts may be registered' ); ?></label><br />
 					<label><input name="registration" type="radio" id="registration3" value="blog"<?php checked( $reg, 'blog' ); ?> /> <?php _e( 'Logged in users may register new sites' ); ?></label><br />

--- a/src/wp-admin/network/settings.php
+++ b/src/wp-admin/network/settings.php
@@ -514,10 +514,7 @@ if ( isset( $_GET['updated'] ) ) {
 					<th scope="row"><?php _e( 'Enable administration menus' ); ?></th>
 					<td>
 						<?php
-						echo '<fieldset><legend class="screen-reader-text">' .
-							/* translators: Hidden accessibility text. */
-							__( 'Enable menus' ) .
-						'</legend>';
+						echo '<fieldset><legend class="screen-reader-text">' . __( 'Enable administration menus' ) . '</legend>';
 
 						foreach ( (array) $menu_items as $key => $val ) {
 							echo "<label><input type='checkbox' name='menu_items[" . $key . "]' value='1'" . ( isset( $menu_perms[ $key ] ) ? checked( $menu_perms[ $key ], '1', false ) : '' ) . ' /> ' . esc_html( $val ) . '</label><br/>';

--- a/src/wp-admin/network/site-info.php
+++ b/src/wp-admin/network/site-info.php
@@ -208,12 +208,7 @@ if ( ! empty( $messages ) ) {
 			<th scope="row"><?php _e( 'Attributes' ); ?></th>
 			<td>
 			<fieldset>
-			<legend class="screen-reader-text">
-				<?php
-				/* translators: Hidden accessibility text. */
-				_e( 'Set site attributes' );
-				?>
-			</legend>
+			<legend class="screen-reader-text"><?php _e( 'Attributes' ); ?></legend>
 			<?php foreach ( $attribute_fields as $field_key => $field_label ) : ?>
 				<label><input type="checkbox" name="blog[<?php echo $field_key; ?>]" value="1" <?php checked( (bool) $details->$field_key, true ); ?> <?php disabled( ! in_array( (int) $details->$field_key, array( 0, 1 ), true ) ); ?> />
 				<?php echo $field_label; ?></label><br />

--- a/src/wp-admin/options-discussion.php
+++ b/src/wp-admin/options-discussion.php
@@ -45,12 +45,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 <table class="form-table indent-children" role="presentation">
 <tr>
 <th scope="row"><?php _e( 'Default post settings' ); ?></th>
-<td><fieldset><legend class="screen-reader-text"><span>
-	<?php
-	/* translators: Hidden accessibility text. */
-	_e( 'Default post settings' );
-	?>
-</span></legend>
+<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Default post settings' ); ?></span></legend>
 <label for="default_pingback_flag">
 <input name="default_pingback_flag" type="checkbox" id="default_pingback_flag" value="1" <?php checked( '1', get_option( 'default_pingback_flag' ) ); ?> />
 <?php _e( 'Attempt to notify any blogs linked to from the post' ); ?></label>
@@ -68,12 +63,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 </tr>
 <tr>
 <th scope="row"><?php _e( 'Other comment settings' ); ?></th>
-<td><fieldset><legend class="screen-reader-text"><span>
-	<?php
-	/* translators: Hidden accessibility text. */
-	_e( 'Other comment settings' );
-	?>
-</span></legend>
+<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Other comment settings' ); ?></span></legend>
 <label for="require_name_email"><input type="checkbox" name="require_name_email" id="require_name_email" value="1" <?php checked( '1', get_option( 'require_name_email' ) ); ?> /> <?php _e( 'Comment author must fill out name and email' ); ?></label>
 <br />
 <label for="comment_registration">
@@ -131,12 +121,7 @@ $thread_comments_depth .= '</select>';
 
 <tr>
 <th scope="row"><?php _e( 'Comment Pagination' ); ?></th>
-<td><fieldset><legend class="screen-reader-text"><span>
-	<?php
-	/* translators: Hidden accessibility text. */
-	_e( 'Comment Pagination' );
-	?>
-</span></legend>
+<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Comment Pagination' ); ?></span></legend>
 <input name="page_comments" type="checkbox" id="page_comments" value="1" <?php checked( '1', get_option( 'page_comments' ) ); ?> />
 <label for="page_comments"><?php _e( 'Break comments into pages' ); ?></label>
 <ul>
@@ -163,12 +148,7 @@ $thread_comments_depth .= '</select>';
 </tr>
 <tr>
 <th scope="row"><?php _e( 'Email me whenever' ); ?></th>
-<td><fieldset><legend class="screen-reader-text"><span>
-	<?php
-	/* translators: Hidden accessibility text. */
-	_e( 'Email me whenever' );
-	?>
-</span></legend>
+<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Email me whenever' ); ?></span></legend>
 <label for="comments_notify">
 <input name="comments_notify" type="checkbox" id="comments_notify" value="1" <?php checked( '1', get_option( 'comments_notify' ) ); ?> />
 <?php _e( 'Anyone posts a comment' ); ?> </label>
@@ -180,12 +160,7 @@ $thread_comments_depth .= '</select>';
 </tr>
 <tr>
 <th scope="row"><?php _e( 'Before a comment appears' ); ?></th>
-<td><fieldset><legend class="screen-reader-text"><span>
-	<?php
-	/* translators: Hidden accessibility text. */
-	_e( 'Before a comment appears' );
-	?>
-</span></legend>
+<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Before a comment appears' ); ?></span></legend>
 <label for="comment_moderation">
 <input name="comment_moderation" type="checkbox" id="comment_moderation" value="1" <?php checked( '1', get_option( 'comment_moderation' ) ); ?> />
 <?php _e( 'Comment must be manually approved' ); ?> </label>
@@ -195,12 +170,7 @@ $thread_comments_depth .= '</select>';
 </tr>
 <tr>
 <th scope="row"><?php _e( 'Comment Moderation' ); ?></th>
-<td><fieldset><legend class="screen-reader-text"><span>
-	<?php
-	/* translators: Hidden accessibility text. */
-	_e( 'Comment Moderation' );
-	?>
-</span></legend>
+<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Comment Moderation' ); ?></span></legend>
 <p><label for="comment_max_links">
 <?php
 printf(
@@ -219,12 +189,7 @@ printf(
 </tr>
 <tr>
 <th scope="row"><?php _e( 'Disallowed Comment Keys' ); ?></th>
-<td><fieldset><legend class="screen-reader-text"><span>
-	<?php
-	/* translators: Hidden accessibility text. */
-	_e( 'Disallowed Comment Keys' );
-	?>
-</span></legend>
+<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Disallowed Comment Keys' ); ?></span></legend>
 <p><label for="disallowed_keys"><?php _e( 'When a comment contains any of these words in its content, author name, URL, email, IP address, or browser&#8217;s user agent string, it will be put in the Trash. One word or IP address per line. It will match inside words, so &#8220;press&#8221; will match &#8220;WordPress&#8221;.' ); ?></label></p>
 <p>
 <textarea name="disallowed_keys" rows="10" cols="50" id="disallowed_keys" class="large-text code"><?php echo esc_textarea( get_option( 'disallowed_keys' ) ); ?></textarea>
@@ -260,12 +225,7 @@ if ( ! $show_avatars ) {
 </tr>
 <tr class="avatar-settings<?php echo $show_avatars_class; ?>">
 <th scope="row"><?php _e( 'Maximum Rating' ); ?></th>
-<td><fieldset><legend class="screen-reader-text"><span>
-	<?php
-	/* translators: Hidden accessibility text. */
-	_e( 'Maximum Rating' );
-	?>
-</span></legend>
+<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Maximum Rating' ); ?></span></legend>
 
 <?php
 $ratings = array(
@@ -288,12 +248,7 @@ endforeach;
 </tr>
 <tr class="avatar-settings<?php echo $show_avatars_class; ?>">
 <th scope="row"><?php _e( 'Default Avatar' ); ?></th>
-<td class="defaultavatarpicker"><fieldset><legend class="screen-reader-text"><span>
-	<?php
-	/* translators: Hidden accessibility text. */
-	_e( 'Default Avatar' );
-	?>
-</span></legend>
+<td class="defaultavatarpicker"><fieldset><legend class="screen-reader-text"><span><?php _e( 'Default Avatar' ); ?></span></legend>
 
 <p>
 <?php _e( 'For users without a custom avatar of their own, you can either display a generic logo or a generated one based on their email address.' ); ?><br />

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -293,12 +293,7 @@ if ( $new_admin_email && get_option( 'admin_email' ) !== $new_admin_email ) {
 
 <tr>
 <th scope="row"><?php _e( 'Membership' ); ?></th>
-<td> <fieldset><legend class="screen-reader-text"><span>
-	<?php
-	/* translators: Hidden accessibility text. */
-	_e( 'Membership' );
-	?>
-</span></legend><label for="users_can_register">
+<td> <fieldset><legend class="screen-reader-text"><span><?php _e( 'Membership' ); ?></span></legend><label for="users_can_register">
 <input name="users_can_register" type="checkbox" id="users_can_register" value="1" <?php checked( '1', get_option( 'users_can_register' ) ); ?> />
 	<?php _e( 'Anyone can register' ); ?></label>
 </fieldset></td>
@@ -464,12 +459,7 @@ if ( empty( $tzstring ) ) { // Create a UTC+- zone if no timezone string exists.
 <tr>
 <th scope="row"><?php _e( 'Date Format' ); ?></th>
 <td>
-	<fieldset><legend class="screen-reader-text"><span>
-		<?php
-		/* translators: Hidden accessibility text. */
-		_e( 'Date Format' );
-		?>
-	</span></legend>
+	<fieldset><legend class="screen-reader-text"><span><?php _e( 'Date Format' ); ?></span></legend>
 <?php
 	/**
 	 * Filters the default date formats.
@@ -514,12 +504,7 @@ foreach ( $date_formats as $format ) {
 <tr>
 <th scope="row"><?php _e( 'Time Format' ); ?></th>
 <td>
-	<fieldset><legend class="screen-reader-text"><span>
-		<?php
-		/* translators: Hidden accessibility text. */
-		_e( 'Time Format' );
-		?>
-	</span></legend>
+	<fieldset><legend class="screen-reader-text"><span><?php _e( 'Time Format' ); ?></span></legend>
 <?php
 	/**
 	 * Filters the default time formats.

--- a/src/wp-admin/options-media.php
+++ b/src/wp-admin/options-media.php
@@ -58,12 +58,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 <table class="form-table" role="presentation">
 <tr>
 <th scope="row"><?php _e( 'Thumbnail size' ); ?></th>
-<td><fieldset><legend class="screen-reader-text"><span>
-	<?php
-	/* translators: Hidden accessibility text. */
-	_e( 'Thumbnail size' );
-	?>
-</span></legend>
+<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Thumbnail size' ); ?></span></legend>
 <label for="thumbnail_size_w"><?php _e( 'Width' ); ?></label>
 <input name="thumbnail_size_w" type="number" step="1" min="0" id="thumbnail_size_w" value="<?php form_option( 'thumbnail_size_w' ); ?>" class="small-text" />
 <br />
@@ -77,12 +72,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 
 <tr>
 <th scope="row"><?php _e( 'Medium size' ); ?></th>
-<td><fieldset><legend class="screen-reader-text"><span>
-	<?php
-	/* translators: Hidden accessibility text. */
-	_e( 'Medium size' );
-	?>
-</span></legend>
+<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Medium size' ); ?></span></legend>
 <label for="medium_size_w"><?php _e( 'Max Width' ); ?></label>
 <input name="medium_size_w" type="number" step="1" min="0" id="medium_size_w" value="<?php form_option( 'medium_size_w' ); ?>" class="small-text" />
 <br />
@@ -93,12 +83,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 
 <tr>
 <th scope="row"><?php _e( 'Large size' ); ?></th>
-<td><fieldset><legend class="screen-reader-text"><span>
-	<?php
-	/* translators: Hidden accessibility text. */
-	_e( 'Large size' );
-	?>
-</span></legend>
+<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Large size' ); ?></span></legend>
 <label for="large_size_w"><?php _e( 'Max Width' ); ?></label>
 <input name="large_size_w" type="number" step="1" min="0" id="large_size_w" value="<?php form_option( 'large_size_w' ); ?>" class="small-text" />
 <br />

--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -330,12 +330,7 @@ printf(
 	<th scope="row"><?php _e( 'Permalink structure' ); ?></th>
 	<td>
 		<fieldset class="structure-selection">
-			<legend class="screen-reader-text">
-				<?php
-				/* translators: Hidden accessibility text. */
-				_e( 'Permalink structure' );
-				?>
-			</legend>
+			<legend class="screen-reader-text"><?php _e( 'Permalink structure' ); ?></legend>
 			<?php foreach ( $default_structures as $input ) : ?>
 			<div class="row">
 				<input id="permalink-input-<?php echo esc_attr( $input['id'] ); ?>"

--- a/src/wp-admin/options-reading.php
+++ b/src/wp-admin/options-reading.php
@@ -86,12 +86,7 @@ else :
 <tr>
 <th scope="row"><?php _e( 'Your homepage displays' ); ?></th>
 <td id="front-static-pages"><fieldset>
-	<legend class="screen-reader-text"><span>
-		<?php
-		/* translators: Hidden accessibility text. */
-		_e( 'Your homepage displays' );
-		?>
-	</span></legend>
+	<legend class="screen-reader-text"><span><?php _e( 'Your homepage displays' ); ?></span></legend>
 	<p><label>
 		<input name="show_on_front" type="radio" value="posts" class="tog" <?php checked( 'posts', get_option( 'show_on_front' ) ); ?> />
 		<?php _e( 'Your latest posts' ); ?>
@@ -182,12 +177,7 @@ else :
 <tr>
 <th scope="row"><?php _e( 'For each post in a feed, include' ); ?> </th>
 <td><fieldset>
-	<legend class="screen-reader-text"><span>
-		<?php
-		/* translators: Hidden accessibility text. */
-		_e( 'For each post in a feed, include' );
-		?>
-	</span></legend>
+	<legend class="screen-reader-text"><span><?php _e( 'For each post in a feed, include' ); ?></span></legend>
 	<p>
 		<label><input name="rss_use_excerpt" type="radio" value="0" <?php checked( 0, get_option( 'rss_use_excerpt' ) ); ?>	/> <?php _e( 'Full text' ); ?></label><br />
 		<label><input name="rss_use_excerpt" type="radio" value="1" <?php checked( 1, get_option( 'rss_use_excerpt' ) ); ?> /> <?php _e( 'Excerpt' ); ?></label>
@@ -207,15 +197,7 @@ else :
 <tr class="option-site-visibility">
 <th scope="row"><?php has_action( 'blog_privacy_selector' ) ? _e( 'Site visibility' ) : _e( 'Search engine visibility' ); ?> </th>
 <td><fieldset>
-	<legend class="screen-reader-text"><span>
-		<?php
-		has_action( 'blog_privacy_selector' )
-			/* translators: Hidden accessibility text. */
-			? _e( 'Site visibility' )
-			/* translators: Hidden accessibility text. */
-			: _e( 'Search engine visibility' );
-		?>
-	</span></legend>
+	<legend class="screen-reader-text"><span><?php has_action( 'blog_privacy_selector' ) ? _e( 'Site visibility' ) : _e( 'Search engine visibility' ); ?></span></legend>
 <?php if ( has_action( 'blog_privacy_selector' ) ) : ?>
 	<input id="blog-public" type="radio" name="blog_public" value="1" <?php checked( '1', get_option( 'blog_public' ) ); ?> />
 	<label for="blog-public"><?php _e( 'Allow search engines to index this site' ); ?></label><br />

--- a/src/wp-admin/options-writing.php
+++ b/src/wp-admin/options-writing.php
@@ -69,12 +69,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 <?php if ( get_site_option( 'initial_db_version' ) < 32453 ) : ?>
 <tr>
 <th scope="row"><?php _e( 'Formatting' ); ?></th>
-<td><fieldset><legend class="screen-reader-text"><span>
-	<?php
-	/* translators: Hidden accessibility text. */
-	_e( 'Formatting' );
-	?>
-</span></legend>
+<td><fieldset><legend class="screen-reader-text"><span><?php _e( 'Formatting' ); ?></span></legend>
 <label for="use_smilies">
 <input name="use_smilies" type="checkbox" id="use_smilies" value="1" <?php checked( '1', get_option( 'use_smilies' ) ); ?> />
 	<?php _e( 'Convert emoticons like <code>:-)</code> and <code>:-P</code> to graphics on display' ); ?></label><br />


### PR DESCRIPTION
The 'Hidden accessibility text' comment seems inappropriate when a visually hidden legend (`<legend class="screen-reader-text">`) has the same text as visible text next to it.

This removes the comment from several fieldset legends:
- all of the hidden legends in Settings pages (`options-discussion.php`, `options-general.php`, `options-media.php`, `options-permalink.php`, `options-reading.php`, and `options-writing.php`)
- 'Site visibility' or 'Search engine visibility' on the installation page (`install.php`)
- option groups in the `Custom_Background` class (`includes/class-custom-background.php`)
- 'Target' and XFN option groups for the old [Links Manager](https://downloads.wordpress.org/plugin/link-manager.zip) meta boxes (`includes/meta-boxes.php`)
- 'Administration Color Scheme' in profile pages (`includes/misc.php`)
- 'Enable **administration** menus' in `network/settings.php`, matching the hidden legend to the _visible_ text

[Trac 63620](https://core.trac.wordpress.org/ticket/63620)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
