### PR TITLE
On initial user creation, pass an empty WP_User obj for the old user data

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2502,8 +2502,10 @@ function wp_insert_user( $userdata ) {
 	$user = new WP_User( $user_id );
 
 	if ( ! $update ) {
+		$old_user_data = new WP_User();
+
 		/** This action is documented in wp-includes/pluggable.php */
-		do_action( 'wp_set_password', $userdata['user_pass'], $user_id, $userdata );
+		do_action( 'wp_set_password', $userdata['user_pass'], $user_id, $old_user_data );
 	}
 
 	/**


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/22114