### PR TITLE
HTML API: Use `assertEqualHTML()` in post filtering tests.

### DIFF
--- a/tests/phpunit/tests/post/filtering.php
+++ b/tests/phpunit/tests/post/filtering.php
@@ -35,7 +35,7 @@ EOF;
 		$id   = self::factory()->post->create( array( 'post_content' => $content ) );
 		$post = get_post( $id );
 
-		$this->assertSame( $expected, $post->post_content );
+		$this->assertEqualHTML( $expected, $post->post_content );
 	}
 
 	// A simple test to make sure unbalanced tags are fixed.
@@ -52,7 +52,7 @@ EOF;
 		$id   = self::factory()->post->create( array( 'post_content' => $content ) );
 		$post = get_post( $id );
 
-		$this->assertSame( $expected, $post->post_content );
+		$this->assertEqualHTML( $expected, $post->post_content );
 	}
 
 	// Test KSES filtering of disallowed attribute.
@@ -69,7 +69,7 @@ EOF;
 		$id   = self::factory()->post->create( array( 'post_content' => $content ) );
 		$post = get_post( $id );
 
-		$this->assertSame( $expected, $post->post_content );
+		$this->assertEqualHTML( $expected, $post->post_content );
 	}
 
 	/**
@@ -89,7 +89,7 @@ EOF;
 		$id   = self::factory()->post->create( array( 'post_content' => $content ) );
 		$post = get_post( $id );
 
-		$this->assertSame( $expected, $post->post_content );
+		$this->assertEqualHTML( $expected, $post->post_content );
 	}
 
 	// Make sure unbalanced tags are untouched when the balance option is off.
@@ -109,6 +109,6 @@ EOF;
 		$id   = self::factory()->post->create( array( 'post_content' => $content ) );
 		$post = get_post( $id );
 
-		$this->assertSame( $content, $post->post_content );
+		$this->assertEqualHTML( $content, $post->post_content );
 	}
 }


### PR DESCRIPTION
Trac ticket: Core-63694

Prep work for #9248.