### PR TITLE
Fix `_oembed_rest_pre_serve_request()` return type consistency

### DIFF
--- a/src/wp-includes/embed.php
+++ b/src/wp-includes/embed.php
@@ -791,7 +791,7 @@ function _oembed_rest_pre_serve_request( $served, $result, $request, $server ) {
 	// Bail if there's no XML.
 	if ( ! $result ) {
 		status_header( 501 );
-		return get_status_header_desc( 501 );
+		die( get_status_header_desc( 501 ) );
 	}
 
 	if ( ! headers_sent() ) {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63652

Fixes inconsistent return behavior in `_oembed_rest_pre_serve_request()`

The function is attached to the `rest_pre_serve_request` filter and should maintain consistent return types. Previously, one error path used `die()` while another returned a string, violating the filter's expected boolean return.
This PR replaces `return` with `die()` to match the existing error handling pattern

