### PR TITLE
refactor: use PHPMailer's parseAddresses

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -233,42 +233,6 @@ if ( ! function_exists( 'wp_mail' ) ) :
 			return $pre_wp_mail;
 		}
 
-		if ( isset( $atts['to'] ) ) {
-			$to = $atts['to'];
-		}
-
-		if ( ! is_array( $to ) ) {
-			$to = explode( ',', $to );
-		}
-
-		if ( isset( $atts['subject'] ) ) {
-			$subject = $atts['subject'];
-		}
-
-		if ( isset( $atts['message'] ) ) {
-			$message = $atts['message'];
-		}
-
-		if ( isset( $atts['headers'] ) ) {
-			$headers = $atts['headers'];
-		}
-
-		if ( isset( $atts['attachments'] ) ) {
-			$attachments = $atts['attachments'];
-		}
-
-		if ( ! is_array( $attachments ) ) {
-			$attachments = explode( "\n", str_replace( "\r\n", "\n", $attachments ) );
-		}
-
-		if ( isset( $atts['embeds'] ) ) {
-			$embeds = $atts['embeds'];
-		}
-
-		if ( ! is_array( $embeds ) ) {
-			$embeds = explode( "\n", str_replace( "\r\n", "\n", $embeds ) );
-		}
-
 		global $phpmailer;
 
 		// (Re)create it, if it's gone missing.
@@ -284,10 +248,15 @@ if ( ! function_exists( 'wp_mail' ) ) :
 			};
 		}
 
-		// Headers.
+		// Process Headers First.
 		$cc       = array();
 		$bcc      = array();
 		$reply_to = array();
+		$charset  = get_bloginfo( 'charset' );
+
+		if ( isset( $atts['headers'] ) ) {
+			$headers = $atts['headers'];
+		}
 
 		if ( empty( $headers ) ) {
 			$headers = array();
@@ -323,25 +292,6 @@ if ( ! function_exists( 'wp_mail' ) ) :
 
 					switch ( strtolower( $name ) ) {
 						// Mainly for legacy -- process a "From:" header if it's there.
-						case 'from':
-							$bracket_pos = strpos( $content, '<' );
-							if ( false !== $bracket_pos ) {
-								// Text before the bracketed email is the "From" name.
-								if ( $bracket_pos > 0 ) {
-									$from_name = substr( $content, 0, $bracket_pos );
-									$from_name = str_replace( '"', '', $from_name );
-									$from_name = trim( $from_name );
-								}
-
-								$from_email = substr( $content, $bracket_pos + 1 );
-								$from_email = str_replace( '>', '', $from_email );
-								$from_email = trim( $from_email );
-
-								// Avoid setting an empty $from_email.
-							} elseif ( '' !== trim( $content ) ) {
-								$from_email = trim( $content );
-							}
-							break;
 						case 'content-type':
 							if ( str_contains( $content, ';' ) ) {
 								list( $type, $charset_content ) = explode( ';', $content );
@@ -350,7 +300,6 @@ if ( ! function_exists( 'wp_mail' ) ) :
 									$charset = trim( str_replace( array( 'charset=', '"' ), '', $charset_content ) );
 								} elseif ( false !== stripos( $charset_content, 'boundary=' ) ) {
 									$boundary = trim( str_replace( array( 'BOUNDARY=', 'boundary=', '"' ), '', $charset_content ) );
-									$charset  = '';
 								}
 
 								// Avoid setting an empty $content_type.
@@ -358,14 +307,25 @@ if ( ! function_exists( 'wp_mail' ) ) :
 								$content_type = trim( $content );
 							}
 							break;
+						case 'from':
+							if ( ! empty( $content ) ) {
+								$addresses = $phpmailer->parseAddresses( $content, null, $charset );
+								if ( ! empty( $addresses[0]['name'] ) ) {
+									$from_name = $addresses[0]['name'];
+								}
+								if ( ! empty( $addresses[0]['address'] ) ) {
+									$from_email = $addresses[0]['address'];
+								}
+							}
+							break;
 						case 'cc':
-							$cc = array_merge( (array) $cc, explode( ',', $content ) );
+							$cc = array_merge( (array) $cc, $phpmailer->parseAddresses( $content, null, $charset ) );
 							break;
 						case 'bcc':
-							$bcc = array_merge( (array) $bcc, explode( ',', $content ) );
+							$bcc = array_merge( (array) $bcc, $phpmailer->parseAddresses( $content, null, $charset ) );
 							break;
 						case 'reply-to':
-							$reply_to = array_merge( (array) $reply_to, explode( ',', $content ) );
+							$reply_to = array_merge( (array) $reply_to, $phpmailer->parseAddresses( $content, null, $charset ) );
 							break;
 						default:
 							// Add it to our grand headers array.
@@ -374,6 +334,40 @@ if ( ! function_exists( 'wp_mail' ) ) :
 					}
 				}
 			}
