### PR TITLE
Restore original return value for `WP_Script_Modules::get_dependencies()`

### DIFF
--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -566,7 +566,7 @@ class WP_Script_Modules {
 	 * @param string[] $ids          The identifiers of the script modules for which to gather dependencies.
 	 * @param string[] $import_types Optional. Import types of dependencies to retrieve: 'static', 'dynamic', or both.
 	 *                                         Default is both.
-	 * @return array<string, array> Script modules keyed by ID.
+	 * @return array<string, array> List of dependencies, keyed by script module identifier.
 	 */
 	private function get_dependencies( array $ids, array $import_types = array( 'static', 'dynamic' ) ): array {
 		$all_dependencies = array();

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -398,7 +398,7 @@ class WP_Script_Modules {
 				! $this->registered[ $id ]['in_footer']
 			) {
 				// If any dependency is set to be printed in footer, skip printing this module in head.
-				$dependencies = $this->get_dependencies( array( $id ) );
+				$dependencies = array_keys( $this->get_dependencies( array( $id ) ) );
 				foreach ( $dependencies as $dependency_id ) {
 					if (
 						in_array( $dependency_id, $this->queue, true ) &&
@@ -528,7 +528,7 @@ class WP_Script_Modules {
 	 */
 	private function get_import_map(): array {
 		$imports = array();
-		foreach ( $this->get_dependencies( $this->queue ) as $id ) {
+		foreach ( array_keys( $this->get_dependencies( $this->queue ) ) as $id ) {
 			$src = $this->get_src( $id );
 			if ( '' !== $src ) {
 				$imports[ $id ] = $src;
@@ -566,7 +566,7 @@ class WP_Script_Modules {
 	 * @param string[] $ids          The identifiers of the script modules for which to gather dependencies.
 	 * @param string[] $import_types Optional. Import types of dependencies to retrieve: 'static', 'dynamic', or both.
 	 *                                         Default is both.
-	 * @return string[] List of IDs for script module dependencies.
+	 * @return array<string, array> Script modules keyed by ID.
 	 */
 	private function get_dependencies( array $ids, array $import_types = array( 'static', 'dynamic' ) ): array {
 		$all_dependencies = array();
@@ -584,7 +584,7 @@ class WP_Script_Modules {
 					in_array( $dependency['import'], $import_types, true ) &&
 					isset( $this->registered[ $dependency['id'] ] )
 				) {
-					$all_dependencies[ $dependency['id'] ] = true;
+					$all_dependencies[ $dependency['id'] ] = $this->registered[ $dependency['id'] ];
 
 					// Add this dependency to the list to get dependencies for.
 					$id_queue[] = $dependency['id'];
@@ -592,7 +592,7 @@ class WP_Script_Modules {
 			}
 		}
 
-		return array_keys( $all_dependencies );
+		return $all_dependencies;
 	}
 
 	/**


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/61734#comment:55

This reverts the `WP_Script_Modules::get_dependencies()` change in https://github.com/WordPress/wordpress-develop/commit/25420f05cdb013a5a6fb78c910009af7bc842fa5 which was developed in https://github.com/WordPress/wordpress-develop/pull/9867 to fix Core-63486.

As of WP 6.8, `WP_Script_Modules::get_dependencies()` had this return signature:

https://github.com/WordPress/wordpress-develop/blob/58edb2f700ae2adb3c3c295e0e8be525009d3dbf/src/wp-includes/class-wp-script-modules.php#L306

The aforementioned commit for 6.9 changed it to:

https://github.com/WordPress/wordpress-develop/blob/7a840d3672ee11d6e3486e426b500cfaac7cb72c/src/wp-includes/class-wp-script-modules.php#L569

Since the method was private, I didn't think there would be a problem to make this change. However, it turns out that Query Monitor is [using](https://github.com/johnbillion/query-monitor/blob/f7ec89b87d88bd66f68bca52d2e4f2c679b63c04/classes/Collector_Assets.php#L298-L299) this private method via the Reflection API. This is because core is not yet exposing the necessary accessor methods from `WP_Script_Modules`, and so QM is forced to use a private method. This is something which should be no longer be necessary as of Core-60597.

In the meantime, we can restore the original return value for the method since it isn't particularly difficult to do so for 6.9-beta2.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/61734

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
