### PR TITLE
"Remove duplicate translation calls in timezone message formatting"

### DIFF
--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -445,6 +445,7 @@ if ( empty( $tzstring ) ) { // Create a UTC+- zone if no timezone string exists.
 				__( 'Standard time begins on: %s.' );
 			printf(
 				$message,
+				/* translators: Localized date and time format, see https://www.php.net/manual/datetime.format.php */
 				'<code>' . wp_date( __( 'F j, Y g:i a' ), $transitions[1]['ts'] ) . '</code>'
 			);
 		} else {

--- a/src/wp-admin/options-general.php
+++ b/src/wp-admin/options-general.php
@@ -445,7 +445,7 @@ if ( empty( $tzstring ) ) { // Create a UTC+- zone if no timezone string exists.
 				__( 'Standard time begins on: %s.' );
 			printf(
 				$message,
-				'<code>' . wp_date( __( 'F j, Y' ) . ' ' . __( 'g:i a' ), $transitions[1]['ts'] ) . '</code>'
+				'<code>' . wp_date( __( 'F j, Y g:i a' ), $transitions[1]['ts'] ) . '</code>'
 			);
 		} else {
 			_e( 'This timezone does not observe daylight saving time.' );


### PR DESCRIPTION
Included the space in the date/time format

Trac ticket: https://core.trac.wordpress.org/ticket/64197

