### PR TITLE
Themes: Restore 'Live Preview' for block themes.

### DIFF
--- a/src/wp-admin/includes/class-theme-installer-skin.php
+++ b/src/wp-admin/includes/class-theme-installer-skin.php
@@ -121,14 +121,24 @@ class Theme_Installer_Skin extends WP_Upgrader_Skin {
 
 		$install_actions = array();
 
-		if ( current_user_can( 'edit_theme_options' ) && current_user_can( 'customize' ) && ! $theme_info->is_block_theme() ) {
-			$customize_url = add_query_arg(
-				array(
-					'theme'  => urlencode( $stylesheet ),
-					'return' => urlencode( admin_url( 'web' === $this->type ? 'theme-install.php' : 'themes.php' ) ),
-				),
-				admin_url( 'customize.php' )
-			);
+		if ( current_user_can( 'edit_theme_options' ) && current_user_can( 'customize' ) ) {
+			if ( $theme_info->is_block_theme() ) {
+				$customize_url = add_query_arg(
+					array(
+						'wp_theme_preview' => urlencode( $stylesheet ),
+						'return'           => urlencode( admin_url( 'web' === $this->type ? 'theme-install.php' : 'themes.php' ) ),
+					),
+					admin_url( 'site-editor.php' )
+				);
+			} else {
+				$customize_url = add_query_arg(
+					array(
+						'theme'  => urlencode( $stylesheet ),
+						'return' => urlencode( admin_url( 'web' === $this->type ? 'theme-install.php' : 'themes.php' ) ),
+					),
+					admin_url( 'customize.php' )
+				);
+			}
 
 			$install_actions['preview'] = sprintf(
 				'<a href="%s" class="hide-if-no-customize load-customize">' .

--- a/src/wp-admin/includes/class-theme-installer-skin.php
+++ b/src/wp-admin/includes/class-theme-installer-skin.php
@@ -121,7 +121,7 @@ class Theme_Installer_Skin extends WP_Upgrader_Skin {
 
 		$install_actions = array();
 
-		if ( current_user_can( 'edit_theme_options' ) && current_user_can( 'customize' ) ) {
+		if ( current_user_can( 'edit_theme_options' ) && ( $theme_info->is_block_theme() || current_user_can( 'customize' ) ) ) {
 			if ( $theme_info->is_block_theme() ) {
 				$customize_url = add_query_arg(
 					array(

--- a/src/wp-admin/themes.php
+++ b/src/wp-admin/themes.php
@@ -645,7 +645,7 @@ foreach ( $themes as $theme ) :
 			><?php _ex( 'Cannot Activate', 'theme' ); ?></a>
 
 			<?php
-			if ( ! $theme['blockTheme'] && current_user_can( 'edit_theme_options' ) && current_user_can( 'customize' ) ) {
+			if ( current_user_can( 'edit_theme_options' ) && current_user_can( 'customize' ) ) {
 				/* translators: %s: Theme name. */
 				$live_preview_aria_label = sprintf( _x( 'Live Preview %s', 'theme' ), '{{ data.name }}' );
 				?>
@@ -1034,15 +1034,13 @@ function wp_theme_auto_update_setting_template() {
 						aria-label="<?php echo esc_attr( $aria_label ); ?>"
 					><?php _ex( 'Cannot Activate', 'theme' ); ?></a>
 
-					<# if ( ! data.blockTheme ) { #>
-						<?php
-						/* translators: %s: Theme name. */
-						$live_preview_aria_label = sprintf( _x( 'Live Preview %s', 'theme' ), '{{ data.name }}' );
-						?>
-						<a class="button button-primary hide-if-no-customize disabled"
-							aria-label="<?php echo esc_attr( $live_preview_aria_label ); ?>"
-						><?php _e( 'Live Preview' ); ?></a>
-					<# } #>
+					<?php
+					/* translators: %s: Theme name. */
+					$live_preview_aria_label = sprintf( _x( 'Live Preview %s', 'theme' ), '{{ data.name }}' );
+					?>
+					<a class="button button-primary hide-if-no-customize disabled"
+						aria-label="<?php echo esc_attr( $live_preview_aria_label ); ?>"
+					><?php _e( 'Live Preview' ); ?></a>
 				<# } #>
 			<# } #>
 		</div>
@@ -1261,16 +1259,14 @@ function wp_theme_auto_update_setting_template() {
 
 			<div class="inactive-theme">
 				<# if ( data.compatibleWP && data.compatiblePHP ) { #>
-					<# if ( ! data.blockTheme ) { #>
-						<?php
-						/* translators: %s: Theme name. */
-						$live_preview_aria_label = sprintf( _x( 'Live Preview %s', 'theme' ), '{{ data.name }}' );
-						?>
-						<a class="button button-primary load-customize hide-if-no-customize"
-							href="{{{ data.actions.customize }}}"
-							aria-label="<?php echo esc_attr( $live_preview_aria_label ); ?>"
-						><?php _e( 'Live Preview' ); ?></a>
-					<# } #>
+					<?php
+					/* translators: %s: Theme name. */
+					$live_preview_aria_label = sprintf( _x( 'Live Preview %s', 'theme' ), '{{ data.name }}' );
+					?>
+					<a class="button button-primary load-customize hide-if-no-customize"
+						href="{{{ data.actions.customize }}}"
+						aria-label="<?php echo esc_attr( $live_preview_aria_label ); ?>"
+					><?php _e( 'Live Preview' ); ?></a>
 
 					<# if ( data.actions.activate ) { #>
 						<?php
@@ -1283,15 +1279,13 @@ function wp_theme_auto_update_setting_template() {
 						><?php _e( 'Activate' ); ?></a>
 					<# } #>
 				<# } else { #>
-					<# if ( ! data.blockTheme ) { #>
-						<?php
-						/* translators: %s: Theme name. */
-						$live_preview_aria_label = sprintf( _x( 'Live Preview %s', 'theme' ), '{{ data.name }}' );
-						?>
-						<a class="button button-primary hide-if-no-customize disabled"
-							aria-label="<?php echo esc_attr( $live_preview_aria_label ); ?>"
-						><?php _e( 'Live Preview' ); ?></a>
-					<# } #>
+					<?php
+					/* translators: %s: Theme name. */
+					$live_preview_aria_label = sprintf( _x( 'Live Preview %s', 'theme' ), '{{ data.name }}' );
+					?>
+					<a class="button button-primary hide-if-no-customize disabled"
+						aria-label="<?php echo esc_attr( $live_preview_aria_label ); ?>"
+					><?php _e( 'Live Preview' ); ?></a>
 
 					<# if ( data.actions.activate ) { #>
 						<?php


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

What this changes
- Shows “Live Preview” for inactive block themes on Themes and Add Themes screens.

How to test
1) Install Twenty Twenty-Five, keep it inactive → Appearance → Themes → Details → “Live Preview” is present.
2) Click it → Site Editor opens with ?wp_theme_preview=<stylesheet>.
3) Upload a block theme zip → success card shows “Live Preview” and behaves as above.
4) Classic themes still preview via the Customizer.


Trac ticket: https://core.trac.wordpress.org/ticket/64159

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
