### PR TITLE
Tests: Improves the documentation and structure of test cases

### DIFF
--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -821,6 +821,8 @@ class Tests_Post extends WP_UnitTestCase {
 	 *
 	 * @ticket 26798
 	 *
+	 * @covers ::wp_insert_post
+	 *
 	 * @dataProvider data_wp_insert_post_handle_malformed_post_date
 	 *
 	 * @param string $input    The input post_date value.
@@ -846,12 +848,7 @@ class Tests_Post extends WP_UnitTestCase {
 	/**
 	 * Data provider for test_wp_insert_post_handle_malformed_post_date().
 	 *
-	 * @return array[] {
-	 *     Arguments passed to test.
-	 *
-	 *     @type string $input    The input post_date value.
-	 *     @type bool   $expected Whether the post is expected to be inserted.
-	 * }
+	 * @return array<string, array{ date: string, expected: bool }>
 	 */
 	public static function data_wp_insert_post_handle_malformed_post_date() {
 		return array(
@@ -954,6 +951,8 @@ class Tests_Post extends WP_UnitTestCase {
 	 *
 	 * @ticket 26798
 	 *
+	 * @covers ::wp_resolve_post_date
+	 *
 	 * @dataProvider data_wp_resolve_post_date_regex
 	 *
 	 * @param string       $date     The input post_date value.
@@ -970,12 +969,7 @@ class Tests_Post extends WP_UnitTestCase {
 	/**
 	 * Data provider for test_wp_resolve_post_date_regex().
 	 *
-	 * @return array[] {
-	 *     Arguments passed to test.
-	 *
-	 *     @type string       $date     The input post_date value.
-	 *     @type string|false $expected The expected resolved post date, or false if invalid
-	 * }
+	 * @return array<string, array{ date: string, expected: string|false }>
 	 */
 	public static function data_wp_resolve_post_date_regex() {
 		return array(

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -848,99 +848,99 @@ class Tests_Post extends WP_UnitTestCase {
 	/**
 	 * Data provider for test_wp_insert_post_handle_malformed_post_date().
 	 *
-	 * @return array<string, array{ date: string, expected: bool }>
+	 * @return array<array{ date: string, expected: bool }>
 	 */
-	public static function data_wp_insert_post_handle_malformed_post_date() {
+	public static function data_wp_insert_post_handle_malformed_post_date(): array {
 		return array(
 			array(
-				'2012-01-01',
-				true,
+				'date'     => '2012-01-01',
+				'expected' => true,
 			),
 			// 24-hour time format.
 			array(
-				'2012-01-01 13:00:00',
-				true,
+				'date'     => '2012-01-01 13:00:00',
+				'expected' => true,
 			),
 			// ISO8601 date with timezone.
 			array(
-				'2016-01-16T00:00:00Z',
-				true,
+				'date'     => '2016-01-16T00:00:00Z',
+				'expected' => true,
 			),
 			// ISO8601 date with timezone offset.
 			array(
-				'2016-01-16T00:00:00+0100',
-				true,
+				'date'     => '2016-01-16T00:00:00+0100',
+				'expected' => true,
 			),
 			// RFC3339 Format.
 			array(
-				'1970-01-01T01:00:00+01:00',
-				true,
+				'date'     => '1970-01-01T01:00:00+01:00',
+				'expected' => true,
 			),
 			// RSS Format
 			array(
-				'1970-01-01T01:00:00+0100',
-				true,
+				'date'     => '1970-01-01T01:00:00+0100',
+				'expected' => true,
 			),
 			// Leap year.
 			array(
-				'2012-02-29',
-				true,
+				'date'     => '2012-02-29',
+				'expected' => true,
 			),
 			// Strange formats.
 			array(
-				'2012-01-01 0',
-				true,
+				'date'     => '2012-01-01 0',
+				'expected' => true,
 			),
 			array(
-				'2012-01-01 25:00:00',
-				true,
+				'date'     => '2012-01-01 25:00:00',
+				'expected' => true,
 			),
 			array(
-				'2012-01-01 00:60:00',
-				true,
+				'date'     => '2012-01-01 00:60:00',
+				'expected' => true,
 			),
 			// Dates without leading zeros (valid but malformed format).
 			array(
-				'2012-08-1',
-				true,
+				'date'     => '2012-08-1',
+				'expected' => true,
 			),
 			array(
-				'2012-1-08 00:00:00',
-				true,
+				'date'     => '2012-1-08 00:00:00',
+				'expected' => true,
 			),
 			array(
-				'2012-01-8 00:00:00',
-				true,
+				'date'     => '2012-01-8 00:00:00',
+				'expected' => true,
 			),
 			// Failures.
 			array(
-				'2012-08-0z',
-				false,
+				'date'     => '2012-08-0z',
+				'expected' => false,
 			),
 			array(
-				'201-01-08 00:00:00',
-				false,
+				'date'     => '201-01-08 00:00:00',
+				'expected' => false,
 			),
 			array(
-				'201-01-08 00:60:00',
-				false,
+				'date'     => '201-01-08 00:60:00',
+				'expected' => false,
 			),
 			array(
-				'201a-01-08 00:00:00',
-				false,
+				'date'     => '201a-01-08 00:00:00',
+				'expected' => false,
 			),
 			array(
-				'2012-31-08 00:00:00',
-				false,
+				'date'     => '2012-31-08 00:00:00',
+				'expected' => false,
 			),
 			array(
-				'2012-01-48 00:00:00',
-				false,
+				'date'     => '2012-01-48 00:00:00',
+				'expected' => false,
 			),
 			// Not a leap year.
 			array(
-				'2011-02-29',
-				false,
+				'date'     => '2011-02-29',
+				'expected' => false,
 			),
 		);
 	}
@@ -969,100 +969,100 @@ class Tests_Post extends WP_UnitTestCase {
 	/**
 	 * Data provider for test_wp_resolve_post_date_regex().
 	 *
-	 * @return array<string, array{ date: string, expected: string|false }>
+	 * @return array<array{ date: string, expected: string|false }>
 	 */
-	public static function data_wp_resolve_post_date_regex() {
+	public static function data_wp_resolve_post_date_regex(): array {
 		return array(
 			array(
-				'2012-01-01',
-				'2012-01-01',
+				'date'     => '2012-01-01',
+				'expected' => '2012-01-01',
 			),
 			array(
-				'2012-01-01 00:00:00',
-				'2012-01-01 00:00:00',
+				'date'     => '2012-01-01 00:00:00',
+				'expected' => '2012-01-01 00:00:00',
 			),
 			// ISO8601 date with timezone.
 			array(
-				'2016-01-16T00:00:00Z',
-				'2016-01-16T00:00:00Z',
+				'date'     => '2016-01-16T00:00:00Z',
+				'expected' => '2016-01-16T00:00:00Z',
 			),
 			// ISO8601 date with timezone offset.
 			array(
-				'2016-01-16T00:00:00+0100',
-				'2016-01-16T00:00:00+0100',
+				'date'     => '2016-01-16T00:00:00+0100',
+				'expected' => '2016-01-16T00:00:00+0100',
 			),
 			// RFC3339 Format.
 			array(
-				'1970-01-01T01:00:00+01:00',
-				'1970-01-01T01:00:00+01:00',
+				'date'     => '1970-01-01T01:00:00+01:00',
+				'expected' => '1970-01-01T01:00:00+01:00',
 			),
 			// RSS Format
 			array(
-				'1970-01-01T01:00:00+0100',
-				'1970-01-01T01:00:00+0100',
+				'date'     => '1970-01-01T01:00:00+0100',
+				'expected' => '1970-01-01T01:00:00+0100',
 			),
 			// 24-hour time format.
 			array(
-				'2012-01-01 13:00:00',
-				'2012-01-01 13:00:00',
+				'date'     => '2012-01-01 13:00:00',
+				'expected' => '2012-01-01 13:00:00',
 			),
 			array(
-				'2016-01-16T00:0',
-				'2016-01-16T00:0',
+				'date'     => '2016-01-16T00:0',
+				'expected' => '2016-01-16T00:0',
 			),
 			array(
-				'2012-01-01 0',
-				'2012-01-01 0',
+				'date'     => '2012-01-01 0',
+				'expected' => '2012-01-01 0',
 			),
 			array(
-				'2012-01-01 00:00',
-				'2012-01-01 00:00',
+				'date'     => '2012-01-01 00:00',
+				'expected' => '2012-01-01 00:00',
 			),
 			array(
-				'2012-01-01 25:00:00',
-				'2012-01-01 25:00:00',
+				'date'     => '2012-01-01 25:00:00',
+				'expected' => '2012-01-01 25:00:00',
 			),
 			array(
-				'2012-01-01 00:60:00',
-				'2012-01-01 00:60:00',
+				'date'     => '2012-01-01 00:60:00',
+				'expected' => '2012-01-01 00:60:00',
 			),
 			array(
-				'2012-01-01 00:00:60',
-				'2012-01-01 00:00:60',
+				'date'     => '2012-01-01 00:00:60',
+				'expected' => '2012-01-01 00:00:60',
 			),
 			// Dates without leading zeros (valid but malformed format).
 			array(
-				'2012-1-08',
-				'2012-1-08',
+				'date'     => '2012-1-08',
+				'expected' => '2012-1-08',
 			),
 			array(
-				'2012-01-8',
-				'2012-01-8',
+				'date'     => '2012-01-8',
+				'expected' => '2012-01-8',
 			),
 			array(
-				'201-01-08',
-				false,
+				'date'     => '201-01-08',
+				'expected' => false,
 			),
 			array(
-				'201a-01-08',
-				false,
+				'date'     => '201a-01-08',
+				'expected' => false,
 			),
 			array(
-				'2012-31-08',
-				false,
+				'date'     => '2012-31-08',
+				'expected' => false,
 			),
 			array(
-				'2012-01-48 00:00:00',
-				false,
+				'date'     => '2012-01-48 00:00:00',
+				'expected' => false,
 			),
 			// Leap year.
 			array(
-				'2012-02-29',
-				'2012-02-29',
+				'date'     => '2012-02-29',
+				'expected' => '2012-02-29',
 			),
 			array(
-				'2011-02-29',
-				false,
+				'date'     => '2011-02-29',
+				'expected' => false,
 			),
 		);
 	}

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -816,9 +816,8 @@ class Tests_Post extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The purpose of this test is to ensure that invalid dates do not
-	 * cause PHP errors when wp_insert_post() is called, and that the
-	 * posts are not actually "inserted" (created).
+	 * Tests that invalid dates do not cause PHP errors when wp_insert_post()
+	 * is called, and that the posts are not actually "inserted" (created).
 	 *
 	 * @ticket 26798
 	 *

--- a/tests/phpunit/tests/post.php
+++ b/tests/phpunit/tests/post.php
@@ -816,13 +816,16 @@ class Tests_Post extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The purpose of this test is to ensure that invalid dates do not
+	 * cause PHP errors when wp_insert_post() is called, and that the
+	 * posts are not actually "inserted" (created).
+	 *
 	 * @ticket 26798
 	 *
 	 * @dataProvider data_wp_insert_post_handle_malformed_post_date
 	 *
-	 * The purpose of this test is to ensure that invalid dates do not
-	 * cause PHP errors when wp_insert_post() is called, and that the
-	 * posts are not actually "inserted" (created).
+	 * @param string $input    The input post_date value.
+	 * @param bool   $expected Whether the post is expected to be inserted.
 	 */
 	public function test_wp_insert_post_handle_malformed_post_date( $input, $expected ) {
 		$post = array(
@@ -842,9 +845,16 @@ class Tests_Post extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 26798
+	 * Data provider for test_wp_insert_post_handle_malformed_post_date().
+	 *
+	 * @return array[] {
+	 *     Arguments passed to test.
+	 *
+	 *     @type string $input    The input post_date value.
+	 *     @type bool   $expected Whether the post is expected to be inserted.
+	 * }
 	 */
-	public function data_wp_insert_post_handle_malformed_post_date() {
+	public static function data_wp_insert_post_handle_malformed_post_date() {
 		return array(
 			array(
 				'2012-01-01',
@@ -940,12 +950,15 @@ class Tests_Post extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests the regex inside of wp_resolve_post_date(), with
+	 * the emphasis on the date format (not the time).
+	 *
 	 * @ticket 26798
 	 *
 	 * @dataProvider data_wp_resolve_post_date_regex
 	 *
-	 * Tests the regex inside of wp_resolve_post_date(), with
-	 * the emphasis on the date format (not the time).
+	 * @param string       $date     The input post_date value.
+	 * @param string|false $expected The expected resolved post date, or false if invalid
 	 */
 	public function test_wp_resolve_post_date_regex( $date, $expected ) {
 		// Attempt to resolve post date.
@@ -956,9 +969,16 @@ class Tests_Post extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @ticket 26798
+	 * Data provider for test_wp_resolve_post_date_regex().
+	 *
+	 * @return array[] {
+	 *     Arguments passed to test.
+	 *
+	 *     @type string       $date     The input post_date value.
+	 *     @type string|false $expected The expected resolved post date, or false if invalid
+	 * }
 	 */
-	public function data_wp_resolve_post_date_regex() {
+	public static function data_wp_resolve_post_date_regex() {
 		return array(
 			array(
 				'2012-01-01',


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/26798

This PR improves the documentation and structure of test cases related to post date handling in `tests/phpunit/tests/post.php`. The main focus is on updating docblocks for clarity and converting data provider methods to static methods, which is a best practice in PHPUnit.

* Updated the docblocks for `test_wp_insert_post_handle_malformed_post_date()` and `test_wp_resolve_post_date_regex()` to clearly describe the parameters and expected behavior of each test, making the intent and usage of the tests more understandable.
* Converted the data provider methods `data_wp_insert_post_handle_malformed_post_date()` and `data_wp_resolve_post_date_regex()` to static methods and enhanced their docblocks to specify the structure of the returned data, aligning with PHPUnit best practices.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**