### PR TITLE
55586: fix error when get_block_wrapper_attributes() is called outside of a block instance

### DIFF
--- a/src/wp-includes/class-wp-block-supports.php
+++ b/src/wp-includes/class-wp-block-supports.php
@@ -94,7 +94,7 @@ class WP_Block_Supports {
 	 * @return string[] Array of HTML attribute values keyed by their name.
 	 */
 	public function apply_block_supports() {
-		if (array_key_exists('blockName', self::$block_to_render)) {
+		if ( array_key_exists( 'blockName', self::$block_to_render ) ) {
 			$block_type = WP_Block_Type_Registry::get_instance()->get_registered(
 				self::$block_to_render['blockName']
 			);

--- a/src/wp-includes/class-wp-block-supports.php
+++ b/src/wp-includes/class-wp-block-supports.php
@@ -31,7 +31,7 @@ class WP_Block_Supports {
 	 * @since 5.6.0
 	 * @var array
 	 */
-	public static $block_to_render = null;
+	public static $block_to_render = array();
 
 	/**
 	 * Container for the main instance of the class.
@@ -94,9 +94,13 @@ class WP_Block_Supports {
 	 * @return string[] Array of HTML attribute values keyed by their name.
 	 */
 	public function apply_block_supports() {
-		$block_type = WP_Block_Type_Registry::get_instance()->get_registered(
-			self::$block_to_render['blockName']
-		);
+		if (array_key_exists('blockName', self::$block_to_render)) {
+			$block_type = WP_Block_Type_Registry::get_instance()->get_registered(
+				self::$block_to_render['blockName']
+			);
+		} else {
+			$block_type = null;
+		}
 
 		// If no render_callback, assume styles have been previously handled.
 		if ( ! $block_type || empty( $block_type ) ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

- Update `WP_Block_Supports::$block_to_render` to be `an array()` by default.
- Add an additional check within `WP_Block_Supports::apply_block_supports()` before trying to access a key on the array when it doesn't exist.

Trac ticket: [#55586](https://core.trac.wordpress.org/ticket/55586)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
