### PR TITLE
Improve robustness of `feed_links_extra()` when global `$post` is unexpectedly empty

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -3348,7 +3348,7 @@ function feed_links_extra( $args = array() ) {
 		 */
 		$show_post_comments_feed = apply_filters( 'feed_links_extra_show_post_comments_feed', $show_comments_feed );
 
-		if ( $show_post_comments_feed && ( comments_open( $post ) || pings_open( $post ) || $post->comment_count > 0 ) ) {
+		if ( $show_post_comments_feed && ( comments_open( $post ) || pings_open( $post ) || (int) $post->comment_count > 0 ) ) {
 			$title = sprintf(
 				$args['singletitle'],
 				get_bloginfo( 'name' ),

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -3326,7 +3326,8 @@ function feed_links_extra( $args = array() ) {
 	 */
 	$args = apply_filters( 'feed_links_extra_args', $args );
 
-	if ( is_singular() ) {
+	// Singular objects only, excluding a single `show_on_front` Home Page.
+	if ( is_singular() && ! is_home() ) {
 		$id   = 0;
 		$post = get_post( $id );
 

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -3326,9 +3326,8 @@ function feed_links_extra( $args = array() ) {
 	 */
 	$args = apply_filters( 'feed_links_extra_args', $args );
 
-	// Singular objects only, excluding a single `show_on_front` Home Page.
 	$queried_object = get_queried_object();
-	if ( is_singular() && ! is_home() && $queried_object instanceof WP_Post ) {
+	if ( is_singular() && $queried_object instanceof WP_Post ) {
 		$post = $queried_object;
 
 		/** This filter is documented in wp-includes/general-template.php */

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -3327,9 +3327,8 @@ function feed_links_extra( $args = array() ) {
 	$args = apply_filters( 'feed_links_extra_args', $args );
 
 	// Singular objects only, excluding a single `show_on_front` Home Page.
-	if ( is_singular() && ! is_home() ) {
-		$id   = 0;
-		$post = get_post( $id );
+	$post = get_post();
+	if ( is_singular() && ! is_home() && $post instanceof WP_Post ) {
 
 		/** This filter is documented in wp-includes/general-template.php */
 		$show_comments_feed = apply_filters( 'feed_links_show_comments_feed', true );

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -3348,12 +3348,17 @@ function feed_links_extra( $args = array() ) {
 		 */
 		$show_post_comments_feed = apply_filters( 'feed_links_extra_show_post_comments_feed', $show_comments_feed );
 
-		if ( $show_post_comments_feed && ( comments_open() || pings_open() || $post->comment_count > 0 ) ) {
+		if ( $show_post_comments_feed && ( comments_open( $post ) || pings_open( $post ) || $post->comment_count > 0 ) ) {
 			$title = sprintf(
 				$args['singletitle'],
 				get_bloginfo( 'name' ),
 				$args['separator'],
-				the_title_attribute( array( 'echo' => false ) )
+				the_title_attribute(
+					array(
+						'echo' => false,
+						'post' => $post,
+					)
+				)
 			);
 
 			$feed_link = get_post_comments_feed_link( $post->ID );

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -3327,8 +3327,9 @@ function feed_links_extra( $args = array() ) {
 	$args = apply_filters( 'feed_links_extra_args', $args );
 
 	// Singular objects only, excluding a single `show_on_front` Home Page.
-	$post = get_post();
-	if ( is_singular() && ! is_home() && $post instanceof WP_Post ) {
+	$queried_object = get_queried_object();
+	if ( is_singular() && ! is_home() && $queried_object instanceof WP_Post ) {
+		$post = $queried_object;
 
 		/** This filter is documented in wp-includes/general-template.php */
 		$show_comments_feed = apply_filters( 'feed_links_show_comments_feed', true );

--- a/tests/phpunit/tests/general/feedLinksExtra.php
+++ b/tests/phpunit/tests/general/feedLinksExtra.php
@@ -634,4 +634,15 @@ class Tests_General_FeedLinksExtra extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * @ticket 63263
+	 */
+	public function test_feed_links_extra_should_not_fail_if_global_post_empty() {
+		$post_id = self::factory()->post->create();
+		$this->go_to( get_permalink( $post_id ) );
+		$GLOBALS['post'] = null;
+
+		$this->assertEmpty( get_echo( 'feed_links_extra' ) );
+	}
 }

--- a/tests/phpunit/tests/general/feedLinksExtra.php
+++ b/tests/phpunit/tests/general/feedLinksExtra.php
@@ -638,11 +638,11 @@ class Tests_General_FeedLinksExtra extends WP_UnitTestCase {
 	/**
 	 * @ticket 63263
 	 */
-	public function test_feed_links_extra_should_not_fail_if_global_post_empty() {
+	public function test_feed_links_extra_should_work_fail_if_global_post_empty() {
 		$post_id = self::factory()->post->create();
 		$this->go_to( get_permalink( $post_id ) );
 		$GLOBALS['post'] = null;
 
-		$this->assertEmpty( get_echo( 'feed_links_extra' ) );
+		$this->assertNotEmpty( get_echo( 'feed_links_extra' ) );
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/63263

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
