### PR TITLE
Remove unnecessary “Comments” column when attachment pages are disabled

### DIFF
--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -367,7 +367,7 @@ class WP_Media_List_Table extends WP_List_Table {
 		if ( ! $this->detached ) {
 			$posts_columns['parent'] = _x( 'Uploaded to', 'column name' );
 
-			if ( post_type_supports( 'attachment', 'comments' ) && ! empty( get_option( 'wp_attachment_pages_enabled' ) ) ) {
+			if ( post_type_supports( 'attachment', 'comments' ) && get_option( 'wp_attachment_pages_enabled' ) ) {
 				$posts_columns['comments'] = sprintf(
 					'<span class="vers comment-grey-bubble" title="%1$s" aria-hidden="true"></span><span class="screen-reader-text">%2$s</span>',
 					esc_attr__( 'Comments' ),

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -367,7 +367,7 @@ class WP_Media_List_Table extends WP_List_Table {
 		if ( ! $this->detached ) {
 			$posts_columns['parent'] = _x( 'Uploaded to', 'column name' );
 
-			if ( post_type_supports( 'attachment', 'comments' ) ) {
+			if ( post_type_supports( 'attachment', 'comments' ) && ! empty( get_option('wp_attachment_pages_enabled') ) ) {
 				$posts_columns['comments'] = sprintf(
 					'<span class="vers comment-grey-bubble" title="%1$s" aria-hidden="true"></span><span class="screen-reader-text">%2$s</span>',
 					esc_attr__( 'Comments' ),

--- a/src/wp-admin/includes/class-wp-media-list-table.php
+++ b/src/wp-admin/includes/class-wp-media-list-table.php
@@ -367,7 +367,7 @@ class WP_Media_List_Table extends WP_List_Table {
 		if ( ! $this->detached ) {
 			$posts_columns['parent'] = _x( 'Uploaded to', 'column name' );
 
-			if ( post_type_supports( 'attachment', 'comments' ) && ! empty( get_option('wp_attachment_pages_enabled') ) ) {
+			if ( post_type_supports( 'attachment', 'comments' ) && ! empty( get_option( 'wp_attachment_pages_enabled' ) ) ) {
 				$posts_columns['comments'] = sprintf(
 					'<span class="vers comment-grey-bubble" title="%1$s" aria-hidden="true"></span><span class="screen-reader-text">%2$s</span>',
 					esc_attr__( 'Comments' ),


### PR DESCRIPTION
PR for Trac ticket: https://core.trac.wordpress.org/ticket/64201

This PR removes the “**Comments**” column from the Media Library when attachment pages are disabled.

When the `wp_attachment_pages_enabled` option is empty or evaluates to false, attachments no longer have dedicated front-end pages. In such cases, displaying the “Comments” column in the Media Library becomes redundant, since comments are not accessible or visible on attachment pages.

#### Benefits:

- Prevents confusion for users by hiding irrelevant UI

- Keeps the Media Library interface cleaner

- Aligns with the expected behaviour when attachment pages are disabled
