### PR TITLE
wp_die() updates for Media Component

### DIFF
--- a/src/wp-admin/async-upload.php
+++ b/src/wp-admin/async-upload.php
@@ -32,7 +32,7 @@ if ( isset( $_REQUEST['action'] ) && 'upload-attachment' === $_REQUEST['action']
 }
 
 if ( ! current_user_can( 'upload_files' ) ) {
-	wp_die( __( 'Sorry, you are not allowed to upload files.' ) );
+	wp_die( __( 'Sorry, you are not allowed to upload files.' ), 403 );
 }
 
 // Just fetch the detail form for that attachment.
@@ -40,7 +40,7 @@ if ( isset( $_REQUEST['attachment_id'] ) && (int) $_REQUEST['attachment_id'] && 
 	$id   = (int) $_REQUEST['attachment_id'];
 	$post = get_post( $id );
 	if ( 'attachment' !== $post->post_type ) {
-		wp_die( __( 'Invalid post type.' ) );
+		wp_die( __( 'Invalid post type.' ), 400 );
 	}
 
 	switch ( $_REQUEST['fetch'] ) {

--- a/src/wp-admin/includes/class-file-upload-upgrader.php
+++ b/src/wp-admin/includes/class-file-upload-upgrader.php
@@ -79,7 +79,7 @@ class File_Upload_Upgrader {
 							self_admin_url( 'plugin-install.php' ),
 							__( 'Return to the Plugin Installer' )
 						);
-						wp_die( __( 'Incompatible Archive.' ) . '<br />' . $plugins_page, 422 );
+						wp_die( __( 'Incompatible Archive.' ) . '<br />' . $plugins_page, 415 );
 					}
 
 					if ( 'themezip' === $form ) {
@@ -88,7 +88,7 @@ class File_Upload_Upgrader {
 							self_admin_url( 'theme-install.php' ),
 							__( 'Return to the Theme Installer' )
 						);
-						wp_die( __( 'Incompatible Archive.' ) . '<br />' . $themes_page, 422 );
+						wp_die( __( 'Incompatible Archive.' ) . '<br />' . $themes_page, 415 );
 					}
 				}
 			}

