### PR TITLE
Interactivity API: Add support for lazy-loaded derived state props

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -289,7 +289,7 @@ final class WP_Interactivity_API {
 			}
 		}
 		if ( ! empty( $derived_props ) ) {
-			$data['derivedStatePropsAccessed'] = $derived_props;
+			$data['derivedStateClosures'] = $derived_props;
 		}
 
 		return $data;

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -59,7 +59,7 @@ final class WP_Interactivity_API {
 	private $config_data = array();
 
 	/**
-	 * Keeps track of all derived state props accessed during server-side rendering.
+	 * Keeps track of all derived state closures accessed during server-side rendering.
 	 *
 	 * This data is serialized and sent to the client as part of the interactivity
 	 * data, and is handled later in the client to support derived state props that
@@ -68,7 +68,7 @@ final class WP_Interactivity_API {
 	 * @since 6.9.0
 	 * @var array
 	 */
-	private $derived_state_props_accessed = array();
+	private $derived_state_closures = array();
 
 	/**
 	 * Flag that indicates whether the `data-wp-router-region` directive has
@@ -257,7 +257,7 @@ final class WP_Interactivity_API {
 		if (
 			empty( $this->state_data ) &&
 			empty( $this->config_data ) &&
-			empty( $this->derived_state_props_accessed )
+			empty( $this->derived_state_closures )
 		) {
 			return $data;
 		}
@@ -283,7 +283,7 @@ final class WP_Interactivity_API {
 		}
 
 		$derived_props = array();
-		foreach ( $this->derived_state_props_accessed as $key => $value ) {
+		foreach ( $this->derived_state_closures as $key => $value ) {
 			if ( ! empty( $value ) ) {
 				$derived_props[ $key ] = $value;
 			}
@@ -681,12 +681,12 @@ final class WP_Interactivity_API {
 					 *
 					 * @since 6.9.0
 					 */
-					$this->derived_state_props_accessed[ $ns ] = $this->derived_state_props_accessed[ $ns ] ?? array();
+					$this->derived_state_closures[ $ns ] = $this->derived_state_closures[ $ns ] ?? array();
 
 					// Builds path for the current property and add it to tracking if not already present.
 					$current_path = implode( '.', array_slice( $path_segments, 0, $index + 1 ) );
-					if ( ! in_array( $current_path, $this->derived_state_props_accessed[ $ns ], true ) ) {
-						$this->derived_state_props_accessed[ $ns ][] = $current_path;
+					if ( ! in_array( $current_path, $this->derived_state_closures[ $ns ], true ) ) {
+						$this->derived_state_closures[ $ns ][] = $current_path;
 					}
 				} catch ( Throwable $e ) {
 					_doing_it_wrong(

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -1272,13 +1272,11 @@ HTML;
 				 *
 				 * Nested `data-wp-each` directives could render
 				 * `data-wp-each-child` elements at the top level as well, and
-				 * they should be ignored.
+				 * they should be overwritten.
 				 */
 				$i = new WP_Interactivity_API_Directives_Processor( $processed_item );
 				while ( $i->next_tag() ) {
-					if ( ! $i->get_attribute( 'data-wp-each-child' ) ) {
-						$i->set_attribute( 'data-wp-each-child', $namespace_value . '::' . $path );
-					}
+					$i->set_attribute( 'data-wp-each-child', $namespace_value . '::' . $path );
 					$i->next_balanced_tag_closer_tag();
 				}
 				$processed_content .= $i->get_updated_html();

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -1196,6 +1196,7 @@ HTML;
 	 * `template` tag.
 	 *
 	 * @since 6.5.0
+	 * @since 6.9.0 Include the list path in the rendered `data-wp-each-child` directives.
 	 *
 	 * @param WP_Interactivity_API_Directives_Processor $p               The directives processor instance.
 	 * @param string                                    $mode            Whether the processing is entering or exiting the tag.
@@ -1264,10 +1265,20 @@ HTML;
 					return;
 				}
 
-				// Adds the `data-wp-each-child` to each top-level tag.
+				/*
+				 * Adds the `data-wp-each-child` directive to each top-level tag
+				 * rendered by this `data-wp-each` directive. The value is the
+				 * `data-wp-each` directive's namespace and path.
+				 *
+				 * Nested `data-wp-each` directives could render
+				 * `data-wp-each-child` elements at the top level as well, and
+				 * they should be ignored.
+				 */
 				$i = new WP_Interactivity_API_Directives_Processor( $processed_item );
 				while ( $i->next_tag() ) {
-					$i->set_attribute( 'data-wp-each-child', $namespace_value . '::' . $path );
+					if ( ! $i->get_attribute( 'data-wp-each-child' ) ) {
+						$i->set_attribute( 'data-wp-each-child', $namespace_value . '::' . $path );
+					}
 					$i->next_balanced_tag_closer_tag();
 				}
 				$processed_content .= $i->get_updated_html();

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -675,7 +675,12 @@ final class WP_Interactivity_API {
 				try {
 					$current = $current();
 
-					// Tracks derived state properties that are accessed during rendering.
+					/*
+					 * Tracks derived state properties that are accessed during
+					 * rendering.
+					 *
+					 * @since 6.9.0
+					 */
 					$this->derived_state_props_accessed[ $ns ] = $this->derived_state_props_accessed[ $ns ] ?? array();
 
 					// Builds path for the current property and add it to tracking if not already present.
@@ -1273,6 +1278,8 @@ HTML;
 				 * Nested `data-wp-each` directives could render
 				 * `data-wp-each-child` elements at the top level as well, and
 				 * they should be overwritten.
+				 *
+				 * @since 6.9.0
 				 */
 				$i = new WP_Interactivity_API_Directives_Processor( $processed_item );
 				while ( $i->next_tag() ) {

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -1241,8 +1241,8 @@ HTML;
 			}
 
 			// Extracts the namespace from the directive attribute value.
-			$namespace_value         = end( $this->namespace_stack );
-			list( $namespace_value ) = is_string( $attribute_value ) && ! empty( $attribute_value )
+			$namespace_value                = end( $this->namespace_stack );
+			list( $namespace_value, $path ) = is_string( $attribute_value ) && ! empty( $attribute_value )
 				? $this->extract_directive_value( $attribute_value, $namespace_value )
 				: array( $namespace_value, null );
 
@@ -1267,7 +1267,7 @@ HTML;
 				// Adds the `data-wp-each-child` to each top-level tag.
 				$i = new WP_Interactivity_API_Directives_Processor( $processed_item );
 				while ( $i->next_tag() ) {
-					$i->set_attribute( 'data-wp-each-child', true );
+					$i->set_attribute( 'data-wp-each-child', $namespace_value . '::' . $path );
 					$i->next_balanced_tag_closer_tag();
 				}
 				$processed_content .= $i->get_updated_html();

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -59,6 +59,18 @@ final class WP_Interactivity_API {
 	private $config_data = array();
 
 	/**
+	 * Keeps track of all derived state props accessed during server-side rendering.
+	 *
+	 * This data is serialized and sent to the client as part of the interactivity
+	 * data, and is handled later in the client to support derived state props that
+	 * are lazily hydrated.
+	 *
+	 * @since 6.9.0
+	 * @var array
+	 */
+	private $derived_state_props_accessed = array();
+
+	/**
 	 * Flag that indicates whether the `data-wp-router-region` directive has
 	 * been found in the HTML and processed.
 	 *
@@ -236,12 +248,17 @@ final class WP_Interactivity_API {
 	 * interactivity stores and the configuration will be available using a `getConfig` utility.
 	 *
 	 * @since 6.7.0
+	 * @since 6.9.0 Serializes derived state props accessed during directive processing.
 	 *
 	 * @param array $data Data to filter.
 	 * @return array Data for the Interactivity API script module.
 	 */
 	public function filter_script_module_interactivity_data( array $data ): array {
-		if ( empty( $this->state_data ) && empty( $this->config_data ) ) {
+		if (
+			empty( $this->state_data ) &&
+			empty( $this->config_data ) &&
+			empty( $this->derived_state_props_accessed )
+		) {
 			return $data;
 		}
 
@@ -263,6 +280,16 @@ final class WP_Interactivity_API {
 		}
 		if ( ! empty( $state ) ) {
 			$data['state'] = $state;
+		}
+
+		$derived_props = array();
+		foreach ( $this->derived_state_props_accessed as $key => $value ) {
+			if ( ! empty( $value ) ) {
+				$derived_props[ $key ] = $value;
+			}
+		}
+		if ( ! empty( $derived_props ) ) {
+			$data['derivedStatePropsAccessed'] = $derived_props;
 		}
 
 		return $data;
@@ -598,7 +625,7 @@ final class WP_Interactivity_API {
 		// Extracts the value from the store using the reference path.
 		$path_segments = explode( '.', $path );
 		$current       = $store;
-		foreach ( $path_segments as $path_segment ) {
+		foreach ( $path_segments as $index => $path_segment ) {
 			/*
 			 * Special case for numeric arrays and strings. Add length
 			 * property mimicking JavaScript behavior.
@@ -647,6 +674,15 @@ final class WP_Interactivity_API {
 				array_push( $this->namespace_stack, $ns );
 				try {
 					$current = $current();
+
+					// Tracks derived state properties that are accessed during rendering.
+					$this->derived_state_props_accessed[ $ns ] = $this->derived_state_props_accessed[ $ns ] ?? array();
+
+					// Builds path for the current property and add it to tracking if not already present.
+					$current_path = implode( '.', array_slice( $path_segments, 0, $index + 1 ) );
+					if ( ! in_array( $current_path, $this->derived_state_props_accessed[ $ns ], true ) ) {
+						$this->derived_state_props_accessed[ $ns ][] = $current_path;
+					}
 				} catch ( Throwable $e ) {
 					_doing_it_wrong(
 						__METHOD__,

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-each.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-each.php
@@ -88,8 +88,8 @@ class Tests_WP_Interactivity_API_WP_Each extends WP_UnitTestCase {
 			'<template data-wp-each="myPlugin::state.list">' .
 				'<span data-wp-text="myPlugin::context.item"></span>' .
 			'</template>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item">1</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item">2</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item">1</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item">2</span>' .
 			'<div id="after-wp-each" data-wp-bind--id="myPlugin::state.after">Text</div>';
 		$new      = $this->interactivity->process_directives( $original );
 		$this->assertSame( $expected, $new );
@@ -140,8 +140,8 @@ class Tests_WP_Interactivity_API_WP_Each extends WP_UnitTestCase {
 				'<template data-wp-each="myPlugin::state.list">' .
 					'<span data-wp-bind--id="myPlugin::context.id" data-wp-text="myPlugin::context.item"></span>' .
 				'</template>' .
-				'<span data-wp-each-child id="some-id" data-wp-bind--id="myPlugin::context.id" data-wp-text="myPlugin::context.item">1</span>' .
-				'<span data-wp-each-child id="some-id" data-wp-bind--id="myPlugin::context.id" data-wp-text="myPlugin::context.item">2</span>' .
+				'<span data-wp-each-child="myPlugin::state.list" id="some-id" data-wp-bind--id="myPlugin::context.id" data-wp-text="myPlugin::context.item">1</span>' .
+				'<span data-wp-each-child="myPlugin::state.list" id="some-id" data-wp-bind--id="myPlugin::context.id" data-wp-text="myPlugin::context.item">2</span>' .
 				'<div id="after-wp-each" data-wp-bind--id="myPlugin::context.after" data-wp-text="myPlugin::context.item">New text</div>' .
 			'</div>';
 		$new      = $this->interactivity->process_directives( $original );
@@ -168,8 +168,8 @@ class Tests_WP_Interactivity_API_WP_Each extends WP_UnitTestCase {
 				'<template data-wp-each="myPlugin::context.list">' .
 					'<span data-wp-text="myPlugin::context.item"></span>' .
 				'</template>' .
-				'<span data-wp-each-child data-wp-text="myPlugin::context.item">1</span>' .
-				'<span data-wp-each-child data-wp-text="myPlugin::context.item">2</span>' .
+				'<span data-wp-each-child="myPlugin::context.list" data-wp-text="myPlugin::context.item">1</span>' .
+				'<span data-wp-each-child="myPlugin::context.list" data-wp-text="myPlugin::context.item">2</span>' .
 				'<div id="after-wp-each" data-wp-bind--id="myPlugin::state.after">Text</div>' .
 			'</div>';
 		$new      = $this->interactivity->process_directives( $original );
@@ -196,8 +196,8 @@ class Tests_WP_Interactivity_API_WP_Each extends WP_UnitTestCase {
 				'<template data-wp-each="state.list">' .
 					'<span data-wp-text="context.item"></span>' .
 				'</template>' .
-				'<span data-wp-each-child data-wp-text="context.item">1</span>' .
-				'<span data-wp-each-child data-wp-text="context.item">2</span>' .
+				'<span data-wp-each-child="myPlugin::state.list" data-wp-text="context.item">1</span>' .
+				'<span data-wp-each-child="myPlugin::state.list" data-wp-text="context.item">2</span>' .
 				'<div id="after-wp-each" data-wp-bind--id="state.after">Text</div>' .
 			'</div>';
 		$new      = $this->interactivity->process_directives( $original );
@@ -223,10 +223,10 @@ class Tests_WP_Interactivity_API_WP_Each extends WP_UnitTestCase {
 				'<span data-wp-text="myPlugin::context.item"></span>' .
 				'<span data-wp-text="myPlugin::context.item"></span>' .
 			'</template>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item">1</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item">1</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item">2</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item">2</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item">1</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item">1</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item">2</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item">2</span>' .
 			'<div id="after-wp-each" data-wp-bind--id="myPlugin::state.after">Text</div>';
 		$new      = $this->interactivity->process_directives( $original );
 		$this->assertSame( $expected, $new );
@@ -251,10 +251,10 @@ class Tests_WP_Interactivity_API_WP_Each extends WP_UnitTestCase {
 				'<img data-wp-bind--id="myPlugin::context.item">' .
 				'<img data-wp-bind--id="myPlugin::context.item">' .
 			'</template>' .
-			'<img data-wp-each-child id="1" data-wp-bind--id="myPlugin::context.item">' .
-			'<img data-wp-each-child id="1" data-wp-bind--id="myPlugin::context.item">' .
-			'<img data-wp-each-child id="2" data-wp-bind--id="myPlugin::context.item">' .
-			'<img data-wp-each-child id="2" data-wp-bind--id="myPlugin::context.item">' .
+			'<img data-wp-each-child="myPlugin::state.list" id="1" data-wp-bind--id="myPlugin::context.item">' .
+			'<img data-wp-each-child="myPlugin::state.list" id="1" data-wp-bind--id="myPlugin::context.item">' .
+			'<img data-wp-each-child="myPlugin::state.list" id="2" data-wp-bind--id="myPlugin::context.item">' .
+			'<img data-wp-each-child="myPlugin::state.list" id="2" data-wp-bind--id="myPlugin::context.item">' .
 			'<div id="after-wp-each" data-wp-bind--id="myPlugin::state.after">Text</div>';
 		$new      = $this->interactivity->process_directives( $original );
 		$this->assertSame( $expected, $new );
@@ -280,10 +280,10 @@ class Tests_WP_Interactivity_API_WP_Each extends WP_UnitTestCase {
 				'<img data-wp-bind--id="myPlugin::context.item">' .
 				'<span data-wp-text="myPlugin::context.item"></span>' .
 			'</template>' .
-			'<img data-wp-each-child id="1" data-wp-bind--id="myPlugin::context.item">' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item">1</span>' .
-			'<img data-wp-each-child id="2" data-wp-bind--id="myPlugin::context.item">' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item">2</span>' .
+			'<img data-wp-each-child="myPlugin::state.list" id="1" data-wp-bind--id="myPlugin::context.item">' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item">1</span>' .
+			'<img data-wp-each-child="myPlugin::state.list" id="2" data-wp-bind--id="myPlugin::context.item">' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item">2</span>' .
 			'<div id="after-wp-each" data-wp-bind--id="myPlugin::state.after">Text</div>';
 		$new      = $this->interactivity->process_directives( $original );
 		$this->assertSame( $expected, $new );
@@ -310,10 +310,10 @@ class Tests_WP_Interactivity_API_WP_Each extends WP_UnitTestCase {
 					'id: <span data-wp-text="myPlugin::context.item"></span>' .
 				'</div>' .
 			'</template>' .
-			'<div data-wp-each-child id="1" data-wp-bind--id="myPlugin::context.item">' .
+			'<div data-wp-each-child="myPlugin::state.list" id="1" data-wp-bind--id="myPlugin::context.item">' .
 				'id: <span data-wp-text="myPlugin::context.item">1</span>' .
 			'</div>' .
-			'<div data-wp-each-child id="2" data-wp-bind--id="myPlugin::context.item">' .
+			'<div data-wp-each-child="myPlugin::state.list" id="2" data-wp-bind--id="myPlugin::context.item">' .
 				'id: <span data-wp-text="myPlugin::context.item">2</span>' .
 			'</div>' .
 			'<div id="after-wp-each" data-wp-bind--id="myPlugin::state.after">Text</div>';
@@ -355,10 +355,10 @@ class Tests_WP_Interactivity_API_WP_Each extends WP_UnitTestCase {
 				'<span data-wp-text="myPlugin::context.item.id"></span>' .
 				'<span data-wp-text="myPlugin::context.item.name"></span>' .
 			'</template>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item.id">1</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item.name">one</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item.id">2</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item.name">two</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item.id">1</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item.name">one</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item.id">2</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item.name">two</span>' .
 			'<div id="after-wp-each" data-wp-bind--id="myPlugin::state.after">Text</div>';
 		$new      = $this->interactivity->process_directives( $original );
 		$this->assertSame( $expected, $new );
@@ -381,8 +381,8 @@ class Tests_WP_Interactivity_API_WP_Each extends WP_UnitTestCase {
 			'<template data-wp-each--myitem="myPlugin::state.list">' .
 				'<span data-wp-text="myPlugin::context.myitem"></span>' .
 			'</template>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.myitem">1</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.myitem">2</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.myitem">1</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.myitem">2</span>' .
 			'<div id="after-wp-each" data-wp-bind--id="myPlugin::state.after">Text</div>';
 		$new      = $this->interactivity->process_directives( $original );
 		$this->assertSame( $expected, $new );
@@ -406,8 +406,8 @@ class Tests_WP_Interactivity_API_WP_Each extends WP_UnitTestCase {
 			'<template data-wp-each--my-item="myPlugin::state.list">' .
 				'<span data-wp-text="myPlugin::context.myItem"></span>' .
 			'</template>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.myItem">1</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.myItem">2</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.myItem">1</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.myItem">2</span>' .
 			'<div id="after-wp-each" data-wp-bind--id="myPlugin::state.after">Text</div>';
 		$new      = $this->interactivity->process_directives( $original );
 		$this->assertSame( $expected, $new );

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-each.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-each.php
@@ -473,18 +473,18 @@ class Tests_WP_Interactivity_API_WP_Each extends WP_UnitTestCase {
 					'<span data-wp-text="myPlugin::context.item2"></span>' .
 				'</template>' .
 			'</template>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item1">1</span>' .
-			'<template data-wp-each-child data-wp-each--item2="myPlugin::state.list2">' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item1">1</span>' .
+			'<template data-wp-each-child="myPlugin::state.list" data-wp-each--item2="myPlugin::state.list2">' .
 				'<span data-wp-text="myPlugin::context.item2"></span>' .
 			'</template>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item2">3</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item2">4</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item1">2</span>' .
-			'<template data-wp-each-child data-wp-each--item2="myPlugin::state.list2">' .
+			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item2">3</span>' .
+			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item2">4</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item1">2</span>' .
+			'<template data-wp-each-child="myPlugin::state.list" data-wp-each--item2="myPlugin::state.list2">' .
 				'<span data-wp-text="myPlugin::context.item2"></span>' .
 			'</template>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item2">3</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item2">4</span>' .
+			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item2">3</span>' .
+			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item2">4</span>' .
 			'<div id="after-wp-each" data-wp-bind--id="myPlugin::state.after">Text</div>';
 		$new      = $this->interactivity->process_directives( $original );
 		$this->assertSame( $expected, $new );
@@ -515,22 +515,22 @@ class Tests_WP_Interactivity_API_WP_Each extends WP_UnitTestCase {
 					'<span data-wp-text="myPlugin::context.item2"></span>' .
 				'</template>' .
 			'</template>' .
-			'<template data-wp-each-child data-wp-each--item2="myPlugin::state.list2">' .
+			'<template data-wp-each-child="myPlugin::state.list" data-wp-each--item2="myPlugin::state.list2">' .
 				'<span data-wp-text="myPlugin::context.item1"></span>' .
 				'<span data-wp-text="myPlugin::context.item2"></span>' .
 			'</template>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item1">1</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item2">3</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item1">1</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item2">4</span>' .
-			'<template data-wp-each-child data-wp-each--item2="myPlugin::state.list2">' .
+			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item1">1</span>' .
+			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item2">3</span>' .
+			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item1">1</span>' .
+			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item2">4</span>' .
+			'<template data-wp-each-child="myPlugin::state.list" data-wp-each--item2="myPlugin::state.list2">' .
 				'<span data-wp-text="myPlugin::context.item1"></span>' .
 				'<span data-wp-text="myPlugin::context.item2"></span>' .
 			'</template>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item1">2</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item2">3</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item1">2</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item2">4</span>' .
+			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item1">2</span>' .
+			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item2">3</span>' .
+			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item1">2</span>' .
+			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item2">4</span>' .
 			'<div id="after-wp-each" data-wp-bind--id="myPlugin::state.after">Text</div>';
 		$new      = $this->interactivity->process_directives( $original );
 		$this->assertSame( $expected, $new );
@@ -559,16 +559,16 @@ class Tests_WP_Interactivity_API_WP_Each extends WP_UnitTestCase {
 					'<span data-wp-text="myPlugin::context.number"></span>' .
 				'</template>' .
 			'</template>' .
-			'<template data-wp-each-child data-wp-each--number="myPlugin::context.list">' .
+			'<template data-wp-each-child="myPlugin::state.list2" data-wp-each--number="myPlugin::context.list">' .
 				'<span data-wp-text="myPlugin::context.number"></span>' .
 			'</template>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.number">1</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.number">2</span>' .
-			'<template data-wp-each-child data-wp-each--number="myPlugin::context.list">' .
+			'<span data-wp-each-child="myPlugin::context.list" data-wp-text="myPlugin::context.number">1</span>' .
+			'<span data-wp-each-child="myPlugin::context.list" data-wp-text="myPlugin::context.number">2</span>' .
+			'<template data-wp-each-child="myPlugin::state.list2" data-wp-each--number="myPlugin::context.list">' .
 				'<span data-wp-text="myPlugin::context.number"></span>' .
 			'</template>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.number">3</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.number">4</span>' .
+			'<span data-wp-each-child="myPlugin::context.list" data-wp-text="myPlugin::context.number">3</span>' .
+			'<span data-wp-each-child="myPlugin::context.list" data-wp-text="myPlugin::context.number">4</span>' .
 			'<div id="after-wp-each" data-wp-bind--id="myPlugin::state.after">Text</div>';
 		$new      = $this->interactivity->process_directives( $original );
 		$this->assertSame( $expected, $new );
@@ -671,15 +671,15 @@ class Tests_WP_Interactivity_API_WP_Each extends WP_UnitTestCase {
 			'<template data-wp-each="myPlugin::state.list">' .
 				'<span data-wp-text="myPlugin::context.item"></span>' .
 			'</template>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item">1</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item">2</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item">1</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item">2</span>' .
 			'<div data-wp-bind--id="myPlugin::state.after">Text</div>';
 		$expected = '' .
 			'<template data-wp-each="myPlugin::state.list">' .
 				'<span data-wp-text="myPlugin::context.item"></span>' .
 			'</template>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item">1</span>' .
-			'<span data-wp-each-child data-wp-text="myPlugin::context.item">2</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item">1</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item">2</span>' .
 			'<div id="after-wp-each" data-wp-bind--id="myPlugin::state.after">Text</div>';
 		$new      = $this->interactivity->process_directives( $original );
 		$this->assertSame( $expected, $new );

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-each.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-each.php
@@ -477,14 +477,14 @@ class Tests_WP_Interactivity_API_WP_Each extends WP_UnitTestCase {
 			'<template data-wp-each-child="myPlugin::state.list" data-wp-each--item2="myPlugin::state.list2">' .
 				'<span data-wp-text="myPlugin::context.item2"></span>' .
 			'</template>' .
-			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item2">3</span>' .
-			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item2">4</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item2">3</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item2">4</span>' .
 			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item1">2</span>' .
 			'<template data-wp-each-child="myPlugin::state.list" data-wp-each--item2="myPlugin::state.list2">' .
 				'<span data-wp-text="myPlugin::context.item2"></span>' .
 			'</template>' .
-			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item2">3</span>' .
-			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item2">4</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item2">3</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item2">4</span>' .
 			'<div id="after-wp-each" data-wp-bind--id="myPlugin::state.after">Text</div>';
 		$new      = $this->interactivity->process_directives( $original );
 		$this->assertSame( $expected, $new );
@@ -519,18 +519,18 @@ class Tests_WP_Interactivity_API_WP_Each extends WP_UnitTestCase {
 				'<span data-wp-text="myPlugin::context.item1"></span>' .
 				'<span data-wp-text="myPlugin::context.item2"></span>' .
 			'</template>' .
-			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item1">1</span>' .
-			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item2">3</span>' .
-			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item1">1</span>' .
-			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item2">4</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item1">1</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item2">3</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item1">1</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item2">4</span>' .
 			'<template data-wp-each-child="myPlugin::state.list" data-wp-each--item2="myPlugin::state.list2">' .
 				'<span data-wp-text="myPlugin::context.item1"></span>' .
 				'<span data-wp-text="myPlugin::context.item2"></span>' .
 			'</template>' .
-			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item1">2</span>' .
-			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item2">3</span>' .
-			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item1">2</span>' .
-			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.item2">4</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item1">2</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item2">3</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item1">2</span>' .
+			'<span data-wp-each-child="myPlugin::state.list" data-wp-text="myPlugin::context.item2">4</span>' .
 			'<div id="after-wp-each" data-wp-bind--id="myPlugin::state.after">Text</div>';
 		$new      = $this->interactivity->process_directives( $original );
 		$this->assertSame( $expected, $new );
@@ -562,13 +562,13 @@ class Tests_WP_Interactivity_API_WP_Each extends WP_UnitTestCase {
 			'<template data-wp-each-child="myPlugin::state.list2" data-wp-each--number="myPlugin::context.list">' .
 				'<span data-wp-text="myPlugin::context.number"></span>' .
 			'</template>' .
-			'<span data-wp-each-child="myPlugin::context.list" data-wp-text="myPlugin::context.number">1</span>' .
-			'<span data-wp-each-child="myPlugin::context.list" data-wp-text="myPlugin::context.number">2</span>' .
+			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.number">1</span>' .
+			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.number">2</span>' .
 			'<template data-wp-each-child="myPlugin::state.list2" data-wp-each--number="myPlugin::context.list">' .
 				'<span data-wp-text="myPlugin::context.number"></span>' .
 			'</template>' .
-			'<span data-wp-each-child="myPlugin::context.list" data-wp-text="myPlugin::context.number">3</span>' .
-			'<span data-wp-each-child="myPlugin::context.list" data-wp-text="myPlugin::context.number">4</span>' .
+			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.number">3</span>' .
+			'<span data-wp-each-child="myPlugin::state.list2" data-wp-text="myPlugin::context.number">4</span>' .
 			'<div id="after-wp-each" data-wp-bind--id="myPlugin::state.after">Text</div>';
 		$new      = $this->interactivity->process_directives( $original );
 		$this->assertSame( $expected, $new );

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -400,7 +400,7 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 						),
 					),
 				),
-				'derivedStatePropsAccessed' => array(
+				'derivedStateClosures' => array(
 					'pluginWithInvokedDerivedState' => array(
 						'state.derivedProp',
 						'state.nested.derivedProp',

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -319,7 +319,7 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 	 * @ticket XXX
 	 */
 	public function test_invoked_derived_state_props_are_serialized() {
-		$returns_whatever = function () { 
+		$returns_whatever = function () {
 			return 'whatever';
 		};
 
@@ -329,31 +329,40 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 
 		$filter = $this->get_script_data_filter_result(
 			function () use ( $returns_whatever, $returns_array ) {
-				$this->interactivity->state( 'pluginWithInvokedDerivedState', array(
-					'derivedProp' => $returns_whatever,
-					'nested'      => array (
-						'derivedProp'             => $returns_whatever,
-						'derivedPropReturnsArray' => $returns_array,
-					),
-				) );
-
-				$this->interactivity->state( 'pluginWithInvokedDerivedStateReturningArray', array(
-					'derivedProp' => $returns_whatever,
-					'nested'      => array (
-						'derivedProp'             => $returns_whatever,
-						'derivedPropReturnsArray' => $returns_array,
-					),
-				) );
-
-				$this->interactivity->state( 'pluginWithoutInvokedDerivedState', array(
-					'derivedProp' => $returns_whatever,
-					'nested'      => array (
+				$this->interactivity->state(
+					'pluginWithInvokedDerivedState',
+					array(
 						'derivedProp' => $returns_whatever,
-					),
-				) );
+						'nested'      => array(
+							'derivedProp'             => $returns_whatever,
+							'derivedPropReturnsArray' => $returns_array,
+						),
+					)
+				);
+
+				$this->interactivity->state(
+					'pluginWithInvokedDerivedStateReturningArray',
+					array(
+						'derivedProp' => $returns_whatever,
+						'nested'      => array(
+							'derivedProp'             => $returns_whatever,
+							'derivedPropReturnsArray' => $returns_array,
+						),
+					)
+				);
+
+				$this->interactivity->state(
+					'pluginWithoutInvokedDerivedState',
+					array(
+						'derivedProp' => $returns_whatever,
+						'nested'      => array(
+							'derivedProp' => $returns_whatever,
+						),
+					)
+				);
 
 				$this->set_internal_context_stack( array() );
-				
+
 				// Multiple evaluations should be serialized only once.
 				$this->set_internal_namespace_stack( 'pluginWithInvokedDerivedState' );
 				$this->evaluate( 'state.derivedProp' );
@@ -370,23 +379,23 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				'state'                     => array(
-					'pluginWithInvokedDerivedState'               => array(
+					'pluginWithInvokedDerivedState'    => array(
 						'derivedProp' => $returns_whatever,
-						'nested'      => array (
+						'nested'      => array(
 							'derivedProp'             => $returns_whatever,
 							'derivedPropReturnsArray' => $returns_array,
 						),
 					),
 					'pluginWithInvokedDerivedStateReturningArray' => array(
 						'derivedProp' => $returns_whatever,
-						'nested'      => array (
+						'nested'      => array(
 							'derivedProp'             => $returns_whatever,
 							'derivedPropReturnsArray' => $returns_array,
 						),
 					),
-					'pluginWithoutInvokedDerivedState'            => array(
+					'pluginWithoutInvokedDerivedState' => array(
 						'derivedProp' => $returns_whatever,
-						'nested'      => array (
+						'nested'      => array(
 							'derivedProp' => $returns_whatever,
 						),
 					),
@@ -399,7 +408,7 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 					'pluginWithInvokedDerivedStateReturningArray' => array(
 						'state.nested.derivedProp',
 					),
-				)
+				),
 			),
 			$filter->get_args()[0][0]
 		);

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -378,7 +378,7 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 
 		$this->assertSame(
 			array(
-				'state'                     => array(
+				'state'                => array(
 					'pluginWithInvokedDerivedState'    => array(
 						'derivedProp' => $returns_whatever,
 						'nested'      => array(

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -25,6 +25,7 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 		$this->interactivity = new WP_Interactivity_API();
+		wp_default_script_modules();
 	}
 
 	public function charset_iso_8859_1() {
@@ -310,6 +311,98 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( array( 'state' => array( 'myPlugin' => array( 'emptyArray' => array() ) ) ), $filter->get_args()[0][0] );
+	}
+	/**
+	 * Tests that derived state props invoked during directive evaluation are
+	 * serialized correctly.
+	 *
+	 * @ticket XXX
+	 */
+	public function test_invoked_derived_state_props_are_serialized() {
+		$returns_whatever = function () { 
+			return 'whatever';
+		};
+
+		$returns_array = function () {
+			return array( 'prop' => 'whatever' );
+		};
+
+		$filter = $this->get_script_data_filter_result(
+			function () use ( $returns_whatever, $returns_array ) {
+				$this->interactivity->state( 'pluginWithInvokedDerivedState', array(
+					'derivedProp' => $returns_whatever,
+					'nested'      => array (
+						'derivedProp'             => $returns_whatever,
+						'derivedPropReturnsArray' => $returns_array,
+					),
+				) );
+
+				$this->interactivity->state( 'pluginWithInvokedDerivedStateReturningArray', array(
+					'derivedProp' => $returns_whatever,
+					'nested'      => array (
+						'derivedProp'             => $returns_whatever,
+						'derivedPropReturnsArray' => $returns_array,
+					),
+				) );
+
+				$this->interactivity->state( 'pluginWithoutInvokedDerivedState', array(
+					'derivedProp' => $returns_whatever,
+					'nested'      => array (
+						'derivedProp' => $returns_whatever,
+					),
+				) );
+
+				$this->set_internal_context_stack( array() );
+				
+				// Multiple evaluations should be serialized only once.
+				$this->set_internal_namespace_stack( 'pluginWithInvokedDerivedState' );
+				$this->evaluate( 'state.derivedProp' );
+				$this->evaluate( 'state.derivedProp' );
+				$this->evaluate( 'state.nested.derivedProp' );
+				$this->evaluate( 'state.nested.derivedProp' );
+
+				// Only the path part that points to a derived state prop should be serialized.
+				$this->set_internal_namespace_stack( 'pluginWithInvokedDerivedStateReturningArray' );
+				$this->evaluate( 'state.nested.derivedProp.prop' );
+			}
+		);
+
+		$this->assertSame(
+			array(
+				'state'                     => array(
+					'pluginWithInvokedDerivedState'               => array(
+						'derivedProp' => $returns_whatever,
+						'nested'      => array (
+							'derivedProp'             => $returns_whatever,
+							'derivedPropReturnsArray' => $returns_array,
+						),
+					),
+					'pluginWithInvokedDerivedStateReturningArray' => array(
+						'derivedProp' => $returns_whatever,
+						'nested'      => array (
+							'derivedProp'             => $returns_whatever,
+							'derivedPropReturnsArray' => $returns_array,
+						),
+					),
+					'pluginWithoutInvokedDerivedState'            => array(
+						'derivedProp' => $returns_whatever,
+						'nested'      => array (
+							'derivedProp' => $returns_whatever,
+						),
+					),
+				),
+				'derivedStatePropsAccessed' => array(
+					'pluginWithInvokedDerivedState' => array(
+						'state.derivedProp',
+						'state.nested.derivedProp',
+					),
+					'pluginWithInvokedDerivedStateReturningArray' => array(
+						'state.nested.derivedProp',
+					),
+				)
+			),
+			$filter->get_args()[0][0]
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI.php
@@ -316,7 +316,7 @@ class Tests_Interactivity_API_WpInteractivityAPI extends WP_UnitTestCase {
 	 * Tests that derived state props invoked during directive evaluation are
 	 * serialized correctly.
 	 *
-	 * @ticket XXX
+	 * @ticket 63898
 	 */
 	public function test_invoked_derived_state_props_are_serialized() {
 		$returns_whatever = function () {


### PR DESCRIPTION
This PR handles the server-side part to add support for "lazy" derived state props. From the trac ticket description:

> There is a problem with [derived state props](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/api-reference/#derived-state) when the store containing them is not loaded before hydration, which can happen with stores loaded asynchronously, e.g., @wordpress/interactivity-router, and also they have a PHP equivalent used for server-side rendering.
> 
> In that case, when those missing derived state props are evaluated, they will return `undefined`, and the directives subscribed to that value will replace the value generated on the server with the PHP function with `undefined`, effectively removing the HTML generated on the server.
> 
> The Interactivity API should be aware of which values were generated on the server via a PHP Closure (derived state props) and avoid replacing the directive's value on the client until a getter is available that can correctly recalculate it.

The way it works is by informing the iAPI runtime which Closures have been evaluated on the server, and serializing their paths into a data structure that is serialized along with the initial state and configuration.

There's also a special case with the `data-wp-each-child` directive. I should know if the corresponding parent `data-wp-each` directive is using a derived state prop to render the list. For nested `data-wp-each` directives, the value assigned in `data-wp-each-child` elements is the one of the top-most `data-wp-each` directive.

Trac ticket: https://core.trac.wordpress.org/ticket/63898

Related Gutenberg issue: https://github.com/WordPress/gutenberg/issues/70872
Related Gutenberg PR: https://github.com/WordPress/gutenberg/pull/71125

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
