### PR TITLE
Fixes #64088: Button to add a post tag breaks into new line in German translation

### DIFF
--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -1406,6 +1406,7 @@ p.description code,
 
 #poststuff .tagsdiv .ajaxtag {
 	margin-top: 1em;
+	display: flex;
 }
 
 #poststuff .tagsdiv .howto {
@@ -1417,7 +1418,7 @@ p.description code,
 }
 
 .tagsdiv .newtag {
-	width: 180px;
+	flex: 1;
 }
 
 .tagsdiv .the-tags {


### PR DESCRIPTION
Hi there,

this would be as simple fix for my ticket #64088 on Trac.
It adjusts the width of the input element in the post tags widget dynamically according to the width of the "Add Post Tag" button using Flexbox.

Trac ticket: https://core.trac.wordpress.org/ticket/64088
