### PR TITLE
Never show notes on the comments page

### DIFF
--- a/src/wp-admin/edit-comments.php
+++ b/src/wp-admin/edit-comments.php
@@ -16,11 +16,6 @@ if ( ! current_user_can( 'edit_posts' ) ) {
 	);
 }
 
-// Never show notes on the comments page.
-if ( 'note' === $_REQUEST['comment_type'] ) {
-	unset( $_REQUEST['comment_type'] );
-}
-
 $wp_list_table = _get_list_table( 'WP_Comments_List_Table' );
 $pagenum       = $wp_list_table->get_pagenum();
 

--- a/src/wp-admin/edit-comments.php
+++ b/src/wp-admin/edit-comments.php
@@ -16,6 +16,11 @@ if ( ! current_user_can( 'edit_posts' ) ) {
 	);
 }
 
+// Never show notes on the comments page.
+if ( 'note' === $_REQUEST['comment_type'] ) {
+	unset( $_REQUEST['comment_type'] );
+}
+
 $wp_list_table = _get_list_table( 'WP_Comments_List_Table' );
 $pagenum       = $wp_list_table->get_pagenum();
 

--- a/src/wp-admin/includes/class-wp-comments-list-table.php
+++ b/src/wp-admin/includes/class-wp-comments-list-table.php
@@ -100,7 +100,7 @@ class WP_Comments_List_Table extends WP_List_Table {
 		}
 
 		$comment_type = '';
-		
+
 		if ( ! empty( $_REQUEST['comment_type'] ) && 'note' !== $_REQUEST['comment_type'] ) {
 			$comment_type = $_REQUEST['comment_type'];
 		}

--- a/src/wp-admin/includes/class-wp-comments-list-table.php
+++ b/src/wp-admin/includes/class-wp-comments-list-table.php
@@ -100,6 +100,7 @@ class WP_Comments_List_Table extends WP_List_Table {
 		}
 
 		$comment_type = ! empty( $_REQUEST['comment_type'] ) ? $_REQUEST['comment_type'] : '';
+		$comment_type = 'note' === $comment_type ? '' : $comment_type;
 
 		$search = ( isset( $_REQUEST['s'] ) ) ? $_REQUEST['s'] : '';
 

--- a/src/wp-admin/includes/class-wp-comments-list-table.php
+++ b/src/wp-admin/includes/class-wp-comments-list-table.php
@@ -99,8 +99,11 @@ class WP_Comments_List_Table extends WP_List_Table {
 			$comment_status = 'all';
 		}
 
-		$comment_type = ! empty( $_REQUEST['comment_type'] ) ? $_REQUEST['comment_type'] : '';
-		$comment_type = 'note' === $comment_type ? '' : $comment_type;
+		$comment_type = '';
+		
+		if ( ! empty( $_REQUEST['comment_type'] ) && 'note' !== $_REQUEST['comment_type'] ) {
+			$comment_type = $_REQUEST['comment_type'];
+		}
 
 		$search = ( isset( $_REQUEST['s'] ) ) ? $_REQUEST['s'] : '';
 

--- a/tests/phpunit/tests/admin/wpCommentsListTable.php
+++ b/tests/phpunit/tests/admin/wpCommentsListTable.php
@@ -220,21 +220,21 @@ OPTIONS;
 	 * @ticket 64198
 	 */
 	public function test_comments_list_table_does_not_show_note_comment_type() {
-		$post_id = self::factory()->post->create();
-		$note_id = self::factory()->comment->create(
+		$post_id    = self::factory()->post->create();
+		$note_id    = self::factory()->comment->create(
 			array(
-				'comment_post_ID'   => $post_id,
-				'comment_content'   => 'This is a note.',
-				'comment_type'      => 'note',
-				'comment_approved'  => '1',
+				'comment_post_ID'  => $post_id,
+				'comment_content'  => 'This is a note.',
+				'comment_type'     => 'note',
+				'comment_approved' => '1',
 			)
 		);
 		$comment_id = self::factory()->comment->create(
 			array(
-				'comment_post_ID'   => $post_id,
-				'comment_content'   => 'This is a regular comment.',
-				'comment_type'      => '',
-				'comment_approved'  => '1',
+				'comment_post_ID'  => $post_id,
+				'comment_content'  => 'This is a regular comment.',
+				'comment_type'     => '',
+				'comment_approved' => '1',
 			)
 		);
 		// Request the note comment type.

--- a/tests/phpunit/tests/admin/wpCommentsListTable.php
+++ b/tests/phpunit/tests/admin/wpCommentsListTable.php
@@ -213,4 +213,35 @@ OPTIONS;
 		);
 		$this->assertSame( $expected, $this->table->get_views() );
 	}
+
+	/**
+	 * Verify that the comments table never shows the note comment_type.
+	 *
+	 * @ticket 64198
+	 */
+	public function test_comments_list_table_does_not_show_note_comment_type() {
+		$post_id = self::factory()->post->create();
+		$note_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'   => $post_id,
+				'comment_content'   => 'This is a note.',
+				'comment_type'      => 'note',
+				'comment_approved'  => '1',
+			)
+		);
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'   => $post_id,
+				'comment_content'   => 'This is a regular comment.',
+				'comment_type'      => '',
+				'comment_approved'  => '1',
+			)
+		);
+		// Request the note comment type.
+		$_REQUEST['comment_type'] = 'note';
+		$this->table->prepare_items();
+		$items = $this->table->items;
+		$this->assertCount( 1, $items );
+		$this->assertEquals( $comment_id, $items[0]->comment_ID );
+	}
 }


### PR DESCRIPTION
Fix an issue where notes can appear on the Comments page if the `comment_type=note` query parameter is passed to the page.

Even though notes are stored in the comments table, they are distinct and have somewhat different in behavior that makes them i'll suited to displaying on the Comments page. For example, comments are approved, notes are resolved. Comments can be trashed and later restored, noted can only be 'deleted' (although technically they still go in the trash).

We did explore displaying notes on the Comments page anod other surfaces outside the editor such as the Post list pages in https://github.com/WordPress/gutenberg/pull/71743 without arriving at a satisfactory solution.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: Core-64198

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
