### PR TITLE
Desmith/alt api endpoints

### DIFF
--- a/src/wp-admin/admin-ajax.php
+++ b/src/wp-admin/admin-ajax.php
@@ -136,6 +136,7 @@ $core_actions_post = array(
 	'wp-privacy-erase-personal-data',
 	'health-check-site-status-result',
 	'health-check-dotorg-communication',
+	'health-check-alt-update-api-communication',
 	'health-check-is-in-debug-mode',
 	'health-check-background-updates',
 	'health-check-loopback-requests',

--- a/src/wp-admin/includes/class-wp-community-events.php
+++ b/src/wp-admin/includes/class-wp-community-events.php
@@ -98,7 +98,7 @@ class WP_Community_Events {
 		// Include an unmodified $wp_version.
 		require ABSPATH . WPINC . '/version.php';
 
-		$api_url                    = 'http://api.wordpress.org/events/1.0/';
+		$api_url                    = WP_UPDATE_API_DEFAULT . '/events/1.0/';
 		$request_args               = $this->get_request_args( $location_search, $timezone );
 		$request_args['user-agent'] = 'WordPress/' . $wp_version . '; ' . home_url( '/' );
 

--- a/src/wp-admin/includes/class-wp-community-events.php
+++ b/src/wp-admin/includes/class-wp-community-events.php
@@ -98,7 +98,7 @@ class WP_Community_Events {
 		// Include an unmodified $wp_version.
 		require ABSPATH . WPINC . '/version.php';
 
-		$api_url                    = WP_UPDATE_API_DEFAULT . '/events/1.0/';
+		$api_url                    = wp_get_api_request_url( '/events/1.0/' );
 		$request_args               = $this->get_request_args( $location_search, $timezone );
 		$request_args['user-agent'] = 'WordPress/' . $wp_version . '; ' . home_url( '/' );
 

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -319,9 +319,9 @@ class WP_Debug_Data {
 						__( 'Unable to reach %1$s (%2$s): %3$s' ),
 						$update_dom;
 						gethostbyname( $update_dom ),
-						$wp_update_api->get_error_message(),
+						$wp_update_api->get_error_message()
 					),
-					'debug' => $wp_update_api->get_error_message(),
+					'debug' => $wp_update_api->get_error_message()
 				);
 			}
 		}

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -301,9 +301,9 @@ class WP_Debug_Data {
 			'debug' => true,
 		);
 
