### PR TITLE
External Libraries: Adopt standard get_temp_dir() in Text_Diff

### DIFF
--- a/src/wp-includes/Text/Diff.php
+++ b/src/wp-includes/Text/Diff.php
@@ -227,29 +227,7 @@ class Text_Diff {
      */
     static function _getTempDir()
     {
-        $tmp_locations = array('/tmp', '/var/tmp', 'c:\WUTemp', 'c:\temp',
-                               'c:\windows\temp', 'c:\winnt\temp');
-
-        /* Try PHP's upload_tmp_dir directive. */
-        $tmp = ini_get('upload_tmp_dir');
-
-        /* Otherwise, try to determine the TMPDIR environment variable. */
-        if (!strlen($tmp)) {
-            $tmp = getenv('TMPDIR');
-        }
-
-        /* If we still cannot determine a value, then cycle through a list of
-         * preset possibilities. */
-        while (!strlen($tmp) && count($tmp_locations)) {
-            $tmp_check = array_shift($tmp_locations);
-            if (@is_dir($tmp_check)) {
-                $tmp = $tmp_check;
-            }
-        }
-
-        /* If it is still empty, we have failed, so return false; otherwise
-         * return the directory determined. */
-        return strlen($tmp) ? $tmp : false;
+        return get_temp_dir();
     }
 
     /**

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -2209,10 +2209,12 @@ function wp_normalize_path( $path ) {
  *
  * Function's preference is the return value of sys_get_temp_dir(),
  * followed by your PHP temporary upload directory, followed by WP_CONTENT_DIR,
- * before finally defaulting to /tmp/
+ * before finally defaulting to /tmp/.
+ *
+ * Note that sys_get_temp_dir honors the TMPDIR environment variable.
  *
  * In the event that this function does not find a writable location,
- * It may be overridden by the WP_TEMP_DIR constant in your wp-config.php file.
+ * it may be overridden by the WP_TEMP_DIR constant in your wp-config.php file.
  *
  * @since 2.5.0
  *


### PR DESCRIPTION
This was placing files in a potentially different place than the rest of WordPress, and its potential false return value was not checked by the only caller in `Text_Diff_Engine_shell`.

I considered changing our `get_temp_dir` implementations to check the additional directories that `Text_Diff::_getTempDir` considered, but decided against it. The Text_Diff code predates the introduction of sys_get_temp_dir in PHP 5.2, and so likely only checking these to make up for that. The latest upstream version of the code that this is based on, also no longer does this and simply calls sys_get_temp_dir instead. Specifically, it removed `_getTempDir` in favor of `tempnam(null)` [1], and later switched to the horde/util package, [2] which uses `sys_get_temp_dir`. [3]

[1]: https://github.com/horde/Text_Diff/commit/323c4783b9
[2]: https://github.com/horde/Text_Diff/commit/152f6aacf8
[3]: https://github.com/horde/Util/blob/v2.5.12/lib/Horde/Util.php#L200

Trac ticket: https://core.trac.wordpress.org/ticket/63711

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
