### PR TITLE
Add test for post meta cache persistence after post update

### DIFF
--- a/tests/phpunit/tests/post/updatePostCache.php
+++ b/tests/phpunit/tests/post/updatePostCache.php
@@ -138,4 +138,41 @@ class Tests_Post_UpdatePostCache extends WP_UnitTestCase {
 			'The filter is not set to "raw"'
 		);
 	}
+
+	/**
+	 * Test that post meta cache persists when post is updated.
+	 *
+	 * @ticket 63167
+	 */
+	public function test_post_meta_cache_is_invalidated_after_post_update() {
+		// Create a post and assign meta.
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, 'foo', 'bar' );
+
+		// Prime the cache by fetching meta.
+		$meta = get_post_meta( $post_id, 'foo', true );
+		$this->assertSame( 'bar', $meta, 'Meta should return the stored value.' );
+
+		// Confirm that meta is cached.
+		$cache_key = (string) $post_id;
+		$cache     = wp_cache_get( $cache_key, 'post_meta' );
+		$this->assertNotEmpty( $cache, 'Meta cache should be primed.' );
+		$this->assertSame( 'bar', $cache['foo'][0], 'Cached value should match.' );
+
+		// Update the post (this should trigger clean_post_cache()).
+		wp_update_post(
+			array(
+				'ID'         => $post_id,
+				'post_title' => 'Updated title',
+			)
+		);
+
+		// After update, the post_meta cache should persist.
+		$cache_after = wp_cache_get( $cache_key, 'post_meta' );
+		$this->assertNotEmpty( $cache_after, 'Meta cache should persist after post update.' );
+
+		// Meta should still be accessible after post update.
+		$meta_after = get_post_meta( $post_id, 'foo', true );
+		$this->assertSame( 'bar', $meta_after, 'Meta value should still persist after post update.' );
+	}
 }

--- a/tests/phpunit/tests/post/updatePostCache.php
+++ b/tests/phpunit/tests/post/updatePostCache.php
@@ -173,6 +173,6 @@ class Tests_Post_UpdatePostCache extends WP_UnitTestCase {
 
 		// Meta should still be accessible after post update.
 		$meta_after = get_post_meta( $post_id, 'foo', true );
-		$this->assertSame( 'bar', $meta_after, 'Meta value should still persist after post update.' );
+		$this->assertSame( 'bar', $meta_after, 'Meta value should still persist after cache invalidation.' );
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->
This test verifies that post meta cache persists (is not invalidated) when a post is updated, which documents the actual WordPress cache behavior.

Trac ticket:
https://core.trac.wordpress.org/ticket/64225
https://core.trac.wordpress.org/ticket/63167

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
