### PR TITLE
WP_HTTP: Fallback for existing filename in streaming mode already exists

### DIFF
--- a/src/wp-includes/class-wp-http.php
+++ b/src/wp-includes/class-wp-http.php
@@ -310,6 +310,11 @@ class WP_Http {
 		if ( $parsed_args['stream'] ) {
 			if ( empty( $parsed_args['filename'] ) ) {
 				$parsed_args['filename'] = get_temp_dir() . basename( $url );
+
+				// If that file exists, fallback to a temporary file.
+				if ( file_exists( $parsed_args['filename'] ) ) {
+					$parsed_args['filename'] = wp_tempnam( basename( $url ) );
+				}
 			}
 
 			// Force some settings if we are streaming to a file and check for existence


### PR DESCRIPTION
This only is for the case of `stream => true` without a specified filename to stream to, in that case, it's expected that a temporary file path would be returned.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket:  https://core.trac.wordpress.org/ticket/64212



---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
