### PR TITLE
feat: add filter for customizable post statuses using plain permalinks

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -124,6 +124,29 @@ function wp_force_plain_post_permalink( $post = null, $sample = null ) {
 		return true;
 	}
 
+	/**
+	 * Filters the post statuses that should use plain permalinks instead of pretty permalinks.
+	 *
+	 * By default, posts with 'draft', 'pending', 'auto-draft', and 'future' statuses
+	 * will use plain permalinks (e.g., /?p=123) for security and consistency reasons.
+	 *
+	 * To allow scheduled posts to use pretty permalinks, you can remove 'future' from this array:
+	 *
+	 * add_filter( 'wp_force_plain_post_permalink_statuses', function( $statuses ) {
+	 *     return array_diff( $statuses, [ 'future' ] );
+	 * });
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param string[] $statuses Array of post status names that should use plain permalinks.
+	 * @param WP_Post  $post     The post object.
+	 */
+	$plain_permalink_statuses = apply_filters(
+		'wp_force_plain_post_permalink_statuses',
+		array( 'draft', 'pending', 'auto-draft', 'future' ),
+		$post
+	);
+
 	if (
 		// Publicly viewable links never have plain permalinks.
 		is_post_status_viewable( $post_status_obj ) ||
@@ -133,7 +156,9 @@ function wp_force_plain_post_permalink( $post = null, $sample = null ) {
 			current_user_can( 'read_post', $post->ID )
 		) ||
 		// Protected posts don't have plain links if getting a sample URL.
-		( $post_status_obj->protected && $sample )
+		( $post_status_obj->protected && $sample ) ||
+		// Allow customization of which post statuses should use plain permalinks.
+		! in_array( $post->post_status, $plain_permalink_statuses, true )
 	) {
 		return false;
 	}

--- a/tests/phpunit/tests/link.php
+++ b/tests/phpunit/tests/link.php
@@ -195,7 +195,7 @@ class Tests_Link extends WP_UnitTestCase {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_status' => 'future',
-				'post_date'   => date( 'Y-m-d H:i:s', strtotime( '+1 day' ) ),
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '+1 day' ) ),
 				'post_name'   => 'future-post',
 			)
 		);
@@ -213,7 +213,7 @@ class Tests_Link extends WP_UnitTestCase {
 		// Add filter to allow future posts to use pretty permalinks.
 		add_filter(
 			'wp_force_plain_post_permalink_statuses',
-			function( $statuses ) {
+			function ( $statuses ) {
 				return array_diff( $statuses, array( 'future' ) );
 			}
 		);
@@ -221,7 +221,7 @@ class Tests_Link extends WP_UnitTestCase {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_status' => 'future',
-				'post_date'   => date( 'Y-m-d H:i:s', strtotime( '+1 day' ) ),
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '+1 day' ) ),
 				'post_name'   => 'future-post',
 			)
 		);
