### PR TITLE
Ensure `db` commands work with `env:cli`

### DIFF
--- a/tools/local-env/scripts/docker.js
+++ b/tools/local-env/scripts/docker.js
@@ -20,6 +20,11 @@ if ( [ 'exec', 'run' ].includes( dockerCommand[0] ) && ! process.stdin.isTTY ) {
 	dockerCommand.splice( 1, 0, '--no-TTY' );
 }
 
+// Add a --defaults flag to any db command WP-CLI command. See https://core.trac.wordpress.org/ticket/63876.
+if ( dockerCommand.includes( 'cli' ) && dockerCommand.includes( 'db' ) && ! dockerCommand.includes( '--defaults' ) ) {
+	dockerCommand.push( '--defaults' );
+}
+
 // Execute any Docker compose command passed to this script.
 const returns = spawnSync(
 	'docker',


### PR DESCRIPTION
In r60735, a change was made to the installation-related code in the local development environment that invokes any `wp db` commands to circumvent a failure caused by the presence of a self-signed certificate within the certificate chain.

However, that did not fix any `wp db` commands called through the `env:cli` npm script. This aims to do that by adding `--defaults` anytime `env:cli` is run with a command nested under `db`.

Trac ticket: Core-64218.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
