### PR TITLE
wp.sanitize.stripTags could rely on the browser for HTML parsing - [Core - 64274]

### DIFF
--- a/src/js/_enqueues/wp/sanitize.js
+++ b/src/js/_enqueues/wp/sanitize.js
@@ -23,11 +23,10 @@
 		 * @return {string} Stripped text.
 		 */
 		stripTags: function( text ) {
-			let _text = text || '';
 
 			const domParser = new DOMParser();
 			const htmlDocument = domParser.parseFromString(
-				_text,
+				text,
 				'text/html'
 			);
 
@@ -40,7 +39,7 @@
 			 *
 			 * See: https://github.com/WordPress/wordpress-develop/pull/10536#discussion_r2550615378
 			 */
-			htmlDocument.body.innerText = htmlDocument.body.innerText || '';
+			htmlDocument.body.innerText = htmlDocument.body.innerText;
 
 			// Return the text with stripped tags.
 			return htmlDocument.body.innerHTML;

--- a/src/js/_enqueues/wp/sanitize.js
+++ b/src/js/_enqueues/wp/sanitize.js
@@ -26,7 +26,20 @@
 			let _text = text || '';
 
 			const domParser = new DOMParser();
-			const htmlDocument = domParser.parseFromString( _text, 'text/html' );
+			const htmlDocument = domParser.parseFromString(
+				_text,
+				'text/html'
+			);
+
+			/*
+			 * This looks funny and appears to be a no-op, but it
+			 * enforces the escaping. How? when _read_ the `innerText`
+			 * property decodes character references, returning a raw
+			 * string. When _written_, however, it re-encodes to ensure
+			 * that the rendered text replicates what it’s given.
+			 *
+			 * See: https://github.com/WordPress/wordpress-develop/pull/10536#discussion_r2550615378
+			 */
 			htmlDocument.body.innerText = htmlDocument.body.innerText || '';
 
 			// Return the text with stripped tags.

--- a/src/js/_enqueues/wp/sanitize.js
+++ b/src/js/_enqueues/wp/sanitize.js
@@ -25,12 +25,12 @@
 		stripTags: function( text ) {
 			let _text = text || '';
 
-			const htmlElement = document.createElement( 'div' );
-			htmlElement.innerHTML = _text;
-			_text = htmlElement.textContent || htmlElement.innerText || '';
+			const domParser = new DOMParser();
+			const htmlDocument = domParser.parseFromString( _text, 'text/html' );
+			htmlDocument.body.innerText = htmlDocument.body.innerText || '';
 
 			// Return the text with stripped tags.
-			return _text;
+			return htmlDocument.body.innerHTML;
 		},
 
 		/**

--- a/src/js/_enqueues/wp/sanitize.js
+++ b/src/js/_enqueues/wp/sanitize.js
@@ -23,7 +23,6 @@
 		 * @return {string} Stripped text.
 		 */
 		stripTags: function( text ) {
-
 			const domParser = new DOMParser();
 			const htmlDocument = domParser.parseFromString(
 				text,
@@ -31,13 +30,13 @@
 			);
 
 			/*
-			 * This looks funny and appears to be a no-op, but it
-			 * enforces the escaping. How? when _read_ the `innerText`
-			 * property decodes character references, returning a raw
-			 * string. When _written_, however, it re-encodes to ensure
-			 * that the rendered text replicates what it’s given.
+			 * The following self-assignment appears to be a no-op, but it isn't.
+			 * It enforces the escaping. Reading the `innerText` property decodes
+			 * character references, returning a raw string. When written, however,
+			 * the text is re-escaped to ensure that the rendered text replicates
+			 * what it's given.
 			 *
-			 * See: https://github.com/WordPress/wordpress-develop/pull/10536#discussion_r2550615378
+			 * See <https://github.com/WordPress/wordpress-develop/pull/10536#discussion_r2550615378>.
 			 */
 			htmlDocument.body.innerText = htmlDocument.body.innerText;
 

--- a/src/js/_enqueues/wp/sanitize.js
+++ b/src/js/_enqueues/wp/sanitize.js
@@ -25,17 +25,9 @@
 		stripTags: function( text ) {
 			let _text = text || '';
 
-			// Do the search-replace until there is nothing to be replaced.
-			do {
-				// Keep pre-replace text for comparison.
-				text = _text;
-
-				// Do the replacement.
-				_text = text
-					.replace( /<!--[\s\S]*?(-->|$)/g, '' )
-					.replace( /<(script|style)[^>]*>[\s\S]*?(<\/\1>|$)/ig, '' )
-					.replace( /<\/?[a-z][\s\S]*?(>|$)/ig, '' );
-			} while ( _text !== text );
+			const htmlElement = document.createElement( 'div' );
+			htmlElement.innerHTML = _text;
+			_text = htmlElement.textContent || htmlElement.innerText || '';
 
 			// Return the text with stripped tags.
 			return _text;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64274

- Used HTML parsing instead of regex matching.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
