### PR TITLE
Install: Prevent passwords consisting only of spaces during installation

### DIFF
--- a/src/wp-admin/install.php
+++ b/src/wp-admin/install.php
@@ -434,6 +434,10 @@ switch ( $step ) {
 			// TODO: Poka-yoke.
 			display_setup_form( __( 'Your passwords do not match. Please try again.' ) );
 			$error = true;
+		} elseif ( ! empty( $admin_password ) && empty( trim( $admin_password ) ) ) {
+			// TODO: Poka-yoke.
+			display_setup_form( __( '<strong>Error:</strong> Passwords cannot consist only of whitespace characters.' ) );
+			$error = true;
 		} elseif ( empty( $admin_email ) ) {
 			// TODO: Poka-yoke.
 			display_setup_form( __( 'You must provide an email address.' ) );


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/27740

This PR fixes a bug where a user can complete the WordPress installation with a password consisting only of whitespace characters (e.g., spaces). While the installation succeeds, the user is immediately locked out because the login screen trims the password, treats it as empty, and shows an error.

This patch adds a validation check in `wp-admin/install.php` to detect if a non-empty password becomes empty after being trimmed. If so, it displays an error and prevents the installation from proceeding. This change does not affect the feature where leaving the password field blank generates a random password.

