### PR TITLE
Moved register/unregister block pattern and category functions

### DIFF
--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -22,7 +22,6 @@ function register_block_pattern( $pattern_name, $pattern_properties ) {
 	return WP_Block_Patterns_Registry::get_instance()->register( $pattern_name, $pattern_properties );
 }
 
-
 /**
  * Unregisters a block pattern.
  *
@@ -34,7 +33,6 @@ function register_block_pattern( $pattern_name, $pattern_properties ) {
 function unregister_block_pattern( $pattern_name ) {
 	return WP_Block_Patterns_Registry::get_instance()->unregister( $pattern_name );
 }
-
 
 /**
  * Registers a new pattern category.

--- a/src/wp-includes/block-patterns.php
+++ b/src/wp-includes/block-patterns.php
@@ -9,6 +9,61 @@
 add_theme_support( 'core-block-patterns' );
 
 /**
+ * Registers a new block pattern.
+ *
+ * @since 5.5.0
+ *
+ * @param string $pattern_name       Block pattern name including namespace.
+ * @param array  $pattern_properties List of properties for the block pattern.
+ *                                   See WP_Block_Patterns_Registry::register() for accepted arguments.
+ * @return bool True if the pattern was registered with success and false otherwise.
+ */
+function register_block_pattern( $pattern_name, $pattern_properties ) {
+	return WP_Block_Patterns_Registry::get_instance()->register( $pattern_name, $pattern_properties );
+}
+
+
+/**
+ * Unregisters a block pattern.
+ *
+ * @since 5.5.0
+ *
+ * @param string $pattern_name Block pattern name including namespace.
+ * @return bool True if the pattern was unregistered with success and false otherwise.
+ */
+function unregister_block_pattern( $pattern_name ) {
+	return WP_Block_Patterns_Registry::get_instance()->unregister( $pattern_name );
+}
+
+
+/**
+ * Registers a new pattern category.
+ *
+ * @since 5.5.0
+ *
+ * @param string $category_name       Pattern category name including namespace.
+ * @param array  $category_properties List of properties for the block pattern.
+ *                                    See WP_Block_Pattern_Categories_Registry::register() for
+ *                                    accepted arguments.
+ * @return bool True if the pattern category was registered with success and false otherwise.
+ */
+function register_block_pattern_category( $category_name, $category_properties ) {
+	return WP_Block_Pattern_Categories_Registry::get_instance()->register( $category_name, $category_properties );
+}
+
+/**
+ * Unregisters a pattern category.
+ *
+ * @since 5.5.0
+ *
+ * @param string $category_name Pattern category name including namespace.
+ * @return bool True if the pattern category was unregistered with success and false otherwise.
+ */
+function unregister_block_pattern_category( $category_name ) {
+	return WP_Block_Pattern_Categories_Registry::get_instance()->unregister( $category_name );
+}
+
+/**
  * Registers the core block patterns and categories.
  *
  * @since 5.5.0

--- a/src/wp-includes/class-wp-block-pattern-categories-registry.php
+++ b/src/wp-includes/class-wp-block-pattern-categories-registry.php
@@ -162,30 +162,3 @@ final class WP_Block_Pattern_Categories_Registry {
 		return self::$instance;
 	}
 }
-
-/**
- * Registers a new pattern category.
- *
- * @since 5.5.0
- *
- * @param string $category_name       Pattern category name including namespace.
- * @param array  $category_properties List of properties for the block pattern.
- *                                    See WP_Block_Pattern_Categories_Registry::register() for
- *                                    accepted arguments.
- * @return bool True if the pattern category was registered with success and false otherwise.
- */
-function register_block_pattern_category( $category_name, $category_properties ) {
-	return WP_Block_Pattern_Categories_Registry::get_instance()->register( $category_name, $category_properties );
-}
-
-/**
- * Unregisters a pattern category.
- *
- * @since 5.5.0
- *
- * @param string $category_name Pattern category name including namespace.
- * @return bool True if the pattern category was unregistered with success and false otherwise.
- */
-function unregister_block_pattern_category( $category_name ) {
-	return WP_Block_Pattern_Categories_Registry::get_instance()->unregister( $category_name );
-}

--- a/src/wp-includes/class-wp-block-patterns-registry.php
+++ b/src/wp-includes/class-wp-block-patterns-registry.php
@@ -277,29 +277,3 @@ final class WP_Block_Patterns_Registry {
 		return self::$instance;
 	}
 }
-
-/**
- * Registers a new block pattern.
- *
- * @since 5.5.0
- *
- * @param string $pattern_name       Block pattern name including namespace.
- * @param array  $pattern_properties List of properties for the block pattern.
- *                                   See WP_Block_Patterns_Registry::register() for accepted arguments.
- * @return bool True if the pattern was registered with success and false otherwise.
- */
-function register_block_pattern( $pattern_name, $pattern_properties ) {
-	return WP_Block_Patterns_Registry::get_instance()->register( $pattern_name, $pattern_properties );
-}
-
-/**
- * Unregisters a block pattern.
- *
- * @since 5.5.0
- *
- * @param string $pattern_name Block pattern name including namespace.
- * @return bool True if the pattern was unregistered with success and false otherwise.
- */
-function unregister_block_pattern( $pattern_name ) {
-	return WP_Block_Patterns_Registry::get_instance()->unregister( $pattern_name );
-}


### PR DESCRIPTION
PR contains following changes:
1. Moved `register_block_pattern_category ` and `unregister_block_pattern_category` from `src/wp-includes/class-wp-block-pattern-categories-registry.php` to `src/wp-includes/block-patterns.php`
2. Moved `register_block_pattern ` and `unregister_block_pattern` from `src/wp-includes/class-wp-block-patterns-registry.php` to `src/wp-includes/block-patterns.php`

Trac ticket: https://core.trac.wordpress.org/ticket/64234

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
