### PR TITLE
Remove `Pullquote` block from theme twenty nineteen

### DIFF
--- a/src/wp-content/themes/twentynineteen/inc/block-patterns.php
+++ b/src/wp-content/themes/twentynineteen/inc/block-patterns.php
@@ -187,8 +187,8 @@ if ( function_exists( 'register_block_pattern' ) ) {
 					'<!-- /wp:heading -->',
 
 					// Section 1: Redefine brands.
-					'<!-- wp:cover {"overlayColor":"primary","align":"wide"} -->',
-					'<div class="wp-block-cover alignwide has-primary-background-color has-background-dim"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"white"} -->',
+					'<!-- wp:cover {"overlayColor":"primary","minHeight":220,"align":"wide"} -->',
+					'<div class="wp-block-cover alignwide has-primary-background-color has-background-dim" style="min-height:220px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"white"} -->',
 					'<h3 class="has-white-color has-text-color">' . esc_html__( 'Redefine brands', 'twentynineteen' ) . '</h3>',
 					'<!-- /wp:heading -->',
 
@@ -198,8 +198,8 @@ if ( function_exists( 'register_block_pattern' ) ) {
 					'<!-- /wp:cover -->',
 
 					// Section 2: Activate new customers.
-					'<!-- wp:cover {"overlayColor":"dark-gray","align":"wide"} -->',
-					'<div class="wp-block-cover alignwide has-dark-gray-background-color has-background-dim"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"white"} -->',
+					'<!-- wp:cover {"overlayColor":"dark-gray","minHeight":220,"align":"wide"} -->',
+					'<div class="wp-block-cover alignwide has-dark-gray-background-color has-background-dim" style="min-height:220px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"white"} -->',
 					'<h3 class="has-white-color has-text-color">' . esc_html__( 'Activate new customers', 'twentynineteen' ) . '</h3>',
 					'<!-- /wp:heading -->',
 
@@ -209,8 +209,8 @@ if ( function_exists( 'register_block_pattern' ) ) {
 					'<!-- /wp:cover -->',
 
 					// Section 3: Spark interest on social media.
-					'<!-- wp:cover {"customOverlayColor":"#f7f7f7","align":"wide"} -->',
-					'<div class="wp-block-cover alignwide has-background-dim" style="background-color:#f7f7f7"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"dark-gray"} -->',
+					'<!-- wp:cover {"customOverlayColor":"#f7f7f7","minHeight":220,"align":"wide"} -->',
+					'<div class="wp-block-cover alignwide has-background-dim" style="background-color:#f7f7f7;min-height:220px"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"dark-gray"} -->',
 					'<h3 class="has-dark-gray-color has-text-color">' . esc_html__( 'Spark interest on social media', 'twentynineteen' ) . '</h3>',
 					'<!-- /wp:heading -->',
 

--- a/src/wp-content/themes/twentynineteen/inc/block-patterns.php
+++ b/src/wp-content/themes/twentynineteen/inc/block-patterns.php
@@ -185,15 +185,39 @@ if ( function_exists( 'register_block_pattern' ) ) {
 					'<!-- wp:heading -->',
 					'<h2>' . esc_html__( 'What We Do', 'twentynineteen' ) . '</h2>',
 					'<!-- /wp:heading -->',
-					'<!-- wp:pullquote {"align":"wide","className":"is-style-solid-color"} -->',
-					'<figure class="wp-block-pullquote alignwide is-style-solid-color"><blockquote><p>' . esc_html__( 'Redefine brands', 'twentynineteen' ) . '</p><cite>' . esc_html__( 'We help startups define (or refine) a clear brand identity.', 'twentynineteen' ) . '</cite></blockquote></figure>',
-					'<!-- /wp:pullquote -->',
-					'<!-- wp:pullquote {"mainColor":"dark-gray","customTextColor":"#ffffff","align":"wide","className":"is-style-solid-color"} -->',
-					'<figure class="wp-block-pullquote alignwide has-background has-dark-gray-background-color is-style-solid-color"><blockquote class="has-text-color" style="color:#ffffff"><p>' . esc_html__( 'Activate new customers', 'twentynineteen' ) . '</p><cite>' . esc_html__( 'We help businesses grow.', 'twentynineteen' ) . '</cite></blockquote></figure>',
-					'<!-- /wp:pullquote -->',
-					'<!-- wp:pullquote {"customMainColor":"#f7f7f7","customTextColor":"#111111","align":"wide","className":"is-style-solid-color"} -->',
-					'<figure class="wp-block-pullquote alignwide has-background is-style-solid-color" style="background-color:#f7f7f7"><blockquote class="has-text-color" style="color:#111111"><p>' . esc_html__( 'Spark interest on social media', 'twentynineteen' ) . '</p><cite>' . esc_html__( 'We help companies communicate with their customers.', 'twentynineteen' ) . '</cite></blockquote></figure>',
-					'<!-- /wp:pullquote -->',
+
+					// Section 1: Redefine brands.
+					'<!-- wp:cover {"overlayColor":"primary","align":"wide"} -->',
+					'<div class="wp-block-cover alignwide has-primary-background-color has-background-dim"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"white"} -->',
+					'<h3 class="has-white-color has-text-color">' . esc_html__( 'Redefine brands', 'twentynineteen' ) . '</h3>',
+					'<!-- /wp:heading -->',
+
+					'<!-- wp:paragraph {"textColor":"white"} -->',
+					'<p class="has-white-color has-text-color">' . esc_html__( 'We help startups define (or refine) a clear brand identity.', 'twentynineteen' ) . '</p>',
+					'<!-- /wp:paragraph --></div></div>',
+					'<!-- /wp:cover -->',
+
+					// Section 2: Activate new customers.
+					'<!-- wp:cover {"overlayColor":"dark-gray","align":"wide"} -->',
+					'<div class="wp-block-cover alignwide has-dark-gray-background-color has-background-dim"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"white"} -->',
+					'<h3 class="has-white-color has-text-color">' . esc_html__( 'Activate new customers', 'twentynineteen' ) . '</h3>',
+					'<!-- /wp:heading -->',
+
+					'<!-- wp:paragraph {"textColor":"white"} -->',
+					'<p class="has-white-color has-text-color">' . esc_html__( 'We help businesses grow.', 'twentynineteen' ) . '</p>',
+					'<!-- /wp:paragraph --></div></div>',
+					'<!-- /wp:cover -->',
+
+					// Section 3: Spark interest on social media.
+					'<!-- wp:cover {"customOverlayColor":"#f7f7f7","align":"wide"} -->',
+					'<div class="wp-block-cover alignwide has-background-dim" style="background-color:#f7f7f7"><div class="wp-block-cover__inner-container"><!-- wp:heading {"level":3,"textColor":"dark-gray"} -->',
+					'<h3 class="has-dark-gray-color has-text-color">' . esc_html__( 'Spark interest on social media', 'twentynineteen' ) . '</h3>',
+					'<!-- /wp:heading -->',
+
+					'<!-- wp:paragraph {"textColor":"dark-gray"} -->',
+					'<p class="has-dark-gray-color has-text-color">' . esc_html__( 'We help companies communicate with their customers.', 'twentynineteen' ) . '</p>',
+					'<!-- /wp:paragraph --></div></div>',
+					'<!-- /wp:cover -->',
 				)
 			),
 		)

--- a/src/wp-content/themes/twentyten/block-patterns.php
+++ b/src/wp-content/themes/twentyten/block-patterns.php
@@ -44,7 +44,7 @@ if ( function_exists( 'register_block_pattern' ) ) {
 			'title'         => esc_html__( 'Highlighted Quote', 'twentyten' ),
 			'categories'    => array( 'twentyten' ),
 			'viewportWidth' => 700,
-			'content'       => '<!-- wp:cover {"overlayColor":"light-gray"} --><div class="wp-block-cover has-light-gray-background-color has-background-dim"><div class="wp-block-cover__inner-container"><!-- wp:quote {"className":"is-style-large is-style-plain"} --><blockquote class="wp-block-quote is-style-large is-style-plain"><p><em>' . esc_html__( '"Take time off&hellip; The world will not fall apart without you."', 'twentyten' ) . '</em></p><cite>' . esc_html__( '— Malebo Sephodi', 'twentyten' ) . '</cite></blockquote><!-- /wp:quote --></div></div><!-- /wp:cover -->',
+			'content'       => '<!-- wp:cover {"overlayColor":"light-gray"} --><div class="wp-block-cover has-light-gray-background-color has-background-dim"><div class="wp-block-cover__inner-container"><!-- wp:quote {"className":"is-style-plain highlighted-quote"} --><blockquote class="wp-block-quote is-style-plain highlighted-quote"><p><em>' . esc_html__( '"Take time off&hellip; The world will not fall apart without you."', 'twentyten' ) . '</em></p><cite>' . esc_html__( '— Malebo Sephodi', 'twentyten' ) . '</cite></blockquote><!-- /wp:quote --></div></div><!-- /wp:cover -->',
 		)
 	);
 

