### PR TITLE
Reply-To header in comment reply emails

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -1826,7 +1826,7 @@ if ( ! function_exists( 'wp_notify_postauthor' ) ) :
 		} else {
 			$from = "From: \"$comment->comment_author\" <$wp_email>";
 			if ( '' !== $comment->comment_author_email ) {
-				$reply_to = "Reply-To: $comment->comment_author <$comment->comment_author_email>";
+				$reply_to = "Reply-To: \"$comment->comment_author\" <$comment->comment_author_email>";
 			}
 		}
 

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -1826,7 +1826,7 @@ if ( ! function_exists( 'wp_notify_postauthor' ) ) :
 		} else {
 			$from = "From: \"$comment->comment_author\" <$wp_email>";
 			if ( '' !== $comment->comment_author_email ) {
-				$reply_to = "Reply-To: \"$comment->comment_author_email\" <$comment->comment_author_email>";
+				$reply_to = "Reply-To: $comment->comment_author <$comment->comment_author_email>";
 			}
 		}
 

--- a/tests/phpunit/tests/comment.php
+++ b/tests/phpunit/tests/comment.php
@@ -1163,6 +1163,38 @@ class Tests_Comment extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Check Reply-To Header is set correctly for reply comments.
+	 *
+	 * @group 49661
+	 * @covers ::wp_new_comment_notify_postauthor
+	 */
+	public function test_reply_comment_notification_includes_reply_to_header() {
+		$parent = self::factory()->comment->create(
+			array(
+				'comment_post_ID' => self::$post_id,
+			)
+		);
+
+		$reply_author_name  = 'Jane Doe';
+		$reply_author_email = 'jane@example.com';
+
+		$reply = self::factory()->comment->create(
+			array(
+				'comment_post_ID'      => self::$post_id,
+				'comment_parent'       => $parent,
+				'comment_author'       => $reply_author_name,
+				'comment_author_email' => $reply_author_email,
+				'comment_approved'     => '1',
+			)
+		);
+
+		wp_new_comment_notify_postauthor( $reply );
+		$mailer = tests_retrieve_phpmailer_instance();
+		$header = $mailer->get_sent()->header;
+		$this->assertStringContainsString( 'Reply-To: ' . $reply_author_name . ' <' . $reply_author_email . '>', $header );
+	}
+
+	/**
 	 * Callback for the `comment_notification_text` & `comment_moderation_text` filters.
 	 *
 	 * @param string $notify_message The comment notification or moderation email text.


### PR DESCRIPTION
After further review and testing, I have observed that the problem is not within `Reply-To` in the `wp_notify_postauthor` function but the fact that currently the parsing of anything not `From` (and even the From) is extremely poor. In Trac #62940 we aim to improve this significantly, by simplifying the code and unifying the parsing for all To, From, Bcc, CC and Reply-To headers. 

For this reason, this PR will be blocked until #62940 is merged. 

The only "improvement" that this extremely simple PR brings, is adding the commenter name to the Reply-To and the corresponding Unit Test, testing that the expected output is correct (but this will only pass, again when #62940 is merged).

Trac ticket: https://core.trac.wordpress.org/ticket/49661

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
