### PR TITLE
Also adjust search right margin for themes and plugins

### DIFF
--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -727,7 +727,6 @@ p.search-box {
 	clear: left;
 }
 
-.search-box input[name="s"],
 .tablenav .search-plugins input[name="s"],
 .tagsdiv .newtag {
 	float: left;
@@ -1653,10 +1652,14 @@ table.form-table td .updated p {
 	}
 
 	p.search-box input[name="s"] {
-		float: none;
 		width: 100%;
+		float: none;
 		margin-bottom: 10px;
 		vertical-align: middle;
+	}
+	.js.plugins-php .search-box .wp-filter-search {
+		width: 100%;
+		margin-bottom: 0;
 	}
 
 	p.search-box input[type="submit"] {

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -961,12 +961,7 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 	}
 
 	.themes-php .wp-filter-search {
-		float: none;
-		clear: both;
-		left: 0;
-		right: 0;
 		width: 100%;
-		max-width: 280px;
 	}
 
 	.theme-install-php .wp-filter p.search-box {


### PR DESCRIPTION
The existing patch fixes a small right margin adjust for posts, pages, and comments. There is a larger margin gap on plugins and themes, and this also covers those.

Trac ticket: https://core.trac.wordpress.org/ticket/63310

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
