### PR TITLE
Add PHPDoc block for the twentynineteen_can_show_post_thumbnail filter in Twenty Nineteen Theme

### DIFF
--- a/src/wp-content/themes/twentynineteen/inc/helper-functions.php
+++ b/src/wp-content/themes/twentynineteen/inc/helper-functions.php
@@ -11,7 +11,14 @@
  * Determines if post thumbnail can be displayed.
  */
 function twentynineteen_can_show_post_thumbnail() {
-	return apply_filters( 'twentynineteen_can_show_post_thumbnail', ! post_password_required() && ! is_attachment() && has_post_thumbnail() );
+	$show_post_thumbnail = ! post_password_required() && ! is_attachment() && has_post_thumbnail();
+	/**
+	 * Filters whether to show post thumbnail.
+	 *
+	 * @param bool $show_post_thumbnail Whether to show post thumbnail.
+	 *
+	 */
+	return apply_filters( 'twentynineteen_can_show_post_thumbnail', $show_post_thumbnail );
 }
 
 /**

--- a/src/wp-content/themes/twentynineteen/inc/helper-functions.php
+++ b/src/wp-content/themes/twentynineteen/inc/helper-functions.php
@@ -11,7 +11,7 @@
  * Determines if post thumbnail can be displayed.
  */
 function twentynineteen_can_show_post_thumbnail() {
-	$show_post_thumbnail = ! post_password_required() && ! is_attachment() && has_post_thumbnail();
+	$show_post_thumbnail = ( ! post_password_required() && ! is_attachment() && has_post_thumbnail() );
 	/**
 	 * Filters whether to show post thumbnail.
 	 *

--- a/src/wp-content/themes/twentynineteen/inc/helper-functions.php
+++ b/src/wp-content/themes/twentynineteen/inc/helper-functions.php
@@ -16,7 +16,6 @@ function twentynineteen_can_show_post_thumbnail() {
 	 * Filters whether to show post thumbnail.
 	 *
 	 * @param bool $show_post_thumbnail Whether to show post thumbnail.
-	 *
 	 */
 	return apply_filters( 'twentynineteen_can_show_post_thumbnail', $show_post_thumbnail );
 }

--- a/src/wp-content/themes/twentynineteen/inc/helper-functions.php
+++ b/src/wp-content/themes/twentynineteen/inc/helper-functions.php
@@ -12,6 +12,7 @@
  */
 function twentynineteen_can_show_post_thumbnail() {
 	$show_post_thumbnail = ( ! post_password_required() && ! is_attachment() && has_post_thumbnail() );
+
 	/**
 	 * Filters whether to show post thumbnail.
 	 *

--- a/src/wp-content/themes/twentynineteen/inc/helper-functions.php
+++ b/src/wp-content/themes/twentynineteen/inc/helper-functions.php
@@ -16,6 +16,8 @@ function twentynineteen_can_show_post_thumbnail() {
 	/**
 	 * Filters whether to show post thumbnail.
 	 *
+	 * @since Twenty Nineteen 1.0
+	 *
 	 * @param bool $show_post_thumbnail Whether to show post thumbnail.
 	 */
 	return apply_filters( 'twentynineteen_can_show_post_thumbnail', $show_post_thumbnail );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63645

