### PR TITLE
Unit test: `is_post_status_viewable()` improvement

### DIFF
--- a/tests/phpunit/tests/post/isPostStatusViewable.php
+++ b/tests/phpunit/tests/post/isPostStatusViewable.php
@@ -2,6 +2,8 @@
 
 /**
  * @group post
+ *
+ * @covers is_post_status_viewable
  */
 class Tests_Post_IsPostStatusViewable extends WP_UnitTestCase {
 
@@ -21,6 +23,7 @@ class Tests_Post_IsPostStatusViewable extends WP_UnitTestCase {
 	 * This may include emulations of built in (_builtin) statuses.
 	 *
 	 * @ticket 49380
+	 *
 	 * @dataProvider data_custom_post_statuses
 	 *
 	 * @param array $cps_args Registration arguments.
@@ -46,10 +49,9 @@ class Tests_Post_IsPostStatusViewable extends WP_UnitTestCase {
 	 *     bool  Expected result.
 	 * }
 	 */
-	public function data_custom_post_statuses() {
+	public static function data_custom_post_statuses() {
 		return array(
-			// 0. False for non-publicly queryable types.
-			array(
+			'False for non-publicly queryable types' => array(
 				array(
 					'publicly_queryable' => false,
 					'_builtin'           => false,
@@ -57,8 +59,7 @@ class Tests_Post_IsPostStatusViewable extends WP_UnitTestCase {
 				),
 				false,
 			),
-			// 1. True for publicly queryable types.
-			array(
+			'True for publicly queryable types' => array(
 				array(
 					'publicly_queryable' => true,
 					'_builtin'           => false,
@@ -66,8 +67,7 @@ class Tests_Post_IsPostStatusViewable extends WP_UnitTestCase {
 				),
 				true,
 			),
-			// 2. False for built-in non-public types.
-			array(
+			'False for built-in non-public types' => array(
 				array(
 					'publicly_queryable' => false,
 					'_builtin'           => true,
@@ -75,8 +75,7 @@ class Tests_Post_IsPostStatusViewable extends WP_UnitTestCase {
 				),
 				false,
 			),
-			// 3. False for non-built-in public types.
-			array(
+			'False for non-built-in public types' =>array(
 				array(
 					'publicly_queryable' => false,
 					'_builtin'           => false,
@@ -84,8 +83,7 @@ class Tests_Post_IsPostStatusViewable extends WP_UnitTestCase {
 				),
 				false,
 			),
-			// 4. True for built-in public types.
-			array(
+			'True for built-in public types' => array(
 				array(
 					'publicly_queryable' => false,
 					'_builtin'           => true,
@@ -99,8 +97,9 @@ class Tests_Post_IsPostStatusViewable extends WP_UnitTestCase {
 	/**
 	 * Test built-in and unregistered post status.
 	 *
-	 * @dataProvider data_built_unregistered_in_status_types
 	 * @ticket 49380
+	 *
+	 * @dataProvider data_built_unregistered_in_status_types
 	 *
 	 * @param mixed $status   Post status to check.
 	 * @param bool  $expected Expected viewable status.
@@ -120,7 +119,7 @@ class Tests_Post_IsPostStatusViewable extends WP_UnitTestCase {
 	 *     @type bool  $expected Expected viewable status.
 	 * }
 	 */
-	public function data_built_unregistered_in_status_types() {
+	public static function data_built_unregistered_in_status_types() {
 		return array(
 			array( 'publish', true ),
 			array( 'future', false ),

--- a/tests/phpunit/tests/post/isPostStatusViewable.php
+++ b/tests/phpunit/tests/post/isPostStatusViewable.php
@@ -59,7 +59,7 @@ class Tests_Post_IsPostStatusViewable extends WP_UnitTestCase {
 				),
 				false,
 			),
-			'True for publicly queryable types' => array(
+			'True for publicly queryable types'      => array(
 				array(
 					'publicly_queryable' => true,
 					'_builtin'           => false,
@@ -67,7 +67,7 @@ class Tests_Post_IsPostStatusViewable extends WP_UnitTestCase {
 				),
 				true,
 			),
-			'False for built-in non-public types' => array(
+			'False for built-in non-public types'    => array(
 				array(
 					'publicly_queryable' => false,
 					'_builtin'           => true,
@@ -75,7 +75,7 @@ class Tests_Post_IsPostStatusViewable extends WP_UnitTestCase {
 				),
 				false,
 			),
-			'False for non-built-in public types' => array(
+			'False for non-built-in public types'    => array(
 				array(
 					'publicly_queryable' => false,
 					'_builtin'           => false,
@@ -83,7 +83,7 @@ class Tests_Post_IsPostStatusViewable extends WP_UnitTestCase {
 				),
 				false,
 			),
-			'True for built-in public types' => array(
+			'True for built-in public types'         => array(
 				array(
 					'publicly_queryable' => false,
 					'_builtin'           => true,
@@ -139,6 +139,7 @@ class Tests_Post_IsPostStatusViewable extends WP_UnitTestCase {
 			array( false, false ),
 			array( true, false ),
 			array( 20, false ),
+			array( null, false ),
 			array( '', false ),
 		);
 	}

--- a/tests/phpunit/tests/post/isPostStatusViewable.php
+++ b/tests/phpunit/tests/post/isPostStatusViewable.php
@@ -75,7 +75,7 @@ class Tests_Post_IsPostStatusViewable extends WP_UnitTestCase {
 				),
 				false,
 			),
-			'False for non-built-in public types' =>array(
+			'False for non-built-in public types' => array(
 				array(
 					'publicly_queryable' => false,
 					'_builtin'           => false,


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63167

* Converted the `data_custom_post_statuses` and `data_built_unregistered_in_status_types` data provider methods to static, slight performance improvement.
* Added the `@covers is_post_status_viewable` annotation to the test class to explicitly declare the function under test.
* Improved the readability of the test data arrays in `data_custom_post_statuses` by replacing numeric indexes with descriptive string keys for each test case.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**