### PR TITLE
Script loader: Remove "inline:" prefix from sourceURLs

### DIFF
--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -223,7 +223,7 @@ class WP_Scripts extends WP_Dependencies {
 		}
 
 		$output .= sprintf(
-			"\n//# sourceURL=inline:%s",
+			"\n//# sourceURL=%s",
 			rawurlencode( "{$handle}-js-extra" )
 		);
 
@@ -527,7 +527,7 @@ class WP_Scripts extends WP_Dependencies {
 		}
 
 		$data[] = sprintf(
-			'//# sourceURL=inline:%s',
+			'//# sourceURL=%s',
 			rawurlencode( "{$handle}-js-{$position}" )
 		);
 

--- a/src/wp-includes/class-wp-styles.php
+++ b/src/wp-includes/class-wp-styles.php
@@ -338,7 +338,7 @@ class WP_Styles extends WP_Dependencies {
 		}
 
 		$output[] = sprintf(
-			'/*# sourceURL=inline:%s */',
+			'/*# sourceURL=%s */',
 			rawurlencode( "{$handle}-inline-css" )
 		);
 

--- a/tests/phpunit/tests/blocks/editor.php
+++ b/tests/phpunit/tests/blocks/editor.php
@@ -762,7 +762,7 @@ class Tests_Blocks_Editor extends WP_UnitTestCase {
 <script src="{$baseurl}/wp-includes/js/dist/api-fetch.min.js?ver=test" id="wp-api-fetch-js"></script>
 <script id="wp-api-fetch-js-after">
 wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( {"/test/v0/test-62797":{"body":["Unclosed comment and a script open tag \\u003C!--\\u003Cscript\\u003E"],"headers":{"Allow":"GET"}}} ) );
-//# sourceURL=inline:wp-api-fetch-js-after
+//# sourceURL=wp-api-fetch-js-after
 </script>
 
 HTML;

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -120,7 +120,7 @@ JS;
 		$output    = get_echo( 'wp_print_scripts' );
 		$expected  = "<script type='text/javascript' src='http://example.org/ms-isa-1.js' id='ms-isa-1-js' data-wp-strategy='{$strategy}'></script>\n";
 		$expected .= wp_get_inline_script_tag(
-			"console.log('after one');\n//# sourceURL=inline:ms-isa-1-js-after",
+			"console.log('after one');\n//# sourceURL=ms-isa-1-js-after",
 			array(
 				'id' => 'ms-isa-1-js-after',
 			)
@@ -148,7 +148,7 @@ JS;
 
 		$expected  = "<script type='text/javascript' src='http://example.org/ms-insa-3.js' id='ms-insa-3-js'></script>\n";
 		$expected .= wp_get_inline_script_tag(
-			"console.log('after one');\n//# sourceURL=inline:ms-insa-3-js-after",
+			"console.log('after one');\n//# sourceURL=ms-insa-3-js-after",
 			array(
 				'id' => 'ms-insa-3-js-after',
 			)
@@ -182,7 +182,7 @@ JS;
 		$output = get_echo( 'wp_print_scripts' );
 
 		$expected  = wp_get_inline_script_tag(
-			"console.log('before first');\n//# sourceURL=inline:ds-i1-1-js-before",
+			"console.log('before first');\n//# sourceURL=ds-i1-1-js-before",
 			array(
 				'id' => 'ds-i1-1-js-before',
 			)
@@ -191,7 +191,7 @@ JS;
 		$expected .= "<script type='text/javascript' src='http://example.org/ds-i1-2.js' id='ds-i1-2-js' {$strategy}='{$strategy}' data-wp-strategy='{$strategy}'></script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.org/ds-i1-3.js' id='ds-i1-3-js' {$strategy}='{$strategy}' data-wp-strategy='{$strategy}'></script>\n";
 		$expected .= wp_get_inline_script_tag(
-			"console.log('before last');\n//# sourceURL=inline:ms-i1-1-js-before",
+			"console.log('before last');\n//# sourceURL=ms-i1-1-js-before",
 			array(
 				'id'   => 'ms-i1-1-js-before',
 				'type' => 'text/javascript',
@@ -513,27 +513,27 @@ JS;
 <script id="blocking-not-async-without-dependency-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-not-async-without-dependency: before inline" )
-//# sourceURL=inline:blocking-not-async-without-dependency-js-before
+//# sourceURL=blocking-not-async-without-dependency-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=blocking-not-async-without-dependency:%20script' id='blocking-not-async-without-dependency-js'></script>
 <script id="blocking-not-async-without-dependency-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-not-async-without-dependency: after inline" )
-//# sourceURL=inline:blocking-not-async-without-dependency-js-after
+//# sourceURL=blocking-not-async-without-dependency-js-after
 /* ]]> */
 </script>
 <script id="async-with-blocking-dependency-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "async-with-blocking-dependency: before inline" )
-//# sourceURL=inline:async-with-blocking-dependency-js-before
+//# sourceURL=async-with-blocking-dependency-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=async-with-blocking-dependency:%20script' id='async-with-blocking-dependency-js' data-wp-strategy='async'></script>
 <script id="async-with-blocking-dependency-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "async-with-blocking-dependency: after inline" )
-//# sourceURL=inline:async-with-blocking-dependency-js-after
+//# sourceURL=async-with-blocking-dependency-js-after
 /* ]]> */
 </script>
 HTML
@@ -562,40 +562,40 @@ HTML
 <script id="async-no-dependency-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "async-no-dependency: before inline" )
-//# sourceURL=inline:async-no-dependency-js-before
+//# sourceURL=async-no-dependency-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=async-no-dependency:%20script' id='async-no-dependency-js' data-wp-strategy='async'></script>
 <script id="async-no-dependency-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "async-no-dependency: after inline" )
-//# sourceURL=inline:async-no-dependency-js-after
+//# sourceURL=async-no-dependency-js-after
 /* ]]> */
 </script>
 <script id="async-one-async-dependency-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "async-one-async-dependency: before inline" )
-//# sourceURL=inline:async-one-async-dependency-js-before
+//# sourceURL=async-one-async-dependency-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=async-one-async-dependency:%20script' id='async-one-async-dependency-js' data-wp-strategy='async'></script>
 <script id="async-one-async-dependency-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "async-one-async-dependency: after inline" )
-//# sourceURL=inline:async-one-async-dependency-js-after
+//# sourceURL=async-one-async-dependency-js-after
 /* ]]> */
 </script>
 <script id="async-two-async-dependencies-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "async-two-async-dependencies: before inline" )
-//# sourceURL=inline:async-two-async-dependencies-js-before
+//# sourceURL=async-two-async-dependencies-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=async-two-async-dependencies:%20script' id='async-two-async-dependencies-js' data-wp-strategy='async'></script>
 <script id="async-two-async-dependencies-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "async-two-async-dependencies: after inline" )
-//# sourceURL=inline:async-two-async-dependencies-js-after
+//# sourceURL=async-two-async-dependencies-js-after
 /* ]]> */
 </script>
 HTML
@@ -616,27 +616,27 @@ HTML
 <script id="async-with-blocking-dependent-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "async-with-blocking-dependent: before inline" )
-//# sourceURL=inline:async-with-blocking-dependent-js-before
+//# sourceURL=async-with-blocking-dependent-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=async-with-blocking-dependent:%20script' id='async-with-blocking-dependent-js' data-wp-strategy='async'></script>
 <script id="async-with-blocking-dependent-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "async-with-blocking-dependent: after inline" )
-//# sourceURL=inline:async-with-blocking-dependent-js-after
+//# sourceURL=async-with-blocking-dependent-js-after
 /* ]]> */
 </script>
 <script id="blocking-dependent-of-async-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-dependent-of-async: before inline" )
-//# sourceURL=inline:blocking-dependent-of-async-js-before
+//# sourceURL=blocking-dependent-of-async-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=blocking-dependent-of-async:%20script' id='blocking-dependent-of-async-js'></script>
 <script id="blocking-dependent-of-async-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-dependent-of-async: after inline" )
-//# sourceURL=inline:blocking-dependent-of-async-js-after
+//# sourceURL=blocking-dependent-of-async-js-after
 /* ]]> */
 </script>
 HTML
@@ -657,27 +657,27 @@ HTML
 <script id="async-with-defer-dependent-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "async-with-defer-dependent: before inline" )
-//# sourceURL=inline:async-with-defer-dependent-js-before
+//# sourceURL=async-with-defer-dependent-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=async-with-defer-dependent:%20script' id='async-with-defer-dependent-js' data-wp-strategy='async'></script>
 <script id="async-with-defer-dependent-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "async-with-defer-dependent: after inline" )
-//# sourceURL=inline:async-with-defer-dependent-js-after
+//# sourceURL=async-with-defer-dependent-js-after
 /* ]]> */
 </script>
 <script id="defer-dependent-of-async-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-async: before inline" )
