### PR TITLE
63836: add error codes to wp_die in post.php

### DIFF
--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -92,7 +92,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04 ]
-        memcached: [ false, true ]
+        memcached: [ false ]
         php: ${{ fromJSON( needs.build-test-matrix.outputs.php-versions ) }}
         db-version: ${{ fromJSON( needs.build-test-matrix.outputs.mysql-versions ) }}
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        memcached: [ true, false ]
+        memcached: [ false ]
         multisite: [ true, false ]
         subject: ${{ fromJson( needs.determine-matrix.outputs.subjects ) }}
     with:
@@ -119,7 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        memcached: [ true, false ]
+        memcached: [ false ]
         multisite: [ true, false ]
         # A matrix value is needed in the 'name' directive for proper grouping in the GitHub UI.
         label: [ Compare ]

--- a/.github/workflows/reusable-end-to-end-tests.yml
+++ b/.github/workflows/reusable-end-to-end-tests.yml
@@ -81,6 +81,12 @@ jobs:
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
           persist-credentials: false
 
+      - name: Create a Docker override file
+        if: ${{ contains( fromJSON('["8.3", "8.4"]'), inputs.php-version ) }}
+        env:
+          PHP_VERSION: ${{ inputs.php-version }}
+        run: cp "tools/local-env/php-$PHP_VERSION-docker-compose.override.yml" docker-compose.override.yml
+
       - name: Set up Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:

--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -121,6 +121,12 @@ jobs:
           fetch-depth: ${{ github.event_name == 'workflow_dispatch' && '2' || '1' }}
           persist-credentials: false
 
+      - name: Create a Docker override file
+        if: ${{ contains( fromJSON('["8.3", "8.4"]'), inputs.php-version ) }}
+        env:
+          PHP_VERSION: ${{ inputs.php-version }}
+        run: cp "tools/local-env/php-$PHP_VERSION-docker-compose.override.yml" docker-compose.override.yml
+
       - name: Set up Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -136,6 +136,12 @@ jobs:
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
           persist-credentials: false
 
+      - name: Create a Docker override file
+        if: ${{ contains( fromJSON('["8.3", "8.4"]'), inputs.php ) }}
+        env:
+          PHP_VERSION: ${{ inputs.php }}
+        run: cp "tools/local-env/php-${{ env.PHP_VERSION }}-docker-compose.override.yml" docker-compose.override.yml
+
       - name: Set up Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -91,6 +91,12 @@ jobs:
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
           persist-credentials: false
 
+      - name: Create a Docker override file
+        if: ${{ contains( fromJSON('["8.3", "8.4"]'), inputs.php ) }}
+        env:
+          PHP_VERSION: ${{ inputs.php }}
+        run: cp "tools/local-env/php-$PHP_VERSION-docker-compose.override.yml" docker-compose.override.yml
+
       - name: Set up Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:

