### PR TITLE
Fix: Add year to revision comparison interface timestamps

### DIFF
--- a/src/wp-admin/includes/revision.php
+++ b/src/wp-admin/includes/revision.php
@@ -249,7 +249,7 @@ function wp_prepare_revisions_for_js( $post, $selected_revision_id, $from = null
 			'title'      => get_the_title( $post->ID ),
 			'author'     => $authors[ $revision->post_author ],
 			'date'       => date_i18n( __( 'M j, Y @ H:i' ), $modified ),
-			'dateShort'  => date_i18n( _x( 'j M @ H:i', 'revision date short format' ), $modified ),
+			'dateShort'  => date_i18n( _x( 'j M, Y @ H:i', 'revision date short format' ), $modified ),
 			/* translators: %s: Human-readable time difference. */
 			'timeAgo'    => sprintf( __( '%s ago' ), human_time_diff( $modified_gmt, $now_gmt ) ),
 			'autosave'   => $autosave,

--- a/src/wp-admin/includes/revision.php
+++ b/src/wp-admin/includes/revision.php
@@ -249,7 +249,7 @@ function wp_prepare_revisions_for_js( $post, $selected_revision_id, $from = null
 			'title'      => get_the_title( $post->ID ),
 			'author'     => $authors[ $revision->post_author ],
 			'date'       => date_i18n( __( 'M j, Y @ H:i' ), $modified ),
-			'dateShort'  => date_i18n( _x( 'j M, Y @ H:i', 'revision date short format' ), $modified ),
+			'dateShort'  => date_i18n( _x( 'j M Y @ H:i', 'revision date short format' ), $modified ),
 			/* translators: %s: Human-readable time difference. */
 			'timeAgo'    => sprintf( __( '%s ago' ), human_time_diff( $modified_gmt, $now_gmt ) ),
 			'autosave'   => $autosave,


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR adds the year to revision timestamps in the "Compare Revisions" interface. The revision comparison interface currently shows dates like "26 Jul @ 11:16" without the year, making it difficult to distinguish between revisions from different years.

Updated the dateShort format in `wp_prepare_revisions_for_js()` to include the year:

- **Before:** 'j M @ H:i' → "26 Jul @ 11:16"
- **After:** 'j M, Y @ H:i' → "26 Jul, 2022 @ 11:16"

Trac ticket: https://core.trac.wordpress.org/ticket/63816


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
