### PR TITLE
Set consistent margin-bottom for .wp-filter in list-tables.css

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -1457,7 +1457,7 @@ ul.cat-checklist input[name="post_category[]"]:indeterminate::before {
 }
 
 .plugin-install-php .wp-filter {
-	margin-bottom: 0;
+	margin-bottom: 1rem;
 }
 
 /* Plugin card table view */


### PR DESCRIPTION
Set the plugins tab bottom margin to 1rem, matching the old description margin.

Trac ticket: https://core.trac.wordpress.org/ticket/64337

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
