### PR TITLE
Move Imagick specific test method to the Imagick specific test class

### DIFF
--- a/tests/phpunit/tests/image/editorImagick.php
+++ b/tests/phpunit/tests/image/editorImagick.php
@@ -935,4 +935,64 @@ class Tests_Image_Editor_Imagick extends WP_Image_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Test AVIF quality filters.
+	 *
+	 * @ticket 61614
+	 */
+	public function test_quality_with_avif_conversion_file_sizes() {
+		$temp_dir = get_temp_dir();
+		$file     = $temp_dir . '/33772.jpg';
+		copy( DIR_TESTDATA . '/images/33772.jpg', $file );
+
+		$editor = wp_get_image_editor( $file );
+		print_r( $editor );
+		// Only continue if the server supports AVIF.
+		if ( ! $editor->supports_mime_type( 'image/avif' ) ) {
+			$this->markTestSkipped( 'AVIF is not supported by the selected image editor.' );
+		}
+
+		$attachment_id = self::factory()->attachment->create_object(
+			array(
+				'post_mime_type' => 'image/jpeg',
+				'file'           => $file,
+			)
+		);
+
+		// Test sizes with AVIF images.
+		add_filter( 'image_editor_output_format', array( $this, 'image_editor_output_avif' ) );
+		$avif_sizes = wp_generate_attachment_metadata( $attachment_id, $file );
+		remove_filter( 'image_editor_output_format', array( $this, 'image_editor_output_avif' ) );
+
+		// Set the compression quality to a lower setting and test again, verifying that file sizes are all smaller.
+		add_filter( 'image_editor_output_format', array( $this, 'image_editor_output_avif' ) );
+		add_filter( 'wp_editor_set_quality', array( $this, 'image_editor_change_quality_low' ) );
+		$smaller_avif_sizes = wp_generate_attachment_metadata( $attachment_id, $file );
+		remove_filter( 'wp_editor_set_quality', array( $this, 'image_editor_change_quality_low' ) );
+		remove_filter( 'image_editor_output_format', array( $this, 'image_editor_output_avif' ) );
+
+		// Sub-sizes: for each size, the AVIF should be smaller than the JPEG.
+		$sizes_to_compare = array_intersect_key( $avif_sizes['sizes'], $smaller_avif_sizes['sizes'] );
+
+		$this->assertNotEmpty( $sizes_to_compare );
+
+		foreach ( $sizes_to_compare as $size => $size_data ) {
+			$this->assertLessThan( $avif_sizes['sizes'][ $size ]['filesize'], $smaller_avif_sizes['sizes'][ $size ]['filesize'] );
+		}
+	}
+
+	/**
+	 * Output AVIF images.
+	 */
+	public function image_editor_output_avif() {
+		return array( 'image/jpeg' => 'image/avif' );
+	}
+
+	/**
+	 * Output only low quality images.
+	 */
+	public function image_editor_change_quality_low( $quality ) {
+		return 15;
+	}
 }

