### PR TITLE
Minor test doc update

### DIFF
--- a/tests/phpunit/tests/blocks/renderCommentTemplate.php
+++ b/tests/phpunit/tests/blocks/renderCommentTemplate.php
@@ -79,6 +79,7 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 55505
+	 *
 	 * @covers ::build_comment_query_vars_from_block
 	 */
 	public function test_build_comment_query_vars_from_block_with_context() {
@@ -110,6 +111,7 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 55567
+	 *
 	 * @covers ::build_comment_query_vars_from_block
 	 */
 	public function test_build_comment_query_vars_from_block_with_context_no_pagination() {
@@ -140,6 +142,7 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 55505
+	 *
 	 * @covers ::build_comment_query_vars_from_block
 	 */
 	public function test_build_comment_query_vars_from_block_no_context() {
@@ -170,6 +173,7 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 	 * Regression: https://github.com/WordPress/gutenberg/issues/40758.
 	 *
 	 * @ticket 55658
+	 *
 	 * @covers ::build_comment_query_vars_from_block
 	 */
 	public function test_build_comment_query_vars_from_block_pagination_with_no_comments() {
@@ -222,6 +226,7 @@ class Tests_Blocks_RenderReusableCommentTemplate extends WP_UnitTestCase {
 	 *
 	 * @ticket 55505
 	 * @ticket 60806
+	 *
 	 * @covers ::build_comment_query_vars_from_block
 	 */
 	public function test_build_comment_query_vars_from_block_sets_max_num_pages() {
@@ -421,6 +426,7 @@ END
 	 * Test that unapproved comments are included if it is a preview.
 	 *
 	 * @ticket 55634
+	 *
 	 * @covers ::build_comment_query_vars_from_block
 	 */
 	public function test_build_comment_query_vars_from_block_with_comment_preview() {
@@ -537,9 +543,9 @@ END
 			'render_block',
 			static function ( $block_content, $block ) use ( $parsed_comment_author_name_block ) {
 				/*
-				* Insert a Comment Author Name block (which requires `commentId`
-				* block context to work) after the Comment Content block.
-				*/
+				 * Insert a Comment Author Name block (which requires `commentId`
+				 * block context to work) after the Comment Content block.
+				 */
 				if ( 'core/comment-content' !== $block['blockName'] ) {
 					return $block_content;
 				}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63168

This PR makes minor improvements to the documentation in the test suite for comment template rendering. Specifically, it adds a blank line between the `@ticket` and `@covers` annotations in several test methods, also correct indentation for inline comment.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
