### PR TITLE
Check presence of 'slug'-key before accessing it.

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -3255,7 +3255,7 @@ class WP_Theme_JSON {
 					// Set names for theme presets based on the slug if they are not set and can use default names.
 					if ( 'theme' === $origin && $preset_metadata['use_default_names'] ) {
 						foreach ( $content as $key => $item ) {
-							if ( ! isset( $item['name'] ) ) {
+							if ( ! isset( $item['name'] ) && isset( $item['slug'] ) ) {
 								$name = static::get_name_from_defaults( $item['slug'], $base_path );
 								if ( null !== $name ) {
 									$content[ $key ]['name'] = $name;


### PR DESCRIPTION
This fixes the following warning spamming my logs:

```
PHP message: PHP Warning: Undefined array key "slug" in [...]/wp-includes/class-wp-theme-json.php on line 3264;
```

It appears to me that there is a discrepancy between my theme.json and that code. However, my theme.json was only changed through the official editor. Unfortunately, I'm unable to recall all the steps I did.

Nonetheless, I would propose adding a isset( $item['slug'] ) check before accessing it in the code that is raising the above warning.

Trac ticket: https://core.trac.wordpress.org/ticket/63756#ticket