### PR TITLE
Add wp_schedule_bulk_events function for bulk event scheduling

### DIFF
--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -449,8 +449,7 @@ function wp_reschedule_event( $timestamp, $recurrence, $hook, $args = array(), $
  * @param bool   $wp_error   Optional. Whether to return a WP_Error on failure. Default false.
  * @return bool|WP_Error True if event successfully scheduled. False or WP_Error on failure.
  */
-function wp_schedule_bulk_events( int $timestamp, string $hook, array $args, bool $wp_error = false )
-{
+function wp_schedule_bulk_events( int $timestamp, string $hook, array $args, bool $wp_error = false ) {
 	// check if all arguments are arrays
 	$is_array_args = array_reduce( $args, fn($carry, $item) => $carry && is_array($item), true );
 
@@ -463,7 +462,7 @@ function wp_schedule_bulk_events( int $timestamp, string $hook, array $args, boo
 	$bulk_value = $orig_value = get_option( 'cron', array() );
 
 	// when updating the cron option, keep a copy of the original value (to skip update for now)
-	$tmp_update_option = function ($new_value, $old_value) use (&$bulk_value) {
+	$tmp_update_option = function ( $new_value, $old_value ) use (&$bulk_value) {
 		$bulk_value = $new_value;
 		return $old_value;
 	};
@@ -487,8 +486,8 @@ function wp_schedule_bulk_events( int $timestamp, string $hook, array $args, boo
 	remove_filter( 'pre_option_cron', $tmp_get_option, 10 );
 
 	// if the cron option was changed in the meantime, abort
-	if ( $orig_value !== get_option( 'cron', array() ) ) {
-		return $wp_error ? new \WP_Error( 'wp_schedule_bulk_events_failed', __( 'Failed to verify bulk schedule cron events, value has changed' , 'wordpress' ) ) : false;
+	if ( get_option( 'cron', array() ) !== $orig_value ) {
+		return $wp_error ? new \WP_Error( 'wp_schedule_bulk_events_failed', __( 'Failed to verify bulk schedule cron events, value has changed', 'wordpress' ) ) : false;
 	}
 
 	// update cron option

--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -459,7 +459,7 @@ function wp_schedule_bulk_events( int $timestamp, string $hook, array $args, boo
 	}
 
 	// get current cron events
-	$bulk_value = $orig_value = get_option( 'cron', array( ) );
+	$bulk_value = $orig_value = get_option( 'cron', array() );
 
 	// when updating the cron option, keep a copy of the original value (to skip update for now)
 	$tmp_update_option = function ( $new_value, $old_value ) use ( &$bulk_value ) {

--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -440,6 +440,66 @@ function wp_reschedule_event( $timestamp, $recurrence, $hook, $args = array(), $
 }
 
 /**
+ * Schedule a bulk of events.
+ *
+ * @param int    $timestamp  Unix timestamp (UTC) for when to next run the event.
+ * @param string $hook       Action hook to execute when the event is run.
+ * @param array  $args       An array of arrays containing arguments to pass to the
+ *                           hook's callback function. The array keys are ignored.
+ * @param bool   $wp_error   Optional. Whether to return a WP_Error on failure. Default false.
+ * @return bool|WP_Error True if event successfully scheduled. False or WP_Error on failure.
+ */
+function wp_schedule_bulk_events(int $timestamp, string $hook, array $args, bool $wp_error = false)
+{
+    // check if all arguments are arrays
+    $is_array_args = array_reduce( $args, fn($carry, $item) => $carry && is_array($item), true );
+
+    // if not, schedule a single event
+    if ( ! $is_array_args) {
+        return wp_schedule_single_event( $timestamp, $hook, $args, $wp_error );
+    }
+
+    // get current cron events
+    $bulk_value = $orig_value = get_option( 'cron', [] );
+
+    // when updating the cron option, keep a copy of the original value (to skip update for now)
+    $tmp_update_option = function ($new_value, $old_value) use (&$bulk_value) {
+        $bulk_value = $new_value;
+        return $old_value;
+    };
+
+    // when getting the cron option, return the modified value
+    $tmp_get_option = function () use (&$bulk_value) {
+        return $bulk_value;
+    };
+
+    // add filters from above
+    add_filter( 'pre_update_option_cron', $tmp_update_option, 10, 2 );
+    add_filter( 'pre_option_cron', $tmp_get_option, 10 );
+
+    // add cron events
+    foreach ( $args as $arg ) {
+        wp_schedule_single_event( $timestamp, $hook, $arg, $wp_error );
+    }
+
+    // remove filters
+    remove_filter( 'pre_update_option_cron', $tmp_update_option, 10, 2 );
+    remove_filter( 'pre_option_cron', $tmp_get_option, 10 );
+
+    // if the cron option was changed in the meantime, abort
+    if ($orig_value !== get_option( 'cron', [] )) {
+        return $wp_error ? new \WP_Error('wp_schedule_bulk_events_failed', __('Failed to verify bulk schedule cron events, value has changed', 'wordpress')) : false;
+    }
+
+    // update cron option
+    if ( ! update_option( 'cron', $bulk_value )) {
+        return $wp_error ? new \WP_Error('wp_schedule_bulk_events_failed', __('Failed to update bulk schedule cron events', 'wordpress')) : false;
+    }
+
+    return true;
+}
+
+/**
  * Unschedules a previously scheduled event.
  *
  * The `$timestamp` and `$hook` parameters are required so that the event can be

--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -451,7 +451,9 @@ function wp_reschedule_event( $timestamp, $recurrence, $hook, $args = array(), $
  */
 function wp_schedule_bulk_events( int $timestamp, string $hook, array $args, bool $wp_error = false ) {
 	// check if all arguments are arrays
-	$is_array_args = array_reduce( $args, fn( $carry, $item ) => $carry && is_array( $item ), true );
+	$is_array_args = array_reduce( $args, function ( $carry, $item ) {
+		return $carry && is_array( $item );
+	}, true );
 
 	// if not, schedule a single event
 	if ( ! $is_array_args ) {

--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -451,7 +451,7 @@ function wp_reschedule_event( $timestamp, $recurrence, $hook, $args = array(), $
  */
 function wp_schedule_bulk_events( int $timestamp, string $hook, array $args, bool $wp_error = false ) {
 	// check if all arguments are arrays
-	$is_array_args = array_reduce( 
+	$is_array_args = array_reduce(
 		$args,
 		function ( $carry, $item ) {
 			return $carry && is_array( $item );

--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -485,7 +485,9 @@ function wp_schedule_bulk_events( int $timestamp, string $hook, array $args, boo
 
 	// add cron events
 	foreach ( $args as $arg ) {
-		wp_schedule_single_event( $timestamp, $hook, $arg, $wp_error );
+		if ( wp_next_scheduled( $hook, $arg ) === false ) {
+			wp_schedule_single_event( $timestamp, $hook, $arg, $wp_error );
+		}
 	}
 
 	// remove filters

--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -459,7 +459,8 @@ function wp_schedule_bulk_events( int $timestamp, string $hook, array $args, boo
 	}
 
 	// get current cron events
-	$bulk_value = $orig_value = get_option( 'cron', array() );
+	$orig_value = get_option( 'cron', array() );
+	$bulk_value = $orig_value;
 
 	// when updating the cron option, keep a copy of the original value (to skip update for now)
 	$tmp_update_option = function ( $new_value, $old_value ) use ( &$bulk_value ) {

--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -451,7 +451,7 @@ function wp_reschedule_event( $timestamp, $recurrence, $hook, $args = array(), $
  */
 function wp_schedule_bulk_events( int $timestamp, string $hook, array $args, bool $wp_error = false ) {
 	// check if all arguments are arrays
-	$is_array_args = array_reduce( $args, fn($carry, $item) => $carry && is_array($item), true );
+	$is_array_args = array_reduce( $args, fn( $carry, $item ) => $carry && is_array( $item ), true );
 
 	// if not, schedule a single event
 	if ( ! $is_array_args ) {
@@ -459,16 +459,16 @@ function wp_schedule_bulk_events( int $timestamp, string $hook, array $args, boo
 	}
 
 	// get current cron events
-	$bulk_value = $orig_value = get_option( 'cron', array() );
+	$bulk_value = $orig_value = get_option( 'cron', array( ) );
 
 	// when updating the cron option, keep a copy of the original value (to skip update for now)
-	$tmp_update_option = function ( $new_value, $old_value ) use (&$bulk_value) {
+	$tmp_update_option = function ( $new_value, $old_value ) use ( &$bulk_value ) {
 		$bulk_value = $new_value;
 		return $old_value;
 	};
 
 	// when getting the cron option, return the modified value
-	$tmp_get_option = function () use (&$bulk_value) {
+	$tmp_get_option = function () use ( &$bulk_value ) {
 		return $bulk_value;
 	};
 

--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -449,54 +449,54 @@ function wp_reschedule_event( $timestamp, $recurrence, $hook, $args = array(), $
  * @param bool   $wp_error   Optional. Whether to return a WP_Error on failure. Default false.
  * @return bool|WP_Error True if event successfully scheduled. False or WP_Error on failure.
  */
-function wp_schedule_bulk_events(int $timestamp, string $hook, array $args, bool $wp_error = false)
+function wp_schedule_bulk_events( int $timestamp, string $hook, array $args, bool $wp_error = false )
 {
-    // check if all arguments are arrays
-    $is_array_args = array_reduce( $args, fn($carry, $item) => $carry && is_array($item), true );
+	// check if all arguments are arrays
+	$is_array_args = array_reduce( $args, fn($carry, $item) => $carry && is_array($item), true );
 
-    // if not, schedule a single event
-    if ( ! $is_array_args) {
-        return wp_schedule_single_event( $timestamp, $hook, $args, $wp_error );
-    }
+	// if not, schedule a single event
+	if ( ! $is_array_args ) {
+		return wp_schedule_single_event( $timestamp, $hook, $args, $wp_error );
+	}
 
-    // get current cron events
-    $bulk_value = $orig_value = get_option( 'cron', [] );
+	// get current cron events
+	$bulk_value = $orig_value = get_option( 'cron', array() );
 
-    // when updating the cron option, keep a copy of the original value (to skip update for now)
-    $tmp_update_option = function ($new_value, $old_value) use (&$bulk_value) {
-        $bulk_value = $new_value;
-        return $old_value;
-    };
+	// when updating the cron option, keep a copy of the original value (to skip update for now)
+	$tmp_update_option = function ($new_value, $old_value) use (&$bulk_value) {
+		$bulk_value = $new_value;
+		return $old_value;
+	};
 
-    // when getting the cron option, return the modified value
-    $tmp_get_option = function () use (&$bulk_value) {
-        return $bulk_value;
-    };
+	// when getting the cron option, return the modified value
+	$tmp_get_option = function () use (&$bulk_value) {
+		return $bulk_value;
+	};
 
-    // add filters from above
-    add_filter( 'pre_update_option_cron', $tmp_update_option, 10, 2 );
-    add_filter( 'pre_option_cron', $tmp_get_option, 10 );
+	// add filters from above
+	add_filter( 'pre_update_option_cron', $tmp_update_option, 10, 2 );
+	add_filter( 'pre_option_cron', $tmp_get_option, 10 );
 
-    // add cron events
-    foreach ( $args as $arg ) {
-        wp_schedule_single_event( $timestamp, $hook, $arg, $wp_error );
-    }
+	// add cron events
+	foreach ( $args as $arg ) {
+		wp_schedule_single_event( $timestamp, $hook, $arg, $wp_error );
+	}
 
-    // remove filters
-    remove_filter( 'pre_update_option_cron', $tmp_update_option, 10, 2 );
-    remove_filter( 'pre_option_cron', $tmp_get_option, 10 );
+	// remove filters
+	remove_filter( 'pre_update_option_cron', $tmp_update_option, 10, 2 );
+	remove_filter( 'pre_option_cron', $tmp_get_option, 10 );
 
-    // if the cron option was changed in the meantime, abort
-    if ($orig_value !== get_option( 'cron', [] )) {
-        return $wp_error ? new \WP_Error('wp_schedule_bulk_events_failed', __('Failed to verify bulk schedule cron events, value has changed', 'wordpress')) : false;
-    }
+	// if the cron option was changed in the meantime, abort
+	if ( $orig_value !== get_option( 'cron', array() ) ) {
+		return $wp_error ? new \WP_Error( 'wp_schedule_bulk_events_failed', __( 'Failed to verify bulk schedule cron events, value has changed' , 'wordpress' ) ) : false;
+	}
 
-    // update cron option
-    if ( ! update_option( 'cron', $bulk_value )) {
-        return $wp_error ? new \WP_Error('wp_schedule_bulk_events_failed', __('Failed to update bulk schedule cron events', 'wordpress')) : false;
-    }
+	// update cron option
+	if ( ! update_option( 'cron', $bulk_value ) ) {
+		return $wp_error ? new \WP_Error( 'wp_schedule_bulk_events_failed', __( 'Failed to update bulk schedule cron events', 'wordpress' ) ) : false;
+	}
 
-    return true;
+	return true;
 }
 
 /**

--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -451,9 +451,13 @@ function wp_reschedule_event( $timestamp, $recurrence, $hook, $args = array(), $
  */
 function wp_schedule_bulk_events( int $timestamp, string $hook, array $args, bool $wp_error = false ) {
 	// check if all arguments are arrays
-	$is_array_args = array_reduce( $args, function ( $carry, $item ) {
-		return $carry && is_array( $item );
-	}, true );
+	$is_array_args = array_reduce( 
+		$args,
+		function ( $carry, $item ) {
+			return $carry && is_array( $item );
+		},
+		true
+	);
 
 	// if not, schedule a single event
 	if ( ! $is_array_args ) {

--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -494,12 +494,12 @@ function wp_schedule_bulk_events( int $timestamp, string $hook, array $args, boo
 
 	// if the cron option was changed in the meantime, abort
 	if ( get_option( 'cron', array() ) !== $orig_value ) {
-		return $wp_error ? new \WP_Error( 'wp_schedule_bulk_events_failed', __( 'Failed to verify bulk schedule cron events, value has changed', 'wordpress' ) ) : false;
+		return $wp_error ? new \WP_Error( 'wp_schedule_bulk_events_verify_failed', __( 'Failed to verify bulk schedule cron events, value has changed', 'wordpress' ) ) : false;
 	}
 
 	// update cron option
 	if ( ! update_option( 'cron', $bulk_value ) ) {
-		return $wp_error ? new \WP_Error( 'wp_schedule_bulk_events_failed', __( 'Failed to update bulk schedule cron events', 'wordpress' ) ) : false;
+		return $wp_error ? new \WP_Error( 'wp_schedule_bulk_events_update_failed', __( 'Failed to update bulk schedule cron events', 'wordpress' ) ) : false;
 	}
 
 	return true;


### PR DESCRIPTION
Introduces wp_schedule_bulk_events to allow scheduling multiple cron events at once. This function optimizes bulk scheduling by batching updates to the cron option and includes error handling for concurrent modifications.

Trac ticket: [https://core.trac.wordpress.org/ticket/63938](https://core.trac.wordpress.org/ticket/63938)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