-//# sourceURL=inline:defer-dependent-of-async-js-before
+//# sourceURL=defer-dependent-of-async-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-async:%20script' id='defer-dependent-of-async-js' data-wp-strategy='defer'></script>
 <script id="defer-dependent-of-async-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-async: after inline" )
-//# sourceURL=inline:defer-dependent-of-async-js-after
+//# sourceURL=defer-dependent-of-async-js-after
 /* ]]> */
 </script>
 HTML
@@ -701,26 +701,26 @@ HTML
 <script id="blocking-bundle-of-none-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-bundle-of-none: before inline" )
-//# sourceURL=inline:blocking-bundle-of-none-js-before
+//# sourceURL=blocking-bundle-of-none-js-before
 /* ]]> */
 </script>
 <script id="blocking-bundle-of-none-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-bundle-of-none: after inline" )
-//# sourceURL=inline:blocking-bundle-of-none-js-after
+//# sourceURL=blocking-bundle-of-none-js-after
 /* ]]> */
 </script>
 <script id="defer-dependent-of-blocking-bundle-of-none-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-blocking-bundle-of-none: before inline" )
-//# sourceURL=inline:defer-dependent-of-blocking-bundle-of-none-js-before
+//# sourceURL=defer-dependent-of-blocking-bundle-of-none-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-blocking-bundle-of-none:%20script' id='defer-dependent-of-blocking-bundle-of-none-js' data-wp-strategy='defer'></script>
 <script id="defer-dependent-of-blocking-bundle-of-none-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-blocking-bundle-of-none: after inline" )
-//# sourceURL=inline:defer-dependent-of-blocking-bundle-of-none-js-after
+//# sourceURL=defer-dependent-of-blocking-bundle-of-none-js-after
 /* ]]> */
 </script>
 HTML
@@ -747,40 +747,40 @@ HTML
 <script id="blocking-bundle-member-one-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-bundle-member-one: before inline" )
-//# sourceURL=inline:blocking-bundle-member-one-js-before
+//# sourceURL=blocking-bundle-member-one-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=blocking-bundle-member-one:%20script' id='blocking-bundle-member-one-js'></script>
 <script id="blocking-bundle-member-one-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-bundle-member-one: after inline" )
