### PR TITLE
Add load_on_client_navigation to wp_register_script_module

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -181,7 +181,8 @@ function register_block_script_module_id( $metadata, $field_name, $index = 0 ) {
 		( isset( $metadata['supports']['interactivity'] ) && true === $metadata['supports']['interactivity'] ) ||
 		( isset( $metadata['supports']['interactivity']['interactive'] ) && true === $metadata['supports']['interactivity']['interactive'] )
 	) {
-		$args['fetchpriority'] = 'low';
+		$args['fetchpriority']             = 'low';
+		$args['load_on_client_navigation'] = true;
 	}
 
 	wp_register_script_module(

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -76,6 +76,7 @@ class WP_Script_Modules {
 	 *     Optional. An array of additional args. Default empty array.
 	 *
 	 *     @type 'auto'|'low'|'high' $fetchpriority Fetch priority. Default 'auto'. Optional.
+	 *     @type bool               $load_on_client_navigation Whether the script module should be loaded on client navigation. Default false. Optional.
 	 * }
 	 */
 	public function register( string $id, string $src, array $deps = array(), $version = false, array $args = array() ) {
@@ -120,11 +121,12 @@ class WP_Script_Modules {
 			}
 
 			$this->registered[ $id ] = array(
-				'src'           => $src,
-				'version'       => $version,
-				'enqueue'       => isset( $this->enqueued_before_registered[ $id ] ),
-				'dependencies'  => $dependencies,
-				'fetchpriority' => $fetchpriority,
+				'src'                       => $src,
+				'version'                   => $version,
+				'enqueue'                   => isset( $this->enqueued_before_registered[ $id ] ),
+				'dependencies'              => $dependencies,
+				'fetchpriority'             => $fetchpriority,
+				'load_on_client_navigation' => isset( $args['load_on_client_navigation'] ) ? $args['load_on_client_navigation'] : false,
 			);
 		}
 	}
@@ -210,6 +212,7 @@ class WP_Script_Modules {
 	 *     Optional. An array of additional args. Default empty array.
 	 *
 	 *     @type 'auto'|'low'|'high' $fetchpriority Fetch priority. Default 'auto'. Optional.
+	 *     @type bool $load_on_client_navigation Whether the script module should be loaded on client navigation. Default false. Optional.
 	 * }
 	 */
 	public function enqueue( string $id, string $src = '', array $deps = array(), $version = false, array $args = array() ) {
@@ -291,6 +294,9 @@ class WP_Script_Modules {
 			if ( 'auto' !== $script_module['fetchpriority'] ) {
 				$args['fetchpriority'] = $script_module['fetchpriority'];
 			}
+			if ( isset( $script_module['load_on_client_navigation'] ) && true === $script_module['load_on_client_navigation'] ) {
+				$args['data-wp-router-options'] = wp_json_encode( array( 'loadOnClientNavigation' => true ) );
+			}
 			wp_print_script_tag( $args );
 		}
 	}
