### PR TITLE
Fix Twenty Nineteen editor paragraph font-size inheritance

### DIFF
--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -668,7 +668,7 @@ body {
 }
 
 p {
-  font-size: 22px;
+  font-size: inherit;
 }
 
 h1,

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -104,7 +104,7 @@ body {
 }
 
 p {
-	font-size: $font__size_base;
+	font-size: inherit;
 }
 
 h1,


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/60880

### Before
https://github.com/user-attachments/assets/87654af7-c976-481b-bfda-57099221b13d

### After
https://github.com/user-attachments/assets/6ab7c723-b1fc-44bd-b432-561aa53a03a5


