### PR TITLE
Formatting: Rely on _wp_can_use_pcre_u() to detect Unicode PCRE support.

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2195,20 +2195,13 @@ function sanitize_file_name( $filename ) {
 
 	$special_chars = array( '?', '[', ']', '/', '\\', '=', '<', '>', ':', ';', ',', "'", '"', '&', '$', '#', '*', '(', ')', '|', '~', '`', '!', '{', '}', '%', '+', '’', '«', '»', '”', '“', chr( 0 ) );
 
-	// Check for support for utf8 in the installed PCRE library once and store the result in a static.
-	static $utf8_pcre = null;
-	if ( ! isset( $utf8_pcre ) ) {
-		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-		$utf8_pcre = @preg_match( '/^./u', 'a' );
-	}
-
 	if ( ! wp_is_valid_utf8( $filename ) ) {
 		$_ext     = pathinfo( $filename, PATHINFO_EXTENSION );
 		$_name    = pathinfo( $filename, PATHINFO_FILENAME );
 		$filename = sanitize_title_with_dashes( $_name ) . '.' . $_ext;
 	}
 
-	if ( $utf8_pcre ) {
+	if ( _wp_can_use_pcre_u() ) {
 		/**
 		 * Replace all whitespace characters with a basic space (U+0020).
 		 *


### PR DESCRIPTION
Trac ticket: Core-63863.

The `sanitize_file_name()` function attempts to make its own manual detection of Unicode PCRE support, but WordPress already provides a more-robust method of doing so. In order to avoid re-computation, it also stores the result in a static var inside the function. That check is already stored in a static var, however, inside `_wp_can_use_pcre_u()` check and so the extra cache is largely ineffective.

This patch leans on the recently-updated `_wp_can_use_pcre_u()` check and removes the superfluous static var.

Follow-up to [#9576](https://github.com/WordPress/wordpress-develop/pull/9576)
Follow-up to [[60694]](https://core.trac.wordpress.org/changeset/60694)

Work extracted from [#9498](https://github.com/WordPress/wordpress-develop/pull/9498)