### PR TITLE
Fix: Prevent emoji in plugin titles from floating as icons in the plugin admin list

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1312,7 +1312,7 @@ ul.cat-checklist input[name="post_category[]"]:indeterminate::before {
 	padding-right: 12px;
 	white-space: nowrap;
 }
-
+/* modified for the emoji */
 .plugins .plugin-title .dashicons,
 .plugins .plugin-title img.dashicons,
 .plugins .plugin-title img[class*="icon"],

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1313,13 +1313,16 @@ ul.cat-checklist input[name="post_category[]"]:indeterminate::before {
 	white-space: nowrap;
 }
 
-.plugins .plugin-title img,
-.plugins .plugin-title .dashicons {
+.plugins .plugin-title .dashicons,
+.plugins .plugin-title img.dashicons,
+.plugins .plugin-title img[class*="icon"],
+.plugins .plugin-title img[src*="data:image"] {
 	float: left;
 	padding: 0 10px 0 0;
 	width: 64px;
 	height: 64px;
 }
+
 
 .plugins .plugin-title .dashicons:before {
 	padding: 2px;


### PR DESCRIPTION
This PR fixes a layout issue in the WordPress admin plugin list screen where plugin titles containing emojis are displayed incorrectly.

The current CSS rule floats all <img> elements inside .plugin-title, which unintentionally affects emojis (as some browsers render them as images). This causes the emoji to be pulled out of the text and floated to the left.

What’s Fixed
Updated the CSS selector to target only actual icons and image elements meant for layout (e.g., .dashicons, icon classes, data URIs), ensuring emoji characters remain inline with the text.

Before
Plugin title: myplugin❤️wordpress
Rendered as: ❤️mypluginwordpress

After (With Fix)
Rendered correctly as: myplugin❤️wordpress

``` css
.plugins .plugin-title .dashicons,
.plugins .plugin-title img.dashicons,
.plugins .plugin-title img[class*="icon"],
.plugins .plugin-title img[src*="data:image"] {
    float: left;
    padding: 0 10px 0 0;
    width: 64px;
    height: 64px;
}
```

Trac Ticket : https://core.trac.wordpress.org/ticket/63120

This change improves visual consistency for plugin authors using emojis in their titles.
