### PR TITLE
Retry database reset a few times to allow time for it to come online.

### DIFF
--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -49,7 +49,7 @@ wait_on( {
 		process.exit( 1 );
 	} )
 	.then( () => {
-		wp_cli( 'db reset --yes' );
+		wp_cli_retry( 'db reset --yes' );
 		const installCommand = process.env.LOCAL_MULTISITE === 'true'  ? 'multisite-install' : 'install';
 		wp_cli( `core ${ installCommand } --title="WordPress Develop" --admin_user=admin --admin_password=password --admin_email=test@example.com --skip-email --url=http://localhost:${process.env.LOCAL_PORT}` );
 	} )
@@ -65,4 +65,19 @@ wait_on( {
  */
 function wp_cli( cmd ) {
 	execSync( `npm --silent run env:cli -- ${cmd} --path=/var/www/${process.env.LOCAL_DIR}`, { stdio: 'inherit' } );
+}
+
+function wp_cli_retry( cmd, retries = 5 ) {
+	try {
+		wp_cli( cmd );
+	} catch ( e ) {
+		if ( retries > 0 ) {
+			console.warn( `Retrying command "${cmd}" (${retries} retries left)...` );
+			// Wait a bit before retrying.
+			setTimeout( () => {}, 1000 );
+			wp_cli_retry( cmd, retries - 1 );
+		} else {
+			throw e;
+		}
+	}
 }

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -67,6 +67,15 @@ function wp_cli( cmd ) {
 	execSync( `npm --silent run env:cli -- ${cmd} --path=/var/www/${process.env.LOCAL_DIR}`, { stdio: 'inherit' } );
 }
 
+/**
+ * Runs a WP-CLI command in the Docker environment with retry logic.
+ *
+ * If the command fails, the function will retry the command the
+ * specified number of times with a short delay between attempts.
+ *
+ * @param {string} cmd The WP-CLI command to run.
+ * @param {number} retries The number of retries left. Default to 5.
+ */
 function wp_cli_retry( cmd, retries = 5 ) {
 	try {
 		wp_cli( cmd );


### PR DESCRIPTION
This is an attempt to recover if the database server hasn't completed booting when the web server starts.

If the `wp db reset` command fails, it will be retried a number of times to ensure that the error is permanent rather than temporary. 

On the test suite, I've been seeing a lot of failures that are seemingly caused by a race condition rather than an error when docker is started. As a case in point, [see this action run](https://github.com/WordPress/wordpress-develop/actions/runs/16559505260/job/46826407121).

I've not seen any such errors with this code but that may be dumb luck rather than anything I've fixed.

Trac ticket: https://core.trac.wordpress.org/ticket/63167

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
