### PR TITLE
PHP 8.5: Replace non-canonical scalar type casts with canonical versions

### DIFF
--- a/src/wp-includes/IXR/class-IXR-message.php
+++ b/src/wp-includes/IXR/class-IXR-message.php
@@ -177,7 +177,7 @@ class IXR_Message
                 $valueFlag = true;
                 break;
             case 'double':
-                $value = (double)trim($this->_currentTagContents);
+                $value = (float)trim($this->_currentTagContents);
                 $valueFlag = true;
                 break;
             case 'string':
@@ -196,7 +196,7 @@ class IXR_Message
                 }
                 break;
             case 'boolean':
-                $value = (boolean)trim($this->_currentTagContents);
+                $value = (bool)trim($this->_currentTagContents);
                 $valueFlag = true;
                 break;
             case 'base64':

--- a/src/wp-includes/class-json.php
+++ b/src/wp-includes/class-json.php
@@ -662,8 +662,8 @@ class Services_JSON
                     // return (float)$str;
 
                     // Return float or int, as appropriate
-                    return ((float)$str == (integer)$str)
-                        ? (integer)$str
+                    return ((float)$str == (int)$str)
+                        ? (int)$str
                         : (float)$str;
 
                 } elseif (preg_match('/^("|\').*(\1)$/s', $str, $m) && $m[1] == $m[2]) {


### PR DESCRIPTION
PHP 8.5 deprecates non-canonical scalar type casts (boolean|double|integer|binary). Therefore, their canonical versions should be used.

See https://php.watch/versions/8.5/boolean-double-integer-binary-casts-deprecated.

The changes in this commit are the only non-canonical scalar type cases in Core files that are maintained directly.
Another occurrence has been submitted for getID3 [upstream](https://github.com/JamesHeinrich/getID3/pull/469).

This PR is handled as part of https://core.trac.wordpress.org/ticket/63061.