### PR TITLE
Fix/64056 php warnings for non resizable image while subsizes

### DIFF
--- a/src/wp-admin/includes/image.php
+++ b/src/wp-admin/includes/image.php
@@ -103,10 +103,14 @@ function wp_get_missing_image_subsizes( $attachment_id ) {
 		$imagesize  = wp_getimagesize( $image_file );
 	}
 
+	// Fallback to the "full" size dimensions.
+	$full_width  = 0;
+	$full_height = 0;
+
 	if ( ! empty( $imagesize ) ) {
 		$full_width  = $imagesize[0];
 		$full_height = $imagesize[1];
-	} else {
+	} elseif ( ! empty( $image_meta['width'] ) && ! empty( $image_meta['height'] ) ) {
 		$full_width  = (int) $image_meta['width'];
 		$full_height = (int) $image_meta['height'];
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64056#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
