### PR TITLE
CI: Try fixing PHP 8.4 workflow by using 7 week old Docker image

### DIFF
--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -81,7 +81,7 @@ on:
         required: false
 
 env:
-  LOCAL_PHP: ${{ inputs.php }}-fpm
+  LOCAL_PHP: ${{ '8.4-fpm' == inputs.php && 'sha256:706cf32b9d761ef3f122aafea07c0e16b41f8fd2bf2574422615ac283c1e913d' || format( '{0}-fpm', inputs.php ) }}
   LOCAL_PHP_XDEBUG: ${{ inputs.coverage-report || false }}
   LOCAL_PHP_XDEBUG_MODE: ${{ inputs.coverage-report && 'coverage' || 'develop,debug' }}
   LOCAL_DB_TYPE: ${{ inputs.db-type }}


### PR DESCRIPTION
PHPUnit tests have been consistently failing in CI for PHP 8.3 and 8.4. I had a `wordpressdevelop/php` Docker image that's about 7 weeks old lying around locally in my cache. Let's see if pinning the SHA will fix the PHP 8.4 tests.

Edit: Oops, that was for the `latest` designation. @desrosj reminded me that that's set to PHP 8.2 😕 

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
