### PR TITLE
Block Bindings: Support Image block's `caption` attribute, remove `<figcaption>` if empty

### DIFF
--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -109,7 +109,7 @@ class WP_Block {
 	private const BLOCK_BINDINGS_SUPPORTED_ATTRIBUTES = array(
 		'core/paragraph' => array( 'content' ),
 		'core/heading'   => array( 'content' ),
-		'core/image'     => array( 'id', 'url', 'title', 'alt' ),
+		'core/image'     => array( 'id', 'url', 'title', 'alt', 'caption' ),
 		'core/button'    => array( 'url', 'text', 'linkTarget', 'rel' ),
 		'core/post-date' => array( 'datetime' ),
 	);

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -434,7 +434,18 @@ class WP_Block {
 					) ) {
 						// TODO: Use `WP_HTML_Processor::set_inner_html` method once it's available.
 						$block_reader->release_bookmark( 'iterate-selectors' );
-						$block_reader->replace_rich_text( wp_kses_post( $source_value ) );
+						/*
+						 * If the value returned from the Block Bindings source is empty
+						 * for a block attribute that whose selector is `rich-text` or `html`,
+						 * we remove the HTML node denoted by its selector. For example, this
+						 * means removing an Image block's `<figcaption>` node if there's no
+						 * caption supplied.
+						 */
+						if ( empty( $source_value ) ) {
+							$block_reader->remove_node();
+						} else {
+							$block_reader->replace_rich_text( wp_kses_post( $source_value ) );
+						}
 						return $block_reader->get_updated_html();
 					} else {
 						$block_reader->seek( 'iterate-selectors' );

--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -502,6 +502,37 @@ class WP_Block {
 
 				return true;
 			}
+
+			public function remove_node() {
+				if ( $this->is_tag_closer() ) {
+					return false;
+				}
+
+				$depth = $this->get_current_depth();
+
+				$this->set_bookmark( '_wp_block_bindings_tag_opener' );
+				// The bookmark names are prefixed with `_` so the key below has an extra `_`.
+				$tag_opener = $this->bookmarks['__wp_block_bindings_tag_opener'];
+				$start      = $tag_opener->start;
+				$this->release_bookmark( '_wp_block_bindings_tag_opener' );
+
+				// Find matching tag closer.
+				while ( $this->next_token() && $this->get_current_depth() >= $depth ) {
+				}
+
+				$this->set_bookmark( '_wp_block_bindings_tag_closer' );
+				$tag_closer = $this->bookmarks['__wp_block_bindings_tag_closer'];
+				$end        = $tag_closer->start + $tag_closer->length;
+				$this->release_bookmark( '_wp_block_bindings_tag_closer' );
+
+				$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+					$start,
+					$end - $start,
+					''
+				);
+
+				return true;
+			}
 		};
 
 		return $internal_processor_class::create_fragment( $block_content );

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -83,7 +83,7 @@ HTML
 				,
 				'<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">test source value</a></div>',
 			),
-			'image block' => array(
+			'image block'     => array(
 				'caption',
 				<<<HTML
 <!-- wp:image {"id":66,"sizeSlug":"large","linkDestination":"none"} -->
@@ -91,8 +91,8 @@ HTML
 <!-- /wp:image -->
 HTML
 			,
-			'<figure class="wp-block-image size-large"><img src="breakfast.jpg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption">test source value</figcaption></figure>'
-			)
+				'<figure class="wp-block-image size-large"><img src="breakfast.jpg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption">test source value</figcaption></figure>',
+			),
 		);
 	}
 
@@ -176,7 +176,7 @@ HTML;
 
 		$this->assertSame(
 			'',
-			$block->attributes[ 'caption' ],
+			$block->attributes['caption'],
 			"The 'caption' attribute should be updated with the empty string value returned by the source."
 		);
 		$this->assertSame(

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -83,6 +83,16 @@ HTML
 				,
 				'<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">test source value</a></div>',
 			),
+			'image block' => array(
+				'caption',
+				<<<HTML
+<!-- wp:image {"id":66,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="breakfast.jpg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption">Breakfast at a <em>café</em> in Wrocław.</figcaption></figure>
+<!-- /wp:image -->
+HTML
+			,
+			'<figure class="wp-block-image size-large"><img src="breakfast.jpg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption">test source value</figcaption></figure>'
+			)
 		);
 	}
 

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -143,6 +143,50 @@ HTML
 		);
 	}
 
