### PR TITLE
Site Health: Display EMPTY_TRASH_DAYS constant value in info tab

### DIFF
--- a/src/wp-admin/includes/class-wp-debug-data.php
+++ b/src/wp-admin/includes/class-wp-debug-data.php
@@ -1592,6 +1592,11 @@ class WP_Debug_Data {
 				'value' => $db_collate,
 				'debug' => $db_collate_debug,
 			),
+			'EMPTY_TRASH_DAYS'    => array(
+				'label' => 'EMPTY_TRASH_DAYS',
+				'value' => ( defined( 'EMPTY_TRASH_DAYS' ) ? EMPTY_TRASH_DAYS : __( 'Undefined' ) ),
+				'debug' => ( defined( 'EMPTY_TRASH_DAYS' ) ? EMPTY_TRASH_DAYS : 'undefined' ),
+			),
 		);
 
 		return array(


### PR DESCRIPTION

This PR introduces visibility for the EMPTY_TRASH_DAYS constant in the Site Health “WordPress Constants” section.
It helps site administrators quickly identify how long trashed content is retained before permanent deletion.

Trac ticket: https://core.trac.wordpress.org/ticket/64189

**Screenshot**
<img width="1436" height="724" alt="Screenshot 2025-11-06 at 3 45 43 PM" src="https://github.com/user-attachments/assets/f759f274-b4e6-47e8-90c1-7abe2e0d5bb7" />
