### PR TITLE
For Pull Requests, go with a much smaller matrix for phpunit

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -71,6 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        event: ['${{ github.event_name }}']
         os: [ ubuntu-24.04 ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
         db-type: [ 'mysql' ]
@@ -206,6 +207,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        event: ['${{ github.event_name }}']
         os: [ ubuntu-24.04 ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
         db-type: [ 'mariadb' ]
@@ -452,6 +454,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        event: ['${{ github.event_name }}']
         os: [ ubuntu-24.04 ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
         db-type: [ 'mysql', 'mariadb' ]

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -79,6 +79,64 @@ jobs:
         multisite: [ false, true ]
         memcached: [ false ]
 
+        exclude:
+            # Trim the matrix on Pull Requests to reduce the number of concurrent jobs.
+            # Each PHP version is tested againgst one version of MySQL.
+            - event: pull_request
+              php: '7.2'
+              db-version: '8.0'
+            - event: pull_request
+              php: '7.2'
+              db-version: '8.4'
+            - event: pull_request
+              php: '7.3'
+              db-version: '5.7'
+            - event: pull_request
+              php: '7.3'
+              db-version: '8.4'
+            - event: pull_request
+              php: '7.4'
+              db-version: '5.7'
+            - event: pull_request
+              php: '7.4'
+              db-version: '8.0'
+            - event: pull_request
+              php: '8.0'
+              db-version: '8.0'
+            - event: pull_request
+              php: '8.0'
+              db-version: '8.4'
+            - event: pull_request
+              php: '8.1'
+              db-version: '5.7'
+            - event: pull_request
+              php: '8.1'
+              db-version: '8.4'
+            - event: pull_request
+              php: '8.2'
+              db-version: '5.7'
+            - event: pull_request
+              php: '8.2'
+              db-version: '8.0'
+            - event: pull_request
+              php: '8.3'
+              db-version: '8.0'
+            - event: pull_request
+              php: '8.3'
+              db-version: '8.4'
+            - event: pull_request
+              php: '8.4'
+              db-version: '5.7'
+            - event: pull_request
+              php: '8.4'
+              db-version: '8.4'
+            - event: pull_request
+              php: '8.5'
+              db-version: '5.7'
+            - event: pull_request
+              php: '8.5'
+              db-version: '8.0'
+
         include:
           # Include jobs that test with memcached.
           - os: ubuntu-24.04
@@ -155,6 +213,200 @@ jobs:
         multisite: [ false, true ]
         memcached: [ false ]
 
+        exclude:
+          # Trim the matrix on Pull Requests to reduce the number of concurrent jobs.
+          # Each PHP version is tested against one version of MariaDB.
+          # Each MariaDB version is tested at least once.
+          - event: pull_request
+            php: '7.2'
+            db-version: '10.3'
+          - event: pull_request
+            php: '7.2'
+            db-version: '10.4'
+          - event: pull_request
+            php: '7.2'
+            db-version: '10.5'
+          - event: pull_request
+            php: '7.2'
+            db-version: '10.6'
+          - event: pull_request
+            php: '7.2'
+            db-version: '10.11'
+          - event: pull_request
+            php: '7.2'
+            db-version: '11.4'
+          - event: pull_request
+            php: '7.2'
+            db-version: '11.8'
+          - event: pull_request
+            php: '7.3'
+            db-version: '5.5'
+          - event: pull_request
+            php: '7.3'
+            db-version: '10.4'
+          - event: pull_request
+            php: '7.3'
+            db-version: '10.5'
+          - event: pull_request
+            php: '7.3'
+            db-version: '10.6'
+          - event: pull_request
+            php: '7.3'
+            db-version: '10.11'
+          - event: pull_request
+            php: '7.3'
+            db-version: '11.4'
+          - event: pull_request
+            php: '7.3'
+            db-version: '11.8'
+          - event: pull_request
+            php: '7.4'
+            db-version: '5.5'
+          - event: pull_request
+            php: '7.4'
+            db-version: '10.3'
+          - event: pull_request
+            php: '7.4'
+            db-version: '10.5'
+          - event: pull_request
+            php: '7.4'
+            db-version: '10.6'
+          - event: pull_request
+            php: '7.4'
+            db-version: '10.11'
+          - event: pull_request
+            php: '7.4'
+            db-version: '11.4'
+          - event: pull_request
+            php: '7.4'
+            db-version: '11.8'
+          - event: pull_request
+            php: '8.0'
+            db-version: '5.5'
+          - event: pull_request
+            php: '8.0'
+            db-version: '10.3'
+          - event: pull_request
+            php: '8.0'
+            db-version: '10.4'
+          - event: pull_request
+            php: '8.0'
+            db-version: '10.6'
+          - event: pull_request
+            php: '8.0'
+            db-version: '10.11'
+          - event: pull_request
+            php: '8.0'
+            db-version: '11.4'
+          - event: pull_request
+            php: '8.0'
+            db-version: '11.8'
+          - event: pull_request
+            php: '8.1'
+            db-version: '5.5'
+          - event: pull_request
+            php: '8.1'
+            db-version: '10.3'
+          - event: pull_request
+            php: '8.1'
+            db-version: '10.4'
+          - event: pull_request
+            php: '8.1'
+            db-version: '10.5'
+          - event: pull_request
+            php: '8.1'
+            db-version: '10.11'
+          - event: pull_request
+            php: '8.1'
+            db-version: '11.4'
+          - event: pull_request
+            php: '8.1'
+            db-version: '11.8'
+          - event: pull_request
+            php: '8.2'
+            db-version: '5.5'
+          - event: pull_request
+            php: '8.2'
+            db-version: '10.3'
+          - event: pull_request
+            php: '8.2'
+            db-version: '10.4'
+          - event: pull_request
+            php: '8.2'
+            db-version: '10.5'
+          - event: pull_request
+            php: '8.2'
+            db-version: '10.6'
+          - event: pull_request
+            php: '8.2'
+            db-version: '11.4'
+          - event: pull_request
+            php: '8.2'
+            db-version: '11.8'
+          - event: pull_request
+            php: '8.3'
+            db-version: '5.5'
+          - event: pull_request
+            php: '8.3'
+            db-version: '10.3'
+          - event: pull_request
+            php: '8.3'
+            db-version: '10.4'
+          - event: pull_request
+            php: '8.3'
+            db-version: '10.5'
+          - event: pull_request
+            php: '8.3'
+            db-version: '10.6'
+          - event: pull_request
+            php: '8.3'
+            db-version: '10.11'
+          - event: pull_request
+            php: '8.3'
+            db-version: '11.8'
+          - event: pull_request
+            php: '8.4'
+            db-version: '5.5'
+          - event: pull_request
+            php: '8.4'
+            db-version: '10.3'
+          - event: pull_request
+            php: '8.4'
+            db-version: '10.4'
+          - event: pull_request
+            php: '8.4'
+            db-version: '10.5'
+          - event: pull_request
+            php: '8.4'
+            db-version: '10.6'
+          - event: pull_request
+            php: '8.4'
+            db-version: '10.11'
+          - event: pull_request
+            php: '8.4'
+            db-version: '11.4'
+          - event: pull_request
+            php: '8.5'
+            db-version: '5.5'
+          - event: pull_request
+            php: '8.5'
+            db-version: '10.3'
+          - event: pull_request
+            php: '8.5'
+            db-version: '10.4'
+          - event: pull_request
+            php: '8.5'
+            db-version: '10.5'
+          - event: pull_request
+            php: '8.5'
+            db-version: '10.6'
+          - event: pull_request
+            php: '8.5'
+            db-version: '10.11'
+          - event: pull_request
+            php: '8.5'
+            db-version: '11.4'
+
         include:
         # Include jobs that test with memcached.
         - os: ubuntu-24.04
@@ -219,6 +471,24 @@ jobs:
             db-version: '9.4'
           - db-type: 'mysql'
             db-version: '12.0'
+          # On Pull requests, only test each innovation release once.
+          - event: pull_request
+            php: '7.3'
+          - event: pull_request
+            php: '7.4'
+          - event: pull_request
+            php: '8.0'
+          - event: pull_request
+            php: '8.1'
+          - event: pull_request
+            php: '8.1'
+          - event: pull_request
+            php: '8.2'
+          - event: pull_request
+            php: '8.4'
+          - event: pull_request
+            php: '8.5'
+
     with:
       os: ${{ matrix.os }}
       php: ${{ matrix.php }}


### PR DESCRIPTION
Slack Discussion: https://wordpress.slack.com/archives/C02RQBWTW/p1761040717220989

This changes the matrix for phpunit so that each version of PHP is only tested once vs each type of db rather than against every combination of database version

Trac ticket: https://core.trac.wordpress.org/ticket/63167

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
