### PR TITLE
WP_Term_Query::get_terms() - fix warning

### DIFF
--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -849,7 +849,7 @@ class WP_Term_Query {
 					if ( is_array( $children ) ) {
 						foreach ( $children as $child_id ) {
 							$child = get_term( $child_id, $term->taxonomy );
-							if ( $child->count ) {
+							if ( $child instanceof WP_Term && $child->count ) {
 								continue 2;
 							}
 						}


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/63877

Need to check the return value from the call to `get_term()`.



---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
