### PR TITLE
Remove `wp-block-styles` theme support precondition for loading block styles on demand

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3591,7 +3591,7 @@ function wp_load_classic_theme_block_styles_on_demand() {
 	 */
 	add_filter( 'wp_should_output_buffer_template_for_enhancement', '__return_true', 0 );
 
-	// If a site has opted out of the template enhancement output buffer, then we must abort.
+	// If a site has opted out of the template enhancement output buffer, then bail.
 	if ( ! wp_should_output_buffer_template_for_enhancement() ) {
 		return;
 	}
@@ -3601,13 +3601,13 @@ function wp_load_classic_theme_block_styles_on_demand() {
 	/*
 	 * Load separate block styles so that the large block-library stylesheet is not enqueued unconditionally,
 	 * and so that block-specific styles will only be enqueued when they are used on the page.
-	 * A priority of zero allows for this to be easily overridden by themes which wish to opt-out.
+	 * A priority of zero allows for this to be easily overridden by themes which wish to opt out.
 	 */
 	add_filter( 'should_load_separate_core_block_assets', '__return_true', 0 );
 
 	/*
 	 * Also ensure that block assets are loaded on demand (although the default value is from should_load_separate_core_block_assets).
-	 * As above, a priority of zero allows for this to be easily overridden by themes which wish to opt-out.
+	 * As above, a priority of zero allows for this to be easily overridden by themes which wish to opt out.
 	 */
 	add_filter( 'should_load_block_assets_on_demand', '__return_true', 0 );
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3575,8 +3575,11 @@ function wp_remove_surrounding_empty_script_tags( $contents ) {
  * Adds hooks to load block styles on demand in classic themes.
  *
  * @since 6.9.0
+ *
+ * @see _add_default_theme_supports()
  */
 function wp_load_classic_theme_block_styles_on_demand() {
+	// This is not relevant to block themes, as they are opted in to loading separate styles on demand via _add_default_theme_supports().
 	if ( wp_is_block_theme() ) {
 		return;
 	}
@@ -3588,25 +3591,29 @@ function wp_load_classic_theme_block_styles_on_demand() {
 	 */
 	add_filter( 'wp_should_output_buffer_template_for_enhancement', '__return_true', 0 );
 
+	// If a site has opted out of the template enhancement output buffer, then we must abort.
 	if ( ! wp_should_output_buffer_template_for_enhancement() ) {
 		return;
 	}
 
-	/*
-	 * If the theme supports block styles, add filters to ensure they are loaded separately and on demand. Without this,
-	 * if a theme does not want or support block styles, then enabling these filters can result in undesired separate
-	 * block-specific styles being enqueued, though a theme may also be trying to nullify the wp-block-library
-	 * stylesheet.
-	 */
-	if ( current_theme_supports( 'wp-block-styles' ) ) {
-		/*
-		 * Load separate block styles so that the large block-library stylesheet is not enqueued unconditionally,
-		 * and so that block-specific styles will only be enqueued when they are used on the page.
-		 */
-		add_filter( 'should_load_separate_core_block_assets', '__return_true', 0 );
+	// The following to filters are added by default for block themes in _add_default_theme_supports().
 
-		// Also ensure that block assets are loaded on demand (although the default value is from should_load_separate_core_block_assets).
-		add_filter( 'should_load_block_assets_on_demand', '__return_true', 0 );
+	/*
+	 * Load separate block styles so that the large block-library stylesheet is not enqueued unconditionally,
+	 * and so that block-specific styles will only be enqueued when they are used on the page.
+	 * A priority of zero allows for this to be easily overridden by themes which wish to opt-out.
+	 */
+	add_filter( 'should_load_separate_core_block_assets', '__return_true', 0 );
+
+	/*
+	 * Also ensure that block assets are loaded on demand (although the default value is from should_load_separate_core_block_assets).
+	 * As above, a priority of zero allows for this to be easily overridden by themes which wish to opt-out.
+	 */
+	add_filter( 'should_load_block_assets_on_demand', '__return_true', 0 );
+
+	// If even with the filtering
+	if ( ! wp_should_load_separate_core_block_assets() || ! wp_should_load_block_assets_on_demand() ) {
+		return;
 	}
 
 	// Add hooks which require the presence of the output buffer. Ideally the above two filters could be added here, but they run too early.

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3596,7 +3596,7 @@ function wp_load_classic_theme_block_styles_on_demand() {
 		return;
 	}
 
-	// The following to filters are added by default for block themes in _add_default_theme_supports().
+	// The following two filters are added by default for block themes in _add_default_theme_supports().
 
 	/*
 	 * Load separate block styles so that the large block-library stylesheet is not enqueued unconditionally,
@@ -3611,7 +3611,7 @@ function wp_load_classic_theme_block_styles_on_demand() {
 	 */
 	add_filter( 'should_load_block_assets_on_demand', '__return_true', 0 );
 
-	// If even with the filtering
+	// If a site has explicitly opted out of loading block styles on demand via filters with priorities higher than above, then abort.
 	if ( ! wp_should_load_separate_core_block_assets() || ! wp_should_load_block_assets_on_demand() ) {
 		return;
 	}

--- a/tests/phpunit/tests/template.php
+++ b/tests/phpunit/tests/template.php
@@ -1393,35 +1393,39 @@ class Tests_Template extends WP_UnitTestCase {
 	 */
 	public function data_wp_load_classic_theme_block_styles_on_demand(): array {
 		return array(
-			'block_theme'                                => array(
+			'block_theme'                              => array(
 				'theme'                   => 'block-theme',
 				'set_up'                  => static function () {},
-				'expected_on_demand'      => false,
+				'expected_load_separate'  => true,
+				'expected_on_demand'      => true,
 				'expected_buffer_started' => false,
 			),
-			'classic_theme_with_output_buffer_blocked'   => array(
+			'classic_theme_with_output_buffer_blocked' => array(
 				'theme'                   => 'default',
 				'set_up'                  => static function () {
 					add_filter( 'wp_should_output_buffer_template_for_enhancement', '__return_false' );
 				},
+				'expected_load_separate'  => false,
 				'expected_on_demand'      => false,
 				'expected_buffer_started' => false,
 			),
-			'classic_theme_with_block_styles_support'    => array(
+			'classic_theme_with_should_load_separate_core_block_assets_opt_out' => array(
 				'theme'                   => 'default',
 				'set_up'                  => static function () {
-					add_theme_support( 'wp-block-styles' );
+					add_filter( 'should_load_separate_core_block_assets', '__return_false' );
 				},
+				'expected_load_separate'  => false,
 				'expected_on_demand'      => true,
-				'expected_buffer_started' => true,
+				'expected_buffer_started' => false,
 			),
-			'classic_theme_without_block_styles_support' => array(
+			'classic_theme_with_should_load_block_assets_on_demand_out_out' => array(
 				'theme'                   => 'default',
 				'set_up'                  => static function () {
-					remove_theme_support( 'wp-block-styles' );
+					add_filter( 'should_load_block_assets_on_demand', '__return_false' );
 				},
+				'expected_load_separate'  => true,
 				'expected_on_demand'      => false,
-				'expected_buffer_started' => true,
+				'expected_buffer_started' => false,
 			),
 		);
 	}
@@ -1436,7 +1440,7 @@ class Tests_Template extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_wp_load_classic_theme_block_styles_on_demand
 	 */
-	public function test_wp_load_classic_theme_block_styles_on_demand( string $theme, ?Closure $set_up, bool $expected_on_demand, bool $expected_buffer_started ) {
+	public function test_wp_load_classic_theme_block_styles_on_demand( string $theme, ?Closure $set_up, bool $expected_load_separate, bool $expected_on_demand, bool $expected_buffer_started ) {
 		$this->assertFalse( wp_should_load_separate_core_block_assets(), 'Expected wp_should_load_separate_core_block_assets() to return false initially.' );
 		$this->assertFalse( wp_should_load_block_assets_on_demand(), 'Expected wp_should_load_block_assets_on_demand() to return true' );
 		$this->assertFalse( has_action( 'wp_template_enhancement_output_buffer_started', 'wp_hoist_late_printed_styles' ), 'Expected wp_template_enhancement_output_buffer_started action to be added for classic themes.' );
@@ -1447,8 +1451,9 @@ class Tests_Template extends WP_UnitTestCase {
 		}
 
 		wp_load_classic_theme_block_styles_on_demand();
+		_add_default_theme_supports();
 
-		$this->assertSame( $expected_on_demand, wp_should_load_separate_core_block_assets(), 'Expected wp_should_load_separate_core_block_assets() return value.' );
+		$this->assertSame( $expected_load_separate, wp_should_load_separate_core_block_assets(), 'Expected wp_should_load_separate_core_block_assets() return value.' );
 		$this->assertSame( $expected_on_demand, wp_should_load_block_assets_on_demand(), 'Expected wp_should_load_block_assets_on_demand() return value.' );
 		$this->assertSame( $expected_buffer_started, (bool) has_action( 'wp_template_enhancement_output_buffer_started', 'wp_hoist_late_printed_styles' ), 'Expected wp_template_enhancement_output_buffer_started action added status.' );
 	}

--- a/tests/phpunit/tests/template.php
+++ b/tests/phpunit/tests/template.php
@@ -1427,6 +1427,13 @@ class Tests_Template extends WP_UnitTestCase {
 				'expected_on_demand'      => false,
 				'expected_buffer_started' => false,
 			),
+			'classic_theme_without_any_opt_out'        => array(
+				'theme'                   => 'default',
+				'set_up'                  => static function () {},
+				'expected_load_separate'  => true,
+				'expected_on_demand'      => true,
+				'expected_buffer_started' => true,
+			),
 		);
 	}
 


### PR DESCRIPTION
See [rationale](https://core.trac.wordpress.org/ticket/64099#comment:30). This reverts part of r61076, the part which added the `wp-block-styles` theme support check. 

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64099

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
