### PR TITLE
Docs: Fix incorrect @global variable name in revision.php

### DIFF
--- a/src/wp-admin/revision.php
+++ b/src/wp-admin/revision.php
@@ -15,7 +15,7 @@ require_once __DIR__ . '/admin.php';
 require ABSPATH . 'wp-admin/includes/revision.php';
 
 /**
- * @global int    $revision Optional. The revision ID.
+ * @global int    $revision_id Optional. The revision ID.
  * @global string $action   The action to take.
  *                          Accepts 'restore', 'view' or 'edit'.
  * @global int    $from     The revision to compare from.


### PR DESCRIPTION
This PR fixes a minor documentation issue in `wp-admin/revision.php`.

The `@global` docblock incorrectly referenced `$revision` instead of `$revision_id`.  
This change updates the variable name to match the actual code used below.

Trac ticket: https://core.trac.wordpress.org/ticket/64084#ticket


