### PR TITLE
Add tests to the `WP_Block_Styles_Registry`

### DIFF
--- a/tests/phpunit/tests/blocks/wpBlockStylesRegistry.php
+++ b/tests/phpunit/tests/blocks/wpBlockStylesRegistry.php
@@ -122,7 +122,7 @@ class Tests_Blocks_wpBlockStylesRegistry extends WP_UnitTestCase {
 			$this->registry->is_registered( $name, 'fancy' ),
 			'The block type should have the block style registered when the label is valid.'
 		);
-		$this->assertEquals(
+		$this->assertSame(
 			$style_properties['label'],
 			$this->registry->get_registered_styles_for_block( $name )['fancy']['label'],
 			'The registered block style should have the same label.'

--- a/tests/phpunit/tests/blocks/wpBlockStylesRegistry.php
+++ b/tests/phpunit/tests/blocks/wpBlockStylesRegistry.php
@@ -150,7 +150,7 @@ class Tests_Blocks_wpBlockStylesRegistry extends WP_UnitTestCase {
 			$this->registry->is_registered( $name, 'fancy' ),
 			'The block type should have the block style registered when the label is missing.'
 		);
-		$this->assertEquals(
+		$this->assertSame(
 			$style_properties['name'],
 			$this->registry->get_registered_styles_for_block( $name )['fancy']['label'],
 			'The registered block style should have a name and label equal.'

--- a/tests/phpunit/tests/blocks/wpBlockStylesRegistry.php
+++ b/tests/phpunit/tests/blocks/wpBlockStylesRegistry.php
@@ -128,4 +128,32 @@ class Tests_Blocks_wpBlockStylesRegistry extends WP_UnitTestCase {
 			'The registered block style should have the same label.'
 		);
 	}
+
+	/**
+	 * Should register the block style when `label` is missing, using `name` as the label.
+	 *
+	 * @ticket 52592
+	 *
+	 * @covers WP_Block_Styles_Registry::register
+	 * @covers WP_Block_Styles_Registry::is_registered
+	 * @covers WP_Block_Styles_Registry::get_registered_styles_for_block
+	 */
+	public function test_register_block_style_without_label() {
+		$name             = 'core/paragraph';
+		$style_properties = array(
+			'name' => 'fancy',
+		);
+		$result           = $this->registry->register( $name, $style_properties );
+
+		$this->assertTrue( $result, 'The block style should be registered when the label is missing.' );
+		$this->assertTrue(
+			$this->registry->is_registered( $name, 'fancy' ),
+			'The block type should have the block style registered when the label is missing.'
+		);
+		$this->assertEquals(
+			$style_properties['name'],
+			$this->registry->get_registered_styles_for_block( $name )['fancy']['label'],
+			'The registered block style should have a name and label equal.'
+		);
+	}
 }

--- a/tests/phpunit/tests/blocks/wpBlockStylesRegistry.php
+++ b/tests/phpunit/tests/blocks/wpBlockStylesRegistry.php
@@ -98,4 +98,34 @@ class Tests_Blocks_wpBlockStylesRegistry extends WP_UnitTestCase {
 			'Both empty block and style name should return false.'
 		);
 	}
+
+	/**
+	 * Should accept valid string style label.
+	 * The registered style should have the same label.
+	 *
+	 * @ticket 52592
+	 *
+	 * @covers WP_Block_Styles_Registry::register
+	 * @covers WP_Block_Styles_Registry::is_registered
+	 * @covers WP_Block_Styles_Registry::get_registered_styles_for_block
+	 */
+	public function test_register_block_style_with_label() {
+		$name             = 'core/paragraph';
+		$style_properties = array(
+			'name'  => 'fancy',
+			'label' => 'Fancy',
+		);
+		$result           = $this->registry->register( $name, $style_properties );
+
+		$this->assertTrue( $result, 'The block style should be registered when the label is a valid string.' );
+		$this->assertTrue(
+			$this->registry->is_registered( $name, 'fancy' ),
+			'The block type should have the block style registered when the label is valid.'
+		);
+		$this->assertEquals(
+			$style_properties['label'],
+			$this->registry->get_registered_styles_for_block( $name )['fancy']['label'],
+			'The registered block style should have the same label.'
+		);
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR adds tests to the `WP_Block_Styles_Registry` class.

Trac ticket: https://core.trac.wordpress.org/ticket/63167

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
