### PR TITLE
Ensure upgrade tests do not test past the specified version

### DIFF
--- a/.github/workflows/reusable-support-json-reader-v1.yml
+++ b/.github/workflows/reusable-support-json-reader-v1.yml
@@ -8,7 +8,7 @@ on:
   workflow_call:
     inputs:
       wp-version:
-        description: 'The WordPress version to test . Accepts major and minor versions, "latest", or "nightly". Major releases must not end with ".0".'
+        description: 'The WordPress version to test. Accepts major and minor versions, "latest", or "nightly". Major releases must not end with ".0".'
         type: string
         default: 'nightly'
       repository:

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -63,8 +63,8 @@ permissions: {}
 jobs:
   generate-exclusions:
     name: Generate test exclusions
-    runs-on: 'ubuntu-24.04'
-    if: ${{ github.repository == 'WordPress/wordpress-develop' }}
+    runs-on: 'ubuntu-22.04'
+    if: ${{ true || github.repository == 'WordPress/wordpress-develop' }}
     timeout-minutes: 5
     outputs:
       matrix_exclusions: ${{ steps.set-exclusions.outputs.matrix_exclusions }}
@@ -74,7 +74,7 @@ jobs:
         id: set-exclusions
         shell: bash
         env:
-          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '5.5.10' }}
         run: |
           # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
           # MySQL 9.0+ will also not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -181,7 +181,7 @@ jobs:
   upgrade-tests-recent-releases:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
-    needs: [ 'generate-exclusions' ]
+    needs: [ 'generate-exclusions', 'generate-matrix-for-input-version' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     permissions:
       contents: read
@@ -332,7 +332,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-    needs: [ generate-exclusions, upgrade-tests-recent-releases, upgrade-tests-wp-6x-mysql, upgrade-tests-wp-5x-php-7x-mysql, upgrade-tests-wp-5x-php-8x-mysql, upgrade-tests-oldest-wp-mysql ]
+    needs: [ generate-exclusions, upgrade-tests-recent-releases, upgrade-tests-input-version, upgrade-tests-wp-6x-mysql, upgrade-tests-wp-5x-php-7x-mysql, upgrade-tests-wp-5x-php-8x-mysql, upgrade-tests-oldest-wp-mysql ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name != 'pull_request' && always() }}
     with:
       calling_status: ${{ contains( needs.*.result, 'cancelled' ) && 'cancelled' || contains( needs.*.result, 'failure' ) && 'failure' || 'success' }}

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -74,7 +74,7 @@ jobs:
         id: set-exclusions
         shell: bash
         env:
-          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || 'latest' }}
         run: |
           # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
           # MySQL 9.0+ will also not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.
@@ -86,7 +86,8 @@ jobs:
           ]'
 
           # The defaults are sufficient when not testing a specific version.
-          if [[ -z "$NEW_VERSION" ]] || \
+          if [[ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]] || \
+             [[ -z "$NEW_VERSION" ]] || \
              [[ "$NEW_VERSION" == "latest" ]] || \
              [[ "$NEW_VERSION" == "nightly" ]]; then
             echo "matrix_exclusions=$(echo "$DEFAULT_EXCLUSIONS" | tr -d '\n' | tr -d ' ')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -74,7 +74,7 @@ jobs:
         id: set-exclusions
         shell: bash
         env:
-          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '5.9' }}
+          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
         run: |
           # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
           # MySQL 9.0+ will also not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -140,7 +140,7 @@ jobs:
         wp: [ '6.7', '6.8' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || fromJSON( '[]' ) }}
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -168,7 +168,7 @@ jobs:
         wp: [ '6.0', '6.3', '6.4', '6.5' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || fromJSON( '[]' ) }}
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -196,7 +196,7 @@ jobs:
         wp: [ '5.0', '5.1', '5.3', '5.4', '5.5', '5.6', '5.9' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || fromJSON( '[]' ) }}
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -228,7 +228,7 @@ jobs:
         wp: [ '5.3', '5.4', '5.5', '5.6', '5.9' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || fromJSON( '[]' ) }}
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -261,7 +261,7 @@ jobs:
         wp: [ '4.7' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || fromJSON( '[]' ) }}
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -150,7 +150,7 @@ jobs:
         wp: [ '6.7', '6.8' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || fromJSON( '[]' ) }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -178,7 +178,7 @@ jobs:
         wp: [ '6.0', '6.3', '6.4', '6.5' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || fromJSON( '[]' ) }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -206,7 +206,7 @@ jobs:
         wp: [ '5.0', '5.1', '5.3', '5.4', '5.5', '5.6', '5.9' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || fromJSON( '[]' ) }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -238,7 +238,7 @@ jobs:
         wp: [ '5.3', '5.4', '5.5', '5.6', '5.9' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || fromJSON( '[]' ) }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -271,7 +271,7 @@ jobs:
         wp: [ '4.7' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || fromJSON( '[]' ) }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -114,7 +114,17 @@ jobs:
             fi
 
             # Increment to next version.
-            TEST_VERSION="$(echo "$TEST_VERSION" | cut -d. -f1).$(($(echo "$TEST_VERSION" | cut -d. -f2) + 1))"
+            MAJOR=$(echo "$TEST_VERSION" | cut -d. -f1)
+            MINOR=$(echo "$TEST_VERSION" | cut -d. -f2)
+            MINOR=$((MINOR + 1))
+
+            # Roll over to next major version if minor reaches 10
+            if [[ $MINOR -eq 10 ]]; then
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+            fi
+
+            TEST_VERSION="$MAJOR.$MINOR"
           done
 
           # Add the current version and close the array.

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -28,6 +28,7 @@ on:
 
 env:
   CURRENTLY_SUPPORTED_BRANCH: '6.8'
+  OLDEST_SECURITY_BRANCH: '4.7'
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
@@ -81,12 +82,13 @@ jobs:
             {"php":"7.2","db-version":"8.4"},
             {"php":"7.3","db-version":"8.4"},
             {"php":"7.2","db-version":"9.4"},
-            {"php":"7.3","db-version":"9.4"}
+            {"php":"7.3","db-version":"9.4"},
           ]'
 
-          if [[ "$NEW_VERSION" == "latest" ]] || \
+          if [[ -z "$NEW_VERSION" ]] || \
+             [[ "$NEW_VERSION" == "latest" ]] || \
              [[ "$NEW_VERSION" == "nightly" ]] || \
-             [[ -z "$NEW_VERSION" ]]; then
+             [[ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]]; then
             COMPACTED=$(echo "$DEFAULT_EXCLUSIONS" | tr -d '\n' | tr -d ' ')
             echo "matrix_exclusions=$COMPACTED" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -74,7 +74,7 @@ jobs:
         id: set-exclusions
         shell: bash
         env:
-          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || 'latest' }}
+          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '5.9' }}
         run: |
           # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
           # MySQL 9.0+ will also not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.
@@ -86,8 +86,7 @@ jobs:
           ]'
 
           # The defaults are sufficient when not testing a specific version.
-          if [[ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]] || \
-             [[ -z "$NEW_VERSION" ]] || \
+          if [[ -z "$NEW_VERSION" ]] || \
              [[ "$NEW_VERSION" == "latest" ]] || \
              [[ "$NEW_VERSION" == "nightly" ]]; then
             echo "matrix_exclusions=$(echo "$DEFAULT_EXCLUSIONS" | tr -d '\n' | tr -d ' ')" >> "$GITHUB_OUTPUT"
