### PR TITLE
Posts: Display `Scheduled` state for future-dated private posts

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2295,6 +2295,9 @@ function get_post_states( $post ) {
 	if ( 'private' === $post->post_status && 'private' !== $post_status ) {
 		$post_states['private'] = _x( 'Private', 'post status' );
 	}
+	if ( 'private' === $post->post_status && strtotime( $post->post_date_gmt ) > time() ) {
+		$post_states['scheduled'] = _x( 'Scheduled', 'post status' );
+	}
 
 	if ( 'draft' === $post->post_status ) {
 		if ( get_post_meta( $post->ID, '_customize_changeset_uuid', true ) ) {

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -784,4 +784,27 @@ class Tests_Post extends WP_UnitTestCase {
 			get_post_states( $post )
 		);
 	}
+
+	/**
+	 * Tests that the _post_states() function correctly renders the HTML
+	 * for a future-dated private post.
+	 *
+	 * @ticket 18264
+	 */
+	public function test_post_states_renders_correctly_for_future_private_post() {
+		$future_date = gmdate( 'Y-m-d H:i:s', time() + HOUR_IN_SECONDS );
+
+		$post        = self::factory()->post->create_and_get(
+			array(
+				'post_status'   => 'private',
+				'post_date'     => get_date_from_gmt( $future_date ),
+				'post_date_gmt' => $future_date,
+			)
+		);
+
+		$rendered_states = _post_states( $post, false );
+
+		$this->assertStringContainsString( 'Private', $rendered_states );
+		$this->assertStringContainsString( 'Scheduled', $rendered_states );
+	}
 }

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -794,7 +794,7 @@ class Tests_Post extends WP_UnitTestCase {
 	public function test_post_states_renders_correctly_for_future_private_post() {
 		$future_date = gmdate( 'Y-m-d H:i:s', time() + HOUR_IN_SECONDS );
 
-		$post        = self::factory()->post->create_and_get(
+		$post = self::factory()->post->create_and_get(
 			array(
 				'post_status'   => 'private',
 				'post_date'     => get_date_from_gmt( $future_date ),

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -759,4 +759,29 @@ class Tests_Post extends WP_UnitTestCase {
 		$this->assertTrue( use_block_editor_for_post( $restless_post_id ) );
 		remove_filter( 'use_block_editor_for_post', '__return_true' );
 	}
+
+	/**
+	 * Tests that a private post with a future date returns both 'Private' and 'Scheduled' states.
+	 *
+	 * @ticket 18264
+	 */
+	public function test_get_post_states_for_future_dated_private_post() {
+		$future_date = gmdate( 'Y-m-d H:i:s', time() + HOUR_IN_SECONDS );
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_status'   => 'private',
+				'post_date'     => get_date_from_gmt( $future_date ),
+				'post_date_gmt' => $future_date,
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'private'   => 'Private',
+				'scheduled' => 'Scheduled',
+			),
+			get_post_states( $post )
+		);
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/18264


This PR fixes a UI inconsistency where private posts scheduled for a future date do not display the "Scheduled" state in the `All Posts` list table. Public and password-protected posts correctly show this state, and this change brings the behavior for private posts into alignment.

The fix adds a condition to the `get_post_states()` function. It checks if a post with a 'private' status has a `post_date_gmt` set in the future and, if so, appends the "Scheduled" state to be displayed.

**How to test:**

1.  Create a new post.
2.  In the editor's panel, set the status to "Private".
3.  In the same panel, click on "Publish" and select a date and time in the future.
4.  Navigate to the "All Posts" screen.
5.  Verify that the post you just created now displays the text "Private, Scheduled" next to its title.

This change also introduces new unit tests to ensure correctness and prevent future regressions. The tests confirm that a future-dated private post correctly receives both "Private" and "Scheduled" states.

Run the tests - 

```bash
npm run test:php -- --filter=Tests_Post 
```
