### PR TITLE
code quality: remove needless conditionals from `wp_resolve_numeric_slug_conflicts()`

### DIFF
--- a/src/wp-includes/rewrite.php
+++ b/src/wp-includes/rewrite.php
@@ -412,7 +412,7 @@ function wp_resolve_numeric_slug_conflicts( $query_vars = array() ) {
 
 	// This is the potentially clashing slug.
 	$value = '';
-	if ( $compare && array_key_exists( $compare, $query_vars ) ) {
+	if ( array_key_exists( $compare, $query_vars ) ) {
 		$value = $query_vars[ $compare ];
 	}
 
@@ -460,9 +460,7 @@ function wp_resolve_numeric_slug_conflicts( $query_vars = array() ) {
 	}
 
 	// If we've gotten to this point, we have a slug/date clash. First, adjust for nextpage.
-	if ( '' !== $maybe_page ) {
-		$query_vars['page'] = (int) $maybe_page;
-	}
+	$query_vars['page'] = $maybe_page;
 
 	// Next, unset autodetected date-related query vars.
 	unset( $query_vars['year'] );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR removes two unnecessary conditional checks from within `wp_resolve_numeric_slug_conflicts()`:

- a truthy check for `$compare`, when a falsey `$compare` causes an earlier return on the preceeding codeblock (L409)
- A check to ensure `$maybe_page` isn't an empty string, when `$maybe_page` is already cast to an `int` (L448).

While this issue was surfaced via PHPStan in https://github.com/WordPress/wordpress-develop/pull/7619 (trac: https://core.trac.wordpress.org/ticket/61175 ), it can be remediated independently of that ticket.

Trac ticket: https://core.trac.wordpress.org/ticket/63268


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
