### PR TITLE
Customizer and Theme Installer spinners should have different z-index - Refreshing 36911.patch

### DIFF
--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -1829,7 +1829,7 @@ body.full-overlay-active {
 .theme-install-overlay iframe {
 	height: 100%;
 	width: 100%;
-	z-index: 20;
+	position: relative; /* needed to be on top of the spinner */
 	transition: opacity 0.3s;
 }
 
@@ -1925,7 +1925,6 @@ body.full-overlay-active {
 
 .theme-install-overlay .wp-full-overlay-main {
 	position: absolute;
-	z-index: 0;
 	background-color: #f0f0f1;
 }
 
@@ -1944,7 +1943,6 @@ body.full-overlay-active {
 	position: absolute;
 	left: 50%;
 	top: 50%;
-	z-index: -1;
 	margin: -10px 0 0 -10px;
 	transform: translateZ(0);
 	background: transparent url(../images/spinner.gif) no-repeat center center;


### PR DESCRIPTION
Refreshing patch
Tests below
Trac ticket: https://core.trac.wordpress.org/ticket/36911

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
