### PR TITLE
General: Prevent php warning for not readable files

### DIFF
--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -1330,12 +1330,18 @@ final class WP_Theme implements ArrayAccess {
 			$files = (array) $this->get_files( 'php', 1, true );
 
 			foreach ( $files as $file => $full_path ) {
-				if ( ! preg_match( '|Template Name:(.*)$|mi', file_get_contents( $full_path ), $header ) ) {
+				$file_content = @file_get_contents( $full_path );
+
+				if ( ! $file_content ) {
+					continue;
+				}
+
+				if ( ! preg_match( '|Template Name:(.*)$|mi', $file_content, $header ) ) {
 					continue;
 				}
 
 				$types = array( 'page' );
-				if ( preg_match( '|Template Post Type:(.*)$|mi', file_get_contents( $full_path ), $type ) ) {
+				if ( preg_match( '|Template Post Type:(.*)$|mi', $file_content, $type ) ) {
 					$types = explode( ',', _cleanup_header_comment( $type[1] ) );
 				}
 


### PR DESCRIPTION
Having unreadable php-files in theme-directory triggers following php-warning:

> file_get_contents(/path/to/theme//maySubdir/file.php): Failed to open stream: No such file or directory in /wp-includes/class-wp-theme.php#L1333

This PR hardens the `get_post_templates()` function a bit.

Trac:
https://core.trac.wordpress.org/ticket/63743