### PR TITLE
Add `_doing_it_wrong()` notices for missing script, style, and script module dependencies

### DIFF
--- a/src/wp-includes/class-wp-dependencies.php
+++ b/src/wp-includes/class-wp-dependencies.php
@@ -105,6 +105,18 @@ class WP_Dependencies {
 	private $queued_before_register = array();
 
 	/**
+	 * List of IDs for dependencies encountered which themselves have missing dependencies.
+	 *
+	 * A dependency handle is added to this list when it is discovered to have missing dependencies. At this time, a
+	 * warning is emitted with {@see _doing_it_wrong()}. The handle is then added to this list, so that duplicate
+	 * warnings don't occur.
+	 *
+	 * @since 7.0.0
+	 * @var string[]
+	 */
+	private $dependencies_with_missing_dependencies = array();
+
+	/**
 	 * Processes the items and dependencies.
 	 *
 	 * Processes the items passed to it or the queue, and their dependencies.
@@ -207,11 +219,14 @@ class WP_Dependencies {
 			if ( ! isset( $this->registered[ $handle ] ) ) {
 				$keep_going = false; // Item doesn't exist.
 			} elseif ( count( $missing_dependencies ) > 0 ) {
-				_doing_it_wrong(
-					__METHOD__,
-					$this->get_dependency_warning_message( $handle, $missing_dependencies ),
-					'7.0.0'
-				);
+				if ( ! in_array( $handle, $this->dependencies_with_missing_dependencies, true ) ) {
+					_doing_it_wrong(
+						__METHOD__,
+						$this->get_dependency_warning_message( $handle, $missing_dependencies ),
+						'7.0.0'
+					);
+					$this->dependencies_with_missing_dependencies[] = $handle;
+				}
 				$keep_going = false; // Item requires dependencies that don't exist.
 			} elseif ( $this->registered[ $handle ]->deps && ! $this->all_deps( $this->registered[ $handle ]->deps, true, $new_group ) ) {
 				$keep_going = false; // Item requires dependencies that don't exist.

--- a/src/wp-includes/class-wp-dependencies.php
+++ b/src/wp-includes/class-wp-dependencies.php
@@ -221,7 +221,7 @@ class WP_Dependencies {
 			} elseif ( count( $missing_dependencies ) > 0 ) {
 				if ( ! in_array( $handle, $this->dependencies_with_missing_dependencies, true ) ) {
 					_doing_it_wrong(
-						__METHOD__,
+						get_class( $this ) . '::add',
 						$this->get_dependency_warning_message( $handle, $missing_dependencies ),
 						'7.0.0'
 					);

--- a/src/wp-includes/class-wp-dependencies.php
+++ b/src/wp-includes/class-wp-dependencies.php
@@ -199,8 +199,11 @@ class WP_Dependencies {
 				continue;
 			}
 
-			$keep_going = true;
-			$missing_dependencies = ( isset( $this->registered[ $handle ] ) && $this->registered[ $handle ]->deps ) ? array_diff( $this->registered[ $handle ]->deps, array_keys( $this->registered ) ) : array();
+			$keep_going           = true;
+			$missing_dependencies = array();
+			if ( isset( $this->registered[ $handle ] ) && $this->registered[ $handle ]->deps ) {
+				$missing_dependencies = array_diff( $this->registered[ $handle ]->deps, array_keys( $this->registered ) );
+			}
 			if ( ! isset( $this->registered[ $handle ] ) ) {
 				$keep_going = false; // Item doesn't exist.
 			} elseif ( $missing_dependencies ) {

--- a/src/wp-includes/class-wp-dependencies.php
+++ b/src/wp-includes/class-wp-dependencies.php
@@ -105,7 +105,7 @@ class WP_Dependencies {
 	private $queued_before_register = array();
 
 	/**
-	 * List of IDs for dependencies encountered which themselves have missing dependencies.
+	 * List of handles for dependencies encountered which themselves have missing dependencies.
 	 *
 	 * A dependency handle is added to this list when it is discovered to have missing dependencies. At this time, a
 	 * warning is emitted with {@see _doing_it_wrong()}. The handle is then added to this list, so that duplicate

--- a/src/wp-includes/class-wp-dependencies.php
+++ b/src/wp-includes/class-wp-dependencies.php
@@ -201,29 +201,17 @@ class WP_Dependencies {
 
 			$keep_going           = true;
 			$missing_dependencies = array();
-			if ( isset( $this->registered[ $handle ] ) && $this->registered[ $handle ]->deps ) {
+			if ( isset( $this->registered[ $handle ] ) && count( $this->registered[ $handle ]->deps ) > 0 ) {
 				$missing_dependencies = array_diff( $this->registered[ $handle ]->deps, array_keys( $this->registered ) );
 			}
 			if ( ! isset( $this->registered[ $handle ] ) ) {
 				$keep_going = false; // Item doesn't exist.
-			} elseif ( $missing_dependencies ) {
-				// Prevent duplicate notices.
-				static $reported = array();
-
-				if ( ! isset( $reported[ $handle ] ) ) {
-					$reported[ $handle ] = true;
-
-					_doing_it_wrong(
-						__METHOD__,
-						sprintf(
-							/* translators: 1: Script module ID, 2: Comma-separated list of missing dependency IDs. */
-							__( 'The script with the handle %1$s was enqueued with dependencies that are not registered: %2$s.' ),
-							$handle,
-							implode( ', ', $missing_dependencies )
-						),
-						'7.0.0'
-					);
-				}
+			} elseif ( count( $missing_dependencies ) > 0 ) {
+				_doing_it_wrong(
+					__METHOD__,
+					$this->get_dependency_warning_message( $handle, $missing_dependencies ),
+					'7.0.0'
+				);
 				$keep_going = false; // Item requires dependencies that don't exist.
 			} elseif ( $this->registered[ $handle ]->deps && ! $this->all_deps( $this->registered[ $handle ]->deps, true, $new_group ) ) {
 				$keep_going = false; // Item requires dependencies that don't exist.
@@ -555,5 +543,23 @@ class WP_Dependencies {
 		 * wp_hash() function.
 		 */
 		return 'W/"' . md5( $etag ) . '"';
+	}
+
+	/**
+	 * Gets a dependency warning message for a handle.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string   $handle                     Handle with missing dependencies.
+	 * @param string[] $missing_dependency_handles Missing dependency handles.
+	 * @return string Formatted, localized warning message.
+	 */
+	protected function get_dependency_warning_message( $handle, $missing_dependency_handles ) {
+		return sprintf(
+			/* translators: 1: Handle, 2: Comma-separated list of missing dependency handles. */
+			__( 'The handle %1$s was enqueued with dependencies that are not registered: %2$s.' ),
+			$handle,
+			implode( ', ', $missing_dependency_handles )
+		);
 	}
 }

