### PR TITLE
Twenty Fourteen: Bump version for 6.8.2.

### DIFF
--- a/src/wp-content/themes/twentyfourteen/functions.php
+++ b/src/wp-content/themes/twentyfourteen/functions.php
@@ -345,10 +345,10 @@ function twentyfourteen_scripts() {
 	wp_enqueue_style( 'genericons', get_template_directory_uri() . '/genericons/genericons.css', array(), '3.0.3' );
 
 	// Load our main stylesheet.
-	wp_enqueue_style( 'twentyfourteen-style', get_stylesheet_uri(), array(), '20250415' );
+	wp_enqueue_style( 'twentyfourteen-style', get_stylesheet_uri(), array(), '20250715' );
 
 	// Theme block stylesheet.
-	wp_enqueue_style( 'twentyfourteen-block-style', get_template_directory_uri() . '/css/blocks.css', array( 'twentyfourteen-style' ), '20240708' );
+	wp_enqueue_style( 'twentyfourteen-block-style', get_template_directory_uri() . '/css/blocks.css', array( 'twentyfourteen-style' ), '20250715' );
 
 	// Load the Internet Explorer specific stylesheet.
 	wp_enqueue_style( 'twentyfourteen-ie', get_template_directory_uri() . '/css/ie.css', array( 'twentyfourteen-style' ), '20140711' );

--- a/src/wp-content/themes/twentyfourteen/readme.txt
+++ b/src/wp-content/themes/twentyfourteen/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg
 Requires at least: 3.6
 Tested up to: 6.8
 Requires PHP: 5.2.4
-Stable tag: 4.2
+Stable tag: 4.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: blog, news, two-columns, three-columns, left-sidebar, right-sidebar, custom-background, custom-header, custom-menu, editor-style, featured-images, flexible-header, footer-widgets, full-width-template, microformats, post-formats, rtl-language-support, sticky-post, theme-options, translation-ready, accessibility-ready, block-patterns
@@ -63,6 +63,11 @@ Source: https://stocksnap.io/photo/fog-mountain-ZKN6UKFKEO
         https://stocksnap.io/photo/guy-man-7CFLDIWXK5
 
 == Changelog ==
+
+= 4.3 =
+* Released: July 15, 2025
+
+https://wordpress.org/documentation/article/twenty-fourteen-changelog/#Version_4.3
 
 = 4.2 =
 * Released: April 15, 2025

--- a/src/wp-content/themes/twentyfourteen/style.css
+++ b/src/wp-content/themes/twentyfourteen/style.css
@@ -4,7 +4,7 @@ Theme URI: https://wordpress.org/themes/twentyfourteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: In 2014, our default theme lets you create a responsive magazine website with a sleek, modern design. Feature your favorite homepage content in either a grid or a slider. Use the three widget areas to customize your website, and change your content's layout with a full-width page template and a contributor page to show off your authors. Creating a magazine website with WordPress has never been easier.
-Version: 4.2
+Version: 4.3
 Requires at least: 3.6
 Tested up to: 6.8
 Requires PHP: 5.2.4


### PR DESCRIPTION
This bumps the version of Twenty Fourteen for WordPress 6.8.2.

Trac ticket: https://core.trac.wordpress.org/ticket/63681