### PR TITLE
Bugfix/wp upgrader

### DIFF
--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -1063,7 +1063,7 @@ class WP_Upgrader {
 		// Try to lock.
 		$lock_result = $wpdb->query( $wpdb->prepare( "INSERT IGNORE INTO `$wpdb->options` ( `option_name`, `option_value`, `autoload` ) VALUES (%s, %s, 'off') /* LOCK */", $lock_option, time() ) );
 
-		if ( ! $lock_result ) {
+		if ( 0 === $lock_result ) {
 			$lock_result = get_option( $lock_option );
 
 			// If a lock couldn't be created, and there isn't a lock, bail.

--- a/tests/phpunit/tests/admin/wpUpgrader.php
+++ b/tests/phpunit/tests/admin/wpUpgrader.php
@@ -1571,6 +1571,59 @@ class Tests_Admin_WpUpgrader extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that `WP_Upgrader::create_lock()` creates the 'lock' option.
+	 *
+	 * @covers WP_Upgrader::create_lock
+	 */
+	public function test_create_lock_should_create_lock_option() {
+		global $wpdb;
+
+		WP_Upgrader::create_lock( 'lock' );
+
+		// Check that the lock option was created with a timestamp less than or equal to now.
+		$this->assertLessThanOrEqual(
+			time(),
+			get_option( 'lock.lock' ),
+			'The lock option was not created as expected.'
+		);
+
+		$wpdb->delete(
+			$wpdb->options,
+			array( 'option_name' => 'lock.lock' ),
+			'%s'
+		);
+	}
+
+	/**
+	 * Tests that `WP_Upgrader::create_lock()` releases expired lock.
+	 *
+	 * @ticket 64080
+	 *
+	 * @covers WP_Upgrader::create_lock
+	 */
+	public function test_create_lock_should_release_lock() {
+		global $wpdb;
+
+		WP_Upgrader::create_lock( 'lock' );
+
+		sleep( 2 );
+
+		$recreate_lock = WP_Upgrader::create_lock( 'lock', 1 );
+
+		$this->assertSame(
+			true,
+			$recreate_lock,
+			'The lock was not re-created as expected.'
+		);
+
+		$wpdb->delete(
+			$wpdb->options,
+			array( 'option_name' => 'lock.lock' ),
+			'%s'
+		);
+	}
+
+	/**
 	 * Tests that `WP_Upgrader::release_lock()` removes the 'lock' option.
 	 *
 	 * @ticket 54245

--- a/tests/phpunit/tests/admin/wpUpgrader.php
+++ b/tests/phpunit/tests/admin/wpUpgrader.php
@@ -1600,8 +1600,7 @@ class Tests_Admin_WpUpgrader extends WP_UnitTestCase {
 
 		$recreate_lock = WP_Upgrader::create_lock( 'lock', 1 );
 
-		$this->assertSame(
-			true,
+		$this->assertTrue(
 			$recreate_lock,
 			'The lock was not re-created as expected.'
 		);

--- a/tests/phpunit/tests/admin/wpUpgrader.php
+++ b/tests/phpunit/tests/admin/wpUpgrader.php
@@ -1604,7 +1604,7 @@ class Tests_Admin_WpUpgrader extends WP_UnitTestCase {
 	public function test_create_lock_should_release_lock() {
 		global $wpdb;
 
-		WP_Upgrader::create_lock( 'lock' );
+		$this->assertTrue( WP_Upgrader::create_lock( 'lock' );
 
 		$this->assertTrue( update_option( 'lock.lock', time() - 2 ) );
 

--- a/tests/phpunit/tests/admin/wpUpgrader.php
+++ b/tests/phpunit/tests/admin/wpUpgrader.php
@@ -1606,7 +1606,7 @@ class Tests_Admin_WpUpgrader extends WP_UnitTestCase {
 
 		WP_Upgrader::create_lock( 'lock' );
 
-		sleep( 2 );
+		$this->assertTrue( update_option( 'lock.lock', time() - 2 ) );
 
 		$recreate_lock = WP_Upgrader::create_lock( 'lock', 1 );
 

--- a/tests/phpunit/tests/admin/wpUpgrader.php
+++ b/tests/phpunit/tests/admin/wpUpgrader.php
@@ -1576,8 +1576,6 @@ class Tests_Admin_WpUpgrader extends WP_UnitTestCase {
 	 * @covers WP_Upgrader::create_lock
 	 */
 	public function test_create_lock_should_create_lock_option() {
-		global $wpdb;
-
 		WP_Upgrader::create_lock( 'lock' );
 
 		// Check that the lock option was created with a timestamp less than or equal to now.
@@ -1585,12 +1583,6 @@ class Tests_Admin_WpUpgrader extends WP_UnitTestCase {
 			time(),
 			get_option( 'lock.lock' ),
 			'The lock option was not created as expected.'
-		);
-
-		$wpdb->delete(
-			$wpdb->options,
-			array( 'option_name' => 'lock.lock' ),
-			'%s'
 		);
 	}
 
@@ -1602,9 +1594,7 @@ class Tests_Admin_WpUpgrader extends WP_UnitTestCase {
 	 * @covers WP_Upgrader::create_lock
 	 */
 	public function test_create_lock_should_release_lock() {
-		global $wpdb;
-
-		$this->assertTrue( WP_Upgrader::create_lock( 'lock' );
+		$this->assertTrue( WP_Upgrader::create_lock( 'lock' ) );
 
 		$this->assertTrue( update_option( 'lock.lock', time() - 2 ) );
 
@@ -1614,12 +1604,6 @@ class Tests_Admin_WpUpgrader extends WP_UnitTestCase {
 			true,
 			$recreate_lock,
 			'The lock was not re-created as expected.'
-		);
-
-		$wpdb->delete(
-			$wpdb->options,
-			array( 'option_name' => 'lock.lock' ),
-			'%s'
 		);
 	}
 


### PR DESCRIPTION
Check for correct return value in `create_lock()` in lock creating query.
`wpdb::query()` returns `0` when there are no rows affected, eg. the lock already exists and no `INSERT` was performed.

Add two tests for `WP_upgrader::create_lock()`

Trac ticket: https://core.trac.wordpress.org/ticket/64080

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
