### PR TITLE
Administration: Sanitize category and tag base to prevent URL encoding issues in permalinks

### DIFF
--- a/src/wp-admin/options-permalink.php
+++ b/src/wp-admin/options-permalink.php
@@ -126,21 +126,15 @@ if ( isset( $_POST['permalink_structure'] ) || isset( $_POST['category_base'] ) 
 	}
 
 	if ( isset( $_POST['category_base'] ) ) {
-		$category_base = $_POST['category_base'];
-
-		if ( ! empty( $category_base ) ) {
-			$category_base = $blog_prefix . preg_replace( '#/+#', '/', '/' . str_replace( '#', '', $category_base ) );
-		}
+		$category_base = ltrim( $_POST['category_base'], '/' );
+		$category_base = empty( $category_base ) ? '' : $blog_prefix . '/' . implode( '/', array_map( 'sanitize_title_with_dashes', preg_split( '|/+|', $category_base ) ) );
 
 		$wp_rewrite->set_category_base( $category_base );
 	}
 
 	if ( isset( $_POST['tag_base'] ) ) {
-		$tag_base = $_POST['tag_base'];
-
-		if ( ! empty( $tag_base ) ) {
-			$tag_base = $blog_prefix . preg_replace( '#/+#', '/', '/' . str_replace( '#', '', $tag_base ) );
-		}
+		$tag_base = ltrim( $_POST['tag_base'], '/' );
+		$tag_base = empty( $tag_base ) ? '' : $blog_prefix . '/' . implode( '/', array_map( 'sanitize_title_with_dashes', preg_split( '|/+|', $tag_base ) ) );
 
 		$wp_rewrite->set_tag_base( $tag_base );
 	}

--- a/tests/phpunit/tests/admin/optionsPermalink.php
+++ b/tests/phpunit/tests/admin/optionsPermalink.php
@@ -7,6 +7,23 @@
  * @group rewrite
  */
 class Tests_Admin_OptionsPermalink extends WP_UnitTestCase {
+	public function set_up() {
+		parent::set_up();
+
+		$this->set_permalink_structure( '/%postname%/' );
+		create_initial_taxonomies();
+	}
+
+	public function tear_down() {
+		global $wp_rewrite;
+
+		$wp_rewrite->set_category_base( '' );
+		$wp_rewrite->set_tag_base( '' );
+		$wp_rewrite->flush_rules();
+
+		parent::tear_down();
+	}
+
 	/**
 	 * Data provider for base sanitization tests.
 	 */

--- a/tests/phpunit/tests/admin/optionsPermalink.php
+++ b/tests/phpunit/tests/admin/optionsPermalink.php
@@ -27,7 +27,10 @@ class Tests_Admin_OptionsPermalink extends WP_UnitTestCase {
 	 * @ticket 16839
 	 * @dataProvider data_base_sanitization
 	 */
-	public function test_base_sanitization() {
+	public function test_base_sanitization( $input, $expected ) {
+		$base = ltrim( $input, '/' );
+		$result = empty( $base ) ? '' : '/' . implode( '/', array_map( 'sanitize_title_with_dashes', preg_split( '|/+|', $base ) ) );
 		
+		$this->assertSame( $expected, $result );
 	}
 }

--- a/tests/phpunit/tests/admin/optionsPermalink.php
+++ b/tests/phpunit/tests/admin/optionsPermalink.php
@@ -7,4 +7,17 @@
  * @group rewrite
  */
 class Tests_Admin_OptionsPermalink extends WP_UnitTestCase {
+	/**
+	 * Data provider for base sanitization tests.
+	 */
+	public function data_base_sanitization() {
+		return [
+			[ 'Foo Bar', '/foo-bar' ],
+			[ 'Foo & Bar!', '/foo-bar' ],
+			[ 'Foo Bar/Baz Qux', '/foo-bar/baz-qux' ],
+			[ '', '' ],
+			[ '/Foo Bar', '/foo-bar' ],
+			[ 'Multiple/Slashes', '/multiple/slashes' ],
+		];
+	}
 }

--- a/tests/phpunit/tests/admin/optionsPermalink.php
+++ b/tests/phpunit/tests/admin/optionsPermalink.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * Tests for wp-admin/options-permalink.php
+ *
+ * @group admin
+ * @group rewrite
+ */
+class Tests_Admin_OptionsPermalink extends WP_UnitTestCase {
+}

--- a/tests/phpunit/tests/admin/optionsPermalink.php
+++ b/tests/phpunit/tests/admin/optionsPermalink.php
@@ -11,13 +11,13 @@ class Tests_Admin_OptionsPermalink extends WP_UnitTestCase {
 	 * Data provider for base sanitization tests.
 	 */
 	public function data_base_sanitization() {
-		return [
-			[ 'Foo Bar', '/foo-bar' ],
-			[ 'Foo & Bar!', '/foo-bar' ],
-			[ 'Foo Bar/Baz Qux', '/foo-bar/baz-qux' ],
-			[ '', '' ],
-			[ '/Foo Bar', '/foo-bar' ],
-			[ 'Multiple/Slashes', '/multiple/slashes' ],
-		];
+		return array(
+			array( 'Foo Bar', '/foo-bar' ),
+			array( 'Foo & Bar!', '/foo-bar' ),
+			array( 'Foo Bar/Baz Qux', '/foo-bar/baz-qux' ),
+			array( '', '' ),
+			array( '/Foo Bar', '/foo-bar' ),
+			array( 'Multiple/Slashes', '/multiple/slashes' ),
+		);
 	}
 }

--- a/tests/phpunit/tests/admin/optionsPermalink.php
+++ b/tests/phpunit/tests/admin/optionsPermalink.php
@@ -20,4 +20,14 @@ class Tests_Admin_OptionsPermalink extends WP_UnitTestCase {
 			array( 'Multiple/Slashes', '/multiple/slashes' ),
 		);
 	}
+
+	/**
+	 * Test category and tag base sanitization.
+	 *
+	 * @ticket 16839
+	 * @dataProvider data_base_sanitization
+	 */
+	public function test_base_sanitization() {
+		
+	}
 }

