### PR TITLE
KSES: Prevent stripslashes from stripping escaped slashes

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -1824,7 +1824,7 @@ function wp_kses_no_null( $content, $options = null ) {
  * @return string Fixed string with quoted slashes.
  */
 function wp_kses_stripslashes( $content ) {
-	return preg_replace( '%\\\\"%', '"', $content );
+	return preg_replace( '%(?<!\\\\)(\\\\\\\\)*\\\\"%', '$1"', $content );
 }
 
 /**

--- a/tests/phpunit/tests/kses.php
+++ b/tests/phpunit/tests/kses.php
@@ -2377,4 +2377,36 @@ HTML;
 			),
 		);
 	}
+
+	/**
+	 * @dataProvider data_kses_stripslashes
+	 *
+	 * @ticket TBD
+	 *
+	 * @param string $input    Input string.
+	 * @param array  $expected Expected result after applying `wp_kses_stripslashes()`.
+	 */
+	public function test_kses_stripslashes( $input, $expected ) {
+		$this->assertSame( $expected, wp_kses_stripslashes( $input ) );
+	}
+
+	/**
+	 * Data provider for test_specific_attributes_preserved_in_context.
+	 *
+	 * @return array
+	 */
+	public static function data_kses_stripslashes() {
+		return array(
+			'Text untouched'                      => array( 'Text is untouched', 'Text is untouched' ),
+			'Multibyte untouched'                 => array( 'áêiõü🏴󠁧󠁢󠁥󠁮󠁧󠁿', 'áêiõü🏴󠁧󠁢󠁥󠁮󠁧󠁿' ),
+			'HTML characters untouched'           => array( '<>&\'"', '<>&\'"' ),
+			'" on its own untouched'              => array( '"', '"' ),
+			'\\" to "'                            => array( '\\"', '"' ),
+			'\\\' ignored'                        => array( '\\\'', '\\\'' ),
+			'\\ ignored'                          => array( '\\', '\\' ),
+
+			'unescaped \\ before " is stripped'   => array( '\\\\\\"', '\\\\"' ),
+			'escaped \\ before " is not stripped' => array( '\\\\"', '\\\\"' ),
+		);
+	}
 }


### PR DESCRIPTION
Companion to https://github.com/WordPress/gutenberg/pull/71291 and https://github.com/WordPress/wordpress-develop/pull/9558.

Prevent `wp_kses_stripslashes()` from stripping slashes that are escaped themselves and do no escape the `"`.

See https://github.com/WordPress/gutenberg/issues/16508 and https://github.com/WordPress/gutenberg/pull/6619.

[[649]](https://core.trac.wordpress.org/changeset/649) introduced this slash stripping in the original version of KSES introduced in Core. It's remained the same ever since:

[In trac](https://core.trac.wordpress.org/browser/trunk/wp-includes/kses.php?rev=649#L394):

https://github.com/WordPress/wordpress-develop/blob/f27aff65fef37354ada14a2e670705c35fc22bcd/wp-includes/kses.php#L387-L395

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
