### PR TITLE
FIx: Trim Cookie Paths

### DIFF
--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -301,14 +301,14 @@ function wp_cookie_constants() {
 	 * @since 1.2.0
 	 */
 	if ( ! defined( 'COOKIEPATH' ) ) {
-		define( 'COOKIEPATH', preg_replace( '|https?://[^/]+|i', '', get_option( 'home' ) . '/' ) );
+		define( 'COOKIEPATH', trim( preg_replace( '|https?://[^/]+|i', '', get_option( 'home' ) . '/' ) ) );
 	}
 
 	/**
 	 * @since 1.5.0
 	 */
 	if ( ! defined( 'SITECOOKIEPATH' ) ) {
-		define( 'SITECOOKIEPATH', preg_replace( '|https?://[^/]+|i', '', get_option( 'siteurl' ) . '/' ) );
+		define( 'SITECOOKIEPATH', trim( preg_replace( '|https?://[^/]+|i', '', get_option( 'siteurl' ) . '/' ) ) );
 	}
 
 	/**
@@ -322,7 +322,7 @@ function wp_cookie_constants() {
 	 * @since 2.6.0
 	 */
 	if ( ! defined( 'PLUGINS_COOKIE_PATH' ) ) {
-		define( 'PLUGINS_COOKIE_PATH', preg_replace( '|https?://[^/]+|i', '', WP_PLUGIN_URL ) );
+		define( 'PLUGINS_COOKIE_PATH', trim( preg_replace( '|https?://[^/]+|i', '', WP_PLUGIN_URL ) ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/load/wpCookieConstants.php
+++ b/tests/phpunit/tests/load/wpCookieConstants.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Tests for wp_cookie_constants().
+ *
+ * @group load
+ * @covers ::wp_cookie_constants
+ */
+
+class Tests_Load_wpCookieConstants extends WP_UnitTestCase {
+
+	/**
+	 * Ensure that COOKIEPATH, SITECOOKIEPATH and PLUGINS_COOKIE_PATH are trimmed
+	 * when option values contain leading/trailing spaces.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_trim_cookie_paths_from_options_with_spaces() {
+		update_option( 'home', ' http://example.org/ ' );
+		update_option( 'siteurl', ' http://example.org/ ' );
+
+		wp_plugin_directory_constants();
+		wp_cookie_constants();
+
+		$this->assertSame( '/', COOKIEPATH );
+		$this->assertSame( '/', SITECOOKIEPATH );
+		$this->assertSame( '/wp-content/plugins', PLUGINS_COOKIE_PATH );
+
+		$this->assertSame( trim( COOKIEPATH ), COOKIEPATH );
+		$this->assertSame( trim( SITECOOKIEPATH ), SITECOOKIEPATH );
+		$this->assertSame( trim( PLUGINS_COOKIE_PATH ), PLUGINS_COOKIE_PATH );
+
+		$this->assertStringNotContainsString( ' ', COOKIEPATH );
+		$this->assertStringNotContainsString( ' ', SITECOOKIEPATH );
+		$this->assertStringNotContainsString( ' ', PLUGINS_COOKIE_PATH );
+	}
+
+	/**
+	 * When options are normal (no spaces), constants should be their expected defaults.
+	 */
+	public function test_cookie_paths_are_unchanged_when_no_spaces() {
+		update_option( 'home', 'http://example.com' );
+		update_option( 'siteurl', 'http://example.com' );
+
+		wp_plugin_directory_constants();
+		wp_cookie_constants();
+
+		$this->assertSame( '/', COOKIEPATH );
+		$this->assertSame( '/', SITECOOKIEPATH );
+		$this->assertSame( '/wp-content/plugins', PLUGINS_COOKIE_PATH );
+	}
+}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR ensures that cookie path constants are trimmed so that accidental leading or trailing whitespace in `home`, `siteurl`, or plugin URLs cannot create invalid cookie paths.

Affected constants: `COOKIEPATH`, `SITECOOKIEPATH`, `PLUGINS_COOKIE_PATH` (defined in `default-constants.php`)

Code used for testing: 
```php
update_option( 'home', ' http://example.org/ ' );
update_option( 'siteurl', ' http://example.org/ ' );
```

Trac ticket: https://core.trac.wordpress.org/ticket/49633

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
