### PR TITLE
Add test coverage for current_user_can_for_site()

### DIFF
--- a/tests/phpunit/tests/user/capabilities.php
+++ b/tests/phpunit/tests/user/capabilities.php
@@ -1421,7 +1421,7 @@ class Tests_User_Capabilities extends WP_UnitTestCase {
 		$this->assertSame( 'edit_posts', $cap->edit_posts );
 
 		$this->assertTrue( $author->has_cap( $cap->create_posts ) );
-		$this->assertTrue( $author->has_cap( $cap->edit_posts ) );
+	$this->assertTrue( $author->has_cap( $cap->edit_posts ) );
 		$this->assertTrue( $contributor->has_cap( $cap->edit_posts ) );
 		$this->assertFalse( $contributor->has_cap( $cap->create_posts ) );
 		$this->assertFalse( $subscriber->has_cap( $cap->create_posts ) );


### PR DESCRIPTION
Adds test coverage for current_user_can_for_site() and user_can_for_site().
Replaces remaining uses of deprecated current_user_can_for_blog() in tests.

See: https://core.trac.wordpress.org/ticket/38433