### PR TITLE
Block Bindings: Add support for Navigation Link and Submenu's `url` attr

### DIFF
--- a/src/wp-includes/block-bindings.php
+++ b/src/wp-includes/block-bindings.php
@@ -140,11 +140,13 @@ function get_block_bindings_source( string $source_name ) {
  */
 function get_block_bindings_supported_attributes( $block_type ) {
 	$block_bindings_supported_attributes = array(
-		'core/paragraph' => array( 'content' ),
-		'core/heading'   => array( 'content' ),
-		'core/image'     => array( 'id', 'url', 'title', 'alt', 'caption' ),
-		'core/button'    => array( 'url', 'text', 'linkTarget', 'rel' ),
-		'core/post-date' => array( 'datetime' ),
+		'core/paragraph'          => array( 'content' ),
+		'core/heading'            => array( 'content' ),
+		'core/image'              => array( 'id', 'url', 'title', 'alt', 'caption' ),
+		'core/button'             => array( 'url', 'text', 'linkTarget', 'rel' ),
+		'core/post-date'          => array( 'datetime' ),
+		'core/navigation-link'    => array( 'url' ),
+		'core/navigation-submenu' => array( 'url' ),
 	);
 
 	$supported_block_attributes =


### PR DESCRIPTION
Backport of https://github.com/WordPress/gutenberg/pull/72418 (and https://github.com/WordPress/gutenberg/pull/72442).

Trac ticket: https://core.trac.wordpress.org/ticket/64116

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
