### PR TITLE
Compat: Replace warning-suppression in _wp_can_use_pcre_u

### DIFF
--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -54,7 +54,10 @@ function _wp_can_use_pcre_u( $set = null ) {
 			function ( $errno, $errstr ) use ( &$utf8_pcre ) {
 				if ( str_starts_with( $errstr, 'preg_match():' ) ) {
 					$utf8_pcre = false;
+					return true;
 				}
+
+				return false;
 			},
 			E_WARNING
 		);

--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -48,8 +48,20 @@ function _wp_can_use_pcre_u( $set = null ) {
 	}
 
 	if ( 'reset' === $utf8_pcre ) {
-		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- intentional error generated to detect PCRE/u support.
-		$utf8_pcre = @preg_match( '/^./u', 'a' );
+		$utf8_pcre = true;
+
+		set_error_handler(
+			function ( $errno, $errstr ) use ( &$utf8_pcre ) {
+				if ( str_starts_with( $errstr, 'preg_match():' ) ) {
+					$utf8_pcre = false;
+				}
+			},
+			E_WARNING
+		);
+
+		preg_match( '/^./u', '' );
+
+		restore_error_handler();
 	}
 
 	return $utf8_pcre;

--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -62,7 +62,12 @@ function _wp_can_use_pcre_u( $set = null ) {
 			E_WARNING
 		);
 
-		preg_match( '/^./u', '' );
+		/*
+		 * Attempt to compile a PCRE pattern with the PCRE_UTF8 flag. For
+		 * systems lacking Unicode support this will trigger a warning
+		 * during compilation, which the error handler will intercept.
+		 */
+		preg_match( '//u', '' );
 
 		restore_error_handler();
 	}


### PR DESCRIPTION
Trac ticket: Core-63865

## Testing

I’ve confirmed two specific changes in this patch by recompiling PHP without the `u` flag. I wasn’t sure how to do this via the CLI flags so I commented out [the flag parsing](https://github.com/php/php-src/blob/99068da2b1c90f893a96895d930e7df84a2f8d9f/ext/pcre/php_pcre.c#L721) and this presented the expected error.

 - [x] It’s sufficient to have an empty PCRE pattern when the flag is present.
 - [x] It’s sufficient to have an empty match string.

That is, `preg_match( '//u', '' )` is enough to trigger the warning and so we don’t have to add extra noise in the function call, muddying the intention of the code.