### PR TITLE
HTML API: Reduce skip_script_data length checks

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1497,27 +1497,31 @@ class WP_HTML_Tag_Processor {
 			$at += strcspn( $html, '-<', $at );
 
 			/*
-			 * *IMPORTANT:* Any changes to this loop *must* ensure the conditions described in this
-			 * comment remain valid.
+			 * Optimization: Every exit out of the script element requires no less than eight
+			 * additional bytes in the document. Some of the checks below transition internally
+			 * on strings shorter than eight bytes, and because of that they may be missed by
+			 * this check. However, since those transitions are insufficient to escape, this
+			 * function should still fail as incomplete.
 			 *
-			 * The rest of this loop matches different byte sequences. If a script close tag is not
-			 * found, the function will return false. The script close tag is the longest byte
-			 * sequenced to match. Therefore, a single length check for at least 8 additional
-			 * bytes allows for an early `false` return OR subsequent matches without length checks.
+			 * This may need updating if those internal transitions become significant or
+			 * exported from this function in some way, such as when building safe methods
+			 * to embed JavaScript or data inside a SCRIPT element.
 			 *
 			 *     $at may be here.
-			 *       ↓
-			 *       </script>
-			 *        ╰──┬───╯
+			 *        ↓
+			 *     ...</script>
+			 *         ╰──┬───╯
 			 *     $at + 8 additional bytes are required for a non-false return value.
 			 *
-			 * The length of shorter matches is already satisfied:
+			 * This single check eliminates the need to check lengths for the shorter spans.
+			 * For example, when leaving the script escaped state back into script data state.
 			 *
-			 *     $at may be here.
-			 *          ↓
-			 *          -->
-			 *           ├╯
-			 *     $at + 2 additional characters does not require an additional length check.
+			 *                                    $at may be here.
+			 *                                                 ↓
+			 *     <!-- <script>\n console.log( "</script>" ); -->
+			 *                                                  ├╯
+			 *                   $at + 2 additional characters does not
+			 *                   require an additional length check.
 			 */
 			if ( $at + 8 >= $doc_length ) {
 				return false;

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1497,15 +1497,27 @@ class WP_HTML_Tag_Processor {
 			$at += strcspn( $html, '-<', $at );
 
 			/*
-			 * A SCRIPT close tag `</script>` must be found or this function will
-			 * return false. If a close tag would not fit in the remaining string,
-			 * no further work is necessary.
+			 * *IMPORTANT:* Any changes to this loop *must* ensure the conditions described in this
+			 * comment remain valid.
 			 *
-			 *     $at is potentially here
+			 * The rest of this loop matches different byte sequences. If a script close tag is not
+			 * found, the function will return false. The script close tag is the longest byte
+			 * sequenced to match. Therefore, a single length check for at least 8 additional
+			 * bytes allows for an early `false` return OR subsequent matches without length checks.
+			 *
+			 *     $at may be here.
 			 *       ↓
 			 *       </script>
 			 *        ╰──┬───╯
-			 *     $at + 8 additional characters is the minimum length required to skip script data.
+			 *     $at + 8 additional bytes are required for a non-false return value.
+			 *
+			 * The length of shorter matches is already satisfied:
+			 *
+			 *     $at may be here.
+			 *          ↓
+			 *          -->
+			 *           ├╯
+			 *     $at + 2 additional characters does not require an additional length check.
 			 */
 			if ( $at + 8 >= $doc_length ) {
 				return false;

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1497,15 +1497,14 @@ class WP_HTML_Tag_Processor {
 			$at += strcspn( $html, '-<', $at );
 
 			/*
-			 * Optimization: Every exit out of the script element requires no less than eight
-			 * additional bytes in the document. Some of the checks below transition internally
-			 * on strings shorter than eight bytes, and because of that they may be missed by
-			 * this check. However, since those transitions are insufficient to escape, this
-			 * function should still fail as incomplete.
+			 * Optimization: Terminating a complete script element requires at least eight
+			 * additional bytes in the document. Some checks below may cause local escaped
+			 * state transitions when processing shorter strings, but those transitions are
+			 * irrelevant if the script tag is incomplete and the function must return false.
 			 *
-			 * This may need updating if those internal transitions become significant or
-			 * exported from this function in some way, such as when building safe methods
-			 * to embed JavaScript or data inside a SCRIPT element.
+			 * This may need updating if those transitions become significant or exported from
+			 * this function in some way, such as when building safe methods to embed JavaScript
+			 * or data inside a SCRIPT element.
 			 *
 			 *     $at may be here.
 			 *        ↓
@@ -1513,15 +1512,21 @@ class WP_HTML_Tag_Processor {
 			 *         ╰──┬───╯
 			 *     $at + 8 additional bytes are required for a non-false return value.
 			 *
-			 * This single check eliminates the need to check lengths for the shorter spans.
-			 * For example, when leaving the script escaped state back into script data state.
+			 * This single check eliminates the need to check lengths for the shorter spans:
 			 *
-			 *                                    $at may be here.
-			 *                                                 ↓
-			 *     <!-- <script>\n console.log( "</script>" ); -->
-			 *                                                  ├╯
-			 *                   $at + 2 additional characters does not
-			 *                   require an additional length check.
+			 *           $at may be here.
+			 *                  ↓
+			 *     <script><!-- --></script>
+			 *                   ├╯
+			 *             $at + 2 additional characters does not require a length check.
+			 *
+			 * The transition from "escaped" to "unescaped" is not relevant if the document ends:
+			 *
+			 *           $at may be here.
+			 *                  ↓
+			 *     <script><!-- -->[[END-OF-DOCUMENT]]
+			 *                   ╰──┬───╯
+			 *             $at + 8 additional bytes is not satisfied, return false.
 			 */
 			if ( $at + 8 >= $doc_length ) {
 				return false;

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1495,6 +1495,15 @@ class WP_HTML_Tag_Processor {
 
 		while ( false !== $at && $at < $doc_length ) {
 			$at += strcspn( $html, '-<', $at );
+			/*
+			 * Ultimately a SCRIPT closer (`</script>`) must be found or this function will
+			 * return false.
+			 * `</script` is the longest sequence that can be matched, so subsequent length checks
+			 * are redundant.
+			 */
+			if ( $at + 8 >= $doc_length ) {
+				return false;
+			}
 
 			/*
 			 * For all script states a "-->"  transitions
@@ -1502,7 +1511,6 @@ class WP_HTML_Tag_Processor {
 			 * even if that's the current state.
 			 */
 			if (
-				$at + 2 < $doc_length &&
 				'-' === $html[ $at ] &&
 				'-' === $html[ $at + 1 ] &&
 				'>' === $html[ $at + 2 ]
@@ -1510,10 +1518,6 @@ class WP_HTML_Tag_Processor {
 				$at   += 3;
 				$state = 'unescaped';
 				continue;
-			}
-
-			if ( $at + 1 >= $doc_length ) {
-				return false;
 			}
 
 			/*
@@ -1537,7 +1541,6 @@ class WP_HTML_Tag_Processor {
 			 * parsing after updating the state.
 			 */
 			if (
-				$at + 2 < $doc_length &&
 				'!' === $html[ $at ] &&
 				'-' === $html[ $at + 1 ] &&
 				'-' === $html[ $at + 2 ]
@@ -1561,7 +1564,6 @@ class WP_HTML_Tag_Processor {
 			 * proceed scanning to the next potential token in the text.
 			 */
 			if ( ! (
-				$at + 6 < $doc_length &&
 				( 's' === $html[ $at ] || 'S' === $html[ $at ] ) &&
 				( 'c' === $html[ $at + 1 ] || 'C' === $html[ $at + 1 ] ) &&
 				( 'r' === $html[ $at + 2 ] || 'R' === $html[ $at + 2 ] ) &&

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1581,9 +1581,6 @@ class WP_HTML_Tag_Processor {
 			 * "<script123" should not end a script region even though
 			 * "<script" is found within the text.
 			 */
-			if ( $at + 6 >= $doc_length ) {
-				continue;
-			}
 			$at += 6;
 			$c   = $html[ $at ];
 			if ( ' ' !== $c && "\t" !== $c && "\r" !== $c && "\n" !== $c && '/' !== $c && '>' !== $c ) {

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1495,11 +1495,17 @@ class WP_HTML_Tag_Processor {
 
 		while ( false !== $at && $at < $doc_length ) {
 			$at += strcspn( $html, '-<', $at );
+
 			/*
 			 * Ultimately a SCRIPT closer (`</script>`) must be found or this function will
-			 * return false.
-			 * `</script` is the longest sequence that can be matched, so subsequent length checks
-			 * are redundant.
+			 * return false. This removes the need for additional length checks and allows
+			 * for an early return if it's impossible to find a closer.
+			 *
+			 * $at is potentially here
+			 *   ↓
+			 *   </script>
+			 *    ╰──┬───╯
+			 * $at + 8 additional characters is the minimum length required to skip script data.
 			 */
 			if ( $at + 8 >= $doc_length ) {
 				return false;

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1613,8 +1613,6 @@ class WP_HTML_Tag_Processor {
 				}
 
 				if ( $this->bytes_already_parsed >= $doc_length ) {
-					$this->parser_state = self::STATE_INCOMPLETE_INPUT;
-
 					return false;
 				}
 

--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -1497,15 +1497,15 @@ class WP_HTML_Tag_Processor {
 			$at += strcspn( $html, '-<', $at );
 
 			/*
-			 * Ultimately a SCRIPT closer (`</script>`) must be found or this function will
-			 * return false. This removes the need for additional length checks and allows
-			 * for an early return if it's impossible to find a closer.
+			 * A SCRIPT close tag `</script>` must be found or this function will
+			 * return false. If a close tag would not fit in the remaining string,
+			 * no further work is necessary.
 			 *
-			 * $at is potentially here
-			 *   ↓
-			 *   </script>
-			 *    ╰──┬───╯
-			 * $at + 8 additional characters is the minimum length required to skip script data.
+			 *     $at is potentially here
+			 *       ↓
+			 *       </script>
+			 *        ╰──┬───╯
+			 *     $at + 8 additional characters is the minimum length required to skip script data.
 			 */
 			if ( $at + 8 >= $doc_length ) {
 				return false;

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -1982,6 +1982,49 @@ HTML;
 	}
 
 	/**
+	 * Test that script tags are parsed correctly.
+	 *
+	 * Script tag parsing is very complicated, see the following resources for more details:
+	 *
+	 * - https://html.spec.whatwg.org/multipage/parsing.html#script-data-state
+	 * - https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
+	 *
+	 * @ticket 63738
+	 *
+	 * @dataProvider data_script_tag
+	 */
+	public function test_script_tag_parsing( string $input, bool $closes ) {
+		$processor = new WP_HTML_Tag_Processor( $input );
+
+		if ( $closes ) {
+			$this->assertTrue( $processor->next_token(), 'Expected to find complete script tag.' );
+			$this->assertSame( 'SCRIPT', $processor->get_tag() );
+			return;
+		}
+
+		$this->assertFalse( $processor->next_token(), 'Expected to fail next_token().' );
+		$this->assertTrue( $processor->paused_at_incomplete_token(), 'Expected an incomplete SCRIPT tag token.' );
+	}
+
+	/**
+	 * Data provider.
+	 */
+	public static function data_script_tag(): array {
+		return array(
+			'Basic script tag'                          => array( '<script></script>', true ),
+			'Script with type attribute'                => array( '<script type="text/javascript"></script>', true ),
+			'Script data escaped'                       => array( '<script><!--</script>', true ),
+			'Script data double-escaped exit (comment)' => array( '<script><!--<script>--></script>', true ),
+			'Script data double-escaped exit (closed)'  => array( '<script><!--<script></script></script>', true ),
+			'Script data double-escaped exit (closed/truncated)' => array( '<script><!--<script></script </script>', true ),
+			'Script data no double-escape'              => array( '<script><!-- --><script></script>', true ),
+
+			'Script tag with self-close flag (ignored)' => array( '<script />', false ),
+			'Script data double-escaped'                => array( '<script><!--<script></script>', false ),
+		);
+	}
+
+	/**
 	 * Invalid tag names are comments on tag closers.
 	 *
 	 * @ticket 58007
@@ -3045,48 +3088,5 @@ HTML
 		foreach ( self::data_alphabet_by_characters_lowercase() as $data ) {
 			yield strtoupper( $data[0] ) => array( strtoupper( $data[0] ) );
 		}
-	}
-
-	/**
-	 * Test that script tags are parsed correctly.
-	 *
-	 * Script tag parsing is very complicated, see the following resources for more details:
-	 *
-	 * - https://html.spec.whatwg.org/multipage/parsing.html#script-data-state
-	 * - https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
-	 *
-	 * @ticket 63738
-	 *
-	 * @dataProvider data_script_tag
-	 */
-	public function test_script_tag_parsing( string $input, bool $closes ) {
-		$processor = new WP_HTML_Tag_Processor( $input );
-
-		if ( $closes ) {
-			$this->assertTrue( $processor->next_token(), 'Expected to find complete script tag.' );
-			$this->assertSame( 'SCRIPT', $processor->get_tag() );
-			return;
-		}
-
-		$this->assertFalse( $processor->next_token(), 'Expected to fail next_token().' );
-		$this->assertTrue( $processor->paused_at_incomplete_token(), 'Expected an incomplete SCRIPT tag token.' );
-	}
-
-	/**
-	 * Data provider.
-	 */
-	public static function data_script_tag(): array {
-		return array(
-			'Basic script tag'                          => array( '<script></script>', true ),
-			'Script with type attribute'                => array( '<script type="text/javascript"></script>', true ),
-			'Script data escaped'                       => array( '<script><!--</script>', true ),
-			'Script data double-escaped exit (comment)' => array( '<script><!--<script>--></script>', true ),
-			'Script data double-escaped exit (closed)'  => array( '<script><!--<script></script></script>', true ),
-			'Script data double-escaped exit (closed/truncated)' => array( '<script><!--<script></script </script>', true ),
-			'Script data no double-escape'              => array( '<script><!-- --><script></script>', true ),
-
-			'Script tag with self-close flag (ignored)' => array( '<script />', false ),
-			'Script data double-escaped'                => array( '<script><!--<script></script>', false ),
-		);
 	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -3046,4 +3046,49 @@ HTML
 			yield strtoupper( $data[0] ) => array( strtoupper( $data[0] ) );
 		}
 	}
+
+	/**
+	 * Test that script tags are parsed correctly.
+	 *
+	 * Script tag parsing is very complicated, see the following resources for more details:
+	 *
+	 * - https://html.spec.whatwg.org/multipage/parsing.html#script-data-state
+	 * - https://html.spec.whatwg.org/multipage/scripting.html#restrictions-for-contents-of-script-elements
+	 *
+	 * @ticket 63738
+	 *
+	 * @dataProvider data_script_tag
+	 */
+	public function test_script_tag_parsing( string $input, bool $closes ) {
+		$processor = new WP_HTML_Tag_Processor( $input );
+
+		if ( $closes ) {
+			$this->assertTrue( $processor->next_token(), 'Expected to find complete script tag.' );
+			$this->assertSame( 'SCRIPT', $processor->get_tag() );
+			return;
+		}
+
+		$this->assertFalse( $processor->next_token(), 'Expected to fail next_token().' );
+		$this->assertTrue( $processor->paused_at_incomplete_token(), 'Expected an incomplete SCRIPT tag token.' );
+	}
+
+	/**
+	 * Data provider.
+	 */
+	public static function data_script_tag(): array {
+		return array(
+			'Basic script tag'                             => array( '<script></script>', true ),
+			'Script with type attribute'                   => array( '<script type="text/javascript"></script>', true ),
+			'Script data escaped'                          => array( '<script><!--</script>', true ),
+			'Script data double-escaped exit (comment)'    => array( '<script><!--<script>--></script>', true ),
+			'Script data double-escaped exit (closed)'     => array( '<script><!--<script></script></script>', true ),
+			'Script data double-escaped exit (closed/truncated)' => array( '<script><!--<script></script </script>', true ),
+			'Script data no double-escape'                 => array( '<script><!-- --><script></script>', true ),
+			'Script data no double-escape (short comment)' => array( '<script><!--><script></script>', true ),
+			'Script data almost double-escaped'            => array( '<script><!--<script</script>', true ),
+
+			'Script tag with self-close flag (ignored)'    => array( '<script />', false ),
+			'Script data double-escaped'                   => array( '<script><!--<script></script>', false ),
+		);
+	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -3077,18 +3077,16 @@ HTML
 	 */
 	public static function data_script_tag(): array {
 		return array(
-			'Basic script tag'                             => array( '<script></script>', true ),
-			'Script with type attribute'                   => array( '<script type="text/javascript"></script>', true ),
-			'Script data escaped'                          => array( '<script><!--</script>', true ),
-			'Script data double-escaped exit (comment)'    => array( '<script><!--<script>--></script>', true ),
-			'Script data double-escaped exit (closed)'     => array( '<script><!--<script></script></script>', true ),
+			'Basic script tag'                          => array( '<script></script>', true ),
+			'Script with type attribute'                => array( '<script type="text/javascript"></script>', true ),
+			'Script data escaped'                       => array( '<script><!--</script>', true ),
+			'Script data double-escaped exit (comment)' => array( '<script><!--<script>--></script>', true ),
+			'Script data double-escaped exit (closed)'  => array( '<script><!--<script></script></script>', true ),
 			'Script data double-escaped exit (closed/truncated)' => array( '<script><!--<script></script </script>', true ),
-			'Script data no double-escape'                 => array( '<script><!-- --><script></script>', true ),
-			'Script data no double-escape (short comment)' => array( '<script><!--><script></script>', true ),
-			'Script data almost double-escaped'            => array( '<script><!--<script</script>', true ),
+			'Script data no double-escape'              => array( '<script><!-- --><script></script>', true ),
 
-			'Script tag with self-close flag (ignored)'    => array( '<script />', false ),
-			'Script data double-escaped'                   => array( '<script><!--<script></script>', false ),
+			'Script tag with self-close flag (ignored)' => array( '<script />', false ),
+			'Script data double-escaped'                => array( '<script><!--<script></script>', false ),
 		);
 	}
 }


### PR DESCRIPTION
Trac ticket: Core-63738

Reduce the number of length checks in `WP_HTML_Tag_Processor::skip_script_data()`.

<!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
