### PR TITLE
Options: Invalidate object cache when `update_option()` DB write fails

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -963,6 +963,19 @@ function update_option( $option, $value, $autoload = null ) {
 
 	$result = $wpdb->update( $wpdb->options, $update_args, array( 'option_name' => $option ) );
 	if ( ! $result ) {
+		if ( ! wp_installing() ) {
+			$alloptions = wp_load_alloptions( true );
+
+			if ( isset( $alloptions[ $option ] ) ) {
+				unset( $alloptions[ $option ] );
+				wp_cache_set( 'alloptions', $alloptions, 'options' );
+			} else {
+				wp_cache_delete( 'alloptions', 'options' );
+			}
+
+			wp_cache_delete( $option, 'options' );
+		}
+
 		return false;
 	}
 

--- a/tests/phpunit/tests/option/updateOption.php
+++ b/tests/phpunit/tests/option/updateOption.php
@@ -225,4 +225,41 @@ class Tests_Option_UpdateOption extends WP_UnitTestCase {
 	public function __return_foo() {
 		return 'foo';
 	}
+
+	/**
+	 * @ticket 26402
+	 *
+	 * @covers ::update_option
+	 */
+	public function test_should_invalidate_cache_when_db_update_fails() {
+		global $wpdb;
+
+		$option_name  = 'test_option_update_fail';
+		$option_value = 'initial';
+
+		add_option( $option_name, $option_value );
+		$this->assertSame( $option_value, get_option( $option_name ) );
+
+		$wpdb->delete( $wpdb->options, array( 'option_name' => $option_name ) );
+
+		tests_add_filter(
+			'query',
+			function ( $query ) use ( $wpdb ) {
+				if ( stripos( $query, "update `$wpdb->options`" ) === 0 ) {
+					return false; // Simulate DB update failure.
+				}
+				return $query;
+			}
+		);
+
+		$result = update_option( $option_name, 'new_value' );
+
+		$this->assertFalse( $result, 'Expected update_option() to fail when DB update fails.' );
+		$this->assertFalse( wp_cache_get( $option_name, 'options' ) );
+
+		// Verify alloptions cache no longer contains the option.
+		$alloptions = wp_cache_get( 'alloptions', 'options' );
+		$this->assertIsArray( $alloptions );
+		$this->assertArrayNotHasKey( $option_name, $alloptions );
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/26402

When `update_option()` fails to update the database (e.g., option deleted directly from DB while still in cache), the stale cached value may persist indefinitely with persistent object caching.

This PR - 

- Added cache invalidation in `update_option()` when `$wpdb->update()` returns false.
- Clears `alloptions` entry (if autoloaded) or individual option cache to ensure no stale data is served.
- Adds tests to verify that the alloptions cache no longer contains the option.



