### PR TITLE
REST API: Expands the functionality of the Themes REST API

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-themes-controller.php
@@ -50,7 +50,26 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 					'permission_callback' => array( $this, 'get_items_permissions_check' ),
 					'args'                => $this->get_collection_params(),
 				),
-				'schema' => array( $this, 'get_item_schema' ),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'args'                => array(
+						'slug'   => array(
+							'type'        => 'string',
+							'required'    => true,
+							'description' => __( 'WordPress.org theme directory slug.' ),
+							'pattern'     => '[\w\-]+',
+						),
+						'status' => array(
+							'description' => __( 'The theme activation status.' ),
+							'type'        => 'string',
+							'enum'        => array( 'inactive', 'active' ),
+							'default'     => 'inactive',
+						),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
 			)
 		);
 
@@ -69,6 +88,17 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_item' ),
 					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'delete_item_permissions_check' ),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
 			)
@@ -431,6 +461,56 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Checks read permission for a given theme.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param string $theme_slug Theme slug to check.
+	 * @return true|WP_Error
+	 */
+	protected function check_read_permission( $theme_slug ) {
+		$theme = wp_get_theme( $theme_slug );
+		if ( ! $theme->exists() ) {
+			return new WP_Error( 'rest_theme_not_found', __( 'Theme not found.' ), array( 'status' => 404 ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Matches request with the theme.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param WP_REST_Request $request Request data.
+	 * @param WP_Theme $theme Theme object.
+	 * @return bool
+	 */
+	protected function does_theme_match_request( $request, $theme ) {
+		$status       = $request['status'];
+		$theme_status = ( $this->is_same_theme( $theme, wp_get_theme() ) ) ? 'active' : 'inactive';
+		if ( ! is_array( $status ) || in_array( $theme_status, $status, true ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Retrieves theme data.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param string $theme_slug Theme slug to be retrieved.
+	 * @return WP_Theme|WP_Error
+	 */
+	protected function get_theme_data( $theme_slug ) {
+		$theme = wp_get_theme( $theme_slug );
+		if ( ! $theme->exists() ) {
+			return new WP_Error( 'rest_theme_not_found', __( 'Theme not found.' ), array( 'status' => 404 ) );
+		}
+		return $theme;
+	}
+
+	/**
 	 * Prepares the theme support value for inclusion in the REST API response.
 	 *
 	 * @since 5.5.0
@@ -632,6 +712,7 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 					'description' => __( 'A named status for the theme.' ),
 					'type'        => 'string',
 					'enum'        => array( 'inactive', 'active' ),
+					'context'     => array( 'view', 'edit' ),
 				),
 				'default_template_types'      => array(
 					'description' => __( 'A list of default template types.' ),
@@ -749,5 +830,254 @@ class WP_REST_Themes_Controller extends WP_REST_Controller {
 		}
 
 		return $statuses;
+	}
+	/**
+	 * Checks permissions to update a theme (switch themes).
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return true|WP_Error True if the request has access to edit items, WP_Error object otherwise.
+	 */
+	public function update_item_permissions_check( $request ) {
+		if ( ! current_user_can( 'switch_themes' ) ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to switch themes for this site.' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Update a theme (switch themes).
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function update_item( $request ) {
+		$theme_slug = $request['theme'];
+
+		$theme = $this->get_theme_data( $theme_slug );
+		if ( is_wp_error( $theme ) ) {
+			return $theme;
+		}
+
+		// Check if we need to switch the theme
+		if ( isset( $request['status'] ) && 'active' === $request['status'] ) {
+			switch_theme( $theme_slug );
+		}
+
+		return $this->prepare_item_for_response( $theme, $request );
+	}
+
+	/**
+	 * Checks permissions to install a theme.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return true|WP_Error True if the request has access to create items, WP_Error object otherwise.
+	 */
+	public function create_item_permissions_check( $request ) {
+		if ( ! current_user_can( 'install_themes' ) ) {
+			return new WP_Error( 'rest_forbidden', __( 'Sorry, you are not allowed to install themes on this site.' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Install a theme.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function create_item( $request ) {
+		$slug = $request['slug'];
+		require_once ABSPATH . 'wp-admin/includes/theme-install.php';
+		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+
+		// Verify filesystem is accessible first.
+		$filesystem_available = $this->is_filesystem_available();
+		if ( is_wp_error( $filesystem_available ) ) {
+			return $filesystem_available;
+		}
+
+		// Get theme information from WordPress.org API.
+		$api = themes_api(
+			'theme_information',
+			array(
+				'slug'   => $slug,
+				'fields' => array( 'sections' => false ),
+			)
+		);
+		if ( is_wp_error( $api ) ) {
+			if ( str_contains( $api->get_error_message(), 'Theme not found.' ) ) {
+				$api->add_data( array( 'status' => 404 ) );
+			} else {
+				$api->add_data( array( 'status' => 500 ) );
+			}
+			return $api;
+		}
+
+		$skin     = new WP_Ajax_Upgrader_Skin();
+		$upgrader = new Theme_Upgrader( $skin );
+
+		$result = $upgrader->install( $api->download_link );
+		if ( is_wp_error( $result ) ) {
+			$result->add_data( array( 'status' => 500 ) );
+			return $result;
+		}
+
+		// Get the installed theme file
+		$theme_file = $upgrader->theme_info();
+		if ( ! $theme_file ) {
+			return new WP_Error(
+				'unable_to_determine_installed_theme',
+				__( 'Unable to determine what theme was installed.' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$theme = wp_get_theme( $theme_file );
+
+		// Check if we need to activate the theme
+		if ( isset( $request['status'] ) && 'active' === $request['status'] ) {
+			switch_theme( $theme_file );
+		}
+
+		$response = $this->prepare_item_for_response( $theme, $request );
+		$response->set_status( 201 );
+		$response->header( 'Location', rest_url( sprintf( '%s/%s/%s', $this->namespace, $this->rest_base, $theme_file ) ) );
+
+		return $response;
+	}
+
+
+	/**
+	 * Checks if the filesystem is available to perform theme installations.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @return true|WP_Error True if the filesystem is available, or an error object if not.
+	 */
+	protected function is_filesystem_available() {
+		$filesystem_method = get_filesystem_method();
+
+		if ( 'direct' === $filesystem_method ) {
+			return true;
+		}
+
+		ob_start();
+		$credentials = request_filesystem_credentials( site_url() );
+		ob_end_clean();
+
+		if ( $credentials ) {
+			return true;
+		}
+
+		return new WP_Error( 'fs_unavailable', __( 'Could not access filesystem.' ), array( 'status' => 500 ) );
+	}
+
+	/**
+	 * Checks if a given request has access to delete a theme.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has access to delete the item, WP_Error object otherwise.
+	 */
+	public function delete_item_permissions_check( $request ) {
+		if ( ! current_user_can( 'delete_themes' ) ) {
+			return new WP_Error(
+				'rest_cannot_delete_theme',
+				__( 'Sorry, you are not allowed to delete themes for this site.' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		$theme = $this->get_theme_data( $request['theme'] );
+		if ( is_wp_error( $theme ) ) {
+			return $theme;
+		}
+
+		// Cannot delete active theme.
+		if ( $this->is_same_theme( $theme, wp_get_theme() ) ) {
+			return new WP_Error(
+				'rest_cannot_delete_active_theme',
+				__( 'Cannot delete the active theme.' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Deletes a theme.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function delete_item( $request ) {
+		$theme = $this->get_theme_data( $request['theme'] );
+		if ( is_wp_error( $theme ) ) {
+			return $theme;
+		}
+
+		// Verify filesystem is accessible first.
+		$filesystem_available = $this->is_filesystem_available();
+		if ( is_wp_error( $filesystem_available ) ) {
+			return $filesystem_available;
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/theme.php';
+		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+
+		$previous_theme_data = $this->prepare_item_for_response( $theme, $request );
+
+		$result = delete_theme( $theme->get_stylesheet() );
+		if ( is_wp_error( $result ) ) {
+			$result->add_data( array( 'status' => 500 ) );
+			return $result;
+		}
+
+		return new WP_REST_Response(
+			array(
+				'deleted'  => true,
+				'previous' => $previous_theme_data->get_data(),
+			),
+			200
+		);
+	}
+
+	/**
+	 * Validates theme param.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param string $value Theme parameter value.
+	 * @return true|WP_Error
+	 */
+	public function validate_theme_param( $value ) {
+		if ( ! is_string( $value ) || empty( $value ) ) {
+			return new WP_Error( 'rest_invalid_theme', __( 'Invalid theme.' ), array( 'status' => 400 ) );
+		}
+		return true;
+	}
+
+	/**
+	 * Sanitizes theme param.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param string $value Theme parameter value.
+	 * @return string
+	 */
+	public function sanitize_theme_param( $value ) {
+		return urldecode( $value );
 	}
 }

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -21,7 +21,13 @@ mockedApiResponse.Schema = {
         "wp-site-health/v1",
         "wp-block-editor/v1"
     ],
-    "authentication": [],
+    "authentication": {
+        "application-passwords": {
+            "endpoints": {
+                "authorization": "http://example.org/wp-admin/authorize-application.php"
+            }
+        }
+    },
     "routes": {
         "/": {
             "namespace": "",
@@ -848,14 +854,7 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": {
-                                "footnotes": {
-                                    "type": "string",
-                                    "title": "",
-                                    "description": "",
-                                    "default": ""
-                                }
-                            },
+                            "properties": [],
                             "required": false
                         },
                         "sticky": {
@@ -1139,14 +1138,7 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": {
-                                "footnotes": {
-                                    "type": "string",
-                                    "title": "",
-                                    "description": "",
-                                    "default": ""
-                                }
-                            },
+                            "properties": [],
                             "required": false
                         },
                         "sticky": {
@@ -1585,14 +1577,7 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": {
-                                "footnotes": {
-                                    "type": "string",
-                                    "title": "",
-                                    "description": "",
-                                    "default": ""
-                                }
-                            },
+                            "properties": [],
                             "required": false
                         },
                         "sticky": {
@@ -2068,14 +2053,7 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": {
-                                "footnotes": {
-                                    "type": "string",
-                                    "title": "",
-                                    "description": "",
-                                    "default": ""
-                                }
-                            },
+                            "properties": [],
                             "required": false
                         },
                         "template": {
@@ -2331,14 +2309,7 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": {
-                                "footnotes": {
-                                    "type": "string",
-                                    "title": "",
-                                    "description": "",
-                                    "default": ""
-                                }
-                            },
+                            "properties": [],
                             "required": false
                         },
                         "template": {
@@ -2744,14 +2715,7 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": {
-                                "footnotes": {
-                                    "type": "string",
-                                    "title": "",
-                                    "description": "",
-                                    "default": ""
-                                }
-                            },
+                            "properties": [],
                             "required": false
                         },
                         "template": {
@@ -4788,24 +4752,7 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": {
-                                "wp_pattern_sync_status": {
-                                    "type": "string",
-                                    "title": "",
-                                    "description": "",
-                                    "default": "",
-                                    "enum": [
-                                        "partial",
-                                        "unsynced"
-                                    ]
-                                },
-                                "footnotes": {
-                                    "type": "string",
-                                    "title": "",
-                                    "description": "",
-                                    "default": ""
-                                }
-                            },
+                            "properties": [],
                             "required": false
                         },
                         "template": {
@@ -5014,24 +4961,7 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": {
-                                "wp_pattern_sync_status": {
-                                    "type": "string",
-                                    "title": "",
-                                    "description": "",
-                                    "default": "",
-                                    "enum": [
-                                        "partial",
-                                        "unsynced"
-                                    ]
-                                },
-                                "footnotes": {
-                                    "type": "string",
-                                    "title": "",
-                                    "description": "",
-                                    "default": ""
-                                }
-                            },
+                            "properties": [],
                             "required": false
                         },
                         "template": {
@@ -5395,24 +5325,7 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": {
-                                "wp_pattern_sync_status": {
-                                    "type": "string",
-                                    "title": "",
-                                    "description": "",
-                                    "default": "",
-                                    "enum": [
-                                        "partial",
-                                        "unsynced"
-                                    ]
-                                },
-                                "footnotes": {
-                                    "type": "string",
-                                    "title": "",
-                                    "description": "",
-                                    "default": ""
-                                }
-                            },
+                            "properties": [],
                             "required": false
                         },
                         "template": {
@@ -9795,26 +9708,7 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": {
-                                "persisted_preferences": {
-                                    "type": "object",
-                                    "title": "",
-                                    "description": "",
-                                    "default": [],
-                                    "context": [
-                                        "edit"
-                                    ],
-                                    "properties": {
-                                        "_modified": {
-                                            "description": "The date and time the preferences were updated.",
-                                            "type": "string",
-                                            "format": "date-time",
-                                            "readonly": false
-                                        }
-                                    },
-                                    "additionalProperties": true
-                                }
-                            },
+                            "properties": [],
                             "required": false
                         }
                     }
@@ -9952,26 +9846,7 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": {
-                                "persisted_preferences": {
-                                    "type": "object",
-                                    "title": "",
-                                    "description": "",
-                                    "default": [],
-                                    "context": [
-                                        "edit"
-                                    ],
-                                    "properties": {
-                                        "_modified": {
-                                            "description": "The date and time the preferences were updated.",
-                                            "type": "string",
-                                            "format": "date-time",
-                                            "readonly": false
-                                        }
-                                    },
-                                    "additionalProperties": true
-                                }
-                            },
+                            "properties": [],
                             "required": false
                         }
                     }
@@ -10116,26 +9991,7 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": {
-                                "persisted_preferences": {
-                                    "type": "object",
-                                    "title": "",
-                                    "description": "",
-                                    "default": [],
-                                    "context": [
-                                        "edit"
-                                    ],
-                                    "properties": {
-                                        "_modified": {
-                                            "description": "The date and time the preferences were updated.",
-                                            "type": "string",
-                                            "format": "date-time",
-                                            "readonly": false
-                                        }
-                                    },
-                                    "additionalProperties": true
-                                }
-                            },
+                            "properties": [],
                             "required": false
                         }
                     }
@@ -12655,8 +12511,7 @@ mockedApiResponse.PostsCollection = [
         "template": "",
         "format": "standard",
         "meta": {
-            "meta_key": "meta_value",
-            "footnotes": ""
+            "meta_key": "meta_value"
         },
         "categories": [
             1
@@ -12774,8 +12629,7 @@ mockedApiResponse.PostModel = {
     "template": "",
     "format": "standard",
     "meta": {
-        "meta_key": "meta_value",
-        "footnotes": ""
+        "meta_key": "meta_value"
     },
     "categories": [
         1
@@ -12815,8 +12669,7 @@ mockedApiResponse.postRevisions = [
             "rendered": ""
         },
         "meta": {
-            "meta_key": "",
-            "footnotes": ""
+            "meta_key": ""
         },
         "_links": {
             "parent": [
@@ -12848,8 +12701,7 @@ mockedApiResponse.postRevisions = [
             "rendered": "<p>REST API Client Fixture: Post</p>\n"
         },
         "meta": {
-            "meta_key": "",
-            "footnotes": ""
+            "meta_key": ""
         },
         "_links": {
             "parent": [
@@ -12883,8 +12735,7 @@ mockedApiResponse.revision = {
         "rendered": "<p>REST API Client Fixture: Post</p>\n"
     },
     "meta": {
-        "meta_key": "",
-        "footnotes": ""
+        "meta_key": ""
     }
 };
 
@@ -12911,8 +12762,7 @@ mockedApiResponse.postAutosaves = [
             "rendered": ""
         },
         "meta": {
-            "meta_key": "",
-            "footnotes": ""
+            "meta_key": ""
         },
         "_links": {
             "parent": [
@@ -12946,8 +12796,7 @@ mockedApiResponse.autosave = {
         "rendered": ""
     },
     "meta": {
-        "meta_key": "",
-        "footnotes": ""
+        "meta_key": ""
     }
 };
 
@@ -12984,8 +12833,7 @@ mockedApiResponse.PagesCollection = [
         "ping_status": "closed",
         "template": "",
         "meta": {
-            "meta_key": "",
-            "footnotes": ""
+            "meta_key": ""
         },
         "class_list": [
             "post-7",
@@ -13085,8 +12933,7 @@ mockedApiResponse.PageModel = {
     "ping_status": "closed",
     "template": "",
     "meta": {
-        "meta_key": "",
-        "footnotes": ""
+        "meta_key": ""
     },
     "class_list": [
         "post-7",
@@ -13120,8 +12967,7 @@ mockedApiResponse.pageRevisions = [
             "rendered": ""
         },
         "meta": {
-            "meta_key": "",
-            "footnotes": ""
+            "meta_key": ""
         },
         "_links": {
             "parent": [
@@ -13153,8 +12999,7 @@ mockedApiResponse.pageRevisions = [
             "rendered": "<p>REST API Client Fixture: Page</p>\n"
         },
         "meta": {
-            "meta_key": "",
-            "footnotes": ""
+            "meta_key": ""
         },
         "_links": {
             "parent": [
@@ -13188,8 +13033,7 @@ mockedApiResponse.pageRevision = {
         "rendered": "<p>REST API Client Fixture: Page</p>\n"
     },
     "meta": {
-        "meta_key": "",
-        "footnotes": ""
+        "meta_key": ""
     }
 };
 
@@ -13216,8 +13060,7 @@ mockedApiResponse.pageAutosaves = [
             "rendered": ""
         },
         "meta": {
-            "meta_key": "",
-            "footnotes": ""
+            "meta_key": ""
         },
         "_links": {
             "parent": [
@@ -13251,8 +13094,7 @@ mockedApiResponse.pageAutosave = {
         "rendered": ""
     },
     "meta": {
-        "meta_key": "",
-        "footnotes": ""
+        "meta_key": ""
     }
 };
 

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -21,13 +21,7 @@ mockedApiResponse.Schema = {
         "wp-site-health/v1",
         "wp-block-editor/v1"
     ],
-    "authentication": {
-        "application-passwords": {
-            "endpoints": {
-                "authorization": "http://example.org/wp-admin/authorize-application.php"
-            }
-        }
-    },
+    "authentication": [],
     "routes": {
         "/": {
             "namespace": "",
@@ -854,7 +848,14 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": [],
+                            "properties": {
+                                "footnotes": {
+                                    "type": "string",
+                                    "title": "",
+                                    "description": "",
+                                    "default": ""
+                                }
+                            },
                             "required": false
                         },
                         "sticky": {
@@ -1138,7 +1139,14 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": [],
+                            "properties": {
+                                "footnotes": {
+                                    "type": "string",
+                                    "title": "",
+                                    "description": "",
+                                    "default": ""
+                                }
+                            },
                             "required": false
                         },
                         "sticky": {
@@ -1577,7 +1585,14 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": [],
+                            "properties": {
+                                "footnotes": {
+                                    "type": "string",
+                                    "title": "",
+                                    "description": "",
+                                    "default": ""
+                                }
+                            },
                             "required": false
                         },
                         "sticky": {
@@ -2053,7 +2068,14 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": [],
+                            "properties": {
+                                "footnotes": {
+                                    "type": "string",
+                                    "title": "",
+                                    "description": "",
+                                    "default": ""
+                                }
+                            },
                             "required": false
                         },
                         "template": {
@@ -2309,7 +2331,14 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": [],
+                            "properties": {
+                                "footnotes": {
+                                    "type": "string",
+                                    "title": "",
+                                    "description": "",
+                                    "default": ""
+                                }
+                            },
                             "required": false
                         },
                         "template": {
@@ -2715,7 +2744,14 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": [],
+                            "properties": {
+                                "footnotes": {
+                                    "type": "string",
+                                    "title": "",
+                                    "description": "",
+                                    "default": ""
+                                }
+                            },
                             "required": false
                         },
                         "template": {
@@ -4752,7 +4788,24 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": [],
+                            "properties": {
+                                "wp_pattern_sync_status": {
+                                    "type": "string",
+                                    "title": "",
+                                    "description": "",
+                                    "default": "",
+                                    "enum": [
+                                        "partial",
+                                        "unsynced"
+                                    ]
+                                },
+                                "footnotes": {
+                                    "type": "string",
+                                    "title": "",
+                                    "description": "",
+                                    "default": ""
+                                }
+                            },
                             "required": false
                         },
                         "template": {
@@ -4961,7 +5014,24 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": [],
+                            "properties": {
+                                "wp_pattern_sync_status": {
+                                    "type": "string",
+                                    "title": "",
+                                    "description": "",
+                                    "default": "",
+                                    "enum": [
+                                        "partial",
+                                        "unsynced"
+                                    ]
+                                },
+                                "footnotes": {
+                                    "type": "string",
+                                    "title": "",
+                                    "description": "",
+                                    "default": ""
+                                }
+                            },
                             "required": false
                         },
                         "template": {
@@ -5325,7 +5395,24 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": [],
+                            "properties": {
+                                "wp_pattern_sync_status": {
+                                    "type": "string",
+                                    "title": "",
+                                    "description": "",
+                                    "default": "",
+                                    "enum": [
+                                        "partial",
+                                        "unsynced"
+                                    ]
+                                },
+                                "footnotes": {
+                                    "type": "string",
+                                    "title": "",
+                                    "description": "",
+                                    "default": ""
+                                }
+                            },
                             "required": false
                         },
                         "template": {
@@ -9708,7 +9795,26 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": [],
+                            "properties": {
+                                "persisted_preferences": {
+                                    "type": "object",
+                                    "title": "",
+                                    "description": "",
+                                    "default": [],
+                                    "context": [
+                                        "edit"
+                                    ],
+                                    "properties": {
+                                        "_modified": {
+                                            "description": "The date and time the preferences were updated.",
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "readonly": false
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                }
+                            },
                             "required": false
                         }
                     }
@@ -9846,7 +9952,26 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": [],
+                            "properties": {
+                                "persisted_preferences": {
+                                    "type": "object",
+                                    "title": "",
+                                    "description": "",
+                                    "default": [],
+                                    "context": [
+                                        "edit"
+                                    ],
+                                    "properties": {
+                                        "_modified": {
+                                            "description": "The date and time the preferences were updated.",
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "readonly": false
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                }
+                            },
                             "required": false
                         }
                     }
@@ -9991,7 +10116,26 @@ mockedApiResponse.Schema = {
                         "meta": {
                             "description": "Meta fields.",
                             "type": "object",
-                            "properties": [],
+                            "properties": {
+                                "persisted_preferences": {
+                                    "type": "object",
+                                    "title": "",
+                                    "description": "",
+                                    "default": [],
+                                    "context": [
+                                        "edit"
+                                    ],
+                                    "properties": {
+                                        "_modified": {
+                                            "description": "The date and time the preferences were updated.",
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "readonly": false
+                                        }
+                                    },
+                                    "additionalProperties": true
+                                }
+                            },
                             "required": false
                         }
                     }
@@ -11024,7 +11168,8 @@ mockedApiResponse.Schema = {
         "/wp/v2/themes": {
             "namespace": "wp/v2",
             "methods": [
-                "GET"
+                "GET",
+                "POST"
             ],
             "endpoints": [
                 {
@@ -11045,6 +11190,29 @@ mockedApiResponse.Schema = {
                             "required": false
                         }
                     }
+                },
+                {
+                    "methods": [
+                        "POST"
+                    ],
+                    "args": {
+                        "slug": {
+                            "type": "string",
+                            "description": "WordPress.org theme directory slug.",
+                            "pattern": "[\\w\\-]+",
+                            "required": true
+                        },
+                        "status": {
+                            "description": "The theme activation status.",
+                            "type": "string",
+                            "enum": [
+                                "inactive",
+                                "active"
+                            ],
+                            "default": "inactive",
+                            "required": false
+                        }
+                    }
                 }
             ],
             "_links": {
@@ -11054,12 +11222,51 @@ mockedApiResponse.Schema = {
         "/wp/v2/themes/(?P<stylesheet>[^\\/:<>\\*\\?\"\\|]+(?:\\/[^\\/:<>\\*\\?\"\\|]+)?)": {
             "namespace": "wp/v2",
             "methods": [
-                "GET"
+                "GET",
+                "POST",
+                "PUT",
+                "PATCH",
+                "DELETE"
             ],
             "endpoints": [
                 {
                     "methods": [
                         "GET"
+                    ],
+                    "args": {
+                        "stylesheet": {
+                            "description": "The theme's stylesheet. This uniquely identifies the theme.",
+                            "type": "string",
+                            "required": false
+                        }
+                    }
+                },
+                {
+                    "methods": [
+                        "POST",
+                        "PUT",
+                        "PATCH"
+                    ],
+                    "args": {
+                        "stylesheet": {
+                            "description": "The theme's stylesheet. This uniquely identifies the theme.",
+                            "type": "string",
+                            "required": false
+                        },
+                        "status": {
+                            "description": "A named status for the theme.",
+                            "type": "string",
+                            "enum": [
+                                "inactive",
+                                "active"
+                            ],
+                            "required": false
+                        }
+                    }
+                },
+                {
+                    "methods": [
+                        "DELETE"
                     ],
                     "args": {
                         "stylesheet": {
@@ -12448,7 +12655,8 @@ mockedApiResponse.PostsCollection = [
         "template": "",
         "format": "standard",
         "meta": {
-            "meta_key": "meta_value"
+            "meta_key": "meta_value",
+            "footnotes": ""
         },
         "categories": [
             1
@@ -12566,7 +12774,8 @@ mockedApiResponse.PostModel = {
     "template": "",
     "format": "standard",
     "meta": {
-        "meta_key": "meta_value"
+        "meta_key": "meta_value",
+        "footnotes": ""
     },
     "categories": [
         1
@@ -12606,7 +12815,8 @@ mockedApiResponse.postRevisions = [
             "rendered": ""
         },
         "meta": {
-            "meta_key": ""
+            "meta_key": "",
+            "footnotes": ""
         },
         "_links": {
             "parent": [
@@ -12638,7 +12848,8 @@ mockedApiResponse.postRevisions = [
             "rendered": "<p>REST API Client Fixture: Post</p>\n"
         },
         "meta": {
-            "meta_key": ""
+            "meta_key": "",
+            "footnotes": ""
         },
         "_links": {
             "parent": [
@@ -12672,7 +12883,8 @@ mockedApiResponse.revision = {
         "rendered": "<p>REST API Client Fixture: Post</p>\n"
     },
     "meta": {
-        "meta_key": ""
+        "meta_key": "",
+        "footnotes": ""
     }
 };
 
@@ -12699,7 +12911,8 @@ mockedApiResponse.postAutosaves = [
             "rendered": ""
         },
         "meta": {
-            "meta_key": ""
+            "meta_key": "",
+            "footnotes": ""
         },
         "_links": {
             "parent": [
@@ -12733,7 +12946,8 @@ mockedApiResponse.autosave = {
         "rendered": ""
     },
     "meta": {
-        "meta_key": ""
+        "meta_key": "",
+        "footnotes": ""
     }
 };
 
@@ -12770,7 +12984,8 @@ mockedApiResponse.PagesCollection = [
         "ping_status": "closed",
         "template": "",
         "meta": {
-            "meta_key": ""
+            "meta_key": "",
+            "footnotes": ""
         },
         "class_list": [
             "post-7",
@@ -12870,7 +13085,8 @@ mockedApiResponse.PageModel = {
     "ping_status": "closed",
     "template": "",
     "meta": {
-        "meta_key": ""
+        "meta_key": "",
+        "footnotes": ""
     },
     "class_list": [
         "post-7",
@@ -12904,7 +13120,8 @@ mockedApiResponse.pageRevisions = [
             "rendered": ""
         },
         "meta": {
-            "meta_key": ""
+            "meta_key": "",
+            "footnotes": ""
         },
         "_links": {
             "parent": [
@@ -12936,7 +13153,8 @@ mockedApiResponse.pageRevisions = [
             "rendered": "<p>REST API Client Fixture: Page</p>\n"
         },
         "meta": {
-            "meta_key": ""
+            "meta_key": "",
+            "footnotes": ""
         },
         "_links": {
             "parent": [
@@ -12970,7 +13188,8 @@ mockedApiResponse.pageRevision = {
         "rendered": "<p>REST API Client Fixture: Page</p>\n"
     },
     "meta": {
-        "meta_key": ""
+        "meta_key": "",
+        "footnotes": ""
     }
 };
 
@@ -12997,7 +13216,8 @@ mockedApiResponse.pageAutosaves = [
             "rendered": ""
         },
         "meta": {
-            "meta_key": ""
+            "meta_key": "",
+            "footnotes": ""
         },
         "_links": {
             "parent": [
@@ -13031,7 +13251,8 @@ mockedApiResponse.pageAutosave = {
         "rendered": ""
     },
     "meta": {
-        "meta_key": ""
+        "meta_key": "",
+        "footnotes": ""
     }
 };
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Adds endpoints to install, activate (switch), and delete themes via the REST API.

**Implements:**
- POST /wp/v2/themes (install)
- PUT /wp/v2/themes/<stylesheet> (activate)
- DELETE /wp/v2/themes/<stylesheet> (delete)

Trac ticket: https://core.trac.wordpress.org/ticket/54293

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
