### PR TITLE
sanitize_file_name(): Normalize all space characters to a space.

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2038,10 +2038,11 @@ function sanitize_file_name( $filename ) {
 		/**
 		 * Replace all whitespace characters with a basic space (U+0020).
 		 *
-		 * Characters in the White_Space category are listed with “Zs” in
-		 * their entry in the UnicodeData file maintained at the linked URL.
+		 * The “Zs” in the pattern selects characters in the `Space_Separator`
+		 * category, which includes all characters considered as white space
+		 * in the Unicode standard.
 		 *
-		 * @see https://www.unicode.org/Public/UCD/latest/ucd/UnicodeData.txt
+		 * @see https://www.unicode.org/reports/tr44/#General_Category_Values
 		 */
 		$filename = preg_replace( '#\p{Zs}#siu', ' ', $filename );
 	}

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2043,7 +2043,7 @@ function sanitize_file_name( $filename ) {
 		 *
 		 * @see https://www.unicode.org/Public/UCD/latest/ucd/UnicodeData.txt
 		 */
-		$filename = preg_replace( "#\p{Zs}#siu", ' ', $filename );
+		$filename = preg_replace( '#\p{Zs}#siu', ' ', $filename );
 	}
 
 	/**

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2035,7 +2035,15 @@ function sanitize_file_name( $filename ) {
 	}
 
 	if ( $utf8_pcre ) {
-		$filename = preg_replace( "#\x{00a0}#siu", ' ', $filename );
+		/**
+		 * Replace all whitespace characters with a basic space (U+0020).
+		 *
+		 * Characters in the White_Space category are listed with “Zs” in
+		 * their entry in the UnicodeData file maintained at the linked URL.
+		 *
+		 * @see https://www.unicode.org/Public/UCD/latest/ucd/UnicodeData.txt
+		 */
+		$filename = preg_replace( "#\p{Zs}#siu", ' ', $filename );
 	}
 
 	/**

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2039,10 +2039,11 @@ function sanitize_file_name( $filename ) {
 		 * Replace all whitespace characters with a basic space (U+0020).
 		 *
 		 * The “Zs” in the pattern selects characters in the `Space_Separator`
-		 * category, which includes all characters considered as white space
-		 * in the Unicode standard.
+		 * category, which is what Unicode considers space characters.
 		 *
 		 * @see https://www.unicode.org/reports/tr44/#General_Category_Values
+		 * @see https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-6/#G17548
+		 * @see https://www.php.net/manual/en/regexp.reference.unicode.php
 		 */
 		$filename = preg_replace( '#\p{Zs}#siu', ' ', $filename );
 	}

--- a/tests/phpunit/tests/formatting/sanitizeFileName.php
+++ b/tests/phpunit/tests/formatting/sanitizeFileName.php
@@ -35,13 +35,17 @@ class Tests_Formatting_SanitizeFileName extends WP_UnitTestCase {
 	 * Test that spaces are correctly replaced with dashes.
 	 *
 	 * @ticket 16330
+	 * @ticket 62995
 	 */
 	public function test_replaces_spaces() {
 		$urls = array(
-			'unencoded space.png'  => 'unencoded-space.png',
-			'encoded-space.jpg'    => 'encoded-space.jpg',
-			'plus+space.jpg'       => 'plusspace.jpg',
-			'multi %20 +space.png' => 'multi-20-space.png',
+			'unencoded space.png'                         => 'unencoded-space.png',
+			'encoded-space.jpg'                           => 'encoded-space.jpg',
+			'plus+space.jpg'                              => 'plusspace.jpg',
+			'multi %20 +space.png'                        => 'multi-20-space.png',
+			"Screenshot 2025-02-19 at 2.17.33\u{202F}PM.png" => 'Screenshot-2025-02-19-at-2.17.33-PM.png',
+			"Filename with non-breaking\u{00A0}space.txt" => 'Filename-with-non-breaking-space.txt',
+			"Filename with thin\u{2009}space.txt"         => 'Filename-with-thin-space.txt',
 		);
 
 		foreach ( $urls as $test => $expected ) {


### PR DESCRIPTION
Trac ticket: Core-62995

The `sanitize_file_name()` function normalizes the no-break space to a normal space (U+0020) in order to prevent issues saving files with the no-break space in it.

This patch expands the replacement to all space characters, since it’s known that macOS stores a NARROW NO-BREAK SPACE (U+202F) in screenshot filenames between the time and the am/pm indicator.

There are deeper issues with the way this function works, but this patch resolves a known and common problem without raising any of the deeper refactoring questions.