### PR TITLE
Plugins: Preflight activation to avoid WSOD when plugin syntax is incompatible with current PHP

### DIFF
--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -654,9 +654,9 @@ function activate_plugin( $plugin, $redirect = '', $network_wide = false, $silen
 		return $valid;
 	}
 
-	$plugin_is_sage = safe_plugin_activation_check( $plugin );
-	if ( is_wp_error( $plugin_is_sage ) ) {
-		return $plugin_is_sage;
+	$safety_check = safe_plugin_activation_check( $plugin );
+	if ( is_wp_error( $safety_check ) ) {
+		return $safety_check;
 	}
 
 	$requirements = validate_plugin_requirements( $plugin );
@@ -1101,49 +1101,65 @@ function validate_active_plugins() {
 	return $invalid;
 }
 
-/* * Safely includes a plugin file and checks for fatal errors.
+/**
+ * Safely includes a plugin file and checks for fatal errors.
  *
  * This function is used to safely include a plugin file during activation
  * without causing fatal errors that could break the activation process.
+ * It converts PHP errors to exceptions for better error handling.
  *
  * @since 5.2.0
  *
- * @param string $plugin_file Path to the plugin file relative to the plugins' directory.
+ * @param string $plugin_file Path to the plugin file relative to the plugins directory.
  * @return true|WP_Error True on success, WP_Error on failure.
  */
 function safe_plugin_activation_check( $plugin_file ) {
-	// Use output buffering to catch fatal errors
 	ob_start();
-	$error_handler = set_error_handler(
-		function ( $severity, $message, $file, $line ) {
-			return new WP_Error(
-				'plugin_activation_error',
-				sprintf(
-					/* translators: %s: Error message. */
-					__( 'Plugin activation failed with error: %s' ),
-					$message
-				),
-				array(
-					'file' => $file,
-					'line' => $line,
-				)
-			);
-		}
-	);
+
+	$previous_handler = set_error_handler(function($severity, $message, $file, $line) {
+		throw new ErrorException($message, 0, $severity, $file, $line);
+	});
 
 	try {
 		include_once WP_PLUGIN_DIR . '/' . $plugin_file;
 		ob_end_clean();
-		restore_error_handler();
+
+		if ( $previous_handler !== null ) {
+			restore_error_handler();
+		}
+
 		return true;
-	} catch ( Throwable $e ) {
+
+	} catch (ParseError $e) {
 		ob_end_clean();
-		restore_error_handler();
+
+		if ( $previous_handler !== null ) {
+			restore_error_handler();
+		}
+
+		return new WP_Error(
+			'plugin_parse_error',
+			sprintf(
+				__('Plugin activation failed due to syntax error: %s'),
+				$e->getMessage()
+			),
+			array(
+				'file' => $e->getFile(),
+				'line' => $e->getLine(),
+			)
+		);
+
+	} catch (Throwable $e) {
+		ob_end_clean();
+
+		if ( $previous_handler !== null ) {
+			restore_error_handler();
+		}
+
 		return new WP_Error(
 			'plugin_activation_exception',
 			sprintf(
-				/* translators: %s: Exception message. */
-				__( 'Plugin activation failed with exception: %s' ),
+				__('Plugin activation failed with exception: %s'),
 				$e->getMessage()
 			),
 			array(

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -654,6 +654,11 @@ function activate_plugin( $plugin, $redirect = '', $network_wide = false, $silen
 		return $valid;
 	}
 
+	$plugin_is_sage = safe_plugin_activation_check( $plugin );
+	if ( is_wp_error( $plugin_is_sage ) ) {
+		return $plugin_is_sage;
+	}
+
 	$requirements = validate_plugin_requirements( $plugin );
 	if ( is_wp_error( $requirements ) ) {
 		return $requirements;
@@ -1094,6 +1099,59 @@ function validate_active_plugins() {
 		}
 	}
 	return $invalid;
+}
+
+/* * Safely includes a plugin file and checks for fatal errors.
+ *
+ * This function is used to safely include a plugin file during activation
+ * without causing fatal errors that could break the activation process.
+ *
+ * @since 5.2.0
+ *
+ * @param string $plugin_file Path to the plugin file relative to the plugins' directory.
+ * @return true|WP_Error True on success, WP_Error on failure.
+ */
+function safe_plugin_activation_check( $plugin_file ) {
+	// Use output buffering to catch fatal errors
+	ob_start();
+	$error_handler = set_error_handler(
+		function ( $severity, $message, $file, $line ) {
+			return new WP_Error(
+				'plugin_activation_error',
+				sprintf(
+					/* translators: %s: Error message. */
+					__( 'Plugin activation failed with error: %s' ),
+					$message
+				),
+				array(
+					'file' => $file,
+					'line' => $line,
+				)
+			);
+		}
+	);
+
+	try {
+		include_once WP_PLUGIN_DIR . '/' . $plugin_file;
+		ob_end_clean();
+		restore_error_handler();
+		return true;
+	} catch ( Throwable $e ) {
+		ob_end_clean();
+		restore_error_handler();
+		return new WP_Error(
+			'plugin_activation_exception',
+			sprintf(
+				/* translators: %s: Exception message. */
+				__( 'Plugin activation failed with exception: %s' ),
+				$e->getMessage()
+			),
+			array(
+				'file' => $e->getFile(),
+				'line' => $e->getLine(),
+			)
+		);
+	}
 }
 
 /**

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -1116,31 +1116,34 @@ function validate_active_plugins() {
 function safe_plugin_activation_check( $plugin_file ) {
 	ob_start();
 
-	$previous_handler = set_error_handler(function($severity, $message, $file, $line) {
-		throw new ErrorException($message, 0, $severity, $file, $line);
-	});
+	$previous_handler = set_error_handler(
+		function ( $severity, $message, $file, $line ) {
+			throw new ErrorException( $message, 0, $severity, $file, $line );
+		}
+	);
 
 	try {
 		include_once WP_PLUGIN_DIR . '/' . $plugin_file;
 		ob_end_clean();
 
-		if ( $previous_handler !== null ) {
+		if ( null !== $previous_handler ) {
 			restore_error_handler();
 		}
 
 		return true;
 
-	} catch (ParseError $e) {
+	} catch ( ParseError $e ) {
 		ob_end_clean();
 
-		if ( $previous_handler !== null ) {
+		if ( null !== $previous_handler ) {
 			restore_error_handler();
 		}
 
 		return new WP_Error(
 			'plugin_parse_error',
 			sprintf(
-				__('Plugin activation failed due to syntax error: %s'),
+			/* translators: %s: The error message returned when a plugin fails to activate due to syntax errors. */
+				__( 'Plugin activation failed due to syntax error: %s' ),
 				$e->getMessage()
 			),
 			array(
@@ -1149,17 +1152,18 @@ function safe_plugin_activation_check( $plugin_file ) {
 			)
 		);
 
-	} catch (Throwable $e) {
+	} catch ( Throwable $e ) {
 		ob_end_clean();
 
-		if ( $previous_handler !== null ) {
+		if ( null !== $previous_handler ) {
 			restore_error_handler();
 		}
 
 		return new WP_Error(
 			'plugin_activation_exception',
 			sprintf(
-				__('Plugin activation failed with exception: %s'),
+			/* translators: %s: The exception message returned when a plugin fails to activate. */
+				__( 'Plugin activation failed with exception: %s' ),
 				$e->getMessage()
 			),
 			array(

--- a/tests/phpunit/tests/admin/includesPlugin.php
+++ b/tests/phpunit/tests/admin/includesPlugin.php
@@ -600,6 +600,57 @@ class Tests_Admin_IncludesPlugin extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::safe_plugin_activation_check
+	 */
+	public function test_safe_plugin_activation_check_with_syntax_error() {
+		// Create a plugin with actual syntax error (missing closing brace)
+		$plugin = $this->_create_plugin(
+			"<?php\n/*\nPlugin Name: Test Plugin\n*/\n\nfunction test_function() {\n  echo 'Missing closing brace';\n  // Missing }",
+			'test-plugin-with-syntax-error.php'
+		);
+
+		$result = safe_plugin_activation_check( $plugin[0] );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertEquals( 'plugin_parse_error', $result->get_error_code() );
+
+		unlink( $plugin[1] );
+	}
+
+	/**
+	 * @covers ::safe_plugin_activation_check
+	 */
+	public function test_safe_plugin_activation_check_with_valid_plugin() {
+		$plugin = $this->_create_plugin(
+			"<?php\n/*\nPlugin Name: Test Plugin\n*/\n\nfunction test_function() {\n  echo 'Valid PHP code';\n}",
+			'test-plugin-valid.php'
+		);
+
+		$result = safe_plugin_activation_check( $plugin[0] );
+
+		$this->assertTrue( $result );
+
+		unlink( $plugin[1] );
+	}
+
+	/**
+	 * @covers ::safe_plugin_activation_check
+	 */
+	public function test_safe_plugin_activation_check_with_exception() {
+		$plugin = $this->_create_plugin(
+			"<?php\n/*\nPlugin Name: Test Plugin\n*/\n\nthrow new Exception('Test exception');",
+			'test-plugin-with-exception.php'
+		);
+
+		$result = safe_plugin_activation_check( $plugin[0] );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertEquals( 'plugin_activation_exception', $result->get_error_code() );
+
+		unlink( $plugin[1] );
+	}
+
+	/**
 	 * @covers ::validate_active_plugins
 	 */
 	public function test_validate_active_plugins_empty() {


### PR DESCRIPTION
**Trac ticket:** [https://core.trac.wordpress.org/ticket/63882](https://core.trac.wordpress.org/ticket/63882)

### Summary

Prevents sites from entering a fatal error (WSOD) when activating a plugin that uses PHP syntax incompatible with the current runtime. Before persisting the plugin as active, a preflight check safely includes the plugin file. If a parse error or exception occurs, activation is aborted and the error is displayed without saving the plugin to the database.

### Technical Changes

* Introduced `safe_plugin_activation_check()` in `plugin.php` to sandbox plugin file loading, converting errors/exceptions into `WP_Error`.
* Updated `activate_plugin()` to call `safe_plugin_activation_check()` before persisting the plugin.
* Early returns with `WP_Error` if activation would trigger a fatal error.

### Tests

* Added PHPUnit tests in `tests/phpunit/tests/admin/includesPlugin.php`.
* Coverage includes:

  * Plugins with syntax errors.
  * Plugins throwing runtime exceptions.
  * Valid plugins activating successfully.

### Notes

* Includes unit tests.
* Follows WordPress PHP coding standards.
* Happy to iterate on feedback and naming conventions.
* Please **allow edits by maintainers**.
