### PR TITLE
Twenty Eleven: Fix follow blog pattern text color

### DIFF
--- a/src/wp-content/themes/twentyeleven/inc/block-patterns.php
+++ b/src/wp-content/themes/twentyeleven/inc/block-patterns.php
@@ -86,8 +86,8 @@ if ( function_exists( 'register_block_pattern' ) ) {
 			'title'         => esc_html__( 'Follow Blog', 'twentyeleven' ),
 			'categories'    => array( 'twentyeleven' ),
 			'viewportWidth' => 1000,
-			'content'       => '<!-- wp:cover {"overlayColor":"black","minHeight":900,"minHeightUnit":"px","align":"center"} -->
-				<div class="wp-block-cover aligncenter has-black-background-color has-background-dim" style="min-height:900px"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":85}}} -->
+			'content'       => '<!-- wp:cover {"overlayColor":"black","textColor":"white","minHeight":900,"minHeightUnit":"px","align":"center"} -->
+				<div class="wp-block-cover aligncenter has-black-background-color has-background-dim has-white-color has-text-color" style="min-height:900px"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":85}}} -->
 				<p class="has-text-align-center" style="font-size:85px">' . esc_html__( 'Get In Touch', 'twentyeleven' ) . '</p>
 				<!-- /wp:paragraph -->
 				<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":25}}} -->


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/61022

This PR fixes "Follow Blog Pattern" but explicitly adding the Theme's "white" color as the text color.

### Before:
<img width="1880" height="1018" alt="image" src="https://github.com/user-attachments/assets/58a0a97b-e44b-4f2f-8704-aa407868b774" />


### After:
<img width="1876" height="1016" alt="image" src="https://github.com/user-attachments/assets/0b844370-ba17-4dee-a8cf-1af12623b2dc" />


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