-//# sourceURL=inline:blocking-bundle-member-one-js-after
+//# sourceURL=blocking-bundle-member-one-js-after
 /* ]]> */
 </script>
 <script id="blocking-bundle-member-two-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-bundle-member-two: before inline" )
-//# sourceURL=inline:blocking-bundle-member-two-js-before
+//# sourceURL=blocking-bundle-member-two-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=blocking-bundle-member-two:%20script' id='blocking-bundle-member-two-js'></script>
 <script id="blocking-bundle-member-two-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-bundle-member-two: after inline" )
-//# sourceURL=inline:blocking-bundle-member-two-js-after
+//# sourceURL=blocking-bundle-member-two-js-after
 /* ]]> */
 </script>
 <script id="defer-dependent-of-blocking-bundle-of-two-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-blocking-bundle-of-two: before inline" )
-//# sourceURL=inline:defer-dependent-of-blocking-bundle-of-two-js-before
+//# sourceURL=defer-dependent-of-blocking-bundle-of-two-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-blocking-bundle-of-two:%20script' id='defer-dependent-of-blocking-bundle-of-two-js' data-wp-strategy='defer'></script>
 <script id="defer-dependent-of-blocking-bundle-of-two-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-blocking-bundle-of-two: after inline" )
-//# sourceURL=inline:defer-dependent-of-blocking-bundle-of-two-js-after
+//# sourceURL=defer-dependent-of-blocking-bundle-of-two-js-after
 /* ]]> */
 </script>
 HTML
@@ -806,26 +806,26 @@ HTML
 <script id="defer-bundle-of-none-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-bundle-of-none: before inline" )
-//# sourceURL=inline:defer-bundle-of-none-js-before
+//# sourceURL=defer-bundle-of-none-js-before
 /* ]]> */
 </script>
 <script id="defer-bundle-of-none-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-bundle-of-none: after inline" )
-//# sourceURL=inline:defer-bundle-of-none-js-after
+//# sourceURL=defer-bundle-of-none-js-after
 /* ]]> */
 </script>
 <script id="defer-dependent-of-defer-bundle-of-none-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-defer-bundle-of-none: before inline" )
-//# sourceURL=inline:defer-dependent-of-defer-bundle-of-none-js-before
+//# sourceURL=defer-dependent-of-defer-bundle-of-none-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-defer-bundle-of-none:%20script' id='defer-dependent-of-defer-bundle-of-none-js' data-wp-strategy='defer'></script>
 <script id="defer-dependent-of-defer-bundle-of-none-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-defer-bundle-of-none: after inline" )
-//# sourceURL=inline:defer-dependent-of-defer-bundle-of-none-js-after
+//# sourceURL=defer-dependent-of-defer-bundle-of-none-js-after
 /* ]]> */
 </script>
 HTML
@@ -849,40 +849,40 @@ HTML
 <script id="blocking-dependency-with-defer-following-dependency-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-dependency-with-defer-following-dependency: before inline" )
-//# sourceURL=inline:blocking-dependency-with-defer-following-dependency-js-before
+//# sourceURL=blocking-dependency-with-defer-following-dependency-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=blocking-dependency-with-defer-following-dependency:%20script' id='blocking-dependency-with-defer-following-dependency-js'></script>
 <script id="blocking-dependency-with-defer-following-dependency-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-dependency-with-defer-following-dependency: after inline" )
-//# sourceURL=inline:blocking-dependency-with-defer-following-dependency-js-after
+//# sourceURL=blocking-dependency-with-defer-following-dependency-js-after
 /* ]]> */
 </script>
 <script id="defer-dependency-with-blocking-preceding-dependency-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependency-with-blocking-preceding-dependency: before inline" )
-//# sourceURL=inline:defer-dependency-with-blocking-preceding-dependency-js-before
+//# sourceURL=defer-dependency-with-blocking-preceding-dependency-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependency-with-blocking-preceding-dependency:%20script' id='defer-dependency-with-blocking-preceding-dependency-js' data-wp-strategy='defer'></script>
 <script id="defer-dependency-with-blocking-preceding-dependency-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependency-with-blocking-preceding-dependency: after inline" )
-//# sourceURL=inline:defer-dependency-with-blocking-preceding-dependency-js-after
+//# sourceURL=defer-dependency-with-blocking-preceding-dependency-js-after
 /* ]]> */
 </script>
 <script id="defer-dependent-of-blocking-and-defer-dependencies-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-blocking-and-defer-dependencies: before inline" )
-//# sourceURL=inline:defer-dependent-of-blocking-and-defer-dependencies-js-before
+//# sourceURL=defer-dependent-of-blocking-and-defer-dependencies-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-blocking-and-defer-dependencies:%20script' id='defer-dependent-of-blocking-and-defer-dependencies-js' data-wp-strategy='defer'></script>
 <script id="defer-dependent-of-blocking-and-defer-dependencies-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-blocking-and-defer-dependencies: after inline" )
-//# sourceURL=inline:defer-dependent-of-blocking-and-defer-dependencies-js-after
+//# sourceURL=defer-dependent-of-blocking-and-defer-dependencies-js-after
 /* ]]> */
 </script>
 HTML
@@ -906,40 +906,40 @@ HTML
 <script id="defer-dependency-with-blocking-following-dependency-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependency-with-blocking-following-dependency: before inline" )
