### PR TITLE
Do not return a non-existent update when tablename contains backticks

### DIFF
--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2962,8 +2962,8 @@ function dbDelta( $queries = '', $execute = true ) { // phpcs:ignore WordPress.N
 	// Create a tablename index for an array ($cqueries) of recognized query types.
 	foreach ( $queries as $qry ) {
 		if ( preg_match( '|CREATE TABLE ([^ ]*)|', $qry, $matches ) ) {
-			$cqueries[ trim( $matches[1], '`' ) ] = $qry;
-			$for_update[ $matches[1] ]            = 'Created table ' . $matches[1];
+			$cqueries[ trim( $matches[1], '`' ) ]   = $qry;
+			$for_update[ trim( $matches[1], '`' ) ] = 'Created table ' . $matches[1];
 			continue;
 		}
 

--- a/tests/phpunit/tests/db/dbDelta.php
+++ b/tests/phpunit/tests/db/dbDelta.php
@@ -1090,4 +1090,26 @@ class Tests_DB_dbDelta extends WP_UnitTestCase {
 			$updates
 		);
 	}
+
+	public function test_no_update_reported_when_tablename_in_backticks() {
+		global $wpdb;
+
+		$updates = dbDelta(
+			"
+			CREATE TABLE `{$wpdb->prefix}dbdelta_test` (
+				id bigint(20) NOT NULL AUTO_INCREMENT,
+				column_1 varchar(255) NOT NULL,
+				column_2 text,
+				column_3 blob,
+				PRIMARY KEY  (id),
+				KEY key_1 (column_1($this->max_index_length)),
+				KEY compound_key (id,column_1($this->max_index_length)),
+				FULLTEXT KEY fulltext_key (column_1)
+			) {$this->db_engine}
+			",
+			false
+		);
+
+		$this->assertEmpty( $updates );
+	}
 }


### PR DESCRIPTION
<!-- Insert a description of your changes here -->

This change ensures that dbDelta does not erroneously return an apparent update to tables when the tablename contains backticks. 

Trac ticket: https://core.trac.wordpress.org/ticket/63976

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
