### PR TITLE
#63167 Apply formatting to `wp_die()` output during PHPUnit test runs

### DIFF
--- a/tests/phpunit/includes/functions.php
+++ b/tests/phpunit/includes/functions.php
@@ -228,7 +228,7 @@ function _wp_die_handler_txt( $message, $title, $args ) {
 	list( $message, $title, $args ) = _wp_die_process_input( $message, $title, $args );
 
 	$message = html_entity_decode( strip_tags( $message ) );
-	$title = html_entity_decode( strip_tags( $title ) );
+	$title   = html_entity_decode( strip_tags( $title ) );
 
 	echo "\033[0;31m";
 	echo "\nwp_die() called\n";
@@ -265,7 +265,7 @@ function _wp_die_handler_exit( $message, $title, $args ) {
 	list( $message, $title, $args ) = _wp_die_process_input( $message, $title, $args );
 
 	$message = html_entity_decode( strip_tags( $message ) );
-	$title = html_entity_decode( strip_tags( $title ) );
+	$title   = html_entity_decode( strip_tags( $title ) );
 
 	echo "\033[0;31m";
 	echo "\nwp_die() called\n";

--- a/tests/phpunit/includes/functions.php
+++ b/tests/phpunit/includes/functions.php
@@ -227,8 +227,13 @@ function _wp_die_handler_filter_exit() {
 function _wp_die_handler_txt( $message, $title, $args ) {
 	list( $message, $title, $args ) = _wp_die_process_input( $message, $title, $args );
 
+	$message = html_entity_decode( strip_tags( $message ) );
+	$title = html_entity_decode( strip_tags( $title ) );
+
+	echo "\033[0;31m";
 	echo "\nwp_die() called\n";
 	echo "Message: $message\n";
+	echo "\033[0m";
 
 	if ( ! empty( $title ) ) {
 		echo "Title: $title\n";
@@ -259,8 +264,13 @@ function _wp_die_handler_txt( $message, $title, $args ) {
 function _wp_die_handler_exit( $message, $title, $args ) {
 	list( $message, $title, $args ) = _wp_die_process_input( $message, $title, $args );
 
+	$message = html_entity_decode( strip_tags( $message ) );
+	$title = html_entity_decode( strip_tags( $title ) );
+
+	echo "\033[0;31m";
 	echo "\nwp_die() called\n";
 	echo "Message: $message\n";
+	echo "\033[0m";
 
 	if ( ! empty( $title ) ) {
 		echo "Title: $title\n";


### PR DESCRIPTION
If `wp_die()` is called during a PHPUnit test run, for example due to invalid credentials in wp-tests-config.php, the output is difficult to grok. This change proposes:

* Stripping HTML tags
* Decoding HTML entities
* Colouring the error message red

## Before

<img alt="" src="https://github.com/user-attachments/assets/601eff65-843c-480e-be0a-342622fada4f" />

## After

<img alt="" src="https://github.com/user-attachments/assets/433cd522-7a3a-4ef1-ab4f-82245ccd7c3d" />

Trac ticket: https://core.trac.wordpress.org/ticket/63167