### PR TITLE
General: Add input validation to `get_calendar()` for invalid week and month parameters

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2299,6 +2299,10 @@ function get_calendar( $args = array() ) {
 	$w = 0;
 	if ( isset( $_GET['w'] ) ) {
 		$w = (int) $_GET['w'];
+		// Validate week number - should be between 1 and 53
+		if ( $w < 1 || $w > 53 ) {
+			$w = 0;
+		}
 	}
 
 	/*
@@ -2372,9 +2376,15 @@ function get_calendar( $args = array() ) {
 	if ( ! empty( $monthnum ) && ! empty( $year ) ) {
 		$thismonth = (int) $monthnum;
 		$thisyear  = (int) $year;
+		
+		// Validate month number - should be between 1 and 12
+		if ( $thismonth < 1 || $thismonth > 12 ) {
+			$thismonth = (int) current_time( 'm' );
+			$thisyear  = (int) current_time( 'Y' );
+		}
 	} elseif ( ! empty( $w ) ) {
 		// We need to get the month from MySQL.
-		$thisyear = (int) substr( $m, 0, 4 );
+		$thisyear = ! empty( $m ) ? (int) substr( $m, 0, 4 ) : (int) current_time( 'Y' );
 		// It seems MySQL's weeks disagree with PHP's.
 		$d         = ( ( $w - 1 ) * 7 ) + 6;
 		$thismonth = (int) $wpdb->get_var(
@@ -2390,6 +2400,11 @@ function get_calendar( $args = array() ) {
 			$thismonth = 1;
 		} else {
 			$thismonth = (int) substr( $m, 4, 2 );
+			// Validate month from $m parameter
+			if ( $thismonth < 1 || $thismonth > 12 ) {
+				$thismonth = (int) current_time( 'm' );
+				$thisyear  = (int) current_time( 'Y' );
+			}
 		}
 	} else {
 		$thisyear  = (int) current_time( 'Y' );

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2376,7 +2376,7 @@ function get_calendar( $args = array() ) {
 	if ( ! empty( $monthnum ) && ! empty( $year ) ) {
 		$thismonth = (int) $monthnum;
 		$thisyear  = (int) $year;
-		
+
 		// Validate month number - should be between 1 and 12
 		if ( $thismonth < 1 || $thismonth > 12 ) {
 			$thismonth = (int) current_time( 'm' );

--- a/tests/phpunit/tests/general-template/get-calendar-test.php
+++ b/tests/phpunit/tests/general-template/get-calendar-test.php
@@ -43,4 +43,55 @@ class Tests_General_Template_GetCalendar extends WP_UnitTestCase {
 
 		wp_delete_post( $post_id, true );
 	}
+
+	/**
+	 * Tests if get_calendar() handles invalid month numbers correctly.
+	 *
+	 * @ticket 41011
+	 */
+	public function test_get_calendar_invalid_month_numbers() {
+		global $monthnum, $year;
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+			)
+		);
+
+		$original_monthnum = $monthnum;
+		$original_year     = $year;
+
+		$monthnum          = '13';
+		$year              = '2023';
+		$calendar_month_13 = get_calendar( array( 'display' => false ) );
+
+		$monthnum         = '0';
+		$year             = '2023';
+		$calendar_month_0 = get_calendar( array( 'display' => false ) );
+
+		$monthnum                = '-1';
+		$year                    = '2023';
+		$calendar_month_negative = get_calendar( array( 'display' => false ) );
+
+		$monthnum             = '6';
+		$year                 = '2023';
+		$calendar_valid_month = get_calendar( array( 'display' => false ) );
+
+		$monthnum         = null;
+		$year             = null;
+		$calendar_current = get_calendar( array( 'display' => false ) );
+
+		$this->assertEquals( $calendar_current, $calendar_month_13, 'Month 13 should fall back to current month' );
+		$this->assertEquals( $calendar_current, $calendar_month_0, 'Month 0 should fall back to current month' );
+		$this->assertEquals( $calendar_current, $calendar_month_negative, 'Negative month should fall back to current month' );
+
+		if ( current_time( 'm' ) !== '06' || current_time( 'Y' ) !== '2023' ) {
+			$this->assertNotEquals( $calendar_current, $calendar_valid_month, 'Valid specific month should be different from current' );
+		}
+
+		$monthnum = $original_monthnum;
+		$year     = $original_year;
+
+		wp_delete_post( $post_id, true );
+	}
 }

--- a/tests/phpunit/tests/general-template/get-calendar-test.php
+++ b/tests/phpunit/tests/general-template/get-calendar-test.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * Class responsible for testing the functionality of the get_calendar() template function
+ * in various scenarios, including input validation for invalid parameters.
+ *
+ * @covers get_calendar()
+ */
+class Tests_General_Template_GetCalendar extends WP_UnitTestCase {
+}

--- a/tests/phpunit/tests/general-template/get-calendar-test.php
+++ b/tests/phpunit/tests/general-template/get-calendar-test.php
@@ -7,4 +7,40 @@
  * @covers get_calendar()
  */
 class Tests_General_Template_GetCalendar extends WP_UnitTestCase {
+	/**
+	 * Tests if get_calendar() handles invalid week numbers correctly.
+	 *
+	 * @ticket 41011
+	 */
+	public function test_get_calendar_invalid_week_numbers() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+			)
+		);
+
+		$_GET['w']     = 1400;
+		$calendar_high = get_calendar( array( 'display' => false ) );
+
+		$_GET['w']         = -5;
+		$calendar_negative = get_calendar( array( 'display' => false ) );
+
+		$_GET['w']     = 0;
+		$calendar_zero = get_calendar( array( 'display' => false ) );
+
+		$_GET['w']      = 25;
+		$calendar_valid = get_calendar( array( 'display' => false ) );
+
+		unset( $_GET['w'] );
+
+		$calendar_normal = get_calendar( array( 'display' => false ) );
+
+		$this->assertEquals( $calendar_normal, $calendar_high, 'High week number should fall back to normal calendar' );
+		$this->assertEquals( $calendar_normal, $calendar_negative, 'Negative week number should fall back to normal calendar' );
+		$this->assertEquals( $calendar_normal, $calendar_zero, 'Zero week number should fall back to normal calendar' );
+
+		$this->assertNotEquals( $calendar_normal, $calendar_valid, 'Valid week number should produce different calendar' );
+
+		wp_delete_post( $post_id, true );
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/41011

This PR addresses security and stability issues in the `get_calendar()` function by adding proper input validation for week and month parameters.

This PR validates - 
- `$w` parameter is between 1-53, falls back to normal calendar for invalid values
- `$monthnum` is between 1-12, falls back to the current month for invalid values  
- month component of `$m` parameter
- Fixed `substr()` error when `$m` is null but `$w` is provided


Props @pbearne for the original patch and tests.
Refreshed Implementation of PR - https://github.com/WordPress/wordpress-develop/pull/8064

