### PR TITLE
Remove unnecessary login URL from new user notification email.

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -2381,8 +2381,6 @@ if ( ! function_exists( 'wp_new_user_notification' ) ) :
 		 */
 		$message .= network_site_url( 'wp-login.php?login=' . rawurlencode( $user->user_login ) . "&key=$key&action=rp", 'login' ) . "\r\n\r\n";
 
-		$message .= wp_login_url() . "\r\n";
-
 		$wp_new_user_notification_email = array(
 			'to'      => $user->user_email,
 			/* translators: Login details notification email subject. %s: Site title. */

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3409,7 +3409,7 @@ function wp_enqueue_block_style( $block_name, $args ) {
 }
 
 /**
- * Loads classic theme styles on classic themes in the frontend.
+ * Loads classic theme styles on classic themes.
  *
  * This is used for backwards compatibility for Button and File blocks specifically.
  *


### PR DESCRIPTION
This PR updates the `wp_new_user_notification()` function to remove the unnecessary login URL that appears at the end of the new user notification email.

This URL is confusing and unusable because the user cannot log in before setting a password.  
On some email clients, line breaks are collapsed, causing the login URL to appear merged with the reset-password link.

Removing the login URL prevents users from being directed to an unusable login screen.

Trac ticket: https://core.trac.wordpress.org/ticket/64316