### PR TITLE
Trac ticket: https://core.trac.wordpress.org/ticket/63665

### DIFF
--- a/src/wp-includes/class-wp-http-cookie.php
+++ b/src/wp-includes/class-wp-http-cookie.php
@@ -227,7 +227,7 @@ class WP_Http_Cookie {
 	 *
 	 * @return string Header encoded cookie name and value.
 	 */
-	public function getHeaderValue() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+	public function get_header_value() {
 		if ( ! isset( $this->name ) || ! isset( $this->value ) ) {
 			return '';
 		}
@@ -250,8 +250,8 @@ class WP_Http_Cookie {
 	 *
 	 * @return string
 	 */
-	public function getFullHeader() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
-		return 'Cookie: ' . $this->getHeaderValue();
+	public function get_full_header() {
+		return 'Cookie: ' . $this->get_header_value();
 	}
 
 	/**

--- a/src/wp-includes/class-wp-http.php
+++ b/src/wp-includes/class-wp-http.php
@@ -818,7 +818,7 @@ class WP_Http {
 
 			$cookies_header = '';
 			foreach ( (array) $r['cookies'] as $cookie ) {
-				$cookies_header .= $cookie->getHeaderValue() . '; ';
+				$cookies_header .= $cookie->get_header_value() . '; ';
 			}
 
 			$cookies_header         = substr( $cookies_header, 0, -2 );


### PR DESCRIPTION
Renames WP_Http_Cookie methods to snake_case to follow WordPress coding standards.

- getHeaderValue() → get_header_value()
- getFullHeader() → get_full_header()
- Updates all usages in core
- Removes phpcs:ignore comments

Trac ticket: https://core.trac.wordpress.org/ticket/63665

This is a pure refactoring/consistency change, no functional impact.