### PR TITLE
Remove `e2e-test-utils`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,6 @@
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.15",
 				"@wordpress/babel-preset-default": "8.19.1",
 				"@wordpress/dependency-extraction-webpack-plugin": "6.19.1",
-				"@wordpress/e2e-test-utils": "11.19.1",
 				"@wordpress/e2e-test-utils-playwright": "1.19.1",
 				"@wordpress/prettier-config": "4.19.1",
 				"@wordpress/scripts": "30.12.1",
@@ -7491,30 +7490,6 @@
 				"npm": ">=8.19.2"
 			}
 		},
-		"node_modules/@wordpress/e2e-test-utils": {
-			"version": "11.19.1",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils/-/e2e-test-utils-11.19.1.tgz",
-			"integrity": "sha512-4V1IT0zg3tf1KtkjRwISAtr2Rbd+rdIDxchT27nFQ1eUbYsk+b8uMOqPSBix2lJG2XWchAEGNSk7gFXzziqyyw==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@wordpress/api-fetch": "^7.19.1",
-				"@wordpress/keycodes": "^4.19.1",
-				"@wordpress/url": "^4.19.1",
-				"change-case": "^4.1.2",
-				"form-data": "^4.0.0",
-				"node-fetch": "2.7.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"jest": ">=29",
-				"puppeteer-core": ">=23"
-			}
-		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
 			"version": "1.19.1",
 			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.19.1.tgz",
@@ -7563,22 +7538,6 @@
 			},
 			"engines": {
 				"node": ">=10.0.0"
-			}
-		},
-		"node_modules/@wordpress/e2e-test-utils/node_modules/form-data": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-			"integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"es-set-tostringtag": "^2.1.0",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/@wordpress/edit-post": {
@@ -26241,27 +26200,6 @@
 				"node": ">=10.5.0"
 			}
 		},
-		"node_modules/node-fetch": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"whatwg-url": "^5.0.0"
-			},
-			"engines": {
-				"node": "4.x || >=6.0.0"
-			},
-			"peerDependencies": {
-				"encoding": "^0.1.0"
-			},
-			"peerDependenciesMeta": {
-				"encoding": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/node-forge": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
@@ -33769,13 +33707,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/tr46": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/tree-kill": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -34665,13 +34596,6 @@
 			"integrity": "sha512-/CFAm1mNxSmOj6i0Co+iGFJ58OS4NRGVP+AWS/l509uIK5a1bSoIVaHz/ZumpHTfHSZBpgrJ+wjfpAOrTHok5Q==",
 			"dev": true
 		},
-		"node_modules/webidl-conversions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-			"dev": true,
-			"license": "BSD-2-Clause"
-		},
 		"node_modules/webpack": {
 			"version": "5.98.0",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
@@ -35303,17 +35227,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/whatwg-url": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"tr46": "~0.0.3",
-				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.15",
 		"@wordpress/babel-preset-default": "8.19.1",
 		"@wordpress/dependency-extraction-webpack-plugin": "6.19.1",
-		"@wordpress/e2e-test-utils": "11.19.1",
 		"@wordpress/e2e-test-utils-playwright": "1.19.1",
 		"@wordpress/prettier-config": "4.19.1",
 		"@wordpress/scripts": "30.12.1",


### PR DESCRIPTION
`e2e-test-utils` was replaced with `e2e-test-utils-playwright` in https://core.trac.wordpress.org/ticket/59517 and is no longer needed. This removes a few dependencies but we can't get rid of Puppeteer just yet because `grunt-contrib-qunit` still depends on it for the QUnit tests (see https://core.trac.wordpress.org/ticket/59644).

Trac ticket: https://core.trac.wordpress.org/ticket/63171