### PR TITLE
Build/Test Tools: Remove unnecessary `docker` branding

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json.
 {
     "name": "WordPress Core Development",
-    "dockerComposeFile": "docker-compose.yml",
+    "dockerComposeFile": "compose.yml",
     "service": "app",
     "workspaceFolder": "/workspace",
 

--- a/.github/workflows/local-development-environment.yml
+++ b/.github/workflows/local-development-environment.yml
@@ -1,4 +1,4 @@
-name: Local Docker Environment
+name: Local Development Environment
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
     paths:
       # Any changes to Docker related files.
       - '.env.example'
-      - 'docker-compose.yml'
+      - 'compose.yml'
       # Any changes to local environment related files
       - 'tools/local-env/**'
       # These files configure npm and the task runner. Changes could affect the outcome.
@@ -22,9 +22,9 @@ on:
       # These files define the versions to test.
       - '.version-support-*.json'
       # Changes to this and related workflow files should always be verified.
-      - '.github/workflows/local-docker-environment.yml'
+      - '.github/workflows/local-development-environment.yml'
       - '.github/workflows/reusable-support-json-reader-v1.yml'
-      - '.github/workflows/reusable-test-docker-environment-v1.yml'
+      - '.github/workflows/reusable-test-local-development-environment-v1.yml'
   pull_request:
     branches:
       - trunk
@@ -33,7 +33,7 @@ on:
     paths:
       # Any changes to Docker related files.
       - '.env.example'
-      - 'docker-compose.yml'
+      - 'compose.yml'
       # Any changes to local environment related files
       - 'tools/local-env/**'
       # These files configure npm and the task runner. Changes could affect the outcome.
@@ -46,9 +46,9 @@ on:
       # These files define the versions to test.
       - '.version-support-*.json'
       # Changes to this and related workflow files should always be verified.
-      - '.github/workflows/local-docker-environment.yml'
+      - '.github/workflows/local-development-environment.yml'
       - '.github/workflows/reusable-support-json-reader-v1.yml'
-      - '.github/workflows/reusable-test-docker-environment-v1.yml'
+      - '.github/workflows/reusable-test-local-development-environment-v1.yml'
   workflow_dispatch:
 
 # Cancels all previous workflow runs for pull requests that have not completed.
@@ -80,7 +80,7 @@ jobs:
   # Tests the local Docker environment.
   environment-tests-mysql:
     name: PHP ${{ matrix.php }}
-    uses: ./.github/workflows/reusable-test-local-docker-environment-v1.yml
+    uses: ./.github/workflows/reusable-test-local-development-environment-v1.yml
     permissions:
       contents: read
     needs: [ build-test-matrix ]

--- a/.github/workflows/reusable-test-local-development-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-development-environment-v1.yml
@@ -3,7 +3,7 @@
 #
 # This workflow is used by `trunk` and branches >= 6.8.
 ##
-name: Test local Docker environment
+name: Test Local Development Environment
 
 on:
   workflow_call:

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -8,7 +8,7 @@ on:
     paths:
       - '.github/workflows/test-coverage.yml'
       - '.github/workflows/reusable-phpunit-tests-v3.yml'
-      - 'docker-compose.yml'
+      - 'compose.yml'
       - 'phpunit.xml.dist'
       - 'tests/phpunit/multisite.xml'
   pull_request:
@@ -17,7 +17,7 @@ on:
     paths:
       - '.github/workflows/test-coverage.yml'
       - '.github/workflows/reusable-phpunit-tests-v3.yml'
-      - 'docker-compose.yml'
+      - 'compose.yml'
       - 'phpunit.xml.dist'
       - 'tests/phpunit/multisite.xml'
   # Once daily at 00:00 UTC.

--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,8 @@ wp-tests-config.php
 
 # Files for local environment config
 /docker-compose.override.yml
+# The compose.override.yml is the new preferred Compose file name.
+/compose.override.yml
 
 # Visual regression test diffs
 tests/visual-regression/specs/__snapshots__

--- a/compose.yml
+++ b/compose.yml
@@ -4,7 +4,7 @@ services:
   # The web server container.
   ##
   wordpress-develop:
-    image: nginx:alpine
+    image: docker.io/nginx:alpine
 
     networks:
       - wpdevnet
@@ -32,7 +32,7 @@ services:
   # The PHP container.
   ##
   php:
-    image: wordpressdevelop/php:${LOCAL_PHP-latest}
+    image: docker.io/wordpressdevelop/php:${LOCAL_PHP-latest}
 
     networks:
       - wpdevnet
@@ -64,7 +64,7 @@ services:
   # The MySQL container.
   ##
   mysql:
-    image: ${LOCAL_DB_TYPE-mysql}:${LOCAL_DB_VERSION-latest}
+    image: docker.io/${LOCAL_DB_TYPE-mysql}:${LOCAL_DB_VERSION-latest}
 
     networks:
       - wpdevnet
@@ -95,7 +95,7 @@ services:
   # The WP CLI container.
   ##
   cli:
-    image: wordpressdevelop/cli:${LOCAL_PHP-latest}
+    image: docker.io/wordpressdevelop/cli:${LOCAL_PHP-latest}
 
     networks:
       - wpdevnet
@@ -130,7 +130,7 @@ services:
   # The Memcached container.
   ##
   memcached:
-    image: memcached
+    image: docker.io/memcached:latest
 
     networks:
       - wpdevnet

--- a/tools/local-env/scripts/utils.js
+++ b/tools/local-env/scripts/utils.js
@@ -8,7 +8,7 @@ const local_env_utils = {
 	 * Determines which Docker compose files are required to properly configure the local environment given the
 	 * specified PHP version, database type, and database version.
 	 *
-	 * By default, only the standard docker-compose.yml file will be used.
+	 * By default, only the standard compose.yml file will be used.
 	 *
 	 * When PHP 7.2 or 7.3 is used in combination with MySQL 8.4, an override file will also be returned to ensure
 	 * that the mysql_native_password plugin authentication plugin is on and available for use.
@@ -16,10 +16,10 @@ const local_env_utils = {
 	 * @return {string[]} Compose files.
 	 */
 	get_compose_files: function() {
-		const composeFiles = [ 'docker-compose.yml' ];
+		const composeFiles = [ 'compose.yml' ];
 
-		if ( existsSync( 'docker-compose.override.yml' ) ) {
-			composeFiles.push( 'docker-compose.override.yml' );
+		if ( existsSync( 'compose.override.yml' ) ) {
+			composeFiles.push( 'compose.override.yml' );
 		}
 
 		if ( process.env.LOCAL_DB_TYPE !== 'mysql' ) {


### PR DESCRIPTION
This PR brings following improvements:
- Add container repository (`docker.io`) to `compose.yaml`
- Remove `docker-` prefix -> more generic & prefix not needed
- add "missing" container tags

Trac:
https://core.trac.wordpress.org/ticket/63628