### PR TITLE
Respect plugin's `Domain Path` when looking for translations for scripts

### DIFF
--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1267,7 +1267,13 @@ function load_script_textdomain( $handle, $domain = 'default', $path = '' ) {
 	// Check if a custom path was registered for the domain.
 	$reg_path = $wp_textdomain_registry->get( $domain, $locale );
 	if ( $reg_path ) {
-		$reg_path     = untrailingslashit( $reg_path );
+		$reg_path = untrailingslashit( $reg_path );
+
+		$translations = load_script_translations( $reg_path . '/' . $handle_filename, $handle, $domain );
+		if ( $translations ) {
+			return $translations;
+		}
+
 		$translations = load_script_translations( $reg_path . '/' . $md5_filename, $handle, $domain );
 		if ( $translations ) {
 			return $translations;

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1134,6 +1134,8 @@ function load_child_theme_textdomain( $domain, $path = false ) {
  *
  * @see WP_Scripts::set_translations()
  *
+ * @global WP_Textdomain_Registry $wp_textdomain_registry WordPress Textdomain Registry.
+ *
  * @param string $handle Name of the script to register a translation domain to.
  * @param string $domain Optional. Text domain. Default 'default'.
  * @param string $path   Optional. The full file path to the directory containing translation files.

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1152,16 +1152,17 @@ function load_script_textdomain( $handle, $domain = 'default', $path = '' ) {
 		return false;
 	}
 
-	$path   = untrailingslashit( $path );
 	$locale = determine_locale();
-
-	// If a path was given and the handle file exists simply return it.
-	$file_base       = 'default' === $domain ? $locale : $domain . '-' . $locale;
-	$handle_filename = $file_base . '-' . $handle . '.json';
 
 	if ( ! $path ) {
 		$path = $wp_textdomain_registry->get( $domain, $locale );
 	}
+
+	$path = untrailingslashit( $path );
+
+	// If a path was given and the handle file exists simply return it.
+	$file_base       = 'default' === $domain ? $locale : $domain . '-' . $locale;
+	$handle_filename = $file_base . '-' . $handle . '.json';
 
 	if ( $path ) {
 		$translations = load_script_translations( $path . '/' . $handle_filename, $handle, $domain );

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1157,6 +1157,10 @@ function load_script_textdomain( $handle, $domain = 'default', $path = '' ) {
 	$file_base       = 'default' === $domain ? $locale : $domain . '-' . $locale;
 	$handle_filename = $file_base . '-' . $handle . '.json';
 
+	if ( ! $path ) {
+		$path = $wp_textdomain_registry->get( $domain, $locale );
+	}
+
 	if ( $path ) {
 		$translations = load_script_translations( $path . '/' . $handle_filename, $handle, $domain );
 
@@ -1259,22 +1263,6 @@ function load_script_textdomain( $handle, $domain = 'default', $path = '' ) {
 	if ( $path ) {
 		$translations = load_script_translations( $path . '/' . $md5_filename, $handle, $domain );
 
-		if ( $translations ) {
-			return $translations;
-		}
-	}
-
-	// Check if a custom path was registered for the domain.
-	$reg_path = $wp_textdomain_registry->get( $domain, $locale );
-	if ( $reg_path ) {
-		$reg_path = untrailingslashit( $reg_path );
-
-		$translations = load_script_translations( $reg_path . '/' . $handle_filename, $handle, $domain );
-		if ( $translations ) {
-			return $translations;
-		}
-
-		$translations = load_script_translations( $reg_path . '/' . $md5_filename, $handle, $domain );
 		if ( $translations ) {
 			return $translations;
 		}

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1141,6 +1141,9 @@ function load_child_theme_textdomain( $domain, $path = false ) {
  *                      false if the script textdomain could not be loaded.
  */
 function load_script_textdomain( $handle, $domain = 'default', $path = '' ) {
+	/** @var WP_Textdomain_Registry $wp_textdomain_registry */
+	global $wp_textdomain_registry;
+
 	$wp_scripts = wp_scripts();
 
 	if ( ! isset( $wp_scripts->registered[ $handle ] ) ) {
@@ -1256,6 +1259,16 @@ function load_script_textdomain( $handle, $domain = 'default', $path = '' ) {
 	if ( $path ) {
 		$translations = load_script_translations( $path . '/' . $md5_filename, $handle, $domain );
 
+		if ( $translations ) {
+			return $translations;
+		}
+	}
+
+	// Check if a custom path was registered for the domain.
+	$reg_path = $wp_textdomain_registry->get( $domain, $locale );
+	if ( $reg_path ) {
+		$reg_path     = untrailingslashit( $reg_path );
+		$translations = load_script_translations( $reg_path . '/' . $md5_filename, $handle, $domain );
 		if ( $translations ) {
 			return $translations;
 		}

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -2607,6 +2607,36 @@ HTML;
 	}
 
 	/**
+	 * @ticket 63944
+	 */
+	public function test_wp_set_script_translations_respects_domainpath_for_plugin() {
+		global $wp_textdomain_registry;
+
+		wp_register_script( 'wp-i18n', '/wp-includes/js/dist/wp-i18n.js', array(), null );
+		wp_enqueue_script( 'plugin-local', '/wp-content/plugins/my-plugin/js/script.js', array(), null );
+		$wp_textdomain_registry->set_custom_path( 'internationalized-plugin', DIR_TESTDATA . '/languages/plugins' );
+		wp_set_script_translations( 'plugin-local', 'internationalized-plugin' );
+
+		$expected  = "<script type='text/javascript' src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
+		$expected .= str_replace(
+			array(
+				'__DOMAIN__',
+				'__HANDLE__',
+				'__JSON_TRANSLATIONS__',
+			),
+			array(
+				'internationalized-plugin',
+				'plugin-local',
+				file_get_contents( DIR_TESTDATA . '/languages/plugins/internationalized-plugin-en_US-2f86cb96a0233e7cb3b6f03ad573be0b.json' ),
+			),
+			$this->wp_scripts_print_translations_output
+		);
+		$expected .= "<script type='text/javascript' src='/wp-content/plugins/my-plugin/js/script.js' id='plugin-local-js'></script>\n";
+
+		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
+	}
+
+	/**
 	 * @ticket 45103
 	 */
 	public function test_wp_set_script_translations_for_theme() {

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -2609,13 +2609,15 @@ HTML;
 	/**
 	 * @ticket 63944
 	 */
-	public function test_wp_set_script_translations_respects_domainpath_for_plugin() {
+	public function test_wp_set_script_translations_uses_registered_domainpath_for_plugin() {
 		global $wp_textdomain_registry;
 
 		wp_register_script( 'wp-i18n', '/wp-includes/js/dist/wp-i18n.js', array(), null );
-		wp_enqueue_script( 'plugin-local', '/wp-content/plugins/my-plugin/js/script.js', array(), null );
+		wp_enqueue_script( 'domain-path-plugin', '/wp-content/plugins/my-plugin/js/script.js', array(), null );
+
+		// Simulate a plugin declaring DomainPath: /languages by registering a custom path.
 		$wp_textdomain_registry->set_custom_path( 'internationalized-plugin', DIR_TESTDATA . '/languages/plugins' );
-		wp_set_script_translations( 'plugin-local', 'internationalized-plugin' );
+		wp_set_script_translations( 'domain-path-plugin', 'internationalized-plugin' );
 
 		$expected  = "<script type='text/javascript' src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
 		$expected .= str_replace(
@@ -2626,12 +2628,47 @@ HTML;
 			),
 			array(
 				'internationalized-plugin',
-				'plugin-local',
+				'domain-path-plugin',
 				file_get_contents( DIR_TESTDATA . '/languages/plugins/internationalized-plugin-en_US-2f86cb96a0233e7cb3b6f03ad573be0b.json' ),
 			),
 			$this->wp_scripts_print_translations_output
 		);
-		$expected .= "<script type='text/javascript' src='/wp-content/plugins/my-plugin/js/script.js' id='plugin-local-js'></script>\n";
+		$expected .= "<script type='text/javascript' src='/wp-content/plugins/my-plugin/js/script.js' id='domain-path-plugin-js'></script>\n";
+
+		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
+	}
+
+	/**
+	 * @ticket 63944
+	 *
+	 * Ensure human-readable script translation filenames are found when a
+	 * textdomain has a custom DomainPath registered and no explicit $path is passed.
+	 */
+	public function test_wp_set_script_translations_prefers_human_readable_filename_in_registered_domainpath() {
+		global $wp_textdomain_registry;
+
+		wp_register_script( 'wp-i18n', '/wp-includes/js/dist/wp-i18n.js', array(), null );
+		wp_enqueue_script( 'script-handle', '/wp-admin/js/script.js', array(), null );
+
+		// Register the admin textdomain path and use the admin translations file for this script-handle test.
+		$wp_textdomain_registry->set_custom_path( 'admin', DIR_TESTDATA . '/languages' );
+		wp_set_script_translations( 'script-handle', 'admin' );
+
+		$expected  = "<script type='text/javascript' src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
+		$expected .= str_replace(
+			array(
+				'__DOMAIN__',
+				'__HANDLE__',
+				'__JSON_TRANSLATIONS__',
+			),
+			array(
+				'admin',
+				'script-handle',
+				file_get_contents( DIR_TESTDATA . '/languages/admin-en_US-script-handle.json' ),
+			),
+			$this->wp_scripts_print_translations_output
+		);
+		$expected .= "<script type='text/javascript' src='/wp-admin/js/script.js' id='script-handle-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
## Summary
- `load_script_textdomain()` did not consult a textdomain's registered `DomainPath` (the custom path set by `load_plugin_textdomain()` / the plugin header). As a result, JS translations required an explicit `$path` to `wp_set_script_translations()` while PHP translations using `__()` honored `DomainPath`.

## Changes
- `load_script_textdomain()` now checks the registry path (if present) and tries loading translations from that path (human-readable filename first, then md5-hashed filename) before falling back to `WP_LANG_DIR` lookups.
- Added unit tests for both plugin domain path check
Trac ticket: https://core.trac.wordpress.org/ticket/63944

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
