### PR TITLE
Add a `post-branching` Grunt task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,6 +59,22 @@ module.exports = function(grunt) {
 			'!wp-includes/assets/script-modules-packages.min.php',
 		],
 
+		// All workflow files that should be deleted in old branches.
+		workflowFiles = [
+			// Reusable workflows should only be called from `trunk` in branches.
+			'.github/workflows/reusable-*.yml',
+			// These workflows are only intended to run from `trunk`.
+			'.github/workflows/commit-built-file-changes.yml',
+			'.github/workflows/failed-workflow.yml',
+			'.github/workflows/install-testing.yml',
+			'.github/workflows/test-and-zip-default-themes.yml',
+			'.github/workflows/install-testing.yml',
+			'.github/workflows/slack-notifications.yml',
+			'.github/workflows/test-coverage.yml',
+			'.github/workflows/test-old-branches.yml',
+			'.github/workflows/upgrade-testing.yml'
+		]
+
 		// Prepend `dir` to `file`, and keep `!` in place.
 		setFilePath = function( dir, file ) {
 			if ( '!' === file.charAt( 0 ) ) {
@@ -219,20 +235,15 @@ module.exports = function(grunt) {
 			qunit: ['tests/qunit/compiled.html'],
 
 			// This is only meant to run within a numbered branch after branching has occurred.
-			workflows: [
-				// Reusable workflows should only be called from `trunk` in branches.
-				'.github/workflows/reusable-*.yml',
-				// These workflows are only intended to run from `trunk`. Delete them to avoid any confusion.
-				'.github/workflows/commit-built-file-changes.yml',
-				'.github/workflows/failed-workflow.yml',
-				'.github/workflows/install-testing.yml',
-				'.github/workflows/test-and-zip-default-themes.yml',
-				'.github/workflows/install-testing.yml',
-				'.github/workflows/slack-notifications.yml',
-				'.github/workflows/test-coverage.yml',
-				'.github/workflows/test-old-branches.yml',
-				'.github/workflows/upgrade-testing.yml'
-			]
+			workflows: {
+				filter: function( filepath ) {
+					var allowedTasks = [ 'post-branching', 'clean:workflows' ];
+					return allowedTasks.some( function( task ) {
+						return grunt.cli.tasks.indexOf( task ) !== -1;
+					} );
+				},
+				src: workflowFiles
+			},
 		},
 		file_append: {
 			// grunt-file-append supports only strings for input and output.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -73,7 +73,7 @@ module.exports = function(grunt) {
 			'.github/workflows/test-coverage.yml',
 			'.github/workflows/test-old-branches.yml',
 			'.github/workflows/upgrade-testing.yml'
-		]
+		],
 
 		// Prepend `dir` to `file`, and keep `!` in place.
 		setFilePath = function( dir, file ) {
@@ -236,7 +236,7 @@ module.exports = function(grunt) {
 
 			// This is only meant to run within a numbered branch after branching has occurred.
 			workflows: {
-				filter: function( filepath ) {
+				filter: function() {
 					var allowedTasks = [ 'post-branching', 'clean:workflows' ];
 					return allowedTasks.some( function( task ) {
 						return grunt.cli.tasks.indexOf( task ) !== -1;

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -218,7 +218,7 @@ module.exports = function(grunt) {
 			},
 			qunit: ['tests/qunit/compiled.html'],
 
-			// This is only meant to run within a numberd branch after branching has occurred.
+			// This is only meant to run within a numbered branch after branching has occurred.
 			workflows: [
 				// Reusable workflows should only be called from `trunk` in branches.
 				'.github/workflows/reusable-*.yml',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -216,7 +216,23 @@ module.exports = function(grunt) {
 				cwd: WORKING_DIR,
 				src: []
 			},
-			qunit: ['tests/qunit/compiled.html']
+			qunit: ['tests/qunit/compiled.html'],
+
+			// This is only meant to run within a numberd branch after branching has occurred.
+			workflows: [
+				// Reusable workflows should only be called from `trunk` in branches.
+				'.github/workflows/reusable-*.yml',
+				// These workflows are only intended to run from `trunk`. Delete them to avoid any confusion.
+				'.github/workflows/commit-built-file-changes.yml',
+				'.github/workflows/failed-workflow.yml',
+				'.github/workflows/install-testing.yml',
+				'.github/workflows/test-and-zip-default-themes.yml',
+				'.github/workflows/install-testing.yml',
+				'.github/workflows/slack-notifications.yml',
+				'.github/workflows/test-coverage.yml',
+				'.github/workflows/test-old-branches.yml',
+				'.github/workflows/upgrade-testing.yml'
+			]
 		},
 		file_append: {
 			// grunt-file-append supports only strings for input and output.
@@ -1706,6 +1722,11 @@ module.exports = function(grunt) {
 
 	grunt.registerTask( 'replace:workflow-references-remote-to-local', [
 		'copy:workflow-references-remote-to-local',
+	]);
+
+	grunt.registerTask( 'post-branching', [
+		'clean:workflows',
+		'replace:workflow-references-local-to-remote'
 	]);
 
 	/**


### PR DESCRIPTION
This new `post-branching` task is meant for any tasks that should be run immediately after creating a new numbered branch. Currently, this only consists of GitHub Actions-related tasks.

In addition to the pre-existing `replace:workflow-references-local-to-remote` task, a new `clean:workflows` task is being added that deletes the workflow files that are only intended for `trunk`.

See https://github.com/WordPress/wordpress-develop/commit/983db645469eaeabcc13aa409fcc66f3ed5ac535 for the commit showing post-branching changes for the 6.8 branch.

Trac ticket: Core-64227

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
