### PR TITLE
Fix term insertion when auto-generated slug exceeds 200 chars (Trac #46010)

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2573,7 +2573,10 @@ function wp_insert_term( $term, $taxonomy, $args = array() ) {
 	}
 
 	$slug = wp_unique_term_slug( $slug, (object) $args );
-
+	// Truncate the slug if it's longer than 200 characters to avoid DB errors (see #46010).
+	if ( strlen( $slug ) > 200 ) {
+		$slug = substr( $slug, 0, 200 );
+	}
 	$data = compact( 'name', 'slug', 'term_group' );
 
 	/**


### PR DESCRIPTION
…db insert errors (Ticket #46010)

<!--
Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR adds a truncation check to ensure that term slugs longer than 200 characters are properly shortened before insertion.
This prevents database errors that occur when creating categories, tags, or other terms with very long names.

Trac ticket: https://core.trac.wordpress.org/ticket/46010

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
