### PR TITLE
Abilities: Add support for ability deprecation

### DIFF
--- a/src/wp-includes/abilities-api.php
+++ b/src/wp-includes/abilities-api.php
@@ -245,6 +245,7 @@ declare( strict_types = 1 );
  * @since 6.9.0
  * @since 7.1.0 Added the `public` meta argument.
  * @since 7.2.0 The `category` argument is now optional and defaults to `uncategorized`.
+ * @since 7.2.0 Added the `deprecated` meta property.
  *
  * @see WP_Abilities_Registry::register()
  * @see wp_register_ability_category()
@@ -441,7 +442,7 @@ function wp_get_ability( string $name ): ?WP_Ability {
  *
  * The current behavior is to trigger a user error if `WP_DEBUG` is true.
  *
- * @since 7.1.0
+ * @since 7.2.0
  *
  * @param string $ability_name The ability that was executed.
  * @param string $version      Optional. The version of the ability provider that deprecated the ability.
@@ -453,7 +454,7 @@ function _deprecated_ability( string $ability_name, string $version = '', string
 	/**
 	 * Fires when a deprecated ability is executed.
 	 *
-	 * @since 7.1.0
+	 * @since 7.2.0
 	 *
 	 * @param string $ability_name The ability that was executed.
 	 * @param string $replacement  The ability that should be used as a replacement.
@@ -465,7 +466,7 @@ function _deprecated_ability( string $ability_name, string $version = '', string
 	/**
 	 * Filters whether to trigger an error for deprecated abilities.
 	 *
-	 * @since 7.1.0
+	 * @since 7.2.0
 	 *
 	 * @param bool $trigger Whether to trigger the error for deprecated abilities. Default true.
 	 */
@@ -582,6 +583,7 @@ function _deprecated_ability( string $ability_name, string $version = '', string
  *
  * @since 6.9.0
  * @since 7.1.0 Added the `$args` parameter for filtering support.
+ * @since 7.2.0 Added support for filtering by the `deprecated` meta property.
  *
  * @see WP_Abilities_Registry::get_all_registered()
  *

--- a/src/wp-includes/abilities-api.php
+++ b/src/wp-includes/abilities-api.php
@@ -539,9 +539,10 @@ function _deprecated_ability( string $ability_name, string $version = '', string
  *         'meta' => array( 'deprecated' => false ),
  *     ) );
  *
- *     // Return only deprecated abilities.
+ *     // Return only deprecated abilities. Passing `true` matches any deprecated
+ *     // ability. An array of details narrows the results further.
  *     $abilities = wp_get_abilities( array(
- *         'meta' => array( 'deprecated' => array() ),
+ *         'meta' => array( 'deprecated' => true ),
  *     ) );
  *
  *     // Filter by category.
@@ -623,6 +624,15 @@ function wp_get_abilities( array $args = array() ): array {
 	$meta                  = isset( $args['meta'] ) && is_array( $args['meta'] ) ? $args['meta'] : array();
 	$item_include_callback = isset( $args['item_include_callback'] ) && is_callable( $args['item_include_callback'] ) ? $args['item_include_callback'] : null;
 	$result_callback       = isset( $args['result_callback'] ) && is_callable( $args['result_callback'] ) ? $args['result_callback'] : null;
+
+	/*
+	 * Normalize the `deprecated` meta filter shorthand. Stored values are `false`
+	 * or an array of details, so `true` becomes an empty set of conditions that
+	 * matches any deprecated ability.
+	 */
+	if ( isset( $meta['deprecated'] ) && true === $meta['deprecated'] ) {
+		$meta['deprecated'] = array();
+	}
 
 	$matched = array();
 

--- a/src/wp-includes/abilities-api.php
+++ b/src/wp-includes/abilities-api.php
@@ -231,6 +231,17 @@ declare( strict_types = 1 );
  *         'show_in_rest' => false,
  *     ),
  *
+ * Mark an ability as deprecated while keeping exact-name retrieval and execution
+ * available for backward compatibility:
+ *
+ *     'meta' => array(
+ *         'deprecated' => array(
+ *             'since'       => '2.0.0',
+ *             'replacement' => 'my-plugin/new-ability',
+ *             'message'     => __( 'The replacement supports the new data format.', 'my-plugin' ),
+ *         ),
+ *     ),
+ *
  * @since 6.9.0
  * @since 7.1.0 Added the `public` meta argument.
  * @since 7.2.0 The `category` argument is now optional and defaults to `uncategorized`.
@@ -282,6 +293,15 @@ declare( strict_types = 1 );
  *                                                      clients such as the REST API, MCP, or AI agents. Seeds
  *                                                      the default for per-channel flags like `$show_in_rest`.
  *                                                      Defaults to false.
+ *         @type false|array<string, string> $deprecated {
+ *             Optional. Deprecation details. Set to an array to mark the ability as deprecated. At least one
+ *             supported detail must be provided. Deprecated abilities remain available by exact name and can
+ *             be explicitly included or excluded from discovery through meta filtering. Default false.
+ *
+ *             @type string $since       Optional. Version of the ability provider that deprecated the ability.
+ *             @type string $replacement Optional. Namespaced ability to use instead.
+ *             @type string $message     Optional. Additional migration guidance.
+ *         }
  *         @type bool                     $show_in_rest Optional. Whether to expose this ability in the REST API.
  *                                                      When true, the ability can be invoked via HTTP requests.
  *                                                      Default is the value of `$public` when set, false otherwise.
@@ -414,6 +434,83 @@ function wp_get_ability( string $name ): ?WP_Ability {
 }
 
 /**
+ * Marks an ability as deprecated and informs when it has been used.
+ *
+ * There is a {@see 'deprecated_ability_run'} hook that will be called that can be used
+ * to get the backtrace up to what code executed the deprecated ability.
+ *
+ * The current behavior is to trigger a user error if `WP_DEBUG` is true.
+ *
+ * @since 7.1.0
+ *
+ * @param string $ability_name The ability that was executed.
+ * @param string $version      Optional. The version of the ability provider that deprecated the ability.
+ *                             Default empty string.
+ * @param string $replacement  Optional. The ability that should be used instead. Default empty string.
+ * @param string $message      Optional. Additional migration guidance. Default empty string.
+ */
+function _deprecated_ability( string $ability_name, string $version = '', string $replacement = '', string $message = '' ): void {
+	/**
+	 * Fires when a deprecated ability is executed.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param string $ability_name The ability that was executed.
+	 * @param string $replacement  The ability that should be used as a replacement.
+	 * @param string $version      The version of the ability provider that deprecated the ability.
+	 * @param string $message      Additional migration guidance.
+	 */
+	do_action( 'deprecated_ability_run', $ability_name, $replacement, $version, $message );
+
+	/**
+	 * Filters whether to trigger an error for deprecated abilities.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param bool $trigger Whether to trigger the error for deprecated abilities. Default true.
+	 */
+	if ( WP_DEBUG && apply_filters( 'deprecated_ability_trigger_error', true ) ) {
+		if ( $version ) {
+			if ( $replacement ) {
+				$notice = sprintf(
+					/* translators: 1: Ability name, 2: Version number, 3: Alternative ability name. */
+					__( 'Ability %1$s is <strong>deprecated</strong> since version %2$s! Use %3$s instead.' ),
+					$ability_name,
+					$version,
+					$replacement
+				);
+			} else {
+				$notice = sprintf(
+					/* translators: 1: Ability name, 2: Version number. */
+					__( 'Ability %1$s is <strong>deprecated</strong> since version %2$s with no alternative available.' ),
+					$ability_name,
+					$version
+				);
+			}
+		} elseif ( $replacement ) {
+			$notice = sprintf(
+				/* translators: 1: Ability name, 2: Alternative ability name. */
+				__( 'Ability %1$s is <strong>deprecated</strong>! Use %2$s instead.' ),
+				$ability_name,
+				$replacement
+			);
+		} else {
+			$notice = sprintf(
+				/* translators: %s: Ability name. */
+				__( 'Ability %s is <strong>deprecated</strong> with no alternative available.' ),
+				$ability_name
+			);
+		}
+
+		if ( $message ) {
+			$notice .= ' ' . $message;
+		}
+
+		wp_trigger_error( '', $notice, E_USER_DEPRECATED );
+	}
+}
+
+/**
  * Retrieves registered abilities, optionally filtered by the given arguments.
  *
  * When called without arguments, returns all registered abilities. When called
@@ -435,6 +532,16 @@ function wp_get_ability( string $name ): ?WP_Ability {
  *
  *     // All abilities (unchanged behaviour).
  *     $abilities = wp_get_abilities();
+ *
+ *     // Exclude deprecated abilities explicitly.
+ *     $abilities = wp_get_abilities( array(
+ *         'meta' => array( 'deprecated' => false ),
+ *     ) );
+ *
+ *     // Return only deprecated abilities.
+ *     $abilities = wp_get_abilities( array(
+ *         'meta' => array( 'deprecated' => array() ),
+ *     ) );
  *
  *     // Filter by category.
  *     $abilities = wp_get_abilities( array( 'category' => 'content' ) );
@@ -800,117 +907,4 @@ function wp_get_ability_categories(): array {
 	}
 
 	return $registry->get_all_registered();
-}
-
-/**
- * Marks an ability as deprecated and informs when it has been used.
- *
- * This function should be called from within a deprecated ability's execute callback
- * to notify developers that they are using an obsolete ability. The function logs
- * the deprecation and triggers a notice when WP_DEBUG is enabled.
- *
- * Example:
- *
- *     function my_plugin_old_ability_callback( $input ) {
- *         _deprecated_ability( 'my-plugin/old-ability', '1.5.0', 'my-plugin/new-ability' );
- *         // Legacy implementation...
- *     }
- *
- * @since 7.0.0
- *
- * @param string $ability_name The name of the ability that is deprecated.
- * @param string $version      Optional. The version in which the ability was deprecated.
- *                             Default empty string.
- * @param string $replacement  Optional. The name of the ability that should be used instead.
- *                             Default empty string.
- */
-function _deprecated_ability( string $ability_name, string $version = '', string $replacement = '' ): void {
-
-	/**
-	 * Fires when a deprecated ability is called.
-	 *
-	 * @since 7.0.0
-	 *
-	 * @param string $ability_name The ability that was called.
-	 * @param string $replacement  The ability that should have been called.
-	 * @param string $version      The version in which the ability was deprecated.
-	 */
-	do_action( 'deprecated_ability_run', $ability_name, $replacement, $version );
-
-	/**
-	 * Filters whether to trigger an error for deprecated abilities.
-	 *
-	 * @since 7.0.0
-	 *
-	 * @param bool $trigger Whether to trigger the error for deprecated abilities. Default true.
-	 */
-	if ( WP_DEBUG && apply_filters( 'deprecated_ability_trigger_error', true ) ) {
-		if ( function_exists( '__' ) ) {
-			if ( $replacement ) {
-				if ( $version ) {
-					$message = sprintf(
-						/* translators: 1: Ability name, 2: Version number, 3: Alternative ability name. */
-						__( 'Ability %1$s is <strong>deprecated</strong> since version %2$s! Use %3$s instead.' ),
-						$ability_name,
-						$version,
-						$replacement
-					);
-				} else {
-					$message = sprintf(
-						/* translators: 1: Ability name, 2: Alternative ability name. */
-						__( 'Ability %1$s is <strong>deprecated</strong>! Use %2$s instead.' ),
-						$ability_name,
-						$replacement
-					);
-				}
-			} else {
-				if ( $version ) {
-					$message = sprintf(
-						/* translators: 1: Ability name, 2: Version number. */
-						__( 'Ability %1$s is <strong>deprecated</strong> since version %2$s with no alternative available.' ),
-						$ability_name,
-						$version
-					);
-				} else {
-					$message = sprintf(
-						/* translators: %s: Ability name. */
-						__( 'Ability %s is <strong>deprecated</strong> with no alternative available.' ),
-						$ability_name
-					);
-				}
-			}
-		} else {
-			if ( $replacement ) {
-				if ( $version ) {
-					$message = sprintf(
-						'Ability %1$s is <strong>deprecated</strong> since version %2$s! Use %3$s instead.',
-						$ability_name,
-						$version,
-						$replacement
-					);
-				} else {
-					$message = sprintf(
-						'Ability %1$s is <strong>deprecated</strong>! Use %2$s instead.',
-						$ability_name,
-						$replacement
-					);
-				}
-			} else {
-				if ( $version ) {
-					$message = sprintf(
-						'Ability %1$s is <strong>deprecated</strong> since version %2$s with no alternative available.',
-						$ability_name,
-						$version
-					);
-				} else {
-					$message = sprintf(
-						'Ability %s is <strong>deprecated</strong> with no alternative available.',
-						$ability_name
-					);
-				}
-			}
-		}
-
-		wp_trigger_error( '', $message, E_USER_DEPRECATED );
-	}
 }

--- a/src/wp-includes/abilities-api.php
+++ b/src/wp-includes/abilities-api.php
@@ -801,3 +801,116 @@ function wp_get_ability_categories(): array {
 
 	return $registry->get_all_registered();
 }
+
+/**
+ * Marks an ability as deprecated and informs when it has been used.
+ *
+ * This function should be called from within a deprecated ability's execute callback
+ * to notify developers that they are using an obsolete ability. The function logs
+ * the deprecation and triggers a notice when WP_DEBUG is enabled.
+ *
+ * Example:
+ *
+ *     function my_plugin_old_ability_callback( $input ) {
+ *         _deprecated_ability( 'my-plugin/old-ability', '1.5.0', 'my-plugin/new-ability' );
+ *         // Legacy implementation...
+ *     }
+ *
+ * @since 7.0.0
+ *
+ * @param string $ability_name The name of the ability that is deprecated.
+ * @param string $version      Optional. The version in which the ability was deprecated.
+ *                             Default empty string.
+ * @param string $replacement  Optional. The name of the ability that should be used instead.
+ *                             Default empty string.
+ */
+function _deprecated_ability( string $ability_name, string $version = '', string $replacement = '' ): void {
+
+	/**
+	 * Fires when a deprecated ability is called.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string $ability_name The ability that was called.
+	 * @param string $replacement  The ability that should have been called.
+	 * @param string $version      The version in which the ability was deprecated.
+	 */
+	do_action( 'deprecated_ability_run', $ability_name, $replacement, $version );
+
+	/**
+	 * Filters whether to trigger an error for deprecated abilities.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param bool $trigger Whether to trigger the error for deprecated abilities. Default true.
+	 */
+	if ( WP_DEBUG && apply_filters( 'deprecated_ability_trigger_error', true ) ) {
+		if ( function_exists( '__' ) ) {
+			if ( $replacement ) {
+				if ( $version ) {
+					$message = sprintf(
+						/* translators: 1: Ability name, 2: Version number, 3: Alternative ability name. */
+						__( 'Ability %1$s is <strong>deprecated</strong> since version %2$s! Use %3$s instead.' ),
+						$ability_name,
+						$version,
+						$replacement
+					);
+				} else {
+					$message = sprintf(
+						/* translators: 1: Ability name, 2: Alternative ability name. */
+						__( 'Ability %1$s is <strong>deprecated</strong>! Use %2$s instead.' ),
+						$ability_name,
+						$replacement
+					);
+				}
+			} else {
+				if ( $version ) {
+					$message = sprintf(
+						/* translators: 1: Ability name, 2: Version number. */
+						__( 'Ability %1$s is <strong>deprecated</strong> since version %2$s with no alternative available.' ),
+						$ability_name,
+						$version
+					);
+				} else {
+					$message = sprintf(
+						/* translators: %s: Ability name. */
+						__( 'Ability %s is <strong>deprecated</strong> with no alternative available.' ),
+						$ability_name
+					);
+				}
+			}
+		} else {
+			if ( $replacement ) {
+				if ( $version ) {
+					$message = sprintf(
+						'Ability %1$s is <strong>deprecated</strong> since version %2$s! Use %3$s instead.',
+						$ability_name,
+						$version,
+						$replacement
+					);
+				} else {
+					$message = sprintf(
+						'Ability %1$s is <strong>deprecated</strong>! Use %2$s instead.',
+						$ability_name,
+						$replacement
+					);
+				}
+			} else {
+				if ( $version ) {
+					$message = sprintf(
+						'Ability %1$s is <strong>deprecated</strong> since version %2$s with no alternative available.',
+						$ability_name,
+						$version
+					);
+				} else {
+					$message = sprintf(
+						'Ability %s is <strong>deprecated</strong> with no alternative available.',
+						$ability_name
+					);
+				}
+			}
+		}
+
+		wp_trigger_error( '', $message, E_USER_DEPRECATED );
+	}
+}

--- a/src/wp-includes/abilities-api/class-wp-abilities-registry.php
+++ b/src/wp-includes/abilities-api/class-wp-abilities-registry.php
@@ -42,6 +42,7 @@ final class WP_Abilities_Registry {
 	 * @since 6.9.0
 	 * @since 7.1.0 Added the `public` meta argument.
 	 * @since 7.2.0 The `category` argument is now optional and defaults to `uncategorized`.
+	 * @since 7.2.0 Added the `deprecated` meta property.
 	 *
 	 * @see wp_register_ability()
 	 *
@@ -122,6 +123,7 @@ final class WP_Abilities_Registry {
 		 * @since 6.9.0
 		 * @since 7.1.0 Added the `public` meta argument.
 		 * @since 7.2.0 The `category` argument is now optional and defaults to `uncategorized`.
+		 * @since 7.2.0 Added the `deprecated` meta property.
 		 *
 		 * @param array<string, mixed> $args {
 		 *     An associative array of arguments for the ability.

--- a/src/wp-includes/abilities-api/class-wp-abilities-registry.php
+++ b/src/wp-includes/abilities-api/class-wp-abilities-registry.php
@@ -78,6 +78,15 @@ final class WP_Abilities_Registry {
 	 *                                                      to clients such as the REST API, MCP, or AI agents.
 	 *                                                      Seeds the default for per-channel flags like
 	 *                                                      `$show_in_rest`. Defaults to false.
+	 *         @type false|array<string, string> $deprecated {
+	 *             Optional. Deprecation details. Set to an array to mark the ability as deprecated. At least one
+	 *             supported detail must be provided. Deprecated abilities remain available by exact name and can
+	 *             be explicitly included or excluded from discovery through meta filtering. Default false.
+	 *
+	 *             @type string $since       Optional. Version of the ability provider that deprecated the ability.
+	 *             @type string $replacement Optional. Namespaced ability to use instead.
+	 *             @type string $message     Optional. Additional migration guidance.
+	 *         }
 	 *         @type bool                     $show_in_rest Optional. Whether to expose this ability in the REST API.
 	 *                                                      Default is the value of `$public` when set, false otherwise.
 	 *     }
@@ -135,6 +144,15 @@ final class WP_Abilities_Registry {
 		 *                                                        available to clients such as the REST API, MCP, or AI
 		 *                                                        agents. Seeds the default for per-channel flags like
 		 *                                                        `$show_in_rest`. Defaults to false.
+		 *         @type false|array<string, string> $deprecated {
+		 *             Optional. Deprecation details. Set to an array to mark the ability as deprecated. At least one
+		 *             supported detail must be provided. Deprecated abilities remain available by exact name and can
+		 *             be explicitly included or excluded from discovery through meta filtering. Default false.
+		 *
+		 *             @type string $since       Optional. Version of the ability provider that deprecated the ability.
+		 *             @type string $replacement Optional. Namespaced ability to use instead.
+		 *             @type string $message     Optional. Additional migration guidance.
+		 *         }
 		 *         @type bool                       $show_in_rest Optional. Whether to expose this ability in the REST API.
 		 *                                                        Default is the value of `$public` when set, false otherwise.
 		 *     }

--- a/src/wp-includes/abilities-api/class-wp-ability.php
+++ b/src/wp-includes/abilities-api/class-wp-ability.php
@@ -140,6 +140,7 @@ class WP_Ability {
 	 *
 	 * @since 6.9.0
 	 * @since 7.1.0 Added the `public` meta argument.
+	 * @since 7.2.0 Added the `deprecated` meta property.
 	 *
 	 * @see wp_register_ability()
 	 *
@@ -220,6 +221,7 @@ class WP_Ability {
 	 *
 	 * @since 6.9.0
 	 * @since 7.1.0 Added the `public` meta argument.
+	 * @since 7.2.0 Added support for the `deprecated` meta property.
 	 *
 	 * @see WP_Abilities_Registry::register()
 	 *
@@ -829,6 +831,7 @@ class WP_Ability {
 	 * @since 6.9.0
 	 * @since 7.1.0 Added the `wp_ability_invoked` action.
 	 * @since 7.1.0 Added the `wp_pre_execute_ability` filter.
+	 * @since 7.2.0 Added deprecation notices for abilities with the `deprecated` meta property.
 	 *
 	 * @param mixed $input Optional. The input data for the ability. Default `null`.
 	 * @return mixed|WP_Error The result of the ability execution, or WP_Error on failure.

--- a/src/wp-includes/abilities-api/class-wp-ability.php
+++ b/src/wp-includes/abilities-api/class-wp-ability.php
@@ -401,6 +401,12 @@ class WP_Ability {
 					);
 				}
 
+				if ( 'replacement' === $key && ! preg_match( '/^[a-z0-9-]+\/[a-z0-9-]+$/', $args['meta']['deprecated'][ $key ] ) ) {
+					throw new InvalidArgumentException(
+						__( 'The ability deprecation `replacement` value should be a namespaced ability name, i.e. "my-plugin/my-ability". It can only contain lowercase alphanumeric characters, dashes and the forward slash.' )
+					);
+				}
+
 				$has_deprecation_details = true;
 			}
 

--- a/src/wp-includes/abilities-api/class-wp-ability.php
+++ b/src/wp-includes/abilities-api/class-wp-ability.php
@@ -356,6 +356,7 @@ class WP_Ability {
 			$args['meta'] ?? array(),
 			array(
 				'annotations' => static::$default_annotations,
+				'deprecated'  => false,
 			)
 		);
 
@@ -680,6 +681,13 @@ class WP_Ability {
 				sprintf( __( 'Ability "%s" does not have a valid execute callback.' ), $this->name )
 			);
 		} else {
+			// Trigger deprecation notice if the ability is deprecated.
+			if ( $this->get_meta_item( 'deprecated', false ) === true ) {
+				$version     = $this->get_meta_item( 'deprecated_version', '' );
+				$replacement = $this->get_meta_item( 'deprecated_replacement', '' );
+				_deprecated_ability( $this->name, $version, $replacement );
+			}
+
 			$result = $this->invoke_callback( $this->execute_callback, $input );
 		}
 

--- a/src/wp-includes/abilities-api/class-wp-ability.php
+++ b/src/wp-includes/abilities-api/class-wp-ability.php
@@ -169,11 +169,20 @@ class WP_Ability {
 	 *             @type bool|null $idempotent  Optional. If true, calling the ability repeatedly with the same arguments
 	 *                                          will have no additional effect on its environment.
 	 *         }
-	 *         @type bool                     $public       Optional. Whether the ability is meant to be available
-	 *                                                      to clients such as the REST API, MCP, or AI agents.
-	 *                                                      Seeds the default for per-channel flags like
-	 *                                                      `$show_in_rest`. Defaults to false.
-	 *         @type bool                     $show_in_rest Optional. Whether to expose this ability in the REST API.
+	 *         @type bool                       $public       Optional. Whether the ability is meant to be available
+	 *                                                        to clients such as the REST API, MCP, or AI agents.
+	 *                                                        Seeds the default for per-channel flags like
+	 *                                                        `$show_in_rest`. Defaults to false.
+	 *         @type false|array<string, string> $deprecated {
+	 *             Optional. Deprecation details. Set to an array to mark the ability as deprecated. At least one
+	 *             supported detail must be provided. Deprecated abilities remain available by exact name and can
+	 *             be explicitly included or excluded from discovery through meta filtering. Default false.
+	 *
+	 *             @type string $since       Optional. Version of the ability provider that deprecated the ability.
+	 *             @type string $replacement Optional. Namespaced ability to use instead.
+	 *             @type string $message     Optional. Additional migration guidance.
+	 *         }
+	 *         @type bool                       $show_in_rest Optional. Whether to expose this ability in the REST API.
 	 *                                                      Default is the value of `$public` when set, false otherwise.
 	 *     }
 	 * }
@@ -239,11 +248,20 @@ class WP_Ability {
 	 *             @type bool|null $idempotent  Optional. If true, calling the ability repeatedly with the same arguments
 	 *                                          will have no additional effect on its environment.
 	 *         }
-	 *         @type bool                     $public       Optional. Whether the ability is meant to be available
-	 *                                                      to clients such as the REST API, MCP, or AI agents.
-	 *                                                      Seeds the default for per-channel flags like
-	 *                                                      `$show_in_rest`. Defaults to false.
-	 *         @type bool                     $show_in_rest Optional. Whether to expose this ability in the REST API.
+	 *         @type bool                       $public       Optional. Whether the ability is meant to be available
+	 *                                                        to clients such as the REST API, MCP, or AI agents.
+	 *                                                        Seeds the default for per-channel flags like
+	 *                                                        `$show_in_rest`. Defaults to false.
+	 *         @type false|array<string, string> $deprecated {
+	 *             Optional. Deprecation details. Set to an array to mark the ability as deprecated. At least one
+	 *             supported detail must be provided. Deprecated abilities remain available by exact name and can
+	 *             be explicitly included or excluded from discovery through meta filtering. Default false.
+	 *
+	 *             @type string $since       Optional. Version of the ability provider that deprecated the ability.
+	 *             @type string $replacement Optional. Namespaced ability to use instead.
+	 *             @type string $message     Optional. Additional migration guidance.
+	 *         }
+	 *         @type bool                       $show_in_rest Optional. Whether to expose this ability in the REST API.
 	 *                                                      Default is the value of `$public` when set, false otherwise.
 	 *     }
 	 * }
@@ -272,10 +290,17 @@ class WP_Ability {
 	 *             @type bool|null $idempotent  If true, calling the ability repeatedly with the same arguments
 	 *                                          will have no additional effect on its environment.
 	 *         }
-	 *         @type bool                     $public       Whether the ability is meant to be available to clients
-	 *                                                      such as the REST API, MCP, or AI agents. Defaults to
-	 *                                                      false.
-	 *         @type bool                     $show_in_rest Whether to expose this ability in the REST API.
+	 *         @type bool                       $public       Whether the ability is meant to be available to clients
+	 *                                                        such as the REST API, MCP, or AI agents. Defaults to
+	 *                                                        false.
+	 *         @type false|array<string, string> $deprecated {
+	 *             Deprecation details, or false when the ability is not deprecated.
+	 *
+	 *             @type string $since       Optional. Version of the ability provider that deprecated the ability.
+	 *             @type string $replacement Optional. Namespaced ability to use instead.
+	 *             @type string $message     Optional. Additional migration guidance.
+	 *         }
+	 *         @type bool                       $show_in_rest Whether to expose this ability in the REST API.
 	 *     }
 	 * }
 	 * @throws InvalidArgumentException if an argument is invalid.
