### PR TITLE
Docs: Add missing @title tag in ms-default-filters.php

### DIFF
--- a/src/wp-includes/ms-default-filters.php
+++ b/src/wp-includes/ms-default-filters.php
@@ -1,4 +1,3 @@
-<?php
 /**
  * Sets up the default filters and actions for Multisite.
  *
@@ -7,11 +6,13 @@
  *
  * Not all of the Multisite default hooks are found in ms-default-filters.php
  *
+ * @title Actions and Filters
  * @package WordPress
  * @subpackage Multisite
  * @see default-filters.php
  * @since 3.0.0
  */
+
 
 add_action( 'init', 'ms_subdomain_constants' );
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR adds a missing @title tag to the `ms-default-filters.php` file to improve inline documentation clarity and help contributors understand the purpose of the file.

Related Issue: https://github.com/WordPress/Advanced-administration-handbook/issues/453


Trac ticket: (https://core.trac.wordpress.org/ticket/63782#ticket)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
