### PR TITLE
Trac 64012 avoid counting post editor admin inline comments alongside user comments

### DIFF
--- a/src/wp-admin/includes/comment.php
+++ b/src/wp-admin/includes/comment.php
@@ -157,7 +157,7 @@ function get_pending_comments_num( $post_id ) {
 	$post_id_array = array_map( 'intval', $post_id_array );
 	$post_id_in    = "'" . implode( "', '", $post_id_array ) . "'";
 
-	$pending = $wpdb->get_results( "SELECT comment_post_ID, COUNT(comment_ID) as num_comments FROM $wpdb->comments WHERE comment_post_ID IN ( $post_id_in ) AND comment_approved = '0' GROUP BY comment_post_ID", ARRAY_A );
+	$pending = $wpdb->get_results( "SELECT comment_post_ID, COUNT(comment_ID) as num_comments FROM $wpdb->comments WHERE comment_post_ID IN ( $post_id_in ) AND comment_approved = '0' AND comment_type != 'block_comment' GROUP BY comment_post_ID", ARRAY_A );
 
 	if ( $single ) {
 		if ( empty( $pending ) ) {

--- a/src/wp-admin/includes/comment.php
+++ b/src/wp-admin/includes/comment.php
@@ -159,6 +159,14 @@ function get_pending_comments_num( $post_id ) {
 
 	$pending = $wpdb->get_results( "SELECT comment_post_ID, COUNT(comment_ID) as num_comments FROM $wpdb->comments WHERE comment_post_ID IN ( $post_id_in ) AND comment_approved = '0' AND comment_type != 'block_comment' GROUP BY comment_post_ID", ARRAY_A );
 
+	/**
+	 * Filter the number of pending comments for a post or posts.
+	 * @since 6.8.2
+	 * @param array $pending Array of pending comments information.
+	 * @param int[] $post_id_array Array of post IDs.
+	 */
+	$pending = apply_filters( 'pre_get_pending_comments_num', $pending, $post_id_array );
+
 	if ( $single ) {
 		if ( empty( $pending ) ) {
 			return 0;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR modifies the get_pending_comments_num() function to exclude editorial comments from the pending count and makes the function more extensible.

Changes Made:

Fixed the query by excluding `block_comment`  type. 

Added extensibility: Introduced the `pre_get_pending_comments_num` filter hook. This allows developers to modify the query arguments used for counting, making it future-proof for custom comment types or additional filtering needs.

Trac ticket: https://core.trac.wordpress.org/ticket/64012

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