-//# sourceURL=inline:defer-dependency-with-blocking-following-dependency-js-before
+//# sourceURL=defer-dependency-with-blocking-following-dependency-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependency-with-blocking-following-dependency:%20script' id='defer-dependency-with-blocking-following-dependency-js' data-wp-strategy='defer'></script>
 <script id="defer-dependency-with-blocking-following-dependency-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependency-with-blocking-following-dependency: after inline" )
-//# sourceURL=inline:defer-dependency-with-blocking-following-dependency-js-after
+//# sourceURL=defer-dependency-with-blocking-following-dependency-js-after
 /* ]]> */
 </script>
 <script id="blocking-dependency-with-defer-preceding-dependency-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-dependency-with-defer-preceding-dependency: before inline" )
-//# sourceURL=inline:blocking-dependency-with-defer-preceding-dependency-js-before
+//# sourceURL=blocking-dependency-with-defer-preceding-dependency-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=blocking-dependency-with-defer-preceding-dependency:%20script' id='blocking-dependency-with-defer-preceding-dependency-js'></script>
 <script id="blocking-dependency-with-defer-preceding-dependency-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-dependency-with-defer-preceding-dependency: after inline" )
-//# sourceURL=inline:blocking-dependency-with-defer-preceding-dependency-js-after
+//# sourceURL=blocking-dependency-with-defer-preceding-dependency-js-after
 /* ]]> */
 </script>
 <script id="defer-dependent-of-defer-and-blocking-dependencies-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-defer-and-blocking-dependencies: before inline" )
-//# sourceURL=inline:defer-dependent-of-defer-and-blocking-dependencies-js-before
+//# sourceURL=defer-dependent-of-defer-and-blocking-dependencies-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-defer-and-blocking-dependencies:%20script' id='defer-dependent-of-defer-and-blocking-dependencies-js' data-wp-strategy='defer'></script>
 <script id="defer-dependent-of-defer-and-blocking-dependencies-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-defer-and-blocking-dependencies: after inline" )
-//# sourceURL=inline:defer-dependent-of-defer-and-blocking-dependencies-js-after
+//# sourceURL=defer-dependent-of-defer-and-blocking-dependencies-js-after
 /* ]]> */
 </script>
 HTML
@@ -960,27 +960,27 @@ HTML
 <script id="defer-with-async-dependent-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-with-async-dependent: before inline" )
-//# sourceURL=inline:defer-with-async-dependent-js-before
+//# sourceURL=defer-with-async-dependent-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-with-async-dependent:%20script' id='defer-with-async-dependent-js' data-wp-strategy='defer'></script>
 <script id="defer-with-async-dependent-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-with-async-dependent: after inline" )
-//# sourceURL=inline:defer-with-async-dependent-js-after
+//# sourceURL=defer-with-async-dependent-js-after
 /* ]]> */
 </script>
 <script id="async-dependent-of-defer-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "async-dependent-of-defer: before inline" )
-//# sourceURL=inline:async-dependent-of-defer-js-before
+//# sourceURL=async-dependent-of-defer-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=async-dependent-of-defer:%20script' id='async-dependent-of-defer-js' data-wp-strategy='async'></script>
 <script id="async-dependent-of-defer-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "async-dependent-of-defer: after inline" )
-//# sourceURL=inline:async-dependent-of-defer-js-after
+//# sourceURL=async-dependent-of-defer-js-after
 /* ]]> */
 </script>
 HTML
@@ -997,7 +997,7 @@ HTML
 <script id="defer-with-before-inline-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-with-before-inline: before inline" )
-//# sourceURL=inline:defer-with-before-inline-js-before
+//# sourceURL=defer-with-before-inline-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-with-before-inline:%20script' id='defer-with-before-inline-js' defer='defer' data-wp-strategy='defer'></script>
@@ -1016,7 +1016,7 @@ HTML
 <script id="defer-with-after-inline-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-with-after-inline: after inline" )
-//# sourceURL=inline:defer-with-after-inline-js-after
+//# sourceURL=defer-with-after-inline-js-after
 /* ]]> */
 </script>
 HTML
@@ -1064,14 +1064,14 @@ HTML
 <script id="defer-dependent-of-nested-aliases-js-before" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-nested-aliases: before inline" )
-//# sourceURL=inline:defer-dependent-of-nested-aliases-js-before
+//# sourceURL=defer-dependent-of-nested-aliases-js-before
 /* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-nested-aliases:%20script' id='defer-dependent-of-nested-aliases-js' data-wp-strategy='defer'></script>
 <script id="defer-dependent-of-nested-aliases-js-after" type="text/javascript">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-nested-aliases: after inline" )
-//# sourceURL=inline:defer-dependent-of-nested-aliases-js-after
+//# sourceURL=defer-dependent-of-nested-aliases-js-after
 /* ]]> */
 </script>
 HTML
@@ -1670,7 +1670,7 @@ HTML
 		// Enqueue and add data.
 		wp_enqueue_script( 'test-only-data', 'example.com', array(), null );
 		wp_script_add_data( 'test-only-data', 'data', 'testing' );
-		$expected  = "<script type='text/javascript' id='test-only-data-js-extra'>\n/* <![CDATA[ */\ntesting\n//# sourceURL=inline:test-only-data-js-extra\n/* ]]> */\n</script>\n";
+		$expected  = "<script type='text/javascript' id='test-only-data-js-extra'>\n/* <![CDATA[ */\ntesting\n//# sourceURL=test-only-data-js-extra\n/* ]]> */\n</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-only-data-js'></script>\n";
 
 		// Go!
