### PR TITLE
Cache feeds in site transients.

### DIFF
--- a/src/wp-includes/class-wp-feed-cache-transient.php
+++ b/src/wp-includes/class-wp-feed-cache-transient.php
@@ -84,8 +84,8 @@ class WP_Feed_Cache_Transient implements SimplePie\Cache\Base {
 			$data = $data->data;
 		}
 
-		set_transient( $this->name, $data, $this->lifetime );
-		set_transient( $this->mod_name, time(), $this->lifetime );
+		set_site_transient( $this->name, $data, $this->lifetime );
+		set_site_transient( $this->mod_name, time(), $this->lifetime );
 		return true;
 	}
 
@@ -97,7 +97,7 @@ class WP_Feed_Cache_Transient implements SimplePie\Cache\Base {
 	 * @return array Data for `SimplePie::$data`.
 	 */
 	public function load() {
-		return get_transient( $this->name );
+		return get_site_transient( $this->name );
 	}
 
 	/**
@@ -108,7 +108,7 @@ class WP_Feed_Cache_Transient implements SimplePie\Cache\Base {
 	 * @return int Timestamp.
 	 */
 	public function mtime() {
-		return get_transient( $this->mod_name );
+		return get_site_transient( $this->mod_name );
 	}
 
 	/**
@@ -119,7 +119,7 @@ class WP_Feed_Cache_Transient implements SimplePie\Cache\Base {
 	 * @return bool False if value was not set and true if value was set.
 	 */
 	public function touch() {
-		return set_transient( $this->mod_name, time(), $this->lifetime );
+		return set_site_transient( $this->mod_name, time(), $this->lifetime );
 	}
 
 	/**
@@ -130,8 +130,8 @@ class WP_Feed_Cache_Transient implements SimplePie\Cache\Base {
 	 * @return true Always true.
 	 */
 	public function unlink() {
-		delete_transient( $this->name );
-		delete_transient( $this->mod_name );
+		delete_site_transient( $this->name );
+		delete_site_transient( $this->mod_name );
 		return true;
 	}
 }

--- a/src/wp-includes/class-wp-feed-cache-transient.php
+++ b/src/wp-includes/class-wp-feed-cache-transient.php
@@ -12,6 +12,7 @@
  *
  * @since 2.8.0
  * @since 6.7.0 Now properly implements the SimplePie\Cache\Base interface.
+ * @since 6.9.0 Switched to Multisite's global cache via the `*_site_transient()` functions.
  */
 #[AllowDynamicProperties]
 class WP_Feed_Cache_Transient implements SimplePie\Cache\Base {

--- a/tests/phpunit/tests/feed/fetchFeed.php
+++ b/tests/phpunit/tests/feed/fetchFeed.php
@@ -79,7 +79,7 @@ class Tests_Feed_FetchFeed extends WP_UnitTestCase {
 		switch_to_blog( $second_blog_id );
 
 		fetch_feed( 'https://wordpress.org/news/feed/' );
-		$this->assertEquals( 1, $filter->get_call_count(), 'The feed cache should be be global.' );
+		$this->assertEquals( 1, $filter->get_call_count(), 'The feed cache should be global.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/feed/fetchFeed.php
+++ b/tests/phpunit/tests/feed/fetchFeed.php
@@ -58,6 +58,31 @@ class Tests_Feed_FetchFeed extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure that fetch_feed uses the global cache on Multisite.
+	 *
+	 * @ticket 63719
+	 *
+	 * @group feed
+	 * @group ms-required
+	 *
+	 * @covers ::fetch_feed
+	 * @covers WP_Feed_Cache_Transient
+	 */
+	public function test_fetch_feed_uses_global_cache() {
+		$second_blog_id = self::factory()->blog->create();
+
+		$filter = new MockAction();
+		add_filter( 'pre_http_request', array( $filter, 'filter' ) );
+
+		fetch_feed( 'https://wordpress.org/news/feed/' );
+
+		switch_to_blog( $second_blog_id );
+
+		fetch_feed( 'https://wordpress.org/news/feed/' );
+		$this->assertEquals( 1, $filter->get_call_count(), 'The feed cache should be be global.' );
+	}
+
+	/**
 	 * Mock response for `fetch_feed()`.
 	 *
 	 * This simulates a response from WordPress.org's server for the news feed


### PR DESCRIPTION
Modifies the RSS cache to use site transients so the feeds are cached globally on multisite installs.

~No tests until the ticket fixing feed caching is merged.~

Trac ticket: https://core.trac.wordpress.org/ticket/63719

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