--- a/src/wp-content/themes/twentyten/block-patterns.php
+++ b/src/wp-content/themes/twentyten/block-patterns.php
@@ -44,7 +44,7 @@ if ( function_exists( 'register_block_pattern' ) ) {
 			'title'         => esc_html__( 'Highlighted Quote', 'twentyten' ),
 			'categories'    => array( 'twentyten' ),
 			'viewportWidth' => 700,
-			'content'       => '<!-- wp:cover {"overlayColor":"light-gray"} --><div class="wp-block-cover has-light-gray-background-color has-background-dim"><div class="wp-block-cover__inner-container"><!-- wp:pullquote {"textColor":"black","className":"is-style-solid-color"} --><figure class="wp-block-pullquote is-style-solid-color"><blockquote class="has-text-color has-black-color"><p><em>' . esc_html__( '"Take time off&hellip; The world will not fall apart without you."', 'twentyten' ) . '</em></p><cite>' . esc_html__( '— Malebo Sephodi', 'twentyten' ) . '</cite></blockquote></figure><!-- /wp:pullquote --></div></div><!-- /wp:cover -->',
+			'content'       => '<!-- wp:cover {"overlayColor":"light-gray"} --><div class="wp-block-cover has-light-gray-background-color has-background-dim"><div class="wp-block-cover__inner-container"><!-- wp:quote {"className":"is-style-large is-style-plain"} --><blockquote class="wp-block-quote is-style-large is-style-plain"><p><em>' . esc_html__( '"Take time off&hellip; The world will not fall apart without you."', 'twentyten' ) . '</em></p><cite>' . esc_html__( '— Malebo Sephodi', 'twentyten' ) . '</cite></blockquote><!-- /wp:quote --></div></div><!-- /wp:cover -->',
 		)
 	);
 

