### PR TITLE
Fix `WP_Object_Cache` deep copy for objects nested in arrays

### DIFF
--- a/src/wp-includes/class-wp-object-cache.php
+++ b/src/wp-includes/class-wp-object-cache.php
@@ -313,6 +313,8 @@ class WP_Object_Cache {
 
 		if ( is_object( $data ) ) {
 			$data = clone $data;
+		} elseif ( is_array( $data ) ) {
+			$data = $this->deep_copy( $data );
 		}
 
 		$this->cache[ $group ][ $key ] = $data;
@@ -640,5 +642,33 @@ class WP_Object_Cache {
 			echo '<li><strong>Group:</strong> ' . esc_html( $group ) . ' - ( ' . number_format( strlen( serialize( $cache ) ) / KB_IN_BYTES, 2 ) . 'k )</li>';
 		}
 		echo '</ul>';
+	}
+
+	/**
+	* Performs a deep copy of an item to ensure that arrays of objects
+	* are properly duplicated
+	*
+	* @param mixed $data The data to be duplicated
+	* @return mixed copy of the data
+	*/
+	public function deep_copy( $data ) {
+		if ( is_object( $data ) ) {
+			return clone $data;
+		} elseif ( is_array( $data ) ) {
+			$new = array();
+			foreach ( $data as $key => $value ) {
+				if ( is_object( $value ) ) {
+					$new[ $key ] = clone $value;
+				} elseif ( is_array( $value ) ) {
+					$new[ $key ] = $this->deep_copy( $value );
+				} else {
+					$new[ $key ] = $value;
+				}
+			}
+
+			return $new;
+		} else {
+			return $data;
+		}
 	}
 }