@@ -351,6 +376,39 @@ class WP_Ability {
 			);
 		}
 
+		if ( isset( $args['meta']['deprecated'] ) && false !== $args['meta']['deprecated'] ) {
+			if ( ! is_array( $args['meta']['deprecated'] ) ) {
+				throw new InvalidArgumentException(
+					__( 'The ability meta should provide `deprecated` as false or an array of deprecation details.' )
+				);
+			}
+
+			$has_deprecation_details = false;
+			foreach ( array( 'since', 'replacement', 'message' ) as $key ) {
+				if ( ! array_key_exists( $key, $args['meta']['deprecated'] ) ) {
+					continue;
+				}
+
+				if ( ! is_string( $args['meta']['deprecated'][ $key ] ) || '' === $args['meta']['deprecated'][ $key ] ) {
+					throw new InvalidArgumentException(
+						sprintf(
+							/* translators: %s: Deprecation metadata key. */
+							__( 'The ability deprecation `%s` value should be a non-empty string.' ),
+							$key
+						)
+					);
+				}
+
+				$has_deprecation_details = true;
+			}
+
+			if ( ! $has_deprecation_details ) {
+				throw new InvalidArgumentException(
+					__( 'The ability deprecation details should provide at least one of `since`, `replacement`, or `message`.' )
+				);
+			}
+		}
+
 		// Set defaults for optional meta.
 		$args['meta'] = wp_parse_args(
 			$args['meta'] ?? array(),
@@ -359,6 +417,9 @@ class WP_Ability {
 				'deprecated'  => false,
 			)
 		);
