### PR TITLE
Logged out users should not be able to edit the anonymous user account.

### DIFF
--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -60,8 +60,8 @@ function map_meta_cap( $cap, $user_id, ...$args ) {
 			break;
 		case 'edit_user':
 		case 'edit_users':
-			// Anonymous users can't edit users, not even themselves.
-			if ( 0 === $user_id ) {
+			// Non-existent users can't edit users, not even themselves.
+			if ( $user_id < 1 ) {
 				$caps[] = 'do_not_allow';
 				break;
 			}

--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -60,6 +60,12 @@ function map_meta_cap( $cap, $user_id, ...$args ) {
 			break;
 		case 'edit_user':
 		case 'edit_users':
+			// Anonymous users can't edit users, not even themselves.
+			if ( 0 === $user_id ) {
+				$caps[] = 'do_not_allow';
+				break;
+			}
+
 			// Allow user to edit themselves.
 			if ( 'edit_user' === $cap && isset( $args[0] ) && $user_id === (int) $args[0] ) {
 				break;

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -1856,7 +1856,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 	 *
 	 * @return array[] Data provider.
 	 */
-	public function data_user_can_edit_self() {
+	public static function data_user_can_edit_self() {
 		return array(
 			array( 'anonymous', false ),
 			array( 'administrator', true ),

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -1833,6 +1833,8 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 	/**
 	 * Test if a user can edit their own profile based on their role.
 	 *
+	 * @ticket 63684
+	 *
 	 * @dataProvider data_user_can_edit_self
 	 *
 	 * @param string $role          The role of the user.

--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -1830,11 +1830,39 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 		$this->assertFalse( current_user_can( 'edit_user', $other_user->ID ) );
 	}
 
-	public function test_user_can_edit_self() {
-		foreach ( self::$users as $role => $user ) {
-			wp_set_current_user( $user->ID );
+	/**
+	 * Test if a user can edit their own profile based on their role.
+	 *
+	 * @dataProvider data_user_can_edit_self
+	 *
+	 * @param string $role          The role of the user.
+	 * @param bool   $can_edit_self Whether the user can edit their own profile.
+	 */
+	public function test_user_can_edit_self( $role, $can_edit_self = true ) {
+		$user = self::$users[ $role ];
+		wp_set_current_user( $user->ID );
+
+		if ( $can_edit_self ) {
 			$this->assertTrue( current_user_can( 'edit_user', $user->ID ), "User with role {$role} should have the capability to edit their own profile" );
+		} else {
+			$this->assertFalse( current_user_can( 'edit_user', $user->ID ), "User with role {$role} should not have the capability to edit their own profile" );
 		}
+	}
+
+	/**
+	 * Data provider for test_user_can_edit_self.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public function data_user_can_edit_self() {
+		return array(
+			array( 'anonymous', false ),
+			array( 'administrator', true ),
+			array( 'editor', true ),
+			array( 'author', true ),
+			array( 'contributor', true ),
+			array( 'subscriber', true ),
+		);
 	}
 
 	public function test_only_admins_and_super_admins_can_remove_users() {


### PR DESCRIPTION
Modifies the `current_user_can( 'edit_user' .... )` meta capability to ensure that non-existent & anonymous users can not edit themselves.

* First commit: just the test changes so we've got an assertion that anonymous users can't edit themselves. It fails.
* Subsequent commit: ensure non-existent users get the `do_not_allow` keyword when attempting to edit a user.

Trac ticket: https://core.trac.wordpress.org/ticket/63684
