### PR TITLE
Improve single comment endpoint read permissions checks

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -1890,7 +1890,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	 * @return bool Whether the comment can be read.
 	 */
 	protected function check_read_permission( $comment, $request ) {
-		if ( 'comment' === $comment->comment_type && ! empty( $comment->comment_post_ID ) ) {
+		if ( 'note' !== $comment->comment_type && ! empty( $comment->comment_post_ID ) ) {
 			$post = get_post( $comment->comment_post_ID );
 			if ( $post ) {
 				if ( $this->check_read_post_permission( $post, $request ) && 1 === (int) $comment->comment_approved ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -123,20 +123,14 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	 * @return true|WP_Error True if the request has read access, error object otherwise.
 	 */
 	public function get_items_permissions_check( $request ) {
-		$is_note         = 'note' === $request['type'];
-		$is_edit_context = 'edit' === $request['context'];
+		$is_note          = 'note' === $request['type'];
+		$is_edit_context  = 'edit' === $request['context'];
+		$protected_params = array( 'author', 'author_exclude', 'author_email', 'type', 'status' );
+		$forbidden_params = array();
 
 		if ( ! empty( $request['post'] ) ) {
 			foreach ( (array) $request['post'] as $post_id ) {
 				$post = get_post( $post_id );
-
-				if ( $post && $is_note && ! $this->check_post_type_supports_notes( $post->post_type ) ) {
-					return new WP_Error(
-						'rest_comment_not_supported_post_type',
-						__( 'Sorry, this post type does not support notes.' ),
-						array( 'status' => 403 )
-					);
-				}
 
 				if ( ! empty( $post_id ) && $post && ! $this->check_read_post_permission( $post, $request ) ) {
 					return new WP_Error(
@@ -148,6 +142,36 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 					return new WP_Error(
 						'rest_cannot_read',
 						__( 'Sorry, you are not allowed to read comments without a post.' ),
+						array( 'status' => rest_authorization_required_code() )
+					);
+				}
+
+				if ( $post && $is_note && ! $this->check_post_type_supports_notes( $post->post_type ) ) {
+					if ( current_user_can( get_post_type_object( $post->post_type )->cap->edit_posts ) ) {
+						return new WP_Error(
+							'rest_comment_not_supported_post_type',
+							__( 'Sorry, this post type does not support notes.' ),
+							array( 'status' => 403 )
+						);
+					}
+
+					foreach ( $protected_params as $param ) {
+						if ( 'status' === $param ) {
+							if ( 'approve' !== $request[ $param ] ) {
+								$forbidden_params[] = $param;
+							}
+						} elseif ( 'type' === $param ) {
+							if ( 'comment' !== $request[ $param ] ) {
+								$forbidden_params[] = $param;
+							}
+						} elseif ( ! empty( $request[ $param ] ) ) {
+							$forbidden_params[] = $param;
+						}
+					}
+					return new WP_Error(
+						'rest_forbidden_param',
+						/* translators: %s: List of forbidden parameters. */
+						sprintf( __( 'Query parameter not permitted: %s' ), implode( ', ', $forbidden_params ) ),
 						array( 'status' => rest_authorization_required_code() )
 					);
 				}
@@ -174,23 +198,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		}
 
 		if ( ! current_user_can( 'edit_posts' ) ) {
-			$protected_params = array( 'author', 'author_exclude', 'author_email', 'type', 'status' );
-			$forbidden_params = array();
-
-			foreach ( $protected_params as $param ) {
-				if ( 'status' === $param ) {
-					if ( 'approve' !== $request[ $param ] ) {
-						$forbidden_params[] = $param;
-					}
-				} elseif ( 'type' === $param ) {
-					if ( 'comment' !== $request[ $param ] ) {
-						$forbidden_params[] = $param;
-					}
-				} elseif ( ! empty( $request[ $param ] ) ) {
-					$forbidden_params[] = $param;
-				}
-			}
-
 			if ( ! empty( $forbidden_params ) ) {
 				return new WP_Error(
 					'rest_forbidden_param',

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -198,6 +198,20 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 		}
 
 		if ( ! current_user_can( 'edit_posts' ) ) {
+			foreach ( $protected_params as $param ) {
+				if ( 'status' === $param ) {
+					if ( 'approve' !== $request[ $param ] ) {
+						$forbidden_params[] = $param;
+					}
+				} elseif ( 'type' === $param ) {
+					if ( 'comment' !== $request[ $param ] ) {
+						$forbidden_params[] = $param;
+					}
+				} elseif ( ! empty( $request[ $param ] ) ) {
+					$forbidden_params[] = $param;
+				}
+			}
+
 			if ( ! empty( $forbidden_params ) ) {
 				return new WP_Error(
 					'rest_forbidden_param',

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -147,7 +147,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 				}
 
 				if ( $post && $is_note && ! $this->check_post_type_supports_notes( $post->post_type ) ) {
-					if ( current_user_can( get_post_type_object( $post->post_type )->cap->edit_posts ) ) {
+					if ( current_user_can( 'edit_post', $post->ID ) {
 						return new WP_Error(
 							'rest_comment_not_supported_post_type',
 							__( 'Sorry, this post type does not support notes.' ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -1890,6 +1890,10 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	 * @return bool Whether the comment can be read.
 	 */
 	protected function check_read_permission( $comment, $request ) {
+		if ( 0 === get_current_user_id() ) {
+			return false;
+		}
+
 		if ( ! empty( $comment->comment_post_ID ) ) {
 			$post = get_post( $comment->comment_post_ID );
 			if ( $post ) {
@@ -1897,10 +1901,6 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 					return true;
 				}
 			}
-		}
-
-		if ( 0 === get_current_user_id() ) {
-			return false;
 		}
 
 		if ( empty( $comment->comment_post_ID ) && ! current_user_can( 'moderate_comments' ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -147,7 +147,7 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 				}
 
 				if ( $post && $is_note && ! $this->check_post_type_supports_notes( $post->post_type ) ) {
-					if ( current_user_can( 'edit_post', $post->ID ) {
+					if ( current_user_can( 'edit_post', $post->ID ) ) {
 						return new WP_Error(
 							'rest_comment_not_supported_post_type',
 							__( 'Sorry, this post type does not support notes.' ),

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php
@@ -1890,17 +1890,17 @@ class WP_REST_Comments_Controller extends WP_REST_Controller {
 	 * @return bool Whether the comment can be read.
 	 */
 	protected function check_read_permission( $comment, $request ) {
-		if ( 0 === get_current_user_id() ) {
-			return false;
-		}
-
-		if ( ! empty( $comment->comment_post_ID ) ) {
+		if ( 'comment' === $comment->comment_type && ! empty( $comment->comment_post_ID ) ) {
 			$post = get_post( $comment->comment_post_ID );
 			if ( $post ) {
 				if ( $this->check_read_post_permission( $post, $request ) && 1 === (int) $comment->comment_approved ) {
 					return true;
 				}
 			}
+		}
+
+		if ( 0 === get_current_user_id() ) {
+			return false;
 		}
 
 		if ( empty( $comment->comment_post_ID ) && ! current_user_can( 'moderate_comments' ) ) {

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -4140,6 +4140,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	 */
 	public function data_comment_type_provider() {
 		return array(
+			'comment type'    => array( 'comment', 5 ),
 			'annotation type' => array( 'annotation', 5 ),
 			'discussion type' => array( 'discussion', 9 ),
 			'note type'       => array( 'note', 3 ),
@@ -4172,12 +4173,13 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 		$request->set_param( 'type', $comment_type );
+		$request->set_param( 'per_page', self::$per_page );
 
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 
 		$comments = $response->get_data();
-		$this->assertCount( $count, $comments );
+		$this->assertCount( 'comment' === $comment_type ? $count + self::$total_comments: $count, $comments );
 	}
 
 	/**
@@ -4212,8 +4214,10 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$request->set_param( 'per_page', self::$per_page );
 
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertEquals( 401, $response->get_status() );
-		$this->assertErrorResponse( 'rest_forbidden_param', $response, 401 );
+		$this->assertEquals( 'comment' === $comment_type ? 200 : 401, $response->get_status() );
+		if ( 'comment' !== $comment_type ) {
+			$this->assertErrorResponse( 'rest_forbidden_param', $response, 401 );
+		}
 	}
 
 	/**
@@ -4244,6 +4248,9 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%d', $comment_id ) );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertEquals( 401, $response->get_status() );
+		$this->assertEquals( 'comment' === $comment_type ? 200 : 401, $response->get_status() );
+		if ( 'comment' !== $comment_type ) {
+			$this->assertErrorResponse( 'rest_cannot_read', $response, 401 );
+		}
 	}
 }

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -4150,19 +4150,19 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'post_id'          => self::$post_id,
 		);
 
-		$count_1 = 5;
+		$count_1              = 5;
 		$args['comment_type'] = $comment_type_1;
 		for ( $i = 0; $i < $count_1; $i++ ) {
 			self::factory()->comment->create( $args );
 		}
 
-		$count_2 = 9;
+		$count_2              = 9;
 		$args['comment_type'] = $comment_type_2;
 		for ( $i = 0; $i < $count_2; $i++ ) {
 			self::factory()->comment->create( $args );
 		}
 
-		$count_3 = 3;
+		$count_3              = 3;
 		$args['comment_type'] = $note_comment_type;
 		for ( $i = 0; $i < $count_3; $i++ ) {
 			self::factory()->comment->create( $args );
@@ -4206,7 +4206,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertErrorResponse( 'rest_forbidden_param', $response, 401 );
 
 		$request->set_param( 'comment_type', $note_comment_type );
-		foreach( $note_type_ids as $note_type_id ) {
+		foreach ( $note_type_ids as $note_type_id ) {
 			$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%d', $note_type_id ) );
 			$response = rest_get_server()->dispatch( $request );
 			$this->assertEquals( 401, $response->get_status() );

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -4137,16 +4137,13 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	 * Test comment permissions.
 	 *
 	 * @ticket 44157
-	 *
-	 * @return void
 	 */
 	public function test_get_items_type_arg() {
-		// Authorized admin user.
 		wp_set_current_user( self::$admin_id );
-		$comment_type_1 = 'annotation';
-		$comment_type_2 = 'discussion';
-		$comment_type_3 = 'note';
-		$args           = array(
+		$comment_type_1    = 'annotation';
+		$comment_type_2    = 'discussion';
+		$note_comment_type = 'note';
+		$args              = array(
 			'comment_approved' => 1,
 			'comment_post_ID'  => self::$post_id,
 			'user_id'          => self::$author_id,
@@ -4166,7 +4163,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		}
 
 		$count_3 = 3;
-		$args['comment_type'] = $comment_type_3;
+		$args['comment_type'] = $note_comment_type;
 		for ( $i = 0; $i < $count_3; $i++ ) {
 			self::factory()->comment->create( $args );
 		}
@@ -4174,7 +4171,6 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
 		$request->set_param( 'type', $comment_type_1 );
 
-		// Admin user and no type gets the two comments of comment type 'all' (the default).
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$comments = $response->get_data();
@@ -4185,16 +4181,17 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( 200, $response->get_status() );
 		$comments = $response->get_data();
 		$this->assertCount( $count_2, $comments );
-		$comment_type_ids = wp_list_pluck( $comments, 'id' ); // So we can iterate through them later :) .
+		$comment_type_ids = wp_list_pluck( $comments, 'id' );
 
-		$request->set_param( 'type', $comment_type_3 );
+		$request->set_param( 'type', $note_comment_type );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 		$comments = $response->get_data();
 		$this->assertCount( $count_3, $comments );
+		$note_type_ids = wp_list_pluck( $comments, 'id' );
 
-		// Unset the current user.
-		wp_set_current_user( null );
+		// Log out the current user.
+		wp_logout();
 
 		$request->set_param( 'type', 'comments' );
 		$request->set_param( 'per_page', self::$per_page );
@@ -4203,12 +4200,19 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$comments = $response->get_data();
 		$this->assertErrorResponse( 'rest_forbidden_param', $response, 401 );
 
-		$request->set_param( 'type', $comment_type_2 );
+		$request->set_param( 'comment_type', $comment_type_2 );
 		$response = rest_get_server()->dispatch( $request );
 		$comments = $response->get_data();
 		$this->assertErrorResponse( 'rest_forbidden_param', $response, 401 );
 
-		// But the unauthenticated user can see them at their individual endpoints.
+		$request->set_param( 'comment_type', $note_comment_type );
+		foreach( $note_type_ids as $note_type_id ) {
+			$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%d', $note_type_id ) );
+			$response = rest_get_server()->dispatch( $request );
+			$this->assertEquals( 401, $response->get_status() );
+		}
+
+		// Custom comment types should also not be visible to unauthenticated users.
 		foreach ( $comment_type_ids as $comment_type_id ) {
 			$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%d', $comment_type_id ) );
 			$response = rest_get_server()->dispatch( $request );

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -4134,89 +4134,116 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertStringContainsString( 'type=note', $children[0]['href'] );
 	}
 	/**
-	 * Test comment permissions.
+	 * Data provider for comment type tests.
 	 *
-	 * @ticket 44157
+	 * @return array
 	 */
-	public function test_get_items_type_arg() {
+	public function data_comment_type_provider() {
+		return array(
+			'annotation type' => array( 'annotation', 5 ),
+			'discussion type' => array( 'discussion', 9 ),
+			'note type'       => array( 'note', 3 ),
+		);
+	}
+
+	/**
+	 * Test retrieving comments by type as authenticated user.
+	 *
+	 * @dataProvider data_comment_type_provider
+	 * @ticket 44157
+	 *
+	 * @param string $comment_type The comment type to test.
+	 * @param int    $count        The number of comments to create.
+	 */
+	public function test_get_items_type_arg_authenticated( $comment_type, $count ) {
 		wp_set_current_user( self::$admin_id );
-		$comment_type_1    = 'annotation';
-		$comment_type_2    = 'discussion';
-		$note_comment_type = 'note';
-		$args              = array(
+
+		$args = array(
 			'comment_approved' => 1,
 			'comment_post_ID'  => self::$post_id,
 			'user_id'          => self::$author_id,
-			'post_id'          => self::$post_id,
+			'comment_type'     => $comment_type,
 		);
 
-		$count_1              = 5;
-		$args['comment_type'] = $comment_type_1;
-		for ( $i = 0; $i < $count_1; $i++ ) {
-			self::factory()->comment->create( $args );
-		}
-
-		$count_2              = 9;
-		$args['comment_type'] = $comment_type_2;
-		for ( $i = 0; $i < $count_2; $i++ ) {
-			self::factory()->comment->create( $args );
-		}
-
-		$count_3              = 3;
-		$args['comment_type'] = $note_comment_type;
-		for ( $i = 0; $i < $count_3; $i++ ) {
+		// Create comments of the specified type.
+		for ( $i = 0; $i < $count; $i++ ) {
 			self::factory()->comment->create( $args );
 		}
 
 		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
-		$request->set_param( 'type', $comment_type_1 );
+		$request->set_param( 'type', $comment_type );
 
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
-		$comments = $response->get_data();
-		$this->assertCount( $count_1, $comments );
 
-		$request->set_param( 'type', $comment_type_2 );
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
 		$comments = $response->get_data();
-		$this->assertCount( $count_2, $comments );
-		$comment_type_ids = wp_list_pluck( $comments, 'id' );
+		$this->assertCount( $count, $comments );
+	}
 
-		$request->set_param( 'type', $note_comment_type );
-		$response = rest_get_server()->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
-		$comments = $response->get_data();
-		$this->assertCount( $count_3, $comments );
-		$note_type_ids = wp_list_pluck( $comments, 'id' );
+	/**
+	 * Test retrieving comments by type as unauthenticated user.
+	 *
+	 * @dataProvider data_comment_type_provider
+	 * @ticket 44157
+	 *
+	 * @param string $comment_type The comment type to test.
+	 * @param int    $count        The number of comments to create.
+	 */
+	public function test_get_items_type_arg_unauthenticated( $comment_type, $count ) {
+		// First, create comments as admin.
+		wp_set_current_user( self::$admin_id );
 
-		// Log out the current user.
+		$args = array(
+			'comment_approved' => 1,
+			'comment_post_ID'  => self::$post_id,
+			'user_id'          => self::$author_id,
+			'comment_type'     => $comment_type,
+		);
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			self::factory()->comment->create( $args );
+		}
+
+		// Log out and test as unauthenticated user.
 		wp_logout();
 
-		$request->set_param( 'type', 'comments' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$request->set_param( 'type', $comment_type );
 		$request->set_param( 'per_page', self::$per_page );
+
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
-		$comments = $response->get_data();
 		$this->assertErrorResponse( 'rest_forbidden_param', $response, 401 );
+	}
 
-		$request->set_param( 'comment_type', $comment_type_2 );
+	/**
+	 * Test retrieving individual comments by type as unauthenticated user.
+	 *
+	 * @dataProvider data_comment_type_provider
+	 * @ticket 44157
+	 *
+	 * @param string $comment_type The comment type to test.
+	 * @param int    $count        The number of comments to create (only 1 used).
+	 */
+	public function test_get_individual_comment_type_unauthenticated( $comment_type, $count ) {
+		// Create a single comment as admin.
+		wp_set_current_user( self::$admin_id );
+
+		$args = array(
+			'comment_approved' => 1,
+			'comment_post_ID'  => self::$post_id,
+			'user_id'          => self::$author_id,
+			'comment_type'     => $comment_type,
+		);
+
+		$comment_id = self::factory()->comment->create( $args );
+
+		// Log out and test as unauthenticated user.
+		wp_logout();
+
+		$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%d', $comment_id ) );
 		$response = rest_get_server()->dispatch( $request );
-		$comments = $response->get_data();
-		$this->assertErrorResponse( 'rest_forbidden_param', $response, 401 );
 
-		$request->set_param( 'comment_type', $note_comment_type );
-		foreach ( $note_type_ids as $note_type_id ) {
-			$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%d', $note_type_id ) );
-			$response = rest_get_server()->dispatch( $request );
-			$this->assertEquals( 401, $response->get_status() );
-		}
-
-		// Custom comment types should also not be visible to unauthenticated users.
-		foreach ( $comment_type_ids as $comment_type_id ) {
-			$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%d', $comment_type_id ) );
-			$response = rest_get_server()->dispatch( $request );
-			$this->assertEquals( 401, $response->get_status() );
-		}
+		$this->assertEquals( 401, $response->get_status() );
 	}
 }

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -4133,4 +4133,86 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertStringContainsString( 'status=all', $children[0]['href'] );
 		$this->assertStringContainsString( 'type=note', $children[0]['href'] );
 	}
+	/**
+	 * Test comment permissions.
+	 *
+	 * @ticket 44157
+	 *
+	 * @return void
+	 */
+	public function test_get_items_type_arg() {
+		// Authorized admin user.
+		wp_set_current_user( self::$admin_id );
+		$comment_type_1 = 'annotation';
+		$comment_type_2 = 'discussion';
+		$comment_type_3 = 'note';
+		$args           = array(
+			'comment_approved' => 1,
+			'comment_post_ID'  => self::$post_id,
+			'user_id'          => self::$author_id,
+			'post_id'          => self::$post_id,
+		);
+
+		$count_1 = 5;
+		$args['comment_type'] = $comment_type_1;
+		for ( $i = 0; $i < $count_1; $i++ ) {
+			self::factory()->comment->create( $args );
+		}
+
+		$count_2 = 9;
+		$args['comment_type'] = $comment_type_2;
+		for ( $i = 0; $i < $count_2; $i++ ) {
+			self::factory()->comment->create( $args );
+		}
+
+		$count_3 = 3;
+		$args['comment_type'] = $comment_type_3;
+		for ( $i = 0; $i < $count_3; $i++ ) {
+			self::factory()->comment->create( $args );
+		}
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/comments' );
+		$request->set_param( 'type', $comment_type_1 );
+
+		// Admin user and no type gets the two comments of comment type 'all' (the default).
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$comments = $response->get_data();
+		$this->assertCount( $count_1, $comments );
+
+		$request->set_param( 'type', $comment_type_2 );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$comments = $response->get_data();
+		$this->assertCount( $count_2, $comments );
+		$comment_type_ids = wp_list_pluck( $comments, 'id' ); // So we can iterate through them later :) .
+
+		$request->set_param( 'type', $comment_type_3 );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$comments = $response->get_data();
+		$this->assertCount( $count_3, $comments );
+
+		// Unset the current user.
+		wp_set_current_user( null );
+
+		$request->set_param( 'type', 'comments' );
+		$request->set_param( 'per_page', self::$per_page );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+		$comments = $response->get_data();
+		$this->assertErrorResponse( 'rest_forbidden_param', $response, 401 );
+
+		$request->set_param( 'type', $comment_type_2 );
+		$response = rest_get_server()->dispatch( $request );
+		$comments = $response->get_data();
+		$this->assertErrorResponse( 'rest_forbidden_param', $response, 401 );
+
+		// But the unauthenticated user can see them at their individual endpoints.
+		foreach ( $comment_type_ids as $comment_type_id ) {
+			$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%d', $comment_type_id ) );
+			$response = rest_get_server()->dispatch( $request );
+			$this->assertEquals( 401, $response->get_status() );
+		}
+	}
 }

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -4226,50 +4226,24 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$request->set_param( 'per_page', self::$per_page );
 
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertEquals( 'note' !== $comment_type ? 200 : 401, $response->get_status() );
-		if ( 'note' === $comment_type ) {
+
+		// Only comments can be retrieved from the /comments (multiple) endpoint when unauthenticated.
+		$this->assertEquals( 'comment' === $comment_type ? 200 : 401, $response->get_status() );
+		if ( 'comment' !== $comment_type ) {
 			$this->assertErrorResponse( 'rest_forbidden_param', $response, 401 );
 		}
 
-		// Next, test getting the individual comments.
+		// Individual comments.
 		foreach( $comments as $comment ) {
 			$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%d', $comment ) );
 			$response = rest_get_server()->dispatch( $request );
-			$this->assertEquals( 'note' !== $comment_type ? 200 : 401, $response->get_status() );
+
+			// Individual comments using the /comments/<id> endpoint can (unexpectedly) be
+			// retrieved by unauthenticated users - except for the 'note' type which is restricted.
+			// See https://core.trac.wordpress.org/ticket/44157.
+			$this->assertEquals( 'note' === $comment_type ? 401 : 200, $response->get_status() );
 		}
 	}
 
-	/**
-	 * Test retrieving individual comments by type as unauthenticated user.
-	 *
-	 * @dataProvider data_comment_type_provider
-	 * @ticket 44157
-	 *
-	 * @param string $comment_type The comment type to test.
-	 * @param int    $count        The number of comments to create (only 1 used).
-	 */
-	public function test_get_individual_comment_type_unauthenticated( $comment_type, $count ) {
-		// Create a single comment as admin.
-		wp_set_current_user( self::$admin_id );
 
-		$args = array(
-			'comment_approved' => 1,
-			'comment_post_ID'  => self::$post_id,
-			'user_id'          => self::$author_id,
-			'comment_type'     => $comment_type,
-		);
-
-		$comment_id = self::factory()->comment->create( $args );
-
-		// Log out and test as unauthenticated user.
-		wp_logout();
-
-		$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%d', $comment_id ) );
-		$response = rest_get_server()->dispatch( $request );
-
-		$this->assertEquals( 'comment' === $comment_type ? 200 : 401, $response->get_status() );
-		if ( 'comment' !== $comment_type ) {
-			$this->assertErrorResponse( 'rest_cannot_read', $response, 401 );
-		}
-	}
 }

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -4133,10 +4133,11 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertStringContainsString( 'status=all', $children[0]['href'] );
 		$this->assertStringContainsString( 'type=note', $children[0]['href'] );
 	}
+
 	/**
 	 * Data provider for comment type tests.
 	 *
-	 * @return array
+	 * @return array[] Data provider.
 	 */
 	public function data_comment_type_provider() {
 		return array(

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -4180,6 +4180,16 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 
 		$comments = $response->get_data();
 		$this->assertCount( 'comment' === $comment_type ? $count + self::$total_comments: $count, $comments );
+
+		// Next, test getting the individual comments.
+		foreach( $comments as $comment ) {
+			$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%d', $comment['id'] ) );
+			$response = rest_get_server()->dispatch( $request );
+
+			$this->assertEquals( 200, $response->get_status() );
+			$data = $response->get_data();
+			$this->assertEquals( $comment_type, $data['type'] );
+		}
 	}
 
 	/**
@@ -4202,8 +4212,10 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			'comment_type'     => $comment_type,
 		);
 
+		$comments = array();
+
 		for ( $i = 0; $i < $count; $i++ ) {
-			self::factory()->comment->create( $args );
+			$comments[] = self::factory()->comment->create( $args );
 		}
 
 		// Log out and test as unauthenticated user.
@@ -4217,6 +4229,13 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( 'comment' === $comment_type ? 200 : 401, $response->get_status() );
 		if ( 'comment' !== $comment_type ) {
 			$this->assertErrorResponse( 'rest_forbidden_param', $response, 401 );
+		}
+
+		// Next, test getting the individual comments.
+		foreach( $comments as $comment ) {
+			$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%d', $comment ) );
+			$response = rest_get_server()->dispatch( $request );
+			$this->assertEquals( 'comment' === $comment_type ? 200 : 401, $response->get_status() );
 		}
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -4176,19 +4176,20 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$request->set_param( 'per_page', self::$per_page );
 
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status(), 'Comments endpoint is expected to return a 200 status' );
 
-		$comments = $response->get_data();
-		$this->assertCount( 'comment' === $comment_type ? $count + self::$total_comments : $count, $comments );
+		$comments       = $response->get_data();
+		$expected_count = 'comment' === $comment_type ? $count + self::$total_comments : $count;
+		$this->assertCount( $expected_count, $comments, "comment type '{$comment_type}' is expect to have {$expected_count} comments" );
 
 		// Next, test getting the individual comments.
 		foreach ( $comments as $comment ) {
 			$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%d', $comment['id'] ) );
 			$response = rest_get_server()->dispatch( $request );
 
-			$this->assertEquals( 200, $response->get_status() );
+			$this->assertSame( 200, $response->get_status(), 'Individual comment endpoint is expected to return a 200 status' );
 			$data = $response->get_data();
-			$this->assertEquals( $comment_type, $data['type'] );
+			$this->assertSame( $comment_type, $data['type'], "Individual comment is expected to have type '{$comment_type}'" );
 		}
 	}
 
@@ -4228,9 +4229,10 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$response = rest_get_server()->dispatch( $request );
 
 		// Only comments can be retrieved from the /comments (multiple) endpoint when unauthenticated.
-		$this->assertEquals( 'comment' === $comment_type ? 200 : 401, $response->get_status() );
+		$expected_status = 'comment' === $comment_type ? 200 : 401;
+		$this->assertSame( $expected_status, $response->get_status(), 'Comments endpoint did not return the expected status' );
 		if ( 'comment' !== $comment_type ) {
-			$this->assertErrorResponse( 'rest_forbidden_param', $response, 401 );
+			$this->assertErrorResponse( 'rest_forbidden_param', $response, 401, 'Comments endpoint did not return the expected error response for forbidden parameters' );
 		}
 
 		// Individual comments.
@@ -4241,7 +4243,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			// Individual comments using the /comments/<id> endpoint can (unexpectedly) be
 			// retrieved by unauthenticated users - except for the 'note' type which is restricted.
 			// See https://core.trac.wordpress.org/ticket/44157.
-			$this->assertEquals( 'note' === $comment_type ? 401 : 200, $response->get_status() );
+			$this->assertSame( 'note' === $comment_type ? 401 : 200, $response->get_status(), 'Individual comment endpoint did not return the expected status' );
 		}
 	}
 }

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -4226,8 +4226,8 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$request->set_param( 'per_page', self::$per_page );
 
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertEquals( 'comment' === $comment_type ? 200 : 401, $response->get_status() );
-		if ( 'comment' !== $comment_type ) {
+		$this->assertEquals( 'note' !== $comment_type ? 200 : 401, $response->get_status() );
+		if ( 'note' === $comment_type ) {
 			$this->assertErrorResponse( 'rest_forbidden_param', $response, 401 );
 		}
 
@@ -4235,7 +4235,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		foreach( $comments as $comment ) {
 			$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%d', $comment ) );
 			$response = rest_get_server()->dispatch( $request );
-			$this->assertEquals( 'comment' === $comment_type ? 200 : 401, $response->get_status() );
+			$this->assertEquals( 'note' !== $comment_type ? 200 : 401, $response->get_status() );
 		}
 	}
 

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -4241,8 +4241,8 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%d', $comment ) );
 			$response = rest_get_server()->dispatch( $request );
 
-			// Individual comments using the /comments/<id> endpoint can (unexpectedly) be
-			// retrieved by unauthenticated users - except for the 'note' type which is restricted.
+			// Individual comments using the /comments/<id> endpoint can be retrieved by
+			// unauthenticated users - except for the 'note' type which is restricted.
 			// See https://core.trac.wordpress.org/ticket/44157.
 			$this->assertSame( 'note' === $comment_type ? 401 : 200, $response->get_status(), 'Individual comment endpoint did not return the expected status' );
 		}

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -4179,10 +4179,10 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		$this->assertEquals( 200, $response->get_status() );
 
 		$comments = $response->get_data();
-		$this->assertCount( 'comment' === $comment_type ? $count + self::$total_comments: $count, $comments );
+		$this->assertCount( 'comment' === $comment_type ? $count + self::$total_comments : $count, $comments );
 
 		// Next, test getting the individual comments.
-		foreach( $comments as $comment ) {
+		foreach ( $comments as $comment ) {
 			$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%d', $comment['id'] ) );
 			$response = rest_get_server()->dispatch( $request );
 
@@ -4234,7 +4234,7 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 		}
 
 		// Individual comments.
-		foreach( $comments as $comment ) {
+		foreach ( $comments as $comment ) {
 			$request  = new WP_REST_Request( 'GET', sprintf( '/wp/v2/comments/%d', $comment ) );
 			$response = rest_get_server()->dispatch( $request );
 
@@ -4244,6 +4244,4 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			$this->assertEquals( 'note' === $comment_type ? 401 : 200, $response->get_status() );
 		}
 	}
-
-
 }

--- a/tests/phpunit/tests/rest-api/rest-comments-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-comments-controller.php
@@ -4135,20 +4135,6 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 	}
 
 	/**
-	 * Data provider for comment type tests.
-	 *
-	 * @return array[] Data provider.
-	 */
-	public function data_comment_type_provider() {
-		return array(
-			'comment type'    => array( 'comment', 5 ),
-			'annotation type' => array( 'annotation', 5 ),
-			'discussion type' => array( 'discussion', 9 ),
-			'note type'       => array( 'note', 3 ),
-		);
-	}
-
-	/**
 	 * Test retrieving comments by type as authenticated user.
 	 *
 	 * @dataProvider data_comment_type_provider
@@ -4246,5 +4232,19 @@ class WP_Test_REST_Comments_Controller extends WP_Test_REST_Controller_Testcase 
 			// See https://core.trac.wordpress.org/ticket/44157.
 			$this->assertSame( 'note' === $comment_type ? 401 : 200, $response->get_status(), 'Individual comment endpoint did not return the expected status' );
 		}
+	}
+
+	/**
+	 * Data provider for comment type tests.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public function data_comment_type_provider() {
+		return array(
+			'comment type'    => array( 'comment', 5 ),
+			'annotation type' => array( 'annotation', 5 ),
+			'discussion type' => array( 'discussion', 9 ),
+			'note type'       => array( 'note', 3 ),
+		);
 	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/44157
<!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
