### PR TITLE
HTML API: Simplify META tag encoding processing

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1760,6 +1760,11 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 			case '+META':
 				$this->insert_html_element( $this->state->current_token );
 
+				// All following conditions depend on "tentative" encoding confidence.
+				if ( 'tentative' !== $this->state->encoding_confidence ) {
+					return true;
+				}
+
 				/*
 				 * > If the active speculative HTML parser is null, then:
 				 * >   - If the element has a charset attribute, and getting an encoding from
@@ -1767,7 +1772,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				 * >     tentative, then change the encoding to the resulting encoding.
 				 */
 				$charset = $this->get_attribute( 'charset' );
-				if ( is_string( $charset ) && 'tentative' === $this->state->encoding_confidence ) {
+				if ( is_string( $charset ) ) {
 					$this->bail( 'Cannot yet process META tags with charset to determine encoding.' );
 				}
 
@@ -1784,8 +1789,7 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 				if (
 					is_string( $http_equiv ) &&
 					is_string( $content ) &&
-					0 === strcasecmp( $http_equiv, 'Content-Type' ) &&
-					'tentative' === $this->state->encoding_confidence
+					0 === strcasecmp( $http_equiv, 'Content-Type' )
 				) {
 					$this->bail( 'Cannot yet process META tags with http-equiv Content-Type to determine encoding.' );
 				}

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorMetaTag.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorMetaTag.php
@@ -5,7 +5,7 @@
  * @package WordPress
  * @subpackage HTML-API
  *
- * @since TBD
+ * @since 6.9
  *
  * @group html-api
  *
@@ -29,7 +29,7 @@ class Tests_HtmlApi_WpHtmlProcessorMetaTag extends WP_UnitTestCase {
 	/**
 	 * Ensures that META tags correctly handle encoding confidence.
 	 *
-	 * @ticket TBD
+	 * @ticket 63738
 	 *
 	 * @dataProvider data_supported_meta_tags
 	 */
@@ -59,7 +59,7 @@ class Tests_HtmlApi_WpHtmlProcessorMetaTag extends WP_UnitTestCase {
 	/**
 	 * Ensures that unsupported encoding META tags bail.
 	 *
-	 * @ticket TBD
+	 * @ticket 63738
 	 *
 	 * @dataProvider data_unsupported_meta_tags
 	 */

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorMetaTag.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorMetaTag.php
@@ -34,39 +34,14 @@ class Tests_HtmlApi_WpHtmlProcessorMetaTag extends WP_UnitTestCase {
 	 * @dataProvider data_supported_meta_tags
 	 */
 	public function test_supported_meta_tag( string $html ) {
-		$html  = '<!DOCTYPE html>' . $html;
-		$class = new class('') extends WP_HTML_Processor {
+		$html      = '<!DOCTYPE html>' . $html;
+		$processor = new class($html) extends WP_HTML_Processor {
 			public function __construct( $html ) {
 				parent::__construct( $html, parent::CONSTRUCTOR_UNLOCK_CODE );
 			}
-
-			public static function create( string $html ): self {
-				$instance = self::create_full_parser( $html );
-				// Reset encoding so META tags can handle it.
-				$reflection = new ReflectionClass( $instance );
-				$property   = $reflection->getParentClass()->getProperty( 'state' );
-				$property->setAccessible( true );
-				$state                      = $property->getValue( $instance );
-				$state->encoding            = null;
-				$state->encoding_confidence = 'tentative';
-				return $instance;
-			}
-
-			public function get_state_encoding(): ?string {
-				$reflection = new ReflectionClass( $this );
-				return $reflection->getParentClass()->getProperty( 'state' )->getValue( $this )->encoding;
-			}
-
-			public function get_state_encoding_confidence(): string {
-				$reflection = new ReflectionClass( $this );
-				return $reflection->getParentClass()->getProperty( 'state' )->getValue( $this )->encoding_confidence;
-			}
 		};
 
-		$processor = $class::create( $html );
 		$this->assertTrue( $processor->next_tag( 'META' ) );
-		$this->assertSame( 'tentative', $processor->get_state_encoding_confidence() );
-		$this->assertNull( $processor->get_state_encoding() );
 	}
 
 	/**
@@ -89,27 +64,14 @@ class Tests_HtmlApi_WpHtmlProcessorMetaTag extends WP_UnitTestCase {
 	 * @dataProvider data_unsupported_meta_tags
 	 */
 	public function test_unsupported_meta_tags( string $html, string $unsupported_message ) {
-		$html  = '<!DOCTYPE html>' . $html;
-		$class = new class('') extends WP_HTML_Processor {
+		$html      = '<!DOCTYPE html>' . $html;
+		$processor = new class($html) extends WP_HTML_Processor {
 			public function __construct( $html ) {
 				parent::__construct( $html, parent::CONSTRUCTOR_UNLOCK_CODE );
 			}
-
-			public static function create( string $html ): self {
-				$instance = self::create_full_parser( $html );
-				// Reset encoding so META tags can handle it.
-				$reflection = new ReflectionClass( $instance );
-				$property   = $reflection->getParentClass()->getProperty( 'state' );
-				$property->setAccessible( true );
-				$state                      = $property->getValue( $instance );
-				$state->encoding            = null;
-				$state->encoding_confidence = 'tentative';
-				return $instance;
-			}
 		};
 
-		$processor = $class::create( $html );
 		$this->assertFalse( $processor->next_tag( 'META' ) );
-		$this->assertSame( $unsupported_message, $processor->get_unsupported_exception()->getMessage() );
+		$this->assertInstanceOf( WP_HTML_Unsupported_Exception::class, $processor->get_unsupported_exception() );
 	}
 }

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorMetaTag.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorMetaTag.php
@@ -49,10 +49,10 @@ class Tests_HtmlApi_WpHtmlProcessorMetaTag extends WP_UnitTestCase {
 	 */
 	public function data_unsupported_meta_tags(): array {
 		return array(
-			'With charset'    => array( '<meta charset="utf8">', 'Cannot yet process META tags with charset to determine encoding.' ),
-			'With CHARSET'    => array( '<meta CHARSET="utf8">', 'Cannot yet process META tags with charset to determine encoding.' ),
-			'With http-equiv' => array( '<meta http-equiv="content-type" content="">', 'Cannot yet process META tags with http-equiv Content-Type to determine encoding.' ),
-			'With http-equiv' => array( '<meta http-equiv="Content-Type" content="UTF-8">', 'Cannot yet process META tags with http-equiv Content-Type to determine encoding.' ),
+			'With charset'                => array( '<meta charset="utf8">', 'Cannot yet process META tags with charset to determine encoding.' ),
+			'With CHARSET'                => array( '<meta CHARSET="utf8">', 'Cannot yet process META tags with charset to determine encoding.' ),
+			'With http-equiv'             => array( '<meta http-equiv="content-type" content="">', 'Cannot yet process META tags with http-equiv Content-Type to determine encoding.' ),
+			'With http-equiv and content' => array( '<meta http-equiv="Content-Type" content="UTF-8">', 'Cannot yet process META tags with http-equiv Content-Type to determine encoding.' ),
 		);
 	}
 

--- a/tests/phpunit/tests/html-api/wpHtmlProcessorMetaTag.php
+++ b/tests/phpunit/tests/html-api/wpHtmlProcessorMetaTag.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Unit tests covering WP_HTML_Processor META tag handling.
+ *
+ * @package WordPress
+ * @subpackage HTML-API
+ *
+ * @since TBD
+ *
+ * @group html-api
+ *
+ * @coversDefaultClass WP_HTML_Processor
+ */
+class Tests_HtmlApi_WpHtmlProcessorMetaTag extends WP_UnitTestCase {
+	/**
+	 * Data provider.
+	 */
+	public static function data_supported_meta_tags(): array {
+		return array(
+			'No attributes'                        => array( '<meta>' ),
+			'Unrelated attributes'                 => array( '<meta not-charset="OK">' ),
+			'Boolean charset'                      => array( '<meta charset>' ),
+			'HTTP Equiv: accept'                   => array( '<meta http-equiv="accept" content="">' ),
+			'HTTP Equiv: content-type, no content' => array( '<meta http-equiv="content-type">' ),
+			'Boolean HTTP Equiv'                   => array( '<meta http-equiv content="">' ),
+		);
+	}
+
+	/**
+	 * Ensures that META tags correctly handle encoding confidence.
+	 *
+	 * @ticket TBD
+	 *
+	 * @dataProvider data_supported_meta_tags
+	 */
+	public function test_supported_meta_tag( string $html ) {
+		$html  = '<!DOCTYPE html>' . $html;
+		$class = new class('') extends WP_HTML_Processor {
+			public function __construct( $html ) {
+				parent::__construct( $html, parent::CONSTRUCTOR_UNLOCK_CODE );
+			}
+
+			public static function create( string $html ): self {
+				$instance = self::create_full_parser( $html );
+				// Reset encoding so META tags can handle it.
+				$reflection = new ReflectionClass( $instance );
+				$property   = $reflection->getParentClass()->getProperty( 'state' );
+				$property->setAccessible( true );
+				$state                      = $property->getValue( $instance );
+				$state->encoding            = null;
+				$state->encoding_confidence = 'tentative';
+				return $instance;
+			}
+
+			public function get_state_encoding(): ?string {
+				$reflection = new ReflectionClass( $this );
+				return $reflection->getParentClass()->getProperty( 'state' )->getValue( $this )->encoding;
+			}
+
+			public function get_state_encoding_confidence(): string {
+				$reflection = new ReflectionClass( $this );
+				return $reflection->getParentClass()->getProperty( 'state' )->getValue( $this )->encoding_confidence;
+			}
+		};
+
+		$processor = $class::create( $html );
+		$this->assertTrue( $processor->next_tag( 'META' ) );
+		$this->assertSame( 'tentative', $processor->get_state_encoding_confidence() );
+		$this->assertNull( $processor->get_state_encoding() );
+	}
+
+	/**
+	 * Data provider.
+	 */
+	public function data_unsupported_meta_tags(): array {
+		return array(
+			'With charset'    => array( '<meta charset="utf8">', 'Cannot yet process META tags with charset to determine encoding.' ),
+			'With CHARSET'    => array( '<meta CHARSET="utf8">', 'Cannot yet process META tags with charset to determine encoding.' ),
+			'With http-equiv' => array( '<meta http-equiv="content-type" content="">', 'Cannot yet process META tags with http-equiv Content-Type to determine encoding.' ),
+			'With http-equiv' => array( '<meta http-equiv="Content-Type" content="UTF-8">', 'Cannot yet process META tags with http-equiv Content-Type to determine encoding.' ),
+		);
+	}
+
+	/**
+	 * Ensures that unsupported encoding META tags bail.
+	 *
+	 * @ticket TBD
+	 *
+	 * @dataProvider data_unsupported_meta_tags
+	 */
+	public function test_unsupported_meta_tags( string $html, string $unsupported_message ) {
+		$html  = '<!DOCTYPE html>' . $html;
+		$class = new class('') extends WP_HTML_Processor {
+			public function __construct( $html ) {
+				parent::__construct( $html, parent::CONSTRUCTOR_UNLOCK_CODE );
+			}
+
+			public static function create( string $html ): self {
+				$instance = self::create_full_parser( $html );
+				// Reset encoding so META tags can handle it.
+				$reflection = new ReflectionClass( $instance );
+				$property   = $reflection->getParentClass()->getProperty( 'state' );
+				$property->setAccessible( true );
+				$state                      = $property->getValue( $instance );
+				$state->encoding            = null;
+				$state->encoding_confidence = 'tentative';
+				return $instance;
+			}
+		};
+
+		$processor = $class::create( $html );
+		$this->assertFalse( $processor->next_tag( 'META' ) );
+		$this->assertSame( $unsupported_message, $processor->get_unsupported_exception()->getMessage() );
+	}
+}


### PR DESCRIPTION
Trac ticket: Core-63738

Simplify META tag handling with regards to encoding confidence.

With any of the standard HTML Processor creation paths (`WP_HTML_Processor::create_fragment()` and `WP_HTML_Processor::create_full_parser()`), the encoding is never set to `tentative`. It is either `irrelevant` (on fragments) or `certain` on full parsers. In both cases, only the `UTF-8` encoding is supported.

This is an optimization to lift a necessary condition to the top level and avoid processing in the case we expect to encounter in almost every case.

---

Fragments follow this path to set `irrelevant`:
https://github.com/WordPress/wordpress-develop/blob/1c8185e12dd9fb1606eb22118f09aef46e6737d0/src/wp-includes/html-api/class-wp-html-processor.php#L319
https://github.com/WordPress/wordpress-develop/blob/1c8185e12dd9fb1606eb22118f09aef46e6737d0/src/wp-includes/html-api/class-wp-html-processor.php#L547

And full parsers set `certain` here:
https://github.com/WordPress/wordpress-develop/blob/1c8185e12dd9fb1606eb22118f09aef46e6737d0/src/wp-includes/html-api/class-wp-html-processor.php#L345


Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
