### PR TITLE
Remove generated CSS alts in dashicons.css

### DIFF
--- a/src/wp-includes/css/dashicons.css
+++ b/src/wp-includes/css/dashicons.css
@@ -40,1400 +40,1400 @@
 /* Icons */
 
 .dashicons-admin-appearance:before {
-	content: "\f100" / '';
+	content: "\f100";
 }
 
 .dashicons-admin-collapse:before {
-	content: "\f148" / '';
+	content: "\f148";
 }
 
 .dashicons-admin-comments:before {
-	content: "\f101" / '';
+	content: "\f101";
 }
 
 .dashicons-admin-customizer:before {
-	content: "\f540" / '';
+	content: "\f540";
 }
 
 .dashicons-admin-generic:before {
-	content: "\f111" / '';
+	content: "\f111";
 }
 
 .dashicons-admin-home:before {
-	content: "\f102" / '';
+	content: "\f102";
 }
 
 .dashicons-admin-links:before {
-	content: "\f103" / '';
+	content: "\f103";
 }
 
 .dashicons-admin-media:before {
-	content: "\f104" / '';
+	content: "\f104";
 }
 
 .dashicons-admin-multisite:before {
-	content: "\f541" / '';
+	content: "\f541";
 }
 
 .dashicons-admin-network:before {
-	content: "\f112" / '';
+	content: "\f112";
 }
 
 .dashicons-admin-page:before {
-	content: "\f105" / '';
+	content: "\f105";
 }
 
 .dashicons-admin-plugins:before {
-	content: "\f106" / '';
+	content: "\f106";
 }
 
 .dashicons-admin-post:before {
-	content: "\f109" / '';
+	content: "\f109";
 }
 
 .dashicons-admin-settings:before {
-	content: "\f108" / '';
+	content: "\f108";
 }
 
 .dashicons-admin-site-alt:before {
-	content: "\f11d" / '';
+	content: "\f11d";
 }
 
 .dashicons-admin-site-alt2:before {
-	content: "\f11e" / '';
+	content: "\f11e";
 }
 
 .dashicons-admin-site-alt3:before {
-	content: "\f11f" / '';
+	content: "\f11f";
 }
 
 .dashicons-admin-site:before {
-	content: "\f319" / '';
+	content: "\f319";
 }
 
 .dashicons-admin-tools:before {
-	content: "\f107" / '';
+	content: "\f107";
 }
 
 .dashicons-admin-users:before {
-	content: "\f110" / '';
+	content: "\f110";
 }
 
 .dashicons-airplane:before {
-	content: "\f15f" / '';
+	content: "\f15f";
 }
 
 .dashicons-album:before {
-	content: "\f514" / '';
+	content: "\f514";
 }
 
 .dashicons-align-center:before {
-	content: "\f134" / '';
+	content: "\f134";
 }
 
 .dashicons-align-full-width:before {
-	content: "\f114" / '';
+	content: "\f114";
 }
 
 .dashicons-align-left:before {
-	content: "\f135" / '';
+	content: "\f135";
 }
 
 .dashicons-align-none:before {
-	content: "\f138" / '';
+	content: "\f138";
 }
 
 .dashicons-align-pull-left:before {
-	content: "\f10a" / '';
+	content: "\f10a";
 }
 
 .dashicons-align-pull-right:before {
-	content: "\f10b" / '';
+	content: "\f10b";
 }
 
 .dashicons-align-right:before {
-	content: "\f136" / '';
+	content: "\f136";
 }
 
 .dashicons-align-wide:before {
-	content: "\f11b" / '';
+	content: "\f11b";
 }
 
 .dashicons-amazon:before {
-	content: "\f162" / '';
+	content: "\f162";
 }
 
 .dashicons-analytics:before {
-	content: "\f183" / '';
+	content: "\f183";
 }
 
 .dashicons-archive:before {
-	content: "\f480" / '';
+	content: "\f480";
 }
 
 .dashicons-arrow-down-alt:before {
-	content: "\f346" / '';
+	content: "\f346";
 }
 
 .dashicons-arrow-down-alt2:before {
-	content: "\f347" / '';
+	content: "\f347";
 }
 
 .dashicons-arrow-down:before {
-	content: "\f140" / '';
+	content: "\f140";
 }
 
 .dashicons-arrow-left-alt:before {
-	content: "\f340" / '';
+	content: "\f340";
 }
 
 .dashicons-arrow-left-alt2:before {
-	content: "\f341" / '';
+	content: "\f341";
 }
 
 .dashicons-arrow-left:before {
-	content: "\f141" / '';
+	content: "\f141";
 }
 
 .dashicons-arrow-right-alt:before {
-	content: "\f344" / '';
+	content: "\f344";
 }
 
 .dashicons-arrow-right-alt2:before {
-	content: "\f345" / '';
+	content: "\f345";
 }
 
 .dashicons-arrow-right:before {
-	content: "\f139" / '';
+	content: "\f139";
 }
 
 .dashicons-arrow-up-alt:before {
-	content: "\f342" / '';
+	content: "\f342";
 }
 
 .dashicons-arrow-up-alt2:before {
-	content: "\f343" / '';
+	content: "\f343";
 }
 
 .dashicons-arrow-up-duplicate:before {
-	content: "\f143" / '';
+	content: "\f143";
 }
 
 .dashicons-arrow-up:before {
-	content: "\f142" / '';
+	content: "\f142";
 }
 
 .dashicons-art:before {
-	content: "\f309" / '';
+	content: "\f309";
 }
 
 .dashicons-awards:before {
-	content: "\f313" / '';
+	content: "\f313";
 }
 
 .dashicons-backup:before {
-	content: "\f321" / '';
+	content: "\f321";
 }
 
 .dashicons-bank:before {
-	content: "\f16a" / '';
+	content: "\f16a";
 }
 
 .dashicons-beer:before {
-	content: "\f16c" / '';
+	content: "\f16c";
 }
 
 .dashicons-bell:before {
-	content: "\f16d" / '';
+	content: "\f16d";
 }
 
 .dashicons-block-default:before {
-	content: "\f12b" / '';
+	content: "\f12b";
 }
 
 .dashicons-book-alt:before {
-	content: "\f331" / '';
+	content: "\f331";
 }
 
 .dashicons-book:before {
-	content: "\f330" / '';
+	content: "\f330";
 }
 
 .dashicons-buddicons-activity:before {
-	content: "\f452" / '';
+	content: "\f452";
 }
 
 .dashicons-buddicons-bbpress-logo:before {
-	content: "\f477" / '';
+	content: "\f477";
 }
 
 .dashicons-buddicons-buddypress-logo:before {
-	content: "\f448" / '';
+	content: "\f448";
 }
 
 .dashicons-buddicons-community:before {
-	content: "\f453" / '';
+	content: "\f453";
 }
 
 .dashicons-buddicons-forums:before {
-	content: "\f449" / '';
+	content: "\f449";
 }
 
 .dashicons-buddicons-friends:before {
-	content: "\f454" / '';
+	content: "\f454";
 }
 
 .dashicons-buddicons-groups:before {
-	content: "\f456" / '';
+	content: "\f456";
 }
 
 .dashicons-buddicons-pm:before {
-	content: "\f457" / '';
+	content: "\f457";
 }
 
 .dashicons-buddicons-replies:before {
-	content: "\f451" / '';
+	content: "\f451";
 }
 
 .dashicons-buddicons-topics:before {
-	content: "\f450" / '';
+	content: "\f450";
 }
 
 .dashicons-buddicons-tracking:before {
-	content: "\f455" / '';
+	content: "\f455";
 }
 
 .dashicons-building:before {
-	content: "\f512" / '';
+	content: "\f512";
 }
 
 .dashicons-businessman:before {
-	content: "\f338" / '';
+	content: "\f338";
 }
 
 .dashicons-businessperson:before {
-	content: "\f12e" / '';
+	content: "\f12e";
 }
 
 .dashicons-businesswoman:before {
-	content: "\f12f" / '';
+	content: "\f12f";
 }
 
 .dashicons-button:before {
-	content: "\f11a" / '';
+	content: "\f11a";
 }
 
 .dashicons-calculator:before {
-	content: "\f16e" / '';
+	content: "\f16e";
 }
 
 .dashicons-calendar-alt:before {
-	content: "\f508" / '';
+	content: "\f508";
 }
 
 .dashicons-calendar:before {
-	content: "\f145" / '';
+	content: "\f145";
 }
 
 .dashicons-camera-alt:before {
-	content: "\f129" / '';
+	content: "\f129";
 }
 
 .dashicons-camera:before {
-	content: "\f306" / '';
+	content: "\f306";
 }
 
 .dashicons-car:before {
-	content: "\f16b" / '';
+	content: "\f16b";
 }
 
 .dashicons-carrot:before {
-	content: "\f511" / '';
+	content: "\f511";
 }
 
 .dashicons-cart:before {
-	content: "\f174" / '';
+	content: "\f174";
 }
 
 .dashicons-category:before {
-	content: "\f318" / '';
+	content: "\f318";
 }
 
 .dashicons-chart-area:before {
-	content: "\f239" / '';
+	content: "\f239";
 }
 
 .dashicons-chart-bar:before {
-	content: "\f185" / '';
+	content: "\f185";
 }
 
 .dashicons-chart-line:before {
-	content: "\f238" / '';
+	content: "\f238";
 }
 
 .dashicons-chart-pie:before {
-	content: "\f184" / '';
+	content: "\f184";
 }
 
 .dashicons-clipboard:before {
-	content: "\f481" / '';
+	content: "\f481";
 }
 
 .dashicons-clock:before {
-	content: "\f469" / '';
+	content: "\f469";
 }
 
 .dashicons-cloud-saved:before {
-	content: "\f137" / '';
+	content: "\f137";
 }
 
 .dashicons-cloud-upload:before {
-	content: "\f13b" / '';
+	content: "\f13b";
 }
 
 .dashicons-cloud:before {
-	content: "\f176" / '';
+	content: "\f176";
 }
 
 .dashicons-code-standards:before {
-	content: "\f13a" / '';
+	content: "\f13a";
 }
 
 .dashicons-coffee:before {
-	content: "\f16f" / '';
+	content: "\f16f";
 }
 
 .dashicons-color-picker:before {
-	content: "\f131" / '';
+	content: "\f131";
 }
 
 .dashicons-columns:before {
-	content: "\f13c" / '';
+	content: "\f13c";
 }
 
 .dashicons-controls-back:before {
-	content: "\f518" / '';
+	content: "\f518";
 }
 
 .dashicons-controls-forward:before {
-	content: "\f519" / '';
+	content: "\f519";
 }
 
 .dashicons-controls-pause:before {
-	content: "\f523" / '';
+	content: "\f523";
 }
 
 .dashicons-controls-play:before {
-	content: "\f522" / '';
+	content: "\f522";
 }
 
 .dashicons-controls-repeat:before {
-	content: "\f515" / '';
+	content: "\f515";
 }
 
 .dashicons-controls-skipback:before {
-	content: "\f516" / '';
+	content: "\f516";
 }
 
 .dashicons-controls-skipforward:before {
-	content: "\f517" / '';
+	content: "\f517";
 }
 
 .dashicons-controls-volumeoff:before {
-	content: "\f520" / '';
+	content: "\f520";
 }
 
 .dashicons-controls-volumeon:before {
-	content: "\f521" / '';
+	content: "\f521";
 }
 
 .dashicons-cover-image:before {
-	content: "\f13d" / '';
+	content: "\f13d";
 }
 
 .dashicons-dashboard:before {
-	content: "\f226" / '';
+	content: "\f226";
 }
 
 .dashicons-database-add:before {
-	content: "\f170" / '';
+	content: "\f170";
 }
 
 .dashicons-database-export:before {
-	content: "\f17a" / '';
+	content: "\f17a";
 }
 
 .dashicons-database-import:before {
-	content: "\f17b" / '';
+	content: "\f17b";
 }
 
 .dashicons-database-remove:before {
-	content: "\f17c" / '';
+	content: "\f17c";
 }
 
 .dashicons-database-view:before {
-	content: "\f17d" / '';
+	content: "\f17d";
 }
 
 .dashicons-database:before {
-	content: "\f17e" / '';
+	content: "\f17e";
 }
 
 .dashicons-desktop:before {
-	content: "\f472" / '';
+	content: "\f472";
 }
 
 .dashicons-dismiss:before {
-	content: "\f153" / '';
+	content: "\f153";
 }
 
 .dashicons-download:before {
-	content: "\f316" / '';
+	content: "\f316";
 }
 
 .dashicons-drumstick:before {
-	content: "\f17f" / '';
+	content: "\f17f";
 }
 
 .dashicons-edit-large:before {
-	content: "\f327" / '';
+	content: "\f327";
 }
 
 .dashicons-edit-page:before {
-	content: "\f186" / '';
+	content: "\f186";
 }
 
 .dashicons-edit:before {
-	content: "\f464" / '';
+	content: "\f464";
 }
 
 .dashicons-editor-aligncenter:before {
-	content: "\f207" / '';
+	content: "\f207";
 }
 
 .dashicons-editor-alignleft:before {
-	content: "\f206" / '';
+	content: "\f206";
 }
 
 .dashicons-editor-alignright:before {
-	content: "\f208" / '';
+	content: "\f208";
 }
 
 .dashicons-editor-bold:before {
-	content: "\f200" / '';
+	content: "\f200";
 }
 
 .dashicons-editor-break:before {
-	content: "\f474" / '';
+	content: "\f474";
 }
 
 .dashicons-editor-code-duplicate:before {
-	content: "\f494" / '';
+	content: "\f494";
 }
 
 .dashicons-editor-code:before {
-	content: "\f475" / '';
+	content: "\f475";
 }
 
 .dashicons-editor-contract:before {
-	content: "\f506" / '';
+	content: "\f506";
 }
 
 .dashicons-editor-customchar:before {
-	content: "\f220" / '';
+	content: "\f220";
 }
 
 .dashicons-editor-expand:before {
-	content: "\f211" / '';
+	content: "\f211";
 }
 
 .dashicons-editor-help:before {
-	content: "\f223" / '';
+	content: "\f223";
 }
 
 .dashicons-editor-indent:before {
-	content: "\f222" / '';
+	content: "\f222";
 }
 
 .dashicons-editor-insertmore:before {
-	content: "\f209" / '';
+	content: "\f209";
 }
 
 .dashicons-editor-italic:before {
-	content: "\f201" / '';
+	content: "\f201";
 }
 
 .dashicons-editor-justify:before {
-	content: "\f214" / '';
+	content: "\f214";
 }
 
 .dashicons-editor-kitchensink:before {
-	content: "\f212" / '';
+	content: "\f212";
 }
 
 .dashicons-editor-ltr:before {
-	content: "\f10c" / '';
+	content: "\f10c";
 }
 
 .dashicons-editor-ol-rtl:before {
-	content: "\f12c" / '';
+	content: "\f12c";
 }
 
 .dashicons-editor-ol:before {
-	content: "\f204" / '';
+	content: "\f204";
 }
 
 .dashicons-editor-outdent:before {
-	content: "\f221" / '';
+	content: "\f221";
 }
 
 .dashicons-editor-paragraph:before {
-	content: "\f476" / '';
+	content: "\f476";
 }
 
 .dashicons-editor-paste-text:before {
-	content: "\f217" / '';
+	content: "\f217";
 }
 
 .dashicons-editor-paste-word:before {
-	content: "\f216" / '';
+	content: "\f216";
 }
 
 .dashicons-editor-quote:before {
-	content: "\f205" / '';
+	content: "\f205";
 }
 
 .dashicons-editor-removeformatting:before {
-	content: "\f218" / '';
+	content: "\f218";
 }
 
 .dashicons-editor-rtl:before {
-	content: "\f320" / '';
+	content: "\f320";
 }
 
 .dashicons-editor-spellcheck:before {
-	content: "\f210" / '';
+	content: "\f210";
 }
 
 .dashicons-editor-strikethrough:before {
-	content: "\f224" / '';
+	content: "\f224";
 }
 
 .dashicons-editor-table:before {
-	content: "\f535" / '';
+	content: "\f535";
 }
 
 .dashicons-editor-textcolor:before {
-	content: "\f215" / '';
+	content: "\f215";
 }
 
 .dashicons-editor-ul:before {
-	content: "\f203" / '';
+	content: "\f203";
 }
 
 .dashicons-editor-underline:before {
-	content: "\f213" / '';
+	content: "\f213";
 }
 
 .dashicons-editor-unlink:before {
-	content: "\f225" / '';
+	content: "\f225";
 }
 
 .dashicons-editor-video:before {
-	content: "\f219" / '';
+	content: "\f219";
 }
 
 .dashicons-ellipsis:before {
-	content: "\f11c" / '';
+	content: "\f11c";
 }
 
 .dashicons-email-alt:before {
-	content: "\f466" / '';
+	content: "\f466";
 }
 
 .dashicons-email-alt2:before {
-	content: "\f467" / '';
+	content: "\f467";
 }
 
 .dashicons-email:before {
-	content: "\f465" / '';
+	content: "\f465";
 }
 
 .dashicons-embed-audio:before {
-	content: "\f13e" / '';
+	content: "\f13e";
 }
 
 .dashicons-embed-generic:before {
-	content: "\f13f" / '';
+	content: "\f13f";
 }
 
 .dashicons-embed-photo:before {
-	content: "\f144" / '';
+	content: "\f144";
 }
 
 .dashicons-embed-post:before {
-	content: "\f146" / '';
+	content: "\f146";
 }
 
 .dashicons-embed-video:before {
-	content: "\f149" / '';
+	content: "\f149";
 }
 
 .dashicons-excerpt-view:before {
-	content: "\f164" / '';
+	content: "\f164";
 }
 
 .dashicons-exit:before {
-	content: "\f14a" / '';
+	content: "\f14a";
 }
 
 .dashicons-external:before {
-	content: "\f504" / '';
+	content: "\f504";
 }
 
 .dashicons-facebook-alt:before {
-	content: "\f305" / '';
+	content: "\f305";
 }
 
 .dashicons-facebook:before {
-	content: "\f304" / '';
+	content: "\f304";
 }
 
 .dashicons-feedback:before {
-	content: "\f175" / '';
+	content: "\f175";
 }
 
 .dashicons-filter:before {
-	content: "\f536" / '';
+	content: "\f536";
 }
 
 .dashicons-flag:before {
-	content: "\f227" / '';
+	content: "\f227";
 }
 
 .dashicons-food:before {
-	content: "\f187" / '';
+	content: "\f187";
 }
 
 .dashicons-format-aside:before {
-	content: "\f123" / '';
+	content: "\f123";
 }
 
 .dashicons-format-audio:before {
-	content: "\f127" / '';
+	content: "\f127";
 }
 
 .dashicons-format-chat:before {
-	content: "\f125" / '';
+	content: "\f125";
 }
 
 .dashicons-format-gallery:before {
-	content: "\f161" / '';
+	content: "\f161";
 }
 
 .dashicons-format-image:before {
-	content: "\f128" / '';
+	content: "\f128";
 }
 
 .dashicons-format-quote:before {
-	content: "\f122" / '';
+	content: "\f122";
 }
 
 .dashicons-format-status:before {
-	content: "\f130" / '';
+	content: "\f130";
 }
 
 .dashicons-format-video:before {
-	content: "\f126" / '';
+	content: "\f126";
 }
 
 .dashicons-forms:before {
-	content: "\f314" / '';
+	content: "\f314";
 }
 
 .dashicons-fullscreen-alt:before {
-	content: "\f188" / '';
+	content: "\f188";
 }
 
 .dashicons-fullscreen-exit-alt:before {
-	content: "\f189" / '';
+	content: "\f189";
 }
 
 .dashicons-games:before {
-	content: "\f18a" / '';
+	content: "\f18a";
 }
 
 .dashicons-google:before {
-	content: "\f18b" / '';
+	content: "\f18b";
 }
 
 .dashicons-googleplus:before {
-	content: "\f462" / '';
+	content: "\f462";
 }
 
 .dashicons-grid-view:before {
-	content: "\f509" / '';
+	content: "\f509";
 }
 
 .dashicons-groups:before {
-	content: "\f307" / '';
+	content: "\f307";
 }
 
 .dashicons-hammer:before {
-	content: "\f308" / '';
+	content: "\f308";
 }
 
 .dashicons-heading:before {
-	content: "\f10e" / '';
+	content: "\f10e";
 }
 
 .dashicons-heart:before {
-	content: "\f487" / '';
+	content: "\f487";
 }
 
 .dashicons-hidden:before {
-	content: "\f530" / '';
+	content: "\f530";
 }
 
 .dashicons-hourglass:before {
-	content: "\f18c" / '';
+	content: "\f18c";
 }
 
 .dashicons-html:before {
-	content: "\f14b" / '';
+	content: "\f14b";
 }
 
 .dashicons-id-alt:before {
-	content: "\f337" / '';
+	content: "\f337";
 }
 
 .dashicons-id:before {
-	content: "\f336" / '';
+	content: "\f336";
 }
 
 .dashicons-image-crop:before {
-	content: "\f165" / '';
+	content: "\f165";
 }
 
 .dashicons-image-filter:before {
-	content: "\f533" / '';
+	content: "\f533";
 }
 
 .dashicons-image-flip-horizontal:before {
-	content: "\f169" / '';
+	content: "\f169";
 }
 
 .dashicons-image-flip-vertical:before {
-	content: "\f168" / '';
+	content: "\f168";
 }
 
 .dashicons-image-rotate-left:before {
-	content: "\f166" / '';
+	content: "\f166";
 }
 
 .dashicons-image-rotate-right:before {
-	content: "\f167" / '';
+	content: "\f167";
 }
 
 .dashicons-image-rotate:before {
-	content: "\f531" / '';
+	content: "\f531";
 }
 
 .dashicons-images-alt:before {
-	content: "\f232" / '';
+	content: "\f232";
 }
 
 .dashicons-images-alt2:before {
-	content: "\f233" / '';
+	content: "\f233";
 }
 
 .dashicons-index-card:before {
-	content: "\f510" / '';
+	content: "\f510";
 }
 
 .dashicons-info-outline:before {
-	content: "\f14c" / '';
+	content: "\f14c";
 }
 
 .dashicons-info:before {
-	content: "\f348" / '';
+	content: "\f348";
 }
 
 .dashicons-insert-after:before {
-	content: "\f14d" / '';
+	content: "\f14d";
 }
 
 .dashicons-insert-before:before {
-	content: "\f14e" / '';
+	content: "\f14e";
 }
 
 .dashicons-insert:before {
-	content: "\f10f" / '';
+	content: "\f10f";
 }
 
 .dashicons-instagram:before {
-	content: "\f12d" / '';
+	content: "\f12d";
 }
 
 .dashicons-laptop:before {
-	content: "\f547" / '';
+	content: "\f547";
 }
 
 .dashicons-layout:before {
-	content: "\f538" / '';
+	content: "\f538";
 }
 
 .dashicons-leftright:before {
-	content: "\f229" / '';
+	content: "\f229";
 }
 
 .dashicons-lightbulb:before {
-	content: "\f339" / '';
+	content: "\f339";
 }
 
 .dashicons-linkedin:before {
-	content: "\f18d" / '';
+	content: "\f18d";
 }
 
 .dashicons-list-view:before {
-	content: "\f163" / '';
+	content: "\f163";
 }
 
 .dashicons-location-alt:before {
-	content: "\f231" / '';
+	content: "\f231";
 }
 
 .dashicons-location:before {
-	content: "\f230" / '';
+	content: "\f230";
 }
 
 .dashicons-lock-duplicate:before {
-	content: "\f315" / '';
+	content: "\f315";
 }
 
 .dashicons-lock:before {
-	content: "\f160" / '';
+	content: "\f160";
 }
 
 .dashicons-marker:before {
-	content: "\f159" / '';
+	content: "\f159";
 }
 
 .dashicons-media-archive:before {
-	content: "\f501" / '';
+	content: "\f501";
 }
 
 .dashicons-media-audio:before {
-	content: "\f500" / '';
+	content: "\f500";
 }
 
 .dashicons-media-code:before {
-	content: "\f499" / '';
+	content: "\f499";
 }
 
 .dashicons-media-default:before {
-	content: "\f498" / '';
+	content: "\f498";
 }
 
 .dashicons-media-document:before {
-	content: "\f497" / '';
+	content: "\f497";
 }
 
 .dashicons-media-interactive:before {
-	content: "\f496" / '';
+	content: "\f496";
 }
 
 .dashicons-media-spreadsheet:before {
-	content: "\f495" / '';
+	content: "\f495";
 }
 
 .dashicons-media-text:before {
-	content: "\f491" / '';
+	content: "\f491";
 }
 
 .dashicons-media-video:before {
-	content: "\f490" / '';
+	content: "\f490";
 }
 
 .dashicons-megaphone:before {
-	content: "\f488" / '';
+	content: "\f488";
 }
 
 .dashicons-menu-alt:before {
-	content: "\f228" / '';
+	content: "\f228";
 }
 
 .dashicons-menu-alt2:before {
-	content: "\f329" / '';
+	content: "\f329";
 }
 
 .dashicons-menu-alt3:before {
-	content: "\f349" / '';
+	content: "\f349";
 }
 
 .dashicons-menu:before {
-	content: "\f333" / '';
+	content: "\f333";
 }
 
 .dashicons-microphone:before {
-	content: "\f482" / '';
+	content: "\f482";
 }
 
 .dashicons-migrate:before {
-	content: "\f310" / '';
+	content: "\f310";
 }
 
 .dashicons-minus:before {
-	content: "\f460" / '';
+	content: "\f460";
 }
 
 .dashicons-money-alt:before {
-	content: "\f18e" / '';
+	content: "\f18e";
 }
 
 .dashicons-money:before {
-	content: "\f526" / '';
+	content: "\f526";
 }
 
 .dashicons-move:before {
-	content: "\f545" / '';
+	content: "\f545";
 }
 
 .dashicons-nametag:before {
-	content: "\f484" / '';
+	content: "\f484";
 }
 
 .dashicons-networking:before {
-	content: "\f325" / '';
+	content: "\f325";
 }
 
 .dashicons-no-alt:before {
-	content: "\f335" / '';
+	content: "\f335";
 }
 
 .dashicons-no:before {
-	content: "\f158" / '';
+	content: "\f158";
 }
 
 .dashicons-open-folder:before {
-	content: "\f18f" / '';
+	content: "\f18f";
 }
 
 .dashicons-palmtree:before {
-	content: "\f527" / '';
+	content: "\f527";
 }
 
 .dashicons-paperclip:before {
-	content: "\f546" / '';
+	content: "\f546";
 }
 
 .dashicons-pdf:before {
-	content: "\f190" / '';
+	content: "\f190";
 }
 
 .dashicons-performance:before {
-	content: "\f311" / '';
+	content: "\f311";
 }
 
 .dashicons-pets:before {
-	content: "\f191" / '';
+	content: "\f191";
 }
 
 .dashicons-phone:before {
-	content: "\f525" / '';
+	content: "\f525";
 }
 
 .dashicons-pinterest:before {
-	content: "\f192" / '';
+	content: "\f192";
 }
 
 .dashicons-playlist-audio:before {
-	content: "\f492" / '';
+	content: "\f492";
 }
 
 .dashicons-playlist-video:before {
-	content: "\f493" / '';
+	content: "\f493";
 }
 
 .dashicons-plugins-checked:before {
-	content: "\f485" / '';
+	content: "\f485";
 }
 
 .dashicons-plus-alt:before {
-	content: "\f502" / '';
+	content: "\f502";
 }
 
 .dashicons-plus-alt2:before {
-	content: "\f543" / '';
+	content: "\f543";
 }
 
 .dashicons-plus:before {
-	content: "\f132" / '';
+	content: "\f132";
 }
 
 .dashicons-podio:before {
-	content: "\f19c" / '';
+	content: "\f19c";
 }
 
 .dashicons-portfolio:before {
-	content: "\f322" / '';
+	content: "\f322";
 }
 
 .dashicons-post-status:before {
-	content: "\f173" / '';
+	content: "\f173";
 }
 
 .dashicons-pressthis:before {
-	content: "\f157" / '';
+	content: "\f157";
 }
 
 .dashicons-printer:before {
-	content: "\f193" / '';
+	content: "\f193";
 }
 
 .dashicons-privacy:before {
-	content: "\f194" / '';
+	content: "\f194";
 }
 
 .dashicons-products:before {
-	content: "\f312" / '';
+	content: "\f312";
 }
 
 .dashicons-randomize:before {
-	content: "\f503" / '';
+	content: "\f503";
 }
 
 .dashicons-reddit:before {
-	content: "\f195" / '';
+	content: "\f195";
 }
 
 .dashicons-redo:before {
-	content: "\f172" / '';
+	content: "\f172";
 }
 
 .dashicons-remove:before {
-	content: "\f14f" / '';
+	content: "\f14f";
 }
 
 .dashicons-rest-api:before {
-	content: "\f124" / '';
+	content: "\f124";
 }
 
 .dashicons-rss:before {
-	content: "\f303" / '';
+	content: "\f303";
 }
 
 .dashicons-saved:before {
-	content: "\f15e" / '';
+	content: "\f15e";
 }
 
 .dashicons-schedule:before {
-	content: "\f489" / '';
+	content: "\f489";
 }
 
 .dashicons-screenoptions:before {
-	content: "\f180" / '';
+	content: "\f180";
 }
 
 .dashicons-search:before {
-	content: "\f179" / '';
+	content: "\f179";
 }
 
 .dashicons-share-alt:before {
-	content: "\f240" / '';
+	content: "\f240";
 }
 
 .dashicons-share-alt2:before {
-	content: "\f242" / '';
+	content: "\f242";
 }
 
 .dashicons-share:before {
-	content: "\f237" / '';
+	content: "\f237";
 }
 
 .dashicons-shield-alt:before {
-	content: "\f334" / '';
+	content: "\f334";
 }
 
 .dashicons-shield:before {
-	content: "\f332" / '';
+	content: "\f332";
 }
 
 .dashicons-shortcode:before {
-	content: "\f150" / '';
+	content: "\f150";
 }
 
 .dashicons-slides:before {
-	content: "\f181" / '';
+	content: "\f181";
 }
 
 .dashicons-smartphone:before {
-	content: "\f470" / '';
+	content: "\f470";
 }
 
 .dashicons-smiley:before {
-	content: "\f328" / '';
+	content: "\f328";
 }
 
 .dashicons-sort:before {
-	content: "\f156" / '';
+	content: "\f156";
 }
 
 .dashicons-sos:before {
-	content: "\f468" / '';
+	content: "\f468";
 }
 
 .dashicons-spotify:before {
-	content: "\f196" / '';
+	content: "\f196";
 }
 
 .dashicons-star-empty:before {
-	content: "\f154" / '';
+	content: "\f154";
 }
 
 .dashicons-star-filled:before {
-	content: "\f155" / '';
+	content: "\f155";
 }
 
 .dashicons-star-half:before {
-	content: "\f459" / '';
+	content: "\f459";
 }
 
 .dashicons-sticky:before {
-	content: "\f537" / '';
+	content: "\f537";
 }
 
 .dashicons-store:before {
-	content: "\f513" / '';
+	content: "\f513";
 }
 
 .dashicons-superhero-alt:before {
-	content: "\f197" / '';
+	content: "\f197";
 }
 
 .dashicons-superhero:before {
-	content: "\f198" / '';
+	content: "\f198";
 }
 
 .dashicons-table-col-after:before {
-	content: "\f151" / '';
+	content: "\f151";
 }
 
 .dashicons-table-col-before:before {
-	content: "\f152" / '';
+	content: "\f152";
 }
 
 .dashicons-table-col-delete:before {
-	content: "\f15a" / '';
+	content: "\f15a";
 }
 
 .dashicons-table-row-after:before {
-	content: "\f15b" / '';
+	content: "\f15b";
 }
 
 .dashicons-table-row-before:before {
-	content: "\f15c" / '';
+	content: "\f15c";
 }
 
 .dashicons-table-row-delete:before {
-	content: "\f15d" / '';
+	content: "\f15d";
 }
 
 .dashicons-tablet:before {
-	content: "\f471" / '';
+	content: "\f471";
 }
 
 .dashicons-tag:before {
-	content: "\f323" / '';
+	content: "\f323";
 }
 
 .dashicons-tagcloud:before {
-	content: "\f479" / '';
+	content: "\f479";
 }
 
 .dashicons-testimonial:before {
-	content: "\f473" / '';
+	content: "\f473";
 }
 
 .dashicons-text-page:before {
-	content: "\f121" / '';
+	content: "\f121";
 }
 
 .dashicons-text:before {
-	content: "\f478" / '';
+	content: "\f478";
 }
 
 .dashicons-thumbs-down:before {
-	content: "\f542" / '';
+	content: "\f542";
 }
 
 .dashicons-thumbs-up:before {
-	content: "\f529" / '';
+	content: "\f529";
 }
 
 .dashicons-tickets-alt:before {
-	content: "\f524" / '';
+	content: "\f524";
 }
 
 .dashicons-tickets:before {
-	content: "\f486" / '';
+	content: "\f486";
 }
 
 .dashicons-tide:before {
-	content: "\f10d" / '';
+	content: "\f10d";
 }
 
 .dashicons-translation:before {
-	content: "\f326" / '';
+	content: "\f326";
 }
 
 .dashicons-trash:before {
-	content: "\f182" / '';
+	content: "\f182";
 }
 
 .dashicons-twitch:before {
-	content: "\f199" / '';
+	content: "\f199";
 }
 
 .dashicons-twitter-alt:before {
-	content: "\f302" / '';
+	content: "\f302";
 }
 
 .dashicons-twitter:before {
-	content: "\f301" / '';
+	content: "\f301";
 }
 
 .dashicons-undo:before {
-	content: "\f171" / '';
+	content: "\f171";
 }
 
 .dashicons-universal-access-alt:before {
-	content: "\f507" / '';
+	content: "\f507";
 }
 
 .dashicons-universal-access:before {
-	content: "\f483" / '';
+	content: "\f483";
 }
 
 .dashicons-unlock:before {
-	content: "\f528" / '';
+	content: "\f528";
 }
 
 .dashicons-update-alt:before {
-	content: "\f113" / '';
+	content: "\f113";
 }
 
 .dashicons-update:before {
-	content: "\f463" / '';
+	content: "\f463";
 }
 
 .dashicons-upload:before {
-	content: "\f317" / '';
+	content: "\f317";
 }
 
 .dashicons-vault:before {
-	content: "\f178" / '';
+	content: "\f178";
 }
 
 .dashicons-video-alt:before {
-	content: "\f234" / '';
+	content: "\f234";
 }
 
 .dashicons-video-alt2:before {
-	content: "\f235" / '';
+	content: "\f235";
 }
 
 .dashicons-video-alt3:before {
-	content: "\f236" / '';
+	content: "\f236";
 }
 
 .dashicons-visibility:before {
-	content: "\f177" / '';
+	content: "\f177";
 }
 
 .dashicons-warning:before {
-	content: "\f534" / '';
+	content: "\f534";
 }
 
 .dashicons-welcome-add-page:before {
-	content: "\f133" / '';
+	content: "\f133";
 }
 
 .dashicons-welcome-comments:before {
-	content: "\f117" / '';
+	content: "\f117";
 }
 
 .dashicons-welcome-learn-more:before {
-	content: "\f118" / '';
+	content: "\f118";
 }
 
 .dashicons-welcome-view-site:before {
-	content: "\f115" / '';
+	content: "\f115";
 }
 
 .dashicons-welcome-widgets-menus:before {
-	content: "\f116" / '';
+	content: "\f116";
 }
 
 .dashicons-welcome-write-blog:before {
-	content: "\f119" / '';
+	content: "\f119";
 }
 
 .dashicons-whatsapp:before {
-	content: "\f19a" / '';
+	content: "\f19a";
 }
 
 .dashicons-wordpress-alt:before {
-	content: "\f324" / '';
+	content: "\f324";
 }
 
 .dashicons-wordpress:before {
-	content: "\f120" / '';
+	content: "\f120";
 }
 
 .dashicons-xing:before {
-	content: "\f19d" / '';
+	content: "\f19d";
 }
 
 .dashicons-yes-alt:before {
-	content: "\f12a" / '';
+	content: "\f12a";
 }
 
 .dashicons-yes:before {
-	content: "\f147" / '';
+	content: "\f147";
 }
 
 .dashicons-youtube:before {
-	content: "\f19b" / '';
+	content: "\f19b";
 }
 
 /* Additional CSS classes, manually added to the CSS template file */
 
 .dashicons-editor-distractionfree:before {
-	content: "\f211" / '';
+	content: "\f211";
 }
 
 /* This is a typo, but was previously released. It should remain for backward compatibility. See https://core.trac.wordpress.org/ticket/30832. */
 .dashicons-exerpt-view:before {
-	content: "\f164" / '';
+	content: "\f164";
 }
 
 .dashicons-format-links:before {
-	content: "\f103" / '';
+	content: "\f103";
 }
 
 .dashicons-format-standard:before {
-	content: "\f109" / '';
+	content: "\f109";
 }
 
 .dashicons-post-trash:before {
-	content: "\f182" / '';
+	content: "\f182";
 }
 
 .dashicons-share1:before {
-	content: "\f237" / '';
+	content: "\f237";
 }
 
 .dashicons-welcome-edit-page:before {
-	content: "\f119" / '';
+	content: "\f119";
 }


### PR DESCRIPTION
This will prevent plugins and themes that require dashicons.css from breaking support for older Safari versions.

For clarity, this does *not* resolve the issue reported in the related ticket; core menu icons will still be missing in unsupported Safari browsers. But it will prevent this issue from expanding to 3rd party applications that require `dashicons.css` as a dependency.

Trac ticket: https://core.trac.wordpress.org/ticket/64266

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
