### PR TITLE
Use original stylesheet URL for `sourceURL` when it was inlined and there are no other inline styles present

### DIFF
--- a/src/wp-includes/class-wp-styles.php
+++ b/src/wp-includes/class-wp-styles.php
@@ -333,14 +333,27 @@ class WP_Styles extends WP_Dependencies {
 	public function print_inline_style( $handle, $display = true ) {
 		$output = $this->get_data( $handle, 'after' );
 
-		if ( empty( $output ) ) {
+		if ( empty( $output ) || ! is_array( $output ) ) {
 			return false;
 		}
 
 		if ( ! $this->do_concat ) {
+
+			// Obtain the original `src` for a stylesheet possibly inlined by wp_maybe_inline_styles().
+			$inlined_src = $this->get_data( $handle, 'inlined_src' );
+
+			// If there's only one `after` inline style, and that inline style had been inlined, then use the $inlined_src
+			// as the sourceURL. Otherwise, if there is more than one inline `after` style associated with the handle,
+			// then resort to using the handle to construct the sourceURL since there isn't a single source.
+			if ( count( $output ) === 1 && is_string( $inlined_src ) && strlen( $inlined_src ) > 0 ) {
+				$source_url = $inlined_src;
+			} else {
+				$source_url = rawurlencode( "{$handle}-inline-css" );
+			}
+
 			$output[] = sprintf(
 				'/*# sourceURL=%s */',
-				rawurlencode( "{$handle}-inline-css" )
+				$source_url
 			);
 		}
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3116,6 +3116,9 @@ function wp_maybe_inline_styles() {
 			 */
 			$style['css'] = _wp_normalize_relative_css_links( $style['css'], $style['src'] );
 
+			// Keep track of the original `src` for the style that was inlined so that the `sourceURL` comment can be added.
+			$wp_styles->add_data( $style['handle'], 'inlined_src', $style['src'] );
+
 			// Set `src` to `false` and add styles inline.
 			$wp_styles->registered[ $style['handle'] ]->src = false;
 			if ( empty( $wp_styles->registered[ $style['handle'] ]->extra['after'] ) ) {

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -616,7 +616,7 @@ CSS;
 	 * @see self::test_wp_maybe_inline_styles()
 	 * @return array<string, array{additional_inline_style: string|null, styles_inline_size_limit: int|null}>
 	 */
-	public function data_provider_test_wp_maybe_inline_styles(): array {
+	public static function data_provider_test_wp_maybe_inline_styles(): array {
 		return array(
 			'regular_limit_without_additional_inline_styles' => array(
 				'additional_inline_style'  => null,

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -524,21 +524,84 @@ CSS;
 
 	/**
 	 * @ticket 58394
+	 * @ticket 63887
 	 *
 	 * @covers ::wp_maybe_inline_styles
+	 * @covers ::wp_add_inline_style
+	 * @covers ::wp_print_styles
+	 * @covers WP_Styles::do_items
+	 * @covers WP_Styles::do_item
+	 * @covers WP_Styles::print_inline_style
+	 *
+	 * @dataProvider data_provider_test_wp_maybe_inline_styles
 	 */
-	public function test_wp_maybe_inline_styles() {
-		wp_register_style( 'test-handle', '/' . WPINC . '/css/classic-themes.css' );
-		wp_style_add_data( 'test-handle', 'path', ABSPATH . WPINC . '/css/classic-themes.css' );
-
-		wp_enqueue_style( 'test-handle' );
+	public function test_wp_maybe_inline_styles( ?string $additional_inline_style ) {
+		// TODO: Add test case for limit.
+		$rel_path = 'css/classic-themes.css';
+		$src_url  = includes_url( $rel_path );
+		$src_path = ABSPATH . WPINC . '/' . $rel_path;
+		$css      = file_get_contents( $src_path );
+		$handle   = 'test-handle';
+		wp_register_style( $handle, $src_url );
+		wp_style_add_data( $handle, 'path', $src_path );
+		if ( isset( $additional_inline_style ) ) {
+			wp_add_inline_style( $handle, $additional_inline_style );
+		}
+		wp_enqueue_style( $handle );
 
 		wp_maybe_inline_styles();
 
-		$this->assertFalse( $GLOBALS['wp_styles']->registered['test-handle']->src, 'Source of style should be reset to false' );
+		$this->assertFalse( $GLOBALS['wp_styles']->registered[ $handle ]->src, 'Source of style should be reset to false' );
 
-		$css = file_get_contents( ABSPATH . WPINC . '/css/classic-themes.css' );
-		$this->assertSameSets( $GLOBALS['wp_styles']->registered['test-handle']->extra['after'], array( $css ), 'Source of style should set to after property' );
+		$expected_after   = array();
+		$expected_after[] = $css;
+		if ( isset( $additional_inline_style ) ) {
+			$expected_after[] = $additional_inline_style;
+		}
+		$this->assertSameSets( $GLOBALS['wp_styles']->registered[ $handle ]->extra['after'], $expected_after, 'Source of style should set to after property' );
+		$this->assertArrayHasKey( 'inlined_src', $GLOBALS['wp_styles']->registered[ $handle ]->extra );
+		$this->assertSame( $src_url, $GLOBALS['wp_styles']->registered[ $handle ]->extra['inlined_src'] );
+
+		$printed_styles = get_echo( 'wp_print_styles', array( $handle ) );
+		$processor      = new WP_HTML_Tag_Processor( $printed_styles );
+
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame( 'STYLE', $processor->get_tag() );
+		$this->assertSame( $handle . '-inline-css', $processor->get_attribute( 'id' ) );
+		$this->assertSame( 'text/css', $processor->get_attribute( 'type' ) );
+		$styles = array(
+			$css,
+		);
+
+		if ( isset( $additional_inline_style ) ) {
+			$styles[]   = $additional_inline_style;
+			$source_url = $handle . '-inline-css';
+		} else {
+			$source_url = $src_url;
+		}
+		$styles[] = "/*# sourceURL=$source_url */";
+
+		$expected_text = "\n" . implode( "\n", $styles ) . "\n";
+		$this->assertSame( $expected_text, $processor->get_modifiable_text() );
+
+		$this->assertFalse( $processor->next_tag() );
+	}
+
+	/**
+	 * Data provider for test_wp_maybe_inline_styles.
+	 *
+	 * @see self::test_wp_maybe_inline_styles()
+	 * @return array<string, array{additional_inline_style: string|null}>
+	 */
+	public function data_provider_test_wp_maybe_inline_styles(): array {
+		return array(
+			'without_additional_inline_styles' => array(
+				'additional_inline_style' => null,
+			),
+			'with_additional_inline_styles'    => array(
+				'additional_inline_style' => '/* additional inline style */',
+			),
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -535,14 +535,22 @@ CSS;
 	 *
 	 * @dataProvider data_provider_test_wp_maybe_inline_styles
 	 */
-	public function test_wp_maybe_inline_styles( ?string $additional_inline_style ) {
-		// TODO: Add test case for limit.
+	public function test_wp_maybe_inline_styles( ?string $additional_inline_style, ?int $styles_inline_size_limit ) {
 		$rel_path = 'css/classic-themes.css';
 		$src_url  = includes_url( $rel_path );
 		$src_path = ABSPATH . WPINC . '/' . $rel_path;
 		$css      = file_get_contents( $src_path );
 		$handle   = 'test-handle';
-		wp_register_style( $handle, $src_url );
+
+		if ( isset( $styles_inline_size_limit ) ) {
+			add_filter(
+				'styles_inline_size_limit',
+				static function () use ( $styles_inline_size_limit ): int {
+					return $styles_inline_size_limit;
+				}
+			);
+		}
+		wp_register_style( $handle, $src_url, array(), null );
 		wp_style_add_data( $handle, 'path', $src_path );
 		if ( isset( $additional_inline_style ) ) {
 			wp_add_inline_style( $handle, $additional_inline_style );
@@ -551,38 +559,53 @@ CSS;
 
 		wp_maybe_inline_styles();
 
-		$this->assertFalse( $GLOBALS['wp_styles']->registered[ $handle ]->src, 'Source of style should be reset to false' );
+		$expected_after = array();
+		if ( ! isset( $styles_inline_size_limit ) || strlen( $css ) <= $styles_inline_size_limit ) {
+			$expected_after[] = $css;
+			$this->assertFalse( wp_styles()->registered[ $handle ]->src, 'Source of style should be reset to false' );
+			$this->assertArrayHasKey( 'inlined_src', wp_styles()->registered[ $handle ]->extra );
+			$this->assertSame( $src_url, wp_styles()->registered[ $handle ]->extra['inlined_src'] );
+		} else {
+			$this->assertArrayNotHasKey( 'inlined_src', wp_styles()->registered[ $handle ]->extra );
+		}
 
-		$expected_after   = array();
-		$expected_after[] = $css;
 		if ( isset( $additional_inline_style ) ) {
 			$expected_after[] = $additional_inline_style;
 		}
-		$this->assertSameSets( $GLOBALS['wp_styles']->registered[ $handle ]->extra['after'], $expected_after, 'Source of style should set to after property' );
-		$this->assertArrayHasKey( 'inlined_src', $GLOBALS['wp_styles']->registered[ $handle ]->extra );
-		$this->assertSame( $src_url, $GLOBALS['wp_styles']->registered[ $handle ]->extra['inlined_src'] );
+
+		$after = wp_styles()->get_data( $handle, 'after' );
+		if ( false === $after ) {
+			$after = array();
+		}
+		$this->assertSameSets( $after, $expected_after, 'Source of style should set to after property' );
 
 		$printed_styles = get_echo( 'wp_print_styles', array( $handle ) );
 		$processor      = new WP_HTML_Tag_Processor( $printed_styles );
 
-		$this->assertTrue( $processor->next_tag() );
-		$this->assertSame( 'STYLE', $processor->get_tag() );
-		$this->assertSame( $handle . '-inline-css', $processor->get_attribute( 'id' ) );
-		$this->assertSame( 'text/css', $processor->get_attribute( 'type' ) );
-		$styles = array(
-			$css,
-		);
-
-		if ( isset( $additional_inline_style ) ) {
-			$styles[]   = $additional_inline_style;
-			$source_url = $handle . '-inline-css';
-		} else {
-			$source_url = $src_url;
+		if ( isset( $styles_inline_size_limit ) && strlen( $css ) > $styles_inline_size_limit ) {
+			$this->assertTrue( $processor->next_tag() );
+			$this->assertSame( 'LINK', $processor->get_tag() );
+			$this->assertSame( 'stylesheet', $processor->get_attribute( 'rel' ) );
+			$this->assertSame( $src_url, $processor->get_attribute( 'href' ) );
 		}
-		$styles[] = "/*# sourceURL=$source_url */";
 
-		$expected_text = "\n" . implode( "\n", $styles ) . "\n";
-		$this->assertSame( $expected_text, $processor->get_modifiable_text() );
+		if ( count( $expected_after ) > 0 ) {
+			$this->assertTrue( $processor->next_tag() );
+			$this->assertSame( 'STYLE', $processor->get_tag() );
+			$this->assertSame( $handle . '-inline-css', $processor->get_attribute( 'id' ) );
+			$this->assertSame( 'text/css', $processor->get_attribute( 'type' ) );
+
+			$expected_inline_styles = $expected_after;
+			if ( isset( $additional_inline_style ) ) {
+				$source_url = $handle . '-inline-css';
+			} else {
+				$source_url = $src_url;
+			}
+			$expected_inline_styles[] = "/*# sourceURL=$source_url */";
+
+			$expected_text = "\n" . implode( "\n", $expected_inline_styles ) . "\n";
+			$this->assertSame( $expected_text, $processor->get_modifiable_text() );
+		}
 
 		$this->assertFalse( $processor->next_tag() );
 	}
@@ -591,15 +614,25 @@ CSS;
 	 * Data provider for test_wp_maybe_inline_styles.
 	 *
 	 * @see self::test_wp_maybe_inline_styles()
-	 * @return array<string, array{additional_inline_style: string|null}>
+	 * @return array<string, array{additional_inline_style: string|null, styles_inline_size_limit: int|null}>
 	 */
 	public function data_provider_test_wp_maybe_inline_styles(): array {
 		return array(
-			'without_additional_inline_styles' => array(
-				'additional_inline_style' => null,
+			'regular_limit_without_additional_inline_styles' => array(
+				'additional_inline_style'  => null,
+				'styles_inline_size_limit' => null,
 			),
-			'with_additional_inline_styles'    => array(
-				'additional_inline_style' => '/* additional inline style */',
+			'regular_limit_with_additional_inline_style' => array(
+				'additional_inline_style'  => '/* additional inline style */',
+				'styles_inline_size_limit' => null,
+			),
+			'zero_limit_without_additional_inline_style' => array(
+				'additional_inline_style'  => null,
+				'styles_inline_size_limit' => 0,
+			),
+			'zero_limit_with_additional_inline_style'    => array(
+				'additional_inline_style'  => '/* additional inline style */',
+				'styles_inline_size_limit' => 0,
 			),
 		);
 	}


### PR DESCRIPTION
This addresses the [last feedback](https://core.trac.wordpress.org/ticket/63887#comment:43) I had for the `sourceURL` ticket Core-63887. For inline styles which had been inlined from registered external stylesheets via `wp_maybe_inline_styles()`, this will defer to using the original stylesheet URL for the `sourceURL` as opposed to fabricating one from the stylesheet handle. This makes the `sourceURL` much more useful for debugging, as it indicates where the stylesheet is located. This would then allow a dev to make a change to the CSS more easily.

```diff
--- before.html	2025-10-06 21:39:15
+++ after.html	2025-10-06 21:39:15
@@ -42,7 +42,7 @@
         line-height: inherit;
         text-decoration: inherit;
       }
-      /*# sourceURL=wp-block-site-title-inline-css */
+      /*# sourceURL=http://localhost:8000/wp-includes/blocks/site-title/style.css */
     </style>
     <style id="wp-block-page-list-inline-css">
       .wp-block-navigation .wp-block-page-list {
@@ -60,7 +60,7 @@
       .wp-block-page-list {
         box-sizing: border-box;
       }
-      /*# sourceURL=wp-block-page-list-inline-css */
+      /*# sourceURL=http://localhost:8000/wp-includes/blocks/page-list/style.css */
     </style>
     <link
       rel="stylesheet"
@@ -76,7 +76,7 @@
       :where(.wp-block-group.wp-block-group-is-layout-constrained) {
         position: relative;
       }
-      /*# sourceURL=wp-block-group-inline-css */
+      /*# sourceURL=http://localhost:8000/wp-includes/blocks/group/style.css */
     </style>
     <style id="wp-block-post-featured-image-inline-css">
       .wp-block-post-featured-image {
@@ -159,7 +159,7 @@
       .wp-block-post-featured-image:where(.alignleft, .alignright) {
         width: 100%;
       }
-      /*# sourceURL=wp-block-post-featured-image-inline-css */
+      /*# sourceURL=http://localhost:8000/wp-includes/blocks/post-featured-image/style.css */
     </style>
     <style id="wp-block-post-title-inline-css">
       .wp-block-post-title {
@@ -176,7 +176,7 @@
         line-height: inherit;
         text-decoration: inherit;
       }
-      /*# sourceURL=wp-block-post-title-inline-css */
+      /*# sourceURL=http://localhost:8000/wp-includes/blocks/post-title/style.css */
     </style>
     <style id="wp-block-paragraph-inline-css">
       .is-small-text {
@@ -226,7 +226,7 @@
       p.has-text-align-right[style*="writing-mode:vertical-rl"] {
         rotate: 180deg;
       }
-      /*# sourceURL=wp-block-paragraph-inline-css */
+      /*# sourceURL=http://localhost:8000/wp-includes/blocks/paragraph/style.css */
     </style>
     <style id="wp-block-quote-inline-css">
       .wp-block-quote {
@@ -254,13 +254,13 @@
       .wp-block-quote > cite {
         display: block;
       }
-      /*# sourceURL=wp-block-quote-inline-css */
+      /*# sourceURL=http://localhost:8000/wp-includes/blocks/quote/style.css */
     </style>
     <style id="wp-block-post-content-inline-css">
       .wp-block-post-content {
         display: flow-root;
       }
-      /*# sourceURL=wp-block-post-content-inline-css */
+      /*# sourceURL=http://localhost:8000/wp-includes/blocks/post-content/style.css */
     </style>
     <style id="wp-block-site-logo-inline-css">
       .wp-block-site-logo {
@@ -292,19 +292,19 @@
       :root :where(.wp-block-site-logo.is-style-rounded) {
         border-radius: 9999px;
       }
-      /*# sourceURL=wp-block-site-logo-inline-css */
+      /*# sourceURL=http://localhost:8000/wp-includes/blocks/site-logo/style.css */
     </style>
     <style id="wp-block-site-tagline-inline-css">
       .wp-block-site-tagline {
         box-sizing: border-box;
       }
-      /*# sourceURL=wp-block-site-tagline-inline-css */
+      /*# sourceURL=http://localhost:8000/wp-includes/blocks/site-tagline/style.css */
     </style>
     <style id="wp-block-spacer-inline-css">
       .wp-block-spacer {
         clear: both;
       }
-      /*# sourceURL=wp-block-spacer-inline-css */
+      /*# sourceURL=http://localhost:8000/wp-includes/blocks/spacer/style.css */
     </style>
     <style id="wp-block-columns-inline-css">
       .wp-block-columns {
@@ -385,7 +385,7 @@
       .wp-block-column.is-vertically-aligned-top {
         width: 100%;
       }
-      /*# sourceURL=wp-block-columns-inline-css */
+      /*# sourceURL=http://localhost:8000/wp-includes/blocks/columns/style.css */
     </style>
     <style id="wp-block-navigation-link-inline-css">
       .wp-block-navigation .wp-block-navigation-item__label {
@@ -408,7 +408,7 @@
         margin-left: 8px;
         text-transform: uppercase;
       }
-      /*# sourceURL=wp-block-navigation-link-inline-css */
+      /*# sourceURL=http://localhost:8000/wp-includes/blocks/navigation-link/style.css */
     </style>
     <style id="wp-emoji-styles-inline-css">
       img.wp-smiley,
@@ -623,7 +623,7 @@
           --wp-admin--admin-bar--position-offset: 0px;
         }
       }
-      /*# sourceURL=wp-block-library-inline-css */
+      /*# sourceURL=/wp-includes/css/dist/block-library/common.css */
     </style>
     <style id="global-styles-inline-css">
       :root {
@@ -1518,7 +1518,7 @@
         display: block;
       }
 
-      /*# sourceURL=twentytwentyfive-style-inline-css */
+      /*# sourceURL=http://localhost:8000/wp-content/themes/twentytwentyfive/style.css */
     </style>
     <link rel="https://api.w.org/" href="http://localhost:8000/wp-json/" />
     <link
```

Trac ticket: https://core.trac.wordpress.org/ticket/63887

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
