### PR TITLE
Theme Package: Replace keyCode with key in key event handling in the theme folder

### DIFF
--- a/src/wp-content/themes/twentyfourteen/js/slider.js
+++ b/src/wp-content/themes/twentyfourteen/js/slider.js
@@ -73,12 +73,12 @@
 				// KEYBOARD
 				if ( $( slider.containerSelector ).length === 1 ) {
 					$( document ).bind( 'keyup', function( event ) {
-						var keycode = event.keyCode,
+						var keycode = event.key,
 							target = false;
-						if ( ! slider.animating && ( keycode === 39 || keycode === 37 ) ) {
-							if ( keycode === 39 ) {
+						if ( ! slider.animating && ( keycode === 'ArrowRight' || keycode === 'ArrowLeft' ) ) {
+							if ( keycode === 'ArrowRight' ) {
 								target = slider.getTarget( 'next' );
-							} else if ( keycode === 37 ) {
+							} else if ( keycode === 'ArrowLeft' ) {
 								target = slider.getTarget( 'prev' );
 							}
 

--- a/src/wp-content/themes/twentytwenty/assets/js/index.js
+++ b/src/wp-content/themes/twentytwenty/assets/js/index.js
@@ -157,7 +157,7 @@ twentytwenty.coverModals = {
 	// Close modal on escape key press.
 	closeOnEscape: function() {
 		document.addEventListener( 'keydown', function( event ) {
-			if ( event.keyCode === 27 ) {
+			if ( event.key === 'Escape' ) {
 				event.preventDefault();
 				document.querySelectorAll( '.cover-modal.active' ).forEach( function( element ) {
 					this.untoggleModal( element );
@@ -401,7 +401,7 @@ twentytwenty.modalMenu = {
 				lastEl = elements[ elements.length - 1 ];
 				firstEl = elements[0];
 				activeEl = _doc.activeElement;
-				tabKey = event.keyCode === 9;
+				tabKey = event.key === 'Tab';
 				shiftKey = event.shiftKey;
 
 				if ( ! shiftKey && tabKey && lastEl === activeEl ) {

--- a/src/wp-content/themes/twentytwentyone/assets/js/primary-navigation.js
+++ b/src/wp-content/themes/twentytwentyone/assets/js/primary-navigation.js
@@ -149,9 +149,9 @@ function twentytwentyoneExpandSubMenu( el ) { // jshint ignore:line
 			selectors = 'input, a, button';
 			elements = modal.querySelectorAll( selectors );
 			elements = Array.prototype.slice.call( elements );
-			tabKey = event.keyCode === 9;
+			tabKey = event.key === 'Tab';
 			shiftKey = event.shiftKey;
-			escKey = event.keyCode === 27;
+			escKey = event.key === 'Escape';
 			activeEl = document.activeElement; // eslint-disable-line @wordpress/no-global-active-element
 			lastEl = elements[ elements.length - 1 ];
 			firstEl = elements[0];


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63759

This PR replaces the deprecated keyCode property with key in key event handlers within the **theme folder**.