### PR TITLE
Simplify a condition in the HTML API's `get_url_in_content` function.

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5989,7 +5989,7 @@ function get_url_in_content( $content ) {
 	$processor = new WP_HTML_Tag_Processor( $content );
 	while ( $processor->next_tag( 'A' ) ) {
 		$href = $processor->get_attribute( 'href' );
-		if ( is_string( $href ) && ! empty( $href ) ) {
+		if ( is_string( $href ) && '' !== $href ) {
 			return sanitize_url( $href );
 		}
 	}


### PR DESCRIPTION
As there's an `is_string()` check already, the `! empty( $href )` can be simplified to a string comparison, as other variable types that are checked in `empty()` won't appear.

`empty()` also returns `false` for the string `"0"` which would however be a valid (relative) URL and thus should be detectable by the function.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63694#comment:21

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
