### PR TITLE
Fix HEIF/HEIC test on PHP 8.5

### DIFF
--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -614,7 +614,7 @@ if ( ! defined( 'IMG_AVIF' ) ) {
 	define( 'IMG_AVIF', IMAGETYPE_AVIF );
 }
 
-// IMAGETYPE_HEIC constant is only defined in PHP 8.5 or later.
-if ( ! defined( 'IMAGETYPE_HEIC' ) ) {
-	define( 'IMAGETYPE_HEIC', 20 );
+// IMAGETYPE_HEIF constant is only defined in PHP 8.5 or later.
+if ( ! defined( 'IMAGETYPE_HEIF' ) ) {
+	define( 'IMAGETYPE_HEIF', 20 );
 }

--- a/src/wp-includes/compat.php
+++ b/src/wp-includes/compat.php
@@ -614,7 +614,7 @@ if ( ! defined( 'IMG_AVIF' ) ) {
 	define( 'IMG_AVIF', IMAGETYPE_AVIF );
 }
 
-// IMAGETYPE_HEIC constant is not yet defined in PHP as of PHP 8.3.
+// IMAGETYPE_HEIC constant is only defined in PHP 8.5 or later.
 if ( ! defined( 'IMAGETYPE_HEIC' ) ) {
-	define( 'IMAGETYPE_HEIC', 99 );
+	define( 'IMAGETYPE_HEIC', 20 );
 }

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -5829,7 +5829,7 @@ function wp_getimagesize( $filename, ?array &$image_info = null ) {
 			return array(
 				$size['width'],
 				$size['height'],
-				IMAGETYPE_HEIC,
+				IMAGETYPE_HEIF,
 				sprintf(
 					'width="%d" height="%d"',
 					$size['width'],

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -1584,18 +1584,18 @@ class Tests_Functions extends WP_UnitTestCase {
 			$expected = array_merge(
 				$expected,
 				array(
-					'bits' => 8,
-					'channels' => 3,
-					'mime' => 'image/heif',
-					'width_unit' => 'px',
+					'bits'        => 8,
+					'channels'    => 3,
+					'mime'        => 'image/heif',
+					'width_unit'  => 'px',
 					'height_unit' => 'px',
 				)
 			);
 		} else {
 			$expected['mime'] = 'image/heic';
 		}
-		
-		$result   = wp_getimagesize( $file );
+
+		$result = wp_getimagesize( $file );
 		$this->assertSame( $expected, $result );
 	}
 

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -1577,9 +1577,7 @@ class Tests_Functions extends WP_UnitTestCase {
 			'width="1180" height="1180"',
 		);
 
-		/*
-		 * As of PHP 8.5.0, getimagesize() supports HEIF/HEIC files.
-		 */
+		// As of PHP 8.5.0, getimagesize() supports HEIF/HEIC files.
 		if ( PHP_VERSION_ID >= 80500 ) {
 			$expected = array_merge(
 				$expected,

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -1575,8 +1575,26 @@ class Tests_Functions extends WP_UnitTestCase {
 			1180,
 			IMAGETYPE_HEIC,
 			'width="1180" height="1180"',
-			'mime' => 'image/heic',
 		);
+
+		/*
+		 * As of PHP 8.5.0, getimagesize() supports HEIF/HEIC files.
+		 */
+		if ( PHP_VERSION_ID >= 80500 ) {
+			$expected = array_merge(
+				$expected,
+				array(
+					'bits' => 8,
+					'channels' => 3,
+					'mime' => 'image/heif',
+					'width_unit' => 'px',
+					'height_unit' => 'px',
+				)
+			);
+		} else {
+			$expected['mime'] = 'image/heic';
+		}
+		
 		$result   = wp_getimagesize( $file );
 		$this->assertSame( $expected, $result );
 	}

--- a/tests/phpunit/tests/functions.php
+++ b/tests/phpunit/tests/functions.php
@@ -1573,7 +1573,7 @@ class Tests_Functions extends WP_UnitTestCase {
 		$expected = array(
 			1180,
 			1180,
-			IMAGETYPE_HEIC,
+			IMAGETYPE_HEIF,
 			'width="1180" height="1180"',
 		);
 


### PR DESCRIPTION
This configures a value of `20` for the `IMAGETYPE_HEIF` constant. While not [yet officially documented](https://www.php.net/manual/en/function.exif-imagetype.php), [HEIF/HEIC support was officially added in PHP 8.5](https://github.com/php/php-src/commit/dfac2da7fba930570fcda99205cfcf53dbe2e909).

Also, with native support for HEIC/HEIF in PHP, additional exif information is returned. The test has been updated to expect that info.

Trac ticket: Core-64322

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
