### PR TITLE
Alternate solution for 63239

### DIFF
--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -168,7 +168,6 @@
 
 .media-item .filename {
 	padding: 14px 0;
-	overflow: hidden;
 	margin-left: 6px;
 }
 
@@ -1246,6 +1245,10 @@ audio, video {
 
 .wp-core-ui .mejs-time {
 	box-sizing: content-box;
+}
+
+.media-item-wrapper .attachment-details {
+	display: flex;
 }
 
 /* =Media Queries

--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -172,7 +172,6 @@
 }
 
 .media-item .pinkynail {
-	float: left;
 	margin: 14px;
 	max-height: 70px;
 	max-width: 70px;


### PR DESCRIPTION
This is an alternate solution for 63239, switching the parent container to flex & removing overflow: hidden.


Trac ticket: https://core.trac.wordpress.org/ticket/63239

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
