### PR TITLE
Backport: update theme.json to inherit button styles on frontend

### DIFF
--- a/src/wp-includes/theme.json
+++ b/src/wp-includes/theme.json
@@ -383,6 +383,10 @@
 				"typography": {
 					"fontSize": "inherit",
 					"fontFamily": "inherit",
+					"fontStyle": "inherit",
+					"fontWeight": "inherit",
+					"letterSpacing": "inherit",
+					"textTransform": "inherit",
 					"lineHeight": "inherit",
 					"textDecoration": "none"
 				},


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!
Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->
Part of: https://github.com/WordPress/gutenberg/issues/60403
Backport for: https://github.com/WordPress/gutenberg/pull/70676

The provided code change updates the `theme.json` file to include additional typography styles for button elements. Specifically, it adds "fontStyle", "fontWeight", "letterSpacing", and "textTransform" properties with a value of "inherit". This change aims to address an issue where these styles were not being applied to button elements, despite being set at the root level via Global Styles. The issue was reproducible by updating typography styles in the Site Editor and inserting a Search block, which did not display the expected styles on the front end.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
- Go to the Site Editor > Global Styles > Typography > Text > Typography panel
- Update all styles.
- Insert a Search block in a post and check if it's style is getting inherited on the front end.

## Screenshots or screencast <!-- if applicable -->

### Before
<!-- Add before image URL if available -->
<img width="689" alt="Screenshot 2025-07-10 at 3 11 07 PM" src="https://github.com/user-attachments/assets/283640ff-e53b-40a3-be0f-127c03bb3fde" />

### After
<!-- Add after image URL if available -->
<img width="701" alt="Screenshot 2025-07-10 at 3 11 20 PM" src="https://github.com/user-attachments/assets/22b52e1e-033c-4f54-b502-c6986be62563" />

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->
https://core.trac.wordpress.org/ticket/63700
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
