### PR TITLE
Report sites that have MyISAM tables during update requests

### DIFF
--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -127,7 +127,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 
 	// Only report when a site has MyISAM tables to save bytes.
 	if ( $myisam_tables > 0 ) {
-		$query['myisam_table_count'] = $myisam_tables;
+		$query['myisam_count'] = $myisam_tables;
 	}
 
 	if ( function_exists( 'gd_info' ) ) {

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *                           Defaults to false, true if $extra_stats is set.
  */
 function wp_version_check( $extra_stats = array(), $force_check = false ) {
-	global $wpdb, $wp_local_package;
+	global $wpdb, $wp_local_package, $table_prefix;
 
 	if ( wp_installing() ) {
 		return;
@@ -113,6 +113,22 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 		),
 		'image_support'      => array(),
 	);
+
+	// Check for default tables using the MyISAM engine.
+	$table_names   = implode( "','", $wpdb->tables() );
+	$myisam_tables = (int) $wpdb->get_var(
+		$wpdb->prepare(
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- This query cannot use interpolation.
+			"SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA = %s AND TABLE_NAME IN ('$table_names') AND ENGINE = %s;",
+			DB_NAME,
+			'MyISAM'
+		)
+	);
+
+	// Only report when a site has MyISAM tables to save bytes.
+	if ( $myisam_tables > 0 ) {
+		$query['myisam_table_count'] = $myisam_tables;
+	}
 
 	if ( function_exists( 'gd_info' ) ) {
 		$gd_info = gd_info();

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -106,6 +106,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 		'users'              => get_user_count(),
 		'multisite_enabled'  => $multisite_enabled,
 		'initial_db_version' => get_site_option( 'initial_db_version' ),
+		'myisam_tables'      => array(),
 		'extensions'         => array_combine( $extensions, array_map( 'phpversion', $extensions ) ),
 		'platform_flags'     => array(
 			'os'   => PHP_OS,
@@ -116,18 +117,19 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 
 	// Check for default tables using the MyISAM engine.
 	$table_names   = implode( "','", $wpdb->tables() );
-	$myisam_tables = (int) $wpdb->get_var(
+	$myisam_tables = $wpdb->get_results(
 		$wpdb->prepare(
 			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- This query cannot use interpolation.
-			"SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA = %s AND TABLE_NAME IN ('$table_names') AND ENGINE = %s;",
+			"SELECT TABLE_NAME FROM information_schema.TABLES WHERE TABLE_SCHEMA = %s AND TABLE_NAME IN ('$table_names') AND ENGINE = %s;",
 			DB_NAME,
 			'MyISAM'
-		)
+		),
+		OBJECT_K
 	);
 
 	// Only report when a site has MyISAM tables to save bytes.
-	if ( $myisam_tables > 0 ) {
-		$query['myisam_count'] = $myisam_tables;
+	if ( ! empty( $myisam_tables ) ) {
+		$query['myisam_tables'] = array_keys( $myisam_tables );
 	}
 
 	if ( function_exists( 'gd_info' ) ) {

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -129,7 +129,24 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 
 	// Only report when a site has MyISAM tables to save bytes.
 	if ( ! empty( $myisam_tables ) ) {
-		$query['myisam_tables'] = array_keys( $myisam_tables );
+		$all_unprefixed_tables = $wpdb->tables( 'all', false );
+
+		// Including the table prefix is not necessary.
+		$unprefixed_myisam_tables = array_reduce(
+			array_keys( $myisam_tables ),
+			function( $carry, $prefixed_myisam_table ) use ( $all_unprefixed_tables ) {
+				foreach ( $all_unprefixed_tables as $unprefixed ) {
+					if ( str_ends_with( $prefixed_myisam_table, $unprefixed ) ) {
+						$carry[] = $unprefixed;
+						break;
+					}
+				}
+				return $carry;
+			},
+			array()
+		);
+
+		$query['myisam_tables'] = $unprefixed_myisam_tables;
 	}
 
 	if ( function_exists( 'gd_info' ) ) {

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -134,7 +134,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 		// Including the table prefix is not necessary.
 		$unprefixed_myisam_tables = array_reduce(
 			array_keys( $myisam_tables ),
-			function( $carry, $prefixed_myisam_table ) use ( $all_unprefixed_tables ) {
+			function ( $carry, $prefixed_myisam_table ) use ( $all_unprefixed_tables ) {
 				foreach ( $all_unprefixed_tables as $unprefixed ) {
 					if ( str_ends_with( $prefixed_myisam_table, $unprefixed ) ) {
 						$carry[] = $unprefixed;

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -127,7 +127,6 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 		OBJECT_K
 	);
 
-	// Only report when a site has MyISAM tables to save bytes.
 	if ( ! empty( $myisam_tables ) ) {
 		$all_unprefixed_tables = $wpdb->tables( 'all', false );
 

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -29,7 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *                           Defaults to false, true if $extra_stats is set.
  */
 function wp_version_check( $extra_stats = array(), $force_check = false ) {
-	global $wpdb, $wp_local_package, $table_prefix;
+	global $wpdb, $wp_local_package;
 
 	if ( wp_installing() ) {
 		return;

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -192,6 +192,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 	 */
 	$query = apply_filters( 'core_version_check_query_args', $query );
 
+	error_log( print_r( $query, true ) );
 	$post_body = array(
 		'translations' => wp_json_encode( $translations ),
 	);

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -192,7 +192,6 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 	 */
 	$query = apply_filters( 'core_version_check_query_args', $query );
 
-	error_log( print_r( $query, true ) );
 	$post_body = array(
 		'translations' => wp_json_encode( $translations ),
 	);


### PR DESCRIPTION
This checks the default WordPress Core tables for the MyISAM engine when an update is requested and reports a non-zero number to wordpress.org.

Trac ticket: https://core.trac.wordpress.org/ticket/63640

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
