### PR TITLE
Formatting: Preserve '=' characters in `add_query_arg()` values

### DIFF
--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -1197,7 +1197,7 @@ function add_query_arg( ...$args ) {
 
 	$ret = build_query( $qs );
 	$ret = trim( $ret, '?' );
-	$ret = preg_replace( '#=(&|$)#', '$1', $ret );
+	$ret = preg_replace( '/(?<=^|&)[^=]+=(&|$)/', '$1', $ret );
 	$ret = $protocol . $base . $ret . $frag;
 	$ret = rtrim( $ret, '?' );
 	$ret = str_replace( '?#', '#', $ret );

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -1197,7 +1197,7 @@ function add_query_arg( ...$args ) {
 
 	$ret = build_query( $qs );
 	$ret = trim( $ret, '?' );
-	$ret = preg_replace( '/(?<=^|&)[^=]+=(&|$)/', '$1', $ret );
+	$ret = preg_replace( '/(?<=^|&)([^=]+)=(&|$)/', '$1$2', $ret );
 	$ret = $protocol . $base . $ret . $frag;
 	$ret = rtrim( $ret, '?' );
 	$ret = str_replace( '?#', '#', $ret );

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -600,6 +600,16 @@ class Tests_Functions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 50279
+	 * @group add_query_arg
+	 */
+	public function test_add_query_arg_preserves_empty_and_equal_sign_values() {
+		$this->assertSame( '/?baz&foo=1', add_query_arg( 'foo', '1', '/?baz=' ) );
+		$this->assertSame( '/?api_id=xxxxx%3D%3D&bar=2', add_query_arg( 'bar', '2', '/?api_id=xxxxx==' ) );
+		$this->assertSame( '/?empty_param&foo=1', add_query_arg( 'foo', '1', '/?empty_param=' ) );
+	}
+
+	/**
 	 * Data provider.
 	 *
 	 * @return array


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/50279

This PR improves the regex in `add_query_arg()` to only strip the `=` sign
for truly empty values (e.g., `foo=` → `foo`), while preserving valid `=`
characters that appear inside query values (such as Base64 padding `xxxxx==`).

- Updated regex from `#=(&|$)#` to `/((?<=^|&)[^=]+=)(&|$)/` to ensure only
  empty values are matched.
- Retains backward compatibility: empty values remain normalized.
- Prevents corruption of values ending in `=`.

