### PR TITLE
Charset: Polyfill utf8_encode() and utf8_decode().

### DIFF
--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -247,6 +247,73 @@ function _mb_strlen( $str, $encoding = null ) {
 		: strlen( $str );
 }
 
+if ( ! function_exists( 'utf8_encode' ) ) :
+	if ( extension_loaded( 'mbstring' ) ) :
+		/**
+		 * Converts a string from ISO-8859-1 to UTF-8.
+		 *
+		 * @deprecated Use {@see \mb_convert_encoding()} instead.
+		 *
+		 * @since 6.9.0
+		 *
+		 * @param string $iso_8859_1_text Text treated as ISO-8859-1 (latin1) bytes.
+		 * @return string Text converted into a UTF-8.
+		 */
+		function utf8_encode( $iso_8859_1_text ): string {
+			_deprecated_function( __FUNCTION__, '6.9.0', 'mb_convert_encoding' );
+
+			return mb_convert_encoding( $iso_8859_1_text, 'UTF-8', 'ISO-8859-1' );
+		}
+
+	else :
+		/**
+		 * @ignore
+		 * @private
+		 *
+		 * @since 6.9.0
+		 */
+		function utf8_encode( $iso_8859_1_text ): string {
+			_deprecated_function( __FUNCTION__, '6.9.0', 'mb_convert_encoding' );
+
+			return _wp_utf8_encode_fallback( $iso_8859_1_text );
+		}
+
+	endif;
+endif;
+
+if ( ! function_exists( 'utf8_decode' ) ) :
+	if ( extension_loaded( 'mbstring' ) ) :
+		/**
+		 * Converts a string from UTF-8 to ISO-8859-1.
+		 *
+		 * @deprecated Use {@see \mb_convert_encoding()} instead.
+		 *
+		 * @since 6.9.0
+		 *
+		 * @param string $utf8_text Text treated as UTF-8.
+		 * @return string Text converted into ISO-8859-1.
+		 */
+		function utf8_decode( $utf8_text ): string {
+			_deprecated_function( __FUNCTION__, '6.9.0', 'mb_convert_encoding' );
+
+			return mb_convert_encoding( $utf8_text, 'ISO-8859-1', 'UTF-8' );
+		}
+	else :
+		/**
+		 * @ignore
+		 * @private
+		 *
+		 * @since 6.9.0
+		 */
+		function utf8_decode( $utf8_text ): string {
+			_deprecated_function( __FUNCTION__, '6.9.0', 'mb_convert_encoding' );
+
+			return _wp_utf8_decode_fallback( $utf8_text );
+		}
+
+	endif;
+endif;
+
 // sodium_crypto_box() was introduced in PHP 7.2.
 if ( ! function_exists( 'sodium_crypto_box' ) ) {
 	require ABSPATH . WPINC . '/sodium_compat/autoload.php';

--- a/tests/phpunit/tests/formatting/deprecatedUtfEncodeDecode.php
+++ b/tests/phpunit/tests/formatting/deprecatedUtfEncodeDecode.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * @group formatting
+ */
+class Tests_DeprecatedUtf8EncodeDecodeTest extends WP_UnitTestCase {
+	/**
+	 * Ensures that the fallback for {@see \utf8_encode()} maps the ISO-8859-1 characters properly.
+	 *
+	 * @ticket 63863.
+	 */
+	public function test_utf8_encode_characters() {
+		for ( $i = 0; $i <= 0xFF; $i++ ) {
+			$c     = chr( $i );
+			$hex_i = strtoupper( str_pad( dechex( $i ), 2, '0', STR_PAD_LEFT ) );
+
+			$this->assertSame(
+				bin2hex( mb_convert_encoding( $c, 'UTF-8', 'ISO-8859-1' ) ),
+				bin2hex( _wp_utf8_encode_fallback( $c ) ),
+				"Failed to convert U+{$hex_i} properly."
+			);
+		}
+	}
+
+	/**
+	 * Ensures that the fallback for {@see \utf8_encode()} properly
+	 * matches the legacy behavior for a given set of test cases.
+	 *
+	 * @ticket 63863.
+	 *
+	 * @dataProvider data_utf8_strings
+	 */
+	public function test_utf8_encode_cases( $input ) {
+		$this->assertSame(
+			mb_convert_encoding( $input, 'UTF-8', 'ISO-8859-1' ),
+			_wp_utf8_encode_fallback( $input ),
+			'Failed to properly convert.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[].
+	 */
+	public static function data_utf8_strings() {
+		return array(
+			'Basic valid string' => array( 'Dan eats cinnamon toast.' ),
+			'Valid with Emoji'   => array( 'The best Emoji is 🅰.' ),
+			'Truncated bytes'    => array( substr( 'England has 🏴󠁧󠁢󠁥󠁮󠁧󠁿', 0, -1 ) ),
+			'Minimal subpart'    => array( "One \xC0, two \xE2\x80, three \xF0\x95\x85." ),
+		);
+	}
+
+	/**
+	 * Ensures that the fallback for {@see \utf8_decode()} maps the UTF-8 characters properly.
+	 *
+	 * @ticket 63863.
+	 */
+	public function test_utf8_decode_characters() {
+		for ( $i = 0; $i <= 0x10FFFF; $i++ ) {
+			$hex_i = strtoupper( str_pad( dechex( $i ), 2, '0', STR_PAD_LEFT ) );
+
+			if ( $i < 0xD800 || $i > 0xE000 ) {
+				$c = mb_chr( $i );
+			} else {
+				/*
+				 * Since the UTF-16 surrogate halves are not valid Unicode characters,
+				 * these have to be manually constructed as invalid UTF-8.
+				 */
+				$byte1 = 0xE0 | ( $i >> 12 );
+				$byte2 = 0x80 | ( ( $i >> 6 ) & 0x3F );
+				$byte3 = 0x80 | ( $i & 0x3F );
+
+				$c = "{$byte1}{$byte2}{$byte3}";
+			}
+
+			$this->assertSame(
+				bin2hex( mb_convert_encoding( $c, 'ISO-8859-1', 'UTF-8' ) ),
+				bin2hex( _wp_utf8_decode_fallback( $c ) ),
+				"Failed to convert U+{$hex_i} properly."
+			);
+		}
+	}
+
+	/**
+	 * Ensures that the fallback for {@see \utf8_encode()} properly
+	 * matches the legacy behavior for a given set of test cases.
+	 *
+	 * @ticket 63863.
+	 *
+	 * @dataProvider data_iso_8859_1_strings
+	 */
+	public function test_utf8_decode_cases( $input ) {
+		$this->assertSame(
+			mb_convert_encoding( $input, 'ISO-8859-1', 'UTF-8' ),
+			_wp_utf8_decode_fallback( $input ),
+			'Failed to properly convert.'
+		);
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array[].
+	 */
+	public static function data_iso_8859_1_strings() {
+		return array(
+			'Basic valid string'     => array( 'Dan eats cinnamon toast' ),
+			'Latin1 supplement'      => array( 'Pi\xF1a is another name for Pineapple.' ),
+			'Bytes as invalid UTF-8' => array( 'The \x95 is invalid UTF-8.' ),
+		);
+	}
+}


### PR DESCRIPTION
Trac ticket: Core-55603
Trac ticket: Core-63863

Proposes polyfills for the `utf8_encode()` and `utf8_decode()` functions which are being deprecated.

The polyfills should be 100% identical in operation to the existing code. I have tested all possible Unicode characters and all bytes from 0x00–0xFF against three functions:

 - the existing `utf8_XXcode()` function
 - `mb_convert_encoding()` with the appropriate to/from encodings
 - the polyfills

In the final tests there is no check against `utf8_encode()` and `utf8_decode()` because (a) I found them to be identical to the call to `mb_convert_encoding()` and (b) if the functions will be deprecated anyway there’s no use adding all of the warnings to the test suite.

The new functions call `_deprecated_function()` to let plugin and theme developers know that they ought to replace calls to these methods with something more appropriate.