### PR TITLE
Administration: Replace incorrect `cite` elements with `span` for author names

### DIFF
--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -3067,6 +3067,10 @@ div.action-links {
 	font-size: 13px;
 }
 
+.plugin-author {
+	font-style: italic;
+}
+
 /* For non-js plugin installation screen ticket #36430. */
 .update-php .button.button-primary {
 	margin-right: 1em;

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -1084,7 +1084,8 @@ body #dashboard-widgets .postbox form .submit {
 	color: #646970;
 }
 
-#latest-comments #the-comment-list .comment-meta cite {
+#latest-comments #the-comment-list .comment-meta cite,
+#latest-comments #the-comment-list .comment-meta .comment-author {
 	font-style: normal;
 	font-weight: 400;
 }

--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -553,7 +553,7 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 			$author = wp_kses( $plugin['author'], $plugins_allowedtags );
 			if ( ! empty( $author ) ) {
 				/* translators: %s: Plugin author. */
-				$author = ' <cite>' . sprintf( __( 'By %s' ), $author ) . '</cite>';
+				$author = ' <span class="plugin-author">' . sprintf( __( 'By %s' ), $author ) . '</span>';
 			}
 
 			$requires_php = isset( $plugin['requires_php'] ) ? $plugin['requires_php'] : null;

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -853,7 +853,7 @@ function _wp_dashboard_recent_comments_row( &$comment, $show_date = true ) {
 					printf(
 						/* translators: 1: Comment author, 2: Post link, 3: Notification if the comment is pending. */
 						__( 'From %1$s on %2$s %3$s' ),
-						'<cite class="comment-author">' . get_comment_author_link( $comment ) . '</cite>',
+						'<span class="comment-author">' . get_comment_author_link( $comment ) . '</span>',
 						$comment_post_link,
 						'<span class="approve">' . __( '[Pending]' ) . '</span>'
 					);
@@ -861,7 +861,7 @@ function _wp_dashboard_recent_comments_row( &$comment, $show_date = true ) {
 					printf(
 						/* translators: 1: Comment author, 2: Notification if the comment is pending. */
 						__( 'From %1$s %2$s' ),
-						'<cite class="comment-author">' . get_comment_author_link( $comment ) . '</cite>',
+						'<span class="comment-author">' . get_comment_author_link( $comment ) . '</span>',
 						'<span class="approve">' . __( '[Pending]' ) . '</span>'
 					);
 				}

--- a/src/wp-admin/includes/plugin.php
+++ b/src/wp-admin/includes/plugin.php
@@ -210,7 +210,7 @@ function _get_plugin_data_markup_translate( $plugin_file, $plugin_data, $markup 
 		if ( $plugin_data['Author'] ) {
 			$plugin_data['Description'] .= sprintf(
 				/* translators: %s: Plugin author. */
-				' <cite>' . __( 'By %s.' ) . '</cite>',
+				' <span class="plugin-author">' . __( 'By %s.' ) . '</span>',
 				$plugin_data['Author']
 			);
 		}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/17520

This PR fixes incorrect usage of `<cite>` elements for author names throughout the WP admin to comply with HTML5 semantic standards.

The HTML5 specification states that `<cite>` should only be used for titles of works (books, movies, songs, etc.), not for author names. This change replaces all instances where `<cite>` incorrectly wraps author names with semantically appropriate `<span>` elements.


- Plugin Install List Table: Replace `<cite>` with `<span class="plugin-author">` for plugin authors
- Plugin Data Markup: Replace `<cite>` with `<span class="plugin-author">` in plugin descriptions  
- Dashboard Comments: Replace `<cite class="comment-author">` with `<span class="comment-author">`
- CSS Updates: Add styling rules for new classes to maintain visual consistency