@@ -307,11 +313,18 @@ class WP_Script_Modules {
 		foreach ( $this->get_dependencies( array_keys( $this->get_marked_for_enqueue() ), array( 'static' ) ) as $id => $script_module ) {
 			// Don't preload if it's marked for enqueue.
 			if ( true !== $script_module['enqueue'] ) {
+				$attrs = '';
+				if ( 'auto' !== $script_module['fetchpriority'] ) {
+					$attrs .= sprintf( ' fetchpriority="%s"', esc_attr( $script_module['fetchpriority'] ) );
+				}
+				if ( isset( $script_module['load_on_client_navigation'] ) && true === $script_module['load_on_client_navigation'] ) {
+					$attrs .= sprintf( ' data-wp-router-options="%s"', esc_attr( wp_json_encode( array( 'loadOnClientNavigation' => true ) ) ) );
+				}
 				echo sprintf(
 					'<link rel="modulepreload" href="%s" id="%s"%s>',
 					esc_url( $this->get_src( $id ) ),
 					esc_attr( $id . '-js-modulepreload' ),
-					'auto' !== $script_module['fetchpriority'] ? sprintf( ' fetchpriority="%s"', esc_attr( $script_module['fetchpriority'] ) ) : ''
+					$attrs
 				);
 			}
 		}

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -296,7 +296,7 @@ class WP_Script_Modules {
 				$args['fetchpriority'] = $script_module['fetchpriority'];
 			}
 			if ( isset( $script_module['load_on_client_navigation'] ) && true === $script_module['load_on_client_navigation'] ) {
-				$args['data-wp-router-options'] = wp_json_encode( array( 'loadOnClientNavigation' => true ) );
+				$args['data-wp-router-options'] = '{ "loadOnClientNavigation": true }';
 			}
 			wp_print_script_tag( $args );
 		}

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -220,8 +220,9 @@ class WP_Script_Modules {
 	 * @param array             $args     {
 	 *     Optional. An array of additional args. Default empty array.
 	 *
-	 *     @type 'auto'|'low'|'high' $fetchpriority Fetch priority. Default 'auto'. Optional.
-	 *     @type bool $load_on_client_navigation Whether the script module should be loaded on client navigation. Default false. Optional.
+	 *     @type 'auto'|'low'|'high' $fetchpriority             Fetch priority. Default 'auto'. Optional.
+	 *     @type bool                $load_on_client_navigation Whether the script module should be loaded on client
+	 *                                                          navigation. Default false. Optional.
 	 * }
 	 */
 	public function enqueue( string $id, string $src = '', array $deps = array(), $version = false, array $args = array() ) {

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -313,18 +313,11 @@ class WP_Script_Modules {
 		foreach ( $this->get_dependencies( array_keys( $this->get_marked_for_enqueue() ), array( 'static' ) ) as $id => $script_module ) {
 			// Don't preload if it's marked for enqueue.
 			if ( true !== $script_module['enqueue'] ) {
-				$attrs = '';
-				if ( 'auto' !== $script_module['fetchpriority'] ) {
-					$attrs .= sprintf( ' fetchpriority="%s"', esc_attr( $script_module['fetchpriority'] ) );
-				}
-				if ( isset( $script_module['load_on_client_navigation'] ) && true === $script_module['load_on_client_navigation'] ) {
-					$attrs .= sprintf( ' data-wp-router-options="%s"', esc_attr( wp_json_encode( array( 'loadOnClientNavigation' => true ) ) ) );
-				}
 				echo sprintf(
 					'<link rel="modulepreload" href="%s" id="%s"%s>',
 					esc_url( $this->get_src( $id ) ),
 					esc_attr( $id . '-js-modulepreload' ),
-					$attrs
+					'auto' !== $script_module['fetchpriority'] ? sprintf( ' fetchpriority="%s"', esc_attr( $script_module['fetchpriority'] ) ) : ''
 				);
 			}
 		}

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -84,7 +84,7 @@ class WP_Script_Modules {
 	 * @param array             $args     {
 	 *     Optional. An array of additional args. Default empty array.
 	 *
-	 *     @type 'auto'|'low'|'high' $fetchpriority Fetch priority. Default 'auto'. Optional.
+	 *     @type 'auto'|'low'|'high' $fetchpriority             Fetch priority. Default 'auto'. Optional.
 	 *     @type bool                $load_on_client_navigation Whether the script module should be loaded on client
 	 *                                                          navigation. Default false. Optional.
 	 * }

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -76,7 +76,8 @@ class WP_Script_Modules {
 	 *     Optional. An array of additional args. Default empty array.
 	 *
 	 *     @type 'auto'|'low'|'high' $fetchpriority Fetch priority. Default 'auto'. Optional.
-	 *     @type bool               $load_on_client_navigation Whether the script module should be loaded on client navigation. Default false. Optional.
+	 *     @type bool                $load_on_client_navigation Whether the script module should be loaded on client
+	 *                                                          navigation. Default false. Optional.
 	 * }
 	 */
 	public function register( string $id, string $src, array $deps = array(), $version = false, array $args = array() ) {

--- a/src/wp-includes/script-modules.php
+++ b/src/wp-includes/script-modules.php
@@ -108,7 +108,7 @@ function wp_register_script_module( string $id, string $src, array $deps = array
  *     Optional. An array of additional args. Default empty array.
  *
  *     @type 'auto'|'low'|'high' $fetchpriority Fetch priority. Default 'auto'. Optional.
- *     @type bool $load_on_client_navigation Signal whether the script module should be loaded on client navigation. Optional
+ *     @type bool $load_on_client_navigation Whether the script module should be loaded on client navigation. Optional.
  * }
  */
 function wp_enqueue_script_module( string $id, string $src = '', array $deps = array(), $version = false, array $args = array() ) {

--- a/src/wp-includes/script-modules.php
+++ b/src/wp-includes/script-modules.php
@@ -65,6 +65,8 @@ function wp_script_modules(): WP_Script_Modules {
  *     Optional. An array of additional args. Default empty array.
  *
  *     @type 'auto'|'low'|'high' $fetchpriority Fetch priority. Default 'auto'. Optional.
+ *     @type bool               $load_on_client_navigation Whether the script module should be loaded on client
+ *                                                         navigation. Default false. Optional.
  * }
  */
 function wp_register_script_module( string $id, string $src, array $deps = array(), $version = false, array $args = array() ) {

--- a/src/wp-includes/script-modules.php
+++ b/src/wp-includes/script-modules.php
@@ -108,6 +108,7 @@ function wp_register_script_module( string $id, string $src, array $deps = array
  *     Optional. An array of additional args. Default empty array.
  *
  *     @type 'auto'|'low'|'high' $fetchpriority Fetch priority. Default 'auto'. Optional.
+ *     @type bool $load_on_client_navigation Signal whether the script module should be loaded on client navigation. Optional
  * }
  */
 function wp_enqueue_script_module( string $id, string $src = '', array $deps = array(), $version = false, array $args = array() ) {

--- a/src/wp-includes/script-modules.php
+++ b/src/wp-includes/script-modules.php
@@ -64,8 +64,8 @@ function wp_script_modules(): WP_Script_Modules {
  * @param array             $args    {
  *     Optional. An array of additional args. Default empty array.
  *
- *     @type 'auto'|'low'|'high' $fetchpriority Fetch priority. Default 'auto'. Optional.
- *     @type bool               $load_on_client_navigation Whether the script module should be loaded on client
+ *     @type 'auto'|'low'|'high' $fetchpriority             Fetch priority. Default 'auto'. Optional.
+ *     @type bool                $load_on_client_navigation Whether the script module should be loaded on client
  *                                                         navigation. Default false. Optional.
  * }
  */

--- a/src/wp-includes/script-modules.php
+++ b/src/wp-includes/script-modules.php
@@ -109,8 +109,9 @@ function wp_register_script_module( string $id, string $src, array $deps = array
  * @param array             $args    {
  *     Optional. An array of additional args. Default empty array.
  *
- *     @type 'auto'|'low'|'high' $fetchpriority Fetch priority. Default 'auto'. Optional.
- *     @type bool $load_on_client_navigation Whether the script module should be loaded on client navigation. Optional.
+ *     @type 'auto'|'low'|'high' $fetchpriority             Fetch priority. Default 'auto'. Optional.
+ *     @type bool                $load_on_client_navigation Whether the script module should be loaded on client
+ *                                                          navigation. Default false. Optional.
  * }
  */
 function wp_enqueue_script_module( string $id, string $src = '', array $deps = array(), $version = false, array $args = array() ) {

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -1512,4 +1512,87 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 
 		$this->assertNotFalse( register_block_type_from_metadata( $windows_like_path ) );
 	}
+
+	/**
+	 * Tests that load_on_client_navigation is set to true for blocks with interactivity support.
+	 *
+	 * @covers ::register_block_script_module_id
+	 */
+	public function test_register_block_script_module_id_with_interactivity_support() {
+		$metadata = array(
+			'file'             => DIR_TESTDATA . '/blocks/notice/block.json',
+			'name'             => 'tests/interactive-block',
+			'viewScriptModule' => 'file:./block.js',
+			'supports'         => array(
+				'interactivity' => true,
+			),
+		);
+
+		$result = register_block_script_module_id( $metadata, 'viewScriptModule' );
+
+		$this->assertSame( 'tests-interactive-block-view-script-module', $result );
+
+		// Enqueue and verify the script module has the data-wp-router-options attribute.
+		wp_enqueue_script_module( 'tests-interactive-block-view-script-module' );
+
+		$output = get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) );
+
+		$this->assertStringContainsString( 'data-wp-router-options=', $output );
+		$this->assertStringContainsString( '{"loadOnClientNavigation":true}', $output );
+	}
+
+	/**
+	 * Tests that load_on_client_navigation is set to true for blocks with interactive flag.
+	 *
+	 * @covers ::register_block_script_module_id
+	 */
+	public function test_register_block_script_module_id_with_interactive_flag() {
+		$metadata = array(
+			'file'             => DIR_TESTDATA . '/blocks/notice/block.json',
+			'name'             => 'tests/interactive-block-2',
+			'viewScriptModule' => 'file:./block.js',
+			'supports'         => array(
+				'interactivity' => array(
+					'interactive' => true,
+				),
+			),
+		);
+
+		$result = register_block_script_module_id( $metadata, 'viewScriptModule' );
+
+		$this->assertSame( 'tests-interactive-block-2-view-script-module', $result );
+
+		// Enqueue and verify the script module has the data-wp-router-options attribute.
+		wp_enqueue_script_module( 'tests-interactive-block-2-view-script-module' );
+
+		$output = get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) );
+
+		$this->assertStringContainsString( 'data-wp-router-options=', $output );
+		$this->assertStringContainsString( '{"loadOnClientNavigation":true}', $output );
+	}
+
+	/**
+	 * Tests that load_on_client_navigation is not set for blocks without interactivity support.
+	 *
+	 * @covers ::register_block_script_module_id
+	 */
+	public function test_register_block_script_module_id_without_interactivity_support() {
+		$metadata = array(
+			'file'             => DIR_TESTDATA . '/blocks/notice/block.json',
+			'name'             => 'tests/non-interactive-block',
+			'viewScriptModule' => 'file:./block.js',
+		);
+
+		$result = register_block_script_module_id( $metadata, 'viewScriptModule' );
+
+		$this->assertSame( 'tests-non-interactive-block-view-script-module', $result );
+
+		// Enqueue and verify the script module does not have the data-wp-router-options attribute.
+		wp_enqueue_script_module( 'tests-non-interactive-block-view-script-module' );
+
+		$output = get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) );
+
+		$this->assertStringContainsString( 'tests-non-interactive-block-view-script-module', $output );
+		$this->assertStringNotContainsString( 'data-wp-router-options=', $output );
+	}
 }

--- a/tests/phpunit/tests/blocks/register.php
+++ b/tests/phpunit/tests/blocks/register.php
@@ -1519,6 +1519,9 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 * @covers ::register_block_script_module_id
 	 */
 	public function test_register_block_script_module_id_with_interactivity_support() {
+		global $wp_script_modules;
+		$wp_script_modules = null;
+
 		$metadata = array(
 			'file'             => DIR_TESTDATA . '/blocks/notice/block.json',
 			'name'             => 'tests/interactive-block',
@@ -1538,7 +1541,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		$output = get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) );
 
 		$this->assertStringContainsString( 'data-wp-router-options=', $output );
-		$this->assertStringContainsString( '{"loadOnClientNavigation":true}', $output );
+		$this->assertStringContainsString( 'loadOnClientNavigation', $output );
 	}
 
 	/**
@@ -1547,6 +1550,9 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 * @covers ::register_block_script_module_id
 	 */
 	public function test_register_block_script_module_id_with_interactive_flag() {
+		global $wp_script_modules;
+		$wp_script_modules = null;
+
 		$metadata = array(
 			'file'             => DIR_TESTDATA . '/blocks/notice/block.json',
 			'name'             => 'tests/interactive-block-2',
@@ -1568,7 +1574,7 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 		$output = get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) );
 
 		$this->assertStringContainsString( 'data-wp-router-options=', $output );
-		$this->assertStringContainsString( '{"loadOnClientNavigation":true}', $output );
+		$this->assertStringContainsString( 'loadOnClientNavigation', $output );
 	}
 
 	/**
@@ -1577,6 +1583,9 @@ class Tests_Blocks_Register extends WP_UnitTestCase {
 	 * @covers ::register_block_script_module_id
 	 */
 	public function test_register_block_script_module_id_without_interactivity_support() {
+		global $wp_script_modules;
+		$wp_script_modules = null;
+
 		$metadata = array(
 			'file'             => DIR_TESTDATA . '/blocks/notice/block.json',
 			'name'             => 'tests/non-interactive-block',

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -116,14 +116,10 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 
 			$id              = preg_replace( '/-js-modulepreload$/', '', $p->get_attribute( 'id' ) );
 			$fetchpriority   = $p->get_attribute( 'fetchpriority' );
-			$router_options  = $p->get_attribute( 'data-wp-router-options' );
 			$preloads[ $id ] = array(
 				'url'           => $p->get_attribute( 'href' ),
 				'fetchpriority' => is_string( $fetchpriority ) ? $fetchpriority : 'auto',
 			);
-			if ( is_string( $router_options ) ) {
-				$preloads[ $id ]['router_options'] = json_decode( $router_options, true );
-			}
 		}
 
 		return $preloads;

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -1741,7 +1741,7 @@ HTML;
 	public function test_load_on_client_navigation_defaults_to_false_for_registered_modules() {
 		$this->script_modules->register( 'foo', '/foo.js' );
 		$registered_modules = $this->get_registered_script_modules( $this->script_modules );
-		$this->assertSame( false, $registered_modules['foo']['load_on_client_navigation'] );
+		$this->assertFalse( $registered_modules['foo']['load_on_client_navigation'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -67,10 +67,14 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 
 			$id             = preg_replace( '/-js-module$/', '', (string) $p->get_attribute( 'id' ) );
 			$fetchpriority  = $p->get_attribute( 'fetchpriority' );
+			$router_options = $p->get_attribute( 'data-wp-router-options' );
 			$modules[ $id ] = array(
 				'url'           => $p->get_attribute( 'src' ),
 				'fetchpriority' => is_string( $fetchpriority ) ? $fetchpriority : 'auto',
 			);
+			if ( is_string( $router_options ) ) {
+				$modules[ $id ]['router_options'] = json_decode( $router_options, true );
+			}
 		}
 
 		return $modules;
@@ -112,10 +116,14 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 
 			$id              = preg_replace( '/-js-modulepreload$/', '', $p->get_attribute( 'id' ) );
 			$fetchpriority   = $p->get_attribute( 'fetchpriority' );
+			$router_options  = $p->get_attribute( 'data-wp-router-options' );
 			$preloads[ $id ] = array(
 				'url'           => $p->get_attribute( 'href' ),
 				'fetchpriority' => is_string( $fetchpriority ) ? $fetchpriority : 'auto',
 			);
+			if ( is_string( $router_options ) ) {
+				$preloads[ $id ]['router_options'] = json_decode( $router_options, true );
+			}
 		}
 
 		return $preloads;
@@ -1370,5 +1378,70 @@ HTML;
 			'number 1' => array( 1 ),
 			'string'   => array( 'string' ),
 		);
+	}
+
+	/**
+	 * Tests that load_on_client_navigation attribute is handled correctly for enqueued script modules.
+	 *
+	 * @covers WP_Script_Modules::register
+	 * @covers WP_Script_Modules::enqueue
+	 * @covers WP_Script_Modules::print_enqueued_script_modules
+	 */
+	public function test_load_on_client_navigation_for_enqueued_modules() {
+		// Default (no load_on_client_navigation set).
+		$this->script_modules->register( 'default', '/default.js' );
+		$this->script_modules->enqueue( 'default' );
+
+		// With load_on_client_navigation set to true.
+		$this->script_modules->register( 'with-true', '/with-true.js', array(), false, array( 'load_on_client_navigation' => true ) );
+		$this->script_modules->enqueue( 'with-true' );
+
+		// With load_on_client_navigation set to false.
+		$this->script_modules->register( 'with-false', '/with-false.js', array(), false, array( 'load_on_client_navigation' => false ) );
+		$this->script_modules->enqueue( 'with-false' );
+
+		$enqueued_script_modules = $this->get_enqueued_script_modules();
+
+		$this->assertCount( 3, $enqueued_script_modules );
+
+		// Default should not have router_options attribute.
+		$this->assertArrayNotHasKey( 'router_options', $enqueued_script_modules['default'] );
+
+		// True should have router_options attribute with loadOnClientNavigation set to true.
+		$this->assertArrayHasKey( 'router_options', $enqueued_script_modules['with-true'] );
+		$this->assertSame( array( 'loadOnClientNavigation' => true ), $enqueued_script_modules['with-true']['router_options'] );
+
+		// False should not have router_options attribute.
+		$this->assertArrayNotHasKey( 'router_options', $enqueued_script_modules['with-false'] );
+	}
+
+	/**
+	 * Tests that load_on_client_navigation attribute is handled correctly for preloaded dependencies.
+	 *
+	 * @covers WP_Script_Modules::register
+	 * @covers WP_Script_Modules::enqueue
+	 * @covers WP_Script_Modules::print_script_module_preloads
+	 */
+	public function test_load_on_client_navigation_for_preloaded_dependencies() {
+		// Dependency with load_on_client_navigation set to true.
+		$this->script_modules->register( 'dep-with-true', '/dep-with-true.js', array(), false, array( 'load_on_client_navigation' => true ) );
+
+		// Dependency with load_on_client_navigation set to false.
+		$this->script_modules->register( 'dep-with-false', '/dep-with-false.js', array(), false, array( 'load_on_client_navigation' => false ) );
+
+		// Enqueue a module with both dependencies.
+		$this->script_modules->register( 'foo', '/foo.js', array( 'dep-with-true', 'dep-with-false' ) );
+		$this->script_modules->enqueue( 'foo' );
+
+		$preloaded_script_modules = $this->get_preloaded_script_modules();
+
+		$this->assertCount( 2, $preloaded_script_modules );
+
+		// Dependency with true should have router_options attribute.
+		$this->assertArrayHasKey( 'router_options', $preloaded_script_modules['dep-with-true'] );
+		$this->assertSame( array( 'loadOnClientNavigation' => true ), $preloaded_script_modules['dep-with-true']['router_options'] );
+
+		// Dependency with false should not have router_options attribute.
+		$this->assertArrayNotHasKey( 'router_options', $preloaded_script_modules['dep-with-false'] );
 	}
 }

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -73,7 +73,7 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 				'fetchpriority' => is_string( $fetchpriority ) ? $fetchpriority : 'auto',
 			);
 			if ( is_string( $router_options ) ) {
-				$modules[ $id ]['router_options'] = json_decode( $router_options, true );
+				$modules[ $id ]['data-wp-router-options'] = json_decode( $router_options, true );
 			}
 		}
 
