### PR TITLE
Formatting: Rework `wp_check_invalid_utf8()`, add `wp_scrub_utf8()`

### DIFF
--- a/src/wp-includes/utf8.php
+++ b/src/wp-includes/utf8.php
@@ -1,0 +1,135 @@
+<?php
+
+if ( extension_loaded( 'mbstring' ) ) :
+	/**
+	 * Determines if a given byte string represents a valid UTF-8 encoding.
+	 *
+	 * Note that it’s unlikely for non-UTF-8 data to validate as UTF-8, but
+	 * it is still possible. Many texts are simultaneously valid UTF-8,
+	 * valid US-ASCII, and valid ISO-8859-1 (`latin1`).
+	 *
+	 * Example:
+	 *
+	 *     true === wp_is_valid_utf8( '' );
+	 *     true === wp_is_valid_utf8( 'just a test' );
+	 *     true === wp_is_valid_utf8( "\xE2\x9C\x8F" );    // Pencil, U+270F.
+	 *     true === wp_is_valid_utf8( "\u{270F}" );        // Pencil, U+270F.
+	 *     true === wp_is_valid_utf8( '✏' );              // Pencil, U+270F.
+	 *
+	 *     false === wp_is_valid_utf8( "just \xC0 test" ); // Invalid bytes.
+	 *     false === wp_is_valid_utf8( "\xE2\x9C" );       // Invalid/incomplete sequences.
+	 *     false === wp_is_valid_utf8( "\xC1\xBF" );       // Overlong sequences.
+	 *     false === wp_is_valid_utf8( "\xED\xB0\x80" );   // Surrogate halves.
+	 *     false === wp_is_valid_utf8( "B\xFCch" );        // ISO-8859-1 high-bytes.
+	 *                                                     // E.g. The “ü” in ISO-8859-1 is a single byte 0xFC,
+	 *                                                     // but in UTF-8 is the two-byte sequence 0xC3 0xBC.
+	 *
+	 *  A “valid” string consists of “well-formed UTF-8 code unit sequence[s],” meaning
+	 *  that the bytes conform to the UTF-8 encoding scheme, all characters use the minimal
+	 *  byte sequence required by UTF-8, and that no sequence encodes a UTF-16 surrogate
+	 *  code point or any character above the representable range.
+	 *
+	 * @see https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-3/#G32860
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param string $bytes String which might contain text encoded as UTF-8.
+	 * @return bool Whether the provided bytes can decode as valid UTF-8.
+	 */
+	function wp_is_valid_utf8( string $bytes ): bool {
+		return mb_check_encoding( $bytes, 'UTF-8' );
+	}
+else :
+	/**
+	 * Fallback function for validating UTF-8.
+	 *
+	 * @ignore
+	 * @private
+	 *
+	 * @since 6.9.0
+	 */
+	function wp_is_valid_utf8( string $string ): bool {
+		return _wp_is_valid_utf8_fallback( $string );
+	}
+endif;
+
+if (
+	extension_loaded( 'mbstring' ) &&
+	// Maximal subpart substitution introduced by php/php-src@04e59c916f12b322ac55f22314e31bd0176d01cb.
+	version_compare( PHP_VERSION, '8.1.6', '>=' )
+) :
+	/**
+	 * Replaces ill-formed UTF-8 byte sequences with the Unicode Replacement Character.
+	 *
+	 * Knowing what to do in the presence of text encoding issues can be complicated.
+	 * This function replaces invalid spans of bytes to neutralize any corruption that
+	 * may be there and prevent it from causing further problems downstream.
+	 *
+	 * However, it’s not always ideal to replace those bytes. In some settings it may
+	 * be best to leave the invalid bytes in the string so that downstream code can handle
+	 * them in a specific way. Replacing the bytes too early, like escaping for HTML too
+	 * early, can introduce other forms of corruption and data loss.
+	 *
+	 * When in doubt, use this function to replace spans of invalid bytes.
+	 *
+	 * Replacement follows the “maximal subpart” algorithm for secure and interoperable
+	 * strings. This can lead to sequences of multiple replacement characters in a row.
+	 *
+	 * Example:
+	 *
+	 *     // Valid strings come through unchanged.
+	 *     'test' === wp_scrub_utf8( 'test' );
+	 *
+	 *     // Invalid sequences of bytes are replaced.
+	 *     $invalid = "the byte \xC0 is never allowed in a UTF-8 string.";
+	 *     "the byte \u{FFFD} is never allowed in a UTF-8 string." === wp_scrub_utf8( $invalid, true );
+	 *     'the byte � is never allowed in a UTF-8 string.' === wp_scrub_utf8( $invalid, true );
+	 *
+	 *     // Maximal subparts are replaced individually.
+	 *     '.�.' === wp_scrub_utf8( ".\xC0." );              // C0 is never valid.
+	 *     '.�.' === wp_scrub_utf8( ".\xE2\x8C." );          // Missing A3 at end.
+	 *     '.��.' === wp_scrub_utf8( ".\xE2\x8C\xE2\x8C." ); // Maximal subparts replaced separately.
+	 *     '.��.' === wp_scrub_utf8( ".\xC1\xBF." );         // Overlong sequence.
+	 *     '.���.' === wp_scrub_utf8( ".\xED\xA0\x80." );    // Surrogate half.
+	 *
+	 * Note! The Unicode Replacement Character is itself a Unicode character (U+FFFD).
+	 * Once a span of invalid bytes has been replaced by one, it will not be possible
+	 * to know whether the replacement character was originally intended to be there
+	 * or if it is the result of scrubbing bytes. It is ideal to leave replacement for
+	 * display only, but some contexts (e.g. generating XML or passing data into a
+	 * large language model) require valid input strings.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @see https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-5/#G40630
+	 *
+	 * @param string $text String which is assumed to be UTF-8 but may contain invalid sequences of bytes.
+	 * @return string Input text with invalid sequences of bytes replaced with the Unicode replacement character.
+	 */
+	function wp_scrub_utf8( $text ) {
+		/*
+		 * While it looks like setting the substitute character could fail,
+		 * the internal PHP code will never fail when provided a valid
+		 * code point as a number. In this case, there’s no need to check
+		 * its return value to see if it succeeded.
+		 */
+		$prev_replacement_character = mb_substitute_character();
+		mb_substitute_character( 0xFFFD );
+		$scrubbed = mb_scrub( $text, 'UTF-8' );
+		mb_substitute_character( $prev_replacement_character );
+
+		return $scrubbed;
+	}
+else :
+	/**
+	 * Fallback function for scrubbing UTF-8.
+	 *
+	 * @ignore
+	 * @private
+	 *
+	 * @since 6.9.0
+	 */
+	function wp_scrub_utf8( $text ) {
+		return _wp_scrub_utf8_fallback( $text );
+	}
+endif;

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -111,6 +111,7 @@ wp_set_lang_dir();
 // Load early WordPress files.
 require ABSPATH . WPINC . '/class-wp-list-util.php';
 require ABSPATH . WPINC . '/class-wp-token-map.php';
