### PR TITLE
Don't run WP-CLI commands as root

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
 		"env:clean": "node ./tools/local-env/scripts/docker.js down -v --remove-orphans",
 		"env:reset": "node ./tools/local-env/scripts/docker.js down --rmi all -v --remove-orphans",
 		"env:install": "node ./tools/local-env/scripts/install.js",
-		"env:cli": "node ./tools/local-env/scripts/docker.js exec cli wp --allow-root",
+		"env:cli": "node ./tools/local-env/scripts/docker.js exec --user wp_php cli wp",
 		"env:logs": "node ./tools/local-env/scripts/docker.js logs",
 		"env:pull": "node ./tools/local-env/scripts/docker.js pull",
 		"test:performance": "wp-scripts test-playwright --config tests/performance/playwright.config.js",

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -15,9 +15,6 @@ local_env_utils.determine_auth_option();
 // Create wp-config.php.
 wp_cli( `config create --dbname=wordpress_develop --dbuser=root --dbpass=password --dbhost=mysql --force --config-file="wp-config.php"` );
 
-// Since WP-CLI runs as root, the wp-config.php created above will be read-only. This needs to be writable for the sake of E2E tests.
-execSync( 'node ./tools/local-env/scripts/docker.js exec cli chmod 666 wp-config.php' );
-
 // Add the debug settings to wp-config.php.
 // Windows requires this to be done as an additional step, rather than using the --extra-php option in the previous step.
 wp_cli( `config set WP_DEBUG ${process.env.LOCAL_WP_DEBUG} --raw --type=constant` );


### PR DESCRIPTION
The WP-CLI container runs as root. [Its entrypoint script](https://github.com/WordPress/wpdev-docker-images/blob/d4515b944ddd4b7d97c79b2b1adb6944c5b869ee/images/8.4/cli/entrypoint.sh) uses sudo to run commands as the `wp_php` user, but the entrypoint is bypassed when you use `docker compose exec`. This is why the `--allow-root` flag is needed in the `docker compose exec` commands which are used since r60308.

We can't add `user: wp_php` to docker-compose.yml because when the container initially starts the entrypoint script still runs but `wp_php` isn't in the sudoers list and therefore terminates. What we can do is run `docker compose exec` with the `--user wp_php` flag and everything is rosey.

Trac ticket: https://core.trac.wordpress.org/ticket/63167
Trac ticket: https://core.trac.wordpress.org/ticket/63564