### PR TITLE
[In progress] Fix: top level default is not valid json schema.

### DIFF
--- a/src/wp-includes/abilities-api/class-wp-ability.php
+++ b/src/wp-includes/abilities-api/class-wp-ability.php
@@ -445,10 +445,18 @@ class WP_Ability {
 		}
 
 		$input_schema = $this->get_input_schema();
-		if ( ! empty( $input_schema ) && array_key_exists( 'default', $input_schema ) ) {
-			return $input_schema['default'];
+		// This tries to compute a default value from the input schema properties.
+		// It is a very basic implementation and does not cover all JSON Schema features.
+		// It only looks for `default` values in the top-level `properties`.
+		if ( ! empty( $input_schema ) && array_key_exists( 'properties', $input_schema ) ) {
+			$result = array(); 
+			foreach ( $input_schema['properties'] as $property_name => $property_schema ) {
+				if ( array_key_exists( 'default', $property_schema ) ) {
+					$result[ $property_name ] = $property_schema['default'];
+				}
+			}
+			return $result;
 		}
-
 		return null;
 	}
 

--- a/src/wp-includes/abilities.php
+++ b/src/wp-includes/abilities.php
@@ -96,11 +96,11 @@ function wp_register_core_abilities(): void {
 							'type' => 'string',
 							'enum' => $site_info_fields,
 						),
+						'default'              =>  array(),
 						'description' => __( 'Optional: Limit response to specific fields. If omitted, all fields are returned.' ),
 					),
 				),
 				'additionalProperties' => false,
-				'default'              => array(),
 			),
 			'output_schema'       => array(
 				'type'                 => 'object',


### PR DESCRIPTION
JSON schame does not supports a top level default as we are currently doing, this causes problems when the schema is used in a validator.

cc: @gziolo I think it would be good to have this in 6.9 as the current input scheme we are using is not valid and does not work with a validator.

## Testing
Enable the abilities api package so you have the client side wp.abilities object and validation.
Apply the following patch (it fixes a different issue in the client code which is being proposed at https://github.com/WordPress/abilities-api/pull/142):
```
diff --git a/packages/client/src/validation.ts b/packages/client/src/validation.ts
index 030da40..62d3c1a 100644
--- a/packages/client/src/validation.ts
+++ b/packages/client/src/validation.ts
@@ -168,9 +168,9 @@ export function validateValueFromSchema(
 	}
 
 	try {
 		const validate = ajv.compile( args );
-		const valid = validate( value );
+		const valid = validate( value || {} );
 
 		if ( valid ) {
 			return true;
 		}

```
Paste the following code on the browser console:
```
const envInfoAbility = await wp.abilities.getAbility(
	'core/get-site-info'
);
const envInfoResult = await wp.abilities.executeAbility(
	'core/get-site-info'
);
await wp.abilities.registerAbility( {
	...envInfoAbility,
	name: 'core/get-site-info-cli',
	callback: () => envInfoResult,
} );
await wp.abilities.executeAbility( 'core/get-site-info-cli' );
```
It registers a 'core/get-site-info-cli client ability exactly the same as the server one.
Verify things work well.
Paste the same code on trunk and verify there is this error and the ability does not works:

validation.ts:195 Schema compilation error: Error: strict mode: default is ignored in the schema root
    at checkStrictMode (util.js:174:1)
    at checkNoDefault (index.js:139:1)
    at index.js:65:1
    at CodeGen.code (index.js:439:1)
    at index.js:37:101
    at CodeGen.code (index.js:439:1)
    at CodeGen.func (index.js:587:1)
    at validateFunction (index.js:37:1)
    at topSchemaObjCode (index.js:62:1)
    at validateFunctionCode (index.js:21:1)