@@ -242,7 +242,7 @@ class Tests_Link extends WP_UnitTestCase {
 		// Add filter to allow only future posts to use pretty permalinks.
 		add_filter(
 			'wp_force_plain_post_permalink_statuses',
-			function( $statuses ) {
+			function ( $statuses ) {
 				return array_diff( $statuses, array( 'future' ) );
 			}
 		);
@@ -250,7 +250,7 @@ class Tests_Link extends WP_UnitTestCase {
 		$future_post_id = self::factory()->post->create(
 			array(
 				'post_status' => 'future',
-				'post_date'   => date( 'Y-m-d H:i:s', strtotime( '+1 day' ) ),
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '+1 day' ) ),
 				'post_name'   => 'future-post',
 			)
 		);
@@ -282,7 +282,7 @@ class Tests_Link extends WP_UnitTestCase {
 		// Add filter to allow future posts pretty permalinks only for 'post' type.
 		add_filter(
 			'wp_force_plain_post_permalink_statuses',
-			function( $statuses, $post ) {
+			function ( $statuses, $post ) {
 				if ( 'future' === $post->post_status && 'post' === $post->post_type ) {
 					return array_diff( $statuses, array( 'future' ) );
 				}
@@ -296,7 +296,7 @@ class Tests_Link extends WP_UnitTestCase {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_status' => 'future',
-				'post_date'   => date( 'Y-m-d H:i:s', strtotime( '+1 day' ) ),
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '+1 day' ) ),
 				'post_name'   => 'future-post',
 			)
 		);
@@ -306,7 +306,7 @@ class Tests_Link extends WP_UnitTestCase {
 			array(
 				'post_type'   => 'page',
 				'post_status' => 'future',
-				'post_date'   => date( 'Y-m-d H:i:s', strtotime( '+1 day' ) ),
+				'post_date'   => gmdate( 'Y-m-d H:i:s', strtotime( '+1 day' ) ),
 				'post_name'   => 'future-page',
 			)
 		);
@@ -340,5 +340,4 @@ class Tests_Link extends WP_UnitTestCase {
 		// Should return false (allow pretty permalink) for published posts.
 		$this->assertFalse( wp_force_plain_post_permalink( $post ) );
 	}
-
 }

--- a/tests/phpunit/tests/link.php
+++ b/tests/phpunit/tests/link.php
@@ -187,4 +187,158 @@ class Tests_Link extends WP_UnitTestCase {
 		$this->go_to( get_permalink( $attachment_id ) );
 		$this->assertQueryTrue( 'is_attachment', 'is_single', 'is_singular' );
 	}
+
+	/**
+	 * @ticket 32322
+	 */
+	public function test_wp_force_plain_post_permalink_statuses_filter_future_posts_default() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'future',
+				'post_date'   => date( 'Y-m-d H:i:s', strtotime( '+1 day' ) ),
+				'post_name'   => 'future-post',
+			)
+		);
+
+		$post = get_post( $post_id );
+
+		// Should return true (force plain permalink) for future posts by default.
+		$this->assertTrue( wp_force_plain_post_permalink( $post ) );
+	}
+
+	/**
+	 * @ticket 32322
+	 */
+	public function test_wp_force_plain_post_permalink_statuses_filter_allows_customization() {
+		// Add filter to allow future posts to use pretty permalinks.
+		add_filter(
+			'wp_force_plain_post_permalink_statuses',
+			function( $statuses ) {
+				return array_diff( $statuses, array( 'future' ) );
+			}
+		);
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'future',
+				'post_date'   => date( 'Y-m-d H:i:s', strtotime( '+1 day' ) ),
+				'post_name'   => 'future-post',
+			)
+		);
+
+		$post = get_post( $post_id );
+
+		// Should return false (allow pretty permalink) when filter is applied.
+		$this->assertFalse( wp_force_plain_post_permalink( $post ) );
+
+		// Clean up.
+		remove_all_filters( 'wp_force_plain_post_permalink_statuses' );
+	}
+
+	/**
+	 * @ticket 32322
+	 */
+	public function test_wp_force_plain_post_permalink_statuses_filter_selective_by_status() {
+		// Add filter to allow only future posts to use pretty permalinks.
+		add_filter(
+			'wp_force_plain_post_permalink_statuses',
+			function( $statuses ) {
+				return array_diff( $statuses, array( 'future' ) );
+			}
+		);
+
+		$future_post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'future',
+				'post_date'   => date( 'Y-m-d H:i:s', strtotime( '+1 day' ) ),
+				'post_name'   => 'future-post',
+			)
+		);
+
+		$draft_post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'draft',
+				'post_name'   => 'draft-post',
+			)
+		);
+
+		$future_post = get_post( $future_post_id );
+		$draft_post  = get_post( $draft_post_id );
+
+		// Future post should use pretty permalink.
+		$this->assertFalse( wp_force_plain_post_permalink( $future_post ) );
+
+		// Draft post should still use plain permalink.
+		$this->assertTrue( wp_force_plain_post_permalink( $draft_post ) );
+
+		// Clean up.
+		remove_all_filters( 'wp_force_plain_post_permalink_statuses' );
+	}
+
+	/**
+	 * @ticket 32322
+	 */
+	public function test_wp_force_plain_post_permalink_statuses_filter_selective_by_post_type() {
+		// Add filter to allow future posts pretty permalinks only for 'post' type.
+		add_filter(
+			'wp_force_plain_post_permalink_statuses',
+			function( $statuses, $post ) {
+				if ( 'future' === $post->post_status && 'post' === $post->post_type ) {
+					return array_diff( $statuses, array( 'future' ) );
+				}
+				return $statuses;
+			},
+			10,
+			2
+		);
+
+		// Create future post.
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'future',
+				'post_date'   => date( 'Y-m-d H:i:s', strtotime( '+1 day' ) ),
+				'post_name'   => 'future-post',
+			)
+		);
+
+		// Create future page.
+		$page_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'future',
+				'post_date'   => date( 'Y-m-d H:i:s', strtotime( '+1 day' ) ),
+				'post_name'   => 'future-page',
+			)
+		);
+
+		$post = get_post( $post_id );
+		$page = get_post( $page_id );
+
+		// Future post should use pretty permalinks.
+		$this->assertFalse( wp_force_plain_post_permalink( $post ) );
+
+		// Future page should still use plain permalinks.
+		$this->assertTrue( wp_force_plain_post_permalink( $page ) );
+
+		// Clean up.
+		remove_all_filters( 'wp_force_plain_post_permalink_statuses' );
+	}
+
+	/**
+	 * @ticket 32322
+	 */
+	public function test_wp_force_plain_post_permalink_statuses_filter_published_posts_unaffected() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_name'   => 'published-post',
+			)
+		);
+
+		$post = get_post( $post_id );
+
+		// Should return false (allow pretty permalink) for published posts.
+		$this->assertFalse( wp_force_plain_post_permalink( $post ) );
+	}
+
 }


### PR DESCRIPTION
# Allow Customization of Post Statuses That Use Plain Permalinks

## Overview

