### PR TITLE
Add: Unit test to validate core abilities schemas only include valid properties.

### DIFF
--- a/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
@@ -174,4 +174,93 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'wp_version', $ability_data );
 		$this->assertSame( $environment, $ability_data['environment'] );
 	}
+
+	/**
+	 * Tests that all core ability schemas only use valid JSON Schema keywords.
+	 *
+	 * This prevents regressions where invalid keywords like 'examples' are used
+	 * in schema properties (not valid in JSON Schema draft-04 used by WordPress).
+	 *
+	 * @ticket 64098
+	 */
+	public function test_core_abilities_schemas_use_only_valid_keywords(): void {
+		$allowed_keywords = rest_get_allowed_schema_keywords();
+		// Add 'required' which is valid at the property level for draft-04.
+		$allowed_keywords[] = 'required';
+
+		$abilities = wp_get_abilities();
+
+		$this->assertNotEmpty( $abilities, 'Core abilities should be registered.' );
+
+		foreach ( $abilities as $ability ) {
+			$this->assert_schema_uses_valid_keywords(
+				$ability->get_input_schema(),
+				$allowed_keywords,
+				$ability->get_name() . ' input_schema'
+			);
+			$this->assert_schema_uses_valid_keywords(
+				$ability->get_output_schema(),
+				$allowed_keywords,
+				$ability->get_name() . ' output_schema'
+			);
+		}
+	}
+
+	/**
+	 * Recursively validates that a schema only uses allowed keywords.
+	 *
+	 * @param array|null $schema           The schema to validate.
+	 * @param array      $allowed_keywords List of allowed schema keywords.
+	 * @param string     $context          Context for error messages.
+	 */
+	private function assert_schema_uses_valid_keywords( $schema, array $allowed_keywords, string $context ): void {
+		if ( empty( $schema ) || ! is_array( $schema ) ) {
+			return;
+		}
+
+		foreach ( $schema as $key => $value ) {
+			// Skip integer keys (array indices).
+			if ( is_int( $key ) ) {
+				continue;
+			}
+
+			// These keywords contain nested schemas that we recurse into.
+			$nesting_keywords = array( 'properties', 'items', 'additionalProperties', 'patternProperties', 'anyOf', 'oneOf' );
+
+			if ( ! in_array( $key, $nesting_keywords, true ) && ! in_array( $key, $allowed_keywords, true ) ) {
+				$this->fail( "Invalid schema keyword '{$key}' found in {$context}. Valid keywords are: " . implode( ', ', $allowed_keywords ) );
+			}
+
+			// Recursively check nested schemas.
+			if ( 'properties' === $key && is_array( $value ) ) {
+				foreach ( $value as $prop_name => $prop_schema ) {
+					$this->assert_schema_uses_valid_keywords(
+						$prop_schema,
+						$allowed_keywords,
+						"{$context}.properties.{$prop_name}"
+					);
+				}
+			} elseif ( 'items' === $key && is_array( $value ) ) {
+				$this->assert_schema_uses_valid_keywords(
+					$value,
+					$allowed_keywords,
+					"{$context}.items"
+				);
+			} elseif ( ( 'anyOf' === $key || 'oneOf' === $key ) && is_array( $value ) ) {
+				foreach ( $value as $index => $sub_schema ) {
+					$this->assert_schema_uses_valid_keywords(
+						$sub_schema,
+						$allowed_keywords,
+						"{$context}.{$key}[{$index}]"
+					);
+				}
+			} elseif ( 'additionalProperties' === $key && is_array( $value ) ) {
+				$this->assert_schema_uses_valid_keywords(
+					$value,
+					$allowed_keywords,
+					"{$context}.additionalProperties"
+				);
+			}
+		}
+	}
 }

--- a/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
@@ -210,7 +210,7 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 	 * Recursively validates that a schema only uses allowed keywords.
 	 *
 	 * @param array|null $schema           The schema to validate.
-	 * @param array      $allowed_keywords List of allowed schema keywords.
+	 * @param string[]   $allowed_keywords List of allowed schema keywords.
 	 * @param string     $context          Context for error messages.
 	 */
 	private function assert_schema_uses_valid_keywords( $schema, array $allowed_keywords, string $context ): void {

--- a/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
@@ -213,7 +213,7 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 	 * @param string[]   $allowed_keywords List of allowed schema keywords.
 	 * @param string     $context          Context for error messages.
 	 */
-	private function assert_schema_uses_valid_keywords( $schema, array $allowed_keywords, string $context ): void {
+	private function assert_schema_uses_valid_keywords( ?array $schema, array $allowed_keywords, string $context ): void {
 		if ( empty( $schema ) || ! is_array( $schema ) ) {
 			return;
 		}

--- a/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
+++ b/tests/phpunit/tests/abilities-api/wpRegisterCoreAbilities.php
@@ -214,7 +214,7 @@ class Tests_Abilities_API_WpRegisterCoreAbilities extends WP_UnitTestCase {
 	 * @param string     $context          Context for error messages.
 	 */
 	private function assert_schema_uses_valid_keywords( ?array $schema, array $allowed_keywords, string $context ): void {
-		if ( empty( $schema ) || ! is_array( $schema ) ) {
+		if ( null === $schema ) {
 			return;
 		}
 


### PR DESCRIPTION
On https://github.com/WordPress/wordpress-develop/pull/10510 we fixed an issue where some core abilties used invalid schema-04 properties.
This PR adds a unit test to make all the properties used are valid.

## Testing
- Verify the end to end tests pass.
- Apply the following patch:
```
diff --git a/src/wp-includes/abilities.php b/src/wp-includes/abilities.php
index 0320df3b9f..c71eeb158a 100644
--- a/src/wp-includes/abilities.php
+++ b/src/wp-includes/abilities.php
@@ -219,8 +219,9 @@ function wp_register_core_abilities(): void {
 					),
 					'db_server_info' => array(
 						'type'        => 'string',
 						'description' => __( 'The database server vendor and version string reported by the driver.' ),
+						'examples'    => array( '8.0.34', '10.11.6-MariaDB' ),
 					),
 					'wp_version'     => array(
 						'type'        => 'string',
 						'description' => __( 'The WordPress core version running on this site.' ),
```
Verify the end to end tests now fail.


Ticket: https://core.trac.wordpress.org/ticket/64384#ticket