### PR TITLE
Fix 9296: Enable custom Settings API fields in Permalinks page

### DIFF
--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -144,6 +144,21 @@ if ( isset( $_POST['permalink_structure'] ) || isset( $_POST['category_base'] ) 
 
 		$wp_rewrite->set_tag_base( $tag_base );
 	}
+
+	// Handle custom settings registered through the Settings API.
+	$registered_settings = get_registered_settings();
+
+	foreach ( $registered_settings as $option_name => $option_args ) {
+		if ( isset( $option_args['group'] ) && 'permalink' === $option_args['group'] ) {
+			if ( isset( $_POST[ $option_name ] ) ) {
+				$value = wp_unslash( $_POST[ $option_name ] );
+				if ( isset( $option_args['sanitize_callback'] ) && is_callable( $option_args['sanitize_callback'] ) ) {
+					$value = call_user_func( $option_args['sanitize_callback'], $value );
+				}
+				update_option( $option_name, $value );
+			}
+		}
+	}
 }
 
 if ( $iis7_permalinks ) {


### PR DESCRIPTION
## Problem
The WordPress Permalinks settings page (`options-permalink.php`) was not processing custom settings that were registered through the WordPress Settings API. While developers could add custom settings to the page using `register_setting()` with the 'permalink' group, these settings would not persist when the form was submitted.

## Root Cause
The root cause was that `options-permalink.php` lacked the necessary code to process and save custom settings registered through the Settings API. While WordPress provides the infrastructure to register settings with the 'permalink' group, the permalinks page wasn't implementing the logic to handle these settings during form submission.

## Solution
Added code to `options-permalink.php` to properly handle custom settings:
```php
// Handle custom settings registered through the Settings API.
$registered_settings = get_registered_settings();

foreach ( $registered_settings as $option_name => $option_args ) {
    if ( isset( $option_args['group'] ) && 'permalink' === $option_args['group'] ) {
        if ( isset( $_POST[ $option_name ] ) ) {
            $value = wp_unslash( $_POST[ $option_name ] );
            if ( isset( $option_args['sanitize_callback'] ) && is_callable( $option_args['sanitize_callback'] ) ) {
                $value = call_user_func( $option_args['sanitize_callback'], $value );
            }
            update_option( $option_name, $value );
        }
    }
}
```

This addition:
- Retrieves all registered settings
- Processes settings specifically registered to the 'permalink' group
- Properly sanitizes values using registered callbacks
- Saves the settings to the database

### Example Usage
For developers looking to add custom permalink settings, here's how to properly register a setting:

```php
register_setting(
    'permalink',           // settings group
    'my_custom_setting',   // option name
    array(
        'type' => 'string',
        'sanitize_callback' => 'sanitize_text_field',
        'default' => ''
    )
);
```

## Impact
This enhancement enables developers to properly extend the Permalinks settings page using the WordPress Settings API, improving the platform's extensibility while maintaining consistency with WordPress coding standards and best practices.

## Trac Link
- https://core.trac.wordpress.org/ticket/9296