### PR TITLE
Use HTTPS for rpc.pingomatic.com (Update Services)

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -446,7 +446,7 @@ function populate_options( array $options = array() ) {
 		'moderation_keys'                 => '',
 		'active_plugins'                  => array(),
 		'category_base'                   => '',
-		'ping_sites'                      => 'http://rpc.pingomatic.com/',
+		'ping_sites'                      => 'https://rpc.pingomatic.com/',
 		'comment_max_links'               => 2,
 		'gmt_offset'                      => $gmt_offset,
 

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -881,6 +881,11 @@ function upgrade_all() {
 	if ( $wp_current_db_version < 58975 ) {
 		upgrade_670();
 	}
+
+	if ( $wp_current_db_version < 60344 ) {
+		upgrade_682();
+	}
+
 	maybe_disable_link_manager();
 
 	maybe_disable_automattic_widgets();
@@ -2439,6 +2444,39 @@ function upgrade_670() {
 		wp_set_options_autoload( $options, false );
 	}
 }
+
+/**
+ * Executes changes made in WordPress 6.8.2.
+ *
+ * @ignore
+ * @since 6.8.2
+ *
+ * @global int $wp_current_db_version The old (current) database version.
+ */
+function upgrade_682() {
+	global $wp_current_db_version;
+
+	if ( $wp_current_db_version < 60344 ) {
+		// Upgrade pingomatic URLs to use HTTPS.
+		$ping_sites_value = get_option( 'ping_sites' );
+		$ping_sites_value = explode( "\n", $ping_sites_value );
+		$ping_sites_value = array_map(
+			function ( $url ) {
+				$url = trim( $url );
+				$url = sanitize_url( $url );
+				if ( str_ends_with( $url, '://rpc.pingomatic.com/' ) ) {
+					$url = set_url_scheme( $url, 'https' );
+				}
+				return $url;
+			},
+			$ping_sites_value
+		);
+		$ping_sites_value = array_filter( $ping_sites_value );
+		$ping_sites_value = implode( "\n", $ping_sites_value );
+		update_option( 'ping_sites', $ping_sites_value );
+	}
+}
+
 /**
  * Executes network-level upgrade routines.
  *

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2457,14 +2457,17 @@ function upgrade_682() {
 	global $wp_current_db_version;
 
 	if ( $wp_current_db_version < 60344 ) {
-		// Upgrade pingomatic URLs to use HTTPS.
+		// Upgrade Ping-O-Matic and Twingly to use HTTPS.
 		$ping_sites_value = get_option( 'ping_sites' );
 		$ping_sites_value = explode( "\n", $ping_sites_value );
 		$ping_sites_value = array_map(
 			function ( $url ) {
 				$url = trim( $url );
 				$url = sanitize_url( $url );
-				if ( str_ends_with( $url, '://rpc.pingomatic.com/' ) ) {
+				if (
+					str_ends_with( trailingslashit( $url ), '://rpc.pingomatic.com/' )
+					|| str_ends_with( trailingslashit( $url ), '://rpc.twingly.com/' )
+				) {
 					$url = set_url_scheme( $url, 'https' );
 				}
 				return $url;

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -23,7 +23,7 @@ $wp_version = '6.9-alpha-60093-src';
  *
  * @global int $wp_db_version
  */
-$wp_db_version = 58975;
+$wp_db_version = 60344;
 
 /**
  * Holds the TinyMCE version.

--- a/tests/phpunit/tests/option/sanitizeOption.php
+++ b/tests/phpunit/tests/option/sanitizeOption.php
@@ -43,6 +43,7 @@ class Tests_Option_SanitizeOption extends WP_UnitTestCase {
 			array( 'date_format', 'F j, Y', 'F j, Y' ),
 			array( 'date_format', 'F j, Y', 'F j, <strong>Y</strong>' ),
 			array( 'ping_sites', 'http://rpc.pingomatic.com/', 'http://rpc.pingomatic.com/' ),
+			array( 'ping_sites', 'https://rpc.pingomatic.com/', 'https://rpc.pingomatic.com/' ),
 			array( 'ping_sites', "http://www.example.com\nhttp://example.org", "www.example.com \n\texample.org\n\n" ),
 			array( 'gmt_offset', '0', 0 ),
 			array( 'gmt_offset', '1.5', '1.5' ),


### PR DESCRIPTION
* Update schema.php for new sites, and try updating the unit test. - props @sabernhardt
* Add upgrade routine to set the scheme to `https`

Questions:

* Should `sanitize_option` be updated to force HTTPS? I decided against it to allow for site owners choosing not to. But I might be wrong.
* The [upgrade services documentation](https://developer.wordpress.org/advanced-administration/wordpress/update-services/#xml-rpc-ping-services) includes alternative providers. `rpc.twingly.com` now uses HTTPS too, should that be upgraded too?

https://core.trac.wordpress.org/ticket/42007


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
