### PR TITLE
Ensure comments REST controller returns note type children

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -1254,6 +1254,8 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 			array(
 				'count'   => true,
 				'orderby' => 'none',
+				'type'    => $comment->comment_type,
+				'status'  => 'all',
 			)
 		);
 

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -1255,7 +1255,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 				'count'   => true,
 				'orderby' => 'none',
 				'type'    => $comment->comment_type,
-				'status'  => 'all',
 			)
 		);
 

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -4071,9 +4071,9 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	/**
-	 * Test children link for note comment type.
+	 * Test children link for note comment type. Based on test_get_comment_with_children_link.
 	 *
-	 * @ticket TBD
+	 * @ticket 64152
 	 */
 	public function test_get_note_with_children_link() {
 		$comment_id_1 = self::factory()->comment->create(

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -4078,7 +4078,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	public function test_get_note_with_children_link() {
 		$comment_id_1 = self::factory()->comment->create(
 			array(
-				'comment_approved' => 0,
+				'comment_approved' => 1,
 				'comment_post_ID'  => self::$post_id,
 				'user_id'          => self::$subscriber_id,
 				'comment_type'     => 'note',
@@ -4087,7 +4087,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 
 		self::factory()->comment->create(
 			array(
-				'comment_approved' => 0,
+				'comment_approved' => 1,
 				'comment_parent'   => $comment_id_1,
 				'comment_post_ID'  => self::$post_id,
 				'user_id'          => self::$subscriber_id,

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -4069,4 +4069,38 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'reopen'   => array( 'reopen' ),
 		);
 	}
+
+	/**
+	 * Test children link for note comment type.
+	 *
+	 * @ticket TBD
+	 */
+	public function test_get_note_with_children_link() {
+		$comment_id_1 = self::factory()->comment->create(
+			array(
+				'comment_approved' => 0,
+				'comment_post_ID'  => self::$post_id,
+				'user_id'          => self::$subscriber_id,
+				'comment_type'     => 'note',
+			)
+		);
+
+		self::factory()->comment->create(
+			array(
+				'comment_approved' => 0,
+				'comment_parent'   => $comment_id_1,
+				'comment_post_ID'  => self::$post_id,
+				'user_id'          => self::$subscriber_id,
+				'comment_type'     => 'note',
+			)
+		);
+		wp_set_current_user( self::$admin_id );
+		$request = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%s', $comment_id_1 ) );
+		$request->set_param( 'type', 'note' );
+		$request->set_param( 'context', 'edit' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$this->assertArrayHasKey( 'children', $response->get_links() );
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64152

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
