### PR TITLE
Twenty Twenty-One: Bump version for 6.8.2.

### DIFF
--- a/src/wp-content/themes/twentytwentyone/assets/css/ie.css
+++ b/src/wp-content/themes/twentytwentyone/assets/css/ie.css
@@ -9,7 +9,7 @@ Description: Twenty Twenty-One is a blank canvas for your ideas and it makes the
 Requires at least: 5.3
 Tested up to: 6.8
 Requires PHP: 5.6
-Version: 2.5
+Version: 2.6
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentyone

--- a/src/wp-content/themes/twentytwentyone/assets/sass/01-settings/file-header.scss
+++ b/src/wp-content/themes/twentytwentyone/assets/sass/01-settings/file-header.scss
@@ -7,7 +7,7 @@ Description: Twenty Twenty-One is a blank canvas for your ideas and it makes the
 Requires at least: 5.3
 Tested up to: 6.8
 Requires PHP: 5.6
-Version: 2.5
+Version: 2.6
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentyone

--- a/src/wp-content/themes/twentytwentyone/package-lock.json
+++ b/src/wp-content/themes/twentytwentyone/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "twentytwentyone",
-	"version": "2.5.0",
+	"version": "2.6.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "twentytwentyone",
-			"version": "2.5.0",
+			"version": "2.6.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@wordpress/browserslist-config": "^6.14.0",

--- a/src/wp-content/themes/twentytwentyone/package.json
+++ b/src/wp-content/themes/twentytwentyone/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "twentytwentyone",
-	"version": "2.5.0",
+	"version": "2.6.0",
 	"description": "Default WP Theme",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/src/wp-content/themes/twentytwentyone/readme.txt
+++ b/src/wp-content/themes/twentytwentyone/readme.txt
@@ -33,7 +33,7 @@ No data is saved in the database or transferred.
 = 2.6 =
 * Released: July 15, 2025
 
-https://wordpress.org/documentation/article/twenty-twenty-one-changelog/#Version_2.5
+https://wordpress.org/documentation/article/twenty-twenty-one-changelog/#Version_2.6
 
 = 2.5 =
 * Released: April 15, 2025

--- a/src/wp-content/themes/twentytwentyone/readme.txt
+++ b/src/wp-content/themes/twentytwentyone/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg
 Requires at least: 5.3
 Tested up to: 6.8
 Requires PHP: 5.6
-Stable tag: 2.5
+Stable tag: 2.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,6 +29,11 @@ LocalStorage is necessary for the setting to work and is only used when a user c
 No data is saved in the database or transferred.
 
 == Changelog ==
+
+= 2.6 =
+* Released: July 15, 2025
+
+https://wordpress.org/documentation/article/twenty-twenty-one-changelog/#Version_2.5
 
 = 2.5 =
 * Released: April 15, 2025

--- a/src/wp-content/themes/twentytwentyone/style-rtl.css
+++ b/src/wp-content/themes/twentytwentyone/style-rtl.css
@@ -9,7 +9,7 @@ Description: Twenty Twenty-One is a blank canvas for your ideas and it makes the
 Requires at least: 5.3
 Tested up to: 6.8
 Requires PHP: 5.6
-Version: 2.5
+Version: 2.6
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentyone

--- a/src/wp-content/themes/twentytwentyone/style.css
+++ b/src/wp-content/themes/twentytwentyone/style.css
@@ -9,7 +9,7 @@ Description: Twenty Twenty-One is a blank canvas for your ideas and it makes the
 Requires at least: 5.3
 Tested up to: 6.8
 Requires PHP: 5.6
-Version: 2.5
+Version: 2.6
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentyone


### PR DESCRIPTION
This bumps the version of Twenty Twenty-One for WordPress 6.8.2.

Trac ticket: https://core.trac.wordpress.org/ticket/63681