### PR TITLE
Improve error handling in `get_adjacent_post`

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1888,14 +1888,18 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 				return '';
 			}
 			$term_array = wp_get_object_terms( $post->ID, $taxonomy, array( 'fields' => 'ids' ) );
+			if ( is_wp_error( $term_array ) ) {
+				return '';
+			}
 
 			// Remove any exclusions from the term array to include.
 			$term_array = array_diff( $term_array, (array) $excluded_terms );
-			$term_array = array_map( 'intval', $term_array );
 
-			if ( ! $term_array || is_wp_error( $term_array ) ) {
+			if ( ! $term_array ) {
 				return '';
 			}
+
+			$term_array = array_map( 'intval', $term_array );
 
 			$where .= ' AND tt.term_id IN (' . implode( ',', $term_array ) . ')';
 		}

--- a/tests/phpunit/tests/link/getAdjacentPost.php
+++ b/tests/phpunit/tests/link/getAdjacentPost.php
@@ -382,21 +382,19 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 
 		$this->go_to( get_permalink( $post_two->ID ) );
 
-		add_filter( 'wp_get_object_terms', array( $this, 'return_wp_error_for_object_terms' ), 10, 4 );
+		$return_wp_error_for_object_terms = static function () {
+			return new WP_Error( 'test_error', 'Test error from wp_get_object_terms' );
+		};
+
+		add_filter( 'wp_get_object_terms', $return_wp_error_for_object_terms );
 
 		$result = get_adjacent_post( true, '', true, 'wptests_error_tax' );
 
-		remove_filter( 'wp_get_object_terms', array( $this, 'return_wp_error_for_object_terms' ), 10 );
+		remove_filter( 'wp_get_object_terms', $return_wp_error_for_object_terms );
 
 		$this->assertSame( '', $result );
 	}
 
