### PR TITLE
Change color for added menu items and update hover icon (in Customizer)

### DIFF
--- a/src/wp-admin/css/customize-nav-menus.css
+++ b/src/wp-admin/css/customize-nav-menus.css
@@ -665,11 +665,15 @@
 #available-menu-items .menu-item-handle.item-added .item-title,
 #available-menu-items .menu-item-handle.item-added:hover .item-add,
 #available-menu-items .menu-item-handle.item-added .item-add:focus {
-	color: #8c8f94;
+	color: #1d2327;
 }
 
 #available-menu-items .menu-item-handle.item-added .item-add:before {
 	content: "\f147" / '';
+}
+
+#available-menu-items .menu-item-handle.item-added:hover .item-add:before {
+	content: "\f543" / '';
 }
 
 #available-menu-items .accordion-section-title.loading .spinner,

--- a/src/wp-admin/css/customize-nav-menus.css
+++ b/src/wp-admin/css/customize-nav-menus.css
@@ -672,11 +672,6 @@
 	content: "\f147" / '';
 }
 
-#available-menu-items .menu-item-handle.item-added:hover .item-add:before,
-#available-menu-items .menu-item-handle.item-added .item-add:focus:before {
-	content: "\f543" / '';
-}
-
 #available-menu-items .accordion-section-title.loading .spinner,
 #available-menu-items-search.loading .accordion-section-title .spinner {
 	visibility: visible;

--- a/src/wp-admin/css/customize-nav-menus.css
+++ b/src/wp-admin/css/customize-nav-menus.css
@@ -665,14 +665,15 @@
 #available-menu-items .menu-item-handle.item-added .item-title,
 #available-menu-items .menu-item-handle.item-added:hover .item-add,
 #available-menu-items .menu-item-handle.item-added .item-add:focus {
-	color: #1d2327;
+	color: #646970;
 }
 
 #available-menu-items .menu-item-handle.item-added .item-add:before {
 	content: "\f147" / '';
 }
 
-#available-menu-items .menu-item-handle.item-added:hover .item-add:before {
+#available-menu-items .menu-item-handle.item-added:hover .item-add:before,
+#available-menu-items .menu-item-handle.item-added .item-add:focus:before {
 	content: "\f543" / '';
 }
 


### PR DESCRIPTION
This change makes the added menu item in Customizer WCAG compliant while leaving subtle effects to let the user know that they already added the menu item, but also, if they want they can add it again. This decision was made because it's the least amount of CSS changes while still making sense.

The same dark gray color used initially for menu item labels in Customizer is reused because a color change is not needed. The user will already see the checkmark icon indicating that the item was successfully added. Since you can add the same menu item multiple times (which should stay as-is in case a user has a complex repetitive menu or some reason I'm not thinking of), I also changed the on hover icon to the plus icon. This way, after adding, the user sees the check mark (☑️ great, it added!). If they want to re-add, instead of seeing the initial blue hover color, they see the dark gray _but_ also the plus icon. This combination says, "you already added this, but add it again if you want."

Other solutions would add more lines of CSS or require more changes. I'm a fan of fixing the WCAG issue with minimal changes.

Trac ticket: https://core.trac.wordpress.org/ticket/64013

---

Current:
<img width="1057" height="349" alt="Screenshot 2025-11-23 at 10 21 01 AM" src="https://github.com/user-attachments/assets/31345504-f45e-409e-9e81-0d4a30048536" />

New, after adding:
<img width="1057" height="349" alt="Screenshot 2025-11-23 at 10 37 02 AM" src="https://github.com/user-attachments/assets/02dc3303-6a8a-459b-8278-54594afcb95a" />

New, after adding and on hover:
<img width="1057" height="349" alt="Screenshot 2025-11-23 at 10 37 16 AM" src="https://github.com/user-attachments/assets/3a9da374-7cd6-4290-ae29-7430dab635c1" />