### PR TITLE
Twenty Twenty: Fix font inconsistency in Latest Posts block editor.

### DIFF
--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block-rtl.css
@@ -1064,6 +1064,10 @@ hr.wp-block-separator.is-style-dots::before {
 	margin-top: 15px;
 }
 
+.wp-block-latest-posts__post-full-content p {
+	font-family: inherit;
+}
+
 .wp-block-latest-posts__post-full-content > p:first-child {
 	margin-top: 1em;
 }

--- a/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
+++ b/src/wp-content/themes/twentytwenty/assets/css/editor-style-block.css
@@ -1068,6 +1068,10 @@ hr.wp-block-separator.is-style-dots::before {
 	margin-top: 15px;
 }
 
+.wp-block-latest-posts__post-full-content p {
+	font-family: inherit;
+}
+
 .wp-block-latest-posts__post-full-content > p:first-child {
 	margin-top: 1em;
 }


### PR DESCRIPTION
This PR was previously opened [here](https://github.com/WordPress/wordpress-develop/pull/9455), but since there was no further activity on it, I’ve created a new PR based on the latest trunk, including the changes mentioned in this [comment](https://github.com/WordPress/wordpress-develop/pull/9455#pullrequestreview-3419122258)

Trac ticket: https://core.trac.wordpress.org/ticket/63798

This PR fixes a font styling inconsistency in the Twenty Twenty theme where the Latest Posts block displays post content using different fonts in the editor and the frontend when “Full post” content is selected.

### Testing

As outlined [here](https://github.com/WordPress/wordpress-develop/pull/9455#issue-3314672759)