### PR TITLE
Block Bindings: Migrate term-data from `key` args to `field`.

### DIFF
--- a/src/wp-includes/block-bindings/term-data.php
+++ b/src/wp-includes/block-bindings/term-data.php
@@ -14,12 +14,12 @@
  * @access private
  *
  * @param array    $source_args    Array containing source arguments used to look up the override value.
- *                                 Example: array( "key" => "name" ).
+ *                                 Example: array( "field" => "name" ).
  * @param WP_Block $block_instance The block instance.
  * @return mixed The value computed for the source.
  */
 function _block_bindings_term_data_get_value( array $source_args, $block_instance ) {
-	if ( empty( $source_args['key'] ) ) {
+	if ( empty( $source_args['field'] ) ) {
 		return null;
 	}
 
@@ -65,7 +65,7 @@ function _block_bindings_term_data_get_value( array $source_args, $block_instanc
 		}
 	}
 
-	switch ( $source_args['key'] ) {
+	switch ( $source_args['field'] ) {
 		case 'id':
 			return esc_html( (string) $term_id );
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Adds new `field` argument for term-data source.

Trac ticket: https://core.trac.wordpress.org/ticket/64112
---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
