### PR TITLE
Move `wp_cron()` to run at `shutdown` instead of `wp_loaded` to avoid increasing TTFB

### DIFF
--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -974,11 +974,11 @@ function spawn_cron( $gmt_time = 0 ) {
 /**
  * Registers _wp_cron() to run on the {@see 'shutdown'} action.
  *
- * The {@see spawn_cron()} function attempts to make a non-blocking loopback request to `wp-cron.php` (when alternative
- * cron is not being used). However, the {@see wp_remote_post()} function does not always respect the `timeout` and
+ * The spawn_cron() function attempts to make a non-blocking loopback request to `wp-cron.php` (when alternative
+ * cron is not being used). However, the wp_remote_post() function does not always respect the `timeout` and
  * `blocking` parameters. A timeout of `0.01` may end up taking 1 second. When this runs at the {@see 'wp_loaded'}
  * action, it increases the Time To First Byte (TTFB) since the HTML cannot be sent while waiting for the cron request
- * to initiate. Moving the spawning of cron to the {@see 'shutdown'} allows for the server to flush the HTML document to
+ * to initiate. Moving the spawning of cron to the {@see 'shutdown'} hook allows for the server to flush the HTML document to
  * the browser while waiting for the request.
  *
  * @since 2.1.0

--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -985,17 +985,12 @@ function spawn_cron( $gmt_time = 0 ) {
  * @since 2.1.0
  * @since 5.1.0 Return value added to indicate success or failure.
  * @since 5.7.0 Functionality moved to _wp_cron() to which this becomes a wrapper.
+ * @since 6.9.0 The `_wp_cron()` function is moved to the shutdown action to prevent the async loopback request from increasing TTFB.
  *
- * @return false|int|void On success an integer indicating number of events spawned (0 indicates no
- *                        events needed to be spawned), false if spawning fails for one or more events or
- *                        void if the function registered _wp_cron() to run on the action.
+ * @return void The function registered _wp_cron() to run on the shutdown action.
  */
 function wp_cron() {
-	if ( did_action( 'wp_loaded' ) ) {
-		return _wp_cron();
-	}
-
-	add_action( 'wp_loaded', '_wp_cron', 20 );
+	add_action( 'shutdown', '_wp_cron' );
 }
 
 /**

--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -972,24 +972,21 @@ function spawn_cron( $gmt_time = 0 ) {
 }
 
 /**
- * Registers _wp_cron() to run on the {@see 'wp_loaded'} action.
+ * Registers _wp_cron() to run on the {@see 'shutdown'} action.
  *
- * If the {@see 'wp_loaded'} action has already fired, this function calls
- * _wp_cron() directly.
- *
- * Warning: This function may return Boolean FALSE, but may also return a non-Boolean
- * value which evaluates to FALSE. For information about casting to booleans see the
- * {@link https://www.php.net/manual/en/language.types.boolean.php PHP documentation}. Use
- * the `===` operator for testing the return value of this function.
+ * The {@see spawn_cron()} function attempts to make a non-blocking loopback request to `wp-cron.php` (when alternative
+ * cron is not being used). However, the {@see wp_remote_post()} function does not always respect the `timeout` and
+ * `blocking` parameters. A timeout of `0.01` may end up taking 1 second. When this runs at the {@see 'wp_loaded'}
+ * action, it increases the Time To First Byte (TTFB) since the HTML cannot be sent while waiting for the cron request
+ * to initiate. Moving the spawning of cron to the {@see 'shutdown'} allows for the server to flush the HTML document to
+ * the browser while waiting for the request.
  *
  * @since 2.1.0
  * @since 5.1.0 Return value added to indicate success or failure.
  * @since 5.7.0 Functionality moved to _wp_cron() to which this becomes a wrapper.
- * @since 6.9.0 The `_wp_cron()` function is moved to the shutdown action to prevent the async loopback request from increasing TTFB.
- *
- * @return void The function registered _wp_cron() to run on the shutdown action.
+ * @since 6.9.0 The _wp_cron() callback is moved from wp_loaded to the shutdown action; the function always returns void.
  */
-function wp_cron() {
+function wp_cron(): void {
 	add_action( 'shutdown', '_wp_cron' );
 }
 

--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -984,7 +984,7 @@ function spawn_cron( $gmt_time = 0 ) {
  * @since 2.1.0
  * @since 5.1.0 Return value added to indicate success or failure.
  * @since 5.7.0 Functionality moved to _wp_cron() to which this becomes a wrapper.
- * @since 6.9.0 The _wp_cron() callback is moved from wp_loaded to the shutdown action; the function always returns void.
+ * @since 6.9.0 The _wp_cron() callback is moved from {@see 'wp_loaded'} to the {@see 'shutdown'} action; the function always returns void.
  */
 function wp_cron(): void {
 	if ( doing_action( 'shutdown' ) ) {

--- a/src/wp-includes/cron.php
+++ b/src/wp-includes/cron.php
@@ -987,7 +987,11 @@ function spawn_cron( $gmt_time = 0 ) {
  * @since 6.9.0 The _wp_cron() callback is moved from wp_loaded to the shutdown action; the function always returns void.
  */
 function wp_cron(): void {
-	add_action( 'shutdown', '_wp_cron' );
+	if ( doing_action( 'shutdown' ) ) {
+		_wp_cron();
+	} else {
+		add_action( 'shutdown', '_wp_cron' );
+	}
 }
 
 /**

--- a/tests/phpunit/tests/cron.php
+++ b/tests/phpunit/tests/cron.php
@@ -1339,7 +1339,7 @@ class Tests_Cron extends WP_UnitTestCase {
 	public function test_wp_cron_before_shutdown() {
 		remove_all_actions( 'shutdown' );
 		wp_cron();
-		$this->assertSame( 10, has_action( 'shutdown', '_wp_cron' ) );
+		$this->assertSame( 10, has_action( 'shutdown', '_wp_cron' ), 'Expected _wp_cron() to be scheduled for shutdown.' );
 	}
 
 	/**
@@ -1351,6 +1351,6 @@ class Tests_Cron extends WP_UnitTestCase {
 		remove_all_actions( 'shutdown' );
 		add_action( 'shutdown', 'wp_cron' );
 		do_action( 'shutdown' );
-		$this->assertFalse( has_action( 'shutdown', '_wp_cron' ), 'Expected wp_cron() to not add _wp_cron() to rub at shutdown.' );
+		$this->assertFalse( has_action( 'shutdown', '_wp_cron' ), 'Expected wp_cron() to not add _wp_cron() to run at shutdown.' );
 	}
 }

--- a/tests/phpunit/tests/cron.php
+++ b/tests/phpunit/tests/cron.php
@@ -1336,9 +1336,21 @@ class Tests_Cron extends WP_UnitTestCase {
 	 *
 	 * @covers ::wp_cron
 	 */
-	public function test_wp_cron() {
+	public function test_wp_cron_before_shutdown() {
 		remove_all_actions( 'shutdown' );
 		wp_cron();
 		$this->assertSame( 10, has_action( 'shutdown', '_wp_cron' ) );
+	}
+
+	/**
+	 * @ticket 63858
+	 *
+	 * @covers ::wp_cron
+	 */
+	public function test_wp_cron_already_at_shutdown() {
+		remove_all_actions( 'shutdown' );
+		add_action( 'shutdown', 'wp_cron' );
+		do_action( 'shutdown' );
+		$this->assertFalse( has_action( 'shutdown', '_wp_cron' ), 'Expected wp_cron() to not add _wp_cron() to rub at shutdown.' );
 	}
 }

--- a/tests/phpunit/tests/cron.php
+++ b/tests/phpunit/tests/cron.php
@@ -1330,4 +1330,15 @@ class Tests_Cron extends WP_UnitTestCase {
 		$this->assertWPError( $unscheduled );
 		$this->assertSame( 'could_not_set', $unscheduled->get_error_code() );
 	}
+
+	/**
+	 * @ticket 63858
+	 *
+	 * @covers ::wp_cron
+	 */
+	public function test_wp_cron() {
+		remove_all_actions( 'shutdown' );
+		wp_cron();
+		$this->assertSame( 10, has_action( 'shutdown', '_wp_cron' ) );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63858

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
