### PR TITLE
WP_Query: Apply LIMIT clause for singular queries with explicit posts_per_page

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2795,7 +2795,7 @@ class WP_Query {
 		}
 
 		// Paging.
-		if ( empty( $q['nopaging'] ) && ! $this->is_singular ) {
+		if ( empty( $q['nopaging'] ) && ( ! $this->is_singular || ( isset( $q['posts_per_page'] ) && $q['posts_per_page'] > 0 ) ) ) {
 			$page = absint( $q['paged'] );
 			if ( ! $page ) {
 				$page = 1;

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2795,7 +2795,7 @@ class WP_Query {
 		}
 
 		// Paging.
-		if ( empty( $q['nopaging'] ) && ( ! $this->is_singular || ( isset( $q['posts_per_page'] ) && $q['posts_per_page'] > 0 ) ) ) {
+		if ( empty( $q['nopaging'] ) && ( ! $this->is_singular || ( isset( $q['posts_per_page'] ) && $q['posts_per_page'] > 0 && ( ! isset( $q['paged'] ) || $q['paged'] <= 1 ) ) ) ) {
 			$page = absint( $q['paged'] );
 			if ( ! $page ) {
 				$page = 1;

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2795,7 +2795,7 @@ class WP_Query {
 		}
 
 		// Paging.
-		if ( empty( $q['nopaging'] ) && ( ! $this->is_singular || ( isset( $q['posts_per_page'] ) && $q['posts_per_page'] > 0 && ( ! isset( $q['paged'] ) || $q['paged'] <= 1 ) ) ) ) {
+		if ( empty( $q['nopaging'] ) && ! $this->is_feed && ( ! $this->is_singular || ( isset( $q['posts_per_page'] ) && $q['posts_per_page'] > 0 && ( ! isset( $q['paged'] ) || $q['paged'] <= 1 ) ) ) ) {
 			$page = absint( $q['paged'] );
 			if ( ! $page ) {
 				$page = 1;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR fixes a bug in WP_Query::get_posts() where the pagination logic incorrectly skips adding LIMIT clauses for singular queries, even when posts_per_page is explicitly set.

Trac ticket: https://core.trac.wordpress.org/ticket/63902

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
