### PR TITLE
Bump the minimum recommended version of PHP to 8.3

### DIFF
--- a/src/readme.html
+++ b/src/readme.html
@@ -58,7 +58,7 @@
 
 <h3>Recommendations</h3>
 <ul>
-	<li><a href="https://www.php.net/">PHP</a> version <strong>7.4</strong> or greater.</li>
+	<li><a href="https://www.php.net/">PHP</a> version <strong>8.3</strong> or greater.</li>
 	<li><a href="https://www.mysql.com/">MySQL</a> version <strong>8.0</strong> or greater OR <a href="https://mariadb.org/">MariaDB</a> version <strong>10.6</strong> or greater.</li>
 	<li>The <a href="https://httpd.apache.org/docs/2.2/mod/mod_rewrite.html">mod_rewrite</a> Apache module.</li>
 	<li><a href="https://wordpress.org/news/2016/12/moving-toward-ssl/">HTTPS</a> support.</li>


### PR DESCRIPTION
Meta ticket: https://meta.trac.wordpress.org/ticket/6612