### PR TITLE
Docs: Add missing @return descriptions in bundled themes.

### DIFF
--- a/src/wp-content/themes/twentyeleven/functions.php
+++ b/src/wp-content/themes/twentyeleven/functions.php
@@ -988,7 +988,9 @@ if ( ! function_exists( 'wp_get_list_item_separator' ) ) :
 	 *
 	 * Added for backward compatibility to support pre-6.0.0 WordPress versions.
 	 *
-	 * @since 6.0.0
+	 * @since Twenty Eleven 4.1
+	 *
+	 * @return string Locale-specific list item separator.
 	 */
 	function wp_get_list_item_separator() {
 		/* translators: Used between list items, there is a space after the comma. */

--- a/src/wp-content/themes/twentyfifteen/functions.php
+++ b/src/wp-content/themes/twentyfifteen/functions.php
@@ -366,7 +366,7 @@ if ( ! function_exists( 'twentyfifteen_fonts_url' ) ) :
 	 * @since Twenty Fifteen 1.0
 	 * @since Twenty Fifteen 3.4 Replaced Google URL with self-hosted fonts.
 	 *
-	 * @return string Fonts URL for the theme.
+	 * @return string Font stylesheet or empty string if disabled.
 	 */
 	function twentyfifteen_fonts_url() {
 		$fonts_url = '';

--- a/src/wp-content/themes/twentyfifteen/functions.php
+++ b/src/wp-content/themes/twentyfifteen/functions.php
@@ -366,7 +366,7 @@ if ( ! function_exists( 'twentyfifteen_fonts_url' ) ) :
 	 * @since Twenty Fifteen 1.0
 	 * @since Twenty Fifteen 3.4 Replaced Google URL with self-hosted fonts.
 	 *
-	 * @return string Font stylesheet or empty string if disabled.
+	 * @return string Font stylesheet URL or empty string if disabled.
 	 */
 	function twentyfifteen_fonts_url() {
 		$fonts_url = '';

--- a/src/wp-content/themes/twentyfourteen/functions.php
+++ b/src/wp-content/themes/twentyfourteen/functions.php
@@ -315,7 +315,7 @@ if ( ! function_exists( 'twentyfourteen_font_url' ) ) :
 	 * @since Twenty Fourteen 1.0
 	 * @since Twenty Fourteen 3.6 Replaced Google URL with self-hosted fonts.
 	 *
-	 * @return string Fonts URL for the theme.
+	 * @return string Font stylesheet or empty string if disabled.
 	 */
 	function twentyfourteen_font_url() {
 		$font_url = '';

--- a/src/wp-content/themes/twentyfourteen/functions.php
+++ b/src/wp-content/themes/twentyfourteen/functions.php
@@ -315,7 +315,7 @@ if ( ! function_exists( 'twentyfourteen_font_url' ) ) :
 	 * @since Twenty Fourteen 1.0
 	 * @since Twenty Fourteen 3.6 Replaced Google URL with self-hosted fonts.
 	 *
-	 * @return string
+	 * @return string Fonts URL for the theme.
 	 */
 	function twentyfourteen_font_url() {
 		$font_url = '';
@@ -755,6 +755,8 @@ if ( ! class_exists( 'Featured_Content' ) && 'plugins.php' !== $GLOBALS['pagenow
  * `is_customize_preview` function was introduced.
  *
  * @global WP_Customize_Manager $wp_customize Customizer object.
+ *
+ * @return bool True if the site is being previewed in the Customizer, false otherwise.
  */
 if ( ! function_exists( 'is_customize_preview' ) ) :
 	function is_customize_preview() {

--- a/src/wp-content/themes/twentyfourteen/functions.php
+++ b/src/wp-content/themes/twentyfourteen/functions.php
@@ -756,7 +756,7 @@ if ( ! class_exists( 'Featured_Content' ) && 'plugins.php' !== $GLOBALS['pagenow
  *
  * @global WP_Customize_Manager $wp_customize Customizer object.
  *
- * @return bool True if the site is being previewed in the Customizer, false otherwise.
+ * @return bool Whether the site is being previewed in the Customizer.
  */
 if ( ! function_exists( 'is_customize_preview' ) ) :
 	function is_customize_preview() {

--- a/src/wp-content/themes/twentyfourteen/functions.php
+++ b/src/wp-content/themes/twentyfourteen/functions.php
@@ -315,7 +315,7 @@ if ( ! function_exists( 'twentyfourteen_font_url' ) ) :
 	 * @since Twenty Fourteen 1.0
 	 * @since Twenty Fourteen 3.6 Replaced Google URL with self-hosted fonts.
 	 *
-	 * @return string Font stylesheet or empty string if disabled.
+	 * @return string Font stylesheet URL or empty string if disabled.
 	 */
 	function twentyfourteen_font_url() {
 		$font_url = '';

--- a/src/wp-content/themes/twentyfourteen/inc/widgets.php
+++ b/src/wp-content/themes/twentyfourteen/inc/widgets.php
@@ -26,7 +26,7 @@ class Twenty_Fourteen_Ephemera_Widget extends WP_Widget {
 	 *
 	 * @since Twenty Fourteen 1.0
 	 *
-	 * @return Twenty_Fourteen_Ephemera_Widget
+	 * @return Twenty_Fourteen_Ephemera_Widget Widget instance.
 	 */
 	public function __construct() {
 		parent::__construct(

--- a/src/wp-content/themes/twentynineteen/classes/class-twentynineteen-svg-icons.php
+++ b/src/wp-content/themes/twentynineteen/classes/class-twentynineteen-svg-icons.php
@@ -27,6 +27,7 @@ class TwentyNineteen_SVG_Icons {
 	 * @param string $group The group of icons ('ui' or 'social').
 	 * @param string $icon  The specific icon to retrieve.
 	 * @param int    $size  The desired width and height for the SVG icon.
+	 * @return string|null SVG code for the icon, or null if not found.
 	 */
 	public static function get_svg( $group, $icon, $size ) {
 		if ( 'ui' === $group ) {
@@ -51,6 +52,7 @@ class TwentyNineteen_SVG_Icons {
 	 *
 	 * @param string $uri  The URL of the social network link.
 	 * @param int    $size The desired width and height for the SVG icon.
+	 * @return string|null SVG code for the social link icon, or null if not found.
 	 */
 	public static function get_social_link_svg( $uri, $size ) {
 		static $regex_map; // Only compute regex map once, for performance.

--- a/src/wp-content/themes/twentynineteen/functions.php
+++ b/src/wp-content/themes/twentynineteen/functions.php
@@ -181,9 +181,9 @@ if ( ! function_exists( 'wp_get_list_item_separator' ) ) :
 	 *
 	 * Added for backward compatibility to support pre-6.0.0 WordPress versions.
 	 *
-	 * @since 6.0.0
+	 * @since Twenty Nineteen 2.3
 	 *
-	 * @return string List item separator.
+	 * @return string Locale-specific list item separator.
 	 */
 	function wp_get_list_item_separator() {
 		/* translators: Used between list items, there is a space after the comma. */

--- a/src/wp-content/themes/twentynineteen/functions.php
+++ b/src/wp-content/themes/twentynineteen/functions.php
@@ -182,6 +182,8 @@ if ( ! function_exists( 'wp_get_list_item_separator' ) ) :
 	 * Added for backward compatibility to support pre-6.0.0 WordPress versions.
 	 *
 	 * @since 6.0.0
+	 *
+	 * @return string List item separator.
 	 */
 	function wp_get_list_item_separator() {
 		/* translators: Used between list items, there is a space after the comma. */

--- a/src/wp-content/themes/twentynineteen/inc/customizer.php
+++ b/src/wp-content/themes/twentynineteen/inc/customizer.php
@@ -142,7 +142,7 @@ add_action( 'customize_controls_enqueue_scripts', 'twentynineteen_panels_js' );
  * Sanitizes custom color choice.
  *
  * @param string $choice Whether image filter is active.
- * @return string
+ * @return string Sanitized color option.
  */
 function twentynineteen_sanitize_color_option( $choice ) {
 	$valid = array(

--- a/src/wp-content/themes/twentynineteen/inc/template-functions.php
+++ b/src/wp-content/themes/twentynineteen/inc/template-functions.php
@@ -11,7 +11,7 @@
  * Adds custom classes to the array of body classes.
  *
  * @param array $classes Classes for the body element.
- * @return array The filtered body class list.
+ * @return string[] The filtered body class list.
  */
 function twentynineteen_body_classes( $classes ) {
 

--- a/src/wp-content/themes/twentynineteen/inc/template-functions.php
+++ b/src/wp-content/themes/twentynineteen/inc/template-functions.php
@@ -11,7 +11,7 @@
  * Adds custom classes to the array of body classes.
  *
  * @param array $classes Classes for the body element.
- * @return array
+ * @return array The filtered body class list.
  */
 function twentynineteen_body_classes( $classes ) {
 

--- a/src/wp-content/themes/twentyseventeen/functions.php
+++ b/src/wp-content/themes/twentyseventeen/functions.php
@@ -289,7 +289,7 @@ if ( ! function_exists( 'twentyseventeen_fonts_url' ) ) :
 	 * @since Twenty Seventeen 1.0
 	 * @since Twenty Seventeen 3.2 Replaced Google URL with self-hosted fonts.
 	 *
-	 * @return string Font stylesheet or empty string if disabled.
+	 * @return string Font stylesheet URL or empty string if disabled.
 	 */
 	function twentyseventeen_fonts_url() {
 		$fonts_url = '';

--- a/src/wp-content/themes/twentyseventeen/functions.php
+++ b/src/wp-content/themes/twentyseventeen/functions.php
@@ -289,7 +289,7 @@ if ( ! function_exists( 'twentyseventeen_fonts_url' ) ) :
 	 * @since Twenty Seventeen 1.0
 	 * @since Twenty Seventeen 3.2 Replaced Google URL with self-hosted fonts.
 	 *
-	 * @return string Fonts URL for the theme.
+	 * @return string Font stylesheet or empty string if disabled.
 	 */
 	function twentyseventeen_fonts_url() {
 		$fonts_url = '';

--- a/src/wp-content/themes/twentyseventeen/functions.php
+++ b/src/wp-content/themes/twentyseventeen/functions.php
@@ -681,7 +681,9 @@ if ( ! function_exists( 'wp_get_list_item_separator' ) ) :
 	 *
 	 * Added for backward compatibility to support pre-6.0.0 WordPress versions.
 	 *
-	 * @since 6.0.0
+	 * @since Twenty Seventeen 3.0
+	 *
+	 * @return string Locale-specific list item separator.
 	 */
 	function wp_get_list_item_separator() {
 		/* translators: Used between list items, there is a space after the comma. */

--- a/src/wp-content/themes/twentyseventeen/inc/template-functions.php
+++ b/src/wp-content/themes/twentyseventeen/inc/template-functions.php
@@ -11,7 +11,7 @@
  * Adds custom classes to the array of body classes.
  *
  * @param array $classes Classes for the body element.
- * @return array
+ * @return array Filtered body classes with theme-specific additions.
  */
 function twentyseventeen_body_classes( $classes ) {
 	// Add class of group-blog to blogs with more than 1 published author.

--- a/src/wp-content/themes/twentyseventeen/inc/template-functions.php
+++ b/src/wp-content/themes/twentyseventeen/inc/template-functions.php
@@ -11,7 +11,7 @@
  * Adds custom classes to the array of body classes.
  *
  * @param array $classes Classes for the body element.
- * @return array Filtered body classes with theme-specific additions.
+ * @return string[] Filtered body classes with theme-specific additions.
  */
 function twentyseventeen_body_classes( $classes ) {
 	// Add class of group-blog to blogs with more than 1 published author.

--- a/src/wp-content/themes/twentyseventeen/inc/template-tags.php
+++ b/src/wp-content/themes/twentyseventeen/inc/template-tags.php
@@ -184,7 +184,7 @@ function twentyseventeen_front_page_section( $partial = null, $id = 0 ) {
 /**
  * Returns true if a blog has more than 1 category.
  *
- * @return bool True if the blog has more than 1 category, false otherwise.
+ * @return bool Whether the blog has more than 1 category.
  */
 function twentyseventeen_categorized_blog() {
 	$category_count = get_transient( 'twentyseventeen_categories' );

--- a/src/wp-content/themes/twentyseventeen/inc/template-tags.php
+++ b/src/wp-content/themes/twentyseventeen/inc/template-tags.php
@@ -184,7 +184,7 @@ function twentyseventeen_front_page_section( $partial = null, $id = 0 ) {
 /**
  * Returns true if a blog has more than 1 category.
  *
- * @return bool
+ * @return bool True if the blog has more than 1 category, false otherwise.
  */
 function twentyseventeen_categorized_blog() {
 	$category_count = get_transient( 'twentyseventeen_categories' );

--- a/src/wp-content/themes/twentysixteen/functions.php
+++ b/src/wp-content/themes/twentysixteen/functions.php
@@ -334,7 +334,7 @@ if ( ! function_exists( 'twentysixteen_fonts_url' ) ) :
 	 * @since Twenty Sixteen 1.0
 	 * @since Twenty Sixteen 2.9 Replaced Google URL with self-hosted fonts.
 	 *
-	 * @return string Font stylesheet or empty string if disabled.
+	 * @return string Font stylesheet URL or empty string if disabled.
 	 */
 	function twentysixteen_fonts_url() {
 		$fonts_url = '';

--- a/src/wp-content/themes/twentysixteen/functions.php
+++ b/src/wp-content/themes/twentysixteen/functions.php
@@ -334,7 +334,7 @@ if ( ! function_exists( 'twentysixteen_fonts_url' ) ) :
 	 * @since Twenty Sixteen 1.0
 	 * @since Twenty Sixteen 2.9 Replaced Google URL with self-hosted fonts.
 	 *
-	 * @return string Fonts URL for the theme.
+	 * @return string Font stylesheet or empty string if disabled.
 	 */
 	function twentysixteen_fonts_url() {
 		$fonts_url = '';

--- a/src/wp-content/themes/twentythirteen/functions.php
+++ b/src/wp-content/themes/twentythirteen/functions.php
@@ -270,7 +270,7 @@ if ( ! function_exists( 'twentythirteen_fonts_url' ) ) :
 	 * @since Twenty Thirteen 1.0
 	 * @since Twenty Thirteen 3.8 Replaced Google URL with self-hosted fonts.
 	 *
-	 * @return string Font stylesheet or empty string if disabled.
+	 * @return string Font stylesheet URL or empty string if disabled.
 	 */
 	function twentythirteen_fonts_url() {
 		$fonts_url = '';

--- a/src/wp-content/themes/twentythirteen/functions.php
+++ b/src/wp-content/themes/twentythirteen/functions.php
@@ -473,7 +473,9 @@ if ( ! function_exists( 'wp_get_list_item_separator' ) ) :
 	 *
 	 * Added for backward compatibility to support pre-6.0.0 WordPress versions.
 	 *
-	 * @since 6.0.0
+	 * @since Twenty Thirteen 3.7
+	 *
+	 * @return string Locale-specific list item separator.
 	 */
 	function wp_get_list_item_separator() {
 		/* translators: Used between list items, there is a space after the comma. */

--- a/src/wp-content/themes/twentytwelve/functions.php
+++ b/src/wp-content/themes/twentytwelve/functions.php
@@ -396,7 +396,9 @@ if ( ! function_exists( 'wp_get_list_item_separator' ) ) :
 	 *
 	 * Added for backward compatibility to support pre-6.0.0 WordPress versions.
 	 *
-	 * @since 6.0.0
+	 * @since Twenty Twelve 3.7
+	 *
+	 * @return string Locale-specific list item separator.
 	 */
 	function wp_get_list_item_separator() {
 		/* translators: Used between list items, there is a space after the comma. */

--- a/src/wp-content/themes/twentytwelve/functions.php
+++ b/src/wp-content/themes/twentytwelve/functions.php
@@ -160,7 +160,7 @@ if ( ! function_exists( 'twentytwelve_get_font_url' ) ) :
 	 * @since Twenty Twelve 1.2
 	 * @since Twenty Twelve 3.9 Replaced Google URL with self-hosted font.
 	 *
-	 * @return string Font stylesheet or empty string if disabled.
+	 * @return string Font stylesheet URL or empty string if disabled.
 	 */
 	function twentytwelve_get_font_url() {
 		$font_url = '';

--- a/src/wp-content/themes/twentytwenty/classes/class-twentytwenty-customize.php
+++ b/src/wp-content/themes/twentytwenty/classes/class-twentytwenty-customize.php
@@ -459,7 +459,7 @@ if ( ! class_exists( 'TwentyTwenty_Customize' ) ) {
 		 * @since Twenty Twenty 1.0
 		 *
 		 * @param bool $checked Whether or not a box is checked.
-		 * @return bool True if the checkbox is checked, false otherwise.
+		 * @return bool Whether the checkbox is checked.
 		 */
 		public static function sanitize_checkbox( $checked ) {
 			return ( ( isset( $checked ) && true === $checked ) ? true : false );

--- a/src/wp-content/themes/twentytwenty/classes/class-twentytwenty-customize.php
+++ b/src/wp-content/themes/twentytwenty/classes/class-twentytwenty-customize.php
@@ -459,7 +459,7 @@ if ( ! class_exists( 'TwentyTwenty_Customize' ) ) {
 		 * @since Twenty Twenty 1.0
 		 *
 		 * @param bool $checked Whether or not a box is checked.
-		 * @return bool
+		 * @return bool True if the checkbox is checked, false otherwise.
 		 */
 		public static function sanitize_checkbox( $checked ) {
 			return ( ( isset( $checked ) && true === $checked ) ? true : false );

--- a/src/wp-content/themes/twentytwenty/functions.php
+++ b/src/wp-content/themes/twentytwenty/functions.php
@@ -304,7 +304,7 @@ add_action( 'init', 'twentytwenty_menus' );
  * @since Twenty Twenty 1.0
  *
  * @param string $html The HTML output from get_custom_logo() (core function).
- * @return string Custom logo HTML with retina support.
+ * @return string|false Custom logo HTML or false if not available.
  */
 function twentytwenty_get_custom_logo( $html ) {
 
@@ -635,7 +635,7 @@ add_action( 'after_setup_theme', 'twentytwenty_block_editor_settings' );
  * Overwrite default more tag with styling and screen reader markup.
  *
  * @param string $html The default output HTML for the more tag.
- * @return string The filtered HTML of the more tag, wrapped in a wrapper div.
+ * @return string The the read more link wrapped in a `div`.
  */
 function twentytwenty_read_more_tag( $html ) {
 	return preg_replace( '/<a(.*)>(.*)<\/a>/iU', sprintf( '<div class="read-more-button-wrap"><a$1><span class="faux-button">$2</span> <span class="screen-reader-text">"%1$s"</span></a></div>', get_the_title( get_the_ID() ) ), $html );

--- a/src/wp-content/themes/twentytwenty/functions.php
+++ b/src/wp-content/themes/twentytwenty/functions.php
@@ -304,7 +304,7 @@ add_action( 'init', 'twentytwenty_menus' );
  * @since Twenty Twenty 1.0
  *
  * @param string $html The HTML output from get_custom_logo() (core function).
- * @return string|false Custom logo HTML or false if not available.
+ * @return string Custom logo HTML with "retina" resolution applied if enabled.
  */
 function twentytwenty_get_custom_logo( $html ) {
 

--- a/src/wp-content/themes/twentytwenty/functions.php
+++ b/src/wp-content/themes/twentytwenty/functions.php
@@ -304,7 +304,7 @@ add_action( 'init', 'twentytwenty_menus' );
  * @since Twenty Twenty 1.0
  *
  * @param string $html The HTML output from get_custom_logo() (core function).
- * @return string
+ * @return string Custom logo HTML with retina support.
  */
 function twentytwenty_get_custom_logo( $html ) {
 
@@ -635,7 +635,7 @@ add_action( 'after_setup_theme', 'twentytwenty_block_editor_settings' );
  * Overwrite default more tag with styling and screen reader markup.
  *
  * @param string $html The default output HTML for the more tag.
- * @return string
+ * @return string The filtered HTML of the more tag, wrapped in a wrapper div.
  */
 function twentytwenty_read_more_tag( $html ) {
 	return preg_replace( '/<a(.*)>(.*)<\/a>/iU', sprintf( '<div class="read-more-button-wrap"><a$1><span class="faux-button">$2</span> <span class="screen-reader-text">"%1$s"</span></a></div>', get_the_title( get_the_ID() ) ), $html );
@@ -736,7 +736,7 @@ function twentytwenty_get_color_for_area( $area = 'content', $context = 'text' )
  *
  * @since Twenty Twenty 1.0
  *
- * @return array
+ * @return array Customizer color variables for the preview.
  */
 function twentytwenty_get_customizer_color_vars() {
 	$colors = array(
@@ -755,7 +755,7 @@ function twentytwenty_get_customizer_color_vars() {
  *
  * @since Twenty Twenty 1.0
  *
- * @return array
+ * @return array Elements to apply custom colors to.
  */
 function twentytwenty_get_elements_array() {
 

--- a/src/wp-content/themes/twentytwenty/inc/custom-css.php
+++ b/src/wp-content/themes/twentytwenty/inc/custom-css.php
@@ -20,6 +20,7 @@ if ( ! function_exists( 'twentytwenty_generate_css' ) ) {
 	 * @param string $prefix   The CSS prefix.
 	 * @param string $suffix   The CSS suffix.
 	 * @param bool   $display  Print the styles.
+	 * @return string Generated CSS.
 	 */
 	function twentytwenty_generate_css( $selector, $style, $value, $prefix = '', $suffix = '', $display = true ) {
 
@@ -54,6 +55,7 @@ if ( ! function_exists( 'twentytwenty_get_customizer_css' ) ) {
 	 * @since Twenty Twenty 1.0
 	 *
 	 * @param string $type Whether to return CSS for the "front-end", "block-editor", or "classic-editor".
+	 * @return string CSS styles built from Customizer options.
 	 */
 	function twentytwenty_get_customizer_css( $type = 'front-end' ) {
 

--- a/src/wp-content/themes/twentytwenty/inc/template-tags.php
+++ b/src/wp-content/themes/twentytwenty/inc/template-tags.php
@@ -148,7 +148,7 @@ function twentytwenty_site_description( $display = true ) {
  * @since Twenty Twenty 1.0
  *
  * @param object $comment Comment data.
- * @return bool
+ * @return bool True if the comment is by the post author, false otherwise.
  */
 function twentytwenty_is_comment_by_post_author( $comment = null ) {
 
@@ -249,6 +249,7 @@ add_filter( 'edit_post_link', 'twentytwenty_edit_post_link', 10, 3 );
  *
  * @param int    $post_id  The ID of the post.
  * @param string $location The location where the meta is shown.
+ * @return string Post meta HTML.
  */
 function twentytwenty_get_post_meta( $post_id = null, $location = 'single-top' ) {
 

--- a/src/wp-content/themes/twentytwenty/inc/template-tags.php
+++ b/src/wp-content/themes/twentytwenty/inc/template-tags.php
@@ -148,7 +148,7 @@ function twentytwenty_site_description( $display = true ) {
  * @since Twenty Twenty 1.0
  *
  * @param object $comment Comment data.
- * @return bool True if the comment is by the post author, false otherwise.
+ * @return bool Whether the comment is by the post author.
  */
 function twentytwenty_is_comment_by_post_author( $comment = null ) {
 

--- a/src/wp-content/themes/twentytwentyone/functions.php
+++ b/src/wp-content/themes/twentytwentyone/functions.php
@@ -655,7 +655,9 @@ if ( ! function_exists( 'wp_get_list_item_separator' ) ) :
 	 *
 	 * Added for backward compatibility to support pre-6.0.0 WordPress versions.
 	 *
-	 * @since 6.0.0
+	 * @since Twenty Twenty-One 1.6
+	 *
+	 * @return string Locale-specific list item separator.
 	 */
 	function wp_get_list_item_separator() {
 		/* translators: Used between list items, there is a space after the comma. */

--- a/src/wp-content/themes/twentytwentyone/inc/custom-css.php
+++ b/src/wp-content/themes/twentytwentyone/inc/custom-css.php
@@ -18,7 +18,7 @@
  * @param string $prefix   The CSS prefix.
  * @param string $suffix   The CSS suffix.
  * @param bool   $display  Print the styles.
- * @return string
+ * @return string Generated CSS.
  */
 function twenty_twenty_one_generate_css( $selector, $style, $value, $prefix = '', $suffix = '', $display = true ) {
 

--- a/src/wp-content/themes/twentytwentyone/inc/template-functions.php
+++ b/src/wp-content/themes/twentytwentyone/inc/template-functions.php
@@ -13,7 +13,7 @@
  * @since Twenty Twenty-One 1.0
  *
  * @param array $classes Classes for the body element.
- * @return array Filtered body classes with theme-specific additions.
+ * @return string[] Body classes with theme-specific additions.
  */
 function twenty_twenty_one_body_classes( $classes ) {
 
@@ -43,7 +43,7 @@ add_filter( 'body_class', 'twenty_twenty_one_body_classes' );
  * @since Twenty Twenty-One 1.0
  *
  * @param array $classes An array of CSS classes.
- * @return array Filtered post classes with 'entry' class added.
+ * @return string[] Post classes with 'entry' class added.
  */
 function twenty_twenty_one_post_classes( $classes ) {
 	$classes[] = 'entry';

--- a/src/wp-content/themes/twentytwentyone/inc/template-functions.php
+++ b/src/wp-content/themes/twentytwentyone/inc/template-functions.php
@@ -13,7 +13,7 @@
  * @since Twenty Twenty-One 1.0
  *
  * @param array $classes Classes for the body element.
- * @return array
+ * @return array Filtered body classes with theme-specific additions.
  */
 function twenty_twenty_one_body_classes( $classes ) {
 
@@ -43,7 +43,7 @@ add_filter( 'body_class', 'twenty_twenty_one_body_classes' );
  * @since Twenty Twenty-One 1.0
  *
  * @param array $classes An array of CSS classes.
- * @return array
+ * @return array Filtered post classes with 'entry' class added.
  */
 function twenty_twenty_one_post_classes( $classes ) {
 	$classes[] = 'entry';
@@ -91,7 +91,7 @@ add_action( 'wp_footer', 'twenty_twenty_one_supports_js' );
  * @since Twenty Twenty-One 1.0
  *
  * @param array $defaults The form defaults.
- * @return array
+ * @return array Comment form defaults with adjusted textarea height.
  */
 function twenty_twenty_one_comment_form_defaults( $defaults ) {
 
@@ -200,7 +200,7 @@ add_filter( 'the_title', 'twenty_twenty_one_post_title' );
  * @param string $group The icon group.
  * @param string $icon  The icon.
  * @param int    $size  The icon size in pixels.
- * @return string
+ * @return string SVG code for the requested icon.
  */
 function twenty_twenty_one_get_icon_svg( $group, $icon, $size = 24 ) {
 	return Twenty_Twenty_One_SVG_Icons::get_svg( $group, $icon, $size );
@@ -212,7 +212,7 @@ function twenty_twenty_one_get_icon_svg( $group, $icon, $size = 24 ) {
  * @since Twenty Twenty-One 1.0
  *
  * @param string $calendar_output The generated HTML of the calendar.
- * @return string
+ * @return string Calendar HTML with SVG navigation arrows.
  */
 function twenty_twenty_one_change_calendar_nav_arrows( $calendar_output ) {
 	$calendar_output = str_replace( '&laquo; ', is_rtl() ? twenty_twenty_one_get_icon_svg( 'ui', 'arrow_right' ) : twenty_twenty_one_get_icon_svg( 'ui', 'arrow_left' ), $calendar_output );
@@ -229,7 +229,7 @@ add_filter( 'get_calendar', 'twenty_twenty_one_change_calendar_nav_arrows' );
  * @since Twenty Twenty-One 1.0
  *
  * @param string $type Whether to return CSS for the "front-end", "block-editor", or "classic-editor".
- * @return string
+ * @return string CSS styles for non-Latin languages based on the site locale.
  */
 function twenty_twenty_one_get_non_latin_css( $type = 'front-end' ) {
 


### PR DESCRIPTION
This PR addresses missing or incomplete `@return` tag documentation in several bundled themes.

**Changes include:**
*   Adding descriptions to `@return` tags in `functions.php` and other include files for Twenty Twenty, Twenty Seventeen, and Twenty Twenty-One.
*   Adding missing `@return` tags and descriptions in Twenty Fourteen and Twenty Nineteen.

**Trac ticket:** https://core.trac.wordpress.org/ticket/64277