### PR TITLE
Use a real dataprovider instead of a method called and looped.

### DIFF
--- a/tests/phpunit/tests/adminbar.php
+++ b/tests/phpunit/tests/adminbar.php
@@ -731,23 +731,23 @@ class Tests_AdminBar extends WP_UnitTestCase {
 	/**
 	 * @ticket 39082
 	 * @group ms-required
+	 * @dataProvider data_my_sites_network_menu_items
 	 */
-	public function test_my_sites_network_menu_for_regular_user() {
+	public function test_my_sites_network_menu_for_regular_user( $id, $cap ) {
 		wp_set_current_user( self::$editor_id );
 
 		$wp_admin_bar = $this->get_standard_admin_bar();
 
 		$nodes = $wp_admin_bar->get_nodes();
-		foreach ( $this->get_my_sites_network_menu_items() as $id => $cap ) {
-			$this->assertArrayNotHasKey( $id, $nodes, sprintf( 'Menu item %s must not display for a regular user.', $id ) );
-		}
+		$this->assertArrayNotHasKey( $id, $nodes, sprintf( 'Menu item %s must not display for a regular user.', $id ) );
 	}
 
 	/**
 	 * @ticket 39082
 	 * @group ms-required
+	 * @dataProvider data_my_sites_network_menu_items
 	 */
-	public function test_my_sites_network_menu_for_super_admin() {
+	public function test_my_sites_network_menu_for_super_admin( $id, $cap ) {
 		wp_set_current_user( self::$editor_id );
 
 		grant_super_admin( self::$editor_id );
@@ -755,16 +755,15 @@ class Tests_AdminBar extends WP_UnitTestCase {
 		revoke_super_admin( self::$editor_id );
 
 		$nodes = $wp_admin_bar->get_nodes();
-		foreach ( $this->get_my_sites_network_menu_items() as $id => $cap ) {
-			$this->assertArrayHasKey( $id, $nodes, sprintf( 'Menu item %s must display for a super admin.', $id ) );
-		}
+		$this->assertArrayHasKey( $id, $nodes, sprintf( 'Menu item %s must display for a super admin.', $id ) );
 	}
 
 	/**
 	 * @ticket 39082
 	 * @group ms-required
+	 * @dataProvider data_my_sites_network_menu_items
 	 */
-	public function test_my_sites_network_menu_for_regular_user_with_network_caps() {
+	public function test_my_sites_network_menu_for_regular_user_with_network_caps( $id, $cap ) {
 		global $current_user;
 
 		$network_user_caps = array( 'manage_network', 'manage_network_themes', 'manage_network_plugins' );
@@ -780,25 +779,34 @@ class Tests_AdminBar extends WP_UnitTestCase {
 		}
 
 		$nodes = $wp_admin_bar->get_nodes();
-		foreach ( $this->get_my_sites_network_menu_items() as $id => $cap ) {
-			if ( in_array( $cap, $network_user_caps, true ) ) {
-				$this->assertArrayHasKey( $id, $nodes, sprintf( 'Menu item %1$s must display for a user with the %2$s cap.', $id, $cap ) );
-			} else {
-				$this->assertArrayNotHasKey( $id, $nodes, sprintf( 'Menu item %1$s must not display for a user without the %2$s cap.', $id, $cap ) );
-			}
+		if ( in_array( $cap, $network_user_caps, true ) ) {
+			$this->assertArrayHasKey( $id, $nodes, sprintf( 'Menu item %1$s must display for a user with the %2$s cap.', $id, $cap ) );
+		} else {
+			$this->assertArrayNotHasKey( $id, $nodes, sprintf( 'Menu item %1$s must not display for a user without the %2$s cap.', $id, $cap ) );
 		}
 	}
 
-	private function get_my_sites_network_menu_items() {
+	/**
+	 * Data provider for test_my_sites_network_menu_for_regular_user() and
+	 * test_my_sites_network_menu_for_super_admin().
+	 *
+	 * @return array {
+	 *     @type array {
+	 *         @type string $id  The ID of the menu item.
+	 *         @type string $cap The capability required to see the menu item.
+	 *     }
+	 * }
+	 */
+	public function data_my_sites_network_menu_items() {
 		return array(
-			'my-sites-super-admin' => 'manage_network',
-			'network-admin'        => 'manage_network',
-			'network-admin-d'      => 'manage_network',
-			'network-admin-s'      => 'manage_sites',
-			'network-admin-u'      => 'manage_network_users',
-			'network-admin-t'      => 'manage_network_themes',
-			'network-admin-p'      => 'manage_network_plugins',
-			'network-admin-o'      => 'manage_network_options',
+			array( 'my-sites-super-admin', 'manage_network' ),
+			array( 'network-admin', 'manage_network' ),
+			array( 'network-admin-d', 'manage_network' ),
+			array( 'network-admin-s', 'manage_sites' ),
+			array( 'network-admin-u', 'manage_network_users' ),
+			array( 'network-admin-t', 'manage_network_themes' ),
+			array( 'network-admin-p', 'manage_network_plugins' ),
+			array( 'network-admin-o', 'manage_network_options' ),
 		);
 	}
 


### PR DESCRIPTION
`get_my_sites_network_menu_items` was essentially being used as a dataprovider before without the benefit of being an actual dataprovider.

Trac ticket: https://core.trac.wordpress.org/ticket/63167

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
