### PR TITLE
Image Editor: Fix crop function inconsistencies

### DIFF
--- a/src/js/_enqueues/lib/image-edit.js
+++ b/src/js/_enqueues/lib/image-edit.js
@@ -1365,6 +1365,16 @@
 
 		this.currentCropSelection = null;
 
+		// Check if both width and height fields are empty - clear selection like "Clear Crop"
+		if ( elX.val() === '' && elY.val() === '' ) {
+			ias.cancelSelection();
+			this.setDisabled($('.imgedit-crop-apply'), 0);
+			$('#imgedit-start-x-' + postid).val('0');
+			$('#imgedit-start-y-' + postid).val('0');
+			$('#imgedit-selection-' + postid).val('');
+			return;
+		}
+
 		if ( false === this.validateNumeric( el ) ) {
 			return;
 		}
@@ -1507,7 +1517,13 @@
 	 *                        void when it is.
 	 */
 	validateNumeric: function( el ) {
-		if ( false === this.intval( $( el ).val() ) ) {
+		var value = $( el ).val();
+		// Allow empty values - they will be handled appropriately by setNumSelection
+		if ( value === '' ) {
+			return true;
+		}
+		// Check if the value is a valid number and not false from intval
+		if ( false === this.intval( value ) || isNaN( parseFloat( value ) ) || parseFloat( value ) < 0 ) {
 			$( el ).val( '' );
 			return false;
 		}

--- a/src/wp-admin/includes/image-edit.php
+++ b/src/wp-admin/includes/image-edit.php
@@ -267,7 +267,7 @@ function wp_image_editor( $post_id, $msg = false ) {
 					</div>
 				</fieldset>
 				<div class="imgedit-crop-apply imgedit-menu container">
-					<button class="button-primary" type="button" onclick="imageEdit.handleCropToolClick( <?php echo "$post_id, '$nonce'"; ?>, this );" class="imgedit-crop-apply button"><?php esc_html_e( 'Apply Crop' ); ?></button> <button type="button" onclick="imageEdit.handleCropToolClick( <?php echo "$post_id, '$nonce'"; ?>, this );" class="imgedit-crop-clear button" disabled="disabled"><?php esc_html_e( 'Clear Crop' ); ?></button>
+					<button type="button" onclick="imageEdit.handleCropToolClick( <?php echo "$post_id, '$nonce'"; ?>, this );" class="imgedit-crop-apply button button-primary"><?php esc_html_e( 'Apply Crop' ); ?></button> <button type="button" onclick="imageEdit.handleCropToolClick( <?php echo "$post_id, '$nonce'"; ?>, this );" class="imgedit-crop-clear button" disabled="disabled"><?php esc_html_e( 'Clear Crop' ); ?></button>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Fixes #63673

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
**Summary**
- Fix button styling by consolidating duplicate class attributes on Apply Crop button
- Improve input field validation to handle empty values and auto-clear selection
- Add logic to automatically clear crop selection when both width/height fields are empty
- Enhance numeric validation to prevent weird input behavior with small numbers

Trac ticket: https://core.trac.wordpress.org/ticket/63673
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
