### PR TITLE
Media: only add required attribute to media_upload_form on media screen

### DIFF
--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -2276,7 +2276,8 @@ function media_upload_form( $errors = null ) {
 	 * @since 2.6.0
 	 */
 	do_action( 'pre-html-upload-ui' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
-	$required = 'media' === get_current_screen()->id ? ' required' : '';
+	$current_screen = get_current_screen();
+	$required       = $current_screen && 'media' === $current_screen->id ? ' required' : '';
 	?>
 	<p id="async-upload-wrap">
 		<label class="screen-reader-text" for="async-upload">

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -2276,6 +2276,7 @@ function media_upload_form( $errors = null ) {
 	 * @since 2.6.0
 	 */
 	do_action( 'pre-html-upload-ui' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+
 	$current_screen = get_current_screen();
 	$required       = $current_screen && 'media' === $current_screen->id ? ' required' : '';
 	?>
@@ -2286,7 +2287,7 @@ function media_upload_form( $errors = null ) {
 			_ex( 'Upload', 'verb' );
 			?>
 		</label>
-		<input type="file" name="async-upload" id="async-upload"<?php echo $required; ?>/>
+		<input type="file" name="async-upload" id="async-upload"<?php echo $required; ?> />
 		<?php submit_button( _x( 'Upload', 'verb' ), 'primary', 'html-upload', false ); ?>
 		<a href="#" onclick="try{top.tb_remove();}catch(e){}; return false;"><?php _e( 'Cancel' ); ?></a>
 	</p>

--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -2276,7 +2276,7 @@ function media_upload_form( $errors = null ) {
 	 * @since 2.6.0
 	 */
 	do_action( 'pre-html-upload-ui' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
-
+	$required = 'media' === get_current_screen()->id ? ' required' : '';
 	?>
 	<p id="async-upload-wrap">
 		<label class="screen-reader-text" for="async-upload">
@@ -2285,7 +2285,7 @@ function media_upload_form( $errors = null ) {
 			_ex( 'Upload', 'verb' );
 			?>
 		</label>
-		<input type="file" name="async-upload" id="async-upload" required />
+		<input type="file" name="async-upload" id="async-upload"<?php echo $required; ?>/>
 		<?php submit_button( _x( 'Upload', 'verb' ), 'primary', 'html-upload', false ); ?>
 		<a href="#" onclick="try{top.tb_remove();}catch(e){}; return false;"><?php _e( 'Cancel' ); ?></a>
 	</p>


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64305<!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
