### PR TITLE
Use correct type for `$request_id`

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -4802,7 +4802,7 @@ function wp_user_request_action_description( $action_name ) {
  *
  * @since 4.9.6
  *
- * @param string $request_id ID of the request created via wp_create_user_request().
+ * @param int $request_id ID of the request created via wp_create_user_request().
  * @return true|WP_Error True on success, `WP_Error` on failure.
  */
 function wp_send_user_request( $request_id ) {


### PR DESCRIPTION
`$request_id` is "ID of the request created via wp_create_user_request()."

`wp_create_user_request()` returns `int`, so correct type for phpdoc type should be should be `int`.

Trac ticket: https://core.trac.wordpress.org/ticket/63682

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