@@ -140,7 +139,7 @@ jobs:
         wp: [ '6.7', '6.8' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || fromJSON( '[]' ) }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -168,7 +167,7 @@ jobs:
         wp: [ '6.0', '6.3', '6.4', '6.5' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || fromJSON( '[]' ) }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -196,7 +195,7 @@ jobs:
         wp: [ '5.0', '5.1', '5.3', '5.4', '5.5', '5.6', '5.9' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || fromJSON( '[]' ) }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -228,7 +227,7 @@ jobs:
         wp: [ '5.3', '5.4', '5.5', '5.6', '5.9' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || fromJSON( '[]' ) }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -261,7 +260,7 @@ jobs:
         wp: [ '4.7' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || fromJSON( '[]' ) }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -104,13 +104,14 @@ jobs:
           CURRENT_VERSION=$(echo "$CURRENTLY_SUPPORTED_BRANCH" | grep -oE '[0-9]+\.[0-9]+')
           TEST_VERSION="$INPUT_VERSION"
 
+          # Create an exclusion list.
+          GENERATED_EXCLUSIONS=''
+
           while [[ "$TEST_VERSION" != "$CURRENT_VERSION" ]]; do
             # Only test the current version when a minor version has been specified.
             if [[ "$TEST_VERSION" != "$INPUT_VERSION" || "$MAJOR_RELEASE" == "true" ]]; then
               GENERATED_EXCLUSIONS+='{"wp":"'"$TEST_VERSION"'"},'
             fi
-
-            GENERATED_EXCLUSIONS+='{"wp":"'"$TEST_VERSION"'"},'
 
             # Increment to next version.
             TEST_VERSION="$(echo "$TEST_VERSION" | cut -d. -f1).$(($(echo "$TEST_VERSION" | cut -d. -f2) + 1))"

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -181,8 +181,8 @@ jobs:
   upgrade-tests-recent-releases:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
-    needs: [ 'generate-exclusions', 'generate-matrix-for-input-version' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
+    needs: [ 'generate-exclusions' ]
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -68,7 +68,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       matrix_exclusions: ${{ steps.set-exclusions.outputs.matrix_exclusions }}
-      version: ${{ steps.set-exclusions.outputs.major_version }}
+      major_version: ${{ steps.set-exclusions.outputs.major_version }}
 
     steps:
       - name: Set exclusions output
@@ -106,7 +106,7 @@ jobs:
           TEST_VERSION="$INPUT_VERSION"
 
           # Save the major version number as an output.
-          echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "major_version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
 
           # Create an exclusion list.
           GENERATED_EXCLUSIONS=''
@@ -146,9 +146,9 @@ jobs:
     needs: [ 'generate-exclusions' ]
     permissions:
       contents: read
-    if: ${{ true || github.repository == 'WordPress/wordpress-develop' && github.event_name == 'workflow_dispatch' && ! contains( fromJSON('["6.7", "6.8"]'), inputs.new-version ) }}
+    if: ${{ true || github.repository == 'WordPress/wordpress-develop' && github.event_name == 'workflow_dispatch' && ! contains( fromJSON('["6.7", "6.8"]'), needs.generate-exclusions.outputs.major_version ) }}
     with:
-      wp-version: ${{ needs.generate-exclusions.outputs.version }}
+      wp-version: ${{ needs.generate-exclusions.outputs.major_version }}
 
   upgrade-tests-input-version:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.1.4' }}

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -74,7 +74,7 @@ jobs:
         id: set-exclusions
         shell: bash
         env:
-          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '5.5.10' }}
+          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || 'v5.7.0' }}
         run: |
           # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
           # MySQL 9.0+ will also not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -155,6 +155,7 @@ jobs:
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-matrix-for-input-version' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
+    needs: [ 'generate-exclusions', 'generate-matrix-for-input-version' ]
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -73,11 +73,11 @@ jobs:
         env:
           NEW_VERSION: ${{ inputs.new-version && inputs.new-version || 'latest' }}
         run: |
+          # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
+          # MySQL 9.0+ will also not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.
           DEFAULT_EXCLUSIONS='[
-            # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
             {"php":"7.2","db-version":"8.4"},
             {"php":"7.3","db-version":"8.4"},
-            # MySQL 9.0+ will not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.
             {"php":"7.2","db-version":"9.4"},
             {"php":"7.3","db-version":"9.4"}
           ]'

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -106,7 +106,7 @@ jobs:
           TEST_VERSION="$INPUT_VERSION"
 
           # Save the major version number as an output.
-          echo "major_version=$(echo "$INPUT_VERSION" | cut -d. -f1)" >> "$GITHUB_OUTPUT"
+          echo "major_version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
 
           # Create an exclusion list.
           GENERATED_EXCLUSIONS=''

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -63,7 +63,7 @@ jobs:
   generate-exclusions:
     name: Generate test exclusions
     runs-on: 'ubuntu-24.04'
-    if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     timeout-minutes: 5
 
     steps:
@@ -71,7 +71,7 @@ jobs:
         id: set-exclusions
         shell: bash
         env:
-          NEW_VERSION: ${{ inputs.new-version }}
+          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || 'latest' }}
         run: |
           DEFAULT_EXCLUSIONS='[
             # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -81,6 +81,10 @@ permissions: {}
 # example, if the value of inputs.new-version is 6.4.4, the jobs testing versions 6.5 and higher will be skipped because
 # that would be a downgrade test.
 jobs:
+  # Generates a list of combinations to exclude in for each test matrix based on the version of WordPress being tested.
+  #
+  # When a major version is being tested (6.4 or 6.4.0), no upgrade would occur, so that version is excluded.
+  # When a minor version is being tested (6.4.1, 6.4.2, etc), the corresponding major version (6.4) is tested.
   generate-exclusions:
     name: Create combination exclusion list
     runs-on: 'ubuntu-24.04'

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -153,7 +153,6 @@ jobs:
   upgrade-tests-input-version:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
-    needs: [ 'generate-matrix-for-input-version' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     needs: [ 'generate-exclusions', 'generate-matrix-for-input-version' ]
     permissions:

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -167,7 +167,7 @@ jobs:
         wp: [ '${{ inputs.new-version }}' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-matrix-for-input-version.outputs.matrix_exclusions ) || '[]' }}
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -26,6 +26,9 @@ on:
         type: string
         default: 'latest'
 
+env:
+  CURRENTLY_SUPPORTED_BRANCH: '6.8'
+
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
   # The concurrency group contains the workflow name and the branch name for pull requests
@@ -57,10 +60,40 @@ permissions: {}
 #    - 5.6.x Docker containers are available and work, but 5.6 only accounts for ~2.3% of installs as of 12/6/2024.defaults:
 #    - 5.7.x accounts for ~20% of installs, so this is used below instead.
 jobs:
