### PR TITLE
Update Google Fonts collection data url for 6.9 release

### DIFF
--- a/src/wp-includes/fonts.php
+++ b/src/wp-includes/fonts.php
@@ -266,7 +266,7 @@ function _wp_register_default_font_collections() {
 		array(
 			'name'          => _x( 'Google Fonts', 'font collection name' ),
 			'description'   => __( 'Install from Google Fonts. Fonts are copied to and served from your site.' ),
-			'font_families' => 'https://s.w.org/images/fonts/wp-6.7/collections/google-fonts-with-preview.json',
+			'font_families' => 'https://s.w.org/images/fonts/wp-6.9/collections/google-fonts-with-preview.json',
 			'categories'    => array(
 				array(
 					'name' => _x( 'Sans Serif', 'font category' ),

--- a/tests/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
+++ b/tests/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
@@ -583,7 +583,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 			'lineGapOverride'       => '10%',
 			'sizeAdjust'            => '90%',
 			'unicodeRange'          => 'U+0025-00FF, U+4??',
-			'preview'               => 'https://s.w.org/images/fonts/16.7/previews/open-sans/open-sans-400-normal.svg',
+			'preview'               => 'https://s.w.org/images/fonts/wp-6.9/previews/open-sans/open-sans-400-normal.svg',
 			'src'                   => 'https://fonts.gstatic.com/s/open-sans/v30/KFOkCnqEu92Fr1MmgWxPKTM1K9nz.ttf',
 		);
 

--- a/tests/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
+++ b/tests/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
@@ -28,7 +28,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 		'name'       => 'Open Sans',
 		'slug'       => 'open-sans',
 		'fontFamily' => '"Open Sans", sans-serif',
-		'preview'    => 'https://s.w.org/images/fonts/16.7/previews/open-sans/open-sans-400-normal.svg',
+		'preview'    => 'https://s.w.org/images/fonts/wp-6.9/previews/open-sans/open-sans-400-normal.svg',
 	);
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
@@ -48,7 +48,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 				'name'       => 'Open Sans',
 				'slug'       => 'open-sans',
 				'fontFamily' => '"Open Sans", sans-serif',
-				'preview'    => 'https://s.w.org/images/fonts/16.7/previews/open-sans/open-sans-400-normal.svg',
+				'preview'    => 'https://s.w.org/images/fonts/wp-6.9/previews/open-sans/open-sans-400-normal.svg',
 			)
 		);
 		self::$font_family_id2 = self::create_font_family_post(
@@ -665,7 +665,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 					'name'       => 'Open Sans',
 					'slug'       => 'open-sans',
 					'fontFamily' => '"Open Sans", sans-serif',
-					'preview'    => 'https://s.w.org/images/fonts/16.7/previews/open-sans/open-sans-400-normal.svg',
+					'preview'    => 'https://s.w.org/images/fonts/wp-6.9/previews/open-sans/open-sans-400-normal.svg',
 				)
 			)
 		);
@@ -682,7 +682,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 		$settings = array(
 			'name'       => 'Open Sans',
 			'fontFamily' => 'Open Sans, "Noto Sans", sans-serif',
-			'preview'    => 'https://s.w.org/images/fonts/16.9/previews/open-sans/open-sans-400-normal.svg',
+			'preview'    => 'https://s.w.org/images/fonts/wp-6.9/previews/open-sans/open-sans-400-normal.svg',
 		);
 
 		$font_family_id = self::create_font_family_post( array( 'slug' => 'open-sans-2' ) );
@@ -738,7 +738,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 		return array(
 			array( array( 'name' => 'Opened Sans' ) ),
 			array( array( 'fontFamily' => '"Opened Sans", sans-serif' ) ),
-			array( array( 'preview' => 'https://s.w.org/images/fonts/16.7/previews/opened-sans/opened-sans-400-normal.svg' ) ),
+			array( array( 'preview' => 'https://s.w.org/images/fonts/wp-6.9/previews/opened-sans/opened-sans-400-normal.svg' ) ),
 			// Empty preview is allowed.
 			array( array( 'preview' => '' ) ),
 		);


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64007

## Testing Instructions 

- Open the site editor.
- Global Styles > Typography > Manage Fonts > Install Fonts tab
- Confirm the following points:
  - Font previews should be displayed correctly
  - Fonts can be installed correctly, especially the new fonts mentioned here: https://github.com/WordPress/google-fonts-to-wordpress-collection/issues/42#issue-3433701964
  - Fonts can be filtered with the keyword or category

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
