### PR TITLE
Adds 'enctype="multipart/form-data"' to the form

### DIFF
--- a/src/wp-admin/network/site-new.php
+++ b/src/wp-admin/network/site-new.php
@@ -204,7 +204,7 @@ if ( ! empty( $messages ) ) {
 }
 ?>
 <p><?php echo wp_required_field_message(); ?></p>
-<form method="post" action="<?php echo esc_url( network_admin_url( 'site-new.php?action=add-site' ) ); ?>" novalidate="novalidate">
+<form method="post" action="<?php echo esc_url( network_admin_url( 'site-new.php?action=add-site' ) ); ?>" novalidate="novalidate" enctype="multipart/form-data">
 <?php wp_nonce_field( 'add-blog', '_wpnonce_add-blog' ); ?>
 	<table class="form-table" role="presentation">
 		<tr class="form-field form-required">


### PR DESCRIPTION
This PR adds the enctype="multipart/form-data" attribute to the site creation form on /wp-admin/network/site-new.php.

Related ticket: https://core.trac.wordpress.org/ticket/62086