--- a/src/wp-includes/class-wp-dependencies.php
+++ b/src/wp-includes/class-wp-dependencies.php
@@ -557,7 +557,7 @@ class WP_Dependencies {
 	protected function get_dependency_warning_message( $handle, $missing_dependency_handles ) {
 		return sprintf(
 			/* translators: 1: Handle, 2: Comma-separated list of missing dependency handles. */
-			__( 'The handle %1$s was enqueued with dependencies that are not registered: %2$s.' ),
+			__( 'The handle "%1$s" was enqueued with dependencies that are not registered: %2$s.' ),
 			$handle,
 			implode( ', ', $missing_dependency_handles )
 		);

--- a/src/wp-includes/class-wp-dependencies.php
+++ b/src/wp-includes/class-wp-dependencies.php
@@ -200,9 +200,27 @@ class WP_Dependencies {
 			}
 
 			$keep_going = true;
+			$missing_dependencies = ( isset( $this->registered[ $handle ] ) && $this->registered[ $handle ]->deps ) ? array_diff( $this->registered[ $handle ]->deps, array_keys( $this->registered ) ) : array();
 			if ( ! isset( $this->registered[ $handle ] ) ) {
 				$keep_going = false; // Item doesn't exist.
-			} elseif ( $this->registered[ $handle ]->deps && array_diff( $this->registered[ $handle ]->deps, array_keys( $this->registered ) ) ) {
+			} elseif ( $missing_dependencies ) {
+				// Prevent duplicate notices.
+				static $reported = array();
+
+				if ( ! isset( $reported[ $handle ] ) ) {
+					$reported[ $handle ] = true;
+
+					_doing_it_wrong(
+						__METHOD__,
+						sprintf(
+							/* translators: 1: Script module ID, 2: Comma-separated list of missing dependency IDs. */
+							__( 'The script with the handle %1$s was enqueued with dependencies that are not registered: %2$s.' ),
+							$handle,
+							implode( ', ', $missing_dependencies )
+						),
+						'7.0.0'
+					);
+				}
 				$keep_going = false; // Item requires dependencies that don't exist.
 			} elseif ( $this->registered[ $handle ]->deps && ! $this->all_deps( $this->registered[ $handle ]->deps, true, $new_group ) ) {
 				$keep_going = false; // Item requires dependencies that don't exist.

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -722,7 +722,26 @@ class WP_Script_Modules {
 		}
 
 		// If the item requires dependencies that do not exist, fail.
-		if ( count( array_diff( $dependency_ids, array_keys( $this->registered ) ) ) > 0 ) {
+		$missing_dependencies = array_diff( $dependency_ids, array_keys( $this->registered ) );
+		if ( count( $missing_dependencies ) > 0 ) {
+			// Prevent duplicate notices.
+			static $reported = array();
+
+			if ( ! isset( $reported[ $id ] ) ) {
+				$reported[ $id ] = true;
+
+				_doing_it_wrong(
+					__METHOD__,
+					sprintf(
+						/* translators: 1: Script module ID, 2: Comma-separated list of missing dependency IDs. */
+						__( 'The script module %1$s was enqueued with dependencies that are not registered: %2$s.' ),
+						$id,
+						implode( ', ', $missing_dependencies )
+					),
+					'7.0.0'
+				);
+			}
+
 			return false;
 		}
 

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -728,7 +728,7 @@ class WP_Script_Modules {
 				__METHOD__,
 				sprintf(
 					/* translators: 1: Script module ID, 2: Comma-separated list of missing dependency IDs. */
-					__( 'The script module %1$s was enqueued with dependencies that are not registered: %2$s.' ),
+					__( 'The script module "%1$s" was enqueued with dependencies that are not registered: %2$s.' ),
 					$id,
 					implode( ', ', $missing_dependencies )
 				),

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -740,7 +740,7 @@ class WP_Script_Modules {
 					get_class( $this ) . '::register',
 					sprintf(
 						/* translators: 1: Script module ID, 2: Comma-separated list of missing dependency IDs. */
-						__( 'The script module "%1$s" was enqueued with dependencies that are not registered: %2$s.' ),
+						__( 'The script module with the ID "%1$s" was enqueued with dependencies that are not registered: %2$s.' ),
 						$id,
 						implode( ', ', $missing_dependencies )
 					),

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -724,23 +724,16 @@ class WP_Script_Modules {
 		// If the item requires dependencies that do not exist, fail.
 		$missing_dependencies = array_diff( $dependency_ids, array_keys( $this->registered ) );
 		if ( count( $missing_dependencies ) > 0 ) {
-			// Prevent duplicate notices.
-			static $reported = array();
-
-			if ( ! isset( $reported[ $id ] ) ) {
-				$reported[ $id ] = true;
-
-				_doing_it_wrong(
-					__METHOD__,
-					sprintf(
-						/* translators: 1: Script module ID, 2: Comma-separated list of missing dependency IDs. */
-						__( 'The script module %1$s was enqueued with dependencies that are not registered: %2$s.' ),
-						$id,
-						implode( ', ', $missing_dependencies )
-					),
-					'7.0.0'
-				);
-			}
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					/* translators: 1: Script module ID, 2: Comma-separated list of missing dependency IDs. */
+					__( 'The script module %1$s was enqueued with dependencies that are not registered: %2$s.' ),
+					$id,
+					implode( ', ', $missing_dependencies )
+				),
+				'7.0.0'
+			);
 
 			return false;
 		}

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -71,6 +71,17 @@ class WP_Script_Modules {
 	);
 
 	/**
+	 * List of IDs for script modules encountered which have missing dependencies.
+	 *
+	 * An ID is added to this list when it is discovered to have missing dependencies. At this time, a warning is
+	 * emitted with {@see _doing_it_wrong()}. The ID is then added to this list, so that duplicate warnings don't occur.
+	 *
+	 * @since 7.0.0
+	 * @var string[]
+	 */
+	private $modules_with_missing_dependencies = array();
+
+	/**
 	 * Registers the script module if no script module with that script module
 	 * identifier has already been registered.
 	 *
@@ -724,16 +735,19 @@ class WP_Script_Modules {
 		// If the item requires dependencies that do not exist, fail.
 		$missing_dependencies = array_diff( $dependency_ids, array_keys( $this->registered ) );
 		if ( count( $missing_dependencies ) > 0 ) {
-			_doing_it_wrong(
-				__METHOD__,
-				sprintf(
+			if ( ! in_array( $id, $this->modules_with_missing_dependencies, true ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					sprintf(
 					/* translators: 1: Script module ID, 2: Comma-separated list of missing dependency IDs. */
-					__( 'The script module "%1$s" was enqueued with dependencies that are not registered: %2$s.' ),
-					$id,
-					implode( ', ', $missing_dependencies )
-				),
-				'7.0.0'
-			);
+						__( 'The script module "%1$s" was enqueued with dependencies that are not registered: %2$s.' ),
+						$id,
+						implode( ', ', $missing_dependencies )
+					),
+					'7.0.0'
+				);
+				$this->modules_with_missing_dependencies[] = $id;
+			}
 
 			return false;
 		}

