### PR TITLE
Media: Add Delete Permanently button to trash modal and fix button colors

### DIFF
--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -1868,11 +1868,16 @@
 }
 
 .media-modal .delete-attachment,
-.media-modal .trash-attachment,
-.media-modal .untrash-attachment {
+.media-modal .trash-attachment {
 	display: inline;
 	padding: 0;
 	color: #d63638;
+}
+
+.media-modal .untrash-attachment {
+	display: inline;
+	padding: 0;
+	color: #2271b1;
 }
 
 .media-modal .delete-attachment:hover,

--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -1883,10 +1883,13 @@
 .media-modal .delete-attachment:hover,
 .media-modal .delete-attachment:focus,
 .media-modal .trash-attachment:hover,
-.media-modal .trash-attachment:focus,
+.media-modal .trash-attachment:focus {
+	color: #d63638;
+}
+
 .media-modal .untrash-attachment:hover,
 .media-modal .untrash-attachment:focus {
-	color: #d63638;
+	color: #135e96;
 }
 
 /**

--- a/src/wp-includes/media-template.php
+++ b/src/wp-includes/media-template.php
@@ -749,6 +749,8 @@ function wp_print_media_templates() {
 					<?php if ( MEDIA_TRASH ) : ?>
 					<# if ( 'trash' === data.status ) { #>
 						<button type="button" class="button-link untrash-attachment"><?php _e( 'Restore from Trash' ); ?></button>
+						<span class="links-separator">|</span>
+						<button type="button" class="button-link delete-attachment"><?php _e( 'Delete permanently' ); ?></button>
 					<# } else { #>
 						<button type="button" class="button-link trash-attachment"><?php _e( 'Move to Trash' ); ?></button>
 					<# } #>

--- a/src/wp-includes/media-template.php
+++ b/src/wp-includes/media-template.php
@@ -580,6 +580,8 @@ function wp_print_media_templates() {
 					<?php if ( MEDIA_TRASH ) : ?>
 						<# if ( 'trash' === data.status ) { #>
 							<button type="button" class="button-link untrash-attachment"><?php _e( 'Restore from Trash' ); ?></button>
+							<span class="links-separator">|</span>
+							<button type="button" class="button-link delete-attachment"><?php _e( 'Delete permanently' ); ?></button>
 						<# } else { #>
 							<button type="button" class="button-link trash-attachment"><?php _e( 'Move to Trash' ); ?></button>
 						<# } #>


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/38026

This PR adds a missing "Delete Permanently" button to the media details modal when files are in the trash.

- Adds "Delete Permanently" button alongside "Restore from Trash" in both attachment detail templates
- Changes "Restore from Trash" button color from red to WordPress admin blue for better UX
- Maintains red color for destructive delete/trash actions
- Ensures consistency between list view and grid view modal interfaces

Testing:
1. Enable `define('MEDIA_TRASH', true)` in `wp-config.php`
2. Move the media file to the trash
3. Open details modal in grid view
4. Verify both "Restore from Trash" (blue) and "Delete Permanently" (red) buttons are present and functional

