### PR TITLE
60111 fix/dark mode scripts redundant imports

### DIFF
--- a/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
+++ b/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
@@ -72,7 +72,7 @@ class Twenty_Twenty_One_Dark_Mode {
 			array( 'in_footer' => true )
 		);
 
-		if (is_admin()) {
+		if ( is_admin() ) {
 			wp_enqueue_script(
 				'twentytwentyone-editor-dark-mode-support',
 				get_template_directory_uri() . '/assets/js/editor-dark-mode-support.js',

--- a/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
+++ b/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
@@ -294,7 +294,6 @@ class Twenty_Twenty_One_Dark_Mode {
 			return;
 		}
 		$this->the_html();
-		$this->the_script();
 	}
 
 	/**
@@ -355,19 +354,6 @@ class Twenty_Twenty_One_Dark_Mode {
 		</style>
 
 		<?php
-	}
-
-	/**
-	 * Prints the dark-mode switch script.
-	 *
-	 * @since Twenty Twenty-One 1.0
-	 *
-	 * @return void
-	 */
-	public function the_script() {
-		echo '<script>';
-		include get_template_directory() . '/assets/js/dark-mode-toggler.js'; // phpcs:ignore WPThemeReview.CoreFunctionality.FileInclude
-		echo '</script>';
 	}
 
 	/**

--- a/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
+++ b/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
@@ -72,13 +72,15 @@ class Twenty_Twenty_One_Dark_Mode {
 			array( 'in_footer' => true )
 		);
 
-		wp_enqueue_script(
-			'twentytwentyone-editor-dark-mode-support',
-			get_template_directory_uri() . '/assets/js/editor-dark-mode-support.js',
-			array( 'twentytwentyone-dark-mode-support-toggle' ),
-			'1.0.0',
-			array( 'in_footer' => true )
-		);
+		if (is_admin()) {
+			wp_enqueue_script(
+				'twentytwentyone-editor-dark-mode-support',
+				get_template_directory_uri() . '/assets/js/editor-dark-mode-support.js',
+				array( 'twentytwentyone-dark-mode-support-toggle' ),
+				'1.0.0',
+				array( 'in_footer' => true )
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
There were a couple of quirks found in the Trac ticket about assets enqueuing in the Twenty Twenty-One theme. This PR fixes those issues by:
1. Loading the `editor-dark-mode-support.js` script only if `is_admin()` is true since that script is not needed on the frontend.
2. Removing `the_script()` function because it was enqueuing the `dark-mode-toggler.js` again via an `include` statement when it is already being enqueued in `editor_custom_color_variables()`

Trac ticket: https://core.trac.wordpress.org/ticket/60111

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
