### PR TITLE
Improve error message in `WP_Block_Templates_Registry::unregister()` to include template name

### DIFF
--- a/src/wp-includes/class-wp-block-templates-registry.php
+++ b/src/wp-includes/class-wp-block-templates-registry.php
@@ -221,14 +221,15 @@ final class WP_Block_Templates_Registry {
 	 */
 	public function unregister( $template_name ) {
 		if ( ! $this->is_registered( $template_name ) ) {
+			/* translators: %s: Template name. */
+			$error_message = sprintf( __( 'Template "%s" is not registered.' ), $template_name );
+
 			_doing_it_wrong(
 				__METHOD__,
-				/* translators: %s: Template name. */
-				sprintf( __( 'Template "%s" is not registered.' ), $template_name ),
+				$error_message,
 				'6.7.0'
 			);
-			/* translators: %s: Template name. */
-			return new WP_Error( 'template_not_registered', __( 'Template "%s" is not registered.' ) );
+			return new WP_Error( 'template_not_registered', $error_message );
 		}
 
 		$unregistered_template = $this->registered_templates[ $template_name ];

--- a/tests/phpunit/tests/block-template.php
+++ b/tests/phpunit/tests/block-template.php
@@ -482,7 +482,7 @@ class Tests_Block_Template extends WP_UnitTestCase {
 	 * Tests that unregister_block_template() returns a WP_Error when trying to unregister a non-registered template,
 	 * and that the error message includes the template name.
 	 *
-	 * @ticket n.e.x.t
+	 * @ticket 64072
 	 *
 	 * @covers ::unregister_block_template
 	 */

--- a/tests/phpunit/tests/block-template.php
+++ b/tests/phpunit/tests/block-template.php
@@ -479,6 +479,34 @@ class Tests_Block_Template extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that unregister_block_template() returns a WP_Error when trying to unregister a non-registered template,
+	 * and that the error message includes the template name.
+	 *
+	 * @ticket n.e.x.t
+	 *
+	 * @covers ::unregister_block_template
+	 */
+	public function test_unregister_block_template_error_message_includes_template_name() {
+		$template_name = 'test-plugin//unregistered-template';
+
+		// Ensure template is not registered.
+		unregister_block_template( $template_name );
+
+		// Expect _doing_it_wrong() notice.
+		$this->setExpectedIncorrectUsage( 'WP_Block_Templates_Registry::unregister' );
+
+		// Try to unregister again, should return WP_Error.
+		$error = unregister_block_template( $template_name );
+
+		$this->assertInstanceOf( 'WP_Error', $error );
+		$this->assertStringContainsString(
+			$template_name,
+			$error->get_error_message(),
+			'Error message should include the template name.'
+		);
+	}
+
+	/**
 	 * Registers a test block to log `in_the_loop()` results.
 	 *
 	 * @param array $in_the_loop_logs Array to log function results in. Passed by reference.


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64072

* Updated the `unregister` method in `WP_Block_Templates_Registry` to ensure that the error message returned when trying to unregister a non-registered template includes the template name, making debugging easier.
* Added a new PHPUnit test to verify that `unregister_block_template()` returns a `WP_Error` containing the template name when attempting to unregister a template that is not registered. This test also checks for the correct usage notice.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**