### PR TITLE
Modified strip_shortcode_tag() to return HTML entities

### DIFF
--- a/src/wp-includes/shortcodes.php
+++ b/src/wp-includes/shortcodes.php
@@ -757,7 +757,9 @@ function strip_shortcodes( $content ) {
 function strip_shortcode_tag( $m ) {
 	// Allow [[foo]] syntax for escaping a tag.
 	if ( '[' === $m[1] && ']' === $m[6] ) {
-		return substr( $m[0], 1, -1 );
+		// Convert escaped shortcode to HTML entities to prevent unexpected execution
+		// when do_shortcode() is called later (e.g., in excerpt generation).
+		return '&#91;' . substr( $m[0], 2, -2 ) . '&#93;';
 	}
 
 	return $m[1] . $m[6];


### PR DESCRIPTION


Modified strip_shortcode_tag() to return HTML entities (&#91;gallery&#93;) instead of raw brackets

Trac ticket: https://core.trac.wordpress.org/ticket/26649

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
