### PR TITLE
Cleaning old functions wp_add_post_meta in Tests

### DIFF
--- a/tests/phpunit/tests/meta/slashes.php
+++ b/tests/phpunit/tests/meta/slashes.php
@@ -44,16 +44,10 @@ class Tests_Meta_Slashes extends WP_UnitTestCase {
 	public function test_edit_post() {
 		$post_id = self::$post_id;
 
-		if ( function_exists( 'wp_add_post_meta' ) ) {
-			$meta_1 = wp_add_post_meta( $post_id, 'slash_test_1', 'foo' );
-			$meta_2 = wp_add_post_meta( $post_id, 'slash_test_2', 'foo' );
-			$meta_3 = wp_add_post_meta( $post_id, 'slash_test_3', 'foo' );
-		} else {
-			// Expects slashed data.
-			$meta_1 = add_post_meta( $post_id, 'slash_test_1', addslashes( 'foo' ) );
-			$meta_2 = add_post_meta( $post_id, 'slash_test_2', addslashes( 'foo' ) );
-			$meta_3 = add_post_meta( $post_id, 'slash_test_3', addslashes( 'foo' ) );
-		}
+		// Expects slashed data.
+		$meta_1 = add_post_meta( $post_id, 'slash_test_1', addslashes( 'foo' ) );
+		$meta_2 = add_post_meta( $post_id, 'slash_test_2', addslashes( 'foo' ) );
+		$meta_3 = add_post_meta( $post_id, 'slash_test_3', addslashes( 'foo' ) );
 
 		$_POST                  = array();
 		$_POST['post_ID']       = $post_id;


### PR DESCRIPTION
A little clean-up in tests. Nothing amazing

Trac ticket: https://core.trac.wordpress.org/ticket/64033

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
