### PR TITLE
mail: reset PHPMailer encoding between wp_mail() calls

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -381,8 +381,8 @@ if ( ! function_exists( 'wp_mail' ) ) :
 		$phpmailer->clearAttachments();
 		$phpmailer->clearCustomHeaders();
 		$phpmailer->clearReplyTos();
-		$phpmailer->Body    = '';
-		$phpmailer->AltBody = '';
+		$phpmailer->Body     = '';
+		$phpmailer->AltBody  = '';
 		$phpmailer->Encoding = PHPMailer\PHPMailer\PHPMailer::ENCODING_8BIT;
 
 		// Set "From" name and email.

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -383,6 +383,7 @@ if ( ! function_exists( 'wp_mail' ) ) :
 		$phpmailer->clearReplyTos();
 		$phpmailer->Body    = '';
 		$phpmailer->AltBody = '';
+		$phpmailer->Encoding = PHPMailer\PHPMailer\PHPMailer::ENCODING_8BIT;
 
 		// Set "From" name and email.
 

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -383,7 +383,7 @@ if ( ! function_exists( 'wp_mail' ) ) :
 		$phpmailer->clearReplyTos();
 		$phpmailer->Body     = '';
 		$phpmailer->AltBody  = '';
-		$phpmailer->Encoding = '';
+		$phpmailer->Encoding = PHPMailer\PHPMailer\PHPMailer::ENCODING_8BIT;
 
 		// Set "From" name and email.
 

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -383,7 +383,7 @@ if ( ! function_exists( 'wp_mail' ) ) :
 		$phpmailer->clearReplyTos();
 		$phpmailer->Body     = '';
 		$phpmailer->AltBody  = '';
-		$phpmailer->Encoding = PHPMailer\PHPMailer\PHPMailer::ENCODING_8BIT;
+		$phpmailer->Encoding = '';
 
 		// Set "From" name and email.
 

--- a/tests/phpunit/includes/mock-mailer.php
+++ b/tests/phpunit/includes/mock-mailer.php
@@ -20,7 +20,6 @@ class MockPHPMailer extends WP_PHPMailer {
 	public $mock_sent = array();
 
 	public function preSend() {
-		$this->Encoding = '8bit';
 		return parent::preSend();
 	}
 

--- a/tests/phpunit/tests/pluggable/wpMail.php
+++ b/tests/phpunit/tests/pluggable/wpMail.php
@@ -641,6 +641,6 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 		wp_mail( WP_TESTS_EMAIL, 'A follow up short email', 'Short email' );
 
 		$mailer = tests_retrieve_phpmailer_instance();
-		$this->assertEquals( '', $mailer->Encoding );
+		$this->assertEquals( '7bit', $mailer->Encoding );
 	}
 }

--- a/tests/phpunit/tests/pluggable/wpMail.php
+++ b/tests/phpunit/tests/pluggable/wpMail.php
@@ -638,9 +638,9 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 		$mailer = tests_retrieve_phpmailer_instance();
 		$this->assertEquals( 'quoted-printable', $mailer->Encoding );
 
-		wp_mail( WP_TESTS_EMAIL, 'A follow up short email', 'Short email –' );
+		wp_mail( WP_TESTS_EMAIL, 'A follow up short email', 'Short email' );
 
 		$mailer = tests_retrieve_phpmailer_instance();
-		$this->assertEquals( '8bit', $mailer->Encoding );
+		$this->assertEquals( '', $mailer->Encoding );
 	}
 }

--- a/tests/phpunit/tests/pluggable/wpMail.php
+++ b/tests/phpunit/tests/pluggable/wpMail.php
@@ -625,4 +625,22 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 			$this->assertStringContainsString( 'cid:' . $key, $mailer->get_sent()->body, 'The cid ' . $key . ' is not referenced in the mail body.' );
 		}
 	}
+
+	/**
+	 * Test that the encoding of the email does not bleed between long and short emails.
+	 *
+	 * @ticket 33972
+	 */
+	function test_wp_mail_encoding_does_not_bleed() {
+		$content = str_repeat( 'A', 1000 );
+		wp_mail( WP_TESTS_EMAIL, 'Looong line testing', $content );
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertEquals( 'quoted-printable', $mailer->Encoding );
+
+		wp_mail( WP_TESTS_EMAIL, 'A follow up short email', 'Short email –' );
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertEquals( '8bit', $mailer->Encoding );
+	}
 }

--- a/tests/phpunit/tests/pluggable/wpMail.php
+++ b/tests/phpunit/tests/pluggable/wpMail.php
@@ -631,7 +631,7 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 	 *
 	 * @ticket 33972
 	 */
-	function test_wp_mail_encoding_does_not_bleed() {
+	public function test_wp_mail_encoding_does_not_bleed() {
 		$content = str_repeat( 'A', 1000 );
 		wp_mail( WP_TESTS_EMAIL, 'Looong line testing', $content );
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/33972