### PR TITLE
Try Twenty Twenty workaround to enable loading block assets on demand

### DIFF
--- a/src/wp-content/themes/twentytwenty/functions.php
+++ b/src/wp-content/themes/twentytwenty/functions.php
@@ -111,6 +111,36 @@ function twentytwenty_theme_support() {
 		)
 	);
 
+	/*
+	 * As of 6.9, classic themes default to loading block styles on demand by hosting them from the footer to the head.
+	 * Block styles are only registered separately for each block in register_block_type_from_metadata() when the theme
+	 * also supports 'wp-block-styles'. Nevertheless, this also hase the effect of enqueueing the block theme styles.
+	 * Since Twenty Twenty never adopted these block theme styles, any such styles need to be excluded from being
+	 * printed.
+	 */
+	if ( 0 && version_compare( $GLOBALS['wp_version'], '6.9-beta2', '>=' ) ) {
+		add_theme_support( 'wp-block-styles' );
+
+		add_filter(
+			'print_styles_array',
+			static function ( $handles ) {
+				// This undoes <https://github.com/WordPress/wordpress-develop/blob/781fb28d4773147edb17b0fd7eefa52671b5daa6/src/wp-includes/script-loader.php#L2480>.
+				$handles = array_diff(
+					$handles,
+					array( 'wp-block-library-theme' )
+				);
+
+				// This undoes <https://github.com/WordPress/wordpress-develop/blob/781fb28d4773147edb17b0fd7eefa52671b5daa6/src/wp-includes/blocks.php#L511>.
+				return array_filter(
+					$handles,
+					static function ( $handle ) {
+						return ! preg_match( '/^wp-block-.+?-theme$/', $handle );
+					}
+				);
+			}
+		);
+	}
+
 	// Add support for full and wide align images.
 	add_theme_support( 'align-wide' );
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

This is not a serious proposal for core merge, but it is a POC that shows the desired outcome: a dramatic reduction (50%) in the amount of CSS added to a page (e.g. Sample Page) in Twenty Twenty.

Trac ticket: https://core.trac.wordpress.org/ticket/64166

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