@@ -1400,14 +1400,14 @@ HTML;
 
 		$this->assertCount( 3, $enqueued_script_modules );
 
-		// Default should not have router_options attribute.
-		$this->assertArrayNotHasKey( 'router_options', $enqueued_script_modules['default'] );
+		// Default should not have data-wp-router-options attribute.
+		$this->assertArrayNotHasKey( 'data-wp-router-options', $enqueued_script_modules['default'] );
 
-		// True should have router_options attribute with loadOnClientNavigation set to true.
-		$this->assertArrayHasKey( 'router_options', $enqueued_script_modules['with-true'] );
-		$this->assertSame( array( 'loadOnClientNavigation' => true ), $enqueued_script_modules['with-true']['router_options'] );
+		// True should have data-wp-router-options attribute with loadOnClientNavigation set to true.
+		$this->assertArrayHasKey( 'data-wp-router-options', $enqueued_script_modules['with-true'] );
+		$this->assertSame( array( 'loadOnClientNavigation' => true ), $enqueued_script_modules['with-true']['data-wp-router-options'] );
 
-		// False should not have router_options attribute.
-		$this->assertArrayNotHasKey( 'router_options', $enqueued_script_modules['with-false'] );
+		// False should not have data-wp-router-options attribute.
+		$this->assertArrayNotHasKey( 'data-wp-router-options', $enqueued_script_modules['with-false'] );
 	}
 }

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -1414,34 +1414,4 @@ HTML;
 		// False should not have router_options attribute.
 		$this->assertArrayNotHasKey( 'router_options', $enqueued_script_modules['with-false'] );
 	}
