### PR TITLE
REST API media endpoint: Update post relation to use api.w.org namespace / prefix

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -985,7 +985,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			$post = get_post( $post->post_parent );
 
 			if ( ! empty( $post ) ) {
-				$links['https://api.w.org/post'] = array(
+				$links['https://api.w.org/attached-to'] = array(
 					'href'       => rest_url( rest_get_route_for_post( $post ) ),
 					'embeddable' => true,
 					'post_type'  => $post->post_type,

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -985,7 +985,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 			$post = get_post( $post->post_parent );
 
 			if ( ! empty( $post ) ) {
-				$links['post'] = array(
+				$links['https://api.w.org/post'] = array(
 					'href'       => rest_url( rest_get_route_for_post( $post ) ),
 					'embeddable' => true,
 					'post_type'  => $post->post_type,

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1887,13 +1887,13 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 		$this->assertArrayHasKey( 'self', $links );
 		$this->assertArrayHasKey( 'author', $links );
-		$this->assertArrayHasKey( 'post', $links );
+		$this->assertArrayHasKey( 'https://api.w.org/post', $links );
 
 		$this->assertCount( 1, $links['author'] );
-		$this->assertSame( rest_url( '/wp/v2/posts/' . $post ), $links['post'][0]['href'] );
-		$this->assertSame( 'post', $links['post'][0]['attributes']['post_type'] );
-		$this->assertSame( $post, $links['post'][0]['attributes']['id'] );
-		$this->assertTrue( $links['post'][0]['attributes']['embeddable'] );
+		$this->assertSame( rest_url( '/wp/v2/posts/' . $post ), $links['https://api.w.org/post'][0]['href'] );
+		$this->assertSame( 'post', $links['https://api.w.org/post'][0]['attributes']['post_type'] );
+		$this->assertSame( $post, $links['https://api.w.org/post'][0]['attributes']['id'] );
+		$this->assertTrue( $links['https://api.w.org/post'][0]['attributes']['embeddable'] );
 	}
 
 	public function test_publish_action_ldo_not_registered() {

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -1887,13 +1887,13 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 
 		$this->assertArrayHasKey( 'self', $links );
 		$this->assertArrayHasKey( 'author', $links );
-		$this->assertArrayHasKey( 'https://api.w.org/post', $links );
+		$this->assertArrayHasKey( 'https://api.w.org/attached-to', $links );
 
 		$this->assertCount( 1, $links['author'] );
-		$this->assertSame( rest_url( '/wp/v2/posts/' . $post ), $links['https://api.w.org/post'][0]['href'] );
-		$this->assertSame( 'post', $links['https://api.w.org/post'][0]['attributes']['post_type'] );
-		$this->assertSame( $post, $links['https://api.w.org/post'][0]['attributes']['id'] );
-		$this->assertTrue( $links['https://api.w.org/post'][0]['attributes']['embeddable'] );
+		$this->assertSame( rest_url( '/wp/v2/posts/' . $post ), $links['https://api.w.org/attached-to'][0]['href'] );
+		$this->assertSame( 'post', $links['https://api.w.org/attached-to'][0]['attributes']['post_type'] );
+		$this->assertSame( $post, $links['https://api.w.org/attached-to'][0]['attributes']['id'] );
+		$this->assertTrue( $links['https://api.w.org/attached-to'][0]['attributes']['embeddable'] );
 	}
 
 	public function test_publish_action_ldo_not_registered() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR updates the `post` link within the REST API media attachment response to use the `https://api.w.org/` prefix, as `post` isn't a valid IANA link relation: https://www.iana.org/assignments/link-relations/link-relations.xhtml

Kudos @TimothyBJacobs for catching this.

### Testing instructions

These are basically the same testing instructions as in https://github.com/WordPress/wordpress-develop/pull/10027:

If you'd like to test this from within the block editor:

1. Open up the media library and upload an image.
2. From the list view within the media library, click Attach under the Uploaded To column and attach the media items to a post
3. Make a note of the id of your images (i.e. grab it from the url)
4. Open the block editor, and try running the following from your browser console (note you might have to run these commands twice as the first call will return undefined as the request hasn't been resolved yet):

```
// Replace 27 with the id of an image that is attached to a post — you should see `wp:attached-to` in the list of `_links`
wp.data.select( 'core' ).getEntityRecord( 'postType', 'attachment', 27 );
// Again, replace 27 with the id of an image that is attached to a post — in this call, you should see the `wp:attached-to` under `_embedded` in the response
wp.data.select( 'core' ).getEntityRecord( 'postType', 'attachment', 27, { _embed: 'wp:attached-to' } );
```

Trac ticket: https://core.trac.wordpress.org/ticket/64034

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