--- a/src/wp-admin/post.php
+++ b/src/wp-admin/post.php
@@ -124,23 +124,23 @@ switch ( $action ) {
 		}
 
 		if ( ! $post ) {
-			wp_die( __( 'You attempted to edit an item that does not exist. Perhaps it was deleted?' ) );
+			wp_die( __( 'You attempted to edit an item that does not exist. Perhaps it was deleted?' ), 404 );
 		}
 
 		if ( ! $post_type_object ) {
-			wp_die( __( 'Invalid post type.' ) );
+			wp_die( __( 'Invalid post type.' ), 400 );
 		}
 
 		if ( ! in_array( $typenow, get_post_types( array( 'show_ui' => true ) ), true ) ) {
-			wp_die( __( 'Sorry, you are not allowed to edit posts in this post type.' ) );
+			wp_die( __( 'Sorry, you are not allowed to edit posts in this post type.' ), 403 );
 		}
 
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
-			wp_die( __( 'Sorry, you are not allowed to edit this item.' ) );
+			wp_die( __( 'Sorry, you are not allowed to edit this item.' ), 403 );
 		}
 
 		if ( 'trash' === $post->post_status ) {
-			wp_die( __( 'You cannot edit this item because it is in the Trash. Please restore it and try again.' ) );
+			wp_die( __( 'You cannot edit this item because it is in the Trash. Please restore it and try again.' ), 404 );
 		}
 
 		if ( ! empty( $_GET['get-post-lock'] ) ) {
@@ -239,26 +239,26 @@ switch ( $action ) {
 		check_admin_referer( 'trash-post_' . $post_id );
 
 		if ( ! $post ) {
-			wp_die( __( 'The item you are trying to move to the Trash no longer exists.' ) );
+			wp_die( __( 'The item you are trying to move to the Trash no longer exists.' ), 404 );
 		}
 
 		if ( ! $post_type_object ) {
-			wp_die( __( 'Invalid post type.' ) );
+			wp_die( __( 'Invalid post type.' ), 400 );
 		}
 
 		if ( ! current_user_can( 'delete_post', $post_id ) ) {
-			wp_die( __( 'Sorry, you are not allowed to move this item to the Trash.' ) );
+			wp_die( __( 'Sorry, you are not allowed to move this item to the Trash.' ), 403 );
 		}
 
 		$user_id = wp_check_post_lock( $post_id );
 		if ( $user_id ) {
 			$user = get_userdata( $user_id );
 			/* translators: %s: User's display name. */
-			wp_die( sprintf( __( 'You cannot move this item to the Trash. %s is currently editing.' ), $user->display_name ) );
+			wp_die( sprintf( __( 'You cannot move this item to the Trash. %s is currently editing.' ), $user->display_name ), 400 );
 		}
 
 		if ( ! wp_trash_post( $post_id ) ) {
-			wp_die( __( 'Error in moving the item to Trash.' ) );
+			wp_die( __( 'Error in moving the item to Trash.' ), 500 );
 		}
 
 		wp_redirect(
@@ -276,19 +276,19 @@ switch ( $action ) {
 		check_admin_referer( 'untrash-post_' . $post_id );
 
 		if ( ! $post ) {
-			wp_die( __( 'The item you are trying to restore from the Trash no longer exists.' ) );
+			wp_die( __( 'The item you are trying to restore from the Trash no longer exists.' ), 404 );
 		}
 
 		if ( ! $post_type_object ) {
-			wp_die( __( 'Invalid post type.' ) );
+			wp_die( __( 'Invalid post type.' ), 400 );
 		}
 
 		if ( ! current_user_can( 'delete_post', $post_id ) ) {
-			wp_die( __( 'Sorry, you are not allowed to restore this item from the Trash.' ) );
+			wp_die( __( 'Sorry, you are not allowed to restore this item from the Trash.' ), 403 );
 		}
 
 		if ( ! wp_untrash_post( $post_id ) ) {
-			wp_die( __( 'Error in restoring the item from Trash.' ) );
+			wp_die( __( 'Error in restoring the item from Trash.' ), 500 );
 		}
 
 		$sendback = add_query_arg(
@@ -305,25 +305,25 @@ switch ( $action ) {
 		check_admin_referer( 'delete-post_' . $post_id );
 
 		if ( ! $post ) {
-			wp_die( __( 'This item has already been deleted.' ) );
+			wp_die( __( 'This item has already been deleted.' ), 404 );
 		}
 
 		if ( ! $post_type_object ) {
-			wp_die( __( 'Invalid post type.' ) );
+			wp_die( __( 'Invalid post type.' ), 400 );
 		}
 
 		if ( ! current_user_can( 'delete_post', $post_id ) ) {
-			wp_die( __( 'Sorry, you are not allowed to delete this item.' ) );
+			wp_die( __( 'Sorry, you are not allowed to delete this item.' ), 403 );
 		}
 
 		if ( 'attachment' === $post->post_type ) {
 			$force = ( ! MEDIA_TRASH );
 			if ( ! wp_delete_attachment( $post_id, $force ) ) {
-				wp_die( __( 'Error in deleting the attachment.' ) );
+				wp_die( __( 'Error in deleting the attachment.' ), 500 );
 			}
 		} else {
 			if ( ! wp_delete_post( $post_id, true ) ) {
-				wp_die( __( 'Error in deleting the item.' ) );
+				wp_die( __( 'Error in deleting the item.' ), 500 );
 			}
 		}
 

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -297,7 +297,6 @@ class WP_Block {
 		$block_type                 = $this->name;
 		$parsed_block               = $this->parsed_block;
 		$computed_attributes        = array();
-
 		$supported_block_attributes =
 			self::BLOCK_BINDINGS_SUPPORTED_ATTRIBUTES[ $block_type ] ??
 			array();

--- a/src/wp-includes/class-wp-customize-control.php
+++ b/src/wp-includes/class-wp-customize-control.php
@@ -566,7 +566,7 @@ class WP_Customize_Control {
 				<?php
 				break;
 			case 'textarea':
-				if ( !array_key_exists( 'rows', $this->input_attrs ) ) {
+				if ( ! array_key_exists( 'rows', $this->input_attrs ) ) {
 					$this->input_attrs['rows'] = 5;
 				}
 				?>

--- a/src/wp-includes/class-wp-customize-control.php
+++ b/src/wp-includes/class-wp-customize-control.php
@@ -566,6 +566,9 @@ class WP_Customize_Control {
 				<?php
 				break;
 			case 'textarea':
+				if ( !array_key_exists( 'rows', $this->input_attrs ) ) {
+					$this->input_attrs['rows'] = 5;
+				}
 				?>
 				<?php if ( ! empty( $this->label ) ) : ?>
 					<label for="<?php echo esc_attr( $input_id ); ?>" class="customize-control-title"><?php echo esc_html( $this->label ); ?></label>
@@ -575,7 +578,6 @@ class WP_Customize_Control {
 				<?php endif; ?>
 				<textarea
 					id="<?php echo esc_attr( $input_id ); ?>"
-					rows="5"
 					<?php echo $describedby_attr; ?>
 					<?php $this->input_attrs(); ?>
 					<?php $this->link(); ?>

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -849,7 +849,8 @@ class WP_Term_Query {
 					if ( is_array( $children ) ) {
 						foreach ( $children as $child_id ) {
 							$child = get_term( $child_id, $term->taxonomy );
-							if ( $child->count ) {
+
+							if ( $child instanceof WP_Term && $child->count ) {
 								continue 2;
 							}
 						}

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5978,16 +5978,20 @@ function wp_unslash( $value ) {
  *
  * @since 3.6.0
  *
- * @param string $content A string which might contain a URL.
- * @return string|false The found URL.
+ * @param string $content A string which might contain an `A` element with a non-empty `href` attribute.
+ * @return string|false Database-escaped URL via {@see esc_url()} if found, otherwise `false`.
  */
 function get_url_in_content( $content ) {
 	if ( empty( $content ) ) {
 		return false;
 	}
 
-	if ( preg_match( '/<a\s[^>]*?href=([\'"])(.+?)\1/is', $content, $matches ) ) {
-		return sanitize_url( $matches[2] );
+	$processor = new WP_HTML_Tag_Processor( $content );
+	while ( $processor->next_tag( 'A' ) ) {
+		$href = $processor->get_attribute( 'href' );
+		if ( is_string( $href ) && ! empty( $href ) ) {
+			return sanitize_url( $href );
+		}
 	}
 
 	return false;

--- a/tools/local-env/php-8.3-docker-compose.override.yml
+++ b/tools/local-env/php-8.3-docker-compose.override.yml
@@ -1,0 +1,16 @@
+# This override file is a temporary solution to force the use of specific versions of the
+# `wordpressdevelop/php` and `wordpressdevelop/cli` images while the cause of recent failures
+# can be investigated. See https://core.trac.wordpress.org/ticket/63876.
+services:
+
+  php:
+    image: wordpressdevelop/php@sha256:c0ba85936a9d1ac2c98bf3da2d62ceb0e5787a6b11e383630df0c5a5bf2534b5
+
+  cli:
+    image: wordpressdevelop/cli@sha256:85ad7d7a9c3bd9a8775fc83aea7f7dfc0aad25b2bc4f7d740696b28cd2a0ef89
+
+  memcached:
+    # Pinning to the latest `bookworm` image is a temporary solution
+    # while the cause of recent failures can be investigated.
+    # See https://core.trac.wordpress.org/ticket/63876.
+    image: memcached:1.6.38-bookworm

--- a/tools/local-env/php-8.4-docker-compose.override.yml
+++ b/tools/local-env/php-8.4-docker-compose.override.yml
@@ -1,0 +1,16 @@
+# This override file is a temporary solution to force the use of specific versions of the
+# `wordpressdevelop/php` and `wordpressdevelop/cli` images while the cause of recent failures
+# can be investigated. See https://core.trac.wordpress.org/ticket/63876.
+services:
+
+  php:
+    image: wordpressdevelop/php@sha256:56d6cbf10d25bfcb80852c09c2fc2e967922881b233b6161ad2999df509eb59a
+
+  cli:
+    image: wordpressdevelop/cli@sha256:379f27b0c623c5cee5a7fbef1d617ce47fd3ba19158bac2e51861876fd68fdbf
+
+  memcached:
+    # Pinning to the latest `bookworm` image is a temporary solution
+    # while the cause of recent failures can be investigated.
+    # See https://core.trac.wordpress.org/ticket/63876.
+    image: memcached:1.6.38-bookworm


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Add error codes to each instance of wp_die in ./src/wp-admin/post.php

Trac ticket: [63836](https://core.trac.wordpress.org/ticket/63836)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