+
+		// Treat a null `deprecated` value as unset.
+		$args['meta']['deprecated'] = $args['meta']['deprecated'] ?? false;
 
 		$args['meta']['annotations'] = wp_parse_args(
 			$args['meta']['annotations'],
@@ -681,13 +742,6 @@ class WP_Ability {
 				sprintf( __( 'Ability "%s" does not have a valid execute callback.' ), $this->name )
 			);
 		} else {
-			// Trigger deprecation notice if the ability is deprecated.
-			if ( $this->get_meta_item( 'deprecated', false ) === true ) {
-				$version     = $this->get_meta_item( 'deprecated_version', '' );
-				$replacement = $this->get_meta_item( 'deprecated_replacement', '' );
-				_deprecated_ability( $this->name, $version, $replacement );
-			}
-
 			$result = $this->invoke_callback( $this->execute_callback, $input );
 		}
 
@@ -794,6 +848,16 @@ class WP_Ability {
 		 * @param WP_Ability $ability      The ability instance.
 		 */
 		do_action( 'wp_ability_invoked', $this->name, $input, $this );
+
+		$deprecated = $this->get_meta_item( 'deprecated', false );
+		if ( is_array( $deprecated ) ) {
+			_deprecated_ability(
+				$this->name,
+				$deprecated['since'] ?? '',
+				$deprecated['replacement'] ?? '',
+				$deprecated['message'] ?? ''
+			);
+		}
 
 		$pre_execute_sentinel = new WP_Filter_Sentinel();
 

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -244,6 +244,8 @@ function rest_api_default_filters() {
 		add_filter( 'deprecated_function_trigger_error', '__return_false' );
 		add_action( 'deprecated_argument_run', 'rest_handle_deprecated_argument', 10, 3 );
 		add_filter( 'deprecated_argument_trigger_error', '__return_false' );
+		add_action( 'deprecated_ability_run', 'rest_handle_deprecated_ability', 10, 4 );
+		add_filter( 'deprecated_ability_trigger_error', '__return_false' );
 		add_action( 'doing_it_wrong_run', 'rest_handle_doing_it_wrong', 10, 3 );
 		add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
 	}
@@ -765,6 +767,42 @@ function rest_handle_deprecated_argument( $function_name, $message, $version ) {
 	}
 
 	header( sprintf( 'X-WP-DeprecatedParam: %s', $string ) );
+}
+
+/**
+ * Handles _deprecated_ability() errors.
+ *
+ * @since 7.2.0
+ *
+ * @param string $ability_name The ability that was executed.
+ * @param string $replacement  The ability that should be used as a replacement.
+ * @param string $version      The version of the ability provider that deprecated the ability.
+ * @param string $message      Additional migration guidance.
+ */
+function rest_handle_deprecated_ability( $ability_name, $replacement, $version, $message ) {
+	if ( ! WP_DEBUG || headers_sent() ) {
+		return;
+	}
+
+	if ( $version && $replacement ) {
+		/* translators: 1: Ability name, 2: Version number, 3: Alternative ability name. */
+		$string = sprintf( __( '%1$s (since %2$s; use %3$s instead)' ), $ability_name, $version, $replacement );
+	} elseif ( $version ) {
+		/* translators: 1: Ability name, 2: Version number. */
+		$string = sprintf( __( '%1$s (since %2$s; no alternative available)' ), $ability_name, $version );
+	} elseif ( $replacement ) {
+		/* translators: 1: Ability name, 2: Alternative ability name. */
+		$string = sprintf( __( '%1$s (use %2$s instead)' ), $ability_name, $replacement );
+	} else {
+		/* translators: %s: Ability name. */
+		$string = sprintf( __( '%s (no alternative available)' ), $ability_name );
+	}
+
+	if ( $message ) {
+		$string .= ' ' . $message;
+	}
+
+	header( sprintf( 'X-WP-DeprecatedAbility: %s', $string ) );
 }
 
 /**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
@@ -245,6 +245,7 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 	 *
 	 * @since 6.9.0
 	 * @since 7.1.0 Added the `meta.public` property.
+	 * @since 7.2.0 Added the `deprecated` meta property to the ability schema.
 	 *
 	 * @return array<string, mixed> Item schema data.
 	 */
