### PR TITLE
Block Bindings: Support Image block's `caption` attribute

### DIFF
--- a/src/wp-includes/class-wp-block.php
+++ b/src/wp-includes/class-wp-block.php
@@ -109,7 +109,7 @@ class WP_Block {
 	private const BLOCK_BINDINGS_SUPPORTED_ATTRIBUTES = array(
 		'core/paragraph' => array( 'content' ),
 		'core/heading'   => array( 'content' ),
-		'core/image'     => array( 'id', 'url', 'title', 'alt' ),
+		'core/image'     => array( 'id', 'url', 'title', 'alt', 'caption' ),
 		'core/button'    => array( 'url', 'text', 'linkTarget', 'rel' ),
 		'core/post-date' => array( 'datetime' ),
 	);

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -295,7 +295,7 @@ HTML;
 	 * Furthermore tests if the caption attribute is correctly processed.
 	 *
 	 * @ticket 60282
-	 * @ticket XXXXX
+	 * @ticket 64031
 	 *
 	 * @covers ::register_block_bindings_source
 	 */

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -102,6 +102,16 @@ HTML
 				,
 				'<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">test source value</a></div>',
 			),
+			'image block' => array(
+				'caption',
+				<<<HTML
+<!-- wp:image {"id":66,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="breakfast.jpg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption">Breakfast at a <em>café</em> in Wrocław.</figcaption></figure>
+<!-- /wp:image -->
+HTML
+			,
+			'<figure class="wp-block-image size-large"><img src="breakfast.jpg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption">test source value</figcaption></figure>'
+			),
 			'test block'      => array(
 				'myAttribute',
 				<<<HTML

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -102,7 +102,7 @@ HTML
 				,
 				'<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">test source value</a></div>',
 			),
-			'image block' => array(
+			'image block'     => array(
 				'caption',
 				<<<HTML
 <!-- wp:image {"id":66,"sizeSlug":"large","linkDestination":"none"} -->
@@ -110,7 +110,7 @@ HTML
 <!-- /wp:image -->
 HTML
 			,
-			'<figure class="wp-block-image size-large"><img src="breakfast.jpg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption">test source value</figcaption></figure>'
+				'<figure class="wp-block-image size-large"><img src="breakfast.jpg" alt="" class="wp-image-1"/><figcaption class="wp-element-caption">test source value</figcaption></figure>',
 			),
 			'test block'      => array(
 				'myAttribute',

--- a/tests/phpunit/tests/block-bindings/render.php
+++ b/tests/phpunit/tests/block-bindings/render.php
@@ -292,13 +292,21 @@ HTML;
 	 * Tests if the block content is updated with the value returned by the source
 	 * for the Image block in the placeholder state.
 	 *
+	 * Furthermore tests if the caption attribute is correctly processed.
+	 *
 	 * @ticket 60282
+	 * @ticket XXXXX
 	 *
 	 * @covers ::register_block_bindings_source
 	 */
 	public function test_update_block_with_value_from_source_image_placeholder() {
-		$get_value_callback = function () {
-			return 'https://example.com/image.jpg';
+		$get_value_callback = function ( $source_args, $block_instance, $attribute_name ) {
+			if ( 'url' === $attribute_name ) {
+				return 'https://example.com/image.jpg';
+			}
+			if ( 'caption' === $attribute_name ) {
+				return 'Example Image';
+			}
 		};
 
 		register_block_bindings_source(
@@ -310,8 +318,8 @@ HTML;
 		);
 
 		$block_content = <<<HTML
-<!-- wp:image {"metadata":{"bindings":{"url":{"source":"test/source"}}}} -->
-<figure class="wp-block-image"><img alt=""/></figure>
+<!-- wp:image {"metadata":{"bindings":{"url":{"source":"test/source"},"caption":{"source":"test/source"}}}} -->
+<figure class="wp-block-image"><img alt=""/><figcaption class="wp-element-caption"></figcaption></figure>
 <!-- /wp:image -->
 HTML;
 		$parsed_blocks = parse_blocks( $block_content );
@@ -324,7 +332,12 @@ HTML;
 			"The 'url' attribute should be updated with the value returned by the source."
 		);
 		$this->assertSame(
-			'<figure class="wp-block-image"><img src="https://example.com/image.jpg" alt=""/></figure>',
+			'Example Image',
+			$block->attributes['caption'],
+			"The 'caption' attribute should be updated with the value returned by the source."
+		);
+		$this->assertSame(
+			'<figure class="wp-block-image"><img src="https://example.com/image.jpg" alt=""/><figcaption class="wp-element-caption">Example Image</figcaption></figure>',
 			trim( $result ),
 			'The block content should be updated with the value returned by the source.'
 		);


### PR DESCRIPTION
Backport of https://github.com/WordPress/gutenberg/pull/71483.

Supersedes https://github.com/WordPress/wordpress-develop/pull/9702 for reasons stated [here](https://core.trac.wordpress.org/ticket/63919#comment:4).

TODO:

- [x] Carry over [additional test coverage from GB](https://github.com/WordPress/gutenberg/pull/71691/files#diff-7220479c54d2ef974dec9ae5fa7f738ce71ca8879333f6751828a707098f9bf2), see [this convo](https://github.com/WordPress/wordpress-develop/pull/9702#discussion_r2344141353). 
- [x] Need to file a new Trac ticket -- https://core.trac.wordpress.org/ticket/63919 is no longer pertinent.
- [x] We should also update [this back-compat changelog in GB](https://github.com/WordPress/gutenberg/pull/71483/files#diff-749aec929bf6ec005ace1d322816dbb1e5d3b8bdfb87d2d44609cdbe744dd7e1R1) to point to this PR: https://github.com/WordPress/gutenberg/pull/71849.

Trac ticket: https://core.trac.wordpress.org/ticket/64031

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
