### PR TITLE
#64104: Improve `get_the_modified_author()` with `$post` argument and handle warning where global `$post` is empty

### DIFF
--- a/src/wp-includes/author-template.php
+++ b/src/wp-includes/author-template.php
@@ -87,14 +87,17 @@ function the_author( $deprecated = '', $deprecated_echo = true ) {
  *
  * @since 2.8.0
  *
+ * @param int $post_id Optional. Post ID. Defaults to the current post.
  * @return string|void The author's display name, empty string if unknown.
  */
-function get_the_modified_author() {
-	if ( ! get_post() ) {
+function get_the_modified_author( $post_id = 0 ) {
+	$post_id = $post_id ? $post_id : get_post()->ID;
+
+	if ( ! $post_id ) {
 		return;
 	}
 
-	$last_id = get_post_meta( get_post()->ID, '_edit_last', true );
+	$last_id = get_post_meta( $post_id, '_edit_last', true );
 
 	if ( $last_id ) {
 		$last_user = get_userdata( $last_id );

--- a/src/wp-includes/author-template.php
+++ b/src/wp-includes/author-template.php
@@ -96,22 +96,21 @@ function get_the_modified_author( $post = null ) {
 	if ( ! $post ) {
 		return null;
 	}
-	$last_id = get_post_meta( $post->ID, '_edit_last', true );
 
+	$last_user = null;
+	$last_id   = get_post_meta( $post->ID, '_edit_last', true );
 	if ( $last_id ) {
 		$last_user = get_userdata( $last_id );
-
-		/**
-		 * Filters the display name of the author who last edited the current post.
-		 *
-		 * @since 2.8.0
-		 *
-		 * @param string $display_name The author's display name, empty string if unknown.
-		 */
-		return apply_filters( 'the_modified_author', $last_user ? $last_user->display_name : '' );
 	}
 
-	return null;
+	/**
+	 * Filters the display name of the author who last edited the current post.
+	 *
+	 * @since 2.8.0
+	 *
+	 * @param string $display_name The author's display name, empty string if unknown.
+	 */
+	return apply_filters( 'the_modified_author', $last_user ? $last_user->display_name : '' );
 }
 
 /**

--- a/src/wp-includes/author-template.php
+++ b/src/wp-includes/author-template.php
@@ -89,7 +89,7 @@ function the_author( $deprecated = '', $deprecated_echo = true ) {
  * @since 6.9.0 Added the `$post` parameter. Unknown return value is now explicitly null instead of void.
  *
  * @param int|WP_Post|null $post Optional. Post ID or post object. Default is global `$post` object.
- * @return string|null The author's display name. Empty string if unknown, or null if no valid post.
+ * @return string|null The author's display name. Empty string if user is unavailable. Null if there was no last editor or the post is invalid.
  */
 function get_the_modified_author( $post = null ) {
 	$post = get_post( $post );
@@ -97,18 +97,18 @@ function get_the_modified_author( $post = null ) {
 		return null;
 	}
 
-	$last_user = null;
-	$last_id   = get_post_meta( $post->ID, '_edit_last', true );
-	if ( $last_id ) {
-		$last_user = get_userdata( $last_id );
+	$last_id = get_post_meta( $post->ID, '_edit_last', true );
+	if ( ! $last_id ) {
+		return null;
 	}
+	$last_user = get_userdata( $last_id );
 
 	/**
 	 * Filters the display name of the author who last edited the current post.
 	 *
 	 * @since 2.8.0
 	 *
-	 * @param string $display_name The author's display name, empty string if unknown.
+	 * @param string $display_name The author's display name, empty string if user is unavailable.
 	 */
 	return apply_filters( 'the_modified_author', $last_user ? $last_user->display_name : '' );
 }

--- a/src/wp-includes/author-template.php
+++ b/src/wp-includes/author-template.php
@@ -86,18 +86,17 @@ function the_author( $deprecated = '', $deprecated_echo = true ) {
  * Retrieves the author who last edited the current post.
  *
  * @since 2.8.0
+ * @since 6.9.0 Added the `$post` parameter.
  *
- * @param int $post_id Optional. Post ID. Defaults to the current post.
+ * @param int|WP_Post|null $post Optional. Post ID or post object. Default is global `$post` object.
  * @return string|void The author's display name, empty string if unknown.
  */
-function get_the_modified_author( $post_id = 0 ) {
-	$post_id = $post_id ? $post_id : get_post()->ID;
-
-	if ( ! $post_id ) {
+function get_the_modified_author( $post = null ) {
+	$post = get_post( $post );
+	if ( ! $post ) {
 		return;
 	}
-
-	$last_id = get_post_meta( $post_id, '_edit_last', true );
+	$last_id = get_post_meta( $post->ID, '_edit_last', true );
 
 	if ( $last_id ) {
 		$last_user = get_userdata( $last_id );

--- a/src/wp-includes/author-template.php
+++ b/src/wp-includes/author-template.php
@@ -89,7 +89,7 @@ function the_author( $deprecated = '', $deprecated_echo = true ) {
  * @since 6.9.0 Added the `$post` parameter. Unknown return value is now explicitly null instead of void.
  *
  * @param int|WP_Post|null $post Optional. Post ID or post object. Default is global `$post` object.
- * @return string|null The author's display name, or null if unknown.
+ * @return string|null The author's display name. Empty string if unknown, or null if no valid post.
  */
 function get_the_modified_author( $post = null ) {
 	$post = get_post( $post );

--- a/src/wp-includes/author-template.php
+++ b/src/wp-includes/author-template.php
@@ -86,15 +86,15 @@ function the_author( $deprecated = '', $deprecated_echo = true ) {
  * Retrieves the author who last edited the current post.
  *
  * @since 2.8.0
- * @since 6.9.0 Added the `$post` parameter.
+ * @since 6.9.0 Added the `$post` parameter. Unknown return value is now explicitly null instead of void.
  *
  * @param int|WP_Post|null $post Optional. Post ID or post object. Default is global `$post` object.
- * @return string|void The author's display name, empty string if unknown.
+ * @return string|null The author's display name, or null if unknown.
  */
 function get_the_modified_author( $post = null ) {
 	$post = get_post( $post );
 	if ( ! $post ) {
-		return;
+		return null;
 	}
 	$last_id = get_post_meta( $post->ID, '_edit_last', true );
 
@@ -110,6 +110,8 @@ function get_the_modified_author( $post = null ) {
 		 */
 		return apply_filters( 'the_modified_author', $last_user ? $last_user->display_name : '' );
 	}
+
+	return null;
 }
 
 /**

--- a/src/wp-includes/author-template.php
+++ b/src/wp-includes/author-template.php
@@ -90,6 +90,10 @@ function the_author( $deprecated = '', $deprecated_echo = true ) {
  * @return string|void The author's display name, empty string if unknown.
  */
 function get_the_modified_author() {
+	if ( ! get_post() ) {
+		return;
+	}
+
 	$last_id = get_post_meta( get_post()->ID, '_edit_last', true );
 
 	if ( $last_id ) {

--- a/tests/phpunit/tests/user/getTheModifiedAuthor.php
+++ b/tests/phpunit/tests/user/getTheModifiedAuthor.php
@@ -89,8 +89,8 @@ class Tests_User_GetTheModifiedAuthor extends WP_UnitTestCase {
 
 		$another_post_id = self::factory()->post->create();
 
-		$this->assertSame( '', get_the_modified_author( $another_post_id ) );
-		$this->assertSame( '', get_the_modified_author( get_post( $another_post_id ) ) );
+		$this->assertNull( get_the_modified_author( $another_post_id ) );
+		$this->assertNull( get_the_modified_author( get_post( $another_post_id ) ) );
 
 		add_post_meta( $another_post_id, '_edit_last', $editor_id );
 		$this->assertSame( $expected_display_name, get_the_modified_author( $another_post_id ) );

--- a/tests/phpunit/tests/user/getTheModifiedAuthor.php
+++ b/tests/phpunit/tests/user/getTheModifiedAuthor.php
@@ -64,4 +64,36 @@ class Tests_User_GetTheModifiedAuthor extends WP_UnitTestCase {
 		$GLOBALS['post'] = null;
 		$this->assertNull( get_the_modified_author() );
 	}
+
+	/**
+	 * @ticket 64104
+	 */
+	public function test_get_the_modified_author_when_invalid_post() {
+		$this->assertNull( get_the_modified_author( -1 ) );
+	}
+
+	/**
+	 * @ticket 64104
+	 */
+	public function test_get_the_modified_author_for_another_post() {
+		$expected_display_name = 'Test Editor';
+
+		$editor_id = self::factory()->user->create(
+			array(
+				'role'         => 'editor',
+				'user_login'   => 'test_editor',
+				'display_name' => $expected_display_name,
+				'description'  => 'test_editor',
+			)
+		);
+
+		$another_post_id = self::factory()->post->create();
+
+		$this->assertSame( '', get_the_modified_author( $another_post_id ) );
+		$this->assertSame( '', get_the_modified_author( get_post( $another_post_id ) ) );
+
+		add_post_meta( $another_post_id, '_edit_last', $editor_id );
+		$this->assertSame( $expected_display_name, get_the_modified_author( $another_post_id ) );
+		$this->assertSame( $expected_display_name, get_the_modified_author( get_post( $another_post_id ) ) );
+	}
 }

--- a/tests/phpunit/tests/user/getTheModifiedAuthor.php
+++ b/tests/phpunit/tests/user/getTheModifiedAuthor.php
@@ -56,4 +56,12 @@ class Tests_User_GetTheModifiedAuthor extends WP_UnitTestCase {
 
 		$this->assertSame( '', get_the_modified_author() );
 	}
+
+	/**
+	 * @ticket 64104
+	 */
+	public function test_get_the_modified_author_when_post_global_does_not_exist() {
+		$GLOBALS['post'] = null;
+		$this->assertNull( get_the_modified_author() );
+	}
 }

--- a/tests/phpunit/tests/user/getTheModifiedAuthor.php
+++ b/tests/phpunit/tests/user/getTheModifiedAuthor.php
@@ -37,7 +37,7 @@ class Tests_User_GetTheModifiedAuthor extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$GLOBALS['post'] = self::$post_id;
+		$GLOBALS['post'] = get_post( self::$post_id );
 	}
 
 	public function test_get_the_modified_author() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64104

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
