### PR TITLE
Revert "Security: Set the `frame-ancestors` directive in `send_frame_options_header()`

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -7139,14 +7139,10 @@ function wp_find_hierarchy_loop_tortoise_hare( $callback, $start, $override = ar
  *
  * @since 3.1.3
  *
- * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Frame-Options
- * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/frame-ancestors
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
  */
 function send_frame_options_header() {
-	if ( ! headers_sent() ) {
-		header( 'X-Frame-Options: SAMEORIGIN' );
-		header( "Content-Security-Policy: frame-ancestors 'self';" );
-	}
+	header( 'X-Frame-Options: SAMEORIGIN' );
 }
 
 /**


### PR DESCRIPTION
This reverts commit 1ffab3205eee727d1f8703698e45c3868ac8220b.

It seems that PHPUnit tests have been consistently failing in CI for PHP 8.3 and 8.4, since what seems to coincide with the time that https://core.trac.wordpress.org/changeset/60657 was committed. Let's see if reverting that commit will indeed get tests to pass.

Trac ticket:

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
