### PR TITLE
Global Styles: Preserve block style variations in global styles revisions.

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-revisions-controller.php
@@ -313,7 +313,7 @@ class WP_REST_Global_Styles_Revisions_Controller extends WP_REST_Revisions_Contr
 
 		if ( ! empty( $global_styles_config['styles'] ) || ! empty( $global_styles_config['settings'] ) ) {
 			/*
-			 * Register block style variations from the revision data.
+			 * Register block style variations from the theme data.
 			 * This is required so the variations pass sanitization of theme.json data.
 			 */
 			if ( ! empty( $global_styles_config['styles']['blocks'] ) ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-revisions-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-revisions-controller.php
@@ -312,6 +312,15 @@ class WP_REST_Global_Styles_Revisions_Controller extends WP_REST_Revisions_Contr
 		$theme_json = null;
 
 		if ( ! empty( $global_styles_config['styles'] ) || ! empty( $global_styles_config['settings'] ) ) {
+			/*
+			 * Register block style variations from the revision data.
+			 * This is required so the variations pass sanitization of theme.json data.
+			 */
+			if ( ! empty( $global_styles_config['styles']['blocks'] ) ) {
+				$variations = WP_Theme_JSON_Resolver::get_style_variations( 'block' );
+				wp_register_block_style_variations_from_theme_json_partials( $variations );
+			}
+
 			$theme_json           = new WP_Theme_JSON( $global_styles_config, 'custom' );
 			$global_styles_config = $theme_json->get_raw_data();
 			if ( rest_is_field_included( 'settings', $fields ) ) {

--- a/tests/phpunit/tests/rest-api/rest-global-styles-revisions-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-global-styles-revisions-controller.php
@@ -984,6 +984,400 @@ class WP_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_REST_Contr
 	}
 
 	/**
+	 * Tests that block style variations in revisions are preserved.
+	 *
+	 * @ticket TBD
+	 *
+	 * @covers WP_REST_Global_Styles_Revisions_Controller::prepare_item_for_response
+	 */
+	public function test_get_item_preserves_block_style_variations() {
+		wp_set_current_user( self::$admin_id );
+		switch_theme( 'block-theme-child-with-block-style-variations' );
+
+		// Create a global styles post for the theme.
+		$global_styles_id = wp_insert_post(
+			array(
+				'post_content' => wp_json_encode(
+					array(
+						'version'                     => WP_Theme_JSON::LATEST_SCHEMA,
+						'isGlobalStylesUserThemeJSON' => true,
+					)
+				),
+				'post_status'  => 'publish',
+				'post_title'   => 'Custom Styles',
+				'post_type'    => 'wp_global_styles',
+				'post_name'    => 'wp-global-styles-block-theme-child-with-block-style-variations',
+				'tax_input'    => array(
+					'wp_theme' => 'block-theme-child-with-block-style-variations',
+				),
+			),
+			true
+		);
+
+		// Update with block style variations to create a revision.
+		$config_with_variations = array(
+			'version'                     => WP_Theme_JSON::LATEST_SCHEMA,
+			'isGlobalStylesUserThemeJSON' => true,
+			'styles'                      => array(
+				'blocks' => array(
+					'core/group' => array(
+						'variations' => array(
+							'block-style-variation-a' => array(
+								'color' => array(
+									'background' => '#123456',
+									'text'       => '#abcdef',
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		wp_update_post(
+			array(
+				'ID'           => $global_styles_id,
+				'post_content' => wp_json_encode( $config_with_variations ),
+			),
+			true
+		);
+
+		// Get the revision.
+		$revisions  = wp_get_post_revisions( $global_styles_id );
+		$revision   = array_shift( $revisions );
+		$request    = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . $global_styles_id . '/revisions/' . $revision->ID );
+		$response   = rest_get_server()->dispatch( $request );
+		$data       = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status(), 'Response status should be 200.' );
+		$this->assertArrayHasKey( 'styles', $data, 'Response should contain styles.' );
+		$this->assertArrayHasKey( 'blocks', $data['styles'], 'Styles should contain blocks.' );
+		$this->assertArrayHasKey( 'core/group', $data['styles']['blocks'], 'Blocks should contain core/group.' );
+		$this->assertArrayHasKey( 'variations', $data['styles']['blocks']['core/group'], 'core/group should contain variations.' );
+		$this->assertArrayHasKey(
+			'block-style-variation-a',
+			$data['styles']['blocks']['core/group']['variations'],
+			'Variations should contain block-style-variation-a.'
+		);
+
+		// Verify the variation styles are preserved.
+		$variation = $data['styles']['blocks']['core/group']['variations']['block-style-variation-a'];
+		$this->assertSame( '#123456', $variation['color']['background'], 'Variation background color should be preserved.' );
+		$this->assertSame( '#abcdef', $variation['color']['text'], 'Variation text color should be preserved.' );
+
+		// Clean up.
+		wp_delete_post( $global_styles_id, true );
+	}
+
+	/**
+	 * Tests that multiple block style variations are preserved.
+	 *
+	 * @ticket TBD
+	 *
+	 * @covers WP_REST_Global_Styles_Revisions_Controller::prepare_item_for_response
+	 */
+	public function test_multiple_block_variations_are_preserved() {
+		wp_set_current_user( self::$admin_id );
+		switch_theme( 'block-theme-child-with-block-style-variations' );
+
+		// Create a global styles post for the theme.
+		$global_styles_id = wp_insert_post(
+			array(
+				'post_content' => wp_json_encode(
+					array(
+						'version'                     => WP_Theme_JSON::LATEST_SCHEMA,
+						'isGlobalStylesUserThemeJSON' => true,
+					)
+				),
+				'post_status'  => 'publish',
+				'post_title'   => 'Custom Styles',
+				'post_type'    => 'wp_global_styles',
+				'post_name'    => 'wp-global-styles-multiple-variations',
+				'tax_input'    => array(
+					'wp_theme' => 'block-theme-child-with-block-style-variations',
+				),
+			),
+			true
+		);
+
+		// Update with multiple block style variations to create a revision.
+		$config_with_variations = array(
+			'version'                     => WP_Theme_JSON::LATEST_SCHEMA,
+			'isGlobalStylesUserThemeJSON' => true,
+			'styles'                      => array(
+				'blocks' => array(
+					'core/group'   => array(
+						'variations' => array(
+							'block-style-variation-a' => array(
+								'color' => array(
+									'background' => 'red',
+								),
+							),
+						),
+					),
+					'core/columns' => array(
+						'variations' => array(
+							'block-style-variation-a' => array(
+								'color' => array(
+									'background' => 'blue',
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		wp_update_post(
+			array(
+				'ID'           => $global_styles_id,
+				'post_content' => wp_json_encode( $config_with_variations ),
+			),
+			true
+		);
+
+		// Get the revision.
+		$revisions  = wp_get_post_revisions( $global_styles_id );
+		$revision   = array_shift( $revisions );
+		$request    = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . $global_styles_id . '/revisions/' . $revision->ID );
+		$response   = rest_get_server()->dispatch( $request );
+		$data       = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status(), 'Response status should be 200.' );
+
+		// Verify both blocks have their variations preserved.
+		$this->assertArrayHasKey(
+			'block-style-variation-a',
+			$data['styles']['blocks']['core/group']['variations'],
+			'core/group should have block-style-variation-a.'
+		);
+		$this->assertArrayHasKey(
+			'block-style-variation-a',
+			$data['styles']['blocks']['core/columns']['variations'],
+			'core/columns should have block-style-variation-a.'
+		);
+
+		// Verify the styles are different for each block.
+		$this->assertSame(
+			'red',
+			$data['styles']['blocks']['core/group']['variations']['block-style-variation-a']['color']['background'],
+			'core/group variation should have red background.'
+		);
+		$this->assertSame(
+			'blue',
+			$data['styles']['blocks']['core/columns']['variations']['block-style-variation-a']['color']['background'],
+			'core/columns variation should have blue background.'
+		);
+
+		// Clean up.
+		wp_delete_post( $global_styles_id, true );
+	}
+
+	/**
+	 * Tests that theme-defined block style variations are registered for revisions.
+	 *
+	 * @ticket TBD
+	 *
+	 * @covers WP_REST_Global_Styles_Revisions_Controller::prepare_item_for_response
+	 */
+	public function test_theme_variations_are_registered_for_revisions() {
+		wp_set_current_user( self::$admin_id );
+		switch_theme( 'block-theme-child-with-block-style-variations' );
+
+		// Verify the theme has a block style variation defined.
+		$theme_variations = WP_Theme_JSON_Resolver::get_style_variations( 'block' );
+		$this->assertNotEmpty( $theme_variations, 'Theme should have block style variations defined.' );
+
+		// Create a global styles post for the theme.
+		$global_styles_id = wp_insert_post(
+			array(
+				'post_content' => wp_json_encode(
+					array(
+						'version'                     => WP_Theme_JSON::LATEST_SCHEMA,
+						'isGlobalStylesUserThemeJSON' => true,
+					)
+				),
+				'post_status'  => 'publish',
+				'post_title'   => 'Custom Styles',
+				'post_type'    => 'wp_global_styles',
+				'post_name'    => 'wp-global-styles-theme-variations',
+				'tax_input'    => array(
+					'wp_theme' => 'block-theme-child-with-block-style-variations',
+				),
+			),
+			true
+		);
+
+		// Update with the theme's block style variation.
+		$config_with_theme_variation = array(
+			'version'                     => WP_Theme_JSON::LATEST_SCHEMA,
+			'isGlobalStylesUserThemeJSON' => true,
+			'styles'                      => array(
+				'blocks' => array(
+					'core/group' => array(
+						'variations' => array(
+							'block-style-variation-a' => array(
+								'color' => array(
+									'background' => 'purple',
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		wp_update_post(
+			array(
+				'ID'           => $global_styles_id,
+				'post_content' => wp_json_encode( $config_with_theme_variation ),
+			),
+			true
+		);
+
+		// Get the revision.
+		$revisions  = wp_get_post_revisions( $global_styles_id );
+		$revision   = array_shift( $revisions );
+		$request    = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . $global_styles_id . '/revisions/' . $revision->ID );
+		$response   = rest_get_server()->dispatch( $request );
+		$data       = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status(), 'Response status should be 200.' );
+
+		// Verify the theme variation is preserved in the revision.
+		$this->assertArrayHasKey(
+			'block-style-variation-a',
+			$data['styles']['blocks']['core/group']['variations'],
+			'Theme-defined variation should be preserved in revision.'
+		);
+
+		// Clean up.
+		wp_delete_post( $global_styles_id, true );
+	}
+
+	/**
+	 * Tests that block style variations are preserved in the revisions collection endpoint.
+	 *
+	 * @ticket TBD
+	 *
+	 * @covers WP_REST_Global_Styles_Revisions_Controller::get_items
+	 * @covers WP_REST_Global_Styles_Revisions_Controller::prepare_item_for_response
+	 */
+	public function test_get_items_preserves_block_style_variations() {
+		wp_set_current_user( self::$admin_id );
+		switch_theme( 'block-theme-child-with-block-style-variations' );
+
+		// Create a global styles post for the theme.
+		$global_styles_id = wp_insert_post(
+			array(
+				'post_content' => wp_json_encode(
+					array(
+						'version'                     => WP_Theme_JSON::LATEST_SCHEMA,
+						'isGlobalStylesUserThemeJSON' => true,
+					)
+				),
+				'post_status'  => 'publish',
+				'post_title'   => 'Custom Styles',
+				'post_type'    => 'wp_global_styles',
+				'post_name'    => 'wp-global-styles-variations-collection',
+				'tax_input'    => array(
+					'wp_theme' => 'block-theme-child-with-block-style-variations',
+				),
+			),
+			true
+		);
+
+		// Create first revision with variations.
+		$config_variation_1 = array(
+			'version'                     => WP_Theme_JSON::LATEST_SCHEMA,
+			'isGlobalStylesUserThemeJSON' => true,
+			'styles'                      => array(
+				'blocks' => array(
+					'core/group' => array(
+						'variations' => array(
+							'block-style-variation-a' => array(
+								'color' => array(
+									'background' => 'green',
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		wp_update_post(
+			array(
+				'ID'           => $global_styles_id,
+				'post_content' => wp_json_encode( $config_variation_1 ),
+			),
+			true
+		);
+
+		// Create second revision with different variation styles.
+		$config_variation_2 = array(
+			'version'                     => WP_Theme_JSON::LATEST_SCHEMA,
+			'isGlobalStylesUserThemeJSON' => true,
+			'styles'                      => array(
+				'blocks' => array(
+					'core/group' => array(
+						'variations' => array(
+							'block-style-variation-a' => array(
+								'color' => array(
+									'background' => 'orange',
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		wp_update_post(
+			array(
+				'ID'           => $global_styles_id,
+				'post_content' => wp_json_encode( $config_variation_2 ),
+			),
+			true
+		);
+
+		// Get all revisions.
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . $global_styles_id . '/revisions' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( 200, $response->get_status(), 'Response status should be 200.' );
+		$this->assertCount( 2, $data, 'Should have 2 revisions.' );
+
+		// Verify first revision (most recent - orange).
+		$this->assertArrayHasKey(
+			'block-style-variation-a',
+			$data[0]['styles']['blocks']['core/group']['variations'],
+			'First revision should have block-style-variation-a.'
+		);
+		$this->assertSame(
+			'orange',
+			$data[0]['styles']['blocks']['core/group']['variations']['block-style-variation-a']['color']['background'],
+			'First revision should have orange background.'
+		);
+
+		// Verify second revision (older - green).
+		$this->assertArrayHasKey(
+			'block-style-variation-a',
+			$data[1]['styles']['blocks']['core/group']['variations'],
+			'Second revision should have block-style-variation-a.'
+		);
+		$this->assertSame(
+			'green',
+			$data[1]['styles']['blocks']['core/group']['variations']['block-style-variation-a']['color']['background'],
+			'Second revision should have green background.'
+		);
+
+		// Clean up.
+		wp_delete_post( $global_styles_id, true );
+	}
+
+	/**
 	 * @doesNotPerformAssertions
 	 */
 	public function test_context_param() {

--- a/tests/phpunit/tests/rest-api/rest-global-styles-revisions-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-global-styles-revisions-controller.php
@@ -1043,11 +1043,11 @@ class WP_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_REST_Contr
 		);
 
 		// Get the revision.
-		$revisions  = wp_get_post_revisions( $global_styles_id );
-		$revision   = array_shift( $revisions );
-		$request    = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . $global_styles_id . '/revisions/' . $revision->ID );
-		$response   = rest_get_server()->dispatch( $request );
-		$data       = $response->get_data();
+		$revisions = wp_get_post_revisions( $global_styles_id );
+		$revision  = array_shift( $revisions );
+		$request   = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . $global_styles_id . '/revisions/' . $revision->ID );
+		$response  = rest_get_server()->dispatch( $request );
+		$data      = $response->get_data();
 
 		$this->assertSame( 200, $response->get_status(), 'Response status should be 200.' );
 		$this->assertArrayHasKey( 'styles', $data, 'Response should contain styles.' );
@@ -1137,11 +1137,11 @@ class WP_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_REST_Contr
 		);
 
 		// Get the revision.
-		$revisions  = wp_get_post_revisions( $global_styles_id );
-		$revision   = array_shift( $revisions );
-		$request    = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . $global_styles_id . '/revisions/' . $revision->ID );
-		$response   = rest_get_server()->dispatch( $request );
-		$data       = $response->get_data();
+		$revisions = wp_get_post_revisions( $global_styles_id );
+		$revision  = array_shift( $revisions );
+		$request   = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . $global_styles_id . '/revisions/' . $revision->ID );
+		$response  = rest_get_server()->dispatch( $request );
+		$data      = $response->get_data();
 
 		$this->assertSame( 200, $response->get_status(), 'Response status should be 200.' );
 
@@ -1236,11 +1236,11 @@ class WP_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_REST_Contr
 		);
 
 		// Get the revision.
-		$revisions  = wp_get_post_revisions( $global_styles_id );
-		$revision   = array_shift( $revisions );
-		$request    = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . $global_styles_id . '/revisions/' . $revision->ID );
-		$response   = rest_get_server()->dispatch( $request );
-		$data       = $response->get_data();
+		$revisions = wp_get_post_revisions( $global_styles_id );
+		$revision  = array_shift( $revisions );
+		$request   = new WP_REST_Request( 'GET', '/wp/v2/global-styles/' . $global_styles_id . '/revisions/' . $revision->ID );
+		$response  = rest_get_server()->dispatch( $request );
+		$data      = $response->get_data();
 
 		$this->assertSame( 200, $response->get_status(), 'Response status should be 200.' );
 

--- a/tests/phpunit/tests/rest-api/rest-global-styles-revisions-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-global-styles-revisions-controller.php
@@ -986,7 +986,7 @@ class WP_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_REST_Contr
 	/**
 	 * Tests that block style variations in revisions are preserved.
 	 *
-	 * @ticket TBD
+	 * @ticket 64292
 	 *
 	 * @covers WP_REST_Global_Styles_Revisions_Controller::prepare_item_for_response
 	 */
@@ -1072,7 +1072,7 @@ class WP_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_REST_Contr
 	/**
 	 * Tests that multiple block style variations are preserved.
 	 *
-	 * @ticket TBD
+	 * @ticket 64292
 	 *
 	 * @covers WP_REST_Global_Styles_Revisions_Controller::prepare_item_for_response
 	 */
@@ -1176,7 +1176,7 @@ class WP_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_REST_Contr
 	/**
 	 * Tests that theme-defined block style variations are registered for revisions.
 	 *
-	 * @ticket TBD
+	 * @ticket 64292
 	 *
 	 * @covers WP_REST_Global_Styles_Revisions_Controller::prepare_item_for_response
 	 */
@@ -1258,7 +1258,7 @@ class WP_REST_Global_Styles_Revisions_Controller_Test extends WP_Test_REST_Contr
 	/**
 	 * Tests that block style variations are preserved in the revisions collection endpoint.
 	 *
-	 * @ticket TBD
+	 * @ticket 64292
 	 *
 	 * @covers WP_REST_Global_Styles_Revisions_Controller::get_items
 	 * @covers WP_REST_Global_Styles_Revisions_Controller::prepare_item_for_response


### PR DESCRIPTION
## Description

Fixes an issue where block style variations were being stripped from global styles revisions when retrieved via the REST API.

Trac ticket: https://core.trac.wordpress.org/ticket/64292

### Problem

When retrieving global styles revisions through the REST API, any block style variations (e.g., `styles.blocks.core/group.variations.my-variation`) were being removed during `WP_Theme_JSON` sanitization. This occurred because:

1. `WP_Theme_JSON::sanitize()` only preserves variations that exist in `$valid_variations`
2. `$valid_variations` is populated from `WP_Block_Styles_Registry` (registered block styles)
3. The revisions controller wasn't registering theme-defined variations before instantiation
4. Unregistered variations were stripped by `remove_keys_not_in_schema()`

### Why This Matters

- **Gutenberg works, Core doesn't**: Gutenberg registers variations late through ` WP_Theme_JSON_Resolver_Gutenberg::get_merged_data()`
- **Data loss**: Revision history was losing block style variation data
- **Inconsistent behavior**: Different outcomes depending on request lifecycle/initialization order

### Solution

Register theme-defined block style variations in `WP_REST_Global_Styles_Revisions_Controller::prepare_item_for_response()` before instantiating `WP_Theme_JSON`, ensuring variations pass sanitization regardless of initialization order.

**Changed file**: `src/wp-includes/rest-api/endpoints/class-wp-rest-global-styles-revisions-controller.php`

## Testing Instructions

Switch to a theme with block style variations (e.g., Twenty Twenty-Five)

Go to Global styles > Group and select a style variation

Change the style variation and save. Create a few revisions.

In the site editor, apply the variation to a group block and save the post.

Now open the global styles > revisions and ensure that, when you click on a past revision the style variation applies to the group block.


https://github.com/user-attachments/assets/63d3f461-6444-4eea-ab56-1775c4e2d86e

You can also check that the REST API returns the full revisions:

```
await wp.data.resolveSelect( 'core' ).getRevisions( 'root', 'globalStyles', await wp.data.resolveSelect( 'core' ).__experimentalGetCurrentGlobalStylesId() )
```

Run the test suite for bonus points

```
npm run test:php -- --filter=WP_REST_Global_Styles_Revisions_Controller_Test
```


### Props

@ellatrix for finding the bug in https://github.com/WordPress/gutenberg/pull/73440 and @aaronrobertshaw for initial investigation