### PR TITLE
Tests: Update unsupported image format tests to use TGA instead of AVIF

### DIFF
--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -28,9 +28,9 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	private static $test_file2;
 
 	/**
-	 * @var string The path to the AVIF test image.
+	 * @var string The path to the TGA test image.
 	 */
-	private static $test_avif_file;
+	private static $test_tga_file;
 
 	/**
 	 * @var string The path to the SVG test image.
@@ -82,8 +82,8 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		if ( file_exists( self::$test_file2 ) ) {
 			unlink( self::$test_file2 );
 		}
-		if ( file_exists( self::$test_avif_file ) ) {
-			unlink( self::$test_avif_file );
+		if ( file_exists( self::$test_tga_file ) ) {
+			unlink( self::$test_tga_file );
 		}
 
 		self::delete_user( self::$editor_id );
@@ -114,10 +114,10 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 			copy( $orig_file2, self::$test_file2 );
 		}
 
-		$orig_avif_file       = DIR_TESTDATA . '/images/avif-lossy.avif';
-		self::$test_avif_file = get_temp_dir() . 'avif-lossy.avif';
-		if ( ! file_exists( self::$test_avif_file ) ) {
-			copy( $orig_avif_file, self::$test_avif_file );
+		$orig_tga_file       = DIR_TESTDATA . '/images/test-image.tga';
+		self::$test_tga_file = get_temp_dir() . 'test-image.tga';
+		if ( ! file_exists( self::$test_tga_file ) ) {
+			copy( $orig_tga_file, self::$test_tga_file );
 		}
 
 		$test_svg_file       = DIR_TESTDATA . '/uploads/video-play.svg';
@@ -2574,17 +2574,27 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	 */
 	public function test_upload_unsupported_image_type() {
 
-		// Only run this test when the editor doesn't support AVIF.
-		if ( wp_image_editor_supports( array( 'AVIF' ) ) ) {
-			$this->markTestSkipped( 'The image editor suppports AVIF.' );
+		// Only run this test when the editor doesn't support TGA.
+		if ( wp_image_editor_supports( array( 'mime_type' => 'image/tga' ) ) ) {
+			$this->markTestSkipped( 'The image editor supports TGA.' );
 		}
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
 
 		wp_set_current_user( self::$author_id );
-		$request->set_header( 'Content-Type', 'image/avif' );
-		$request->set_header( 'Content-Disposition', 'attachment; filename=avif-lossy.avif' );
-		$request->set_body( file_get_contents( self::$test_avif_file ) );
+		$request->set_header( 'Content-Type', 'image/tga' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=test-image.tga' );
+		$request->set_file_params(
+			array(
+				'file' => array(
+					'file'     => file_get_contents( self::$test_tga_file ),
+					'name'     => 'test-image.tga',
+					'size'     => filesize( self::$test_tga_file ),
+					'tmp_name' => self::$test_tga_file,
+					'type'     => 'image/tga',
+				),
+			)
+		);
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_upload_image_type_not_supported', $response, 400 );
@@ -2597,22 +2607,34 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 	 */
 	public function test_upload_unsupported_image_type_with_filter() {
 
-		// Only run this test when the editor doesn't support AVIF.
-		if ( wp_image_editor_supports( array( 'AVIF' ) ) ) {
-			$this->markTestSkipped( 'The image editor suppports AVIF.' );
+		// Only run this test when the editor doesn't support TGA.
+		if ( wp_image_editor_supports( array( 'mime_type' => 'image/tga' ) ) ) {
+			$this->markTestSkipped( 'The image editor supports TGA.' );
 		}
 
-		add_filter( 'wp_prevent_unsupported_image_uploads', '__return_false' );
+		add_filter( 'wp_prevent_unsupported_mime_type_uploads', '__return_false' );
 
 		$request = new WP_REST_Request( 'POST', '/wp/v2/media' );
 
 		wp_set_current_user( self::$author_id );
-		$request->set_header( 'Content-Type', 'image/avif' );
-		$request->set_header( 'Content-Disposition', 'attachment; filename=avif-lossy.avif' );
-		$request->set_body( file_get_contents( self::$test_avif_file ) );
+		$request->set_header( 'Content-Type', 'image/tga' );
+		$request->set_header( 'Content-Disposition', 'attachment; filename=test-image.tga' );
+		$request->set_file_params(
+			array(
+				'file' => array(
+					'file'     => file_get_contents( self::$test_tga_file ),
+					'name'     => 'test-image.tga',
+					'size'     => filesize( self::$test_tga_file ),
+					'tmp_name' => self::$test_tga_file,
+					'type'     => 'image/tga',
+				),
+			)
+		);
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertSame( 201, $response->get_status() );
+		$this->assertErrorResponse( 'rest_upload_unknown_error', $response, 500 );
+
+		remove_filter( 'wp_prevent_unsupported_mime_type_uploads', '__return_false' );
 	}
 
 	/**


### PR DESCRIPTION
Update unsupported image format tests to use TGA instead of AVIF

Trac ticket:
https://core.trac.wordpress.org/ticket/64225
https://core.trac.wordpress.org/ticket/63167

Updated REST API test methods using the unsupported image format to test unsupported logic checks

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