+  generate-exclusions:
+    name: Generate test exclusions
+    runs-on: 'ubuntu-24.04'
+    if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name == 'workflow_dispatch' }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Set exclusions output
+        id: set-exclusions
+        shell: bash
+        env:
+          NEW_VERSION: ${{ inputs.new-version }}
+        run: |
+          DEFAULT_EXCLUSIONS='[
+            # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
+            {"php":"7.2","db-version":"8.4"},
+            {"php":"7.3","db-version":"8.4"},
+            # MySQL 9.0+ will not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.
+            {"php":"7.2","db-version":"9.4"},
+            {"php":"7.3","db-version":"9.4"}
+          ]'
+
+          if [[ "$NEW_VERSION" == "latest" ]] || \
+             [[ "$NEW_VERSION" == "nightly" ]] || \
+             [[ -z "$NEW_VERSION" ]]; then
+            echo matrix_exclusions="$DEFAULT_EXCLUSIONS" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
   # Tests the full list of PHP/MySQL combinations for the two most recent versions of WordPress.
   upgrade-tests-recent-releases:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
+    needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     permissions:
       contents: read
@@ -74,17 +107,7 @@ jobs:
         wp: [ '6.7', '6.8' ]
         multisite: [ false, true ]
 
-        exclude:
-          # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
-          - php: '7.2'
-            db-version: '8.4'
-          - php: '7.3'
-            db-version: '8.4'
-          # MySQL 9.0+ will not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.
-          - php: '7.2'
-            db-version: '9.4'
-          - php: '7.3'
-            db-version: '9.4'
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -98,6 +121,7 @@ jobs:
   upgrade-tests-wp-6x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
+    needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     permissions:
       contents: read
@@ -111,10 +135,7 @@ jobs:
         wp: [ '6.0', '6.3', '6.4', '6.5' ]
         multisite: [ false, true ]
 
-        exclude:
-          # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
-          - php: '7.2'
-            db-version: '8.4'
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -128,6 +149,7 @@ jobs:
   upgrade-tests-wp-5x-php-7x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
+    needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     permissions:
       contents: read
@@ -141,10 +163,7 @@ jobs:
         wp: [ '5.0', '5.1', '5.3', '5.4', '5.5', '5.6', '5.9' ]
         multisite: [ false, true ]
 
-        exclude:
-          # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
-          - php: '7.2'
-            db-version: '8.4'
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -162,6 +181,7 @@ jobs:
   upgrade-tests-wp-5x-php-8x-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
+    needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     permissions:
       contents: read
@@ -174,6 +194,8 @@ jobs:
         db-version: [ '5.7', '8.4' ]
         wp: [ '5.3', '5.4', '5.5', '5.6', '5.9' ]
         multisite: [ false, true ]
+
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -192,6 +214,7 @@ jobs:
   upgrade-tests-oldest-wp-mysql:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
+    needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     permissions:
       contents: read
@@ -205,17 +228,7 @@ jobs:
         wp: [ '4.7' ]
         multisite: [ false, true ]
 
-        exclude:
-          # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
-          - php: '7.2'
-            db-version: '8.4'
-          - php: '7.3'
-            db-version: '8.4'
-          # MySQL 9.0+ will not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.
-          - php: '7.2'
-            db-version: '9.4'
-          - php: '7.3'
-            db-version: '9.4'
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -231,7 +244,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-    needs: [ upgrade-tests-recent-releases, upgrade-tests-wp-6x-mysql, upgrade-tests-wp-5x-php-7x-mysql, upgrade-tests-wp-5x-php-8x-mysql, upgrade-tests-oldest-wp-mysql ]
+    needs: [ generate-exclusions, upgrade-tests-recent-releases, upgrade-tests-wp-6x-mysql, upgrade-tests-wp-5x-php-7x-mysql, upgrade-tests-wp-5x-php-8x-mysql, upgrade-tests-oldest-wp-mysql ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name != 'pull_request' && always() }}
     with:
       calling_status: ${{ contains( needs.*.result, 'cancelled' ) && 'cancelled' || contains( needs.*.result, 'failure' ) && 'failure' || 'success' }}

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -95,7 +95,7 @@ jobs:
 
           # Determine if this is a major release.
           MAJOR_RELEASE=false
-          if [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[1-9][0-9]*$ ]]; then
+          if [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
             MAJOR_RELEASE=true
           fi
 

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
     inputs:
       new-version:
-        description: 'The version to test installing. Accepts major and minor versions, "latest", or "nightly". Major releases must not end with ".0".'
+        description: 'The version to test upgrading to. Accepts both major and minor versions, "latest", or "nightly". Major releases must not end with ".0".'
         type: string
         default: 'latest'
 
@@ -85,14 +85,42 @@ jobs:
             {"php":"7.3","db-version":"9.4"},
           ]'
 
-          if [[ -z "$NEW_VERSION" ]] || \
+          # The defaults are sufficient when not testing a specific version.
+          if [[ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]] || \
+             [[ -z "$NEW_VERSION" ]] || \
              [[ "$NEW_VERSION" == "latest" ]] || \
-             [[ "$NEW_VERSION" == "nightly" ]] || \
-             [[ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]]; then
-            COMPACTED=$(echo "$DEFAULT_EXCLUSIONS" | tr -d '\n' | tr -d ' ')
-            echo "matrix_exclusions=$COMPACTED" >> "$GITHUB_OUTPUT"
+             [[ "$NEW_VERSION" == "nightly" ]]; then
+            echo "matrix_exclusions=$(echo "$DEFAULT_EXCLUSIONS" | tr -d '\n' | tr -d ' ')" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          # Determine if this is a major release.
+          MAJOR_RELEASE=false
+          if [[ "$MAJOR_RELEASE" =~ ^[0-9]+\.[0-9]+\.[1-9][0-9]*$ ]]; then
+            MAJOR_RELEASE=true
+          fi
+
+          # Strip any preceding "v" and drop any ".0" values for major releases.
+          INPUT_VERSION=$(echo "$NEW_VERSION" | grep -oE '[0-9]+\.[0-9]+')
+          CURRENT_VERSION=$(echo "$CURRENTLY_SUPPORTED_BRANCH" | grep -oE '[0-9]+\.[0-9]+')
+          TEST_VERSION="$INPUT_VERSION"
+
+          while [[ "$TEST_VERSION" != "$CURRENT_VERSION" ]]; do
+            # Only test the current version when a minor version has been specified.
+            if [[ "$TEST_VERSION" == "$INPUT_VERSION" && "$MAJOR_RELEASE" == "false" ]]; then
+              continue
+            fi
+
+            GENERATED_EXCLUSIONS+='{"wp":"'"$TEST_VERSION"'"},'
+
+            # Increment to next version.
+            TEST_VERSION="$(echo "$TEST_VERSION" | cut -d. -f1).$(echo $(echo "$TEST_VERSION" | cut -d. -f2) + 1)"
+          done
+
+          # Add the current version and close the array.
+          GENERATED_EXCLUSIONS+='{"wp":"'"$TEST_VERSION"'"}]'
+
+          echo "matrix_exclusions=$(echo "${DEFAULT_EXCLUSIONS%]}${GENERATED_EXCLUSIONS}" | tr -d '\n' | tr -d ' ')" >> "$GITHUB_OUTPUT"
 
   # Tests the full list of PHP/MySQL combinations for the two most recent versions of WordPress.
   upgrade-tests-recent-releases:

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -68,6 +68,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       matrix_exclusions: ${{ steps.set-exclusions.outputs.matrix_exclusions }}
+      major_version: ${{ steps.set-exclusions.outputs.major_version }}
 
     steps:
       - name: Set exclusions output