@@ -1708,7 +1708,7 @@ HTML
 		wp_enqueue_script( 'test-conditional-with-data', 'example.com', array(), null );
 		wp_script_add_data( 'test-conditional-with-data', 'data', 'testing' );
 		wp_script_add_data( 'test-conditional-with-data', 'conditional', 'lt IE 9' );
-		$expected  = "<!--[if lt IE 9]>\n<script type='text/javascript' id='test-conditional-with-data-js-extra'>\n/* <![CDATA[ */\ntesting\n//# sourceURL=inline:test-conditional-with-data-js-extra\n/* ]]> */\n</script>\n<![endif]-->\n";
+		$expected  = "<!--[if lt IE 9]>\n<script type='text/javascript' id='test-conditional-with-data-js-extra'>\n/* <![CDATA[ */\ntesting\n//# sourceURL=test-conditional-with-data-js-extra\n/* ]]> */\n</script>\n<![endif]-->\n";
 		$expected .= "<!--[if lt IE 9]>\n<script type='text/javascript' src='http://example.com' id='test-conditional-with-data-js'></script>\n<![endif]-->\n";
 		$expected  = str_replace( "'", '"', $expected );
 
@@ -1932,7 +1932,7 @@ HTML
 <script type='text/javascript' id='test-example-js-before'>
 /* <![CDATA[ */
 console.log("before");
-//# sourceURL=inline:test-example-js-before
+//# sourceURL=test-example-js-before
 /* ]]> */
 </script>
 HTML;
@@ -1953,7 +1953,7 @@ HTML;
 <script type='text/javascript' id='test-example-js-after'>
 /* <![CDATA[ */
 console.log("after");
-//# sourceURL=inline:test-example-js-after
+//# sourceURL=test-example-js-after
 /* ]]> */
 </script>
 HTML;
@@ -1969,9 +1969,9 @@ HTML;
 		wp_add_inline_script( 'test-example', 'console.log("before");', 'before' );
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
 
-		$expected  = "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=inline:test-example-js-before\n/* ]]> */\n</script>\n";
+		$expected  = "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=inline:test-example-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -1984,7 +1984,7 @@ HTML;
 		wp_enqueue_script( 'test-example' );
 		wp_add_inline_script( 'test-example', 'console.log("before");', 'before' );
 
-		$expected = "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=inline:test-example-js-before\n/* ]]> */\n</script>\n";
+		$expected = "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -1997,7 +1997,7 @@ HTML;
 		wp_enqueue_script( 'test-example' );
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
 
-		$expected = "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=inline:test-example-js-after\n/* ]]> */\n</script>\n";
+		$expected = "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2011,8 +2011,8 @@ HTML;
 		wp_add_inline_script( 'test-example', 'console.log("before");', 'before' );
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
 
-		$expected  = "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=inline:test-example-js-before\n/* ]]> */\n</script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=inline:test-example-js-after\n/* ]]> */\n</script>\n";
+		$expected  = "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2027,9 +2027,9 @@ HTML;
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
 
-		$expected  = "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\nconsole.log(\"before\");\n//# sourceURL=inline:test-example-js-before\n/* ]]> */\n</script>\n";
+		$expected  = "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\nconsole.log(\"after\");\n//# sourceURL=inline:test-example-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2043,10 +2043,10 @@ HTML;
 		wp_add_inline_script( 'test-example', 'console.log("before");', 'before' );
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
 
-		$expected  = "<script type='text/javascript' id='test-example-js-extra'>\n/* <![CDATA[ */\nvar testExample = {\"foo\":\"bar\"};\n//# sourceURL=inline:test-example-js-extra\n/* ]]> */\n</script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=inline:test-example-js-before\n/* ]]> */\n</script>\n";
+		$expected  = "<script type='text/javascript' id='test-example-js-extra'>\n/* <![CDATA[ */\nvar testExample = {\"foo\":\"bar\"};\n//# sourceURL=test-example-js-extra\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=inline:test-example-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2067,9 +2067,9 @@ HTML;
 		wp_add_inline_script( 'one', 'console.log("before one");', 'before' );
 		wp_add_inline_script( 'two', 'console.log("before two");', 'before' );
 
-		$expected  = "<script type='text/javascript' id='one-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before one\");\n//# sourceURL=inline:one-js-before\n/* ]]> */\n</script>\n";
+		$expected  = "<script type='text/javascript' id='one-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before one\");\n//# sourceURL=one-js-before\n/* ]]> */\n</script>\n";
 		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}one.js?ver={$wp_version}' id='one-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='two-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before two\");\n//# sourceURL=inline:two-js-before\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='two-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before two\");\n//# sourceURL=two-js-before\n/* ]]> */\n</script>\n";
 		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}two.js?ver={$wp_version}' id='two-js'></script>\n";
 		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}three.js?ver={$wp_version}' id='three-js'></script>\n";
 
@@ -2091,7 +2091,7 @@ HTML;
 
 		wp_add_inline_script( 'one', 'console.log("before one");', 'before' );
 
-		$expected  = "<script type='text/javascript' id='one-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before one\");\n//# sourceURL=inline:one-js-before\n/* ]]> */\n</script>\n";
+		$expected  = "<script type='text/javascript' id='one-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before one\");\n//# sourceURL=one-js-before\n/* ]]> */\n</script>\n";
 		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}one.js?ver={$wp_version}' id='one-js'></script>\n";
 		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}two.js?ver={$wp_version}' id='two-js'></script>\n";
 		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}three.js?ver={$wp_version}' id='three-js'></script>\n";
