### PR TITLE
Add block visibility support

### DIFF
--- a/src/wp-includes/block-supports/block-visibility.php
+++ b/src/wp-includes/block-supports/block-visibility.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Block visibility block support flag.
+ *
+ * @package WordPress
+ * @since 6.9.0
+ */
+
+/**
+ * Render nothing if the block is hidden.
+ *
+ * @since 6.9.0
+ * @access private
+ *
+ * @param  string $block_content Rendered block content.
+ * @param  array  $block         Block object.
+ * @return string                Filtered block content.
+ */
+function wp_render_block_visibility_support( $block_content, $block ) {
+	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+
+	if ( ! $block_type || ! block_has_support( $block_type, 'blockVisibility', true ) ) {
+		return $block_content;
+	}
+
+	if ( isset( $block['attrs']['metadata']['blockVisibility'] ) && false === $block['attrs']['metadata']['blockVisibility'] ) {
+		return '';
+	}
+
+	return $block_content;
+}
+
+add_filter( 'render_block', 'wp_render_block_visibility_support', 10, 2 );

--- a/src/wp-includes/block-supports/block-visibility.php
+++ b/src/wp-includes/block-supports/block-visibility.php
@@ -12,9 +12,9 @@
  * @since 6.9.0
  * @access private
  *
- * @param  string $block_content Rendered block content.
- * @param  array  $block         Block object.
- * @return string                Filtered block content.
+ * @param string $block_content Rendered block content.
+ * @param array  $block         Block object.
+ * @return string Filtered block content.
  */
 function wp_render_block_visibility_support( $block_content, $block ) {
 	$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -391,6 +391,7 @@ require ABSPATH . WPINC . '/block-supports/shadow.php';
 require ABSPATH . WPINC . '/block-supports/background.php';
 require ABSPATH . WPINC . '/block-supports/block-style-variations.php';
 require ABSPATH . WPINC . '/block-supports/aria-label.php';
+require ABSPATH . WPINC . '/block-supports/block-visibility.php';
 require ABSPATH . WPINC . '/style-engine.php';
 require ABSPATH . WPINC . '/style-engine/class-wp-style-engine.php';
 require ABSPATH . WPINC . '/style-engine/class-wp-style-engine-css-declarations.php';

--- a/tests/phpunit/tests/block-supports/block-visibility.php
+++ b/tests/phpunit/tests/block-supports/block-visibility.php
@@ -108,4 +108,3 @@ class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
 		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when blockVisibility support is not opted in.' );
 	}
 }
-

--- a/tests/phpunit/tests/block-supports/block-visibility.php
+++ b/tests/phpunit/tests/block-supports/block-visibility.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Test the block visibility block support.
+ *
+ * @package WordPress
+ * @subpackage Block Supports
+ * @since 6.9.0
+ *
+ * @group block-supports
+ *
+ * @covers ::wp_render_block_visibility_support
+ */
+class Tests_Block_Supports_Block_Visibility extends WP_UnitTestCase {
+	/**
+	 * @var string|null
+	 */
+	private $test_block_name;
+
+	public function set_up() {
+		parent::set_up();
+		$this->test_block_name = null;
+	}
+
+	public function tear_down() {
+		unregister_block_type( $this->test_block_name );
+		$this->test_block_name = null;
+		parent::tear_down();
+	}
+
+	/**
+	 * Registers a new block for testing block visibility support.
+	 *
+	 * @param string $block_name Name for the test block.
+	 * @param array  $supports   Array defining block support configuration.
+	 *
+	 * @return WP_Block_Type The block type for the newly registered test block.
+	 */
+	private function register_visibility_block_with_support( $block_name, $supports = array() ) {
+		$this->test_block_name = $block_name;
+		register_block_type(
+			$this->test_block_name,
+			array(
+				'api_version' => 3,
+				'attributes'  => array(
+					'metadata' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => $supports,
+			)
+		);
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		return $registry->get_registered( $this->test_block_name );
+	}
+
+	/**
+	 * Tests that block visibility support renders empty string when block is hidden
+	 * and blockVisibility support is opted in.
+	 *
+	 * @ticket 64061
+	 */
+	public function test_block_visibility_support_hides_block_when_visibility_false() {
+		$block_type = $this->register_visibility_block_with_support(
+			'test/visibility-block',
+			array( 'blockVisibility' => true )
+		);
+
+		$block_content = '<p>This is a test block.</p>';
+		$block         = array(
+			'blockName' => 'test/visibility-block',
+			'attrs'     => array(
+				'metadata' => array(
+					'blockVisibility' => false,
+				),
+			),
+		);
+
+		$result = wp_render_block_visibility_support( $block_content, $block );
+
+		$this->assertSame( '', $result, 'Block content should be empty when blockVisibility is false and support is opted in.' );
+	}
+
+	/**
+	 * Tests that block visibility support renders block normally when visibility is false
+	 * but blockVisibility support is not opted in.
+	 *
+	 * @ticket 64061
+	 */
+	public function test_block_visibility_support_shows_block_when_support_not_opted_in() {
+		$block_type = $this->register_visibility_block_with_support(
+			'test/visibility-block',
+			array( 'blockVisibility' => false )
+		);
+
+		$block_content = '<p>This is a test block.</p>';
+		$block         = array(
+			'blockName' => 'test/visibility-block',
+			'attrs'     => array(
+				'metadata' => array(
+					'blockVisibility' => false,
+				),
+			),
+		);
+
+		$result = wp_render_block_visibility_support( $block_content, $block );
+
+		$this->assertSame( $block_content, $result, 'Block content should remain unchanged when blockVisibility support is not opted in.' );
+	}
+}
+


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64061

### Testing Instructions

- Create a new post.
- Create content by using the following HTML:
  ```html
  <!-- wp:paragraph {"metadata":{"blockVisibility":false}} -->
  <p>This text should NOT be visible on the front end.</p>
  <!-- /wp:paragraph -->

  <!-- wp:paragraph {"metadata":{"blockVisibility":true}} -->
  <p>This text should be visible on the front end.</p>
  <!-- /wp:paragraph -->

  <!-- wp:paragraph-->
  <p>This text should be visible on the front end.</p>
  <!-- /wp:post-content -->
  ```
- Confirm that the first block of three paragraphs does not render anything on the frontend.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
