### PR TITLE
Docs: Update comment for wp_enqueue_classic_theme_styles().

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3409,7 +3409,7 @@ function wp_enqueue_block_style( $block_name, $args ) {
 }
 
 /**
- * Loads classic theme styles on classic themes.
+ * Loads classic theme styles in themes which lack a theme.json file.
  *
  * This is used for backwards compatibility for Button and File blocks specifically.
  *

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3409,7 +3409,7 @@ function wp_enqueue_block_style( $block_name, $args ) {
 }
 
 /**
- * Loads classic theme styles on classic themes in the frontend.
+ * Loads classic theme styles on classic themes.
  *
  * This is used for backwards compatibility for Button and File blocks specifically.
  *

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3409,7 +3409,7 @@ function wp_enqueue_block_style( $block_name, $args ) {
 }
 
 /**
- * Loads classic theme styles in themes which lack a theme.json file.
+ * Loads classic theme styles when the current theme lacks a theme.json file.
  *
  * This is used for backwards compatibility for Button and File blocks specifically.
  *


### PR DESCRIPTION
This PR updates the docblock for `wp_enqueue_classic_theme_styles()` to remove
the incorrect “in the frontend” phrase.

The function is executed on both the editor and the front end.

Trac ticket: https://core.trac.wordpress.org/ticket/64317