### PR TITLE
Make cache in wp_count_posts & wp_count_attachments persistent

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3891,7 +3891,7 @@ function wp_delete_post( $post_id = 0, $force_delete = false ) {
 
 	clean_post_cache( $post );
 
-	wp_cache_set_last_changed( $post->post_type . '_count' );( $post->post_type );
+	wp_cache_set_last_changed( $post->post_type . '_count' );;
 
 	if ( is_post_type_hierarchical( $post->post_type ) && $children ) {
 		foreach ( $children as $child ) {
@@ -6725,7 +6725,7 @@ function wp_delete_attachment( $post_id, $force_delete = false ) {
 	wp_delete_attachment_files( $post_id, $meta, $backup_sizes, $file );
 
 	clean_post_cache( $post );
-	wp_cache_set_last_changed( $post->post_type . '_count' );( $post->post_type );
+	wp_cache_set_last_changed( $post->post_type . '_count' );;
 
 	return $post;
 }
@@ -7913,7 +7913,7 @@ function _transition_post_status( $new_status, $old_status, $post ) {
 	}
 
 	if ( $new_status !== $old_status ) {
-		wp_cache_set_last_changed( $post->post_type . '_count' );( $post->post_type );
+		wp_cache_set_last_changed( $post->post_type . '_count' );;
 	}
 
 	// Always clears the hook in case the post status bounced from future to draft.

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3385,9 +3385,10 @@ function wp_count_posts( $type = 'post', $perm = '' ) {
 		return new stdClass();
 	}
 
-	$cache_key = _count_posts_cache_key( $type, $perm );
+	$cache_key    = _count_posts_cache_key( $type, $perm );
+	$last_changed = wp_cache_get_last_changed( 'posts' );
 
-	$counts = wp_cache_get( $cache_key, 'counts' );
+	$counts = wp_cache_get_salted( $cache_key, 'post-queries', $last_changed );
 	if ( false !== $counts ) {
 		// We may have cached this before every status was registered.
 		foreach ( get_post_stati() as $status ) {
@@ -3422,7 +3423,7 @@ function wp_count_posts( $type = 'post', $perm = '' ) {
 	}
 
 	$counts = (object) $counts;
-	wp_cache_set( $cache_key, $counts, 'counts' );
+	wp_cache_set_salted( $cache_key, $counts, 'post-queries', $last_changed );
 
 	/**
 	 * Filters the post counts by status for the current post type.
@@ -3457,12 +3458,13 @@ function wp_count_posts( $type = 'post', $perm = '' ) {
 function wp_count_attachments( $mime_type = '' ) {
 	global $wpdb;
 
-	$cache_key = sprintf(
+	$cache_key    = sprintf(
 		'attachments%s',
 		! empty( $mime_type ) ? ':' . str_replace( '/', '_', implode( '-', (array) $mime_type ) ) : ''
 	);
+	$last_changed = wp_cache_get_last_changed( 'posts' );
 
-	$counts = wp_cache_get( $cache_key, 'counts' );
+	$counts = wp_cache_get_salted( $cache_key, 'post-queries', $last_changed );
 
 	if ( false === $counts ) {
 		$and   = wp_post_mime_type_where( $mime_type );
@@ -3474,7 +3476,7 @@ function wp_count_attachments( $mime_type = '' ) {
 		}
 		$counts['trash'] = $wpdb->get_var( "SELECT COUNT( * ) FROM $wpdb->posts WHERE post_type = 'attachment' AND post_status = 'trash' $and" );
 
-		wp_cache_set( $cache_key, (object) $counts, 'counts' );
+		wp_cache_set_salted( $cache_key, (object) $counts, 'post-queries', $last_changed );
 	}
 
 	/**
@@ -7908,8 +7910,8 @@ function _transition_post_status( $new_status, $old_status, $post ) {
 	}
 
 	if ( $new_status !== $old_status ) {
-		wp_cache_delete( _count_posts_cache_key( $post->post_type ), 'counts' );
-		wp_cache_delete( _count_posts_cache_key( $post->post_type, 'readable' ), 'counts' );
+		wp_cache_delete( _count_posts_cache_key( $post->post_type ), 'post-queries' );
+		wp_cache_delete( _count_posts_cache_key( $post->post_type, 'readable' ), 'post-queries' );
 	}
 
 	// Always clears the hook in case the post status bounced from future to draft.

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3891,7 +3891,7 @@ function wp_delete_post( $post_id = 0, $force_delete = false ) {
 
 	clean_post_cache( $post );
 
-	wp_cache_set_post_count_last_changed( $post->post_type );
+	wp_cache_set_last_changed( $post->post_type . '_count' );( $post->post_type );
 
 	if ( is_post_type_hierarchical( $post->post_type ) && $children ) {
 		foreach ( $children as $child ) {
@@ -6725,7 +6725,7 @@ function wp_delete_attachment( $post_id, $force_delete = false ) {
 	wp_delete_attachment_files( $post_id, $meta, $backup_sizes, $file );
 
 	clean_post_cache( $post );
-	wp_cache_set_post_count_last_changed( $post->post_type );
+	wp_cache_set_last_changed( $post->post_type . '_count' );( $post->post_type );
 
 	return $post;
 }
@@ -7913,7 +7913,7 @@ function _transition_post_status( $new_status, $old_status, $post ) {
 	}
 
 	if ( $new_status !== $old_status ) {
-		wp_cache_set_post_count_last_changed( $post->post_type );
+		wp_cache_set_last_changed( $post->post_type . '_count' );( $post->post_type );
 	}
 
 	// Always clears the hook in case the post status bounced from future to draft.
@@ -8354,15 +8354,6 @@ function wp_add_trashed_suffix_to_post_name_for_post( $post ) {
 	$wpdb->update( $wpdb->posts, array( 'post_name' => $post_name ), array( 'ID' => $post->ID ) );
 	clean_post_cache( $post->ID );
 	return $post_name;
-}
-
-/**
- * Sets the last changed time for the 'posts' cache group.
- *
- * @since 6.9.0
- */
-function wp_cache_set_post_count_last_changed( $post_type ) {
-	wp_cache_set_last_changed( $post_type . '_count' );
 }
 
 /**

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3891,7 +3891,7 @@ function wp_delete_post( $post_id = 0, $force_delete = false ) {
 
 	clean_post_cache( $post );
 
-	wp_cache_set_last_changed( $post->post_type . '_count' );;
+	wp_cache_set_last_changed( $post->post_type . '_count' );
 
 	if ( is_post_type_hierarchical( $post->post_type ) && $children ) {
 		foreach ( $children as $child ) {
@@ -6725,7 +6725,7 @@ function wp_delete_attachment( $post_id, $force_delete = false ) {
 	wp_delete_attachment_files( $post_id, $meta, $backup_sizes, $file );
 
 	clean_post_cache( $post );
-	wp_cache_set_last_changed( $post->post_type . '_count' );;
+	wp_cache_set_last_changed( $post->post_type . '_count' );
 
 	return $post;
 }
@@ -7913,7 +7913,7 @@ function _transition_post_status( $new_status, $old_status, $post ) {
 	}
 
 	if ( $new_status !== $old_status ) {
-		wp_cache_set_last_changed( $post->post_type . '_count' );;
+		wp_cache_set_last_changed( $post->post_type . '_count' );
 	}
 
 	// Always clears the hook in case the post status bounced from future to draft.

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -3386,7 +3386,7 @@ function wp_count_posts( $type = 'post', $perm = '' ) {
 	}
 
 	$cache_key    = _count_posts_cache_key( $type, $perm );
-	$last_changed = wp_cache_get_last_changed( 'posts' );
+	$last_changed = wp_cache_get_last_changed( $type . '_count' );
 
 	$counts = wp_cache_get_salted( $cache_key, 'post-queries', $last_changed );
 	if ( false !== $counts ) {
@@ -3462,7 +3462,7 @@ function wp_count_attachments( $mime_type = '' ) {
 		'attachments%s',
 		! empty( $mime_type ) ? ':' . str_replace( '/', '_', implode( '-', (array) $mime_type ) ) : ''
 	);
-	$last_changed = wp_cache_get_last_changed( 'posts' );
+	$last_changed = wp_cache_get_last_changed( 'attachment_count' );
 
 	$counts = wp_cache_get_salted( $cache_key, 'post-queries', $last_changed );
 
@@ -3890,6 +3890,8 @@ function wp_delete_post( $post_id = 0, $force_delete = false ) {
 	do_action( 'deleted_post', $post_id, $post );
 
 	clean_post_cache( $post );
+
+	wp_cache_set_post_count_last_changed( $post->post_type );
 
 	if ( is_post_type_hierarchical( $post->post_type ) && $children ) {
 		foreach ( $children as $child ) {
@@ -6723,6 +6725,7 @@ function wp_delete_attachment( $post_id, $force_delete = false ) {
 	wp_delete_attachment_files( $post_id, $meta, $backup_sizes, $file );
 
 	clean_post_cache( $post );
+	wp_cache_set_post_count_last_changed( $post->post_type );
 
 	return $post;
 }
@@ -7910,8 +7913,7 @@ function _transition_post_status( $new_status, $old_status, $post ) {
 	}
 
 	if ( $new_status !== $old_status ) {
-		wp_cache_delete( _count_posts_cache_key( $post->post_type ), 'post-queries' );
-		wp_cache_delete( _count_posts_cache_key( $post->post_type, 'readable' ), 'post-queries' );
+		wp_cache_set_post_count_last_changed( $post->post_type );
 	}
 
 	// Always clears the hook in case the post status bounced from future to draft.
@@ -8352,6 +8354,15 @@ function wp_add_trashed_suffix_to_post_name_for_post( $post ) {
 	$wpdb->update( $wpdb->posts, array( 'post_name' => $post_name ), array( 'ID' => $post->ID ) );
 	clean_post_cache( $post->ID );
 	return $post_name;
+}
+
+/**
+ * Sets the last changed time for the 'posts' cache group.
+ *
+ * @since 6.9.0
+ */
+function wp_cache_set_post_count_last_changed( $post_type ) {
+	wp_cache_set_last_changed( $post_type . '_count' );
 }
 
 /**

--- a/tests/phpunit/tests/post/wpCountAttachments.php
+++ b/tests/phpunit/tests/post/wpCountAttachments.php
@@ -26,7 +26,7 @@ class Tests_Post_wpCountAttachments extends WP_UnitTestCase {
 			)
 		);
 		$expected     = wp_count_attachments( $mime_type );
-		$last_changed = wp_cache_get_last_changed( 'posts' );
+		$last_changed = wp_cache_get_last_changed( 'attachment_count' );
 
 		$actual = wp_cache_get_salted( $cache_key, 'post-queries', $last_changed );
 

--- a/tests/phpunit/tests/post/wpCountAttachments.php
+++ b/tests/phpunit/tests/post/wpCountAttachments.php
@@ -25,8 +25,10 @@ class Tests_Post_wpCountAttachments extends WP_UnitTestCase {
 				'post_mime_type' => $mime_type,
 			)
 		);
-		$expected = wp_count_attachments( $mime_type );
-		$actual   = wp_cache_get( $cache_key, 'counts' );
+		$expected     = wp_count_attachments( $mime_type );
+		$last_changed = wp_cache_get_last_changed( 'posts' );
+
+		$actual = wp_cache_get_salted( $cache_key, 'post-queries', $last_changed );
 
 		$this->assertEquals( $expected, $actual );
 	}


### PR DESCRIPTION
Make cache in wp_count_posts & wp_count_attachments persistent, by changing cache groups to `post-queries` and use the new `wp_cache_get_salted` and `wp_cache_set_salted` functions for cache invalidation. 

Trac ticket: https://core.trac.wordpress.org/ticket/63945
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
