### PR TITLE
Block Bindings: Add `post-data` source, allow binding Date block's `datetime` attr

### DIFF
--- a/src/wp-includes/block-bindings/post-data.php
+++ b/src/wp-includes/block-bindings/post-data.php
@@ -13,7 +13,7 @@
  * @since 6.9.0
  * @access private
  *
- * @param array    $source_args    Array containing source arguments used to look up the override value.
+ * @param array    $source_args    Array containing arguments used to look up the source value.
  *                                 Example: array( "key" => "foo" ).
  * @param WP_Block $block_instance The block instance.
  * @return mixed The value computed for the source.

--- a/src/wp-includes/block-bindings/post-data.php
+++ b/src/wp-includes/block-bindings/post-data.php
@@ -62,7 +62,7 @@ function _register_block_bindings_post_data_source() {
 		array(
 			'label'              => _x( 'Post Data', 'block bindings source' ),
 			'get_value_callback' => '_block_bindings_post_data_get_value',
-			'uses_context'       => array( 'postId', 'postType' ),
+			'uses_context'       => array( 'postId', ),
 		)
 	);
 }

--- a/src/wp-includes/block-bindings/post-data.php
+++ b/src/wp-includes/block-bindings/post-data.php
@@ -60,7 +60,7 @@ function _register_block_bindings_post_data_source() {
 		array(
 			'label'              => _x( 'Post Data', 'block bindings source' ),
 			'get_value_callback' => '_block_bindings_post_data_get_value',
-			'uses_context'       => array( 'postId', ),
+			'uses_context'       => array( 'postId' ),
 		)
 	);
 }

--- a/src/wp-includes/block-bindings/post-data.php
+++ b/src/wp-includes/block-bindings/post-data.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Post Data source for the block bindings.
+ * Post Data source for Block Bindings.
  *
  * @since 6.9.0
  * @package WordPress

