### PR TITLE
Add `upload_url()` helper to retrieve the uploads directory URL

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -3663,6 +3663,31 @@ function content_url( $path = '' ) {
 }
 
 /**
+ * Retrieves the uploads directory URL.
+ *
+ * Returns either the base uploads URL (e.g. https://example.com/wp-content/uploads)
+ * or, when requested, the URL to the current time-based subdirectory
+ * (e.g. https://example.com/wp-content/uploads/2025/09) if year/month folders are enabled.
+ *
+ * This is a convenience wrapper around wp_upload_dir().
+ *
+ * @since 6.9.0
+ *
+ * @param bool $with_subdir Optional. Whether to include the time-based subdirectory
+ *                          when it is configured (mirrors wp_upload_dir()['url'] vs ['baseurl']). Default true.
+ * @return string Uploads URL. Empty string on failure.
+ */
+function upload_url( $with_subdir = true ) {
+    $uploads = wp_upload_dir();
+
+    if ( ! empty( $uploads['error'] ) ) {
+        return '';
+    }
+
+    return $with_subdir ? $uploads['url'] : $uploads['baseurl'];
+}
+
+/**
  * Retrieves a URL within the plugins or mu-plugins directory.
  *
  * Defaults to the plugins directory URL if no arguments are supplied.

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -3678,13 +3678,13 @@ function content_url( $path = '' ) {
  * @return string Uploads URL. Empty string on failure.
  */
 function upload_url( $with_subdir = true ) {
-    $uploads = wp_upload_dir();
+	$uploads = wp_upload_dir();
 
-    if ( ! empty( $uploads['error'] ) ) {
-        return '';
-    }
+	if ( ! empty( $uploads['error'] ) ) {
+		return '';
+	}
 
-    return $with_subdir ? $uploads['url'] : $uploads['baseurl'];
+	return $with_subdir ? $uploads['url'] : $uploads['baseurl'];
 }
 
 /**

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -3669,12 +3669,10 @@ function content_url( $path = '' ) {
  * or, when requested, the URL to the current time-based subdirectory
  * (e.g. https://example.com/wp-content/uploads/2025/09) if year/month folders are enabled.
  *
- * This is a convenience wrapper around wp_upload_dir().
- *
  * @since 6.9.0
  *
  * @param bool $with_subdir Optional. Whether to include the time-based subdirectory
- *                          when it is configured (mirrors wp_upload_dir()['url'] vs ['baseurl']). Default true.
+ *                          when it is configured. Default true.
  * @return string Uploads URL. Empty string on failure.
  */
 function upload_url( $with_subdir = true ) {

--- a/tests/phpunit/tests/upload.php
+++ b/tests/phpunit/tests/upload.php
@@ -119,4 +119,19 @@ class Tests_Upload extends WP_UnitTestCase {
 		$this->assertSame( $expected['url'], upload_url( true ) );
 		$this->assertSame( $expected['baseurl'], upload_url( false ) );
 	}
+
+	/**
+	 * Tests the upload_url() function when year/month folders are disabled.
+	 *
+	 * @ticket 33963
+	 */
+	public function test_upload_url_without_yearmonth_folders() {
+		update_option( 'uploads_use_yearmonth_folders', 0 );
+
+		$expected = wp_upload_dir();
+
+		$this->assertFalse( $expected['error'] );
+		$this->assertSame( $expected['url'], upload_url() );
+		$this->assertSame( $expected['baseurl'], upload_url( false ) );
+	}
 }

--- a/tests/phpunit/tests/upload.php
+++ b/tests/phpunit/tests/upload.php
@@ -105,4 +105,18 @@ class Tests_Upload extends WP_UnitTestCase {
 		$this->assertSame( $subdir, $info['subdir'] );
 		$this->assertFalse( $info['error'] );
 	}
+
+	/**
+	 * Tests the upload_url() function with default settings.
+	 *
+	 * @ticket 33963
+	 */
+	public function test_upload_url() {
+		$expected = wp_upload_dir();
+		$this->assertFalse( $expected['error'] );
+
+		$this->assertSame( $expected['url'], upload_url() );
+		$this->assertSame( $expected['url'], upload_url( true ) );
+		$this->assertSame( $expected['baseurl'], upload_url( false ) );
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/33963


Adds a new `upload_url()` helper function that returns the uploads directory URL.

- Defaults to returning the current time-based uploads URL (`wp_upload_dir()['url']`).
- Optionally returns the base uploads URL without the subdirectory.
- Returns an empty string on error.
- Provides clearer naming and documentation compared to direct `wp_upload_dir()` access.


