### PR TITLE
Change default comment fetch count from 20 to 10 for consistency

### DIFF
--- a/src/js/_enqueues/admin/post.js
+++ b/src/js/_enqueues/admin/post.js
@@ -41,7 +41,7 @@ window.wp = window.wp || {};
 		get : function(total, num) {
 			var st = this.st, data;
 			if ( ! num )
-				num = 20;
+				num = 10;
 
 			this.st += num;
 			this.total = total;

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -914,7 +914,7 @@ function post_comment_meta_box( $post ) {
 		$hidden = get_hidden_meta_boxes( get_current_screen() );
 		if ( ! in_array( 'commentsdiv', $hidden, true ) ) {
 			?>
-			<script type="text/javascript">jQuery(function(){commentsBox.get(<?php echo $total; ?>, 20);});</script>
+			<script type="text/javascript">jQuery(function(){commentsBox.get(<?php echo $total; ?>, 10);});</script>
 			<?php
 		}
 

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -914,7 +914,7 @@ function post_comment_meta_box( $post ) {
 		$hidden = get_hidden_meta_boxes( get_current_screen() );
 		if ( ! in_array( 'commentsdiv', $hidden, true ) ) {
 			?>
-			<script type="text/javascript">jQuery(function(){commentsBox.get(<?php echo $total; ?>, 10);});</script>
+			<script type="text/javascript">jQuery(function(){commentsBox.get(<?php echo $total; ?>, 20);});</script>
 			<?php
 		}
 


### PR DESCRIPTION
This pull request updates the default value of num (number of comments to fetch per request) in the commentsBox.get() method from 20 to 10. 
This ensures that:  
- The initial AJAX call (triggered by the comment meta box) 
- All subsequent “Show more comments” calls  fetch the same number of comments (10 by default), resulting in a consistent UX.  

This change avoids unexpected jumps in the number of comments loaded on first and subsequent loads.
Trac ticket: https://core.trac.wordpress.org/ticket/53310