-
-	/**
-	 * Tests that load_on_client_navigation attribute is handled correctly for preloaded dependencies.
-	 *
-	 * @covers WP_Script_Modules::register
-	 * @covers WP_Script_Modules::enqueue
-	 * @covers WP_Script_Modules::print_script_module_preloads
-	 */
-	public function test_load_on_client_navigation_for_preloaded_dependencies() {
-		// Dependency with load_on_client_navigation set to true.
-		$this->script_modules->register( 'dep-with-true', '/dep-with-true.js', array(), false, array( 'load_on_client_navigation' => true ) );
-
-		// Dependency with load_on_client_navigation set to false.
-		$this->script_modules->register( 'dep-with-false', '/dep-with-false.js', array(), false, array( 'load_on_client_navigation' => false ) );
-
-		// Enqueue a module with both dependencies.
-		$this->script_modules->register( 'foo', '/foo.js', array( 'dep-with-true', 'dep-with-false' ) );
-		$this->script_modules->enqueue( 'foo' );
-
-		$preloaded_script_modules = $this->get_preloaded_script_modules();
-
-		$this->assertCount( 2, $preloaded_script_modules );
-
-		// Dependency with true should have router_options attribute.
-		$this->assertArrayHasKey( 'router_options', $preloaded_script_modules['dep-with-true'] );
-		$this->assertSame( array( 'loadOnClientNavigation' => true ), $preloaded_script_modules['dep-with-true']['router_options'] );
-
-		// Dependency with false should not have router_options attribute.
-		$this->assertArrayNotHasKey( 'router_options', $preloaded_script_modules['dep-with-false'] );
-	}
 }

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -1377,37 +1377,87 @@ HTML;
 	}
 
 	/**
-	 * Tests that load_on_client_navigation attribute is handled correctly for enqueued script modules.
+	 * Tests that load_on_client_navigation defaults to false when registering a script module.
+	 *
+	 * @covers WP_Script_Modules::register
+	 */
+	public function test_load_on_client_navigation_defaults_to_false_for_registered_modules() {
+		$this->script_modules->register( 'foo', '/foo.js' );
+		$registered_modules = $this->get_registered_script_modules( $this->script_modules );
+		$this->assertSame( false, $registered_modules['foo']['load_on_client_navigation'] );
+	}
+
+	/**
+	 * Tests that load_on_client_navigation can be set to true when registering a script module.
+	 *
+	 * @covers WP_Script_Modules::register
+	 */
+	public function test_load_on_client_navigation_true_for_registered_modules() {
+		$this->script_modules->register( 'foo', '/foo.js', array(), false, array( 'load_on_client_navigation' => true ) );
+		$registered_modules = $this->get_registered_script_modules( $this->script_modules );
+		$this->assertSame( true, $registered_modules['foo']['load_on_client_navigation'] );
+	}
+
+	/**
+	 * Tests that load_on_client_navigation can be set to false when registering a script module.
+	 *
+	 * @covers WP_Script_Modules::register
+	 */
+	public function test_load_on_client_navigation_false_for_registered_modules() {
+		$this->script_modules->register( 'foo', '/foo.js', array(), false, array( 'load_on_client_navigation' => false ) );
+		$registered_modules = $this->get_registered_script_modules( $this->script_modules );
+		$this->assertSame( false, $registered_modules['foo']['load_on_client_navigation'] );
+	}
+
+	/**
+	 * Tests that load_on_client_navigation attribute is not added by default for enqueued script modules.
 	 *
 	 * @covers WP_Script_Modules::register
 	 * @covers WP_Script_Modules::enqueue
 	 * @covers WP_Script_Modules::print_enqueued_script_modules
 	 */
