### PR TITLE
Formatting: Strip CJK punctuation from slugs in `sanitize_title_with_dashes()`

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2507,6 +2507,13 @@ function sanitize_title_with_dashes( $title, $raw_title = '', $context = 'displa
 				'%cc%80',
 				'%cc%84',
 				'%cc%8c',
+				// CJK punctuation.
+				'%e3%80%82', // 。 (U+3002, Ideographic Full Stop)
+				'%ef%bc%8c', // ， (U+FF0C, Fullwidth Comma)
+				'%ef%bc%81', // ！ (U+FF01, Fullwidth Exclamation Mark)
+				'%ef%bc%9a', // ： (U+FF1A, Fullwidth Colon)
+				'%e3%80%8a', // 《 (U+300A, Left Double Angle Bracket)
+				'%e3%80%8b', // 》 (U+300B, Right Double Angle Bracket)
 				// Non-visible characters that display without a width.
 				'%e2%80%8b', // Zero width space.
 				'%e2%80%8c', // Zero width non-joiner.

--- a/tests/phpunit/tests/formatting/sanitizeTitleWithDashes.php
+++ b/tests/phpunit/tests/formatting/sanitizeTitleWithDashes.php
@@ -369,11 +369,11 @@ class Tests_Formatting_SanitizeTitleWithDashes extends WP_UnitTestCase {
 	 */
 	public function test_strips_cjk_punctuation() {
 		$this->assertSame( 'hello-world', sanitize_title_with_dashes( 'Hello World。', '', 'save' ) );
-		$this->assertSame( 'test-title', sanitize_title_with_dashes( 'Test，Title', '', 'save' ) );
-		$this->assertSame( 'amazing-post', sanitize_title_with_dashes( 'Amazing！Post', '', 'save' ) );
-		$this->assertSame( 'great-content', sanitize_title_with_dashes( 'Great：Content', '', 'save' ) );
-		$this->assertSame( 'book-title', sanitize_title_with_dashes( '《Book》Title', '', 'save' ) );
-		$this->assertSame( 'mixed-punctuation', sanitize_title_with_dashes( 'Mixed。，！：《》Punctuation', '', 'save' ) );
+		$this->assertSame( 'testtitle', sanitize_title_with_dashes( 'Test，Title', '', 'save' ) );
+		$this->assertSame( 'amazingpost', sanitize_title_with_dashes( 'Amazing！Post', '', 'save' ) );
+		$this->assertSame( 'greatcontent', sanitize_title_with_dashes( 'Great：Content', '', 'save' ) );
+		$this->assertSame( 'booktitle', sanitize_title_with_dashes( '《Book》Title', '', 'save' ) );
+		$this->assertSame( 'mixedpunctuation', sanitize_title_with_dashes( 'Mixed。，！：《》Punctuation', '', 'save' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/formatting/sanitizeTitleWithDashes.php
+++ b/tests/phpunit/tests/formatting/sanitizeTitleWithDashes.php
@@ -363,4 +363,16 @@ class Tests_Formatting_SanitizeTitleWithDashes extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * @ticket 22402
+	 */
+	public function test_strips_cjk_punctuation() {
+		$this->assertSame( 'hello-world', sanitize_title_with_dashes( 'Hello World。', '', 'save' ) );
+		$this->assertSame( 'test-title', sanitize_title_with_dashes( 'Test，Title', '', 'save' ) );
+		$this->assertSame( 'amazing-post', sanitize_title_with_dashes( 'Amazing！Post', '', 'save' ) );
+		$this->assertSame( 'great-content', sanitize_title_with_dashes( 'Great：Content', '', 'save' ) );
+		$this->assertSame( 'book-title', sanitize_title_with_dashes( '《Book》Title', '', 'save' ) );
+		$this->assertSame( 'mixed-punctuation', sanitize_title_with_dashes( 'Mixed。，！：《》Punctuation', '', 'save' ) );
+	}
 }

--- a/tests/phpunit/tests/formatting/sanitizeTitleWithDashes.php
+++ b/tests/phpunit/tests/formatting/sanitizeTitleWithDashes.php
@@ -375,4 +375,15 @@ class Tests_Formatting_SanitizeTitleWithDashes extends WP_UnitTestCase {
 		$this->assertSame( 'book-title', sanitize_title_with_dashes( '《Book》Title', '', 'save' ) );
 		$this->assertSame( 'mixed-punctuation', sanitize_title_with_dashes( 'Mixed。，！：《》Punctuation', '', 'save' ) );
 	}
+
+	/**
+	 * @ticket 22402
+	 */
+	public function test_preserves_cjk_punctuation_when_not_save() {
+		$this->assertSame( 'hello-world%e3%80%82', sanitize_title_with_dashes( 'Hello World。' ) );
+		$this->assertSame( 'test%ef%bc%8ctitle', sanitize_title_with_dashes( 'Test，Title' ) );
+		$this->assertSame( 'amazing%ef%bc%81post', sanitize_title_with_dashes( 'Amazing！Post' ) );
+		$this->assertSame( 'great%ef%bc%9acontent', sanitize_title_with_dashes( 'Great：Content' ) );
+		$this->assertSame( '%e3%80%8abook%e3%80%8btitle', sanitize_title_with_dashes( '《Book》Title' ) );
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/22402

Currently, `sanitize_title_with_dashes()` only strips ASCII non-alphanumeric characters from slugs, but preserves multi-byte punctuation marks. This results in non-western (and some western)  punctuation appearing in URL slugs as encoded characters.

This patch adds common CJK punctuation marks to the existing character blacklist:
- 。 (U+3002, Ideographic Full Stop)
- ， (U+FF0C, Fullwidth Comma)
- ！ (U+FF01, Fullwidth Exclamation Mark)
- ： (U+FF1A, Fullwidth Colon)
- 《》 (U+300A/300B, Double Angle Brackets)

Before: "Hello World。" -> slug is `hello-world%e3%80%82`
After:    "Hello World。" -> slug is `hello-world`

The fix follows the existing pattern of explicitly listing problematic characters and only affects the 'save' context. 

