### PR TITLE
Test block comments not included in comment queries.

### DIFF
--- a/tests/phpunit/tests/comment/query.php
+++ b/tests/phpunit/tests/comment/query.php
@@ -140,6 +140,13 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 				'comment_type'     => 'luigi',
 			)
 		);
+		$c6 = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$post_id,
+				'comment_approved' => '1',
+				'comment_type'     => 'block_comment',
+			)
+		);
 
 		$q     = new WP_Comment_Query();
 		$found = $q->query(
@@ -149,7 +156,8 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSameSets( array( $c1, $c2, $c3, $c4, $c5 ), $found );
+		$this->assertSameSets( array( $c1, $c2, $c3, $c4, $c5 ), $found, 'Empty string should return all public comments.' );
+		$this->assertNotContains( $c6, $found, 'Empty string should not return block comments.' );
 	}
 
 	/**
@@ -192,6 +200,13 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 				'comment_type'     => 'luigi',
 			)
 		);
+		$c6 = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$post_id,
+				'comment_approved' => '1',
+				'comment_type'     => 'block_comment',
+			)
+		);
 
 		$q     = new WP_Comment_Query();
 		$found = $q->query(
@@ -201,7 +216,7 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSameSets( array( $c1 ), $found );
+		$this->assertSameSets( array( $c1 ), $found, 'Comment type should return only regular comments.' );
 	}
 
 	/**
@@ -235,6 +250,13 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 				'comment_type'     => 'trackback',
 			)
 		);
+		$c5 = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$post_id,
+				'comment_approved' => '1',
+				'comment_type'     => 'block_comment',
+			)
+		);
 
 		$q     = new WP_Comment_Query();
 		$found = $q->query(
@@ -244,7 +266,7 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSameSets( array( $c2, $c3 ), $found );
+		$this->assertSameSets( array( $c2, $c3 ), $found, 'Pingback type should return only pingbacks.' );
 	}
 
 	/**
@@ -278,6 +300,13 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 				'comment_type'     => 'pingback',
 			)
 		);
+		$c5 = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$post_id,
+				'comment_approved' => '1',
+				'comment_type'     => 'block_comment',
+			)
+		);
 
 		$q     = new WP_Comment_Query();
 		$found = $q->query(
@@ -287,7 +316,7 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSameSets( array( $c2, $c3 ), $found );
+		$this->assertSameSets( array( $c2, $c3 ), $found, 'Trackback type should return only trackbacks.' );
 	}
 
 	/**
@@ -330,6 +359,13 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 				'comment_type'     => 'luigi',
 			)
 		);
+		$c6 = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$post_id,
+				'comment_approved' => '1',
+				'comment_type'     => 'block_comment',
+			)
+		);
 
 		$q     = new WP_Comment_Query();
 		$found = $q->query(
@@ -339,7 +375,7 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSameSets( array( $c2, $c3 ), $found );
+		$this->assertSameSets( array( $c2, $c3 ), $found, 'Pings type should return only trackbacks and pingbacks.' );
 	}
 
 	/**
@@ -391,6 +427,13 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 				'comment_type'     => 'mario',
 			)
 		);
+		$c7 = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$post_id,
+				'comment_approved' => '1',
+				'comment_type'     => 'block_comment',
+			)
+		);
 
 		$q     = new WP_Comment_Query();
 		$found = $q->query(
@@ -400,7 +443,7 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSameSets( array( $c1, $c4, $c6 ), $found );
+		$this->assertSameSets( array( $c1, $c4, $c6 ), $found, 'Comments + custom type should return regular comments and custom type.' );
 	}
 
 	/**
@@ -450,6 +493,13 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 				'comment_type'     => 'mario',
 			)
 		);
+		$c7 = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => self::$post_id,
+				'comment_approved' => '1',
+				'comment_type'     => 'block_comment',
+			)
+		);
 
 		$q     = new WP_Comment_Query();
 		$found = $q->query(
@@ -459,7 +509,8 @@ class Tests_Comment_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSameSets( array( $c1, $c2, $c3, $c4, $c6 ), $found );
+		$this->assertSameSets( array( $c1, $c2, $c3, $c4, $c6 ), $found, 'Not in luigi should return all but luigi.' );
+		$this->assertNotContains( $c7, $found, 'Not in luigi should not return block comments.' );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Backport tests for block_comments being excluded from comment queries.

Trac ticket: TBA

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
