### PR TITLE
Add `array_first()` and `array_last()` in `compat.php`

### DIFF
--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -539,6 +539,46 @@ if ( ! function_exists( 'array_all' ) ) {
 	}
 }
 
+if ( ! function_exists( 'array_first' ) ) {
+	/**
+	 * Polyfill for `array_first()` function added in PHP 8.5.
+	 *
+	 * Returns the first element of an array.
+	 *
+	 * @since 6.8.3
+	 *
+	 * @param array $array The array to get the first element from.
+	 * @return mixed|null The first element of the array, or null if the array is empty.
+	 */
+	function array_first( array $array ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.arrayFound
+		if ( empty( $array ) ) {
+			return null;
+		}
+
+		return $array[ array_key_first( $array ) ];
+	}
+}
+
+if ( ! function_exists( 'array_last' ) ) {
+	/**
+	 * Polyfill for `array_last()` function added in PHP 8.5.
+	 *
+	 * Returns the last element of an array.
+	 *
+	 * @since 6.8.3
+	 *
+	 * @param array $array The array to get the last element from.
+	 * @return mixed|null The last element of the array, or null if the array is empty.
+	 */
+	function array_last( array $array ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.arrayFound
+		if ( empty( $array ) ) {
+			return null;
+		}
+
+		return $array[ array_key_last( $array ) ];
+	}
+}
+
 // IMAGETYPE_AVIF constant is only defined in PHP 8.x or later.
 if ( ! defined( 'IMAGETYPE_AVIF' ) ) {
 	define( 'IMAGETYPE_AVIF', 19 );

--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -545,7 +545,7 @@ if ( ! function_exists( 'array_first' ) ) {
 	 *
 	 * Returns the first element of an array.
 	 *
-	 * @since 6.8.3
+	 * @since 6.9.0
 	 *
 	 * @param array $array The array to get the first element from.
 	 * @return mixed|null The first element of the array, or null if the array is empty.
@@ -555,7 +555,9 @@ if ( ! function_exists( 'array_first' ) ) {
 			return null;
 		}
 
-		return $array[ array_key_first( $array ) ];
+		foreach ( $array as $value ) {
+			return $value;
+		}
 	}
 }
 
