### PR TITLE
#63166 Replace some mentions of MySQL with more generic terminology

### DIFF
--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -941,7 +941,7 @@ class wpdb {
 	/**
 	 * Changes the current SQL mode, and ensures its WordPress compatibility.
 	 *
-	 * If no modes are passed, it will ensure the current MySQL server modes are compatible.
+	 * If no modes are passed, it will ensure the current SQL server modes are compatible.
 	 *
 	 * @since 3.9.0
 	 *
@@ -1369,7 +1369,7 @@ class wpdb {
 	}
 
 	/**
-	 * Quotes an identifier for a MySQL database, e.g. table/field names.
+	 * Quotes an identifier such as a table or field name.
 	 *
 	 * @since 6.2.0
 	 *
@@ -1957,7 +1957,7 @@ class wpdb {
 		$client_flags = defined( 'MYSQL_CLIENT_FLAGS' ) ? MYSQL_CLIENT_FLAGS : 0;
 
 		/*
-		 * Set the MySQLi error reporting off because WordPress handles its own.
+		 * Switch error reporting off because WordPress handles its own.
 		 * This is due to the default value change from `MYSQLI_REPORT_OFF`
 		 * to `MYSQLI_REPORT_ERROR|MYSQLI_REPORT_STRICT` in PHP 8.1.
 		 */
@@ -2100,7 +2100,7 @@ class wpdb {
 		}
 
 		$host = ! empty( $matches['host'] ) ? $matches['host'] : '';
-		// MySQLi port cannot be a string; must be null or an integer.
+		// Port cannot be a string; must be null or an integer.
 		$port = ! empty( $matches['port'] ) ? absint( $matches['port'] ) : null;
 
 		return array( $host, $port, $socket, $is_ipv6 );
@@ -2290,7 +2290,7 @@ class wpdb {
 		if ( $this->dbh instanceof mysqli ) {
 			$this->last_error = mysqli_error( $this->dbh );
 		} else {
-			$this->last_error = __( 'Unable to retrieve the error message from MySQL' );
+			$this->last_error = __( 'Unable to retrieve the error message from the database server' );
 		}
 
 		if ( $this->last_error ) {
@@ -3473,7 +3473,7 @@ class wpdb {
 	}
 
 	/**
-	 * Checks if the query is accessing a collation considered safe on the current version of MySQL.
+	 * Checks if the query is accessing a collation considered safe.
 	 *
 	 * @since 4.2.0
 	 *
@@ -3987,7 +3987,7 @@ class wpdb {
 	}
 
 	/**
-	 * Determines whether MySQL database is at least the required minimum version.
+	 * Determines whether the database server is at least the required minimum version.
 	 *
 	 * @since 2.5.0
 	 *
@@ -4047,7 +4047,7 @@ class wpdb {
 	 *
 	 * Capability sniffs for the database server and current version of WPDB.
 	 *
-	 * Database sniffs are based on the version of MySQL the site is using.
+	 * Database sniffs are based on the version of the database server in use.
 	 *
 	 * WPDB sniffs are added as new features are introduced to allow theme and plugin
 	 * developers to determine feature support. This is to account for drop-ins which may
@@ -4119,7 +4119,7 @@ class wpdb {
 	}
 
 	/**
-	 * Retrieves the database server version.
+	 * Retrieves the database server version number.
 	 *
 	 * @since 2.7.0
 	 *
@@ -4130,11 +4130,11 @@ class wpdb {
 	}
 
 	/**
-	 * Returns the version of the MySQL server.
+	 * Returns the raw version string of the database server.
 	 *
 	 * @since 5.5.0
 	 *
-	 * @return string Server version as a string.
+	 * @return string Database server version as a string.
 	 */
 	public function db_server_info() {
 		return mysqli_get_server_info( $this->dbh );

--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -139,8 +139,11 @@ function wp_populate_basic_auth_from_authorization_header() {
 }
 
 /**
- * Checks for the required PHP version, and the mysqli extension or
- * a database drop-in.
+ * Checks the server requirements.
+ *
+ *   - PHP version
+ *   - PHP extensions
+ *   - MySQL or MariaDB version (unless a database drop-in is present)
  *
  * Dies if requirements are not met.
  *

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -35,7 +35,7 @@ require ABSPATH . WPINC . '/version.php';
 require ABSPATH . WPINC . '/compat.php';
 require ABSPATH . WPINC . '/load.php';
 
-// Check for the required PHP version and for the MySQL extension or a database drop-in.
+// Check the server requirements.
 wp_check_php_mysql_versions();
 
 // Include files required for initialization.


### PR DESCRIPTION
MySQL isn't the only supported database server, so this updates docs and one i18n string to use more generic terminology.

* Trac ticket: https://core.trac.wordpress.org/ticket/63166
* Trac ticket: https://core.trac.wordpress.org/ticket/60037