### PR TITLE
Pin Importer plugin version with old PHP support - 6.3 branch

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -25,7 +25,6 @@ require_once ABSPATH . WPINC . '/version.php';
 require_once ABSPATH . WPINC . '/compat.php';
 require_once ABSPATH . WPINC . '/load.php';
 
-
 // Check for the required PHP version and for the MySQL extension or a database drop-in.
 wp_check_php_mysql_versions();
 

--- a/src/index.php
+++ b/src/index.php
@@ -25,6 +25,7 @@ require_once ABSPATH . WPINC . '/version.php';
 require_once ABSPATH . WPINC . '/compat.php';
 require_once ABSPATH . WPINC . '/load.php';
 
+
 // Check for the required PHP version and for the MySQL extension or a database drop-in.
 wp_check_php_mysql_versions();
 

--- a/tools/local-env/scripts/install.js
+++ b/tools/local-env/scripts/install.js
@@ -55,6 +55,11 @@ function wp_cli( cmd ) {
 function install_wp_importer() {
 	const testPluginDirectory = 'tests/phpunit/data/plugins/wordpress-importer';
 
+
+	// The final version of the WordPress Importer plugin with support for PHP < 7.2 is 0.9.0.
+	const phpVersion = parseFloat(process.env.LOCAL_PHP.split('-')[0]);
+	const branchFlag = phpVersion < 7.2 ? '--branch 0.9.0' : '';
+
 	execSync( `docker compose exec -T php rm -rf ${testPluginDirectory}`, { stdio: 'inherit' } );
-	execSync( `docker compose exec -T php git clone https://github.com/WordPress/wordpress-importer.git ${testPluginDirectory} --depth=1`, { stdio: 'inherit' } );
+	execSync( `docker compose exec -T php git clone ${branchFlag} https://github.com/WordPress/wordpress-importer.git ${testPluginDirectory} --depth=1`, { stdio: 'inherit' } );
 }


### PR DESCRIPTION
This fixes the failing WordPress Importer plugin tests by pinning the final version of the plugin with support for PHP < 7.2.

Trac ticket: Core-63983

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
