### PR TITLE
fix: Reply-To header in comment reply emails

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -1826,7 +1826,7 @@ if ( ! function_exists( 'wp_notify_postauthor' ) ) :
 		} else {
 			$from = "From: \"$comment->comment_author\" <$wp_email>";
 			if ( '' !== $comment->comment_author_email ) {
-				$reply_to = "Reply-To: \"$comment->comment_author_email\" <$comment->comment_author_email>";
+				$reply_to = "Reply-To: $comment->comment_author <$comment->comment_author_email>";
 			}
 		}
 

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -1163,6 +1163,38 @@ class Tests_Comment extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Check Reply-To Header is set correctly for reply comments.
+	 *
+	 * @group 49661
+	 * @covers ::wp_new_comment_notify_postauthor
+	 */
+	public function test_reply_comment_notification_includes_reply_to_header() {
+		$parent = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+			)
+		);
+
+		$reply_author_name  = 'Jane Doe';
+		$reply_author_email = 'jane@example.com';
+
+		$reply = self::factory()->comment->create(
+			array(
+				'comment_post_ID'      => self::$post_id,
+				'comment_parent'       => $parent,
+				'comment_author'       => $reply_author_name,
+				'comment_author_email' => $reply_author_email,
+				'comment_approved'     => '1',
+			)
+		);
+
+		wp_new_comment_notify_postauthor( $reply );
+		$mailer = tests_retrieve_phpmailer_instance();
+		$header = $mailer->get_sent()->header;
+		$this->assertStringContainsString( 'Reply-To: ' . $reply_author_name . ' <' . $reply_author_email . '>', $header );
+	}
+
+	/**
 	 * Callback for the `comment_notification_text` & `comment_moderation_text` filters.
 	 *
 	 * @param string $notify_message The comment notification or moderation email text.


### PR DESCRIPTION
```
The Reply-To header in comment reply notification emails was being 
manually formatted with quotes, similar to the From header. 
However, PHPMailer treats these headers differently:

- From headers are set via `setFrom()`, which applies proper quoting
  and encoding internally.
- Reply-To headers in core were added as custom headers via 
 `addCustomHeader()`, which passes the value through `encodeHeader()`
  and escapes quotes a second time.

This mismatch caused author names with quotes to be encoded as:
Reply-To: \"Author\" <author@example.com>

This commit fixes this issue.

See Trac #49661
```

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: [#49661](https://core.trac.wordpress.org/ticket/49661)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
