### PR TITLE
Use locale-aware string comparison for tag and timezone sorting

### DIFF
--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -1071,7 +1071,7 @@ function wp_generate_tag_cloud( $tags, $args = '' ) {
  *             or greater than zero if `$a->name` is greater than `$b->name`.
  */
 function _wp_object_name_sort_cb( $a, $b ) {
-	return strnatcasecmp( $a->name, $b->name );
+	return _wp_locale_strcmp( $a->name, $b->name );
 }
 
 /**

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6566,13 +6566,16 @@ function wp_timezone_override_offset() {
 function _wp_locale_strcmp( $a, $b ) {
 	if ( class_exists( 'Collator' ) ) {
 		static $collator = null;
+
 		if ( null === $collator ) {
 			$collator = new Collator( str_replace( '_', '-', get_locale() ) );
 		}
+
 		if ( $collator ) {
 			return $collator->compare( $a, $b );
 		}
 	}
+
 	return strnatcasecmp( $a, $b );
 }
 

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6570,8 +6570,8 @@ function _wp_locale_strcmp( $a, $b ) {
 		if ( null === $collator ) {
 			$collator = new Collator( str_replace( '_', '-', get_locale() ) );
 			if ( ! $collator ) {
-                $collator = false;
-            }
+				$collator = false;
+			}
 		}
 
 		if ( $collator ) {

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6569,6 +6569,9 @@ function _wp_locale_strcmp( $a, $b ) {
 
 		if ( null === $collator ) {
 			$collator = new Collator( str_replace( '_', '-', get_locale() ) );
+			if ( ! $collator ) {
+                $collator = false;
+            }
 		}
 
 		if ( $collator ) {

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -6554,6 +6554,29 @@ function wp_timezone_override_offset() {
 }
 
 /**
+ * Locale-aware string comparison.
+ *
+ * @since 6.9.0
+ * @access private
+ *
+ * @param string $a First string.
+ * @param string $b Second string.
+ * @return int|false
+ */
+function _wp_locale_strcmp( $a, $b ) {
+	if ( class_exists( 'Collator' ) ) {
+		static $collator = null;
+		if ( null === $collator ) {
+			$collator = new Collator( str_replace( '_', '-', get_locale() ) );
+		}
+		if ( $collator ) {
+			return $collator->compare( $a, $b );
+		}
+	}
+	return strnatcasecmp( $a, $b );
+}
+
+/**
  * Sort-helper for timezones.
  *
  * @since 2.9.0
@@ -6587,15 +6610,15 @@ function _wp_timezone_choice_usort_callback( $a, $b ) {
 			return 1;
 		}
 
-		return strnatcasecmp( $a['city'], $b['city'] );
+		return _wp_locale_strcmp( $a['city'], $b['city'] );
 	}
 
 	if ( $a['t_continent'] === $b['t_continent'] ) {
 		if ( $a['t_city'] === $b['t_city'] ) {
-			return strnatcasecmp( $a['t_subcity'], $b['t_subcity'] );
+			return _wp_locale_strcmp( $a['t_subcity'], $b['t_subcity'] );
 		}
 
-		return strnatcasecmp( $a['t_city'], $b['t_city'] );
+		return _wp_locale_strcmp( $a['t_city'], $b['t_city'] );
 	} else {
 		// Force Etc to the bottom of the list.
 		if ( 'Etc' === $a['continent'] ) {
@@ -6606,7 +6629,7 @@ function _wp_timezone_choice_usort_callback( $a, $b ) {
 			return -1;
 		}
 
-		return strnatcasecmp( $a['t_continent'], $b['t_continent'] );
+		return _wp_locale_strcmp( $a['t_continent'], $b['t_continent'] );
 	}
 }
 

--- a/tests/phpunit/tests/functions/wpTimezoneChoiceUsortCallback.php
+++ b/tests/phpunit/tests/functions/wpTimezoneChoiceUsortCallback.php
@@ -639,4 +639,54 @@ class Tests_Functions_WpTimezoneChoiceUsortCallback extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Test locale-aware sorting for translated timezone names.
+	 *
+	 * @ticket 11740
+	 */
+	public function test_wp_timezone_choice_usort_callback_locale_aware() {
+		if ( ! class_exists( 'Collator' ) ) {
+			$this->markTestSkipped( 'Intl extension not available.' );
+		}
+
+		add_filter(
+			'locale',
+			function () {
+				return 'cs_CZ';
+			}
+		);
+
+		$timezones = array(
+			array(
+				'continent'   => 'Europe',
+				'city'        => 'Rome',
+				't_continent' => 'Evropa',
+				't_city'      => 'Řím',
+				't_subcity'   => '',
+			),
+			array(
+				'continent'   => 'Europe',
+				'city'        => 'Amsterdam',
+				't_continent' => 'Evropa',
+				't_city'      => 'Amsterdam',
+				't_subcity'   => '',
+			),
+			array(
+				'continent'   => 'Europe',
+				'city'        => 'Stockholm',
+				't_continent' => 'Evropa',
+				't_city'      => 'Stockholm',
+				't_subcity'   => '',
+			),
+		);
+
+		usort( $timezones, '_wp_timezone_choice_usort_callback' );
+
+		$this->assertSame( 'Amsterdam', $timezones[0]['t_city'] );
+		$this->assertSame( 'Řím', $timezones[1]['t_city'] );
+		$this->assertSame( 'Stockholm', $timezones[2]['t_city'] );
+
+		remove_all_filters( 'locale' );
+	}
 }

--- a/tests/phpunit/tests/functions/wpTimezoneChoiceUsortCallback.php
+++ b/tests/phpunit/tests/functions/wpTimezoneChoiceUsortCallback.php
@@ -689,4 +689,33 @@ class Tests_Functions_WpTimezoneChoiceUsortCallback extends WP_UnitTestCase {
 
 		remove_all_filters( 'locale' );
 	}
+
+	/**
+	 * Test fallback behavior when Intl extension is not available.
+	 *
+	 * @ticket 11740
+	 */
+	public function test_wp_timezone_choice_usort_callback_fallback() {
+		$timezones = array(
+			array(
+				'continent'   => 'Europe',
+				'city'        => 'Rome',
+				't_continent' => 'Europe',
+				't_city'      => 'Rome',
+				't_subcity'   => '',
+			),
+			array(
+				'continent'   => 'Europe',
+				'city'        => 'Amsterdam',
+				't_continent' => 'Europe',
+				't_city'      => 'Amsterdam',
+				't_subcity'   => '',
+			),
+		);
+
+		usort( $timezones, '_wp_timezone_choice_usort_callback' );
+
+		$this->assertSame( 'Amsterdam', $timezones[0]['t_city'] );
+		$this->assertSame( 'Rome', $timezones[1]['t_city'] );
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/11740


This PR - 

- Introduces `_wp_locale_strcmp()` helper function for locale-aware string comparison
- Applies locale-aware sorting to tag clouds and timezone selection
- Fixes locale-based character sorting where Czech "Řím" incorrectly appeared before "Amsterdam"
- Added unit tests to prevent regression

