### PR TITLE
Terms: Add support for array `orderby` in `WP_Term_Query`

### DIFF
--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -461,11 +461,6 @@ class WP_Term_Query {
 			}
 
 			$orderby = implode( ', ', $orderby_array );
-
-			// Fallback to default if all orderby fields are invalid.
-			if ( empty( $orderby ) ) {
-				$orderby = $this->parse_orderby( 'name' );
-			}
 		} else {
 			$orderby = $this->parse_orderby( $_orderby );
 		}

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -445,7 +445,24 @@ class WP_Term_Query {
 			$_orderby = 'term_id';
 		}
 
-		$orderby = $this->parse_orderby( $_orderby );
+		if ( is_array( $_orderby ) ) {
+			$orderby_array = array();
+			
+			foreach ( $_orderby as $orderby_field => $order ) {
+				$parsed = $this->parse_orderby( $orderby_field );
+				
+				if ( ! $parsed ) {
+					continue;
+				}
+				
+				$order = $this->parse_order( $order );
+				$orderby_array[] = $parsed . ' ' . $order;
+			}
+			
+			$orderby = implode( ', ', $orderby_array );
+		} else {
+			$orderby = $this->parse_orderby( $_orderby );
+		}
 
 		if ( $orderby ) {
 			$orderby = "ORDER BY $orderby";

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -449,14 +449,14 @@ class WP_Term_Query {
 			$orderby_array = array();
 			
 			foreach ( $_orderby as $orderby_field => $order ) {
-				$parsed = $this->parse_orderby( $orderby_field );
+				$parsed_orderby = $this->parse_orderby( $orderby_field );
 				
-				if ( ! $parsed ) {
+				if ( ! $parsed_orderby ) {
 					continue;
 				}
 				
 				$order = $this->parse_order( $order );
-				$orderby_array[] = $parsed . ' ' . $order;
+				$orderby_array[] = "{$parsed_orderby} {$order}";
 			}
 			
 			$orderby = implode( ', ', $orderby_array );

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -460,6 +460,11 @@ class WP_Term_Query {
 			}
 			
 			$orderby = implode( ', ', $orderby_array );
+
+			// Fallback to default if all orderby fields are invalid. 
+			if ( empty( $orderby ) ) {
+				$orderby = $this->parse_orderby( 'name' );
+			}
 		} else {
 			$orderby = $this->parse_orderby( $_orderby );
 		}

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -447,21 +447,21 @@ class WP_Term_Query {
 
 		if ( is_array( $_orderby ) ) {
 			$orderby_array = array();
-			
+
 			foreach ( $_orderby as $orderby_field => $order ) {
 				$parsed_orderby = $this->parse_orderby( $orderby_field );
-				
+
 				if ( ! $parsed_orderby ) {
 					continue;
 				}
-				
-				$order = $this->parse_order( $order );
+
+				$order           = $this->parse_order( $order );
 				$orderby_array[] = "{$parsed_orderby} {$order}";
 			}
-			
+
 			$orderby = implode( ', ', $orderby_array );
 
-			// Fallback to default if all orderby fields are invalid. 
+			// Fallback to default if all orderby fields are invalid.
 			if ( empty( $orderby ) ) {
 				$orderby = $this->parse_orderby( 'name' );
 			}

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -92,6 +92,7 @@ class WP_Term_Query {
 	 * @since 5.1.0 Introduced the 'meta_compare_key' parameter.
 	 * @since 5.3.0 Introduced the 'meta_type_key' parameter.
 	 * @since 6.4.0 Introduced the 'cache_results' parameter.
+	 * @since 6.8.0 Added support for array of orderby fields.
 	 *
 	 * @param string|array $query {
 	 *     Optional. Array or query string of term query parameters. Default empty.

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -92,7 +92,7 @@ class WP_Term_Query {
 	 * @since 5.1.0 Introduced the 'meta_compare_key' parameter.
 	 * @since 5.3.0 Introduced the 'meta_type_key' parameter.
 	 * @since 6.4.0 Introduced the 'cache_results' parameter.
-	 * @since 6.8.0 Added support for array of orderby fields.
+	 * @since 6.9.0 Added support for array of orderby fields.
 	 *
 	 * @param string|array $query {
 	 *     Optional. Array or query string of term query parameters. Default empty.

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -768,7 +768,7 @@ class WP_Term_Query {
 
 		$this->sql_clauses['select']  = "SELECT $distinct $fields";
 		$this->sql_clauses['from']    = "FROM $wpdb->terms AS t $join";
-		$this->sql_clauses['orderby'] = $orderby ? "$orderby $order" : '';
+		$this->sql_clauses['orderby'] = $orderby ? ( is_array( $this->query_vars['orderby'] ) ? $orderby : "$orderby $order" ) : '';
 		$this->sql_clauses['limits']  = $limits;
 
 		// Beginning of the string is on a new line to prevent leading whitespace. See https://core.trac.wordpress.org/ticket/56841.

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -100,7 +100,7 @@ class WP_Term_Query {
 	 *                                                   should be limited.
 	 *     @type int|int[]       $object_ids             Object ID, or array of object IDs. Results will be
 	 *                                                   limited to terms associated with these objects.
-	 *     @type string          $orderby                Field(s) to order terms by. Accepts:
+	 *     @type string|array    $orderby                Field(s) to order terms by. Accepts:
 	 *                                                   - Term fields ('name', 'slug', 'term_group', 'term_id', 'id',
 	 *                                                     'description', 'parent', 'term_order'). Unless `$object_ids`
 	 *                                                     is not empty, 'term_order' is treated the same as 'term_id'.

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -112,6 +112,7 @@ class WP_Term_Query {
 	 *                                                   - The value of `$meta_key`.
 	 *                                                   - The array keys of `$meta_query`.
 	 *                                                   - 'none' to omit the ORDER BY clause.
+	 *                                                   - Array of orderby fields as keys with order ('ASC'/'DESC') as values.
 	 *                                                   Default 'name'.
 	 *     @type string          $order                  Whether to order terms in ascending or descending order.
 	 *                                                   Accepts 'ASC' (ascending) or 'DESC' (descending).

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -1185,4 +1185,39 @@ class Tests_Term_Query extends WP_UnitTestCase {
 
 		$this->assertSame( ltrim( $q->request ), $q->request, 'The query has leading whitespace' );
 	}
+
+	/**
+	 * @ticket 63890
+	 */
+	public function test_orderby_array_multiple_fields() {
+		register_taxonomy( 'wptests_tax_orderby', 'post' );
+
+		$terms = self::factory()->term->create_many(
+			4,
+			array(
+				'taxonomy' => 'wptests_tax_orderby',
+			)
+		);
+
+		add_term_meta( $terms[0], 'priority', 2 );
+		add_term_meta( $terms[1], 'priority', 1 );
+		add_term_meta( $terms[2], 'priority', 2 );
+		add_term_meta( $terms[3], 'priority', 1 );
+
+		$q = new WP_Term_Query(
+			array(
+				'taxonomy'   => 'wptests_tax_orderby',
+				'orderby'    => array(
+					'meta_value_num' => 'DESC',
+					'term_id'        => 'ASC',
+				),
+				'meta_key'   => 'priority',
+				'hide_empty' => false,
+				'fields'     => 'ids',
+			)
+		);
+
+		$expected = array( $terms[0], $terms[2], $terms[1], $terms[3] );
+		$this->assertSame( $expected, $q->terms );
+	}
 }

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -1271,4 +1271,41 @@ class Tests_Term_Query extends WP_UnitTestCase {
 		$expected = array( $term1, $term3, $term2 );
 		$this->assertSame( $expected, $q->terms );
 	}
+
+	/**
+	 * @ticket 63890
+	 */
+	public function test_orderby_array_backward_compatibility() {
+		register_taxonomy( 'wptests_tax_compat', 'post' );
+
+		$terms = self::factory()->term->create_many(
+			3,
+			array(
+				'taxonomy' => 'wptests_tax_compat',
+			)
+		);
+
+		$q1 = new WP_Term_Query(
+			array(
+				'taxonomy'   => 'wptests_tax_compat',
+				'orderby'    => 'term_id',
+				'order'      => 'ASC',
+				'hide_empty' => false,
+				'fields'     => 'ids',
+			)
+		);
+
+		$this->assertSame( $terms, $q1->terms );
+
+		$q2 = new WP_Term_Query(
+			array(
+				'taxonomy'   => 'wptests_tax_compat',
+				'orderby'    => array( 'term_id' => 'ASC' ),
+				'hide_empty' => false,
+				'fields'     => 'ids',
+			)
+		);
+
+		$this->assertSame( $terms, $q2->terms );
+	}
 }

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -1308,4 +1308,33 @@ class Tests_Term_Query extends WP_UnitTestCase {
 
 		$this->assertSame( $terms, $q2->terms );
 	}
+
+	/**
+	 * @ticket 63890
+	 */
+	public function test_orderby_array_all_invalid_fields_fallback() {
+		register_taxonomy( 'wptests_tax_fallback', 'post' );
+
+		$terms = self::factory()->term->create_many(
+			2,
+			array(
+				'taxonomy' => 'wptests_tax_fallback',
+			)
+		);
+
+		$q = new WP_Term_Query(
+			array(
+				'taxonomy'   => 'wptests_tax_fallback',
+				'orderby'    => array(
+					'invalid_field1' => 'ASC',
+					'invalid_field2' => 'DESC',
+				),
+				'hide_empty' => false,
+				'fields'     => 'ids',
+			)
+		);
+
+		$this->assertNotEmpty( $q->terms );
+		$this->assertCount( 2, $q->terms );
+	}
 }

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -1220,4 +1220,55 @@ class Tests_Term_Query extends WP_UnitTestCase {
 		$expected = array( $terms[0], $terms[2], $terms[1], $terms[3] );
 		$this->assertSame( $expected, $q->terms );
 	}
+
+	/**
+	 * @ticket 63890
+	 */
+	public function test_orderby_array_with_name_and_count() {
+		register_taxonomy( 'wptests_tax_orderby_name', 'post' );
+
+		$term1 = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax_orderby_name',
+				'name'     => 'Beta Term',
+			)
+		);
+		$term2 = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax_orderby_name',
+				'name'     => 'Zeta Term',
+			)
+		);
+		$term3 = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax_orderby_name',
+				'name'     => 'Alpha Term',
+			)
+		);
+
+		$post1 = self::factory()->post->create();
+		$post2 = self::factory()->post->create();
+		$post3 = self::factory()->post->create();
+		$post4 = self::factory()->post->create();
+
+		wp_set_object_terms( $post1, array( $term1 ), 'wptests_tax_orderby_name' );
+		wp_set_object_terms( $post2, array( $term1 ), 'wptests_tax_orderby_name' );
+		wp_set_object_terms( $post3, array( $term2 ), 'wptests_tax_orderby_name' );
+		wp_set_object_terms( $post4, array( $term3 ), 'wptests_tax_orderby_name' );
+
+		$q = new WP_Term_Query(
+			array(
+				'taxonomy'   => 'wptests_tax_orderby_name',
+				'orderby'    => array(
+					'count' => 'DESC',
+					'name'  => 'ASC',
+				),
+				'hide_empty' => false,
+				'fields'     => 'ids',
+			)
+		);
+
+		$expected = array( $term1, $term3, $term2 );
+		$this->assertSame( $expected, $q->terms );
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63890

This PR adds support for the array `orderby` parameter in `WP_Term_Query` to match `WP_Query` functionality.

- Enables multiple sort conditions with individual ASC/DESC orders
- Maintains full backward compatibility with string orderby
- Follows coding standards and WP_Query patterns
- Includes test coverage



