### PR TITLE
64018: Clarify documentation for the action hook before template determination

### DIFF
--- a/src/wp-includes/template-loader.php
+++ b/src/wp-includes/template-loader.php
@@ -6,7 +6,11 @@
  */
 if ( wp_using_themes() ) {
 	/**
-	 * Fires before determining which template to load.
+	 * This action hook executes just before WordPress determines which template page to load.
+	 *
+	 * It is a good hook to use if you need to do a redirect with full knowledge of the content that has been queried.
+	 * Loading a different template is not a good use of this action hook. Instead, use the `template_include` filter
+	 * hook to return the path to the new template you want to use.
 	 *
 	 * @since 1.5.0
 	 */


### PR DESCRIPTION
Improves PHPDoc of template_redirect hook, following the example of the official documentation.

https://developer.wordpress.org/reference/hooks/template_redirect/

Trac ticket: https://core.trac.wordpress.org/ticket/64018#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
