### PR TITLE
Block Bindings: Add postType to context for Post Data source

### DIFF
--- a/src/wp-includes/block-bindings/post-data.php
+++ b/src/wp-includes/block-bindings/post-data.php
@@ -60,7 +60,7 @@ function _register_block_bindings_post_data_source() {
 		array(
 			'label'              => _x( 'Post Data', 'block bindings source' ),
 			'get_value_callback' => '_block_bindings_post_data_get_value',
-			'uses_context'       => array( 'postId' ),
+			'uses_context'       => array( 'postId', 'postType' ), // Both are needed on the client side.
 		)
 	);
 }


### PR DESCRIPTION
The Post Data source is currently only providing `postId` providing, but not `postType` context, even though the client side [requires the latter](https://github.com/WordPress/gutenberg/blob/b8972ed0afe7bc97c12e00bce911ceed124ec33e/packages/editor/src/bindings/post-data.js#L37-L59). Since that requirement is not met, the source doesn't work quite properly in the editor. (Among other things, it shows up as read-only in the editor.)

Found while testing https://github.com/WordPress/gutenberg/pull/71542.

Trac ticket: https://core.trac.wordpress.org/ticket/63994

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
