### PR TITLE
Fix font-size inconsistency for preformatted block in editor (Twenty Nineteen Theme)

### DIFF
--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -1260,6 +1260,11 @@ figcaption,
   margin-left: 0;
 }
 
+/** === Preformatted === */
+.wp-block-preformatted {
+  font-size: 0.71111em;
+}
+
 /** === Verse === */
 .wp-block-verse,
 .wp-block-verse pre {

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -654,6 +654,12 @@ figcaption,
 
 }
 
+/** === Preformatted === */
+
+.wp-block-preformatted {
+	font-size: $font__size-xs;
+}
+
 /** === Verse === */
 
 .wp-block-verse,


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/61770

This pull request addresses a styling inconsistency in the Twenty Nineteen theme.

The theme sets a font-size for the preformatted block on the frontend (see `_blocks.scss`, line 346), but no corresponding font-size is defined for the editor. As a result, the preformatted block in the editor inherits the body font-size, creating a mismatch between editor and frontend styles.

This PR fixes that by explicitly setting the same font-size for the `.wp-block-preformatted` selector in the editor styles. It uses the `$font__size-xs` SCSS variable, which is used in `_blocks.scss` to set the font-size for preformatted block (frontend).

As the Twenty Nineteen theme uses SCSS, changes were made to the `style-editor.scss` file, and the `build` command was used to generate the corresponding CSS files.

### Editor
<img width="1470" alt="Screenshot 2025-07-01 at 2 32 55 PM" src="https://github.com/user-attachments/assets/dff651be-ef98-4f86-be04-247783db0424" />

### Frontend
<img width="1470" alt="Screenshot 2025-07-01 at 2 33 39 PM" src="https://github.com/user-attachments/assets/3d3213be-98bc-4de6-a16a-7994f1bc2df3" />
