### PR TITLE
Toolbar: Truncate long display name to prevent layout issues

### DIFF
--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -262,7 +262,7 @@ function wp_admin_bar_sidebar_toggle( $wp_admin_bar ) {
 function wp_admin_bar_my_account_item( $wp_admin_bar ) {
 	$user_id      = get_current_user_id();
 	$current_user = wp_get_current_user();
-	$display_name = mb_strimwidth( $current_user->display_name, 0, 40, '...' );
+	$display_name = wp_html_excerpt( $current_user->display_name, 40, '&hellip;' );
 
 	if ( ! $user_id ) {
 		return;
@@ -307,7 +307,7 @@ function wp_admin_bar_my_account_item( $wp_admin_bar ) {
 function wp_admin_bar_my_account_menu( $wp_admin_bar ) {
 	$user_id      = get_current_user_id();
 	$current_user = wp_get_current_user();
-	$display_name = mb_strimwidth( $current_user->display_name, 0, 40, '...' );
+	$display_name = wp_html_excerpt( $current_user->display_name, 40, '&hellip;' );
 
 	if ( ! $user_id ) {
 		return;

--- a/src/wp-includes/admin-bar.php
+++ b/src/wp-includes/admin-bar.php
@@ -262,6 +262,7 @@ function wp_admin_bar_sidebar_toggle( $wp_admin_bar ) {
 function wp_admin_bar_my_account_item( $wp_admin_bar ) {
 	$user_id      = get_current_user_id();
 	$current_user = wp_get_current_user();
+	$display_name = mb_strimwidth( $current_user->display_name, 0, 40, '...' );
 
 	if ( ! $user_id ) {
 		return;
@@ -277,7 +278,7 @@ function wp_admin_bar_my_account_item( $wp_admin_bar ) {
 
 	$avatar = get_avatar( $user_id, 26 );
 	/* translators: %s: Current user's display name. */
-	$howdy = sprintf( __( 'Howdy, %s' ), '<span class="display-name">' . $current_user->display_name . '</span>' );
+	$howdy = sprintf( __( 'Howdy, %s' ), '<span class="display-name">' . $display_name . '</span>' );
 	$class = empty( $avatar ) ? '' : 'with-avatar';
 
 	$wp_admin_bar->add_node(
@@ -289,7 +290,7 @@ function wp_admin_bar_my_account_item( $wp_admin_bar ) {
 			'meta'   => array(
 				'class'      => $class,
 				/* translators: %s: Current user's display name. */
-				'menu_title' => sprintf( __( 'Howdy, %s' ), $current_user->display_name ),
+				'menu_title' => sprintf( __( 'Howdy, %s' ), $display_name ),
 				'tabindex'   => ( false !== $profile_url ) ? '' : 0,
 			),
 		)
@@ -306,6 +307,7 @@ function wp_admin_bar_my_account_item( $wp_admin_bar ) {
 function wp_admin_bar_my_account_menu( $wp_admin_bar ) {
 	$user_id      = get_current_user_id();
 	$current_user = wp_get_current_user();
+	$display_name = mb_strimwidth( $current_user->display_name, 0, 40, '...' );
 
 	if ( ! $user_id ) {
 		return;
@@ -327,7 +329,7 @@ function wp_admin_bar_my_account_menu( $wp_admin_bar ) {
 	);
 
 	$user_info  = get_avatar( $user_id, 64 );
-	$user_info .= "<span class='display-name'>{$current_user->display_name}</span>";
+	$user_info .= "<span class='display-name'>{$display_name}</span>";
 
 	if ( $current_user->display_name !== $current_user->user_login ) {
 		$user_info .= "<span class='username'>{$current_user->user_login}</span>";


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
Long user display names can cause the admin bar and user info dropdown layout to break, especially on smaller screens. This PR fixes the issue by truncating the display name to 40 characters in the backend before rendering, ensuring the layout remains stable and consistent.

Trac ticket: https://core.trac.wordpress.org/ticket/63607

### Before

<img width="1370" alt="Screenshot 2025-07-01 at 10 50 42 PM" src="https://github.com/user-attachments/assets/f2e1a8f1-6b0b-487e-86f7-9d025d96e347" />

### After

<img width="1368" alt="Screenshot 2025-07-01 at 11 07 28 PM" src="https://github.com/user-attachments/assets/418fc5b0-4175-4178-9d9e-40be4c023938" />
