### PR TITLE
Fix fatal error on revisions with post meta of type array

### DIFF
--- a/src/wp-includes/revision.php
+++ b/src/wp-includes/revision.php
@@ -187,7 +187,7 @@ function wp_save_post_revision( $post_id ) {
 			$post_has_changed = false;
 
 			foreach ( array_keys( _wp_post_revision_fields( $post ) ) as $field ) {
-				if ( normalize_whitespace( $post->$field ) !== normalize_whitespace( $latest_revision->$field ) ) {
+				if ( normalize_whitespace( serialize( $post->$field ) ) !== normalize_whitespace( serialize( $latest_revision->$field ) ) ) {
 					$post_has_changed = true;
 					break;
 				}

--- a/src/wp-includes/revision.php
+++ b/src/wp-includes/revision.php
@@ -187,7 +187,7 @@ function wp_save_post_revision( $post_id ) {
 			$post_has_changed = false;
 
 			foreach ( array_keys( _wp_post_revision_fields( $post ) ) as $field ) {
-				if ( normalize_whitespace( serialize( $post->$field ) ) !== normalize_whitespace( serialize( $latest_revision->$field ) ) ) {
+				if ( normalize_whitespace( maybe_serialize( $post->$field ) ) !== normalize_whitespace( maybe_serialize( $latest_revision->$field ) ) ) {
 					$post_has_changed = true;
 					break;
 				}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This is my proposed fix for ticket 64314, where a fatal error happens when trying to save a post if you have enabled revision for a post meta that is an array.

In this proposed fix I'm using `serialize` to make any type of variable a string. I've chosen that because:
- The smallest number of changes to the code
- The same line of code will work for any type of variable
- Is the way how WP saves arrays in the database, so seamed like a good choice.

Trac ticket: [64314](https://core.trac.wordpress.org/ticket/64314)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

# Drafted Commit Message

```
Revisions: Prevent fatal error in PHP 8+ when saving a post revision with revisioned non-scalar post meta.

Developed in https://github.com/WordPress/wordpress-develop/pull/10560

Follow-up to [56714].

Props LAPSrj, manhphucofficial, westonruter.
See #20299.
Fixes #64314.
```
