### PR TITLE
HTML API: Use `assertEqualHTML()` in `wp_kses()` tests.

### DIFF
--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -168,7 +168,12 @@ class Tests_Comment extends WP_UnitTestCase {
 		wp_set_current_user( 0 );
 
 		$comment = get_comment( $comment_id );
-		$this->assertEqualHTML( '<a href="http://example.localhost/something.html" rel="nofollow ugc">click</a>', $comment->comment_content, '<body>', 'Comment: ' . $comment->comment_content );
+		$this->assertEqualHTML(
+			'<a href="http://example.localhost/something.html" rel="nofollow ugc">click</a>',
+			$comment->comment_content,
+			'<body>',
+			'Comment: ' . $comment->comment_content
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -17,7 +17,7 @@ class Tests_Kses extends WP_UnitTestCase {
 	public function test_wp_filter_post_kses_address( $content, $expected ) {
 		global $allowedposttags;
 
-		$this->assertSame( $expected, wp_kses( $content, $allowedposttags ) );
+		$this->assertEqualHTML( $expected, wp_kses( $content, $allowedposttags ) );
 	}
 
 	/**
@@ -65,7 +65,7 @@ class Tests_Kses extends WP_UnitTestCase {
 	public function test_wp_filter_post_kses_a( $content, $expected ) {
 		global $allowedposttags;
 
-		$this->assertSame( $expected, wp_kses( $content, $allowedposttags ) );
+		$this->assertEqualHTML( $expected, wp_kses( $content, $allowedposttags ) );
 	}
 
 	/**
@@ -120,7 +120,7 @@ class Tests_Kses extends WP_UnitTestCase {
 	 * @param string $expected Expected output following KSES parsing.
 	 */
 	public function test_wp_kses_video( $source, $context, $expected ) {
-		$this->assertSame( $expected, wp_kses( $source, $context ) );
+		$this->assertEqualHTML( $expected, wp_kses( $source, $context ) );
 	}
 
 	/**
@@ -171,7 +171,7 @@ class Tests_Kses extends WP_UnitTestCase {
 	public function test_wp_filter_post_kses_abbr( $content, $expected ) {
 		global $allowedposttags;
 
-		$this->assertSame( $expected, wp_kses( $content, $allowedposttags ) );
+		$this->assertEqualHTML( $expected, wp_kses( $content, $allowedposttags ) );
 	}
 
 	/**
@@ -232,7 +232,7 @@ EOF;
 <a href="">CLICK ME</a>
 EOF;
 
-		$this->assertSame( $expected, wp_kses( $content, $allowedposttags ) );
+		$this->assertEqualHTML( $expected, wp_kses( $content, $allowedposttags ) );
 	}
 
 	public function test_wp_kses_bad_protocol() {
@@ -546,8 +546,8 @@ EOF;
 		$expect_stripped_content = 'Alot of hyphens.';
 		$expect_valid_content    = '<hyphenated-tag attribute="value">Alot of hyphens.</hyphenated-tag>';
 
-		$this->assertSame( $expect_stripped_content, wp_kses_post( $content ) );
-		$this->assertSame( $expect_valid_content, wp_kses( $content, $custom_tags ) );
+		$this->assertEqualHTML( $expect_stripped_content, wp_kses_post( $content ) );
+		$this->assertEqualHTML( $expect_valid_content, wp_kses( $content, $custom_tags ) );
 	}
 
 	/**
@@ -613,7 +613,7 @@ EOF;
 	 * @dataProvider data_normalize_entities
 	 */
 	public function test_wp_kses_normalize_entities( string $input, string $expected ) {
-		$this->assertSame( $expected, wp_kses_normalize_entities( $input ) );
+		$this->assertEqualHTML( $expected, wp_kses_normalize_entities( $input ) );
 	}
 
 	/**
@@ -625,7 +625,7 @@ EOF;
 	public function test_ctrl_removal( $content, $expected ) {
 		global $allowedposttags;
 
-		return $this->assertSame( $expected, wp_kses( $content, $allowedposttags ) );
+		return $this->assertEqualHTML( $expected, wp_kses( $content, $allowedposttags ) );
 	}
 
 	public function data_ctrl_removal() {
@@ -662,7 +662,7 @@ EOF;
 	public function test_slash_zero_removal( $content, $expected ) {
 		global $allowedposttags;
 
-		return $this->assertSame( $expected, wp_kses( $content, $allowedposttags ) );
+		return $this->assertEqualHTML( $expected, wp_kses( $content, $allowedposttags ) );
 	}
 
 	public function data_slash_zero_removal() {
@@ -917,7 +917,7 @@ EOF;
 
 		$content = '<p>This is <bdo dir="rtl">a BDO tag</bdo>. Weird, <bdo dir="ltr">right?</bdo></p>';
 
-		$this->assertSame( $content, wp_kses( $content, $allowedposttags ) );
+		$this->assertEqualHTML( $content, wp_kses( $content, $allowedposttags ) );
 	}
 
 	/**
@@ -928,7 +928,7 @@ EOF;
 
 		$content = '<ruby>✶<rp>: </rp><rt>Star</rt><rp>, </rp><rt lang="fr">Étoile</rt><rp>.</rp></ruby>';
 
-		$this->assertSame( $content, wp_kses( $content, $allowedposttags ) );
+		$this->assertEqualHTML( $content, wp_kses( $content, $allowedposttags ) );
 	}
 
 	/**
@@ -939,7 +939,7 @@ EOF;
 
 		$content = '<ol reversed="reversed"><li>Item 1</li><li>Item 2</li><li>Item 3</li></ol>';
 
-		$this->assertSame( $content, wp_kses( $content, $allowedposttags ) );
+		$this->assertEqualHTML( $content, wp_kses( $content, $allowedposttags ) );
 	}
 
 	/**
@@ -949,7 +949,7 @@ EOF;
 		$element   = 'foo';
 		$attribute = 'title="foo" class="bar"';
 
-		$this->assertSame( "<{$element}>", wp_kses_attr( $element, $attribute, array( 'foo' => array() ), array() ) );
+		$this->assertEqualHTML( "<{$element}>", wp_kses_attr( $element, $attribute, array( 'foo' => array() ), array() ) );
 	}
 
 	/**
@@ -959,7 +959,7 @@ EOF;
 		$element   = 'foo';
 		$attribute = 'title="foo" class="bar"';
 
-		$this->assertSame( "<{$element}>", wp_kses_attr( $element, $attribute, array( 'foo' => true ), array() ) );
+		$this->assertEqualHTML( "<{$element}>", wp_kses_attr( $element, $attribute, array( 'foo' => true ), array() ) );
 	}
 
 	/**
@@ -969,7 +969,7 @@ EOF;
 		$element   = 'foo';
 		$attribute = 'title="foo" class="bar"';
 
-		$this->assertSame( "<{$element} title=\"foo\">", wp_kses_attr( $element, $attribute, array( 'foo' => array( 'title' => true ) ), array() ) );
+		$this->assertEqualHTML( "<{$element} title=\"foo\">", wp_kses_attr( $element, $attribute, array( 'foo' => array( 'title' => true ) ), array() ) );
 	}
 
 	/**
@@ -979,7 +979,7 @@ EOF;
 		$element   = 'foo';
 		$attribute = 'title="foo" class="bar"';
 
-		$this->assertSame( "<{$element}>", wp_kses_attr( $element, $attribute, array( 'foo' => false ), array() ) );
+		$this->assertEqualHTML( "<{$element}>", wp_kses_attr( $element, $attribute, array( 'foo' => false ), array() ) );
 	}
 
 	/**
@@ -1423,7 +1423,7 @@ EOF;
 		$test     = '<div data-foo="foo" data-bar="bar" datainvalid="gone" data-two-hyphens="remains">Pens and pencils</div>';
 		$expected = '<div data-foo="foo" data-bar="bar" data-two-hyphens="remains">Pens and pencils</div>';
 
-		$this->assertSame( $expected, wp_kses_post( $test ) );
+		$this->assertEqualHTML( $expected, wp_kses_post( $test ) );
 	}
 
 	/**
@@ -1435,7 +1435,7 @@ EOF;
 		$test     = '<div data--leading="remains" data-trailing-="remains" data-middle--double="remains">Pens and pencils</div>';
 		$expected = '<div data--leading="remains" data-trailing-="remains" data-middle--double="remains">Pens and pencils</div>';
 
-		$this->assertSame( $expected, wp_kses_post( $test ) );
+		$this->assertEqualHTML( $expected, wp_kses_post( $test ) );
 	}
 
 	/**
@@ -1456,7 +1456,7 @@ EOF;
 
 		$actual = wp_kses( $content, $allowed_html );
 
-		$this->assertSame( $expected, $actual );
+		$this->assertEqualHTML( $expected, $actual );
 	}
 
 	/**
@@ -1476,7 +1476,7 @@ EOF;
 
 		$actual = wp_kses( $content, $allowed_html );
 
-		$this->assertSame( $expected, $actual );
+		$this->assertEqualHTML( $expected, $actual );
 	}
 
 	/**
@@ -1761,7 +1761,7 @@ EOF;
 
 		$html = implode( ' ', $html );
 
-		$this->assertSame( $html, wp_kses_post( $html ) );
+		$this->assertEqualHTML( $html, wp_kses_post( $html ) );
 	}
 
 	/**
@@ -1779,7 +1779,7 @@ EOF;
 
 		$html = implode( ' ', $test );
 
-		$this->assertSame( $html, wp_kses_post( $html ) );
+		$this->assertEqualHTML( $html, wp_kses_post( $html ) );
 	}
 
 	/**
@@ -1793,7 +1793,7 @@ EOF;
 	 * @param string $expected The expected result from KSES.
 	 */
 	public function test_wp_kses_object_tag_allowed( $html, $expected ) {
-		$this->assertSame( $expected, wp_kses_post( $html ) );
+		$this->assertEqualHTML( $expected, wp_kses_post( $html ) );
 	}
 
 	/**
@@ -1904,7 +1904,7 @@ EOF;
 	 */
 	public function test_wp_kses_object_data_url_with_port_number_allowed( $html, $expected ) {
 		add_filter( 'upload_dir', array( $this, 'wp_kses_upload_dir_filter' ), 10, 2 );
-		$this->assertSame( $expected, wp_kses_post( $html ) );
+		$this->assertEqualHTML( $expected, wp_kses_post( $html ) );
 	}
 
 	/**
@@ -1970,7 +1970,7 @@ HTML;
 
 		remove_filter( 'wp_kses_allowed_html', array( $this, 'filter_wp_kses_object_added_in_html_filter' ) );
 
-		$this->assertSame( $html, $filtered_html );
+		$this->assertEqualHTML( $html, $filtered_html );
 	}
 
 	public function filter_wp_kses_object_added_in_html_filter( $tags, $context ) {
@@ -2001,9 +2001,10 @@ HTML;
 	 * @param string $expected_output How `wp_kses()` ought to transform the comment.
 	 */
 	public function test_wp_kses_preserves_html_comments( $html_comment, $expected_output ) {
-		$this->assertSame(
+		$this->assertEqualHTML(
 			$expected_output,
 			wp_kses( $html_comment, array() ),
+			'<body>',
 			'Failed to properly preserve HTML comment.'
 		);
 	}
@@ -2033,7 +2034,7 @@ HTML;
 	 * @param array  $allowed_html The allowed HTML to pass to KSES.
 	 */
 	public function test_wp_kses_allowed_values_list( $content, $expected, $allowed_html ) {
-		$this->assertSame( $expected, wp_kses( $content, $allowed_html ) );
+		$this->assertEqualHTML( $expected, wp_kses( $content, $allowed_html ) );
 	}
 
 	/**
@@ -2091,7 +2092,7 @@ HTML;
 	 * @param array  $allowed_html The allowed HTML to pass to KSES.
 	 */
 	public function test_wp_kses_required_attribute( $content, $expected, $allowed_html ) {
-		$this->assertSame( $expected, wp_kses( $content, $allowed_html ) );
+		$this->assertEqualHTML( $expected, wp_kses( $content, $allowed_html ) );
 	}
 
 	/**
@@ -2312,7 +2313,7 @@ HTML;
 	public function test_target_attribute_preserved_in_context( $context, $input, $expected ) {
 		$allowed = wp_kses_allowed_html( $context );
 		$this->assertTrue( isset( $allowed['a']['target'] ), "Target attribute not allowed in {$context}" );
-		$this->assertEquals( $expected, wp_kses( $input, $context ) );
+		$this->assertEqualHTML( $expected, wp_kses( $input, $context ) );
 	}
 
 	/**


### PR DESCRIPTION
Trac ticket: Core-63694

Prep work for #9248 