### PR TITLE
Comments: Show custom comment form fields for logged-in users.

### DIFF
--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2806,7 +2806,7 @@ function comment_form( $args = array(), $post = null ) {
 
 					echo $args['comment_notes_after'];
 
-				} elseif ( ! is_user_logged_in() ) {
+				} elseif ( ! is_user_logged_in() || ! in_array( $name, array( 'author', 'email', 'url', 'cookies' ), true ) ) {
 
 					if ( $first_field === $name ) {
 						/**

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2593,6 +2593,8 @@ function comment_form( $args = array(), $post = null ) {
 		}
 	}
 
+	$original_fields = $fields;
+
 	/**
 	 * Filters the default comment form fields.
 	 *
@@ -2806,7 +2808,7 @@ function comment_form( $args = array(), $post = null ) {
 
 					echo $args['comment_notes_after'];
 
-				} elseif ( ! is_user_logged_in() || ! in_array( $name, array( 'author', 'email', 'url', 'cookies' ), true ) ) {
+				} elseif ( ! is_user_logged_in() || ! isset( $original_fields[ $name ] ) ) {
 
 					if ( $first_field === $name ) {
 						/**

--- a/tests/phpunit/tests/comment/commentForm.php
+++ b/tests/phpunit/tests/comment/commentForm.php
@@ -227,4 +227,47 @@ class Tests_Comment_CommentForm extends WP_UnitTestCase {
 		$this->assertTrue( $p->next_tag( array( 'tag_name' => 'FORM' ) ), 'Expected FORM tag.' );
 		$this->assertTrue( $p->get_attribute( 'novalidate' ), 'Expected FORM to have novalidate attribute.' );
 	}
+
+	/**
+	 * @ticket 16576
+	 */
+	public function test_custom_fields_shown_default_fields_hidden_for_logged_in_users() {
+		$user_id = self::factory()->user->create(
+			array(
+				'role'       => 'subscriber',
+				'user_login' => 'testuser',
+				'user_email' => 'test@example.com',
+			)
+		);
+
+		wp_set_current_user( $user_id );
+		$this->assertTrue( is_user_logged_in() );
+
+		$args = array(
+			'fields' => array(
+				'author'       => '<p><label for="author">Name</label><input type="text" name="author" id="author" /></p>',
+				'email'        => '<p><label for="email">Email</label><input type="email" name="email" id="email" /></p>',
+				'url'          => '<p><label for="url">Website</label><input type="url" name="url" id="url" /></p>',
+				'cookies'      => '<p><input type="checkbox" name="wp-comment-cookies-consent" id="wp-comment-cookies-consent" /><label for="wp-comment-cookies-consent">Save my details</label></p>',
+				'custom_field' => '<p><label for="custom_field">Custom Field</label><input type="text" name="custom_field" id="custom_field" /></p>',
+				'department'   => '<p><label for="department">Department</label><select name="department" id="department"><option value="sales">Sales</option></select></p>',
+			),
+		);
+
+		$form = get_echo( 'comment_form', array( $args, self::$post_id ) );
+
+		// Custom fields should be present
+		$this->assertStringContainsString( 'name="custom_field"', $form );
+		$this->assertStringContainsString( 'name="department"', $form );
+		$this->assertStringContainsString( 'Custom Field', $form );
+		$this->assertStringContainsString( 'Department', $form );
+
+		// Default fields should NOT be present
+		$this->assertStringNotContainsString( 'name="author"', $form );
+		$this->assertStringNotContainsString( 'name="email"', $form );
+		$this->assertStringNotContainsString( 'name="url"', $form );
+		$this->assertStringNotContainsString( 'wp-comment-cookies-consent', $form );
+
+		wp_set_current_user( 0 );
+	}
 }

--- a/tests/phpunit/tests/comment/commentForm.php
+++ b/tests/phpunit/tests/comment/commentForm.php
@@ -270,4 +270,29 @@ class Tests_Comment_CommentForm extends WP_UnitTestCase {
 
 		wp_set_current_user( 0 );
 	}
+
+	/**
+	 * @ticket 16576
+	 */
+	public function test_all_fields_displayed_for_non_logged_in_users() {
+		wp_set_current_user( 0 );
+		$this->assertFalse( is_user_logged_in() );
+
+		$args = array(
+			'fields' => array(
+				'author'       => '<p><label for="author">Name</label><input type="text" name="author" id="author" /></p>',
+				'email'        => '<p><label for="email">Email</label><input type="email" name="email" id="email" /></p>',
+				'url'          => '<p><label for="url">Website</label><input type="url" name="url" id="url" /></p>',
+				'custom_field' => '<p><label for="custom_field">Custom Field</label><input type="text" name="custom_field" id="custom_field" /></p>',
+			),
+		);
+
+		$form = get_echo( 'comment_form', array( $args, self::$post_id ) );
+
+		// All fields should be present for non-logged-in users
+		$this->assertStringContainsString( 'name="author"', $form );
+		$this->assertStringContainsString( 'name="email"', $form );
+		$this->assertStringContainsString( 'name="url"', $form );
+		$this->assertStringContainsString( 'name="custom_field"', $form );
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/16576

This PR fixes the issue where custom comment form fields added via the `fields` parameter are only visible to non-logged-in users. Logged-in users should be able to use custom comment fields. Currently, only default WordPress fields (author, email, and url) are hidden for logged-in users since this data comes from their profile, but custom fields should remain visible.


This PR modifies the field processing logic in `comment_form()` to show custom fields to both logged-in and non-logged-in users, while continuing to hide default WordPress fields for logged-in users.

 #### Testing Instructions
1. Add custom fields to the comment form using the `fields` parameter
2. Test as both a logged-in and a non-logged-in user
3. Verify custom fields appear for both user types
4. Verify that default fields (author, email, url) only appear for non-logged-in users


## Screenshots 

| User Type | Before | After |
|:---------:|:------:|:-----:|
| **Logged-in User** | <img width="400" height="320" alt="Before - Logged-in user" src="https://github.com/user-attachments/assets/2595afdc-0fbd-4eb9-9ad4-8ea2d9c5f757" /> | <img width="400" height="320" alt="After - Logged-in user" src="https://github.com/user-attachments/assets/6a81c9c5-e4bc-4802-8c0c-11072b0955ae" /> |
| **Non-logged-in User** | <img width="400" height="320" alt="Before - Non-logged-in user" src="https://github.com/user-attachments/assets/13aba6d5-621e-4075-805e-64e503b06c5a" /> | <img width="400" height="320" alt="After - Non-logged-in user" src="https://github.com/user-attachments/assets/0f9f15c8-5187-4b94-8137-46751b944b04" /> |