@@ -104,6 +105,9 @@ jobs:
           CURRENT_VERSION=$(echo "$CURRENTLY_SUPPORTED_BRANCH" | grep -oE '[0-9]+\.[0-9]+')
           TEST_VERSION="$INPUT_VERSION"
 
+          # Save the major version number as an output.
+          echo "major_version=$(echo "$INPUT_VERSION" | cut -d. -f1)" >> "$GITHUB_OUTPUT"
+
           # Create an exclusion list.
           GENERATED_EXCLUSIONS=''
 
@@ -139,11 +143,12 @@ jobs:
   generate-matrix-for-input-version:
     name: Build Test Matrix for Input Version
     uses: ./.github/workflows/reusable-support-json-reader-v1.yml
+    needs: [ 'generate-exclusions' ]
     permissions:
       contents: read
     if: ${{ true || github.repository == 'WordPress/wordpress-develop' && github.event_name == 'workflow_dispatch' && ! contains( fromJSON('["6.7", "6.8"]'), inputs.new-version ) }}
     with:
-      wp-version: ${{ inputs.new-version }}
+      wp-version: ${{ needs.generate-exclusions.outputs.major_version }}
 
   upgrade-tests-input-version:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.1.4' }}

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -172,7 +172,7 @@ jobs:
         php: ${{ fromJSON( needs.generate-matrix-for-input-version.outputs.php-versions ) }}
         db-type: [ 'mysql' ]
         db-version: ${{ fromJSON( needs.generate-matrix-for-input-version.outputs.mysql-versions ) }}
-        wp: [ '${{ inputs.new-version }}' ]
+        wp: [ '6.1.4' ]
         multisite: [ false, true ]
 
         exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -63,7 +63,7 @@ permissions: {}
 jobs:
   generate-exclusions:
     name: Generate test exclusions
-    runs-on: 'ubuntu-22.04'
+    runs-on: 'ubuntu-24.04'
     if: ${{ true || github.repository == 'WordPress/wordpress-develop' }}
     timeout-minutes: 5
     outputs:
@@ -131,6 +131,46 @@ jobs:
           GENERATED_EXCLUSIONS+='{"wp":"'"$TEST_VERSION"'"}]'
 
           echo "matrix_exclusions=$(echo "${DEFAULT_EXCLUSIONS%]}${GENERATED_EXCLUSIONS}" | tr -d '\n' | tr -d ' ')" >> "$GITHUB_OUTPUT"
+
+  # The full list of combinations for a specified version should always be tested.
+  #
+  # Since all supported combinations are already tested for the WordPress versions listed in the upgrade-tests-recent-releases
+  # job, those versions should be excluded here to avoid duplicate testing.
+  generate-matrix-for-input-version:
+    name: Build Test Matrix for Input Version
+    uses: ./.github/workflows/reusable-support-json-reader-v1.yml
+    permissions:
+      contents: read
+    if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name == 'workflow_dispatch' && ! contains( fromJSON('["6.7", "6.8"]'), inputs.new-version ) }}
+    with:
+      wp-version: ${{ inputs.new-version }}
+
+  upgrade-tests-input-version:
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+    uses: ./.github/workflows/reusable-upgrade-testing.yml
+    needs: [ 'generate-matrix-for-input-version' ]
+    if: ${{ github.repository == 'WordPress/wordpress-develop' }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'ubuntu-24.04' ]
+        php: ${{ fromJSON( needs.build-test-matrix.outputs.php-versions ) }}
+        db-type: [ 'mysql' ]
+        db-version: ${{ fromJSON( needs.build-test-matrix.outputs.mysql-versions ) }}
+        wp: [ '${{ inputs.new-version }}' ]
+        multisite: [ false, true ]
+
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
+    with:
+      os: ${{ matrix.os }}
+      php: ${{ matrix.php }}
+      db-type: ${{ matrix.db-type }}
+      db-version: ${{ matrix.db-version }}
+      wp: ${{ matrix.wp }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+      multisite: ${{ matrix.multisite }}
 
   # Tests the full list of PHP/MySQL combinations for the two most recent versions of WordPress.
   upgrade-tests-recent-releases:

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -74,7 +74,7 @@ jobs:
         id: set-exclusions
         shell: bash
         env:
-          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || 'v5.2' }}
+          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || 'v4.8.24' }}
         run: |
           # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
           # MySQL 9.0+ will also not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -85,7 +85,8 @@ jobs:
           if [[ "$NEW_VERSION" == "latest" ]] || \
              [[ "$NEW_VERSION" == "nightly" ]] || \
              [[ -z "$NEW_VERSION" ]]; then
-            echo matrix_exclusions="$DEFAULT_EXCLUSIONS" >> "$GITHUB_OUTPUT"
+            COMPACTED=$(echo "$DEFAULT_EXCLUSIONS" | tr -d '\n' | tr -d ' ')
+            echo "matrix_exclusions=$COMPACTED" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -74,7 +74,7 @@ jobs:
         id: set-exclusions
         shell: bash
         env:
-          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || 'v4.8.24' }}
+          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || 'v4.9.22' }}
         run: |
           # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
           # MySQL 9.0+ will also not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.
@@ -150,7 +150,7 @@ jobs:
         wp: [ '6.7', '6.8' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || fromJSON( '[]' ) }}
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -178,7 +178,7 @@ jobs:
         wp: [ '6.0', '6.3', '6.4', '6.5' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || fromJSON( '[]' ) }}
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -206,7 +206,7 @@ jobs:
         wp: [ '5.0', '5.1', '5.3', '5.4', '5.5', '5.6', '5.9' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || fromJSON( '[]' ) }}
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -238,7 +238,7 @@ jobs:
         wp: [ '5.3', '5.4', '5.5', '5.6', '5.9' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || fromJSON( '[]' ) }}
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}
@@ -271,7 +271,7 @@ jobs:
         wp: [ '4.7' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || fromJSON( '[]' ) }}
+        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -74,7 +74,7 @@ jobs:
         id: set-exclusions
         shell: bash
         env:
-          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || 'v5.7.0' }}
+          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || 'v5.2' }}
         run: |
           # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
           # MySQL 9.0+ will also not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -36,14 +36,6 @@ env:
     { "php": "7.3","db-version": "8.4" },
     { "php": "7.2","db-version": "9.4" },
     { "php": "7.3","db-version": "9.4" },
-    { "db-version": "5.0" },
-    { "db-version": "5.1" },
-    { "db-version": "5.5" },
-    { "db-version": "9.0" },
-    { "db-version": "9.1" },
-    { "db-version": "9.2" },
-    { "db-version": "9.3" },
-    { "db-version": "9.4" },
   ]'
 
 # Cancels all previous workflow runs for pull requests that have not completed.

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -74,7 +74,7 @@ jobs:
         id: set-exclusions
         shell: bash
         env:
-          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || 'latest' }}
+          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
         run: |
           # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
           # MySQL 9.0+ will also not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.
@@ -86,8 +86,7 @@ jobs:
           ]'
 
           # The defaults are sufficient when not testing a specific version.
