### PR TITLE
Command Palette: Don't include palate on Network Admin

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3428,6 +3428,10 @@ function wp_enqueue_classic_theme_styles() {
  * @global array  $submenu
  */
 function wp_enqueue_command_palette_assets() {
+	if ( is_network_admin() ) {
+		return;
+	}
+
 	global $menu, $submenu;
 
 	$command_palette_settings = array();


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64125

In the network admin screen, commands primarily intended for site editors don't work, such as `Go to : Styles` and `Go to: Templates`.

These commands are registered in JS, namely Gutenberg. Ideally, we'd need to detect network admin status client-side and disable comments. As a temporary fix, disable the command palette itself in the network admin area to avoid 404 errors.

### Testing Instructions

- Define `LOCAL_MULTISITE=true` in the `.env` file
- Run: `npm run env:start`, `npm run env:install`, and `npm run dev`
- Access to `http://localhost:8889/wp-admin/network/`
- Try to launch the Comand Palette and confirm that nothing happens
