### PR TITLE
Re-add WP specific modifications for Twemoji

### DIFF
--- a/src/js/_enqueues/vendor/twemoji.js
+++ b/src/js/_enqueues/vendor/twemoji.js
@@ -305,6 +305,14 @@ var twemoji = (function (
       // should not be parsed as script, style, and others
       else if (nodeType === 1 && !('ownerSVGElement' in subnode) &&
           !shouldntBeParsed.test(subnode.nodeName.toLowerCase())) {
+
+        // WP start
+        // Use doNotParse() callback if set.
+        if ( twemoji.doNotParse && twemoji.doNotParse( subnode ) ) {
+            continue;
+        }
+        // WP end
+
         grabAllTextNodes(subnode, allText);
       }
     }
@@ -520,6 +528,14 @@ var twemoji = (function (
     if (!how || typeof how === 'function') {
       how = {callback: how};
     }
+
+	// WP start
+    // Allow passing of the doNotParse() callback in the settings.
+    // The callback is used in `grabAllTextNodes()` (DOM mode only) as a filter
+    // that allows bypassing of some of the text nodes. It gets the current subnode as argument.
+    twemoji.doNotParse = how.doNotParse;
+    // WP end
+
     // if first argument is string, inject html <img> tags
     // otherwise use the DOM tree and parse text nodes only
     return (typeof what === 'string' ? parseString : parseNode)(what, {


### PR DESCRIPTION
This re-adds some WordPress specific code added to the Twemoji library that was removed when the library was updated in r61134.

Trac ticket: Core-64184

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
