### PR TITLE
Fix: Check for class existence before aliasing in PHPUnit compatibility

### DIFF
--- a/tests/phpunit/includes/phpunit6/compat.php
+++ b/tests/phpunit/includes/phpunit6/compat.php
@@ -2,18 +2,27 @@
 
 if ( class_exists( 'PHPUnit\Runner\Version' ) && version_compare( PHPUnit\Runner\Version::id(), '6.0', '>=' ) ) {
 
-	class_alias( 'PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase' );
-	class_alias( 'PHPUnit\Framework\Exception', 'PHPUnit_Framework_Exception' );
-	class_alias( 'PHPUnit\Framework\ExpectationFailedException', 'PHPUnit_Framework_ExpectationFailedException' );
-	class_alias( 'PHPUnit\Framework\Error\Deprecated', 'PHPUnit_Framework_Error_Deprecated' );
-	class_alias( 'PHPUnit\Framework\Error\Notice', 'PHPUnit_Framework_Error_Notice' );
-	class_alias( 'PHPUnit\Framework\Error\Warning', 'PHPUnit_Framework_Error_Warning' );
-	class_alias( 'PHPUnit\Framework\Test', 'PHPUnit_Framework_Test' );
-	class_alias( 'PHPUnit\Framework\Warning', 'PHPUnit_Framework_Warning' );
-	class_alias( 'PHPUnit\Framework\AssertionFailedError', 'PHPUnit_Framework_AssertionFailedError' );
-	class_alias( 'PHPUnit\Framework\TestSuite', 'PHPUnit_Framework_TestSuite' );
-	class_alias( 'PHPUnit\Framework\TestListener', 'PHPUnit_Framework_TestListener' );
-	class_alias( 'PHPUnit\Util\GlobalState', 'PHPUnit_Util_GlobalState' );
+	$aliases = array(
+		'PHPUnit\Framework\TestCase'                   => 'PHPUnit_Framework_TestCase',
+		'PHPUnit\Framework\Exception'                  => 'PHPUnit_Framework_Exception',
+		'PHPUnit\Framework\ExpectationFailedException' => 'PHPUnit_Framework_ExpectationFailedException',
+		'PHPUnit\Framework\Error\Deprecated'           => 'PHPUnit_Framework_Error_Deprecated',
+		'PHPUnit\Framework\Error\Notice'               => 'PHPUnit_Framework_Error_Notice',
+		'PHPUnit\Framework\Error\Warning'              => 'PHPUnit_Framework_Error_Warning',
+		'PHPUnit\Framework\Test'                       => 'PHPUnit_Framework_Test',
+		'PHPUnit\Framework\Warning'                    => 'PHPUnit_Framework_Warning',
+		'PHPUnit\Framework\AssertionFailedError'       => 'PHPUnit_Framework_AssertionFailedError',
+		'PHPUnit\Framework\TestSuite'                  => 'PHPUnit_Framework_TestSuite',
+		'PHPUnit\Framework\TestListener'               => 'PHPUnit_Framework_TestListener',
+		'PHPUnit\Util\GlobalState'                     => 'PHPUnit_Util_GlobalState',
+	);
+
+	foreach ( $aliases as $original => $alias ) {
+		if ( class_exists( $original ) ) {
+			class_alias( $original, $alias );
+		}
+	}
+
 	if ( class_exists( 'PHPUnit\Util\Getopt' ) ) {
 		class_alias( 'PHPUnit\Util\Getopt', 'PHPUnit_Util_Getopt' );
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

This PR resolves the warning triggered when running the PHPUnit test suite with PHPUnit 10 or higher. Instead of directly using `class_alias`, it first check whether the class exist or not. This ensures that the alias is only created when the class is available.

Trac ticket: https://core.trac.wordpress.org/ticket/63833

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
