### PR TITLE
Unable to set rows attribute for textarea input in the Customizer

### DIFF
--- a/src/wp-includes/class-wp-customize-control.php
+++ b/src/wp-includes/class-wp-customize-control.php
@@ -124,7 +124,7 @@ class WP_Customize_Control {
 	/**
 	 * List of custom input attributes for control output, where attribute names are the keys and values are the values.
 	 *
-	 * Not used for 'checkbox', 'radio', 'select', 'textarea', or 'dropdown-pages' control types.
+	 * Not used for 'checkbox', 'radio', 'select', or 'dropdown-pages' control types.
 	 *
 	 * @since 4.0.0
 	 * @var array
@@ -201,7 +201,7 @@ class WP_Customize_Control {
 	 *                                                 Default empty array.
 	 *     @type array                $input_attrs     List of custom input attributes for control output, where
 	 *                                                 attribute names are the keys and values are the values. Not
-	 *                                                 used for 'checkbox', 'radio', 'select', 'textarea', or
+	 *                                                 used for 'checkbox', 'radio', 'select', or
 	 *                                                 'dropdown-pages' control types. Default empty array.
 	 *     @type bool                 $allow_addition  Show UI for adding new content, currently only used for the
 	 *                                                 dropdown-pages control. Default false.
@@ -566,6 +566,9 @@ class WP_Customize_Control {
 				<?php
 				break;
 			case 'textarea':
+				if ( ! array_key_exists( 'rows', $this->input_attrs ) ) {
+					$this->input_attrs['rows'] = 5;
+				}
 				?>
 				<?php if ( ! empty( $this->label ) ) : ?>
 					<label for="<?php echo esc_attr( $input_id ); ?>" class="customize-control-title"><?php echo esc_html( $this->label ); ?></label>
@@ -575,7 +578,6 @@ class WP_Customize_Control {
 				<?php endif; ?>
 				<textarea
 					id="<?php echo esc_attr( $input_id ); ?>"
-					rows="5"
 					<?php echo $describedby_attr; ?>
 					<?php $this->input_attrs(); ?>
 					<?php $this->link(); ?>


### PR DESCRIPTION
== Important
If this happens to be merged, docs should be updated
I'm adding this PR to also update docs (and fixing the PHPCS mistake in the original patch)

Trac ticket: https://core.trac.wordpress.org/ticket/47445

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
