### PR TITLE
change margin of search-box in admin to inline with menu entries

### DIFF
--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -726,7 +726,7 @@ p.search-box {
 	column-gap: 0.5rem;
 	position: relative;
 	float: right;
-	margin: 11px 0;
+	margin: 6px 0;
 }
 
 .network-admin.themes-php p.search-box {


### PR DESCRIPTION
On the Plugins page, the .search-box element is visually misaligned, it does not line up with the surrounding menu entries. This creates an inconsistent and slightly jarring user experience.

I simply adjusted the CSS rule for .search-box in forms.css to `margin: 6px 0;` as suggested by [@Presskopp](https://profiles.wordpress.org/presskopp).

Trac ticket: [https://core.trac.wordpress.org/ticket/63726](https://core.trac.wordpress.org/ticket/63726)

