### PR TITLE
HTML API: Rely on HTML API in `oEmbed` filtering tests.

### DIFF
--- a/tests/phpunit/tests/oembed/filterResult.php
+++ b/tests/phpunit/tests/oembed/filterResult.php
@@ -9,26 +9,57 @@ class Tests_Filter_oEmbed_Result extends WP_UnitTestCase {
 
 		$actual = wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), 'https://www.youtube.com/watch?v=72xdCU__XCk' );
 
-		$this->assertSame( $html, $actual );
+		$this->assertEqualHTML( $html, $actual );
 	}
 
 	public function test_filter_oembed_result_with_untrusted_provider() {
 		$html   = '<p></p><iframe onload="alert(1)" src="http://example.com/sample-page/"></iframe>';
 		$actual = wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), 'http://example.com/sample-page/' );
 
-		$matches = array();
-		preg_match( '|src=".*#\?secret=([\w\d]+)" data-secret="([\w\d]+)"|', $actual, $matches );
+		$processor = new WP_HTML_Tag_Processor( $actual );
 
-		$this->assertArrayHasKey( 1, $matches );
-		$this->assertArrayHasKey( 2, $matches );
-		$this->assertSame( $matches[1], $matches[2] );
+		$this->assertTrue(
+			$processor->next_tag( 'IFRAME' ),
+			'Failed to find expected IFRAME element in filtered output.'
+		);
+
+		$src = $processor->get_attribute( 'src' );
+		$this->assertIsString(
+			$src,
+			isset( $src )
+				? 'Expected "src" attribute on IFRAME with string value but found boolean attribute instead.'
+				: 'Failed to find expected "src" attribute on IFRAME element.'
+		);
+
+		$query_string = parse_url( $src, PHP_URL_FRAGMENT );
+		$this->assertStringStartsWith(
+			'?',
+			$query_string,
+			'Should have found URL fragment in "src" attribute resembling a query string.'
+		);
+
+		$query_string = substr( $query_string, 1 );
+		$query_args   = array();
+		parse_str( $query_string, $query_args );
+
+		$this->assertArrayHasKey(
+			'secret',
+			$query_args,
+			'Failed to find expected query arg "secret" in IFRAME "src" attribute.'
+		);
+
+		$this->assertSame(
+			$query_args['secret'],
+			$processor->get_attribute( 'data-secret' ),
+			'Expected to find identical copy of secret from IFRAME "src" in the "data-secret" attribute.'
+		);
 	}
 
 	public function test_filter_oembed_result_only_one_iframe_is_allowed() {
 		$html   = '<div><iframe></iframe><iframe></iframe><p></p></div>';
 		$actual = wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), '' );
 
-		$this->assertSame( '<iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted"></iframe>', $actual );
+		$this->assertEqualHTML( '<iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted"></iframe>', $actual );
 	}
 
 	public function test_filter_oembed_result_with_newlines() {
@@ -41,7 +72,7 @@ EOD;
 
 		$actual = wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), '' );
 
-		$this->assertSame( '<iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted"></iframe>', $actual );
+		$this->assertEqualHTML( '<iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted"></iframe>', $actual );
 	}
 
 	public function test_filter_oembed_result_without_iframe() {
@@ -60,18 +91,48 @@ EOD;
 		$html   = '<iframe src="https://wordpress.org"></iframe>';
 		$actual = wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), '' );
 
-		$matches = array();
-		preg_match( '|src="https://wordpress.org#\?secret=([\w\d]+)" data-secret="([\w\d]+)"|', $actual, $matches );
+		$processor = new WP_HTML_Tag_Processor( $actual );
 
-		$this->assertArrayHasKey( 1, $matches );
-		$this->assertArrayHasKey( 2, $matches );
-		$this->assertSame( $matches[1], $matches[2] );
+		$this->assertTrue(
+			$processor->next_tag( 'IFRAME' ),
+			'Failed to find expected IFRAME element in filtered output.'
+		);
+
+		$src = $processor->get_attribute( 'src' );
+		$this->assertMatchesRegularExpression(
+			'~^https://wordpress.org~',
+			$src,
+			'Failed to find expected "src" attribute on IFRAME element.'
+		);
+
+		$query_string = parse_url( $src, PHP_URL_FRAGMENT );
+		$this->assertStringStartsWith(
+			'?',
+			$query_string,
+			'Should have found URL fragment in "src" attribute resembling a query string.'
+		);
+
+		$query_string = substr( $query_string, 1 );
+		$query_args   = array();
+		parse_str( $query_string, $query_args );
+
+		$this->assertArrayHasKey(
+			'secret',
+			$query_args,
+			'Failed to find expected query arg "secret" in IFRAME "src" attribute.'
+		);
+
+		$this->assertSame(
+			$query_args['secret'],
+			$processor->get_attribute( 'data-secret' ),
+			'Expected to find identical copy of secret from IFRAME "src" in the "data-secret" attribute.'
+		);
 	}
 
 	public function test_filter_oembed_result_wrong_type_provided() {
 		$actual = wp_filter_oembed_result( 'some string', (object) array( 'type' => 'link' ), '' );
 
-		$this->assertSame( 'some string', $actual );
+		$this->assertEqualHTML( 'some string', $actual );
 	}
 
 	public function test_filter_oembed_result_invalid_result() {
@@ -83,14 +144,14 @@ EOD;
 		$html   = '<blockquote></blockquote><iframe></iframe>';
 		$actual = wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), '' );
 
