### PR TITLE
Block editor: Conditionally enqueue front end assets for fitText.

### DIFF
--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -306,6 +306,9 @@ function wp_typography_get_preset_inline_style_value( $style_value, $css_propert
  * @return string Filtered block content.
  */
 function wp_render_typography_support( $block_content, $block ) {
+	if ( ! empty( $block['attrs']['fitText'] ) ) {
+		wp_enqueue_script_module( '@wordpress/block-editor/utils/fit-text-frontend' );
+	}
 	if ( ! isset( $block['attrs']['style']['typography']['fontSize'] ) ) {
 		return $block_content;
 	}


### PR DESCRIPTION
This commit backports to core the php changes required for the fitText implementation which was worked on at https://github.com/WordPress/gutenberg/pull/71904. It can be merged even before the packages are updated because unless the fitText support is used nothing happens.

Ticket: https://core.trac.wordpress.org/ticket/64119