@@ -2118,9 +2118,9 @@ HTML;
 
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one&amp;ver={$wp_version}'></script>\n";
 		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}two.js?ver={$wp_version}' id='two-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='two-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after two\");\n//# sourceURL=inline:two-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='two-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after two\");\n//# sourceURL=two-js-after\n/* ]]> */\n</script>\n";
 		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}three.js?ver={$wp_version}' id='three-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='three-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after three\");\n//# sourceURL=inline:three-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='three-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after three\");\n//# sourceURL=three-js-after\n/* ]]> */\n</script>\n";
 		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}four.js?ver={$wp_version}' id='four-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
@@ -2136,14 +2136,14 @@ HTML;
 		$wp_scripts->default_dirs = array( '/wp-admin/js/', '/wp-includes/js/' ); // Default dirs as in wp-includes/script-loader.php.
 
 		$expected_localized  = "<!--[if gte IE 9]>\n";
-		$expected_localized .= "<script type='text/javascript' id='test-example-js-extra'>\n/* <![CDATA[ */\nvar testExample = {\"foo\":\"bar\"};\n//# sourceURL=inline:test-example-js-extra\n/* ]]> */\n</script>\n";
+		$expected_localized .= "<script type='text/javascript' id='test-example-js-extra'>\n/* <![CDATA[ */\nvar testExample = {\"foo\":\"bar\"};\n//# sourceURL=test-example-js-extra\n/* ]]> */\n</script>\n";
 		$expected_localized .= "<![endif]-->\n";
 		$expected_localized  = str_replace( "'", '"', $expected_localized );
 
 		$expected  = "<!--[if gte IE 9]>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=inline:test-example-js-before\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=inline:test-example-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
 		$expected .= "<![endif]-->\n";
 		$expected  = str_replace( "'", '"', $expected );
 
@@ -2171,7 +2171,7 @@ HTML;
 
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core,jquery-migrate&amp;ver={$wp_version}'></script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=inline:test-example-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
 
 		wp_enqueue_script( 'test-example', 'http://example.com', array( 'jquery' ), null );
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
@@ -2196,7 +2196,7 @@ HTML;
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core,jquery-migrate&amp;ver={$wp_version}'></script>\n";
 		$expected .= "<!--[if gte IE 9]>\n";
 		$expected .= "<script type=\"text/javascript\" src=\"http://example.com\" id=\"test-example-js\"></script>\n";
-		$expected .= "<script type=\"text/javascript\" id=\"test-example-js-after\">\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=inline:test-example-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script type=\"text/javascript\" id=\"test-example-js-after\">\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
 		$expected .= "<![endif]-->\n";
 
 		wp_enqueue_script( 'test-example', 'http://example.com', array( 'jquery' ), null );
@@ -2222,7 +2222,7 @@ HTML;
 		$wp_scripts->do_concat = true;
 
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core,jquery-migrate&amp;ver={$wp_version}'></script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=inline:test-example-js-before\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
 
 		wp_enqueue_script( 'test-example', 'http://example.com', array( 'jquery' ), null );
@@ -2247,18 +2247,18 @@ HTML;
 		$wp_scripts->do_concat = true;
 
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core,jquery-migrate,wp-dom-ready,wp-hooks&amp;ver={$wp_version}'></script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=inline:test-example-js-before\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
 		$expected .= "<script type='text/javascript' src='/wp-includes/js/dist/i18n.min.js' id='wp-i18n-js'></script>\n";
 		$expected .= "<script type='text/javascript' id='wp-i18n-js-after'>\n";
 		$expected .= "/* <![CDATA[ */\n";
 		$expected .= "wp.i18n.setLocaleData( { 'text direction\u0004ltr': [ 'ltr' ] } );\n";
-		$expected .= "//# sourceURL=inline:wp-i18n-js-after\n";
+		$expected .= "//# sourceURL=wp-i18n-js-after\n";
 		$expected .= "/* ]]> */\n";
 		$expected .= "</script>\n";
 		$expected .= "<script type='text/javascript' src='/wp-includes/js/dist/a11y.min.js' id='wp-a11y-js'></script>\n";
 		$expected .= "<script type='text/javascript' src='http://example2.com' id='test-example2-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='test-example2-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=inline:test-example2-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='test-example2-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example2-js-after\n/* ]]> */\n</script>\n";
 		wp_enqueue_script( 'test-example', 'http://example.com', array( 'jquery' ), null );
 		wp_add_inline_script( 'test-example', 'console.log("before");', 'before' );
 		wp_enqueue_script( 'test-example2', 'http://example2.com', array( 'wp-a11y' ), null );
@@ -2302,7 +2302,7 @@ HTML;
 		$expected_tail .= "<script type='text/javascript' id='customize-dependency-js-after'>\n";
 		$expected_tail .= "/* <![CDATA[ */\n";
 		$expected_tail .= "tryCustomizeDependency()\n";
-		$expected_tail .= "//# sourceURL=inline:customize-dependency-js-after\n";
+		$expected_tail .= "//# sourceURL=customize-dependency-js-after\n";
 		$expected_tail .= "/* ]]> */\n";
 		$expected_tail .= "</script>\n";
 
