### PR TITLE
Query: undefined variable $q in WP_Query::generate_cache_key()

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -5043,7 +5043,7 @@ class WP_Query {
 		}
 
 		// Add a default orderby value of date to ensure same cache key generation.
-		if ( ! isset( $q['orderby'] ) ) {
+		if ( ! isset( $args['orderby'] ) ) {
 			$args['orderby'] = 'date';
 		}
 


### PR DESCRIPTION
Follow up to: https://core.trac.wordpress.org/ticket/59442

The `generate_cache_key()` method in `WP_Query` references an undefined variable `$q` on line 5046:

```php
if ( ! isset( $q['orderby'] ) ) {
    $args['orderby'] = 'date';
}
```

The method only has two parameters: `$args` and `$sql`. The variable `$q` is not defined anywhere in this method scope.

Introduced in https://core.trac.wordpress.org/changeset/58122 / https://github.com/10up/wordpress-develop/commit/3a6cca9ff772c77c86a3cf7c5a69398acc4c2272


This patch replaces the undefined `$q` variable with the correct `$args` parameter:

```php
if ( ! isset( $args['orderby'] ) ) {
    $args['orderby'] = 'date';
}
```

Trac ticket: https://core.trac.wordpress.org/ticket/64135 




