### PR TITLE
Add PHPDoc block for the twentysixteen_author_avatar_size filter in Twenty Sixteen Theme

### DIFF
--- a/src/wp-content/themes/twentysixteen/inc/template-tags.php
+++ b/src/wp-content/themes/twentysixteen/inc/template-tags.php
@@ -19,6 +19,13 @@ if ( ! function_exists( 'twentysixteen_entry_meta' ) ) :
 	 */
 	function twentysixteen_entry_meta() {
 		if ( 'post' === get_post_type() ) {
+			/**
+			 * Filters the Twenty Sixteen author avatar size.
+			 *
+			 * @since Twenty Sixteen 1.0
+			 *
+			 * @param int The height and width avatar dimension in pixels. Default 49.
+			 */
 			$author_avatar_size = apply_filters( 'twentysixteen_author_avatar_size', 49 );
 			printf(
 				'<span class="byline">%1$s<span class="screen-reader-text">%2$s </span><span class="author vcard"><a class="url fn n" href="%3$s">%4$s</a></span></span>',

--- a/src/wp-content/themes/twentysixteen/inc/template-tags.php
+++ b/src/wp-content/themes/twentysixteen/inc/template-tags.php
@@ -20,11 +20,11 @@ if ( ! function_exists( 'twentysixteen_entry_meta' ) ) :
 	function twentysixteen_entry_meta() {
 		if ( 'post' === get_post_type() ) {
 			/**
-			 * Filters the Twenty Sixteen author avatar size.
+			 * Filters the Twenty Sixteen entry meta avatar size.
 			 *
 			 * @since Twenty Sixteen 1.0
 			 *
-			 * @param int The height and width avatar dimension in pixels. Default 49.
+			 * @param int $size The avatar height and width size in pixels.
 			 */
 			$author_avatar_size = apply_filters( 'twentysixteen_author_avatar_size', 49 );
 			printf(


### PR DESCRIPTION


<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63647

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
