### PR TITLE
#63678 Warn when a user has reached 'max_questions' mysql parameter

### DIFF
--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -2299,6 +2299,19 @@ class wpdb {
 			$this->last_error = __( 'Unable to retrieve the error message from the database server' );
 		}
 
+		// User has reached 'max_questions' stop retrying
+		if ( 1226 === $mysql_errno ) {
+			$message = '<h1>' . __( 'Cannot query database' ) . "</h1>\n";
+			$message .= '<p>' . __( 'The database server could be connected to (which means username and password is okay) but the query could not be performed.' ) . '<br>';
+			$message .= sprintf( $this->last_error );
+			$message .= '<p>' . sprintf(
+				/* translators: %s: Support forums URL. */
+				__( 'If you are unsure what these terms mean you should probably contact your host. If you still need help you can always visit the <a href="%s">WordPress support forums</a>.' ),
+				__( 'https://wordpress.org/support/forums/' )
+			) . "</p>\n";
+			wp_die( $message );
+		}
+
 		if ( $this->last_error ) {
 			// Clear insert_id on a subsequent failed insert.
 			if ( $this->insert_id && preg_match( '/^\s*(insert|replace)\s/i', $query ) ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

 Wordpress redirect to wp-admin/install.php when a user is rate limited in mysql,

instead of catching and displaying a valid error message

Trac ticket: https://core.trac.wordpress.org/ticket/63678

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