--- a/src/wp-content/themes/twentyten/blocks.css
+++ b/src/wp-content/themes/twentyten/blocks.css
@@ -86,6 +86,12 @@ p.has-drop-cap:not(:focus)::first-letter {
 	padding: 0 3em;
 }
 
+.wp-block-quote.is-style-large p,
+.wp-block-quote.is-large p {
+	font-size: 1.5em;
+	line-height: 1.3;
+}
+
 .wp-block-quote cite {
 	color: inherit;
 	font-size: inherit;

--- a/src/wp-content/themes/twentyten/blocks.css
+++ b/src/wp-content/themes/twentyten/blocks.css
@@ -86,9 +86,8 @@ p.has-drop-cap:not(:focus)::first-letter {
 	padding: 0 3em;
 }
 
-.wp-block-quote.is-style-large p,
-.wp-block-quote.is-large p {
-	font-size: 1.5em;
+.wp-block-quote.highlighted-quote p {
+	font-size: 2em;
 	line-height: 1.3;
 }
 

--- a/src/wp-content/themes/twentyten/editor-blocks.css
+++ b/src/wp-content/themes/twentyten/editor-blocks.css
@@ -223,6 +223,12 @@ p.has-drop-cap:not(:focus)::first-letter {
 	padding: 0 3em;
 }
 
+.wp-block-quote.is-style-large p,
+.wp-block-quote.is-large p {
+	font-size: 1.5em;
+	line-height: 1.3;
+}
+
 .wp-block-quote .wp-block-quote__citation {
 	font-size: 16px;
 	font-weight: 600;

--- a/src/wp-content/themes/twentyten/editor-blocks.css
+++ b/src/wp-content/themes/twentyten/editor-blocks.css
@@ -223,9 +223,8 @@ p.has-drop-cap:not(:focus)::first-letter {
 	padding: 0 3em;
 }
 
-.wp-block-quote.is-style-large p,
-.wp-block-quote.is-large p {
-	font-size: 1.5em;
+.wp-block-quote.highlighted-quote p {
+	font-size: 2em;
 	line-height: 1.3;
 }
 


### PR DESCRIPTION
## Summary

The `Pullquote` block will be deprecated soon. Check this GitHub issue for more details: https://github.com/WordPress/gutenberg/issues/11610

Hence, replacing `Pullquote` block across all themes with other similar blocks. This PR is changing following items:
1. `What We Do` pattern of the twenty nineteen theme
2. `Highlighted Quote` pattern of the twenty ten theme

Trac ticket: https://core.trac.wordpress.org/ticket/64068

### Screenshots

| Theme | Pattern |
|--------|--------|
| `What We Do` pattern of the twenty nineteen theme | <img width="425" height="522" alt="What We Do pattern of the twenty nineteen theme" src="https://github.com/user-attachments/assets/1877bd7c-f797-456e-b100-c8f3744228f2" /> |
| `Highlighted Quote` pattern of the twenty ten theme | <img width="672" height="530" alt="Highlighted Quote pattern of the twenty ten theme" src="https://github.com/user-attachments/assets/763b1bc3-9ebe-4271-886d-13b8e0f7f07e" /> | 


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