@@ -565,7 +567,7 @@ if ( ! function_exists( 'array_last' ) ) {
 	 *
 	 * Returns the last element of an array.
 	 *
-	 * @since 6.8.3
+	 * @since 6.9.0
 	 *
 	 * @param array $array The array to get the last element from.
 	 * @return mixed|null The last element of the array, or null if the array is empty.

--- a/tests/phpunit/tests/compat/arrayFirst.php
+++ b/tests/phpunit/tests/compat/arrayFirst.php
@@ -81,7 +81,10 @@ class Tests_Compat_arrayFirst extends WP_UnitTestCase {
 	 * @ticket 63853
 	 */
 	public function test_array_first_with_end_pointer() {
-		$arr = array( 'key1' => 'val1', 'key2' => 'val2' );
+		$arr = array(
+			'key1' => 'val1',
+			'key2' => 'val2',
+		);
 		// change the pointer to the last element
 		end( $arr );
 

--- a/tests/phpunit/tests/compat/arrayFirst.php
+++ b/tests/phpunit/tests/compat/arrayFirst.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * @group compat
+ *
+ * @covers ::array_first
+ */
+class Tests_Compat_arrayFirst extends WP_UnitTestCase {
+
+	/**
+	 * Test that array_first() is always available (either from PHP or WP).
+	 */
+	public function test_array_first_availability(): void {
+		$this->assertTrue( function_exists( 'array_first' ) );
+	}
+
+	/**
+	 * @dataProvider data_array_first
+	 *
+	 * @ticket 63853
+	 *
+	 * @param mixed $expected The value extracted from the given array.
+	 * @param array $arr      The array to get the first value from.
+	 */
+	public function test_array_first( $expected, $arr ): void {
+		$this->assertSame( $expected, array_first( $arr ) );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[]
+	 */
+	public function data_array_first(): array {
+		$obj = new \stdClass();
+		return array(
+			'string values'        => array(
+				'expected' => 'a',
+				'arr'      => array( 'a', 'b', 'c' ),
+			),
+			'associative array'    => array(
+				'expected' => 10,
+				'arr'      => array(
+					'foo' => 10,
+					'bar' => 20,
+				),
+			),
+			'empty array'          => array(
+				'expected' => null,
+				'arr'      => array(),
+			),
+			'single element array' => array(
+				'expected' => 42,
+				'arr'      => array( 42 ),
+			),
+			'null values'          => array(
+				'expected' => null,
+				'arr'      => array( null, 'b', 'c' ),
+			),
+			'objects'              => array(
+				'expected' => $obj,
+				'arr'      => array(
+					$obj,
+					1,
+					2,
+				),
+			),
+			'boolean values'       => array(
+				'expected' => false,
+				'arr'      => array( false, true, 1, 2, 3 ),
+			),
+		);
+	}
+}

--- a/tests/phpunit/tests/compat/arrayFirst.php
+++ b/tests/phpunit/tests/compat/arrayFirst.php
@@ -15,9 +15,9 @@ class Tests_Compat_arrayFirst extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @dataProvider data_array_first
-	 *
 	 * @ticket 63853
+	 *
+	 * @dataProvider data_array_first
 	 *
 	 * @param mixed $expected The value extracted from the given array.
 	 * @param array $arr      The array to get the first value from.

--- a/tests/phpunit/tests/compat/arrayFirst.php
+++ b/tests/phpunit/tests/compat/arrayFirst.php
@@ -78,7 +78,7 @@ class Tests_Compat_arrayFirst extends WP_UnitTestCase {
 	/**
 	 * Test that array_first() returns the pointer is not the first element.
 	 *
-	 * @ticket 45055
+	 * @ticket 63853
 	 */
 	public function test_array_first_with_end_pointer() {
 		$arr = array( 'key1' => 'val1', 'key2' => 'val2' );

--- a/tests/phpunit/tests/compat/arrayFirst.php
+++ b/tests/phpunit/tests/compat/arrayFirst.php
@@ -85,8 +85,8 @@ class Tests_Compat_arrayFirst extends WP_UnitTestCase {
 		// change the pointer to the last element
 		end( $arr );
 
-		$key = array_first( $arr );
+		$val = array_first( $arr );
 		$this->assertSame( 'val2', current( $arr ) );
-		$this->assertSame( 'val1', $key );
+		$this->assertSame( 'val1', $val );
 	}
 }

--- a/tests/phpunit/tests/compat/arrayFirst.php
+++ b/tests/phpunit/tests/compat/arrayFirst.php
@@ -28,6 +28,7 @@ class Tests_Compat_arrayFirst extends WP_UnitTestCase {
 		$this->assertSame( $expected, array_first( $arr ) );
 	}
 
+
 	/**
 	 * Data provider.
 	 *
@@ -72,5 +73,20 @@ class Tests_Compat_arrayFirst extends WP_UnitTestCase {
 				'arr'      => array( false, true, 1, 2, 3 ),
 			),
 		);
+	}
+
+	/**
+	 * Test that array_first() returns the pointer is not the first element.
+	 *
+	 * @ticket 45055
+	 */
+	public function test_array_first_with_end_pointer() {
+		$arr = array( 'key1' => 'val1', 'key2' => 'val2' );
+		// change the pointer to the last element
+		end( $arr );
+
+		$key = array_first( $arr );
+		$this->assertSame( 'val2', current( $arr ) );
+		$this->assertSame( 'val1', $key );
 	}
 }

--- a/tests/phpunit/tests/compat/arrayFirst.php
+++ b/tests/phpunit/tests/compat/arrayFirst.php
@@ -8,6 +8,8 @@
 class Tests_Compat_arrayFirst extends WP_UnitTestCase {
 
 	/**
+	 * @ticket 63853
+	 *
 	 * Test that array_first() is always available (either from PHP or WP).
 	 */
 	public function test_array_first_availability(): void {

--- a/tests/phpunit/tests/compat/arrayKeyFirst.php
+++ b/tests/phpunit/tests/compat/arrayKeyFirst.php
@@ -15,20 +15,6 @@ class Tests_Compat_arrayKeyFirst extends WP_UnitTestCase {
 		$this->assertTrue( function_exists( 'array_key_first' ) );
 	}
 
-	/**
-	 * Test that array_key_first() returns the pointer is not the first element.
-	 *
-	 * @ticket 45055
-	 */
-	public function test_array_key_first_with_end_pointer() {
-		$arr = array( 'key1' => 'val1', 'key2' => 'val2' );
-		// change the pointer to the last element
-		end( $arr );
-
-		$key = array_key_first( $arr );
-		$this->assertSame( 'key2', key( $arr ) );
-		$this->assertSame( 'key1', $key );
-	}
 
 	/**
 	 * @dataProvider data_array_key_first

--- a/tests/phpunit/tests/compat/arrayKeyFirst.php
+++ b/tests/phpunit/tests/compat/arrayKeyFirst.php
@@ -16,6 +16,21 @@ class Tests_Compat_arrayKeyFirst extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that array_key_first() returns the pointer is not the first element.
+	 *
+	 * @ticket 45055
+	 */
+	public function test_array_key_first_with_end_pointer() {
+		$arr = array( 'key1' => 'val1', 'key2' => 'val2' );
+		// change the pointer to the last element
+		end( $arr );
+
+		$key = array_key_first( $arr );
+		$this->assertSame( 'key2', key( $arr ) );
+		$this->assertSame( 'key1', $key );
+	}
+
+	/**
 	 * @dataProvider data_array_key_first
 	 *
 	 * @ticket 45055

--- a/tests/phpunit/tests/compat/arrayKeyFirst.php
+++ b/tests/phpunit/tests/compat/arrayKeyFirst.php
@@ -15,7 +15,6 @@ class Tests_Compat_arrayKeyFirst extends WP_UnitTestCase {
 		$this->assertTrue( function_exists( 'array_key_first' ) );
 	}
 
-
 	/**
 	 * @dataProvider data_array_key_first
 	 *

--- a/tests/phpunit/tests/compat/arrayLast.php
+++ b/tests/phpunit/tests/compat/arrayLast.php
@@ -15,6 +15,8 @@ class Tests_Compat_arrayLast extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 63853
+	 *
 	 * @dataProvider data_array_last
 	 *
 	 * @param mixed $expected The expected last value.

--- a/tests/phpunit/tests/compat/arrayLast.php
+++ b/tests/phpunit/tests/compat/arrayLast.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @group compat
+ *
+ * @covers ::array_last
+ */
+class Tests_Compat_arrayLast extends WP_UnitTestCase {
+
+	/**
+	 * Test that array_last() is always available (either from PHP or WP).
+	 */
+	public function test_array_last_availability(): void {
+		$this->assertTrue( function_exists( 'array_last' ) );
+	}
+
+	/**
+	 * @dataProvider data_array_last
+	 *
+	 * @param mixed $expected The expected last value.
+	 * @param array $arr      The array to get the last value from.
+	 */
+	public function test_array_last( $expected, $arr ): void {
+		$this->assertSame( $expected, array_last( $arr ) );
+	}
+
+	/**
+	 * Data provider for array_last().
+	 *
+	 * @return array[]
+	 */
+	public function data_array_last(): array {
+		$obj = new \stdClass();
+		return array(
+			'string values'          => array(
+				'expected' => 'c',
+				'arr'      => array( 'a', 'b', 'c' ),
+			),
+			'associative array'      => array(
+				'expected' => 20,
+				'arr'      => array(
+					'foo' => 10,
+					'bar' => 20,
+				),
+			),
+			'empty array'            => array(
+				'expected' => null,
+				'arr'      => array(),
+			),
+			'single element array'   => array(
+				'expected' => 42,
+				'arr'      => array( 42 ),
+			),
+			'null values'            => array(
+				'expected' => null,
+				'arr'      => array( 'a', 'b', null ),
+			),
+			'objects'                => array(
+				'expected' => $obj,
+				'arr'      => array(
+					1,
+					2,
+					$obj,
+				),
+			),
+			'boolean values'         => array(
+				'expected' => false,
+				'arr'      => array( true, false ),
+			),
+			'null values in between' => array(
+				'expected' => 'c',
+				'arr'      => array( 'a', null, 'b', 'c' ),
+			),
+			'empty string values'    => array(
+				'expected' => '',
+				'arr'      => array( 'a', 'b', '' ),
+			),
+		);
+	}
+}

--- a/tests/phpunit/tests/compat/arrayLast.php
+++ b/tests/phpunit/tests/compat/arrayLast.php
@@ -8,6 +8,8 @@
 class Tests_Compat_arrayLast extends WP_UnitTestCase {
 
 	/**
+	 * @ticket 63853
+	 *
 	 * Test that array_last() is always available (either from PHP or WP).
 	 */
 	public function test_array_last_availability(): void {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
Add polyfills for `array_first()` and `array_last()`, planned for PHP 8.5. These provide a safe, side-effect-free way to fetch the first and last values of an array. This forward-compatibility makes it easier for Core, plugins, and themes to adopt upcoming PHP features while maintaining support for older versions.

The PR includes the polyfills for both functions in `compat.php` as well as unit tests.

Trac ticket: https://core.trac.wordpress.org/ticket/63853

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