-	/**
-	 * Helper method to return a WP_Error for wp_get_object_terms calls.
-	 */
-	public function return_wp_error_for_object_terms( $terms, $object_ids, $taxonomies, $args ) {
-		return new WP_Error( 'test_error', 'Test error from wp_get_object_terms' );
-	}
 
 	/**
 	 * @ticket 63920
@@ -472,24 +470,24 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 			)
 		);
 
-		// All posts have term1. post_two has term1 and term2
+		// All posts have term1. post_two has term1 and term2.
 		wp_set_post_terms( $post_one->ID, array( $term1 ), 'wptests_tax' );
 		wp_set_post_terms( $post_two->ID, array( $term1, $term2 ), 'wptests_tax' );
 		wp_set_post_terms( $post_three->ID, array( $term1 ), 'wptests_tax' );
 
-		// Set the current post to post_two
+		// Set the current post to post_two.
 		$this->go_to( get_permalink( $post_two->ID ) );
 
-		// When we exclude term2, we should still get adjacent posts that share term1
+		// When we exclude term2, we should still get adjacent posts that share term1.
 		$result = get_adjacent_post( true, array( $term2 ), true, 'wptests_tax' );
 
-		// Should find post_one (previous post that shares term1)
+		// Should find post_one (previous post that shares term1).
 		$this->assertEquals( $post_one, $result );
 
-		// Test next post
+		// Test next post.
 		$result = get_adjacent_post( true, array( $term2 ), false, 'wptests_tax' );
 
-		// Should find post_three (next post that shares term1)
+		// Should find post_three (next post that shares term1).
 		$this->assertEquals( $post_three, $result );
 	}
 

--- a/tests/phpunit/tests/link/getAdjacentPost.php
+++ b/tests/phpunit/tests/link/getAdjacentPost.php
@@ -352,6 +352,173 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 63920
+	 */
+	public function test_get_adjacent_post_returns_empty_string_when_wp_get_object_terms_returns_wp_error() {
+		register_taxonomy( 'wptests_error_tax', 'post' );
+
+		$term1 = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_error_tax',
+			)
+		);
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title' => 'First',
+				'post_date'  => '2025-09-01 12:00:00',
+			)
+		);
+
+		$post_two = self::factory()->post->create_and_get(
+			array(
+				'post_title' => 'Second',
+				'post_date'  => '2025-09-02 12:00:00',
+			)
+		);
+
+		wp_set_post_terms( $post->ID, array( $term1 ), 'wptests_error_tax' );
+		wp_set_post_terms( $post_two->ID, array( $term1 ), 'wptests_error_tax' );
+
+		$this->go_to( get_permalink( $post_two->ID ) );
+
+		add_filter( 'wp_get_object_terms', array( $this, 'return_wp_error_for_object_terms' ), 10, 4 );
+
+		$result = get_adjacent_post( true, '', true, 'wptests_error_tax' );
+
+		remove_filter( 'wp_get_object_terms', array( $this, 'return_wp_error_for_object_terms' ), 10 );
+
+		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * Helper method to return a WP_Error for wp_get_object_terms calls.
+	 */
+	public function return_wp_error_for_object_terms( $terms, $object_ids, $taxonomies, $args ) {
+		return new WP_Error( 'test_error', 'Test error from wp_get_object_terms' );
+	}
+
+	/**
+	 * @ticket 63920
+	 */
+	public function test_get_adjacent_post_empty_term_array_after_exclusions() {
+		register_taxonomy( 'wptests_tax', 'post' );
+
+		$term1 = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax',
+			)
+		);
+
+		$post_one = self::factory()->post->create_and_get(
+			array(
+				'post_title' => 'First',
+				'post_date'  => '2025-01-01 12:00:00',
+			)
+		);
+
+		$post_two = self::factory()->post->create_and_get(
+			array(
+				'post_title' => 'Second',
+				'post_date'  => '2025-02-01 12:00:00',
+			)
+		);
+
+		wp_set_post_terms( $post_one->ID, array( $term1 ), 'wptests_tax' );
+		wp_set_post_terms( $post_two->ID, array( $term1 ), 'wptests_tax' );
+
+		$this->go_to( get_permalink( $post_two->ID ) );
+
+		$result = get_adjacent_post( true, array( $term1 ), true, 'wptests_tax' );
+
+		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * @ticket 63920
+	 */
+	public function test_get_adjacent_post_term_array_processing_order() {
+		register_taxonomy( 'wptests_tax', 'post' );
+
+		$term1 = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax',
+			)
+		);
+		$term2 = self::factory()->term->create(
+			array(
+				'taxonomy' => 'wptests_tax',
+			)
+		);
+
+		$post_one = self::factory()->post->create_and_get(
+			array(
+				'post_title' => 'First',
+				'post_date'  => '2025-01-01 12:00:00',
+			)
+		);
+
+		$post_two = self::factory()->post->create_and_get(
+			array(
+				'post_title' => 'Second',
+				'post_date'  => '2025-02-01 12:00:00',
+			)
+		);
+
+		$post_three = self::factory()->post->create_and_get(
+			array(
+				'post_title' => 'Third',
+				'post_date'  => '2025-03-01 12:00:00',
+			)
+		);
+
+		// All posts have term1. post_two has term1 and term2
+		wp_set_post_terms( $post_one->ID, array( $term1 ), 'wptests_tax' );
+		wp_set_post_terms( $post_two->ID, array( $term1, $term2 ), 'wptests_tax' );
+		wp_set_post_terms( $post_three->ID, array( $term1 ), 'wptests_tax' );
+
+		// Set the current post to post_two
+		$this->go_to( get_permalink( $post_two->ID ) );
+
+		// When we exclude term2, we should still get adjacent posts that share term1
+		$result = get_adjacent_post( true, array( $term2 ), true, 'wptests_tax' );
+
+		// Should find post_one (previous post that shares term1)
+		$this->assertEquals( $post_one, $result );
+
+		// Test next post
+		$result = get_adjacent_post( true, array( $term2 ), false, 'wptests_tax' );
+
+		// Should find post_three (next post that shares term1)
+		$this->assertEquals( $post_three, $result );
+	}
+
+	/**
+	 * @ticket 63920
+	 */
+	public function test_get_adjacent_post_invalid_taxonomy() {
+		$post_one = self::factory()->post->create_and_get(
+			array(
+				'post_title' => 'First',
+				'post_date'  => '2025-01-01 12:00:00',
+			)
+		);
+
+		$post_two = self::factory()->post->create_and_get(
+			array(
+				'post_title' => 'Second',
+				'post_date'  => '2025-02-01 12:00:00',
+			)
+		);
+
+		$this->go_to( get_permalink( $post_two->ID ) );
+
+		$result = get_adjacent_post( true, '', true, 'invalid_taxonomy' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
 	 * @ticket 41131
 	 */
 	public function test_get_adjacent_post_cache() {

--- a/tests/phpunit/tests/link/getAdjacentPost.php
+++ b/tests/phpunit/tests/link/getAdjacentPost.php
@@ -387,11 +387,7 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 		};
 
 		add_filter( 'wp_get_object_terms', $return_wp_error_for_object_terms );
-
 		$result = get_adjacent_post( true, '', true, 'wptests_error_tax' );
-
-		remove_filter( 'wp_get_object_terms', $return_wp_error_for_object_terms );
-
 		$this->assertSame( '', $result );
 	}
 

--- a/tests/phpunit/tests/link/getAdjacentPost.php
+++ b/tests/phpunit/tests/link/getAdjacentPost.php
@@ -382,11 +382,12 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 
 		$this->go_to( get_permalink( $post2_id ) );
 
-		$return_wp_error_for_object_terms = static function () {
-			return new WP_Error( 'test_error', 'Test error from wp_get_object_terms' );
-		};
-
-		add_filter( 'wp_get_object_terms', $return_wp_error_for_object_terms );
+		add_filter(
+			'wp_get_object_terms',
+			static function () {
+				return new WP_Error( 'test_error', 'Test error from wp_get_object_terms' );
+			}
+		);
 		$result = get_adjacent_post( true, '', true, 'wptests_error_tax' );
 		$this->assertSame( '', $result );
 	}
