### PR TITLE
Use a dataprover in db tests

### DIFF
--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -122,7 +122,11 @@ class Tests_DB extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 10041
+	 *
 	 * @dataProvider data_esc_like
+	 *
+	 * @param string $input    The input string.
+	 * @param string $expected The expected escaped string.
 	 */
 	public function test_esc_like( $input, $expected ) {
 		global $wpdb;

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -132,23 +132,23 @@ class Tests_DB extends WP_UnitTestCase {
 
 	public function data_esc_like() {
 		return array(
-			'single percent'     => array(
+			'single percent'    => array(
 				'howdy%',
 				'howdy\\%',
 			),
-			'single underscore'  => array(
+			'single underscore' => array(
 				'howdy_',
 				'howdy\\_',
 			),
-			'single slash'       => array(
+			'single slash'      => array(
 				'howdy\\',
 				'howdy\\\\',
 			),
-			'the works'          => array(
+			'the works'         => array(
 				'howdy\\howdy%howdy_',
 				'howdy\\\\howdy\\%howdy\\_',
 			),
-			'plain text'         => array(
+			'plain text'        => array(
 				'howdy\'"[[]*#[^howdy]!+)(*&$#@!~|}{=--`/.,<>?',
 				'howdy\'"[[]*#[^howdy]!+)(*&$#@!~|}{=--`/.,<>?',
 			),

--- a/tests/phpunit/tests/db.php
+++ b/tests/phpunit/tests/db.php
@@ -122,28 +122,37 @@ class Tests_DB extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 10041
+	 * @dataProvider data_esc_like
 	 */
-	public function test_esc_like() {
+	public function test_esc_like( $input, $expected ) {
 		global $wpdb;
 
-		$inputs   = array(
-			'howdy%',              // Single percent.
-			'howdy_',              // Single underscore.
-			'howdy\\',             // Single slash.
-			'howdy\\howdy%howdy_', // The works.
-			'howdy\'"[[]*#[^howdy]!+)(*&$#@!~|}{=--`/.,<>?', // Plain text.
-		);
-		$expected = array(
-			'howdy\\%',
-			'howdy\\_',
-			'howdy\\\\',
-			'howdy\\\\howdy\\%howdy\\_',
-			'howdy\'"[[]*#[^howdy]!+)(*&$#@!~|}{=--`/.,<>?',
-		);
+		$this->assertSame( $expected, $wpdb->esc_like( $input ) );
+	}
 
-		foreach ( $inputs as $key => $input ) {
-			$this->assertSame( $expected[ $key ], $wpdb->esc_like( $input ) );
-		}
+	public function data_esc_like() {
+		return array(
+			'single percent'     => array(
+				'howdy%',
+				'howdy\\%',
+			),
+			'single underscore'  => array(
+				'howdy_',
+				'howdy\\_',
+			),
+			'single slash'       => array(
+				'howdy\\',
+				'howdy\\\\',
+			),
+			'the works'          => array(
+				'howdy\\howdy%howdy_',
+				'howdy\\\\howdy\\%howdy\\_',
+			),
+			'plain text'         => array(
+				'howdy\'"[[]*#[^howdy]!+)(*&$#@!~|}{=--`/.,<>?',
+				'howdy\'"[[]*#[^howdy]!+)(*&$#@!~|}{=--`/.,<>?',
+			),
+		);
 	}
 
 	/**


### PR DESCRIPTION
dataproviders allow for the tests to all run rather than stopping at one failure. They also provide for better messages on failure.


Trac ticket: https://core.trac.wordpress.org/ticket/63167

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
