### PR TITLE
Block Bindings: Migrate Add link field `link` source `key` to `field`.

### DIFF
--- a/src/wp-includes/block-bindings/post-data.php
+++ b/src/wp-includes/block-bindings/post-data.php
@@ -72,7 +72,7 @@ function _block_bindings_post_data_get_value( array $source_args, $block_instanc
 		}
 	}
 
-	if ( 'link' === $source_args['key'] ) {
+	if ( 'link' === $field ) {
 		$permalink = get_permalink( $post_id );
 		return false === $permalink ? null : esc_url( $permalink );
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

https://core.trac.wordpress.org/changeset/60955 moved `post-data` key args to a better fit field one. I forgot to include `link`, noted in https://github.com/WordPress/gutenberg/pull/72382#discussion_r2440578117

Trac ticket: https://core.trac.wordpress.org/ticket/64112

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
