### PR TITLE
get_adjacent_post: Fix adjacent post navigation for posts with identical dates

### DIFF
--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1964,6 +1964,9 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	 */
 	$join = apply_filters( "get_{$adjacent}_post_join", $join, $in_same_term, $excluded_terms, $taxonomy, $post );
 
+	// Prepare the where clause for the adjacent post query.
+	$where_prepared = $wpdb->prepare( "WHERE (p.post_date $op %s OR (p.post_date = %s AND p.ID $op %d)) AND p.post_type = %s $where", $current_post_date, $current_post_date, $post->ID, $post->post_type ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $op is a string literal, either '<' or '>'.
+
 	/**
 	 * Filters the WHERE clause in the SQL for an adjacent post query.
 	 *
@@ -1977,7 +1980,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	 *
 	 * @since 2.5.0
 	 * @since 4.4.0 Added the `$taxonomy` and `$post` parameters.
-	 * @since n.e.x.t Adds ID-based fallback for posts with identical dates in adjacent post queries.
+	 * @since 6.9.0 Adds ID-based fallback for posts with identical dates in adjacent post queries.
 	 *
 	 * @param string       $where          The `WHERE` clause in the SQL.
 	 * @param bool         $in_same_term   Whether post should be in the same taxonomy term.
@@ -1985,7 +1988,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	 * @param string       $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true.
 	 * @param WP_Post      $post           WP_Post object.
 	 */
-	$where = apply_filters( "get_{$adjacent}_post_where", $wpdb->prepare( "WHERE (p.post_date $op %s OR (p.post_date = %s AND p.ID $op %d)) AND p.post_type = %s $where", $current_post_date, $current_post_date, $post->ID, $post->post_type ), $in_same_term, $excluded_terms, $taxonomy, $post );
+	$where = apply_filters( "get_{$adjacent}_post_where", $where_prepared, $in_same_term, $excluded_terms, $taxonomy, $post );
 
 	/**
 	 * Filters the ORDER BY clause in the SQL for an adjacent post query.
@@ -2001,7 +2004,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	 * @since 2.5.0
 	 * @since 4.4.0 Added the `$post` parameter.
 	 * @since 4.9.0 Added the `$order` parameter.
-	 * @since n.e.x.t Adds ID sort to ensure deterministic ordering for posts with identical dates.
+	 * @since 6.9.0 Adds ID sort to ensure deterministic ordering for posts with identical dates.
 	 *
 	 * @param string $order_by The `ORDER BY` clause in the SQL.
 	 * @param WP_Post $post    WP_Post object.

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1939,8 +1939,8 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 		$where .= " AND p.post_status = 'publish'";
 	}
 
-	$op    = $previous ? '<' : '>';
-	$order = $previous ? 'DESC' : 'ASC';
+	$comparison_operator = $previous ? '<' : '>';
+	$order               = $previous ? 'DESC' : 'ASC';
 
 	/**
 	 * Filters the JOIN clause in the SQL for an adjacent post query.
@@ -1965,7 +1965,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	$join = apply_filters( "get_{$adjacent}_post_join", $join, $in_same_term, $excluded_terms, $taxonomy, $post );
 
 	// Prepare the where clause for the adjacent post query.
-	$where_prepared = $wpdb->prepare( "WHERE (p.post_date $op %s OR (p.post_date = %s AND p.ID $op %d)) AND p.post_type = %s $where", $current_post_date, $current_post_date, $post->ID, $post->post_type ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $op is a string literal, either '<' or '>'.
+	$where_prepared = $wpdb->prepare( "WHERE (p.post_date $comparison_operator %s OR (p.post_date = %s AND p.ID $comparison_operator %d)) AND p.post_type = %s $where", $current_post_date, $current_post_date, $post->ID, $post->post_type ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $comparison_operator is a string literal, either '<' or '>'.
 
 	/**
 	 * Filters the WHERE clause in the SQL for an adjacent post query.

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -1977,6 +1977,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	 *
 	 * @since 2.5.0
 	 * @since 4.4.0 Added the `$taxonomy` and `$post` parameters.
+	 * @since n.e.x.t Adds ID-based fallback for posts with identical dates in adjacent post queries.
 	 *
 	 * @param string       $where          The `WHERE` clause in the SQL.
 	 * @param bool         $in_same_term   Whether post should be in the same taxonomy term.
@@ -1984,7 +1985,7 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	 * @param string       $taxonomy       Taxonomy. Used to identify the term used when `$in_same_term` is true.
 	 * @param WP_Post      $post           WP_Post object.
 	 */
-	$where = apply_filters( "get_{$adjacent}_post_where", $wpdb->prepare( "WHERE p.post_date $op %s AND p.post_type = %s $where", $current_post_date, $post->post_type ), $in_same_term, $excluded_terms, $taxonomy, $post );
+	$where = apply_filters( "get_{$adjacent}_post_where", $wpdb->prepare( "WHERE (p.post_date $op %s OR (p.post_date = %s AND p.ID $op %d)) AND p.post_type = %s $where", $current_post_date, $current_post_date, $post->ID, $post->post_type ), $in_same_term, $excluded_terms, $taxonomy, $post );
 
 	/**
 	 * Filters the ORDER BY clause in the SQL for an adjacent post query.
@@ -2000,12 +2001,13 @@ function get_adjacent_post( $in_same_term = false, $excluded_terms = '', $previo
 	 * @since 2.5.0
 	 * @since 4.4.0 Added the `$post` parameter.
 	 * @since 4.9.0 Added the `$order` parameter.
+	 * @since n.e.x.t Adds ID sort to ensure deterministic ordering for posts with identical dates.
 	 *
 	 * @param string $order_by The `ORDER BY` clause in the SQL.
 	 * @param WP_Post $post    WP_Post object.
 	 * @param string  $order   Sort order. 'DESC' for previous post, 'ASC' for next.
 	 */
-	$sort = apply_filters( "get_{$adjacent}_post_sort", "ORDER BY p.post_date $order LIMIT 1", $post, $order );
+	$sort = apply_filters( "get_{$adjacent}_post_sort", "ORDER BY p.post_date $order, p.ID $order LIMIT 1", $post, $order );
 
 	$query        = "SELECT p.ID FROM $wpdb->posts AS p $join $where $sort";
 	$key          = md5( $query );

--- a/tests/phpunit/tests/link/getAdjacentPost.php
+++ b/tests/phpunit/tests/link/getAdjacentPost.php
@@ -587,4 +587,196 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 		$this->assertEquals( $post_four, get_adjacent_post( true, '', false ), 'Result of function call is wrong after after adding new term' );
 		$this->assertSame( get_num_queries() - $num_queries, 2, 'Number of queries run was not two after adding new term' );
 	}
