### PR TITLE
Block Bindings: Add `block_bindings_supported_attributes` filter

### DIFF
--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -304,6 +304,20 @@ class WP_Block {
 		/**
 		 * Filters the supported block attributes for block bindings.
 		 *
+		 * @since 6.9.0
+		 *
+		 * @param string[] $supported_block_attributes The block's attributes that are supported by block bindings.
+		 * @param string   $block_type                 The block type whose attributes are being filtered.
+		 */
+		$supported_block_attributes = apply_filters(
+			'block_bindings_supported_attributes',
+			$supported_block_attributes,
+			$block_type
+		);
+
+		/**
+		 * Filters the supported block attributes for block bindings.
+		 *
 		 * The dynamic portion of the hook name, `$block_type`, refers to the block type
 		 * whose attributes are being filtered.
 		 *


### PR DESCRIPTION
Add a block-agnostic version of the `block_bindings_supported_attributes_{$block_type}` filter (first introduced by [`[60611]`](https://core.trac.wordpress.org/changeset/60611)/https://github.com/WordPress/wordpress-develop/pull/9392)

This will allow adding block bindings support for attributes of multiple different blocks in one go.

See https://github.com/WordPress/gutenberg/pull/71662#issuecomment-3291847715.

Trac ticket: https://core.trac.wordpress.org/ticket/62090

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