--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -737,9 +737,9 @@ class WP_Script_Modules {
 		if ( count( $missing_dependencies ) > 0 ) {
 			if ( ! in_array( $id, $this->modules_with_missing_dependencies, true ) ) {
 				_doing_it_wrong(
-					__METHOD__,
+					get_class( $this ) . '::register',
 					sprintf(
-					/* translators: 1: Script module ID, 2: Comma-separated list of missing dependency IDs. */
+						/* translators: 1: Script module ID, 2: Comma-separated list of missing dependency IDs. */
 						__( 'The script module "%1$s" was enqueued with dependencies that are not registered: %2$s.' ),
 						$id,
 						implode( ', ', $missing_dependencies )

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -1177,7 +1177,7 @@ JS;
 	protected function get_dependency_warning_message( $handle, $missing_dependency_handles ) {
 		return sprintf(
 			/* translators: 1: Script handle, 2: Comma-separated list of missing dependency handles. */
-			__( 'The script with the handle %1$s was enqueued with dependencies that are not registered: %2$s.' ),
+			__( 'The script with the handle "%1$s" was enqueued with dependencies that are not registered: %2$s.' ),
 			$handle,
 			implode( ', ', $missing_dependency_handles )
 		);

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -1164,4 +1164,22 @@ JS;
 		$this->ext_version    = '';
 		$this->ext_handles    = '';
 	}
+
+	/**
+	 * Gets a script-specific dependency warning message.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string   $handle                     Script handle with missing dependencies.
+	 * @param string[] $missing_dependency_handles Missing dependency handles.
+	 * @return string Formatted, localized warning message.
+	 */
+	protected function get_dependency_warning_message( $handle, $missing_dependency_handles ) {
+		return sprintf(
+			/* translators: 1: Script handle, 2: Comma-separated list of missing dependency handles. */
+			__( 'The script with the handle %1$s was enqueued with dependencies that are not registered: %2$s.' ),
+			$handle,
+			implode( ', ', $missing_dependency_handles )
+		);
+	}
 }

--- a/src/wp-includes/class-wp-styles.php
+++ b/src/wp-includes/class-wp-styles.php
@@ -493,4 +493,22 @@ class WP_Styles extends WP_Dependencies {
 		$this->concat_version = '';
 		$this->print_html     = '';
 	}
+
+	/**
+	 * Gets a style-specific dependency warning message.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string   $handle                     Style handle with missing dependencies.
+	 * @param string[] $missing_dependency_handles Missing dependency handles.
+	 * @return string Formatted, localized warning message.
+	 */
+	protected function get_dependency_warning_message( $handle, $missing_dependency_handles ) {
+		return sprintf(
+			/* translators: 1: Style handle, 2: Comma-separated list of missing dependency handles. */
+			__( 'The style with the handle %1$s was enqueued with dependencies that are not registered: %2$s.' ),
+			$handle,
+			implode( ', ', $missing_dependency_handles )
+		);
+	}
 }

--- a/src/wp-includes/class-wp-styles.php
+++ b/src/wp-includes/class-wp-styles.php
@@ -506,7 +506,7 @@ class WP_Styles extends WP_Dependencies {
 	protected function get_dependency_warning_message( $handle, $missing_dependency_handles ) {
 		return sprintf(
 			/* translators: 1: Style handle, 2: Comma-separated list of missing dependency handles. */
-			__( 'The style with the handle %1$s was enqueued with dependencies that are not registered: %2$s.' ),
+			__( 'The style with the handle "%1$s" was enqueued with dependencies that are not registered: %2$s.' ),
 			$handle,
 			implode( ', ', $missing_dependency_handles )
 		);

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -4093,4 +4093,33 @@ HTML;
 		$translations_script_data = $wp_scripts->print_translations( 'test-example', false );
 		$this->assertStringNotContainsStringIgnoringCase( 'sourceURL=', $translations_script_data );
 	}
+
+	/**
+	 * Tests that WP_Scripts emits a _doing_it_wrong() notice for missing dependencies.
+	 *
+	 * @ticket 64229
+	 * @covers WP_Dependencies::all_deps
+	 */
+	public function test_wp_scripts_doing_it_wrong_for_missing_dependencies() {
+		$expected_key = 'WP_Dependencies::all_deps';
+		$this->setExpectedIncorrectUsage( $expected_key );
+
+		wp_register_script( 'registered-dep', '/registered-dep.js' );
+		wp_register_script( 'main', '/main.js', array( 'registered-dep', 'missing-dep' ) );
+		wp_enqueue_script( 'main' );
+
+		get_echo( 'wp_print_scripts' );
+
+		$this->assertArrayHasKey(
+			$expected_key,
+			$this->caught_doing_it_wrong,
+			'Expected WP_Dependencies::all_deps to trigger a _doing_it_wrong() notice for missing dependency.'
+		);
+
+		$this->assertStringContainsString(
+			'The script with the handle main was enqueued with dependencies that are not registered: missing-dep',
+			$this->caught_doing_it_wrong[ $expected_key ],
+			'Expected _doing_it_wrong() notice to indicate missing dependencies for enqueued script.'
+		);
+	}
 }

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -4108,7 +4108,8 @@ HTML;
 		wp_register_script( 'main', '/main.js', array( 'registered-dep', 'missing-dep' ) );
 		wp_enqueue_script( 'main' );
 
-		get_echo( 'wp_print_scripts' );
+		$markup = get_echo( 'wp_print_scripts' );
+		$this->assertStringNotContainsString( 'main.js', $markup, 'Expected script to be absent.' );
 
 		$this->assertArrayHasKey(
 			$expected_key,
@@ -4117,7 +4118,7 @@ HTML;
 		);
 
 		$this->assertStringContainsString(
-			'The script with the handle main was enqueued with dependencies that are not registered: missing-dep',
+			'The script with the handle "main" was enqueued with dependencies that are not registered: missing-dep',
 			$this->caught_doing_it_wrong[ $expected_key ],
 			'Expected _doing_it_wrong() notice to indicate missing dependencies for enqueued script.'
 		);

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -4101,25 +4101,24 @@ HTML;
 	 * @covers WP_Dependencies::all_deps
 	 */
 	public function test_wp_scripts_doing_it_wrong_for_missing_dependencies() {
-		$expected_key = 'WP_Dependencies::all_deps';
-		$this->setExpectedIncorrectUsage( $expected_key );
+		$expected_incorrect_usage = 'WP_Scripts::add';
+		$this->setExpectedIncorrectUsage( $expected_incorrect_usage );
 
 		wp_register_script( 'registered-dep', '/registered-dep.js' );
-		wp_register_script( 'main', '/main.js', array( 'registered-dep', 'missing-dep' ) );
-		wp_enqueue_script( 'main' );
+		wp_enqueue_script( 'main', '/main.js', array( 'registered-dep', 'missing-dep' ) );
 
 		$markup = get_echo( 'wp_print_scripts' );
 		$this->assertStringNotContainsString( 'main.js', $markup, 'Expected script to be absent.' );
 
 		$this->assertArrayHasKey(
-			$expected_key,
+			$expected_incorrect_usage,
 			$this->caught_doing_it_wrong,
-			'Expected WP_Dependencies::all_deps to trigger a _doing_it_wrong() notice for missing dependency.'
+			"Expected $expected_incorrect_usage to trigger a _doing_it_wrong() notice for missing dependency."
 		);
 
 		$this->assertStringContainsString(
 			'The script with the handle "main" was enqueued with dependencies that are not registered: missing-dep',
-			$this->caught_doing_it_wrong[ $expected_key ],
+			$this->caught_doing_it_wrong[ $expected_incorrect_usage ],
 			'Expected _doing_it_wrong() notice to indicate missing dependencies for enqueued script.'
 		);
 	}

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -814,4 +814,37 @@ HTML;
 
 		$this->assertEqualHTML( $expected, $printed );
 	}
+
+	/**
+	 * Tests that WP_Styles emits a _doing_it_wrong() notice for missing dependencies.
+	 *
+	 * @ticket 64229
+	 * @covers WP_Dependencies::all_deps
+	 */
+	public function test_wp_style_doing_it_wrong_for_missing_dependencies() {
+		$expected_key = 'WP_Dependencies::all_deps';
+		$this->setExpectedIncorrectUsage( $expected_key );
+
+		wp_register_style(
+			'main-style',
+			'/main-style.css',
+			array( 'missing-style-dep' )
+		);
+
+		wp_enqueue_style( 'main-style' );
+
+		get_echo( 'wp_print_styles' );
+
+		$this->assertArrayHasKey(
+			$expected_key,
+			$this->caught_doing_it_wrong,
+			'Expected WP_Dependencies::all_deps to trigger a _doing_it_wrong() notice for missing dependency.'
+		);
+
+		$this->assertStringContainsString(
+			'The style with the handle main-style was enqueued with dependencies that are not registered: missing-style-dep',
+			$this->caught_doing_it_wrong[ $expected_key ],
+			'Expected _doing_it_wrong() notice to indicate missing dependencies for enqueued styles.'
+		);
+	}
 }

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -822,29 +822,27 @@ HTML;
 	 * @covers WP_Dependencies::all_deps
 	 */
 	public function test_wp_style_doing_it_wrong_for_missing_dependencies() {
-		$expected_key = 'WP_Dependencies::all_deps';
-		$this->setExpectedIncorrectUsage( $expected_key );
+		$expected_incorrect_usage = 'WP_Styles::add';
+		$this->setExpectedIncorrectUsage( $expected_incorrect_usage );
 
-		wp_register_style(
+		wp_enqueue_style(
 			'main-style',
 			'/main-style.css',
 			array( 'missing-style-dep' )
 		);
 
-		wp_enqueue_style( 'main-style' );
-
 		$markup = get_echo( 'wp_print_styles' );
 		$this->assertStringNotContainsString( 'main-style.css', $markup, 'Expected style to be absent.' );
 
 		$this->assertArrayHasKey(
-			$expected_key,
+			$expected_incorrect_usage,
 			$this->caught_doing_it_wrong,
-			'Expected WP_Dependencies::all_deps to trigger a _doing_it_wrong() notice for missing dependency.'
+			"Expected $expected_incorrect_usage to trigger a _doing_it_wrong() notice for missing dependency."
 		);
 
 		$this->assertStringContainsString(
 			'The style with the handle "main-style" was enqueued with dependencies that are not registered: missing-style-dep',
-			$this->caught_doing_it_wrong[ $expected_key ],
+			$this->caught_doing_it_wrong[ $expected_incorrect_usage ],
 			'Expected _doing_it_wrong() notice to indicate missing dependencies for enqueued styles.'
 		);
 	}

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -833,7 +833,8 @@ HTML;
 
 		wp_enqueue_style( 'main-style' );
 
-		get_echo( 'wp_print_styles' );
+		$markup = get_echo( 'wp_print_styles' );
+		$this->assertStringNotContainsString( 'main-style.css', $markup, 'Expected style to be absent.' );
 
 		$this->assertArrayHasKey(
 			$expected_key,
@@ -842,7 +843,7 @@ HTML;
 		);
 
 		$this->assertStringContainsString(
-			'The style with the handle main-style was enqueued with dependencies that are not registered: missing-style-dep',
+			'The style with the handle "main-style" was enqueued with dependencies that are not registered: missing-style-dep',
 			$this->caught_doing_it_wrong[ $expected_key ],
 			'Expected _doing_it_wrong() notice to indicate missing dependencies for enqueued styles.'
 		);

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -2337,9 +2337,9 @@ HTML;
 		);
 
 		// Assert the message mentions the missing dependency handle.
-		$this->assertStringContainsString( 
-			'The script module main-module was enqueued with dependencies that are not registered: missing-mod-dep', 
-			$this->caught_doing_it_wrong['WP_Script_Modules::sort_item_dependencies'] 
+		$this->assertStringContainsString(
+			'The script module main-module was enqueued with dependencies that are not registered: missing-mod-dep',
+			$this->caught_doing_it_wrong['WP_Script_Modules::sort_item_dependencies']
 		);
 	}
 }

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -1965,6 +1965,9 @@ HTML;
 		global $wp_version;
 		$wp_version = '99.9.9';
 
