### PR TITLE
Media: Fix image editor crop button layout with longer translated text

### DIFF
--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -901,6 +901,15 @@ border color while dragging a file over the uploader drop area */
 	display: block;
 }
 
+.imgedit-panel-active .imgedit-group-controls > .imgedit-crop-apply {
+	display: flex;
+}
+
+.imgedit-crop-apply {
+	gap: 4px;
+	flex-wrap: wrap;
+}
+
 .wp_attachment_holder .imgedit-wrap .image-editor {
 	float: right;
 	width: 250px;


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63672

---
### Screenshots after applying patch
<img width="1469" height="795" alt="Screenshot 2025-07-18 at 5 09 51 PM" src="https://github.com/user-attachments/assets/496ca0ad-80e6-41e1-bf63-c9aec32a2237" />
<img width="1469" height="797" alt="Screenshot 2025-07-18 at 5 11 46 PM" src="https://github.com/user-attachments/assets/04eddea9-dc0a-4690-9865-9e56e1c1a669" />

---
**Note:** This solution leverages the flexbox properties to handle variable text lengths across different languages. I've tested the fix with multiple translations including German, and it maintains consistent spacing and alignment. As I'm relatively new to WordPress core contributions, I welcome any feedback or suggestions for alternative implementations that better align with WordPress standards.
