### PR TITLE
Block Bindings: Allow filtering supported block attributes

### DIFF
--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -99,6 +99,22 @@ class WP_Block {
 	public $inner_content = array();
 
 	/**
+	 * List of supported block attributes for block bindings.
+	 *
+	 * @since 6.9.0
+	 * @var array
+	 *
+	 * @see WP_Block::process_block_bindings()
+	 */
+	private const BLOCK_BINDINGS_SUPPORTED_ATTRIBUTES = array(
+		'core/paragraph' => array( 'content' ),
+		'core/heading'   => array( 'content' ),
+		'core/image'     => array( 'id', 'url', 'title', 'alt' ),
+		'core/button'    => array( 'url', 'text', 'linkTarget', 'rel' ),
+		'core/post-date' => array( 'datetime' ),
+	);
+
+	/**
 	 * Constructor.
 	 *
 	 * Populates object properties from the provided block instance argument.
@@ -282,15 +298,9 @@ class WP_Block {
 		$parsed_block               = $this->parsed_block;
 		$computed_attributes        = array();
 
-		$all_supported_block_attributes = array(
-			'core/paragraph' => array( 'content' ),
-			'core/heading'   => array( 'content' ),
-			'core/image'     => array( 'id', 'url', 'title', 'alt' ),
-			'core/button'    => array( 'url', 'text', 'linkTarget', 'rel' ),
-			'core/post-date' => array( 'datetime' ),
-		);
-
-		$supported_block_attributes = $all_supported_block_attributes[ $block_type ] ?? array();
+		$supported_block_attributes =
+			self::BLOCK_BINDINGS_SUPPORTED_ATTRIBUTES[ $block_type ] ??
+			array();
 
 		/**
 		 * Filters the supported block attributes for block bindings.

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -278,6 +278,7 @@ class WP_Block {
 	 * @return array The computed block attributes for the provided block bindings.
 	 */
 	private function process_block_bindings() {
+		$block_type                 = $this->name;
 		$parsed_block               = $this->parsed_block;
 		$computed_attributes        = array();
 
@@ -289,20 +290,21 @@ class WP_Block {
 			'core/post-date' => array( 'datetime' ),
 		);
 
-		$supported_block_attributes = $all_supported_block_attributes[ $this->name ] ?? array();
+		$supported_block_attributes = $all_supported_block_attributes[ $block_type ] ?? array();
 
 		/**
 		 * Filters the supported block attributes for block bindings.
 		 *
+		 * The dynamic portion of the hook name, `$block_type`, refers to the block type
+		 * whose attributes are being filtered.
+		 *
 		 * @since 6.9.0
 		 *
 		 * @param string[] $supported_block_attributes The block's attributes that are supported by block bindings.
-		 * @param string   $block_name                 The name of the block whose attributes are being filtered.
 		 */
 		$supported_block_attributes = apply_filters(
-			'block_bindings_supported_block_attributes',
-			$supported_block_attributes,
-			$this->name
+			"block_bindings_supported_attributes_{$block_type}",
+			$supported_block_attributes
 		);
 
 		// If the block doesn't have the bindings property, isn't one of the supported

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -288,6 +288,19 @@ class WP_Block {
 			'core/post-date' => array( 'datetime' ),
 		);
 
+		/**
+		 * Filters the supported block attributes for block bindings.
+		 *
+		 * @since 6.9.0
+		 *
+		 * @param array $supported_block_attributes The supported block attributes for block bindings.
+		 *                                          The keys are block names and the values are arrays of attribute names.
+		 */
+		$supported_block_attributes = apply_filters(
+			'block_bindings_supported_block_attributes',
+			$supported_block_attributes
+		);
+
 		// If the block doesn't have the bindings property, isn't one of the supported
 		// block types, or the bindings property is not an array, return the block content.
 		if (

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -280,7 +280,8 @@ class WP_Block {
 	private function process_block_bindings() {
 		$parsed_block               = $this->parsed_block;
 		$computed_attributes        = array();
-		$supported_block_attributes = array(
+
+		$all_supported_block_attributes = array(
 			'core/paragraph' => array( 'content' ),
 			'core/heading'   => array( 'content' ),
 			'core/image'     => array( 'id', 'url', 'title', 'alt' ),
@@ -288,23 +289,26 @@ class WP_Block {
 			'core/post-date' => array( 'datetime' ),
 		);
 
+		$supported_block_attributes = $all_supported_block_attributes[ $this->name ] ?? array();
+
 		/**
 		 * Filters the supported block attributes for block bindings.
 		 *
 		 * @since 6.9.0
 		 *
-		 * @param array $supported_block_attributes The supported block attributes for block bindings.
-		 *                                          The keys are block names and the values are arrays of attribute names.
+		 * @param string[] $supported_block_attributes The block's attributes that are supported by block bindings.
+		 * @param string   $block_name                 The name of the block whose attributes are being filtered.
 		 */
 		$supported_block_attributes = apply_filters(
 			'block_bindings_supported_block_attributes',
-			$supported_block_attributes
+			$supported_block_attributes,
+			$this->name
 		);
 
 		// If the block doesn't have the bindings property, isn't one of the supported
 		// block types, or the bindings property is not an array, return the block content.
 		if (
-			! isset( $supported_block_attributes[ $this->name ] ) ||
+			empty( $supported_block_attributes ) ||
 			empty( $parsed_block['attrs']['metadata']['bindings'] ) ||
 			! is_array( $parsed_block['attrs']['metadata']['bindings'] )
 		) {
@@ -328,7 +332,7 @@ class WP_Block {
 			 * Note that this also omits the `__default` attribute from the
 			 * resulting array.
 			 */
-			foreach ( $supported_block_attributes[ $parsed_block['blockName'] ] as $attribute_name ) {
+			foreach ( $supported_block_attributes as $attribute_name ) {
 				// Retain any non-pattern override bindings that might be present.
 				$updated_bindings[ $attribute_name ] = isset( $bindings[ $attribute_name ] )
 					? $bindings[ $attribute_name ]
@@ -347,7 +351,7 @@ class WP_Block {
 
 		foreach ( $bindings as $attribute_name => $block_binding ) {
 			// If the attribute is not in the supported list, process next attribute.
-			if ( ! in_array( $attribute_name, $supported_block_attributes[ $this->name ], true ) ) {
+			if ( ! in_array( $attribute_name, $supported_block_attributes, true ) ) {
 				continue;
 			}
 			// If no source is provided, or that source is not registered, process next attribute.

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -73,6 +73,64 @@ HTML;
 	}
 
 	/**
+	 * Test if the block_bindings_supported_attributes_{$block_type} filter is applied correctly.
+	 *
+	 * @ticket 62090
+	 */
+	public function test_filter_block_bindings_supported_attributes() {
+		$get_value_callback = function () {
+			return 'test source value';
+		};
+
+		register_block_bindings_source(
+			self::SOURCE_NAME,
+			array(
+				'label'              => self::SOURCE_LABEL,
+				'get_value_callback' => $get_value_callback,
+			)
+		);
+
+		register_block_type(
+			'test/block',
+			array(
+				'attributes' => array(
+					'myAttribute' => array(
+						'type' => 'string',
+					),
+				),
+				'render_callback' => function ( $attributes ) {
+					return '<p>' . esc_html( $attributes['myAttribute'] ) . '</p>';
+				},
+			)
+		);
+
+		add_filter( 'block_bindings_supported_attributes_test/block', function ( $supported_attributes ) {
+			$supported_attributes[] = 'myAttribute';
+			return $supported_attributes;
+		} );
+
+		$block_content = <<<HTML
+<!-- wp:test/block {"metadata":{"bindings":{"myAttribute":{"source":"test/source"}}}} -->
+<p>This should not appear</p>
+<!-- /wp:test/block -->
+HTML;
+		$parsed_blocks = parse_blocks( $block_content );
+		$block         = new WP_Block( $parsed_blocks[0] );
+		$result        = $block->render();
+
+		$this->assertSame(
+			'test source value',
+			$block->attributes['myAttribute'],
+			"The 'content' attribute should be updated with the value returned by the source."
+		);
+		$this->assertSame(
+			'<p>test source value</p>',
+			trim( $result ),
+			'The block content should be updated with the value returned by the source.'
+		);
+	}
+
+	/**
 	 * Test passing arguments to the source.
 	 *
 	 * @ticket 60282

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -140,7 +140,7 @@ HTML;
 		$this->assertSame(
 			'test source value',
 			$block->attributes['myAttribute'],
-			"The 'content' attribute should be updated with the value returned by the source."
+			"The 'myAttribute' attribute should be updated with the value returned by the source."
 		);
 		$this->assertSame(
 			'<p>test source value</p>',

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -17,6 +17,27 @@ class WP_Block_Bindings_Render extends WP_UnitTestCase {
 	);
 
 	/**
+	 * Sets up shared fixtures.
+	 * 
+	 * @since 6.9.0
+	 */
+	public static function wpSetUpBeforeClass() {
+		register_block_type(
+			'test/block',
+			array(
+				'attributes'      => array(
+					'myAttribute' => array(
+						'type' => 'string',
+					),
+				),
+				'render_callback' => function ( $attributes ) {
+					return '<p>' . esc_html( $attributes['myAttribute'] ) . '</p>';
+				},
+			)
+		);
+	}
+
+	/**
 	 * Tear down after each test.
 	 *
 	 * @since 6.5.0
@@ -29,6 +50,15 @@ class WP_Block_Bindings_Render extends WP_UnitTestCase {
 		}
 
 		parent::tear_down();
+	}
+
+	/**
+	 * Tear down after class.
+	 *
+	 * @since 6.9.0
+	 */
+	public static function wpTearDownAfterClass() {
+		unregister_block_type( 'test/block' );
 	}
 
 	/**
@@ -87,20 +117,6 @@ HTML;
 			array(
 				'label'              => self::SOURCE_LABEL,
 				'get_value_callback' => $get_value_callback,
-			)
-		);
-
-		register_block_type(
-			'test/block',
-			array(
-				'attributes'      => array(
-					'myAttribute' => array(
-						'type' => 'string',
-					),
-				),
-				'render_callback' => function ( $attributes ) {
-					return '<p>' . esc_html( $attributes['myAttribute'] ) . '</p>';
-				},
 			)
 		);
 

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -104,10 +104,13 @@ HTML;
 			)
 		);
 
-		add_filter( 'block_bindings_supported_attributes_test/block', function ( $supported_attributes ) {
-			$supported_attributes[] = 'myAttribute';
-			return $supported_attributes;
-		} );
+		add_filter(
+			'block_bindings_supported_attributes_test/block',
+			function ( $supported_attributes ) {
+				$supported_attributes[] = 'myAttribute';
+				return $supported_attributes;
+			}
+		);
 
 		$block_content = <<<HTML
 <!-- wp:test/block {"metadata":{"bindings":{"myAttribute":{"source":"test/source"}}}} -->

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -18,7 +18,7 @@ class WP_Block_Bindings_Render extends WP_UnitTestCase {
 
 	/**
 	 * Sets up shared fixtures.
-	 * 
+	 *
 	 * @since 6.9.0
 	 */
 	public static function wpSetUpBeforeClass() {

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -93,7 +93,7 @@ HTML;
 		register_block_type(
 			'test/block',
 			array(
-				'attributes' => array(
+				'attributes'      => array(
 					'myAttribute' => array(
 						'type' => 'string',
 					),


### PR DESCRIPTION
This has been discussed in https://core.trac.wordpress.org/ticket/62090.

Alternatives considered include:

1.  A dedicated property to denote a block attribute as bindable in `block.json`, e.g.

```json
"attributes": {
	"datetime": {
		"type": "string",
		"bindable": true
	},
}
```

2. Inferring that an attribute is bindable if it has `"role": "content"` set:

```json
"attributes": {
	"datetime": {
		"type": "string",
		"role": "content"
	},
}
```

I agree that the latter is probably a good idea in the long run. However, there are currently 83 block attributes with `"role": "content"` in Gutenberg, and it's not a trivial feat to make all of them bindable. (There are some complications, e.g. attributes such as an image block's `caption` which is only rendered conditionally.)

In the meantime, the absence of an extensibility mechanism for the list of supported block attributes means that _each block has to manually invoke block bindings to ensure backwards compatibility_, as seen e.g. [here](https://github.com/WordPress/gutenberg/pull/71047/files#diff-599951e5a5c3cf5383ba5ebdd009140b51c0c42bff0af304de81001374a245a1R22-R35) for the Date block. This is required so the block doesn't erroneously receive the fallback value for the bound attribute if the GB plugin is run on a WP version that doesn't have that block attribute added to `$supported_block_attributes` in `WP_Block::process_block_bindings()`. On a WP version that _does_ support the block attribute, it means that the relevant code is needlessly run twice.

This is suboptimal. It also puts undue burden on block developers to include the back-compat code in their blocks, instead of being able to mark their bindable block attributes as such; it thus can hamper adoption of Block Bindings, as it makes it much more difficult to update a block to make some of its attributes bindable.

Note that this solution isn't meant to be mutually exclusive with the long-term perspective of having `"role": "content"` determine if a block attribute is bindable or not, as the initial value of `$supported_block_attributes` could be computed by iterating over blocks and including all attributes with that criterion in the list.

Closes #7404.

Trac ticket: https://core.trac.wordpress.org/ticket/62090

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
