### PR TITLE
Added escaping to the handle variable for id attribute for scripts and styles

### DIFF
--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -341,7 +341,7 @@ class WP_Scripts extends WP_Dependencies {
 
 		$translations = $this->print_translations( $handle, false );
 		if ( $translations ) {
-			$translations = wp_get_inline_script_tag( $translations, array( 'id' => "{$handle}-js-translations" ) );
+			$translations = wp_get_inline_script_tag( $translations, array( 'id' => esc_attr( $handle ) . '-js-translations' ) );
 		}
 
 		if ( $this->do_concat ) {
@@ -417,7 +417,7 @@ class WP_Scripts extends WP_Dependencies {
 
 		$attr = array(
 			'src' => $src,
-			'id'  => "{$handle}-js",
+			'id'  => esc_attr( $handle ) . '-js',
 		);
 		if ( $strategy ) {
 			$attr[ $strategy ] = true;

--- a/src/wp-includes/class-wp-styles.php
+++ b/src/wp-includes/class-wp-styles.php
@@ -229,7 +229,7 @@ class WP_Styles extends WP_Dependencies {
 		$tag = sprintf(
 			"<link rel='%s' id='%s-css'%s href='%s'%s media='%s' />\n",
 			$rel,
-			$handle,
+			esc_attr( $handle ),
 			$title,
 			$href,
 			$this->type_attr,
@@ -261,7 +261,7 @@ class WP_Styles extends WP_Dependencies {
 			$rtl_tag = sprintf(
 				"<link rel='%s' id='%s-rtl-css'%s href='%s'%s media='%s' />\n",
 				$rel,
-				$handle,
+				esc_attr( $handle ),
 				$title,
 				$rtl_href,
 				$this->type_attr,


### PR DESCRIPTION
This PR ensures that dependency handles used in id attributes (in both <script> and <link> tags) are properly escaped using esc_attr() in the following methods:
- WP_Styles::do_item()
- WP_Scripts::do_item()

Trac ticket: https://core.trac.wordpress.org/ticket/30036