@@ -350,6 +351,7 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 	 *
 	 * @since 6.9.0
 	 * @since 7.1.0 Added the `namespace` and `meta` parameters and the `rest_abilities_collection_params` filter.
+	 * @since 7.2.0 Added support for filtering by the `deprecated` meta property.
 	 *
 	 * @return array<string, mixed> Collection parameters.
 	 */
@@ -434,6 +436,7 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 		 * boolean, before the meta filter matches it.
 		 *
 		 * @since 7.1.0
+		 * @since 7.2.0 Added the `deprecated` meta collection parameter.
 		 *
 		 * @param array $query_params JSON Schema-formatted collection parameters.
 		 */

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
@@ -317,6 +317,24 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 							'description' => __( 'Whether the ability is meant to be available to clients such as the REST API, MCP, or AI agents. Defaults to false, but individual channel settings such as show_in_rest can override it.' ),
 							'type'        => 'boolean',
 						),
+						'deprecated'  => array(
+							'description' => __( 'Deprecation details for the ability, or false when the ability is not deprecated.' ),
+							'type'        => array( 'boolean', 'object' ),
+							'properties'  => array(
+								'since'       => array(
+									'description' => __( 'Version of the ability provider that deprecated the ability.' ),
+									'type'        => 'string',
+								),
+								'replacement' => array(
+									'description' => __( 'Namespaced ability to use instead.' ),
+									'type'        => 'string',
+								),
+								'message'     => array(
+									'description' => __( 'Additional migration guidance.' ),
+									'type'        => 'string',
+								),
+							),
+						),
 					),
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
@@ -383,6 +401,22 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 							'idempotent'  => array(
 								'description' => __( 'Whether repeated calls with the same arguments have no additional effect.' ),
 								'type'        => array( 'boolean', 'null' ),
+							),
+						),
+						'additionalProperties' => true,
+					),
+					'deprecated'  => array(
+						'description'          => __( 'Limit results by deprecation status or details.' ),
+						'type'                 => array( 'boolean', 'object' ),
+						'properties'           => array(
+							'since'       => array(
+								'type' => 'string',
+							),
+							'replacement' => array(
+								'type' => 'string',
+							),
+							'message'     => array(
+								'type' => 'string',
 							),
 						),
 						'additionalProperties' => true,

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
@@ -408,17 +408,20 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 						'additionalProperties' => true,
 					),
 					'deprecated'  => array(
-						'description'          => __( 'Limit results by deprecation status or details.' ),
+						'description'          => __( 'Limit results by deprecation status or details. Use true to return only deprecated abilities, false to return only active abilities, or an object to match specific deprecation details.' ),
 						'type'                 => array( 'boolean', 'object' ),
 						'properties'           => array(
 							'since'       => array(
-								'type' => 'string',
+								'description' => __( 'Version of the ability provider that deprecated the ability.' ),
+								'type'        => 'string',
 							),
 							'replacement' => array(
-								'type' => 'string',
+								'description' => __( 'Namespaced ability to use instead.' ),
+								'type'        => 'string',
 							),
 							'message'     => array(
-								'type' => 'string',
+								'description' => __( 'Additional migration guidance.' ),
+								'type'        => 'string',
 							),
 						),
 						'additionalProperties' => true,

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -616,6 +616,7 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 		add_action( 'deprecated_class_run', array( $this, 'deprecated_function_run' ), 10, 3 );
 		add_action( 'deprecated_file_included', array( $this, 'deprecated_function_run' ), 10, 4 );
 		add_action( 'deprecated_hook_run', array( $this, 'deprecated_function_run' ), 10, 4 );
+		add_action( 'deprecated_ability_run', array( $this, 'deprecated_function_run' ), 10, 4 );
 		add_action( 'doing_it_wrong_run', array( $this, 'doing_it_wrong_run' ), 10, 3 );
 
 		add_action( 'deprecated_function_trigger_error', '__return_false' );
@@ -623,6 +624,7 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 		add_action( 'deprecated_class_trigger_error', '__return_false' );
 		add_action( 'deprecated_file_trigger_error', '__return_false' );
 		add_action( 'deprecated_hook_trigger_error', '__return_false' );
+		add_action( 'deprecated_ability_trigger_error', '__return_false' );
 		add_action( 'doing_it_wrong_trigger_error', '__return_false' );
 	}
 
