### PR TITLE
Get archives: add filter to customize query LIMIT clause

### DIFF
--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2070,7 +2070,15 @@ function wp_get_archives( $args = '' ) {
 
 	$last_changed = wp_cache_get_last_changed( 'posts' );
 
-	$limit = $parsed_args['limit'];
+	/**
+	 * Filters the SQL LIMIT clause for retrieving archives.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string $limit The limit of the query for the `wp_get_archives` function.
+	 * @param array  $parsed_args An array of default arguments.
+	 */
+	$limit = apply_filters( 'getarchives_limit', $parsed_args['limit'], $parsed_args );
 
 	if ( 'monthly' === $parsed_args['type'] ) {
 		$query   = "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, count(ID) as posts FROM $wpdb->posts $join $where GROUP BY YEAR(post_date), MONTH(post_date) ORDER BY post_date $order $limit";

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2075,7 +2075,7 @@ function wp_get_archives( $args = '' ) {
 	 *
 	 * @since 7.0.0
 	 *
-	 * @param string $limit The limit of the query for the `wp_get_archives` function.
+	 * @param string $limit       The limit of the query for the `wp_get_archives` function.
 	 * @param array  $parsed_args An array of default arguments.
 	 */
 	$limit = apply_filters( 'getarchives_limit', $parsed_args['limit'], $parsed_args );

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2018,6 +2018,17 @@ function wp_get_archives( $args = '' ) {
 		'w'               => get_query_var( 'w' ),
 	);
 
+	/**
+	 * Filters the archive links list arguments.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @see wp_get_archives()
+	 *
+	 * @param array $args An array of arguments.
+	 */
+	$args = apply_filters( 'wp_get_archives_args', $args );
+
 	$parsed_args = wp_parse_args( $args, $defaults );
 
 	$post_type_object = get_post_type_object( $parsed_args['post_type'] );
@@ -2031,19 +2042,9 @@ function wp_get_archives( $args = '' ) {
 		$parsed_args['type'] = 'monthly';
 	}
 
-	/**
-	 * Filters the limit for the number of posts to include in the archive.
-	 *
-	 * @since 7.0.0
-	 *
-	 * @param int   $limit       The limit for the number of posts to include in the archive. Default 0.
-	 * @param array $parsed_args An array of default arguments.
-	 */
-	$limit_number = (int) apply_filters( 'getarchives_limit', absint( $parsed_args['limit'] ), $parsed_args );
-	if ( $limit_number > 0 ) {
-		$limit = " LIMIT $limit_number";
-	} else {
-		$limit = '';
+	if ( ! empty( $parsed_args['limit'] ) ) {
+		$parsed_args['limit'] = absint( $parsed_args['limit'] );
+		$parsed_args['limit'] = ' LIMIT ' . $parsed_args['limit'];
 	}
 
 	$order = strtoupper( $parsed_args['order'] );
@@ -2079,6 +2080,8 @@ function wp_get_archives( $args = '' ) {
 	$output = '';
 
 	$last_changed = wp_cache_get_last_changed( 'posts' );
+
+	$limit = $parsed_args['limit'];
 
 	if ( 'monthly' === $parsed_args['type'] ) {
 		$query   = "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, count(ID) as posts FROM $wpdb->posts $join $where GROUP BY YEAR(post_date), MONTH(post_date) ORDER BY post_date $order $limit";

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2031,9 +2031,19 @@ function wp_get_archives( $args = '' ) {
 		$parsed_args['type'] = 'monthly';
 	}
 
-	if ( ! empty( $parsed_args['limit'] ) ) {
-		$parsed_args['limit'] = absint( $parsed_args['limit'] );
-		$parsed_args['limit'] = ' LIMIT ' . $parsed_args['limit'];
+	/**
+	 * Filters the limit for the number of posts to include in the archive.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param int   $limit       The limit for the number of posts to include in the archive. Default 0.
+	 * @param array $parsed_args An array of default arguments.
+	 */
+	$limit_number = (int) apply_filters( 'getarchives_limit', absint( $parsed_args['limit'] ), $parsed_args );
+	if ( $limit_number > 0 ) {
+		$limit = " LIMIT $limit_number";
+	} else {
+		$limit = '';
 	}
 
 	$order = strtoupper( $parsed_args['order'] );
@@ -2069,16 +2079,6 @@ function wp_get_archives( $args = '' ) {
 	$output = '';
 
 	$last_changed = wp_cache_get_last_changed( 'posts' );
-
-	/**
-	 * Filters the SQL LIMIT clause for retrieving archives.
-	 *
-	 * @since 7.0.0
-	 *
-	 * @param string $limit       The limit of the query for the `wp_get_archives` function.
-	 * @param array  $parsed_args An array of default arguments.
-	 */
-	$limit = apply_filters( 'getarchives_limit', $parsed_args['limit'], $parsed_args );
 
 	if ( 'monthly' === $parsed_args['type'] ) {
 		$query   = "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, count(ID) as posts FROM $wpdb->posts $join $where GROUP BY YEAR(post_date), MONTH(post_date) ORDER BY post_date $order $limit";

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2019,13 +2019,13 @@ function wp_get_archives( $args = '' ) {
 	);
 
 	/**
-	 * Filters the archive links list arguments.
+	 * Filters the arguments for displaying archive links.
 	 *
 	 * @since 7.0.0
 	 *
 	 * @see wp_get_archives()
 	 *
-	 * @param array $args An array of arguments.
+	 * @param array<string, string|int|bool> $args Arguments.
 	 */
 	$args = apply_filters( 'wp_get_archives_args', $args );
 

--- a/tests/phpunit/tests/functions/wpGetArchives.php
+++ b/tests/phpunit/tests/functions/wpGetArchives.php
@@ -218,19 +218,15 @@ EOF;
 
 		$ids = array_slice( array_reverse( self::$post_ids ), 0, 3 );
 
-		$link1 = get_permalink( $ids[0] );
-		$link2 = get_permalink( $ids[1] );
-		$link3 = get_permalink( $ids[2] );
-
-		$title1 = get_post( $ids[0] )->post_title;
-		$title2 = get_post( $ids[1] )->post_title;
-		$title3 = get_post( $ids[2] )->post_title;
-
-		$expected = <<<EOF
-			<li><a href='$link1'>$title1</a></li>
-			<li><a href='$link2'>$title2</a></li>
-			<li><a href='$link3'>$title3</a></li>
-EOF;
+		$expected = join(
+			"\n",
+			array_map(
+				static function ( $id ) {
+					return sprintf( '<li><a href="%s">%s</a></li>', get_permalink( $id ), get_the_title( $id ) );
+				},
+				$ids
+			)
+		);
 		$archives = wp_get_archives(
 			array(
 				'echo'  => false,

--- a/tests/phpunit/tests/functions/wpGetArchives.php
+++ b/tests/phpunit/tests/functions/wpGetArchives.php
@@ -204,4 +204,53 @@ EOF;
 		);
 		$this->assertSame( $expected, trim( $archives ) );
 	}
+
+	/**
+	 * @ticket 7.0.0
+	 */
+	public function test_wp_get_archives_limit_filter() {
+		$ids = array_slice( array_reverse( self::$post_ids ), 0, 3 );
+
+		$title1 = get_post( $ids[0] )->post_title;
+		$title2 = get_post( $ids[1] )->post_title;
+		$title3 = get_post( $ids[2] )->post_title;
+
+		// Test without filter - should return all 3 posts when limit is 3.
+		$archives_without_filter = wp_get_archives(
+			array(
+				'echo'  => false,
+				'type'  => 'postbypost',
+				'limit' => 3,
+			)
+		);
+		$this->assertStringContainsString( $title1, $archives_without_filter );
+		$this->assertStringContainsString( $title2, $archives_without_filter );
+		$this->assertStringContainsString( $title3, $archives_without_filter );
+
+		// Add filter to modify limit to 2.
+		add_filter(
+			'getarchives_limit',
+			function( $limit, $parsed_args ) {
+				// Modify limit from 3 to 2.
+				return ' LIMIT 2';
+			},
+			10,
+			2
+		);
+
+		// Test with filter - should return only 2 posts.
+		$archives_with_filter = wp_get_archives(
+			array(
+				'echo'  => false,
+				'type'  => 'postbypost',
+				'limit' => 3,
+			)
+		);
+		$this->assertStringContainsString( $title1, $archives_with_filter );
+		$this->assertStringContainsString( $title2, $archives_with_filter );
+		$this->assertStringNotContainsString( $title3, $archives_with_filter );
+
+		// Remove filter.
+		remove_all_filters( 'getarchives_limit' );
+	}
 }

--- a/tests/phpunit/tests/functions/wpGetArchives.php
+++ b/tests/phpunit/tests/functions/wpGetArchives.php
@@ -249,8 +249,5 @@ EOF;
 		$this->assertStringContainsString( $title1, $archives_with_filter );
 		$this->assertStringContainsString( $title2, $archives_with_filter );
 		$this->assertStringNotContainsString( $title3, $archives_with_filter );
-
-		// Remove filter.
-		remove_all_filters( 'getarchives_limit' );
 	}
 }

--- a/tests/phpunit/tests/functions/wpGetArchives.php
+++ b/tests/phpunit/tests/functions/wpGetArchives.php
@@ -232,7 +232,7 @@ EOF;
 			'getarchives_limit',
 			function ( $limit, $parsed_args ) {
 				// Modify limit from 3 to 2.
-				return ' LIMIT 2';
+				return 2;
 			},
 			10,
 			2

--- a/tests/phpunit/tests/functions/wpGetArchives.php
+++ b/tests/phpunit/tests/functions/wpGetArchives.php
@@ -227,9 +227,9 @@ EOF;
 		$title3 = get_post( $ids[2] )->post_title;
 
 		$expected = <<<EOF
-<li><a href='$link1'>$title1</a></li>
-	<li><a href='$link2'>$title2</a></li>
-	<li><a href='$link3'>$title3</a></li>
+			<li><a href='$link1'>$title1</a></li>
+			<li><a href='$link2'>$title2</a></li>
+			<li><a href='$link3'>$title3</a></li>
 EOF;
 		$archives = wp_get_archives(
 			array(

--- a/tests/phpunit/tests/functions/wpGetArchives.php
+++ b/tests/phpunit/tests/functions/wpGetArchives.php
@@ -235,6 +235,6 @@ EOF;
 			)
 		);
 
-		$this->assertSameIgnoreEOL( $expected, trim( $archives ) );
+		$this->assertEqualHTML( $expected, $archives );
 	}
 }

--- a/tests/phpunit/tests/functions/wpGetArchives.php
+++ b/tests/phpunit/tests/functions/wpGetArchives.php
@@ -210,11 +210,13 @@ EOF;
 	 */
 	public function test_wp_get_archives_args_filter() {
 		// Test that the filter can modify the limit argument.
-		$filter_callback = function ( $args ) {
-			$args['limit'] = 3;
-			return $args;
-		};
-		add_filter( 'wp_get_archives_args', $filter_callback );
+		add_filter(
+			'wp_get_archives_args',
+			static function ( $args ) {
+				$args['limit'] = 3;
+				return $args;
+			}
+		);
 
 		$ids = array_slice( array_reverse( self::$post_ids ), 0, 3 );
 

--- a/tests/phpunit/tests/functions/wpGetArchives.php
+++ b/tests/phpunit/tests/functions/wpGetArchives.php
@@ -206,7 +206,7 @@ EOF;
 	}
 
 	/**
-	 * @ticket 7.0.0
+	 * @ticket 64304
 	 */
 	public function test_wp_get_archives_limit_filter() {
 		$ids = array_slice( array_reverse( self::$post_ids ), 0, 3 );

--- a/tests/phpunit/tests/functions/wpGetArchives.php
+++ b/tests/phpunit/tests/functions/wpGetArchives.php
@@ -230,7 +230,7 @@ EOF;
 		// Add filter to modify limit to 2.
 		add_filter(
 			'getarchives_limit',
-			function( $limit, $parsed_args ) {
+			function ( $limit, $parsed_args ) {
 				// Modify limit from 3 to 2.
 				return ' LIMIT 2';
 			},

--- a/tests/phpunit/tests/functions/wpGetArchives.php
+++ b/tests/phpunit/tests/functions/wpGetArchives.php
@@ -210,7 +210,7 @@ EOF;
 	 */
 	public function test_wp_get_archives_args_filter() {
 		// Test that the filter can modify the limit argument.
-		$filter_callback = function( $args ) {
+		$filter_callback = function ( $args ) {
 			$args['limit'] = 3;
 			return $args;
 		};

--- a/tests/phpunit/tests/functions/wpGetArchives.php
+++ b/tests/phpunit/tests/functions/wpGetArchives.php
@@ -208,46 +208,37 @@ EOF;
 	/**
 	 * @ticket 64304
 	 */
-	public function test_wp_get_archives_limit_filter() {
+	public function test_wp_get_archives_args_filter() {
+		// Test that the filter can modify the limit argument.
+		$filter_callback = function( $args ) {
+			$args['limit'] = 3;
+			return $args;
+		};
+		add_filter( 'wp_get_archives_args', $filter_callback );
+
 		$ids = array_slice( array_reverse( self::$post_ids ), 0, 3 );
+
+		$link1 = get_permalink( $ids[0] );
+		$link2 = get_permalink( $ids[1] );
+		$link3 = get_permalink( $ids[2] );
 
 		$title1 = get_post( $ids[0] )->post_title;
 		$title2 = get_post( $ids[1] )->post_title;
 		$title3 = get_post( $ids[2] )->post_title;
 
-		// Test without filter - should return all 3 posts when limit is 3.
-		$archives_without_filter = wp_get_archives(
+		$expected = <<<EOF
+<li><a href='$link1'>$title1</a></li>
+	<li><a href='$link2'>$title2</a></li>
+	<li><a href='$link3'>$title3</a></li>
+EOF;
+		$archives = wp_get_archives(
 			array(
 				'echo'  => false,
 				'type'  => 'postbypost',
-				'limit' => 3,
+				'limit' => 5, // This should be overridden by the filter to 3.
 			)
 		);
-		$this->assertStringContainsString( $title1, $archives_without_filter );
-		$this->assertStringContainsString( $title2, $archives_without_filter );
-		$this->assertStringContainsString( $title3, $archives_without_filter );
 
-		// Add filter to modify limit to 2.
-		add_filter(
-			'getarchives_limit',
-			function ( $limit, $parsed_args ) {
-				// Modify limit from 3 to 2.
-				return 2;
-			},
-			10,
-			2
-		);
-
-		// Test with filter - should return only 2 posts.
-		$archives_with_filter = wp_get_archives(
-			array(
-				'echo'  => false,
-				'type'  => 'postbypost',
-				'limit' => 3,
-			)
-		);
-		$this->assertStringContainsString( $title1, $archives_with_filter );
-		$this->assertStringContainsString( $title2, $archives_with_filter );
-		$this->assertStringNotContainsString( $title3, $archives_with_filter );
+		$this->assertSameIgnoreEOL( $expected, trim( $archives ) );
 	}
 }


### PR DESCRIPTION
`wp_get_archives` already comes with 2 filters allowing one to customize some of the aspects of the queries to fetch archives on a site:

- `getarchives_where` allows you to customize the `WHERE` clause
- `getarchives_join` allows you to customize the `JOIN` clause 

I think it would be useful to add a new filter, to allow customizing the `LIMIT` clause as well. In some environments, with sites with lots of posts with longform content, some of those queries can be really resource-intensive.

> [!NOTE]
> I have 2 notes about my PR:
> 1. I used `7.0.0` as the since value. I'm not sure if I'm supposed to use a placeholder until this is ready for commit.
> 2. I used the same filter prefix as the other filters in the function, even though they do not follow the typical `wp_` prefix of other, newer filters. Let me know if I should change that.

*****

Trac ticket: https://core.trac.wordpress.org/ticket/64304



