### PR TITLE
Block editor: [Backport] Make fit text work with the interativity API.

### DIFF
--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -308,6 +308,20 @@ function wp_typography_get_preset_inline_style_value( $style_value, $css_propert
 function wp_render_typography_support( $block_content, $block ) {
 	if ( ! empty( $block['attrs']['fitText'] ) && ! is_admin() ) {
 		wp_enqueue_script_module( '@wordpress/block-editor/utils/fit-text-frontend' );
+
+		// Add Interactivity API directives for fit text to work with client-side navigation.
+		if ( ! empty( $block_content ) ) {
+			$processor = new WP_HTML_Tag_Processor( $block_content );
+			if ( $processor->next_tag() ) {
+				if ( ! $processor->get_attribute( 'data-wp-interactive' ) ) {
+					$processor->set_attribute( 'data-wp-interactive', true );
+				}
+				$processor->set_attribute( 'data-wp-context---core-fit-text', 'core/fit-text::{"fontSize":""}' );
+				$processor->set_attribute( 'data-wp-init---core-fit-text', 'core/fit-text::callbacks.init' );
+				$processor->set_attribute( 'data-wp-style--font-size', 'core/fit-text::context.fontSize' );
+				$block_content = $processor->get_updated_html();
+			}
+		}
 	}
 	if ( ! isset( $block['attrs']['style']['typography']['fontSize'] ) ) {
 		return $block_content;


### PR DESCRIPTION
Backports: https://github.com/WordPress/gutenberg/pull/72923
Backports the required core changes to make fit text work correctly with the interactivity API.

Fit text did not work after navigating to a page using the Interactivity API router. When users navigated to a post via client-side navigation (e.g., in a Query block with pagination), fit text blocks would not recalculate their font sizes, appearing either too large or too small.

This occurred because the fit text initialization only ran on the window.load event, which doesn't fire during client-side navigation.

This PR refactors fit text front end to be an interactivity api first implementation, using an interactivity api init event instead of a window load event.

Ticket: https://core.trac.wordpress.org/ticket/64210

