### PR TITLE
Scripts: Remove sourceURL from print_translations when not printing

### DIFF
--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -351,7 +351,7 @@ class WP_Scripts extends WP_Dependencies {
 		$translations = $this->print_translations( $handle, false );
 		if ( $translations ) {
 			/**
-			 * The soucreURL comment is not included by @see WP_Scripts::print_translations()
+			 * The sourceURL comment is not included by @see WP_Scripts::print_translations()
 			 * when `$display == false` to prevent issues where the script tag contents are used
 			 * by extenders for other purposes, for example concatenated with other script content.
 			 *

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -351,8 +351,8 @@ class WP_Scripts extends WP_Dependencies {
 		$translations = $this->print_translations( $handle, false );
 		if ( $translations ) {
 			/**
-			 * The sourceURL comment is not included by @see WP_Scripts::print_translations()
-			 * when `$display == false` to prevent issues where the script tag contents are used
+			 * The sourceURL comment is not included by {@see WP_Scripts::print_translations()}
+			 * when `$display` is `false` to prevent issues where the script tag contents are used
 			 * by extenders for other purposes, for example concatenated with other script content.
 			 *
 			 * Include the sourceURL comment here as it would be when printed directly.

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -350,8 +350,8 @@ class WP_Scripts extends WP_Dependencies {
 
 		$translations = $this->print_translations( $handle, false );
 		if ( $translations ) {
-			/**
-			 * The sourceURL comment is not included by {@see WP_Scripts::print_translations()}
+			/*
+			 * The sourceURL comment is not included by WP_Scripts::print_translations()
 			 * when `$display` is `false` to prevent issues where the script tag contents are used
 			 * by extenders for other purposes, for example concatenated with other script content.
 			 *

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -350,7 +350,16 @@ class WP_Scripts extends WP_Dependencies {
 
 		$translations = $this->print_translations( $handle, false );
 		if ( $translations ) {
-			$translations = wp_get_inline_script_tag( $translations, array( 'id' => "{$handle}-js-translations" ) );
+			/**
+			 * The soucreURL comment is not included by @see WP_Scripts::print_translations()
+			 * when `$display == false` to prevent issues where the script tag contents are used
+			 * by extenders for other purposes, for example concatenated with other script content.
+			 *
+			 * Include the sourceURL comment here as it would be when printed directly.
+			 */
+			$source_url    = rawurlencode( "{$handle}-js-translations" );
+			$translations .= "\n//# sourceURL={$source_url}";
+			$translations  = wp_get_inline_script_tag( $translations, array( 'id' => "{$handle}-js-translations" ) );
 		}
 
 		if ( $this->do_concat ) {

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -722,18 +722,17 @@ class WP_Scripts extends WP_Dependencies {
 			return false;
 		}
 
-		$source_url = rawurlencode( "{$handle}-js-translations" );
-
 		$output = <<<JS
 ( function( domain, translations ) {
 	var localeData = translations.locale_data[ domain ] || translations.locale_data.messages;
 	localeData[""].domain = domain;
 	wp.i18n.setLocaleData( localeData, domain );
 } )( "{$domain}", {$json_translations} );
-//# sourceURL={$source_url}
 JS;
 
 		if ( $display ) {
+			$source_url = rawurlencode( "{$handle}-js-translations" );
+			$output    .= "\n//# sourceURL={$source_url}";
 			wp_print_inline_script_tag( $output, array( 'id' => "{$handle}-js-translations" ) );
 		}
 

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -4075,4 +4075,22 @@ HTML;
 
 		$this->assertEqualHTML( $expected, $print_scripts );
 	}
+
+	/**
+	 * Ensure that `::print_translations()` does not include the sourceURL comment when `$display` is false.
+	 *
+	 * @ticket 63887
+	 * @covers ::print_translations
+	 */
+	public function test_print_translations_no_display_no_sourceurl() {
+		global $wp_scripts;
+		$this->add_html5_script_theme_support();
+
+		wp_register_script( 'wp-i18n', '/wp-includes/js/dist/wp-i18n.js', array(), null );
+		wp_enqueue_script( 'test-example', '/wp-includes/js/script.js', array(), null );
+		wp_set_script_translations( 'test-example', 'default', DIR_TESTDATA . '/languages' );
+
+		$translations_script_data = $wp_scripts->print_translations( 'test-example', false );
+		$this->assertStringNotContainsStringIgnoringCase( 'sourceURL=', $translations_script_data );
+	}
 }


### PR DESCRIPTION
Prevent adding `sourceURL` comment to script translations when not printed.

[In this comment](https://core.trac.wordpress.org/ticket/63887#comment:57), @ralucaStan reported an issue where a plugin uses `WP_Scripts::print_translations()` with `$display == false` to collect and concatenate multiple script tags into a single script tag. This reveals a possible regression and reveals that it's difficult to anticipate how the script tag contents may be used.

By not printing the `sourceURL` when `$display == false`, it's less likely to introduce problems for extenders in this case.

Trac ticket: https://core.trac.wordpress.org/ticket/63887
Follow-up to r60719.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
