### PR TITLE
KSES: Add `name` attribute to the `details` element

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -149,6 +149,7 @@ if ( ! CUSTOM_TAGS ) {
 		'details'    => array(
 			'align' => true,
 			'open'  => true,
+			'name'  => true,
 		),
 		'div'        => array(
 			'align'   => true,


### PR DESCRIPTION
We should add the `name` attribute to the `details` element in the global `$allowedposttags` array.

The details block supports the `name` attribute since WP 6.8, so it needs to be added. Otherwise, it will be stripped when saving.

Trac ticket: https://core.trac.wordpress.org/ticket/64127

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