+
+	/**
+	 * Test get_adjacent_post with posts having identical post_date.
+	 *
+	 * @ticket 8107
+	 */
+	public function test_get_adjacent_post_with_identical_dates() {
+		$identical_date = '2024-01-01 12:00:00';
+
+		// Create posts with identical dates but different IDs
+		$post_ids = array();
+		for ( $i = 1; $i <= 5; $i++ ) {
+			$post_ids[] = self::factory()->post->create(
+				array(
+					'post_title' => "Post $i",
+					'post_date'  => $identical_date,
+				)
+			);
+		}
+
+		// Test navigation from the middle post (ID: 3rd post)
+		$current_post_id = $post_ids[2]; // 3rd post
+		$this->go_to( get_permalink( $current_post_id ) );
+
+		// Previous post should be the 2nd post (lower ID, same date)
+		$previous = get_adjacent_post( false, '', true );
+		$this->assertInstanceOf( 'WP_Post', $previous );
+		$this->assertEquals( $post_ids[1], $previous->ID );
+
+		// Next post should be the 4th post (higher ID, same date)
+		$next = get_adjacent_post( false, '', false );
+		$this->assertInstanceOf( 'WP_Post', $next );
+		$this->assertEquals( $post_ids[3], $next->ID );
+	}
+
+	/**
+	 * Test get_adjacent_post with mixed dates and identical dates.
+	 *
+	 * @ticket 8107
+	 */
+	public function test_get_adjacent_post_mixed_dates_with_identical_groups() {
+		// Create posts with different dates
+		$post_early = self::factory()->post->create(
+			array(
+				'post_title' => 'Early Post',
+				'post_date'  => '2024-01-01 10:00:00',
+			)
+		);
+
+		// Create multiple posts with identical date
+		$identical_date = '2024-01-01 12:00:00';
+		$post_ids       = array();
+		for ( $i = 1; $i <= 3; $i++ ) {
+			$post_ids[] = self::factory()->post->create(
+				array(
+					'post_title' => "Identical Post $i",
+					'post_date'  => $identical_date,
+				)
+			);
+		}
+
+		$post_late = self::factory()->post->create(
+			array(
+				'post_title' => 'Late Post',
+				'post_date'  => '2024-01-01 14:00:00',
+			)
+		);
+
+		// Test from first identical post
+		$this->go_to( get_permalink( $post_ids[0] ) );
+
+		// Previous should be the early post (different date)
+		$previous = get_adjacent_post( false, '', true );
+		$this->assertInstanceOf( 'WP_Post', $previous );
+		$this->assertEquals( $post_early, $previous->ID );
+
+		// Next should be the second identical post (same date, higher ID)
+		$next = get_adjacent_post( false, '', false );
+		$this->assertInstanceOf( 'WP_Post', $next );
+		$this->assertEquals( $post_ids[1], $next->ID );
+
+		// Test from middle identical post
+		$this->go_to( get_permalink( $post_ids[1] ) );
+
+		// Previous should be the first identical post (same date, lower ID)
+		$previous = get_adjacent_post( false, '', true );
+		$this->assertInstanceOf( 'WP_Post', $previous );
+		$this->assertEquals( $post_ids[0], $previous->ID );
+
+		// Next should be the third identical post (same date, higher ID)
+		$next = get_adjacent_post( false, '', false );
+		$this->assertInstanceOf( 'WP_Post', $next );
+		$this->assertEquals( $post_ids[2], $next->ID );
+
+		// Test from last identical post
+		$this->go_to( get_permalink( $post_ids[2] ) );
+
+		// Previous should be the second identical post (same date, lower ID)
+		$previous = get_adjacent_post( false, '', true );
+		$this->assertInstanceOf( 'WP_Post', $previous );
+		$this->assertEquals( $post_ids[1], $previous->ID );
+
+		// Next should be the late post (different date)
+		$next = get_adjacent_post( false, '', false );
+		$this->assertInstanceOf( 'WP_Post', $next );
+		$this->assertEquals( $post_late, $next->ID );
+	}
+
+	/**
+	 * Test get_adjacent_post navigation through all posts with identical dates.
+	 *
+	 * @ticket 8107
+	 */
+	public function test_get_adjacent_post_navigation_through_identical_dates() {
+		$identical_date = '2024-01-01 12:00:00';
+
+		// Create 4 posts with identical dates
+		$post_ids = array();
+		for ( $i = 1; $i <= 4; $i++ ) {
+			$post_ids[] = self::factory()->post->create(
+				array(
+					'post_title' => "Post $i",
+					'post_date'  => $identical_date,
+				)
+			);
+		}
+
+		// Test navigation sequence: 1 -> 2 -> 3 -> 4
+		$this->go_to( get_permalink( $post_ids[0] ) );
+
+		// From post 1, next should be post 2
+		$next = get_adjacent_post( false, '', false );
+		$this->assertEquals( $post_ids[1], $next->ID );
+
+		// From post 2, previous should be post 1, next should be post 3
+		$this->go_to( get_permalink( $post_ids[1] ) );
+		$previous = get_adjacent_post( false, '', true );
+		$this->assertEquals( $post_ids[0], $previous->ID );
+		$next = get_adjacent_post( false, '', false );
+		$this->assertEquals( $post_ids[2], $next->ID );
+
+		// From post 3, previous should be post 2, next should be post 4
+		$this->go_to( get_permalink( $post_ids[2] ) );
+		$previous = get_adjacent_post( false, '', true );
+		$this->assertEquals( $post_ids[1], $previous->ID );
+		$next = get_adjacent_post( false, '', false );
+		$this->assertEquals( $post_ids[3], $next->ID );
+
+		// From post 4, previous should be post 3
+		$this->go_to( get_permalink( $post_ids[3] ) );
+		$previous = get_adjacent_post( false, '', true );
+		$this->assertEquals( $post_ids[2], $previous->ID );
+	}
+
+	/**
+	 * Test get_adjacent_post with identical dates and category filtering.
+	 *
+	 * @ticket 8107
+	 */
+	public function test_get_adjacent_post_identical_dates_with_category() {
+		$identical_date = '2024-01-01 12:00:00';
+		$category_id    = self::factory()->category->create( array( 'name' => 'Test Category' ) );
+
+		// Create posts with identical dates, some in category
+		$post_ids = array();
+		for ( $i = 1; $i <= 4; $i++ ) {
+			$post_id = self::factory()->post->create(
+				array(
+					'post_title' => "Post $i",
+					'post_date'  => $identical_date,
+				)
+			);
+
+			// Add every other post to the category
+			if ( 0 === $i % 2 ) {
+				wp_set_post_categories( $post_id, array( $category_id ) );
+			}
+
+			$post_ids[] = $post_id;
+		}
+
+		// Test from post 2 (in category)
+		$this->go_to( get_permalink( $post_ids[1] ) );
+
+		// With category filtering, should only see posts in same category
+		$previous = get_adjacent_post( true, '', true, 'category' );
+		$this->assertSame( '', $previous ); // No previous post in category
+
+		$next = get_adjacent_post( true, '', false, 'category' );
+		$this->assertInstanceOf( 'WP_Post', $next );
+		$this->assertEquals( $post_ids[3], $next->ID ); // Post 4 (in category)
+	}
 }

