### PR TITLE
feat: Dynamically add CSS styles for colors in color pallete.

### DIFF
--- a/src/wp-content/themes/twentynineteen/functions.php
+++ b/src/wp-content/themes/twentynineteen/functions.php
@@ -288,6 +288,49 @@ function twentynineteen_scripts() {
 }
 add_action( 'wp_enqueue_scripts', 'twentynineteen_scripts' );
 
+function twentynineteen_generate_color_palette_css() {
+
+	// Check if the theme supports editor color palette.
+	if ( ! current_theme_supports( 'editor-color-palette' ) ) {
+		return;
+	}
+
+    $colors = get_theme_support( 'editor-color-palette' );
+    if ( ! $colors ) {
+        return;
+    }
+    
+    $colors = $colors[0];
+    $css = '';
+    
+    foreach ( $colors as $color ) {
+        // Generate text color classes
+        $css .= sprintf(
+            '.has-%1$s-color { color: %2$s !important; } ',
+            $color['slug'],
+            $color['color']
+        );
+        
+        // Generate background color classes
+        $css .= sprintf(
+            '.has-%1$s-background-color { background-color: %2$s !important; } ',
+            $color['slug'],
+            $color['color']
+        );
+        
+        // Generate border color classes
+        $css .= sprintf(
+            '.has-%1$s-border-color { border-color: %2$s !important; } ',
+            $color['slug'],
+            $color['color']
+        );
+    }
+    
+    $added = wp_add_inline_style( 'twentynineteen-style', $css );
+}
+
+add_action( 'wp_enqueue_scripts', 'twentynineteen_generate_color_palette_css' );
+
 /**
  * Fix skip link focus in IE11.
  *

--- a/src/wp-content/themes/twentynineteen/functions.php
+++ b/src/wp-content/themes/twentynineteen/functions.php
@@ -304,21 +304,21 @@ function twentynineteen_generate_color_palette_css() {
 	$css    = '';
 
 	foreach ( $colors as $color ) {
-		// Generate text color classes
+		// Generate text color classes.
 		$css .= sprintf(
 			'.has-%1$s-color { color: %2$s !important; } ',
 			$color['slug'],
 			$color['color']
 		);
 
-		// Generate background color classes
+		// Generate background color classes.
 		$css .= sprintf(
 			'.has-%1$s-background-color { background-color: %2$s !important; } ',
 			$color['slug'],
 			$color['color']
 		);
 
-		// Generate border color classes
+		// Generate border color classes.
 		$css .= sprintf(
 			'.has-%1$s-border-color { border-color: %2$s !important; } ',
 			$color['slug'],

--- a/src/wp-content/themes/twentynineteen/functions.php
+++ b/src/wp-content/themes/twentynineteen/functions.php
@@ -295,38 +295,38 @@ function twentynineteen_generate_color_palette_css() {
 		return;
 	}
 
-    $colors = get_theme_support( 'editor-color-palette' );
-    if ( ! $colors ) {
-        return;
-    }
-    
-    $colors = $colors[0];
-    $css = '';
-    
-    foreach ( $colors as $color ) {
-        // Generate text color classes
-        $css .= sprintf(
-            '.has-%1$s-color { color: %2$s !important; } ',
-            $color['slug'],
-            $color['color']
-        );
-        
-        // Generate background color classes
-        $css .= sprintf(
-            '.has-%1$s-background-color { background-color: %2$s !important; } ',
-            $color['slug'],
-            $color['color']
-        );
-        
-        // Generate border color classes
-        $css .= sprintf(
-            '.has-%1$s-border-color { border-color: %2$s !important; } ',
-            $color['slug'],
-            $color['color']
-        );
-    }
-    
-    $added = wp_add_inline_style( 'twentynineteen-style', $css );
+	$colors = get_theme_support( 'editor-color-palette' );
+	if ( ! $colors ) {
+		return;
+	}
+
+	$colors = $colors[0];
+	$css    = '';
+
+	foreach ( $colors as $color ) {
+		// Generate text color classes
+		$css .= sprintf(
+			'.has-%1$s-color { color: %2$s !important; } ',
+			$color['slug'],
+			$color['color']
+		);
+
+		// Generate background color classes
+		$css .= sprintf(
+			'.has-%1$s-background-color { background-color: %2$s !important; } ',
+			$color['slug'],
+			$color['color']
+		);
+
+		// Generate border color classes
+		$css .= sprintf(
+			'.has-%1$s-border-color { border-color: %2$s !important; } ',
+			$color['slug'],
+			$color['color']
+		);
+	}
+
+	$added = wp_add_inline_style( 'twentynineteen-style', $css );
 }
 
 add_action( 'wp_enqueue_scripts', 'twentynineteen_generate_color_palette_css' );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This pull request adds a new function to dynamically generate CSS classes for the theme's editor color palette in the `Twentynineteen` WordPress theme. The function ensures that text, background, and border color classes are created based on the theme's defined color palette and applies them as inline styles.

Trac ticket: https://core.trac.wordpress.org/ticket/63623

## Screenshots
|   | Before    | After |
|--| -------- | ------- |
| Editor | <img width="723" height="610" alt="image" src="https://github.com/user-attachments/assets/8ae69622-9aa5-4892-968b-62454d606db9" />  | <img width="723" height="610" alt="image" src="https://github.com/user-attachments/assets/c7ae2d03-0af7-4f4e-8404-9922858cc3af" />  |
| Frontend | <img width="680" height="557" alt="image" src="https://github.com/user-attachments/assets/8093020d-8617-4ff7-aa84-00c1ce2a854d" />  | <img width="690" height="547" alt="image" src="https://github.com/user-attachments/assets/0c330bff-55c2-4bae-861e-4f844514225d" />   |

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
