### PR TITLE
Bundled Themes: Use wp_print_inline_script_tag() for CSP compatibility

### DIFF
--- a/src/wp-content/themes/twentyfifteen/functions.php
+++ b/src/wp-content/themes/twentyfifteen/functions.php
@@ -412,7 +412,7 @@ endif;
  * @since Twenty Fifteen 1.1
  */
 function twentyfifteen_javascript_detection() {
-	echo "<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);</script>\n";
+	wp_print_inline_script_tag( "(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);" );
 }
 add_action( 'wp_head', 'twentyfifteen_javascript_detection', 0 );
 

--- a/src/wp-content/themes/twentynineteen/functions.php
+++ b/src/wp-content/themes/twentynineteen/functions.php
@@ -303,11 +303,7 @@ add_action( 'wp_enqueue_scripts', 'twentynineteen_scripts' );
  */
 function twentynineteen_skip_link_focus_fix() {
 	// The following is minified via `terser --compress --mangle -- js/skip-link-focus-fix.js`.
-	?>
-	<script>
-	/(trident|msie)/i.test(navigator.userAgent)&&document.getElementById&&window.addEventListener&&window.addEventListener("hashchange",function(){var t,e=location.hash.substring(1);/^[A-z0-9_-]+$/.test(e)&&(t=document.getElementById(e))&&(/^(?:a|select|input|button|textarea)$/i.test(t.tagName)||(t.tabIndex=-1),t.focus())},!1);
-	</script>
-	<?php
+	wp_print_inline_script_tag( '/(trident|msie)/i.test(navigator.userAgent)&&document.getElementById&&window.addEventListener&&window.addEventListener("hashchange",function(){var t,e=location.hash.substring(1);/^[A-z0-9_-]+$/.test(e)&&(t=document.getElementById(e))&&(/^(?:a|select|input|button|textarea)$/i.test(t.tagName)||(t.tabIndex=-1),t.focus())},!1);' );
 }
 
 /**

--- a/src/wp-content/themes/twentyseventeen/functions.php
+++ b/src/wp-content/themes/twentyseventeen/functions.php
@@ -406,7 +406,7 @@ add_filter( 'excerpt_more', 'twentyseventeen_excerpt_more' );
  * @since Twenty Seventeen 1.0
  */
 function twentyseventeen_javascript_detection() {
-	echo "<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);</script>\n";
+	wp_print_inline_script_tag( "(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);" );
 }
 add_action( 'wp_head', 'twentyseventeen_javascript_detection', 0 );
 

--- a/src/wp-content/themes/twentysixteen/functions.php
+++ b/src/wp-content/themes/twentysixteen/functions.php
@@ -373,7 +373,7 @@ endif;
  * @since Twenty Sixteen 1.0
  */
 function twentysixteen_javascript_detection() {
-	echo "<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);</script>\n";
+	wp_print_inline_script_tag( "(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);" );
 }
 add_action( 'wp_head', 'twentysixteen_javascript_detection', 0 );
 

--- a/src/wp-content/themes/twentytwenty/functions.php
+++ b/src/wp-content/themes/twentytwenty/functions.php
@@ -252,11 +252,7 @@ add_action( 'wp_enqueue_scripts', 'twentytwenty_register_scripts' );
  */
 function twentytwenty_skip_link_focus_fix() {
 	// The following is minified via `terser --compress --mangle -- assets/js/skip-link-focus-fix.js`.
-	?>
-	<script>
-	/(trident|msie)/i.test(navigator.userAgent)&&document.getElementById&&window.addEventListener&&window.addEventListener("hashchange",function(){var t,e=location.hash.substring(1);/^[A-z0-9_-]+$/.test(e)&&(t=document.getElementById(e))&&(/^(?:a|select|input|button|textarea)$/i.test(t.tagName)||(t.tabIndex=-1),t.focus())},!1);
-	</script>
-	<?php
+	wp_print_inline_script_tag( '/(trident|msie)/i.test(navigator.userAgent)&&document.getElementById&&window.addEventListener&&window.addEventListener("hashchange",function(){var t,e=location.hash.substring(1);/^[A-z0-9_-]+$/.test(e)&&(t=document.getElementById(e))&&(/^(?:a|select|input|button|textarea)$/i.test(t.tagName)||(t.tabIndex=-1),t.focus())},!1) ' );
 }
 
 /**

--- a/src/wp-content/themes/twentytwenty/inc/template-tags.php
+++ b/src/wp-content/themes/twentytwenty/inc/template-tags.php
@@ -661,9 +661,7 @@ add_filter( 'walker_nav_menu_start_el', 'twentytwenty_nav_menu_social_icons', 10
  */
 function twentytwenty_no_js_class() {
 
-	?>
-	<script>document.documentElement.className = document.documentElement.className.replace( 'no-js', 'js' );</script>
-	<?php
+	wp_print_inline_script_tag( "document.documentElement.className = document.documentElement.className.replace( 'no-js', 'js' );" );
 }
 
 add_action( 'wp_head', 'twentytwenty_no_js_class' );

