### PR TITLE
Fix missing blog_id property in get_blogs_of_user() for single-site

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -1051,6 +1051,7 @@ function get_blogs_of_user( $user_id, $all = false ) {
 	if ( ! is_multisite() ) {
 		$site_id                        = get_current_blog_id();
 		$sites                          = array( $site_id => new stdClass() );
+		$sites[ $site_id ]->blog_id     = $site_id;
 		$sites[ $site_id ]->userblog_id = $site_id;
 		$sites[ $site_id ]->blogname    = get_option( 'blogname' );
 		$sites[ $site_id ]->domain      = '';


### PR DESCRIPTION

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
**Summary**
Fixed a backward compatibility issue in WordPress core where get_blogs_of_user() function returns objects missing the blog_id property on single-site installations.

**Problem**
- On single-site WordPress installs, get_blogs_of_user() returns stdClass objects without the blog_id property
- This causes downstream code to break when expecting a valid blog_id (e.g., absint() calls with undefined properties)
- The issue affects core WordPress functions and plugins that rely on the blog_id property being presen

Trac ticket: https://core.trac.wordpress.org/ticket/63730

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
