### PR TITLE
Allow block attributes strings to terminate in \ character

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1601,14 +1601,19 @@ function make_after_block_visitor( $hooked_blocks, $context, $callback = 'insert
  * @return string Serialized attributes.
  */
 function serialize_block_attributes( $block_attributes ) {
-	$encoded_attributes = wp_json_encode( $block_attributes, JSON_HEX_QUOT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
-	$encoded_attributes = preg_replace( '/\\\\\\\\/', '\\u005c', $encoded_attributes );
-	$encoded_attributes = preg_replace( '/--/', '\\u002d\\u002d', $encoded_attributes );
-	$encoded_attributes = preg_replace( '/</', '\\u003c', $encoded_attributes );
-	$encoded_attributes = preg_replace( '/>/', '\\u003e', $encoded_attributes );
-	$encoded_attributes = preg_replace( '/&/', '\\u0026', $encoded_attributes );
+	$encoded_attributes = wp_json_encode( $block_attributes, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 
-	return $encoded_attributes;
+	return strtr(
+		$encoded_attributes,
+		array(
+			'\\\\' => '\\u005c',
+			'--'   => '\\u002d\\u002d',
+			'<'    => '\\u003c',
+			'>'    => '\\u003e',
+			'&'    => '\\u0026',
+			'\"'   => '\\u0022',
+		),
+	);
 }
 
 /**

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1601,13 +1601,11 @@ function make_after_block_visitor( $hooked_blocks, $context, $callback = 'insert
  * @return string Serialized attributes.
  */
 function serialize_block_attributes( $block_attributes ) {
-	$encoded_attributes = wp_json_encode( $block_attributes, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+	$encoded_attributes = wp_json_encode( $block_attributes, JSON_HEX_QUOT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 	$encoded_attributes = preg_replace( '/--/', '\\u002d\\u002d', $encoded_attributes );
 	$encoded_attributes = preg_replace( '/</', '\\u003c', $encoded_attributes );
 	$encoded_attributes = preg_replace( '/>/', '\\u003e', $encoded_attributes );
 	$encoded_attributes = preg_replace( '/&/', '\\u0026', $encoded_attributes );
-	// Regex: /\\"/
-	$encoded_attributes = preg_replace( '/\\\\"/', '\\u0022', $encoded_attributes );
 
 	return $encoded_attributes;
 }

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1612,7 +1612,7 @@ function serialize_block_attributes( $block_attributes ) {
 			'>'    => '\\u003e',
 			'&'    => '\\u0026',
 			'\"'   => '\\u0022',
-		),
+		)
 	);
 }
 

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1611,7 +1611,7 @@ function serialize_block_attributes( $block_attributes ) {
 			'<'    => '\\u003c',
 			'>'    => '\\u003e',
 			'&'    => '\\u0026',
-			'\"'   => '\\u0022',
+			'\\"'  => '\\u0022',
 		)
 	);
 }

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1602,6 +1602,7 @@ function make_after_block_visitor( $hooked_blocks, $context, $callback = 'insert
  */
 function serialize_block_attributes( $block_attributes ) {
 	$encoded_attributes = wp_json_encode( $block_attributes, JSON_HEX_QUOT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+	$encoded_attributes = preg_replace( '/\\\\\\\\/', '\\u005c', $encoded_attributes );
 	$encoded_attributes = preg_replace( '/--/', '\\u002d\\u002d', $encoded_attributes );
 	$encoded_attributes = preg_replace( '/</', '\\u003c', $encoded_attributes );
 	$encoded_attributes = preg_replace( '/>/', '\\u003e', $encoded_attributes );

--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -26,26 +26,29 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 
 	public function data_serialize_identity_from_parsed() {
 		return array(
-			// Void block.
-			array( '<!-- wp:void /-->' ),
+			'Void block'                                  =>
+				array( '<!-- wp:void /-->' ),
 
-			// Freeform content ($block_name = null).
-			array( 'Example.' ),
+			'Freeform content ($block_name = null)'       =>
+				array( 'Example.' ),
 
-			// Block with content.
-			array( '<!-- wp:content -->Example.<!-- /wp:content -->' ),
+			'Block with content'                          =>
+				array( '<!-- wp:content -->Example.<!-- /wp:content -->' ),
 
-			// Block with attributes.
-			array( '<!-- wp:attributes {"key":"value"} /-->' ),
+			'Block with attributes'                       =>
+				array( '<!-- wp:attributes {"key":"value"} /-->' ),
 
-			// Block with inner blocks.
-			array( "<!-- wp:outer --><!-- wp:inner {\"key\":\"value\"} -->Example.<!-- /wp:inner -->\n\nExample.\n\n<!-- wp:void /--><!-- /wp:outer -->" ),
+			'Block with inner blocks'                     =>
+				array( "<!-- wp:outer --><!-- wp:inner {\"key\":\"value\"} -->Example.<!-- /wp:inner -->\n\nExample.\n\n<!-- wp:void /--><!-- /wp:outer -->" ),
 
-			// Block with attribute values that may conflict with HTML comment.
-			array( '<!-- wp:attributes {"key":"\\u002d\\u002d\\u003c\\u003e\\u0026\\u0022"} /-->' ),
+			'Block with attribute values that may conflict with HTML comment' =>
+				array( '<!-- wp:attributes {"key":"\\u002d\\u002d\\u003c\\u003e\\u0026\\u0022"} /-->' ),
 
-			// Block with attribute values that should not be escaped.
-			array( '<!-- wp:attributes {"key":"€1.00 / 3 for €2.00"} /-->' ),
+			'Block with attribute values that should not be escaped' =>
+				array( '<!-- wp:attributes {"key":"€1.00 / 3 for €2.00"} /-->' ),
+
+			'Backslashes in attributes, Gutenberg #16508' =>
+				array( '<!-- wp:attributes {"key":"\\u0022\\\\"} /-->' ),
 		);
 	}
 

--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -19,11 +19,11 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 		$block = array(
 			'blockName'    => 'test',
 			'attrs'        => array(
-				'lt'    => '<',
-				'gt'    => '>',
-				'amp'   => '&',
-				'bs'    => '\\',
-				'quot'  => '"',
+				'lt'         => '<',
+				'gt'         => '>',
+				'amp'        => '&',
+				'bs'         => '\\',
+				'quot'       => '"',
 				'bs-bs-quot' => '\\\\"',
 			),
 			'innerBlocks'  => array(),

--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -11,6 +11,31 @@
  */
 class Tests_Blocks_Serialize extends WP_UnitTestCase {
 	/**
+	 * Ensure there are no issues with special character encoding.
+	 *
+	 * @ticket 63917
+	 */
+	public function test_attribute_encoding() {
+		$block = array(
+			'blockName'    => 'test',
+			'attrs'        => array(
+				'lt'    => '<',
+				'gt'    => '>',
+				'amp'   => '&',
+				'bs'    => '\\',
+				'quot'  => '"',
+				'bs-bs-quot' => '\\\\"',
+			),
+			'innerBlocks'  => array(),
+			'innerHTML'    => '',
+			'innerContent' => array(),
+		);
+
+		$expected = '<!-- wp:test {"lt":"\\u003c","gt":"\\u003e","amp":"\\u0026","bs":"\\u005c","quot":"\\u0022","bs-bs-quot":"\\u005c\\u005c\\u0022"} /-->';
+		$this->assertSame( $expected, serialize_block( $block ) );
+	}
+
+	/**
 	 * @dataProvider data_serialize_identity_from_parsed
 	 *
 	 * @param string $original Original block markup.

--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -10,11 +10,12 @@
  * @group blocks
  */
 class Tests_Blocks_Serialize extends WP_UnitTestCase {
-
 	/**
 	 * @dataProvider data_serialize_identity_from_parsed
 	 *
 	 * @param string $original Original block markup.
+	 *
+	 * @ticket TBD
 	 */
 	public function test_serialize_identity_from_parsed( $original ) {
 		$blocks = parse_blocks( $original );
@@ -24,7 +25,7 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 		$this->assertSame( $original, $actual );
 	}
 
-	public function data_serialize_identity_from_parsed() {
+	public static function data_serialize_identity_from_parsed(): array {
 		return array(
 			'Void block'                                  =>
 				array( '<!-- wp:void /-->' ),
@@ -52,6 +53,44 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 
 			'Tricky backslashes'                          =>
 				array( '<!-- wp:attributes {"bsbsQbsbsbsQ":"\\u005c\\u005c\\u0022\\u005c\\u005c\\u005c\\u005c\\u0022"} /-->' ),
+		);
+	}
+
+	/**
+	 * The serialization was adjusted to use unicode escapes sequences for escaped `\` and `"`
+	 * characters inside JSON strings.
+	 *
+	 * Ensure that the previous escape form can be parsed compatibly and serialized back to
+	 * the new form.
+	 *
+	 * @see https://github.com/WordPress/wordpress-develop/pull/9558
+	 * @see https://github.com/WordPress/gutenberg/pull/71291
+	 *
+	 * @ticket TBD
+	 *
+	 * @dataProvider data_serialize_compatible_forms
+	 *
+	 * @param string $before Previous serialization form.
+	 * @param string $after  New serialization form.
+	 */
+	public function test_older_serialization_is_compatible( string $before, string $after ) {
+		$this->assertNotSame( $before, $after, 'The same serialization should not be provided for before and after.' );
+		$blocks = parse_blocks( $before );
+		$actual = serialize_blocks( $blocks );
+		$this->assertSame( $after, $actual );
+	}
+
+	public static function data_serialize_compatible_forms(): array {
+		return array(
+			'Special characters' => array(
+				'<!-- wp:attributes {"lt":"\\u003c","gt":"\\u003e","amp":"\\u0026","bs":"\\\\","quot":"\\u0022"} /-->',
+				'<!-- wp:attributes {"lt":"\\u003c","gt":"\\u003e","amp":"\\u0026","bs":"\\u005c","quot":"\\u0022"} /-->',
+			),
+
+			'Backslashes'        => array(
+				'<!-- wp:attributes {"bs":"\\\\","bsQuote":"\\\\\\u0022","bsQuoteBs":"\\\\\\u0022\\\\"} /-->',
+				'<!-- wp:attributes {"bs":"\\u005c","bsQuote":"\\u005c\\u0022","bsQuoteBs":"\\u005c\\u0022\\u005c"} /-->',
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -15,7 +15,7 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 	 *
 	 * @param string $original Original block markup.
 	 *
-	 * @ticket TBD
+	 * @ticket 63917
 	 */
 	public function test_serialize_identity_from_parsed( $original ) {
 		$blocks = parse_blocks( $original );
@@ -66,7 +66,7 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 	 * @see https://github.com/WordPress/wordpress-develop/pull/9558
 	 * @see https://github.com/WordPress/gutenberg/pull/71291
 	 *
-	 * @ticket TBD
+	 * @ticket 63917
 	 *
 	 * @dataProvider data_serialize_compatible_forms
 	 *

--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -42,16 +42,16 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 				array( "<!-- wp:outer --><!-- wp:inner {\"key\":\"value\"} -->Example.<!-- /wp:inner -->\n\nExample.\n\n<!-- wp:void /--><!-- /wp:outer -->" ),
 
 			'Block with attribute values that may conflict with HTML comment' =>
-				array( '<!-- wp:attributes {"key":"\u002d\u002d\u003c\u003e\u0026\u0022"} /-->' ),
+				array( '<!-- wp:attributes {"key":"\\u002d\\u002d\\u003c\\u003e\\u0026\\u0022"} /-->' ),
 
 			'Block with attribute values that should not be escaped' =>
 				array( '<!-- wp:attributes {"key":"€1.00 / 3 for €2.00"} /-->' ),
 
 			'Backslashes in attributes, Gutenberg #16508' =>
-				array( '<!-- wp:attributes {"bs":"\u005c","bsQuote":"\u005c\u0022","bsQuoteBs":"\u005c\u0022\u005c"} /-->' ),
+				array( '<!-- wp:attributes {"bs":"\\u005c","bsQuote":"\\u005c\\u0022","bsQuoteBs":"\\u005c\\u0022\\u005c"} /-->' ),
 
 			'Tricky backslashes'                          =>
-				array( '<!-- wp:attributes {"bsbsQbsbsbsQ":"\u005c\u005c\u0022\u005c\u005c\u005c\u005c\u0022"} /-->' ),
+				array( '<!-- wp:attributes {"bsbsQbsbsbsQ":"\\u005c\\u005c\\u0022\\u005c\\u005c\\u005c\\u005c\\u0022"} /-->' ),
 		);
 	}
 

--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -42,13 +42,16 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 				array( "<!-- wp:outer --><!-- wp:inner {\"key\":\"value\"} -->Example.<!-- /wp:inner -->\n\nExample.\n\n<!-- wp:void /--><!-- /wp:outer -->" ),
 
 			'Block with attribute values that may conflict with HTML comment' =>
-				array( '<!-- wp:attributes {"key":"\\u002d\\u002d\\u003c\\u003e\\u0026\\u0022"} /-->' ),
+				array( '<!-- wp:attributes {"key":"\u002d\u002d\u003c\u003e\u0026\u0022"} /-->' ),
 
 			'Block with attribute values that should not be escaped' =>
 				array( '<!-- wp:attributes {"key":"€1.00 / 3 for €2.00"} /-->' ),
 
 			'Backslashes in attributes, Gutenberg #16508' =>
-				array( '<!-- wp:attributes {"bs":"\\u005c","bsQuote":"\\u005c\\u0022","bsQuoteBs":"\\u005c\\u0022\\u005c"} /-->' ),
+				array( '<!-- wp:attributes {"bs":"\u005c","bsQuote":"\u005c\u0022","bsQuoteBs":"\u005c\u0022\u005c"} /-->' ),
+
+			'Tricky backslashes'                          =>
+				array( '<!-- wp:attributes {"bsbsQbsbsbsQ":"\u005c\u005c\u0022\u005c\u005c\u005c\u005c\u0022"} /-->' ),
 		);
 	}
 

--- a/tests/phpunit/tests/blocks/serialize.php
+++ b/tests/phpunit/tests/blocks/serialize.php
@@ -48,7 +48,7 @@ class Tests_Blocks_Serialize extends WP_UnitTestCase {
 				array( '<!-- wp:attributes {"key":"€1.00 / 3 for €2.00"} /-->' ),
 
 			'Backslashes in attributes, Gutenberg #16508' =>
-				array( '<!-- wp:attributes {"key":"\\u0022\\\\"} /-->' ),
+				array( '<!-- wp:attributes {"bs":"\\u005c","bsQuote":"\\u005c\\u0022","bsQuoteBs":"\\u005c\\u0022\\u005c"} /-->' ),
 		);
 	}
 


### PR DESCRIPTION
Change the JSON encoding of block attributes to address problems with strings ending in the `\` character.

The encoding is updated to replace the escaped `\` character with its unicode escape `\u005c`. This simplifies the replacement of escaped `"` characters with its unicode escape `\u0022`. This addresses a bug where plain, syntactic JSON `"` characters following an escaped `\` character were replaced, breaking the JSON syntax and causing block attributes to be ignored entirely.

By replacing escaped `\` characters, subsequent replacements become simpler. Escaped `"` replacement ([applied by `wp_kses_stripslashes()`](https://developer.wordpress.org/reference/functions/wp_kses_stripslashes/) and the motivation for https://github.com/WordPress/gutenberg/pull/6619 that introduced the escaped `"` replacement) can be maintained as a simple replacement with no need for backtracking or other complex regular expression techniques.

This should also make the syntactic JSON `"` characters safe from `wp_kses_stripslashes()` because escaped slashes are been replaced.

This applies the same encoding as https://github.com/WordPress/gutenberg/pull/71291.

~This likely requires https://github.com/WordPress/wordpress-develop/pull/9559.~

See https://github.com/WordPress/gutenberg/issues/16508 and https://github.com/WordPress/gutenberg/pull/6619.



Trac ticket: https://core.trac.wordpress.org/ticket/63917

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
