### PR TITLE
Remove unnecessary filter for image resizing tests

### DIFF
--- a/tests/phpunit/tests/image/base.php
+++ b/tests/phpunit/tests/image/base.php
@@ -6,6 +6,13 @@
 abstract class WP_Image_UnitTestCase extends WP_UnitTestCase {
 
 	/**
+	 * The image editor engine class name to use for testing.
+	 *
+	 * @var string
+	 */
+	public $editor_engine;
+
+	/**
 	 * Set the image editor engine according to the unit test's specification
 	 */
 	public function set_up() {

--- a/tests/phpunit/tests/image/resize.php
+++ b/tests/phpunit/tests/image/resize.php
@@ -12,12 +12,6 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 
 	public function set_up() {
 		parent::set_up();
-
-		add_filter( 'wp_image_editors', array( $this, 'wp_image_editors' ) );
-	}
-
-	public function wp_image_editors() {
-		return array( $this->editor_engine );
 	}
 
 	public function test_resize_jpg() {


### PR DESCRIPTION
The `WP_Image_UnitTestCase` base class already has a filter for `wp_image_editors` that returns the value of `$this->editor_engine`, so this is unnecessary here.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: Core-63167.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