--- a/tests/phpunit/tests/link/getAdjacentPost.php
+++ b/tests/phpunit/tests/link/getAdjacentPost.php
@@ -596,7 +596,7 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 	public function test_get_adjacent_post_with_identical_dates() {
 		$identical_date = '2024-01-01 12:00:00';
 
-		// Create posts with identical dates but different IDs
+		// Create posts with identical dates but different IDs.
 		$post_ids = array();
 		for ( $i = 1; $i <= 5; $i++ ) {
 			$post_ids[] = self::factory()->post->create(
@@ -607,16 +607,16 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 			);
 		}
 
-		// Test navigation from the middle post (ID: 3rd post)
+		// Test navigation from the middle post (ID: 3rd post).
 		$current_post_id = $post_ids[2]; // 3rd post
 		$this->go_to( get_permalink( $current_post_id ) );
 
-		// Previous post should be the 2nd post (lower ID, same date)
+		// Previous post should be the 2nd post (lower ID, same date).
 		$previous = get_adjacent_post( false, '', true );
 		$this->assertInstanceOf( 'WP_Post', $previous );
 		$this->assertEquals( $post_ids[1], $previous->ID );
 
-		// Next post should be the 4th post (higher ID, same date)
+		// Next post should be the 4th post (higher ID, same date).
 		$next = get_adjacent_post( false, '', false );
 		$this->assertInstanceOf( 'WP_Post', $next );
 		$this->assertEquals( $post_ids[3], $next->ID );
@@ -628,7 +628,7 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 	 * @ticket 8107
 	 */
 	public function test_get_adjacent_post_mixed_dates_with_identical_groups() {
-		// Create posts with different dates
+		// Create posts with different dates.
 		$post_early = self::factory()->post->create(
 			array(
 				'post_title' => 'Early Post',
@@ -636,7 +636,7 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 			)
 		);
 
-		// Create multiple posts with identical date
+		// Create multiple posts with identical date.
 		$identical_date = '2024-01-01 12:00:00';
 		$post_ids       = array();
 		for ( $i = 1; $i <= 3; $i++ ) {
@@ -655,41 +655,41 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 			)
 		);
 
-		// Test from first identical post
+		// Test from first identical post.
 		$this->go_to( get_permalink( $post_ids[0] ) );
 
-		// Previous should be the early post (different date)
+		// Previous should be the early post (different date).
 		$previous = get_adjacent_post( false, '', true );
 		$this->assertInstanceOf( 'WP_Post', $previous );
 		$this->assertEquals( $post_early, $previous->ID );
 
-		// Next should be the second identical post (same date, higher ID)
+		// Next should be the second identical post (same date, higher ID).
 		$next = get_adjacent_post( false, '', false );
 		$this->assertInstanceOf( 'WP_Post', $next );
 		$this->assertEquals( $post_ids[1], $next->ID );
 
-		// Test from middle identical post
+		// Test from middle identical post.
 		$this->go_to( get_permalink( $post_ids[1] ) );
 
-		// Previous should be the first identical post (same date, lower ID)
+		// Previous should be the first identical post (same date, lower ID).
 		$previous = get_adjacent_post( false, '', true );
 		$this->assertInstanceOf( 'WP_Post', $previous );
 		$this->assertEquals( $post_ids[0], $previous->ID );
 
-		// Next should be the third identical post (same date, higher ID)
+		// Next should be the third identical post (same date, higher ID).
 		$next = get_adjacent_post( false, '', false );
 		$this->assertInstanceOf( 'WP_Post', $next );
 		$this->assertEquals( $post_ids[2], $next->ID );
 
-		// Test from last identical post
+		// Test from last identical post.
 		$this->go_to( get_permalink( $post_ids[2] ) );
 
-		// Previous should be the second identical post (same date, lower ID)
+		// Previous should be the second identical post (same date, lower ID).
 		$previous = get_adjacent_post( false, '', true );
 		$this->assertInstanceOf( 'WP_Post', $previous );
 		$this->assertEquals( $post_ids[1], $previous->ID );
 
-		// Next should be the late post (different date)
+		// Next should be the late post (different date).
 		$next = get_adjacent_post( false, '', false );
 		$this->assertInstanceOf( 'WP_Post', $next );
 		$this->assertEquals( $post_late, $next->ID );
@@ -703,7 +703,7 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 	public function test_get_adjacent_post_navigation_through_identical_dates() {
 		$identical_date = '2024-01-01 12:00:00';
 
-		// Create 4 posts with identical dates
+		// Create 4 posts with identical dates.
 		$post_ids = array();
 		for ( $i = 1; $i <= 4; $i++ ) {
 			$post_ids[] = self::factory()->post->create(
@@ -714,28 +714,28 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 			);
 		}
 
-		// Test navigation sequence: 1 -> 2 -> 3 -> 4
+		// Test navigation sequence: 1 -> 2 -> 3 -> 4.
 		$this->go_to( get_permalink( $post_ids[0] ) );
 
-		// From post 1, next should be post 2
+		// From post 1, next should be post 2.
 		$next = get_adjacent_post( false, '', false );
 		$this->assertEquals( $post_ids[1], $next->ID );
 
-		// From post 2, previous should be post 1, next should be post 3
+		// From post 2, previous should be post 1, next should be post 3.
 		$this->go_to( get_permalink( $post_ids[1] ) );
 		$previous = get_adjacent_post( false, '', true );
 		$this->assertEquals( $post_ids[0], $previous->ID );
 		$next = get_adjacent_post( false, '', false );
 		$this->assertEquals( $post_ids[2], $next->ID );
 
-		// From post 3, previous should be post 2, next should be post 4
+		// From post 3, previous should be post 2, next should be post 4.
 		$this->go_to( get_permalink( $post_ids[2] ) );
 		$previous = get_adjacent_post( false, '', true );
 		$this->assertEquals( $post_ids[1], $previous->ID );
 		$next = get_adjacent_post( false, '', false );
 		$this->assertEquals( $post_ids[3], $next->ID );
 
-		// From post 4, previous should be post 3
+		// From post 4, previous should be post 3.
 		$this->go_to( get_permalink( $post_ids[3] ) );
 		$previous = get_adjacent_post( false, '', true );
 		$this->assertEquals( $post_ids[2], $previous->ID );
@@ -750,7 +750,7 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 		$identical_date = '2024-01-01 12:00:00';
 		$category_id    = self::factory()->category->create( array( 'name' => 'Test Category' ) );
 
-		// Create posts with identical dates, some in category
+		// Create posts with identical dates, some in category.
 		$post_ids = array();
 		for ( $i = 1; $i <= 4; $i++ ) {
 			$post_id = self::factory()->post->create(
@@ -760,7 +760,7 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 				)
 			);
 
-			// Add every other post to the category
+			// Add every other post to the category.
 			if ( 0 === $i % 2 ) {
 				wp_set_post_categories( $post_id, array( $category_id ) );
 			}
@@ -768,10 +768,10 @@ class Tests_Link_GetAdjacentPost extends WP_UnitTestCase {
 			$post_ids[] = $post_id;
 		}
 
-		// Test from post 2 (in category)
+		// Test from post 2 (in category).
 		$this->go_to( get_permalink( $post_ids[1] ) );
 
-		// With category filtering, should only see posts in same category
+		// With category filtering, should only see posts in same category.
 		$previous = get_adjacent_post( true, '', true, 'category' );
 		$this->assertSame( '', $previous ); // No previous post in category
 

--- a/tests/phpunit/tests/url.php
+++ b/tests/phpunit/tests/url.php
@@ -590,11 +590,6 @@ class Tests_URL extends WP_UnitTestCase {
 			);
 		}
 
-		if ( ! isset( $GLOBALS['post'] ) ) {
-			$GLOBALS['post'] = null;
-		}
-		$orig_post = $GLOBALS['post'];
-
 		// Test from the middle post (2nd post).
 		$GLOBALS['post'] = get_post( $post_ids[1] );
 

--- a/tests/phpunit/tests/url.php
+++ b/tests/phpunit/tests/url.php
@@ -569,4 +569,69 @@ class Tests_URL extends WP_UnitTestCase {
 			);
 		}
 	}
