### PR TITLE
feat: add filter for old slug redirect status and update tests

### DIFF
--- a/src/wp-includes/query.php
+++ b/src/wp-includes/query.php
@@ -1120,7 +1120,7 @@ function wp_old_slug_redirect() {
 		/**
 		 * Filters the old slug redirect status code.
 		 *
-		 * @since 6.8.0
+		 * @since 6.9.0
 		 *
 		 * @param int $status The HTTP response status code to use for the redirect.
 		 * @param int $id     The post ID being redirected to.

--- a/src/wp-includes/query.php
+++ b/src/wp-includes/query.php
@@ -1117,7 +1117,21 @@ function wp_old_slug_redirect() {
 			return;
 		}
 
-		wp_redirect( $link, 301 ); // Permanent redirect.
+		/**
+		 * Filters the old slug redirect status code.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param int $status The HTTP response status code to use for the redirect.
+		 * @param int $id     The post ID being redirected to.
+		 */
+		$status = apply_filters( 'old_slug_redirect_status', 301, $id );
+
+		if ( ! $status ) {
+			return;
+		}
+
+		wp_redirect( $link, $status );
 		exit;
 	}
 }

--- a/tests/phpunit/tests/rewrite/oldSlugRedirect.php
+++ b/tests/phpunit/tests/rewrite/oldSlugRedirect.php
@@ -37,9 +37,9 @@ class Tests_Rewrite_OldSlugRedirect extends WP_UnitTestCase {
 
 	public function tear_down() {
 		$this->old_slug_redirect_url = null;
-		$this->redirect_status = null;
-		$this->redirect_location = null;
-		$this->redirect_post_id = null;
+		$this->redirect_status       = null;
+		$this->redirect_location     = null;
+		$this->redirect_post_id      = null;
 
 		parent::tear_down();
 	}
@@ -238,32 +238,32 @@ class Tests_Rewrite_OldSlugRedirect extends WP_UnitTestCase {
 
 		// Test default 301 status.
 		add_filter( 'wp_redirect', array( $this, 'capture_redirect_status' ), 10, 2 );
-		
+
 		$this->go_to( $old_permalink );
 		wp_old_slug_redirect();
-		
+
 		$this->assertSame( 301, $this->redirect_status );
 		$this->assertSame( self::$post_id, $this->redirect_post_id );
 
 		// Test custom 302 status.
 		add_filter( 'old_slug_redirect_status', array( $this, 'filter_redirect_status_to_302' ), 10, 2 );
-		
+
 		$this->go_to( $old_permalink );
 		wp_old_slug_redirect();
-		
+
 		$this->assertSame( 302, $this->redirect_status );
 		$this->assertSame( self::$post_id, $this->redirect_post_id );
 
 		// Test that returning 0 prevents redirect.
 		remove_filter( 'old_slug_redirect_status', array( $this, 'filter_redirect_status_to_302' ) );
 		add_filter( 'old_slug_redirect_status', array( $this, 'filter_redirect_status_to_zero' ), 10, 2 );
-		
-		$this->redirect_status = null;
+
+		$this->redirect_status  = null;
 		$this->redirect_post_id = null;
-		
+
 		$this->go_to( $old_permalink );
 		wp_old_slug_redirect();
-		
+
 		$this->assertNull( $this->redirect_status );
 		$this->assertNull( $this->redirect_post_id );
 
@@ -273,7 +273,7 @@ class Tests_Rewrite_OldSlugRedirect extends WP_UnitTestCase {
 	}
 
 	public function capture_redirect_status( $location, $status ) {
-		$this->redirect_status = $status;
+		$this->redirect_status   = $status;
 		$this->redirect_location = $location;
 		// Prevent actual redirect in tests.
 		return false;

--- a/tests/phpunit/tests/rewrite/oldSlugRedirect.php
+++ b/tests/phpunit/tests/rewrite/oldSlugRedirect.php
@@ -227,14 +227,18 @@ class Tests_Rewrite_OldSlugRedirect extends WP_UnitTestCase {
 	 * @ticket 52737
 	 */
 	public function test_old_slug_redirect_status_filter() {
+		// Use the same pattern as the working test
 		$old_permalink = user_trailingslashit( get_permalink( self::$post_id ) );
 
 		wp_update_post(
 			array(
 				'ID'        => self::$post_id,
-				'post_name' => 'bar-baz',
+				'post_name' => 'status-filter-test',
 			)
 		);
+
+		// Remove the default URL filter temporarily to test the redirect status
+		remove_filter( 'old_slug_redirect_url', array( $this, 'filter_old_slug_redirect_url' ) );
 
 		// Test default 301 status.
 		add_filter( 'wp_redirect', array( $this, 'capture_redirect_status' ), 10, 2 );
@@ -244,6 +248,10 @@ class Tests_Rewrite_OldSlugRedirect extends WP_UnitTestCase {
 
 		$this->assertSame( 301, $this->redirect_status );
 		$this->assertSame( self::$post_id, $this->redirect_post_id );
+
+		// Reset state for next test
+		$this->redirect_status = null;
+		$this->redirect_post_id = null;
 
 		// Test custom 302 status.
 		add_filter( 'old_slug_redirect_status', array( $this, 'filter_redirect_status_to_302' ), 10, 2 );
@@ -270,6 +278,9 @@ class Tests_Rewrite_OldSlugRedirect extends WP_UnitTestCase {
 		// Clean up.
 		remove_filter( 'wp_redirect', array( $this, 'capture_redirect_status' ) );
 		remove_filter( 'old_slug_redirect_status', array( $this, 'filter_redirect_status_to_zero' ) );
+		
+		// Restore the URL filter
+		add_filter( 'old_slug_redirect_url', array( $this, 'filter_old_slug_redirect_url' ), 10, 1 );
 	}
 
 	public function capture_redirect_status( $location, $status ) {

--- a/tests/phpunit/tests/rewrite/oldSlugRedirect.php
+++ b/tests/phpunit/tests/rewrite/oldSlugRedirect.php
@@ -7,6 +7,9 @@
  */
 class Tests_Rewrite_OldSlugRedirect extends WP_UnitTestCase {
 	protected $old_slug_redirect_url;
+	protected $redirect_status;
+	protected $redirect_location;
+	protected $redirect_post_id;
 
 	protected static $post_id;
 
@@ -34,6 +37,9 @@ class Tests_Rewrite_OldSlugRedirect extends WP_UnitTestCase {
 
 	public function tear_down() {
 		$this->old_slug_redirect_url = null;
+		$this->redirect_status = null;
+		$this->redirect_location = null;
+		$this->redirect_post_id = null;
 
 		parent::tear_down();
 	}
@@ -213,5 +219,73 @@ class Tests_Rewrite_OldSlugRedirect extends WP_UnitTestCase {
 	public function filter_old_slug_redirect_url( $url ) {
 		$this->old_slug_redirect_url = $url;
 		return false;
+	}
+
+	/**
+	 * Test that the old_slug_redirect_status filter works correctly.
+	 *
+	 * @ticket 52737
+	 */
+	public function test_old_slug_redirect_status_filter() {
+		$old_permalink = user_trailingslashit( get_permalink( self::$post_id ) );
+
+		wp_update_post(
+			array(
+				'ID'        => self::$post_id,
+				'post_name' => 'bar-baz',
+			)
+		);
+
+		// Test default 301 status.
+		add_filter( 'wp_redirect', array( $this, 'capture_redirect_status' ), 10, 2 );
+		
+		$this->go_to( $old_permalink );
+		wp_old_slug_redirect();
+		
+		$this->assertSame( 301, $this->redirect_status );
+		$this->assertSame( self::$post_id, $this->redirect_post_id );
+
+		// Test custom 302 status.
+		add_filter( 'old_slug_redirect_status', array( $this, 'filter_redirect_status_to_302' ), 10, 2 );
+		
+		$this->go_to( $old_permalink );
+		wp_old_slug_redirect();
+		
+		$this->assertSame( 302, $this->redirect_status );
+		$this->assertSame( self::$post_id, $this->redirect_post_id );
+
+		// Test that returning 0 prevents redirect.
+		remove_filter( 'old_slug_redirect_status', array( $this, 'filter_redirect_status_to_302' ) );
+		add_filter( 'old_slug_redirect_status', array( $this, 'filter_redirect_status_to_zero' ), 10, 2 );
+		
+		$this->redirect_status = null;
+		$this->redirect_post_id = null;
+		
+		$this->go_to( $old_permalink );
+		wp_old_slug_redirect();
+		
+		$this->assertNull( $this->redirect_status );
+		$this->assertNull( $this->redirect_post_id );
+
+		// Clean up.
+		remove_filter( 'wp_redirect', array( $this, 'capture_redirect_status' ) );
+		remove_filter( 'old_slug_redirect_status', array( $this, 'filter_redirect_status_to_zero' ) );
+	}
+
+	public function capture_redirect_status( $location, $status ) {
+		$this->redirect_status = $status;
+		$this->redirect_location = $location;
+		// Prevent actual redirect in tests.
+		return false;
+	}
+
+	public function filter_redirect_status_to_302( $status, $post_id ) {
+		$this->redirect_post_id = $post_id;
+		return 302;
+	}
+
+	public function filter_redirect_status_to_zero( $status, $post_id ) {
+		$this->redirect_post_id = $post_id;
+		return 0;
 	}
 }

--- a/tests/phpunit/tests/rewrite/oldSlugRedirect.php
+++ b/tests/phpunit/tests/rewrite/oldSlugRedirect.php
@@ -250,7 +250,7 @@ class Tests_Rewrite_OldSlugRedirect extends WP_UnitTestCase {
 		$this->assertSame( self::$post_id, $this->redirect_post_id );
 
 		// Reset state for next test
-		$this->redirect_status = null;
+		$this->redirect_status  = null;
 		$this->redirect_post_id = null;
 
 		// Test custom 302 status.
@@ -278,7 +278,7 @@ class Tests_Rewrite_OldSlugRedirect extends WP_UnitTestCase {
 		// Clean up.
 		remove_filter( 'wp_redirect', array( $this, 'capture_redirect_status' ) );
 		remove_filter( 'old_slug_redirect_status', array( $this, 'filter_redirect_status_to_zero' ) );
-		
+
 		// Restore the URL filter
 		add_filter( 'old_slug_redirect_url', array( $this, 'filter_old_slug_redirect_url' ), 10, 1 );
 	}


### PR DESCRIPTION
### Overview

This PR introduces a new filter `old_slug_redirect_status` that allows developers to customize the HTTP redirect status code used by the `wp_old_slug_redirect()` function. Currently, the redirect status is hardcoded as 301 (permanent redirect), but this change enables the use of 302 (temporary redirect) or other status codes as needed.

### Background

WordPress automatically redirects old post URLs to new ones when a post's slug changes, helping maintain SEO value and user experience. However, the redirect status code was hardcoded as 301, limiting flexibility for developers who might need different redirect behaviors.

**Fixes:** [#52737](https://core.trac.wordpress.org/ticket/52737)

### Changes Made

#### Core Changes (`src/wp-includes/query.php`)

1. **Added new filter**: `old_slug_redirect_status` in the `wp_old_slug_redirect()` function
2. **Filter parameters**:
   - `$status` (int): The HTTP response status code (default: 301)
   - `$id` (int): The post ID being redirected to
3. **Validation**: Added check to prevent redirect if filter returns falsy value
4. **Documentation**: Added proper PHPDoc with `@since 6.8.0` tag

#### Test Coverage (`tests/phpunit/tests/rewrite/oldSlugRedirect.php`)

1. **New test method**: `test_old_slug_redirect_status_filter()`
2. **Test scenarios**:
   - Default 301 redirect behavior (backward compatibility)
   - Custom 302 redirect status via filter
   - Redirect prevention by returning 0/false
   - Proper post ID parameter passing
3. **Helper methods**: Added filter callbacks and redirect capture functionality

### Usage Examples

#### Change redirect to temporary (302)
```php
add_filter( 'old_slug_redirect_status', function( $status, $post_id ) {
    return 302; // Temporary redirect
}, 10, 2 );
```

#### Conditional redirect based on post type
```php
add_filter( 'old_slug_redirect_status', function( $status, $post_id ) {
    $post = get_post( $post_id );
    if ( $post && $post->post_type === 'product' ) {
        return 302; // Temporary redirect for products
    }
    return $status; // Keep default 301 for other post types
}, 10, 2 );
```

#### Disable redirect for specific posts
```php
add_filter( 'old_slug_redirect_status', function( $status, $post_id ) {
    $disabled_posts = [123, 456, 789];
    if ( in_array( $post_id, $disabled_posts ) ) {
        return false; // No redirect
    }
    return $status;
}, 10, 2 );
```

#### Use different status codes based on post age
```php
add_filter( 'old_slug_redirect_status', function( $status, $post_id ) {
    $post = get_post( $post_id );
    if ( $post ) {
        $post_age_days = ( time() - strtotime( $post->post_date ) ) / DAY_IN_SECONDS;
        
        // Use 302 for recent posts (less than 30 days old)
        if ( $post_age_days < 30 ) {
            return 302;
        }
        
        // Use 301 for older posts (default behavior)
        return 301;
    }
    
    return $status;
}, 10, 2 );
```

### Filter Reference

#### `old_slug_redirect_status`

**Description:** Filters the HTTP status code used for old slug redirects.

**Parameters:**
- `$status` (int): The HTTP response status code to use for the redirect. Default 301.
- `$id` (int): The post ID being redirected to.

**Return Value:** 
- (int|false) The HTTP status code to use, or false to prevent the redirect.

**Example:**
```php
/**
 * Change old slug redirects to use 302 status for draft posts.
 *
 * @param int $status The redirect status code.
 * @param int $id     The post ID being redirected to.
 * @return int|false  Modified status code or false to prevent redirect.
 */
function custom_old_slug_redirect_status( $status, $id ) {
    $post = get_post( $id );
    
    if ( $post && $post->post_status === 'draft' ) {
        return 302; // Temporary redirect for drafts
    }
    
    return $status; // Use default for published posts
}
add_filter( 'old_slug_redirect_status', 'custom_old_slug_redirect_status', 10, 2 );
```