+		if ( $use_global_function && $only_enqueue ) {
+			$this->setExpectedIncorrectUsage( 'WP_Script_Modules::sort_item_dependencies' );
+		}
 		$register = static function ( ...$args ) use ( $use_global_function ) {
 			if ( $use_global_function ) {
 				wp_register_script_module( ...$args );
@@ -2310,6 +2313,33 @@ HTML;
 			$script_modules,
 			'<body>',
 			"Expected script modules to match snapshot:\n$script_modules"
+		);
+	}
+
+	/**
+	 * Tests that a missing script module dependency triggers a _doing_it_wrong() notice.
+	 *
+	 * @ticket 64229
+	 * @covers WP_Script_Modules::sort_item_dependencies
+	 */
+	public function test_missing_script_module_dependency_triggers_incorrect_usage() {
+		$this->setExpectedIncorrectUsage( 'WP_Script_Modules::sort_item_dependencies' );
+
+		$this->script_modules->register( 'main-module', '/main-module.js', array( 'missing-mod-dep' ) );
+		$this->script_modules->enqueue( 'main-module' );
+
+		get_echo( array( $this->script_modules, 'print_enqueued_script_modules' ) );
+
+		$this->assertArrayHasKey(
+			'WP_Script_Modules::sort_item_dependencies',
+			$this->caught_doing_it_wrong,
+			'Expected WP_Script_Modules::sort_item_dependencies to be reported via doing_it_wrong().'
+		);
+
+		// Assert the message mentions the missing dependency handle.
+		$this->assertStringContainsString( 
+			'The script module main-module was enqueued with dependencies that are not registered: missing-mod-dep', 
+			$this->caught_doing_it_wrong['WP_Script_Modules::sort_item_dependencies'] 
 		);
 	}
 }

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -1965,7 +1965,6 @@ HTML;
 		global $wp_version;
 		$wp_version = '99.9.9';
 
