### PR TITLE
Media / Attachments REST API endpoint: update attachments controller to support flip and to customize attachment fields

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -543,6 +543,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 * Applies edits to a media item and creates a new attachment record.
 	 *
 	 * @since 5.5.0
+	 * @since 6.9.0 Adds flips capability and editable fields for the newly-created attachment post.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, WP_Error object on failure.
@@ -563,7 +564,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		) {
 			return new WP_Error(
 				'rest_unknown_attachment',
-				__( 'Unable to get meta information for file.' ),
+				__( 'Unable to get meta information for file.', 'gutenberg' ),
 				array( 'status' => 404 )
 			);
 		}
@@ -573,7 +574,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		if ( ! in_array( $mime_type, $supported_types, true ) ) {
 			return new WP_Error(
 				'rest_cannot_edit_file_type',
-				__( 'This type of file cannot be edited.' ),
+				__( 'This type of file cannot be edited.', 'gutenberg' ),
 				array( 'status' => 400 )
 			);
 		}
@@ -583,6 +584,20 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			$modifiers = $request['modifiers'];
 		} else {
 			$modifiers = array();
+
+			if ( isset( $request['flip']['horizontal'] ) || isset( $request['flip']['vertical'] ) ) {
+				$flip_args = array(
+					'vertical'   => $request['flip']['vertical'] ?? 0,
+					'horizontal' => $request['flip']['horizontal'] ?? 0,
+				);
+
+				$modifiers[] = array(
+					'type' => 'flip',
+					'args' => array(
+						'flip' => $flip_args,
+					),
+				);
+			}
 
 			if ( ! empty( $request['rotation'] ) ) {
 				$modifiers[] = array(
@@ -608,7 +623,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			if ( 0 === count( $modifiers ) ) {
 				return new WP_Error(
 					'rest_image_not_edited',
-					__( 'The image was not edited. Edit the image before applying the changes.' ),
+					__( 'The image was not edited. Edit the image before applying the changes.', 'gutenberg' ),
 					array( 'status' => 400 )
 				);
 			}
@@ -629,7 +644,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		if ( is_wp_error( $image_editor ) ) {
 			return new WP_Error(
 				'rest_unknown_image_file_type',
-				__( 'Unable to edit this image.' ),
+				__( 'Unable to edit this image.', 'gutenberg' ),
 				array( 'status' => 500 )
 			);
 		}
@@ -637,6 +652,21 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		foreach ( $modifiers as $modifier ) {
 			$args = $modifier['args'];
 			switch ( $modifier['type'] ) {
+				case 'flip':
+					/*
+					 * Flips the current image.
+					 * The vertical flip is the first argument (flip along horizontal axis), the horizontal flip is the second argument (flip along vertical axis).
+					 * See: WP_Image_Editor::flip()
+					 */
+					$result = $image_editor->flip( 0 !== (int) $args['flip']['vertical'], 0 !== (int) $args['flip']['horizontal'] );
+					if ( is_wp_error( $result ) ) {
+						return new WP_Error(
+							'rest_image_flip_failed',
+							__( 'Unable to flip this image.', 'gutenberg' ),
+							array( 'status' => 500 )
+						);
+					}
+					break;
 				case 'rotate':
 					// Rotation direction: clockwise vs. counterclockwise.
 					$rotate = 0 - $args['angle'];
@@ -647,7 +677,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 						if ( is_wp_error( $result ) ) {
 							return new WP_Error(
 								'rest_image_rotation_failed',
-								__( 'Unable to rotate this image.' ),
+								__( 'Unable to rotate this image.', 'gutenberg' ),
 								array( 'status' => 500 )
 							);
 						}
@@ -669,7 +699,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 						if ( is_wp_error( $result ) ) {
 							return new WP_Error(
 								'rest_image_crop_failed',
-								__( 'Unable to crop this image.' ),
+								__( 'Unable to crop this image.', 'gutenberg' ),
 								array( 'status' => 500 )
 							);
 						}
@@ -711,23 +741,30 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			return $saved;
 		}
 
-		// Create new attachment post.
-		$new_attachment_post = array(
-			'post_mime_type' => $saved['mime-type'],
-			'guid'           => $uploads['url'] . "/$filename",
-			'post_title'     => $image_name,
-			'post_content'   => '',
-		);
+		// Grab original attachment post so we can use it to set defaults.
+		$original_attachment_post = get_post( $attachment_id );
 
-		// Copy post_content, post_excerpt, and post_title from the edited image's attachment post.
-		$attachment_post = get_post( $attachment_id );
+		// Check request fields and assign default values.
+		$new_attachment_post                 = $this->prepare_item_for_database( $request );
+		$new_attachment_post->post_mime_type = $saved['mime-type'];
+		$new_attachment_post->guid           = $uploads['url'] . "/$filename";
 
-		if ( $attachment_post ) {
-			$new_attachment_post['post_content'] = $attachment_post->post_content;
-			$new_attachment_post['post_excerpt'] = $attachment_post->post_excerpt;
-			$new_attachment_post['post_title']   = $attachment_post->post_title;
-		}
+		// Unset ID so wp_insert_attachment generates a new ID.
+		unset( $new_attachment_post->ID );
 
+		// Set new attachment post title with fallbacks.
+		$new_attachment_post->post_title = $new_attachment_post->post_title ?? $original_attachment_post->post_title ?? $image_name;
+
+		// Set new attachment post caption (post_excerpt).
+		$new_attachment_post->post_excerpt = $new_attachment_post->post_excerpt ?? $original_attachment_post->post_excerpt ?? '';
+
+		// Set new attachment post description (post_content) with fallbacks.
+		$new_attachment_post->post_content = $new_attachment_post->post_content ?? $original_attachment_post->post_content ?? '';
+
+		// Set post parent if set in request, else the default of `0` (no parent).
+		$new_attachment_post->post_parent = $new_attachment_post->post_parent ?? 0;
+
+		// Insert the new attachment post.
 		$new_attachment_id = wp_insert_attachment( wp_slash( $new_attachment_post ), $saved['path'], 0, true );
 
 		if ( is_wp_error( $new_attachment_id ) ) {
@@ -740,8 +777,8 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			return $new_attachment_id;
 		}
 
-		// Copy the image alt text from the edited image.
-		$image_alt = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+		// First, try to use the alt text from the request. If not set, copy the image alt text from the original attachment.
+		$image_alt = isset( $request['alt_text'] ) ? sanitize_text_field( $request['alt_text'] ) : get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
 
 		if ( ! empty( $image_alt ) ) {
 			// update_post_meta() expects slashed.
@@ -790,6 +827,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		 * @param int   $new_attachment_id Attachment post ID for the new image.
 		 * @param int   $attachment_id     Attachment post ID for the edited (parent) image.
 		 */
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$new_image_meta = apply_filters( 'wp_edited_image_metadata', $new_image_meta, $new_attachment_id, $attachment_id );
 
 		wp_update_attachment_metadata( $new_attachment_id, $new_image_meta );
@@ -1480,23 +1518,25 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	 * Gets the request args for the edit item route.
 	 *
 	 * @since 5.5.0
+	 * @since 6.9.0 Adds flips capability and editable fields for the newly-created attachment post.
 	 *
 	 * @return array
 	 */
 	protected function get_edit_media_item_args() {
-		return array(
+		$args = array(
 			'src'       => array(
-				'description' => __( 'URL to the edited image file.' ),
+				'description' => __( 'URL to the edited image file.', 'gutenberg' ),
 				'type'        => 'string',
 				'format'      => 'uri',
 				'required'    => true,
 			),
+			// The `modifiers` param takes precedence over the older format.
 			'modifiers' => array(
-				'description' => __( 'Array of image edits.' ),
+				'description' => __( 'Array of image edits.', 'gutenberg' ),
 				'type'        => 'array',
 				'minItems'    => 1,
 				'items'       => array(
-					'description' => __( 'Image edit.' ),
+					'description' => __( 'Image edit.', 'gutenberg' ),
 					'type'        => 'object',
 					'required'    => array(
 						'type',
@@ -1504,22 +1544,59 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 					),
 					'oneOf'       => array(
 						array(
-							'title'      => __( 'Rotation' ),
+							'title'      => __( 'Flip', 'gutenberg' ),
 							'properties' => array(
 								'type' => array(
-									'description' => __( 'Rotation type.' ),
+									'description' => __( 'Flip type.', 'gutenberg' ),
+									'type'        => 'string',
+									'enum'        => array( 'flip' ),
+								),
+								'args' => array(
+									'description' => __( 'Flip arguments.', 'gutenberg' ),
+									'type'        => 'object',
+									'required'    => array(
+										'flip',
+									),
+									'properties'  => array(
+										'flip' => array(
+											'description' => __( 'Flip direction. [ horizontal, vertical ] 0 for no flip, 1 for flip.', 'gutenberg' ),
+											'type'        => 'object',
+											'required'    => array(
+												'horizontal',
+												'vertical',
+											),
+											'properties'  => array(
+												'horizontal' => array(
+													'description' => __( 'Horizontal flip direction. 0 for no flip, 1 for flip.', 'gutenberg' ),
+													'type' => 'number',
+												),
+												'vertical' => array(
+													'description' => __( 'Vertical flip direction. 0 for no flip, 1 for flip.', 'gutenberg' ),
+													'type' => 'number',
+												),
+											),
+										),
+									),
+								),
+							),
+						),
+						array(
+							'title'      => __( 'Rotation', 'gutenberg' ),
+							'properties' => array(
+								'type' => array(
+									'description' => __( 'Rotation type.', 'gutenberg' ),
 									'type'        => 'string',
 									'enum'        => array( 'rotate' ),
 								),
 								'args' => array(
-									'description' => __( 'Rotation arguments.' ),
+									'description' => __( 'Rotation arguments.', 'gutenberg' ),
 									'type'        => 'object',
 									'required'    => array(
 										'angle',
 									),
 									'properties'  => array(
 										'angle' => array(
-											'description' => __( 'Angle to rotate clockwise in degrees.' ),
+											'description' => __( 'Angle to rotate clockwise in degrees.', 'gutenberg' ),
 											'type'        => 'number',
 										),
 									),
@@ -1527,15 +1604,15 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 							),
 						),
 						array(
-							'title'      => __( 'Crop' ),
+							'title'      => __( 'Crop', 'gutenberg' ),
 							'properties' => array(
 								'type' => array(
-									'description' => __( 'Crop type.' ),
+									'description' => __( 'Crop type.', 'gutenberg' ),
 									'type'        => 'string',
 									'enum'        => array( 'crop' ),
 								),
 								'args' => array(
-									'description' => __( 'Crop arguments.' ),
+									'description' => __( 'Crop arguments.', 'gutenberg' ),
 									'type'        => 'object',
 									'required'    => array(
 										'left',
@@ -1545,19 +1622,19 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 									),
 									'properties'  => array(
 										'left'   => array(
-											'description' => __( 'Horizontal position from the left to begin the crop as a percentage of the image width.' ),
+											'description' => __( 'Horizontal position from the left to begin the crop as a percentage of the image width.', 'gutenberg' ),
 											'type'        => 'number',
 										),
 										'top'    => array(
-											'description' => __( 'Vertical position from the top to begin the crop as a percentage of the image height.' ),
+											'description' => __( 'Vertical position from the top to begin the crop as a percentage of the image height.', 'gutenberg' ),
 											'type'        => 'number',
 										),
 										'width'  => array(
-											'description' => __( 'Width of the crop as a percentage of the image width.' ),
+											'description' => __( 'Width of the crop as a percentage of the image width.', 'gutenberg' ),
 											'type'        => 'number',
 										),
 										'height' => array(
-											'description' => __( 'Height of the crop as a percentage of the image height.' ),
+											'description' => __( 'Height of the crop as a percentage of the image height.', 'gutenberg' ),
 											'type'        => 'number',
 										),
 									),
@@ -1568,7 +1645,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 				),
 			),
 			'rotation'  => array(
-				'description'      => __( 'The amount to rotate the image clockwise in degrees. DEPRECATED: Use `modifiers` instead.' ),
+				'description'      => __( 'The amount to rotate the image clockwise in degrees. DEPRECATED: Use `modifiers` instead.', 'gutenberg' ),
 				'type'             => 'integer',
 				'minimum'          => 0,
 				'exclusiveMinimum' => true,
@@ -1576,29 +1653,57 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 				'exclusiveMaximum' => true,
 			),
 			'x'         => array(
-				'description' => __( 'As a percentage of the image, the x position to start the crop from. DEPRECATED: Use `modifiers` instead.' ),
+				'description' => __( 'As a percentage of the image, the x position to start the crop from. DEPRECATED: Use `modifiers` instead.', 'gutenberg' ),
 				'type'        => 'number',
 				'minimum'     => 0,
 				'maximum'     => 100,
 			),
 			'y'         => array(
-				'description' => __( 'As a percentage of the image, the y position to start the crop from. DEPRECATED: Use `modifiers` instead.' ),
+				'description' => __( 'As a percentage of the image, the y position to start the crop from. DEPRECATED: Use `modifiers` instead.', 'gutenberg' ),
 				'type'        => 'number',
 				'minimum'     => 0,
 				'maximum'     => 100,
 			),
 			'width'     => array(
-				'description' => __( 'As a percentage of the image, the width to crop the image to. DEPRECATED: Use `modifiers` instead.' ),
+				'description' => __( 'As a percentage of the image, the width to crop the image to. DEPRECATED: Use `modifiers` instead.', 'gutenberg' ),
 				'type'        => 'number',
 				'minimum'     => 0,
 				'maximum'     => 100,
 			),
 			'height'    => array(
-				'description' => __( 'As a percentage of the image, the height to crop the image to. DEPRECATED: Use `modifiers` instead.' ),
+				'description' => __( 'As a percentage of the image, the height to crop the image to. DEPRECATED: Use `modifiers` instead.', 'gutenberg' ),
 				'type'        => 'number',
 				'minimum'     => 0,
 				'maximum'     => 100,
 			),
 		);
+
+		/*
+		 * Get the args based on the post schema. This calls `rest_get_endpoint_args_for_schema()`,
+		 * which also takes care of sanitization and validation.
+		 */
+		$update_item_args = $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE );
+
+		if ( isset( $update_item_args['caption'] ) ) {
+			$args['caption'] = $update_item_args['caption'];
+		}
+
+		if ( isset( $update_item_args['description'] ) ) {
+			$args['description'] = $update_item_args['description'];
+		}
+
+		if ( isset( $update_item_args['title'] ) ) {
+			$args['title'] = $update_item_args['title'];
+		}
+
+		if ( isset( $update_item_args['post'] ) ) {
+			$args['post'] = $update_item_args['post'];
+		}
+
+		if ( isset( $update_item_args['alt_text'] ) ) {
+			$args['alt_text'] = $update_item_args['alt_text'];
+		}
+
+		return $args;
 	}
 }

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -827,7 +827,6 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		 * @param int   $new_attachment_id Attachment post ID for the new image.
 		 * @param int   $attachment_id     Attachment post ID for the edited (parent) image.
 		 */
-		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$new_image_meta = apply_filters( 'wp_edited_image_metadata', $new_image_meta, $new_attachment_id, $attachment_id );
 
 		wp_update_attachment_metadata( $new_attachment_id, $new_image_meta );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -587,8 +587,8 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 
 			if ( isset( $request['flip']['horizontal'] ) || isset( $request['flip']['vertical'] ) ) {
 				$flip_args = array(
-					'vertical'   => $request['flip']['vertical'] ?? 0,
-					'horizontal' => $request['flip']['horizontal'] ?? 0,
+					'vertical'   => isset( $request['flip']['vertical'] ) ? (bool) $request['flip']['vertical'] : false,
+					'horizontal' => isset( $request['flip']['horizontal'] ) ? (bool) $request['flip']['horizontal'] : false,
 				);
 
 				$modifiers[] = array(
@@ -658,7 +658,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 					 * The vertical flip is the first argument (flip along horizontal axis), the horizontal flip is the second argument (flip along vertical axis).
 					 * See: WP_Image_Editor::flip()
 					 */
-					$result = $image_editor->flip( 0 !== (int) $args['flip']['vertical'], 0 !== (int) $args['flip']['horizontal'] );
+					$result = $image_editor->flip( $args['flip']['vertical'], $args['flip']['horizontal'] );
 					if ( is_wp_error( $result ) ) {
 						return new WP_Error(
 							'rest_image_flip_failed',
@@ -1558,7 +1558,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 									),
 									'properties'  => array(
 										'flip' => array(
-											'description' => __( 'Flip direction. [ horizontal, vertical ] 0 for no flip, 1 for flip.' ),
+											'description' => __( 'Flip direction. [ horizontal, vertical ]' ),
 											'type'        => 'object',
 											'required'    => array(
 												'horizontal',
@@ -1566,12 +1566,12 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 											),
 											'properties'  => array(
 												'horizontal' => array(
-													'description' => __( 'Horizontal flip direction. 0 for no flip, 1 for flip.' ),
-													'type' => 'number',
+													'description' => __( 'Whether to flip in the horizontal direction.' ),
+													'type' => 'boolean',
 												),
 												'vertical' => array(
-													'description' => __( 'Vertical flip direction. 0 for no flip, 1 for flip.' ),
-													'type' => 'number',
+													'description' => __( 'Whether to flip in the vertical direction.' ),
+													'type' => 'boolean',
 												),
 											),
 										),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -1558,7 +1558,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 									),
 									'properties'  => array(
 										'flip' => array(
-											'description' => __( 'Flip direction. [ horizontal, vertical ]' ),
+											'description' => __( 'Flip direction.' ),
 											'type'        => 'object',
 											'required'    => array(
 												'horizontal',

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -564,7 +564,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		) {
 			return new WP_Error(
 				'rest_unknown_attachment',
-				__( 'Unable to get meta information for file.', 'gutenberg' ),
+				__( 'Unable to get meta information for file.' ),
 				array( 'status' => 404 )
 			);
 		}
@@ -574,7 +574,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		if ( ! in_array( $mime_type, $supported_types, true ) ) {
 			return new WP_Error(
 				'rest_cannot_edit_file_type',
-				__( 'This type of file cannot be edited.', 'gutenberg' ),
+				__( 'This type of file cannot be edited.' ),
 				array( 'status' => 400 )
 			);
 		}
@@ -623,7 +623,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			if ( 0 === count( $modifiers ) ) {
 				return new WP_Error(
 					'rest_image_not_edited',
-					__( 'The image was not edited. Edit the image before applying the changes.', 'gutenberg' ),
+					__( 'The image was not edited. Edit the image before applying the changes.' ),
 					array( 'status' => 400 )
 				);
 			}
@@ -644,7 +644,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		if ( is_wp_error( $image_editor ) ) {
 			return new WP_Error(
 				'rest_unknown_image_file_type',
-				__( 'Unable to edit this image.', 'gutenberg' ),
+				__( 'Unable to edit this image.' ),
 				array( 'status' => 500 )
 			);
 		}
@@ -662,7 +662,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 					if ( is_wp_error( $result ) ) {
 						return new WP_Error(
 							'rest_image_flip_failed',
-							__( 'Unable to flip this image.', 'gutenberg' ),
+							__( 'Unable to flip this image.' ),
 							array( 'status' => 500 )
 						);
 					}
@@ -677,7 +677,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 						if ( is_wp_error( $result ) ) {
 							return new WP_Error(
 								'rest_image_rotation_failed',
-								__( 'Unable to rotate this image.', 'gutenberg' ),
+								__( 'Unable to rotate this image.' ),
 								array( 'status' => 500 )
 							);
 						}
@@ -699,7 +699,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 						if ( is_wp_error( $result ) ) {
 							return new WP_Error(
 								'rest_image_crop_failed',
-								__( 'Unable to crop this image.', 'gutenberg' ),
+								__( 'Unable to crop this image.' ),
 								array( 'status' => 500 )
 							);
 						}
@@ -1525,18 +1525,18 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 	protected function get_edit_media_item_args() {
 		$args = array(
 			'src'       => array(
-				'description' => __( 'URL to the edited image file.', 'gutenberg' ),
+				'description' => __( 'URL to the edited image file.' ),
 				'type'        => 'string',
 				'format'      => 'uri',
 				'required'    => true,
 			),
 			// The `modifiers` param takes precedence over the older format.
 			'modifiers' => array(
-				'description' => __( 'Array of image edits.', 'gutenberg' ),
+				'description' => __( 'Array of image edits.' ),
 				'type'        => 'array',
 				'minItems'    => 1,
 				'items'       => array(
-					'description' => __( 'Image edit.', 'gutenberg' ),
+					'description' => __( 'Image edit.' ),
 					'type'        => 'object',
 					'required'    => array(
 						'type',
@@ -1544,22 +1544,22 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 					),
 					'oneOf'       => array(
 						array(
-							'title'      => __( 'Flip', 'gutenberg' ),
+							'title'      => __( 'Flip' ),
 							'properties' => array(
 								'type' => array(
-									'description' => __( 'Flip type.', 'gutenberg' ),
+									'description' => __( 'Flip type.' ),
 									'type'        => 'string',
 									'enum'        => array( 'flip' ),
 								),
 								'args' => array(
-									'description' => __( 'Flip arguments.', 'gutenberg' ),
+									'description' => __( 'Flip arguments.' ),
 									'type'        => 'object',
 									'required'    => array(
 										'flip',
 									),
 									'properties'  => array(
 										'flip' => array(
-											'description' => __( 'Flip direction. [ horizontal, vertical ] 0 for no flip, 1 for flip.', 'gutenberg' ),
+											'description' => __( 'Flip direction. [ horizontal, vertical ] 0 for no flip, 1 for flip.' ),
 											'type'        => 'object',
 											'required'    => array(
 												'horizontal',
@@ -1567,11 +1567,11 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 											),
 											'properties'  => array(
 												'horizontal' => array(
-													'description' => __( 'Horizontal flip direction. 0 for no flip, 1 for flip.', 'gutenberg' ),
+													'description' => __( 'Horizontal flip direction. 0 for no flip, 1 for flip.' ),
 													'type' => 'number',
 												),
 												'vertical' => array(
-													'description' => __( 'Vertical flip direction. 0 for no flip, 1 for flip.', 'gutenberg' ),
+													'description' => __( 'Vertical flip direction. 0 for no flip, 1 for flip.' ),
 													'type' => 'number',
 												),
 											),
@@ -1581,22 +1581,22 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 							),
 						),
 						array(
-							'title'      => __( 'Rotation', 'gutenberg' ),
+							'title'      => __( 'Rotation' ),
 							'properties' => array(
 								'type' => array(
-									'description' => __( 'Rotation type.', 'gutenberg' ),
+									'description' => __( 'Rotation type.' ),
 									'type'        => 'string',
 									'enum'        => array( 'rotate' ),
 								),
 								'args' => array(
-									'description' => __( 'Rotation arguments.', 'gutenberg' ),
+									'description' => __( 'Rotation arguments.' ),
 									'type'        => 'object',
 									'required'    => array(
 										'angle',
 									),
 									'properties'  => array(
 										'angle' => array(
-											'description' => __( 'Angle to rotate clockwise in degrees.', 'gutenberg' ),
+											'description' => __( 'Angle to rotate clockwise in degrees.' ),
 											'type'        => 'number',
 										),
 									),
@@ -1604,15 +1604,15 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 							),
 						),
 						array(
-							'title'      => __( 'Crop', 'gutenberg' ),
+							'title'      => __( 'Crop' ),
 							'properties' => array(
 								'type' => array(
-									'description' => __( 'Crop type.', 'gutenberg' ),
+									'description' => __( 'Crop type.' ),
 									'type'        => 'string',
 									'enum'        => array( 'crop' ),
 								),
 								'args' => array(
-									'description' => __( 'Crop arguments.', 'gutenberg' ),
+									'description' => __( 'Crop arguments.' ),
 									'type'        => 'object',
 									'required'    => array(
 										'left',
@@ -1622,19 +1622,19 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 									),
 									'properties'  => array(
 										'left'   => array(
-											'description' => __( 'Horizontal position from the left to begin the crop as a percentage of the image width.', 'gutenberg' ),
+											'description' => __( 'Horizontal position from the left to begin the crop as a percentage of the image width.' ),
 											'type'        => 'number',
 										),
 										'top'    => array(
-											'description' => __( 'Vertical position from the top to begin the crop as a percentage of the image height.', 'gutenberg' ),
+											'description' => __( 'Vertical position from the top to begin the crop as a percentage of the image height.' ),
 											'type'        => 'number',
 										),
 										'width'  => array(
-											'description' => __( 'Width of the crop as a percentage of the image width.', 'gutenberg' ),
+											'description' => __( 'Width of the crop as a percentage of the image width.' ),
 											'type'        => 'number',
 										),
 										'height' => array(
-											'description' => __( 'Height of the crop as a percentage of the image height.', 'gutenberg' ),
+											'description' => __( 'Height of the crop as a percentage of the image height.' ),
 											'type'        => 'number',
 										),
 									),
@@ -1645,7 +1645,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 				),
 			),
 			'rotation'  => array(
-				'description'      => __( 'The amount to rotate the image clockwise in degrees. DEPRECATED: Use `modifiers` instead.', 'gutenberg' ),
+				'description'      => __( 'The amount to rotate the image clockwise in degrees. DEPRECATED: Use `modifiers` instead.' ),
 				'type'             => 'integer',
 				'minimum'          => 0,
 				'exclusiveMinimum' => true,
@@ -1653,25 +1653,25 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 				'exclusiveMaximum' => true,
 			),
 			'x'         => array(
-				'description' => __( 'As a percentage of the image, the x position to start the crop from. DEPRECATED: Use `modifiers` instead.', 'gutenberg' ),
+				'description' => __( 'As a percentage of the image, the x position to start the crop from. DEPRECATED: Use `modifiers` instead.' ),
 				'type'        => 'number',
 				'minimum'     => 0,
 				'maximum'     => 100,
 			),
 			'y'         => array(
-				'description' => __( 'As a percentage of the image, the y position to start the crop from. DEPRECATED: Use `modifiers` instead.', 'gutenberg' ),
+				'description' => __( 'As a percentage of the image, the y position to start the crop from. DEPRECATED: Use `modifiers` instead.' ),
 				'type'        => 'number',
 				'minimum'     => 0,
 				'maximum'     => 100,
 			),
 			'width'     => array(
-				'description' => __( 'As a percentage of the image, the width to crop the image to. DEPRECATED: Use `modifiers` instead.', 'gutenberg' ),
+				'description' => __( 'As a percentage of the image, the width to crop the image to. DEPRECATED: Use `modifiers` instead.' ),
 				'type'        => 'number',
 				'minimum'     => 0,
 				'maximum'     => 100,
 			),
 			'height'    => array(
-				'description' => __( 'As a percentage of the image, the height to crop the image to. DEPRECATED: Use `modifiers` instead.', 'gutenberg' ),
+				'description' => __( 'As a percentage of the image, the height to crop the image to. DEPRECATED: Use `modifiers` instead.' ),
 				'type'        => 'number',
 				'minimum'     => 0,
 				'maximum'     => 100,

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -2682,4 +2682,118 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 		$this->assertTrue( $result );
 	}
+
+	/**
+	 * Tests that the attachment fields caption, description, and title, post and alt_text are updated correctly.
+	 * @ticket 64035
+	 * @requires function imagejpeg
+	 */
+	public function test_edit_image_updates_attachment_fields() {
+		wp_set_current_user( self::$superadmin_id );
+		$attachment = self::factory()->attachment->create_upload_object( self::$test_file );
+
+		// In order to test the edit endpoint editable fields, we need to create a new attachment.
+		$params = array(
+			'src'         => wp_get_attachment_image_url( $attachment, 'full' ),
+			'modifiers'   => array(
+				array(
+					'type' => 'crop',
+					'args' => array(
+						'left'   => 10,
+						'top'    => 10,
+						'width'  => 80,
+						'height' => 80,
+					),
+				),
+			),
+			'caption'     => 'Test Caption',
+			'description' => 'Test Description',
+			'title'       => 'Test Title',
+			'post'        => 1,
+			'alt_text'    => 'Test Alt Text',
+		);
+
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment}/edit" );
+		$request->set_body_params( $params );
+		$response = rest_do_request( $request );
+
+		// The edit endpoint creates a new attachment, so we expect a 201 status.
+		$this->assertEquals( 201, $response->get_status() );
+
+		$data              = $response->get_data();
+		$new_attachment_id = $data['id'];
+
+		$updated_attachment = get_post( $new_attachment_id );
+
+		$this->assertSame( 'Test Title', $updated_attachment->post_title, 'Title of the updated attachment is not identical.' );
+
+		$this->assertSame( 'Test Caption', $updated_attachment->post_excerpt, 'Caption of the updated attachment is not identical.' );
+
+		$this->assertSame( 'Test Description', $updated_attachment->post_content, 'Description of the updated attachment is not identical.' );
+
+		$this->assertSame( 1, $updated_attachment->post_parent, 'Post parent of the updated attachment is not identical.' );
+
+		$this->assertSame( 'Test Alt Text', get_post_meta( $new_attachment_id, '_wp_attachment_image_alt', true ), 'Alt text of the updated attachment is not identical.' );
+	}
+
+	/**
+	 * Tests that the image is flipped correctly vertically and horizontally.
+	 *
+	 * @ticket 64035
+	 * @requires function imagejpeg
+	 */
+	public function test_edit_image_vertical_and_horizontal_flip() {
+		wp_set_current_user( self::$superadmin_id );
+		$attachment = self::factory()->attachment->create_upload_object( self::$test_file );
+
+		$this->setup_mock_editor();
+		WP_Image_Editor_Mock::$edit_return['flip'] = new WP_Error();
+
+		$params = array(
+			'flip' => array(
+				'vertical'   => 1,
+				'horizontal' => 1,
+			),
+			'src'  => wp_get_attachment_image_url( $attachment, 'full' ),
+		);
+
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment}/edit" );
+		$request->set_body_params( $params );
+		$response = rest_do_request( $request );
+		$this->assertErrorResponse( 'rest_image_flip_failed', $response, 500 );
+
+		$this->assertCount( 1, WP_Image_Editor_Mock::$spy['flip'] );
+		// The controller converts the integer values to booleans: 0 !== (int) 1 = true.
+		$this->assertSame( array( true, true ), WP_Image_Editor_Mock::$spy['flip'][0], 'Vertical and horizontal flip of the image is not identical.' );
+	}
+
+	/**
+	 * Tests that the image is flipped correctly vertically.
+	 *
+	 * @ticket 64035
+	 * @requires function imagejpeg
+	 */
+	public function test_edit_image_vertical_flip() {
+		wp_set_current_user( self::$superadmin_id );
+		$attachment = self::factory()->attachment->create_upload_object( self::$test_file );
+
+		$this->setup_mock_editor();
+		WP_Image_Editor_Mock::$edit_return['flip'] = new WP_Error();
+
+		$params = array(
+			'flip' => array(
+				'vertical' => 1,
+			),
+			'src'  => wp_get_attachment_image_url( $attachment, 'full' ),
+		);
+
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment}/edit" );
+		$request->set_body_params( $params );
+		$response = rest_do_request( $request );
+		$this->assertErrorResponse( 'rest_image_flip_failed', $response, 500 );
+
+		$this->assertCount( 1, WP_Image_Editor_Mock::$spy['flip'] );
+		// The controller converts the integer values to booleans: 0 !== (int) 1 = true.
+		$this->assertSame( array( true, false ), WP_Image_Editor_Mock::$spy['flip'][0], 'Vertical flip of the image is not identical.' );
+	}
 }

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -2751,8 +2751,8 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 		$params = array(
 			'flip' => array(
-				'vertical'   => 1,
-				'horizontal' => 1,
+				'vertical'   => true,
+				'horizontal' => true,
 			),
 			'src'  => wp_get_attachment_image_url( $attachment, 'full' ),
 		);
@@ -2768,12 +2768,12 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	}
 
 	/**
-	 * Tests that the image is flipped correctly vertically.
+	 * Tests that the image is flipped correctly vertically only.
 	 *
 	 * @ticket 64035
 	 * @requires function imagejpeg
 	 */
-	public function test_edit_image_vertical_flip() {
+	public function test_edit_image_vertical_flip_with_horizontal_false() {
 		wp_set_current_user( self::$superadmin_id );
 		$attachment = self::factory()->attachment->create_upload_object( self::$test_file );
 
@@ -2782,7 +2782,38 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 		$params = array(
 			'flip' => array(
-				'vertical' => 1,
+				'vertical'   => true,
+				'horizontal' => false,
+			),
+			'src'  => wp_get_attachment_image_url( $attachment, 'full' ),
+		);
+
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment}/edit" );
+		$request->set_body_params( $params );
+		$response = rest_do_request( $request );
+		$this->assertErrorResponse( 'rest_image_flip_failed', $response, 500 );
+
+		$this->assertCount( 1, WP_Image_Editor_Mock::$spy['flip'] );
+		// The controller converts the integer values to booleans: 0 !== (int) 1 = true.
+		$this->assertSame( array( true, false ), WP_Image_Editor_Mock::$spy['flip'][0], 'Vertical flip of the image is not identical.' );
+	}	
+
+	/**
+	 * Tests that the image is flipped correctly with only vertical flip in arguments.
+	 *
+	 * @ticket 64035
+	 * @requires function imagejpeg
+	 */
+	public function test_edit_image_vertical_flip_only() {
+		wp_set_current_user( self::$superadmin_id );
+		$attachment = self::factory()->attachment->create_upload_object( self::$test_file );
+
+		$this->setup_mock_editor();
+		WP_Image_Editor_Mock::$edit_return['flip'] = new WP_Error();
+
+		$params = array(
+			'flip' => array(
+				'vertical' => true,
 			),
 			'src'  => wp_get_attachment_image_url( $attachment, 'full' ),
 		);

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -2796,7 +2796,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		$this->assertCount( 1, WP_Image_Editor_Mock::$spy['flip'] );
 		// The controller converts the integer values to booleans: 0 !== (int) 1 = true.
 		$this->assertSame( array( true, false ), WP_Image_Editor_Mock::$spy['flip'][0], 'Vertical flip of the image is not identical.' );
-	}	
+	}
 
 	/**
 	 * Tests that the image is flipped correctly with only vertical flip in arguments.

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -3445,7 +3445,7 @@ mockedApiResponse.Schema = {
                                                 ],
                                                 "properties": {
                                                     "flip": {
-                                                        "description": "Flip direction. [ horizontal, vertical ]",
+                                                        "description": "Flip direction.",
                                                         "type": "object",
                                                         "required": [
                                                             "horizontal",

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -21,7 +21,13 @@ mockedApiResponse.Schema = {
         "wp-site-health/v1",
         "wp-block-editor/v1"
     ],
-    "authentication": [],
+    "authentication": {
+        "application-passwords": {
+            "endpoints": {
+                "authorization": "http://example.org/wp-admin/authorize-application.php"
+            }
+        }
+    },
     "routes": {
         "/": {
             "namespace": "",

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -3445,7 +3445,7 @@ mockedApiResponse.Schema = {
                                                 ],
                                                 "properties": {
                                                     "flip": {
-                                                        "description": "Flip direction. [ horizontal, vertical ] 0 for no flip, 1 for flip.",
+                                                        "description": "Flip direction. [ horizontal, vertical ]",
                                                         "type": "object",
                                                         "required": [
                                                             "horizontal",
@@ -3453,12 +3453,12 @@ mockedApiResponse.Schema = {
                                                         ],
                                                         "properties": {
                                                             "horizontal": {
-                                                                "description": "Horizontal flip direction. 0 for no flip, 1 for flip.",
-                                                                "type": "number"
+                                                                "description": "Whether to flip in the horizontal direction.",
+                                                                "type": "boolean"
                                                             },
                                                             "vertical": {
-                                                                "description": "Vertical flip direction. 0 for no flip, 1 for flip.",
-                                                                "type": "number"
+                                                                "description": "Whether to flip in the vertical direction.",
+                                                                "type": "boolean"
                                                             }
                                                         }
                                                     }

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -21,13 +21,7 @@ mockedApiResponse.Schema = {
         "wp-site-health/v1",
         "wp-block-editor/v1"
     ],
-    "authentication": {
-        "application-passwords": {
-            "endpoints": {
-                "authorization": "http://example.org/wp-admin/authorize-application.php"
-            }
-        }
-    },
+    "authentication": [],
     "routes": {
         "/": {
             "namespace": "",
@@ -3428,6 +3422,45 @@ mockedApiResponse.Schema = {
                                 ],
                                 "oneOf": [
                                     {
+                                        "title": "Flip",
+                                        "properties": {
+                                            "type": {
+                                                "description": "Flip type.",
+                                                "type": "string",
+                                                "enum": [
+                                                    "flip"
+                                                ]
+                                            },
+                                            "args": {
+                                                "description": "Flip arguments.",
+                                                "type": "object",
+                                                "required": [
+                                                    "flip"
+                                                ],
+                                                "properties": {
+                                                    "flip": {
+                                                        "description": "Flip direction. [ horizontal, vertical ] 0 for no flip, 1 for flip.",
+                                                        "type": "object",
+                                                        "required": [
+                                                            "horizontal",
+                                                            "vertical"
+                                                        ],
+                                                        "properties": {
+                                                            "horizontal": {
+                                                                "description": "Horizontal flip direction. 0 for no flip, 1 for flip.",
+                                                                "type": "number"
+                                                            },
+                                                            "vertical": {
+                                                                "description": "Vertical flip direction. 0 for no flip, 1 for flip.",
+                                                                "type": "number"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
                                         "title": "Rotation",
                                         "properties": {
                                             "type": {
@@ -3531,6 +3564,87 @@ mockedApiResponse.Schema = {
                             "type": "number",
                             "minimum": 0,
                             "maximum": 100,
+                            "required": false
+                        },
+                        "caption": {
+                            "description": "The attachment caption.",
+                            "type": "object",
+                            "properties": {
+                                "raw": {
+                                    "description": "Caption for the attachment, as it exists in the database.",
+                                    "type": "string",
+                                    "context": [
+                                        "edit"
+                                    ]
+                                },
+                                "rendered": {
+                                    "description": "HTML caption for the attachment, transformed for display.",
+                                    "type": "string",
+                                    "context": [
+                                        "view",
+                                        "edit",
+                                        "embed"
+                                    ],
+                                    "readonly": true
+                                }
+                            },
+                            "required": false
+                        },
+                        "description": {
+                            "description": "The attachment description.",
+                            "type": "object",
+                            "properties": {
+                                "raw": {
+                                    "description": "Description for the attachment, as it exists in the database.",
+                                    "type": "string",
+                                    "context": [
+                                        "edit"
+                                    ]
+                                },
+                                "rendered": {
+                                    "description": "HTML description for the attachment, transformed for display.",
+                                    "type": "string",
+                                    "context": [
+                                        "view",
+                                        "edit"
+                                    ],
+                                    "readonly": true
+                                }
+                            },
+                            "required": false
+                        },
+                        "title": {
+                            "description": "The title for the post.",
+                            "type": "object",
+                            "properties": {
+                                "raw": {
+                                    "description": "Title for the post, as it exists in the database.",
+                                    "type": "string",
+                                    "context": [
+                                        "edit"
+                                    ]
+                                },
+                                "rendered": {
+                                    "description": "HTML title for the post, transformed for display.",
+                                    "type": "string",
+                                    "context": [
+                                        "view",
+                                        "edit",
+                                        "embed"
+                                    ],
+                                    "readonly": true
+                                }
+                            },
+                            "required": false
+                        },
+                        "post": {
+                            "description": "The ID for the associated post of the attachment.",
+                            "type": "integer",
+                            "required": false
+                        },
+                        "alt_text": {
+                            "description": "Alternative text to display when attachment is not displayed.",
+                            "type": "string",
                             "required": false
                         }
                     }


### PR DESCRIPTION
## What?

This PR is the first step to enhance media editor capabilities as described in #55238 [Phase 3: Collaboration > Media Library](https://github.com/WordPress/gutenberg/issues/55238).

It adds the following functionality:

- the ability to flip an image horizontally and vertically
- the ability to send arguments to update the new image's `caption`, `description`, and `title`, `post` and `alt_text` fields.


## Why?

As outlined in https://github.com/WordPress/gutenberg/issues/55238, the extended functionality will allow folks to start experimenting with a redesigned media library.

It will also allow flip controls in the existing image block toolbar.

## Testing Instructions

### Unit tests

`npm run test:php -- --filter WP_Test_REST_Attachments_Controller`

### Manual testing

Check that existing use of the `media/{$id}/edit` endpoint has no regressions:

1. Insert an image into a post
2. Click on the crop symbol in the toolbar of the image block
3. Edit and save the image. 
4. Check in the Network tab of your browser's console that the POST to `media/{$id}/edit` took place with the correct payload.
5. Check that a new file has been created in the Media Library `/wp-admin/upload.php`

Trac ticket: https://core.trac.wordpress.org/ticket/64035

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
