### PR TITLE
Charset: Add explanatory note about what constitutes “valid” UTF-8

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -941,9 +941,9 @@ function seems_utf8( $str ) {
  *                                                     // but in UTF-8 is the two-byte sequence 0xC3 0xBC.
  *
  * A “valid” string consists of “well-formed UTF-8 code unit sequence[s],” meaning
- * that the byte sequence follows the UTF-8 encoding scheme, that all representations
- * for a character are the smallest possible representation, and that no sequence
- * encodes a UTF-16 surrogate character or any character above the representable range.
+ * that the bytes conform to the UTF-8 encoding scheme, all characters use the minimal
+ * byte sequence required by UTF-8, and that no sequence encodes a UTF-16 surrogate
+ * code point or any character above the representable range.
  *
  * @see https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-3/#G32860
  *

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -940,6 +940,13 @@ function seems_utf8( $str ) {
  *                                                     // E.g. The “ü” in ISO-8859-1 is a single byte 0xFC,
  *                                                     // but in UTF-8 is the two-byte sequence 0xC3 0xBC.
  *
+ * A “valid” string consists of “well-formed UTF-8 code unit sequence[s],” meaning
+ * that the byte sequence follows the UTF-8 encoding scheme, that all representations
+ * for a character are the smallest possible representation, and that no sequence
+ * encodes a UTF-16 surrogate character or any character above the representable range.
+ *
+ * @see https://www.unicode.org/versions/Unicode16.0.0/core-spec/chapter-3/#G32860
+ *
  * @see _wp_is_valid_utf8_fallback
  *
  * @since 6.9.0


### PR DESCRIPTION
Trac ticket: Core-38044

This patch adds a clarifying note about what constitutes a valid UTF-8 byte stream.