### PR TITLE
General: Only override `$table_prefix` if not defined

### DIFF
--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -138,7 +138,7 @@ require_wp_db();
  *
  * @global string $table_prefix The database table prefix.
  */
-$GLOBALS['table_prefix'] = $table_prefix;
+$GLOBALS['table_prefix'] = isset( $GLOBALS['table_prefix'] ) ? $GLOBALS['table_prefix'] : $table_prefix;
 
 // Set the database table prefix and the format specifiers for database table columns.
 wp_set_wpdb_vars();


### PR DESCRIPTION
Only set the variable `$table_prefix`, if set before (e.g. via some kind of custom bootstrapper).

To use `??=` operator we need `>= php8.4`, but happily referring to your documentation, this is already the current minimum requirement :D
https://wordpress.org/about/requirements/
-> bumped version in `composer.json`

PS: Don't know how to remove php-version matrix in github workflow, need some help here to get the pipe fixed :-)

Trac:
https://core.trac.wordpress.org/ticket/63627