### PR TITLE
Implement YAML aliases and anchors for branches and paths in workflow files

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -4,7 +4,7 @@ on:
   # JSHint was introduced in WordPress 3.8.
   # PHPCS checking was introduced in WordPress 5.1.
   push:
-    branches:
+    branches: &branches
       - trunk
       - '3.[89]'
       - '[4-9].[0-9]'
@@ -13,10 +13,7 @@ on:
       - '[0-9]+.[0-9].[0-9]+'
       - '!3.7.[0-9]+'
   pull_request:
-    branches:
-      - trunk
-      - '3.[89]'
-      - '[4-9].[0-9]'
+    branches: *branches
     paths:
       # Any change to a PHP or JavaScript file should run checks.
       - '**.js'

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -3,7 +3,7 @@ name: End-to-end Tests
 on:
   # The end-to-end test suite was introduced in WordPress 5.3.
   push:
-    branches:
+    branches: &branches
       - trunk
       - '5.[3-9]'
       - '[6-9].[0-9]'
@@ -13,10 +13,7 @@ on:
       - '![34].[0-9].[0-9]+'
       - '!5.[0-2].[0-9]+'
   pull_request:
-    branches:
-      - trunk
-      - '5.[3-9]'
-      - '[6-9].[0-9]'
+    branches: *branches
     paths:
       # Any change to a PHP, CSS, or JavaScript file should run checks.
       - '**.css'

--- a/.github/workflows/install-testing.yml
+++ b/.github/workflows/install-testing.yml
@@ -5,19 +5,16 @@ name: Installation Tests
 
 on:
   push:
-    branches:
+    branches: &branches
       - trunk
     # Always test the workflow after it's updated.
-    paths:
+    paths: &paths
       - '.github/workflows/install-testing.yml'
       - '.version-support-*.json'
       - '.github/workflows/reusable-support-json-reader-v1.yml'
   pull_request:
-    # Always test the workflow when changes are suggested.
-    paths:
-      - '.version-support-*.json'
-      - '.github/workflows/install-testing.yml'
-      - '.github/workflows/reusable-support-json-reader-v1.yml'
+    branches: *branches
+    paths: *paths
 
   schedule:
     - cron: '0 0 * * 1'

--- a/.github/workflows/javascript-tests.yml
+++ b/.github/workflows/javascript-tests.yml
@@ -3,7 +3,7 @@ name: JavaScript Tests
 on:
   # JavaScript testing was introduced in WordPress 3.8.
   push:
-    branches:
+    branches: &branches
       - trunk
       - '3.[89]'
       - '[4-9].[0-9]'
@@ -12,10 +12,7 @@ on:
       - '[0-9]+.[0-9].[0-9]+'
       - '!3.7.[0-9]+'
   pull_request:
-    branches:
-      - trunk
-      - '3.[89]'
-      - '[4-9].[0-9]'
+    branches: *branches
     paths:
       # Any change to a JavaScript file should run tests.
       - '**.js'

--- a/.github/workflows/local-docker-environment.yml
+++ b/.github/workflows/local-docker-environment.yml
@@ -2,11 +2,11 @@ name: Local Docker Environment
 
 on:
   push:
-    branches:
+    branches: &branches
       - trunk
       - '6.[8-9]'
       - '[7-9].[0-9]'
-    paths:
+    paths: &paths
       # Any changes to Docker related files.
       - '.env.example'
       - 'docker-compose.yml'
@@ -28,31 +28,8 @@ on:
       - '.github/workflows/reusable-support-json-reader-v1.yml'
       - '.github/workflows/reusable-test-docker-environment-v1.yml'
   pull_request:
-    branches:
-      - trunk
-      - '6.[8-9]'
-      - '[7-9].[0-9]'
-    paths:
-      # Any changes to Docker related files.
-      - '.env.example'
-      - 'docker-compose.yml'
-      # Any changes to local environment related files
-      - 'tools/local-env/**'
-      # These files configure npm and the task runner. Changes could affect the outcome.
-      - 'package*.json'
-      - 'Gruntfile.js'
-      - 'webpack.config.js'
-      - 'tools/webpack/**'
-      - '.npmrc'
-      - '.nvmrc'
-      # These files configure Composer. Changes could affect the local environment.
-      - 'composer.*'
-      # These files define the versions to test.
-      - '.version-support-*.json'
-      # Changes to this and related workflow files should always be verified.
-      - '.github/workflows/local-docker-environment.yml'
-      - '.github/workflows/reusable-support-json-reader-v1.yml'
-      - '.github/workflows/reusable-test-docker-environment-v1.yml'
+    branches: *branches
+    paths: *paths
   workflow_dispatch:
 
 # Cancels all previous workflow runs for pull requests that have not completed.

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -2,7 +2,7 @@ name: Performance Tests
 
 on:
   push:
