### PR TITLE
Upgrade runner image versions for MacOS and Windows jobs

### DIFF
--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'macos-14', 'windows-2022' ]
+        os: [ 'macos-15', 'windows-2022' ]
         directory: [ 'src', 'build' ]
     with:
       os: ${{ matrix.os }}
@@ -129,7 +129,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'macos-14', 'windows-2022' ]
+        os: [ 'macos-15', 'windows-2022' ]
         directory: [ 'src', 'build' ]
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'macos-15', 'windows-2022' ]
+        os: [ 'macos-15', 'windows-2025' ]
         directory: [ 'src', 'build' ]
     with:
       os: ${{ matrix.os }}
@@ -129,7 +129,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'macos-15', 'windows-2022' ]
+        os: [ 'macos-15', 'windows-2025' ]
         directory: [ 'src', 'build' ]
     with:
       os: ${{ matrix.os }}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

While the `-latest` alias is no longer used in Core workflows (see [Changeset-59720](https://core.trac.wordpress.org/changeset/59720)), GitHub has [begun rolling out a change to their MacOS runner images](https://github.com/actions/runner-images/issues/12520) that tags the `macos-15` as `macos-latest` instead of `macos-14`.

Similarly, the `windows-latest` alias will be updated to point to `windows-2025` in [during the month of September](https://github.com/actions/runner-images/issues/12677).

This changes the workflows running on MacOS and Windows images to use the versions that will now be considered the "latest" versions.

Trac ticket: Core-63170.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
