### PR TITLE
Template activation: update migration

### DIFF
--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -2497,8 +2497,10 @@ function upgrade_690() {
 	global $wp_current_db_version;
 
 	if ( $wp_current_db_version < 60718 ) {
-		// Query all templates in the database that are linked to the current
-		// theme and activate them. See `get_block_templates`.
+		/*
+		 * Query all templates in the database that are linked to the current
+		 * theme and activate them. See `get_block_templates()`.
+		 */
 		$template_query_args = array(
 			'post_status'         => 'publish',
 			'post_type'           => 'wp_template',

--- a/src/wp-admin/includes/upgrade.php
+++ b/src/wp-admin/includes/upgrade.php
@@ -886,6 +886,10 @@ function upgrade_all() {
 		upgrade_682();
 	}
 
+	if ( $wp_current_db_version < 60718 ) {
+		upgrade_690();
+	}
+
 	maybe_disable_link_manager();
 
 	maybe_disable_automattic_widgets();
@@ -2478,6 +2482,46 @@ function upgrade_682() {
 		$ping_sites_value = array_filter( $ping_sites_value );
 		$ping_sites_value = implode( "\n", $ping_sites_value );
 		update_option( 'ping_sites', $ping_sites_value );
+	}
+}
+
+/**
+ * Executes changes made in WordPress 6.9.0.
+ *
+ * @ignore
+ * @since 6.9.0
+ *
+ * @global int $wp_current_db_version The old (current) database version.
+ */
+function upgrade_690() {
+	global $wp_current_db_version;
+
+	if ( $wp_current_db_version < 60718 ) {
+		// Query all templates in the database that are linked to the current
+		// theme and activate them. See `get_block_templates`.
+		$template_query_args = array(
+			'post_status'         => 'publish',
+			'post_type'           => 'wp_template',
+			'posts_per_page'      => -1,
+			'no_found_rows'       => true,
+			'lazy_load_term_meta' => false,
+			'tax_query'           => array(
+				array(
+					'taxonomy' => 'wp_theme',
+					'field'    => 'name',
+					'terms'    => get_stylesheet(),
+				),
+			),
+		);
+
+		$template_query   = new WP_Query( $template_query_args );
+		$active_templates = array();
+
+		foreach ( $template_query->posts as $post ) {
+			$active_templates[ $post->post_name ] = $post->ID;
+		}
+
+		update_option( 'active_templates', $active_templates );
 	}
 }
 

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -23,7 +23,7 @@ $wp_version = '6.9-beta1-61040-src';
  *
  * @global int $wp_db_version
  */
-$wp_db_version = 60717;
+$wp_db_version = 60718;
 
 /**
  * Holds the TinyMCE version.


### PR DESCRIPTION
Adds the migration logic needed for template activation.

See https://github.com/WordPress/gutenberg/pull/67125. See https://github.com/WordPress/gutenberg/issues/66950.

Any template is the database that is linked to the current theme should be activated. The existing query can be found at https://developer.wordpress.org/reference/functions/get_block_templates/, it's a 100% copy of that. Also note a few lines down that the status is set to `publish` when `wp_id` is not set.

Trac ticket: https://core.trac.wordpress.org/ticket/64133

Testing instructions: this can be tested by adding a new _inactive_ template, then applying this patch. The admin should redirect to a database upgrade, after which the template you just added should be activated. This simulates templates edits pre-6.9.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