-    branches:
+    branches: &branches
       - trunk
       - '6.[2-9]'
       - '[7-9].[0-9]'
@@ -12,10 +12,7 @@ on:
       - '![45].[0-9].[0-9]+'
       - '!6.[01].[0-9]+'
   pull_request:
-    branches:
-      - trunk
-      - '6.[2-9]'
-      - '[7-9].[0-9]'
+    branches: *branches
     paths:
       # Any change to a PHP, CSS, or JavaScript file should run checks.
       - '**.css'

--- a/.github/workflows/php-compatibility.yml
+++ b/.github/workflows/php-compatibility.yml
@@ -3,7 +3,7 @@ name: PHP Compatibility
 on:
   # PHP compatibility testing was introduced in WordPress 5.5.
   push:
-    branches:
+    branches: &branches
       - trunk
       - '5.[5-9]'
       - '[6-9].[0-9]'
@@ -13,10 +13,7 @@ on:
       - '![34].[0-9].[0-9]+'
       - '!5.[0-4].[0-9]+'
   pull_request:
-    branches:
-      - trunk
-      - '5.[5-9]'
-      - '[6-9].[0-9]'
+    branches: *branches
     paths:
       # This workflow only scans PHP files.
       - '**.php'

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -2,7 +2,7 @@ name: PHPUnit Tests
 
 on:
   push:
-    branches:
+    branches: &branches
       - trunk
       - '3.[7-9]'
       - '[4-9].[0-9]'
@@ -10,10 +10,7 @@ on:
       - '[0-9]+.[0-9]'
       - '[0-9]+.[0-9].[0-9]+'
   pull_request:
-    branches:
-      - trunk
-      - '3.[7-9]'
-      - '[4-9].[0-9]'
+    branches: *branches
     paths:
       # Any change to a PHP, CSS, JavaScript, JSON, HTML, or otherwise tested file should run checks.
       - '**.css'

--- a/.github/workflows/test-and-zip-default-themes.yml
+++ b/.github/workflows/test-and-zip-default-themes.yml
@@ -2,11 +2,11 @@ name: Test Default Themes & Create ZIPs
 
 on:
   push:
-    branches:
+    branches: &branches
       - trunk
       - '3.[89]'
       - '[4-9].[0-9]'
-    paths:
+    paths: &paths
       # Changing the preferred version of Node.js could affect themes with build processes.
       - '.npmrc'
       - '.nvmrc'
@@ -19,22 +19,8 @@ on:
       # Changes to this workflow file should always verify success.
       - '.github/workflows/test-and-zip-default-themes.yml'
   pull_request:
-    branches:
-      - trunk
-      - '3.[89]'
-      - '[4-9].[0-9]'
-    paths:
-      # Changing the preferred version of Node.js could affect themes with build processes.
-      - '.npmrc'
-      - '.nvmrc'
-      # Changes to any themes with a build script should be confirmed.
-      - 'src/wp-content/themes/twentynineteen/**'
-      - 'src/wp-content/themes/twentytwenty/**'
-      - 'src/wp-content/themes/twentytwentyone/**'
-      - 'src/wp-content/themes/twentytwentytwo/**'
-      - 'src/wp-content/themes/twentytwentyfive/**'
-      # Changes to this workflow file should always verify success.
-      - '.github/workflows/test-and-zip-default-themes.yml'
+    branches: *branches
+    paths: *paths
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/test-build-processes.yml
+++ b/.github/workflows/test-build-processes.yml
@@ -2,7 +2,7 @@ name: Test Build Processes
 
 on:
   push:
-    branches:
+    branches: &branches
       - trunk
       - '3.[7-9]'
       - '[4-9].[0-9]'
@@ -10,10 +10,7 @@ on:
       - '[0-9]+.[0-9]'
       - '[0-9]+.[0-9].[0-9]+'
   pull_request:
-    branches:
-      - trunk
-      - '3.[7-9]'
-      - '[4-9].[0-9]'
+    branches: *branches
     paths:
       # Any change to a PHP, CSS, JavaScript, or JSON file should run checks.
       - '**.css'

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -3,23 +3,17 @@ name: Code Coverage Report
 on:
   # Verify
   push:
-    branches:
+    branches: &branches
       - trunk
-    paths:
+    paths: &paths
       - '.github/workflows/test-coverage.yml'
       - '.github/workflows/reusable-phpunit-tests-v3.yml'
       - 'docker-compose.yml'
       - 'phpunit.xml.dist'
       - 'tests/phpunit/multisite.xml'
   pull_request:
-    branches:
-      - trunk
-    paths:
-      - '.github/workflows/test-coverage.yml'
-      - '.github/workflows/reusable-phpunit-tests-v3.yml'
-      - 'docker-compose.yml'
-      - 'phpunit.xml.dist'
-      - 'tests/phpunit/multisite.xml'
+    branches: *branches
+    paths: *paths
   # Once daily at 00:00 UTC.
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/upgrade-develop-testing.yml
+++ b/.github/workflows/upgrade-develop-testing.yml
@@ -5,30 +5,22 @@ name: Upgrade Develop Version Tests
 
 on:
   push:
-    branches:
+    branches: &branches
       - trunk
       - '6.[8-9]'
       - '[7-9].[0-9]'
     tags:
       - '[0-9]+.[0-9]'
       - '[0-9]+.[0-9].[0-9]+'
-    paths:
+    paths: &paths
       # Any change to a source PHP file should run checks.
       - 'src/**.php'
       # Confirm any changes to relevant workflow files.
       - '.github/workflows/upgrade-develop-testing.yml'
       - '.github/workflows/reusable-upgrade-testing.yml'
   pull_request:
-    branches:
-      - trunk
-      - '6.[8-9]'
-      - '[7-9].[0-9]'
-    paths:
-      # Any change to a source PHP file should run checks.
-      - 'src/**.php'
-      # Confirm any changes to relevant workflow files.
-      - '.github/workflows/upgrade-develop-testing.yml'
-      - '.github/workflows/reusable-upgrade-testing.yml'
+    branches: *branches
+    paths: *paths
   workflow_dispatch:
 
 # Cancels all previous workflow runs for pull requests that have not completed.

--- a/.github/workflows/upgrade-testing.yml
+++ b/.github/workflows/upgrade-testing.yml
@@ -5,20 +5,16 @@ name: Upgrade Tests
 
 on:
   push:
-    branches:
+    branches: &branches
       - trunk
     # Always test the workflow after it's updated.
-    paths:
+    paths: &paths
       - '.github/workflows/upgrade-testing.yml'
       - '.github/workflows/reusable-upgrade-testing.yml'
   pull_request:
     # This workflow is only meant to run from trunk. Pull requests changing this file with different BASE branches should be ignored.
-    branches:
-      - trunk
-    # Always test the workflow when changes are suggested.
-    paths:
-      - '.github/workflows/upgrade-testing.yml'
-      - '.github/workflows/reusable-upgrade-testing.yml'
+    branches: *branches
+    paths: *paths
   workflow_dispatch:
     inputs:
       new-version:

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -6,16 +6,14 @@ on:
       - trunk
       - '6.[8-9]'
       - '[7-9].[0-9]'
-    paths:
+    paths: &paths
       # Only run when changes are made to workflow files.
       - '.github/workflows/**'
   pull_request:
     branches:
       - trunk
       - '[0-9].[0-9]'
-    paths:
-      # Only run when changes are made to workflow files.
-      - '.github/workflows/**'
+    paths: *paths
   workflow_dispatch:
 
 # Cancels all previous workflow runs for pull requests that have not completed.


### PR DESCRIPTION
[GitHub recently added support for YAML anchors and aliases in workflow files](https://github.blog/changelog/2025-09-18-actions-yaml-anchors-and-non-public-workflow-templates/). This means we can reduce duplication in the `branches` and `paths` mappings.

One thing that I think will block this being merged for now is that [Actionlint is yet to support this feature](https://github.com/rhysd/actionlint/pull/568). Let's test it out anyway.

Trac ticket: https://core.trac.wordpress.org/ticket/63170