--- a/src/wp-admin/includes/class-file-upload-upgrader.php
+++ b/src/wp-admin/includes/class-file-upload-upgrader.php
@@ -117,7 +117,7 @@ class File_Upload_Upgrader {
 			$this->id   = (int) $_GET[ $urlholder ];
 			$attachment = get_post( $this->id );
 			if ( empty( $attachment ) ) {
-				wp_die( __( 'Please select a file' ), 120 );
+				wp_die(__('Please select a file'), 400);
 			}
 
 			$this->filename = $attachment->post_title;

--- a/src/wp-admin/includes/class-file-upload-upgrader.php
+++ b/src/wp-admin/includes/class-file-upload-upgrader.php
@@ -117,7 +117,7 @@ class File_Upload_Upgrader {
 			$this->id   = (int) $_GET[ $urlholder ];
 			$attachment = get_post( $this->id );
 			if ( empty( $attachment ) ) {
-				wp_die( __('Please select a file'), 400 );
+				wp_die( __( 'Please select a file' ), 400 );
 			}
 
 			$this->filename = $attachment->post_title;

--- a/src/wp-admin/includes/class-file-upload-upgrader.php
+++ b/src/wp-admin/includes/class-file-upload-upgrader.php
@@ -117,7 +117,7 @@ class File_Upload_Upgrader {
 			$this->id   = (int) $_GET[ $urlholder ];
 			$attachment = get_post( $this->id );
 			if ( empty( $attachment ) ) {
-				wp_die(__('Please select a file'), 400);
+				wp_die(__('Please select a file'), 400 );
 			}
 
 			$this->filename = $attachment->post_title;

--- a/src/wp-admin/includes/class-file-upload-upgrader.php
+++ b/src/wp-admin/includes/class-file-upload-upgrader.php
@@ -117,7 +117,7 @@ class File_Upload_Upgrader {
 			$this->id   = (int) $_GET[ $urlholder ];
 			$attachment = get_post( $this->id );
 			if ( empty( $attachment ) ) {
-				wp_die(__('Please select a file'), 400 );
+				wp_die( __('Please select a file'), 400 );
 			}
 
 			$this->filename = $attachment->post_title;

--- a/src/wp-admin/includes/class-file-upload-upgrader.php
+++ b/src/wp-admin/includes/class-file-upload-upgrader.php
@@ -54,7 +54,7 @@ class File_Upload_Upgrader {
 	public function __construct( $form, $urlholder ) {
 
 		if ( empty( $_FILES[ $form ]['name'] ) && empty( $_GET[ $urlholder ] ) ) {
-			wp_die( __( 'Please select a file' ) );
+			wp_die( __( 'Please select a file' ), 400 );
 		}
 
 		// Handle a newly uploaded file. Else, assume it's already been uploaded.
@@ -79,7 +79,7 @@ class File_Upload_Upgrader {
 							self_admin_url( 'plugin-install.php' ),
 							__( 'Return to the Plugin Installer' )
 						);
-						wp_die( __( 'Incompatible Archive.' ) . '<br />' . $plugins_page );
+						wp_die( __( 'Incompatible Archive.' ) . '<br />' . $plugins_page, 422 );
 					}
 
 					if ( 'themezip' === $form ) {
@@ -88,7 +88,7 @@ class File_Upload_Upgrader {
 							self_admin_url( 'theme-install.php' ),
 							__( 'Return to the Theme Installer' )
 						);
-						wp_die( __( 'Incompatible Archive.' ) . '<br />' . $themes_page );
+						wp_die( __( 'Incompatible Archive.' ) . '<br />' . $themes_page, 422 );
 					}
 				}
 			}
@@ -117,7 +117,7 @@ class File_Upload_Upgrader {
 			$this->id   = (int) $_GET[ $urlholder ];
 			$attachment = get_post( $this->id );
 			if ( empty( $attachment ) ) {
-				wp_die( __( 'Please select a file' ) );
+				wp_die( __( 'Please select a file' ), 120 );
 			}
 
 			$this->filename = $attachment->post_title;
@@ -126,7 +126,7 @@ class File_Upload_Upgrader {
 			// Else, It's set to something, Back compat for plugins using the old (pre-3.3) File_Uploader handler.
 			$uploads = wp_upload_dir();
 			if ( ! ( $uploads && false === $uploads['error'] ) ) {
-				wp_die( $uploads['error'] );
+				wp_die( $uploads['error'], 400 );
 			}
 
 			$this->filename = sanitize_file_name( $_GET[ $urlholder ] );

--- a/src/wp-admin/media-new.php
+++ b/src/wp-admin/media-new.php
@@ -13,7 +13,7 @@
 require_once __DIR__ . '/admin.php';
 
 if ( ! current_user_can( 'upload_files' ) ) {
-	wp_die( __( 'Sorry, you are not allowed to upload files.' ) );
+	wp_die( __( 'Sorry, you are not allowed to upload files.' ), 403 );
 }
 
 wp_enqueue_script( 'plupload-handlers' );

--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -10,7 +10,7 @@
 require_once __DIR__ . '/admin.php';
 
 if ( ! current_user_can( 'upload_files' ) ) {
-	wp_die( __( 'Sorry, you are not allowed to upload files.' ) );
+	wp_die( __( 'Sorry, you are not allowed to upload files.' ), 403 );
 }
 
 $message = '';
@@ -293,7 +293,7 @@ if ( $doaction ) {
 			}
 			foreach ( $post_ids as $post_id ) {
 				if ( ! current_user_can( 'delete_post', $post_id ) ) {
-					wp_die( __( 'Sorry, you are not allowed to move this item to the Trash.' ) );
+					wp_die( __( 'Sorry, you are not allowed to move this item to the Trash.' ), 403 );
 				}
 
 				if ( ! wp_trash_post( $post_id ) ) {
@@ -314,7 +314,7 @@ if ( $doaction ) {
 			}
 			foreach ( $post_ids as $post_id ) {
 				if ( ! current_user_can( 'delete_post', $post_id ) ) {
-					wp_die( __( 'Sorry, you are not allowed to restore this item from the Trash.' ) );
+					wp_die( __( 'Sorry, you are not allowed to restore this item from the Trash.' ), 403 );
 				}
 
 				if ( ! wp_untrash_post( $post_id ) ) {
@@ -329,7 +329,7 @@ if ( $doaction ) {
 			}
 			foreach ( $post_ids as $post_id_del ) {
 				if ( ! current_user_can( 'delete_post', $post_id_del ) ) {
-					wp_die( __( 'Sorry, you are not allowed to delete this item.' ) );
+					wp_die( __( 'Sorry, you are not allowed to delete this item.' ), 403 );
 				}
 
 				if ( ! wp_delete_attachment( $post_id_del ) ) {


### PR DESCRIPTION
Update wp_die() to include status codes where appropriate within files related to the Media component.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: [64010](https://core.trac.wordpress.org/ticket/64010)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
