### PR TITLE
Add "Live Preview" button support to plugin install screen. Refresh admin-plugin-preview.0.diff

### DIFF
--- a/src/wp-admin/includes/class-wp-plugin-install-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugin-install-list-table.php
@@ -154,6 +154,8 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 			'per_page' => $per_page,
 			// Send the locale to the API so it can provide context-sensitive results.
 			'locale'   => get_user_locale(),
+			// Always get the preview link if it's available.
+			'fields'   => 'preview_link',
 		);
 
 		switch ( $tab ) {
@@ -566,6 +568,10 @@ class WP_Plugin_Install_List_Table extends WP_List_Table {
 			$action_links = array();
 
 			$action_links[] = wp_get_plugin_action_button( $name, $plugin, $compatible_php, $compatible_wp );
+
+			if ( ! empty( $plugin['preview_link'] ) ) {
+				$action_links[] = wp_get_plugin_preview_button( $plugin );
+			}
 
 			$details_link = self_admin_url(
 				'plugin-install.php?tab=plugin-information&amp;plugin=' . $plugin['slug'] .

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -1059,7 +1059,7 @@ function wp_get_plugin_action_button( $name, $data, $compatible_php, $compatible
  *                if the plugin is already installed.
  */
 function wp_get_plugin_preview_button( $data ) {
-	$data   = (object) $data;
+	$data = (object) $data;
 
 	$status = install_plugin_install_status( $data );
 

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -1066,7 +1066,7 @@ function wp_get_plugin_preview_button( $data ) {
 	if ( 'latest_installed' === $status['status'] || 'newer_installed' === $status['status'] ) {
 		return '';
 	}
-	
+
 	$button = sprintf(
 		'<a class="preview-btn button" href="%s" target="_blank" aria-label="%s" role="button">%s</a>',
 		esc_url( $data->preview_link ),

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -880,6 +880,10 @@ function install_plugin_information() {
 			$button = str_replace( 'class="', 'id="plugin_install_from_iframe" class="', $button );
 		}
 
+		if ( ! empty( $api->preview_link ) ) {
+			$button .= wp_get_plugin_preview_button( $api );
+		}
+
 		echo wp_kses_post( $button );
 	}
 	echo "</div>\n";
@@ -1033,6 +1037,43 @@ function wp_get_plugin_action_button( $name, $data, $compatible_php, $compatible
 				break;
 		}
 	}
+
+	return $button;
+}
+
+/**
+ * Generates the markup for the "Live Preview" button on the plugin list.
+ *
+ * This button links to the plugin's live preview, if available. The button
+ * is only displayed when the plugin is not already installed.
+ *
+ * @since x.x.x
+ *
+ * @param array|object $data           {
+ *     An array or object of plugin data. Can be retrieved from the API.
+ *
+ *     @type string $preview_link The plugin preview link.
+ *     @type string $name         The plugin name.
+ * }
+ * @return string HTML markup for the Live Preview button. Returns an empty string
+ *                if the plugin is already installed.
+ */
+function wp_get_plugin_preview_button( $data ) {
+	$data   = (object) $data;
+
+	$status = install_plugin_install_status( $data );
+
+	if ( 'latest_installed' === $status['status'] || 'newer_installed' === $status['status'] ) {
+		return '';
+	}
+	
+	$button = sprintf(
+		'<a class="preview-btn button" href="%s" target="_blank" aria-label="%s" role="button">%s</a>',
+		esc_url( $data->preview_link ),
+		/* translators: %s: Plugin name. */
+		esc_attr( sprintf( _x( 'Preview %s', 'plugin' ), $data->name ) ),
+		_x( 'Live Preview', 'plugin' )
+	);
 
 	return $button;
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/60194

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
