### PR TITLE
Options API: Fix `delete_option()` cache cleanup for null values

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1233,13 +1233,13 @@ function delete_option( $option ) {
 		if ( in_array( $row->autoload, wp_autoload_values_to_autoload(), true ) ) {
 			$alloptions = wp_load_alloptions( true );
 
-			if ( is_array( $alloptions ) && isset( $alloptions[ $option ] ) ) {
+			if ( is_array( $alloptions ) && array_key_exists( $option, $alloptions ) ) {
 				unset( $alloptions[ $option ] );
 				wp_cache_set( 'alloptions', $alloptions, 'options' );
 			}
-		} else {
-			wp_cache_delete( $option, 'options' );
 		}
+
+		wp_cache_delete( $option, 'options' );
 
 		$notoptions = wp_cache_get( 'notoptions', 'options' );
 

--- a/tests/phpunit/tests/option/option.php
+++ b/tests/phpunit/tests/option/option.php
@@ -613,4 +613,28 @@ class Tests_Option_Option extends WP_UnitTestCase {
 
 		return $stats['cmd_get'];
 	}
+
+	/**
+	 * Test that delete_option() properly removes options with null values from cache.
+	 *
+	 * @ticket 28701
+	 *
+	 * @covers ::delete_option
+	 */
+	public function test_delete_option_with_null_value_in_cache() {
+		$option_name = 'test_null_cache_' . wp_rand();
+
+		add_option( $option_name, 'value', '', true );
+
+		$alloptions                 = wp_load_alloptions();
+		$alloptions[ $option_name ] = null;
+		wp_cache_set( 'alloptions', $alloptions, 'options' );
+
+		delete_option( $option_name );
+
+		$alloptions_after = wp_load_alloptions();
+		$this->assertArrayNotHasKey( $option_name, $alloptions_after );
+
+		$this->assertSame( 'default', get_option( $option_name, 'default' ) );
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/28701

This PR fixes a long-standing bug where `delete_option()` fails to remove options with null values from the alloptions cache.

When an autoloaded option contains `null`, `delete_option()` uses `isset($alloptions[$option])` to check cache presence. Since `isset(null) === false`, options with null values remain in cache after deletion, causing `get_option()` to return stale cached values instead of defaults.

This PR - 

- Replaces `isset()` with `array_key_exists()` for proper null detection
- Always calls `wp_cache_delete()` to ensure complete cache cleanup
- Adds a unit test to prevent regression

