### PR TITLE
Output custom CSS as separate styles in block themes

### DIFF
--- a/src/js/_enqueues/wp/customize/preview.js
+++ b/src/js/_enqueues/wp/customize/preview.js
@@ -639,7 +639,7 @@
 		 * @return {void}
 		 */
 		custom_css: function( value ) {
-			$( '#wp-custom-css' ).text( value );
+			$( '#wp-custom-css-inline-css' ).text( value );
 		},
 
 		/**

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2535,20 +2535,6 @@ function wp_enqueue_global_styles() {
 
 	$stylesheet = wp_get_global_stylesheet();
 
-	if ( $is_block_theme ) {
-		/*
-		 * Dequeue the Customizer's custom CSS
-		 * and add it before the global styles custom CSS.
-		 */
-		remove_action( 'wp_head', 'wp_custom_css_cb', 101 );
-		// Get the custom CSS from the Customizer and add it to the global stylesheet.
-		$custom_css  = wp_get_custom_css();
-		$stylesheet .= $custom_css;
-
-		// Add the global styles custom CSS at the end.
-		$stylesheet .= wp_get_global_stylesheet( array( 'custom-css' ) );
-	}
-
 	if ( empty( $stylesheet ) ) {
 		return;
 	}
@@ -2556,6 +2542,24 @@ function wp_enqueue_global_styles() {
 	wp_register_style( 'global-styles', false );
 	wp_add_inline_style( 'global-styles', $stylesheet );
 	wp_enqueue_style( 'global-styles' );
+
+	if ( $is_block_theme ) {
+		/*
+		* Dequeue the Customizer's custom CSS
+		* and add it before the global styles custom CSS.
+		*/
+		remove_action( 'wp_head', 'wp_custom_css_cb', 101 );
+		$customizer_custom_css  = wp_get_custom_css();
+		wp_register_style( 'wp-custom-css', false );
+		wp_add_inline_style( 'wp-custom-css', $customizer_custom_css );
+		wp_enqueue_style( 'wp-custom-css' );
+
+		// Enqueue the global styles custom CSS.
+		$global_styles_custom_css = wp_get_global_stylesheet( array( 'custom-css' ) );
+		wp_register_style( 'global-styles-custom-css', false );
+		wp_add_inline_style( 'global-styles-custom-css', $global_styles_custom_css );
+		wp_enqueue_style( 'global-styles-custom-css' );
+	}
 
 	// Add each block as an inline css.
 	wp_add_global_styles_for_blocks();

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -1958,7 +1958,7 @@ function wp_custom_css_cb() {
 	if ( $styles || is_customize_preview() ) :
 		$type_attr = current_theme_supports( 'html5', 'style' ) ? '' : ' type="text/css"';
 		?>
-		<style<?php echo $type_attr; ?> id="wp-custom-css">
+		<style<?php echo $type_attr; ?> id="wp-custom-css-inline-css">
 			<?php
 			// Note that esc_html() cannot be used because `div &gt; span` is not interpreted properly.
 			echo strip_tags( $styles );


### PR DESCRIPTION
Alternatives to #9000

Trac ticket: https://core.trac.wordpress.org/ticket/63589

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

---

This PR tries to solve both of these problems by separating the two custom CSS styles from the global style inline styles:

- Allow live preview of custom CSS in the Customizer
- Add the Customizer custom CSS before the global style custom CSS

This means that the output CSS will change as follows in both the Customizer and the frontend.

#### Before

```html
<style id="global-styles-inline-css">
:root{}
.customizer-custom-css {}
.site-editor-custom-css {}
</style>

<style id="core-block-supports-inline-css">
.wp-container-core-navigation-is-layout-xxxxxx {}
</style>
```

#### After

```html
<style id="global-styles-inline-css">
:root{}
</style>

<style id="wp-custom-css-inline-css">
.customizer-custom-css {}
</style>

<style id="global-styles-custom-css-inline-css">
.site-editor-custom-css {}
</style>

<style id="core-block-supports-inline-css">
.wp-container-core-navigation-is-layout-xxxxxx {}
</style>
```