### PR TITLE
`clean_taxonomy_cache()` Regenerate hierarchy only when needed

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -3732,8 +3732,10 @@ function clean_taxonomy_cache( $taxonomy ) {
 	wp_cache_set_terms_last_changed();
 
 	// Regenerate cached hierarchy.
-	delete_option( "{$taxonomy}_children" );
-	_get_term_hierarchy( $taxonomy );
+	if ( is_taxonomy_hierarchical( $taxonomy ) ) {
+		delete_option( "{$taxonomy}_children" );
+		_get_term_hierarchy( $taxonomy );
+	}
 
 	/**
 	 * Fires after a taxonomy's caches have been cleaned.

--- a/tests/phpunit/tests/taxonomy/cleanTaxonomyCache.php
+++ b/tests/phpunit/tests/taxonomy/cleanTaxonomyCache.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @group taxonomy
+ *
+ * @covers ::clean_taxonomy_cache
+ */
+class Tests_Taxonomy_CleanTaxonomyCache extends WP_UnitTestCase {
+	/**
+	 * Ensure clearing the cache of a non-hierarchical taxonomy doesn't attempt to delete the hierarchy cache.
+	 *
+	 * @ticket 64090
+	 */
+	public function test_hierarchy_cache_not_cleared_for_non_hierarchical_taxonomy() {
+		// Prime the tag and category caches by inserting terms.
+		wp_insert_term( 'foo', 'post_tag' );
+		wp_insert_term( 'foo', 'category' );
+
+		/*
+		 * Determine if delete_option( "{$taxonomy}_children" ) is called.
+		 *
+		 * None of the actions in delete_option() or _get_term_hierarchy() fire for
+		 * non-hierarchical taxonomies, so the query filter needs to be used to determine
+		 * if an attempt to delete the option was made.
+		 */
+		$delete_post_tag_children_called = false;
+		add_filter(
+			'query',
+			static function ( $query ) use ( &$delete_post_tag_children_called ) {
+				global $wpdb;
+				if ( "SELECT autoload FROM $wpdb->options WHERE option_name = 'post_tag_children'" === $query ) {
+					$delete_post_tag_children_called = true;
+				}
+				return $query;
+			}
+		);
+
+		$delete_category_children_called = false;
+		add_filter(
+			'query',
+			static function ( $query ) use ( &$delete_category_children_called ) {
+				global $wpdb;
+				if ( "SELECT autoload FROM $wpdb->options WHERE option_name = 'category_children'" === $query ) {
+					$delete_category_children_called = true;
+				}
+				return $query;
+			}
+		);
+
+		// Clear the tag cache and category cache.
+		clean_taxonomy_cache( 'post_tag' );
+		clean_taxonomy_cache( 'category' );
+
+		$this->assertTrue( $delete_category_children_called, 'An attempt to clear the category_children option should be made.' );
+		$this->assertFalse( $delete_post_tag_children_called, 'An attempt to clear the post_tag_children option should not be made.' );
+	}
+}

--- a/tests/phpunit/tests/taxonomy/cleanTaxonomyCache.php
+++ b/tests/phpunit/tests/taxonomy/cleanTaxonomyCache.php
@@ -12,9 +12,8 @@ class Tests_Taxonomy_CleanTaxonomyCache extends WP_UnitTestCase {
 	 * @ticket 64090
 	 */
 	public function test_hierarchy_cache_not_cleared_for_non_hierarchical_taxonomy() {
-		// Prime the tag and category caches by inserting terms.
+		// Prime the tag cache by inserting terms.
 		wp_insert_term( 'foo', 'post_tag' );
-		wp_insert_term( 'foo', 'category' );
 
 		/*
 		 * Determine if delete_option( "{$taxonomy}_children" ) is called.
@@ -35,6 +34,27 @@ class Tests_Taxonomy_CleanTaxonomyCache extends WP_UnitTestCase {
 			}
 		);
 
+		clean_taxonomy_cache( 'post_tag' );
+
+		$this->assertFalse( $delete_post_tag_children_called, 'An attempt to clear the post_tag_children option should not be made.' );
+	}
+
+	/**
+	 * Ensure clearing the cache of a hierarchical taxonomy does attempt to delete the hierarchy cache.
+	 *
+	 * @ticket 64090
+	 */
+	public function test_hierarchy_cache_cleared_for_hierarchical_taxonomy() {
+		// Prime the category cache by inserting terms.
+		wp_insert_term( 'foo', 'category' );
+
+		/*
+		 * Determine if delete_option( "{$taxonomy}_children" ) is called.
+		 *
+		 * None of the actions in delete_option() or _get_term_hierarchy() fire for
+		 * non-hierarchical taxonomies, so the query filter needs to be used to determine
+		 * if an attempt to delete the option was made.
+		 */
 		$delete_category_children_called = false;
 		add_filter(
 			'query',
@@ -47,11 +67,8 @@ class Tests_Taxonomy_CleanTaxonomyCache extends WP_UnitTestCase {
 			}
 		);
 
-		// Clear the tag cache and category cache.
-		clean_taxonomy_cache( 'post_tag' );
 		clean_taxonomy_cache( 'category' );
 
 		$this->assertTrue( $delete_category_children_called, 'An attempt to clear the category_children option should be made.' );
-		$this->assertFalse( $delete_post_tag_children_called, 'An attempt to clear the post_tag_children option should not be made.' );
 	}
 }


### PR DESCRIPTION
Removes a useless DB query (made by `delete_option()`) for non-hierarchical taxonomies when cleaning the taxonomy cache.

Trac ticket: https://core.trac.wordpress.org/ticket/64090

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
