### PR TITLE
Fix docblock formatting issues in REST API classes

### DIFF
--- a/src/wp-includes/rest-api/class-wp-rest-request.php
+++ b/src/wp-includes/rest-api/class-wp-rest-request.php
@@ -535,7 +535,7 @@ class WP_REST_Request implements ArrayAccess {
 	 *
 	 * @since 4.4.0
 	 *
-	 * @return array Parameter map of key to value
+	 * @return array Parameter map of key to value.
 	 */
 	public function get_query_params() {
 		return $this->params['GET'];
@@ -587,7 +587,7 @@ class WP_REST_Request implements ArrayAccess {
 	 *
 	 * @since 4.4.0
 	 *
-	 * @return array Parameter map of key to value
+	 * @return array Parameter map of key to value.
 	 */
 	public function get_file_params() {
 		return $this->params['FILES'];
@@ -613,7 +613,7 @@ class WP_REST_Request implements ArrayAccess {
 	 *
 	 * @since 4.4.0
 	 *
-	 * @return array Parameter map of key to value
+	 * @return array Parameter map of key to value.
 	 */
 	public function get_default_params() {
 		return $this->params['defaults'];

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -226,7 +226,7 @@ class WP_REST_Server {
 	 *
 	 * @param string $code    WP_Error-style code.
 	 * @param string $message Human-readable message.
-	 * @param int    $status  Optional. HTTP status code to send. Default null.
+	 * @param int|null $status  Optional. HTTP status code to send. Default null.
 	 * @return string JSON representation of the error.
 	 */
 	protected function json_error( $code, $message, $status = null ) {

--- a/src/wp-includes/rest-api/class-wp-rest-server.php
+++ b/src/wp-includes/rest-api/class-wp-rest-server.php
@@ -167,7 +167,7 @@ class WP_REST_Server {
 	 * @since 4.4.0
 	 *
 	 * @return WP_Error|null|true WP_Error indicates unsuccessful login, null indicates successful
-	 *                            or no authentication provided
+	 *                            or no authentication provided.
 	 */
 	public function check_authentication() {
 		/**
@@ -227,7 +227,7 @@ class WP_REST_Server {
 	 * @param string $code    WP_Error-style code.
 	 * @param string $message Human-readable message.
 	 * @param int    $status  Optional. HTTP status code to send. Default null.
-	 * @return string JSON representation of the error
+	 * @return string JSON representation of the error.
 	 */
 	protected function json_error( $code, $message, $status = null ) {
 		if ( $status ) {

--- a/src/wp-includes/shortcodes.php
+++ b/src/wp-includes/shortcodes.php
@@ -319,7 +319,7 @@ function _filter_do_shortcode_context() {
  * @global array $shortcode_tags
  *
  * @param array $tagnames Optional. List of shortcodes to find. Defaults to all registered shortcodes.
- * @return string The shortcode search regular expression
+ * @return string The shortcode search regular expression.
  */
 function get_shortcode_regex( $tagnames = null ) {
 	global $shortcode_tags;

--- a/src/wp-includes/template.php
+++ b/src/wp-includes/template.php
@@ -627,7 +627,7 @@ function get_embed_template() {
  *
  * @see get_query_template()
  *
- * @return string Full path to singular template file
+ * @return string Full path to singular template file.
  */
 function get_singular_template() {
 	return get_query_template( 'singular' );


### PR DESCRIPTION
Fix docblock formatting and grammar issues in REST API classes

This commit fixes several docblock formatting inconsistencies
```
src/wp-includes/rest-api/class-wp-rest-request.php
src/wp-includes/rest-api/class-wp-rest-server.php
src/wp-includes/shortcodes.php
src/wp-includes/template.php

```

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64181#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
