### PR TITLE
fix: ensure site title link color displays correctly in editor and frontend

### DIFF
--- a/src/wp-content/themes/twentynineteen/style-editor.css
+++ b/src/wp-content/themes/twentynineteen/style-editor.css
@@ -740,6 +740,18 @@ h6 {
   font-size: 0.71111em;
 }
 
+/** === Site Title Block === */
+.wp-block-site-title a {
+  transition: color 110ms ease-in-out;
+  color: #0073aa;
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+}
+
+.wp-block-site-title a:focus {
+  text-decoration-thickness: 2px;
+}
+
 a {
   transition: color 110ms ease-in-out;
   color: #0073aa;

--- a/src/wp-content/themes/twentynineteen/style-editor.scss
+++ b/src/wp-content/themes/twentynineteen/style-editor.scss
@@ -155,6 +155,19 @@ h6 {
 	font-size: $font__size-xs;
 }
 
+/** === Site Title Block === */
+
+.wp-block-site-title a {
+	@include link-transition;
+	color: $color__link;
+	text-decoration: underline;
+	text-decoration-thickness: 2px;
+
+	&:focus {
+		text-decoration-thickness: 2px;
+	}
+}
+
 a {
 	@include link-transition;
 	color: $color__link;


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/59164

This PR fixes the Site Title block’s link color in the editor to match the frontend.

**Note:** As mentioned in [this comment](https://core.trac.wordpress.org/ticket/59164#comment:3), the background color issue is separate and reported in multiple tickets, so it is not addressed in this PR.

## Screenshot
https://github.com/user-attachments/assets/de68a4d5-7699-4683-a533-68ee22d0b1da

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