+require ABSPATH . WPINC . '/utf8.php';
 require ABSPATH . WPINC . '/formatting.php';
 require ABSPATH . WPINC . '/meta.php';
 require ABSPATH . WPINC . '/functions.php';

--- a/tests/phpunit/tests/unicode/wpScrubUtf8.php
+++ b/tests/phpunit/tests/unicode/wpScrubUtf8.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Unit tests covering WordPress’ UTF-8 handling.
+ *
+ * @package WordPress
+ * @group unicode
+ */
+
+class Tests_WpScrubUtf8 extends WP_UnitTestCase {
+	/**
+	 * Verifies that WordPress can properly detect valid and invalid UTF-8.
+	 *
+	 * @ticket 63837
+	 *
+	 * @dataProvider data_utf8_test_data
+	 *
+	 * @param string      $bytes    Bytes as a PHP string.
+	 * @param string|null $scrubbed Expected checked value, if string isn’t valid UTF-8.
+	 */
+	public function test_properly_checks_utf8( string $bytes, ?string $scrubbed = null ) {
+		if ( null === $scrubbed ) {
+			$this->assertSame(
+				$bytes,
+				wp_check_invalid_utf8( $bytes ),
+				'Should have returned the unchanged string for valid UTF-8 input when not stripping invalid bytes.'
+			);
+
+			$this->assertSame(
+				$bytes,
+				wp_check_invalid_utf8( $bytes, true ),
+				'Should have returned the unchanged string for valid UTF-8 input when stripping invalid bytes.'
+			);
+		} else {
+			$this->assertSame(
+				'',
+				wp_check_invalid_utf8( $bytes ),
+				'Should have rejected invalid input, returning an empty string when not stripping invalid bytes.'
+			);
+
+			$this->assertSame(
+				$scrubbed,
+				wp_check_invalid_utf8( $bytes, true ),
+				'Failed to properly scrub the invalid spans of UTF-8 from the input string.'
+			);
+		}
+	}
+
+	/**
+	 * Verifies that WordPress can properly detect valid UTF-8 while replacing invalid byte sequences.
+	 *
+	 * @ticket 63837
+	 *
+	 * @dataProvider data_utf8_test_data
+	 *
+	 * @param string      $bytes    Bytes as a PHP string.
+	 * @param string|null $scrubbed Expected checked value, if string isn’t valid UTF-8.
+	 */
+	public function test_properly_scrubs_utf8( string $bytes, ?string $scrubbed = null ) {
+		if ( null === $scrubbed ) {
+			$this->assertSame(
+				$bytes,
+				wp_scrub_utf8( $bytes ),
+				'Should have returned the unchanged string for valid UTF-8 input.'
+			);
+		} else {
+			$this->assertSame(
+				bin2hex( $scrubbed ),
+				bin2hex( wp_scrub_utf8( $bytes ) ),
+				'Failed to properly scrub the invalid spans of UTF-8 from the input string.'
+			);
+		}
+	}
+
+	/**
+	 * Verifies that WordPress’ fallback code can properly detect valid UTF-8
+	 * while replacing invalid byte sequences.
+	 *
+	 * @ticket 63837
+	 *
+	 * @dataProvider data_utf8_test_data
+	 *
+	 * @param string      $bytes    Bytes as a PHP string.
+	 * @param string|null $scrubbed Expected checked value, if string isn’t valid UTF-8.
+	 */
+	public function test_fallback_properly_checks_utf8( string $bytes, ?string $scrubbed = null ) {
+		if ( null === $scrubbed ) {
+			$this->assertSame(
+				$bytes,
+				_wp_scrub_utf8_fallback( $bytes ),
+				'Should have returned the unchanged string for valid UTF-8 input.'
+			);
+		} else {
+			$this->assertSame(
+				bin2hex( $scrubbed ),
+				bin2hex( _wp_scrub_utf8_fallback( $bytes ) ),
+				'Failed to properly scrub the invalid spans of UTF-8 from the input string.'
+			);
+		}
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @throws Exception
+	 *
+	 * @return Generator
+	 */
+	public static function data_utf8_test_data() {
+		$test_file        = fopen( __DIR__ . '/../../data/unicode/utf8tests/utf8tests.txt', 'r' );
+		$line_number      = 0;
+		$last_description = '';
+
+		while ( false !== ( $line = fgets( $test_file ) ) ) {
+			++$line_number;
+
+			if ( empty( trim( $line ) ) ) {
+				continue;
+			}
+
+			if ( str_starts_with( $line, '#' ) ) {
+				$last_description = trim( substr( $line, 1 ) );
+				continue;
+			}
+
+			$test_parts = explode( ':', $line );
+			if ( count( $test_parts ) < 3 ) {
+				throw new Exception( 'Wrong test data: check utf8tests.txt' );
+			}
+
+			list( $reference, $classification, $test_data ) = $test_parts;
+
+			$reference      = trim( $reference );
+			$classification = trim( $classification );
+			$test_data      = trim( $test_data );
+
+			switch ( $classification ) {
+				case 'valid':
+					yield "{$reference} {$last_description}" => array( $test_data, null );
+					break;
+
+				case 'valid hex':
+				case 'invalid hex':
+					if ( 'invalid hex' === $classification && count( $test_parts ) < 5 ) {
+						throw new Exception( "Test data missing expected “scrubbed” value: check utf8tests.txt:{$line_number}" );
+					}
+
+					$bytes    = hex2bin( str_replace( ' ', '', $test_data ) );
+					$scrubbed = 'invalid hex' === $classification
+						? hex2bin( str_replace( ' ', '', trim( $test_parts[4] ) ) )
+						: null;
+
+					yield "{$reference} {$last_description}" => array( $bytes, $scrubbed );
+					break;
+
+				default:
+					throw new Exception( "Test input file contains unrecognized input classification '{$classification}' (see utf8tests.txt): {$line}" );
+			}
+		}
+	}
+}


### PR DESCRIPTION
Trac Ticket: Core-63837
Trac Ticket: Core-29717
See: ~#9825~, ~#9830~, (~#9498~), ~#9826~, ~#9827~, #9798, ~#9828~, ~#9829~

`wp_check_invalid_utf8()` has been dependent on the runtime configuration of the system running it. For systems without the necessary Unicode support it would simply not perform any validation of the input. Worse, the use of `iconv()` is not only system-dependent, but it also fails to perform substitution when requested, returning `false` instead of the substituted string as described in the function docblock.

In this patch a newer spec-compliant fallback is provided while the function itself defers to `mb_scrub()`. Both of these implementations are spec-compliant (to UTF-8) and perform “Maximal subpart replacement” when encountering invalid byte sequences — an important aspect to maintain secure and quality interoperability between systems.

### Also included as part of this work

 - a new function `wp_scrub_utf8()` which performs the conversion that `wp_check_invalid_utf8()` does if the `blog_charset` is `UTF-8` and if `$strip = true` is passed. this is a more focused function.
 - a new function `_wp_scrub_utf8_fallback()` which is a user-space fallback for when the `mbstring` extension isn’t available