### PR TITLE
Media: Fix return type annotation for `block_core_image_get_lightbox_settings()`

### DIFF
--- a/src/wp-includes/blocks/image.php
+++ b/src/wp-includes/blocks/image.php
@@ -100,7 +100,7 @@ function render_block_core_image( $attributes, $content, $block ) {
  *
  * @param array $block Block data.
  *
- * @return array Filtered block data.
+ * @return array|null Filtered block data.
  */
 function block_core_image_get_lightbox_settings( $block ) {
 	// Gets the lightbox setting from the block attributes.


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63790

This PR fixes the incorrect `@return` annotation in `block_core_image_get_lightbox_settings()`.

The function can return `null` when lightbox settings are not found, but the DocBlock only documents `array` as the return type. This PR updates the annotation to `@return array|null` to accurately reflect the actual return behavior.

