### PR TITLE
HTML API: Use `assertEqualHTML` in `wp_rel_ugc()` tests.

### DIFF
--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -168,7 +168,7 @@ class Tests_Comment extends WP_UnitTestCase {
 		wp_set_current_user( 0 );
 
 		$comment = get_comment( $comment_id );
-		$this->assertSame( '<a href="http://example.localhost/something.html" rel="nofollow ugc">click</a>', $comment->comment_content, 'Comment: ' . $comment->comment_content );
+		$this->assertEqualHTML( '<a href="http://example.localhost/something.html" rel="nofollow ugc">click</a>', $comment->comment_content, '<body>', 'Comment: ' . $comment->comment_content );
 	}
 
 	/**

--- a/tests/phpunit/tests/formatting/wpRelUgc.php
+++ b/tests/phpunit/tests/formatting/wpRelUgc.php
@@ -12,8 +12,8 @@ class Tests_Formatting_wpRelUgc extends WP_UnitTestCase {
 	 */
 	public function test_add_ugc() {
 		$content  = '<p>This is some cool <a href="/">Code</a></p>';
-		$expected = '<p>This is some cool <a href=\"/\" rel=\"nofollow ugc\">Code</a></p>';
-		$this->assertSame( $expected, wp_rel_ugc( $content ) );
+		$expected = '<p>This is some cool <a href="/" rel="nofollow ugc">Code</a></p>';
+		$this->assertEqualHTML( $expected, stripslashes( wp_rel_ugc( $content ) ) );
 	}
 
 	/**
@@ -21,8 +21,8 @@ class Tests_Formatting_wpRelUgc extends WP_UnitTestCase {
 	 */
 	public function test_convert_ugc() {
 		$content  = '<p>This is some cool <a href="/" rel="weird">Code</a></p>';
-		$expected = '<p>This is some cool <a href=\"/\" rel=\"weird nofollow ugc\">Code</a></p>';
-		$this->assertSame( $expected, wp_rel_ugc( $content ) );
+		$expected = '<p>This is some cool <a href="/" rel="weird nofollow ugc">Code</a></p>';
+		$this->assertEqualHTML( $expected, stripslashes( wp_rel_ugc( $content ) ) );
 	}
 
 	/**
@@ -30,7 +30,7 @@ class Tests_Formatting_wpRelUgc extends WP_UnitTestCase {
 	 * @dataProvider data_wp_rel_ugc
 	 */
 	public function test_wp_rel_ugc( $input, $output, $expect_deprecation = false ) {
-		$this->assertSame( wp_slash( $output ), wp_rel_ugc( $input ) );
+		$this->assertEqualHTML( $output, stripslashes( wp_rel_ugc( $input ) ) );
 	}
 
 	public function data_wp_rel_ugc() {
@@ -81,7 +81,7 @@ class Tests_Formatting_wpRelUgc extends WP_UnitTestCase {
 	public function test_append_ugc_with_valueless_attribute() {
 
 		$content  = '<p>This is some cool <a href="demo.com" download rel="hola">Code</a></p>';
-		$expected = '<p>This is some cool <a href=\"demo.com\" download rel=\"hola nofollow ugc\">Code</a></p>';
-		$this->assertSame( $expected, wp_rel_ugc( $content ) );
+		$expected = '<p>This is some cool <a href="demo.com" download rel="hola nofollow ugc">Code</a></p>';
+		$this->assertEqualHTML( $expected, stripslashes( wp_rel_ugc( $content ) ) );
 	}
 }


### PR DESCRIPTION
Trac ticket: Core-63694

Prep work for #9252.
Part of #9248.