-		$this->setExpectedIncorrectUsage( 'WP_Script_Modules::sort_item_dependencies' );
 		$register = static function ( ...$args ) use ( $use_global_function ) {
 			if ( $use_global_function ) {
 				wp_register_script_module( ...$args );
@@ -2060,7 +2059,7 @@ HTML;
 			"Snapshot:\n" . var_export( $actual, true )
 		);
 
-		$deregister( array( 'b', 'c ' ) );
+		$deregister( array( 'b', 'c' ) );
 
 		// Test that registered dependency in footer doesn't place dependant in footer.
 		$register( 'd', '/d.js', array(), '1.0.0', array( 'in_footer' => true ) );

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -2336,7 +2336,7 @@ HTML;
 
 		// Assert the message mentions the missing dependency handle.
 		$this->assertStringContainsString(
-			'The script module "main-module" was enqueued with dependencies that are not registered: missing-mod-dep',
+			'The script module with the ID "main-module" was enqueued with dependencies that are not registered: missing-mod-dep',
 			$this->caught_doing_it_wrong[ $expected_incorrect_usage ]
 		);
 	}

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -2321,24 +2321,24 @@ HTML;
 	 * @covers WP_Script_Modules::sort_item_dependencies
 	 */
 	public function test_missing_script_module_dependency_triggers_incorrect_usage() {
-		$this->setExpectedIncorrectUsage( 'WP_Script_Modules::sort_item_dependencies' );
+		$expected_incorrect_usage = 'WP_Script_Modules::register';
+		$this->setExpectedIncorrectUsage( $expected_incorrect_usage );
 
-		$this->script_modules->register( 'main-module', '/main-module.js', array( 'missing-mod-dep' ) );
-		$this->script_modules->enqueue( 'main-module' );
+		$this->script_modules->enqueue( 'main-module', '/main-module.js', array( 'missing-mod-dep' ) );
 
 		$markup = get_echo( array( $this->script_modules, 'print_enqueued_script_modules' ) );
 		$this->assertStringNotContainsString( 'main-module.js', $markup, 'Expected script module to be absent.' );
 
 		$this->assertArrayHasKey(
-			'WP_Script_Modules::sort_item_dependencies',
+			$expected_incorrect_usage,
 			$this->caught_doing_it_wrong,
-			'Expected WP_Script_Modules::sort_item_dependencies to be reported via doing_it_wrong().'
+			'Expected WP_Script_Modules::register to be reported via doing_it_wrong().'
 		);
 
 		// Assert the message mentions the missing dependency handle.
 		$this->assertStringContainsString(
 			'The script module "main-module" was enqueued with dependencies that are not registered: missing-mod-dep',
-			$this->caught_doing_it_wrong['WP_Script_Modules::sort_item_dependencies']
+			$this->caught_doing_it_wrong[ $expected_incorrect_usage ]
 		);
 	}
 }

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -1965,9 +1965,7 @@ HTML;
 		global $wp_version;
 		$wp_version = '99.9.9';
 
