### PR TITLE
Fix: Core abilities schemas.

### DIFF
--- a/src/wp-includes/abilities.php
+++ b/src/wp-includes/abilities.php
@@ -100,8 +100,7 @@ function wp_register_core_abilities(): void {
 					),
 				),
 				'additionalProperties' => false,
-				// Casting to object so when it is serilized to JSON it shows as {} instead of [].
-				'default'              => (object) array(),
+				'default'              => array(),
 			),
 			'output_schema'       => array(
 				'type'                 => 'object',

--- a/src/wp-includes/abilities.php
+++ b/src/wp-includes/abilities.php
@@ -100,7 +100,8 @@ function wp_register_core_abilities(): void {
 					),
 				),
 				'additionalProperties' => false,
-				'default'              => array(),
+				// Casting to object so when it is serilized to JSON it shows as {} instead of [].
+				'default'              => (object) array(),
 			),
 			'output_schema'       => array(
 				'type'                 => 'object',
@@ -220,7 +221,6 @@ function wp_register_core_abilities(): void {
 					'db_server_info' => array(
 						'type'        => 'string',
 						'description' => __( 'The database server vendor and version string reported by the driver.' ),
-						'examples'    => array( '8.0.34', '10.11.6-MariaDB' ),
 					),
 					'wp_version'     => array(
 						'type'        => 'string',

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
@@ -214,6 +214,21 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 			'meta'          => $ability->get_meta(),
 		);
 
+		// Convert top-level defaults to an object when its type is object and
+		// they are an empty array so they get serialized as {} instead of [].
+		if ( isset( $data['input_schema']['type'] ) && 'object' === $data['input_schema']['type'] && isset( $data['input_schema']['default'] ) ) {
+			$default = $data['input_schema']['default'];
+			if ( is_array( $default ) && empty( $default ) ) {
+				$data['input_schema']['default'] = (object) $default;
+			}
+		}
+		if ( isset( $data['output_schema']['type'] ) && 'object' === $data['output_schema']['type'] && isset( $data['output_schema']['default'] ) ) {
+			$default = $data['output_schema']['default'];
+			if ( is_array( $default ) && empty( $default ) ) {
+				$data['output_schema']['default'] = (object) $default;
+			}
+		}
+
 		$context = $request['context'] ?? 'view';
 		$data    = $this->add_additional_fields_to_object( $data, $request );
 		$data    = $this->filter_response_by_context( $data, $context );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-abilities-v1-list-controller.php
@@ -195,6 +195,27 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 	}
 
 	/**
+	 * Normalizes schema empty object defaults.
+	 *
+	 * Converts empty array defaults to objects when the schema type is 'object'
+	 * to ensure proper JSON serialization as {} instead of [].
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param array<string, mixed> $schema The schema array.
+	 * @return array<string, mixed> The normalized schema.
+	 */
+	private function normalize_schema_empty_object_defaults( array $schema ): array {
+		if ( isset( $schema['type'] ) && 'object' === $schema['type'] && isset( $schema['default'] ) ) {
+			$default = $schema['default'];
+			if ( is_array( $default ) && empty( $default ) ) {
+				$schema['default'] = (object) $default;
+			}
+		}
+		return $schema;
+	}
+
+	/**
 	 * Prepares an ability for response.
 	 *
 	 * @since 6.9.0
@@ -209,25 +230,10 @@ class WP_REST_Abilities_V1_List_Controller extends WP_REST_Controller {
 			'label'         => $ability->get_label(),
 			'description'   => $ability->get_description(),
 			'category'      => $ability->get_category(),
-			'input_schema'  => $ability->get_input_schema(),
-			'output_schema' => $ability->get_output_schema(),
+			'input_schema'  => $this->normalize_schema_empty_object_defaults( $ability->get_input_schema() ),
+			'output_schema' => $this->normalize_schema_empty_object_defaults( $ability->get_output_schema() ),
 			'meta'          => $ability->get_meta(),
 		);
-
-		// Convert top-level defaults to an object when its type is object and
-		// they are an empty array so they get serialized as {} instead of [].
-		if ( isset( $data['input_schema']['type'] ) && 'object' === $data['input_schema']['type'] && isset( $data['input_schema']['default'] ) ) {
-			$default = $data['input_schema']['default'];
-			if ( is_array( $default ) && empty( $default ) ) {
-				$data['input_schema']['default'] = (object) $default;
-			}
-		}
-		if ( isset( $data['output_schema']['type'] ) && 'object' === $data['output_schema']['type'] && isset( $data['output_schema']['default'] ) ) {
-			$default = $data['output_schema']['default'];
-			if ( is_array( $default ) && empty( $default ) ) {
-				$data['output_schema']['default'] = (object) $default;
-			}
-		}
 
 		$context = $request['context'] ?? 'view';
 		$data    = $this->add_additional_fields_to_object( $data, $request );

--- a/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
@@ -68,7 +68,7 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 
 		$this->assertSame( 'object', $input_schema['type'] );
 		$this->assertArrayHasKey( 'default', $input_schema );
-		$this->assertEquals( (object) array(), $input_schema['default'] );
+		$this->assertSame( array(), $input_schema['default'] );
 
 		// Input schema should have optional fields array.
 		$this->assertArrayHasKey( 'fields', $input_schema['properties'] );

--- a/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
@@ -68,7 +68,7 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 
 		$this->assertSame( 'object', $input_schema['type'] );
 		$this->assertArrayHasKey( 'default', $input_schema );
-		$this->assertSame( array(), $input_schema['default'] );
+		$this->assertEquals( (object) array(), $input_schema['default'] );
 
 		// Input schema should have optional fields array.
 		$this->assertArrayHasKey( 'fields', $input_schema['properties'] );


### PR DESCRIPTION
Supersede: https://github.com/WordPress/wordpress-develop/pull/10508

This PR fixes two issues with the schema of our core abilities:
- It includes examples, which is not compliant with the draft-04 JSON schema we are using, causing problems when the schema is used on client validation.
- One of the defaults is an empty array that gets passed to the client as [] and not {}. When [] is validated on the client it is not a valid input and things fail.

cc: @gziolo 

Ticket: https://core.trac.wordpress.org/ticket/64252

## Testing

On the browser console execute:
wp.apiFetch({ path: '/wp-abilities/v1/abilities/'} ).then(console.log);

Verify ability core/get-environment-info has no examples on the output schema.
Verify core/get-site-info input schema default is {} and not [].

Test abilities API plugin with PR https://github.com/WordPress/abilities-api/pull/144, do the testing instructions of that PR and verify things worked.