### PR TITLE
Fixes stale cron list upon finishing a long-running job

### DIFF
--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -507,7 +507,7 @@ function wp_unschedule_event( $timestamp, $hook, $args = array(), $wp_error = fa
 		return $pre;
 	}
 
-	$crons = _get_cron_array();
+	$crons = _get_cron_array( true );
 	$key   = md5( serialize( $args ) );
 
 	unset( $crons[ $timestamp ][ $hook ][ $key ] );
@@ -1223,9 +1223,14 @@ function wp_get_ready_cron_jobs() {
  * @since 6.1.0 Return type modified to consistently return an array.
  * @access private
  *
+ * @param bool $fresh whether a non-cached version is required
  * @return array[] Array of cron events.
  */
-function _get_cron_array() {
+function _get_cron_array( $fresh = false ) {
+	if ( $fresh ) {
+		wp_cache_delete( 'alloptions', 'options' ); // there doesn't seem to be a more surgical way
+	}
+
 	$cron = get_option( 'cron' );
 	if ( ! is_array( $cron ) ) {
 		return array();


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Cron events system breaks by ignoring events added *during* processing of an event queue. 

Trac ticket: https://core.trac.wordpress.org/ticket/63830

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