+		}
+
+		if ( isset( $atts['to'] ) ) {
+			$to = $atts['to'];
+		}
+
+		$raw_to = array();
+		if ( ! is_array( $to ) ) {
+			$raw_to = explode( ',', $to );
+			$to     = $phpmailer->parseAddresses( $to, null, $charset );
+		}
+
+		if ( isset( $atts['subject'] ) ) {
+			$subject = $atts['subject'];
+		}
+
+		if ( isset( $atts['message'] ) ) {
+			$message = $atts['message'];
+		}
+
+		if ( isset( $atts['attachments'] ) ) {
+			$attachments = $atts['attachments'];
+		}
+
+		if ( ! is_array( $attachments ) ) {
+			$attachments = explode( "\n", str_replace( "\r\n", "\n", $attachments ) );
+		}
+
+		if ( isset( $atts['embeds'] ) ) {
+			$embeds = $atts['embeds'];
+		}
+
+		if ( ! is_array( $embeds ) ) {
+			$embeds = explode( "\n", str_replace( "\r\n", "\n", $embeds ) );
 		}
 
 		// Empty out the values that may be set.
@@ -457,14 +451,8 @@ if ( ! function_exists( 'wp_mail' ) ) :
 			foreach ( (array) $addresses as $address ) {
 				try {
 					// Break $recipient into name and address parts if in the format "Foo <bar@baz.com>".
-					$recipient_name = '';
-
-					if ( preg_match( '/(.*)<(.+)>/', $address, $matches ) ) {
-						if ( count( $matches ) === 3 ) {
-							$recipient_name = $matches[1];
-							$address        = $matches[2];
-						}
-					}
+					$recipient_name = $address['name'] ?? '';
+					$address        = $address['address'];
 
 					switch ( $address_header ) {
 						case 'to':
@@ -489,7 +477,7 @@ if ( ! function_exists( 'wp_mail' ) ) :
 		// Set to use PHP's mail().
 		$phpmailer->isMail();
 
-		// Set Content-Type and charset.
+		// Set Content-Type and Charset.
 
 		// If we don't have a Content-Type from the input headers.
 		if ( ! isset( $content_type ) ) {
@@ -510,11 +498,6 @@ if ( ! function_exists( 'wp_mail' ) ) :
 		// Set whether it's plaintext, depending on $content_type.
 		if ( 'text/html' === $content_type ) {
 			$phpmailer->isHTML( true );
-		}
-
-		// If we don't have a charset from the input headers.
-		if ( ! isset( $charset ) ) {
-			$charset = get_bloginfo( 'charset' );
 		}
 
 		/**
@@ -609,7 +592,10 @@ if ( ! function_exists( 'wp_mail' ) ) :
 		 */
 		do_action_ref_array( 'phpmailer_init', array( &$phpmailer ) );
 
-		$mail_data = compact( 'to', 'subject', 'message', 'headers', 'attachments' );
+		$mail_data = array(
+			'to' => $raw_to,
+			...compact( 'subject', 'message', 'headers', 'attachments' ),
+		);
 
 		// Send!
 		try {

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -592,9 +592,9 @@ if ( ! function_exists( 'wp_mail' ) ) :
 		 */
 		do_action_ref_array( 'phpmailer_init', array( &$phpmailer ) );
 
-		$mail_data = array(
-			'to' => $raw_to,
-			...compact( 'subject', 'message', 'headers', 'attachments' ),
+		$mail_data = array_merge(
+			array( 'to' => $raw_to ),
+			compact( 'subject', 'message', 'headers', 'attachments' )
 		);
 
 		// Send!

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -270,11 +270,10 @@ if ( ! function_exists( 'wp_mail' ) ) :
 			} else {
 				$tempheaders = $headers;
 			}
-			$headers = array();
+			$headers        = array();
+			$parsed_headers = array();
 
-			// If it's actually got contents.
 			if ( ! empty( $tempheaders ) ) {
-				// Iterate through the raw headers.
 				foreach ( (array) $tempheaders as $header ) {
 					if ( ! str_contains( $header, ':' ) ) {
 						if ( false !== stripos( $header, 'boundary=' ) ) {
@@ -287,26 +286,34 @@ if ( ! function_exists( 'wp_mail' ) ) :
 					list( $name, $content ) = explode( ':', trim( $header ), 2 );
 
 					// Cleanup crew.
-					$name    = trim( $name );
+					$name    = strtolower( trim( $name ) );
 					$content = trim( $content );
 
-					switch ( strtolower( $name ) ) {
-						// Mainly for legacy -- process a "From:" header if it's there.
-						case 'content-type':
-							if ( str_contains( $content, ';' ) ) {
-								list( $type, $charset_content ) = explode( ';', $content );
-								$content_type                   = trim( $type );
-								if ( false !== stripos( $charset_content, 'charset=' ) ) {
-									$charset = trim( str_replace( array( 'charset=', '"' ), '', $charset_content ) );
-								} elseif ( false !== stripos( $charset_content, 'boundary=' ) ) {
-									$boundary = trim( str_replace( array( 'BOUNDARY=', 'boundary=', '"' ), '', $charset_content ) );
-								}
+					$parsed_headers[ $name ] = $content;
+				}
 
-								// Avoid setting an empty $content_type.
-							} elseif ( '' !== trim( $content ) ) {
-								$content_type = trim( $content );
-							}
-							break;
+				/**
+				 * Set the charset from Content-Type, if present.
+				 */
+				if ( isset( $parsed_headers['content-type'] ) ) {
+					$content = $parsed_headers['content-type'];
+					if ( str_contains( $content, ';' ) ) {
+						list( $type, $charset_content ) = explode( ';', $content );
+						$content_type                   = trim( $type );
+						if ( false !== stripos( $charset_content, 'charset=' ) ) {
+							$charset = trim( str_replace( array( 'charset=', '"' ), '', $charset_content ) );
+						} elseif ( false !== stripos( $charset_content, 'boundary=' ) ) {
+							$boundary = trim( str_replace( array( 'BOUNDARY=', 'boundary=', '"' ), '', $charset_content ) );
+						}
+
+						// Avoid setting an empty $content_type.
+					} elseif ( '' !== trim( $content ) ) {
+						$content_type = trim( $content );
+					}
+				}
+
+				foreach ( $parsed_headers as $name => $content ) {
+					switch ( $name ) {
 						case 'from':
 							if ( ! empty( $content ) ) {
 								$addresses = $phpmailer->parseAddresses( $content, null, $charset );
@@ -333,6 +340,7 @@ if ( ! function_exists( 'wp_mail' ) ) :
 							break;
 					}
 				}
+				$parsed_headers = array();
 			}
 		}
 

--- a/tests/phpunit/tests/pluggable/wpMail.php
+++ b/tests/phpunit/tests/pluggable/wpMail.php
@@ -628,33 +628,24 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 
 	public function address_provider() {
 		return array(
-			'from encoded name'               => array(
-				'type'     => 'From',
-				'header'   => 'From: =?UTF-8?B?VGVzdA==?= <test@example.com>',
-				'expected' => array( 'test@example.com', 'Test' ),
+			'single encoded name'                  => array(
+				'content'  => '=?UTF-8?B?Sm9obg==?= <john@example.com>',
+				'expected' => array(
+					array( 'john@example.com', 'John' ),
+				),
 			),
-			'cc multiple encoded names'       => array(
-				'type'     => 'Cc',
-				'header'   => 'Cc: =?UTF-8?B?Sm9obg==?= <john@example.com>, Jane <jane@example.com>',
+			'multiple names with one encoded name' => array(
+				'content'  => '=?UTF-8?B?Sm9obg==?= <john@example.com>, Jane <jane@example.com>',
 				'expected' => array(
 					array( 'john@example.com', 'John' ),
 					array( 'jane@example.com', 'Jane' ),
 				),
 			),
-			'bcc multiple encoded names'      => array(
-				'type'     => 'Bcc',
-				'header'   => 'Bcc: =?UTF-8?B?Sm9obg==?= <john@example.com>, Jane <jane@example.com>',
+			'multiple encoded names'               => array(
+				'content'  => '=?UTF-8?B?Sm9obg==?= <john@example.com>, =?UTF-8?B?SmFuZQ==?= <jane@example.com>',
 				'expected' => array(
 					array( 'john@example.com', 'John' ),
 					array( 'jane@example.com', 'Jane' ),
-				),
-			),
-			'reply-to multiple encoded names' => array(
-				'type'     => 'Reply-To',
-				'header'   => 'Reply-To: =?UTF-8?B?SmFuZQ==?= <jane@example.com>, =?UTF-8?B?Sm9obg==?= <john@example.com>',
-				'expected' => array(
-					'jane@example.com' => array( 'jane@example.com', 'Jane' ),
-					'john@example.com' => array( 'john@example.com', 'John' ),
 				),
 			),
 		);
@@ -664,47 +655,61 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 	 * @ticket 62940
 	 * @dataProvider address_provider
 	 */
-	public function test_wp_mail_single_line_utf8_header( $type, $header, $expected ) {
-		wp_mail( 'test@example.com', 'subject', 'message', $header );
-		$mailer = tests_retrieve_phpmailer_instance();
+	public function test_wp_mail_single_line_utf8_header( $content, $expected ) {
+		$headers = array( 'Cc', 'Bcc', 'Reply-To' );
 
-		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		switch ( $type ) {
-			case 'From':
-				$this->assertSame( $expected, array( $mailer->From, $mailer->FromName ) );
-				break;
+		foreach ( $headers as $header ) {
+			$mail_header = sprintf( '%s: %s', $header, $content );
+			wp_mail( 'test@example.com', 'subject', 'message', $mail_header );
+			$mailer = tests_retrieve_phpmailer_instance();
 
-			case 'Cc':
-				$this->assertSame( $expected, $mailer->getCcAddresses() );
-				break;
+			switch ( $header ) {
+				case 'Cc':
+					$this->assertSame( $expected, $mailer->getCcAddresses() );
+					break;
 
-			case 'Bcc':
-				$this->assertSame( $expected, $mailer->getBccAddresses() );
-				break;
+				case 'Bcc':
+					$this->assertSame( $expected, $mailer->getBccAddresses() );
+					break;
 
-			case 'Reply-To':
-				$this->assertSame( $expected, $mailer->getReplyToAddresses() );
-				break;
+				case 'Reply-To':
+					// Reply-To returns associative array, so modify expected data accordingly.
+					$expected_reply_to = array();
+					foreach ( $expected as $addr ) {
+						$expected_reply_to[ $addr[0] ] = $addr;
+					}
+					$this->assertSame( $expected_reply_to, $mailer->getReplyToAddresses() );
+					break;
 
-			default:
-				$this->fail( "Unknown header type: {$type}" );
-				break;
+				default:
+					$this->fail( "Unknown header type: {$header}" );
+					break;
+			}
+			reset_phpmailer_instance();
 		}
-		// phpcs:enable
+	}
+
+	/**
+	 * @ticket 62940
+	 * @dataProvider address_provider
+	 */
+	public function test_wp_mail_single_line_utf8_header_multiple_to( $content, $expected ) {
+		wp_mail( $content, 'subject', 'message' );
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertSame( $expected, $mailer->getToAddresses() );
 	}
 
 	/**
 	 * @ticket 62940
 	 */
-	public function test_wp_mail_single_line_utf8_header_multiple_to() {
-		$to = '=?UTF-8?B?Sm9obg==?= <john@example.com>, Jane <jane@example.com>';
-		wp_mail( $to, 'subject', 'message' );
-		$mailer   = tests_retrieve_phpmailer_instance();
-		$expected = array(
-			array( 'john@example.com', 'John' ),
-			array( 'jane@example.com', 'Jane' ),
-		);
-		$this->assertSame( $expected, $mailer->getToAddresses() );
+	public function test_wp_mail_encoded_from() {
+		$header   = 'From: =?UTF-8?B?VGVzdA==?= <test@example.com>';
+		$expected = array( 'test@example.com', 'Test' );
+		wp_mail( 'john@example.com', 'subject', 'message', $header );
+		$mailer = tests_retrieve_phpmailer_instance();
+
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$this->assertSame( $expected, array( $mailer->From, $mailer->FromName ) );
 	}
 
 	public function addr_list_provider() {

--- a/tests/phpunit/tests/pluggable/wpMail.php
+++ b/tests/phpunit/tests/pluggable/wpMail.php
@@ -625,17 +625,85 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 			$this->assertStringContainsString( 'cid:' . $key, $mailer->get_sent()->body, 'The cid ' . $key . ' is not referenced in the mail body.' );
 		}
 	}
+
+	public function addressProvider() {
+		return array(
+			'from encoded name'               => array(
+				'type'     => 'From',
+				'header'   => 'From: =?UTF-8?B?VGVzdA==?= <test@example.com>',
+				'expected' => array( 'test@example.com', 'Test' ),
+			),
+			'cc multiple encoded names'       => array(
+				'type'     => 'Cc',
+				'header'   => 'Cc: =?UTF-8?B?Sm9obg==?= <john@example.com>, Jane <jane@example.com>',
+				'expected' => array(
+					array( 'john@example.com', 'John' ),
+					array( 'jane@example.com', 'Jane' ),
+				),
+			),
+			'bcc multiple encoded names'      => array(
+				'type'     => 'Bcc',
+				'header'   => 'Bcc: =?UTF-8?B?Sm9obg==?= <john@example.com>, Jane <jane@example.com>',
+				'expected' => array(
+					array( 'john@example.com', 'John' ),
+					array( 'jane@example.com', 'Jane' ),
+				),
+			),
+			'reply-to multiple encoded names' => array(
+				'type'     => 'Reply-To',
+				'header'   => 'Reply-To: =?UTF-8?B?SmFuZQ==?= <jane@example.com>, =?UTF-8?B?Sm9obg==?= <john@example.com>',
+				'expected' => array(
+					'jane@example.com' => array( 'jane@example.com', 'Jane' ),
+					'john@example.com' => array( 'john@example.com', 'John' ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @ticket 62940
+	 * @dataProvider addressProvider
+	 */
+	public function test_wp_mail_single_line_utf8_header( $type, $header, $expected ) {
+		wp_mail( 'test@example.com', 'subject', 'message', $header );
+		$mailer = tests_retrieve_phpmailer_instance();
+
+		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		switch ( $type ) {
+			case 'From':
+				$this->assertSame( $expected, array( $mailer->From, $mailer->FromName ) );
+				break;
+
+			case 'Cc':
+				$this->assertSame( $expected, $mailer->getCcAddresses() );
+				break;
+
+			case 'Bcc':
+				$this->assertSame( $expected, $mailer->getBccAddresses() );
+				break;
+
+			case 'Reply-To':
+				$this->assertSame( $expected, $mailer->getReplyToAddresses() );
+				break;
+
+			default:
+				$this->fail( "Unknown header type: {$type}" );
+				break;
+		}
+		// phpcs:enable
+	}
+
 	/**
 	 * @ticket 62940
 	 */
-	public function test_wp_mail_single_line_utf8_header() {
-		$headers = 'From: =?UTF-8?B?VGVzdA==?= <test@example.com>';
-		wp_mail( 'test@test.com', 'subject', 'message', $headers );
-
-		$mailer = tests_retrieve_phpmailer_instance();
-		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-		$this->assertSame( 'test@example.com', $mailer->From );
-		$this->assertSame( 'Test', $mailer->FromName );
-		// phpcs:enable
+	public function test_wp_mail_single_line_utf8_header_multiple_to() {
+		$to = '=?UTF-8?B?Sm9obg==?= <john@example.com>, Jane <jane@example.com>';
+		wp_mail( $to, 'subject', 'message' );
+		$mailer   = tests_retrieve_phpmailer_instance();
+		$expected = array(
+			array( 'john@example.com', 'John' ),
+			array( 'jane@example.com', 'Jane' ),
+		);
+		$this->assertSame( $expected, $mailer->getToAddresses() );
 	}
 }

--- a/tests/phpunit/tests/pluggable/wpMail.php
+++ b/tests/phpunit/tests/pluggable/wpMail.php
@@ -626,7 +626,7 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 		}
 	}
 
-	public function addressProvider() {
+	public function address_provider() {
 		return array(
 			'from encoded name'               => array(
 				'type'     => 'From',
@@ -662,7 +662,7 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 62940
-	 * @dataProvider addressProvider
+	 * @dataProvider address_provider
 	 */
 	public function test_wp_mail_single_line_utf8_header( $type, $header, $expected ) {
 		wp_mail( 'test@example.com', 'subject', 'message', $header );
@@ -705,5 +705,43 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 			array( 'jane@example.com', 'Jane' ),
 		);
 		$this->assertSame( $expected, $mailer->getToAddresses() );
+	}
+
+	public function addr_list_provider() {
+		return array(
+			'comma in quoted name'          => array(
+				'type'     => 'From',
+				'header'   => 'From: "John, Doe" <johndoe@example.com>',
+				'expected' => array( 'johndoe@example.com', 'John, Doe' ),
+			),
+			'angled bracket in quoted name' => array(
+				'type'     => 'From',
+				'header'   => 'From: "John<Doe" <johndoe@example.com>',
+				'expected' => array( 'johndoe@example.com', 'John<Doe' ),
+			),
+		);
+	}
+
+
+	/**
+	 * @ticket 62940
+	 * @dataProvider addr_list_provider
+	 * @requires extension imap
+	 */
+	public function test_wp_mail_headers_with_imap_extension( $type, $header, $expected ) {
+		wp_mail( 'test@example.com', 'Subject', 'Message', $header );
+		$mailer = tests_retrieve_phpmailer_instance();
+
+		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		switch ( $type ) {
+			case 'From':
+				$this->assertSame( $expected, array( $mailer->From, $mailer->FromName ) );
+				break;
+
+			default:
+				$this->fail( "Unknown header type: {$type}" );
+				break;
+		}
+		// phpcs:enable
 	}
 }

--- a/tests/phpunit/tests/pluggable/wpMail.php
+++ b/tests/phpunit/tests/pluggable/wpMail.php
@@ -625,4 +625,17 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 			$this->assertStringContainsString( 'cid:' . $key, $mailer->get_sent()->body, 'The cid ' . $key . ' is not referenced in the mail body.' );
 		}
 	}
+	/**
+	 * @ticket 62940
+	 */
+	public function test_wp_mail_single_line_utf8_header() {
+		$headers = 'From: =?UTF-8?B?VGVzdA==?= <test@example.com>';
+		wp_mail( 'test@test.com', 'subject', 'message', $headers );
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		$this->assertSame( 'test@example.com', $mailer->From );
+		$this->assertSame( 'Test', $mailer->FromName );
+		// phpcs:enable
+	}
 }


### PR DESCRIPTION
Current implementation uses naive approach of
splitting email address headers at `,`. This makes perfectly valid headers like
`"Jane, Doe" <jane@example.com>` break. But this is a perfectly valid RFC-5322 email address header.

We should use PHPMailer's parseAddresses() function which uses IMAP extension (if available) which addresses this issue instead of the current implementation.

<!-- Insert a description of your changes here -->

Trac ticket: [#62940](https://core.trac.wordpress.org/ticket/62940)

TODO:

- [x] Add Unit Tests with IMAP Extension enabled.