### PR TITLE
fix: wpautop tag mismatch

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -495,6 +495,10 @@ function wpautop( $text, $br = true ) {
 	// Add a double line break after hr tags, which are self closing.
 	$text = preg_replace( '!(<hr\s*?/?>)!', "$1\n\n", $text );
 
+	// Treat <div> as special and put a new line below opening tags and above closing tags
+	$text = preg_replace( '!(<div>)!', "$1\n", $text );
+	$text = preg_replace( '!(</div>)!', "\n$1", $text );
+
 	// Standardize newline characters to "\n".
 	$text = str_replace( array( "\r\n", "\r" ), "\n", $text );
 
@@ -549,6 +553,10 @@ function wpautop( $text, $br = true ) {
 
 	// Under certain strange conditions it could create a P of entirely whitespace.
 	$text = preg_replace( '|<p>\s*</p>|', '', $text );
+
+	// Remove the space we added to the <div> tag
+	$text = preg_replace( "!(<div>)[/\n]+!", '$1', $text );
+	$text = preg_replace( "![/\n]+(</div>)!", '$1', $text );
 
 	// Add a closing <p> inside <div>, <address>, or <form> tag if missing.
 	$text = preg_replace( '!<p>([^<]+)</(div|address|form)>!', '<p>$1</p></$2>', $text );

--- a/tests/phpunit/tests/formatting/wpAutop.php
+++ b/tests/phpunit/tests/formatting/wpAutop.php
@@ -544,6 +544,16 @@ Paragraph two.';
 	}
 
 	/**
+	 * @ticket 37672
+	 */
+	public function test_that_div_content_is_correctly_peed() {
+		$content  = "<div>\nThis is a paragraph.\n\nThis is another paragraph.\n</div>";
+		$expected = "<div>\n<p>This is a paragraph.</p>\n<p>This is another paragraph.</p>\n</div>";
+
+		$this->assertEquals( $expected, trim( wpautop( $content ) ) );
+	}
+
+	/**
 	 * wpautop() should not convert line breaks after <br /> tags
 	 *
 	 * @ticket 33377


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: [https://core.trac.wordpress.org/ticket/37672](https://core.trac.wordpress.org/ticket/37672)

Code used in testing:
```php

function wpautop_test_shortcode() {
    $text = <<<EOT
<div>
This is a paragraph.

This is another paragraph.
</div>
EOT;

    return wpautop($text);
}
add_shortcode('wpautop_test', 'wpautop_test_shortcode');
```


### Before:
<img width="1427" height="878" alt="image" src="https://github.com/user-attachments/assets/caf3bbbc-c300-4548-ba79-7c6a09902ec4" />


### After:
<img width="1428" height="879" alt="image" src="https://github.com/user-attachments/assets/c0f2394f-3177-4e1c-8d7e-616c0650b8de" />
