### PR TITLE
Docs: Add missing variable names to @param tags in bundled themes.

### DIFF
--- a/src/wp-content/themes/twentyeleven/category.php
+++ b/src/wp-content/themes/twentyeleven/category.php
@@ -30,7 +30,7 @@ get_header(); ?>
 						 *
 						 * @since Twenty Eleven 1.0
 						 *
-						 * @param string The default category description HTML.
+						 * @param string $html The default category description HTML.
 						 */
 						echo apply_filters( 'category_archive_meta', '<div class="category-archive-meta">' . $category_description . '</div>' );
 					}

--- a/src/wp-content/themes/twentyeleven/functions.php
+++ b/src/wp-content/themes/twentyeleven/functions.php
@@ -188,7 +188,7 @@ if ( ! function_exists( 'twentyeleven_setup' ) ) :
 			 *
 			 * @since Twenty Eleven 1.0
 			 *
-			 * @param int The default header image width in pixels. Default 1000.
+			 * @param int $width The default header image width in pixels. Default 1000.
 			 */
 			'width'                  => apply_filters( 'twentyeleven_header_image_width', 1000 ),
 			/**
@@ -196,7 +196,7 @@ if ( ! function_exists( 'twentyeleven_setup' ) ) :
 			 *
 			 * @since Twenty Eleven 1.0
 			 *
-			 * @param int The default header image height in pixels. Default 288.
+			 * @param int $height The default header image height in pixels. Default 288.
 			 */
 			'height'                 => apply_filters( 'twentyeleven_header_image_height', 288 ),
 			// Support flexible heights.

--- a/src/wp-content/themes/twentyten/author.php
+++ b/src/wp-content/themes/twentyten/author.php
@@ -45,7 +45,7 @@ if ( get_the_author_meta( 'description' ) ) :
 							 *
 							 * @since Twenty Ten 1.0
 							 *
-							 * @param int The height and width avatar dimensions in pixels. Default 60.
+							 * @param int $size The height and width avatar dimensions in pixels. Default 60.
 							 */
 							$author_bio_avatar_size = apply_filters( 'twentyten_author_bio_avatar_size', 60 );
 							echo get_avatar( get_the_author_meta( 'user_email' ), $author_bio_avatar_size );

--- a/src/wp-content/themes/twentyten/loop-attachment.php
+++ b/src/wp-content/themes/twentyten/loop-attachment.php
@@ -127,7 +127,7 @@ if ( have_posts() ) {
 							 *
 							 * @since Twenty Ten 1.0
 							 *
-							 * @param int The default attachment width in pixels. Default 900.
+							 * @param int $width The default attachment width in pixels. Default 900.
 							 */
 							$attachment_width = apply_filters( 'twentyten_attachment_size', 900 );
 							/**
@@ -135,7 +135,7 @@ if ( have_posts() ) {
 							 *
 							 * @since Twenty Ten 1.0
 							 *
-							 * @param int The default attachment height in pixels. Default 900.
+							 * @param int $height The default attachment height in pixels. Default 900.
 							 */
 							$attachment_height = apply_filters( 'twentyten_attachment_height', 900 );
 							// Filterable image width with, essentially, no limit for image height.

--- a/src/wp-content/themes/twentytwenty/functions.php
+++ b/src/wp-content/themes/twentytwenty/functions.php
@@ -819,7 +819,7 @@ function twentytwenty_get_elements_array() {
 	 *
 	 * @since Twenty Twenty 1.0
 	 *
-	 * @param array Array of elements.
+	 * @param array $elements Array of elements.
 	 */
 	return apply_filters( 'twentytwenty_get_elements_array', $elements );
 }

--- a/src/wp-content/themes/twentytwenty/inc/template-tags.php
+++ b/src/wp-content/themes/twentytwenty/inc/template-tags.php
@@ -266,7 +266,7 @@ function twentytwenty_get_post_meta( $post_id = null, $location = 'single-top' )
 	 *
 	 * @since Twenty Twenty 1.0
 	 *
-	 * @param array Array of post types.
+	 * @param array $post_types Array of post types.
 	 */
 	$disallowed_post_types = apply_filters( 'twentytwenty_disallowed_post_types_for_meta_output', array( 'page' ) );
 

--- a/src/wp-content/themes/twentytwenty/template-parts/content-cover.php
+++ b/src/wp-content/themes/twentytwenty/template-parts/content-cover.php
@@ -59,7 +59,7 @@
 							 *
 							 * @since Twenty Twenty 1.0
 							 *
-							 * @param bool Whether to show the categories in article header. Default true.
+							 * @param bool $show_categories Whether to show the categories in article header. Default true.
 							 */
 							$show_categories = apply_filters( 'twentytwenty_show_categories_in_entry_header', true );
 

--- a/src/wp-content/themes/twentytwenty/template-parts/entry-header.php
+++ b/src/wp-content/themes/twentytwenty/template-parts/entry-header.php
@@ -25,7 +25,7 @@ if ( is_singular() ) {
 		 *
 		 * @since Twenty Twenty 1.0
 		 *
-		 * @param bool Whether to show the categories in header. Default true.
+		 * @param bool $show_categories Whether to show the categories in header. Default true.
 		 */
 		$show_categories = apply_filters( 'twentytwenty_show_categories_in_entry_header', true );
 


### PR DESCRIPTION
### Description
This PR adds missing variable names to `@param` tags in Twenty Eleven, Twenty Ten, and Twenty Twenty themes. 

### Changes
**Twenty Eleven:** `category.php`, `functions.php`
**Twenty Ten:** `loop-attachment.php`, `author.php`
**Twenty Twenty:** `functions.php`, `inc/template-tags.php`, `template-parts/entry-header.php`,  `template-parts/content-cover.php`

### Testing Instructions
1. Navigate to the affected files.
2. Verify that the docblocks for the mentioned filters now include the variable names in the @param tags.
3. Ensure no PHP errors or warnings are generated.

Trac ticket: https://core.trac.wordpress.org/ticket/64224