### PR TITLE
63714 - Ensure `wp_get_attachment_image()` doesn't overwrite an already valid user-provided width and height

### DIFF
--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1094,12 +1094,12 @@ function wp_get_attachment_image( $attachment_id, $size = 'thumbnail', $icon = f
 		$attr = wp_parse_args( $attr, $default_attr );
 
 		// Ensure that the `$width` doesn't overwrite an already valid user-provided width.
-		if ( is_numeric( $width ) && ( ! isset( $attr['width'] ) || ! is_numeric( $attr['width'] ) ) ) {
+		if ( ! isset( $attr['width'] ) || ! is_numeric( $attr['width'] ) ) {
 			$attr['width'] = $width;
 		}
 
 		// Ensure that the `$height` doesn't overwrite an already valid user-provided height.
-		if ( is_numeric( $height ) && ( ! isset( $attr['height'] ) || ! is_numeric( $attr['height'] ) ) ) {
+		if ( ! isset( $attr['height'] ) || ! is_numeric( $attr['height'] ) ) {
 			$attr['height'] = $height;
 		}
 

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -1091,9 +1091,17 @@ function wp_get_attachment_image( $attachment_id, $size = 'thumbnail', $icon = f
 		 */
 		$context = apply_filters( 'wp_get_attachment_image_context', 'wp_get_attachment_image' );
 
-		$attr           = wp_parse_args( $attr, $default_attr );
-		$attr['width']  = $width;
-		$attr['height'] = $height;
+		$attr = wp_parse_args( $attr, $default_attr );
+
+		// Ensure that the `$width` doesn't overwrite an already valid user-provided width.
+		if ( is_numeric( $width ) && ( ! isset( $attr['width'] ) || ! is_numeric( $attr['width'] ) ) ) {
+			$attr['width'] = $width;
+		}
+
+		// Ensure that the `$height` doesn't overwrite an already valid user-provided height.
+		if ( is_numeric( $height ) && ( ! isset( $attr['height'] ) || ! is_numeric( $attr['height'] ) ) ) {
+			$attr['height'] = $height;
+		}
 
 		$loading_optimization_attr = wp_get_loading_optimization_attributes(
 			'img',

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -1635,6 +1635,33 @@ EOF;
 	}
 
 	/**
+	 * Test that `wp_get_attachment_image` doesn't overwrite an already valid user-provided width and height.
+	 *
+	 * @ticket 63714
+	 */
+	public function test_wp_get_attachment_image_not_overwrite_user_provided_width_height() {
+		[$src, $width, $height] = wp_get_attachment_image_src( self::$large_id, 'large' );
+
+		$user_provided_width  = is_numeric( $width ) ? (int) $width + 1 : 999;
+		$user_provided_height = is_numeric( $height ) ? (int) $height + 1 : 199;
+
+		$img = wp_get_attachment_image(
+			self::$large_id,
+			'large',
+			false,
+			array(
+				'width'  => $user_provided_width,
+				'height' => $user_provided_height,
+			)
+		);
+
+		$expected_width_attribute  = 'width="' . $user_provided_width . '"';
+		$expected_height_attribute = 'height="' . $user_provided_height . '"';
+		$this->assertStringContainsString( $expected_width_attribute, $img, 'User-provided width should not be changed.' );
+		$this->assertStringContainsString( $expected_height_attribute, $img, 'User-provided height should not be changed.' );
+	}
+
+	/**
 	 * Test that `wp_get_attachment_image()` returns a proper alt value.
 	 *
 	 * @ticket 34635

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -1640,25 +1640,18 @@ EOF;
 	 * @ticket 63714
 	 */
 	public function test_wp_get_attachment_image_not_overwrite_user_provided_width_height() {
-		[$src, $width, $height] = wp_get_attachment_image_src( self::$large_id, 'large' );
-
-		$user_provided_width  = is_numeric( $width ) ? (int) $width + 1 : 999;
-		$user_provided_height = is_numeric( $height ) ? (int) $height + 1 : 199;
-
 		$img = wp_get_attachment_image(
 			self::$large_id,
 			'large',
 			false,
 			array(
-				'width'  => $user_provided_width,
-				'height' => $user_provided_height,
+				'width'  => 999,
+				'height' => 999,
 			)
 		);
 
-		$expected_width_attribute  = 'width="' . $user_provided_width . '"';
-		$expected_height_attribute = 'height="' . $user_provided_height . '"';
-		$this->assertStringContainsString( $expected_width_attribute, $img, 'User-provided width should not be changed.' );
-		$this->assertStringContainsString( $expected_height_attribute, $img, 'User-provided height should not be changed.' );
+		$this->assertStringContainsString( 'width="999"', $img, 'User-provided width should not be changed.' );
+		$this->assertStringContainsString( 'height="999"', $img, 'User-provided height should not be changed.' );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63714

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
