### PR TITLE
WP Package: Replace keyCode with key in key event handling in the wp folder

### DIFF
--- a/src/js/_enqueues/wp/code-editor.js
+++ b/src/js/_enqueues/wp/code-editor.js
@@ -227,16 +227,14 @@ if ( 'undefined' === typeof window.wp.codeEditor ) {
 			$textarea.data( 'next-tab-blurs', false );
 		});
 		codemirror.on( 'keydown', function onKeydown( editor, event ) {
-			var tabKeyCode = 9, escKeyCode = 27;
-
 			// Take note of the ESC keypress so that the next TAB can focus outside the editor.
-			if ( escKeyCode === event.keyCode ) {
+			if ( 'Escape' === event.key ) {
 				$textarea.data( 'next-tab-blurs', true );
 				return;
 			}
 
 			// Short-circuit if tab key is not being pressed or the tab key press should move focus.
-			if ( tabKeyCode !== event.keyCode || ! $textarea.data( 'next-tab-blurs' ) ) {
+			if ( 'Tab' !== event.key || ! $textarea.data( 'next-tab-blurs' ) ) {
 				return;
 			}
 

--- a/src/js/_enqueues/wp/customize/controls.js
+++ b/src/js/_enqueues/wp/customize/controls.js
@@ -1778,17 +1778,17 @@
 				}
 
 				// Pressing the right arrow key fires a theme:next event.
-				if ( 39 === event.keyCode ) {
+				if ( 'ArrowRight' === event.key ) {
 					section.nextTheme();
 				}
 
 				// Pressing the left arrow key fires a theme:previous event.
-				if ( 37 === event.keyCode ) {
+				if ( 'ArrowLeft' === event.key ) {
 					section.previousTheme();
 				}
 
 				// Pressing the escape key fires a theme:collapse event.
-				if ( 27 === event.keyCode ) {
+				if ( 'Escape' === event.key ) {
 					if ( section.$body.hasClass( 'modal-open' ) ) {
 
 						// Escape from the details modal.
@@ -2637,7 +2637,7 @@
 
 				// Return if it's not the tab key
 				// When navigating with prev/next focus is already handled.
-				if ( 9 !== event.keyCode ) {
+				if ( 'Tab' !== event.key ) {
 					return;
 				}
 
@@ -5462,8 +5462,7 @@
 
 			// Prevent collapsing section when hitting Esc to tab out of editor.
 			control.editor.codemirror.on( 'keydown', function onKeydown( codemirror, event ) {
-				var escKeyCode = 27;
-				if ( escKeyCode === event.keyCode ) {
+				if ( 'Escape' === event.key ) {
 					event.stopPropagation();
 				}
 			});
@@ -5545,9 +5544,9 @@
 			} );
 
 			$textarea.on( 'keydown', function onKeydown( event ) {
-				var selectionStart, selectionEnd, value, tabKeyCode = 9, escKeyCode = 27;
+				var selectionStart, selectionEnd, value;
 
-				if ( escKeyCode === event.keyCode ) {
+				if ( 'Escape' === event.key ) {
 					if ( ! $textarea.data( 'next-tab-blurs' ) ) {
 						$textarea.data( 'next-tab-blurs', true );
 						event.stopPropagation(); // Prevent collapsing the section.
@@ -5556,7 +5555,7 @@
 				}
 
 				// Short-circuit if tab key is not being pressed or if a modifier key *is* being pressed.
-				if ( tabKeyCode !== event.keyCode || event.ctrlKey || event.altKey || event.shiftKey ) {
+				if ( 'Tab' !== event.key || event.ctrlKey || event.altKey || event.shiftKey ) {
 					return;
 				}
 

--- a/src/js/_enqueues/wp/editor/dfw.js
+++ b/src/js/_enqueues/wp/editor/dfw.js
@@ -1166,14 +1166,14 @@
 		 */
 		function fadeOut( event ) {
 			var isMac,
-				key = event && event.keyCode;
+				key = event && event.key;
 
 			if ( window.navigator.platform ) {
 				isMac = ( window.navigator.platform.indexOf( 'Mac' ) > -1 );
 			}
 
 			// Fade in and returns on Escape and keyboard shortcut Alt+Shift+W and Ctrl+Opt+W.
-			if ( key === 27 || ( key === 87 && event.altKey && ( ( ! isMac && event.shiftKey ) || ( isMac && event.ctrlKey ) ) ) ) {
+			if ( key === 'Escape' || ( key === 'w' && event.altKey && ( ( ! isMac && event.shiftKey ) || ( isMac && event.ctrlKey ) ) ) ) {
 				fadeIn( event );
 				return;
 			}
@@ -1181,15 +1181,15 @@
 			// Return if any of the following keys or combinations of keys is pressed.
 			if ( event && ( event.metaKey || ( event.ctrlKey && ! event.altKey ) || ( event.altKey && event.shiftKey ) || ( key && (
 				// Special keys ( tab, ctrl, alt, esc, arrow keys... ).
-				( key <= 47 && key !== 8 && key !== 13 && key !== 32 && key !== 46 ) ||
+				( ['Tab', 'Control', 'Alt', 'Shift', 'Escape', 'CapsLock', 'NumLock', 'ScrollLock', 'Pause', 'Insert', 'Home', 'End', 'PageUp', 'PageDown', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'PrintScreen'].includes(key) ) ||
 				// Windows keys.
-				( key >= 91 && key <= 93 ) ||
+				( ['Meta', 'OS', 'ContextMenu'].includes(key) ) ||
 				// F keys.
-				( key >= 112 && key <= 135 ) ||
-				// Num Lock, Scroll Lock, OEM.
-				( key >= 144 && key <= 150 ) ||
+				( /^F([1-9]|1[0-9]|2[0-4])$/.test(key) ) ||
 				// OEM or non-printable.
-				key >= 224
+				key.startsWith('Dead') ||
+				key === 'Unidentified' ||
+				key.length > 1 && !['Enter', 'Backspace', 'Delete', ' '].includes(key)
 			) ) ) ) {
 				return;
 			}
@@ -1446,7 +1446,7 @@
 		 * @return {void}
 		 */
 		function toggleViaKeyboard( event ) {
-			if ( event.altKey && event.shiftKey && 87 === event.keyCode ) {
+			if ( event.altKey && event.shiftKey && 'w' === event.key ) {
 				toggle();
 			}
 		}

--- a/src/js/_enqueues/wp/theme-plugin-editor.js
+++ b/src/js/_enqueues/wp/theme-plugin-editor.js
@@ -523,19 +523,6 @@ wp.themePluginEditor = (function( $ ) {
 
 				elem = elem.nextElementSibling;
 			}
-
-			this.keyCode = Object.freeze({
-				RETURN: 13,
-				SPACE: 32,
-				PAGEUP: 33,
-				PAGEDOWN: 34,
-				END: 35,
-				HOME: 36,
-				LEFT: 37,
-				UP: 38,
-				RIGHT: 39,
-				DOWN: 40
-			});
 		};
 
 		TreeitemLink.prototype.init = function () {
@@ -602,7 +589,7 @@ wp.themePluginEditor = (function( $ ) {
 			}
 
 			if (event.shift) {
-				if (event.keyCode == this.keyCode.SPACE || event.keyCode == this.keyCode.RETURN) {
+				if (event.key == ' ' || event.key == 'Enter') {
 					event.stopPropagation();
 					this.stopDefaultClick = true;
 				}
@@ -613,9 +600,9 @@ wp.themePluginEditor = (function( $ ) {
 				}
 			}
 			else {
-				switch (event.keyCode) {
-					case this.keyCode.SPACE:
-					case this.keyCode.RETURN:
+				switch (event.key) {
+					case ' ':
+					case 'Enter':
 						if (this.isExpandable) {
 							if (this.isExpanded()) {
 								this.tree.collapseTreeitem(this);
@@ -631,17 +618,17 @@ wp.themePluginEditor = (function( $ ) {
 						}
 						break;
 
-					case this.keyCode.UP:
+					case 'ArrowUp':
 						this.tree.setFocusToPreviousItem(this);
 						flag = true;
 						break;
 
-					case this.keyCode.DOWN:
+					case 'ArrowDown':
 						this.tree.setFocusToNextItem(this);
 						flag = true;
 						break;
 
-					case this.keyCode.RIGHT:
+					case 'ArrowRight':
 						if (this.isExpandable) {
 							if (this.isExpanded()) {
 								this.tree.setFocusToNextItem(this);
@@ -653,7 +640,7 @@ wp.themePluginEditor = (function( $ ) {
 						flag = true;
 						break;
 
-					case this.keyCode.LEFT:
+					case 'ArrowLeft':
 						if (this.isExpandable && this.isExpanded()) {
 							this.tree.collapseTreeitem(this);
 							flag = true;
@@ -666,12 +653,12 @@ wp.themePluginEditor = (function( $ ) {
 						}
 						break;
 
-					case this.keyCode.HOME:
+					case 'Home':
 						this.tree.setFocusToFirstItem();
 						flag = true;
 						break;
 
-					case this.keyCode.END:
+					case 'End':
 						this.tree.setFocusToLastItem();
 						flag = true;
 						break;

--- a/src/js/_enqueues/wp/theme.js
+++ b/src/js/_enqueues/wp/theme.js
@@ -742,7 +742,7 @@ themes.view.Details = wp.Backbone.View.extend({
 
 		// Detect if the click is inside the overlay and don't close it
 		// unless the target was the div.back button.
-		if ( $( event.target ).is( '.theme-backdrop' ) || $( event.target ).is( '.close' ) || event.keyCode === 27 ) {
+		if ( $( event.target ).is( '.theme-backdrop' ) || $( event.target ).is( '.close' ) || event.key === 'Escape' ) {
 
 			// Add a temporary closing class while overlay fades out.
 			$( 'body' ).addClass( 'closing-overlay' );
@@ -1007,7 +1007,7 @@ themes.view.Preview = themes.view.Details.extend({
 
 	keyEvent: function( event ) {
 		// The escape key closes the preview.
-		if ( event.keyCode === 27 ) {
+		if ( event.key === 'Escape' ) {
 			this.undelegateEvents();
 			this.close();
 		}
@@ -1018,12 +1018,12 @@ themes.view.Preview = themes.view.Details.extend({
 		}
 
 		// The right arrow key, next theme.
-		if ( event.keyCode === 39 ) {
+		if ( event.key === 'ArrowRight' ) {
 			_.once( this.nextTheme() );
 		}
 
 		// The left arrow key, previous theme.
-		if ( event.keyCode === 37 ) {
+		if ( event.key === 'ArrowLeft' ) {
 			this.previousTheme();
 		}
 	},
@@ -1127,17 +1127,17 @@ themes.view.Themes = wp.Backbone.View.extend({
 			}
 
 			// Pressing the right arrow key fires a theme:next event.
-			if ( event.keyCode === 39 ) {
+			if ( event.key === 'ArrowRight' ) {
 				self.overlay.nextTheme();
 			}
 
 			// Pressing the left arrow key fires a theme:previous event.
-			if ( event.keyCode === 37 ) {
+			if ( event.key === 'ArrowLeft' ) {
 				self.overlay.previousTheme();
 			}
 
 			// Pressing the escape key fires a theme:collapse event.
-			if ( event.keyCode === 27 ) {
+			if ( event.key === 'Escape' ) {
 				self.overlay.collapse( event );
 			}
 		});

--- a/src/js/_enqueues/wp/updates.js
+++ b/src/js/_enqueues/wp/updates.js
@@ -2188,9 +2188,9 @@
 	 * @param {Event} event Event interface.
 	 */
 	wp.updates.keydown = function( event ) {
-		if ( 27 === event.keyCode ) {
+		if ( 'Escape' === event.key ) {
 			wp.updates.requestForCredentialsModalCancel();
-		} else if ( 9 === event.keyCode ) {
+		} else if ( 'Tab' === event.key ) {
 
 			// #upgrade button must always be the last focus-able element in the dialog.
 			if ( 'upgrade' === event.target.id && ! event.shiftKey ) {

--- a/src/js/_enqueues/wp/widgets/custom-html.js
+++ b/src/js/_enqueues/wp/widgets/custom-html.js
@@ -262,8 +262,7 @@ wp.customHtmlWidgets = ( function( $ ) {
 			// Prevent hitting Esc from collapsing the widget control.
 			if ( wp.customize ) {
 				control.editor.codemirror.on( 'keydown', function onKeydown( codemirror, event ) {
-					var escKeyCode = 27;
-					if ( escKeyCode === event.keyCode ) {
+					if ( 'Escape' === event.key ) {
 						event.stopPropagation();
 					}
 				});


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63759

This PR replaces the deprecated keyCode property with key in key event handlers within the **wp folder**.

---
### Note
I'm not sure whether the virtual keyboard keys need to be replaced (check [dfw.js](https://github.com/WordPress/wordpress-develop/blob/trunk/src/js/_enqueues/wp/editor/dfw.js#L250)). I  haven't made any changes to them yet. Please let me know if this also needs to be updated.