### PR TITLE
Remove duplication from the label for the upgrade tests workflow runs.

### DIFF
--- a/.github/workflows/reusable-upgrade-testing.yml
+++ b/.github/workflows/reusable-upgrade-testing.yml
@@ -57,7 +57,7 @@ jobs:
   # - Updates the database.
   # - Checks the version of WordPress after the upgrade.
   upgrade-tests:
-    name: ${{ inputs.wp }} to ${{ inputs.new-version }} / PHP ${{ inputs.php }} with ${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.multisite && ' multisite' || '' }}
+    name: PHP ${{ inputs.php }} with ${{ 'mariadb' == inputs.db-type && 'MariaDB' || 'MySQL' }} ${{ inputs.db-version }}${{ inputs.multisite && ' multisite' || '' }}
     permissions:
       contents: read
     runs-on: ${{ inputs.os }}


### PR DESCRIPTION
There's duplication in the labels of the upgrade test workflow runs. This fixes that.

Trac ticket: https://core.trac.wordpress.org/ticket/63170

## Before

`Upgrade Tests / 4.7 to latest / 4.7 to latest / PHP 7.2 with MySQL 5.7`
`Upgrade Develop Version Tests / Upgrade from 5.3 / 5.3 to develop / PHP 7.4 with mysql:5.7`

## After

`Upgrade Tests / 4.7 to latest / PHP 7.2 with MySQL 5.7`
`Upgrade Develop Version Tests / Upgrade from 5.3 / PHP 7.4 with mysql:5.7`