### PR TITLE
Fix: Update `get_delete_post_link()` to support post types with multiple `_edit_link` placeholders

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1577,7 +1577,19 @@ function get_delete_post_link( $post = 0, $deprecated = '', $force_delete = fals
 
 	$action = ( $force_delete || ! EMPTY_TRASH_DAYS ) ? 'delete' : 'trash';
 
-	$delete_link = add_query_arg( 'action', $action, admin_url( sprintf( $post_type_object->_edit_link, $post->ID ) ) );
+	// Build args dynamically depending on placeholders in _edit_link.
+	$format = $post_type_object->_edit_link;
+	$args   = [];
+
+	$placeholders = substr_count( $format, '%s' ) + substr_count( $format, '%d' );
+
+	$args = ( 2 === $placeholders ) ? [ $post->post_type, $post->ID ] : $args = [ $post->ID ];
+
+	$delete_link = add_query_arg(
+		'action',
+		$action,
+		admin_url( vsprintf( $format, $args ) )
+	);
 
 	/**
 	 * Filters the post delete link.
@@ -1588,7 +1600,12 @@ function get_delete_post_link( $post = 0, $deprecated = '', $force_delete = fals
 	 * @param int    $post_id      Post ID.
 	 * @param bool   $force_delete Whether to bypass the Trash and force deletion. Default false.
 	 */
-	return apply_filters( 'get_delete_post_link', wp_nonce_url( $delete_link, "$action-post_{$post->ID}" ), $post->ID, $force_delete );
+	return apply_filters(
+		'get_delete_post_link',
+		wp_nonce_url( $delete_link, "$action-post_{$post->ID}" ),
+		$post->ID,
+		$force_delete
+	);
 }
 
 /**

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1579,11 +1579,11 @@ function get_delete_post_link( $post = 0, $deprecated = '', $force_delete = fals
 
 	// Build args dynamically depending on placeholders in _edit_link.
 	$format = $post_type_object->_edit_link;
-	$args   = [];
+	$args   = array();
 
 	$placeholders = substr_count( $format, '%s' ) + substr_count( $format, '%d' );
 
-	$args = ( 2 === $placeholders ) ? [ $post->post_type, $post->ID ] : $args = [ $post->ID ];
+	$args = ( 2 === $placeholders ) ? array( $post->post_type, $post->ID ) : $args = array( $post->ID );
 
 	$delete_link = add_query_arg(
 		'action',


### PR DESCRIPTION
Trac Ticket: Core-61716

## Problem

- `get_delete_post_link()` assumes _edit_link contains only a single placeholder (e.g. post.php?post=%d).
Gutenberg post types such as wp_template and wp_template_part define _edit_link with multiple placeholders (e.g. site-editor.php?postType=%s&postId=%s&canvas=edit).

- This mismatch causes `sprintf()` to throw an ArgumentCountError when generating delete links.

## Solution

- Update `get_delete_post_link()` to dynamically count placeholders in _edit_link and adjust the arguments passed to `vsprintf()`.

- This ensures compatibility with both classic and Gutenberg CPTs, prevents fatal errors, and future-proofs the function against additional placeholders.