### PR TITLE
Command Palette: Use Tag processor instead of regex in the enqueue function.

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3442,9 +3442,11 @@ function wp_enqueue_command_palette_assets() {
 			}
 
 			// Remove all HTML tags and their contents.
-			$menu_label = $menu_item[0];
-			while ( preg_match( '/<[^>]*>/', $menu_label ) ) {
-				$menu_label = preg_replace( '/<[^>]*>.*?<\/[^>]*>|<[^>]*\/>|<[^>]*>/s', '', $menu_label );
+			$processor = new WP_HTML_Tag_Processor( $menu_item[0] );
+			while ( $processor->next_token() ) {
+				if ( '#text' === $processor->get_token_name() ) {
+					$menu_label .= $processor->get_modifiable_text();
+				}
 			}
 			$menu_label = trim( $menu_label );
 			$menu_url   = '';
@@ -3471,9 +3473,12 @@ function wp_enqueue_command_palette_assets() {
 					}
 
 					// Remove all HTML tags and their contents.
-					$submenu_label = $submenu_item[0];
-					while ( preg_match( '/<[^>]*>/', $submenu_label ) ) {
-						$submenu_label = preg_replace( '/<[^>]*>.*?<\/[^>]*>|<[^>]*\/>|<[^>]*>/s', '', $submenu_label );
+					$processor     = new WP_HTML_Tag_Processor( $submenu_item[0] );
+					$submenu_label = '';
+					while ( $processor->next_token() ) {
+						if ( '#text' === $processor->get_token_name() ) {
+							$submenu_label .= $processor->get_modifiable_text();
+						}
 					}
 					$submenu_label = trim( $submenu_label );
 					$submenu_url   = '';


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Refactors the code on the command palette enqueue function to strip the HTML by using the Tag Processor instead of a couple of regex functions.

Proposed by @dmsnell . Props to him.

Trac ticket: https://core.trac.wordpress.org/ticket/64196

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