@@ -2338,7 +2338,7 @@ HTML;
 		wp_enqueue_script( 'four', '/wp-includes/js/script4.js' );
 
 		$expected  = "<script type='text/javascript' src='/wp-includes/js/script.js?ver={$wp_version}' id='one-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='one-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after one\");\n//# sourceURL=inline:one-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='one-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after one\");\n//# sourceURL=one-js-after\n/* ]]> */\n</script>\n";
 		$expected .= "<script type='text/javascript' src='/wp-includes/js/script2.js?ver={$wp_version}' id='two-js'></script>\n";
 		$expected .= "<script type='text/javascript' src='/wp-includes/js/script3.js?ver={$wp_version}' id='three-js'></script>\n";
 		$expected .= "<script type='text/javascript' src='/wp-includes/js/script4.js?ver={$wp_version}' id='four-js'></script>\n";
@@ -2362,7 +2362,7 @@ HTML;
 		wp_enqueue_script( 'four', '/wp-includes/js/script4.js' );
 
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one,two&amp;ver={$wp_version}'></script>\n";
-		$expected .= "<script type='text/javascript' id='three-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before three\");\n//# sourceURL=inline:three-js-before\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='three-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before three\");\n//# sourceURL=three-js-before\n/* ]]> */\n</script>\n";
 		$expected .= "<script type='text/javascript' src='/wp-includes/js/script3.js?ver={$wp_version}' id='three-js'></script>\n";
 		$expected .= "<script type='text/javascript' src='/wp-includes/js/script4.js?ver={$wp_version}' id='four-js'></script>\n";
 
@@ -2382,8 +2382,8 @@ HTML;
 					'/*before foo 1*/',
 				),
 				'delayed'        => false,
-				'expected_data'  => "/*before foo 1*/\n//# sourceURL=inline:foo-js-before",
-				'expected_tag'   => "<script id='foo-js-before' type='text/javascript'>\n/* <![CDATA[ */\n/*before foo 1*/\n//# sourceURL=inline:foo-js-before\n/* ]]> */\n</script>\n",
+				'expected_data'  => "/*before foo 1*/\n//# sourceURL=foo-js-before",
+				'expected_tag'   => "<script id='foo-js-before' type='text/javascript'>\n/* <![CDATA[ */\n/*before foo 1*/\n//# sourceURL=foo-js-before\n/* ]]> */\n</script>\n",
 			),
 			'after-blocking'  => array(
 				'position'       => 'after',
@@ -2392,8 +2392,8 @@ HTML;
 					'/*after foo 2*/',
 				),
 				'delayed'        => false,
-				'expected_data'  => "/*after foo 1*/\n/*after foo 2*/\n//# sourceURL=inline:foo-js-after",
-				'expected_tag'   => "<script id='foo-js-after' type='text/javascript'>\n/* <![CDATA[ */\n/*after foo 1*/\n/*after foo 2*/\n//# sourceURL=inline:foo-js-after\n/* ]]> */\n</script>\n",
+				'expected_data'  => "/*after foo 1*/\n/*after foo 2*/\n//# sourceURL=foo-js-after",
+				'expected_tag'   => "<script id='foo-js-after' type='text/javascript'>\n/* <![CDATA[ */\n/*after foo 1*/\n/*after foo 2*/\n//# sourceURL=foo-js-after\n/* ]]> */\n</script>\n",
 			),
 			'before-delayed'  => array(
 				'position'       => 'before',
@@ -2401,8 +2401,8 @@ HTML;
 					'/*before foo 1*/',
 				),
 				'delayed'        => true,
-				'expected_data'  => "/*before foo 1*/\n//# sourceURL=inline:foo-js-before",
-				'expected_tag'   => "<script id='foo-js-before' type='text/javascript'>\n/* <![CDATA[ */\n/*before foo 1*/\n//# sourceURL=inline:foo-js-before\n/* ]]> */\n</script>\n",
+				'expected_data'  => "/*before foo 1*/\n//# sourceURL=foo-js-before",
+				'expected_tag'   => "<script id='foo-js-before' type='text/javascript'>\n/* <![CDATA[ */\n/*before foo 1*/\n//# sourceURL=foo-js-before\n/* ]]> */\n</script>\n",
 			),
 			'after-delayed'   => array(
 				'position'       => 'after',
@@ -2411,8 +2411,8 @@ HTML;
 					'/*after foo 2*/',
 				),
 				'delayed'        => true,
-				'expected_data'  => "/*after foo 1*/\n/*after foo 2*/\n//# sourceURL=inline:foo-js-after",
-				'expected_tag'   => "<script id='foo-js-after' type='text/javascript'>\n/* <![CDATA[ */\n/*after foo 1*/\n/*after foo 2*/\n//# sourceURL=inline:foo-js-after\n/* ]]> */\n</script>\n",
+				'expected_data'  => "/*after foo 1*/\n/*after foo 2*/\n//# sourceURL=foo-js-after",
+				'expected_tag'   => "<script id='foo-js-after' type='text/javascript'>\n/* <![CDATA[ */\n/*after foo 1*/\n/*after foo 2*/\n//# sourceURL=foo-js-after\n/* ]]> */\n</script>\n",
 			),
 		);
 	}
@@ -3054,7 +3054,7 @@ HTML;
 		wp_enqueue_script( 'test-example', 'example.com', array(), null );
 		wp_localize_script( 'test-example', 'testExample', $l10n_data );
 
-		$expected  = "<script type='text/javascript' id='test-example-js-extra'>\n/* <![CDATA[ */\nvar testExample = {$expected};\n//# sourceURL=inline:test-example-js-extra\n/* ]]> */\n</script>\n";
+		$expected  = "<script type='text/javascript' id='test-example-js-extra'>\n/* <![CDATA[ */\nvar testExample = {$expected};\n//# sourceURL=test-example-js-extra\n/* ]]> */\n</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
@@ -3638,7 +3638,7 @@ HTML;
 <script src="/example.js?ver=0.0" id="# test/</script> #-js"></script>
 <script id="# test/</script> #-js-after">
 "ok";