+	public function test_remove_containing_tag_if_rich_text_attribute_source_value_is_empty() {
+		$get_value_callback = function () {
+			return '';
+		};
+
+		register_block_bindings_source(
+			self::SOURCE_NAME,
+			array(
+				'label'              => self::SOURCE_LABEL,
+				'get_value_callback' => $get_value_callback,
+			)
+		);
+
+		$block_content = <<<HTML
+<!-- wp:image {"id":66,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="breakfast.jpg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption">Breakfast at a <em>café</em> in Wrocław.</figcaption></figure>
+<!-- /wp:image -->
+HTML;
+		$parsed_blocks = parse_blocks( $block_content );
+
+		$parsed_blocks[0]['attrs']['metadata'] = array(
+			'bindings' => array(
+				'caption' => array(
+					'source' => self::SOURCE_NAME,
+				),
+			),
+		);
+
+		$block  = new WP_Block( $parsed_blocks[0] );
+		$result = $block->render();
+
+		$this->assertSame(
+			'',
+			$block->attributes[ 'caption' ],
+			"The 'caption' attribute should be updated with the empty string value returned by the source."
+		);
+		$this->assertSame(
+			'<figure class="wp-block-image size-large"><img src="breakfast.jpg" alt="" class="wp-image-1"/></figure>',
+			trim( $result ),
+			'The <figcaption> and its rich text content should be removed.'
+		);
+	}
+
+
 	/**
 	 * Test if the block_bindings_supported_attributes_{$block_type} filter is applied correctly.
 	 *

--- a/tests/phpunit/tests/block-bindings/wp-block-get-block-bindings-processor.php
+++ b/tests/phpunit/tests/block-bindings/wp-block-get-block-bindings-processor.php
@@ -101,4 +101,26 @@ class Tests_Blocks_GetBlockBindingsProcessor extends WP_UnitTestCase {
 			$processor->get_updated_html()
 		);
 	}
+
+	public function test_remove_node() {
+		$figure_opener = '<figure class="wp-block-image">';
+		$img           = '<img src="breakfast.jpg" alt="" class="wp-image-1"/>';
+		$figure_closer = '</figure>';
+		$processor     = self::$get_block_bindings_processor_method->invoke(
+			null,
+			$figure_opener .
+			$img .
+			'<figcaption class="wp-element-caption">Breakfast at a <em>café</em> in Berlin</figcaption>' .
+			$figure_closer
+		);
+
+		$processor->next_tag( array( 'tag_name' => 'figcaption' ) );
+
+		$this->assertTrue( $processor->remove_node() );
+
+		$this->assertEquals(
+			$figure_opener . $img . $figure_closer,
+			$processor->get_updated_html()
+		);
+	}
 }


### PR DESCRIPTION
Implement "conditional" Block Bindings, using the example of the Image block's `caption` attribute. The following cases need to be supported when that attribute is bound to a Block Bindings source:

- [x] If the block was saved with a caption, and the Block Bindings source value is not empty, the caption is replaced with the latter.
- [x] If the block was saved with a caption, and the Block Bindings source value is empty, the `<figcaption>` element is removed.
- [x] If the block was saved without a caption, and the Block Bindings source value is not empty, a `<figcaption>` element is added (with the caption set to the Block Bindings source value).
  - We can implement this by changing `save.js` to include a `<figcaption>`. This is implemented by https://github.com/WordPress/gutenberg/pull/71483. If the `caption` attribute is empty _after_ binding, the empty `<figcaption>` element will be removed by the logic that handles the case described by the second item in this list.

The logic implemented in this PR isn't specific to the Image block; it can be extended to any block that conditionally includes an HTML element that corresponds to a `rich-text` block attribute (e.g. the Pullquote block's `citation` attribute, which corresponds to a `<cite>` element). See [here](https://github.com/WordPress/gutenberg/pull/71483#issuecomment-3248702364) for some discussion related to this solution.

See the screenshots in the "Testing Instructions" section for an illustrative example.

## Testing Instructions
The first two cases from the above list are covered by unit tests.

To test manually, follow these instructions:

Create a new post, and paste the following markup:

```html
<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
<div class="wp-block-group"><!-- wp:image {"width":"126px","height":"auto","sizeSlug":"large","metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"Bulbasur Override"}} -->
<figure class="wp-block-image size-large is-resized"><img src="https://img.pokemondb.net/artwork/large/bulbasaur.jpg" alt="" style="width:126px;height:auto"/><figcaption class="wp-element-caption">Replace</figcaption></figure>
<!-- /wp:image -->

<!-- wp:image {"width":"107px","height":"auto","sizeSlug":"large","metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"Charmander Override"}} -->
<figure class="wp-block-image size-large is-resized"><img src="https://img.pokemondb.net/artwork/large/charmander.jpg" alt="" style="width:107px;height:auto"/><figcaption class="wp-element-caption"></figcaption></figure>
<!-- /wp:image -->

<!-- wp:image {"width":"118px","height":"auto","sizeSlug":"large","metadata":{"bindings":{"__default":{"source":"core/pattern-overrides"}},"name":"Squirtle Override"}} -->
<figure class="wp-block-image size-large is-resized"><img src="https://img.pokemondb.net/artwork/large/squirtle.jpg" alt="" style="width:118px;height:auto"/><figcaption class="wp-element-caption">Remove</figcaption></figure>
<!-- /wp:image --></div>
<!-- /wp:group -->
```

The resulting content should look like this:

<img width="418" height="191" alt="image" src="https://github.com/user-attachments/assets/2e8d8390-719d-478f-b382-400a10bff47c" />

In the Visual Editor, select all three image blocks. Then, from the block toolbar, select "Create Pattern". Assign a name of your choice to the pattern (e.g. "Pokemons").

Below the three image blocks that now form a pattern, insert another instance of the "Pokemons" pattern. Then, edit the newly inserted instance as follows:

1. Change the caption of the first image to "Bulbasaur".
2. Add a caption to the second image ("Charmander").
3. Remove the caption of third image.

Publish the post, and verify that the result looks like this:

<img width="429" height="354" alt="image" src="https://github.com/user-attachments/assets/97baa824-a21f-4b47-b48d-98135094c1e2" />

(Testing instructions largely copied from https://github.com/WordPress/gutenberg/pull/70642.)

Supersedes https://github.com/ockham/wordpress-develop/pull/5.

Trac ticket: https://core.trac.wordpress.org/ticket/63919

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
