### PR TITLE
Attachments/media endpoint: Add an embeddable post as a link in attachments REST API response

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -982,10 +982,16 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		$links = parent::prepare_links( $post );
 
 		if ( ! empty( $post->post_parent ) ) {
-			$links['post'] = array(
-				'href'       => rest_url( rest_get_route_for_post( $post->post_parent ) ),
-				'embeddable' => true,
-			);
+			$post = get_post( $post->post_parent );
+
+			if ( ! empty( $post ) ) {
+				$links['post'] = array(
+					'href'       => rest_url( rest_get_route_for_post( $post ) ),
+					'embeddable' => true,
+					'post_type'  => $post->post_type,
+					'id'         => $post->ID,
+				);
+			}
 		}
 
 		return $links;

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -971,7 +971,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	}
 
 	/**
-	 * Prepares links for the request.
+	 * Prepares attachment links for the request.
 	 *
 	 * @since 6.9.0
 	 *

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -971,6 +971,27 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	}
 
 	/**
+	 * Prepares links for the request.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param WP_Post $post Post object.
+	 * @return array Links for the given attachment.
+	 */
+	protected function prepare_links( $post ) {
+		$links = parent::prepare_links( $post );
+
+		if ( ! empty( $post->post_parent ) ) {
+			$links['post'] = array(
+				'href'       => rest_url( rest_get_route_for_post( $post->post_parent ) ),
+				'embeddable' => true,
+			);
+		}
+
+		return $links;
+	}
+
+	/**
 	 * Retrieves the attachment's schema, conforming to JSON Schema.
 	 *
 	 * @since 4.7.0

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1887,7 +1887,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertArrayHasKey( 'post', $links );
 
 		$this->assertCount( 1, $links['author'] );
-		$this->assertSame( "http://example.org/index.php?rest_route=/wp/v2/posts/{$post}", $links['post'][0]['href'] );
+		$this->assertSame( rest_url( '/wp/v2/posts/' . $post ), $links['post'][0]['href'] );
 		$this->assertTrue( $links['post'][0]['attributes']['embeddable'] );
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1855,6 +1855,9 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertTrue( $links['author'][0]['attributes']['embeddable'] );
 	}
 
+	/**
+	 * @ticket 64034
+	 */
 	public function test_links_contain_parent() {
 		wp_set_current_user( self::$editor_id );
 

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1891,6 +1891,8 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 		$this->assertCount( 1, $links['author'] );
 		$this->assertSame( rest_url( '/wp/v2/posts/' . $post ), $links['post'][0]['href'] );
+		$this->assertSame( 'post', $links['post'][0]['attributes']['post_type'] );
+		$this->assertSame( $post, $links['post'][0]['attributes']['id'] );
 		$this->assertTrue( $links['post'][0]['attributes']['embeddable'] );
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1848,10 +1848,47 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 		$this->assertArrayHasKey( 'self', $links );
 		$this->assertArrayHasKey( 'author', $links );
+		$this->assertArrayNotHasKey( 'post', $links );
 
 		$this->assertCount( 1, $links['author'] );
 		$this->assertArrayHasKey( 'embeddable', $links['author'][0]['attributes'] );
 		$this->assertTrue( $links['author'][0]['attributes']['embeddable'] );
+	}
+
+	public function test_links_contain_parent() {
+		wp_set_current_user( self::$editor_id );
+
+		$post       = self::factory()->post->create(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'Test Post',
+			)
+		);
+		$attachment = self::factory()->attachment->create_object(
+			array(
+				'file'           => self::$test_file,
+				'post_author'    => self::$editor_id,
+				'post_parent'    => $post,
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
+
+		$this->assertGreaterThan( 0, $attachment );
+
+		$request = new WP_REST_Request( 'GET', "/wp/v2/media/{$attachment}" );
+		$request->set_query_params( array( 'context' => 'edit' ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$links    = $response->get_links();
+
+		$this->assertArrayHasKey( 'self', $links );
+		$this->assertArrayHasKey( 'author', $links );
+		$this->assertArrayHasKey( 'post', $links );
+
+		$this->assertCount( 1, $links['author'] );
+		$this->assertSame( "http://example.org/index.php?rest_route=/wp/v2/posts/{$post}", $links['post'][0]['href'] );
+		$this->assertTrue( $links['post'][0]['attributes']['embeddable'] );
 	}
 
 	public function test_publish_action_ldo_not_registered() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

In the attachments controller (i.e. for the `media` endpoint) add `post` to the links in the API response, that provides a link to the API call to get the linked post — i.e. the parent, or the post that the media item is attached to.

The purpose is to make it easier to fetch linked posts or pages that media items are attached to, via the REST API. This is part of some of the work I've been exploring for the new media library (proposed in https://github.com/WordPress/gutenberg/issues/55238). When listing (or providing UI to make changes to) the "uploaded to" field (or "attached to" or whatever it should be called), it'll be easier to do so if we can embed the post in the API response for media items.

Trac ticket: https://core.trac.wordpress.org/ticket/64034

## Testing instructions

If you'd like to test this from within the block editor:

1. Open up the media library and upload a couple of images.
2. From the list view within the media library, click Attach under the Uploaded To column and attach one of the media items to a post
3. Make a note of the ids of your two images (i.e. grab them from the url)
4. Open the block editor, and try running the following from your browser console (note you might have to run these commands _twice_ as the first call will return `undefined` as the request hasn't been resolved yet):

```
// Replace 27 with the id of an image that is attached to a post — you should see `post` in the list of `_links`
wp.data.select( 'core' ).getEntityRecord( 'postType', 'attachment', 27 );
// Again, replace 27 with the id of an image that is attached to a post — in this call, you should see the post under `_embedded` in the response
wp.data.select( 'core' ).getEntityRecord( 'postType', 'attachment', 27, { _embed: 'post' } );
```

5. Try the above but with the id of an image that is not attached to a post. You shouldn't see `post` in the list of `_links`.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
