### PR TITLE
Enhancement: Add toggle functionality disable enable publish button

### DIFF
--- a/src/js/_enqueues/admin/post.js
+++ b/src/js/_enqueues/admin/post.js
@@ -316,6 +316,39 @@ jQuery( function($) {
 		copyAttachmentURLSuccessTimeout,
 		__ = wp.i18n.__, _x = wp.i18n._x;
 
+	/**
+	 * Toggles the publish button's disabled state based on the title and content fields.
+	 *
+	 * The Publish button is disabled if both the title and content are empty.
+	 *
+	 * @since 6.6.0
+	 */
+	function togglePublishButtonState() {
+		var $title = $( '#title' ),
+			$publishButton = $( '#publish' ),
+			editor = window.tinymce && window.tinymce.get( 'content' ),
+			content;
+
+		if ( editor && ! editor.isHidden() ) {
+			content = editor.getContent( { format: 'text' } );
+		} else {
+			content = $textarea.val();
+		}
+
+		if ( ! $title.val().trim() && ! content.trim() ) {
+			$publishButton.prop( 'disabled', true );
+		} else {
+			$publishButton.prop( 'disabled', false );
+		}
+	}
+
+	// Set initial state and bind events to check publish button state.
+	togglePublishButtonState();
+	$( '#title, #content' ).on( 'input keyup', togglePublishButtonState );
+	$document.on( 'tinymce-editor-init', function( event, editor ) {
+		editor.on( 'keyup input', togglePublishButtonState );
+	} );
+
 	postboxes.add_postbox_toggles(pagenow);
 
 	/*


### PR DESCRIPTION
This PR solves : https://core.trac.wordpress.org/ticket/62769

Summary
This PR adds logic to disable the "Publish" button in the Classic Editor interface when both the post title and content fields are empty. The button is automatically re-enabled once either field has valid input.