### PR TITLE
Account for non-multisite installs in `WP_Date_Query::validate_column()` to fix PHP 8.5 deprecation notice

### DIFF
--- a/src/wp-includes/class-wp-date-query.php
+++ b/src/wp-includes/class-wp-date-query.php
@@ -525,11 +525,13 @@ class WP_Date_Query {
 				$wpdb->users    => array(
 					'user_registered',
 				),
-				$wpdb->blogs    => array(
+			);
+			if ( is_multisite() ) {
+				$known_columns[ $wpdb->blogs ] = array(
 					'registered',
 					'last_updated',
-				),
-			);
+				);
+			}
 
 			// If it's a known column name, add the appropriate table prefix.
 			foreach ( $known_columns as $table_name => $table_columns ) {

--- a/src/wp-includes/class-wp-date-query.php
+++ b/src/wp-includes/class-wp-date-query.php
@@ -482,16 +482,23 @@ class WP_Date_Query {
 		global $wpdb;
 
 		$valid_columns = array(
-			'post_date',
-			'post_date_gmt',
-			'post_modified',
-			'post_modified_gmt',
-			'comment_date',
-			'comment_date_gmt',
-			'user_registered',
-			'registered',
-			'last_updated',
+			'post_date',         // Part of $wpdb->posts.
+			'post_date_gmt',     // Part of $wpdb->posts.
+			'post_modified',     // Part of $wpdb->posts.
+			'post_modified_gmt', // Part of $wpdb->posts.
+			'comment_date',      // Part of $wpdb->comments.
+			'comment_date_gmt',  // Part of $wpdb->comments.
+			'user_registered',   // Part of $wpdb->users.
 		);
+		if ( is_multisite() ) {
+			$valid_columns = array_merge(
+				$valid_columns,
+				array(
+					'registered',   // Part of $wpdb->blogs.
+					'last_updated', // Part of $wpdb->blogs.
+				)
+			);
+		}
 
 		// Attempt to detect a table prefix.
 		if ( ! str_contains( $column, '.' ) ) {

--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -467,7 +467,7 @@ class wpdb {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	public $blogs;
 
@@ -476,7 +476,7 @@ class wpdb {
 	 *
 	 * @since 5.1.0
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	public $blogmeta;
 
@@ -485,7 +485,7 @@ class wpdb {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	public $registration_log;
 
@@ -494,7 +494,7 @@ class wpdb {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	public $signups;
 
@@ -503,7 +503,7 @@ class wpdb {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	public $site;
 
@@ -512,7 +512,7 @@ class wpdb {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	public $sitecategories;
 
@@ -521,7 +521,7 @@ class wpdb {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	public $sitemeta;
 


### PR DESCRIPTION
This avoids a deprecation warning in PHP 8.5:

```
Using null as an array offset is deprecated, use an empty string instead

/var/www/src/wp-includes/class-wp-date-query.php:516
/var/www/src/wp-includes/class-wp-date-query.php:170
/var/www/src/wp-includes/class-wp-query.php:2138
/var/www/src/wp-includes/class-wp-query.php:3958
/var/www/src/wp-includes/class-wp.php:704
/var/www/src/wp-includes/class-wp.php:824
/var/www/tests/phpunit/includes/abstract-testcase.php:1346
/var/www/tests/phpunit/includes/testcase-canonical.php:303
/var/www/tests/phpunit/tests/canonical.php:68
/var/www/vendor/bin/phpunit:122
```

Specifically, the issue is that `$wpdb->blogs` is `null` when not on a single-site install. So this ensures that the `$wpdb->blogs` column is only added to the `$known_columns` array when on multisite. 

It also updates the `$valid_columns` array to only include multisite-related columns when on multisite, namely `registered` and `last_updated`. 

> [!NOTE]
> Some multisite columns appear to not have been accounted for: `wp_blog_versions.last_updated`, `wp_registration_log.date_registered`, and `wp_signups.activated`.

Lastly, the phpdoc `@var` tags for `$wpdb->blogs`, `$wpdb->blogmeta`, and the other multisite-specific tables have been updated to indicate they may be `null`.

Trac ticket: https://core.trac.wordpress.org/ticket/63957

This issue was introduced in r37477 (https://github.com/WordPress/wordpress-develop/commit/381930974cdcf35b0db6539aaf91ea90d37c3787) for WordPress 4.6.0.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
