### PR TITLE
Remove deprecated user contact methods from documentation and tests

### DIFF
--- a/src/wp-includes/author-template.php
+++ b/src/wp-includes/author-template.php
@@ -124,13 +124,11 @@ function the_modified_author() {
  * Valid values for the `$field` parameter include:
  *
  * - admin_color
- * - aim
  * - comment_shortcuts
  * - description
  * - display_name
  * - first_name
  * - ID
- * - jabber
  * - last_name
  * - nickname
  * - plugins_last_view
@@ -149,7 +147,6 @@ function the_modified_author() {
  * - user_registered
  * - user_status
  * - user_url
- * - yim
  *
  * @since 2.8.0
  *

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2140,6 +2140,7 @@ function validate_username( $username ) {
  * @since 2.0.0
  * @since 3.6.0 The `aim`, `jabber`, and `yim` fields were removed as default user contact
  *              methods for new installations. See wp_get_user_contact_methods().
+ * @since 6.8.0 The `aim`, `jabber`, and `yim` fields were completely removed.
  * @since 4.7.0 The `locale` field can be passed to `$userdata`.
  * @since 5.3.0 The `user_activation_key` field can be passed to `$userdata`.
  * @since 5.3.0 The `spam` field can be passed to `$userdata` (Multisite only).
@@ -2954,13 +2955,6 @@ function _get_additional_user_keys( $user ) {
  */
 function wp_get_user_contact_methods( $user = null ) {
 	$methods = array();
-	if ( get_site_option( 'initial_db_version' ) < 23588 ) {
-		$methods = array(
-			'aim'    => __( 'AIM' ),
-			'yim'    => __( 'Yahoo IM' ),
-			'jabber' => __( 'Jabber / Google Talk' ),
-		);
-	}
 
 	/**
 	 * Filters the user contact methods.

--- a/tests/phpunit/tests/xmlrpc/wp/getUser.php
+++ b/tests/phpunit/tests/xmlrpc/wp/getUser.php
@@ -60,7 +60,6 @@ class Tests_XMLRPC_wp_getUser extends WP_XMLRPC_UnitTestCase {
 			'display_name'    => 'First Last',
 			'user_url'        => 'http://www.example.com/testuser',
 			'role'            => 'author',
-			'aim'             => 'wordpress',
 			'user_registered' => date_format( date_create( "@{$registered_date}" ), 'Y-m-d H:i:s' ),
 		);
 		$user_id         = wp_insert_user( $user_data );


### PR DESCRIPTION
Removes all references to `aim`, `yim` and `jabber` from the codebase, as these services have shutdown long time ago...

Trac ticket: https://core.trac.wordpress.org/ticket/44374

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
