### PR TITLE
dashboard confuses published posts count with all posts

### DIFF
--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -309,17 +309,24 @@ function wp_dashboard_right_now() {
 		if ( $num_posts && $num_posts->publish ) {
 			if ( 'post' === $post_type ) {
 				/* translators: %s: Number of posts. */
-				$text = _n( '%s Published post', '%s Published posts', $num_posts->publish );
+				$text = _n( '%s Published Post', '%s Published Posts', $num_posts->publish );
 			} else {
 				/* translators: %s: Number of pages. */
-				$text = _n( '%s Published page', '%s Published pages', $num_posts->publish );
+				$text = _n( '%s Published Page', '%s Published Pages', $num_posts->publish );
 			}
 
 			$text             = sprintf( $text, number_format_i18n( $num_posts->publish ) );
 			$post_type_object = get_post_type_object( $post_type );
 
 			if ( $post_type_object && current_user_can( $post_type_object->cap->edit_posts ) ) {
-				printf( '<li class="%1$s-count"><a href="edit.php?post_status=publish&post_type=%1$s">%2$s</a></li>', $post_type, $text );
+				$url = add_query_arg(
+					array(
+						'post_status' => 'publish',
+						'post_type'   => $post_type,
+					),
+					admin_url( 'edit.php' )
+				);
+				printf( '<li class="%1$s-count"><a href="%1$s">%2$s</a></li>', esc_url( $url ), esc_html( $text ) );
 			} else {
 				printf( '<li class="%1$s-count"><span>%2$s</span></li>', $post_type, $text );
 			}

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -309,17 +309,17 @@ function wp_dashboard_right_now() {
 		if ( $num_posts && $num_posts->publish ) {
 			if ( 'post' === $post_type ) {
 				/* translators: %s: Number of posts. */
-				$text = _n( '%s Post', '%s Posts', $num_posts->publish );
+				$text = _n( '%s Published post', '%s Published posts', $num_posts->publish );
 			} else {
 				/* translators: %s: Number of pages. */
-				$text = _n( '%s Page', '%s Pages', $num_posts->publish );
+				$text = _n( '%s Published page', '%s Published pages', $num_posts->publish );
 			}
 
 			$text             = sprintf( $text, number_format_i18n( $num_posts->publish ) );
 			$post_type_object = get_post_type_object( $post_type );
 
 			if ( $post_type_object && current_user_can( $post_type_object->cap->edit_posts ) ) {
-				printf( '<li class="%1$s-count"><a href="edit.php?post_type=%1$s">%2$s</a></li>', $post_type, $text );
+				printf( '<li class="%1$s-count"><a href="edit.php?post_status=publish&post_type=%1$s">%2$s</a></li>', $post_type, $text );
 			} else {
 				printf( '<li class="%1$s-count"><span>%2$s</span></li>', $post_type, $text );
 			}

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -309,10 +309,10 @@ function wp_dashboard_right_now() {
 		if ( $num_posts && $num_posts->publish ) {
 			if ( 'post' === $post_type ) {
 				/* translators: %s: Number of posts. */
-				$text = _n( '%s Published Post', '%s Published Posts', $num_posts->publish );
+				$text = _n( '%s Published post', '%s Published posts', $num_posts->publish );
 			} else {
 				/* translators: %s: Number of pages. */
-				$text = _n( '%s Published Page', '%s Published Pages', $num_posts->publish );
+				$text = _n( '%s Published page', '%s Published pages', $num_posts->publish );
 			}
 
 			$text             = sprintf( $text, number_format_i18n( $num_posts->publish ) );


### PR DESCRIPTION
This ticked poped in the last bug scrub

The comments between joe and myself were basically:

1. Should we make consistent what we see and what we actually received? In this case we should be linking to the published, as the OP suggests
2. Also Joe commented, that we already have a link to all posts in the nav bar, so this could add a different value
3. I wanted to add, that knowing exactly where the link was pointing could be an improvement in the copy (adding "Published")

With these 3 elements here is the patch

Note: The comments have already the right link, so we are not touching this.

Trac ticket: https://core.trac.wordpress.org/ticket/43084

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
