### PR TITLE
esc_url: support HTTPS as default protocol

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4674,7 +4674,8 @@ function esc_url( $url, $protocols = null, $_context = 'display' ) {
 	/*
 	 * If the URL doesn't appear to contain a scheme, we presume
 	 * it needs http:// prepended (unless it's a relative link
-	 * starting with /, # or ?, or a PHP file).
+	 * starting with /, # or ?, or a PHP file). If the first item
+	 * in $protocols is 'https', then https:// is prepended.
 	 */
 	if ( ! str_contains( $url, ':' ) && ! in_array( $url[0], array( '/', '#', '?' ), true ) &&
 		! preg_match( '/^[a-z0-9-]+?\.php/i', $url )

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4679,7 +4679,8 @@ function esc_url( $url, $protocols = null, $_context = 'display' ) {
 	if ( ! str_contains( $url, ':' ) && ! in_array( $url[0], array( '/', '#', '?' ), true ) &&
 		! preg_match( '/^[a-z0-9-]+?\.php/i', $url )
 	) {
-		$url = 'http://' . $url;
+		$scheme = ( is_array( $protocols ) && 'https' === reset( $protocols ) ) ? 'https://' : 'http://';
+		$url    = $scheme . $url;
 	}
 
 	// Replace ampersands and single quotes only when displaying.

--- a/tests/phpunit/tests/formatting/escUrl.php
+++ b/tests/phpunit/tests/formatting/escUrl.php
@@ -90,16 +90,48 @@ class Tests_Formatting_EscUrl extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 23605
+	 * @ticket 52886
+	 *
 	 * @covers ::wp_allowed_protocols
 	 */
 	public function test_protocol() {
 		$this->assertSame( 'http://example.com', esc_url( 'http://example.com' ) );
 		$this->assertSame( '', esc_url( 'nasty://example.com/' ) );
 		$this->assertSame(
-			'',
+			'https://example.com',
 			esc_url(
 				'example.com',
 				array(
+					'https',
+				)
+			)
+		);
+		$this->assertSame(
+			'http://example.com',
+			esc_url(
+				'example.com',
+				array(
+					'http',
+				)
+			)
+		);
+		$this->assertSame(
+			'https://example.com',
+			esc_url(
+				'example.com',
+				array(
+					'https',
+					'http',
+				)
+			)
+		);
+		$this->assertSame(
+			'http://example.com',
+			esc_url(
+				'example.com',
+				array(
+					'http',
 					'https',
 				)
 			)


### PR DESCRIPTION
Prepends `https://` instead of `http://` when 'https' is the first value in the `$protocols` array.

[Trac 52886](https://core.trac.wordpress.org/ticket/52886)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
