### PR TITLE
Blocks/refactor twentytwentyone block processor (take 2)

### DIFF
--- a/src/wp-content/themes/twentytwentyone/inc/template-functions.php
+++ b/src/wp-content/themes/twentytwentyone/inc/template-functions.php
@@ -371,8 +371,8 @@ function twenty_twenty_one_print_first_instance_of_block( $block_name, $content 
 	// Loop over top-level blocks.
 	if ( class_exists( '\WP_Block_Processor' ) && function_exists( '\str_starts_with' ) ) {
 		// Scan for blocks whose block type matches the prefix, if provided a wildcard.
-		$prefix      = rtrim( $block_name, '*' );
-		$match_fully = $prefix === $block_name;
+		$match_text  = rtrim( $block_name, '*' );
+		$match_fully = $match_text === $block_name;
 		$processor   = new WP_Block_Processor( $content );
 
 		while ( $instances_count < $instances && $processor->next_block() ) {
@@ -387,8 +387,8 @@ function twenty_twenty_one_print_first_instance_of_block( $block_name, $content 
 				 * In each case, the condition only holds when the match is successful.
 				 */
 				$match_fully
-					? $processor->is_block_type( $block_name )
-					: str_starts_with( $processor->get_printable_block_type(), $prefix )
+					? $processor->is_block_type( $match_text )
+					: str_starts_with( $processor->get_printable_block_type(), $match_text )
 			) {
 				$blocks_content .= render_block( $processor->extract_full_block_and_advance() );
 				++$instances_count;

--- a/src/wp-content/themes/twentytwentyone/inc/template-functions.php
+++ b/src/wp-content/themes/twentytwentyone/inc/template-functions.php
@@ -361,45 +361,31 @@ function twenty_twenty_one_get_non_latin_css( $type = 'front-end' ) {
  * @return bool Returns true if a block was located & printed, otherwise false.
  */
 function twenty_twenty_one_print_first_instance_of_block( $block_name, $content = null, $instances = 1 ) {
-	$instances_count = 0;
 	$blocks_content  = '';
 
 	if ( ! $content ) {
 		$content = get_the_content();
 	}
 
-	// Parse blocks in the content.
-	$blocks = parse_blocks( $content );
+	$processor      = new WP_Block_Processor( $content );
+	$instance_count = 0;
 
-	// Loop blocks.
-	foreach ( $blocks as $block ) {
+	if ( str_ends_with( $block_name, '*' ) ) {
+		// Scan for blocks whose block type matches the prefix.
+		$prefix = rtrim( $block_name, '*' );
 
-		// Confidence check.
-		if ( ! isset( $block['blockName'] ) ) {
-			continue;
-		}
-
-		// Check if this the block matches the $block_name.
-		$is_matching_block = false;
-
-		// If the block ends with *, try to match the first portion.
-		if ( '*' === $block_name[-1] ) {
-			$is_matching_block = 0 === strpos( $block['blockName'], rtrim( $block_name, '*' ) );
-		} else {
-			$is_matching_block = $block_name === $block['blockName'];
-		}
-
-		if ( $is_matching_block ) {
-			// Increment count.
-			++$instances_count;
-
-			// Add the block HTML.
-			$blocks_content .= render_block( $block );
-
-			// Break the loop if the $instances count was reached.
-			if ( $instances_count >= $instances ) {
-				break;
+		while ( $instance_count < $instances && $processor->next_block() ) {
+			$matched_block_type = $processor->get_printable_block_type();
+			if ( str_starts_with( $matched_block_type, $prefix ) ) {
+				$blocks_content .= render_block( $processor->extract_full_block_and_advance() );
+				++$instance_count;
 			}
+		}
+	} else {
+		// Scan for blocks of the exact block type.
+		while ( $instance_count < $instances && $processor->next_block( $block_name ) ) {
+			$blocks_content .= render_block( $processor->extract_full_block_and_advance() );
+			++$instance_count;
 		}
 	}
 

--- a/src/wp-content/themes/twentytwentyone/inc/template-functions.php
+++ b/src/wp-content/themes/twentytwentyone/inc/template-functions.php
@@ -363,6 +363,7 @@ function twenty_twenty_one_get_non_latin_css( $type = 'front-end' ) {
 function twenty_twenty_one_print_first_instance_of_block( $block_name, $content = null, $instances = 1 ) {
 	// Scan for blocks whose block type matches the prefix, if provided a wildcard.
 	$prefix         = rtrim( $block_name, '*' );
+	$prefix_length  = strlen( $prefix );
 	$match_fully    = $prefix === $block_name;
 	$blocks_content = '';
 	$instance_count = 0;
@@ -376,8 +377,11 @@ function twenty_twenty_one_print_first_instance_of_block( $block_name, $content 
 		$processor = new WP_Block_Processor( $content );
 
 		while ( $instance_count < $instances && $processor->next_block() ) {
+			if ( 1 !== $processor->get_depth() ) {
+				continue;
+			}
+
 			if (
-				1 === $processor->get_depth() &&
 				/*
 				 * Prefix matches with a wildcard require printing the block name,
 				 * while full block-type matching can be delegated to the processor.
@@ -385,7 +389,7 @@ function twenty_twenty_one_print_first_instance_of_block( $block_name, $content 
 				 */
 				$match_fully
 					? $processor->is_block_type( $block_name )
-					: str_starts_with( $processor->get_printable_block_type(), $prefix )
+					: 0 === substr_compare( $processor->get_printable_block_type(), $prefix, 0, $prefix_length )
 			) {
 				$blocks_content .= render_block( $processor->extract_full_block_and_advance() );
 				++$instance_count;

--- a/src/wp-content/themes/twentytwentyone/inc/template-functions.php
+++ b/src/wp-content/themes/twentytwentyone/inc/template-functions.php
@@ -349,54 +349,114 @@ function twenty_twenty_one_get_non_latin_css( $type = 'front-end' ) {
 	);
 }
 
-/**
- * Prints the first instance of a block in the content, and then break away.
- *
- * @since Twenty Twenty-One 1.0
- *
- * @param string      $block_name The full block type name, or a partial match.
- *                                Example: `core/image`, `core-embed/*`.
- * @param string|null $content    The content to search in. Use null for get_the_content().
- * @param int         $instances  How many instances of the block will be printed (max). Default  1.
- * @return bool Returns true if a block was located & printed, otherwise false.
- */
-function twenty_twenty_one_print_first_instance_of_block( $block_name, $content = null, $instances = 1 ) {
-	$blocks_content  = '';
+if ( class_exists( 'WP_Block_Processor' ) ) :
+	/**
+	 * Prints the first instance of a block in the content, and then break away.
+	 *
+	 * @since Twenty Twenty-One 1.0
+	 *
+	 * @param string      $block_name The full block type name, or a partial match.
+	 *                                Example: `core/image`, `core-embed/*`.
+	 * @param string|null $content    The content to search in. Use null for get_the_content().
+	 * @param int         $instances  How many instances of the block will be printed (max). Default  1.
+	 * @return bool Returns true if a block was located & printed, otherwise false.
+	 */
+	function twenty_twenty_one_print_first_instance_of_block( $block_name, $content = null, $instances = 1 ) {
+		$blocks_content  = '';
 
-	if ( ! $content ) {
-		$content = get_the_content();
-	}
+		if ( ! $content ) {
+			$content = get_the_content();
+		}
 
-	$processor      = new WP_Block_Processor( $content );
-	$instance_count = 0;
+		$processor      = new WP_Block_Processor( $content );
+		$instance_count = 0;
 
-	if ( str_ends_with( $block_name, '*' ) ) {
-		// Scan for blocks whose block type matches the prefix.
-		$prefix = rtrim( $block_name, '*' );
+		if ( str_ends_with( $block_name, '*' ) ) {
+			// Scan for blocks whose block type matches the prefix.
+			$prefix = rtrim( $block_name, '*' );
 
-		while ( $instance_count < $instances && $processor->next_block() ) {
-			$matched_block_type = $processor->get_printable_block_type();
-			if ( str_starts_with( $matched_block_type, $prefix ) ) {
+			while ( $instance_count < $instances && $processor->next_block() ) {
+				$matched_block_type = $processor->get_printable_block_type();
+				if ( str_starts_with( $matched_block_type, $prefix ) ) {
+					$blocks_content .= render_block( $processor->extract_full_block_and_advance() );
+					++$instance_count;
+				}
+			}
+		} else {
+			// Scan for blocks of the exact block type.
+			while ( $instance_count < $instances && $processor->next_block( $block_name ) ) {
 				$blocks_content .= render_block( $processor->extract_full_block_and_advance() );
 				++$instance_count;
 			}
 		}
-	} else {
-		// Scan for blocks of the exact block type.
-		while ( $instance_count < $instances && $processor->next_block( $block_name ) ) {
-			$blocks_content .= render_block( $processor->extract_full_block_and_advance() );
-			++$instance_count;
+
+		if ( $blocks_content ) {
+			/** This filter is documented in wp-includes/post-template.php */
+			echo apply_filters( 'the_content', $blocks_content ); // phpcs:ignore WordPress.Security.EscapeOutput
+			return true;
 		}
-	}
 
-	if ( $blocks_content ) {
-		/** This filter is documented in wp-includes/post-template.php */
-		echo apply_filters( 'the_content', $blocks_content ); // phpcs:ignore WordPress.Security.EscapeOutput
-		return true;
+		return false;
 	}
+else :
+	/**
+	 * Fallback with legacy function for installations running WordPress <6.9.0.
+	 *
+	 * @ignore
+	 * @private
+	 */
+	function twenty_twenty_one_print_first_instance_of_block( $block_name, $content = null, $instances = 1 ) {
+		$instances_count = 0;
+		$blocks_content  = '';
 
-	return false;
-}
+		if ( ! $content ) {
+			$content = get_the_content();
+		}
+
+		// Parse blocks in the content.
+		$blocks = parse_blocks( $content );
+
+		// Loop top-level blocks, releasing them from memory as soon as possible.
+		while ( null !== ( $block = array_shift( $blocks ) ) ) {
+
+			// Skip inter-block whitespace and other freeform non-block HTML.
+			if ( ! isset( $block['blockName'] ) ) {
+				continue;
+			}
+
+			// Check if this the block matches the $block_name.
+			$is_matching_block = false;
+
+			// If the block ends with *, try to match the first portion.
+			if ( '*' === $block_name[-1] ) {
+				$is_matching_block = 0 === strpos( $block['blockName'], rtrim( $block_name, '*' ) );
+			} else {
+				$is_matching_block = $block_name === $block['blockName'];
+			}
+
+			if ( $is_matching_block ) {
+				// Increment count.
+				++$instances_count;
+
+				// Add the block HTML.
+				$blocks_content .= render_block( $block );
+
+				// Break the loop if the $instances count was reached.
+				if ( $instances_count >= $instances ) {
+					break;
+				}
+			}
+		}
+
+		if ( $blocks_content ) {
+			/** This filter is documented in wp-includes/post-template.php */
+			echo apply_filters( 'the_content', $blocks_content ); // phpcs:ignore WordPress.Security.EscapeOutput
+			return true;
+		}
+
+		return false;
+	}
+endif;
 
 /**
  * Retrieves protected post password form content.

--- a/src/wp-content/themes/twentytwentyone/inc/template-functions.php
+++ b/src/wp-content/themes/twentytwentyone/inc/template-functions.php
@@ -397,15 +397,10 @@ function twenty_twenty_one_print_first_instance_of_block( $block_name, $content 
 
 		// Loop top-level blocks, releasing them from memory as soon as possible.
 		while ( $instance_count < $instances && null !== ( $block = array_shift( $blocks ) ) ) {
-			// Skip inter-block whitespace and other freeform non-block HTML.
-			if ( ! isset( $block['blockName'] ) ) {
-				continue;
-			}
-
 			if (
 				$match_fully
 					? $block_name === $block['blockName']
-					: str_starts_with( $block['blockName'], $prefix )
+					: str_starts_with( $block['blockName'] ?? '', $prefix )
 			) {
 				$blocks_content .= render_block( $block );
 				++$instance_count;

--- a/src/wp-content/themes/twentytwentyone/inc/template-functions.php
+++ b/src/wp-content/themes/twentytwentyone/inc/template-functions.php
@@ -350,38 +350,32 @@ function twenty_twenty_one_get_non_latin_css( $type = 'front-end' ) {
 }
 
 /**
- * Remove the legacy fallback once the theme’s minimum required version is 6.9.0 or greater.
+ * Prints the first instance of a block in the content, and then break away.
  *
- * @see ../style.css “Requires at least: VERSION_NUMBER”
+ * @since Twenty Twenty-One 1.0
+ *
+ * @param string      $block_name The full block type name, or a partial match.
+ *                                Example: `core/image`, `core-embed/*`.
+ * @param string|null $content    The content to search in. Use null for get_the_content().
+ * @param int         $instances  How many instances of the block will be printed (max). Default  1.
+ * @return bool Returns true if a block was located & printed, otherwise false.
  */
-if ( class_exists( 'WP_Block_Processor' ) ) :
-	/**
-	 * Prints the first instance of a block in the content, and then break away.
-	 *
-	 * @since Twenty Twenty-One 1.0
-	 *
-	 * @param string      $block_name The full block type name, or a partial match.
-	 *                                Example: `core/image`, `core-embed/*`.
-	 * @param string|null $content    The content to search in. Use null for get_the_content().
-	 * @param int         $instances  How many instances of the block will be printed (max). Default  1.
-	 * @return bool Returns true if a block was located & printed, otherwise false.
-	 */
-	function twenty_twenty_one_print_first_instance_of_block( $block_name, $content = null, $instances = 1 ) {
-		$blocks_content  = '';
+function twenty_twenty_one_print_first_instance_of_block( $block_name, $content = null, $instances = 1 ) {
+	// Scan for blocks whose block type matches the prefix, if provided a wildcard.
+	$prefix         = rtrim( $block_name, '*' );
+	$match_fully    = $prefix === $block_name;
+	$blocks_content = '';
+	$instance_count = 0;
 
-		if ( ! $content ) {
-			$content = get_the_content();
-		}
+	if ( ! $content ) {
+		$content = get_the_content();
+	}
 
-		$processor      = new WP_Block_Processor( $content );
-		$instance_count = 0;
+	// Loop over top-level blocks.
+	if ( class_exists( '\WP_Block_Processor' ) ) {
+		$processor = new WP_Block_Processor( $content );
 
-		// Scan for blocks whose block type matches the prefix.
-		$prefix      = rtrim( $block_name, '*' );
-		$match_fully = $prefix === $block_name;
-
-		// Loop over top-level blocks.
-		while ( $processor->next_block() && $instance_count < $instances ) {
+		while ( $instance_count < $instances && $processor->next_block() ) {
 			if (
 				1 === $processor->get_depth() &&
 				/*
@@ -397,77 +391,36 @@ if ( class_exists( 'WP_Block_Processor' ) ) :
 				++$instance_count;
 			}
 		}
-
-		if ( $blocks_content ) {
-			/** This filter is documented in wp-includes/post-template.php */
-			echo apply_filters( 'the_content', $blocks_content ); // phpcs:ignore WordPress.Security.EscapeOutput
-			return true;
-		}
-
-		return false;
-	}
-else :
-	/**
-	 * Fallback with legacy function for installations running WordPress <6.9.0.
-	 *
-	 * @todo Remove once this theme’s minimum support version is 6.9.0 or greater.
-	 * @see ../style.css “Requires at least: VERSION_NUMBER”
-	 *
-	 * @ignore
-	 * @private
-	 */
-	function twenty_twenty_one_print_first_instance_of_block( $block_name, $content = null, $instances = 1 ) {
-		$instances_count = 0;
-		$blocks_content  = '';
-
-		if ( ! $content ) {
-			$content = get_the_content();
-		}
-
+	} else {
 		// Parse blocks in the content.
 		$blocks = parse_blocks( $content );
 
 		// Loop top-level blocks, releasing them from memory as soon as possible.
-		while ( null !== ( $block = array_shift( $blocks ) ) ) {
-
+		while ( $instance_count < $instances && null !== ( $block = array_shift( $blocks ) ) ) {
 			// Skip inter-block whitespace and other freeform non-block HTML.
 			if ( ! isset( $block['blockName'] ) ) {
 				continue;
 			}
 
-			// Check if this the block matches the $block_name.
-			$is_matching_block = false;
-
-			// If the block ends with *, try to match the first portion.
-			if ( '*' === $block_name[-1] ) {
-				$is_matching_block = 0 === strpos( $block['blockName'], rtrim( $block_name, '*' ) );
-			} else {
-				$is_matching_block = $block_name === $block['blockName'];
-			}
-
-			if ( $is_matching_block ) {
-				// Increment count.
-				++$instances_count;
-
-				// Add the block HTML.
+			if (
+				$match_fully
+					? $block_name === $block['blockName']
+					: str_starts_with( $block['blockName'], $prefix )
+			) {
 				$blocks_content .= render_block( $block );
-
-				// Break the loop if the $instances count was reached.
-				if ( $instances_count >= $instances ) {
-					break;
-				}
+				++$instance_count;
 			}
 		}
-
-		if ( $blocks_content ) {
-			/** This filter is documented in wp-includes/post-template.php */
-			echo apply_filters( 'the_content', $blocks_content ); // phpcs:ignore WordPress.Security.EscapeOutput
-			return true;
-		}
-
-		return false;
 	}
-endif;
+
+	if ( $blocks_content ) {
+		/** This filter is documented in wp-includes/post-template.php */
+		echo apply_filters( 'the_content', $blocks_content ); // phpcs:ignore WordPress.Security.EscapeOutput
+		return true;
+	}
+
+	return false;
+}
 
 /**
  * Retrieves protected post password form content.

--- a/src/wp-content/themes/twentytwentyone/inc/template-functions.php
+++ b/src/wp-content/themes/twentytwentyone/inc/template-functions.php
@@ -349,6 +349,11 @@ function twenty_twenty_one_get_non_latin_css( $type = 'front-end' ) {
 	);
 }
 
+/**
+ * Remove the legacy fallback once the theme’s minimum required version is 6.9.0 or greater.
+ *
+ * @see ../style.css “Requires at least: VERSION_NUMBER”
+ */
 if ( class_exists( 'WP_Block_Processor' ) ) :
 	/**
 	 * Prints the first instance of a block in the content, and then break away.
@@ -371,20 +376,23 @@ if ( class_exists( 'WP_Block_Processor' ) ) :
 		$processor      = new WP_Block_Processor( $content );
 		$instance_count = 0;
 
-		if ( str_ends_with( $block_name, '*' ) ) {
-			// Scan for blocks whose block type matches the prefix.
-			$prefix = rtrim( $block_name, '*' );
+		// Scan for blocks whose block type matches the prefix.
+		$prefix      = rtrim( $block_name, '*' );
+		$match_fully = $prefix === $block_name;
 
-			while ( $instance_count < $instances && $processor->next_block() ) {
-				$matched_block_type = $processor->get_printable_block_type();
-				if ( str_starts_with( $matched_block_type, $prefix ) ) {
-					$blocks_content .= render_block( $processor->extract_full_block_and_advance() );
-					++$instance_count;
-				}
-			}
-		} else {
-			// Scan for blocks of the exact block type.
-			while ( $instance_count < $instances && $processor->next_block( $block_name ) ) {
+		// Loop over top-level blocks.
+		while ( $processor->next_block() && $instance_count < $instances ) {
+			if (
+				1 === $processor->get_depth() &&
+				/*
+				 * Prefix matches with a wildcard require printing the block name,
+				 * while full block-type matching can be delegated to the processor.
+				 * In each case, the condition only holds when the match is successful.
+				 */
+				$match_fully
+					? $processor->is_block_type( $block_name )
+					: str_starts_with( $processor->get_printable_block_type(), $prefix )
+			) {
 				$blocks_content .= render_block( $processor->extract_full_block_and_advance() );
 				++$instance_count;
 			}
@@ -401,6 +409,9 @@ if ( class_exists( 'WP_Block_Processor' ) ) :
 else :
 	/**
 	 * Fallback with legacy function for installations running WordPress <6.9.0.
+	 *
+	 * @todo Remove once this theme’s minimum support version is 6.9.0 or greater.
+	 * @see ../style.css “Requires at least: VERSION_NUMBER”
 	 *
 	 * @ignore
 	 * @private

--- a/src/wp-content/themes/twentytwentyone/inc/template-functions.php
+++ b/src/wp-content/themes/twentytwentyone/inc/template-functions.php
@@ -361,8 +361,8 @@ function twenty_twenty_one_get_non_latin_css( $type = 'front-end' ) {
  * @return bool Returns true if a block was located & printed, otherwise false.
  */
 function twenty_twenty_one_print_first_instance_of_block( $block_name, $content = null, $instances = 1 ) {
-	$blocks_content = '';
 	$instance_count = 0;
+	$blocks_content = '';
 
 	if ( ! $content ) {
 		$content = get_the_content();

--- a/src/wp-content/themes/twentytwentyone/inc/template-functions.php
+++ b/src/wp-content/themes/twentytwentyone/inc/template-functions.php
@@ -361,10 +361,6 @@ function twenty_twenty_one_get_non_latin_css( $type = 'front-end' ) {
  * @return bool Returns true if a block was located & printed, otherwise false.
  */
 function twenty_twenty_one_print_first_instance_of_block( $block_name, $content = null, $instances = 1 ) {
-	// Scan for blocks whose block type matches the prefix, if provided a wildcard.
-	$prefix         = rtrim( $block_name, '*' );
-	$prefix_length  = strlen( $prefix );
-	$match_fully    = $prefix === $block_name;
 	$blocks_content = '';
 	$instance_count = 0;
 
@@ -373,8 +369,11 @@ function twenty_twenty_one_print_first_instance_of_block( $block_name, $content 
 	}
 
 	// Loop over top-level blocks.
-	if ( class_exists( '\WP_Block_Processor' ) ) {
-		$processor = new WP_Block_Processor( $content );
+	if ( class_exists( '\WP_Block_Processor' ) && function_exists( '\str_starts_with' ) ) {
+		// Scan for blocks whose block type matches the prefix, if provided a wildcard.
+		$prefix        = rtrim( $block_name, '*' );
+		$match_fully   = $prefix === $block_name;
+		$processor     = new WP_Block_Processor( $content );
 
 		while ( $instance_count < $instances && $processor->next_block() ) {
 			if ( 1 !== $processor->get_depth() ) {
@@ -389,7 +388,7 @@ function twenty_twenty_one_print_first_instance_of_block( $block_name, $content 
 				 */
 				$match_fully
 					? $processor->is_block_type( $block_name )
-					: 0 === substr_compare( $processor->get_printable_block_type(), $prefix, 0, $prefix_length )
+					: str_starts_with( $processor->get_printable_block_type(), $prefix )
 			) {
 				$blocks_content .= render_block( $processor->extract_full_block_and_advance() );
 				++$instance_count;
@@ -399,15 +398,35 @@ function twenty_twenty_one_print_first_instance_of_block( $block_name, $content 
 		// Parse blocks in the content.
 		$blocks = parse_blocks( $content );
 
-		// Loop top-level blocks, releasing them from memory as soon as possible.
-		while ( $instance_count < $instances && null !== ( $block = array_shift( $blocks ) ) ) {
-			if (
-				$match_fully
-					? $block_name === $block['blockName']
-					: str_starts_with( $block['blockName'] ?? '', $prefix )
-			) {
-				$blocks_content .= render_block( $block );
+		// Loop blocks.
+		foreach ( $blocks as $block ) {
+
+			// Confidence check.
+			if ( ! isset( $block['blockName'] ) ) {
+				continue;
+			}
+
+			// Check if this the block matches the $block_name.
+			$is_matching_block = false;
+
+			// If the block ends with *, try to match the first portion.
+			if ( '*' === $block_name[-1] ) {
+				$is_matching_block = 0 === strpos( $block['blockName'], rtrim( $block_name, '*' ) );
+			} else {
+				$is_matching_block = $block_name === $block['blockName'];
+			}
+
+			if ( $is_matching_block ) {
+				// Increment count.
 				++$instance_count;
+
+				// Add the block HTML.
+				$blocks_content .= render_block( $block );
+
+				// Break the loop if the $instances count was reached.
+				if ( $instance_count >= $instances ) {
+					break;
+				}
 			}
 		}
 	}

--- a/src/wp-content/themes/twentytwentyone/inc/template-functions.php
+++ b/src/wp-content/themes/twentytwentyone/inc/template-functions.php
@@ -371,9 +371,9 @@ function twenty_twenty_one_print_first_instance_of_block( $block_name, $content 
 	// Loop over top-level blocks.
 	if ( class_exists( '\WP_Block_Processor' ) && function_exists( '\str_starts_with' ) ) {
 		// Scan for blocks whose block type matches the prefix, if provided a wildcard.
-		$prefix        = rtrim( $block_name, '*' );
-		$match_fully   = $prefix === $block_name;
-		$processor     = new WP_Block_Processor( $content );
+		$prefix      = rtrim( $block_name, '*' );
+		$match_fully = $prefix === $block_name;
+		$processor   = new WP_Block_Processor( $content );
 
 		while ( $instances_count < $instances && $processor->next_block() ) {
 			if ( 1 !== $processor->get_depth() ) {

--- a/src/wp-content/themes/twentytwentyone/inc/template-functions.php
+++ b/src/wp-content/themes/twentytwentyone/inc/template-functions.php
@@ -361,7 +361,7 @@ function twenty_twenty_one_get_non_latin_css( $type = 'front-end' ) {
  * @return bool Returns true if a block was located & printed, otherwise false.
  */
 function twenty_twenty_one_print_first_instance_of_block( $block_name, $content = null, $instances = 1 ) {
-	$instance_count = 0;
+	$instances_count = 0;
 	$blocks_content = '';
 
 	if ( ! $content ) {
@@ -375,7 +375,7 @@ function twenty_twenty_one_print_first_instance_of_block( $block_name, $content 
 		$match_fully   = $prefix === $block_name;
 		$processor     = new WP_Block_Processor( $content );
 
-		while ( $instance_count < $instances && $processor->next_block() ) {
+		while ( $instances_count < $instances && $processor->next_block() ) {
 			if ( 1 !== $processor->get_depth() ) {
 				continue;
 			}
@@ -391,7 +391,7 @@ function twenty_twenty_one_print_first_instance_of_block( $block_name, $content 
 					: str_starts_with( $processor->get_printable_block_type(), $prefix )
 			) {
 				$blocks_content .= render_block( $processor->extract_full_block_and_advance() );
-				++$instance_count;
+				++$instances_count;
 			}
 		}
 	} else {
@@ -418,13 +418,13 @@ function twenty_twenty_one_print_first_instance_of_block( $block_name, $content 
 
 			if ( $is_matching_block ) {
 				// Increment count.
-				++$instance_count;
+				++$instances_count;
 
 				// Add the block HTML.
 				$blocks_content .= render_block( $block );
 
 				// Break the loop if the $instances count was reached.
-				if ( $instance_count >= $instances ) {
+				if ( $instances_count >= $instances ) {
 					break;
 				}
 			}


### PR DESCRIPTION
Trac ticket: Core-64482
See: Core-61401
See: ~#9105~, ~#9841~, (~#9842~ -> #10291), ~#9843~ -> #10292

Refactors the excerpt-generating functionality in `twentytwentyone` to use `WP_Block_Processor` and avoid loading entire posts into memory. This streaming approach scans through the post contents and only parses as much as is required to provide the requested blocks.