--- a/src/wp-includes/block-bindings/post-data.php
+++ b/src/wp-includes/block-bindings/post-data.php
@@ -40,7 +40,7 @@ function _block_bindings_post_data_get_value( array $source_args, $block_instanc
 
 	if ( 'modified' === $source_args['key'] ) {
 		// Only return the modified date if it is later than the publishing date.
-		if ( get_the_modified_date( 'Ymdhi', $post_id ) > get_the_date( 'Ymdhi', $post_id ) ) {
+		if ( get_the_modified_date( 'U', $post_id ) > get_the_date( 'U', $post_id ) ) {
 			return esc_attr( get_the_modified_date( 'c', $post_id ) );
 		} else {
 			return '';

--- a/src/wp-includes/block-bindings/post-data.php
+++ b/src/wp-includes/block-bindings/post-data.php
@@ -39,9 +39,7 @@ function _block_bindings_post_data_get_value( array $source_args, $block_instanc
 	}
 
 	if ( 'modified' === $source_args['key'] ) {
-		/*
-		 * Only return the modified date if it is later than the publishing date.
-		 */
+		// Only return the modified date if it is later than the publishing date.
 		if ( get_the_modified_date( 'Ymdhi', $post_id ) > get_the_date( 'Ymdhi', $post_id ) ) {
 			return esc_attr( get_the_modified_date( 'c', $post_id ) );
 		} else {

--- a/src/wp-includes/block-bindings/post-data.php
+++ b/src/wp-includes/block-bindings/post-data.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Post Data source for the block bindings.
+ *
+ * @since 6.9.0
+ * @package WordPress
+ * @subpackage Block Bindings
+ */
+
+/**
+ * Gets value for Post Data source.
+ *
+ * @since 6.9.0
+ * @access private
+ *
+ * @param array    $source_args    Array containing source arguments used to look up the override value.
+ *                                 Example: array( "key" => "foo" ).
+ * @param WP_Block $block_instance The block instance.
+ * @return mixed The value computed for the source.
+ */
+function _block_bindings_post_data_get_value( array $source_args, $block_instance ) {
+	if ( empty( $source_args['key'] ) ) {
+		return null;
+	}
+
+	if ( empty( $block_instance->context['postId'] ) ) {
+		return null;
+	}
+	$post_id = $block_instance->context['postId'];
+
+	// If a post isn't public, we need to prevent unauthorized users from accessing the post data.
+	$post = get_post( $post_id );
+	if ( ( ! is_post_publicly_viewable( $post ) && ! current_user_can( 'read_post', $post_id ) ) || post_password_required( $post ) ) {
+		return null;
+	}
+
+	if ( 'date' === $source_args['key'] ) {
+		return esc_attr( get_the_date( 'c', $post_id ) );
+	}
+
+	if ( 'modified' === $source_args['key'] ) {
+		/*
+		 * Only return the modified date if it is later than the publishing date.
+		 */
+		if ( get_the_modified_date( 'Ymdhi', $post_id ) > get_the_date( 'Ymdhi', $post_id ) ) {
+			return esc_attr( get_the_modified_date( 'c', $post_id ) );
+		} else {
+			return '';
+		}
+	}
+}
+
+/**
+ * Registers Post Data source in the block bindings registry.
+ *
+ * @since 6.9.0
+ * @access private
+ */
+function _register_block_bindings_post_data_source() {
+	register_block_bindings_source(
+		'core/post-data',
+		array(
+			'label'              => _x( 'Post Data', 'block bindings source' ),
+			'get_value_callback' => '_block_bindings_post_data_get_value',
+			'uses_context'       => array( 'postId', 'postType' ),
+		)
+	);
+}
+
+add_action( 'init', '_register_block_bindings_post_data_source' );

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -285,6 +285,7 @@ class WP_Block {
 			'core/heading'   => array( 'content' ),
 			'core/image'     => array( 'id', 'url', 'title', 'alt' ),
 			'core/button'    => array( 'url', 'text', 'linkTarget', 'rel' ),
+			'core/post-date' => array( 'datetime' ),
 		);
 
 		// If the block doesn't have the bindings property, isn't one of the supported

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -364,6 +364,7 @@ require ABSPATH . WPINC . '/class-wp-classic-to-block-menu-converter.php';
 require ABSPATH . WPINC . '/class-wp-navigation-fallback.php';
 require ABSPATH . WPINC . '/block-bindings.php';
 require ABSPATH . WPINC . '/block-bindings/pattern-overrides.php';
+require ABSPATH . WPINC . '/block-bindings/post-data.php';
 require ABSPATH . WPINC . '/block-bindings/post-meta.php';
 require ABSPATH . WPINC . '/blocks.php';
 require ABSPATH . WPINC . '/blocks/index.php';

--- a/tests/phpunit/includes/functions.php
+++ b/tests/phpunit/includes/functions.php
@@ -348,6 +348,7 @@ function _unhook_block_registration() {
 
 	// Block binding sources.
 	remove_action( 'init', '_register_block_bindings_pattern_overrides_source' );
+	remove_action( 'init', '_register_block_bindings_post_data_source' );
 	remove_action( 'init', '_register_block_bindings_post_meta_source' );
 }
 tests_add_filter( 'init', '_unhook_block_registration', 1000 );

--- a/tests/phpunit/tests/block-bindings/register.php
+++ b/tests/phpunit/tests/block-bindings/register.php
@@ -72,6 +72,7 @@ class Tests_Block_Bindings_Register extends WP_UnitTestCase {
 			$source_one_name         => new WP_Block_Bindings_Source( $source_one_name, $source_one_properties ),
 			$source_two_name         => new WP_Block_Bindings_Source( $source_two_name, $source_two_properties ),
 			$source_three_name       => new WP_Block_Bindings_Source( $source_three_name, $source_three_properties ),
+			'core/post-data'         => get_block_bindings_source( 'core/post-data' ),
 			'core/post-meta'         => get_block_bindings_source( 'core/post-meta' ),
 			'core/pattern-overrides' => get_block_bindings_source( 'core/pattern-overrides' ),
 		);


### PR DESCRIPTION
Core port of https://github.com/WordPress/gutenberg/pull/70585 and https://github.com/WordPress/gutenberg/pull/70982. 

Trac ticket: https://core.trac.wordpress.org/ticket/63741

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
