### PR TITLE
Fix failing tests on PHP images and ImageMagick versions for 6.8

### DIFF
--- a/tests/phpunit/tests/image/editorImagick.php
+++ b/tests/phpunit/tests/image/editorImagick.php
@@ -701,6 +701,10 @@ class Tests_Image_Editor_Imagick extends WP_Image_UnitTestCase {
 	 * Test filter `image_max_bit_depth` correctly sets the maximum bit depth of resized images.
 	 *
 	 * @ticket 62285
+	 *
+	 * Temporarily disabled until we can figure out why it fails on the Trixie based PHP container.
+	 * See https://core.trac.wordpress.org/ticket/63932.
+	 * @requires PHP < 8.3
 	 */
 	public function test_image_max_bit_depth() {
 		$file                 = DIR_TESTDATA . '/images/colors_hdr_p3.avif';
@@ -772,6 +776,14 @@ class Tests_Image_Editor_Imagick extends WP_Image_UnitTestCase {
 	 * @dataProvider data_resizes_are_small_for_16bit_images
 	 */
 	public function test_resizes_are_small_for_16bit_images( $file ) {
+
+		// Temporarily disabled. See https://core.trac.wordpress.org/ticket/63932.
+		if ( DIR_TESTDATA . '/images/png-tests/test8.png' === $file ) {
+			$version = Imagick::getVersion();
+			if ( $version['versionNumber'] >= 0x700 ) {
+				$this->markTestSkipped( 'ImageMagick 7 is unable to optimize grayscale images with 1-bit transparency.' );
+			}
+		}
 
 		$temp_file = DIR_TESTDATA . '/images/test-temp.png';
 

--- a/tests/phpunit/tests/image/resize.php
+++ b/tests/phpunit/tests/image/resize.php
@@ -23,6 +23,8 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 	public function test_resize_jpg() {
 		$image = $this->resize_helper( DIR_TESTDATA . '/images/test-image.jpg', 25, 25 );
 
+		$this->assertNotWPError( $image );
+
 		list( $w, $h, $type ) = getimagesize( $image );
 
 		unlink( $image );
@@ -78,6 +80,8 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 
 		$image = $this->resize_helper( $file, 25, 25 );
 
+		$this->assertNotWPError( $image );
+
 		list( $w, $h, $type ) = wp_getimagesize( $image );
 
 		unlink( $image );
@@ -92,6 +96,10 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 	 * Test resizing AVIF image.
 	 *
 	 * @ticket 51228
+	 *
+	 * Temporarily disabled until we can figure out why it fails on the Trixie based PHP container.
+	 * See https://core.trac.wordpress.org/ticket/63932.
+	 * @requires PHP < 8.3
 	 */
 	public function test_resize_avif() {
 		$file   = DIR_TESTDATA . '/images/avif-lossy.avif';
@@ -103,6 +111,8 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 		}
 
 		$image = $this->resize_helper( $file, 25, 25 );
+
+		$this->assertNotWPError( $image );
 
 		list( $w, $h, $type ) = wp_getimagesize( $image );
 
@@ -130,6 +140,8 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 
 		$image = $this->resize_helper( $file, 25, 25 );
 
+		$this->assertNotWPError( $image );
+
 		list( $w, $h, $type ) = wp_getimagesize( $image );
 
 		unlink( $image );
@@ -151,6 +163,8 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 	public function test_resize_thumb_128x96() {
 		$image = $this->resize_helper( DIR_TESTDATA . '/images/2007-06-17DSC_4173.JPG', 128, 96 );
 
+		$this->assertNotWPError( $image );
+
 		list( $w, $h, $type ) = getimagesize( $image );
 
 		unlink( $image );
@@ -163,6 +177,8 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 
 	public function test_resize_thumb_128x0() {
 		$image = $this->resize_helper( DIR_TESTDATA . '/images/2007-06-17DSC_4173.JPG', 128, 0 );
+
+		$this->assertNotWPError( $image );
 
 		list( $w, $h, $type ) = getimagesize( $image );
 
@@ -177,6 +193,8 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 	public function test_resize_thumb_0x96() {
 		$image = $this->resize_helper( DIR_TESTDATA . '/images/2007-06-17DSC_4173.JPG', 0, 96 );
 
+		$this->assertNotWPError( $image );
+
 		list( $w, $h, $type ) = getimagesize( $image );
 
 		unlink( $image );
@@ -189,6 +207,8 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 
 	public function test_resize_thumb_150x150_crop() {
 		$image = $this->resize_helper( DIR_TESTDATA . '/images/2007-06-17DSC_4173.JPG', 150, 150, true );
+
+		$this->assertNotWPError( $image );
 
 		list( $w, $h, $type ) = getimagesize( $image );
 
@@ -216,6 +236,8 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 	public function test_resize_thumb_50x150_crop() {
 		$image = $this->resize_helper( DIR_TESTDATA . '/images/2007-06-17DSC_4173.JPG', 50, 150, true );
 
+		$this->assertNotWPError( $image );
+
 		list( $w, $h, $type ) = getimagesize( $image );
 
 		unlink( $image );
@@ -240,6 +262,8 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 
 	/**
 	 * Function to help out the tests
+	 *
+	 * @return string|WP_Error The path to the resized image file or a WP_Error on failure.
 	 */
 	protected function resize_helper( $file, $width, $height, $crop = false ) {
 		$editor = wp_get_image_editor( $file );

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -5481,7 +5481,7 @@ EOF;
 		// Sub-sizes: for each size, the AVIF should be smaller than the JPEG.
 		$sizes_to_compare = array_intersect_key( $avif_sizes['sizes'], $smaller_avif_sizes['sizes'] );
 
-		$this->assertNotWPError( $image );
+		$this->assertNotWPError( $sizes_to_compare );
 
 		foreach ( $sizes_to_compare as $size => $size_data ) {
 			$this->assertLessThan( $avif_sizes['sizes'][ $size ]['filesize'], $smaller_avif_sizes['sizes'][ $size ]['filesize'] );

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -5435,6 +5435,9 @@ EOF;
 
 		// Sub-sizes: for each size, the JPEGs should be smaller than the WebP.
 		$sizes_to_compare = array_intersect_key( $jpeg_sizes['sizes'], $webp_sizes['sizes'] );
+
+		$this->assertNotWPError( $image );
+
 		foreach ( $sizes_to_compare as $size => $size_data ) {
 			$this->assertLessThan( $webp_sizes['sizes'][ $size ]['filesize'], $jpeg_sizes['sizes'][ $size ]['filesize'] );
 		}
@@ -5477,6 +5480,8 @@ EOF;
 
 		// Sub-sizes: for each size, the AVIF should be smaller than the JPEG.
 		$sizes_to_compare = array_intersect_key( $avif_sizes['sizes'], $smaller_avif_sizes['sizes'] );
+
+		$this->assertNotWPError( $image );
 
 		foreach ( $sizes_to_compare as $size => $size_data ) {
 			$this->assertLessThan( $avif_sizes['sizes'][ $size ]['filesize'], $smaller_avif_sizes['sizes'][ $size ]['filesize'] );

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -5436,7 +5436,7 @@ EOF;
 		// Sub-sizes: for each size, the JPEGs should be smaller than the WebP.
 		$sizes_to_compare = array_intersect_key( $jpeg_sizes['sizes'], $webp_sizes['sizes'] );
 
-		$this->assertNotWPError( $image );
+		$this->assertNotWPError( $sizes_to_compare );
 
 		foreach ( $sizes_to_compare as $size => $size_data ) {
 			$this->assertLessThan( $webp_sizes['sizes'][ $size ]['filesize'], $jpeg_sizes['sizes'][ $size ]['filesize'] );

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -50,7 +50,7 @@ wait_on( {
 		process.exit( 1 );
 	} )
 	.then( () => {
-		wp_cli( 'db reset --yes' );
+		wp_cli( 'db reset --yes --defaults' );
 		const installCommand = process.env.LOCAL_MULTISITE === 'true'  ? 'multisite-install' : 'install';
 		wp_cli( `core ${ installCommand } --title="WordPress Develop" --admin_user=admin --admin_password=password --admin_email=test@test.com --skip-email --url=http://localhost:${process.env.LOCAL_PORT}` );
 	} )

--- a/wp-config-sample.php
+++ b/wp-config-sample.php
@@ -37,6 +37,7 @@ define( 'DB_CHARSET', 'utf8' );
 /** The database collate type. Don't change this if in doubt. */
 define( 'DB_COLLATE', '' );
 
+
 /**#@+
  * Authentication unique keys and salts.
  *


### PR DESCRIPTION
This backports the following to restore a passing build in the 6.8 branch:
- b6e708d9ebddf58005c9c1c911ab13391ad14fe9 for fixing the TLS/SSL connection issue in newer PHP 8.x containers (see Core-63876).
- 9ca38ce47b7a8a9c9e916e6aff39ec772ccbba55 to skip add media tests that currently fail on ImageMagick 7.x, and improves error handling within tests (see Core-63932).

Trac ticket: Core-63876
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
