### PR TITLE
Add the pattern name to pattern blocks when they are converted

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1869,10 +1869,10 @@ function resolve_pattern_blocks( $blocks ) {
 				++$i;
 				continue;
 			}
-			$blocks_to_insert   = parse_blocks( $pattern['content'] );
+			$blocks_to_insert   = parse_blocks( trim( $pattern['content'] ) );
 
-			// Add the pattern name to make this a pattern instance in the editor.
-			if( count( $blocks_to_insert ) === 2 ) { // should be 1 but we seem to have an empty block always
+			// For single-root patterns, add the pattern name to make this a pattern instance in the editor.
+			if( count( $blocks_to_insert ) === 1 ) {
 				$blocks_to_insert[0]['attrs']['metadata'] = [ 'patternName' => $slug, 'name' => $pattern['title'] ];
 			}
 			$seen_refs[ $slug ] = true;

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1869,8 +1869,12 @@ function resolve_pattern_blocks( $blocks ) {
 				++$i;
 				continue;
 			}
-
 			$blocks_to_insert   = parse_blocks( $pattern['content'] );
+
+			// Add the pattern name to make this a pattern instance in the editor.
+			if( count( $blocks_to_insert ) === 2 ) { // should be 1 but we seem to have an empty block always
+				$blocks_to_insert[0]['attrs']['metadata'] = [ 'patternName' => $slug, 'name' => $pattern['title'] ];
+			}
 			$seen_refs[ $slug ] = true;
 			$prev_inner_content = $inner_content;
 			$inner_content      = null;

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -1872,8 +1872,11 @@ function resolve_pattern_blocks( $blocks ) {
 			$blocks_to_insert   = parse_blocks( trim( $pattern['content'] ) );
 
 			// For single-root patterns, add the pattern name to make this a pattern instance in the editor.
-			if( count( $blocks_to_insert ) === 1 ) {
-				$blocks_to_insert[0]['attrs']['metadata'] = [ 'patternName' => $slug, 'name' => $pattern['title'] ];
+			if ( count( $blocks_to_insert ) === 1 ) {
+				$blocks_to_insert[0]['attrs']['metadata'] = array(
+					'patternName' => $slug,
+					'name'        => $pattern['title'],
+				);
 			}
 			$seen_refs[ $slug ] = true;
 			$prev_inner_content = $inner_content;


### PR DESCRIPTION
This adds the `metadata` attribute to the outermost wrapping block when a pattern is converted to blocks. The metadata contains the `patternName` and `name` attributes.

This will be used to test contentOnly editing (https://github.com/WordPress/gutenberg/issues/71517), so that themes that use patterns automatically opt into this behaviour.