@@ -421,9 +422,7 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 		wp_set_post_terms( $post2_id, array( $term1_id ), 'wptests_tax' );
 
 		$this->go_to( get_permalink( $post2_id ) );
-
 		$result = get_adjacent_post( true, array( $term1_id ), true, 'wptests_tax' );
-
 		$this->assertSame( '', $result );
 	}
 
@@ -507,9 +506,7 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 		);
 
 		$this->go_to( get_permalink( $post2_id ) );
-
 		$result = get_adjacent_post( true, '', true, 'invalid_taxonomy' );
-
 		$this->assertNull( $result );
 	}
 

--- a/tests/phpunit/tests/link/getAdjacentPost.php
+++ b/tests/phpunit/tests/link/getAdjacentPost.php
@@ -357,30 +357,30 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 	public function test_get_adjacent_post_returns_empty_string_when_wp_get_object_terms_returns_wp_error() {
 		register_taxonomy( 'wptests_error_tax', 'post' );
 
-		$term1 = self::factory()->term->create(
+		$term1_id = self::factory()->term->create(
 			array(
 				'taxonomy' => 'wptests_error_tax',
 			)
 		);
 
-		$post = self::factory()->post->create_and_get(
+		$post1_id = self::factory()->post->create(
 			array(
 				'post_title' => 'First',
 				'post_date'  => '2025-09-01 12:00:00',
 			)
 		);
 
-		$post_two = self::factory()->post->create_and_get(
+		$post2_id = self::factory()->post->create(
 			array(
 				'post_title' => 'Second',
 				'post_date'  => '2025-09-02 12:00:00',
 			)
 		);
 
-		wp_set_post_terms( $post->ID, array( $term1 ), 'wptests_error_tax' );
-		wp_set_post_terms( $post_two->ID, array( $term1 ), 'wptests_error_tax' );
+		wp_set_post_terms( $post1_id, array( $term1_id ), 'wptests_error_tax' );
+		wp_set_post_terms( $post2_id, array( $term1_id ), 'wptests_error_tax' );
 
-		$this->go_to( get_permalink( $post_two->ID ) );
+		$this->go_to( get_permalink( $post2_id ) );
 
 		$return_wp_error_for_object_terms = static function () {
 			return new WP_Error( 'test_error', 'Test error from wp_get_object_terms' );
@@ -397,32 +397,32 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 	public function test_get_adjacent_post_empty_term_array_after_exclusions() {
 		register_taxonomy( 'wptests_tax', 'post' );
 
-		$term1 = self::factory()->term->create(
+		$term1_id = self::factory()->term->create(
 			array(
 				'taxonomy' => 'wptests_tax',
 			)
 		);
 
-		$post_one = self::factory()->post->create_and_get(
+		$post1_id = self::factory()->post->create(
 			array(
 				'post_title' => 'First',
 				'post_date'  => '2025-01-01 12:00:00',
 			)
 		);
 
-		$post_two = self::factory()->post->create_and_get(
+		$post2_id = self::factory()->post->create(
 			array(
 				'post_title' => 'Second',
 				'post_date'  => '2025-02-01 12:00:00',
 			)
 		);
 
-		wp_set_post_terms( $post_one->ID, array( $term1 ), 'wptests_tax' );
-		wp_set_post_terms( $post_two->ID, array( $term1 ), 'wptests_tax' );
+		wp_set_post_terms( $post1_id, array( $term1_id ), 'wptests_tax' );
+		wp_set_post_terms( $post2_id, array( $term1_id ), 'wptests_tax' );
 
-		$this->go_to( get_permalink( $post_two->ID ) );
+		$this->go_to( get_permalink( $post2_id ) );
 
-		$result = get_adjacent_post( true, array( $term1 ), true, 'wptests_tax' );
+		$result = get_adjacent_post( true, array( $term1_id ), true, 'wptests_tax' );
 
 		$this->assertSame( '', $result );
 	}
@@ -433,32 +433,32 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 	public function test_get_adjacent_post_term_array_processing_order() {
 		register_taxonomy( 'wptests_tax', 'post' );
 
-		$term1 = self::factory()->term->create(
+		$term1_id = self::factory()->term->create(
 			array(
 				'taxonomy' => 'wptests_tax',
 			)
 		);
-		$term2 = self::factory()->term->create(
+		$term2_id = self::factory()->term->create(
 			array(
 				'taxonomy' => 'wptests_tax',
 			)
 		);
 
-		$post_one = self::factory()->post->create_and_get(
+		$post1_id = self::factory()->post->create(
 			array(
 				'post_title' => 'First',
 				'post_date'  => '2025-01-01 12:00:00',
 			)
 		);
 
-		$post_two = self::factory()->post->create_and_get(
+		$post2_id = self::factory()->post->create(
 			array(
 				'post_title' => 'Second',
 				'post_date'  => '2025-02-01 12:00:00',
 			)
 		);
 
-		$post_three = self::factory()->post->create_and_get(
+		$post3_id = self::factory()->post->create(
 			array(
 				'post_title' => 'Third',
 				'post_date'  => '2025-03-01 12:00:00',
@@ -466,24 +466,26 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 		);
 
 		// All posts have term1. post_two has term1 and term2.
-		wp_set_post_terms( $post_one->ID, array( $term1 ), 'wptests_tax' );
-		wp_set_post_terms( $post_two->ID, array( $term1, $term2 ), 'wptests_tax' );
-		wp_set_post_terms( $post_three->ID, array( $term1 ), 'wptests_tax' );
+		wp_set_post_terms( $post1_id, array( $term1_id ), 'wptests_tax' );
+		wp_set_post_terms( $post2_id, array( $term1_id, $term2_id ), 'wptests_tax' );
+		wp_set_post_terms( $post3_id, array( $term1_id ), 'wptests_tax' );
 
 		// Set the current post to post_two.
-		$this->go_to( get_permalink( $post_two->ID ) );
+		$this->go_to( get_permalink( $post2_id ) );
 
 		// When we exclude term2, we should still get adjacent posts that share term1.
-		$result = get_adjacent_post( true, array( $term2 ), true, 'wptests_tax' );
+		$result = get_adjacent_post( true, array( $term2_id ), true, 'wptests_tax' );
 
 		// Should find post_one (previous post that shares term1).
-		$this->assertEquals( $post_one, $result );
+		$this->assertInstanceOf( WP_Post::class, $result );
+		$this->assertEquals( $post1_id, $result->ID );
 
 		// Test next post.
-		$result = get_adjacent_post( true, array( $term2 ), false, 'wptests_tax' );
+		$result = get_adjacent_post( true, array( $term2_id ), false, 'wptests_tax' );
 
 		// Should find post_three (next post that shares term1).
-		$this->assertEquals( $post_three, $result );
+		$this->assertInstanceOf( WP_Post::class, $result );
+		$this->assertEquals( $post3_id, $result->ID );
 	}
 
 	/**
@@ -497,14 +499,14 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 			)
 		);
 
-		$post_two = self::factory()->post->create_and_get(
+		$post2_id = self::factory()->post->create(
 			array(
 				'post_title' => 'Second',
 				'post_date'  => '2025-02-01 12:00:00',
 			)
 		);
 
-		$this->go_to( get_permalink( $post_two->ID ) );
+		$this->go_to( get_permalink( $post2_id ) );
 
 		$result = get_adjacent_post( true, '', true, 'invalid_taxonomy' );
 

--- a/tests/phpunit/tests/link/getAdjacentPost.php
+++ b/tests/phpunit/tests/link/getAdjacentPost.php
@@ -391,7 +391,6 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 		$this->assertSame( '', $result );
 	}
 
-
 	/**
 	 * @ticket 63920
 	 */
@@ -491,7 +490,7 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 	 * @ticket 63920
 	 */
 	public function test_get_adjacent_post_invalid_taxonomy() {
-		$post_one = self::factory()->post->create_and_get(
+		self::factory()->post->create(
 			array(
 				'post_title' => 'First',
 				'post_date'  => '2025-01-01 12:00:00',


### PR DESCRIPTION
Improves error handling in `get_adjacent_post` to avoid PHP errors when passing non-array values to array functions. Adds phpunit tests to confirm behavior.

Trac ticket: https://core.trac.wordpress.org/ticket/63920

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
