### PR TITLE
Add border radius preset settings to theme json and style engine

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -205,6 +205,15 @@ class WP_Theme_JSON {
 			'classes'           => array(),
 			'properties'        => array( 'box-shadow' ),
 		),
+		array(
+			'path'              => array( 'border', 'radiusSizes' ),
+			'prevent_override'  => false,
+			'use_default_names' => false,
+			'value_key'         => 'size',
+			'css_vars'          => '--wp--preset--border-radius--$slug',
+			'classes'           => array(),
+			'properties'        => array( 'border-radius' ),
+		),
 	);
 
 	/**

--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -142,6 +142,9 @@ final class WP_Style_Engine {
 					'individual' => 'border-%s-radius',
 				),
 				'path'          => array( 'border', 'radius' ),
+				'css_vars'      => array(
+					'border-radius' => '--wp--preset--border-radius--$slug',
+				),
 			),
 			'style'  => array(
 				'property_keys' => array(


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63799#ticket

This PR brings the changes from the following Gutenberg PRs to core:

https://github.com/WordPress/gutenberg/pull/67544

Changes include:

- definitions of presets settings for theme.json
- CSS var settings for style engine


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
