### PR TITLE
Remove ignored `in:body` GraphQL search query 

### DIFF
--- a/.github/workflows/reusable-cleanup-pull-requests.yml
+++ b/.github/workflows/reusable-cleanup-pull-requests.yml
@@ -62,7 +62,6 @@ jobs:
                     nodes {
                       ... on PullRequest {
                         number
-                        state
                         bodyText
                       }
                     }

--- a/.github/workflows/reusable-cleanup-pull-requests.yml
+++ b/.github/workflows/reusable-cleanup-pull-requests.yml
@@ -54,7 +54,7 @@ jobs:
 
             for (const ticket of fixedList) {
               const tracTicketUrl = `https://core.trac.wordpress.org/ticket/${ticket}`;
-              const corePrefix = `Core-${ticket}`;
+              const corePrefix = `core-${ticket}`;
 
               const query = `
                 query($searchQuery: String!) {
@@ -79,6 +79,7 @@ jobs:
               // Since search queries will match anywhere for any activity on a pull request, the body specifically needs to be manually checked.
               const matchingPRs = result.search.nodes
                 .filter(
+                  const bodyLower = pr.bodyText.toLowerCase();
                   pr => pr.bodyText.includes(tracTicketUrl) || pr.bodyText.includes(corePrefix)
                 )
                 .map(pr => pr.number);

--- a/.github/workflows/reusable-cleanup-pull-requests.yml
+++ b/.github/workflows/reusable-cleanup-pull-requests.yml
@@ -63,19 +63,27 @@ jobs:
                       ... on PullRequest {
                         number
                         state
+                        bodyText
                       }
                     }
                   }
                 }
               `;
 
-              const searchQuery = `repo:${context.repo.owner}/${context.repo.repo} is:pr is:open in:body ( "${tracTicketUrl}" OR "${corePrefix}" )`;
+              const searchQuery = `repo:${context.repo.owner}/${context.repo.repo} is:pr is:open ( "${tracTicketUrl}" OR "${corePrefix}" )`;
 
               const result = await github.graphql(query, {
                 searchQuery,
               });
 
-              prNumbers.push(...result.search.nodes.map(pr => pr.number));
+              // Since search queries will match anywhere for any activity on a pull request, the body specifically needs to be manually checked.
+              const matchingPRs = result.search.nodes
+                .filter(
+                  pr => pr.bodyText.includes(tracTicketUrl) || pr.bodyText.includes(corePrefix)
+                )
+                .map(pr => pr.number);
+
+              prNumbers.push(...matchingPRs);
             }
 
             return prNumbers;


### PR DESCRIPTION
The `in:body` qualifier is not respected in GraphQL search queries for some reason.

This adds a `.filter()` before mapping the pull request numbers to the variable that is returned. The filter checks for the presence of the (case insensitive) needles within the pull request's body text, which helps filter out any instances where a Trac ticket is referenced within a comment or PR review.

This also removes the `state` field. Since `is:open` is in the search query, all returned pull requests will be open making the state is unnecessary.

Trac ticket: https://core.trac.wordpress.org/ticket/64175

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
