### PR TITLE
Trigger the wp_cron action from the shutdown hook instead of the init hook to reduce TTFB (⏱️ Time To First Byte) and improve performance 📈

### DIFF
--- a/src/wp-includes/class-wp-customize-manager.php
+++ b/src/wp-includes/class-wp-customize-manager.php
@@ -375,7 +375,7 @@ final class WP_Customize_Manager {
 		add_action( 'wp_loaded', array( $this, 'wp_loaded' ) );
 
 		// Do not spawn cron (especially the alternate cron) while running the Customizer.
-		remove_action( 'init', 'wp_cron' );
+		remove_action( 'shutdown', 'wp_cron' );
 
 		// Do not run update checks when rendering the controls.
 		remove_action( 'admin_init', '_maybe_update_core' );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -404,7 +404,7 @@ add_action( 'rss2_head', 'rss2_site_icon' );
 
 // WP Cron.
 if ( ! defined( 'DOING_CRON' ) ) {
-	add_action( 'init', 'wp_cron' );
+	add_action( 'shutdown', 'wp_cron' );
 }
 
 // HTTPS migration.


### PR DESCRIPTION

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63858

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
