### PR TITLE
Fix: Custom font size taking over fit text.

### DIFF
--- a/src/wp-includes/block-supports/typography.php
+++ b/src/wp-includes/block-supports/typography.php
@@ -306,7 +306,7 @@ function wp_typography_get_preset_inline_style_value( $style_value, $css_propert
  * @return string Filtered block content.
  */
 function wp_render_typography_support( $block_content, $block ) {
-	if ( ! empty( $block['attrs']['fitText'] ) && ! is_admin() ) {
+	if ( ! empty( $block['attrs']['fitText'] ) && $block['attrs']['fitText'] && ! is_admin() ) {
 		wp_enqueue_script_module( '@wordpress/block-editor/utils/fit-text-frontend' );
 
 		// Add Interactivity API directives for fit text to work with client-side navigation.
@@ -322,6 +322,8 @@ function wp_render_typography_support( $block_content, $block ) {
 				$block_content = $processor->get_updated_html();
 			}
 		}
+		// fitText supersedes any other typography features
+		return $block_content;
 	}
 	if ( ! isset( $block['attrs']['style']['typography']['fontSize'] ) ) {
 		return $block_content;


### PR DESCRIPTION
Backports https://github.com/WordPress/gutenberg/pull/73241 into the core.

Fixes an issue where if a paragraph/heading had a custom font size and then was conververted to the stretchy variation. The custom font size on the front end was applied instead of fit text.

cc: @mrwweb

Ticket: https://core.trac.wordpress.org/ticket/64254

## Testing
Insert Paragraph block
Type some text in it
Set a non-default font size for the Paragraph block
Switch the Paragraph to the fit text Paragraph variation
The front-end of the site should not use the font size setting selected in Step 3 and should instead show fit text working normally as in the editor.
