### PR TITLE
Users: Fix Generate Password button requiring two clicks on Add New User screen

### DIFF
--- a/src/js/_enqueues/admin/user-profile.js
+++ b/src/js/_enqueues/admin/user-profile.js
@@ -255,9 +255,6 @@
 			$pass1.attr( 'disabled', false );
 			$pass2.attr( 'disabled', false );
 
-			// Set the password to the generated value.
-			generatePassword();
-
 			// Show generated password in plaintext by default.
 			resetToggle ( false );
 
@@ -265,6 +262,8 @@
 			wp.ajax.post( 'generate-password' )
 				.done( function( data ) {
 					$pass1.data( 'pw', data );
+					// Set the password to the generated value.
+					generatePassword();
 				} );
 		} );
 

--- a/src/js/_enqueues/admin/user-profile.js
+++ b/src/js/_enqueues/admin/user-profile.js
@@ -529,16 +529,4 @@
 			return __( 'The changes you made will be lost if you navigate away from this page.' );
 		}
 	});
-
-	/*
-	 * We need to generate a password as soon as the Reset Password page is loaded,
-	 * to avoid double clicking the button to retrieve the first generated password.
-	 * See ticket #39638.
-	 */
-	$( function() {
-		if ( $( '.reset-pass-submit' ).length ) {
-			$( '.reset-pass-submit button.wp-generate-pw' ).trigger( 'click' );
-		}
-	});
-
 })(jQuery);

--- a/src/js/_enqueues/admin/user-profile.js
+++ b/src/js/_enqueues/admin/user-profile.js
@@ -60,6 +60,12 @@
 		if ( 'mailserver_pass' !== $pass1.prop('id' ) && ! $('#weblog_title').length ) {
 			$( $pass1 ).trigger( 'focus' );
 		}
+
+		// Generate the next password and cache.
+		wp.ajax.post( 'generate-password' )
+			.done( function( data ) {
+				$pass1.data( 'pw', data );
+			} );
 	}
 
 	function bindPass1() {
@@ -255,16 +261,11 @@
 			$pass1.attr( 'disabled', false );
 			$pass2.attr( 'disabled', false );
 
+			// Set the password to the generated value.
+			generatePassword();
+
 			// Show generated password in plaintext by default.
 			resetToggle ( false );
-
-			// Generate the next password and cache.
-			wp.ajax.post( 'generate-password' )
-				.done( function( data ) {
-					$pass1.data( 'pw', data );
-					// Set the password to the generated value.
-					generatePassword();
-				} );
 		} );
 
 		$cancelButton = $pass1Row.find( 'button.wp-cancel-pw' );

--- a/src/js/_enqueues/admin/user-profile.js
+++ b/src/js/_enqueues/admin/user-profile.js
@@ -61,11 +61,13 @@
 			$( $pass1 ).trigger( 'focus' );
 		}
 
-		// Generate the next password and cache.
-		wp.ajax.post( 'generate-password' )
-			.done( function( data ) {
-				$pass1.data( 'pw', data );
-			} );
+		if($( '.wp-generate-pw').length) {
+			// Generate the next password and cache.
+			wp.ajax.post( 'generate-password' )
+				.done( function( data ) {
+					$pass1.data( 'pw', data );
+				} );
+		}
 	}
 
 	function bindPass1() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->
This patch fixes the issue where the Generate Password button requires two clicks on the Add New User screen.

- Moves `generatePassword()` inside the AJAX callback.
- Ensures the password field is updated immediately after the new password is generated.
- Prevents user confusion and improves usability.

Trac ticket: https://core.trac.wordpress.org/ticket/63897

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
