### PR TITLE
WordPress 5.4.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPress",
-	"version": "5.4.16",
+	"version": "5.4.17",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPress",
-	"version": "5.4.16",
+	"version": "5.4.17",
 	"description": "WordPress is open source software you can use to create a beautiful website, blog, or app.",
 	"repository": {
 		"type": "svn",

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -56,6 +56,26 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 					printf(
 						/* translators: %s: WordPress version number */
 						__( '<strong>Version %s</strong> addressed one security issue.' ),
+						'5.4.17'
+					);
+					?>
+					<?php
+					printf(
+						/* translators: %s: HelpHub URL */
+						__( 'For more information, see <a href="%s">the release notes</a>.' ),
+						sprintf(
+							/* translators: %s: WordPress version */
+							esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
+							sanitize_title( '5.4.17' )
+						)
+					);
+					?>
+				</p>
+				<p>
+					<?php
+					printf(
+						/* translators: %s: WordPress version number */
+						__( '<strong>Version %s</strong> addressed one security issue.' ),
 						'5.4.16'
 					);
 					?>

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -13,7 +13,7 @@
  *
  * @global string $wp_version
  */
-$wp_version = '5.4.16-src';
+$wp_version = '5.4.17-src';
 
 /**
  * Holds the WordPress DB revision, increments when changes are made to the WordPress DB schema.


### PR DESCRIPTION
Version bump and changelog update for WordPress 5.4.17

There are no planned security fixes for this release other than updating the bundled root certificates.

Trac ticket: https://core.trac.wordpress.org/ticket/63165