### PR TITLE
Allow to use associative arrays beside indexed arrays in wp_mail $headers

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -6172,14 +6172,19 @@ function wp_staticize_emoji_for_email( $mail ) {
 	}
 
 	foreach ( $headers as $key => $header ) {
-		if ( is_string( $header ) && strpos($header, ':') === false ) {
-			if ( is_numeric ( $key ) ) {
+		if ( is_string( $header ) && strpos( $header, ':' ) === false ) {
+			if ( is_numeric( $key ) ) {
 				continue;
 			}
 		}
 
 		// Explode them out.
-		list( $name, $content ) = ( is_numeric ( $key ) ) ? explode( ':', trim( $header ), 2 ) : array ( $key, $header );
+		list( $name, $content ) = ( is_numeric( $key ) ) ? explode( ':', trim( $header ), 2 ) : array( $key, $header );
+
+		// Skip because Content-Type must be an string.
+		if ( ! is_string( $name ) || ! is_string( $content ) ) {
+			continue;
+		}
 
 		// Cleanup crew.
 		$name    = trim( $name );

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -6174,7 +6174,7 @@ function wp_staticize_emoji_for_email( $mail ) {
 	foreach ( $headers as $key => $header ) {
 		if ( is_string( $header ) &&
 			strpos( $header, ':' ) === false &&
-			! is_numeric( $key )
+			is_numeric( $key )
 		) {
 			continue;
 		}

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -6172,10 +6172,11 @@ function wp_staticize_emoji_for_email( $mail ) {
 	}
 
 	foreach ( $headers as $key => $header ) {
-		if ( is_string( $header ) && strpos( $header, ':' ) === false ) {
-			if ( is_numeric( $key ) ) {
-				continue;
-			}
+		if ( is_string( $header ) &&
+			strpos( $header, ':' ) === false &&
+			! is_numeric( $key )
+		) {
+			continue;
 		}
 
 		// Explode them out.

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -6171,13 +6171,15 @@ function wp_staticize_emoji_for_email( $mail ) {
 		}
 	}
 
-	foreach ( $headers as $header ) {
-		if ( ! str_contains( $header, ':' ) ) {
-			continue;
+	foreach ( $headers as $key => $header ) {
+		if ( is_string( $header ) && strpos($header, ':') === false ) {
+			if ( is_numeric ( $key ) ) {
+				continue;
+			}
 		}
 
 		// Explode them out.
-		list( $name, $content ) = explode( ':', trim( $header ), 2 );
+		list( $name, $content ) = ( is_numeric ( $key ) ) ? explode( ':', trim( $header ), 2 ) : array ( $key, $header );
 
 		// Cleanup crew.
 		$name    = trim( $name );

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -307,7 +307,9 @@ if ( ! function_exists( 'wp_mail' ) ) :
 			if ( ! empty( $tempheaders ) ) {
 				// Iterate through the raw headers.
 				foreach ( (array) $tempheaders as $key => $header ) {
-					if ( strpos($header, ':') === false ) {
+					if ( is_array( $header ) ) {
+						$header = implode( ',', $header ) . ',';
+					} elseif ( strpos( $header, ':' ) === false ) {
 						if ( false !== stripos( $header, 'boundary=' ) ) {
 							$parts    = preg_split( '/boundary=/i', trim( $header ) );
 							$boundary = trim( str_replace( array( "'", '"' ), '', $parts[1] ) );
@@ -317,7 +319,7 @@ if ( ! function_exists( 'wp_mail' ) ) :
 						}
 					}
 					// Explode them out.
-					list( $name, $content ) = ( is_numeric ( $key ) ) ? explode( ':', trim( $header ), 2 ) : array ( $key, $header );
+					list( $name, $content ) = ( is_numeric( $key ) ) ? explode( ':', trim( $header ), 2 ) : array( $key, $header );
 
 					// Cleanup crew.
 					$name    = trim( $name );
@@ -360,7 +362,7 @@ if ( ! function_exists( 'wp_mail' ) ) :
 								$content_type = trim( $content );
 							}
 							break;
-												case 'cc':
+						case 'cc':
 							$cc = array_merge(
 								(array) $cc,
 								( is_array( $content ) ) ? $content : explode( ',', $content )

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -306,16 +306,18 @@ if ( ! function_exists( 'wp_mail' ) ) :
 			// If it's actually got contents.
 			if ( ! empty( $tempheaders ) ) {
 				// Iterate through the raw headers.
-				foreach ( (array) $tempheaders as $header ) {
-					if ( ! str_contains( $header, ':' ) ) {
+				foreach ( (array) $tempheaders as $key => $header ) {
+					if ( strpos($header, ':') === false ) {
 						if ( false !== stripos( $header, 'boundary=' ) ) {
 							$parts    = preg_split( '/boundary=/i', trim( $header ) );
 							$boundary = trim( str_replace( array( "'", '"' ), '', $parts[1] ) );
 						}
-						continue;
+						if ( is_numeric( $key ) ) {
+							continue;
+						}
 					}
 					// Explode them out.
-					list( $name, $content ) = explode( ':', trim( $header ), 2 );
+					list( $name, $content ) = ( is_numeric ( $key ) ) ? explode( ':', trim( $header ), 2 ) : array ( $key, $header );
 
 					// Cleanup crew.
 					$name    = trim( $name );
@@ -358,18 +360,35 @@ if ( ! function_exists( 'wp_mail' ) ) :
 								$content_type = trim( $content );
 							}
 							break;
-						case 'cc':
-							$cc = array_merge( (array) $cc, explode( ',', $content ) );
+												case 'cc':
+							$cc = array_merge(
+								(array) $cc,
+								( is_array( $content ) ) ? $content : explode( ',', $content )
+							);
 							break;
 						case 'bcc':
-							$bcc = array_merge( (array) $bcc, explode( ',', $content ) );
+							$bcc = array_merge(
+								(array) $bcc,
+								( is_array( $content ) ) ? $content : explode( ',', $content )
+							);
 							break;
 						case 'reply-to':
-							$reply_to = array_merge( (array) $reply_to, explode( ',', $content ) );
+							$reply_to = array_merge(
+								(array) $reply_to,
+								( is_array( $content ) ) ? $content : explode( ',', $content )
+							);
 							break;
 						default:
-							// Add it to our grand headers array.
-							$headers[ trim( $name ) ] = trim( $content );
+							$name    = trim( $name );
+							$content = trim( $content );
+							if ( isset( $headers[ $name ] ) ) {
+								if ( ! is_array( $headers[ $name ] ) ) {
+									$headers[ $name ] = array( $headers[ $name ] );
+								}
+								$headers[ $name ][] = $content;
+							} else {
+								$headers[ $name ] = $content;
+							}
 							break;
 					}
 				}
@@ -532,7 +551,13 @@ if ( ! function_exists( 'wp_mail' ) ) :
 				// Only add custom headers not added automatically by PHPMailer.
 				if ( ! in_array( $name, array( 'MIME-Version', 'X-Mailer' ), true ) ) {
 					try {
-						$phpmailer->addCustomHeader( sprintf( '%1$s: %2$s', $name, $content ) );
+						if ( is_array( $content ) ) {
+							foreach ( $content as $value ) {
+								$phpmailer->addCustomHeader( sprintf( '%1$s: %2$s', $name, $value ) );
+							}
+						} else {
+							$phpmailer->addCustomHeader( sprintf( '%1$s: %2$s', $name, $content ) );
+						}
 					} catch ( PHPMailer\PHPMailer\Exception $e ) {
 						continue;
 					}

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -308,7 +308,7 @@ if ( ! function_exists( 'wp_mail' ) ) :
 				// Iterate through the raw headers.
 				foreach ( (array) $tempheaders as $key => $header ) {
 					if ( is_array( $header ) ) {
-						$header = implode( ',', $header ) . ',';
+						$header = implode( ',', $header );
 					} elseif ( strpos( $header, ':' ) === false ) {
 						if ( false !== stripos( $header, 'boundary=' ) ) {
 							$parts    = preg_split( '/boundary=/i', trim( $header ) );

--- a/tests/phpunit/tests/pluggable/wpMail.php
+++ b/tests/phpunit/tests/pluggable/wpMail.php
@@ -556,6 +556,89 @@ class Tests_Pluggable_wpMail extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that multiple headers with the same name are sent correctly.
+	 *
+	 * @ticket 30128
+	 * @ticket 56779
+	 */
+	public function test_wp_mail_with_multiple_same_name_headers() {
+		$to      = 'test@example.com';
+		$subject = 'Testing Multiple Headers';
+		$message = 'This is a test message.';
+		$headers = array(
+			'x-my-things: thing1',
+			'x-my-things: thing2',
+		);
+
+		wp_mail( $to, $subject, $message, $headers );
+
+		$mailer      = tests_retrieve_phpmailer_instance();
+		$sent_header = $mailer->get_sent()->header;
+
+		$this->assertStringContainsString( 'x-my-things: thing1', $sent_header, 'The first header was not sent.' );
+		$this->assertStringContainsString( 'x-my-things: thing2', $sent_header, 'The second header was not sent.' );
+	}
+
+	/**
+	 * Tests that headers are handled correctly in various formats.
+	 *
+	 * @dataProvider data_wp_mail_header_formats
+	 *
+	 * @ticket 30128
+	 */
+	public function test_wp_mail_header_formats( $headers, $expected_strings ) {
+		wp_mail( 'test@example.com', 'Test', 'Message', $headers );
+
+		$mailer      = tests_retrieve_phpmailer_instance();
+		$sent_header = $mailer->get_sent()->header;
+
+		foreach ( $expected_strings as $expected_string ) {
+			$this->assertStringContainsString( $expected_string, $sent_header );
+		}
+	}
+
+	/**
+	 * Data provider for test_wp_mail_header_formats.
+	 */
+	public function data_wp_mail_header_formats() {
+		return array(
+			'associative array'                   => array(
+				'headers'          => array(
+					'From' => 'Me Myself <me@example.org>',
+					'Cc'   => 'Isaaco Harrelson <iharrel@example.org>',
+				),
+				'expected_strings' => array(
+					'From: Me Myself <me@example.org>',
+					'Cc: Isaaco Harrelson <iharrel@example.org>',
+				),
+			),
+			'indexed array'                       => array(
+				'headers'          => array(
+					'From: Me Myself <me@example.org>',
+					'Cc: Isaaco Harrelson <iharrel@example.org>',
+				),
+				'expected_strings' => array(
+					'From: Me Myself <me@example.org>',
+					'Cc: Isaaco Harrelson <iharrel@example.org>',
+				),
+			),
+			'associative array with multiple CCs' => array(
+				'headers'          => array(
+					'From' => 'Me Myself <me@example.org>',
+					'Cc'   => array(
+						'Isaaco Harrelson <iharrel@example.org>',
+						'frederick@wordpress.org',
+					),
+				),
+				'expected_strings' => array(
+					'From: Me Myself <me@example.org>',
+					'Cc: Isaaco Harrelson <iharrel@example.org>, frederick@wordpress.org',
+				),
+			),
+		);
+	}
+
+	/**
 	 * Tests that wp_mail() can send embedded images.
 	 *
 	 * @ticket 28059


### PR DESCRIPTION
Reviewed Patch 30128.2.patch with many improvements

== Explaining the patch

`formatting.php`

In both pluggable and formatting for the wp_staticize_emoji_for_email function, we have to apply the same headers parsing logic. This is a duplication that has existed for more than 10 years, so we have to bear with it. Maybe in the future a refactor can be done, but there are risks of BC, and since this function is only targeting the Content-Type, we will leave it for now.
Basically it takes the same logic as in 30128.2.patch and applies it here. Very straightforward: after exploding, some short-circuiting, if the array is not associative, and the content is not a simple string, then it's not going to be the Content-Type, so keep iterating. 

`pluggable.php`
Similar logic. First, start iterating, but take into account the possibility that the header content can be an associative array; in that case, convert it into the basic comma-separated string before passing it to the switch
I'm relying a lot on the original algorithm provided by `30128.2.patch`
From there, it will keep this as an array. This way it will also serve for the issue presented in #56779 that will become a duplicate after this patch.

`wpMail.php`
For the tests, I will be testing two things:
1. The associative array and multiple associative array nature of the headers
2. The possibility of multiple values with identical keys as part of the same header (more relevant to #56779, but because this patch is actually targeting this problem in parallel, we can hit two birds with one stone).

== Testing Information

- To test this, you can do multiple scenarios, so you need to setup an email with multiple different headers:
1. First: Add two custom headers with identical key. 
- Currently: It will only keep one of the two
- After the patch: It should keep the two 
2. Second: Add associative arrays including the. From, the CC, the BCC and the Reply-To. It can be a combination of one, two, all, and even each of them could have another array within (for example the BCC can have an array of addresses).  Be wary, that From cannot have more than one address, only CC, BCC and Reply-To can have multiple addresses
- Currently: Arrays are not admitted 
- After the patch: You should see all the addresses introduced in the associative array after you send the email and check the result

Trac ticket: https://core.trac.wordpress.org/ticket/30128

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**