### PR TITLE
Hoist `is_object_in_taxonomy` to fix invalid errors

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php
@@ -154,10 +154,6 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 	 * @return bool Whether the terms for the post can be read.
 	 */
 	public function check_read_terms_permission_for_post( $post, $request ) {
-		// If the requested post isn't associated with this taxonomy, deny access.
-		if ( ! is_object_in_taxonomy( $post->post_type, $this->taxonomy ) ) {
-			return false;
-		}
 
 		// Grant access if the post is publicly viewable.
 		if ( is_post_publicly_viewable( $post ) ) {
@@ -203,6 +199,17 @@ class WP_REST_Terms_Controller extends WP_REST_Controller {
 				return new WP_Error(
 					'rest_post_invalid_id',
 					__( 'Invalid post ID.' ),
+					array(
+						'status' => 400,
+					)
+				);
+			}
+
+			// If the requested post isn't associated with this taxonomy, the request is invalid.
+			if ( ! is_object_in_taxonomy( $post->post_type, $this->taxonomy ) ) {
+				return new WP_Error(
+					'rest_post_invalid_type',
+					__( 'Invalid post type.' ),
 					array(
 						'status' => 400,
 					)


### PR DESCRIPTION
The `wp/v2/menus` API will return a 403 if the `post` parameter refers to a `post` object that isn’t a `nav_menu_item`. This isn’t a permissions issue – it’s just an invalid request, and the response should reflect that.

Trac ticket: https://core.trac.wordpress.org/ticket/64045

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
