### PR TITLE
Media: Remove `required` attribute from media uploader file input field

### DIFF
--- a/src/wp-admin/includes/media.php
+++ b/src/wp-admin/includes/media.php
@@ -2285,7 +2285,7 @@ function media_upload_form( $errors = null ) {
 			_ex( 'Upload', 'verb' );
 			?>
 		</label>
-		<input type="file" name="async-upload" id="async-upload" required />
+		<input type="file" name="async-upload" id="async-upload" />
 		<?php submit_button( _x( 'Upload', 'verb' ), 'primary', 'html-upload', false ); ?>
 		<a href="#" onclick="try{top.tb_remove();}catch(e){}; return false;"><?php _e( 'Cancel' ); ?></a>
 	</p>


### PR DESCRIPTION
- Trac ticket: https://core.trac.wordpress.org/ticket/64305
- Alternatives to #10558
- Introduced by https://core.trac.wordpress.org/changeset/60449
---

## Summary

When the media upload form operates as a normal async uploader, the file input element with the `required` attribute is visually hidden. When a form submit is performed on a form element with this attribute, the following error is displayed in the browser console, and the form is not submitted:

```
An invalid form control with name='async-upload' is not focusable.
```


This issue affects all implementations that run the `media_upload_form()` function within a form element.

As a temporary workaround for 6.9, remove the `required` attribute from the file input element.

## Testing Instructions

✅ or ⚠️ indicates that this PR will change the results.

### Default Media Uploader

- Access http://localhost:8889/wp-admin/media-new.php
- Click the "browser uploader" link
- If JS is enabled: The Upload button should be disabled unless a file is attached.
- ⚠️ If JS is disabled: The form will be submitted without attaching a file, but validation will be performed on the server side, and the message "No file was uploaded." will be displayed. Since cases where JS is disabled are rare these days, I think this case is acceptable.

### Legacy Media Uploader

- Access http://localhost:8889/wp-admin/media-upload.php
- Click the "browser uploader" link
- ⚠️ The form will be submitted without attaching a file, but validation will be performed on the server side, and the message "No file was uploaded." will be displayed. Since the legacy uploader will probably be used very little anymore, I think this case is acceptable.

### Backward compatibility with third-party plugins

- Install and activate [the Envira Gallery plugin
](https://ja.wordpress.org/plugins/envira-gallery-lite/)
- Access http://localhost:8889/wp-admin/post-new.php?post_type=envira
- Click the Publish button
- ✅ You can save the post successfully.