### PR TITLE
#63170 Add more missing permissions

### DIFF
--- a/.github/workflows/check-built-files.yml
+++ b/.github/workflows/check-built-files.yml
@@ -46,3 +46,5 @@ jobs:
     # This prevents an unnecessary second run after changes are committed back because Dependabot always rebases and force pushes.
     if: ${{ github.repository == 'wordpress/wordpress-develop' && ( github.actor != 'dependabot[bot]' || github.event.commits < 2 ) }}
     uses: ./.github/workflows/reusable-check-built-files.yml
+    permissions:
+      contents: read

--- a/.github/workflows/reusable-upgrade-testing.yml
+++ b/.github/workflows/reusable-upgrade-testing.yml
@@ -58,7 +58,8 @@ jobs:
   # - Checks the version of WordPress after the upgrade.
   upgrade-tests:
     name: ${{ inputs.wp }} to ${{ inputs.new-version }} / PHP ${{ inputs.php }} with ${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.multisite && ' multisite' || '' }}
-    permissions: {}
+    permissions:
+      contents: read
     runs-on: ${{ inputs.os }}
     timeout-minutes: 20
 

--- a/.github/workflows/upgrade-develop-testing.yml
+++ b/.github/workflows/upgrade-develop-testing.yml
@@ -57,6 +57,8 @@ jobs:
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     needs: [ build ]
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -90,6 +92,8 @@ jobs:
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     if: ${{ github.repository != 'WordPress/wordpress-develop' }}
     needs: [ build ]
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -59,6 +59,8 @@ jobs:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -94,6 +96,8 @@ jobs:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -122,6 +126,8 @@ jobs:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -154,6 +160,8 @@ jobs:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -182,6 +190,8 @@ jobs:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Following on from #9394. If a private fork wants to run these workflows then the correct permissions need to be granted so workflow artifacts can be written to and read from.

Note that some of the conditional logic in the `if` directive restricts these workflows to the `WordPress/wordpress-develop` repo, but the permissions are required anyway because the permissions are now defined in the reusable workflow file.

Trac ticket: https://core.trac.wordpress.org/ticket/63170