### PR TITLE
Default speculative loading eagerness to moderate when page cache is detected and persistent object cache is used

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2386,6 +2386,7 @@ class WP_Site_Health {
 		$description  = '<p>' . __( 'Page cache enhances the speed and performance of your site by saving and serving static pages instead of calling for a page every time a user visits.' ) . '</p>';
 		$description .= '<p>' . __( 'Page cache is detected by looking for an active page cache plugin as well as making three requests to the homepage and looking for one or more of the following HTTP client caching response headers:' ) . '</p>';
 		$description .= '<code>' . implode( '</code>, <code>', array_keys( $this->get_page_cache_headers() ) ) . '.</code>';
+		$description .= '<p>' . __( 'When a page cache is detected, Speculative Loading will use a default eagerness of moderate instead of conservative.' ) . '</p>';
 
 		$result = array(
 			'badge'       => array(
@@ -3408,9 +3409,10 @@ class WP_Site_Health {
 	 * @return WP_Error|array {
 	 *     Page cache detection details or else error information.
 	 *
-	 *     @type bool    $advanced_cache_present        Whether a page cache plugin is present.
-	 *     @type array[] $page_caching_response_headers Sets of client caching headers for the responses.
-	 *     @type float[] $response_timing               Response timings.
+	 *     @type bool     $advanced_cache_present        Whether a page cache plugin is present.
+	 *     @type array[]  $page_caching_response_headers Sets of client caching headers for the responses.
+	 *     @type float[]  $response_timing               Response timings.
+	 *     @type string[] $caching_response_headers      List of response headers detected which indicate page caching.
 	 * }
 	 */
 	private function check_for_page_caching() {
@@ -3433,6 +3435,7 @@ class WP_Site_Health {
 		$page_caching_response_headers = array();
 		$response_timing               = array();
 
+		$all_seen_headers = array();
 		for ( $i = 1; $i <= 3; $i++ ) {
 			$start_time    = microtime( true );
 			$http_response = wp_remote_get( home_url( '/' ), compact( 'sslverify', 'headers' ) );
@@ -3458,6 +3461,7 @@ class WP_Site_Health {
 				$header_values = (array) $header_values;
 				if ( empty( $callback ) || ( is_callable( $callback ) && count( array_filter( $header_values, $callback ) ) > 0 ) ) {
 					$response_headers[ $header ] = $header_values;
+					$all_seen_headers[]          = $header;
 				}
 			}
 
@@ -3465,7 +3469,7 @@ class WP_Site_Health {
 			$response_timing[]               = ( $end_time - $start_time ) * 1000;
 		}
 
-		return array(
+		$result = array(
 			'advanced_cache_present'        => (
 				file_exists( WP_CONTENT_DIR . '/advanced-cache.php' )
 				&&
@@ -3476,7 +3480,17 @@ class WP_Site_Health {
 			),
 			'page_caching_response_headers' => $page_caching_response_headers,
 			'response_timing'               => $response_timing,
+			'caching_response_headers'      => array_unique( $all_seen_headers ),
 		);
+
+		/*
+		 * Store the results in a non-expiring (autoloaded) transient so that Speculative Loading can use this to change
+		 * the default mode from conservative to moderate when page caching is enabled.
+		 * See wp_get_speculation_rules_configuration().
+		 */
+		set_transient( 'health_check_page_cache_detail', $result );
+
+		return $result;
 	}
 
 	/**

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -2386,7 +2386,7 @@ class WP_Site_Health {
 		$description  = '<p>' . __( 'Page cache enhances the speed and performance of your site by saving and serving static pages instead of calling for a page every time a user visits.' ) . '</p>';
 		$description .= '<p>' . __( 'Page cache is detected by looking for an active page cache plugin as well as making three requests to the homepage and looking for one or more of the following HTTP client caching response headers:' ) . '</p>';
 		$description .= '<code>' . implode( '</code>, <code>', array_keys( $this->get_page_cache_headers() ) ) . '.</code>';
-		$description .= '<p>' . __( 'When a page cache is detected, Speculative Loading will use a default eagerness of moderate instead of conservative.' ) . '</p>';
+		$description .= '<p>' . $this->get_speculative_loading_cache_description() . '</p>';
 
 		$result = array(
 			'badge'       => array(
@@ -2520,8 +2520,9 @@ class WP_Site_Health {
 			),
 			'label'       => __( 'A persistent object cache is being used' ),
 			'description' => sprintf(
-				'<p>%s</p>',
-				__( 'A persistent object cache makes your site&#8217;s database more efficient, resulting in faster load times because WordPress can retrieve your site&#8217;s content and settings much more quickly.' )
+				'<p>%s</p><p>%s</p>',
+				__( 'A persistent object cache makes your site&#8217;s database more efficient, resulting in faster load times because WordPress can retrieve your site&#8217;s content and settings much more quickly.' ),
+				$this->get_speculative_loading_cache_description()
 			),
 			'actions'     => sprintf(
 				'<p><a href="%s" target="_blank">%s<span class="screen-reader-text"> %s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a></p>',
@@ -2585,6 +2586,32 @@ class WP_Site_Health {
 		);
 
 		return $result;
+	}
+
+	/**
+	 * Gets the description of speculative loading used in the page cache and persistent object cache tests.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @see self::get_test_persistent_object_cache()
+	 * @see self::get_test_page_cache()
+	 * @see wp_get_speculation_rules_configuration()
+	 *
+	 * @return string Description.
+	 */
+	private function get_speculative_loading_cache_description() {
+		return sprintf(
+			/* translators: 1: Link to the Speculative Loading dev note. 2: Additional link attributes. 3: Accessibility text. */
+			__( 'When a page cache is detected and a persistent object cache is enabled, <a href="%1$s" %2$s>Speculative Loading%3$s</a> will accelerate cross-site navigations by using a default <code>eagerness</code> of <code>moderate</code> instead of <code>conservative</code>.' ),
+			/* translators: Localized Speculative Loading dev note, if one exists. */
+			esc_url( __( 'https://make.wordpress.org/core/2025/03/06/speculative-loading-in-6-8/' ) ),
+			'target="_blank"',
+			sprintf(
+				'<span class="screen-reader-text"> %s</span><span aria-hidden="true" class="dashicons dashicons-external"></span>',
+				/* translators: Hidden accessibility text. */
+				__( '(opens in a new tab)' )
+			)
+		);
 	}
 
 	/**

--- a/src/wp-includes/speculative-loading.php
+++ b/src/wp-includes/speculative-loading.php
@@ -61,6 +61,28 @@ function wp_get_speculation_rules_configuration(): ?array {
 	// Sanitize the configuration and replace 'auto' with current defaults.
 	$default_mode      = 'prefetch';
 	$default_eagerness = 'conservative';
+
+	// Default to moderate eagerness on production when page caching is detected.
+	if ( 'production' === wp_get_environment_type() ) {
+		$page_cache_detail = get_transient( 'health_check_page_cache_detail' );
+		if (
+			is_array( $page_cache_detail ) &&
+			(
+				(
+					isset( $page_cache_detail['advanced_cache_present'] ) &&
+					$page_cache_detail['advanced_cache_present']
+				) ||
+				(
+					isset( $page_cache_detail['caching_response_headers'] ) &&
+					is_array( $page_cache_detail['caching_response_headers'] ) &&
+					count( $page_cache_detail['caching_response_headers'] ) > 0
+				)
+			)
+		) {
+			$default_eagerness = 'moderate';
+		}
+	}
+
 	if ( ! is_array( $config ) ) {
 		return array(
 			'mode'      => $default_mode,

--- a/src/wp-includes/speculative-loading.php
+++ b/src/wp-includes/speculative-loading.php
@@ -62,8 +62,8 @@ function wp_get_speculation_rules_configuration(): ?array {
 	$default_mode      = 'prefetch';
 	$default_eagerness = 'conservative';
 
-	// Default to moderate eagerness on production when page caching is detected.
-	if ( 'production' === wp_get_environment_type() ) {
+	// Default to moderate eagerness on production when page caching is detected and a persistent object cache is used.
+	if ( 'production' === wp_get_environment_type() && wp_using_ext_object_cache() ) {
 		$page_cache_detail = get_transient( 'health_check_page_cache_detail' );
 		if (
 			is_array( $page_cache_detail ) &&


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64066

To test on the `wordpress-develop` environment, modify your `.env` to set `LOCAL_PHP_MEMCACHED` to `true`. By default it is `false`. So this should be present:

```env
LOCAL_PHP_MEMCACHED=true
```

Then do `npm run env:restart`.

You can then install and enable a caching plugin like [WP Super Cache](https://wordpress.org/plugins/wp-super-cache/). 

Once the persistent object cache and page cache are enabled, then go to Site Health to confirm they are both detected. This will also store the result of the page cache detection in a transient for Speculative Loading to refer to.

Then log out of WordPress, and go to the frontend. In the page source, you should see `"eagerness":"moderate"` in the `SCRIPT` for `speculationrules`.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
