### PR TITLE
Add Theme File Editor notice when editing a stylesheet for a block theme and warn when there is a minified version available

### DIFF
--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -240,6 +240,18 @@ if ( preg_match( '/\.css$/', $file ) ) {
 			)
 		);
 	}
+	if ( file_exists( preg_replace( '/\.css$/', '.min.css', $file ) ) ) {
+		$message = '<p><strong>' . __( 'There is a minified version of this stylesheet.' ) . '</strong></p><p>' . sprintf(
+			/* translators: %s: Link to Custom CSS section in the Customizer. */
+			__( 'It is likely that this unminified stylesheet will not be served to visitors.' )
+		) . '</p>';
+		wp_admin_notice(
+			$message,
+			array(
+				'type' => 'warning',
+			)
+		);
+	}
 }
 ?>
 

--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -212,19 +212,34 @@ if ( isset( $_GET['a'] ) ) {
 	);
 }
 
-if ( preg_match( '/\.css$/', $file ) && ! wp_is_block_theme() && current_user_can( 'customize' ) ) {
-	$message = '<p><strong>' . __( 'Did you know?' ) . '</strong></p><p>' . sprintf(
-		/* translators: %s: Link to Custom CSS section in the Customizer. */
-		__( 'There is no need to change your CSS here &mdash; you can edit and live preview CSS changes in the <a href="%s">built-in CSS editor</a>.' ),
-		esc_url( add_query_arg( 'autofocus[section]', 'custom_css', admin_url( 'customize.php' ) ) )
-	) . '</p>';
-	wp_admin_notice(
-		$message,
-		array(
-			'type' => 'info',
-			'id'   => 'message',
-		)
-	);
+if ( preg_match( '/\.css$/', $file ) ) {
+	if ( ! wp_is_block_theme() && current_user_can( 'customize' ) ) {
+		$message = '<p><strong>' . __( 'Did you know?' ) . '</strong></p><p>' . sprintf(
+			/* translators: %s: Link to Custom CSS section in the Customizer. */
+			__( 'There is no need to change your CSS here &mdash; you can edit and live preview CSS changes in the <a href="%s">built-in CSS editor</a>.' ),
+			esc_url( add_query_arg( 'autofocus[section]', 'custom_css', admin_url( 'customize.php' ) ) )
+		) . '</p>';
+		wp_admin_notice(
+			$message,
+			array(
+				'type' => 'info',
+				'id'   => 'message',
+			)
+		);
+	} elseif ( wp_is_block_theme() && current_user_can( 'edit_theme_options' ) ) {
+		$message = '<p><strong>' . __( 'Did you know?' ) . '</strong></p><p>' . sprintf(
+			/* translators: %s: Link to Additional CSS section in the Site Editor. */
+			__( 'There is no need to change your CSS here &mdash; you can edit and live preview CSS changes in the <a href="%s">built-in CSS editor</a>.' ),
+			esc_url( admin_url( 'site-editor.php?p=%2Fstyles&section=%2Fcss' ) )
+		) . '</p>';
+		wp_admin_notice(
+			$message,
+			array(
+				'type' => 'info',
+				'id'   => 'message',
+			)
+		);
+	}
 }
 ?>
 

--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -242,7 +242,6 @@ if ( preg_match( '/\.css$/', $file ) ) {
 	}
 	if ( file_exists( preg_replace( '/\.css$/', '.min.css', $file ) ) ) {
 		$message = '<p><strong>' . __( 'There is a minified version of this stylesheet.' ) . '</strong></p><p>' . sprintf(
-			/* translators: %s: Link to Custom CSS section in the Customizer. */
 			__( 'It is likely that this unminified stylesheet will not be served to visitors.' )
 		) . '</p>';
 		wp_admin_notice(

--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -247,6 +247,7 @@ if ( preg_match( '/\.css$/', $file ) ) {
 			$message,
 			array(
 				'type' => 'warning',
+				'id'   => 'wp-css-min-warning',
 			)
 		);
 	}

--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -228,7 +228,7 @@ if ( preg_match( '/\.css$/', $file ) ) {
 		);
 	} elseif ( wp_is_block_theme() && current_user_can( 'edit_theme_options' ) ) {
 		$message = '<p><strong>' . __( 'Did you know?' ) . '</strong></p><p>' . sprintf(
-			/* translators: %s: Link to Additional CSS section in the Site Editor. */
+			/* translators: %s: Link to add custom CSS section in either the Customizer (classic themes) or Site Editor (block themes). */
 			__( 'There is no need to change your CSS here &mdash; you can edit and live preview CSS changes in the <a href="%s">built-in CSS editor</a>.' ),
 			esc_url( admin_url( 'site-editor.php?p=%2Fstyles&section=%2Fcss' ) )
 		) . '</p>';

--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -241,9 +241,8 @@ if ( preg_match( '/\.css$/', $file ) ) {
 		);
 	}
 	if ( file_exists( preg_replace( '/\.css$/', '.min.css', $file ) ) ) {
-		$message = '<p><strong>' . __( 'There is a minified version of this stylesheet.' ) . '</strong></p><p>' . sprintf(
-			__( 'It is likely that this unminified stylesheet will not be served to visitors.' )
-		) . '</p>';
+		$message = '<p><strong>' . __( 'There is a minified version of this stylesheet.' ) . '</strong></p><p>' .
+			__( 'It is likely that this unminified stylesheet will not be served to visitors.' ) . '</p>';
 		wp_admin_notice(
 			$message,
 			array(

--- a/src/wp-admin/theme-editor.php
+++ b/src/wp-admin/theme-editor.php
@@ -215,7 +215,7 @@ if ( isset( $_GET['a'] ) ) {
 if ( preg_match( '/\.css$/', $file ) ) {
 	if ( ! wp_is_block_theme() && current_user_can( 'customize' ) ) {
 		$message = '<p><strong>' . __( 'Did you know?' ) . '</strong></p><p>' . sprintf(
-			/* translators: %s: Link to Custom CSS section in the Customizer. */
+			/* translators: %s: Link to add custom CSS section in either the Customizer (classic themes) or Site Editor (block themes). */
 			__( 'There is no need to change your CSS here &mdash; you can edit and live preview CSS changes in the <a href="%s">built-in CSS editor</a>.' ),
 			esc_url( add_query_arg( 'autofocus[section]', 'custom_css', admin_url( 'customize.php' ) ) )
 		) . '</p>';


### PR DESCRIPTION
This is a follow-up to https://github.com/WordPress/wordpress-develop/pull/10081 (r60934 and b56b386) based on a discussion with @peterwilsoncc. A CSS comment was added to the `style.css` for TT2 and TT5 to warn against editing since the `style.min.css` will likely be served instead:

```css
/*
 * IMPORTANT: This file is only served on the frontend when `SCRIPT_DEBUG` is enabled;
 * in most instances, the `style.min.css` file will be served. It is not recommended that you
 * use the Theme File Editor to modify this stylesheet. Instead, add the necessary style
 * overrides via "Additional CSS" in the Site Editor.
 */
```

However, the user may not see this easily. Therefore, this PR adds an admin notice when editing a CSS file when there is also a `.min.css` version for that same file name in the current theme.

Additionally, for non-block themes there was an admin info notice about using the Custom CSS in the Customizer to edit CSS, but there was no corresponding notice to prompt users to use Additional CSS in the Site Editor for block themes. So this rectifies that issue. The new notices appear as follows when editing `style.css` in TT5:

<img width="819" height="819" alt="image" src="https://github.com/user-attachments/assets/efb78059-b15a-4b5c-bb3c-585eebda7792" />


Trac ticket: https://core.trac.wordpress.org/ticket/63012

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
