### PR TITLE
Escaping fix: use json encoding withing script tag.

### DIFF
--- a/src/wp-admin/async-upload.php
+++ b/src/wp-admin/async-upload.php
@@ -142,10 +142,10 @@ if ( is_wp_error( $id ) ) {
 	$speak_message = sprintf(
 		/* translators: %s: Name of the file that failed to upload. */
 		__( '%s has failed to upload.' ),
-		esc_js( $_FILES['async-upload']['name'] )
+		$_FILES['async-upload']['name']
 	);
 
-	echo "<script>_.delay(function() {wp.a11y.speak('" . esc_js( $speak_message ) . "');}, 1500);jQuery( 'button#{$button_unique_id}' ).on( 'click', function() {jQuery(this).parents('div.media-item').slideUp(200, function(){jQuery(this).remove();wp.a11y.speak( wp.i18n.__( 'Error dismissed.' ) );jQuery( '#plupload-browse-button' ).trigger( 'focus' );})});</script>\n";
+	echo '<script>_.delay(function() {wp.a11y.speak(' . wp_json_encode( $speak_message ) . ");}, 1500);jQuery( 'button#{$button_unique_id}' ).on( 'click', function() {jQuery(this).parents('div.media-item').slideUp(200, function(){jQuery(this).remove();wp.a11y.speak( wp.i18n.__( 'Error dismissed.' ) );jQuery( '#plupload-browse-button' ).trigger( 'focus' );})});</script>\n";
 	exit;
 }
 


### PR DESCRIPTION
Follow up to r60263.

The original commit uses `esc_js()` within a `<script>` tag rather than `wp_json_encode()`. Per the docs, the `esc_js()` function is [intended to be used within inline script handlers](https://developer.wordpress.org/reference/functions/esc_js/), `onclick="thing"`, rather than within JavaScript tags.

Trac ticket: https://core.trac.wordpress.org/ticket/63114

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