-		if ( $use_global_function && $only_enqueue ) {
-			$this->setExpectedIncorrectUsage( 'WP_Script_Modules::sort_item_dependencies' );
-		}
+		$this->setExpectedIncorrectUsage( 'WP_Script_Modules::sort_item_dependencies' );
 		$register = static function ( ...$args ) use ( $use_global_function ) {
 			if ( $use_global_function ) {
 				wp_register_script_module( ...$args );

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -2326,7 +2326,8 @@ HTML;
 		$this->script_modules->register( 'main-module', '/main-module.js', array( 'missing-mod-dep' ) );
 		$this->script_modules->enqueue( 'main-module' );
 
-		get_echo( array( $this->script_modules, 'print_enqueued_script_modules' ) );
+		$markup = get_echo( array( $this->script_modules, 'print_enqueued_script_modules' ) );
+		$this->assertStringNotContainsString( 'main-module.js', $markup, 'Expected script module to be absent.' );
 
 		$this->assertArrayHasKey(
 			'WP_Script_Modules::sort_item_dependencies',
@@ -2336,7 +2337,7 @@ HTML;
 
 		// Assert the message mentions the missing dependency handle.
 		$this->assertStringContainsString(
-			'The script module main-module was enqueued with dependencies that are not registered: missing-mod-dep',
+			'The script module "main-module" was enqueued with dependencies that are not registered: missing-mod-dep',
 			$this->caught_doing_it_wrong['WP_Script_Modules::sort_item_dependencies']
 		);
 	}


### PR DESCRIPTION
This PR adds developer-facing _doing_it_wrong() notices when a script or script module is enqueued with dependencies that have not been registered.

Currently, WordPress silently skips printing such assets, which makes dependency issues difficult to diagnose. This change improves debugging clarity during development.

**What’s changed**
✅ Classic scripts (WP_Scripts)
- Detects missing dependencies in all_deps().
- Emits a _doing_it_wrong() notice identifying the script handle and missing dependency handles.

✅ Script modules (WP_Script_Modules)
- Detects missing dependencies during dependency sorting.
- Emits a _doing_it_wrong() notice with the module ID and missing dependency IDs.

**Both implementations:** 
- Prevent duplicate notices using a static cache.

Trac ticket: https://core.trac.wordpress.org/ticket/64229

<img width="1470" height="543" alt="image" src="https://github.com/user-attachments/assets/64a0d617-2b42-4544-b119-d20553f38363" />


