### PR TITLE
Fix typo in load.php

### DIFF
--- a/src/wp-includes/load.php
+++ b/src/wp-includes/load.php
@@ -97,7 +97,12 @@ function wp_fix_server_vars() {
 /**
  * Populates the Basic Auth server details from the Authorization header.
  *
- * Some servers running in CGI or FastCGI mode don't pass the Authorization
+<?php
+/**
+ * WordPress environment loader.
+ *
+ * @package WordPress
+ */ * Some servers running in CGI or FastCGI mode don't pass the Authorization
  * header on to WordPress.  If it's been rewritten to the `HTTP_AUTHORIZATION` header,
  * fill in the proper $_SERVER variables instead.
  *
@@ -144,7 +149,12 @@ function wp_populate_basic_auth_from_authorization_header() {
  *   - PHP version
  *   - PHP extensions
  *   - MySQL or MariaDB version (unless a database drop-in is present)
+<?php
+/**
+ * WordPress environment loader.
  *
+ * @package WordPress
+ */ *
  * Dies if requirements are not met.
  *
  * @since 3.0.0


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

What does this PR do?
This PR fixes a small typo in the load.php file inside the wp-includes directory.

Why is this needed?
The typo was causing confusion in the comment/documentation, and fixing it improves code readability and consistency.

Testing Instructions:

Make sure WordPress loads without any issue.

No functional changes were made, only a documentation/comment fix.



Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
