### PR TITLE
Docs: Add @param & @return description for maybe_hash_hex_color()

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -6432,8 +6432,8 @@ function sanitize_hex_color_no_hash( $color ) {
  *
  * @since 3.4.0
  *
- * @param string $color
- * @return string
+ * @param string $color The color value to hash. Can be with or without a hash prefix.
+ * @return string The color with hash prefix if it's a valid hex color, otherwise the original value.
  */
 function maybe_hash_hex_color( $color ) {
 	$unhashed = sanitize_hex_color_no_hash( $color );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->
Add descriptive text for @param and @return tags for standardization. No functional changes.
<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63166

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
