### PR TITLE
Enhancement: Include post_status in get_page_by_path query for better filtering of public and private post types

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6132,11 +6132,16 @@ function get_page_by_path( $page_path, $output = OBJECT, $post_type = 'page' ) {
 
 	$post_types          = esc_sql( $post_types );
 	$post_type_in_string = "'" . implode( "','", $post_types ) . "'";
-	$sql                 = "
-		SELECT ID, post_name, post_parent, post_type
+	
+	$public_statuses = get_post_stati( array( 'public' => true, 'private' => true ) );
+	$public_statuses_sql = "'" . implode( "','", array_map( 'esc_sql', $public_statuses ) ) . "'";
+
+	$sql = "
+		SELECT ID, post_name, post_parent, post_type, post_status
 		FROM $wpdb->posts
 		WHERE post_name IN ($in_string)
 		AND post_type IN ($post_type_in_string)
+		AND post_status IN ($public_statuses_sql)
 	";
 
 	$pages = $wpdb->get_results( $sql, OBJECT_K );

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6132,8 +6132,13 @@ function get_page_by_path( $page_path, $output = OBJECT, $post_type = 'page' ) {
 
 	$post_types          = esc_sql( $post_types );
 	$post_type_in_string = "'" . implode( "','", $post_types ) . "'";
-	
-	$public_statuses = get_post_stati( array( 'public' => true, 'private' => true ) );
+
+	$public_statuses     = get_post_stati(
+		array(
+			'public'  => true,
+			'private' => true,
+		)
+	);
 	$public_statuses_sql = "'" . implode( "','", array_map( 'esc_sql', $public_statuses ) ) . "'";
 
 	$sql = "


### PR DESCRIPTION
This PR updates `get_page_by_path()` to exclude non-public post statuses (such as `draft`, `pending`, and `trash`) from path resolution. Previously, unpublished pages sharing a slug with a published one could incorrectly hijack URL resolution and return the wrong post.

### Changes Made

* Added filtering by valid `post_status` using `get_post_stati( array( 'public' => true, 'private' => true ) )`.
* Ensured only published and intentionally viewable posts are considered when resolving paths.
* Prevented draft or pending posts from conflicting with live URLs.