### PR TITLE
Fix: Output relevant URLs in GitHub Actions logs (Ticket #64299)

### DIFF
--- a/.github/workflows/commit-built-file-changes.yml
+++ b/.github/workflows/commit-built-file-changes.yml
@@ -42,6 +42,32 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Output pull request URL
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const workflowRun = ${{ toJSON(github.event.workflow_run) }};
+            
+            console.log('=== Commit Built File Changes Summary ===');
+            console.log(`Source Workflow Run: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${workflowRun.id}`);
+            
+            if (workflowRun.pull_requests && workflowRun.pull_requests.length > 0) {
+              console.log(`Pull Requests:`);
+              for (const pr of workflowRun.pull_requests) {
+                console.log(`  - https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${pr.number}`);
+              }
+            }
+            
+            if (workflowRun.head_branch) {
+              console.log(`Branch: ${workflowRun.head_branch}`);
+            }
+            
+            if (workflowRun.head_repository) {
+              console.log(`Repository: ${workflowRun.head_repository.full_name}`);
+            }
+            
+            console.log('==========================================');
+
       - name: Download artifact
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:

--- a/.github/workflows/failed-workflow.yml
+++ b/.github/workflows/failed-workflow.yml
@@ -41,6 +41,22 @@ jobs:
               run_id: process.env.RUN_ID,
             });
 
+            // Output relevant URLs to workflow logs
+            console.log('=== Failed Workflow Rerun Summary ===');
+            console.log(`Workflow Run: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.RUN_ID}`);
+            console.log(`Workflow Name: ${workflow_run.data.name}`);
+            console.log(`Workflow Run Attempt: ${workflow_run.data.run_attempt}`);
+            if (workflow_run.data.head_branch) {
+              console.log(`Branch: ${workflow_run.data.head_branch}`);
+            }
+            if (workflow_run.data.pull_requests && workflow_run.data.pull_requests.length > 0) {
+              console.log(`Pull Requests:`);
+              for (const pr of workflow_run.data.pull_requests) {
+                console.log(`  - https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${pr.number}`);
+              }
+            }
+            console.log('====================================');
+
             // Only rerun after the first run attempt.
             if ( workflow_run.data.run_attempt > 1 ) {
               return;

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -70,6 +70,15 @@ jobs:
       ( ! github.event.pull_request.draft && github.event.pull_request.state == 'open' || ! github.event.issue.draft && github.event.issue.state == 'open' )
 
     steps:
+      - name: Output pull request URL
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
+          if [ -n "$PR_NUMBER" ]; then
+            echo "=== Props Bot Summary ==="
+            echo "Pull Request: https://github.com/${{ github.repository }}/pull/${PR_NUMBER}"
+            echo "========================"
+          fi
+
       - name: Gather a list of contributors
         uses: WordPress/props-bot-action@trunk
         with:

--- a/.github/workflows/reusable-cleanup-pull-requests.yml
+++ b/.github/workflows/reusable-cleanup-pull-requests.yml
@@ -94,10 +94,26 @@ jobs:
         with:
           script: |
             const prNumbers = ${{ steps.linked-prs.outputs.result }};
+            const fixedList = "${{ steps.trac-tickets.outputs.fixed_list }}".split(' ').filter(Boolean);
+            const svnRevision = "${{ steps.git-svn-id.outputs.svn_revision_number }}";
+
+            // Output relevant URLs to workflow logs
+            console.log('=== Pull Request Cleanup Summary ===');
+            console.log(`SVN Changeset: https://core.trac.wordpress.org/changeset/${svnRevision}`);
+            console.log(`GitHub Commit: https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${{ github.sha }}`);
+            console.log(`Trac Tickets:`);
+            for (const ticket of fixedList) {
+              console.log(`  - https://core.trac.wordpress.org/ticket/${ticket}`);
+            }
+            console.log(`Pull Requests to be closed:`);
+            for (const prNumber of prNumbers) {
+              console.log(`  - https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${prNumber}`);
+            }
+            console.log('===================================');
 
             const commentBody = `A commit was made that fixes the Trac ticket referenced in the description of this pull request.
 
-            SVN changeset: [${{ steps.git-svn-id.outputs.svn_revision_number }}](https://core.trac.wordpress.org/changeset/${{ steps.git-svn-id.outputs.svn_revision_number }})
+            SVN changeset: [${svnRevision}](https://core.trac.wordpress.org/changeset/${svnRevision})
             GitHub commit: https://github.com/WordPress/wordpress-develop/commit/${{ github.sha }}
 
             This PR will be closed, but please confirm the accuracy of this and reopen if there is more work to be done.`;


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64299

## Summary
Adds logging output to GitHub Actions workflows to display relevant URLs in workflow run logs. This improves visibility into what each workflow is performing.

## Changes Made
- **reusable-cleanup-pull-requests.yml**: Outputs SVN changeset URL, Trac ticket URLs, and pull request URLs being closed
- **failed-workflow.yml**: Outputs the workflow run URL being rerun, along with branch and PR information
- **props-bot.yml**: Outputs the pull request URL being processed  
- **commit-built-file-changes.yml**: Outputs the source workflow run URL and pull request/branch information

## Testing Instructions
1. The workflow-lint action will automatically validate YAML syntax
2. After merge, monitor workflow runs to see the new log outputs
3. Example workflows to check:
   - Props Bot: https://github.com/WordPress/wordpress-develop/actions/workflows/props-bot.yml
   - Failed Workflow: https://github.com/WordPress/wordpress-develop/actions/workflows/failed-workflow.yml