### PR TITLE
Abilities API: Use stricter `doing_action` check when registering

### DIFF
--- a/src/wp-includes/abilities-api.php
+++ b/src/wp-includes/abilities-api.php
@@ -276,7 +276,7 @@ declare( strict_types = 1 );
  * @return WP_Ability|null The registered ability instance on success, `null` on failure.
  */
 function wp_register_ability( string $name, array $args ): ?WP_Ability {
-	if ( ! did_action( 'wp_abilities_api_init' ) ) {
+	if ( ! doing_action( 'wp_abilities_api_init' ) ) {
 		_doing_it_wrong(
 			__FUNCTION__,
 			sprintf(
@@ -465,7 +465,7 @@ function wp_get_abilities(): array {
  * @return WP_Ability_Category|null The registered ability category instance on success, `null` on failure.
  */
 function wp_register_ability_category( string $slug, array $args ): ?WP_Ability_Category {
-	if ( ! did_action( 'wp_abilities_api_categories_init' ) ) {
+	if ( ! doing_action( 'wp_abilities_api_categories_init' ) ) {
 		_doing_it_wrong(
 			__FUNCTION__,
 			sprintf(

--- a/tests/phpunit/tests/abilities-api/wpAbilitiesRegistry.php
+++ b/tests/phpunit/tests/abilities-api/wpAbilitiesRegistry.php
@@ -29,8 +29,9 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 
 		remove_all_filters( 'wp_register_ability_args' );
 
-		// Fire the init hook to allow test ability category registration.
-		do_action( 'wp_abilities_api_categories_init' );
+		// Simulates the Abilities API init hook to allow test ability category registration.
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_categories_init';
 		wp_register_ability_category(
 			'math',
 			array(
@@ -38,6 +39,7 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 				'description' => 'Mathematical operations and calculations.',
 			)
 		);
+		array_pop( $wp_current_filter );
 
 		self::$test_ability_args = array(
 			'label'               => 'Add numbers',

--- a/tests/phpunit/tests/abilities-api/wpAbility.php
+++ b/tests/phpunit/tests/abilities-api/wpAbility.php
@@ -46,9 +46,6 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	 * Tear down after each test.
 	 */
 	public function tear_down(): void {
-		// Clean up registered test ability category.
-		wp_unregister_ability_category( 'math' );
-
 		parent::tear_down();
 	}
 

--- a/tests/phpunit/tests/abilities-api/wpAbility.php
+++ b/tests/phpunit/tests/abilities-api/wpAbility.php
@@ -18,16 +18,6 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	public function set_up(): void {
 		parent::set_up();
 
-		// Fire the init hook to allow test ability category registration.
-		do_action( 'wp_abilities_api_categories_init' );
-		wp_register_ability_category(
-			'math',
-			array(
-				'label'       => 'Math',
-				'description' => 'Mathematical operations and calculations.',
-			)
-		);
-
 		self::$test_ability_properties = array(
 			'label'               => 'Calculator',
 			'description'         => 'Calculates the result of math operations.',

--- a/tests/phpunit/tests/abilities-api/wpRegisterAbilityCategory.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterAbilityCategory.php
@@ -45,13 +45,24 @@ class Tests_Abilities_API_WpRegisterAbilityCategory extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test registering ability category before `abilities_api_categories_init` hook.
+	 * Simulates the `wp_abilities_api_categories_init` action.
+	 */
+	private function simulate_doing_wp_ability_categories_init_action() {
+		global $wp_current_filter;
+
+		$wp_current_filter[] = 'wp_abilities_api_categories_init';
+	}
+
+	/**
+	 * Test registering ability category before `wp_abilities_api_categories_init` hook.
 	 *
 	 * @ticket 64098
 	 *
 	 * @expectedIncorrectUsage wp_register_ability_category
 	 */
 	public function test_register_category_before_init_hook(): void {
+		$this->assertFalse( doing_action( 'wp_abilities_api_categories_init' ) );
+
 		$result = wp_register_ability_category(
 			self::$test_ability_category_name,
 			self::$test_ability_category_args
@@ -70,13 +81,13 @@ class Tests_Abilities_API_WpRegisterAbilityCategory extends WP_UnitTestCase {
 	public function test_register_ability_category_no_init_action(): void {
 		global $wp_actions;
 
-		do_action( 'wp_abilities_api_categories_init' );
-
 		// Store the original action count.
 		$original_count = isset( $wp_actions['init'] ) ? $wp_actions['init'] : 0;
 
 		// Reset the action count to simulate it not being fired.
 		unset( $wp_actions['init'] );
+
+		$this->simulate_doing_wp_ability_categories_init_action();
 
 		$result = wp_register_ability_category(
 			self::$test_ability_category_name,
@@ -97,7 +108,7 @@ class Tests_Abilities_API_WpRegisterAbilityCategory extends WP_UnitTestCase {
 	 * @ticket 64098
 	 */
 	public function test_register_valid_category(): void {
-		do_action( 'wp_abilities_api_categories_init' );
+		$this->simulate_doing_wp_ability_categories_init_action();
 
 		$result = wp_register_ability_category(
 			self::$test_ability_category_name,
@@ -120,13 +131,13 @@ class Tests_Abilities_API_WpRegisterAbilityCategory extends WP_UnitTestCase {
 	public function test_unregister_ability_category_no_init_action(): void {
 		global $wp_actions;
 
-		do_action( 'wp_abilities_api_categories_init' );
-
 		// Store the original action count.
 		$original_count = isset( $wp_actions['init'] ) ? $wp_actions['init'] : 0;
 
 		// Reset the action count to simulate it not being fired.
 		unset( $wp_actions['init'] );
+
+		$this->simulate_doing_wp_ability_categories_init_action();
 
 		$result = wp_unregister_ability_category( self::$test_ability_category_name );
 
@@ -146,7 +157,7 @@ class Tests_Abilities_API_WpRegisterAbilityCategory extends WP_UnitTestCase {
 	 * @expectedIncorrectUsage WP_Ability_Categories_Registry::unregister
 	 */
 	public function test_unregister_nonexistent_category(): void {
-		do_action( 'wp_abilities_api_categories_init' );
+		$this->simulate_doing_wp_ability_categories_init_action();
 
 		$result = wp_unregister_ability_category( 'test-nonexistent' );
 
@@ -159,7 +170,7 @@ class Tests_Abilities_API_WpRegisterAbilityCategory extends WP_UnitTestCase {
 	 * @ticket 64098
 	 */
 	public function test_unregister_existing_category(): void {
-		do_action( 'wp_abilities_api_categories_init' );
+		$this->simulate_doing_wp_ability_categories_init_action();
 
 		wp_register_ability_category(
 			self::$test_ability_category_name,
@@ -182,13 +193,13 @@ class Tests_Abilities_API_WpRegisterAbilityCategory extends WP_UnitTestCase {
 	public function test_has_ability_category_no_init_action(): void {
 		global $wp_actions;
 
-		do_action( 'wp_abilities_api_categories_init' );
-
 		// Store the original action count.
 		$original_count = isset( $wp_actions['init'] ) ? $wp_actions['init'] : 0;
 
 		// Reset the action count to simulate it not being fired.
 		unset( $wp_actions['init'] );
+
+		$this->simulate_doing_wp_ability_categories_init_action();
 
 		$result = wp_has_ability_category( self::$test_ability_category_name );
 
@@ -206,7 +217,7 @@ class Tests_Abilities_API_WpRegisterAbilityCategory extends WP_UnitTestCase {
 	 * @ticket 64098
 	 */
 	public function test_has_registered_nonexistent_ability_category(): void {
-		do_action( 'wp_abilities_api_categories_init' );
+		$this->simulate_doing_wp_ability_categories_init_action();
 
 		$result = wp_has_ability_category( 'test/non-existent' );
 
@@ -219,7 +230,7 @@ class Tests_Abilities_API_WpRegisterAbilityCategory extends WP_UnitTestCase {
 	 * @ticket 64098
 	 */
 	public function test_has_registered_ability_category(): void {
-		do_action( 'wp_abilities_api_categories_init' );
+		$this->simulate_doing_wp_ability_categories_init_action();
 
 		$category_slug = self::$test_ability_category_name;
 
@@ -243,13 +254,13 @@ class Tests_Abilities_API_WpRegisterAbilityCategory extends WP_UnitTestCase {
 	public function test_get_ability_category_no_init_action(): void {
 		global $wp_actions;
 
-		do_action( 'wp_abilities_api_categories_init' );
-
 		// Store the original action count.
 		$original_count = isset( $wp_actions['init'] ) ? $wp_actions['init'] : 0;
 
 		// Reset the action count to simulate it not being fired.
 		unset( $wp_actions['init'] );
+
+		$this->simulate_doing_wp_ability_categories_init_action();
 
 		$result = wp_get_ability_category( self::$test_ability_category_name );
 
@@ -269,7 +280,7 @@ class Tests_Abilities_API_WpRegisterAbilityCategory extends WP_UnitTestCase {
 	 * @expectedIncorrectUsage WP_Ability_Categories_Registry::get_registered
 	 */
 	public function test_get_nonexistent_category(): void {
-		do_action( 'wp_abilities_api_categories_init' );
+		$this->simulate_doing_wp_ability_categories_init_action();
 
 		$result = wp_get_ability_category( 'test-nonexistent' );
 
@@ -316,13 +327,13 @@ class Tests_Abilities_API_WpRegisterAbilityCategory extends WP_UnitTestCase {
 	public function test_get_ability_categories_no_init_action(): void {
 		global $wp_actions;
 
-		do_action( 'wp_abilities_api_categories_init' );
-
 		// Store the original action count.
 		$original_count = isset( $wp_actions['init'] ) ? $wp_actions['init'] : 0;
 
 		// Reset the action count to simulate it not being fired.
 		unset( $wp_actions['init'] );
+
+		$this->simulate_doing_wp_ability_categories_init_action();
 
 		$result = wp_get_ability_categories( self::$test_ability_category_name );
 
@@ -340,7 +351,7 @@ class Tests_Abilities_API_WpRegisterAbilityCategory extends WP_UnitTestCase {
 	 * @ticket 64098
 	 */
 	public function test_get_all_categories(): void {
-		do_action( 'wp_abilities_api_categories_init' );
+		$this->simulate_doing_wp_ability_categories_init_action();
 
 		wp_register_ability_category(
 			self::$test_ability_category_name,

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1CategoriesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1CategoriesController.php
@@ -62,8 +62,6 @@ class Tests_REST_API_WpRestAbilitiesV1CategoriesController extends WP_UnitTestCa
 
 		do_action( 'rest_api_init' );
 
-		// Initialize the API and register test ability categories.
-		do_action( 'wp_abilities_api_categories_init' );
 		$this->register_test_ability_categories();
 
 		wp_set_current_user( self::$admin_user_id );
@@ -93,6 +91,10 @@ class Tests_REST_API_WpRestAbilitiesV1CategoriesController extends WP_UnitTestCa
 	 * Register test ability categories for testing.
 	 */
 	public function register_test_ability_categories(): void {
+		// Simulates the init hook to allow test ability categories registration.
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_categories_init';
+
 		wp_register_ability_category(
 			'test-data-retrieval',
 			array(
@@ -130,6 +132,8 @@ class Tests_REST_API_WpRestAbilitiesV1CategoriesController extends WP_UnitTestCa
 				)
 			);
 		}
+
+		array_pop( $wp_current_filter );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
@@ -37,8 +37,6 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 			)
 		);
 
-		// Fire the init hook to allow test ability categories registration.
-		do_action( 'wp_abilities_api_categories_init' );
 		self::register_test_categories();
 	}
 
@@ -67,8 +65,6 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 
 		do_action( 'rest_api_init' );
 
-		// Initialize Abilities API.
-		do_action( 'wp_abilities_api_init' );
 		$this->register_test_abilities();
 
 		// Set default user for tests
@@ -99,6 +95,10 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 	 * Register test categories for testing.
 	 */
 	public static function register_test_categories(): void {
+		// Simulates the init hook to allow test ability categories registration.
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_categories_init';
+
 		wp_register_ability_category(
 			'math',
 			array(
@@ -122,6 +122,24 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 				'description' => 'General purpose abilities.',
 			)
 		);
+
+		array_pop( $wp_current_filter );
+	}
+
+	/**
+	 * Helper to register a test ability.
+	 *
+	 * @param string $name Ability name.
+	 * @param array  $args Ability arguments.
+	 */
+	private function register_test_ability( string $name, array $args ): void {
+		// Simulates the init hook to allow test abilities registration.
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init';
+
+		wp_register_ability( $name, $args );
+
+		array_pop( $wp_current_filter );
 	}
 
 	/**
@@ -129,7 +147,7 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 	 */
 	private function register_test_abilities(): void {
 		// Register a regular ability.
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/calculator',
 			array(
 				'label'               => 'Calculator',
@@ -173,7 +191,7 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 		);
 
 		// Register a read-only ability.
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/system-info',
 			array(
 				'label'               => 'System Info',
@@ -220,7 +238,7 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 		);
 
 		// Ability that does not show in REST.
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/not-show-in-rest',
 			array(
 				'label'               => 'Hidden from REST',
@@ -235,7 +253,7 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 
 		// Register multiple abilities for pagination testing
 		for ( $i = 1; $i <= 60; $i++ ) {
-			wp_register_ability(
+			$this->register_test_ability(
 				"test/ability-{$i}",
 				array(
 					'label'               => "Test Ability {$i}",
@@ -589,7 +607,7 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 	 */
 	public function test_ability_name_with_valid_special_characters(): void {
 		// Register ability with hyphen (valid).
-		wp_register_ability(
+		$this->register_test_ability(
 			'test-hyphen/ability',
 			array(
 				'label'               => 'Test Hyphen Ability',

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1RunController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1RunController.php
@@ -49,8 +49,6 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 			)
 		);
 
-		// Fire the init hook to allow test ability categories registration.
-		do_action( 'wp_abilities_api_categories_init' );
 		self::register_test_categories();
 	}
 
@@ -78,8 +76,6 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 
 		do_action( 'rest_api_init' );
 
-		// Initialize Abilities API.
-		do_action( 'wp_abilities_api_init' );
 		$this->register_test_abilities();
 
 		// Set default user for tests
@@ -109,6 +105,10 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 	 * Register test categories for testing.
 	 */
 	public static function register_test_categories(): void {
+		// Simulates the init hook to allow test ability category registration.
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_categories_init';
+
 		wp_register_ability_category(
 			'math',
 			array(
@@ -132,6 +132,24 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 				'description' => 'General purpose abilities.',
 			)
 		);
+
+		array_pop( $wp_current_filter );
+	}
+
+	/**
+	 * Helper to register a test ability.
+	 *
+	 * @param string $name Ability name.
+	 * @param array  $args Ability arguments.
+	 */
+	private function register_test_ability( string $name, array $args ): void {
+		// Simulates the init hook to allow test abilities registration.
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init';
+
+		wp_register_ability( $name, $args );
+
+		array_pop( $wp_current_filter );
 	}
 
 	/**
@@ -139,7 +157,7 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 	 */
 	private function register_test_abilities(): void {
 		// Regular ability (POST only).
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/calculator',
 			array(
 				'label'               => 'Calculator',
@@ -176,7 +194,7 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 		);
 
 		// Read-only ability (GET method).
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/user-info',
 			array(
 				'label'               => 'User Info',
@@ -222,7 +240,7 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 		);
 
 		// Destructive ability (DELETE method).
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/delete-user',
 			array(
 				'label'               => 'Delete User',
@@ -263,7 +281,7 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 		);
 
 		// Ability with contextual permissions
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/restricted',
 			array(
 				'label'               => 'Restricted Action',
@@ -294,7 +312,7 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 		);
 
 		// Ability that does not show in REST.
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/not-show-in-rest',
 			array(
 				'label'               => 'Hidden from REST',
@@ -308,7 +326,7 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 		);
 
 		// Ability that returns null
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/null-return',
 			array(
 				'label'               => 'Null Return',
@@ -325,7 +343,7 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 		);
 
 		// Ability that returns WP_Error
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/error-return',
 			array(
 				'label'               => 'Error Return',
@@ -342,7 +360,7 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 		);
 
 		// Ability with invalid output
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/invalid-output',
 			array(
 				'label'               => 'Invalid Output',
@@ -362,7 +380,7 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 		);
 
 		// Read-only ability for query params testing.
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/query-params',
 			array(
 				'label'               => 'Query Params Test',
@@ -463,7 +481,7 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 	 * @ticket 64098
 	 */
 	public function test_regular_ability_requires_post(): void {
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/open-tool',
 			array(
 				'label'               => 'Open Tool',
@@ -793,7 +811,7 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 	 */
 	public function test_output_validation_failure_returns_error(): void {
 		// Register ability with strict output schema.
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/strict-output',
 			array(
 				'label'               => 'Strict Output',
@@ -842,7 +860,7 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 	 */
 	public function test_input_validation_failure_returns_error(): void {
 		// Register ability with strict input schema.
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/strict-input',
 			array(
 				'label'               => 'Strict Input',
@@ -891,7 +909,7 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 	 */
 	public function test_ability_without_annotations_defaults_to_post_method(): void {
 		// Register ability without annotations.
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/no-annotations',
 			array(
 				'label'               => 'No Annotations',
@@ -926,7 +944,7 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 	 * @ticket 64098
 	 */
 	public function test_empty_input_handling_get_method(): void {
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/read-only-empty',
 			array(
 				'label'               => 'Read-only Empty',
@@ -958,7 +976,7 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 	 * @ticket 64098
 	 */
 	public function test_empty_input_handling_get_method_with_normalized_input(): void {
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/read-only-empty-array',
 			array(
 				'label'               => 'Read-only Empty Array',
@@ -994,7 +1012,7 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 	 * @ticket 64098
 	 */
 	public function test_empty_input_handling_post_method(): void {
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/regular-empty',
 			array(
 				'label'               => 'Regular Empty',
@@ -1065,7 +1083,7 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 	 */
 	public function test_php_type_strings_in_input(): void {
 		// Register ability that accepts any input
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/echo',
 			array(
 				'label'               => 'Echo',
@@ -1114,7 +1132,7 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 	 */
 	public function test_mixed_encoding_in_input(): void {
 		// Register ability that accepts any input
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/echo-encoding',
 			array(
 				'label'               => 'Echo Encoding',
@@ -1183,7 +1201,7 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 	 */
 	public function test_invalid_http_methods( string $method ): void {
 		// Register an ability with no permission requirements for this test
-		wp_register_ability(
+		$this->register_test_ability(
 			'test/method-test',
 			array(
 				'label'               => 'Method Test',


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64098

Follow-up for https://github.com/WordPress/wordpress-develop/pull/9410.

Raised by @JasonTheAdams and @felixarntz in https://github.com/WordPress/abilities-api/pull/126#discussion_r2453289205:

> I'm curious why we're using `did_action()` and not `doing_action`?

> I did provide similar feedback somewhere else (I believe on the Core PR) - I think allowing registration at any arbitrary point means we're being "forgiving" to developers doing it wrong, which can then lead to far more obscure problems down the line.
>
> I think clearly defined APIs and, given WordPress's procedural nature, clearly defined registration timing are crucial to avoid more complex problems. Better tell the developer they should fix something rather than them running into a problem later that they have no idea on why it's occurring. 

Although the code modifications were simple, getting the unit tests to pass was quite an adventure. I'm still not entirely convinced I took the most elegant approach for simulating the proper conditions, but my focus was to make the tests pass with the minimal set of changes necessary.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
