### PR TITLE
WordPress 6.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPress",
-	"version": "6.3.5",
+	"version": "6.3.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "WordPress",
-	"version": "6.3.5",
+	"version": "6.3.6",
 	"description": "WordPress is open source software you can use to create a beautiful website, blog, or app.",
 	"repository": {
 		"type": "svn",

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -46,6 +46,27 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 		<div class="about__section changelog has-subtle-background-color">
 			<div class="column">
 				<h2><?php _e( 'Maintenance and Security Releases' ); ?></h2>
+				<p>
+					<?php
+					printf(
+						/* translators: %s: WordPress version number. */
+						__( '<strong>Version %s</strong> addressed one security issue.' ),
+						'6.3.6'
+					);
+					?>
+					<?php
+					printf(
+						/* translators: %s: HelpHub URL. */
+						__( 'For more information, see <a href="%s">the release notes</a>.' ),
+						sprintf(
+							/* translators: %s: WordPress version. */
+							esc_url( __( 'https://wordpress.org/support/wordpress-version/version-%s/' ) ),
+							sanitize_title( '6.3.6' )
+						)
+					);
+					?>
+				</p>
+				<p>
 					<?php
 					printf(
 						/* translators: %s: WordPress version. */

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -16,7 +16,7 @@
  *
  * @global string $wp_version
  */
-$wp_version = '6.3.5-src';
+$wp_version = '6.3.6-src';
 
 /**
  * Holds the WordPress DB revision, increments when changes are made to the WordPress DB schema.


### PR DESCRIPTION
Version bump and changelog update for WordPress 6.3.6

There are no planned security fixes for this release other than updating the bundled root certificates.

Trac ticket: https://core.trac.wordpress.org/ticket/63165