-          if [[ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]] || \
-             [[ -z "$NEW_VERSION" ]] || \
+          if [[ -z "$NEW_VERSION" ]] || \
              [[ "$NEW_VERSION" == "latest" ]] || \
              [[ "$NEW_VERSION" == "nightly" ]]; then
             echo "matrix_exclusions=$(echo "$DEFAULT_EXCLUSIONS" | tr -d '\n' | tr -d ' ')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -76,7 +76,7 @@ jobs:
   # Generates a list of combinations to exclude in for each test matrix based on the version of WordPress being tested.
   #
   # When a major version is being tested (6.4 or 6.4.0), no upgrade would occur, so that version is excluded.
-  # When a minor version is being tested (6.4.1, 6.4.2, etc), the corresponding major version (6.4) is tested.
+  # When a minor version is being tested (6.0.0, 6.4.2, etc), the corresponding major version (6.4) is tested.
   generate-exclusions:
     name: Create combination exclusion list
     runs-on: 'ubuntu-24.04'
@@ -91,7 +91,7 @@ jobs:
         id: set-exclusions
         shell: bash
         env:
-          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
         run: |
           # The defaults are sufficient when not testing a specific version.
           if [[ -z "$NEW_VERSION" ]] || \
@@ -145,7 +145,7 @@ jobs:
 
   # Tests the full list of PHP/MySQL combinations for the two most recent versions of WordPress.
   upgrade-tests-recent-releases:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     needs: [ 'generate-exclusions' ]
@@ -168,12 +168,12 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 6.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 7 & 8.
   upgrade-tests-wp-6x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -196,12 +196,12 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 5.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 7.
   upgrade-tests-wp-5x-php-7x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -224,7 +224,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 5.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 8.
@@ -233,7 +233,7 @@ jobs:
   # - Use of __autoload().
   # - array/string offset with curly braces.
   upgrade-tests-wp-5x-php-8x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -256,7 +256,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
       multisite: ${{ matrix.multisite }}
 
   # The oldest version of WordPress receiving security updates should always be tested against
@@ -266,7 +266,7 @@ jobs:
   # - Use of __autoload().
   # - array/string offset with curly braces.
   upgrade-tests-oldest-wp-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -289,7 +289,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
       multisite: ${{ matrix.multisite }}
 
   slack-notifications:

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -74,7 +74,7 @@ jobs:
         id: set-exclusions
         shell: bash
         env:
-          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || 'v4.9.22' }}
+          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
         run: |
           # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
           # MySQL 9.0+ will also not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.
@@ -134,7 +134,7 @@ jobs:
 
   # Tests the full list of PHP/MySQL combinations for the two most recent versions of WordPress.
   upgrade-tests-recent-releases:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -157,12 +157,12 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || 'latest' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 6.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 7 & 8.
   upgrade-tests-wp-6x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -185,12 +185,12 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || 'latest' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 5.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 7.
   upgrade-tests-wp-5x-php-7x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -213,7 +213,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || 'latest' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 5.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 8.
@@ -222,7 +222,7 @@ jobs:
   # - Use of __autoload().
   # - array/string offset with curly braces.
   upgrade-tests-wp-5x-php-8x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -245,7 +245,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || 'latest' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
       multisite: ${{ matrix.multisite }}
 
   # The oldest version of WordPress receiving security updates should always be tested against
@@ -255,7 +255,7 @@ jobs:
   # - Use of __autoload().
   # - array/string offset with curly braces.
   upgrade-tests-oldest-wp-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'latest' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -278,7 +278,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || 'latest' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
       multisite: ${{ matrix.multisite }}
 
   slack-notifications:

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -172,7 +172,7 @@ jobs:
         php: ${{ fromJSON( needs.generate-matrix-for-input-version.outputs.php-versions ) }}
         db-type: [ 'mysql' ]
         db-version: ${{ fromJSON( needs.generate-matrix-for-input-version.outputs.mysql-versions ) }}
-        wp: [ '6.1.4' ]
+        wp: [ ${{ needs.generate-exclusions.outputs.major_version }} ]
         multisite: [ false, true ]
 
         exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -74,7 +74,7 @@ jobs:
         id: set-exclusions
         shell: bash
         env:
-          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
         run: |
           # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
           # MySQL 9.0+ will also not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.
@@ -146,7 +146,7 @@ jobs:
       wp-version: ${{ inputs.new-version }}
 
   upgrade-tests-input-version:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-matrix-for-input-version' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -169,12 +169,12 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests the full list of PHP/MySQL combinations for the two most recent versions of WordPress.
   upgrade-tests-recent-releases:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -197,12 +197,12 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 6.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 7 & 8.
   upgrade-tests-wp-6x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -225,12 +225,12 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 5.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 7.
   upgrade-tests-wp-5x-php-7x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -253,7 +253,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 5.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 8.
@@ -262,7 +262,7 @@ jobs:
   # - Use of __autoload().
   # - array/string offset with curly braces.
   upgrade-tests-wp-5x-php-8x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -285,7 +285,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
       multisite: ${{ matrix.multisite }}
 
   # The oldest version of WordPress receiving security updates should always be tested against
@@ -295,7 +295,7 @@ jobs:
   # - Use of __autoload().
   # - array/string offset with curly braces.
   upgrade-tests-oldest-wp-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -318,7 +318,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
       multisite: ${{ matrix.multisite }}
 
   slack-notifications:

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -74,7 +74,7 @@ jobs:
         id: set-exclusions
         shell: bash
         env:
-          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
         run: |
           # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
           # MySQL 9.0+ will also not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.
@@ -134,7 +134,7 @@ jobs:
 
   # Tests the full list of PHP/MySQL combinations for the two most recent versions of WordPress.
   upgrade-tests-recent-releases:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -157,12 +157,12 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 6.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 7 & 8.
   upgrade-tests-wp-6x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -185,12 +185,12 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 5.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 7.
   upgrade-tests-wp-5x-php-7x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -213,7 +213,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 5.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 8.
@@ -222,7 +222,7 @@ jobs:
   # - Use of __autoload().
   # - array/string offset with curly braces.
   upgrade-tests-wp-5x-php-8x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -245,7 +245,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
       multisite: ${{ matrix.multisite }}
 
   # The oldest version of WordPress receiving security updates should always be tested against
@@ -255,7 +255,7 @@ jobs:
   # - Use of __autoload().
   # - array/string offset with curly braces.
   upgrade-tests-oldest-wp-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -278,7 +278,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
       multisite: ${{ matrix.multisite }}
 
   slack-notifications:

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -76,7 +76,7 @@ jobs:
   # Generates a list of combinations to exclude in for each test matrix based on the version of WordPress being tested.
   #
   # When a major version is being tested (6.4 or 6.4.0), no upgrade would occur, so that version is excluded.
-  # When a minor version is being tested (6.4.1, 6.4.2, etc), the corresponding major version (6.4) is tested.
+  # When a minor version is being tested (6.4.1, 6.4.2, etc.), the corresponding major version (6.4) is tested.
   generate-exclusions:
     name: Build a list of matrix exclusions
     runs-on: 'ubuntu-24.04'
@@ -91,7 +91,7 @@ jobs:
         id: set-exclusions
         shell: bash
         env:
-          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '5.9' }}
+          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || 'v5.5.10' }}
         run: |
           # The defaults are sufficient when not testing a specific version.
           if [[ -z "$NEW_VERSION" ]] || \
