### PR TITLE
Corrected Inline Document Order

### DIFF
--- a/src/wp-admin/includes/class-wp-screen.php
+++ b/src/wp-admin/includes/class-wp-screen.php
@@ -984,9 +984,9 @@ final class WP_Screen {
 	}
 
 	/**
-	 * @global array $wp_meta_boxes Global meta box state.
-	 *
 	 * @since 3.3.0
+	 *
+	 * @global array $wp_meta_boxes Global meta box state.
 	 *
 	 * @return bool
 	 */

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1058,9 +1058,9 @@ function admin_color_scheme_picker( $user_id ) {
 
 /**
  *
- * @global array $_wp_admin_css_colors
- *
  * @since 3.8.0
+ *
+ * @global array $_wp_admin_css_colors
  */
 function wp_color_scheme_settings() {
 	global $_wp_admin_css_colors;

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2631,9 +2631,9 @@ function get_submit_button( $text = '', $type = 'primary large', $name = 'submit
 /**
  * Prints out the beginning of the admin HTML header.
  *
- * @global bool $is_IE
- *
  * @since 3.3.0
+ *
+ * @global bool $is_IE
  */
 function _wp_admin_html_begin() {
 	global $is_IE;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here --> https://core.trac.wordpress.org/ticket/63166

Corrected `@since` Order in Inline Documents in Below Files:
- src/wp-admin/includes/class-wp-screen.php
- src/wp-admin/includes/misc.php
- src/wp-admin/includes/template.php

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
