### PR TITLE
Fix: Contributor can preview their own post.

### DIFF
--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1549,26 +1549,26 @@ class WP_Posts_List_Table extends WP_List_Table {
 				// For protected post statuses, check if filter allows author preview
 				$current_user_id = get_current_user_id();
 				$is_post_author = $current_user_id && ( $current_user_id === (int) $post->post_author );
-				
+
 				if ( $is_post_author ) {
 					$post_status_obj = get_post_status_object( $post->post_status );
 					if ( $post_status_obj && $post_status_obj->protected ) {
 						/**
 						 * Filters whether an author can preview their own protected post in admin.
-						 * 
+						 *
 						 * @param bool   $can_preview Whether the author can preview. Default true.
 						 * @param int    $post_id     Post ID.
 						 * @param int    $user_id     User ID of the post author.
 						 * @param string $post_status Post status.
 						 */
-						$author_can_preview = apply_filters( 
+						$author_can_preview = apply_filters(
 							'author_can_preview_protected_post', 
-							true, 
-							$post->ID, 
-							$current_user_id, 
-							$post->post_status 
+							true,
+							$post->ID,
+							$current_user_id,
+							$post->post_status
 						);
-						
+
 						// If filter disabled author preview, and user only has read access as author
 						// (not edit access), then disable preview
 						if ( ! $author_can_preview && ! current_user_can( 'edit_post', $post->ID ) ) {

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1546,7 +1546,6 @@ class WP_Posts_List_Table extends WP_List_Table {
 			if ( in_array( $post->post_status, array( 'pending', 'draft', 'future' ), true ) ) {
 
 				$can_preview = $can_read_post;
-        
 				// For protected post statuses, check if filter allows author preview
 				$current_user_id = get_current_user_id();
 				$is_post_author = $current_user_id && ( $current_user_id === (int) $post->post_author );

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1562,7 +1562,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 						 * @param string $post_status Post status.
 						 */
 						$author_can_preview = apply_filters(
-							'author_can_preview_protected_post', 
+							'author_can_preview_protected_post',
 							true,
 							$post->ID,
 							$current_user_id,

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -1479,6 +1479,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 
 		$post_type_object = get_post_type_object( $post->post_type );
 		$can_edit_post    = current_user_can( 'edit_post', $post->ID );
+		$can_read_post    = current_user_can( 'read_post', $post->ID );
 		$actions          = array();
 		$title            = _draft_or_post_title();
 
@@ -1543,7 +1544,40 @@ class WP_Posts_List_Table extends WP_List_Table {
 
 		if ( is_post_type_viewable( $post_type_object ) ) {
 			if ( in_array( $post->post_status, array( 'pending', 'draft', 'future' ), true ) ) {
-				if ( $can_edit_post ) {
+
+				$can_preview = $can_read_post;
+        
+				// For protected post statuses, check if filter allows author preview
+				$current_user_id = get_current_user_id();
+				$is_post_author = $current_user_id && ( $current_user_id === (int) $post->post_author );
+				
+				if ( $is_post_author ) {
+					$post_status_obj = get_post_status_object( $post->post_status );
+					if ( $post_status_obj && $post_status_obj->protected ) {
+						/**
+						 * Filters whether an author can preview their own protected post in admin.
+						 * 
+						 * @param bool   $can_preview Whether the author can preview. Default true.
+						 * @param int    $post_id     Post ID.
+						 * @param int    $user_id     User ID of the post author.
+						 * @param string $post_status Post status.
+						 */
+						$author_can_preview = apply_filters( 
+							'author_can_preview_protected_post', 
+							true, 
+							$post->ID, 
+							$current_user_id, 
+							$post->post_status 
+						);
+						
+						// If filter disabled author preview, and user only has read access as author
+						// (not edit access), then disable preview
+						if ( ! $author_can_preview && ! current_user_can( 'edit_post', $post->ID ) ) {
+							$can_preview = false;
+						}
+					}
+				}
+				if ( $can_preview ) {
 					$preview_link    = get_preview_post_link( $post );
 					$actions['view'] = sprintf(
 						'<a href="%s" rel="bookmark" aria-label="%s">%s</a>',

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3528,27 +3528,80 @@ class WP_Query {
 						// User must be logged in to view unpublished posts.
 						$this->posts = array();
 					} else {
+						// Get current user ID once.
+						$current_user_id = get_current_user_id();
+						$post_id = $this->posts[0]->ID;
+						$is_post_author = $current_user_id && ( $current_user_id === (int) $this->posts[0]->post_author );
+
 						if ( $post_status_obj->protected ) {
-							// User must have edit permissions on the draft to preview.
-							if ( ! current_user_can( $edit_cap, $this->posts[0]->ID ) ) {
-								$this->posts = array();
-							} else {
+							// For protected statuses, check edit permissions OR author status for previews
+							if ( current_user_can( $edit_cap, $post_id ) ) {
 								$this->is_preview = true;
 								if ( 'future' !== $status ) {
 									$this->posts[0]->post_date = current_time( 'mysql' );
 								}
+							} elseif ( $this->is_preview && $is_post_author ) {
+								/**
+								 * Filters whether an author can preview their own protected post.
+								 *
+								 * @since 6.9.0
+								 *
+								 * @param bool   $can_preview    Whether the author can preview. Default true.
+								 * @param int    $post_id        Post ID.
+								 * @param int    $user_id        User ID of the post author.
+								 * @param string $post_status    Post status.
+								 */
+								$can_preview = apply_filters( 
+									'author_can_preview_protected_post', 
+									true, 
+									$post_id, 
+									$current_user_id, 
+									$status 
+								);
+								if ( $can_preview ) {
+									$this->is_preview = true;
+									if ( 'future' !== $status ) {
+										$this->posts[0]->post_date = current_time( 'mysql' );
+									}
+									
+									/**
+									 * Fires when an author previews their own protected post.
+									 *
+									 * @since 6.5.0
+									 *
+									 * @param int    $post_id     Post ID being previewed.
+									 * @param int    $user_id     User ID of the author.
+									 * @param string $post_status Post status.
+									 */
+									do_action( 'author_preview_protected_post', $post_id, $current_user_id, $status );
+								} else {
+									$this->posts = array();
+								}
+							} else {
+								$this->posts = array();
 							}
 						} elseif ( $post_status_obj->private ) {
-							if ( ! current_user_can( $read_cap, $this->posts[0]->ID ) ) {
+							if ( ! current_user_can( $read_cap, $post_id ) && ! $is_post_author ) {
 								$this->posts = array();
 							}
 						} else {
-							$this->posts = array();
+							// For other non-public statuses (e.g., 'future', custom statuses)
+							if ( $this->is_preview && ( current_user_can( $read_cap, $post_id ) || $is_post_author ) ) {
+								$this->is_preview = true;
+								if ( 'future' !== $status ) {
+									$this->posts[0]->post_date = current_time( 'mysql' );
+								}
+							} else {
+								$this->posts = array();
+							}
 						}
 					}
 				} elseif ( ! $post_status_obj ) {
 					// Post status is not registered, assume it's not public.
-					if ( ! current_user_can( $edit_cap, $this->posts[0]->ID ) ) {
+					$current_user_id = get_current_user_id();
+        			$is_post_author = $current_user_id && ( $current_user_id === (int) $this->posts[0]->post_author );
+
+					if ( ! current_user_can( $edit_cap, $this->posts[0]->ID ) && ! $is_post_author ) {
 						$this->posts = array();
 					}
 				}

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3553,7 +3553,7 @@ class WP_Query {
 								 */
 								$can_preview = apply_filters(
 									'author_can_preview_protected_post',
-									true, 
+									true,
 									$post_id,
 									$current_user_id,
 									$status

--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -3551,19 +3551,19 @@ class WP_Query {
 								 * @param int    $user_id        User ID of the post author.
 								 * @param string $post_status    Post status.
 								 */
-								$can_preview = apply_filters( 
-									'author_can_preview_protected_post', 
+								$can_preview = apply_filters(
+									'author_can_preview_protected_post',
 									true, 
-									$post_id, 
-									$current_user_id, 
-									$status 
+									$post_id,
+									$current_user_id,
+									$status
 								);
 								if ( $can_preview ) {
 									$this->is_preview = true;
 									if ( 'future' !== $status ) {
 										$this->posts[0]->post_date = current_time( 'mysql' );
 									}
-									
+
 									/**
 									 * Fires when an author previews their own protected post.
 									 *
@@ -3599,7 +3599,7 @@ class WP_Query {
 				} elseif ( ! $post_status_obj ) {
 					// Post status is not registered, assume it's not public.
 					$current_user_id = get_current_user_id();
-        			$is_post_author = $current_user_id && ( $current_user_id === (int) $this->posts[0]->post_author );
+					$is_post_author = $current_user_id && ( $current_user_id === (int) $this->posts[0]->post_author );
 
 					if ( ! current_user_can( $edit_cap, $this->posts[0]->ID ) && ! $is_post_author ) {
 						$this->posts = array();


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This PR fixes the following things:

- Now the Contributor can preview their own post, even when the post is scheduled.
- Add on filter `author_can_preview_protected_post` which provides developer to customize this behaviour.

Trac ticket: https://core.trac.wordpress.org/ticket/39939

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
