### PR TITLE
General: Add link_current parameter to paginate_links() for accessibility

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -4659,6 +4659,7 @@ function paginate_links( $args = '' ) {
 		'add_fragment'       => '',
 		'before_page_number' => '',
 		'after_page_number'  => '',
+		'link_current'       => false,
 	);
 
 	$args = wp_parse_args( $args, $defaults );
@@ -4729,11 +4730,27 @@ function paginate_links( $args = '' ) {
 
 	for ( $n = 1; $n <= $total; $n++ ) :
 		if ( $n === $current ) :
-			$page_links[] = sprintf(
-				'<span aria-current="%s" class="page-numbers current">%s</span>',
-				esc_attr( $args['aria_current'] ),
-				$args['before_page_number'] . number_format_i18n( $n ) . $args['after_page_number']
-			);
+			if ( $args['link_current'] ) {
+				$current_link = str_replace( '%_%', 1 === $n ? '' : $args['format'], $args['base'] );
+				$current_link = str_replace( '%#%', $n, $current_link );
+				if ( $add_args ) {
+					$link = add_query_arg( $add_args, $current_link );
+				}
+				$current_link .= $args['add_fragment'];
+
+				$page_links[] = sprintf(
+					'<a aria-current="%s" class="page-numbers current" href="%s">%s</a>',
+					esc_attr( $args['aria_current'] ),
+					esc_url( apply_filters( 'paginate_links', $current_link ) ),
+					$args['before_page_number'] . number_format_i18n( $n ) . $args['after_page_number']
+				);
+			} else {
+				$page_links[] = sprintf(
+					'<span aria-current="%s" class="page-numbers current">%s</span>',
+					esc_attr( $args['aria_current'] ),
+					$args['before_page_number'] . number_format_i18n( $n ) . $args['after_page_number']
+				);
+			}
 
 			$dots = true;
 		else :


### PR DESCRIPTION


<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63581

**Summary**

Adds a new `link_current` parameter to the `paginate_links()` function to improve accessibility by allowing the current page to be output as a focusable link element instead of a span.

**Problem**

The current implementation of `paginate_links()` outputs the current page as a `<span>` element, which creates accessibility issues for screen reader users as the current page indicator is not focusable. This makes it difficult for users navigating with keyboards or assistive technologies to interact with the current page element.

**Current behavior:**
```html
<span aria-current="page" class="page-numbers current">2</span>
```

**Desired behavior:**
```html
<a aria-current="page" class="page-numbers current" href="...">2</a>
```

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