--- a/tests/phpunit/tests/image/editorImagick.php
+++ b/tests/phpunit/tests/image/editorImagick.php
@@ -951,7 +951,6 @@ class Tests_Image_Editor_Imagick extends WP_Image_UnitTestCase {
 		copy( DIR_TESTDATA . '/images/33772.jpg', $file );
 
 		$editor = wp_get_image_editor( $file );
-		print_r( $editor );
 		// Only continue if the server supports AVIF.
 		if ( ! $editor->supports_mime_type( 'image/avif' ) ) {
 			$this->markTestSkipped( 'AVIF is not supported by the selected image editor.' );

--- a/tests/phpunit/tests/image/editorImagick.php
+++ b/tests/phpunit/tests/image/editorImagick.php
@@ -953,7 +953,7 @@ class Tests_Image_Editor_Imagick extends WP_Image_UnitTestCase {
 		$editor = wp_get_image_editor( $file );
 		// Only continue if the server supports AVIF.
 		if ( ! $editor->supports_mime_type( 'image/avif' ) ) {
-			$this->markTestSkipped( 'AVIF is not supported by the selected image editor.' );
+			$this->markTestSkipped( sprintf( 'No AVIF support in the editor engine %s on this system.', $this->editor_engine ) );
 		}
 
 		$attachment_id = self::factory()->attachment->create_object(

--- a/tests/phpunit/tests/image/editorImagick.php
+++ b/tests/phpunit/tests/image/editorImagick.php
@@ -940,6 +940,10 @@ class Tests_Image_Editor_Imagick extends WP_Image_UnitTestCase {
 	 * Test AVIF quality filters.
 	 *
 	 * @ticket 61614
+	 *
+	 * Temporarily disabled until we can figure out why it fails on the Trixie based PHP container.
+	 * See https://core.trac.wordpress.org/ticket/63932.
+	 * @requires PHP < 8.3
 	 */
 	public function test_quality_with_avif_conversion_file_sizes() {
 		$temp_dir = get_temp_dir();

--- a/tests/phpunit/tests/image/resize.php
+++ b/tests/phpunit/tests/image/resize.php
@@ -96,6 +96,10 @@ abstract class WP_Tests_Image_Resize_UnitTestCase extends WP_Image_UnitTestCase 
 		$file   = DIR_TESTDATA . '/images/avif-lossy.avif';
 		$editor = wp_get_image_editor( $file );
 
+		if ( 'WP_Image_Editor_GD' === $this->editor_engine && PHP_VERSION < 80100 ) {
+			$this->markTestSkipped( 'AVIF is only supported in GD with PHP >= 8.1.' );
+		}
+
 		// Check if the editor supports the avif mime type.
 		if ( is_wp_error( $editor ) || ! $editor->supports_mime_type( 'image/avif' ) ) {
 			$this->markTestSkipped( sprintf( 'No AVIF support in the editor engine %s on this system.', $this->editor_engine ) );

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -5469,55 +5469,6 @@ EOF;
 	}
 
 	/**
-	 * Test AVIF quality filters.
-	 *
-	 * @ticket 61614
-	 *
-	 * Temporarily disabled until we can figure out why it fails on the Trixie based PHP container.
-	 * See https://core.trac.wordpress.org/ticket/63932.
-	 * @requires PHP < 8.3
-	 */
-	public function test_quality_with_avif_conversion_file_sizes() {
-		$temp_dir = get_temp_dir();
-		$file     = $temp_dir . '/33772.jpg';
-		copy( DIR_TESTDATA . '/images/33772.jpg', $file );
-
-		$editor = wp_get_image_editor( $file );
-		// Only continue if the server supports AVIF.
-		if ( ! $editor->supports_mime_type( 'image/avif' ) ) {
-			$this->markTestSkipped( 'AVIF is not supported by the selected image editor.' );
-		}
-
-		$attachment_id = self::factory()->attachment->create_object(
-			array(
-				'post_mime_type' => 'image/jpeg',
-				'file'           => $file,
-			)
-		);
-
-		// Test sizes with AVIF images.
-		add_filter( 'image_editor_output_format', array( $this, 'image_editor_output_avif' ) );
-		$avif_sizes = wp_generate_attachment_metadata( $attachment_id, $file );
-		remove_filter( 'image_editor_output_format', array( $this, 'image_editor_output_avif' ) );
-
-		// Set the compression quality to a lower setting and test again, verifying that file sizes are all smaller.
-		add_filter( 'image_editor_output_format', array( $this, 'image_editor_output_avif' ) );
-		add_filter( 'wp_editor_set_quality', array( $this, 'image_editor_change_quality_low' ) );
-		$smaller_avif_sizes = wp_generate_attachment_metadata( $attachment_id, $file );
-		remove_filter( 'wp_editor_set_quality', array( $this, 'image_editor_change_quality_low' ) );
-		remove_filter( 'image_editor_output_format', array( $this, 'image_editor_output_avif' ) );
-
-		// Sub-sizes: for each size, the AVIF should be smaller than the JPEG.
-		$sizes_to_compare = array_intersect_key( $avif_sizes['sizes'], $smaller_avif_sizes['sizes'] );
-
-		$this->assertNotEmpty( $sizes_to_compare );
-
-		foreach ( $sizes_to_compare as $size => $size_data ) {
-			$this->assertLessThan( $avif_sizes['sizes'][ $size ]['filesize'], $smaller_avif_sizes['sizes'][ $size ]['filesize'] );
-		}
-	}
-
-	/**
 	 * Test that the `wp_editor_set_quality` filter includes the dimensions in the `$dims` parameter.
 	 *
 	 * @ticket 54648
@@ -6787,13 +6738,6 @@ EOF;
 	}
 
 	/**
-	 * Output AVIF images.
-	 */
-	public function image_editor_output_avif() {
-		return array( 'image/jpeg' => 'image/avif' );
-	}
-
-	/**
 	 * Changes the quality using very low quality for JPEGs and very high quality
 	 * for WebPs, used to verify the filter is applying correctly.
 	 *
@@ -6809,13 +6753,6 @@ EOF;
 		} else {
 			return 30;
 		}
-	}
-
-	/**
-	 * Output only low quality images.
-	 */
-	public function image_editor_change_quality_low( $quality ) {
-		return 15;
 	}
 
 	/**


### PR DESCRIPTION
This moves the `test_quality_with_avif_conversion_file_sizes` test method and related filter hooks to the `Tests_Image_Editor_Imagick` class, which specifically forces the use of `WP_Image_Editor_Imagick`.

In the current location (the `Tests_Media` class), a specific image editor is not enforced, so the test can fall back to using GD when Imagick is not compiled with AVIF support.

Trac ticket: Core-63990.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
