### PR TITLE
Media / Attachments REST API endpoint: cast args to array before sending to wp_slash > wp_insert_attachment

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-attachments-controller.php
@@ -777,7 +777,7 @@ class WP_REST_Attachments_Controller extends WP_REST_Posts_Controller {
 		$new_attachment_post->post_parent = $new_attachment_post->post_parent ?? 0;
 
 		// Insert the new attachment post.
-		$new_attachment_id = wp_insert_attachment( wp_slash( $new_attachment_post ), $saved['path'], 0, true );
+		$new_attachment_id = wp_insert_attachment( wp_slash( (array) $new_attachment_post ), $saved['path'], 0, true );
 
 		if ( is_wp_error( $new_attachment_id ) ) {
 			if ( 'db_update_error' === $new_attachment_id->get_error_code() ) {

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -3097,4 +3097,58 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		// The controller converts the integer values to booleans: 0 !== (int) 1 = true.
 		$this->assertSame( array( true, false ), WP_Image_Editor_Mock::$spy['flip'][0], 'Vertical flip of the image is not identical.' );
 	}
+
+	/**
+	 * Test that wp_slash() is properly applied when creating edited images.
+	 *
+	 * This test verifies that the object returned by prepare_item_for_database()
+	 * is properly cast to an array before being passed to wp_slash(), ensuring
+	 * that string values are properly escaped for database insertion.
+	 *
+	 * @ticket 64149
+	 * @requires function imagejpeg
+	 */
+	public function test_edit_image_wp_slash_with_object_cast() {
+		wp_set_current_user( self::$superadmin_id );
+		$attachment = self::factory()->attachment->create_upload_object( self::$test_file );
+
+		// Create a mock to capture the data passed to wp_insert_attachment.
+		$captured_data = null;
+
+		// Mock wp_insert_attachment to capture the data being passed.
+		add_filter(
+			'wp_insert_attachment_data',
+			function ( $data ) use ( &$captured_data ) {
+				$captured_data = $data;
+				return $data;
+			},
+			10,
+			1
+		);
+
+		$params = array(
+			'rotation'    => 60,
+			'src'         => wp_get_attachment_image_url( $attachment, 'full' ),
+			'title'       => 'Test Title with "quotes" and \'apostrophes\'',
+			'caption'     => 'Test Caption with "quotes" and \'apostrophes\'',
+			'description' => 'Test Description with "quotes" and \'apostrophes\'',
+		);
+
+		$request = new WP_REST_Request( 'POST', "/wp/v2/media/{$attachment}/edit" );
+		$request->set_body_params( $params );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 201, $response->get_status() );
+
+		// Verify that the data was properly slashed (escaped)
+		$this->assertNotNull( $captured_data, 'wp_insert_attachment was not called with data' );
+
+		// Check that quotes are properly escaped in the captured data.
+		$this->assertStringContainsString( 'Test Title with \"quotes\"', $captured_data['post_title'] ?? '', 'Title quotes not properly escaped' );
+		$this->assertStringContainsString( 'Test Caption with \"quotes\"', $captured_data['post_excerpt'] ?? '', 'Caption quotes not properly escaped' );
+		$this->assertStringContainsString( 'Test Description with \"quotes\"', $captured_data['post_content'] ?? '', 'Description quotes not properly escaped' );
+
+		// Verify that the data is an array (not an object).
+		$this->assertIsArray( $captured_data, 'Data passed to wp_insert_attachment should be an array' );
+	}
 }

--- a/tests/phpunit/tests/rest-api/rest-attachments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-attachments-controller.php
@@ -3118,7 +3118,7 @@ class WP_Test_REST_Attachments_Controller extends WP_Test_REST_Post_Type_Control
 		// Mock wp_insert_attachment to capture the data being passed.
 		add_filter(
 			'wp_insert_attachment_data',
-			function ( $data ) use ( &$captured_data ) {
+			static function ( $data ) use ( &$captured_data ) {
 				$captured_data = $data;
 				return $data;
 			},


### PR DESCRIPTION
### Problem

The `prepare_item_for_database()` method returns an object, but `wp_slash()` expects a string or array. Without casting the object to an array, `wp_slash()` would return the object unchanged, meaning string values within the object wouldn't be properly escaped for database insertion.

Props to @justlevine for [spotting it](https://github.com/WordPress/wordpress-develop/commit/117f23f251f9902ccac4477957402cc8dac6f885#r168784907)

### Solution
Cast the object to an array before passing it to `wp_slash()`:

```php
// Before
$new_attachment_id = wp_insert_attachment( wp_slash( $new_attachment_post ), $saved['path'], 0, true );

// After  
$new_attachment_id = wp_insert_attachment( wp_slash( (array) $new_attachment_post ), $saved['path'], 0, true );
```

### Testing

Ensure no regressions to the `media/edit` endpoint.

-  In the block editor, add an image block, then edit the image using the cropper
- Verify the image is saved correctly.

https://github.com/user-attachments/assets/17da31a2-1f85-4b2d-8ae1-85511dd2bec7

To be sure, you can copy that network request as cURL or fetch and add a title or description with apostrophes to the body payload, e.g., 

```json
 "body": "{\"src\":\"http://localhost:4013/wp-content/uploads/2025/10/homemade-smash-burgers-1-edited.jpg\",\"modifiers\":[{\"type\":\"rotate\",\"args\":{\"angle\":90}}],\"title\": \"burger'licious\"}",
```

The results of `wp_slash( (array) $new_attachment_post )` should be

```php
Array ( 'post_title' => burger\\'licious...
```



#### Unit tests

Run the new unit test: `npm run test:php -- --filter test_edit_image_wp_slash_with_object_cast`
Run all attachment controller tests: `npm run test:php -- --filter WP_Test_REST_Attachments_Controller`

cc @justlevine

Trac ticket: https://core.trac.wordpress.org/ticket/64149

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
