### PR TITLE
Administration: Fix remove_submenu_page() to always remove nopriv entry for submenu

### DIFF
--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1484,6 +1484,11 @@ function add_submenu_page( $parent_slug, $page_title, $menu_title, $capability, 
 	if ( ! current_user_can( $capability ) ) {
 		$_wp_submenu_nopriv[ $parent_slug ][ $menu_slug ] = true;
 		return false;
+	} elseif ( isset( $_wp_submenu_nopriv[ $parent_slug ][ $menu_slug ] ) ) {
+		unset( $_wp_submenu_nopriv[ $parent_slug ][ $menu_slug ] );
+		if ( empty( $_wp_submenu_nopriv[ $parent_slug ] ) ) {
+				unset( $_wp_submenu_nopriv[ $parent_slug ] );
+		}
 	}
 
 	/*
@@ -1878,20 +1883,29 @@ function remove_menu_page( $menu_slug ) {
  * @return array|false The removed submenu on success, false if not found.
  */
 function remove_submenu_page( $menu_slug, $submenu_slug ) {
-	global $submenu;
+	global $submenu, $_wp_submenu_nopriv;
 
-	if ( ! isset( $submenu[ $menu_slug ] ) ) {
-		return false;
-	}
-
-	foreach ( $submenu[ $menu_slug ] as $i => $item ) {
-		if ( $submenu_slug === $item[2] ) {
-			unset( $submenu[ $menu_slug ][ $i ] );
-			return $item;
+	$removed = false;
+	if ( isset( $submenu[ $menu_slug ] ) ) {
+		foreach ( $submenu[ $menu_slug ] as $i => $item ) {
+			if ( $submenu_slug === $item[2] ) {
+				unset( $submenu[ $menu_slug ][ $i ] );
+				$removed = $item;
+				break;
+			}
 		}
 	}
 
-	return false;
+	// Remove the submenu from the nopriv array if it exists.
+	if ( isset( $_wp_submenu_nopriv[ $menu_slug ][ $submenu_slug ] ) ) {
+		unset( $_wp_submenu_nopriv[ $menu_slug ][ $submenu_slug ] );
+
+		if ( empty( $_wp_submenu_nopriv[ $menu_slug ] ) ) {
+			unset( $_wp_submenu_nopriv[ $menu_slug ] );
+		}
+	}
+
+	return $removed ? $removed : false;
 }
 
 /**

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1484,11 +1484,6 @@ function add_submenu_page( $parent_slug, $page_title, $menu_title, $capability, 
 	if ( ! current_user_can( $capability ) ) {
 		$_wp_submenu_nopriv[ $parent_slug ][ $menu_slug ] = true;
 		return false;
-	} elseif ( isset( $_wp_submenu_nopriv[ $parent_slug ][ $menu_slug ] ) ) {
-		unset( $_wp_submenu_nopriv[ $parent_slug ][ $menu_slug ] );
-		if ( empty( $_wp_submenu_nopriv[ $parent_slug ] ) ) {
-				unset( $_wp_submenu_nopriv[ $parent_slug ] );
-		}
 	}
 
 	/*

--- a/tests/phpunit/tests/admin/removeSubmenuPage.php
+++ b/tests/phpunit/tests/admin/removeSubmenuPage.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @group plugins
+ * @group admin
+ */
+class Tests_Admin_RemoveSubmenuPage extends WP_UnitTestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+		global $_wp_submenu_nopriv;
+		$_wp_submenu_nopriv = array();
+	}
+
+	/**
+	 * Tests that removing and re-adding a submenu page with different capabilities
+	 * correctly updates the $_wp_submenu_nopriv global and user access.
+	 *
+	 * @ticket 47690
+	 */
+	public function test_remove_and_readd_submenu_page_allows_access() {
+		global $_wp_submenu_nopriv, $plugin_page, $pagenow;
+
+		$parent_slug  = 'tools.php';
+		$submenu_slug = 'my-plugin-page';
+		$page_title   = 'My Plugin Page';
+		$menu_title   = 'My Plugin';
+		$denied_cap   = 'do_not_have_this_cap';
+		$allowed_cap  = 'manage_options';
+
+		// Create an administrator user.
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		// Add submenu page with denied capability. Should add to nopriv.
+		add_submenu_page( $parent_slug, $page_title, $menu_title, $denied_cap, $submenu_slug, '__return_null' );
+		$this->assertArrayHasKey( $submenu_slug, $_wp_submenu_nopriv[ $parent_slug ] );
+
+		// Remove submenu page. Should remove from nopriv.
+		remove_submenu_page( $parent_slug, $submenu_slug );
+		if ( isset( $_wp_submenu_nopriv[ $parent_slug ] ) ) {
+			$this->assertArrayNotHasKey( $submenu_slug, $_wp_submenu_nopriv[ $parent_slug ] );
+		}
+
+		// Re-add submenu page with allowed capability. Should not add to nopriv.
+		add_submenu_page( $parent_slug, $page_title, $menu_title, $allowed_cap, $submenu_slug, '__return_null' );
+		if ( isset( $_wp_submenu_nopriv[ $parent_slug ] ) ) {
+			$this->assertArrayNotHasKey( $submenu_slug, $_wp_submenu_nopriv[ $parent_slug ] );
+		}
+
+		// Simulate access check for this submenu page.
+		$plugin_page = $submenu_slug;
+		$pagenow     = $parent_slug;
+		$this->assertTrue( user_can_access_admin_page() );
+
+		// Clean up global state.
+		unset( $plugin_page, $pagenow );
+	}
+}


### PR DESCRIPTION
Trac ticket: [#47690](https://core.trac.wordpress.org/ticket/47690)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