@@ -145,7 +145,7 @@ jobs:
 
   # Tests the full list of PHP/MySQL combinations for the two most recent versions of WordPress.
   upgrade-tests-recent-releases:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '5.9' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'v5.5.10' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     needs: [ 'generate-exclusions' ]
@@ -168,12 +168,12 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '5.9' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || 'v5.5.10' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 6.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 7 & 8.
   upgrade-tests-wp-6x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '5.9' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'v5.5.10' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -196,12 +196,12 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '5.9' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || 'v5.5.10' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 5.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 7.
   upgrade-tests-wp-5x-php-7x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '5.9' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'v5.5.10' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -214,7 +214,7 @@ jobs:
         php: [ '7.2', '7.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.4' ]
-        wp: [ '5.0', '5.1', '5.3', '5.4', '5.5', '5.6', '5.9' ]
+        wp: [ '5.0', '5.1', '5.3', '5.4', '5.5', '5.6', 'v5.5.10' ]
         multisite: [ false, true ]
 
         exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
@@ -224,7 +224,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '5.9' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || 'v5.5.10' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 5.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 8.
@@ -233,7 +233,7 @@ jobs:
   # - Use of __autoload().
   # - array/string offset with curly braces.
   upgrade-tests-wp-5x-php-8x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '5.9' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'v5.5.10' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -246,7 +246,7 @@ jobs:
         php: [ '8.0', '8.4' ]
         db-type: [ 'mysql' ]
         db-version: [ '5.7', '8.4' ]
-        wp: [ '5.3', '5.4', '5.5', '5.6', '5.9' ]
+        wp: [ '5.3', '5.4', '5.5', '5.6', 'v5.5.10' ]
         multisite: [ false, true ]
 
         exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
@@ -256,7 +256,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '5.9' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || 'v5.5.10' }}
       multisite: ${{ matrix.multisite }}
 
   # The oldest version of WordPress receiving security updates should always be tested against
@@ -266,7 +266,7 @@ jobs:
   # - Use of __autoload().
   # - array/string offset with curly braces.
   upgrade-tests-oldest-wp-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '5.9' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || 'v5.5.10' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -289,7 +289,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '5.9' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || 'v5.5.10' }}
       multisite: ${{ matrix.multisite }}
 
   slack-notifications:

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -84,6 +84,14 @@ jobs:
             {"php":"7.3","db-version":"8.4"},
             {"php":"7.2","db-version":"9.4"},
             {"php":"7.3","db-version":"9.4"},
+            {"db-version":"5.0"},
+            {"db-version":"5.1"},
+            {"db-version":"5.5"},
+            {"db-version":"9.0"},
+            {"db-version":"9.1"},
+            {"db-version":"9.2"},
+            {"db-version":"9.3"},
+            {"db-version":"9.4"},
           ]'
 
           # The defaults are sufficient when not testing a specific version.

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -74,7 +74,7 @@ jobs:
         id: set-exclusions
         shell: bash
         env:
-          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
+          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
         run: |
           # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
           # MySQL 9.0+ will also not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -75,7 +75,7 @@ jobs:
         id: set-exclusions
         shell: bash
         env:
-          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
+          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
         run: |
           # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
           # MySQL 9.0+ will also not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.
@@ -159,7 +159,7 @@ jobs:
       wp-version: ${{ needs.generate-exclusions.outputs.major_version }}
 
   upgrade-tests-input-version:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     needs: [ 'generate-exclusions', 'generate-matrix-for-input-version' ]
@@ -182,12 +182,12 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests the full list of PHP/MySQL combinations for the two most recent versions of WordPress.
   upgrade-tests-recent-releases:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     needs: [ 'generate-exclusions' ]
@@ -210,12 +210,12 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 6.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 7 & 8.
   upgrade-tests-wp-6x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -238,12 +238,12 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 5.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 7.
   upgrade-tests-wp-5x-php-7x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -266,7 +266,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 5.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 8.
@@ -275,7 +275,7 @@ jobs:
   # - Use of __autoload().
   # - array/string offset with curly braces.
   upgrade-tests-wp-5x-php-8x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -298,7 +298,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
       multisite: ${{ matrix.multisite }}
 
   # The oldest version of WordPress receiving security updates should always be tested against
@@ -308,7 +308,7 @@ jobs:
   # - Use of __autoload().
   # - array/string offset with curly braces.
   upgrade-tests-oldest-wp-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -331,7 +331,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
       multisite: ${{ matrix.multisite }}
 
   slack-notifications:

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -141,7 +141,7 @@ jobs:
     uses: ./.github/workflows/reusable-support-json-reader-v1.yml
     permissions:
       contents: read
-    if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name == 'workflow_dispatch' && ! contains( fromJSON('["6.7", "6.8"]'), inputs.new-version ) }}
+    if: ${{ true || github.repository == 'WordPress/wordpress-develop' && github.event_name == 'workflow_dispatch' && ! contains( fromJSON('["6.7", "6.8"]'), inputs.new-version ) }}
     with:
       wp-version: ${{ inputs.new-version }}
 

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -65,6 +65,8 @@ jobs:
     runs-on: 'ubuntu-24.04'
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     timeout-minutes: 5
+    outputs:
+      matrix_exclusions: ${{ steps.set-exclusions.outputs.matrix_exclusions }}
 
     steps:
       - name: Set exclusions output

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -76,9 +76,9 @@ jobs:
   # Generates a list of combinations to exclude in for each test matrix based on the version of WordPress being tested.
   #
   # When a major version is being tested (6.4 or 6.4.0), no upgrade would occur, so that version is excluded.
-  # When a minor version is being tested (6.0.0, 6.4.2, etc), the corresponding major version (6.4) is tested.
+  # When a minor version is being tested (6.4.1, 6.4.2, etc), the corresponding major version (6.4) is tested.
   generate-exclusions:
-    name: Create combination exclusion list
+    name: Build a list of matrix exclusions
     runs-on: 'ubuntu-24.04'
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     timeout-minutes: 5
@@ -91,7 +91,7 @@ jobs:
         id: set-exclusions
         shell: bash
         env:
-          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '5.9' }}
         run: |
           # The defaults are sufficient when not testing a specific version.
           if [[ -z "$NEW_VERSION" ]] || \
@@ -145,7 +145,7 @@ jobs:
 
   # Tests the full list of PHP/MySQL combinations for the two most recent versions of WordPress.
   upgrade-tests-recent-releases:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '5.9' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     needs: [ 'generate-exclusions' ]
@@ -168,12 +168,12 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '5.9' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 6.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 7 & 8.
   upgrade-tests-wp-6x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '5.9' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -196,12 +196,12 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '5.9' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 5.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 7.
   upgrade-tests-wp-5x-php-7x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '5.9' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -224,7 +224,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '5.9' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 5.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 8.
@@ -233,7 +233,7 @@ jobs:
   # - Use of __autoload().
   # - array/string offset with curly braces.
   upgrade-tests-wp-5x-php-8x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '5.9' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -256,7 +256,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '5.9' }}
       multisite: ${{ matrix.multisite }}
 
   # The oldest version of WordPress receiving security updates should always be tested against
