### PR TITLE
Add ltr.css support for RTL-based multilingual sites

### DIFF
--- a/src/wp-includes/class-wp-styles.php
+++ b/src/wp-includes/class-wp-styles.php
@@ -271,6 +271,34 @@ class WP_Styles extends WP_Dependencies {
 				$tag .= $rtl_tag;
 			}
 		}
+		
+		if ( 'rtl' !== $this->text_direction && isset( $obj->extra['ltr'] ) && $obj->extra['ltr'] ) {
+			if ( is_bool( $obj->extra['ltr'] ) || 'replace' === $obj->extra['ltr'] ) {
+				$suffix   = isset( $obj->extra['suffix'] ) ? $obj->extra['suffix'] : '';
+				$ltr_href = str_replace( "{$suffix}.css", "-ltr{$suffix}.css", $this->_css_href( $src, $ver, "$handle-ltr" ) );
+			} else {
+				$ltr_href = $this->_css_href( $obj->extra['ltr'], $ver, "$handle-ltr" );
+			}
+
+			$ltr_tag = sprintf(
+				"<link rel='%s' id='%s-ltr-css'%s href='%s'%s media='%s' />\n",
+				$rel,
+				esc_attr( $handle ),
+				$title ? sprintf( " title='%s'", esc_attr( $title ) ) : '',
+				$ltr_href,
+				$this->type_attr,
+				esc_attr( $media )
+			);
+
+			/** This filter is documented in wp-includes/class-wp-styles.php */
+			$ltr_tag = apply_filters( 'style_loader_tag', $ltr_tag, $handle, $ltr_href, $media );
+
+			if ( 'replace' === $obj->extra['ltr'] ) {
+				$tag = $ltr_tag;
+			} else {
+				$tag .= $ltr_tag;
+			}
+		}
 
 		if ( $this->do_concat ) {
 			$this->print_html .= $tag;

--- a/src/wp-includes/class-wp-styles.php
+++ b/src/wp-includes/class-wp-styles.php
@@ -271,7 +271,7 @@ class WP_Styles extends WP_Dependencies {
 				$tag .= $rtl_tag;
 			}
 		}
