### PR TITLE
Abilities API: Normalize input from schema

### DIFF
--- a/src/wp-includes/abilities-api/class-wp-ability.php
+++ b/src/wp-includes/abilities-api/class-wp-ability.php
@@ -401,6 +401,31 @@ class WP_Ability {
 	}
 
 	/**
+	 * Normalizes the input for the ability, applying the default value from the input schema when needed.
+	 *
+	 * When no input is provided and the input schema is defined with a top-level `default` key, this method returns
+	 * the value of that key. If the input schema does not define a `default`, or if the input schema is empty,
+	 * this method returns null. If input is provided, it is returned as-is.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param mixed $input Optional. The raw input provided for the ability. Default `null`.
+	 * @return mixed The same input, or the default from schema, or `null` if default not set.
+	 */
+	public function normalize_input( $input = null ) {
+		if ( null !== $input ) {
+			return $input;
+		}
+
+		$input_schema = $this->get_input_schema();
+		if ( ! empty( $input_schema ) && array_key_exists( 'default', $input_schema ) ) {
+			return $input_schema['default'];
+		}
+
+		return null;
+	}
+
+	/**
 	 * Validates input data against the input schema.
 	 *
 	 * @since 6.9.0
@@ -536,6 +561,7 @@ class WP_Ability {
 	 * @return mixed|WP_Error The result of the ability execution, or WP_Error on failure.
 	 */
 	public function execute( $input = null ) {
+		$input    = $this->normalize_input( $input );
 		$is_valid = $this->validate_input( $input );
 		if ( is_wp_error( $is_valid ) ) {
 			return $is_valid;

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-run-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-run-controller.php
@@ -159,6 +159,7 @@ class WP_REST_Abilities_V1_Run_Controller extends WP_REST_Controller {
 		}
 
 		$input    = $this->get_input_from_request( $request );
+		$input    = $ability->normalize_input( $input );
 		$is_valid = $ability->validate_input( $input );
 		if ( is_wp_error( $is_valid ) ) {
 			$is_valid->add_data( array( 'status' => 400 ) );

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1RunController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1RunController.php
@@ -921,12 +921,11 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test edge case with empty input for both GET and POST methods.
+	 * Test edge case with empty input for GET method.
 	 *
 	 * @ticket 64098
 	 */
-	public function test_empty_input_handling(): void {
-		// Registers abilities for empty input testing.
+	public function test_empty_input_handling_get_method(): void {
 		wp_register_ability(
 			'test/read-only-empty',
 			array(
@@ -946,6 +945,55 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 			)
 		);
 
+		// Tests GET with no input parameter.
+		$get_request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/test/read-only-empty/run' );
+		$get_response = $this->server->dispatch( $get_request );
+		$this->assertEquals( 200, $get_response->get_status() );
+		$this->assertTrue( $get_response->get_data()['input_was_empty'] );
+	}
+
+	/**
+	 * Test edge case with empty input for GET method, and normalized input using schema.
+	 *
+	 * @ticket 64098
+	 */
+	public function test_empty_input_handling_get_method_with_normalized_input(): void {
+		wp_register_ability(
+			'test/read-only-empty-array',
+			array(
+				'label'               => 'Read-only Empty Array',
+				'description'         => 'Read-only with inferred empty array input from schema.',
+				'category'            => 'general',
+				'input_schema'        => array(
+					'type'    => 'array',
+					'default' => array(),
+				),
+				'execute_callback'    => static function ( $input ) {
+					return is_array( $input ) && empty( $input );
+				},
+				'permission_callback' => '__return_true',
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly' => true,
+					),
+					'show_in_rest' => true,
+				),
+			)
+		);
+
+		// Tests GET with no input parameter.
+		$get_request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/test/read-only-empty-array/run' );
+		$get_response = $this->server->dispatch( $get_request );
+		$this->assertEquals( 200, $get_response->get_status() );
+		$this->assertTrue( $get_response->get_data() );
+	}
+
+	/**
+	 * Test edge case with empty input for POST method.
+	 *
+	 * @ticket 64098
+	 */
+	public function test_empty_input_handling_post_method(): void {
 		wp_register_ability(
 			'test/regular-empty',
 			array(
@@ -961,12 +1009,6 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 				),
 			)
 		);
-
-		// Tests GET with no input parameter.
-		$get_request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/test/read-only-empty/run' );
-		$get_response = $this->server->dispatch( $get_request );
-		$this->assertEquals( 200, $get_response->get_status() );
-		$this->assertTrue( $get_response->get_data()['input_was_empty'] );
 
 		// Tests POST with no body.
 		$post_request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/test/regular-empty/run' );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64139

Bug fix extracted from https://github.com/WordPress/abilities-api/pull/108.

## The problem

Without this patch REST would require a weird empty `?input` field given how the current controller works with input schema that defines specific shape, example:

```php
'input_schema'        => array(
	'type'                 => 'object',
 	'properties'           => array(
		'fields' => array(
			'type'        => 'array',
			'items'       => array(
				'type' => 'string',
				'enum' => $fields,
			),
			'description' => __( 'Optional: Limit response to specific fields. If omitted, all fields are returned.' ),
		),
	),
	'additionalProperties' => false,
	'default'              => array(),
),
```

Working examples:

GET `/run?input` # All fields
GET `/run?input[fields][]`=name # Filtered

We want the REST API controller to infer default value from the input schema, so it's possible to call:

GET `/run` # All fields

## Solution

Normalizes the input for the ability, applying the default value from the input schema when needed.

When no input is provided and the input schema is defined with a top-level `default` key, this method returns the value of that key. If the input schema does not define a `default`, or if the input schema is empty, this method returns null. If input is provided, it is returned as-is.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