-		$this->assertSame( '<blockquote class="wp-embedded-content"></blockquote><iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted" style="position: absolute; visibility: hidden;"></iframe>', $actual );
+		$this->assertEqualHTML( '<blockquote class="wp-embedded-content"></blockquote><iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted" style="position: absolute; visibility: hidden;"></iframe>', $actual );
 	}
 
 	public function test_filter_oembed_result_allowed_html() {
 		$html   = '<blockquote class="foo" id="bar"><strong><a href="" target=""></a></strong></blockquote><iframe></iframe>';
 		$actual = wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), '' );
 
-		$this->assertSame( '<blockquote class="wp-embedded-content"><a href=""></a></blockquote><iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted" style="position: absolute; visibility: hidden;"></iframe>', $actual );
+		$this->assertEqualHTML( '<blockquote class="wp-embedded-content"><a href=""></a></blockquote><iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted" style="position: absolute; visibility: hidden;"></iframe>', $actual );
 	}
 
 	public function data_wp_filter_pre_oembed_custom_result() {
@@ -124,7 +185,7 @@ EOD;
 			'html'  => $html,
 		);
 		$actual = _wp_oembed_get_object()->data2html( $data, 'https://untrusted.localhost' );
-		$this->assertSame( $expected, $actual );
+		$this->assertEqualHTML( $expected, $actual );
 	}
 
 	/**
@@ -134,6 +195,6 @@ EOD;
 		$html   = '<blockquote></blockquote><iframe></iframe>';
 		$actual = _oembed_filter_feed_content( wp_filter_oembed_result( $html, (object) array( 'type' => 'rich' ), '' ) );
 
-		$this->assertSame( '<blockquote class="wp-embedded-content"></blockquote><iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted" ></iframe>', $actual );
+		$this->assertEqualHTML( '<blockquote class="wp-embedded-content"></blockquote><iframe class="wp-embedded-content" sandbox="allow-scripts" security="restricted" ></iframe>', $actual );
 	}
 }

--- a/tests/phpunit/tests/oembed/filterTitleAttributes.php
+++ b/tests/phpunit/tests/oembed/filterTitleAttributes.php
@@ -67,7 +67,7 @@ class Tests_Filter_oEmbed_Iframe_Title_Attribute extends WP_UnitTestCase {
 	public function test_oembed_iframe_title_attribute( $html, $oembed_data, $url, $expected ) {
 		$actual = wp_filter_oembed_iframe_title_attribute( $html, (object) $oembed_data, $url );
 
-		$this->assertSame( $expected, $actual );
+		$this->assertEqualHTML( $expected, $actual );
 	}
 
 	public function test_filter_oembed_iframe_title_attribute() {
@@ -84,7 +84,7 @@ class Tests_Filter_oEmbed_Iframe_Title_Attribute extends WP_UnitTestCase {
 
 		remove_filter( 'oembed_iframe_title_attribute', array( $this, '_filter_oembed_iframe_title_attribute' ) );
 
-		$this->assertSame( '<iframe title="Baz" src=""></iframe>', $actual );
+		$this->assertEqualHTML( '<iframe title="Baz" src=""></iframe>', $actual );
 	}
 
 	public function test_filter_oembed_iframe_title_attribute_does_not_modify_other_tags() {
@@ -101,7 +101,7 @@ class Tests_Filter_oEmbed_Iframe_Title_Attribute extends WP_UnitTestCase {
 
 		remove_filter( 'oembed_iframe_title_attribute', array( $this, '_filter_oembed_iframe_title_attribute' ) );
 
-		$this->assertSame( '<p title="Bar">Baz</p><iframe title="Baz" src=""></iframe>', $actual );
+		$this->assertEqualHTML( '<p title="Bar">Baz</p><iframe title="Baz" src=""></iframe>', $actual );
 	}
 
 	public function _filter_oembed_iframe_title_attribute() {


### PR DESCRIPTION
Trac ticket: Core-63694

Prep work for #9248.