### PR TITLE
Template activation: fix unique slug filtering

### DIFF
--- a/src/wp-includes/theme-templates.php
+++ b/src/wp-includes/theme-templates.php
@@ -50,8 +50,8 @@ function wp_filter_wp_template_unique_post_slug( $override_slug, $slug, $post_id
 	}
 
 	// For wp_template, slugs no longer have to be unique within the same theme.
-	if ( 'wp_template' !== $post_type ) {
-		return $override_slug;
+	if ( 'wp_template' === $post_type ) {
+		return $slug;
 	}
 
 	if ( ! $override_slug ) {


### PR DESCRIPTION
The logic introduced for the unique slug filter in #8063 is incorrect. We should return the desired slug for the `wp_template` post type.

Testing instructions:

Create two templates of the same type (e.g. home). Activating the second one won't take any effect on the front-end, and the template will be marked as "Custom" (instead of "Home").

Trac ticket: https://core.trac.wordpress.org/ticket/64141

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
