### PR TITLE
Rename `post_states_string` to `post_states_html` and improve phpdoc

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2270,7 +2270,7 @@ function _post_states( $post, $display = true ) {
 	 *
 	 * @since 6.9.0
 	 *
-	 * @param string                 $post_states_html All relevant post sta60986tes combined into an HTML string for display.
+	 * @param string                 $post_states_html All relevant post states combined into an HTML string for display.
 	 *                                                 E.g. `&mdash; <span class='post-state'>Draft, </span><span class='post-state'>Sticky</span>`.
 	 * @param string<string, string> $post_states      A mapping of post state slugs to translated post state labels.
 	 *                                                 E.g. `array( 'draft' => 'Draft', 'sticky' => 'Sticky' )`.

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2246,22 +2246,22 @@ function iframe_footer() {
  * @return string Post states string.
  */
 function _post_states( $post, $display = true ) {
-	$post_states        = get_post_states( $post );
-	$post_states_string = '';
+	$post_states      = get_post_states( $post );
+	$post_states_html = '';
 
 	if ( ! empty( $post_states ) ) {
 		$state_count = count( $post_states );
 
 		$i = 0;
 
-		$post_states_string .= ' &mdash; ';
+		$post_states_html .= ' &mdash; ';
 
 		foreach ( $post_states as $state ) {
 			++$i;
 
 			$separator = ( $i < $state_count ) ? ', ' : '';
 
-			$post_states_string .= "<span class='post-state'>{$state}{$separator}</span>";
+			$post_states_html .= "<span class='post-state'>{$state}{$separator}</span>";
 		}
 	}
 
@@ -2270,17 +2270,19 @@ function _post_states( $post, $display = true ) {
 	 *
 	 * @since 6.9.0
 	 *
-	 * @param string   $post_states_string The post states HTML string.
-	 * @param string[] $post_states        The post states.
-	 * @param WP_Post  $post               The current post object.
+	 * @param string                 $post_states_html All relevant post sta60986tes combined into an HTML string for display.
+	 *                                                 E.g. `&mdash; <span class='post-state'>Draft, </span><span class='post-state'>Sticky</span>`.
+	 * @param string<string, string> $post_states      A mapping of post state slugs to translated post state labels.
+	 *                                                 E.g. `array( 'draft' => 'Draft', 'sticky' => 'Sticky' )`.
+	 * @param WP_Post                $post             The current post object.
 	 */
-	$post_states_string = apply_filters( 'post_states_string', $post_states_string, $post_states, $post );
+	$post_states_html = apply_filters( 'post_states_html', $post_states_html, $post_states, $post );
 
 	if ( $display ) {
-		echo $post_states_string;
+		echo $post_states_html;
 	}
 
-	return $post_states_string;
+	return $post_states_html;
 }
 
 /**
@@ -2353,8 +2355,8 @@ function get_post_states( $post ) {
 	 *              are used within the filter, their existence should be checked
 	 *              with `function_exists()` before being used.
 	 *
-	 * @param string[] $post_states An array of post display states.
-	 * @param WP_Post  $post        The current post object.
+	 * @param string<string, string> $post_states A mapping of post state slugs to translated post state labels.
+	 * @param WP_Post                $post        The current post object.
 	 */
 	return apply_filters( 'display_post_states', $post_states, $post );
 }

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2273,7 +2273,7 @@ function _post_states( $post, $display = true ) {
 	 * @param string                 $post_states_html All relevant post states combined into an HTML string for display.
 	 *                                                 E.g. `&mdash; <span class='post-state'>Draft, </span><span class='post-state'>Sticky</span>`.
 	 * @param string<string, string> $post_states      A mapping of post state slugs to translated post state labels.
-	 *                                                 E.g. `array( 'draft' => 'Draft', 'sticky' => 'Sticky' )`.
+	 *                                                 E.g. `array( 'draft' => __( 'Draft' ), 'sticky' => __( 'Sticky' ), ... )`.
 	 * @param WP_Post                $post             The current post object.
 	 */
 	$post_states_html = apply_filters( 'post_states_html', $post_states_html, $post_states, $post );
@@ -2356,6 +2356,7 @@ function get_post_states( $post ) {
 	 *              with `function_exists()` before being used.
 	 *
 	 * @param string<string, string> $post_states A mapping of post state slugs to translated post state labels.
+	 *                                            E.g. `array( 'draft' => __( 'Draft' ), 'sticky' => __( 'Sticky' ), ... )`.
 	 * @param WP_Post                $post        The current post object.
 	 */
 	return apply_filters( 'display_post_states', $post_states, $post );

--- a/tests/phpunit/tests/post/getPostStatus.php
+++ b/tests/phpunit/tests/post/getPostStatus.php
@@ -166,7 +166,7 @@ class Tests_Post_GetPostStatus extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensure the `post_states_string` filter works to modify post state output.
+	 * Ensure the `post_states_html` filter works to modify post state output.
 	 *
 	 * @ticket 51403
 	 *
@@ -176,7 +176,7 @@ class Tests_Post_GetPostStatus extends WP_UnitTestCase {
 	 *
 	 * @param string $post_state The post state to test.
 	 */
-	public function test_filter_post_states_string_should_enable_post_state_html_output_modification( $post_state ) {
+	public function test_filter_post_states_html_should_enable_post_state_html_output_modification( $post_state ) {
 		$post = get_post( self::$post_ids[ $post_state ] );
 
 		$original_output = _post_states( $post, false );
@@ -188,7 +188,7 @@ class Tests_Post_GetPostStatus extends WP_UnitTestCase {
 		}
 
 		add_filter(
-			'post_states_string',
+			'post_states_html',
 			function ( $post_states_string, $post_states, $filtered_post ) use ( $text_to_append, $post ) {
 				$this->assertIsString( $post_states_string, 'Expected first filter arg to be a string.' );
 				$this->assertIsArray( $post_states, 'Expected second filter arg to be an array.' );

--- a/tests/phpunit/tests/post/getPostStatus.php
+++ b/tests/phpunit/tests/post/getPostStatus.php
@@ -170,7 +170,7 @@ class Tests_Post_GetPostStatus extends WP_UnitTestCase {
 	 *
 	 * @ticket 51403
 	 *
-	 * @dataProvider data_filter_post_states_string_should_enable_post_state_html_output_modification
+	 * @dataProvider data_filter_post_states_html_should_enable_post_state_html_output_modification
 	 *
 	 * @covers ::_post_states
 	 *
@@ -189,12 +189,12 @@ class Tests_Post_GetPostStatus extends WP_UnitTestCase {
 
 		add_filter(
 			'post_states_html',
-			function ( $post_states_string, $post_states, $filtered_post ) use ( $text_to_append, $post ) {
-				$this->assertIsString( $post_states_string, 'Expected first filter arg to be a string.' );
+			function ( $post_states_html, $post_states, $filtered_post ) use ( $text_to_append, $post ) {
+				$this->assertIsString( $post_states_html, 'Expected first filter arg to be a string.' );
 				$this->assertIsArray( $post_states, 'Expected second filter arg to be an array.' );
 				$this->assertInstanceOf( WP_Post::class, $filtered_post, 'Expected third filter arg to be a WP_Post' );
 				$this->assertSame( $post->ID, $filtered_post->ID, 'Expected the third filter arg to be the same as the current post.' );
-				return $post_states_string . $text_to_append;
+				return $post_states_html . $text_to_append;
 			},
 			10,
 			3
@@ -206,13 +206,13 @@ class Tests_Post_GetPostStatus extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider for test_filter_post_states_string_should_enable_post_state_html_output_modification().
+	 * Data provider for test_filter_post_states_html_should_enable_post_state_html_output_modification().
 	 *
 	 * @return array[] {
 	 *     @type string $post_state The post state to test.
 	 * }
 	 */
-	public static function data_filter_post_states_string_should_enable_post_state_html_output_modification() {
+	public static function data_filter_post_states_html_should_enable_post_state_html_output_modification() {
 		return array(
 			array( 'publish' ),
 			array( 'future' ),


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/51403

Follow-up to https://github.com/WordPress/wordpress-develop/pull/10000

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
