### PR TITLE
Correct formatting in compat-utf8.php file

### DIFF
--- a/src/wp-includes/compat-utf8.php
+++ b/src/wp-includes/compat-utf8.php
@@ -43,11 +43,11 @@
  * @return int How many code points were successfully scanned.
  */
 function _wp_scan_utf8( string $bytes, int &$at, int &$invalid_length, ?int $max_bytes = null, ?int $max_code_points = null ): int {
-	$byte_length       = strlen( $bytes );
-	$end               = min( $byte_length, $at + ( $max_bytes ?? PHP_INT_MAX ) );
-	$invalid_length    = 0;
-	$count             = 0;
-	$max_count         = $max_code_points ?? PHP_INT_MAX;
+	$byte_length    = strlen( $bytes );
+	$end            = min( $byte_length, $at + ( $max_bytes ?? PHP_INT_MAX ) );
+	$invalid_length = 0;
+	$count          = 0;
+	$max_count      = $max_code_points ?? PHP_INT_MAX;
 
 	for ( $i = $at; $i < $end && $count <= $max_count; $i++ ) {
 		/*


### PR DESCRIPTION
Format corrections in this commit is the produce of executing the `composer format` command of wordpress-develop (/composer.json > scripts > format) on the wordpress-develop codebase.

Trac ticket: https://core.trac.wordpress.org/ticket/63168
