### PR TITLE
Block Supports: Add width to dimensions supports

### DIFF
--- a/src/wp-includes/block-supports/dimensions.php
+++ b/src/wp-includes/block-supports/dimensions.php
@@ -51,27 +51,32 @@ function wp_register_dimensions_support( $block_type ) {
  * @return array Block dimensions CSS classes and inline styles.
  */
 function wp_apply_dimensions_support( $block_type, $block_attributes ) {
-	if ( wp_should_skip_block_supports_serialization( $block_type, 'dimensions' ) ) {
-		return array();
-	}
-
 	$attributes = array();
 
-	// Width support to be added in near future.
+	if ( wp_should_skip_block_supports_serialization( $block_type, 'dimensions' ) ) {
+		return $attributes;
+	}
 
-	$has_min_height_support = block_has_support( $block_type, array( 'dimensions', 'minHeight' ), false );
-	$block_styles           = $block_attributes['style'] ?? null;
+	$block_styles = $block_attributes['style'] ?? null;
 
 	if ( ! $block_styles ) {
 		return $attributes;
 	}
 
-	$skip_min_height                      = wp_should_skip_block_supports_serialization( $block_type, 'dimensions', 'minHeight' );
-	$dimensions_block_styles              = array();
-	$dimensions_block_styles['minHeight'] = null;
-	if ( $has_min_height_support && ! $skip_min_height ) {
-		$dimensions_block_styles['minHeight'] = $block_styles['dimensions']['minHeight'] ?? null;
+	$dimensions_block_styles = array();
+	$supported_features      = array( 'minHeight', 'width' );
+
+	foreach ( $supported_features as $feature ) {
+		$has_support        = block_has_support( $block_type, array( 'dimensions', $feature ), false );
+		$skip_serialization = wp_should_skip_block_supports_serialization( $block_type, 'dimensions', $feature );
+
+		$dimensions_block_styles[ $feature ] = null;
+
+		if ( $has_support && ! $skip_serialization ) {
+			$dimensions_block_styles[ $feature ] = $block_styles['dimensions'][ $feature ] ?? null;
+		}
 	}
+
 	$styles = wp_style_engine_get_styles( array( 'dimensions' => $dimensions_block_styles ) );
 
 	if ( ! empty( $styles['css'] ) ) {

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -237,6 +237,7 @@ class WP_Theme_JSON {
 	 * @since 6.5.0 Added `aspect-ratio` property.
 	 * @since 6.6.0 Added `background-[image|position|repeat|size]` properties.
 	 * @since 6.7.0 Added `background-attachment` property.
+	 * @since 7.0.0 Added `dimensions.width`.
 	 * @var array
 	 */
 	const PROPERTIES_METADATA = array(
@@ -301,6 +302,7 @@ class WP_Theme_JSON {
 		'text-transform'                    => array( 'typography', 'textTransform' ),
 		'filter'                            => array( 'filter', 'duotone' ),
 		'box-shadow'                        => array( 'shadow' ),
+		'width'                             => array( 'dimensions', 'width' ),
 		'writing-mode'                      => array( 'typography', 'writingMode' ),
 	);
 
@@ -396,6 +398,7 @@ class WP_Theme_JSON {
 	 *              'typography.defaultFontSizes', and 'spacing.defaultSpacingSizes'.
 	 * @since 6.9.0 Added support for `border.radiusSizes`.
 	 * @since 7.0.0 Added type markers to the schema for boolean values.
+	 *              Added support for `dimensions.width`.
 	 * @var array
 	 */
 	const VALID_SETTINGS = array(
@@ -435,6 +438,7 @@ class WP_Theme_JSON {
 			'aspectRatios'        => null,
 			'defaultAspectRatios' => null,
 			'minHeight'           => null,
+			'width'               => null,
 		),
 		'layout'                        => array(
 			'contentSize'                   => null,
@@ -528,6 +532,7 @@ class WP_Theme_JSON {
 	 * @since 6.3.0 Added support for `typography.textColumns`.
 	 * @since 6.5.0 Added support for `dimensions.aspectRatio`.
 	 * @since 6.6.0 Added `background` sub properties to top-level only.
+	 * @since 7.0.0 Added support for `dimensions.width`.
 	 * @var array
 	 */
 	const VALID_STYLES = array(
@@ -556,6 +561,7 @@ class WP_Theme_JSON {
 		'dimensions' => array(
 			'aspectRatio' => null,
 			'minHeight'   => null,
+			'width'       => null,
 		),
 		'filter'     => array(
 			'duotone' => null,
@@ -655,11 +661,13 @@ class WP_Theme_JSON {
 	 * generated under their own feature level selector rather than the block's.
 	 *
 	 * @since 6.1.0
+	 * @since 7.0.0 Added support for `dimensions`.
 	 * @var string[]
 	 */
 	const BLOCK_SUPPORT_FEATURE_LEVEL_SELECTORS = array(
 		'__experimentalBorder' => 'border',
 		'color'                => 'color',
+		'dimensions'           => 'dimensions',
 		'spacing'              => 'spacing',
 		'typography'           => 'typography',
 	);
@@ -764,6 +772,7 @@ class WP_Theme_JSON {
 	 * @since 6.2.0 Added `dimensions.minHeight` and `position.sticky`.
 	 * @since 6.4.0 Added `background.backgroundImage`.
 	 * @since 6.5.0 Added `background.backgroundSize` and `dimensions.aspectRatio`.
+	 * @since 7.0.0 Added `dimensions.width`.
 	 * @var array
 	 */
 	const APPEARANCE_TOOLS_OPT_INS = array(
@@ -779,6 +788,7 @@ class WP_Theme_JSON {
 		array( 'color', 'caption' ),
 		array( 'dimensions', 'aspectRatio' ),
 		array( 'dimensions', 'minHeight' ),
+		array( 'dimensions', 'width' ),
 		array( 'position', 'sticky' ),
 		array( 'spacing', 'blockGap' ),
 		array( 'spacing', 'margin' ),

--- a/src/wp-includes/style-engine/class-wp-style-engine.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine.php
@@ -219,6 +219,12 @@ final class WP_Style_Engine {
 					'spacing' => '--wp--preset--spacing--$slug',
 				),
 			),
+			'width'       => array(
+				'property_keys' => array(
+					'default' => 'width',
+				),
+				'path'          => array( 'dimensions', 'width' ),
+			),
 		),
 		'spacing'    => array(
 			'padding' => array(

--- a/tests/phpunit/tests/block-supports/wpApplyDimensionsSupport.php
+++ b/tests/phpunit/tests/block-supports/wpApplyDimensionsSupport.php
@@ -100,4 +100,75 @@ class Tests_Block_Supports_WpApplyDimensionsSupport extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Tests that width block support works as expected.
+	 *
+	 * @ticket 64200
+	 *
+	 * @covers ::wp_apply_dimensions_support
+	 *
+	 * @dataProvider data_width_block_support
+	 *
+	 * @param string $block_name The test block name to register.
+	 * @param mixed  $dimensions The dimensions block support settings.
+	 * @param mixed  $expected   The expected results.
+	 */
+	public function test_width_block_support( $block_name, $dimensions, $expected ) {
+		$this->test_block_name = $block_name;
+		register_block_type(
+			$this->test_block_name,
+			array(
+				'api_version' => 2,
+				'attributes'  => array(
+					'style' => array(
+						'type' => 'object',
+					),
+				),
+				'supports'    => array(
+					'dimensions' => $dimensions,
+				),
+			)
+		);
+		$registry    = WP_Block_Type_Registry::get_instance();
+		$block_type  = $registry->get_registered( $this->test_block_name );
+		$block_attrs = array(
+			'style' => array(
+				'dimensions' => array(
+					'width' => '300px',
+				),
+			),
+		);
+
+		$actual = wp_apply_dimensions_support( $block_type, $block_attrs );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_width_block_support() {
+		return array(
+			'style is applied' => array(
+				'block_name' => 'test/width-style-is-applied',
+				'dimensions' => array(
+					'width' => true,
+				),
+				'expected'   => array(
+					'style' => 'width:300px;',
+				),
+			),
+			'style output is skipped when individual feature serialization is skipped' => array(
+				'block_name' => 'test/width-with-individual-skipped-serialization-block-supports',
+				'dimensions' => array(
+					'width'                           => true,
+					'__experimentalSkipSerialization' => array( 'width' ),
+				),
+				'expected'   => array(),
+			),
+		);
+	}
 }

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -281,6 +281,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			'dimensions' => array(
 				'aspectRatio' => true,
 				'minHeight'   => true,
+				'width'       => true,
 			),
 			'position'   => array(
 				'sticky' => true,
@@ -320,6 +321,7 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 					'dimensions' => array(
 						'aspectRatio' => true,
 						'minHeight'   => true,
+						'width'       => true,
 					),
 					'position'   => array(
 						'sticky' => true,


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64200

This PR brings the changes from the following Gutenberg PRs to core:

https://github.com/WordPress/gutenberg/pull/71905

### Description

Adds a new `dimensions.width` block support to facilitate the creation of new blocks such as the Icon block.

See: https://github.com/WordPress/gutenberg/pull/71227

### Testing

1. Adopt width block support for a dynamic block e.g. Cover via its block.json file
2. Add a width value for the chosen test block in your theme.json file
3. Create a post with the test block type
4. Confirm the global style is applied to your test block

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
