### PR TITLE
Add PHPDoc block for the twentyseventeen_should_show_featured_image filter in Twenty Seventeen Theme

### DIFF
--- a/src/wp-content/themes/twentyseventeen/functions.php
+++ b/src/wp-content/themes/twentyseventeen/functions.php
@@ -708,6 +708,14 @@ endif;
  */
 function twentyseventeen_should_show_featured_image() {
 	$show_featured_image = ( is_single() || ( is_page() && ! twentyseventeen_is_frontpage() ) ) && has_post_thumbnail( get_queried_object_id() );
+	/**
+	 * Filters whether to show the featured image below the header on single posts and pages, unless the page is the front page.
+	 *
+	 * @param bool $display Whether to the featured image below the header on single posts and pages.
+	 *
+	 *@since 3.7.0
+	 *
+	 */
 	return apply_filters( 'twentyseventeen_should_show_featured_image', $show_featured_image );
 }
 

--- a/src/wp-content/themes/twentyseventeen/functions.php
+++ b/src/wp-content/themes/twentyseventeen/functions.php
@@ -711,7 +711,7 @@ function twentyseventeen_should_show_featured_image() {
 	/**
 	 * Filters whether to show the featured image below the header on single posts and pages, unless the page is the front page.
 	 *
-	 * @param bool $display Whether to the featured image below the header on single posts and pages.
+	 * @param bool $show_featured_image Whether to the featured image below the header on single posts and pages.
 	 *
 	 *@since 3.7.0
 	 *

--- a/src/wp-content/themes/twentyseventeen/functions.php
+++ b/src/wp-content/themes/twentyseventeen/functions.php
@@ -711,7 +711,7 @@ function twentyseventeen_should_show_featured_image() {
 	/**
 	 * Filters whether to show the Twenty Seventeen featured image below the header on single posts and pages, unless the page is the front page.
 	 *
-	 * @since 3.7.0
+	 * @since Twenty Seventeen 3.7
 	 *
 	 * @param bool $show_featured_image Whether to display the featured image below the header.
 	 */

--- a/src/wp-content/themes/twentyseventeen/functions.php
+++ b/src/wp-content/themes/twentyseventeen/functions.php
@@ -709,12 +709,11 @@ endif;
 function twentyseventeen_should_show_featured_image() {
 	$show_featured_image = ( is_single() || ( is_page() && ! twentyseventeen_is_frontpage() ) ) && has_post_thumbnail( get_queried_object_id() );
 	/**
-	 * Filters whether to show the featured image below the header on single posts and pages, unless the page is the front page.
-	 *
-	 * @param bool $show_featured_image Whether to the featured image below the header on single posts and pages.
+	 * Filters whether to show the Twenty Seventeen featured image below the header on single posts and pages, unless the page is the front page.
 	 *
 	 * @since 3.7.0
 	 *
+	 * @param bool $show_featured_image whether to show the Twenty Seventeen featured image below the header on single posts and pages.
 	 */
 	return apply_filters( 'twentyseventeen_should_show_featured_image', $show_featured_image );
 }

--- a/src/wp-content/themes/twentyseventeen/functions.php
+++ b/src/wp-content/themes/twentyseventeen/functions.php
@@ -713,7 +713,7 @@ function twentyseventeen_should_show_featured_image() {
 	 *
 	 * @param bool $show_featured_image Whether to the featured image below the header on single posts and pages.
 	 *
-	 *@since 3.7.0
+	 * @since 3.7.0
 	 *
 	 */
 	return apply_filters( 'twentyseventeen_should_show_featured_image', $show_featured_image );

--- a/src/wp-content/themes/twentyseventeen/functions.php
+++ b/src/wp-content/themes/twentyseventeen/functions.php
@@ -713,7 +713,7 @@ function twentyseventeen_should_show_featured_image() {
 	 *
 	 * @since 3.7.0
 	 *
-	 * @param bool $show_featured_image whether to show the Twenty Seventeen featured image below the header on single posts and pages.
+	 * @param bool $show_featured_image Whether to display the featured image below the header.
 	 */
 	return apply_filters( 'twentyseventeen_should_show_featured_image', $show_featured_image );
 }


### PR DESCRIPTION


<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63644