+
+	/**
+	 * Test get_adjacent_post with posts having identical post_date.
+	 *
+	 * @ticket 8107
+	 * @covers ::get_adjacent_post
+	 */
+	public function test_get_adjacent_post_with_identical_dates() {
+		$identical_date = gmdate( 'Y-m-d H:i:s', time() );
+
+		// Create 3 posts with identical dates but different IDs
+		$post_ids = array();
+		for ( $i = 1; $i <= 3; $i++ ) {
+			$post_ids[] = self::factory()->post->create(
+				array(
+					'post_title' => "Identical Post $i",
+					'post_date'  => $identical_date,
+				)
+			);
+		}
+
+		if ( ! isset( $GLOBALS['post'] ) ) {
+			$GLOBALS['post'] = null;
+		}
+		$orig_post = $GLOBALS['post'];
+
+		// Test from the middle post (2nd post)
+		$GLOBALS['post'] = get_post( $post_ids[1] );
+
+		// Previous post should be the 1st post (lower ID, same date)
+		$previous = get_adjacent_post( false, '', true );
+		$this->assertInstanceOf( 'WP_Post', $previous );
+		$this->assertSame( $post_ids[0], $previous->ID );
+
+		// Next post should be the 3rd post (higher ID, same date)
+		$next = get_adjacent_post( false, '', false );
+		$this->assertInstanceOf( 'WP_Post', $next );
+		$this->assertSame( $post_ids[2], $next->ID );
+
+		// Test from the first post
+		$GLOBALS['post'] = get_post( $post_ids[0] );
+
+		// Previous should be empty (no earlier posts)
+		$previous = get_adjacent_post( false, '', true );
+		$this->assertSame( '', $previous );
+
+		// Next should be the 2nd post
+		$next = get_adjacent_post( false, '', false );
+		$this->assertInstanceOf( 'WP_Post', $next );
+		$this->assertSame( $post_ids[1], $next->ID );
+
+		// Test from the last post
+		$GLOBALS['post'] = get_post( $post_ids[2] );
+
+		// Previous should be the 2nd post
+		$previous = get_adjacent_post( false, '', true );
+		$this->assertInstanceOf( 'WP_Post', $previous );
+		$this->assertSame( $post_ids[1], $previous->ID );
+
+		// Next should be empty (no later posts)
+		$next = get_adjacent_post( false, '', false );
+		$this->assertSame( '', $next );
+
+		$GLOBALS['post'] = $orig_post;
+	}
 }