This pull request introduces a new filter `wp_force_plain_post_permalink_statuses` that allows developers to customize which post statuses should use plain permalinks (e.g., `/?p=123`) instead of pretty permalinks (e.g., `/my-post-title/`).

This addresses the long-standing issue where **scheduled posts** show inconsistent permalink formats - pretty permalinks in the admin interface but plain permalinks in theme templates and functions like `the_permalink()`.

## Trac Ticket: [#32322](https://core.trac.wordpress.org/ticket/32322)

---

## Issue Fixed

### Scheduled Posts Show Inconsistent Permalink Formats

- **Problem:**  
  Scheduled posts (status = `future`) display different permalink formats in different contexts:
  - **Admin interface**: Shows pretty permalinks (`/my-scheduled-post/`)
  - **Theme templates**: Shows plain permalinks (`/?p=123`)
  - **Direct access**: Pretty permalink URLs work without redirection

- **Root Cause:**  
  The `wp_force_plain_post_permalink()` function treats all `protected` post statuses (including `future`) as requiring plain permalinks for security, but this creates user confusion since scheduled posts are meant to be public eventually.

- **Solution:**  
  Introduced a filterable array of post statuses that should use plain permalinks, allowing developers to customize this behavior on a per-site basis while maintaining security for truly sensitive content.

---

## Code Changes

### New Filter Implementation

```php
/**
 * Filters the post statuses that should use plain permalinks instead of pretty permalinks.
 *
 * By default, posts with 'draft', 'pending', 'auto-draft', and 'future' statuses
 * will use plain permalinks (e.g., /?p=123) for security and consistency reasons.
 *
 * To allow scheduled posts to use pretty permalinks, you can remove 'future' from this array:
 *
 * add_filter( 'wp_force_plain_post_permalink_statuses', function( $statuses ) {
 *     return array_diff( $statuses, [ 'future' ] );
 * });
 *
 * @since 6.9.0
 *
 * @param string[] $statuses Array of post status names that should use plain permalinks.
 * @param WP_Post  $post     The post object.
 */
$plain_permalink_statuses = apply_filters(
    'wp_force_plain_post_permalink_statuses',
    array( 'draft', 'pending', 'auto-draft', 'future' ),
    $post
);
```

### Updated Logic

```php
if (
    // Publicly viewable links never have plain permalinks.
    is_post_status_viewable( $post_status_obj ) ||
    (
        // Private posts don't have plain permalinks if the user can read them.
        $post_status_obj->private &&
        current_user_can( 'read_post', $post->ID )
    ) ||
    // Protected posts don't have plain links if getting a sample URL.
    ( $post_status_obj->protected && $sample ) ||
    // Allow customization of which post statuses should use plain permalinks.
    ! in_array( $post->post_status, $plain_permalink_statuses, true )
) {
    return false;
}
```

## Usage Examples

### Basic: Allow Scheduled Posts Pretty Permalinks

```php
add_filter( 'wp_force_plain_post_permalink_statuses', function( $statuses ) {
    return array_diff( $statuses, [ 'future' ] );
});
```

### Advanced: Selective by Post Type

```php
add_filter( 'wp_force_plain_post_permalink_statuses', function( $statuses, $post ) {
    // Only allow pretty permalinks for future posts of type 'post'
    if ( 'future' === $post->post_status && 'post' === $post->post_type ) {
        return array_diff( $statuses, [ 'future' ] );
    }
    return $statuses;
}, 10, 2 );
```

### Conditional by User Capability

```php
add_filter( 'wp_force_plain_post_permalink_statuses', function( $statuses, $post ) {
    // Allow editors to see pretty permalinks for future posts
    if ( 'future' === $post->post_status && current_user_can( 'edit_others_posts' ) ) {
        return array_diff( $statuses, [ 'future' ] );
    }
    return $statuses;
}, 10, 2 );
```

---

## Testing Instructions

### Test Case 1: Default Behavior (Unchanged)

1. Create a **scheduled post** with future publication date
2. View the post in **admin** - should show pretty permalink
3. Use `the_permalink()` in a theme template - should show plain permalink
4. **Expected**: No change from current behavior

### Test Case 2: Enable Pretty Permalinks for Future Posts

1. Add the filter to remove 'future' from plain permalink statuses
2. Create a **scheduled post** with future publication date
3. Use `the_permalink()` in a theme template
4. **Expected**: Shows pretty permalink (`/my-scheduled-post/`)

### Test Case 3: Selective Application

1. Add the filter with post type condition (only 'post', not 'page')
2. Create a **scheduled post** and **scheduled page**
3. Check permalinks for both
4. **Expected**: Post shows pretty permalink, page shows plain permalink

### Test Case 4: Security Maintained

1. Apply filter to allow future posts pretty permalinks
2. Create **draft** and **pending** posts
3. Check their permalinks
4. **Expected**: Draft and pending posts still use plain permalinks

### Test Case 5: Direct Access

1. Enable pretty permalinks for future posts
2. Create a scheduled post
3. Try accessing the pretty permalink URL directly
4. **Expected**: Should work without redirection (existing behavior)

---