### PR TITLE
Administration: Fix date column showing post time instead of modified time

### DIFF
--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1196,16 +1196,32 @@ class WP_Posts_List_Table extends WP_List_Table {
 			$t_time    = __( 'Unpublished' );
 			$time_diff = 0;
 		} else {
-			$t_time = sprintf(
-				/* translators: 1: Post date, 2: Post time. */
-				__( '%1$s at %2$s' ),
-				/* translators: Post date format. See https://www.php.net/manual/datetime.format.php */
-				get_the_time( __( 'Y/m/d' ), $post ),
-				/* translators: Post time format. See https://www.php.net/manual/datetime.format.php */
-				get_the_time( __( 'g:i a' ), $post )
-			);
+			// Use modified time for unpublished posts to match "Last Modified" status label
+			$use_modified_time = ! in_array( $post->post_status, array( 'publish', 'future' ), true );
 
-			$time      = get_post_timestamp( $post );
+			if ( $use_modified_time ) {
+				$t_time = sprintf(
+					/* translators: 1: Modified date, 2: Modified time. */
+					__( '%1$s at %2$s' ),
+					/* translators: Modified date format. See https://www.php.net/manual/datetime.format.php */
+					get_the_modified_time( __( 'Y/m/d' ), $post ),
+					/* translators: Modified time format. See https://www.php.net/manual/datetime.format.php */
+					get_the_modified_time( __( 'g:i a' ), $post )
+				);
+				$time = get_post_modified_time( 'U', false, $post );
+			} else {
+				$t_time = sprintf(
+					/* translators: 1: Post date, 2: Post time. */
+					__( '%1$s at %2$s' ),
+					/* translators: Post date format. See https://www.php.net/manual/datetime.format.php */
+					get_the_time( __( 'Y/m/d' ), $post ),
+					/* translators: Post time format. See https://www.php.net/manual/datetime.format.php */
+					get_the_time( __( 'g:i a' ), $post )
+				);
+
+				$time = get_post_timestamp( $post );
+			}
+
 			$time_diff = time() - $time;
 		}
 


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63835

When viewing the admin post/page listing, the "Date" column shows the "Last Modified" label for unpublished private posts, but incorrectly displays the post creation time instead of the actual modification time.

This patch fixes the issue by:
- Determining upfront whether to show post time or modified time based on post status
- Using `get_the_modified_time()` and `get_post_modified_time()` for unpublished posts
- Maintaining consistent timestamp calculations for both display and time difference

All other statuses now correctly show the modified time when labeled "Last Modified".
