### PR TITLE
Twenty Eleven to Twenty Fourteen: add PHPDoc blocks for footer action hooks

### DIFF
--- a/src/wp-content/themes/twentyeleven/footer.php
+++ b/src/wp-content/themes/twentyeleven/footer.php
@@ -25,7 +25,14 @@
 			?>
 
 			<div id="site-generator">
-				<?php do_action( 'twentyeleven_credits' ); ?>
+				<?php
+				/**
+				 * Fires before the Twenty Eleven credits in the footer.
+				 *
+				 * @since Twenty Eleven 1.0
+				 */
+				do_action( 'twentyeleven_credits' );
+				?>
 				<?php
 				if ( function_exists( 'the_privacy_policy_link' ) ) {
 					the_privacy_policy_link( '', '<span role="separator" aria-hidden="true"></span>' );

--- a/src/wp-content/themes/twentyfourteen/footer.php
+++ b/src/wp-content/themes/twentyfourteen/footer.php
@@ -18,7 +18,14 @@
 			<?php get_sidebar( 'footer' ); ?>
 
 			<div class="site-info">
-				<?php do_action( 'twentyfourteen_credits' ); ?>
+				<?php
+				/**
+				 * Fires before the Twenty Fourteen credits in the footer.
+				 *
+				 * @since Twenty Fourteen 1.0
+				 */
+				do_action( 'twentyfourteen_credits' );
+				?>
 				<?php
 				if ( function_exists( 'the_privacy_policy_link' ) ) {
 					the_privacy_policy_link( '', '<span role="separator" aria-hidden="true"></span>' );

--- a/src/wp-content/themes/twentythirteen/footer.php
+++ b/src/wp-content/themes/twentythirteen/footer.php
@@ -15,7 +15,14 @@
 			<?php get_sidebar( 'main' ); ?>
 
 			<div class="site-info">
-				<?php do_action( 'twentythirteen_credits' ); ?>
+				<?php
+				/**
+				 * Fires before the Twenty Thirteen credits in the footer.
+				 *
+				 * @since Twenty Thirteen 1.0
+				 */
+				do_action( 'twentythirteen_credits' );
+				?>
 				<?php
 				if ( function_exists( 'the_privacy_policy_link' ) ) {
 					the_privacy_policy_link( '', '<span role="separator" aria-hidden="true"></span>' );

--- a/src/wp-content/themes/twentytwelve/footer.php
+++ b/src/wp-content/themes/twentytwelve/footer.php
@@ -12,7 +12,14 @@
 	</div><!-- #main .wrapper -->
 	<footer id="colophon" role="contentinfo">
 		<div class="site-info">
-			<?php do_action( 'twentytwelve_credits' ); ?>
+			<?php
+			/**
+			 * Fires before the Twenty Twelve credits in the footer.
+			 *
+			 * @since Twenty Twelve 1.0
+			 */
+			do_action( 'twentytwelve_credits' );
+			?>
 			<?php
 			if ( function_exists( 'the_privacy_policy_link' ) ) {
 				the_privacy_policy_link( '', '<span role="separator" aria-hidden="true"></span>' );


### PR DESCRIPTION


<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63648

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
