### PR TITLE
Introduce `LOCAL_DB_PORTS` env variable for overriding `mysql` container ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       - wpdevnet
 
     ports:
-      - "3306"
+      - "${LOCAL_DB_PORTS-3306}"
 
     environment:
       MYSQL_ROOT_PASSWORD: password


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64014

Given an `.env` updated to append:

```bash
LOCAL_DB_PORTS="33060:3306"
```

I'm able to configure PhpStorm as follows:

<img width="800" height="796" alt="image" src="https://github.com/user-attachments/assets/7c62af98-773d-4a78-817d-f860e483dfbb" />

And I'm then able to access the database:

<img width="1191" height="596" alt="image" src="https://github.com/user-attachments/assets/f661a7ed-056e-41e7-9ae4-775e021c2dd2" />


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