@@ -758,6 +760,8 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	 */
 	public function deprecated_function_run( $function_name, $replacement, $version, $message = '' ) {
 		if ( ! isset( $this->caught_deprecated[ $function_name ] ) ) {
+			$additional_message = $message;
+
 			switch ( current_action() ) {
 				case 'deprecated_function_run':
 					if ( $replacement ) {
@@ -841,6 +845,39 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 							$function_name,
 							$version
 						) . ' ' . $message;
+					}
+					break;
+
+				case 'deprecated_ability_run':
+					if ( $version ) {
+						if ( $replacement ) {
+							$message = sprintf(
+								'Ability %1$s is deprecated since version %2$s! Use %3$s instead.',
+								$function_name,
+								$version,
+								$replacement
+							);
+						} else {
+							$message = sprintf(
+								'Ability %1$s is deprecated since version %2$s with no alternative available.',
+								$function_name,
+								$version
+							);
+						}
+					} elseif ( $replacement ) {
+						$message = sprintf(
+							'Ability %1$s is deprecated! Use %2$s instead.',
+							$function_name,
+							$replacement
+						);
+					} else {
+						$message = sprintf(
+							'Ability %s is deprecated with no alternative available.',
+							$function_name
+						);
+					}
+					if ( $additional_message ) {
+						$message .= ' ' . $additional_message;
 					}
 					break;
 			}

--- a/tests/phpunit/includes/abstract-testcase.php
+++ b/tests/phpunit/includes/abstract-testcase.php
@@ -760,8 +760,6 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 	 */
 	public function deprecated_function_run( $function_name, $replacement, $version, $message = '' ) {
 		if ( ! isset( $this->caught_deprecated[ $function_name ] ) ) {
-			$additional_message = $message;
-
 			switch ( current_action() ) {
 				case 'deprecated_function_run':
 					if ( $replacement ) {
@@ -849,6 +847,8 @@ abstract class WP_UnitTestCase_Base extends PHPUnit_Adapter_TestCase {
 					break;
 
 				case 'deprecated_ability_run':
+					$additional_message = $message;
+
 					if ( $version ) {
 						if ( $replacement ) {
 							$message = sprintf(

--- a/tests/phpunit/tests/abilities-api/wpAbility.php
+++ b/tests/phpunit/tests/abilities-api/wpAbility.php
@@ -472,6 +472,21 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that the `replacement` detail must be a namespaced ability name.
+	 *
+	 * @ticket 64209
+	 */
+	public function test_meta_deprecated_rejects_invalid_replacement(): void {
+		$args                       = self::$test_ability_properties;
+		$args['meta']['deprecated'] = array( 'replacement' => 'Not An Ability' );
+
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'The ability deprecation `replacement` value should be a namespaced ability name' );
+
+		new WP_Ability( self::$test_ability_name, $args );
+	}
+
+	/**
 	 * Tests that executing a deprecated ability emits its structured details.
 	 *
 	 * @ticket 64209

--- a/tests/phpunit/tests/abilities-api/wpAbility.php
+++ b/tests/phpunit/tests/abilities-api/wpAbility.php
@@ -382,6 +382,134 @@ class Tests_Abilities_API_WpAbility extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that `deprecated` metadata defaults to false when not provided.
+	 *
+	 * @ticket 64209
+	 */
+	public function test_meta_deprecated_defaults_to_false(): void {
+		$ability = new WP_Ability( self::$test_ability_name, self::$test_ability_properties );
+
+		$this->assertFalse( $ability->get_meta_item( 'deprecated' ) );
+	}
+
+	/**
+	 * Tests that a null `deprecated` value is treated as unset.
+	 *
+	 * @ticket 64209
+	 */
+	public function test_meta_deprecated_null_is_treated_as_unset(): void {
+		$args                       = self::$test_ability_properties;
+		$args['meta']['deprecated'] = null;
+
+		$ability = new WP_Ability( self::$test_ability_name, $args );
+
+		$this->assertFalse( $ability->get_meta_item( 'deprecated' ) );
+	}
+
+	/**
+	 * Tests that structured `deprecated` metadata is retained.
+	 *
+	 * @ticket 64209
+	 */
+	public function test_meta_deprecated_accepts_structured_details(): void {
+		$deprecated = array(
+			'since'       => '2.0.0',
+			'replacement' => 'test/new-calculator',
+			'message'     => 'Use the new input format.',
+		);
+
+		$args                       = self::$test_ability_properties;
+		$args['meta']['deprecated'] = $deprecated;
+
+		$ability = new WP_Ability( self::$test_ability_name, $args );
+
+		$this->assertSame( $deprecated, $ability->get_meta_item( 'deprecated' ) );
+	}
+
+	/**
+	 * Tests that `deprecated` rejects values other than false or an array.
+	 *
+	 * @ticket 64209
+	 */
+	public function test_meta_deprecated_rejects_invalid_type(): void {
+		$args                       = self::$test_ability_properties;
+		$args['meta']['deprecated'] = true;
+
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'The ability meta should provide `deprecated` as false or an array of deprecation details.' );
+
+		new WP_Ability( self::$test_ability_name, $args );
+	}
+
+	/**
+	 * Tests that `deprecated` requires at least one supported detail.
+	 *
+	 * @ticket 64209
+	 */
+	public function test_meta_deprecated_rejects_empty_details(): void {
+		$args                       = self::$test_ability_properties;
+		$args['meta']['deprecated'] = array();
+
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'The ability deprecation details should provide at least one of `since`, `replacement`, or `message`.' );
+
+		new WP_Ability( self::$test_ability_name, $args );
+	}
+
+	/**
+	 * Tests that supported `deprecated` details must be non-empty strings.
+	 *
+	 * @ticket 64209
+	 */
+	public function test_meta_deprecated_rejects_invalid_detail(): void {
+		$args                       = self::$test_ability_properties;
+		$args['meta']['deprecated'] = array( 'since' => 2 );
+
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'The ability deprecation `since` value should be a non-empty string.' );
+
+		new WP_Ability( self::$test_ability_name, $args );
+	}
+
+	/**
+	 * Tests that executing a deprecated ability emits its structured details.
+	 *
+	 * @ticket 64209
+	 */
+	public function test_execute_deprecated_ability_emits_deprecation(): void {
+		$args                       = self::$test_ability_properties;
+		$args['meta']['deprecated'] = array(
+			'since'       => '2.0.0',
+			'replacement' => 'test/new-calculator',
+			'message'     => 'Use the new input format.',
+		);
+
+		$received = null;
+		$listener = static function ( $name, $replacement, $version, $message ) use ( &$received ): void {
+			$received = compact( 'name', 'replacement', 'version', 'message' );
+		};
+
+		$this->setExpectedDeprecated( self::$test_ability_name );
+		add_action( 'deprecated_ability_run', $listener, 10, 4 );
+
+		$ability = new WP_Ability( self::$test_ability_name, $args );
+		$result  = $ability->execute();
+
+		remove_action( 'deprecated_ability_run', $listener, 10 );
+
+		$this->assertSame( 0, $result );
+		$this->assertSame(
+			array(
+				'name'        => self::$test_ability_name,
+				'replacement' => 'test/new-calculator',
+				'version'     => '2.0.0',
+				'message'     => 'Use the new input format.',
+			),
+			$received
+		);
+	}
+
+	/**
 	 * Data provider for testing the execution of the ability.
 	 *
 	 * @return array<string, array{0: array, 1: callable, 2: mixed, 3: mixed}> Data sets with different configurations.

--- a/tests/phpunit/tests/abilities-api/wpGetAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpGetAbilities.php
@@ -116,6 +116,86 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 	}
 
 	// -------------------------------------------------------------------------
+	// Deprecated abilities
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests that deprecated abilities remain in discovery by default.
+	 *
+	 * @ticket 64209
+	 */
+	public function test_deprecated_abilities_are_included_by_default(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/active-ability' );
+		$this->register_test_ability(
+			'test/deprecated-ability',
+			array(
+				'meta' => array(
+					'deprecated' => array( 'replacement' => 'test/active-ability' ),
+				),
+			)
+		);
+
+		$result = wp_get_abilities();
+
+		$this->assertArrayHasKey( 'test/active-ability', $result );
+		$this->assertArrayHasKey( 'test/deprecated-ability', $result );
+	}
+
+	/**
+	 * Tests that deprecated abilities can be explicitly excluded from discovery.
+	 *
+	 * @ticket 64209
+	 */
+	public function test_deprecated_abilities_can_be_excluded(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/active-ability' );
+		$this->register_test_ability(
+			'test/deprecated-ability',
+			array(
+				'meta' => array(
+					'deprecated' => array( 'replacement' => 'test/active-ability' ),
+				),
+			)
+		);
+
+		$result = wp_get_abilities( array( 'meta' => array( 'deprecated' => false ) ) );
+
+		$this->assertArrayHasKey( 'test/active-ability', $result );
+		$this->assertArrayNotHasKey( 'test/deprecated-ability', $result );
+	}
+
+	/**
+	 * Tests that the meta filter can return only deprecated abilities.
+	 *
+	 * @ticket 64209
+	 */
+	public function test_deprecated_abilities_can_be_filtered_exclusively(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/active-ability' );
+		$this->register_test_ability(
+			'test/deprecated-ability',
+			array(
+				'meta' => array(
+					'deprecated' => array( 'replacement' => 'test/active-ability' ),
+				),
+			)
+		);
+
+		$result = wp_get_abilities(
+			array(
+				'meta' => array( 'deprecated' => array() ),
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'test/active-ability', $result );
+		$this->assertArrayHasKey( 'test/deprecated-ability', $result );
+	}
+
+	// -------------------------------------------------------------------------
 	// Category filter
 	// -------------------------------------------------------------------------
 

--- a/tests/phpunit/tests/abilities-api/wpGetAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpGetAbilities.php
@@ -195,6 +195,30 @@ class Tests_Abilities_API_WpGetAbilities extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'test/deprecated-ability', $result );
 	}
 
+	/**
+	 * Tests that `true` works as a shorthand for any deprecated ability.
+	 *
+	 * @ticket 64209
+	 */
+	public function test_deprecated_abilities_can_be_filtered_with_true_shorthand(): void {
+		$this->simulate_wp_abilities_init();
+
+		$this->register_test_ability( 'test/active-ability' );
+		$this->register_test_ability(
+			'test/deprecated-ability',
+			array(
+				'meta' => array(
+					'deprecated' => array( 'replacement' => 'test/active-ability' ),
+				),
+			)
+		);
+
+		$result = wp_get_abilities( array( 'meta' => array( 'deprecated' => true ) ) );
+
+		$this->assertArrayNotHasKey( 'test/active-ability', $result );
+		$this->assertArrayHasKey( 'test/deprecated-ability', $result );
+	}
+
 	// -------------------------------------------------------------------------
 	// Category filter
 	// -------------------------------------------------------------------------

--- a/tests/phpunit/tests/abilities-api/wpRegisterAbility.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterAbility.php
@@ -196,6 +196,7 @@ class Test_Abilities_API_WpRegisterAbility extends WP_UnitTestCase {
 				'annotations'  => $expected_annotations,
 				'show_in_rest' => true,
 				'public'       => false,
+				'deprecated'   => false,
 			)
 		);
 

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
@@ -167,6 +167,29 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Helper to register a deprecated ability exposed through REST.
+	 */
+	private function register_deprecated_ability(): void {
+		$this->register_test_ability(
+			'test/deprecated-calculator',
+			array(
+				'label'               => 'Deprecated Calculator',
+				'description'         => 'A deprecated calculator ability.',
+				'category'            => 'math',
+				'execute_callback'    => '__return_true',
+				'permission_callback' => '__return_true',
+				'meta'                => array(
+					'show_in_rest' => true,
+					'deprecated'   => array(
+						'since'       => '2.0.0',
+						'replacement' => 'test/calculator',
+					),
+				),
+			)
+		);
+	}
+
+	/**
 	 * Register test abilities for testing.
 	 */
 	private function register_test_abilities(): void {
@@ -316,6 +339,49 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 		$this->assertContains( 'test/calculator', $ability_names );
 		$this->assertContains( 'test/system-info', $ability_names );
 		$this->assertNotContains( 'test/not-show-in-rest', $ability_names );
+	}
+
+	/**
+	 * Tests that collection discovery includes deprecated abilities by default.
+	 *
+	 * @ticket 64209
+	 */
+	public function test_get_items_includes_deprecated_abilities_by_default(): void {
+		$this->register_deprecated_ability();
+
+		$request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities' );
+		$request->set_param( 'per_page', 100 );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$ability_meta = wp_list_pluck( $response->get_data(), 'meta', 'name' );
+
+		$this->assertArrayHasKey( 'test/deprecated-calculator', $ability_meta );
+		$this->assertSame(
+			array(
+				'since'       => '2.0.0',
+				'replacement' => 'test/calculator',
+			),
+			$ability_meta['test/deprecated-calculator']['deprecated']
+		);
+	}
+
+	/**
+	 * Tests that collection discovery can explicitly exclude deprecated abilities.
+	 *
+	 * @ticket 64209
+	 */
+	public function test_get_items_can_exclude_deprecated_abilities(): void {
+		$this->register_deprecated_ability();
+
+		$request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities' );
+		$request->set_param( 'per_page', 100 );
+		$request->set_param( 'meta', array( 'deprecated' => 'false' ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertNotContains( 'test/deprecated-calculator', wp_list_pluck( $response->get_data(), 'name' ) );
 	}
 
 	/**
@@ -694,6 +760,25 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'public', $meta_properties );
 		$this->assertSame( 'boolean', $meta_properties['public']['type'] );
+	}
+
+	/**
+	 * Tests that the item schema declares structured deprecation metadata.
+	 *
+	 * @ticket 64209
+	 */
+	public function test_get_schema_meta_declares_deprecated(): void {
+		$request  = new WP_REST_Request( 'OPTIONS', '/wp-abilities/v1/abilities' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$deprecated = $data['schema']['properties']['meta']['properties']['deprecated'];
+
+		$this->assertSame( array( 'boolean', 'object' ), $deprecated['type'] );
+		$this->assertSame(
+			array( 'since', 'replacement', 'message' ),
+			array_keys( $deprecated['properties'] )
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1ListController.php
@@ -385,6 +385,27 @@ class Tests_REST_API_WpRestAbilitiesV1ListController extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that collection discovery can return only deprecated abilities.
+	 *
+	 * @ticket 64209
+	 */
+	public function test_get_items_can_filter_only_deprecated_abilities(): void {
+		$this->register_deprecated_ability();
+
+		$request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities' );
+		$request->set_param( 'per_page', 100 );
+		$request->set_param( 'meta', array( 'deprecated' => 'true' ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$ability_names = wp_list_pluck( $response->get_data(), 'name' );
+
+		$this->assertContains( 'test/deprecated-calculator', $ability_names );
+		$this->assertNotContains( 'test/calculator', $ability_names );
+	}
+
+	/**
 	 * Test getting a specific ability.
 	 *
 	 * @ticket 64098

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1RunController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1RunController.php
@@ -433,6 +433,38 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that deprecated abilities remain executable through their exact REST route.
+	 *
+	 * @ticket 64209
+	 */
+	public function test_execute_deprecated_ability_by_exact_name(): void {
+		$this->register_test_ability(
+			'test/deprecated-ability',
+			array(
+				'label'               => 'Deprecated Ability',
+				'description'         => 'A deprecated test ability.',
+				'category'            => 'general',
+				'execute_callback'    => static function (): string {
+					return 'executed';
+				},
+				'permission_callback' => '__return_true',
+				'meta'                => array(
+					'show_in_rest' => true,
+					'deprecated'   => array( 'replacement' => 'test/calculator' ),
+				),
+			)
+		);
+
+		$this->setExpectedDeprecated( 'test/deprecated-ability' );
+
+		$request  = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/test/deprecated-ability/run' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'executed', $response->get_data() );
+	}
+
+	/**
 	 * Test executing a read-only ability with GET.
 	 *
 	 * @ticket 64098

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -12743,19 +12743,22 @@ mockedApiResponse.Schema = {
                                     "additionalProperties": true
                                 },
                                 "deprecated": {
-                                    "description": "Limit results by deprecation status or details.",
+                                    "description": "Limit results by deprecation status or details. Use true to return only deprecated abilities, false to return only active abilities, or an object to match specific deprecation details.",
                                     "type": [
                                         "boolean",
                                         "object"
                                     ],
                                     "properties": {
                                         "since": {
+                                            "description": "Version of the ability provider that deprecated the ability.",
                                             "type": "string"
                                         },
                                         "replacement": {
+                                            "description": "Namespaced ability to use instead.",
                                             "type": "string"
                                         },
                                         "message": {
+                                            "description": "Additional migration guidance.",
                                             "type": "string"
                                         }
                                     },

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -12741,6 +12741,25 @@ mockedApiResponse.Schema = {
                                         }
                                     },
                                     "additionalProperties": true
+                                },
+                                "deprecated": {
+                                    "description": "Limit results by deprecation status or details.",
+                                    "type": [
+                                        "boolean",
+                                        "object"
+                                    ],
+                                    "properties": {
+                                        "since": {
+                                            "type": "string"
+                                        },
+                                        "replacement": {
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "additionalProperties": true
                                 }
                             },
                             "additionalProperties": true,


### PR DESCRIPTION
This PR adds a standard way to deprecate an ability without removing it.

## Proposed changes

- Add a `meta.deprecated` property. Its default value is `false`.
- Use an array for deprecated abilities. The array can contain `since`, `replacement`, and `message`.
- Require at least one deprecation detail and validate the values during registration.
- Add `_deprecated_ability()` and show a deprecation notice when the ability runs.
- Keep deprecated abilities available by exact name for backward compatibility.
- Include deprecated abilities in discovery by default. Callers can include or exclude them with `wp_get_abilities()` or REST API filters.
- Expose deprecation details in the REST API schema.

## Why use structured metadata?

`false` clearly means that an ability is active. An array keeps all migration details together and makes them available to PHP, REST API clients, and other tools without parsing a message.

This follows the general pattern used by [`@wordpress/deprecated`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-deprecated/), which also stores deprecation details as structured options. The proposed ability API uses a smaller set of fields that fits server-side ability metadata.

## Tests

The tests cover metadata defaults and validation, execution notices, exact-name execution, discovery filtering, and REST API behavior.

Trac ticket: https://core.trac.wordpress.org/ticket/64209
