### PR TITLE
Tests: Add tests for playlist shortcode script loading for first invalid playlist

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -3045,6 +3045,8 @@ function wp_playlist_shortcode( $attr ) {
 	static $instance = 0;
 	++$instance;
 
+	static $is_loaded = false;
+
 	if ( ! empty( $attr['ids'] ) ) {
 		// 'ids' is explicitly ordered, unless you specify otherwise.
 		if ( empty( $attr['orderby'] ) ) {
@@ -3132,6 +3134,19 @@ function wp_playlist_shortcode( $attr ) {
 
 	if ( empty( $attachments ) ) {
 		return '';
+	}
+
+	if ( ! $is_loaded ) {
+		/**
+		 * Prints and enqueues playlist scripts, styles, and JavaScript templates.
+		 *
+		 * @since 3.9.0
+		 *
+		 * @param string $type  Type of playlist. Possible values are 'audio' or 'video'.
+		 * @param string $style The 'theme' for the playlist. Core provides 'light' and 'dark'.
+		 */
+		do_action( 'wp_playlist_scripts', $atts['type'], $atts['style'] );
+		$is_loaded = true;
 	}
 
 	if ( is_feed() ) {
@@ -3225,18 +3240,6 @@ function wp_playlist_shortcode( $attr ) {
 	$safe_style = esc_attr( $atts['style'] );
 
 	ob_start();
-
-	if ( 1 === $instance ) {
-		/**
-		 * Prints and enqueues playlist scripts, styles, and JavaScript templates.
-		 *
-		 * @since 3.9.0
-		 *
-		 * @param string $type  Type of playlist. Possible values are 'audio' or 'video'.
-		 * @param string $style The 'theme' for the playlist. Core provides 'light' and 'dark'.
-		 */
-		do_action( 'wp_playlist_scripts', $atts['type'], $atts['style'] );
-	}
 	?>
 <div class="wp-playlist wp-<?php echo $safe_type; ?>-playlist wp-playlist-<?php echo $safe_style; ?>">
 	<?php if ( 'audio' === $atts['type'] ) : ?>

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -3136,19 +3136,6 @@ function wp_playlist_shortcode( $attr ) {
 		return '';
 	}
 
-	if ( ! $is_loaded ) {
-		/**
-		 * Prints and enqueues playlist scripts, styles, and JavaScript templates.
-		 *
-		 * @since 3.9.0
-		 *
-		 * @param string $type  Type of playlist. Possible values are 'audio' or 'video'.
-		 * @param string $style The 'theme' for the playlist. Core provides 'light' and 'dark'.
-		 */
-		do_action( 'wp_playlist_scripts', $atts['type'], $atts['style'] );
-		$is_loaded = true;
-	}
-
 	if ( is_feed() ) {
 		$output = "\n";
 		foreach ( $attachments as $att_id => $attachment ) {
@@ -3240,6 +3227,19 @@ function wp_playlist_shortcode( $attr ) {
 	$safe_style = esc_attr( $atts['style'] );
 
 	ob_start();
+
+	if ( ! $is_loaded ) {
+		/**
+		 * Prints and enqueues playlist scripts, styles, and JavaScript templates.
+		 *
+		 * @since 3.9.0
+		 *
+		 * @param string $type  Type of playlist. Possible values are 'audio' or 'video'.
+		 * @param string $style The 'theme' for the playlist. Core provides 'light' and 'dark'.
+		 */
+		do_action( 'wp_playlist_scripts', $atts['type'], $atts['style'] );
+		$is_loaded = true;
+	}
 	?>
 <div class="wp-playlist wp-<?php echo $safe_type; ?>-playlist wp-playlist-<?php echo $safe_style; ?>">
 	<?php if ( 'audio' === $atts['type'] ) : ?>

--- a/tests/phpunit/tests/media/wpPlaylistShortcode.php
+++ b/tests/phpunit/tests/media/wpPlaylistShortcode.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @group media
+ * @covers ::wp_playlist_shortcode
+ */
+class Tests_Media_WpPlaylistShortcode extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 63583
+	 */
+	public function test_should_load_scripts_when_first_playlist_is_invalid() {
+		$scripts_loaded = false;
+
+		add_action(
+			'wp_playlist_scripts',
+			function () use ( &$scripts_loaded ) {
+				$scripts_loaded = true;
+			}
+		);
+
+		$attachment_id = self::factory()->attachment->create_upload_object(
+			DIR_TESTDATA . '/uploads/small-audio.mp3'
+		);
+
+		wp_playlist_shortcode( array( 'ids' => '999999' ) );
+		wp_playlist_shortcode( array( 'ids' => $attachment_id ) );
+
+		$this->assertTrue( $scripts_loaded, 'Scripts should load even when first playlist has invalid ID' );
+
+		remove_all_actions( 'wp_playlist_scripts' );
+	}
+}

--- a/tests/phpunit/tests/media/wpPlaylistShortcode.php
+++ b/tests/phpunit/tests/media/wpPlaylistShortcode.php
@@ -3,7 +3,7 @@
  * @group media
  * @covers ::wp_playlist_shortcode
  */
-class Tests_Media_WpPlaylistShortcode extends WP_UnitTestCase {
+class Tests_Media_Wp_Playlist_Shortcode extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 63583

--- a/tests/phpunit/tests/media/wpPlaylistShortcode.php
+++ b/tests/phpunit/tests/media/wpPlaylistShortcode.php
@@ -9,14 +9,7 @@ class Tests_Media_Wp_Playlist_Shortcode extends WP_UnitTestCase {
 	 * @ticket 63583
 	 */
 	public function test_should_load_scripts_exactly_once_when_first_playlist_is_invalid() {
-		$script_load_count = 0;
-
-		add_action(
-			'wp_playlist_scripts',
-			function () use ( &$script_load_count ) {
-				$script_load_count++;
-			}
-		);
+		global $wp_scripts;
 
 		$attachment_id = self::factory()->attachment->create_upload_object(
 			DIR_TESTDATA . '/uploads/small-audio.mp3'
@@ -26,8 +19,9 @@ class Tests_Media_Wp_Playlist_Shortcode extends WP_UnitTestCase {
 		wp_playlist_shortcode( array( 'ids' => (string) $attachment_id ) );
 		wp_playlist_shortcode( array( 'ids' => (string) $attachment_id ) );
 
-		$this->assertSame( 1, $script_load_count, 'The playlist scripts should be loaded exactly once.' );
+		$queue_count = array_count_values( $wp_scripts->queue );
 
-		remove_all_actions( 'wp_playlist_scripts' );
+		$this->assertArrayHasKey( 'wp-playlist', $queue_count, 'wp-playlist handle should be in the queue.' );
+		$this->assertSame( 1, $queue_count['wp-playlist'], 'The wp-playlist script handle should appear exactly once in the queue.' );
 	}
 }

--- a/tests/phpunit/tests/media/wpPlaylistShortcode.php
+++ b/tests/phpunit/tests/media/wpPlaylistShortcode.php
@@ -8,13 +8,13 @@ class Tests_Media_Wp_Playlist_Shortcode extends WP_UnitTestCase {
 	/**
 	 * @ticket 63583
 	 */
-	public function test_should_load_scripts_when_first_playlist_is_invalid() {
-		$scripts_loaded = false;
+	public function test_should_load_scripts_exactly_once_when_first_playlist_is_invalid() {
+		$script_load_count = 0;
 
 		add_action(
 			'wp_playlist_scripts',
-			function () use ( &$scripts_loaded ) {
-				$scripts_loaded = true;
+			function () use ( &$script_load_count ) {
+				$script_load_count++;
 			}
 		);
 
@@ -23,9 +23,10 @@ class Tests_Media_Wp_Playlist_Shortcode extends WP_UnitTestCase {
 		);
 
 		wp_playlist_shortcode( array( 'ids' => '999999' ) );
-		wp_playlist_shortcode( array( 'ids' => $attachment_id ) );
+		wp_playlist_shortcode( array( 'ids' => (string)$attachment_id ) );
+		wp_playlist_shortcode( array( 'ids' => (string)$attachment_id ) );
 
-		$this->assertTrue( $scripts_loaded, 'Scripts should load even when first playlist has invalid ID' );
+		$this->assertSame( 1, $script_load_count, 'The playlist scripts should be loaded exactly once.' );
 
 		remove_all_actions( 'wp_playlist_scripts' );
 	}

--- a/tests/phpunit/tests/media/wpPlaylistShortcode.php
+++ b/tests/phpunit/tests/media/wpPlaylistShortcode.php
@@ -23,8 +23,8 @@ class Tests_Media_Wp_Playlist_Shortcode extends WP_UnitTestCase {
 		);
 
 		wp_playlist_shortcode( array( 'ids' => '999999' ) );
-		wp_playlist_shortcode( array( 'ids' => (string)$attachment_id ) );
-		wp_playlist_shortcode( array( 'ids' => (string)$attachment_id ) );
+		wp_playlist_shortcode( array( 'ids' => (string) $attachment_id ) );
+		wp_playlist_shortcode( array( 'ids' => (string) $attachment_id ) );
 
 		$this->assertSame( 1, $script_load_count, 'The playlist scripts should be loaded exactly once.' );
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: [#63583](https://core.trac.wordpress.org/ticket/63583)

Patch Used: #9003

---

## Description

Added a unit test for `wp_playlist_shortcode` to ensure that playlist scripts are loaded when a valid playlist follows an invalid one.

## Testing Instructions

Run the following command to verify the tests:
```bash
npm run test:php -- --filter=Tests_Media_Wp_Playlist_Shortcode 
```

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
