### PR TITLE
Fix: Replace writeImage() with getImageBlob() + file_put_contents()

### DIFF
--- a/src/wp-includes/class-wp-image-editor-imagick.php
+++ b/src/wp-includes/class-wp-image-editor-imagick.php
@@ -964,7 +964,11 @@ class WP_Image_Editor_Imagick extends WP_Image_Editor {
 			}
 
 			try {
-				return $image->writeImage( $filename );
+				$image_data = $image->getImageBlob();
+				if ( file_put_contents( $filename, $image_data ) === false ) {
+					return new WP_Error( 'image_save_error', 'Failed to write image data to file', $filename );
+				}
+				return true;
 			} catch ( Exception $e ) {
 				return new WP_Error( 'image_save_error', $e->getMessage(), $filename );
 			}


### PR DESCRIPTION
Fixes duplicate CLOSE_WRITE,CLOSE events during thumbnail generation by replacing ImageMagick's writeImage() method with a combination of getImageBlob() and file_put_contents() for single file operation.

This eliminates the internal buffering that causes two file operations:
1. Write data to buffer
2. Flush buffer to file

Benefits:
- Eliminates duplicate inotify events
- Reduces file I/O operations
- Improves performance for thumbnail generation
- Maintains full compatibility with all ImageMagick versions

Props agiabanis.
Trac ticket: https://core.trac.wordpress.org/ticket/63764
