### PR TITLE
Fix protocol typo in font attribution URL in Twenty Twenty-Five

### DIFF
--- a/src/wp-content/themes/twentytwentyfive/readme.txt
+++ b/src/wp-content/themes/twentytwentyfive/readme.txt
@@ -103,7 +103,7 @@ Source: https://fonts.google.com/specimen/Literata
 
 Roboto Slab Font
 License: SIL Open Font License, 1.1, https://opensource.org/licenses/OFL-1.1
-Reference: hhttps://github.com/googlefonts/robotoslab
+Reference: https://github.com/googlefonts/robotoslab
 Source: https://fonts.google.com/specimen/Roboto+Slab
 
 Beiruti Font


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This pull request corrects a protocol typo in the font attribution section of the Twenty Twenty-Five theme's readme.txt file. The update ensures the referenced URL uses the correct protocol, improving accuracy and reliability of the documentation.

Trac ticket: https://core.trac.wordpress.org/ticket/63747

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
