### PR TITLE
Code Modernization: Replace non-canonical scalar type casts in ID3 library

### DIFF
--- a/src/wp-includes/ID3/module.audio.ogg.php
+++ b/src/wp-includes/ID3/module.audio.ogg.php
@@ -787,29 +787,29 @@ $this->warning('Ogg Theora (v3) not fully supported in this version of getID3 ['
 				switch ($index) {
 					case 'rg_audiophile':
 					case 'replaygain_album_gain':
-						$info['replay_gain']['album']['adjustment'] = (double) $commentvalue[0];
+						$info['replay_gain']['album']['adjustment'] = (float) $commentvalue[0];
 						unset($info['ogg']['comments'][$index]);
 						break;
 
 					case 'rg_radio':
 					case 'replaygain_track_gain':
-						$info['replay_gain']['track']['adjustment'] = (double) $commentvalue[0];
+						$info['replay_gain']['track']['adjustment'] = (float) $commentvalue[0];
 						unset($info['ogg']['comments'][$index]);
 						break;
 
 					case 'replaygain_album_peak':
-						$info['replay_gain']['album']['peak'] = (double) $commentvalue[0];
+						$info['replay_gain']['album']['peak'] = (float) $commentvalue[0];
 						unset($info['ogg']['comments'][$index]);
 						break;
 
 					case 'rg_peak':
 					case 'replaygain_track_peak':
-						$info['replay_gain']['track']['peak'] = (double) $commentvalue[0];
+						$info['replay_gain']['track']['peak'] = (float) $commentvalue[0];
 						unset($info['ogg']['comments'][$index]);
 						break;
 
 					case 'replaygain_reference_loudness':
-						$info['replay_gain']['reference_volume'] = (double) $commentvalue[0];
+						$info['replay_gain']['reference_volume'] = (float) $commentvalue[0];
 						unset($info['ogg']['comments'][$index]);
 						break;
 


### PR DESCRIPTION
PHP 8.5 deprecates four alternative scalar type names in favor of their canonical names:

- boolean → bool
- double → float
- integer → int
- binary → string

This PR replaces deprecated casts in the bundled JSON, IXR, and ID3 libraries to ensure forward compatibility and avoid deprecation notices.

Follow-up to [[60659](https://core.trac.wordpress.org/changeset/60659)].
See Trac: https://core.trac.wordpress.org/ticket/63061