--- a/tests/phpunit/tests/admin/optionsPermalink.php
+++ b/tests/phpunit/tests/admin/optionsPermalink.php
@@ -28,9 +28,9 @@ class Tests_Admin_OptionsPermalink extends WP_UnitTestCase {
 	 * @dataProvider data_base_sanitization
 	 */
 	public function test_base_sanitization( $input, $expected ) {
-		$base = ltrim( $input, '/' );
+		$base   = ltrim( $input, '/' );
 		$result = empty( $base ) ? '' : '/' . implode( '/', array_map( 'sanitize_title_with_dashes', preg_split( '|/+|', $base ) ) );
-		
+
 		$this->assertSame( $expected, $result );
 	}
 }

--- a/tests/phpunit/tests/admin/optionsPermalink.php
+++ b/tests/phpunit/tests/admin/optionsPermalink.php
@@ -50,4 +50,69 @@ class Tests_Admin_OptionsPermalink extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $result );
 	}
+
+	/**
+	 * Data provider for link generation with custom bases.
+	 */
+	public function data_category_base_links() {
+		return array(
+			'latin with space'      => array( 'Foo Bar', 'news' ),
+			'hierarchical segments' => array( 'Foo Bar/Baz Qux', 'updates' ),
+		);
+	}
+
+	/**
+	 * Ensure custom category bases are slugified and produce working archive links.
+	 *
+	 * @ticket 16839
+	 * @dataProvider data_category_base_links
+	 *
+	 * @param string $raw_base      User-entered base.
+	 * @param string $category_slug Category slug.
+	 */
+	public function test_category_base_generates_pretty_links( $raw_base, $category_slug ) {
+		global $wp_rewrite;
+
+		$sanitized_base = $this->sanitize_base_from_settings( $raw_base );
+
+		$this->apply_category_base_and_flush( $sanitized_base );
+
+		$cat_id = self::factory()->category->create( array( 'slug' => $category_slug ) );
+
+		$category_link = get_category_link( $cat_id );
+
+		$this->assertStringContainsString( $sanitized_base . '/' . $category_slug . '/', $category_link );
+
+		$this->go_to( $category_link );
+		$this->assertQueryTrue( 'is_category', 'is_archive' );
+		$this->assertSame( $cat_id, get_queried_object_id() );
+	}
+
+	/**
+	 * Mirrors the sanitization logic used in wp-admin/options-permalink.php.
+	 *
+	 * @param string $raw_base Raw user input.
+	 * @return string Sanitized base with leading slash or empty string.
+	 */
+	private function sanitize_base_from_settings( $raw_base ) {
+		$base = ltrim( $raw_base, '/' );
+
+		return empty( $base ) ? '' : '/' . implode( '/', array_map( 'sanitize_title_with_dashes', preg_split( '|/+|', $base ) ) );
+	}
+
+	/**
+	 * Applies the category base option and refreshes taxonomy rewrites.
+	 *
+	 * @param string $sanitized_base Base to set (leading slash or empty).
+	 */
+	private function apply_category_base_and_flush( $sanitized_base ) {
+		global $wp_rewrite;
+
+		$wp_rewrite->set_category_base( $sanitized_base );
+
+		// Re-register taxonomies and ensure permalink structure stays active before flushing.
+		$this->set_permalink_structure( '/%postname%/' );
+		create_initial_taxonomies();
+		$wp_rewrite->flush_rules();
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/16839

This PR fixes category and tag base sanitization in permalink settings to prevent 404 errors when bases contain spaces or special characters.

When users set a category base with spaces (e.g., "Foo Bar"), WordPress generates URLs like `example.com/Foo%20Bar/category`, which results in 404 errors because rewrite rules expect `example.com/foo-bar/category`.

This PR - 

- Sanitizes category_base and tag_base using `sanitize_title_with_dashes()`
- Handles multiple path segments correctly (e.g., "Foo Bar/Sub" → "foo-bar/sub")
- Maintains backward compatibility with existing slugified bases
- Addresses Unicode character handling mentioned in the original ticket
- Added unit tests covering input scenarios
