### PR TITLE
Fix: Nav Menu add 'No Items' text when 'Most Used' Tab in Category is empty

### DIFF
--- a/src/wp-admin/includes/nav-menu.php
+++ b/src/wp-admin/includes/nav-menu.php
@@ -993,7 +993,7 @@ function wp_nav_menu_item_taxonomy_meta_box( $data_object, $box ) {
 				);
 
 				$args['walker'] = $walker;
-				if ( ! $popular_terms ){
+				if ( ! $popular_terms ) {
 					echo '<p>' . __( 'No items.' ) . '</p>';
 				}
 				echo walk_nav_menu_tree(

--- a/src/wp-admin/includes/nav-menu.php
+++ b/src/wp-admin/includes/nav-menu.php
@@ -993,6 +993,9 @@ function wp_nav_menu_item_taxonomy_meta_box( $data_object, $box ) {
 				);
 
 				$args['walker'] = $walker;
+				if ( ! $popular_terms ){
+					echo '<p>' . __( 'No items.' ) . '</p>';
+				}
 				echo walk_nav_menu_tree(
 					array_map( 'wp_setup_nav_menu_item', $popular_terms ),
 					0,


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/43538

### Before:
<img width="414" height="368" alt="before-blank-most-used-category" src="https://github.com/user-attachments/assets/f324dca7-5270-4181-941a-1c22d77127cc" />

### After:
<img width="417" height="368" alt="after-blank-most-used-category png" src="https://github.com/user-attachments/assets/1a073914-98b9-4ef3-982b-8e7424d6a528" />

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
