### PR TITLE
fix: enhance load_textdomain method to support forced loading of text domain

### DIFF
--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -1505,10 +1505,11 @@ final class WP_Theme implements ArrayAccess {
 	 *
 	 * @since 3.4.0
 	 *
+	 * @param  bool $force Optional. Whether to force loading the textdomain even if it is already loaded. Default false.
 	 * @return bool True if the textdomain was successfully loaded or has already been loaded.
 	 *  False if no textdomain was specified in the file headers, or if the domain could not be loaded.
 	 */
-	public function load_textdomain() {
+	public function load_textdomain( $force = false ) {
 		if ( isset( $this->textdomain_loaded ) ) {
 			return $this->textdomain_loaded;
 		}
@@ -1519,7 +1520,7 @@ final class WP_Theme implements ArrayAccess {
 			return false;
 		}
 
-		if ( is_textdomain_loaded( $textdomain ) ) {
+		if ( ! $force && is_textdomain_loaded( $textdomain ) ) {
 			$this->textdomain_loaded = true;
 			return true;
 		}


### PR DESCRIPTION
## 🐞 Problem

When a plugin loads the same textdomain as a theme before the theme does, the theme’s translations may not load at all. This is because WordPress considers the textdomain already loaded and silently skips it — even if the .mo file is different. This leads to missing translations in themes.

Tracked in [Trac #63725](https://core.trac.wordpress.org/ticket/63725)

## ✅ Solution

This PR introduces a $force parameter to the WP_Theme::load_textdomain() method, allowing themes to explicitly reload their own textdomain — even if it was previously loaded by a plugin.

## 🔧 Changes

Enhancement: Added optional `$force` parameter to WP_Theme::load_textdomain() to enable reloading of already-loaded textdomains.

Behavioral Update: When `$force` is true, the method bypasses the is_textdomain_loaded() check and reloads the .mo file.

## 📌 Notes

This change provides theme authors a way to recover from textdomain conflicts caused by plugins loading the same domain early.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
