### PR TITLE
Media Library - textual fix in Help tab

### DIFF
--- a/src/wp-admin/upload.php
+++ b/src/wp-admin/upload.php
@@ -180,7 +180,7 @@ if ( 'grid' === $mode ) {
 			'content' =>
 				'<p>' . __( 'All the files you&#8217;ve uploaded are listed in the Media Library, with the most recent uploads listed first.' ) . '</p>' .
 				'<p>' . __( 'You can view your media in a simple visual grid or a list with columns. Switch between these views using the icons to the left above the media.' ) . '</p>' .
-				'<p>' . __( 'To delete media items, click the Bulk Select button at the top of the screen. Select any items you wish to delete, then click the Delete Selected button. Clicking the Cancel Selection button takes you back to viewing your media.' ) . '</p>',
+				'<p>' . __( 'To delete media items, click the Bulk select button at the top of the screen. Select any items you wish to delete, then click the Delete permanently button. Clicking the Cancel button takes you back to viewing your media.' ) . '</p>',
 		)
 	);
 


### PR DESCRIPTION
Minor textual fix in Help tab of the Media page (Grid View). 
Make button names in Help info match button names at Media page.

Trac ticket: [Ticket #64289](https://core.trac.wordpress.org/ticket/64289)

![Grid View 1](https://github.com/user-attachments/assets/a457cc37-50d9-4cfa-9657-cd2b8864c762)

![Grid View 2](https://github.com/user-attachments/assets/37ea171d-9779-4af0-802d-c91098e847c3)