--- a/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
+++ b/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
@@ -363,9 +363,8 @@ class Twenty_Twenty_One_Dark_Mode {
 	 * @return void
 	 */
 	public function the_script() {
-		echo '<script>';
-		include get_template_directory() . '/assets/js/dark-mode-toggler.js'; // phpcs:ignore WPThemeReview.CoreFunctionality.FileInclude
-		echo '</script>';
+		$script = file_get_contents( get_template_directory() . '/assets/js/dark-mode-toggler.js' ); // phpcs:ignore WPThemeReview.CoreFunctionality.FileInclude
+		wp_print_inline_script_tag( $script );
 	}
 
 	/**

--- a/src/wp-content/themes/twentytwentyone/functions.php
+++ b/src/wp-content/themes/twentytwentyone/functions.php
@@ -496,17 +496,12 @@ function twenty_twenty_one_skip_link_focus_fix() {
 
 	// If SCRIPT_DEBUG is defined and true, print the unminified file.
 	if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
-		echo '<script>';
-		include get_template_directory() . '/assets/js/skip-link-focus-fix.js';
-		echo '</script>';
+		$script = file_get_contents( get_template_directory() . '/assets/js/skip-link-focus-fix.js' );
 	} else {
 		// The following is minified via `npx terser --compress --mangle -- assets/js/skip-link-focus-fix.js`.
-		?>
-		<script>
-		/(trident|msie)/i.test(navigator.userAgent)&&document.getElementById&&window.addEventListener&&window.addEventListener("hashchange",(function(){var t,e=location.hash.substring(1);/^[A-z0-9_-]+$/.test(e)&&(t=document.getElementById(e))&&(/^(?:a|select|input|button|textarea)$/i.test(t.tagName)||(t.tabIndex=-1),t.focus())}),!1);
-		</script>
-		<?php
+		$script = '/(trident|msie)/i.test(navigator.userAgent)&&document.getElementById&&window.addEventListener&&window.addEventListener("hashchange",(function(){var t,e=location.hash.substring(1);/^[A-z0-9_-]+$/.test(e)&&(t=document.getElementById(e))&&(/^(?:a|select|input|button|textarea)$/i.test(t.tagName)||(t.tabIndex=-1),t.focus())}),!1);';
 	}
+	wp_print_inline_script_tag( $script );
 }
 
 /**
@@ -630,13 +625,11 @@ function twentytwentyone_the_html_classes() {
  * @return void
  */
 function twentytwentyone_add_ie_class() {
-	?>
-	<script>
-	if ( -1 !== navigator.userAgent.indexOf( 'MSIE' ) || -1 !== navigator.appVersion.indexOf( 'Trident/' ) ) {
-		document.body.classList.add( 'is-IE' );
-	}
-	</script>
-	<?php
+	wp_print_inline_script_tag(
+		"if ( -1 !== navigator.userAgent.indexOf( 'MSIE' ) || -1 !== navigator.appVersion.indexOf( 'Trident/' ) ) {
+        document.body.classList.add( 'is-IE' );
+    }"
+	);
 }
 add_action( 'wp_footer', 'twentytwentyone_add_ie_class' );
 

--- a/src/wp-content/themes/twentytwentyone/inc/template-functions.php
+++ b/src/wp-content/themes/twentytwentyone/inc/template-functions.php
@@ -74,7 +74,7 @@ add_action( 'wp_head', 'twenty_twenty_one_pingback_header' );
  * @return void
  */
 function twenty_twenty_one_supports_js() {
-	echo '<script>document.body.classList.remove("no-js");</script>';
+	wp_print_inline_script_tag( "document.body.classList.remove('no-js');" );
 }
 add_action( 'wp_footer', 'twenty_twenty_one_supports_js' );
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR updates bundled themes to use `wp_print_inline_script_tag()` instead of manual `<script>` tag output, enabling Strict Content Security Policy (CSP) compatibility.

Trac ticket: https://core.trac.wordpress.org/ticket/63806

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