-	public function test_load_on_client_navigation_for_enqueued_modules() {
-		// Default (no load_on_client_navigation set).
-		$this->script_modules->register( 'default', '/default.js' );
-		$this->script_modules->enqueue( 'default' );
-
-		// With load_on_client_navigation set to true.
-		$this->script_modules->register( 'with-true', '/with-true.js', array(), false, array( 'load_on_client_navigation' => true ) );
-		$this->script_modules->enqueue( 'with-true' );
-
-		// With load_on_client_navigation set to false.
-		$this->script_modules->register( 'with-false', '/with-false.js', array(), false, array( 'load_on_client_navigation' => false ) );
-		$this->script_modules->enqueue( 'with-false' );
+	public function test_load_on_client_navigation_default_for_enqueued_modules() {
+		$this->script_modules->register( 'foo', '/foo.js' );
+		$this->script_modules->enqueue( 'foo' );
 
 		$enqueued_script_modules = $this->get_enqueued_script_modules();
 
-		$this->assertCount( 3, $enqueued_script_modules );
+		$this->assertCount( 1, $enqueued_script_modules );
+		$this->assertArrayNotHasKey( 'data-wp-router-options', $enqueued_script_modules['foo'] );
+	}
 
-		// Default should not have data-wp-router-options attribute.
-		$this->assertArrayNotHasKey( 'data-wp-router-options', $enqueued_script_modules['default'] );
+	/**
+	 * Tests that load_on_client_navigation attribute is added when set to true for enqueued script modules.
+	 *
+	 * @covers WP_Script_Modules::register
+	 * @covers WP_Script_Modules::enqueue
+	 * @covers WP_Script_Modules::print_enqueued_script_modules
+	 */
+	public function test_load_on_client_navigation_true_for_enqueued_modules() {
+		$this->script_modules->register( 'foo', '/foo.js', array(), false, array( 'load_on_client_navigation' => true ) );
+		$this->script_modules->enqueue( 'foo' );
 
-		// True should have data-wp-router-options attribute with loadOnClientNavigation set to true.
-		$this->assertArrayHasKey( 'data-wp-router-options', $enqueued_script_modules['with-true'] );
-		$this->assertSame( array( 'loadOnClientNavigation' => true ), $enqueued_script_modules['with-true']['data-wp-router-options'] );
+		$enqueued_script_modules = $this->get_enqueued_script_modules();
 
-		// False should not have data-wp-router-options attribute.
-		$this->assertArrayNotHasKey( 'data-wp-router-options', $enqueued_script_modules['with-false'] );
+		$this->assertCount( 1, $enqueued_script_modules );
+		$this->assertArrayHasKey( 'data-wp-router-options', $enqueued_script_modules['foo'] );
+		$this->assertSame( array( 'loadOnClientNavigation' => true ), $enqueued_script_modules['foo']['data-wp-router-options'] );
+	}
+
+	/**
+	 * Tests that load_on_client_navigation attribute is not added when set to false for enqueued script modules.
+	 *
+	 * @covers WP_Script_Modules::register
+	 * @covers WP_Script_Modules::enqueue
+	 * @covers WP_Script_Modules::print_enqueued_script_modules
+	 */
+	public function test_load_on_client_navigation_false_for_enqueued_modules() {
+		$this->script_modules->register( 'foo', '/foo.js', array(), false, array( 'load_on_client_navigation' => false ) );
+		$this->script_modules->enqueue( 'foo' );
+
+		$enqueued_script_modules = $this->get_enqueued_script_modules();
+
+		$this->assertCount( 1, $enqueued_script_modules );
+		$this->assertArrayNotHasKey( 'data-wp-router-options', $enqueued_script_modules['foo'] );
 	}
 }


### PR DESCRIPTION
As stated in https://github.com/WordPress/gutenberg/issues/70873 

"The current iAPI Router implementation simply looks for all JavaScript modules in the HTML and imports them. However, some of them may not be necessary, potentially executing code that is neither related to interactive blocks nor compatible with the Interactivity API."

To solve this, we add an optional (default disabled) property to the `$args` of `wp_register_script_module`. When enabled and combined with interactivity API's new selective loading in [this PR](https://github.com/WordPress/gutenberg/pull/72340), the interactivity API will only preload script modules that have the data attribute `data-wp-router-options` with value `{ "loadOnClientNavigation": true }`. Other script modules will not be preloaded.

Fixes https://core.trac.wordpress.org/ticket/64097

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
