### PR TITLE
Help/About: Spell out abbreviation in About page text

### DIFF
--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -138,7 +138,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 					</svg>
 				</div>
 				<h3><?php _e( 'Performance updates' ); ?></h3>
-				<p><?php _e( 'WordPress 6.9 includes a broad set of performance enhancements. A better <abbr title="Largest Contentful Paint">LCP</abbr> metric is achieved through improved loading of conditional and inlined stylesheets, script loading with fetchpriority support, and additional core optimizations. Editor advances include fixes for layout shifts caused by the Video block and faster loading of the terms selector.' ); ?></p>
+				<p><?php _e( 'WordPress 6.9 includes a broad set of performance enhancements. A better <abbr>LCP</abbr> (Largest Contentful Paint) metric is achieved through improved loading of conditional and inlined stylesheets, script loading with fetchpriority support, and additional core optimizations. Editor advances include fixes for layout shifts caused by the Video block and faster loading of the terms selector.' ); ?></p>
 			</div>
 			<div class="column">
 				<div class="about__image">


### PR DESCRIPTION
The title support on abbr elements is not consistent or accessible, so abbreviations should be spelled out inline in text. This update switches out the title for inline text. Note that I did not pull the HTML out of the string so that the entire thing would be in context, and I don't know if "LCP" is translated in other languages.

<img width="977" height="392" alt="Screenshot 2025-11-17 at 10 08 36 PM" src="https://github.com/user-attachments/assets/5bd97c6c-1871-4520-a573-94491516ade9" />

Trac ticket: https://core.trac.wordpress.org/ticket/63941

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