-		$update_dom = parse_url( wp_get_update_api_base(), PHP_URL_HOST );
+		$update_dom = parse_url( wp_get_api_request_url(), PHP_URL_HOST );
 		if ( WP_UPDATE_API_DEFAULT !== $update_dom ) {
-			$wp_update_api = wp_remote_get( wp_get_update_api_base(), array( 'timeout' => 10 ) );
+			$wp_update_api = wp_remote_get( wp_get_api_request_url(), array( 'timeout' => 10 ) );
 
 			if ( ! is_wp_error( $wp_update_api ) ) {
 				$fields['alt_update_api_communication'] = array(

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -317,7 +317,7 @@ class WP_Debug_Data {
 					'value' => sprintf(
 						/* Translators: 1: hostname of update API, 2: IP address the update API hostname resolves to. 3: The error returned by the lookup */
 						__( 'Unable to reach %1$s (%2$s): %3$s' ),
-						$update_dom;
+						$update_dom,
 						gethostbyname( $update_dom ),
 						$wp_update_api->get_error_message()
 					),

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -155,6 +155,7 @@ class WP_Debug_Data {
 		$core_version           = wp_get_wp_version();
 		$core_updates           = get_core_updates();
 		$core_update_needed     = '';
+		$update_api_base        = wp_get_update_api_base();
 
 		if ( is_array( $core_updates ) ) {
 			foreach ( $core_updates as $core => $update ) {
@@ -292,6 +293,36 @@ class WP_Debug_Data {
 				),
 				'debug' => $wp_dotorg->get_error_message(),
 			);
+		}
+
+		$fields['update_api_base'] = array(
+			'label' => 'Update API URL',
+			'value' => $update_api_base,
+			'debug' => true
+		);
+
+		if ( WP_UPDATE_API_DEFAULT !== wp_get_update_api_base()) {
+			$wp_update_api = wp_remote_get( wp_get_update_api_base(), array( 'timeout' => 10 ) );
+
+			if ( ! is_wp_error( $wp_update_api ) ) {
+				$fields['alt_update_api_communication'] = array(
+					'label' => __( 'Communication with update API' ),
+					'value' => __( 'Update API is reachable.' ),
+					'debug' => 'true',
+				);
+			} else {
+				$fields['alt_update_api_communication'] = array(
+					'label' => __( 'Communication with update API' ),
+					'value' => sprintf(
+						/* Translators: 1: hostname of update API, 2: IP address the update API hostname resolves to. 3: The error returned by the lookup */
+						__('Unable to reach %1$s (%2$s): %3$s' ),
+						parse_url( $update_api_base, PHP_URL_HOST ),
+						gethostbyname( parse_url( $update_api_base, PHP_URL_HOST ) ),
+						$wp_update_api->get_error_message(),
+					),
+					'debug' => $wp_update_api->get_error_message(),
+				);
+			}
 		}
 
 		return array(

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -298,7 +298,7 @@ class WP_Debug_Data {
 		$fields['update_api_base'] = array(
 			'label' => 'Update API URL',
 			'value' => $update_api_base,
-			'debug' => true
+			'debug' => true,
 		);
 
 		$update_dom = parse_url( wp_get_update_api_base(), PHP_URL_HOST );
@@ -316,7 +316,7 @@ class WP_Debug_Data {
 					'label' => __( 'Communication with update API' ),
 					'value' => sprintf(
 						/* Translators: 1: hostname of update API, 2: IP address the update API hostname resolves to. 3: The error returned by the lookup */
-						__('Unable to reach %1$s (%2$s): %3$s' ),
+						__( 'Unable to reach %1$s (%2$s): %3$s' ),
 						$update_dom;
 						gethostbyname( $update_dom ),
 						$wp_update_api->get_error_message(),

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -155,7 +155,7 @@ class WP_Debug_Data {
 		$core_version           = wp_get_wp_version();
 		$core_updates           = get_core_updates();
 		$core_update_needed     = '';
-		$update_api_base        = wp_get_update_api_base();
+		$update_api_base        = wp_get_api_request_url();
 
 		if ( is_array( $core_updates ) ) {
 			foreach ( $core_updates as $core => $update ) {
@@ -301,7 +301,8 @@ class WP_Debug_Data {
 			'debug' => true
 		);
 
-		if ( WP_UPDATE_API_DEFAULT !== wp_get_update_api_base()) {
+		$update_dom = parse_url( wp_get_update_api_base(), PHP_URL_HOST );
+		if ( WP_UPDATE_API_DEFAULT !== $update_dom ) {
 			$wp_update_api = wp_remote_get( wp_get_update_api_base(), array( 'timeout' => 10 ) );
 
 			if ( ! is_wp_error( $wp_update_api ) ) {
@@ -316,8 +317,8 @@ class WP_Debug_Data {
 					'value' => sprintf(
 						/* Translators: 1: hostname of update API, 2: IP address the update API hostname resolves to. 3: The error returned by the lookup */
 						__('Unable to reach %1$s (%2$s): %3$s' ),
-						parse_url( $update_api_base, PHP_URL_HOST ),
-						gethostbyname( parse_url( $update_api_base, PHP_URL_HOST ) ),
+						$update_dom;
+						gethostbyname( $update_dom ),
 						$wp_update_api->get_error_message(),
 					),
 					'debug' => $wp_update_api->get_error_message(),

--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -321,7 +321,7 @@ class WP_Debug_Data {
 						gethostbyname( $update_dom ),
 						$wp_update_api->get_error_message()
 					),
-					'debug' => $wp_update_api->get_error_message()
+					'debug' => $wp_update_api->get_error_message(),
 				);
 			}
 		}

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1307,7 +1307,7 @@ class WP_Site_Health {
 		);
 
 		$wp_dotorg = wp_remote_get(
-			'https://api.wordpress.org',
+			WP_UPDATE_API_DEFAULT,
 			array(
 				'timeout' => 10,
 			)
@@ -1328,7 +1328,7 @@ class WP_Site_Health {
 					sprintf(
 						/* translators: 1: The IP address WordPress.org resolves to. 2: The error returned by the lookup. */
 						__( 'Your site is unable to reach WordPress.org at %1$s, and returned the error: %2$s' ),
-						gethostbyname( 'api.wordpress.org' ),
+						gethostbyname( parse_url( WP_UPDATE_API_DEFAULT, PHP_URL_HOST ) ),
 						$wp_dotorg->get_error_message()
 					)
 				)
@@ -1341,6 +1341,68 @@ class WP_Site_Health {
 				__( 'Get help resolving this issue.' ),
 				/* translators: Hidden accessibility text. */
 				__( '(opens in a new tab)' )
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Tests if the site can communicate with a non-default update API endpoint.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @return array The test results.
+	 */
+	public function get_test_alt_update_api_communication() {
+		$result = array(
+			'label'       => __( 'Can communicate with update API' ),
+			'status'      => '',
+			'badge'       => array(
+				'label' => __( 'Security' ),
+				'color' => 'blue',
+			),
+			'description' => sprintf(
+				'<p>%s</p>',
+				__( 'Communicating with the update API is used to check for new versions, and to both install and update WordPress core, themes or plugins.' )
+			),
+			'actions'     => '',
+			'test'        => 'alt_update_api_communication',
+		);
+
+		$wp_update_api = wp_remote_get(
+			wp_get_update_api_base(),
+			array(
+				'timeout' => 10,
+			)
+		);
+		if ( ! is_wp_error( $wp_update_api ) ) {
+			$result['status'] = 'good';
+		} else {
+			$result['status'] = 'critical';
+
+			$result['label'] = __( 'Could not reach update API' );
+
+			$result['description'] .= sprintf(
+				'<p>%s</p>',
+				sprintf(
+					'<span class="error"><span class="screen-reader-text">%s</span></span> %s',
+					/* translators: Hidden accessibility text. */
+					__( 'Error' ),
+					sprintf(
+						/* translators: 1: update API URL. 2: The IP address the update API endpoint resolves to. 3: The error returned by the lookup. */
+						__( 'Your site is unable to reach the specified update API endpoint (%s) at %s, and returned the error: %s' ),
+						wp_get_update_api_base(),
+						gethostbyname( parse_url( wp_get_update_api_base(), PHP_URL_HOST ) ),
+						$wp_update_api->get_error_message()
+					)
+				)
+			);
+
+			$result['actions'] = sprintf(
+				/* translators: URL of update API */
+				__('Contact the owners of %s for support.'),
+				wp_get_update_api_base()
 			);
 		}
 
@@ -2814,6 +2876,10 @@ class WP_Site_Health {
 					'label' => __( 'Available disk space' ),
 					'test'  => 'available_updates_disk_space',
 				),
+				'update_api_info' => array(
+					'label' => __( 'Update API Info' ),
+					'test'  => 'update_api_info',
+				),
 				'autoloaded_options'           => array(
 					'label' => __( 'Autoloaded options' ),
 					'test'  => 'autoloaded_options',
@@ -2859,6 +2925,16 @@ class WP_Site_Health {
 				'has_rest'  => true,
 				'headers'   => array( 'Authorization' => 'Basic ' . base64_encode( 'user:pwd' ) ),
 				'skip_cron' => true,
+			);
+		}
+
+		// Only check alternate update API endpoint if one has been configured.
+		if ( WP_UPDATE_API_DEFAULT !== wp_get_update_api_base() ) {
+			$tests['async']['alt_update_api_communication'] = array(
+				'label'             => __( 'Communication with update API' ),
+				'test'              => rest_url( 'wp-site-health/v1/tests/alt-update-api-communication' ),
+				'has_rest'          => true,
+				'async_direct_test' => array( WP_Site_Health::get_instance(), 'get_test_alt_update_api_communication' ),
 			);
 		}
 

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1391,7 +1391,7 @@ class WP_Site_Health {
 					__( 'Error' ),
 					sprintf(
 						/* translators: 1: update API URL. 2: The IP address the update API endpoint resolves to. 3: The error returned by the lookup. */
-						__( 'Your site is unable to reach the specified update API endpoint (%s) at %s, and returned the error: %s' ),
+						__( 'Your site is unable to reach the specified update API endpoint (%1$s) at %2$s, and returned the error: %3$s' ),
 						wp_get_api_request_url(),
 						gethostbyname( parse_url( wp_get_api_request_url(), PHP_URL_HOST ) ),
 						$wp_update_api->get_error_message()
@@ -1401,7 +1401,7 @@ class WP_Site_Health {
 
 			$result['actions'] = sprintf(
 				/* translators: URL of update API */
-				__('Contact the owners of %s for support.'),
+				__( 'Contact the owners of %s for support.' ),
 				wp_get_api_request_url()
 			);
 		}

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -1307,7 +1307,7 @@ class WP_Site_Health {
 		);
 
 		$wp_dotorg = wp_remote_get(
-			WP_UPDATE_API_DEFAULT,
+			'http://' . WP_UPDATE_API_DEFAULT . '/',
 			array(
 				'timeout' => 10,
 			)
@@ -1350,7 +1350,7 @@ class WP_Site_Health {
 	/**
 	 * Tests if the site can communicate with a non-default update API endpoint.
 	 *
-	 * @since 6.9.0
+	 * @since 7.0.0
 	 *
 	 * @return array The test results.
 	 */
@@ -1371,7 +1371,7 @@ class WP_Site_Health {
 		);
 
 		$wp_update_api = wp_remote_get(
-			wp_get_update_api_base(),
+			wp_get_api_request_url(),
 			array(
 				'timeout' => 10,
 			)
@@ -1392,8 +1392,8 @@ class WP_Site_Health {
 					sprintf(
 						/* translators: 1: update API URL. 2: The IP address the update API endpoint resolves to. 3: The error returned by the lookup. */
 						__( 'Your site is unable to reach the specified update API endpoint (%s) at %s, and returned the error: %s' ),
-						wp_get_update_api_base(),
-						gethostbyname( parse_url( wp_get_update_api_base(), PHP_URL_HOST ) ),
+						wp_get_api_request_url(),
+						gethostbyname( parse_url( wp_get_api_request_url(), PHP_URL_HOST ) ),
 						$wp_update_api->get_error_message()
 					)
 				)
@@ -1402,7 +1402,7 @@ class WP_Site_Health {
 			$result['actions'] = sprintf(
 				/* translators: URL of update API */
 				__('Contact the owners of %s for support.'),
-				wp_get_update_api_base()
+				wp_get_api_request_url()
 			);
 		}
 
@@ -2929,7 +2929,7 @@ class WP_Site_Health {
 		}
 
 		// Only check alternate update API endpoint if one has been configured.
-		if ( WP_UPDATE_API_DEFAULT !== wp_get_update_api_base() ) {
+		if ( WP_UPDATE_API_DEFAULT !== parse_url( wp_get_api_request_url(), PHP_URL_HOST ) ) {
 			$tests['async']['alt_update_api_communication'] = array(
 				'label'             => __( 'Communication with update API' ),
 				'test'              => rest_url( 'wp-site-health/v1/tests/alt-update-api-communication' ),

--- a/src/wp-admin/includes/credits.php
+++ b/src/wp-admin/includes/credits.php
@@ -32,7 +32,7 @@ function wp_credits( $version = '', $locale = '' ) {
 		|| str_contains( $version, '-' )
 		|| ( isset( $results['data']['version'] ) && ! str_starts_with( $version, $results['data']['version'] ) )
 	) {
-		$url     = WP_UPDATE_API_DEFAULT . "/core/credits/1.1/?version={$version}&locale={$locale}";
+		$url     = wp_get_api_request_url( "/core/credits/1.1/?version={$version}&locale={$locale}" );
 		$options = array( 'user-agent' => 'WordPress/' . $version . '; ' . home_url( '/' ) );
 
 		if ( wp_http_supports( array( 'ssl' ) ) ) {

--- a/src/wp-admin/includes/credits.php
+++ b/src/wp-admin/includes/credits.php
@@ -32,7 +32,7 @@ function wp_credits( $version = '', $locale = '' ) {
 		|| str_contains( $version, '-' )
 		|| ( isset( $results['data']['version'] ) && ! str_starts_with( $version, $results['data']['version'] ) )
 	) {
-		$url     = "http://api.wordpress.org/core/credits/1.1/?version={$version}&locale={$locale}";
+		$url     = WP_UPDATE_API_DEFAULT . "/core/credits/1.1/?version={$version}&locale={$locale}";
 		$options = array( 'user-agent' => 'WordPress/' . $version . '; ' . home_url( '/' ) );
 
 		if ( wp_http_supports( array( 'ssl' ) ) ) {

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1814,7 +1814,7 @@ function wp_check_browser_version() {
 	$response = get_site_transient( 'browser_' . $key );
 
 	if ( false === $response ) {
-		$url     = wp_get_update_api_base( $https = false ) . '/core/browse-happy/1.1/';
+		$url     = wp_get_api_request_url( '/core/browse-happy/1.1/', 'http' );
 		$options = array(
 			'body'       => array( 'useragent' => $_SERVER['HTTP_USER_AGENT'] ),
 			'user-agent' => 'WordPress/' . wp_get_wp_version() . '; ' . home_url( '/' ),

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1814,7 +1814,7 @@ function wp_check_browser_version() {
 	$response = get_site_transient( 'browser_' . $key );
 
 	if ( false === $response ) {
-		$url     = 'http://api.wordpress.org/core/browse-happy/1.1/';
+		$url     = wp_get_update_api_base( $https = false ) . '/core/browse-happy/1.1/';
 		$options = array(
 			'body'       => array( 'useragent' => $_SERVER['HTTP_USER_AGENT'] ),
 			'user-agent' => 'WordPress/' . wp_get_wp_version() . '; ' . home_url( '/' ),

--- a/src/wp-admin/includes/import.php
+++ b/src/wp-admin/includes/import.php
@@ -146,7 +146,7 @@ function wp_get_popular_importers() {
 				'locale'  => $locale,
 				'version' => wp_get_wp_version(),
 			),
-			wp_get_update_api_base( $https = false ) . '/core/importers/1.1/'
+			wp_get_api_request_url( '/core/importers/1.1/', 'http' )
 		);
 		$options = array( 'user-agent' => 'WordPress/' . wp_get_wp_version() . '; ' . home_url( '/' ) );
 

--- a/src/wp-admin/includes/import.php
+++ b/src/wp-admin/includes/import.php
@@ -146,7 +146,7 @@ function wp_get_popular_importers() {
 				'locale'  => $locale,
 				'version' => wp_get_wp_version(),
 			),
-			'http://api.wordpress.org/core/importers/1.1/'
+			wp_get_update_api_base( $https = false ) . '/core/importers/1.1/'
 		);
 		$options = array( 'user-agent' => 'WordPress/' . wp_get_wp_version() . '; ' . home_url( '/' ) );
 

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1579,7 +1579,7 @@ function wp_check_php_version() {
 	$response = get_site_transient( 'php_check_' . $key );
 
 	if ( false === $response ) {
-		$url = 'http://api.wordpress.org/core/serve-happy/1.0/';
+		$url = wp_get_update_api_base( $https = false ) . '/core/serve-happy/1.0/';
 
 		if ( wp_http_supports( array( 'ssl' ) ) ) {
 			$url = set_url_scheme( $url, 'https' );

--- a/src/wp-admin/includes/misc.php
+++ b/src/wp-admin/includes/misc.php
@@ -1579,7 +1579,7 @@ function wp_check_php_version() {
 	$response = get_site_transient( 'php_check_' . $key );
 
 	if ( false === $response ) {
-		$url = wp_get_update_api_base( $https = false ) . '/core/serve-happy/1.0/';
+		$url = wp_get_api_request_url( '/core/serve-happy/1.0/', 'http' );
 
 		if ( wp_http_supports( array( 'ssl' ) ) ) {
 			$url = set_url_scheme( $url, 'https' );

--- a/src/wp-admin/includes/network.php
+++ b/src/wp-admin/includes/network.php
@@ -554,7 +554,7 @@ define( 'BLOG_ID_CURRENT_SITE', 1 );
 
 		if ( ! empty( $keys_salts ) ) {
 			$keys_salts_str = '';
-			$from_api       = wp_remote_get( wp_get_api_request_url( '/secret-key/1.1/salt/') );
+			$from_api       = wp_remote_get( wp_get_api_request_url( '/secret-key/1.1/salt/' ) );
 			if ( is_wp_error( $from_api ) ) {
 				foreach ( $keys_salts as $c => $v ) {
 					$keys_salts_str .= "\ndefine( '$c', '" . wp_generate_password( 64, true, true ) . "' );";

--- a/src/wp-admin/includes/network.php
+++ b/src/wp-admin/includes/network.php
@@ -554,7 +554,7 @@ define( 'BLOG_ID_CURRENT_SITE', 1 );
 
 		if ( ! empty( $keys_salts ) ) {
 			$keys_salts_str = '';
-			$from_api       = wp_remote_get( wp_get_update_api_base() . '/secret-key/1.1/salt/' );
+			$from_api       = wp_remote_get( wp_get_api_request_url( '/secret-key/1.1/salt/') );
 			if ( is_wp_error( $from_api ) ) {
 				foreach ( $keys_salts as $c => $v ) {
 					$keys_salts_str .= "\ndefine( '$c', '" . wp_generate_password( 64, true, true ) . "' );";

--- a/src/wp-admin/includes/network.php
+++ b/src/wp-admin/includes/network.php
@@ -554,7 +554,7 @@ define( 'BLOG_ID_CURRENT_SITE', 1 );
 
 		if ( ! empty( $keys_salts ) ) {
 			$keys_salts_str = '';
-			$from_api       = wp_remote_get( 'https://api.wordpress.org/secret-key/1.1/salt/' );
+			$from_api       = wp_remote_get( wp_get_update_api_base() . '/secret-key/1.1/salt/' );
 			if ( is_wp_error( $from_api ) ) {
 				foreach ( $keys_salts as $c => $v ) {
 					$keys_salts_str .= "\ndefine( '$c', '" . wp_generate_password( 64, true, true ) . "' );";

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -146,7 +146,7 @@ function plugins_api( $action, $args = array() ) {
 
 	if ( false === $res ) {
 
-		$url = wp_get_update_api_base( $https = false ) . '/plugins/info/1.2/';
+		$url = wp_get_api_request_url( '/plugins/info/1.2/' );
 		$url = add_query_arg(
 			array(
 				'action'  => $action,

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -146,7 +146,7 @@ function plugins_api( $action, $args = array() ) {
 
 	if ( false === $res ) {
 
-		$url = 'http://api.wordpress.org/plugins/info/1.2/';
+		$url = wp_get_update_api_base( $https = false ) . '/plugins/info/1.2/';
 		$url = add_query_arg(
 			array(
 				'action'  => $action,

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -542,7 +542,7 @@ function themes_api( $action, $args = array() ) {
 	$res = apply_filters( 'themes_api', false, $action, $args );
 
 	if ( ! $res ) {
-		$url = 'http://api.wordpress.org/themes/info/1.2/';
+		$url = wp_get_update_api_base( $https = false ) . '/themes/info/1.2/';
 		$url = add_query_arg(
 			array(
 				'action'  => $action,

--- a/src/wp-admin/includes/theme.php
+++ b/src/wp-admin/includes/theme.php
@@ -542,7 +542,7 @@ function themes_api( $action, $args = array() ) {
 	$res = apply_filters( 'themes_api', false, $action, $args );
 
 	if ( ! $res ) {
-		$url = wp_get_update_api_base( $https = false ) . '/themes/info/1.2/';
+		$url = wp_get_api_request_url( '/themes/info/1.2/', 'http' );
 		$url = add_query_arg(
 			array(
 				'action'  => $action,

--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -50,7 +50,7 @@ function translations_api( $type, $args = null ) {
 	$res = apply_filters( 'translations_api', false, $type, $args );
 
 	if ( false === $res ) {
-		$url      = wp_get_api_request_url( '/translations/' . $type . '/1.0/' , 'http' );
+		$url      = wp_get_api_request_url( '/translations/' . $type . '/1.0/', 'http' );
 		$http_url = $url;
 		$ssl      = wp_http_supports( array( 'ssl' ) );
 		if ( $ssl ) {

--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -50,7 +50,7 @@ function translations_api( $type, $args = null ) {
 	$res = apply_filters( 'translations_api', false, $type, $args );
 
 	if ( false === $res ) {
-		$url      = wp_get_update_api_base( $https = false ) . '/translations/' . $type . '/1.0/';
+		$url      = wp_get_api_request_url( '/translations/' . $type . '/1.0/' , 'http' );
 		$http_url = $url;
 		$ssl      = wp_http_supports( array( 'ssl' ) );
 		if ( $ssl ) {

--- a/src/wp-admin/includes/translation-install.php
+++ b/src/wp-admin/includes/translation-install.php
@@ -50,7 +50,7 @@ function translations_api( $type, $args = null ) {
 	$res = apply_filters( 'translations_api', false, $type, $args );
 
 	if ( false === $res ) {
-		$url      = 'http://api.wordpress.org/translations/' . $type . '/1.0/';
+		$url      = wp_get_update_api_base( $https = false ) . '/translations/' . $type . '/1.0/';
 		$http_url = $url;
 		$ssl      = wp_http_supports( array( 'ssl' ) );
 		if ( $ssl ) {

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -129,7 +129,8 @@ function find_core_auto_update() {
  * @return array|false An array of checksums on success, false on failure.
  */
 function get_core_checksums( $version, $locale ) {
-	$http_url = wp_get_update_api_base( $https = false ) . '/core/checksums/1.0/?' . http_build_query( compact( 'version', 'locale' ), '', '&' );
+	$path = '/core/checksums/1.0/?' . http_build_query( compact( 'version', 'locale' ), '', '&' );
+	$http_url = wp_get_api_request_url( $path, 'http' );
 	$url      = $http_url;
 
 	$ssl = wp_http_supports( array( 'ssl' ) );

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -1125,39 +1125,3 @@ function wp_get_auto_update_message() {
 
 	return $message;
 }
-
-/**
- * Returns the base URL in use for the wordpress.org API. Defaults to http://api.wordpress.org .
- * 
- * This URL can be overridden by specifying an environment variable `WP_UPDATE_API_BASE` or
- * by using the {@see wp_update_api_base} filter. Providing an empty URL is not allowed and
- * will result in the default being used.
- * 
- * @since 6.8.0
- * 
- * @param bool $https Whether requests should use https instead of http, defaults to true.
- * @return string The base URL in use for the wordpress.org update API.
- */
-function wp_get_update_api_base( $https = true ) {
-	$api_base = WP_UPDATE_API_DEFAULT;
-
-	if ( false !== getenv('WP_UPDATE_API_BASE') ) {
-		$api_base = getenv('WP_UPDATE_API_BASE');
-	}
-
-	/**
-	 * Filters the base URL used for wordpress.org API requests.
-	 *
-	 * @since 6.8.0
-	 *
-	 * @param string $content Default text.
-	 */
-	$api_base = apply_filters( 'wp_update_api_base', $api_base );
-
-	// required for back-compat as many old api references in core use http:// explicitly
-	if ( (! $https) && (substr($api_base, 0, 7) == 'http://') && ($api_base === WP_UPDATE_API_DEFAULT)) {
-		$api_base = str_replace( $api_base, 'http://', 'https://' );
-	}
-
-	return $api_base;
-}

--- a/src/wp-admin/includes/update.php
+++ b/src/wp-admin/includes/update.php
@@ -129,7 +129,7 @@ function find_core_auto_update() {
  * @return array|false An array of checksums on success, false on failure.
  */
 function get_core_checksums( $version, $locale ) {
-	$http_url = 'http://api.wordpress.org/core/checksums/1.0/?' . http_build_query( compact( 'version', 'locale' ), '', '&' );
+	$http_url = wp_get_update_api_base( $https = false ) . '/core/checksums/1.0/?' . http_build_query( compact( 'version', 'locale' ), '', '&' );
 	$url      = $http_url;
 
 	$ssl = wp_http_supports( array( 'ssl' ) );
@@ -1124,4 +1124,40 @@ function wp_get_auto_update_message() {
 	}
 
 	return $message;
+}
+
+/**
+ * Returns the base URL in use for the wordpress.org API. Defaults to http://api.wordpress.org .
+ * 
+ * This URL can be overridden by specifying an environment variable `WP_UPDATE_API_BASE` or
+ * by using the {@see wp_update_api_base} filter. Providing an empty URL is not allowed and
+ * will result in the default being used.
+ * 
+ * @since 6.8.0
+ * 
+ * @param bool $https Whether requests should use https instead of http, defaults to true.
+ * @return string The base URL in use for the wordpress.org update API.
+ */
+function wp_get_update_api_base( $https = true ) {
+	$api_base = WP_UPDATE_API_DEFAULT;
+
+	if ( false !== getenv('WP_UPDATE_API_BASE') ) {
+		$api_base = getenv('WP_UPDATE_API_BASE');
+	}
+
+	/**
+	 * Filters the base URL used for wordpress.org API requests.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @param string $content Default text.
+	 */
+	$api_base = apply_filters( 'wp_update_api_base', $api_base );
+
+	// required for back-compat as many old api references in core use http:// explicitly
+	if ( (! $https) && (substr($api_base, 0, 7) == 'http://') && ($api_base === WP_UPDATE_API_DEFAULT)) {
+		$api_base = str_replace( $api_base, 'http://', 'https://' );
+	}
+
+	return $api_base;
 }

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -358,7 +358,7 @@ switch ( $step ) {
 			$no_api = isset( $_POST['noapi'] );
 
 			if ( ! $no_api ) {
-				$secret_keys = wp_remote_get( 'https://api.wordpress.org/secret-key/1.1/salt/' );
+				$secret_keys = wp_remote_get( wp_get_update_api_base() . '/secret-key/1.1/salt/' );
 			}
 
 			if ( $no_api || is_wp_error( $secret_keys ) ) {

--- a/src/wp-admin/setup-config.php
+++ b/src/wp-admin/setup-config.php
@@ -358,7 +358,7 @@ switch ( $step ) {
 			$no_api = isset( $_POST['noapi'] );
 
 			if ( ! $no_api ) {
-				$secret_keys = wp_remote_get( wp_get_update_api_base() . '/secret-key/1.1/salt/' );
+				$secret_keys = wp_remote_get( wp_get_api_request_url( '/secret-key/1.1/salt/' ) );
 			}
 
 			if ( $no_api || is_wp_error( $secret_keys ) ) {

--- a/src/wp-includes/class-wp-http.php
+++ b/src/wp-includes/class-wp-http.php
@@ -875,7 +875,8 @@ class WP_Http {
 	 * Determines whether an HTTP API request to the given URL should be blocked.
 	 *
 	 * Those who are behind a proxy and want to prevent access to certain hosts may do so. This will
-	 * prevent plugins from working and core functionality, if you don't include `api.wordpress.org`.
+	 * prevent plugins from working and core functionality, if you don't include `api.wordpress.org`
+	 * (or your alternate API host, if configured).
 	 *
 	 * You block external URL requests by defining `WP_HTTP_BLOCK_EXTERNAL` as true in your `wp-config.php`
 	 * file and this will only allow localhost and your site to make requests. The constant

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -142,6 +142,9 @@ function wp_initial_constants() {
 	// Constants for features added to WP that should short-circuit their plugin implementations.
 	define( 'WP_FEATURE_BETTER_PASSWORDS', true );
 
+	// Defines the default URL base for many update-related functions
+	define( 'WP_UPDATE_API_DEFAULT', 'http://api.wordpress.org' );
+
 	/**#@+
 	 * Constants for expressing human-readable intervals
 	 * in their respective number of seconds.

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -142,8 +142,8 @@ function wp_initial_constants() {
 	// Constants for features added to WP that should short-circuit their plugin implementations.
 	define( 'WP_FEATURE_BETTER_PASSWORDS', true );
 
-	// Defines the default URL base for many update-related functions
-	define( 'WP_UPDATE_API_DEFAULT', 'http://api.wordpress.org' );
+	// Defines the default URL host for many update-related functions
+	define( 'WP_UPDATE_API_DEFAULT', 'api.wordpress.org' );
 
 	/**#@+
 	 * Constants for expressing human-readable intervals

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -9238,14 +9238,14 @@ function wp_get_api_request_url( $path = '/', $scheme = 'https' ) {
 		$domain = getenv( 'WP_UPDATE_API_BASE' );
 	}
 
-	$uri = $scheme . '://' . $domain . $path;
+	$url = $scheme . '://' . $domain . $path;
 	/**
 	 * Filters the URL for a WP API request.
 	 *
 	 * @since 7.0.0
 	 *
-	 * @param string $url URL
+	 * @param string $url URL for this WP API request.
 	 */
-	$uri = apply_filters( 'wp_api_request' );
+	apply_filters( 'wp_api_request', $url );
 	return $uri;
 }

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -9246,6 +9246,5 @@ function wp_get_api_request_url( $path = '/', $scheme = 'https' ) {
 	 *
 	 * @param string $url URL for this WP API request.
 	 */
-	apply_filters( 'wp_api_request', $url );
-	return $uri;
+	return apply_filters( 'wp_api_request', $url );
 }

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -9221,3 +9221,39 @@ function wp_verify_fast_hash(
 
 	return hash_equals( $hash, wp_fast_hash( $message ) );
 }
+
+/**
+ * Returns the base URL in use for the wordpress.org API. Defaults to http://api.wordpress.org .
+ * 
+ * This URL can be overridden by specifying an environment variable `WP_UPDATE_API_BASE` or
+ * by using the {@see wp_update_api_base} filter. Providing an empty URL is not allowed and
+ * will result in the default being used.
+ * 
+ * @since 7.0.0
+ * 
+ * @param bool $https Whether requests should use https instead of http, defaults to true.
+ * @return string The base URL in use for the wordpress.org update API.
+ */
+function wp_get_update_api_base( $https = true ) {
+	$api_base = WP_UPDATE_API_DEFAULT;
+
+	if ( false !== getenv('WP_UPDATE_API_BASE') ) {
+		$api_base = getenv('WP_UPDATE_API_BASE');
+	}
+
+	/**
+	 * Filters the base URL used for wordpress.org API requests.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string $content Default text.
+	 */
+	$api_base = apply_filters( 'wp_update_api_base', $api_base );
+
+	// required for back-compat as many old api references in core use http:// explicitly
+	if ( (! $https) && (substr($api_base, 0, 7) == 'http://') && ($api_base === WP_UPDATE_API_DEFAULT)) {
+		$api_base = str_replace( $api_base, 'http://', 'https://' );
+	}
+
+	return $api_base;
+}

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -9234,18 +9234,18 @@ function wp_verify_fast_hash(
  */
 function wp_get_api_request_url( $path = '/', $scheme = 'https' ) {
 	$domain = WP_UPDATE_API_DEFAULT;
-	if (false !== getenv( 'WP_UPDATE_API_BASE' ) ) {
+	if ( false !== getenv( 'WP_UPDATE_API_BASE' ) ) {
 		$domain = getenv( 'WP_UPDATE_API_BASE' );
 	}
 
 	$uri = $scheme . '://' . $domain . $path;
 	/**
 	 * Filters the URL for a WP API request.
-	 * 
+	 *
 	 * @since 7.0.0
-	 * 
+	 *
 	 * @param string $url URL
 	 */
-	$uri = apply_filters( 'wp_api_request');
+	$uri = apply_filters( 'wp_api_request' );
 	return $uri;
 }

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -9223,37 +9223,28 @@ function wp_verify_fast_hash(
 }
 
 /**
- * Returns the base URL in use for the wordpress.org API. Defaults to http://api.wordpress.org .
- * 
- * This URL can be overridden by specifying an environment variable `WP_UPDATE_API_BASE` or
- * by using the {@see wp_update_api_base} filter. Providing an empty URL is not allowed and
- * will result in the default being used.
+ * Given a path, returns the complete URL for a WP API request.
  * 
  * @since 7.0.0
  * 
- * @param bool $https Whether requests should use https instead of http, defaults to true.
- * @return string The base URL in use for the wordpress.org update API.
+ * @param string $path     The API endpoint to request.
+ * @param string $scheme   Optional. Scheme for request. Defaults to https.
+ * @return string          Complete URL for this request.
  */
-function wp_get_update_api_base( $https = true ) {
-	$api_base = WP_UPDATE_API_DEFAULT;
-
-	if ( false !== getenv('WP_UPDATE_API_BASE') ) {
-		$api_base = getenv('WP_UPDATE_API_BASE');
+function wp_get_api_request_url( $path = '/', $scheme = 'https' ) {
+	$domain = WP_UPDATE_API_DEFAULT;
+	if (false !== getenv('WP_UPDATE_API_BASE')) {
+		$domain = getenv('WP_UPDATE_API_BASE');
 	}
 
+	$uri = $scheme . "://" . $domain . $path ;
 	/**
-	 * Filters the base URL used for wordpress.org API requests.
-	 *
+	 * Filters the URL for a WP API request.
+	 * 
 	 * @since 7.0.0
-	 *
-	 * @param string $content Default text.
+	 * 
+	 * @param string $url URL
 	 */
-	$api_base = apply_filters( 'wp_update_api_base', $api_base );
-
-	// required for back-compat as many old api references in core use http:// explicitly
-	if ( (! $https) && (substr($api_base, 0, 7) == 'http://') && ($api_base === WP_UPDATE_API_DEFAULT)) {
-		$api_base = str_replace( $api_base, 'http://', 'https://' );
-	}
-
-	return $api_base;
+	$uri = apply_filters( 'wp_api_request');
+    return $uri;
 }

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -9224,20 +9224,21 @@ function wp_verify_fast_hash(
 
 /**
  * Given a path, returns the complete URL for a WP API request.
- * 
+ *
  * @since 7.0.0
- * 
+ *
  * @param string $path     The API endpoint to request.
  * @param string $scheme   Optional. Scheme for request. Defaults to https.
  * @return string          Complete URL for this request.
+ *
  */
 function wp_get_api_request_url( $path = '/', $scheme = 'https' ) {
 	$domain = WP_UPDATE_API_DEFAULT;
-	if (false !== getenv('WP_UPDATE_API_BASE')) {
-		$domain = getenv('WP_UPDATE_API_BASE');
+	if (false !== getenv( 'WP_UPDATE_API_BASE' ) ) {
+		$domain = getenv( 'WP_UPDATE_API_BASE' );
 	}
 
-	$uri = $scheme . "://" . $domain . $path ;
+	$uri = $scheme . '://' . $domain . $path;
 	/**
 	 * Filters the URL for a WP API request.
 	 * 
@@ -9246,5 +9247,5 @@ function wp_get_api_request_url( $path = '/', $scheme = 'https' ) {
 	 * @param string $url URL
 	 */
 	$uri = apply_filters( 'wp_api_request');
-    return $uri;
+	return $uri;
 }

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
@@ -114,7 +114,7 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 		$raw_patterns = get_site_transient( $transient_key );
 
 		if ( ! $raw_patterns ) {
-			$api_url = wp_get_update_api_base( $https = false ) . '/patterns/1.0/?' . build_query( $query_args );
+                        $api_url = wp_get_api_request_url( '/patterns/1.0/?' . build_query( $query_args ) , 'http' );
 			if ( wp_http_supports( array( 'ssl' ) ) ) {
 				$api_url = set_url_scheme( $api_url, 'https' );
 			}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
@@ -114,7 +114,7 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 		$raw_patterns = get_site_transient( $transient_key );
 
 		if ( ! $raw_patterns ) {
-                        $api_url = wp_get_api_request_url( '/patterns/1.0/?' . build_query( $query_args ) , 'http' );
+			$api_url = wp_get_api_request_url( '/patterns/1.0/?' . build_query( $query_args ), 'http' );
 			if ( wp_http_supports( array( 'ssl' ) ) ) {
 				$api_url = set_url_scheme( $api_url, 'https' );
 			}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-pattern-directory-controller.php
@@ -114,7 +114,7 @@ class WP_REST_Pattern_Directory_Controller extends WP_REST_Controller {
 		$raw_patterns = get_site_transient( $transient_key );
 
 		if ( ! $raw_patterns ) {
-			$api_url = 'http://api.wordpress.org/patterns/1.0/?' . build_query( $query_args );
+			$api_url = wp_get_update_api_base( $https = false ) . '/patterns/1.0/?' . build_query( $query_args );
 			if ( wp_http_supports( array( 'ssl' ) ) ) {
 				$api_url = set_url_scheme( $api_url, 'https' );
 			}

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-site-health-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-site-health-controller.php
@@ -135,7 +135,7 @@ class WP_REST_Site_Health_Controller extends WP_REST_Controller {
 				array(
 					'methods'             => 'GET',
 					'callback'            => array( $this, 'test_alt_update_api_communication' ),
-					'permission_callback' => function() {
+					'permission_callback' => function () {
 						return $this->validate_request_permission( 'alt_update_api_communication' );
 					},
 				),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-site-health-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-site-health-controller.php
@@ -247,7 +247,7 @@ class WP_REST_Site_Health_Controller extends WP_REST_Controller {
 	/**
 	 * Checks that the site can reach an alternate update API.
 	 *
-	 * @since 6.9.0
+	 * @since 7.0.0
 	 *
 	 * @return array
 	 */

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-site-health-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-site-health-controller.php
@@ -129,6 +129,25 @@ class WP_REST_Site_Health_Controller extends WP_REST_Controller {
 			sprintf(
 				'/%s/%s',
 				$this->rest_base,
+				'alt-update-api-communication'
+			),
+			array(
+				array(
+					'methods'             => 'GET',
+					'callback'            => array( $this, 'test_alt_update_api_communication' ),
+					'permission_callback' => function() {
+						return $this->validate_request_permission( 'alt_update_api_communication' );
+					},
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			sprintf(
+				'/%s/%s',
+				$this->rest_base,
 				'authorization-header'
 			),
 			array(
@@ -223,6 +242,18 @@ class WP_REST_Site_Health_Controller extends WP_REST_Controller {
 	public function test_dotorg_communication() {
 		$this->load_admin_textdomain();
 		return $this->site_health->get_test_dotorg_communication();
+	}
+
+	/**
+	 * Checks that the site can reach an alternate update API.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @return array
+	 */
+	public function test_alt_update_api_communication() {
+		$this->load_admin_textdomain();
+		return $this->site_health->get_test_alt_update_api_communication();
 	}
 
 	/**

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -16,8 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * The WordPress version, PHP version, and locale is sent to api.wordpress.org.
  *
- * Checks against the WordPress server at api.wordpress.org. Will only check
- * if WordPress isn't installing.
+ * Checks against the WordPress API. Will only check if WordPress isn't installing.
  *
  * @since 2.3.0
  *
@@ -189,7 +188,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 		$query['channel'] = WP_AUTO_UPDATE_CORE;
 	}
 
-	$url      = 'http://api.wordpress.org/core/version-check/1.7/?' . http_build_query( $query, '', '&' );
+	$url      = wp_get_update_api_base( $https = false ). '/core/version-check/1.7/?' . http_build_query( $query, '', '&' );
 	$http_url = $url;
 	$ssl      = wp_http_supports( array( 'ssl' ) );
 
@@ -311,8 +310,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
  *
  * A list of all plugins installed is sent to api.wordpress.org, along with the site locale.
  *
- * Checks against the WordPress server at api.wordpress.org. Will only check
- * if WordPress isn't installing.
+ * Checks against the WordPress API server. Will only check if WordPress isn't installing.
  *
  * @since 2.3.0
  *
@@ -427,7 +425,7 @@ function wp_update_plugins( $extra_stats = array() ) {
 		$options['body']['update_stats'] = wp_json_encode( $extra_stats );
 	}
 
-	$url      = 'http://api.wordpress.org/plugins/update-check/1.1/';
+	$url      = wp_get_update_api_base( $https = false ). '/plugins/update-check/1.1/';
 	$http_url = $url;
 	$ssl      = wp_http_supports( array( 'ssl' ) );
 
@@ -582,8 +580,7 @@ function wp_update_plugins( $extra_stats = array() ) {
  *
  * A list of all themes installed is sent to api.wordpress.org, along with the site locale.
  *
- * Checks against the WordPress server at api.wordpress.org. Will only check
- * if WordPress isn't installing.
+ * Checks against the WordPress API. Will only check if WordPress isn't installing.
  *
  * @since 2.7.0
  *
@@ -713,7 +710,7 @@ function wp_update_themes( $extra_stats = array() ) {
 		$options['body']['update_stats'] = wp_json_encode( $extra_stats );
 	}
 
-	$url      = 'http://api.wordpress.org/themes/update-check/1.1/';
+	$url      = wp_get_update_api_base( $https = false ) . '/themes/update-check/1.1/';
 	$http_url = $url;
 	$ssl      = wp_http_supports( array( 'ssl' ) );
 

--- a/src/wp-includes/update.php
+++ b/src/wp-includes/update.php
@@ -188,7 +188,7 @@ function wp_version_check( $extra_stats = array(), $force_check = false ) {
 		$query['channel'] = WP_AUTO_UPDATE_CORE;
 	}
 
-	$url      = wp_get_update_api_base( $https = false ). '/core/version-check/1.7/?' . http_build_query( $query, '', '&' );
+	$url      = wp_get_api_request_url( '/core/version-check/1.7/?' . http_build_query( $query, '', '&' ), 'http' );
 	$http_url = $url;
 	$ssl      = wp_http_supports( array( 'ssl' ) );
 
@@ -425,7 +425,7 @@ function wp_update_plugins( $extra_stats = array() ) {
 		$options['body']['update_stats'] = wp_json_encode( $extra_stats );
 	}
 
-	$url      = wp_get_update_api_base( $https = false ). '/plugins/update-check/1.1/';
+	$url      = wp_get_api_request_url( '/plugins/update-check/1.1/', 'http' );
 	$http_url = $url;
 	$ssl      = wp_http_supports( array( 'ssl' ) );
 
@@ -710,7 +710,7 @@ function wp_update_themes( $extra_stats = array() ) {
 		$options['body']['update_stats'] = wp_json_encode( $extra_stats );
 	}
 
-	$url      = wp_get_update_api_base( $https = false ) . '/themes/update-check/1.1/';
+	$url      = wp_get_api_request_url( '/themes/update-check/1.1/', 'http' );
 	$http_url = $url;
 	$ssl      = wp_http_supports( array( 'ssl' ) );
 

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -1196,7 +1196,6 @@ function is_user_member_of_blog( $user_id = 0, $blog_id = 0 ) {
 		return false;
 	}
 
-
 	if ( 1 === $blog_id ) {
 		$capabilities_key = $wpdb->base_prefix . 'capabilities';
 	} else {

--- a/tests/phpunit/tests/rest-api/rest-schema-setup.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-setup.php
@@ -184,6 +184,7 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 			'/wp-site-health/v1/tests/loopback-requests',
 			'/wp-site-health/v1/tests/https-status',
 			'/wp-site-health/v1/tests/dotorg-communication',
+			'/wp-site-health/v1/tests/alt-update-api-communication',
 			'/wp-site-health/v1/tests/authorization-header',
 			'/wp-site-health/v1/tests/page-cache',
 			'/wp-site-health/v1/directory-sizes',


### PR DESCRIPTION
Initial support for overriding `api.wordpress.org` as the location for "WordPress API" requests, most commonly used for theme/plugin updates.

Trac ticket: https://core.trac.wordpress.org/ticket/62132

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
