### PR TITLE
fix potential fatal error on Interactivity API processing directives …

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -439,7 +439,12 @@ final class WP_Interactivity_API {
 					array_pop( $tag_stack );
 				}
 			} else {
-				if ( 0 !== count( $p->get_attribute_names_with_prefix( 'data-wp-each-child' ) ) ) {
+				$each_child_attrs = $p->get_attribute_names_with_prefix( 'data-wp-each-child' );
+				if ( ! is_countable( $each_child_attrs ) ) {
+					continue;
+				}
+
+				if ( 0 !== count( $each_child_attrs ) ) {
 					/*
 					 * If the tag has a `data-wp-each-child` directive, jump to its closer
 					 * tag because those tags have already been processed.

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -440,8 +440,11 @@ final class WP_Interactivity_API {
 				}
 			} else {
 				$each_child_attrs = $p->get_attribute_names_with_prefix( 'data-wp-each-child' );
+				if ( null === $each_child_attrs ) {
+					continue;
+				}
 
-				if ( null !== $each_child_attrs && 0 !== count( $each_child_attrs ) ) {
+				if ( 0 !== count( $each_child_attrs ) ) {
 					/*
 					 * If the tag has a `data-wp-each-child` directive, jump to its closer
 					 * tag because those tags have already been processed.

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -440,11 +440,8 @@ final class WP_Interactivity_API {
 				}
 			} else {
 				$each_child_attrs = $p->get_attribute_names_with_prefix( 'data-wp-each-child' );
-				if ( ! is_countable( $each_child_attrs ) ) {
-					continue;
-				}
 
-				if ( 0 !== count( $each_child_attrs ) ) {
+				if ( null !== $each_child_attrs && 0 !== count( $each_child_attrs ) ) {
 					/*
 					 * If the tag has a `data-wp-each-child` directive, jump to its closer
 					 * tag because those tags have already been processed.

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -845,7 +845,7 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 			'myPlugin',
 			array(
 				'id' => 'some-id',
-			),
+			)
 		);
 
 		$html = '</br><div data-wp-bind--id="myPlugin::state.id">Content</div>';

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -830,7 +830,35 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 			'SPAN opener inside' => array( '<div data-wp-bind--id="myPlugin::state.id"><span>Inner content</div>' ),
 			'SPAN closer after'  => array( '<div data-wp-bind--id="myPlugin::state.id">Inner content</div></span>' ),
 			'SPAN overlapping'   => array( '<div data-wp-bind--id="myPlugin::state.id"><span>Inner content</div></span>' ),
+			'BR self-closing'    => array( '<div data-wp-bind--id="myPlugin::state.id">Content<br></br></div>' ),
 		);
+	}
+
+	/**
+	 * Tests that the `process_directives` handles self-closing tags with invalid
+	 * closing tags without causing fatal errors.
+	 *
+	 * @covers ::process_directives
+	 *
+	 * @expectedIncorrectUsage WP_Interactivity_API::_process_directives
+	 */
+	public function test_process_directives_handles_self_closing_tags_with_invalid_closers() {
+		$this->interactivity->state(
+			'myPlugin',
+			array(
+				'id' => 'some-id',
+			),
+		);
+
+		$html = '<div data-wp-bind--id="myPlugin::state.id">Content<br></br></div>';
+
+		$processed_html = $this->interactivity->process_directives( $html );
+
+		$this->assertSame( $html, $processed_html );
+
+		$p = new WP_HTML_Tag_Processor( $processed_html );
+		$p->next_tag( 'div' );
+		$this->assertNull( $p->get_attribute( 'id' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -830,19 +830,17 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 			'SPAN opener inside' => array( '<div data-wp-bind--id="myPlugin::state.id"><span>Inner content</div>' ),
 			'SPAN closer after'  => array( '<div data-wp-bind--id="myPlugin::state.id">Inner content</div></span>' ),
 			'SPAN overlapping'   => array( '<div data-wp-bind--id="myPlugin::state.id"><span>Inner content</div></span>' ),
-			'BR self-closing'    => array( '<div data-wp-bind--id="myPlugin::state.id">Content<br></br></div>' ),
 		);
 	}
 
 	/**
-	 * Tests that the `process_directives` handles self-closing tags with invalid
-	 * closing tags without causing fatal errors.
+	 * Tests that the `process_directives` handles self-closing BR tags without
+	 * causing fatal errors and processes directives correctly.
 	 *
+	 * @ticket 63891
 	 * @covers ::process_directives
-	 *
-	 * @expectedIncorrectUsage WP_Interactivity_API::_process_directives
 	 */
-	public function test_process_directives_handles_self_closing_tags_with_invalid_closers() {
+	public function test_process_directives_handles_br_self_closing_tags_with_invalid_closers() {
 		$this->interactivity->state(
 			'myPlugin',
 			array(
@@ -850,15 +848,14 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 			),
 		);
 
-		$html = '<div data-wp-bind--id="myPlugin::state.id">Content<br></br></div>';
+		$html = '</br><div data-wp-bind--id="myPlugin::state.id">Content</div>';
 
 		$processed_html = $this->interactivity->process_directives( $html );
 
-		$this->assertSame( $html, $processed_html );
-
 		$p = new WP_HTML_Tag_Processor( $processed_html );
 		$p->next_tag( 'div' );
-		$this->assertNull( $p->get_attribute( 'id' ) );
+
+		$this->assertSame( 'some-id', $p->get_attribute( 'id' ) );
 	}
 
 	/**


### PR DESCRIPTION
 This may be an edge case for posts created with Classic editor or classic editor block.
`_process_directives` function within `WP_Interactivity_API` class will process html and check for closer tags.
if there's a wrong tag like `</br>` (in my case) will result in a TypeError:

```
Fatal error: Uncaught TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in wp-includes/interactivity-api/class-wp-interactivity-api.php on line 442
```

by checking the line of code, `count()` function is applied to `get_attribute_names_with_prefix()` method from `WP_HTML_Tag_Processor` which can eventually return `null`

for newer PHP version (8.0.0 and later) this will throw a fatal error.
probably worth getting an extra check if the funcion is returning a countable variable

Trac ticket: https://core.trac.wordpress.org/ticket/63891


