### PR TITLE
Merge sub properties in `add_post_type_support()`.

### DIFF
--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2280,8 +2280,8 @@ function _add_post_type_submenus() {
  * @since 3.0.0
  * @since 5.3.0 Formalized the existing and already documented `...$args` parameter
  *              by adding it to the function signature.
- * @since 6.9.0 Multiple calls to add support for the same feature with associative
- *              array arguments now merge the arguments instead of overwriting them.
+ * @since 6.9.0 Multiple calls to add support for the same feature with array
+ *              arguments now merge the arguments instead of overwriting them.
  *
  * @global array $_wp_post_type_features
  *

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2262,6 +2262,11 @@ function _add_post_type_submenus() {
  * A third, optional parameter can also be passed along with a feature to provide
  * additional information about supporting that feature.
  *
+ * When calling this function multiple times for the same post type and feature
+ * with associative array arguments, the arguments will be merged rather than
+ * overwritten. This allows multiple calls to add different sub-properties to
+ * the same feature.
+ *
  * Example usage:
  *
  *     add_post_type_support( 'my_post_type', 'comments' );
@@ -2275,6 +2280,8 @@ function _add_post_type_submenus() {
  * @since 3.0.0
  * @since 5.3.0 Formalized the existing and already documented `...$args` parameter
  *              by adding it to the function signature.
+ * @since 6.9.0 Multiple calls to add support for the same feature with associative
+ *              array arguments now merge the arguments instead of overwriting them.
  *
  * @global array $_wp_post_type_features
  *
@@ -2289,7 +2296,21 @@ function add_post_type_support( $post_type, $feature, ...$args ) {
 	$features = (array) $feature;
 	foreach ( $features as $feature ) {
 		if ( $args ) {
-			$_wp_post_type_features[ $post_type ][ $feature ] = $args;
+			// Check if feature already exists with args and if both are associative arrays that should be merged.
+			if ( isset( $_wp_post_type_features[ $post_type ][ $feature ] )
+				&& is_array( $_wp_post_type_features[ $post_type ][ $feature ] )
+				&& isset( $_wp_post_type_features[ $post_type ][ $feature ][0] )
+				&& is_array( $_wp_post_type_features[ $post_type ][ $feature ][0] )
+				&& isset( $args[0] )
+				&& is_array( $args[0] ) ) {
+				// Merge the associative arrays to preserve existing properties.
+				$_wp_post_type_features[ $post_type ][ $feature ][0] = array_merge(
+					$_wp_post_type_features[ $post_type ][ $feature ][0],
+					$args[0]
+				);
+			} else {
+				$_wp_post_type_features[ $post_type ][ $feature ] = $args;
+			}
 		} else {
 			$_wp_post_type_features[ $post_type ][ $feature ] = true;
 		}

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2263,9 +2263,9 @@ function _add_post_type_submenus() {
  * additional information about supporting that feature.
  *
  * When calling this function multiple times for the same post type and feature
- * with associative array arguments, the arguments will be merged rather than
- * overwritten. This allows multiple calls to add different sub-properties to
- * the same feature.
+ * with array arguments, the arguments will be merged rather than overwritten.
+ * This allows multiple calls to add different sub-properties to the same
+ * feature.
  *
  * Example usage:
  *

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2297,9 +2297,7 @@ function add_post_type_support( $post_type, $feature, ...$args ) {
 	foreach ( $features as $feature ) {
 		if ( $args ) {
 			// Check if feature already exists with args and if both are associative arrays that should be merged.
-			if ( isset( $_wp_post_type_features[ $post_type ][ $feature ] )
-				&& is_array( $_wp_post_type_features[ $post_type ][ $feature ] )
-				&& isset( $_wp_post_type_features[ $post_type ][ $feature ][0] )
+			if ( isset( $_wp_post_type_features[ $post_type ][ $feature ][0] )
 				&& is_array( $_wp_post_type_features[ $post_type ][ $feature ][0] )
 				&& isset( $args[0] )
 				&& is_array( $args[0] ) ) {

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2303,7 +2303,7 @@ function add_post_type_support( $post_type, $feature, ...$args ) {
 				isset( $args[0] ) &&
 				is_array( $args[0] )
 			) {
-				// Merge the associative arrays to preserve existing properties.
+				// Merge the arrays to preserve existing properties.
 				$_wp_post_type_features[ $post_type ][ $feature ][0] = array_merge(
 					$_wp_post_type_features[ $post_type ][ $feature ][0],
 					$args[0]

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2296,7 +2296,7 @@ function add_post_type_support( $post_type, $feature, ...$args ) {
 	$features = (array) $feature;
 	foreach ( $features as $feature ) {
 		if ( $args ) {
-			// Check if feature already exists with args and if both are associative arrays that should be merged.
+			// Check if feature already exists with args and if both are arrays that should be merged.
 			if (
 				isset( $_wp_post_type_features[ $post_type ][ $feature ][0] ) &&
 				is_array( $_wp_post_type_features[ $post_type ][ $feature ][0] ) &&

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2297,10 +2297,12 @@ function add_post_type_support( $post_type, $feature, ...$args ) {
 	foreach ( $features as $feature ) {
 		if ( $args ) {
 			// Check if feature already exists with args and if both are associative arrays that should be merged.
-			if ( isset( $_wp_post_type_features[ $post_type ][ $feature ][0] )
-				&& is_array( $_wp_post_type_features[ $post_type ][ $feature ][0] )
-				&& isset( $args[0] )
-				&& is_array( $args[0] ) ) {
+			if (
+				isset( $_wp_post_type_features[ $post_type ][ $feature ][0] ) &&
+				is_array( $_wp_post_type_features[ $post_type ][ $feature ][0] ) &&
+				isset( $args[0] ) &&
+				is_array( $args[0] )
+			) {
 				// Merge the associative arrays to preserve existing properties.
 				$_wp_post_type_features[ $post_type ][ $feature ][0] = array_merge(
 					$_wp_post_type_features[ $post_type ][ $feature ][0],

--- a/tests/phpunit/tests/post/types.php
+++ b/tests/phpunit/tests/post/types.php
@@ -216,6 +216,231 @@ class Tests_Post_Types extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that add_post_type_support() merges array arguments on subsequent calls.
+	 *
+	 * @ticket 64156
+	 */
+	public function test_add_post_type_support_merges_array_arguments() {
+		register_post_type( 'foo' );
+
+		// First call with array arguments.
+		add_post_type_support(
+			'foo',
+			'editor',
+			array(
+				'default-mode' => 'template-locked',
+			)
+		);
+
+		$support = get_all_post_type_supports( 'foo' );
+		$this->assertIsArray( $support['editor'] );
+		$this->assertArrayHasKey( 0, $support['editor'] );
+		$this->assertIsArray( $support['editor'][0] );
+		$this->assertSame( 'template-locked', $support['editor'][0]['default-mode'] );
+
+		// Second call with different array arguments should merge.
+		add_post_type_support(
+			'foo',
+			'editor',
+			array(
+				'block-comments' => true,
+			)
+		);
+
+		$support = get_all_post_type_supports( 'foo' );
+		$this->assertIsArray( $support['editor'] );
+		$this->assertArrayHasKey( 0, $support['editor'] );
+		$this->assertIsArray( $support['editor'][0] );
+		$this->assertSame( 'template-locked', $support['editor'][0]['default-mode'] );
+		$this->assertTrue( $support['editor'][0]['block-comments'] );
+
+		// Third call with yet another property should merge with both previous.
+		add_post_type_support(
+			'foo',
+			'editor',
+			array(
+				'another-option' => 'test-value',
+			)
+		);
+
+		$support = get_all_post_type_supports( 'foo' );
+		$this->assertSame( 'template-locked', $support['editor'][0]['default-mode'] );
+		$this->assertTrue( $support['editor'][0]['block-comments'] );
+		$this->assertSame( 'test-value', $support['editor'][0]['another-option'] );
+
+		_unregister_post_type( 'foo' );
+	}
+
+	/**
+	 * Tests that add_post_type_support() overwrites values when called with the same key.
+	 *
+	 * @ticket 64156
+	 */
+	public function test_add_post_type_support_overwrites_same_key() {
+		register_post_type( 'foo' );
+
+		add_post_type_support(
+			'foo',
+			'editor',
+			array(
+				'default-mode' => 'template-locked',
+			)
+		);
+
+		$support = get_all_post_type_supports( 'foo' );
+		$this->assertSame( 'template-locked', $support['editor'][0]['default-mode'] );
+
+		// Calling with same key but different value should overwrite.
+		add_post_type_support(
+			'foo',
+			'editor',
+			array(
+				'default-mode' => 'unlocked',
+			)
+		);
+
+		$support = get_all_post_type_supports( 'foo' );
+		$this->assertSame( 'unlocked', $support['editor'][0]['default-mode'] );
+
+		_unregister_post_type( 'foo' );
+	}
+
+	/**
+	 * Tests backwards compatibility: calling add_post_type_support() without args still works.
+	 *
+	 * @ticket 64156
+	 */
+	public function test_add_post_type_support_without_args() {
+		register_post_type( 'foo' );
+
+		add_post_type_support( 'foo', 'custom-fields' );
+
+		$this->assertTrue( post_type_supports( 'foo', 'custom-fields' ) );
+		$support = get_all_post_type_supports( 'foo' );
+		$this->assertTrue( $support['custom-fields'] );
+
+		_unregister_post_type( 'foo' );
+	}
+
+	/**
+	 * Tests backwards compatibility: calling add_post_type_support() with args after
+	 * setting it to true should overwrite with args.
+	 *
+	 * @ticket 64156
+	 */
+	public function test_add_post_type_support_with_args_after_true() {
+		register_post_type( 'foo' );
+
+		// First call without args sets to true.
+		add_post_type_support( 'foo', 'editor' );
+
+		$support = get_all_post_type_supports( 'foo' );
+		$this->assertTrue( $support['editor'] );
+
+		// Second call with args should overwrite true with args.
+		add_post_type_support(
+			'foo',
+			'editor',
+			array(
+				'default-mode' => 'template-locked',
+			)
+		);
+
+		$support = get_all_post_type_supports( 'foo' );
+		$this->assertIsArray( $support['editor'] );
+		$this->assertSame( 'template-locked', $support['editor'][0]['default-mode'] );
+
+		_unregister_post_type( 'foo' );
+	}
+
+	/**
+	 * Tests backwards compatibility: calling add_post_type_support() without args after
+	 * setting it with args should overwrite with true.
+	 *
+	 * @ticket 64156
+	 */
+	public function test_add_post_type_support_without_args_after_array() {
+		register_post_type( 'foo' );
+
+		// First call with args.
+		add_post_type_support(
+			'foo',
+			'editor',
+			array(
+				'default-mode' => 'template-locked',
+			)
+		);
+
+		$support = get_all_post_type_supports( 'foo' );
+		$this->assertIsArray( $support['editor'] );
+		$this->assertSame( 'template-locked', $support['editor'][0]['default-mode'] );
+
+		// Second call without args should overwrite args with true.
+		add_post_type_support( 'foo', 'editor' );
+
+		$support = get_all_post_type_supports( 'foo' );
+		$this->assertTrue( $support['editor'] );
+
+		_unregister_post_type( 'foo' );
+	}
+
+	/**
+	 * Tests that add_post_type_support() can add multiple features at once.
+	 *
+	 * @ticket 64156
+	 */
+	public function test_add_post_type_support_multiple_features() {
+		register_post_type( 'foo' );
+
+		add_post_type_support( 'foo', array( 'title', 'editor', 'thumbnail' ) );
+
+		$this->assertTrue( post_type_supports( 'foo', 'title' ) );
+		$this->assertTrue( post_type_supports( 'foo', 'editor' ) );
+		$this->assertTrue( post_type_supports( 'foo', 'thumbnail' ) );
+
+		_unregister_post_type( 'foo' );
+	}
+
+	/**
+	 * Tests that add_post_type_support() works with nested array arguments.
+	 *
+	 * @ticket 64156
+	 */
+	public function test_add_post_type_support_with_nested_arrays() {
+		register_post_type( 'foo' );
+
+		add_post_type_support(
+			'foo',
+			'editor',
+			array(
+				'allowed_blocks' => array( 'core/paragraph', 'core/heading' ),
+			)
+		);
+
+		$support = get_all_post_type_supports( 'foo' );
+		$this->assertIsArray( $support['editor'][0]['allowed_blocks'] );
+		$this->assertContains( 'core/paragraph', $support['editor'][0]['allowed_blocks'] );
+		$this->assertContains( 'core/heading', $support['editor'][0]['allowed_blocks'] );
+
+		// Adding another nested array should merge.
+		add_post_type_support(
+			'foo',
+			'editor',
+			array(
+				'disallowed_blocks' => array( 'core/code' ),
+			)
+		);
+
+		$support = get_all_post_type_supports( 'foo' );
+		$this->assertIsArray( $support['editor'][0]['allowed_blocks'] );
+		$this->assertIsArray( $support['editor'][0]['disallowed_blocks'] );
+		$this->assertContains( 'core/paragraph', $support['editor'][0]['allowed_blocks'] );
+		$this->assertContains( 'core/code', $support['editor'][0]['disallowed_blocks'] );
+
+		_unregister_post_type( 'foo' );
+	}
+
+	/**
 	 * @ticket 21586
 	 * @ticket 41172
 	 */


### PR DESCRIPTION
Previously, calling `add_post_type_support()` multiple times for the same post type and feature with array arguments would overwrite the previous arguments instead of merging them. This prevented plugins and themes from incrementally adding sub-properties to the same feature.

This changes the behavior to merge associative array arguments when the function is called multiple times with the same post type and feature combination.

Example usage:

```php
add_post_type_support( 'page', 'editor', array(
    'default-mode' => 'template-locked',
) );

add_post_type_support( 'page', 'editor', array(
    'block-comments' => true,
) );

// Both properties are now preserved instead of only the last one.
```

The fix maintains full backwards compatibility by only merging when both the existing and new values are associative arrays. All other calling patterns continue to work as before.

Props @fabiankaegy, @Mamaduka, @t-hamano .

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64156#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
