### PR TITLE
First draft at hook to control wp-cron.php endpoint.

### DIFF
--- a/src/wp-cron.php
+++ b/src/wp-cron.php
@@ -21,7 +21,7 @@ ignore_user_abort( true );
 if ( ! empty( $_POST ) || defined( 'DOING_AJAX' ) || defined( 'DOING_CRON' ) ) {
 	if ( ! headers_sent() ) {
 		header( 'Expires: Wed, 11 Jan 1984 05:00:00 GMT' );
-		header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
+		header( 'Cache-Control: no-store, no-cache, must-revalidate, max-age=0' );
 	}
 	die();
 }

--- a/src/wp-cron.php
+++ b/src/wp-cron.php
@@ -18,19 +18,11 @@
 
 ignore_user_abort( true );
 
-if ( ! headers_sent() ) {
-	header( 'Expires: Wed, 11 Jan 1984 05:00:00 GMT' );
-	header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
-}
-
-// Don't run cron until the request finishes, if possible.
-if ( function_exists( 'fastcgi_finish_request' ) ) {
-	fastcgi_finish_request();
-} elseif ( function_exists( 'litespeed_finish_request' ) ) {
-	litespeed_finish_request();
-}
-
 if ( ! empty( $_POST ) || defined( 'DOING_AJAX' ) || defined( 'DOING_CRON' ) ) {
+	if ( ! headers_sent() ) {
+		header( 'Expires: Wed, 11 Jan 1984 05:00:00 GMT' );
+		header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
+	}
 	die();
 }
 
@@ -44,6 +36,29 @@ define( 'DOING_CRON', true );
 if ( ! defined( 'ABSPATH' ) ) {
 	/** Set up WordPress environment */
 	require_once __DIR__ . '/wp-load.php';
+}
+
+/** This filter is documented in wp-includes/default-constants.php */
+if ( ! apply_filters( 'wp_cron_endpoint_enabled', true ) ) {
+	if ( ! headers_sent() ) {
+		header( 'Expires: Wed, 11 Jan 1984 05:00:00 GMT' );
+		header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
+		header( 'X-WP-Cron: Bypass' );
+	}
+	die();
+}
+
+if ( ! headers_sent() ) {
+	header( 'Expires: Wed, 11 Jan 1984 05:00:00 GMT' );
+	header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
+	header( 'X-WP-Cron: Spawned' );
+}
+
+// Don't run cron until the request finishes, if possible.
+if ( function_exists( 'fastcgi_finish_request' ) ) {
+	fastcgi_finish_request();
+} elseif ( function_exists( 'litespeed_finish_request' ) ) {
+	litespeed_finish_request();
 }
 
 // Attempt to raise the PHP memory limit for cron event processing.

--- a/src/wp-cron.php
+++ b/src/wp-cron.php
@@ -48,7 +48,7 @@ if ( ! apply_filters( 'wp_cron_endpoint_enabled', true ) ) {
 
 if ( ! headers_sent() ) {
 	header( 'Expires: Wed, 11 Jan 1984 05:00:00 GMT' );
-	header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
+	header( 'Cache-Control: no-store, no-cache, must-revalidate, max-age=0' );
 	header( 'X-WP-Cron: Spawned' );
 }
 

--- a/src/wp-cron.php
+++ b/src/wp-cron.php
@@ -41,8 +41,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 /** This filter is documented in wp-includes/default-constants.php */
 if ( ! apply_filters( 'wp_cron_endpoint_enabled', true ) ) {
 	if ( ! headers_sent() ) {
-		header( 'Expires: Wed, 11 Jan 1984 05:00:00 GMT' );
-		header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
 		header( 'X-WP-Cron: Bypass' );
 	}
 	die();

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -398,6 +398,34 @@ function wp_functionality_constants() {
 	if ( ! defined( 'WP_CRON_LOCK_TIMEOUT' ) ) {
 		define( 'WP_CRON_LOCK_TIMEOUT', MINUTE_IN_SECONDS );
 	}
+
+	if ( ! defined( 'DISABLE_WP_CRON' ) ) {
+		/**
+		 * Filters whether the wp-cron.php endpoint spawns the WP-Cron process.
+		 *
+		 * Use the filter to disable the wp-cron.php endpoint from spawning cron jobs. This
+		 * filter must only be used if an alternative approach to firing cron jobs is enabled
+		 * on the server.
+		 *
+		 * When disabling the wp-cron.php endpoint, you must ensure that cron jobs are still
+		 * fired by using an alternative method such as WP CLI.
+		 *
+		 * For single site installs, the following WP CLI command can be scheduled via a system
+		 * cron job: `wp cron event run --due-now`. For multi site installs, the command must be
+		 * run for each site by specifying the global `--url` parameter.
+		 *
+		 * When disabling the wp-cron.php endpoint via the filter, the filter must be added on
+		 * or prior to the `plugins_loaded` hook to ensure it takes effect.
+		 *
+		 * @since x.x.x
+		 *
+		 * @link https://developer.wordpress.org/cli/commands/cron/event/
+		 *
+		 * @param bool $wp_cron_endpoint_enabled Whether to enable the wp-cron.php endpoint. Default true.
+		 */
+		$wp_cron_endpoint_enabled = (bool) apply_filters( 'wp_cron_endpoint_enabled', true );
+		define( 'DISABLE_WP_CRON', ! $wp_cron_endpoint_enabled );
+	}
 }
 
 /**

--- a/src/wp-includes/default-constants.php
+++ b/src/wp-includes/default-constants.php
@@ -411,7 +411,7 @@ function wp_functionality_constants() {
 		 * fired by using an alternative method such as WP CLI.
 		 *
 		 * For single site installs, the following WP CLI command can be scheduled via a system
-		 * cron job: `wp cron event run --due-now`. For multi site installs, the command must be
+		 * cron job: `wp cron event run --due-now`. For multisite installs, the command must be
 		 * run for each site by specifying the global `--url` parameter.
 		 *
 		 * When disabling the wp-cron.php endpoint via the filter, the filter must be added on


### PR DESCRIPTION
* Introduces a filter to allow developers to enable/disable the wp-cron.php endpoint, `wp_cron_endpoint_enabled`.
* The default value of the constant `DISABLE_WP_CRON` is defined and set to false if the endpoint is disabled.
* Modifies wp-cron.php endpoint:
   * Adds a header indicating whether jobs are spawned or bypassed
   * Modifies when the request fast-finishes running to allow said header to be sent.



Trac ticket: https://core.trac.wordpress.org/ticket/64157

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
