### PR TITLE
#64076: Emoji loader script can be moved to the footer since non-critical

### DIFF
--- a/src/js/_enqueues/lib/emoji-loader.js
+++ b/src/js/_enqueues/lib/emoji-loader.js
@@ -2,6 +2,8 @@
  * @output wp-includes/js/wp-emoji-loader.js
  */
 
+/* eslint-env es6 */
+
 // Note: This is loaded as a script module, so there is no need for an IIFE to prevent pollution of the global scope.
 
 /**

--- a/src/js/_enqueues/lib/emoji-loader.js
+++ b/src/js/_enqueues/lib/emoji-loader.js
@@ -427,8 +427,7 @@ new Promise( ( resolve ) => {
 		settings.readyCallback = () => {
 			settings.DOMReady = true;
 		};
-	} )
-	.then( () => {
+
 		// When the browser can not render everything we need to load a polyfill.
 		if ( ! settings.supports.everything ) {
 			settings.readyCallback();

--- a/src/js/_enqueues/lib/emoji-loader.js
+++ b/src/js/_enqueues/lib/emoji-loader.js
@@ -18,7 +18,7 @@ const settings = /** @type {WPEmojiSettings} */ (
 	JSON.parse( document.getElementById( 'wp-emoji-settings' ).textContent )
 );
 
-// For compatibility with other scripts that read from this global, in particular wp-emoji.js.
+// For compatibility with other scripts that read from this global, in particular wp-includes/js/wp-emoji.js (source file: js/_enqueues/wp/emoji.js).
 window._wpemojiSettings = settings;
 
 /**

--- a/src/js/_enqueues/lib/emoji-loader.js
+++ b/src/js/_enqueues/lib/emoji-loader.js
@@ -12,8 +12,6 @@
  * @property {?string} source.concatemoji
  * @property {?string} source.twemoji
  * @property {?string} source.wpemoji
- * @property {?boolean} DOMReady
- * @property {?Function} readyCallback
  */
 
 const settings = /** @type {WPEmojiSettings} */ (
@@ -422,16 +420,8 @@ new Promise( ( resolve ) => {
 			settings.supports.everythingExceptFlag &&
 			! settings.supports.flag;
 
-		// Sets DOMReady to false and assigns a ready function to settings.
-		settings.DOMReady = false;
-		settings.readyCallback = () => {
-			settings.DOMReady = true;
-		};
-
 		// When the browser can not render everything we need to load a polyfill.
 		if ( ! settings.supports.everything ) {
-			settings.readyCallback();
-
 			const src = settings.source || {};
 
 			if ( src.concatemoji ) {

--- a/src/js/_enqueues/lib/emoji-loader.js
+++ b/src/js/_enqueues/lib/emoji-loader.js
@@ -18,7 +18,7 @@ const settings = /** @type {WPEmojiSettings} */ (
 	JSON.parse( document.getElementById( 'wp-emoji-settings' ).textContent )
 );
 
-// For compatibility with other scripts that read from this global.
+// For compatibility with other scripts that read from this global, in particular wp-emoji.js.
 window._wpemojiSettings = settings;
 
 /**

--- a/src/js/_enqueues/wp/emoji.js
+++ b/src/js/_enqueues/wp/emoji.js
@@ -277,16 +277,7 @@
 			return twemoji.parse( object, params );
 		}
 
-		/**
-		 * Initialize our emoji support, and set up listeners.
-		 */
-		if ( settings ) {
-			if ( settings.DOMReady ) {
-				load();
-			} else {
-				settings.readyCallback = load;
-			}
-		}
+		load();
 
 		return {
 			parse: parse,

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -5912,7 +5912,11 @@ function print_emoji_detection_script() {
 
 	$printed = true;
 
-	_print_emoji_detection_script();
+	if ( did_action( 'wp_print_footer_scripts' ) ) {
+		_print_emoji_detection_script();
+	} else {
+		add_action( 'wp_print_footer_scripts', '_print_emoji_detection_script' );
+	}
 }
 
 /**


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64076

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
