### PR TITLE
Delete oEmbed postmeta if the related embed is deleted or not longer present in the content

### DIFF
--- a/src/wp-includes/class-wp-embed.php
+++ b/src/wp-includes/class-wp-embed.php
@@ -42,7 +42,11 @@ class WP_Embed {
 		add_filter( 'widget_text_content', array( $this, 'autoembed' ), 8 );
 		add_filter( 'widget_block_content', array( $this, 'autoembed' ), 8 );
 
-		// After a post is saved, cache oEmbed items
+		// After a post is saved, cache oEmbed items items via Ajax.
+		add_action( 'edit_form_advanced', array( $this, 'maybe_run_ajax_cache' ) );
+		add_action( 'edit_page_form', array( $this, 'maybe_run_ajax_cache' ) );
+
+		// After a post is saved, cache oEmbed items directly. See #63667
 		add_action( 'save_post', array( $this, 'cache_oembed' ) );
 	}
 

--- a/src/wp-includes/class-wp-embed.php
+++ b/src/wp-includes/class-wp-embed.php
@@ -45,6 +45,8 @@ class WP_Embed {
 		// After a post is saved, cache oEmbed items via Ajax.
 		add_action( 'edit_form_advanced', array( $this, 'maybe_run_ajax_cache' ) );
 		add_action( 'edit_page_form', array( $this, 'maybe_run_ajax_cache' ) );
+		add_action( 'save_post', array( $this, 'maybe_run_ajax_cache' ) );
+		add_action( 'delete_post', array( $this, 'maybe_run_ajax_cache' ) );
 	}
 
 	/**
@@ -418,6 +420,8 @@ class WP_Embed {
 		if ( empty( $post->ID ) || ! in_array( $post->post_type, $cache_oembed_types, true ) ) {
 			return;
 		}
+
+		$this->delete_oembed_caches( $post_id );
 
 		// Trigger a caching.
 		if ( ! empty( $post->post_content ) ) {

--- a/src/wp-includes/class-wp-embed.php
+++ b/src/wp-includes/class-wp-embed.php
@@ -42,11 +42,8 @@ class WP_Embed {
 		add_filter( 'widget_text_content', array( $this, 'autoembed' ), 8 );
 		add_filter( 'widget_block_content', array( $this, 'autoembed' ), 8 );
 
-		// After a post is saved, cache oEmbed items via Ajax.
-		add_action( 'edit_form_advanced', array( $this, 'maybe_run_ajax_cache' ) );
-		add_action( 'edit_page_form', array( $this, 'maybe_run_ajax_cache' ) );
-		add_action( 'save_post', array( $this, 'maybe_run_ajax_cache' ) );
-		add_action( 'delete_post', array( $this, 'maybe_run_ajax_cache' ) );
+		// After a post is saved, cache oEmbed items
+		add_action( 'save_post', array( $this, 'cache_oembed' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/oembed/WpEmbed.php
+++ b/tests/phpunit/tests/oembed/WpEmbed.php
@@ -196,29 +196,6 @@ class Tests_WP_Embed extends WP_UnitTestCase {
 		$this->assertEmpty( get_post_meta( $post_id, $cachekey_time, true ) );
 	}
 
-	/*
-	 * Test that when a post is deleted, the oembed cache for that post is removed.
-	 *
-	 * @ticket 63667
-	 */
-	public function test_removing_embed_should_remove_cache_oembed() {
-		$url        = 'https://example.com/';
-		$key_suffix = md5( $url . serialize( wp_embed_defaults( $url ) ) );
-		$cachekey   = '_oembed_' . $key_suffix;
-
-		$post_id = self::factory()->post->create( array( 'post_content' => 'https://example.com/' ) );
-
-		$this->wp_embed->cache_oembed( $post_id );
-
-		$this->assertNotEmpty( get_post_meta( $post_id, $cachekey, true ) );
-
-		wp_delete_post( $post_id, true );
-
-		$this->wp_embed->cache_oembed( $post_id );
-
-		$this->assertEmpty( get_post_meta( $post_id, $cachekey, true ) );
-	}
-
 	public function test_shortcode_should_get_cached_data_from_post_meta_for_known_post() {
 		global $post;
 

--- a/tests/phpunit/tests/oembed/WpEmbed.php
+++ b/tests/phpunit/tests/oembed/WpEmbed.php
@@ -160,7 +160,13 @@ class Tests_WP_Embed extends WP_UnitTestCase {
 		$this->assertNotSame( $post_id, $this->wp_embed->post_ID );
 	}
 
-	public function test_cache_oembed_for_post() {
+
+	/*
+	 * Test that when an embed is removed from the post content, the oembed cache is removed.
+	 *
+	 * @ticket 63667
+	 */
+	public function test_cache_oembed_for_post_and_update_removing_embed() {
 		$url           = 'https://example.com/';
 		$expected      = '<b>Embedded content</b>';
 		$key_suffix    = md5( $url . serialize( wp_embed_defaults( $url ) ) );
@@ -176,6 +182,41 @@ class Tests_WP_Embed extends WP_UnitTestCase {
 		$this->assertSame( $post_id, $this->wp_embed->post_ID );
 		$this->assertSame( $expected, get_post_meta( $post_id, $cachekey, true ) );
 		$this->assertNotEmpty( get_post_meta( $post_id, $cachekey_time, true ) );
+
+		wp_update_post(
+			array(
+				'ID'           => $post_id,
+				'post_content' => 'Removing Oembed.',
+			)
+		);
+
+		$this->wp_embed->cache_oembed( $post_id );
+
+		$this->assertEmpty( get_post_meta( $post_id, $cachekey, true ) );
+		$this->assertEmpty( get_post_meta( $post_id, $cachekey_time, true ) );
+	}
+
+	/*
+	 * Test that when a post is deleted, the oembed cache for that post is removed.
+	 *
+	 * @ticket 63667
+	 */
+	public function test_removing_embed_should_remove_cache_oembed() {
+		$url        = 'https://example.com/';
+		$key_suffix = md5( $url . serialize( wp_embed_defaults( $url ) ) );
+		$cachekey   = '_oembed_' . $key_suffix;
+
+		$post_id = self::factory()->post->create( array( 'post_content' => 'https://example.com/' ) );
+
+		$this->wp_embed->cache_oembed( $post_id );
+
+		$this->assertNotEmpty( get_post_meta( $post_id, $cachekey, true ) );
+
+		wp_delete_post( $post_id, true );
+
+		$this->wp_embed->cache_oembed( $post_id );
+
+		$this->assertEmpty( get_post_meta( $post_id, $cachekey, true ) );
 	}
 
 	public function test_shortcode_should_get_cached_data_from_post_meta_for_known_post() {


### PR DESCRIPTION
I've been reviewing PR #9203, but maybe I'm wrong, but I feel it's too convoluted, so a full review won't be possible. After further reviewing, I think that caches should be refreshed after each update or delete action, which include first a deletion before regeneration. I'm taking the already existing function `delete_oembed_caches` although I'm not 100% confident if maybe a more targeted function rather than this should be added for this purpose.

Trac ticket: https://core.trac.wordpress.org/ticket/63667

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
