### PR TITLE
wp_update_post overwrites post_date when updating post_status

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -5257,9 +5257,11 @@ function wp_update_post( $postarr = array(), $wp_error = false, $fire_after_hook
 		$post_cats = $post['post_category'];
 	}
 
-	// Drafts shouldn't be assigned a date unless explicitly done so by the user.
+	// Drafts and Pending Review posts shouldn't be assigned a date unless explicitly done so by the user.
+	// Additionally, if the post_status is being updated to 'future', do not clear the date.
 	if ( isset( $post['post_status'] )
 		&& in_array( $post['post_status'], array( 'draft', 'pending', 'auto-draft' ), true )
+		&& ( ! isset( $postarr['post_status'] ) || 'future' !== $postarr['post_status'] )
 		&& empty( $postarr['edit_date'] ) && ( '0000-00-00 00:00:00' === $post['post_date_gmt'] )
 	) {
 		$clear_date = true;

--- a/tests/phpunit/tests/post/wpInsertPost.php
+++ b/tests/phpunit/tests/post/wpInsertPost.php
@@ -529,7 +529,6 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 55877
-	 * @covers ::wp_insert_post
 	 */
 	public function test_wp_insert_post_should_not_trigger_warning_for_pending_posts_with_unknown_cpt() {
 		$post_id = wp_insert_post(
@@ -604,6 +603,20 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( array( $parent_id ), get_post_ancestors( 0 ) );
+	}
+
+	/**
+	 * @ticket 23474
+	 */
+	public function test_insert_invalid_post_id() {
+		$post_id = self::factory()->post->create();
+		$post    = get_post( $post_id, ARRAY_A );
+
+		$post['ID'] = 123456789;
+
+		$this->assertSame( 0, wp_insert_post( $post ) );
+
+		$this->assertInstanceOf( 'WP_Error', wp_insert_post( $post, true ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/post/wpInsertPost.php
+++ b/tests/phpunit/tests/post/wpInsertPost.php
@@ -607,23 +607,6 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 23474
-	 * @covers ::wp_update_post
-	 */
-	public function test_update_invalid_post_id() {
-		$post_id = self::factory()->post->create();
-		$post    = get_post( $post_id, ARRAY_A );
-
-		$post['ID'] = 123456789;
-
-		$this->assertSame( 0, wp_insert_post( $post ) );
-		$this->assertSame( 0, wp_update_post( $post ) );
-
-		$this->assertInstanceOf( 'WP_Error', wp_insert_post( $post, true ) );
-		$this->assertInstanceOf( 'WP_Error', wp_update_post( $post, true ) );
-	}
-
-	/**
 	 * @ticket 19373
 	 */
 	public function test_insert_programmatic_sanitized() {
@@ -930,48 +913,6 @@ class Tests_Post_wpInsertPost extends WP_UnitTestCase {
 			2,
 			'The dates should be equal'
 		);
-	}
-
-	/**
-	 * Test ensuring that wp_update_post() does not unintentionally modify post tags
-	 * if the post has several tags with the same name but different slugs.
-	 *
-	 * Tags should only be modified if 'tags_input' parameter was explicitly provided,
-	 * and is different from the existing tags.
-	 *
-	 * @ticket 45121
-	 * @covers ::wp_update_post
-	 */
-	public function test_update_post_should_only_modify_post_tags_if_different_tags_input_was_provided() {
-		$tag_1 = wp_insert_term( 'wp_update_post_tag', 'post_tag', array( 'slug' => 'wp_update_post_tag_1' ) );
-		$tag_2 = wp_insert_term( 'wp_update_post_tag', 'post_tag', array( 'slug' => 'wp_update_post_tag_2' ) );
-		$tag_3 = wp_insert_term( 'wp_update_post_tag', 'post_tag', array( 'slug' => 'wp_update_post_tag_3' ) );
-
-		$post_id = self::factory()->post->create(
-			array(
-				'tags_input' => array( $tag_1['term_id'], $tag_2['term_id'] ),
-			)
-		);
-
-		$post = get_post( $post_id );
-
-		$tags = wp_get_post_tags( $post->ID, array( 'fields' => 'ids' ) );
-		$this->assertSameSets( array( $tag_1['term_id'], $tag_2['term_id'] ), $tags );
-
-		wp_update_post( $post );
-
-		$tags = wp_get_post_tags( $post->ID, array( 'fields' => 'ids' ) );
-		$this->assertSameSets( array( $tag_1['term_id'], $tag_2['term_id'] ), $tags );
-
-		wp_update_post(
-			array(
-				'ID'         => $post->ID,
-				'tags_input' => array( $tag_2['term_id'], $tag_3['term_id'] ),
-			)
-		);
-
-		$tags = wp_get_post_tags( $post->ID, array( 'fields' => 'ids' ) );
-		$this->assertSameSets( array( $tag_2['term_id'], $tag_3['term_id'] ), $tags );
 	}
 
 	/**

--- a/tests/phpunit/tests/post/wpPublishPost.php
+++ b/tests/phpunit/tests/post/wpPublishPost.php
@@ -81,37 +81,6 @@ class Tests_Post_wpPublishPost extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 22944
-	 * @covers ::wp_update_post
-	 */
-	public function test_wp_update_post_with_content_filtering() {
-		kses_remove_filters();
-
-		$post_id = wp_insert_post(
-			array(
-				'post_title' => '<script>Test</script>',
-			)
-		);
-		$post    = get_post( $post_id );
-		$this->assertSame( '<script>Test</script>', $post->post_title );
-		$this->assertSame( 'draft', $post->post_status );
-
-		kses_init_filters();
-
-		wp_update_post(
-			array(
-				'ID'          => $post->ID,
-				'post_status' => 'publish',
-			)
-		);
-
-		kses_remove_filters();
-
-		$post = get_post( $post->ID );
-		$this->assertSame( 'Test', $post->post_title );
-	}
-
-	/**
-	 * @ticket 22944
 	 */
 	public function test_wp_publish_post_and_avoid_content_filtering() {
 		kses_remove_filters();

--- a/tests/phpunit/tests/post/wpUpdatePost.php
+++ b/tests/phpunit/tests/post/wpUpdatePost.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * Test wp_update_post() function
+ *
+ * @package WordPress
+ * @subpackage Post
+ *
+ * @since 6.9.0
+ */
+
+/**
+ * Class to Test wp_update_post() function
+ *
+ * @group post
+ * @covers ::wp_update_post
+ */
+class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
+
+	/**
+	 * User IDs for the test.
+	 *
+	 * @var array{administrator: null, editor: null, contributor: null}
+	 */
+	protected static $user_ids = array(
+		'administrator' => null,
+		'editor'        => null,
+		'contributor'   => null,
+	);
+
+	/**
+	 * Set up before class.
+	 *
+	 * @param WP_UnitTest_Factory $factory The Unit Test Factory.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$user_ids = array(
+			'administrator' => $factory->user->create(
+				array(
+					'role' => 'administrator',
+				)
+			),
+			'editor'        => $factory->user->create(
+				array(
+					'role' => 'editor',
+				)
+			),
+			'contributor'   => $factory->user->create(
+				array(
+					'role' => 'contributor',
+				)
+			),
+		);
+
+		$role = get_role( 'administrator' );
+		$role->add_cap( 'publish_mapped_meta_caps' );
+		$role->add_cap( 'publish_unmapped_meta_caps' );
+	}
+
+	/**
+	 * Tear down after class.
+	 */
+	public static function tear_down_after_class() {
+		$role = get_role( 'administrator' );
+		$role->remove_cap( 'publish_mapped_meta_caps' );
+		$role->remove_cap( 'publish_unmapped_meta_caps' );
+
+		parent::tear_down_after_class();
+	}
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		register_post_type(
+			'mapped_meta_caps',
+			array(
+				'capability_type' => array( 'mapped_meta_cap', 'mapped_meta_caps' ),
+				'map_meta_cap'    => true,
+			)
+		);
+
+		register_post_type(
+			'unmapped_meta_caps',
+			array(
+				'capability_type' => array( 'unmapped_meta_cap', 'unmapped_meta_caps' ),
+				'map_meta_cap'    => false,
+			)
+		);
+
+		register_post_type(
+			'no_admin_caps',
+			array(
+				'capability_type' => array( 'no_admin_cap', 'no_admin_caps' ),
+				'map_meta_cap'    => false,
+			)
+		);
+	}
+
+	/**
+	 * Test updating a post with an invalid ID.
+	 *
+	 * @ticket 23474
+	 */
+	public function test_update_invalid_post_id() {
+		$post_id = self::factory()->post->create();
+		$post    = get_post( $post_id, ARRAY_A );
+
+		$post['ID'] = 123456789;
+
+		$this->assertSame( 0, wp_insert_post( $post ) );
+		$this->assertSame( 0, wp_update_post( $post ) );
+
+		$this->assertInstanceOf( 'WP_Error', wp_insert_post( $post, true ) );
+		$this->assertInstanceOf( 'WP_Error', wp_update_post( $post, true ) );
+	}
+
+	/**
+	 * Test ensuring that wp_update_post() does not unintentionally modify post tags
+	 * if the post has several tags with the same name but different slugs.
+	 *
+	 * Tags should only be modified if 'tags_input' parameter was explicitly provided,
+	 * and is different from the existing tags.
+	 *
+	 * @ticket 45121
+	 */
+	public function test_update_post_should_only_modify_post_tags_if_different_tags_input_was_provided() {
+		$tag_1 = wp_insert_term( 'wp_update_post_tag', 'post_tag', array( 'slug' => 'wp_update_post_tag_1' ) );
+		$tag_2 = wp_insert_term( 'wp_update_post_tag', 'post_tag', array( 'slug' => 'wp_update_post_tag_2' ) );
+		$tag_3 = wp_insert_term( 'wp_update_post_tag', 'post_tag', array( 'slug' => 'wp_update_post_tag_3' ) );
+
+		$post_id = self::factory()->post->create(
+			array(
+				'tags_input' => array( $tag_1['term_id'], $tag_2['term_id'] ),
+			)
+		);
+
+		$post = get_post( $post_id );
+
+		$tags = wp_get_post_tags( $post->ID, array( 'fields' => 'ids' ) );
+		$this->assertSameSets( array( $tag_1['term_id'], $tag_2['term_id'] ), $tags );
+
+		wp_update_post( $post );
+
+		$tags = wp_get_post_tags( $post->ID, array( 'fields' => 'ids' ) );
+		$this->assertSameSets( array( $tag_1['term_id'], $tag_2['term_id'] ), $tags );
+
+		wp_update_post(
+			array(
+				'ID'         => $post->ID,
+				'tags_input' => array( $tag_2['term_id'], $tag_3['term_id'] ),
+			)
+		);
+
+		$tags = wp_get_post_tags( $post->ID, array( 'fields' => 'ids' ) );
+		$this->assertSameSets( array( $tag_2['term_id'], $tag_3['term_id'] ), $tags );
+	}
+
+	/**
+	 * Test that wp_update_post() filters post content when 'post_status' is 'draft'.
+	 *
+	 * @ticket 22944
+	 */
+	public function test_wp_update_post_with_content_filtering() {
+		kses_remove_filters();
+
+		$post_id = wp_insert_post(
+			array(
+				'post_title' => '<script>Test</script>',
+			)
+		);
+		$post    = get_post( $post_id );
+		$this->assertSame( '<script>Test</script>', $post->post_title );
+		$this->assertSame( 'draft', $post->post_status );
+
+		kses_init_filters();
+
+		wp_update_post(
+			array(
+				'ID'          => $post->ID,
+				'post_status' => 'publish',
+			)
+		);
+
+		kses_remove_filters();
+
+		$post = get_post( $post->ID );
+		$this->assertSame( 'Test', $post->post_title );
+	}
+
+	/**
+	 * Test that wp_update_post() preserves post_date when changing to future status
+	 *
+	 * @ticket 62468
+	 *
+	 * @dataProvider data_post_status_transitions
+	 *
+	 * @param string $initial_status Initial post status.
+	 */
+	public function test_update_post_preserves_date( $initial_status ) {
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status' => $initial_status,
+			)
+		);
+
+		$future_date = gmdate( 'Y-m-d H:i:s', strtotime( '+1 day' ) );
+		$update_data = array(
+			'ID'          => $post_id,
+			'post_status' => 'future',
+			'post_date'   => $future_date,
+		);
+
+		wp_update_post( $update_data );
+		$updated_post = get_post( $post_id );
+
+		$this->assertSame( $future_date, $updated_post->post_date );
+	}
+
+	/**
+	 * Data provider for test_update_post_preserves_date
+	 *
+	 * @return array[] Test parameters
+	 */
+	public function data_post_status_transitions() {
+		return array(
+			'pending to future' => array(
+				'initial_status' => 'pending',
+			),
+			'draft to future'   => array(
+				'initial_status' => 'draft',
+			),
+		);
+	}
+}

--- a/tests/phpunit/tests/post/wpUpdatePost.php
+++ b/tests/phpunit/tests/post/wpUpdatePost.php
@@ -186,7 +186,7 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test updating a post and preserving post_date when changing to future status
+	 * Test updating a post and preserving post_date when changing to future status.
 	 *
 	 * @ticket 62468
 	 *
@@ -219,9 +219,9 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider for test_update_post_preserves_date_for_future_posts
+	 * Data provider for test_update_post_preserves_date_for_future_posts.
 	 *
-	 * @return array[] Test parameters
+	 * @return array[] Test parameters.
 	 */
 	public function data_update_post_preserves_date_for_future_posts() {
 		return array(

--- a/tests/phpunit/tests/post/wpUpdatePost.php
+++ b/tests/phpunit/tests/post/wpUpdatePost.php
@@ -196,13 +196,16 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 	 * @param string $time_offset     Time offset.
 	 * @param string $expected_status Expected post status.
 	 */
-	public function test_update_post_preserves_date_for_future_posts( $initial_status, $time_offset, $expected_status ) {
+	public function test_update_post_preserves_date_for_future_posts( $initial_status, $time_offset, $expected_status ): void {
 
 		$post_id = self::factory()->post->create(
 			array(
 				'post_status' => $initial_status,
 			)
 		);
+
+		$initial_date_timestamp     = strtotime( get_post( $post_id )->post_date );
+		$initial_date_gmt_timestamp = strtotime( get_post( $post_id )->post_date_gmt );
 
 		$future_date = gmdate( 'Y-m-d H:i:s', strtotime( $time_offset ) );
 		$update_data = array(
@@ -214,10 +217,19 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 		wp_update_post( $update_data );
 		$updated_post = get_post( $post_id );
 
-		$this->assertSame( $future_date, $updated_post->post_date_gmt, 'Post date should be updated accordingly.' );
+		$updated_date_timestamp     = strtotime( get_post( $post_id )->post_date );
+		$updated_date_gmt_timestamp = strtotime( get_post( $post_id )->post_date_gmt );
+
+		if ( substr( $time_offset, 0, 1 ) === '+' ) {
+			$this->assertGreaterThan( $initial_date_timestamp, $updated_date_timestamp, 'Post date should be in the future compared to initial date.' );
+			$this->assertGreaterThan( $initial_date_gmt_timestamp, $updated_date_gmt_timestamp, 'Post date GMT should be in the future compared to initial date GMT.' );
+		} else {
+			$this->assertLessThan( $initial_date_timestamp, $updated_date_timestamp, 'Post date should be in the past compared to initial date.' );
+			$this->assertLessThan( $initial_date_gmt_timestamp, $updated_date_gmt_timestamp, 'Post date GMT should be in the past compared to initial date GMT.' );
+		}
+
 		$this->assertSame( $expected_status, $updated_post->post_status, "Post status should be '{$expected_status}' after update." );
 	}
-
 	/**
 	 * Data provider for test_update_post_preserves_date_for_future_posts.
 	 *

--- a/tests/phpunit/tests/post/wpUpdatePost.php
+++ b/tests/phpunit/tests/post/wpUpdatePost.php
@@ -109,10 +109,8 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 
 		$post['ID'] = 123456789;
 
-		$this->assertSame( 0, wp_insert_post( $post ) );
 		$this->assertSame( 0, wp_update_post( $post ) );
 
-		$this->assertInstanceOf( 'WP_Error', wp_insert_post( $post, true ) );
 		$this->assertInstanceOf( 'WP_Error', wp_update_post( $post, true ) );
 	}
 
@@ -194,11 +192,11 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 	 *
 	 * @ticket 62468
 	 *
-	 * @dataProvider data_post_status_transitions
+	 * @dataProvider data_update_post_preserves_date_for_future_posts
 	 *
 	 * @param string $initial_status Initial post status.
 	 */
-	public function test_update_post_preserves_date( $initial_status ) {
+	public function test_update_post_preserves_date_for_future_posts( $initial_status ) {
 
 		$post_id = self::factory()->post->create(
 			array(
@@ -220,11 +218,11 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider for test_update_post_preserves_date
+	 * Data provider for test_update_post_preserves_date_for_future_posts
 	 *
 	 * @return array[] Test parameters
 	 */
-	public function data_post_status_transitions() {
+	public function data_update_post_preserves_date_for_future_posts() {
 		return array(
 			'pending to future' => array(
 				'initial_status' => 'pending',

--- a/tests/phpunit/tests/post/wpUpdatePost.php
+++ b/tests/phpunit/tests/post/wpUpdatePost.php
@@ -59,12 +59,10 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 	/**
 	 * Tear down after class.
 	 */
-	public static function tear_down_after_class() {
+	public static function wpTearDownAfterClass() {
 		$role = get_role( 'administrator' );
 		$role->remove_cap( 'publish_mapped_meta_caps' );
 		$role->remove_cap( 'publish_unmapped_meta_caps' );
-
-		parent::tear_down_after_class();
 	}
 
 	/**
@@ -194,9 +192,11 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_update_post_preserves_date_for_future_posts
 	 *
-	 * @param string $initial_status Initial post status.
+	 * @param string $initial_status  Initial post status.
+	 * @param string $time_offset     Time offset.
+	 * @param string $expected_status Expected post status.
 	 */
-	public function test_update_post_preserves_date_for_future_posts( $initial_status ) {
+	public function test_update_post_preserves_date_for_future_posts( $initial_status, $time_offset, $expected_status ) {
 
 		$post_id = self::factory()->post->create(
 			array(
@@ -204,7 +204,7 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 			)
 		);
 
-		$future_date = gmdate( 'Y-m-d H:i:s', strtotime( '+1 day' ) );
+		$future_date = gmdate( 'Y-m-d H:i:s', strtotime( $time_offset ) );
 		$update_data = array(
 			'ID'          => $post_id,
 			'post_status' => 'future',
@@ -215,6 +215,7 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 		$updated_post = get_post( $post_id );
 
 		$this->assertSame( $future_date, $updated_post->post_date );
+		$this->assertSame( $expected_status, $updated_post->post_status );
 	}
 
 	/**
@@ -224,11 +225,35 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 	 */
 	public function data_update_post_preserves_date_for_future_posts() {
 		return array(
-			'pending to future' => array(
-				'initial_status' => 'pending',
+			'pending to future with 1 day more' => array(
+				'initial_status'  => 'pending',
+				'time_offset'     => '+1 day',
+				'expected_status' => 'future',
 			),
-			'draft to future'   => array(
-				'initial_status' => 'draft',
+			'draft to future with 1 day more'   => array(
+				'initial_status'  => 'draft',
+				'time_offset'     => '+1 day',
+				'expected_status' => 'future',
+			),
+			'publish to future with 1 day more' => array(
+				'initial_status'  => 'publish',
+				'time_offset'     => '+1 day',
+				'expected_status' => 'publish',
+			),
+			'draft to future with 1 day less'   => array(
+				'initial_status'  => 'draft',
+				'time_offset'     => '-1 day',
+				'expected_status' => 'publish',
+			),
+			'pending to future with 1 day less' => array(
+				'initial_status'  => 'pending',
+				'time_offset'     => '-1 day',
+				'expected_status' => 'publish',
+			),
+			'publish to future with 1 day less' => array(
+				'initial_status'  => 'publish',
+				'time_offset'     => '-1 day',
+				'expected_status' => 'publish',
 			),
 		);
 	}

--- a/tests/phpunit/tests/post/wpUpdatePost.php
+++ b/tests/phpunit/tests/post/wpUpdatePost.php
@@ -206,15 +206,15 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 
 		$future_date = gmdate( 'Y-m-d H:i:s', strtotime( $time_offset ) );
 		$update_data = array(
-			'ID'          => $post_id,
-			'post_status' => 'future',
-			'post_date'   => $future_date,
+			'ID'            => $post_id,
+			'post_status'   => 'future',
+			'post_date_gmt' => $future_date,
 		);
 
 		wp_update_post( $update_data );
 		$updated_post = get_post( $post_id );
 
-		$this->assertSame( $future_date, $updated_post->post_date, 'Post date should be preserved when updating to future status.' );
+		$this->assertSame( $future_date, $updated_post->post_date_gmt, 'Post date should be updated accordingly.' );
 		$this->assertSame( $expected_status, $updated_post->post_status, "Post status should be '{$expected_status}' after update." );
 	}
 
@@ -238,7 +238,7 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 			'publish to future with 1 day more' => array(
 				'initial_status'  => 'publish',
 				'time_offset'     => '+1 day',
-				'expected_status' => 'publish',
+				'expected_status' => 'future',
 			),
 			'draft to future with 1 day less'   => array(
 				'initial_status'  => 'draft',

--- a/tests/phpunit/tests/post/wpUpdatePost.php
+++ b/tests/phpunit/tests/post/wpUpdatePost.php
@@ -107,9 +107,9 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 
 		$post['ID'] = 123456789;
 
-		$this->assertSame( 0, wp_update_post( $post ) );
+		$this->assertSame( 0, wp_update_post( $post ), 'wp_update_post should return 0 for invalid post ID.' );
 
-		$this->assertInstanceOf( 'WP_Error', wp_update_post( $post, true ) );
+		$this->assertInstanceOf( 'WP_Error', wp_update_post( $post, true ), 'wp_update_post should return WP_Error for invalid post ID when $wp_error is true.' );
 	}
 
 	/**
@@ -135,12 +135,12 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 		$post = get_post( $post_id );
 
 		$tags = wp_get_post_tags( $post->ID, array( 'fields' => 'ids' ) );
-		$this->assertSameSets( array( $tag_1['term_id'], $tag_2['term_id'] ), $tags );
+		$this->assertSameSets( array( $tag_1['term_id'], $tag_2['term_id'] ), $tags, 'Post tags should match the initially assigned tags.' );
 
 		wp_update_post( $post );
 
 		$tags = wp_get_post_tags( $post->ID, array( 'fields' => 'ids' ) );
-		$this->assertSameSets( array( $tag_1['term_id'], $tag_2['term_id'] ), $tags );
+		$this->assertSameSets( array( $tag_1['term_id'], $tag_2['term_id'] ), $tags, 'Post tags should not change if tags_input is not provided.' );
 
 		wp_update_post(
 			array(
@@ -150,7 +150,7 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 		);
 
 		$tags = wp_get_post_tags( $post->ID, array( 'fields' => 'ids' ) );
-		$this->assertSameSets( array( $tag_2['term_id'], $tag_3['term_id'] ), $tags );
+		$this->assertSameSets( array( $tag_2['term_id'], $tag_3['term_id'] ), $tags, 'Post tags should be updated if different tags_input is provided.' );
 	}
 
 	/**
@@ -167,8 +167,8 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 			)
 		);
 		$post    = get_post( $post_id );
-		$this->assertSame( '<script>Test</script>', $post->post_title );
-		$this->assertSame( 'draft', $post->post_status );
+		$this->assertSame( '<script>Test</script>', $post->post_title, 'Post title should not be filtered without content filtering.' );
+		$this->assertSame( 'draft', $post->post_status, 'Post status should be draft without content filtering.' );
 
 		kses_init_filters();
 
@@ -182,7 +182,7 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 		kses_remove_filters();
 
 		$post = get_post( $post->ID );
-		$this->assertSame( 'Test', $post->post_title );
+		$this->assertSame( 'Test', $post->post_title, 'Post title should be filtered with content filtering.' );
 	}
 
 	/**
@@ -214,8 +214,8 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 		wp_update_post( $update_data );
 		$updated_post = get_post( $post_id );
 
-		$this->assertSame( $future_date, $updated_post->post_date );
-		$this->assertSame( $expected_status, $updated_post->post_status );
+		$this->assertSame( $future_date, $updated_post->post_date, 'Post date should be preserved when updating to future status.' );
+		$this->assertSame( $expected_status, $updated_post->post_status, "Post status should be '{$expected_status}' after update." );
 	}
 
 	/**

--- a/tests/phpunit/tests/post/wpUpdatePost.php
+++ b/tests/phpunit/tests/post/wpUpdatePost.php
@@ -158,7 +158,7 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that wp_update_post() filters post content when 'post_status' is 'draft'.
+	 * Test the wp_update_post() filters post content when 'post_status' is 'draft'.
 	 *
 	 * @ticket 22944
 	 */
@@ -190,7 +190,7 @@ class Tests_Post_WpUpdatePost extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that wp_update_post() preserves post_date when changing to future status
+	 * Test updating a post and preserving post_date when changing to future status
 	 *
 	 * @ticket 62468
 	 *


### PR DESCRIPTION
For this reviewed patch I've considered these elements:

1. I've taken as the fix:  https://core.trac.wordpress.org/attachment/ticket/62468/fix-wp-update-post.patch
It was unnecesary to preserving date of `publish` and `private` on `draft/pending` posts. Only `future` is relevant in this scenario

2. For the unit tests I've [taken this one](https://github.com/WordPress/wordpress-develop/pull/8118.diff) by @sukhendu2002, removing all the extra AI fluff. The data provider feels a bit overkill but I think it will don't do any harm.

3. Finally, given that here is a good opportunity to open a specific file to cover `wp_update_posts` I've brought all the tests covering this function and merged them all into this file for Unit Tests organizational purposes.

Trac ticket: https://core.trac.wordpress.org/ticket/62468

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
