### PR TITLE
Make Composer available via npm run on host machine

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
 		"env:cli": "node ./tools/local-env/scripts/docker.js exec --user wp_php cli wp",
 		"env:logs": "node ./tools/local-env/scripts/docker.js logs",
 		"env:pull": "node ./tools/local-env/scripts/docker.js pull",
+		"env:composer": "node ./tools/local-env/scripts/docker.js run -T --rm php composer",
 		"test:performance": "wp-scripts test-playwright --config tests/performance/playwright.config.js",
 		"test:php": "node ./tools/local-env/scripts/docker.js run --rm php ./vendor/bin/phpunit",
 		"test:coverage": "npm run test:php -- --coverage-html ./coverage/html/ --coverage-php ./coverage/php/report.php --coverage-text=./coverage/text/report.txt",


### PR DESCRIPTION
## Context
Working on a ticket on my `wordpress-develop` cloned instance, I wanted to lint and format my code but :
* I couldn't find the command in `composer.json` in order to do so;
* I didn't want to install `composer` nor `phpcs` on my host machine because those tools are already available in the container spawned.

##Solutions
To lint my code I used this command : `node ./tools/local-env/scripts/docker.js run -T --rm php composer lint [my_file]`

[@SirLouen](https://profiles.wordpress.org/SirLouen/) suggested to create a new custom script in package.json enabling developers to directly invoke the composer instance of the `wordpressdevelop/php` container from their host machine. Implementing this will simplifies future call to composer specific scripts from host machine (linting, formating etc ...).

Trac ticket: (https://core.trac.wordpress.org/ticket/63912)
