### PR TITLE
Add theme.json path to index block template paths

### DIFF
--- a/src/wp-includes/class-wp-theme.php
+++ b/src/wp-includes/class-wp-theme.php
@@ -1583,6 +1583,7 @@ final class WP_Theme implements ArrayAccess {
 		$paths_to_index_block_template = array(
 			$this->get_file_path( '/templates/index.html' ),
 			$this->get_file_path( '/block-templates/index.html' ),
+			$this->get_file_path( 'theme.json' ),
 		);
 
 		$this->block_theme = false;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: [64241](https://core.trac.wordpress.org/ticket/64241)

Summary:
Added an additional check to improve block theme detection.

Details:
Previously, block theme detection checked for the existence of:

/templates/index.html

/block-templates/index.html

This update adds a new path check for theme.json located in the theme’s root folder. The presence of this file is now also used to identify block themes.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
