### PR TITLE
Fix: Don't load fit text front end scripts on the editor.

### DIFF
--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -306,7 +306,7 @@ function wp_typography_get_preset_inline_style_value( $style_value, $css_propert
  * @return string Filtered block content.
  */
 function wp_render_typography_support( $block_content, $block ) {
-if ( ! empty( $block['attrs']['fitText'] ) && ! is_admin() ) {
+	if ( ! empty( $block['attrs']['fitText'] ) && ! is_admin() ) {
 		wp_enqueue_script_module( '@wordpress/block-editor/utils/fit-text-frontend' );
 	}
 	if ( ! isset( $block['attrs']['style']['typography']['fontSize'] ) ) {

--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -306,7 +306,7 @@ function wp_typography_get_preset_inline_style_value( $style_value, $css_propert
  * @return string Filtered block content.
  */
 function wp_render_typography_support( $block_content, $block ) {
-	if ( ! empty( $block['attrs']['fitText'] ) ) {
+if ( ! empty( $block['attrs']['fitText'] ) && ! is_admin() ) {
 		wp_enqueue_script_module( '@wordpress/block-editor/utils/fit-text-frontend' );
 	}
 	if ( ! isset( $block['attrs']['style']['typography']['fontSize'] ) ) {


### PR DESCRIPTION
Backports PR https://github.com/WordPress/gutenberg/pull/72842 from Gutenberg.

This PR fixes an issue where the FitText frontend script (fit-text-frontend.js) was incorrectly being enqueued and loaded in the block editor when editing posts that contain blocks with the fitText attribute enabled. It had no big impact has the script does not do anything on the editor (the classes the script searches are not there) but still it's useless bytes we are sending.
We are enqueuing using exactly the same pattern as in other blocks, like file. image, or form I suspect in some of theses cases the front end script is also loading on the editor when it is non needed, something we can try to improve after.

Trac ticket: https://core.trac.wordpress.org/ticket/64173

## Testing Instructions

This change is covered by automated tests in Gutenberg.
In core we should just smoke test fit text:
- Add a paragraph with fit text on editor, verify everything works, see the post on the frontend verify fit text still works there.
- Activate a theme with customizer support like "Twenty Sixteen", navigate on the customizer to a post with fit text verify things still work.