@@ -266,7 +266,7 @@ jobs:
   # - Use of __autoload().
   # - array/string offset with curly braces.
   upgrade-tests-oldest-wp-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '5.9' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -289,7 +289,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '5.9' }}
       multisite: ${{ matrix.multisite }}
 
   slack-notifications:

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -68,7 +68,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       matrix_exclusions: ${{ steps.set-exclusions.outputs.matrix_exclusions }}
-      major_version: ${{ steps.set-exclusions.outputs.major_version }}
+      version: ${{ steps.set-exclusions.outputs.major_version }}
 
     steps:
       - name: Set exclusions output
@@ -106,7 +106,7 @@ jobs:
           TEST_VERSION="$INPUT_VERSION"
 
           # Save the major version number as an output.
-          echo "major_version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
 
           # Create an exclusion list.
           GENERATED_EXCLUSIONS=''
@@ -148,7 +148,7 @@ jobs:
       contents: read
     if: ${{ true || github.repository == 'WordPress/wordpress-develop' && github.event_name == 'workflow_dispatch' && ! contains( fromJSON('["6.7", "6.8"]'), inputs.new-version ) }}
     with:
-      wp-version: ${{ needs.generate-exclusions.outputs.major_version }}
+      wp-version: ${{ needs.generate-exclusions.outputs.version }}
 
   upgrade-tests-input-version:
     name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.1.4' }}
@@ -161,13 +161,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-24.04' ]
-        php: ${{ fromJSON( needs.build-test-matrix.outputs.php-versions ) }}
+        php: ${{ fromJSON( needs.generate-matrix-for-input-version.outputs.php-versions ) }}
         db-type: [ 'mysql' ]
-        db-version: ${{ fromJSON( needs.build-test-matrix.outputs.mysql-versions ) }}
+        db-version: ${{ fromJSON( needs.generate-matrix-for-input-version.outputs.mysql-versions ) }}
         wp: [ '${{ inputs.new-version }}' ]
         multisite: [ false, true ]
 
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
+        exclude: ${{ fromJSON( needs.generate-matrix-for-input-version.outputs.matrix_exclusions ) || '[]' }}
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -96,7 +96,7 @@ jobs:
 
           # Determine if this is a major release.
           MAJOR_RELEASE=false
-          if [[ "$MAJOR_RELEASE" =~ ^[0-9]+\.[0-9]+\.[1-9][0-9]*$ ]]; then
+          if [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[1-9][0-9]*$ ]]; then
             MAJOR_RELEASE=true
           fi
 
@@ -107,14 +107,14 @@ jobs:
 
           while [[ "$TEST_VERSION" != "$CURRENT_VERSION" ]]; do
             # Only test the current version when a minor version has been specified.
-            if [[ "$TEST_VERSION" == "$INPUT_VERSION" && "$MAJOR_RELEASE" == "false" ]]; then
-              continue
+            if [[ "$TEST_VERSION" != "$INPUT_VERSION" || "$MAJOR_RELEASE" == "true" ]]; then
+              GENERATED_EXCLUSIONS+='{"wp":"'"$TEST_VERSION"'"},'
             fi
 
             GENERATED_EXCLUSIONS+='{"wp":"'"$TEST_VERSION"'"},'
 
             # Increment to next version.
-            TEST_VERSION="$(echo "$TEST_VERSION" | cut -d. -f1).$(echo $(echo "$TEST_VERSION" | cut -d. -f2) + 1)"
+            TEST_VERSION="$(echo "$TEST_VERSION" | cut -d. -f1).$(($(echo "$TEST_VERSION" | cut -d. -f2) + 1))"
           done
 
           # Add the current version and close the array.

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -29,6 +29,22 @@ on:
 env:
   CURRENTLY_SUPPORTED_BRANCH: '6.8'
   OLDEST_SECURITY_BRANCH: '4.7'
+  # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
+  # MySQL 9.0+ will also not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.
+  DEFAULT_EXCLUSIONS: '[
+    { "php": "7.2","db-version": "8.4" },
+    { "php": "7.3","db-version": "8.4" },
+    { "php": "7.2","db-version": "9.4" },
+    { "php": "7.3","db-version": "9.4" },
+    { "db-version": "5.0" },
+    { "db-version": "5.1" },
+    { "db-version": "5.5" },
+    { "db-version": "9.0" },
+    { "db-version": "9.1" },
+    { "db-version": "9.2" },
+    { "db-version": "9.3" },
+    { "db-version": "9.4" },
+  ]'
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
@@ -42,7 +58,7 @@ concurrency:
 permissions: {}
 
 # Because the number of jobs spawned can quickly balloon out of control, the following methodology is applied when
-# building out the matrix below:
+# building out the test matrix for push events:
 #
 # - The two most recent releases of WordPress are tested against all PHP/MySQL LTS version combinations and the
 #   most recent innovation release.
@@ -60,11 +76,15 @@ permissions: {}
 #      modern architectures.
 #    - 5.6.x Docker containers are available and work, but 5.6 only accounts for ~2.3% of installs as of 12/6/2024.defaults:
 #    - 5.7.x accounts for ~20% of installs, so this is used below instead.
+#
+# When a workflow_dispatch event occurs, testing stops at the major version branch of the version specified. For
+# example, if the value of inputs.new-version is 6.4.4, the jobs testing versions 6.5 and higher will be skipped because
+# that would be a downgrade test.
 jobs:
   generate-exclusions:
-    name: Generate test exclusions
+    name: Create combination exclusion list
     runs-on: 'ubuntu-24.04'
-    if: ${{ true || github.repository == 'WordPress/wordpress-develop' }}
+    if: ${{ github.repository == 'WordPress/wordpress-develop' }}
     timeout-minutes: 5
     outputs:
       matrix_exclusions: ${{ steps.set-exclusions.outputs.matrix_exclusions }}
@@ -77,23 +97,6 @@ jobs:
         env:
           NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
         run: |
-          # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
-          # MySQL 9.0+ will also not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.
-          DEFAULT_EXCLUSIONS='[
-            {"php":"7.2","db-version":"8.4"},
-            {"php":"7.3","db-version":"8.4"},
-            {"php":"7.2","db-version":"9.4"},
-            {"php":"7.3","db-version":"9.4"},
-            {"db-version":"5.0"},
-            {"db-version":"5.1"},
-            {"db-version":"5.5"},
-            {"db-version":"9.0"},
-            {"db-version":"9.1"},
-            {"db-version":"9.2"},
-            {"db-version":"9.3"},
-            {"db-version":"9.4"},
-          ]'
-
           # The defaults are sufficient when not testing a specific version.
           if [[ -z "$NEW_VERSION" ]] || \
              [[ "$NEW_VERSION" == "latest" ]] || \
@@ -143,47 +146,6 @@ jobs:
           GENERATED_EXCLUSIONS+='{"wp":"'"$TEST_VERSION"'"}]'
 
           echo "matrix_exclusions=$(echo "${DEFAULT_EXCLUSIONS%]}${GENERATED_EXCLUSIONS}" | tr -d '\n' | tr -d ' ')" >> "$GITHUB_OUTPUT"
