### PR TITLE
set password action on user insert and update

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2501,6 +2501,11 @@ function wp_insert_user( $userdata ) {
 
 	$user = new WP_User( $user_id );
 
+	if ( ! $update ) {
+		/** This action is documented in wp-includes/pluggable.php */
+		do_action( 'wp_set_password', $userdata['user_pass'], $user_id, $userdata );
+	}
+
 	/**
 	 * Filters a user's meta values and keys immediately after the user is created or updated
 	 * and before any user meta is inserted or updated.
@@ -2683,6 +2688,9 @@ function wp_update_user( $userdata ) {
 		// If password is changing, hash it now.
 		$plaintext_pass        = $userdata['user_pass'];
 		$userdata['user_pass'] = wp_hash_password( $userdata['user_pass'] );
+
+		/** This action is documented in wp-includes/pluggable.php */
+		do_action( 'wp_set_password', $plaintext_pass, $user_id, $user_obj );
 
 		/**
 		 * Filters whether to send the password change email.

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -2356,61 +2356,76 @@ class Tests_User extends WP_UnitTestCase {
 
 	public function test_set_password_action_on_wp_insert_user_with_update_false_and_true() {
 		$mock_action = new MockAction();
-
 		add_action( 'wp_set_password', array( $mock_action, 'action' ), 10, 3 );
 
-		// New User Scenario: $update = false
-		$username = 'testuser_' . wp_rand();
-		$password = 'password123';
+		// Step 1: Insert a new user with mandatory fields.
 		$userdata = array(
-			'user_login' => $username,
-			'user_pass'  => $password,
-			'user_email' => $username . '@example.com',
-			'role'       => 'subscriber',
+			'user_login' => 'testuser_' . wp_rand(),
+			'user_pass'  => 'initialpassword',
+			'user_email' => 'testuser@example.com',
 		);
 
 		$user_id = wp_insert_user( $userdata );
 
-		// Assert that wp_set_password was called
-		$this->assertSame( 1, $mock_action->get_call_count(), 'wp_set_password action was not called for new user' );
+		// Assert that `wp_set_password` was triggered once during user creation.
+		$this->assertSame( 1, $mock_action->get_call_count(), 'wp_set_password was not triggered during user creation.' );
 		$args = $mock_action->get_args();
-		$this->assertSame( $password, $args[0][0], 'Password mismatch for the new user' );
-		$this->assertSame( $user_id, $args[0][1], 'User ID mismatch for the new user' );
+		$this->assertSame( $userdata['user_pass'], $args[0][0], 'Wrong password argument in action.' );
+		$this->assertSame( $user_id, $args[0][1], 'Wrong user ID in action.' );
 
-		// Update Existing User Scenario: $update = true
-		$mock_action->reset(); // Reset the mock for a clean test
-		$updated_userdata = array(
-			'ID'         => $user_id, // Pass existing user ID to trigger an update
-			'user_pass'  => 'newpassword789',
-			'first_name' => 'Test',
-			'last_name'  => 'User',
+		$mock_action->reset(); // Reset mock for the next scenario.
+
+		// Step 2: Update the user password explicitly via `wp_set_password`.
+		$updated_password = 'updatedpassword123';
+		wp_set_password( $updated_password, $user_id );
+
+		// Assert that `wp_set_password` was triggered once during the password update.
+		$this->assertSame( 1, $mock_action->get_call_count(), 'wp_set_password was not triggered during password update.' );
+		$args = $mock_action->get_args();
+		$this->assertSame( $updated_password, $args[0][0], 'Wrong password argument in action when updating user.' );
+		$this->assertSame( $user_id, $args[0][1], 'Wrong user ID in action when updating user.' );
+
+		$mock_action->reset(); // Reset mock for the final scenario.
+
+		// Step 3: Update user data without changing the password and ensure no action is triggered.
+		$non_password_userdata = array(
+			'ID'         => $user_id,
+			'first_name' => 'UpdatedName',
+			'user_login' => $userdata['user_login'], // Keep unchanged.
 		);
 
-		wp_insert_user( $updated_userdata );
+		wp_insert_user( $non_password_userdata );
 
-		// Assert that wp_set_password was NOT called
-		$this->assertSame( 0, $mock_action->get_call_count(), 'wp_set_password action was incorrectly triggered for user update when $update = true' );
+		// Assert that `wp_set_password` is not triggered for non-password updates.
+		$this->assertSame( 0, $mock_action->get_call_count(), 'wp_set_password was incorrectly triggered for non-password update.' );
 	}
 
 	public function test_set_password_action_on_user_update() {
 		$mock_action = new MockAction();
-
 		add_action( 'wp_set_password', array( $mock_action, 'action' ), 10, 3 );
 
-		$user_id      = $this->factory()->user->create( array( 'role' => 'subscriber' ) );
-		$new_password = 'newpassword!@#';
-
-		$update_userdata = array(
-			'ID'        => $user_id,
-			'user_pass' => $new_password,
+		// Step 1: Create a user
+		$user_id = $this->factory()->user->create(
+			array(
+				'role'       => 'subscriber',
+				'user_login' => 'testuser_update',
+				'user_email' => 'testuser_update@example.com',
+				'user_pass'  => 'initialpassword',
+			)
 		);
 
-		wp_update_user( $update_userdata );
+		// Assert initial password action (creation)
+		$this->assertSame( 1, $mock_action->get_call_count(), 'wp_set_password was not triggered during user creation.' );
+		$mock_action->reset(); // Reset for update test
 
-		// Assertions
-		$this->assertSame( 1, $mock_action->get_call_count(), 'The action wp_set_password was not called when updating a user.' );
+		// Step 2: Update the password via wp_set_password
+		$updated_password = 'newpassword123';
+		wp_set_password( $updated_password, $user_id );
+
+		// Assert action triggered
+		$this->assertSame( 1, $mock_action->get_call_count(), 'wp_set_password was not triggered during password update.' );
 		$args = $mock_action->get_args();
-		$this->assertSame( $new_password, $args[0][0], 'The updated password is incorrect.' );
-		$this->assertSame( $user_id, $args[0][1], 'The user ID passed to the action is incorrect.' );
+		$this->assertSame( $updated_password, $args[0][0], 'Invalid password in wp_set_password action.' );
+		$this->assertSame( $user_id, $args[0][1], 'Invalid user ID in wp_set_password action.' );
 	}
 }

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -2353,4 +2353,64 @@ class Tests_User extends WP_UnitTestCase {
 		// Verify there are no updates to 'use_ssl' user meta.
 		$this->assertSame( 1, $db_update_count );
 	}
+
+	public function test_set_password_action_on_wp_insert_user_with_update_false_and_true() {
+		$mock_action = new MockAction();
+
+		add_action( 'wp_set_password', array( $mock_action, 'action' ), 10, 3 );
+
+		// New User Scenario: $update = false
+		$username = 'testuser_' . wp_rand();
+		$password = 'password123';
+		$userdata = array(
+			'user_login' => $username,
+			'user_pass'  => $password,
+			'user_email' => $username . '@example.com',
+			'role'       => 'subscriber',
+		);
+
+		$user_id = wp_insert_user( $userdata );
+
+		// Assert that wp_set_password was called
+		$this->assertSame( 1, $mock_action->get_call_count(), 'wp_set_password action was not called for new user' );
+		$args = $mock_action->get_args();
+		$this->assertSame( $password, $args[0][0], 'Password mismatch for the new user' );
+		$this->assertSame( $user_id, $args[0][1], 'User ID mismatch for the new user' );
+
+		// Update Existing User Scenario: $update = true
+		$mock_action->reset(); // Reset the mock for a clean test
+		$updated_userdata = array(
+			'ID'         => $user_id, // Pass existing user ID to trigger an update
+			'user_pass'  => 'newpassword789',
+			'first_name' => 'Test',
+			'last_name'  => 'User',
+		);
+
+		wp_insert_user( $updated_userdata );
+
+		// Assert that wp_set_password was NOT called
+		$this->assertSame( 0, $mock_action->get_call_count(), 'wp_set_password action was incorrectly triggered for user update when $update = true' );
+	}
+
+	public function test_set_password_action_on_user_update() {
+		$mock_action = new MockAction();
+
+		add_action( 'wp_set_password', array( $mock_action, 'action' ), 10, 3 );
+
+		$user_id      = $this->factory()->user->create( array( 'role' => 'subscriber' ) );
+		$new_password = 'newpassword!@#';
+
+		$update_userdata = array(
+			'ID'        => $user_id,
+			'user_pass' => $new_password,
+		);
+
+		wp_update_user( $update_userdata );
+
+		// Assertions
+		$this->assertSame( 1, $mock_action->get_call_count(), 'The action wp_set_password was not called when updating a user.' );
+		$args = $mock_action->get_args();
+		$this->assertSame( $new_password, $args[0][0], 'The updated password is incorrect.' );
+		$this->assertSame( $user_id, $args[0][1], 'The user ID passed to the action is incorrect.' );
+	}
 }


### PR DESCRIPTION
Fires a wp_set_password action whenever a user is created or updated.

Trac ticket: https://core.trac.wordpress.org/ticket/22114