### PR TITLE
Performance: Optimize ASCII spans in `seems_utf8()`.

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -885,7 +885,9 @@ function seems_utf8( $str ) {
 	$length = strlen( $str );
 	reset_mbstring_encoding();
 
-	for ( $i = 0; $i < $length; $i++ ) {
+	$valid = true;
+
+	for ( $i = 0; $i < $length && $valid; $i++ ) {
 		/*
 		 * Since all US-ASCII bytes, or all octets from x00–x7F, are valid UTF-8,
 		 * it’s possible to skip past ranges of all-ASCII bytes using internal PHP
@@ -895,9 +897,7 @@ function seems_utf8( $str ) {
 		 */
 		$i += strspn(
 			$str,
-			"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f" .
-			"\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f" .
-			" !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\x7f",
+			"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\x7f",
 			$i
 		);
 		if ( $i >= $length ) {
@@ -918,17 +918,35 @@ function seems_utf8( $str ) {
 		} elseif ( ( $c & 0xFE ) === 0xFC ) {
 			$n = 5; // 1111110b
 		} else {
-			return false; // Does not match any model.
+			$n = $length; // This wil reject on the next check.
 		}
 
-		for ( $j = 0; $j < $n; $j++ ) { // n bytes matching 10bbbbbb follow?
-			if ( ( ++$i === $length ) || ( ( ord( $str[ $i ] ) & 0xC0 ) !== 0x80 ) ) {
-				return false;
-			}
+		if ( $i + $n >= $length ) {
+			return false;
 		}
+
+		switch ( $n ) {
+			case 5:
+				$valid &= ( ord( $str[ $i + 5 ] ) & 0xC0 ) === 0x80;
+				// fallthrough
+			case 4:
+				$valid &= ( ord( $str[ $i + 4 ] ) & 0xC0 ) === 0x80;
+				// fallthrough
+			case 3:
+				$valid &= ( ord( $str[ $i + 3 ] ) & 0xC0 ) === 0x80;
+				// fallthrough
+			case 2:
+				$valid &= ( ord( $str[ $i + 2 ] ) & 0xC0 ) === 0x80;
+				// fallthrough
+			case 1:
+				$valid &= ( ord( $str[ $i + 1 ] ) & 0xC0 ) === 0x80;
+				break;
+		}
+
+		$i += $n;
 	}
 
-	return true;
+	return (bool) $valid;
 }
 
 /**

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -888,26 +888,11 @@ function seems_utf8( $str ) {
 	$valid = true;
 
 	for ( $i = 0; $i < $length && $valid; $i++ ) {
-		/*
-		 * Since all US-ASCII bytes, or all octets from x00–x7F, are valid UTF-8,
-		 * it’s possible to skip past ranges of all-ASCII bytes using internal PHP
-		 * functions. On typical HTML pages this can lead to major performance
-		 * improvements; up to around 10x without JIT optimization, and up to
-		 * around 100x with it.
-		 */
-		$i += strspn(
-			$str,
-			"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\x7f",
-			$i
-		);
-		if ( $i >= $length ) {
-			break;
-		}
-
-		// Everything past here starts a multibyte sequence.
 		$c = ord( $str[ $i ] );
 
-		if ( ( $c & 0xE0 ) === 0xC0 ) {
+		if ( $c < 0x80 ) {
+			continue;
+		} elseif ( ( $c & 0xE0 ) === 0xC0 ) {
 			$n = 1; // 110bbbbb
 		} elseif ( ( $c & 0xF0 ) === 0xE0 ) {
 			$n = 2; // 1110bbbb

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -886,11 +886,28 @@ function seems_utf8( $str ) {
 	reset_mbstring_encoding();
 
 	for ( $i = 0; $i < $length; $i++ ) {
+		/*
+		 * Since all US-ASCII bytes, or all octets from x00–x7F, are valid UTF-8,
+		 * it’s possible to skip past ranges of all-ASCII bytes using internal PHP
+		 * functions. On typical HTML pages this can lead to major performance
+		 * improvements; up to around 10x without JIT optimization, and up to
+		 * around 100x with it.
+		 */
+		$i += strspn(
+			$str,
+			"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f" .
+			"\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f" .
+			" !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\x7f",
+			$i
+		);
+		if ( $i >= $length ) {
+			break;
+		}
+
+		// Everything past here starts a multibyte sequence.
 		$c = ord( $str[ $i ] );
 
-		if ( $c < 0x80 ) {
-			$n = 0; // 0bbbbbbb
-		} elseif ( ( $c & 0xE0 ) === 0xC0 ) {
+		if ( ( $c & 0xE0 ) === 0xC0 ) {
 			$n = 1; // 110bbbbb
 		} elseif ( ( $c & 0xF0 ) === 0xE0 ) {
 			$n = 2; // 1110bbbb


### PR DESCRIPTION
Trac ticket: Core-63755
Replaces #9307 

This patch introduces a speedup for the `seems_utf8()` function. Currently, the function scans every byte in user-land PHP code. This is prohibitively slow. In this change, spans of ASCII bytes are fast-tracked through the use of `strspn()`, which can scan valid UTF-8 single-byte characters at around 3600 MB/s instead of around 300 MB/s as is the case with the existing code.

## Performance notes

This function only appears in Core in any meaningful way inside `export_wp()`. It runs inside some title and filename sanitization, and some other code paths with expectedly-short strings. So my benchmarks are being conducted not on page renders (where the impact was undetectable) but rather on an export of an imported copy of my blog, https://fluffyandflakey.blog.

I’ve modified Core in my tests with the following patch which allows me to easily `curl` a request to the test server and time the export in its totality.

```diff
diff --git a/src/wp-settings.php b/src/wp-settings.php
index 60ffc307c5..ffd46a212e 100644
--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -736,6 +736,19 @@ if ( is_multisite() ) {
 	unset( $file );
 }
 
+if ( str_contains( $_SERVER['QUERY_STRING'] ?? '', 'dms_do=export' ) ) {
+	/** Load WordPress export API */
+	require_once ABSPATH . 'wp-admin/includes/export.php';
+
+	ob_start();
+	$ms = -hrtime( true );
+	export_wp();
+	$ms += hrtime( true ); $ms = $ms / 1e6;
+	ob_end_clean();
+	echo "Server-Timing: wp-total;dur={$ms}";
+	die();
+}
+
 /**
  * This hook is fired once WP, all plugins, and the theme are fully loaded and instantiated.
  *
```

## Benchmarks

Surprisingly the first version of this is testing _slower_ than `trunk` and I am not sure why, other than assuming it has to do with one of two things:

<details><summary>how much slower is 2b0414557b92061163059858e1416269d5346bf6?</summary>
<img width="2099" height="2099" alt="repeat-ms" src="https://github.com/user-attachments/assets/ae98868a-30ce-4df1-b88c-5fe1e28faaae" />

</details>

 - ~I’m creating the string via concatenation which might inadvertently create a string on every character. Oops.~
 - The short-length string overhead is too high.

So I pushed out a new commit that makes the string a single static literal and which also attempts to skip some branching and de-optimizations in the CPU. I probably shouldn’t have done that 🤷‍♂️ 

---

This continues to beguile me, because when I test the function on actual strings it runs at 2–3 GB/s compared to 36 MB/s or 290 MB/s in `trunk` (depending on whether the JIT is running and optimized).

I’m still not sure that my tests aren’t wrong, but I did check against a control where the only change was to a comment, and indeed, both test groups ran identically there. I also swapped the `git` SHAs in my test file to ensure that they would run in the opposite order as earlier but it didn’t change the result (there is not a bias from the first-run test group).

Something in this branch is causing slower exports.