### PR TITLE
Fix: #57469 fatal error when a sidebar widgets set to null

### DIFF
--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -1350,7 +1350,7 @@ function retrieve_widgets( $theme_changed = false ) {
 	$sidebars_widgets = _wp_remove_unregistered_widgets( $sidebars_widgets, $registered_widgets_ids );
 	$sidebars_widgets = wp_map_sidebars_widgets( $sidebars_widgets );
 
-	// Replace null values inside the array with an empty array.
+	// Replace non-array values inside the array with an empty array.
 	foreach ( $sidebars_widgets as $key => $value ) {
 		if ( ! is_array( $value ) ) {
 			$sidebars_widgets[ $key ] = array();
@@ -1518,7 +1518,7 @@ function wp_map_sidebars_widgets( $existing_sidebars_widgets ) {
 
 		$old_sidebars_widgets = _wp_remove_unregistered_widgets( $old_sidebars_widgets );
 
-		// Replace null values inside the array with an empty array.
+		// Replace non-array values inside the array with an empty array.
 		foreach ( $new_sidebars_widgets as $key => $value ) {
 			if ( ! is_array( $value ) ) {
 				$new_sidebars_widgets[ $key ] = array();

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -1352,7 +1352,7 @@ function retrieve_widgets( $theme_changed = false ) {
 
 	// Replace null values inside the array with an empty array.
 	foreach ( $sidebars_widgets as $key => $value ) {
-		if ( null === $value ) {
+		if ( ! is_array( $value ) ) {
 			$sidebars_widgets[ $key ] = array();
 		}
 	}
@@ -1520,7 +1520,7 @@ function wp_map_sidebars_widgets( $existing_sidebars_widgets ) {
 
 		// Replace null values inside the array with an empty array.
 		foreach ( $new_sidebars_widgets as $key => $value ) {
-			if ( null === $value ) {
+			if ( ! is_array( $value ) ) {
 				$new_sidebars_widgets[ $key ] = array();
 			}
 		}

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -1350,7 +1350,7 @@ function retrieve_widgets( $theme_changed = false ) {
 	$sidebars_widgets = _wp_remove_unregistered_widgets( $sidebars_widgets, $registered_widgets_ids );
 	$sidebars_widgets = wp_map_sidebars_widgets( $sidebars_widgets );
 
-	// Replace null values inside the array to empty array.
+	// Replace null values inside the array with an empty array.
 	foreach ( $sidebars_widgets as $key => $value ) {
 		if ( null === $value ) {
 			$sidebars_widgets[ $key ] = array();
@@ -1518,7 +1518,7 @@ function wp_map_sidebars_widgets( $existing_sidebars_widgets ) {
 
 		$old_sidebars_widgets = _wp_remove_unregistered_widgets( $old_sidebars_widgets );
 
-		// Replace null values inside the array to empty array.
+		// Replace null values inside the array with an empty array.
 		foreach ( $new_sidebars_widgets as $key => $value ) {
 			if ( null === $value ) {
 				$new_sidebars_widgets[ $key ] = array();

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -1350,6 +1350,13 @@ function retrieve_widgets( $theme_changed = false ) {
 	$sidebars_widgets = _wp_remove_unregistered_widgets( $sidebars_widgets, $registered_widgets_ids );
 	$sidebars_widgets = wp_map_sidebars_widgets( $sidebars_widgets );
 
+	// Replace null values inside the array to empty array.
+	foreach ( $sidebars_widgets as $key => $value ) {
+		if ( null === $value ) {
+			$sidebars_widgets[ $key ] = array();
+		}
+	}
+
 	// Find hidden/lost multi-widget instances.
 	$shown_widgets = array_merge( ...array_values( $sidebars_widgets ) );
 	$lost_widgets  = array_diff( $registered_widgets_ids, $shown_widgets );
@@ -1510,6 +1517,13 @@ function wp_map_sidebars_widgets( $existing_sidebars_widgets ) {
 		}
 
 		$old_sidebars_widgets = _wp_remove_unregistered_widgets( $old_sidebars_widgets );
+
+		// Replace null values inside the array to empty array.
+		foreach ( $new_sidebars_widgets as $key => $value ) {
+			if ( null === $value ) {
+				$new_sidebars_widgets[ $key ] = array();
+			}
+		}
 
 		if ( ! empty( $old_sidebars_widgets ) ) {
 

--- a/tests/phpunit/tests/widgets.php
+++ b/tests/phpunit/tests/widgets.php
@@ -1380,8 +1380,7 @@ class Tests_Widgets extends WP_UnitTestCase {
 
 		$result = retrieve_widgets( true );
 		$this->assertArrayHasKey( 'primary', $result );
-		$this->assertIsArray( $result['primary'], 'Primary sidebar should be an array after normalization.' );
-		$this->assertEmpty( $result['primary'], 'Primary sidebar should be an empty array when original value was null.' );
+		$this->assertSame( array(), $result['primary'], 'Primary sidebar should be an empty array after normalization.' );
 		$this->assertArrayNotHasKey( 'extra_sidebar', $result, 'Unregistered sidebar should be removed.' );
 	}
 
@@ -1411,7 +1410,6 @@ class Tests_Widgets extends WP_UnitTestCase {
 
 		$new_sidebars = wp_map_sidebars_widgets( $prev_theme_sidebars );
 		$this->assertArrayHasKey( 'primary', $new_sidebars );
-		$this->assertIsArray( $new_sidebars['primary'], 'Primary sidebar should be an array after normalization.' );
-		$this->assertEmpty( $new_sidebars['primary'], 'Primary sidebar should be an empty array when original value was null.' );
+		$this->assertSame( array(), $new_sidebars['primary'], 'Primary sidebar should be an empty array after normalization.' );
 	}
 }

--- a/tests/phpunit/tests/widgets.php
+++ b/tests/phpunit/tests/widgets.php
@@ -1359,4 +1359,59 @@ class Tests_Widgets extends WP_UnitTestCase {
 		);
 		$this->assertSameSetsWithIndex( $expected_sidebars, $new_next_theme_sidebars );
 	}
+
+	/**
+	 * Ensures null sidebar values are converted to empty arrays in retrieve_widgets().
+	 *
+	 * @covers ::retrieve_widgets
+	 * @ticket 57469
+	 */
+	public function test_retrieve_widgets_converts_null_sidebar_to_empty_array() {
+		global $sidebars_widgets;
+		wp_widgets_init();
+		$this->register_sidebars( array( 'primary', 'secondary', 'wp_inactive_widgets' ) );
+
+		$sidebars_widgets = array(
+			'primary'             => null,
+			'secondary'           => array( 'text-1' ),
+			'extra_sidebar'       => array( 'unregistered_widget-1' ),
+			'wp_inactive_widgets' => array(),
+		);
+
+		$result = retrieve_widgets( true );
+		$this->assertArrayHasKey( 'primary', $result );
+		$this->assertIsArray( $result['primary'], 'Primary sidebar should be an array after normalization.' );
+		$this->assertEmpty( $result['primary'], 'Primary sidebar should be an empty array when original value was null.' );
+		$this->assertArrayNotHasKey( 'extra_sidebar', $result, 'Unregistered sidebar should be removed.' );
+	}
+
+	/**
+	 * Ensures wp_map_sidebars_widgets() normalizes null sidebar widget arrays.
+	 *
+	 * @covers ::wp_map_sidebars_widgets
+	 * @ticket 57469
+	 */
+	public function test_wp_map_sidebars_widgets_converts_null_sidebar_to_empty_array() {
+		$this->register_sidebars( array( 'primary', 'wp_inactive_widgets' ) );
+		// Theme data containing a null so the normalization loop runs.
+		set_theme_mod(
+			'sidebars_widgets',
+			array(
+				'time' => time(),
+				'data' => array(
+					'primary' => null,
+				),
+			)
+		);
+
+		$prev_theme_sidebars = array(
+			'primary'             => null,
+			'wp_inactive_widgets' => array(),
+		);
+
+		$new_sidebars = wp_map_sidebars_widgets( $prev_theme_sidebars );
+		$this->assertArrayHasKey( 'primary', $new_sidebars );
+		$this->assertIsArray( $new_sidebars['primary'], 'Primary sidebar should be an array after normalization.' );
+		$this->assertEmpty( $new_sidebars['primary'], 'Primary sidebar should be an empty array when original value was null.' );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/57469

The PR ensures that any `NULL` values in the `sidebars_widgets` array are replaced with empty arrays during widget retrieval and mapping.

This is needed as PHP 8.x introduces stricter type and warning behaviors that can break assumptions made in earlier versions.

Code used to testing:
```sql
DELETE FROM `wp_options` WHERE `option_name` = 'sidebars_widgets';
INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('sidebars_widgets','a:2:{s:19:"wp_inactive_widgets";N;s:9:"sidebar-1";N;}','yes');
```

### Before:

https://github.com/user-attachments/assets/6e575c6f-7bc4-4682-b55a-00d6cc05c141

### After:

https://github.com/user-attachments/assets/4342d7d6-4f6c-4e8e-84c1-ab25e6d58eec

