### PR TITLE
HTML API: Make `WP_HTML_Processor::serialize_token()` public.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-processor.php
@@ -1304,10 +1304,11 @@ class WP_HTML_Processor extends WP_HTML_Tag_Processor {
 	 * @see static::serialize()
 	 *
 	 * @since 6.7.0
+	 * @since 6.9.0 Converted from protected to public method.
 	 *
 	 * @return string Serialization of token, or empty string if no serialization exists.
 	 */
-	protected function serialize_token(): string {
+	public function serialize_token(): string {
 		$html       = '';
 		$token_type = $this->get_token_type();
 


### PR DESCRIPTION
Trac ticket: Core-63823
Follows #7331

The `serialize_token()` method was added in WordPress 6.7.0 as a protected member on the `WP_HTML_Processor` class. It wasn’t clear at the time of merging if it would be necessary to expose it as a public method. However, since that time a number of experiments have led to the conclusion that it would be very valuable to do so.

This patch opens up the method for invocation from the outside, trivializing the generation of normative HTML subspans from a parent document.

Follow-up to [[59076]](https://core.trac.wordpress.org/changeset/59076).