-//# sourceURL=inline:%23%20test%2F%3C%2Fscript%3E%20%23-js-after
+//# sourceURL=%23%20test%2F%3C%2Fscript%3E%20%23-js-after
 </script>
 
 HTML;

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -150,7 +150,7 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		$expected  = "<link rel='stylesheet' id='handle-css' href='http://example.com?ver=1' type='text/css' media='all' />\n";
 		$expected .= "<style id='handle-inline-css' type='text/css'>\n";
 		$expected .= "$style\n";
-		$expected .= "/*# sourceURL=inline:handle-inline-css */\n";
+		$expected .= "/*# sourceURL=handle-inline-css */\n";
 		$expected .= "</style>\n";
 
 		wp_enqueue_style( 'handle', 'http://example.com', array(), 1 );
@@ -180,7 +180,7 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		$expected  = "<link rel='stylesheet' id='handle-css' href='http://example.com?ver=1' type='text/css' media='all' />\n";
 		$expected .= "<style id='handle-inline-css' type='text/css'>\n";
 		$expected .= "$style\n";
-		$expected .= "/*# sourceURL=inline:handle-inline-css */\n";
+		$expected .= "/*# sourceURL=handle-inline-css */\n";
 		$expected .= "</style>\n";
 
 		wp_enqueue_style( 'handle', 'http://example.com', array(), 1 );
@@ -276,7 +276,7 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		$expected .= "<style id='handle-inline-css' type='text/css'>\n";
 		$expected .= "$style1\n";
 		$expected .= "$style2\n";
-		$expected .= "/*# sourceURL=inline:handle-inline-css */\n";
+		$expected .= "/*# sourceURL=handle-inline-css */\n";
 		$expected .= "</style>\n";
 
 		wp_enqueue_style( 'handle', 'http://example.com', array(), 1 );
@@ -302,7 +302,7 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		$expected  = "<link rel='stylesheet' id='handle-css' href='http://example.com?ver=1' type='text/css' media='all' />\n";
 		$expected .= "<style id='handle-inline-css' type='text/css'>\n";
 		$expected .= "$style\n";
-		$expected .= "/*# sourceURL=inline:handle-inline-css */\n";
+		$expected .= "/*# sourceURL=handle-inline-css */\n";
 		$expected .= "</style>\n";
 
 		wp_enqueue_style( 'handle', 'http://example.com', array(), 1 );
@@ -336,7 +336,7 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 <link rel='stylesheet' id='handle-css' href='http://example.com?ver=1' type='text/css' media='all' />
 <style id='handle-inline-css' type='text/css'>
 a { color: blue; }
-/*# sourceURL=inline:handle-inline-css */
+/*# sourceURL=handle-inline-css */
 </style>
 <![endif]-->
 
@@ -368,7 +368,7 @@ CSS;
 		$expected .= "<link rel='stylesheet' id='handle-two-css' href='http://example.com?ver=1' type='text/css' media='all' />\n";
 		$expected .= "<style id='handle-three-inline-css' type='text/css'>\n";
 		$expected .= "$style\n";
-		$expected .= "/*# sourceURL=inline:handle-three-inline-css */\n";
+		$expected .= "/*# sourceURL=handle-three-inline-css */\n";
 		$expected .= "</style>\n";
 
 		wp_register_style( 'handle-one', 'http://example.com', array(), 1 );
@@ -651,7 +651,7 @@ CSS;
 <link rel='stylesheet' href="/example.css?ver=0.0" id="# test/</style> #-css" media="all" type="text/css">
 <style id="# test/</style> #-inline-css" type="text/css">
 custom-el { content: "ok"; }
-/*# sourceURL=inline:%23%20test%2F%3C%2Fstyle%3E%20%23-inline-css */
+/*# sourceURL=%23%20test%2F%3C%2Fstyle%3E%20%23-inline-css */
 </style>
 
 HTML;

--- a/tests/phpunit/tests/dependencies/wpLocalizeScript.php
+++ b/tests/phpunit/tests/dependencies/wpLocalizeScript.php
@@ -56,7 +56,7 @@ class Tests_Dependencies_wpLocalizeScript extends WP_UnitTestCase {
 
 		$output = get_echo( 'wp_print_scripts' );
 
-		$expected  = "<script id=\"test-script-js-extra\">\nvar testData = {\"\\u003C!--\":\"\\u003Cscript\\u003E\"};\n//# sourceURL=inline:test-script-js-extra\n</script>\n";
+		$expected  = "<script id=\"test-script-js-extra\">\nvar testData = {\"\\u003C!--\":\"\\u003Cscript\\u003E\"};\n//# sourceURL=test-script-js-extra\n</script>\n";
 		$expected .= "<script src=\"{$base_url}\" id=\"test-script-js\"></script>\n";
 
 		$this->assertEqualHTML( $expected, $output );


### PR DESCRIPTION

Follow-up to https://github.com/WordPress/wordpress-develop/pull/9628 [where it was noted](https://github.com/WordPress/wordpress-develop/pull/9628#pullrequestreview-3163859089):

> > `inline:` breaks LoAF attribution so a pattern like `//# sourceURL=foo.inline.js` is probably better.
> 
> [Referring to Long Animation Frames API.](https://developer.chrome.com/docs/web-platform/long-animation-frames)


Trac ticket: https://core.trac.wordpress.org/ticket/63887

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
