### PR TITLE
Fix #30227

### DIFF
--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -570,7 +570,7 @@ function wpmu_validate_user_signup( $user_name, $user_email ) {
 		if ( $diff > 2 * DAY_IN_SECONDS ) {
 			$wpdb->delete( $wpdb->signups, array( 'user_email' => $user_email ) );
 		} else {
-			$errors->add( 'user_email', __( 'That email address has already been used. Please check your inbox for an activation email. It will become available in a couple of days if you do nothing.' ) );
+			$errors->add( 'user_email', __( 'That email address is pending activation and not available for new registration. If you made a previous attempt with this email address, please check your inbox for an activation email. If left unconfirmed, it will become available in a couple of days.' ) );
 		}
 	}
 

--- a/src/wp-includes/ms-functions.php
+++ b/src/wp-includes/ms-functions.php
@@ -570,7 +570,7 @@ function wpmu_validate_user_signup( $user_name, $user_email ) {
 		if ( $diff > 2 * DAY_IN_SECONDS ) {
 			$wpdb->delete( $wpdb->signups, array( 'user_email' => $user_email ) );
 		} else {
-			$errors->add( 'user_email', __( 'That email address is pending activation and not available for new registration. If you made a previous attempt with this email address, please check your inbox for an activation email. If left unconfirmed, it will become available in a couple of days.' ) );
+			$errors->add( 'user_email', __( 'That email address is pending activation and is not available for new registration. If you made a previous attempt with this email address, please check your inbox for an activation email. If left unconfirmed, it will become available in a couple of days.' ) );
 		}
 	}
 


### PR DESCRIPTION
This PR updates the user-facing message displayed when attempting to create a user with an email address that is already pending activation in a WordPress Multisite network.

References

* Trac ticket: [#30227](https://core.trac.wordpress.org/ticket/30227)
* Original patch: [30227.1.diff](https://core.trac.wordpress.org/attachment/ticket/30227/30227.1.diff)

Props @SirLouen for the copy review.