### PR TITLE
Switch is_user_member_of_blog to only fetch a specific user meta key for capability rather than all meta keys for the user

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -1179,9 +1179,6 @@ function is_user_member_of_blog( $user_id = 0, $blog_id = 0 ) {
 		return false;
 	}
 
-	// No underscore before capabilities in $base_capabilities_key.
-	$base_capabilities_key = $wpdb->base_prefix . 'capabilities';
-	$site_capabilities_key = $wpdb->base_prefix . $blog_id . '_capabilities';
 
 	if ( 1 === $blog_id ) {
 		$has_cap = get_user_meta( $user_id, $base_capabilities_key, true );

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -1179,7 +1179,6 @@ function is_user_member_of_blog( $user_id = 0, $blog_id = 0 ) {
 		return false;
 	}
 
-
 	if ( 1 === $blog_id ) {
 		$capabilities_key = $wpdb->base_prefix . 'capabilities';
 	} else {

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -1181,10 +1181,11 @@ function is_user_member_of_blog( $user_id = 0, $blog_id = 0 ) {
 
 
 	if ( 1 === $blog_id ) {
-		$has_cap = get_user_meta( $user_id, $base_capabilities_key, true );
+		$capabilities_key = $wpdb->base_prefix . 'capabilities';
 	} else {
-		$has_cap = get_user_meta( $user_id, $site_capabilities_key, true );
+		$capabilities_key = $wpdb->base_prefix . $blog_id . '_capabilities';
 	}
+	$has_cap = get_user_meta( $user_id, $capabilities_key, true );
 
 	return is_array( $has_cap );
 }

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -1179,24 +1179,17 @@ function is_user_member_of_blog( $user_id = 0, $blog_id = 0 ) {
 		return false;
 	}
 
-	$keys = get_user_meta( $user_id );
-	if ( empty( $keys ) ) {
-		return false;
-	}
-
 	// No underscore before capabilities in $base_capabilities_key.
 	$base_capabilities_key = $wpdb->base_prefix . 'capabilities';
 	$site_capabilities_key = $wpdb->base_prefix . $blog_id . '_capabilities';
 
-	if ( isset( $keys[ $base_capabilities_key ] ) && 1 === $blog_id ) {
-		return true;
+	if ( 1 === $blog_id ) {
+		$has_cap = get_user_meta( $user_id, $base_capabilities_key, true );
+	} else {
+		$has_cap = get_user_meta( $user_id, $site_capabilities_key, true );
 	}
 
-	if ( isset( $keys[ $site_capabilities_key ] ) ) {
-		return true;
-	}
-
-	return false;
+	return is_array( $has_cap );
 }
 
 /**


### PR DESCRIPTION
https://core.trac.wordpress.org/changeset/33771 introduced performance improvements to is_user_member_of_blog to combat the slowness of [get_blogs_of_user](https://core.trac.wordpress.org/ticket/32472)

It does so by fetching all meta keys ($meta_key = ''). This makes it challenging to use "get_{$meta_type}_metadata" filter, as there's no good way to tell which part we want to short-circuit or apply special handling to.

The proposed approach is to change the logic do check for the specific blog's capability check name.

Trac ticket: https://core.trac.wordpress.org/ticket/63989

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