-		
+
 		if ( 'rtl' !== $this->text_direction && isset( $obj->extra['ltr'] ) && $obj->extra['ltr'] ) {
 			if ( is_bool( $obj->extra['ltr'] ) || 'replace' === $obj->extra['ltr'] ) {
 				$suffix   = isset( $obj->extra['suffix'] ) ? $obj->extra['suffix'] : '';

--- a/tests/phpunit/tests/dependencies/stylesLTRSupport.php
+++ b/tests/phpunit/tests/dependencies/stylesLTRSupport.php
@@ -8,7 +8,7 @@ class Tests_Dependencies_StylesLtrSupport extends WP_UnitTestCase {
 	public function set_up(): void {
 		parent::set_up();
 		switch_to_locale( 'fa_IR' ); // RTL language
-		wp_styles()->registered = [];
+		wp_styles()->registered = array();
 	}
 
 	public function tear_down(): void {

--- a/tests/phpunit/tests/dependencies/stylesLTRSupport.php
+++ b/tests/phpunit/tests/dependencies/stylesLTRSupport.php
@@ -1,13 +1,21 @@
 <?php
 /**
+ * Tests for LTR stylesheet support in wp_register_style() and wp_print_styles().
+ *
  * @group dependencies
  * @group i18n
+ *
+ * @ticket 64193
  */
 class Tests_Dependencies_StylesLtrSupport extends WP_UnitTestCase {
 
 	public function set_up(): void {
 		parent::set_up();
-		switch_to_locale( 'fa_IR' ); // RTL language
+
+		// Switch to an RTL locale to test LTR handling.
+		switch_to_locale( 'fa_IR' );
+
+		// Reset styles registry to ensure a clean environment.
 		wp_styles()->registered = array();
 	}
 
@@ -16,6 +24,9 @@ class Tests_Dependencies_StylesLtrSupport extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
+	/**
+	 * @ticket 64193
+	 */
 	public function test_ltr_css_replace_data_is_set() {
 		$handle = 'sample-style';
 		wp_register_style( $handle, 'https://example.com/style.css' );
@@ -26,6 +37,9 @@ class Tests_Dependencies_StylesLtrSupport extends WP_UnitTestCase {
 		$this->assertSame( 'replace', $styles->registered[ $handle ]->extra['ltr'] );
 	}
 
+	/**
+	 * @ticket 64193
+	 */
 	public function test_ltr_css_suffix_data_is_set() {
 		$handle = 'sample-style-suffix';
 		wp_register_style( $handle, 'https://example.com/style.min.css' );
@@ -36,6 +50,9 @@ class Tests_Dependencies_StylesLtrSupport extends WP_UnitTestCase {
 		$this->assertSame( 'suffix', $styles->registered[ $handle ]->extra['ltr'] );
 	}
 
+	/**
+	 * @ticket 64193
+	 */
 	public function test_no_ltr_data_for_ltr_locale() {
 		restore_previous_locale();
 		switch_to_locale( 'en_US' ); // LTR language
@@ -47,5 +64,43 @@ class Tests_Dependencies_StylesLtrSupport extends WP_UnitTestCase {
 		$styles = wp_styles();
 		$this->assertArrayHasKey( 'ltr', $styles->registered[ $handle ]->extra );
 		$this->assertSame( 'replace', $styles->registered[ $handle ]->extra['ltr'] );
+	}
+
+	/**
+	 * Verify that an LTR stylesheet is printed after its main stylesheet in the HTML output.
+	 *
+	 * @group output
+	 * @ticket 64193
+	 * @expectedDeprecated print_emoji_styles
+	 */
+	public function test_ltr_stylesheet_is_printed_in_output() {
+		global $wp_styles;
+
+		// Reset styles registry to ensure a clean environment.
+		$wp_styles = null;
+		wp_styles();
+
+		// Register main style.
+		wp_register_style( 'ltr-test-style', 'http://example.com/css/style.css', array(), '1.0' );
+
+		// Mark this style as having an LTR variant.
+		wp_style_add_data( 'ltr-test-style', 'ltr', true );
+
+		// Enqueue the style.
+		wp_enqueue_style( 'ltr-test-style' );
+
+		// Capture printed output.
+		ob_start();
+		wp_print_styles();
+		$output = ob_get_clean();
+
+		// Assertions.
+		$this->assertStringContainsString( 'style.css', $output, 'Main stylesheet was not printed in output.' );
+		$this->assertStringContainsString( 'ltr.css', $output, 'LTR stylesheet was not printed in output.' );
+
+		// Verify correct order (LTR after main style).
+		$mainPos = strpos( $output, 'style.css' );
+		$ltrPos  = strpos( $output, 'ltr.css' );
+		$this->assertTrue( $ltrPos > $mainPos, 'LTR stylesheet should appear after the main style.' );
 	}
 }

--- a/tests/phpunit/tests/dependencies/stylesLTRSupport.php
+++ b/tests/phpunit/tests/dependencies/stylesLTRSupport.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * @group dependencies
+ * @group i18n
+ */
+class Tests_Dependencies_StylesLtrSupport extends WP_UnitTestCase {
+
+	public function set_up(): void {
+		parent::set_up();
+		switch_to_locale( 'fa_IR' ); // RTL language
+		wp_styles()->registered = [];
+	}
+
+	public function tear_down(): void {
+		restore_previous_locale();
+		parent::tear_down();
+	}
+
+	public function test_ltr_css_replace_data_is_set() {
+		$handle = 'sample-style';
+		wp_register_style( $handle, 'https://example.com/style.css' );
+		wp_style_add_data( $handle, 'ltr', 'replace' );
+
+		$styles = wp_styles();
+		$this->assertArrayHasKey( 'ltr', $styles->registered[ $handle ]->extra );
+		$this->assertSame( 'replace', $styles->registered[ $handle ]->extra['ltr'] );
+	}
+
+	public function test_ltr_css_suffix_data_is_set() {
+		$handle = 'sample-style-suffix';
+		wp_register_style( $handle, 'https://example.com/style.min.css' );
+		wp_style_add_data( $handle, 'ltr', 'suffix' );
+
+		$styles = wp_styles();
+		$this->assertArrayHasKey( 'ltr', $styles->registered[ $handle ]->extra );
+		$this->assertSame( 'suffix', $styles->registered[ $handle ]->extra['ltr'] );
+	}
+
+	public function test_no_ltr_data_for_ltr_locale() {
+		restore_previous_locale();
+		switch_to_locale( 'en_US' ); // LTR language
+
+		$handle = 'sample-style-ltr';
+		wp_register_style( $handle, 'https://example.com/style.css' );
+		wp_style_add_data( $handle, 'ltr', 'replace' );
+
+		$styles = wp_styles();
+		$this->assertArrayHasKey( 'ltr', $styles->registered[ $handle ]->extra );
+		$this->assertSame( 'replace', $styles->registered[ $handle ]->extra['ltr'] );
+	}
+}

--- a/tests/phpunit/tests/dependencies/stylesLTRSupport.php
+++ b/tests/phpunit/tests/dependencies/stylesLTRSupport.php
@@ -1,21 +1,13 @@
 <?php
 /**
- * Tests for LTR stylesheet support in wp_register_style() and wp_print_styles().
- *
  * @group dependencies
  * @group i18n
- *
- * @ticket 64193
  */
 class Tests_Dependencies_StylesLtrSupport extends WP_UnitTestCase {
 
 	public function set_up(): void {
 		parent::set_up();
-
-		// Switch to an RTL locale to test LTR handling.
-		switch_to_locale( 'fa_IR' );
-
-		// Reset styles registry to ensure a clean environment.
+		switch_to_locale( 'fa_IR' ); // RTL language.
 		wp_styles()->registered = array();
 	}
 
@@ -55,7 +47,7 @@ class Tests_Dependencies_StylesLtrSupport extends WP_UnitTestCase {
 	 */
 	public function test_no_ltr_data_for_ltr_locale() {
 		restore_previous_locale();
-		switch_to_locale( 'en_US' ); // LTR language
+		switch_to_locale( 'en_US' ); // LTR language.
 
 		$handle = 'sample-style-ltr';
 		wp_register_style( $handle, 'https://example.com/style.css' );
@@ -65,15 +57,15 @@ class Tests_Dependencies_StylesLtrSupport extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'ltr', $styles->registered[ $handle ]->extra );
 		$this->assertSame( 'replace', $styles->registered[ $handle ]->extra['ltr'] );
 	}
-
 	/**
-	 * Verify that an LTR stylesheet is printed after its main stylesheet in the HTML output.
+	 * Verify that an LTR stylesheet actually gets printed in HTML output.
 	 *
 	 * @group output
 	 * @ticket 64193
-	 * @expectedDeprecated print_emoji_styles
 	 */
 	public function test_ltr_stylesheet_is_printed_in_output() {
+		$this->setExpectedDeprecated( 'print_emoji_styles' );
+
 		global $wp_styles;
 
 		// Reset styles registry to ensure a clean environment.
@@ -99,8 +91,8 @@ class Tests_Dependencies_StylesLtrSupport extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'ltr.css', $output, 'LTR stylesheet was not printed in output.' );
 
 		// Verify correct order (LTR after main style).
-		$mainPos = strpos( $output, 'style.css' );
-		$ltrPos  = strpos( $output, 'ltr.css' );
-		$this->assertTrue( $ltrPos > $mainPos, 'LTR stylesheet should appear after the main style.' );
+		$main_pos = strpos( $output, 'style.css' );
+		$ltr_pos  = strpos( $output, 'ltr.css' );
+		$this->assertTrue( $ltr_pos > $main_pos, 'LTR stylesheet should appear after the main style.' );
 	}
 }


### PR DESCRIPTION
Adds support for loading `ltr.css` and `style-ltr.css` in RTL-based multilingual WordPress sites, mirroring the existing `rtl.css` and `style-rtl.css` behavior.

This enhancement enables WordPress to automatically detect and load an `ltr.css` file when available, ensuring proper layout and direction handling for left-to-right content within otherwise RTL environments.

Details:
- Introduces `wp_style_add_data( $handle, 'ltr', 'replace' )` and `'suffix'` modes
- Uses `extra['ltr']` and `_css_href()` for consistent file resolution
- Applies `style_loader_tag` filter for extensibility
- Ensures compatibility with single-file enqueue behavior in WordPress Core

Includes:
- Core logic to detect and enqueue LTR variants of stylesheets
- Unit tests covering both metadata registration and HTML output rendering

Props asadister.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64193

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
