### PR TITLE
Fix: disable keyboard focus for disabled widget arrow buttons

### DIFF
--- a/src/js/_enqueues/admin/postbox.js
+++ b/src/js/_enqueues/admin/postbox.js
@@ -217,9 +217,11 @@
 			// Enable all buttons as a reset first.
 			moveUpButtons
 				.attr( 'aria-disabled', 'false' )
+				.prop( 'disabled', false )
 				.removeClass( 'hidden' );
 			moveDownButtons
 				.attr( 'aria-disabled', 'false' )
+				.prop( 'disabled', false )
 				.removeClass( 'hidden' );
 
 			// When there's only one "sortables" area (e.g. in the block editor) and only one visible postbox, hide the buttons.
@@ -230,12 +232,16 @@
 
 			// Set an aria-disabled=true attribute on the first visible "move" buttons.
 			if ( firstSortablesId === firstPostboxSortablesId ) {
-				$( firstPostbox ).find( '.handle-order-higher' ).attr( 'aria-disabled', 'true' );
+				$( firstPostbox ).find( '.handle-order-higher' )
+					.attr( 'aria-disabled', 'true' )
+					.prop( 'disabled', true );
 			}
 
 			// Set an aria-disabled=true attribute on the last visible "move" buttons.
 			if ( lastSortablesId === lastPostboxSortablesId ) {
-				$( '.postbox:visible .handle-order-lower' ).last().attr( 'aria-disabled', 'true' );
+				$( '.postbox:visible .handle-order-lower' ).last()
+					.attr( 'aria-disabled', 'true' )
+					.prop( 'disabled', true );
 			}
 		},
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR prevents keyboard focus for dashboard metabox widget arrows which are disabled

Trac ticket: https://core.trac.wordpress.org/ticket/63970

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
