### PR TITLE
Twenty Twenty: Fix font inconsistency in Latest Posts block editor

### DIFF
--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
@@ -1064,7 +1064,7 @@ hr.wp-block-separator.is-style-dots::before {
 	margin-top: 15px;
 }
 
-.editor-styles-wrapper .wp-block-latest-posts__post-full-content p {
+.wp-block-latest-posts__post-full-content p {
  	font-family: inherit;
 }
 

--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
@@ -1064,6 +1064,10 @@ hr.wp-block-separator.is-style-dots::before {
 	margin-top: 15px;
 }
 
+.editor-styles-wrapper .wp-block-latest-posts__post-full-content p {
+ 	font-family: inherit;
+}
+
 .wp-block-latest-posts__post-full-content > p:first-child {
 	margin-top: 1em;
 }

--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
@@ -1068,7 +1068,7 @@ hr.wp-block-separator.is-style-dots::before {
 	margin-top: 15px;
 }
 
-.editor-styles-wrapper .wp-block-latest-posts__post-full-content p {
+.wp-block-latest-posts__post-full-content p {
  	font-family: inherit;
 }
 

--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
@@ -1068,6 +1068,10 @@ hr.wp-block-separator.is-style-dots::before {
 	margin-top: 15px;
 }
 
+.editor-styles-wrapper .wp-block-latest-posts__post-full-content p {
+ 	font-family: inherit;
+}
+
 .wp-block-latest-posts__post-full-content > p:first-child {
 	margin-top: 1em;
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63798

Fixes a font styling inconsistency in the Twenty Twenty theme where the Latest Posts block displays post content in different fonts between the editor and frontend when "Full post" content is selected.

**NOTE: I created this PR alongside the patch to make testing and updates easier.**

## Testing
**Steps to reproduce the issue:**
1. Activate the Twenty Twenty theme
2. Create or edit a page/post
3. Add a Latest Posts block
4. In block settings, enable "Post Content"
5. Under Content settings, choose "Full post" (instead of Excerpt)
6. Compare font styling in editor vs. published frontend

**Expected result:** Font styling should now match between editor and frontend views.

## Screenshots
### Before

**Editor**

<img width="1470" height="795" alt="Screenshot 2025-08-12 at 8 16 16 PM" src="https://github.com/user-attachments/assets/af681936-146e-4033-b6fc-f0148c6db305" />

**Frontend**

<img width="1470" height="797" alt="Screenshot 2025-08-12 at 8 17 14 PM" src="https://github.com/user-attachments/assets/41aa143b-b84c-4b8b-a921-b021cc11fb05" />

### After

**Editor**

<img width="1470" height="798" alt="Screenshot 2025-08-12 at 8 20 15 PM" src="https://github.com/user-attachments/assets/49256968-fc6c-4a0a-8b4f-2c991f8d7f5b" />


**Frontend**

<img width="1470" height="797" alt="Screenshot 2025-08-12 at 8 17 14 PM" src="https://github.com/user-attachments/assets/41aa143b-b84c-4b8b-a921-b021cc11fb05" />