### PR TITLE
Update `add_meta_boxes` hook documentation to more accurately reflect the proper types

### DIFF
--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -1677,10 +1677,10 @@ function register_and_do_post_meta_boxes( $post ) {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string                    $post_type Post type of the current screen. Can be 'post', 'page',
-	 *                                             custom post types, 'comment', or 'link'.
-	 * @param WP_Post|WP_Comment|object $post      The post, comment, or link object. Type varies depending on
-	 *                                             `$post_type`.
+	 * @param string                    $object_type The type of the current object that meta boxes were added to.
+	 *                                               Can be 'post', 'page', custom post types, 'comment', or 'link'.
+	 * @param WP_Post|WP_Comment|object $object      The post, comment, or link object. Type varies depending on
+	 *                                               `$post_type`.
 	 */
 	do_action( 'add_meta_boxes', $post_type, $post );
 
@@ -1700,8 +1700,8 @@ function register_and_do_post_meta_boxes( $post ) {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param WP_Post|WP_Comment|object $post The post, comment, or link object. Type varies depending on
-	 *                                        the hook name.
+	 * @param WP_Post|WP_Comment|object $object The post, comment, or link object. Type varies depending on
+	 *                                          the hook name.
 	 */
 	do_action( "add_meta_boxes_{$post_type}", $post );
 

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -1712,11 +1712,11 @@ function register_and_do_post_meta_boxes( $post ) {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string                $post_type Post type of the post on Edit Post screen, 'link' on Edit Link screen,
-	 *                                         'dashboard' on Dashboard screen.
-	 * @param string                $context   Meta box context. Possible values include 'normal', 'advanced', 'side'.
-	 * @param WP_Post|object|string $post      Post object on Edit Post screen, link object on Edit Link screen,
-	 *                                         an empty string on Dashboard screen.
+	 * @param string                $object_type Post type of the post on Edit Post screen, 'link' on Edit Link screen,
+	 *                                           'dashboard' on Dashboard screen.
+	 * @param string                $context     Meta box context. Possible values include 'normal', 'advanced', 'side'.
+	 * @param WP_Post|object|string $object      Post object on Edit Post screen, link object on Edit Link screen,
+	 *                                           an empty string on Dashboard screen.
 	 */
 	do_action( 'do_meta_boxes', $post_type, 'normal', $post );
 	/** This action is documented in wp-admin/includes/meta-boxes.php */

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -1678,9 +1678,9 @@ function register_and_do_post_meta_boxes( $post ) {
 	 * @since 3.0.0
 	 *
 	 * @param string                    $post_type Post type of the current screen. Can be 'post', 'page',
-	 *                                            custom post types, 'comment', or 'link'.
-	 * @param WP_Post|WP_Comment|object $post     The post, comment, or link object. Type varies depending on
-	 *                                            `$post_type`.
+	 *                                             custom post types, 'comment', or 'link'.
+	 * @param WP_Post|WP_Comment|object $post      The post, comment, or link object. Type varies depending on
+	 *                                             `$post_type`.
 	 */
 	do_action( 'add_meta_boxes', $post_type, $post );
 

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -1687,17 +1687,21 @@ function register_and_do_post_meta_boxes( $post ) {
 	/**
 	 * Fires after all built-in meta boxes have been added, contextually for the given post type.
 	 *
-	 * The dynamic portion of the hook name, `$post_type`, refers to the post type of the post.
+	 * The dynamic portion of the hook name, `$post_type`, refers to the post type of the post,
+	 * or the object type (comment, link).
 	 *
 	 * Possible hook names include:
 	 *
 	 *  - `add_meta_boxes_post`
 	 *  - `add_meta_boxes_page`
 	 *  - `add_meta_boxes_attachment`
+	 *  - `add_meta_boxes_comment`
+	 *  - `add_meta_boxes_link`
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param WP_Post $post Post object.
+	 * @param WP_Post|WP_Comment|object $post The post, comment, or link object. Type varies depending on
+	 *                                        the hook name.
 	 */
 	do_action( "add_meta_boxes_{$post_type}", $post );
 

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -1680,7 +1680,7 @@ function register_and_do_post_meta_boxes( $post ) {
 	 * @param string                    $object_type The type of the current object that meta boxes were added to.
 	 *                                               Can be 'post', 'page', custom post types, 'comment', or 'link'.
 	 * @param WP_Post|WP_Comment|object $object      The post, comment, or link object. Type varies depending on
-	 *                                               `$post_type`.
+	 *                                               `$object_type`.
 	 */
 	do_action( 'add_meta_boxes', $post_type, $post );
 

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -1677,7 +1677,7 @@ function register_and_do_post_meta_boxes( $post ) {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string                   $post_type Post type of the current screen. Can be 'post', 'page',
+	 * @param string                    $post_type Post type of the current screen. Can be 'post', 'page',
 	 *                                            custom post types, 'comment', or 'link'.
 	 * @param WP_Post|WP_Comment|object $post     The post, comment, or link object. Type varies depending on
 	 *                                            `$post_type`.

--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -1677,8 +1677,10 @@ function register_and_do_post_meta_boxes( $post ) {
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string  $post_type Post type.
-	 * @param WP_Post $post      Post object.
+	 * @param string                   $post_type Post type of the current screen. Can be 'post', 'page',
+	 *                                            custom post types, 'comment', or 'link'.
+	 * @param WP_Post|WP_Comment|object $post     The post, comment, or link object. Type varies depending on
+	 *                                            `$post_type`.
 	 */
 	do_action( 'add_meta_boxes', $post_type, $post );
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This patch updates the documentation for the `add_meta_boxes_{$post_type}` and `add_meta_boxes` hooks to correctly reflect that `$post` will not always be a `WP_Post` object.

Trac ticket: https://core.trac.wordpress.org/ticket/64251

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