--- a/tests/phpunit/tests/url.php
+++ b/tests/phpunit/tests/url.php
@@ -631,7 +631,5 @@ class Tests_URL extends WP_UnitTestCase {
 		// Next should be empty (no later posts).
 		$next = get_adjacent_post( false, '', false );
 		$this->assertSame( '', $next );
-
-		$GLOBALS['post'] = $orig_post;
 	}
 }

--- a/tests/phpunit/tests/url.php
+++ b/tests/phpunit/tests/url.php
@@ -579,7 +579,7 @@ class Tests_URL extends WP_UnitTestCase {
 	public function test_get_adjacent_post_with_identical_dates() {
 		$identical_date = gmdate( 'Y-m-d H:i:s', time() );
 
-		// Create 3 posts with identical dates but different IDs
+		// Create 3 posts with identical dates but different IDs.
 		$post_ids = array();
 		for ( $i = 1; $i <= 3; $i++ ) {
 			$post_ids[] = self::factory()->post->create(
@@ -595,40 +595,40 @@ class Tests_URL extends WP_UnitTestCase {
 		}
 		$orig_post = $GLOBALS['post'];
 
-		// Test from the middle post (2nd post)
+		// Test from the middle post (2nd post).
 		$GLOBALS['post'] = get_post( $post_ids[1] );
 
-		// Previous post should be the 1st post (lower ID, same date)
+		// Previous post should be the 1st post (lower ID, same date).
 		$previous = get_adjacent_post( false, '', true );
 		$this->assertInstanceOf( 'WP_Post', $previous );
 		$this->assertSame( $post_ids[0], $previous->ID );
 
-		// Next post should be the 3rd post (higher ID, same date)
+		// Next post should be the 3rd post (higher ID, same date).
 		$next = get_adjacent_post( false, '', false );
 		$this->assertInstanceOf( 'WP_Post', $next );
 		$this->assertSame( $post_ids[2], $next->ID );
 
-		// Test from the first post
+		// Test from the first post.
 		$GLOBALS['post'] = get_post( $post_ids[0] );
 
-		// Previous should be empty (no earlier posts)
+		// Previous should be empty (no earlier posts).
 		$previous = get_adjacent_post( false, '', true );
 		$this->assertSame( '', $previous );
 
-		// Next should be the 2nd post
+		// Next should be the 2nd post.
 		$next = get_adjacent_post( false, '', false );
 		$this->assertInstanceOf( 'WP_Post', $next );
 		$this->assertSame( $post_ids[1], $next->ID );
 
-		// Test from the last post
+		// Test from the last post.
 		$GLOBALS['post'] = get_post( $post_ids[2] );
 
-		// Previous should be the 2nd post
+		// Previous should be the 2nd post.
 		$previous = get_adjacent_post( false, '', true );
 		$this->assertInstanceOf( 'WP_Post', $previous );
 		$this->assertSame( $post_ids[1], $previous->ID );
 
-		// Next should be empty (no later posts)
+		// Next should be empty (no later posts).
 		$next = get_adjacent_post( false, '', false );
 		$this->assertSame( '', $next );
 


### PR DESCRIPTION
> [!NOTE]
> I came across all these sorting bugs while looking at https://github.com/WordPress/wordpress-develop/pull/10262. I'm not sure if I'm on the right track here, but it seems like a bug that needs to be fixed. 🤷🏻 

### Problem

When multiple posts have identical post_date values (e.g., when bulk publishing drafts), the next/previous post navigation doesn't work. 

The navigation skips posts or behaves unpredictably because the WHERE clause uses strict inequality (`>` or `<`) which excludes posts with the same date.

The `get_adjacent_post()` function's WHERE clause uses:

- **Next post**: `WHERE p.post_date > 'current_date'`
- **Previous post**: `WHERE p.post_date < 'current_date'`

When posts have identical dates, these conditions never match, causing navigation to fail.

### Proposed solution

Modified the WHERE clause to include ID-based fallback for posts with identical dates:

- **Next post**: `WHERE (p.post_date > 'current_date' OR (p.post_date = 'current_date' AND p.ID > current_id))`
- **Previous post**: `WHERE (p.post_date < 'current_date' OR (p.post_date = 'current_date' AND p.ID < current_id))`

This ensures deterministic ordering when posts have identical dates while maintaining backward compatibility.

### Changes

Modified: `src/wp-includes/link-template.php` - Updated WHERE clause logic in `get_adjacent_post()`

Added unit tests in `tests/phpunit/tests/link/getAdjacentPost.ph`p` and `tests/phpunit/tests/url.php`

## Test Steps
1. **Create test scenario:**
    - Publish at least one post (e.g., "Hello World!")
    - Create three draft posts (e.g., "Sample Post 1", "Sample Post 2", "Sample Post 3")
    - Select all three draft posts, then Bulk Actions > Edit
    - Change Status to "Published"
2. **Verify navigation:**
	- View any of the recently published posts
	- Click "Previous Post" - should navigate to another post published at the same time
	- Click "Next Post" - should navigate to another post published at the same time
	- Continue navigating - should be able to navigate through all posts with identical dates
3. **Expected Results:**
	- Previous/next navigation works correctly between all posts with identical dates
	- Navigation is deterministic and consistent
	- No posts are skipped during navigation
	- Navigation works in both directions
4. **Run tests:**
	- `npm run test:php -- --filter Tests_Link_GetAdjacentPost`
	- `npm run test:php -- --filter Tests_URL`


### Screenshots

Given a post list (noticed the duplicate dates)

<img width="1527" height="479" alt="Screenshot 2025-10-22 at 6 20 07 pm" src="https://github.com/user-attachments/assets/7cf31c94-c36a-4985-8c3a-bb00d768c703" />

Navigate through the posts:

https://github.com/user-attachments/assets/0b0e9ee6-51e2-4b71-b18e-67f4ee1185fc



Trac ticket: https://core.trac.wordpress.org/ticket/8107

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
