### PR TITLE
Theme JSON: Fix handling of default presets at block level

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -3250,7 +3250,11 @@ class WP_Theme_JSON {
 			foreach ( static::PRESETS_METADATA as $preset_metadata ) {
 				$prevent_override = $preset_metadata['prevent_override'];
 				if ( is_array( $prevent_override ) ) {
-					$prevent_override = _wp_array_get( $this->theme_json['settings'], $preset_metadata['prevent_override'] );
+					$global_path  = array_merge( array( 'settings' ), $prevent_override );
+					$global_value = _wp_array_get( $this->theme_json, $global_path, null );
+
+					$node_level_path  = array_merge( $node['path'], $prevent_override );
+					$prevent_override = _wp_array_get( $this->theme_json, $node_level_path, $global_value );
 				}
 
 				foreach ( static::VALID_ORIGINS as $origin ) {

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -6411,4 +6411,197 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 
 		$this->assertSame( $expected, $button_variations );
 	}
+
+	public function test_merge_incoming_data_block_level_inherits_global_default_setting() {
+		$defaults = new WP_Theme_JSON(
+			array(
+				'version'  => WP_Theme_JSON::LATEST_SCHEMA,
+				'settings' => array(
+					'color' => array(
+						'defaultDuotone' => true,
+						'duotone'        => array(
+							array(
+								'slug'   => 'dark-grayscale',
+								'colors' => array( '#000000', '#7f7f7f' ),
+								'name'   => 'Default Dark grayscale',
+							),
+						),
+					),
+				),
+			),
+			'default'
+		);
+		$theme    = new WP_Theme_JSON(
+			array(
+				'version'  => WP_Theme_JSON::LATEST_SCHEMA,
+				'settings' => array(
+					'color'  => array(
+						'defaultDuotone' => false,
+					),
+					'blocks' => array(
+						'core/image' => array(
+							'color' => array(
+								// No defaultDuotone setting - should inherit global (false) set by theme.
+								'duotone' => array(
+									array(
+										'slug'   => 'dark-grayscale',
+										'colors' => array( '#000000', '#7f7f7f' ),
+										'name'   => 'Theme Dark grayscale',
+									),
+								),
+							),
+						),
+						'core/cover' => array(
+							'color' => array(
+								'defaultDuotone' => true, // Explicitly enabled at block level
+								'duotone'        => array(
+									array(
+										'slug'   => 'dark-grayscale',
+										'colors' => array( '#000000', '#7f7f7f' ),
+										'name'   => 'Cover Dark grayscale',
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$expected = array(
+			'version'  => WP_Theme_JSON::LATEST_SCHEMA,
+			'settings' => array(
+				'color'  => array(
+					'defaultDuotone' => false,
+					'duotone'        => array(
+						'default' => array(
+							array(
+								'slug'   => 'dark-grayscale',
+								'colors' => array( '#000000', '#7f7f7f' ),
+								'name'   => 'Default Dark grayscale',
+							),
+						),
+					),
+				),
+				'blocks' => array(
+					'core/image' => array(
+						'color' => array(
+							'duotone' => array(
+								'theme' => array(
+									array(
+										'slug'   => 'dark-grayscale',
+										'colors' => array( '#000000', '#7f7f7f' ),
+										'name'   => 'Theme Dark grayscale',
+									),
+								),
+							),
+						),
+					),
+					'core/cover' => array(
+						'color' => array(
+							'defaultDuotone' => true,
+							'duotone'        => array(
+								'theme' => array(
+									// Should be filtered out because block-level defaults are enabled
+									// and slug matches default
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$defaults->merge( $theme );
+		$actual = $defaults->get_raw_data();
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	public function test_merge_incoming_data_unique_slugs_always_preserved() {
+		$defaults = new WP_Theme_JSON(
+			array(
+				'version'  => WP_Theme_JSON::LATEST_SCHEMA,
+				'settings' => array(
+					'color' => array(
+						'defaultDuotone' => true, // Defaults enabled
+						'duotone'        => array(
+							array(
+								'slug'   => 'dark-grayscale',
+								'colors' => array( '#000000', '#7f7f7f' ),
+								'name'   => 'Default Dark grayscale',
+							),
+						),
+					),
+				),
+			),
+			'default'
+		);
+		$theme    = new WP_Theme_JSON(
+			array(
+				'version'  => WP_Theme_JSON::LATEST_SCHEMA,
+				'settings' => array(
+					'blocks' => array(
+						'core/image' => array(
+							'color' => array(
+								'defaultDuotone' => true, // Block-level defaults enabled
+								'duotone'        => array(
+									array(
+										'slug'   => 'custom-unique',
+										'colors' => array( '#ff0000', '#00ff00' ),
+										'name'   => 'Custom Unique',
+									),
+									array(
+										'slug'   => 'dark-grayscale', // Matches default slug
+										'colors' => array( '#111111', '#888888' ),
+										'name'   => 'Theme Dark grayscale',
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$expected = array(
+			'version'  => WP_Theme_JSON::LATEST_SCHEMA,
+			'settings' => array(
+				'color'  => array(
+					'defaultDuotone' => true,
+					'duotone'        => array(
+						'default' => array(
+							array(
+								'slug'   => 'dark-grayscale',
+								'colors' => array( '#000000', '#7f7f7f' ),
+								'name'   => 'Default Dark grayscale',
+							),
+						),
+					),
+				),
+				'blocks' => array(
+					'core/image' => array(
+						'color' => array(
+							'defaultDuotone' => true,
+							'duotone'        => array(
+								'theme' => array(
+									array(
+										'slug'   => 'custom-unique', // Should always be preserved
+										'colors' => array( '#ff0000', '#00ff00' ),
+										'name'   => 'Custom Unique',
+									),
+									// 'dark-grayscale' should be filtered out due to slug match
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$defaults->merge( $theme );
+		$actual = $defaults->get_raw_data();
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
 }

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -6412,6 +6412,15 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		$this->assertSame( $expected, $button_variations );
 	}
 
+	/**
+	 * Tests that block-level settings inherit global default settings when not explicitly set.
+	 *
+	 * When a block doesn't have its own default presets setting, it should inherit
+	 * the global setting from the theme. This affects whether default presets
+	 * are filtered out during merging.
+	 *
+	 * @ticket 64195
+	 */
 	public function test_merge_incoming_data_block_level_inherits_global_default_setting() {
 		$defaults = new WP_Theme_JSON(
 			array(
@@ -6518,6 +6527,16 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 
+	/**
+	 * Tests that presets with unique slugs are preserved during merging.
+	 *
+	 * When merging theme presets, any preset with a slug that doesn't match
+	 * a default preset should always be preserved, regardless of default
+	 * preset settings. Only presets with matching slugs should be filtered out
+	 * when defaults are enabled.
+	 *
+	 * @ticket 64195
+	 */
 	public function test_merge_incoming_data_unique_slugs_always_preserved() {
 		$defaults = new WP_Theme_JSON(
 			array(


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64195

This PR brings the changes from the following Gutenberg PRs to core:

https://github.com/WordPress/gutenberg/pull/72916

### Description

Prevents an issue where block level presets do not work correctly when:

- Default presets are disabled
- Slug matches the default preset

The result is missing presets in the settings and editor UI.

### Testing


For each theme.json example config below:
1. Ensure default presets for the feature being testing is on at the global level
2. Add the block level preset config to your theme.json file
3. Confirm in the editor the expected presets are available generally and at the block level


### Duotone

In the image block, only the "Dark grayscale" duotone preset should be available

```json
{
	"version": 3,
	"appearanceTools": true,
	"settings": {
		"blocks":{
			"core/image": {
				"color": {
					"defaultDuotone": false,
					"duotone": [
						{
							"name": "Dark grayscale",
							"colors": [ "#000000", "#7f7f7f" ],
							"slug": "dark-grayscale"
						}
					]
				}
			}
		}
	}
}
```

### Shadow

In the image block, only the "Natural" shadow preset should be available

```json
{
	"version": 3,
	"settings": {
		"appearanceTools": true,
		"blocks":{
			"core/image": {
				"shadow": {
					"defaultPresets": false,
					"presets": [
						{
							"name": "Natural",
							"slug": "natural",
							"shadow": "6px 6px 9px rgba(0, 0, 0, 0.2)"
						}
					]
				}
			}
		}
	}
}
```

### Font Size

In the Paragraph block, only the "Small" duotone preset should be available

```json
{
	"version": 3,
	"settings": {
		"appearanceTools": true,
		"blocks":{
			"core/paragraph": {
				"typography": {
					"defaultFontSizes": false,
					"fontSizes": [
						{
							"name": "Small",
							"slug": "small",
							"size": "13px"
						}
					]
				}
			}
		}
	}
}
```

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| <img width="277" height="251" alt="Screenshot 2025-11-03 at 7 23 34 pm" src="https://github.com/user-attachments/assets/ce72aed1-0f73-4cbe-86b3-4b6e7d61ed85" /> | <img width="276" height="249" alt="Screenshot 2025-11-03 at 7 20 28 pm" src="https://github.com/user-attachments/assets/6a925b8b-232d-434e-b463-2a166f309cdf" /> |


---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