--- a/src/wp-includes/class-wp-object-cache.php
+++ b/src/wp-includes/class-wp-object-cache.php
@@ -379,6 +379,8 @@ class WP_Object_Cache {
 			$this->cache_hits += 1;
 			if ( is_object( $this->cache[ $group ][ $key ] ) ) {
 				return clone $this->cache[ $group ][ $key ];
+			} elseif ( is_array( $this->cache[ $group ][ $key ] ) ) {
+				return $this->deep_copy( $this->cache[ $group ][ $key ] );
 			} else {
 				return $this->cache[ $group ][ $key ];
 			}

--- a/tests/phpunit/tests/cache.php
+++ b/tests/phpunit/tests/cache.php
@@ -250,6 +250,54 @@ class Tests_Cache extends WP_UnitTestCase {
 		$this->assertSame( 'bravo', $object_a->foo );
 	}
 
+	/**
+	 * 
+	 * @ticket 30430
+	 */
+	public function test_array_with_objects_deep_copy() {
+		if ( wp_using_ext_object_cache() ) {
+			$this->markTestSkipped( 'This test requires that an external object cache is not in use.' );
+		}
+
+		$key = __FUNCTION__;
+		
+		$shallow_object = new stdClass();
+		$shallow_object->foo = 'alpha';
+		
+		$deep_object = new stdClass();
+		$deep_object->value = 'deep_original';
+
+		$array_with_objects = array(
+			'shallow_obj' => $shallow_object,
+			'string' => 'gamma',
+			'nested' => array(
+				'level2' => array(
+					'deep_obj' => $deep_object,
+					'primitive' => 'unchanged'
+				)
+			)
+		);
+
+		$this->cache->set( $key, $array_with_objects );
+
+		$shallow_object->foo = 'modified_alpha';
+		$deep_object->value = 'deep_modified';
+
+		$cached_array = $this->cache->get( $key );
+
+		$this->assertSame( 'alpha', $cached_array['shallow_obj']->foo, 'Shallow cached object should not be affected by changes to original object' );
+		$this->assertSame( 'deep_original', $cached_array['nested']['level2']['deep_obj']->value, 'Deep cached object should not be affected by changes to original object' );
+		$this->assertSame( 'gamma', $cached_array['string'], 'String values should remain unchanged' );
+		$this->assertSame( 'unchanged', $cached_array['nested']['level2']['primitive'], 'Primitive values should remain unchanged' );
+
+		$cached_array['shallow_obj']->foo = 'modified_from_cache';
+		$cached_array['nested']['level2']['deep_obj']->value = 'modified_from_cache';
+
+		$cached_array_again = $this->cache->get( $key );
+		$this->assertSame( 'alpha', $cached_array_again['shallow_obj']->foo, 'Cached data should not be affected by modifications to retrieved objects' );
+		$this->assertSame( 'deep_original', $cached_array_again['nested']['level2']['deep_obj']->value, 'Deep cached data should not be affected by modifications to retrieved objects' );
+	}
+
 	public function test_incr() {
 		$key = __FUNCTION__;
 

--- a/tests/phpunit/tests/cache.php
+++ b/tests/phpunit/tests/cache.php
@@ -298,6 +298,30 @@ class Tests_Cache extends WP_UnitTestCase {
 		$this->assertSame( 'deep_original', $cached_array_again['nested']['level2']['deep_obj']->value, 'Deep cached data should not be affected by modifications to retrieved objects' );
 	}
 
+	/**
+	 * 
+	 * @ticket 30430
+	 */
+	public function test_primitive_arrays_unchanged() {
+		$key = __FUNCTION__;
+		
+		$primitive_array = array(
+			'string' => 'test',
+			'number' => 123,
+			'boolean' => false,
+			'nested' => array(
+				'nested_string' => 'nested_test',
+				'nested_number' => 456
+			)
+		);
+
+		$this->cache->set( $key, $primitive_array );
+
+		$cached_array = $this->cache->get( $key );
+
+		$this->assertSame( $primitive_array, $cached_array, 'Primitive arrays should be cached correctly' );
+	}
+
 	public function test_incr() {
 		$key = __FUNCTION__;
 

--- a/tests/phpunit/tests/cache.php
+++ b/tests/phpunit/tests/cache.php
@@ -251,7 +251,7 @@ class Tests_Cache extends WP_UnitTestCase {
 	}
 
 	/**
-	 * 
+	 *
 	 * @ticket 30430
 	 */
 	public function test_array_with_objects_deep_copy() {
@@ -260,28 +260,28 @@ class Tests_Cache extends WP_UnitTestCase {
 		}
 
 		$key = __FUNCTION__;
-		
-		$shallow_object = new stdClass();
+
+		$shallow_object      = new stdClass();
 		$shallow_object->foo = 'alpha';
-		
-		$deep_object = new stdClass();
+
+		$deep_object        = new stdClass();
 		$deep_object->value = 'deep_original';
 
 		$array_with_objects = array(
 			'shallow_obj' => $shallow_object,
-			'string' => 'gamma',
-			'nested' => array(
+			'string'      => 'gamma',
+			'nested'      => array(
 				'level2' => array(
-					'deep_obj' => $deep_object,
-					'primitive' => 'unchanged'
-				)
-			)
+					'deep_obj'  => $deep_object,
+					'primitive' => 'unchanged',
+				),
+			),
 		);
 
 		$this->cache->set( $key, $array_with_objects );
 
 		$shallow_object->foo = 'modified_alpha';
-		$deep_object->value = 'deep_modified';
+		$deep_object->value  = 'deep_modified';
 
 		$cached_array = $this->cache->get( $key );
 
@@ -290,7 +290,7 @@ class Tests_Cache extends WP_UnitTestCase {
 		$this->assertSame( 'gamma', $cached_array['string'], 'String values should remain unchanged' );
 		$this->assertSame( 'unchanged', $cached_array['nested']['level2']['primitive'], 'Primitive values should remain unchanged' );
 
-		$cached_array['shallow_obj']->foo = 'modified_from_cache';
+		$cached_array['shallow_obj']->foo                    = 'modified_from_cache';
 		$cached_array['nested']['level2']['deep_obj']->value = 'modified_from_cache';
 
 		// Retreiving again should not affect the cached data
@@ -300,20 +300,20 @@ class Tests_Cache extends WP_UnitTestCase {
 	}
 
 	/**
-	 * 
+	 *
 	 * @ticket 30430
 	 */
 	public function test_primitive_arrays_unchanged() {
 		$key = __FUNCTION__;
-		
+
 		$primitive_array = array(
-			'string' => 'test',
-			'number' => 123,
+			'string'  => 'test',
+			'number'  => 123,
 			'boolean' => false,
-			'nested' => array(
+			'nested'  => array(
 				'nested_string' => 'nested_test',
-				'nested_number' => 456
-			)
+				'nested_number' => 456,
+			),
 		);
 
 		$this->cache->set( $key, $primitive_array );

--- a/tests/phpunit/tests/cache.php
+++ b/tests/phpunit/tests/cache.php
@@ -293,6 +293,7 @@ class Tests_Cache extends WP_UnitTestCase {
 		$cached_array['shallow_obj']->foo = 'modified_from_cache';
 		$cached_array['nested']['level2']['deep_obj']->value = 'modified_from_cache';
 
+		// Retreiving again should not affect the cached data
 		$cached_array_again = $this->cache->get( $key );
 		$this->assertSame( 'alpha', $cached_array_again['shallow_obj']->foo, 'Cached data should not be affected by modifications to retrieved objects' );
 		$this->assertSame( 'deep_original', $cached_array_again['nested']['level2']['deep_obj']->value, 'Deep cached data should not be affected by modifications to retrieved objects' );


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/30430

Objects stored in arrays within WP_Object_Cache were sharing references with the original data, causing unexpected mutations when either the original or cached data was modified.

This change adds deep copying functionality to properly clone objects nested within arrays at any level, ensuring cached data remains isolated from the original data structures.

Changes:
- Add deep_copy() method for recursive object cloning in arrays
- Update set() method to deep copy arrays containing objects  
- Update get() method to deep copy arrays when retrieving from cache
- Add unit tests covering shallow and deep nesting scenarios

Fixes reference sharing issue while maintaining performance for primitive arrays.

Follows the implementation of the patch - https://core.trac.wordpress.org/attachment/ticket/30430/wp-deep-copy-withclass2.diff
