### PR TITLE
Menus: Fix `nav_menu_item_args` filter side effects between menu items

### DIFF
--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -144,6 +144,8 @@ class Walker_Nav_Menu extends Walker {
 	 * @since 5.9.0 Renamed `$item` to `$data_object` and `$id` to `$current_object_id`
 	 *              to match parent class for PHP 8 named parameter support.
 	 * @since 6.7.0 Removed redundant title attributes.
+	 * @since 7.2.0 The `$args` object is now cloned before the `nav_menu_item_args` filter
+	 *              to prevent filter modifications from leaking between menu items.
 	 *
 	 * @see Walker::start_el()
 	 *
@@ -157,8 +159,8 @@ class Walker_Nav_Menu extends Walker {
 		// Restores the more descriptive, specific name for use within this method.
 		$menu_item = $data_object;
 
-		$args = (array) $args;
-		if ( isset( $args['item_spacing'] ) && 'discard' === $args['item_spacing'] ) {
+		$args = is_object( $args ) ? clone $args : (object) $args;
+		if ( isset( $args->item_spacing ) && 'discard' === $args->item_spacing ) {
 			$t = '';
 			$n = '';
 		} else {
@@ -179,7 +181,7 @@ class Walker_Nav_Menu extends Walker {
 		 * @param WP_Post  $menu_item Menu item data object.
 		 * @param int      $depth     Depth of menu item. Used for padding.
 		 */
-		$args = apply_filters( 'nav_menu_item_args', (object) $args, $menu_item, $depth );
+		$args = apply_filters( 'nav_menu_item_args', $args, $menu_item, $depth );
 
 		/**
 		 * Filters the CSS classes applied to a menu item's list item element.

--- a/src/wp-includes/class-walker-nav-menu.php
+++ b/src/wp-includes/class-walker-nav-menu.php
@@ -157,7 +157,8 @@ class Walker_Nav_Menu extends Walker {
 		// Restores the more descriptive, specific name for use within this method.
 		$menu_item = $data_object;
 
-		if ( isset( $args->item_spacing ) && 'discard' === $args->item_spacing ) {
+		$args = (array) $args;
+		if ( isset( $args['item_spacing'] ) && 'discard' === $args['item_spacing'] ) {
 			$t = '';
 			$n = '';
 		} else {
@@ -178,7 +179,7 @@ class Walker_Nav_Menu extends Walker {
 		 * @param WP_Post  $menu_item Menu item data object.
 		 * @param int      $depth     Depth of menu item. Used for padding.
 		 */
-		$args = apply_filters( 'nav_menu_item_args', $args, $menu_item, $depth );
+		$args = apply_filters( 'nav_menu_item_args', (object) $args, $menu_item, $depth );
 
 		/**
 		 * Filters the CSS classes applied to a menu item's list item element.

--- a/tests/phpunit/tests/menu/walker-nav-menu.php
+++ b/tests/phpunit/tests/menu/walker-nav-menu.php
@@ -473,6 +473,8 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 			'link_after'  => '',
 		);
 
+		$original_args = (object) $args;
+
 		$output1 = '';
 		$this->walker->start_el( $output1, (object) $item1, 0, (object) $args );
 
@@ -480,6 +482,8 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 		$this->walker->start_el( $output2, (object) $item2, 0, (object) $args );
 
 		remove_filter( 'nav_menu_item_args', array( $this, 'filter_nav_menu_item_args_append_marker' ), 10 );
+
+		$this->assertSame( '', $original_args->before, 'start_el() must not mutate the caller\'s $args object.' );
 
 		// Both menu items should have exactly one 'X' marker, not accumulating.
 		$this->assertStringContainsString( '>X<a href="http://example.com/item1">Item 1</a>', $output1 );

--- a/tests/phpunit/tests/menu/walker-nav-menu.php
+++ b/tests/phpunit/tests/menu/walker-nav-menu.php
@@ -435,4 +435,72 @@ class Tests_Menu_Walker_Nav_Menu extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Tests that modifications to `$args` in the `nav_menu_item_args` filter do not leak between menu items.
+	 *
+	 * @ticket 37344
+	 *
+	 * @covers Walker_Nav_Menu::start_el
+	 */
+	public function test_walker_nav_menu_start_el_should_not_leak_nav_menu_item_args_filter_changes_between_items() {
+		add_filter( 'nav_menu_item_args', array( $this, 'filter_nav_menu_item_args_append_marker' ), 10, 3 );
+
+		$item1 = array(
+			'ID'      => 1,
+			'title'   => 'Item 1',
+			'classes' => array(),
+			'current' => false,
+			'target'  => '',
+			'xfn'     => '',
+			'url'     => 'http://example.com/item1',
+		);
+
+		$item2 = array(
+			'ID'      => 2,
+			'title'   => 'Item 2',
+			'classes' => array(),
+			'current' => false,
+			'target'  => '',
+			'xfn'     => '',
+			'url'     => 'http://example.com/item2',
+		);
+
+		$args = array(
+			'before'      => '',
+			'after'       => '',
+			'link_before' => '',
+			'link_after'  => '',
+		);
+
+		$output1 = '';
+		$this->walker->start_el( $output1, (object) $item1, 0, (object) $args );
+
+		$output2 = '';
+		$this->walker->start_el( $output2, (object) $item2, 0, (object) $args );
+
+		remove_filter( 'nav_menu_item_args', array( $this, 'filter_nav_menu_item_args_append_marker' ), 10 );
+
+		// Both menu items should have exactly one 'X' marker, not accumulating.
+		$this->assertStringContainsString( '>X<a href="http://example.com/item1">Item 1</a>', $output1 );
+		$this->assertStringContainsString( '>X<a href="http://example.com/item2">Item 2</a>', $output2 );
+
+		// Ensure no accumulation - Item 2 should not contain 'XX'.
+		$this->assertStringNotContainsString( '>XX<a href="http://example.com/item2">Item 2</a>', $output2 );
+	}
+
+	/**
+	 * Filter callback for testing nav_menu_item_args filter side effects.
+	 *
+	 * Appends a marker character to the 'before' argument to test for accumulation.
+	 *
+	 * @param stdClass $args      An object of wp_nav_menu() arguments.
+	 * @param WP_Post  $menu_item Menu item data object.
+	 * @param int      $depth     Depth of menu item. Used for padding.
+	 * @return stdClass Modified arguments object.
+	 */
+	public function filter_nav_menu_item_args_append_marker( $args, $menu_item, $depth ) {
+		$args->before .= 'X';
+		return $args;
+	}
 }


### PR DESCRIPTION
When a filter callback hooked to nav_menu_item_args appends to or modifies a property of $args, those changes mutate the original args object and carry over into every subsequent menu item. This happens because PHP objects are passed by reference handle, so any modification inside the filter affects the same object that the walker holds across all start_el() calls.

The fix clones $args at the top of start_el() before passing it to the filter. Each menu item now receives a fresh copy, so filter modifications are scoped to that item only.

Trac ticket: [#37344](https://core.trac.wordpress.org/ticket/37344)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
