### PR TITLE
Adding Edit/PUT Method for Template REST API Endpoint.

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -41,8 +41,8 @@ class WP_REST_Server {
 
 	/**
 	 * Alias for PUT transport method.
-	 * 
-	 * @since 6.9.0
+	 *
+	 * @since 7.0.0
 	 * @var string
 	 */
 	const UPDATABLE = 'PUT, PATCH';

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -40,6 +40,14 @@ class WP_REST_Server {
 	const EDITABLE = 'POST, PUT, PATCH';
 
 	/**
+	 * Alias for PUT transport method.
+	 * 
+	 * @since 6.9.0
+	 * @var string
+	 */
+	const UPDATABLE = 'PUT, PATCH';
+
+	/**
 	 * Alias for DELETE transport method.
 	 *
 	 * @since 4.4.0

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php
@@ -62,6 +62,12 @@ class WP_REST_Templates_Controller extends WP_REST_Controller {
 					'permission_callback' => array( $this, 'create_item_permissions_check' ),
 					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
 				),
+				array(
+					'methods'             => WP_REST_Server::UPDATABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::UPDATABLE ),
+				),
 				'schema' => array( $this, 'get_public_item_schema' ),
 			)
 		);


### PR DESCRIPTION
Maybe if what I was explaining in the OP was not clear, this is an example to showcase what I mean.

Here there is not much to test. The testing part must be done in the Gutenberg Post I mentioned above (using the patch)

Trac ticket: https://core.trac.wordpress.org/ticket/63761

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**