### PR TITLE
Respect user screen option for comments per page in AJAX pagination

### DIFF
--- a/src/js/_enqueues/admin/post.js
+++ b/src/js/_enqueues/admin/post.js
@@ -40,8 +40,11 @@ window.wp = window.wp || {};
 		 */
 		get : function(total, num) {
 			var st = this.st, data;
-			if ( ! num )
-				num = 20;
+			if ( num ) {
+				this.num = num;
+			} else {
+				num = this.num || 10; // Fallback if not set yet
+			}
 
 			this.st += num;
 			this.total = total;
@@ -98,7 +101,7 @@ window.wp = window.wp || {};
 		 */
 		load: function(total){
 			this.st = jQuery('#the-comment-list tr.comment:visible').length;
-			this.get(total);
+			this.get(total, this.num || 10);
 		}
 	};
 

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -912,9 +912,13 @@ function post_comment_meta_box( $post ) {
 		echo '<p id="no-comments">' . __( 'No comments yet.' ) . '</p>';
 	} else {
 		$hidden = get_hidden_meta_boxes( get_current_screen() );
+		$per_page = (int) get_user_option( 'edit_comments_per_page' );
+		if ( ! $per_page ) {
+			$per_page = 10;
+		}
 		if ( ! in_array( 'commentsdiv', $hidden, true ) ) {
 			?>
-			<script type="text/javascript">jQuery(function(){commentsBox.get(<?php echo $total; ?>, 10);});</script>
+			<script type="text/javascript">jQuery(function(){commentsBox.get(<?php echo $total; ?>, <?php echo $per_page; ?>);});</script>
 			<?php
 		}
 


### PR DESCRIPTION
This pull request ensures that the number of comments fetched in the AJAX pagination respects the user-defined “comments per page” screen option.

- On the initial call, the user’s preference is fetched from the server (via prepare_items) and passed to the JavaScript.
- This value is then saved to commentsBox.num and reused in all future “Show more comments” requests.

This makes the AJAX comment loading consistent with the admin screen preferences and improves accessibility and predictability.



Trac ticket: https://core.trac.wordpress.org/ticket/53310


