### PR TITLE
KSES: Deprecate wp_kses_stripslashes

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -1818,10 +1818,13 @@ function wp_kses_no_null( $content, $options = null ) {
  *
  * @since 1.0.0
  *
+ * @deprecated 6.9.0 Not necessary since the `e` PCRE modifier was removed in PHP 7.0.
+ *
  * @param string $content String to strip slashes from.
  * @return string Fixed string with quoted slashes.
  */
 function wp_kses_stripslashes( $content ) {
+	_deprecated_function( __FUNCTION__, '6.9.0' );
 	return preg_replace( '%\\\\"%', '"', $content );
 }
 

--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -1097,8 +1097,6 @@ function _wp_kses_split_callback( $matches ) {
  * @return string Fixed HTML element
  */
 function wp_kses_split2( $content, $allowed_html, $allowed_protocols ) {
-	$content = wp_kses_stripslashes( $content );
-
 	/*
 	 * The regex pattern used to split HTML into chunks attempts
 	 * to split on HTML token boundaries. This function should


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63881


> [wp_kses_stripslashes()](https://developer.wordpress.org/reference/functions/wp_kses_stripslashes/) does not appear to have a purpose in modern PHP. Documentation suggest that it was required to support the e eval regular expression flag:
> 
> This function changes the character sequence \" to just ". It leaves all other slashes alone. The quoting from preg_replace(//e) requires this.
> 
> [Some historical context](https://core.trac.wordpress.org/ticket/19877#comment:1) from @duck_ supports this (bold mine):
> 
> wp_kses_stripslashes is a legacy function that had to be used to deal with addslashes() run when using preg_replace() and the eval modifier. The double quotes remained slashed because the backreference in the PHP string to be evaluated was in single quotes, so a custom slash removal function was used to remove slashes from in front of double quotes.
> 
> I would prefer to actually remove the call as it's no longer necessary. If you're passing slashed data to kses it should be stripped first -- which is why we do stripslashes in wp_filter_kses(). Unfortunately removing the call would cause breakage for those passing in slashed data containing double quoted attributes as this happens to work at the moment.
> 
> There is a potential problem mentioned that should be better understood before proceeding.
> 
> [The flag was removed in PHP 7](https://www.php.net/manual/en/migration70.changed-functions.php), so the e flag is not supported by any PHP version that WordPress supports. wp_kses_stripslashes() is likely obsolete.
> 
> There was work to remove the e flag usage 16-17 years ago:
> 
> [[10339]](https://core.trac.wordpress.org/changeset/10339)
> [[12198]](https://core.trac.wordpress.org/changeset/12198)
> Related tickets:
> 
> [#19877](https://core.trac.wordpress.org/ticket/19877)
> [#56118](https://core.trac.wordpress.org/ticket/56118)
> 
> The function may be doing more harm than good at this point. See:
> - https://github.com/WordPress/gutenberg/issues/6619
> - https://github.com/WordPress/gutenberg/issues/16508


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
