### PR TITLE
64049: REST API: Allow comments to be edited to become empty

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -1902,6 +1902,10 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	 * @return bool True if the content is allowed, false otherwise.
 	 */
 	protected function check_is_comment_content_allowed( $prepared_comment ) {
+		if ( ! isset( $prepared_comment['comment_content'] ) ) {
+			return true;
+		}
+
 		$check = wp_parse_args(
 			$prepared_comment,
 			array(

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -859,8 +859,8 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			if ( is_wp_error( $prepared_args ) ) {
 				return $prepared_args;
 			}
-
-			if ( isset( $prepared_args['comment_content'] ) && empty( $prepared_args['comment_content'] ) ) {
+			$is_block_comment = isset( $prepared_args['type'] ) && 'block_comment' === $prepared_args['type'];
+			if ( ! $is_block_comment && isset( $prepared_args['comment_content'] ) && empty( $prepared_args['comment_content'] ) ) {
 				return new WP_Error(
 					'rest_comment_content_invalid',
 					__( 'Invalid comment content.' ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -859,8 +859,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			if ( is_wp_error( $prepared_args ) ) {
 				return $prepared_args;
 			}
-			$is_block_comment = isset( $prepared_args['type'] ) && 'block_comment' === $prepared_args['type'];
-			if ( ! $is_block_comment && isset( $prepared_args['comment_content'] ) && empty( $prepared_args['comment_content'] ) ) {
+			if ( ! $this->check_is_comment_content_allowed( $prepared_args ) ) {
 				return new WP_Error(
 					'rest_comment_content_invalid',
 					__( 'Invalid comment content.' ),

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -2493,6 +2493,30 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertErrorResponse( 'rest_comment_content_invalid', $response, 400 );
 	}
 
+	/**
+	 * @ticket 64049
+	 */
+	public function test_update_item_no_content_allow_empty_comment_filter() {
+		$post_id = self::factory()->post->create();
+
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'PUT', sprintf( '/wp/v2/comments/%d', self::$approved_id ) );
+		$request->set_param( 'author_email', 'another@email.com' );
+
+		// Sending a request without content is fine.
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		// Sending a request with empty comment is not fine.
+		$request->set_param( 'author_email', 'yetanother@email.com' );
+		$request->set_param( 'content', '' );
+		add_filter( 'allow_empty_comment', '__return_true' );
+		$response = rest_get_server()->dispatch( $request );
+		remove_filter( 'allow_empty_comment', '__return_true' );
+		$this->assertSame( 200, $response->get_status() );
+	}
+
 	public function test_update_item_no_change() {
 		$comment = get_comment( self::$approved_id );
 

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -2508,7 +2508,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertSame( 200, $response->get_status() );
 
-		// Sending a request with empty comment is not fine.
+		// Sending a request with empty comment content is also fine.
 		$request->set_param( 'author_email', 'yetanother@email.com' );
 		$request->set_param( 'content', '' );
 		add_filter( 'allow_empty_comment', '__return_true' );


### PR DESCRIPTION
Originally proposed by @adamsilverstein in https://github.com/WordPress/wordpress-develop/pull/9988, this PR adds tests to his fix while also resolving a potential logical error which could prevent updates to unrelated comment object properties.

- #9988 as written causes an error in some existing unit tests (including my newly-added one for this ticket), `Undefined array key "comment_content"` (failing on the last line of `check_is_comment_content_allowed`) because the controller expects to be able to process _partial objects_: For example, you can pass an object in a PUT which changes the author but alters no other fields.
- We therefore only want to check the content for emptiness (and verify using the filter whether that is allowable) when the property has been passed back.
- Currently, the only path through which `check_is_comment_content_allowed()` can be called is during the create_item method, which ensures `comment_content` is initialized to `''` if not present — this should not result in any change to existing behavior on comment creation or updates.

Trac ticket: https://core.trac.wordpress.org/ticket/64049

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
