### PR TITLE
Passing int term term_exists parent param not respected

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -1630,6 +1630,10 @@ function term_exists( $term, $taxonomy = '', $parent_term = null ) {
 	 */
 	$defaults = apply_filters( 'term_exists_default_query_args', $defaults, $term, $taxonomy, $parent_term );
 
+	if ( ! empty( $taxonomy ) && is_numeric( $parent_term ) ) {
+		$defaults['parent'] = (int) $parent_term;
+	}
+
 	if ( is_int( $term ) ) {
 		if ( 0 === $term ) {
 			return 0;
@@ -1640,10 +1644,6 @@ function term_exists( $term, $taxonomy = '', $parent_term = null ) {
 		$term = trim( wp_unslash( $term ) );
 		if ( '' === $term ) {
 			return null;
-		}
-
-		if ( ! empty( $taxonomy ) && is_numeric( $parent_term ) ) {
-			$defaults['parent'] = (int) $parent_term;
 		}
 
 		$args  = wp_parse_args( array( 'slug' => sanitize_title( $term ) ), $defaults );

--- a/tests/phpunit/tests/term/termExists.php
+++ b/tests/phpunit/tests/term/termExists.php
@@ -401,4 +401,153 @@ class Tests_TermExists extends WP_UnitTestCase {
 		$this->assertNull( term_exists( '' ) );
 		$this->assertNull( term_exists( null ) );
 	}
+
+	/**
+	 * @ticket 55358
+	 * @covers ::term_exists()
+	 */
+	public function test_term_exists_with_numeric_parent_term() {
+		register_taxonomy(
+			'foo',
+			'post',
+			array(
+				'hierarchical' => true,
+			)
+		);
+
+		$parent_term = self::factory()->term->create(
+			array(
+				'taxonomy' => 'foo',
+			)
+		);
+
+		$child_term = self::factory()->term->create(
+			array(
+				'taxonomy' => 'foo',
+				'parent'   => $parent_term,
+				'slug'     => 'child-term',
+			)
+		);
+
+		// Test with numeric parent_term as integer
+		$found = term_exists( 'child-term', 'foo', $parent_term );
+		$this->assertIsArray( $found );
+		$this->assertEquals( $child_term, $found['term_id'] );
+
+		// Test with numeric parent_term as string
+		$found = term_exists( 'child-term', 'foo', (string) $parent_term );
+		$this->assertIsArray( $found );
+		$this->assertEquals( $child_term, $found['term_id'] );
+
+		_unregister_taxonomy( 'foo' );
+	}
+
+	/**
+	 * @ticket 55358
+	 * @covers ::term_exists()
+	 */
+	public function test_term_exists_with_non_numeric_parent_term() {
+		register_taxonomy(
+			'foo',
+			'post',
+			array(
+				'hierarchical' => true,
+			)
+		);
+
+		$parent_term = self::factory()->term->create(
+			array(
+				'taxonomy' => 'foo',
+			)
+		);
+
+		$child_term = self::factory()->term->create(
+			array(
+				'taxonomy' => 'foo',
+				'parent'   => $parent_term,
+				'slug'     => 'child-term',
+			)
+		);
+
+		// Test with non-numeric parent_term (should not set parent filter)
+		$found = term_exists( 'child-term', 'foo', 'not-numeric' );
+		$this->assertIsArray( $found );
+		$this->assertEquals( $child_term, $found['term_id'] );
+
+		// Test with null parent_term (should not set parent filter)
+		$found = term_exists( 'child-term', 'foo', null );
+		$this->assertIsArray( $found );
+		$this->assertEquals( $child_term, $found['term_id'] );
+
+		_unregister_taxonomy( 'foo' );
+	}
+
+	/**
+	 * @ticket 55358
+	 * @covers ::term_exists()
+	 */
+	public function test_term_exists_with_empty_taxonomy_and_numeric_parent() {
+		register_taxonomy(
+			'foo',
+			'post',
+			array(
+				'hierarchical' => true,
+			)
+		);
+
+		$parent_term = self::factory()->term->create(
+			array(
+				'taxonomy' => 'foo',
+			)
+		);
+
+		$child_term = self::factory()->term->create(
+			array(
+				'taxonomy' => 'foo',
+				'parent'   => $parent_term,
+				'slug'     => 'child-term',
+			)
+		);
+
+		// Test with empty taxonomy and numeric parent_term (should not set parent filter)
+		$found = term_exists( 'child-term', '', $parent_term );
+		$this->assertIsString( $found );
+		$this->assertEquals( $child_term, $found );
+
+		_unregister_taxonomy( 'foo' );
+	}
+
+	/**
+	 * @ticket 55358
+	 * @covers ::term_exists()
+	 */
+	public function test_term_exists_with_wordpress_categories() {
+		// Create a parent category
+		$parent_cat = self::factory()->term->create(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'Parent Category',
+				'slug'     => 'parent-category',
+			)
+		);
+
+		// Create a child category
+		$child_cat = self::factory()->term->create(
+			array(
+				'taxonomy' => 'category',
+				'name'     => 'Child Category',
+				'slug'     => 'child-category',
+				'parent'   => $parent_cat,
+			)
+		);
+
+		// Test finding child category with numeric parent
+		$found = term_exists( 'child-category', 'category', $parent_cat );
+		$this->assertIsArray( $found );
+		$this->assertEquals( $child_cat, $found['term_id'] );
+
+		// Test finding child category with wrong parent
+		$found = term_exists( 'child-category', 'category', 999 );
+		$this->assertNull( $found );
+	}
 }


### PR DESCRIPTION
This PR fixes a bug in the `term_exists` function where the `parent_term` wasn’t being considered correctly. When a term ID (as an integer) was passed along with a parent term ID, the function would only check if the term ID existed and completely ignore whether it was under the specified parent.

1. Updated the `term_exists` logic to include the parent in the query when both a term ID and parent term ID are provided.
2. Added a condition to ensure that the parent is checked as part of the query when relevant.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->https://core.trac.wordpress.org/ticket/55358

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
