### PR TITLE
add new mariadb innovation release

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -218,7 +218,7 @@ jobs:
           - db-type: 'mariadb'
             db-version: '9.4'
           - db-type: 'mysql'
-            db-vetsion: '12.0.2'
+            db-version: '12.0.2'
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -218,7 +218,7 @@ jobs:
           - db-type: 'mariadb'
             db-version: '9.4'
           - db-type: 'mysql'
-            db-version: '12.0.2'
+            db-version: '12.0'
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -203,7 +203,7 @@ jobs:
         os: [ ubuntu-24.04 ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         db-type: [ 'mysql', 'mariadb' ]
-        db-version: [ '9.4', '12.0.2' ]
+        db-version: [ '9.4', '12.0' ]
         multisite: [ false, true ]
         memcached: [ false ]
         db-innovation: [ true ]

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -202,8 +202,8 @@ jobs:
       matrix:
         os: [ ubuntu-24.04 ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
-        db-type: [ 'mysql' ]
-        db-version: [ '9.4' ]
+        db-type: [ 'mysql', 'mariadb' ]
+        db-version: [ '9.4', '12.0.2' ]
         multisite: [ false, true ]
         memcached: [ false ]
         db-innovation: [ true ]
@@ -214,6 +214,11 @@ jobs:
             db-version: '9.4'
           - php: '7.3'
             db-version: '9.4'
+          # Exclude version combinations that don't exist.
+          - db-type: 'mariadb'
+            db-version: '9.4'
+          - db-type: 'mysql'
+            db-vetsion: '12.0.2'
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}


### PR DESCRIPTION
There is a new MariaDB innovation release - https://mariadb.com/docs/release-notes/community-server/release-notes-mariadb-12.0-rolling-releases/mariadb-12.0.2-release-notes

Trac ticket: https://core.trac.wordpress.org/ticket/63167

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