-
-  # The full list of combinations for a specified version should always be tested.
-  #
-  # Since all supported combinations are already tested for the WordPress versions listed in the upgrade-tests-recent-releases
-  # job, those versions should be excluded here to avoid duplicate testing.
-  generate-matrix-for-input-version:
-    name: Build Test Matrix for Input Version
-    uses: ./.github/workflows/reusable-support-json-reader-v1.yml
-    needs: [ 'generate-exclusions' ]
-    permissions:
-      contents: read
-    if: ${{ true || github.repository == 'WordPress/wordpress-develop' && github.event_name == 'workflow_dispatch' && ! contains( fromJSON('["6.7", "6.8"]'), needs.generate-exclusions.outputs.major_version ) }}
-    with:
-      wp-version: ${{ needs.generate-exclusions.outputs.major_version }}
-
-  upgrade-tests-input-version:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
-    uses: ./.github/workflows/reusable-upgrade-testing.yml
-    if: ${{ github.repository == 'WordPress/wordpress-develop' }}
-    needs: [ 'generate-exclusions', 'generate-matrix-for-input-version' ]
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ 'ubuntu-24.04' ]
-        php: ${{ fromJSON( needs.generate-matrix-for-input-version.outputs.php-versions ) }}
-        db-type: [ 'mysql' ]
-        db-version: ${{ fromJSON( needs.generate-matrix-for-input-version.outputs.mysql-versions ) }}
-        wp: [ '${{ needs.generate-exclusions.outputs.major_version }}' ]
-        multisite: [ false, true ]
-
-        exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}
-    with:
-      os: ${{ matrix.os }}
-      php: ${{ matrix.php }}
-      db-type: ${{ matrix.db-type }}
-      db-version: ${{ matrix.db-version }}
-      wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
-      multisite: ${{ matrix.multisite }}
 
   # Tests the full list of PHP/MySQL combinations for the two most recent versions of WordPress.
   upgrade-tests-recent-releases:
@@ -340,7 +302,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-    needs: [ generate-exclusions, upgrade-tests-recent-releases, upgrade-tests-input-version, upgrade-tests-wp-6x-mysql, upgrade-tests-wp-5x-php-7x-mysql, upgrade-tests-wp-5x-php-8x-mysql, upgrade-tests-oldest-wp-mysql ]
+    needs: [ generate-exclusions, upgrade-tests-recent-releases, upgrade-tests-wp-6x-mysql, upgrade-tests-wp-5x-php-7x-mysql, upgrade-tests-wp-5x-php-8x-mysql, upgrade-tests-oldest-wp-mysql ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' && github.event_name != 'pull_request' && always() }}
     with:
       calling_status: ${{ contains( needs.*.result, 'cancelled' ) && 'cancelled' || contains( needs.*.result, 'failure' ) && 'failure' || 'success' }}

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -74,7 +74,7 @@ jobs:
         id: set-exclusions
         shell: bash
         env:
-          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+          NEW_VERSION: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
         run: |
           # The PHP <= 7.3/MySQL 8.4 jobs currently fail due to mysql_native_password being disabled by default. See https://core.trac.wordpress.org/ticket/61218.
           # MySQL 9.0+ will also not work on PHP 7.2 & 7.3. See https://core.trac.wordpress.org/ticket/61218.
@@ -146,7 +146,7 @@ jobs:
       wp-version: ${{ inputs.new-version }}
 
   upgrade-tests-input-version:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-matrix-for-input-version' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -169,12 +169,12 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests the full list of PHP/MySQL combinations for the two most recent versions of WordPress.
   upgrade-tests-recent-releases:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -197,12 +197,12 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 6.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 7 & 8.
   upgrade-tests-wp-6x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -225,12 +225,12 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 5.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 7.
   upgrade-tests-wp-5x-php-7x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -253,7 +253,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
       multisite: ${{ matrix.multisite }}
 
   # Tests 5.x releases where the WordPress database version changed on the oldest and newest supported versions of PHP 8.
@@ -262,7 +262,7 @@ jobs:
   # - Use of __autoload().
   # - array/string offset with curly braces.
   upgrade-tests-wp-5x-php-8x-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -285,7 +285,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
       multisite: ${{ matrix.multisite }}
 
   # The oldest version of WordPress receiving security updates should always be tested against
@@ -295,7 +295,7 @@ jobs:
   # - Use of __autoload().
   # - array/string offset with curly braces.
   upgrade-tests-oldest-wp-mysql:
-    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+    name: ${{ matrix.wp }} to ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
     uses: ./.github/workflows/reusable-upgrade-testing.yml
     needs: [ 'generate-exclusions' ]
     if: ${{ github.repository == 'WordPress/wordpress-develop' }}
@@ -318,7 +318,7 @@ jobs:
       db-type: ${{ matrix.db-type }}
       db-version: ${{ matrix.db-version }}
       wp: ${{ matrix.wp }}
-      new-version: ${{ inputs.new-version && inputs.new-version || '6.0.0' }}
+      new-version: ${{ inputs.new-version && inputs.new-version || '6.4.1' }}
       multisite: ${{ matrix.multisite }}
 
   slack-notifications:

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -172,7 +172,7 @@ jobs:
         php: ${{ fromJSON( needs.generate-matrix-for-input-version.outputs.php-versions ) }}
         db-type: [ 'mysql' ]
         db-version: ${{ fromJSON( needs.generate-matrix-for-input-version.outputs.mysql-versions ) }}
-        wp: [ ${{ needs.generate-exclusions.outputs.major_version }} ]
+        wp: [ '${{ needs.generate-exclusions.outputs.major_version }}' ]
         multisite: [ false, true ]
 
         exclude: ${{ fromJSON( needs.generate-exclusions.outputs.matrix_exclusions ) || '[]' }}


### PR DESCRIPTION
Supersedes #10099.

Currently, if you manually dispatch a run of the upgrade testing workflow with a version that is lower than the currently supported major version, the tests run past the specified version instead of stopping  when appropriate.

For example, this [run was dispatched](https://github.com/WordPress/wordpress-develop/actions/runs/18139321312) for version `6.6.4`. The jobs spawned included "Upgrading 6.7 to 6.6.4" and "Upgrading 6.8 to 6.6.4)" despite `6.6.4` being older than those two major versions.

<img width="335" height="717" alt="Screenshot 2025-10-01 at 9 46 40 PM" src="https://github.com/user-attachments/assets/34839297-f2d8-4268-85b2-de185ed2d489" />

The logic does not account for this and no upgrade is actually performed (technically this is a scenario where a downgrade would be tested) because the `--force` argument is not passed to the `wp core update` command.

<img width="1148" height="944" alt="Screenshot 2025-10-01 at 9 47 17 PM" src="https://github.com/user-attachments/assets/d1384d2e-ba16-44f4-91b8-99d0c331a954" />

This PR adds consideration for this scenario through a new job that generates a list of exclusions for all following strategy matrices.

- [Example passing a minor version (6.4.1)](https://github.com/WordPress/wordpress-develop/actions/runs/18199175155)
- [Example passing a major version with trailing `.0` (6.0.0)](https://github.com/WordPress/wordpress-develop/actions/runs/18199262521)
- [Example passing a major version without trailing `.0` (5.9)](https://github.com/WordPress/wordpress-develop/actions/runs/18199771048)
- [Example passing a minor version with `v` appended (v5.5.10)](https://github.com/WordPress/wordpress-develop/actions/runs/18200320042)
- [Example passing a major version with `v` appended and trailing `.0` (v5.7.0)](https://github.com/WordPress/wordpress-develop/actions/runs/18180737247)
- [Example passing a major version with `v` appended and no trailing `.0` (v5.2)](https://github.com/WordPress/wordpress-develop/actions/runs/18180776278)

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
