### PR TITLE
Fast follow: Actually call upgrade_690, avoid attempt to add index twice.

### DIFF
--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -880,11 +880,14 @@ function upgrade_all() {
 
 	if ( $wp_current_db_version < 58975 ) {
 		upgrade_670();
-		upgrade_690();
 	}
 
 	if ( $wp_current_db_version < 60421 ) {
 		upgrade_682();
+	}
+
+	if ( $wp_current_db_version < 60717 ) {
+		upgrade_690();
 	}
 
 	maybe_disable_link_manager();

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2496,15 +2496,17 @@ function upgrade_682() {
 function upgrade_690() {
 	global $wp_current_db_version;
 
-	// Switch Hello Dolly from file to directory format. See #53323
-	$active_plugins = get_option( 'active_plugins' );
-	$old_plugin     = 'hello.php';
-	$new_plugin     = 'hello-dolly/hello.php';
-	$key            = array_search( $old_plugin, $active_plugins, true );
+	if ( $wp_current_db_version < 60717 ) {
+		// Switch Hello Dolly from file to directory format. See #53323
+		$active_plugins = get_option( 'active_plugins' );
+		$old_plugin     = 'hello.php';
+		$new_plugin     = 'hello-dolly/hello.php';
+		$key            = array_search( $old_plugin, $active_plugins, true );
 
-	if ( $key ) {
-		$active_plugins[ $key ] = $new_plugin;
-		update_option( 'active_plugins', $active_plugins );
+		if ( $key ) {
+			$active_plugins[ $key ] = $new_plugin;
+			update_option( 'active_plugins', $active_plugins );
+		}
 	}
 }
 

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2491,11 +2491,10 @@ function upgrade_682() {
  * @ignore
  * @since 6.9.0
  *
- * @global int  $wp_current_db_version The old (current) database version.
- * @global wpdb $wpdb                  WordPress database abstraction object.
+ * @global int $wp_current_db_version The old (current) database version.
  */
 function upgrade_690() {
-	global $wp_current_db_version, $wpdb;
+	global $wp_current_db_version;
 
 	// Switch Hello Dolly from file to directory format. See #53323
 	$active_plugins = get_option( 'active_plugins' );
@@ -2506,10 +2505,6 @@ function upgrade_690() {
 	if ( $key ) {
 		$active_plugins[ $key ] = $new_plugin;
 		update_option( 'active_plugins', $active_plugins );
-	}
-
-	if ( $wp_current_db_version < 60717 ) {
-		$wpdb->query( "ALTER TABLE $wpdb->posts ADD INDEX type_status_author (post_type,post_status,post_author)" );
 	}
 }
 

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2507,6 +2507,9 @@ function upgrade_690() {
 			$active_plugins[ $key ] = $new_plugin;
 			update_option( 'active_plugins', $active_plugins );
 		}
+
+		global $wpdb;
+		$wpdb->query( "ALTER TABLE $wpdb->posts ADD INDEX type_status_author (post_type,post_status,post_author)" );
 	}
 }
 

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2507,9 +2507,6 @@ function upgrade_690() {
 			$active_plugins[ $key ] = $new_plugin;
 			update_option( 'active_plugins', $active_plugins );
 		}
-
-		global $wpdb;
-		$wpdb->query( "ALTER TABLE $wpdb->posts ADD INDEX type_status_author (post_type,post_status,post_author)" );
 	}
 }
 


### PR DESCRIPTION
* Moves the call to `upgrade_690()` so it actually gets called
* Wraps Hello Dolly upgrade code in a version check per standard practice
* Removes the `$wpdb->query()` call to avoid attempting to create the new index twice, once in the upgrade and once in `dbDelta()`.

The final item fixes a warning during upgrade: `WordPress database error Duplicate key name 'type_status_author' for query ALTER TABLE wp_posts ADD INDEX type_status_author (post_type,post_status,post_author) made by wp_upgrade, upgrade_all, upgrade_690`

Combined fast follows for two tickets:

* https://core.trac.wordpress.org/ticket/53323
* https://core.trac.wordpress.org/ticket/50161

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
