### PR TITLE
HTML API: Ensure correct encoding of modified class names

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-tag-processor.php
+++ b/src/wp-includes/html-api/class-wp-html-tag-processor.php
@@ -2342,10 +2342,12 @@ class WP_HTML_Tag_Processor {
 		}
 
 		if ( false === $existing_class && isset( $this->attributes['class'] ) ) {
-			$existing_class = substr(
-				$this->html,
-				$this->attributes['class']->value_starts_at,
-				$this->attributes['class']->value_length
+			$existing_class = WP_HTML_Decoder::decode_attribute(
+				substr(
+					$this->html,
+					$this->attributes['class']->value_starts_at,
+					$this->attributes['class']->value_length
+				)
 			);
 		}
 

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -3029,6 +3029,53 @@ HTML
 	}
 
 	/**
+	 * @ticket 64340
+	 */
+	public function test_class_changes_produce_correct_html() {
+		$processor = new WP_HTML_Tag_Processor( '<div>' );
+		$processor->next_tag();
+
+		$processor->add_class( '&' );
+		$processor->get_updated_html();
+
+		$processor->add_class( '"' );
+		$processor->get_updated_html();
+
+		$processor->add_class( 'OK' );
+		$processor->get_updated_html();
+
+		$this->assertTrue( $processor->has_class( '&' ), 'Missing expected "&" class.' );
+		$this->assertTrue( $processor->has_class( '"' ), 'Missing expected \'"\' class.' );
+		$this->assertTrue( $processor->has_class( 'OK' ), 'Missing expected "OK" class.' );
+
+		$expected = '<div class="&amp; &quot; OK">';
+		$this->assertEqualHTML(
+			$expected,
+			$processor->get_updated_html(),
+			'<body>',
+			'HTML was not correctly updated after adding classes.'
+		);
+
+		$processor->remove_class( '&' );
+		$processor->get_updated_html();
+
+		$processor->remove_class( '"' );
+		$processor->get_updated_html();
+
+		$this->assertFalse( $processor->has_class( '&' ) );
+		$this->assertFalse( $processor->has_class( '"' ) );
+		$this->assertTrue( $processor->has_class( 'OK' ) );
+
+		$expected = '<div class="OK">';
+		$this->assertEqualHTML(
+			$expected,
+			$processor->get_updated_html(),
+			'<body>',
+			'HTML was not correctly updated after removing classes.'
+		);
+	}
+
+	/**
 	 * @covers WP_HTML_Tag_Processor::next_tag
 	 */
 	public function test_handles_malformed_taglike_open_short_html() {

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -2887,11 +2887,11 @@ HTML;
 			),
 			'HTML tag opening inside attribute value'      => array(
 				'input'    => '<pre id="<code" class="wp-block-code <code is poetry&gt;"><code>This &lt;is> a &lt;strong is="true">thing.</code></pre><span>test</span>',
-				'expected' => '<pre foo="bar" id="<code" class="wp-block-code &lt;code is poetry&amp;gt; firstTag"><code class="secondTag">This &lt;is> a &lt;strong is="true">thing.</code></pre><span>test</span>',
+				'expected' => '<pre foo="bar" id="<code" class="wp-block-code &lt;code is poetry&gt; firstTag"><code class="secondTag">This &lt;is> a &lt;strong is="true">thing.</code></pre><span>test</span>',
 			),
 			'HTML tag brackets in attribute values and data markup' => array(
 				'input'    => '<pre id="<code-&gt;-block-&gt;" class="wp-block-code <code is poetry&gt;"><code>This &lt;is> a &lt;strong is="true">thing.</code></pre><span>test</span>',
-				'expected' => '<pre foo="bar" id="<code-&gt;-block-&gt;" class="wp-block-code &lt;code is poetry&amp;gt; firstTag"><code class="secondTag">This &lt;is> a &lt;strong is="true">thing.</code></pre><span>test</span>',
+				'expected' => '<pre foo="bar" id="<code-&gt;-block-&gt;" class="wp-block-code &lt;code is poetry&gt; firstTag"><code class="secondTag">This &lt;is> a &lt;strong is="true">thing.</code></pre><span>test</span>',
 			),
 			'Single and double quotes in attribute value'  => array(
 				'input'    => '<p title="Demonstrating how to use single quote (\') and double quote (&quot;)"><span>test</span>',

--- a/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
+++ b/tests/phpunit/tests/html-api/wpHtmlTagProcessor.php
@@ -3032,11 +3032,8 @@ HTML
 	 * @ticket 64340
 	 */
 	public function test_class_changes_produce_correct_html() {
-		$processor = new WP_HTML_Tag_Processor( '<div>' );
+		$processor = new WP_HTML_Tag_Processor( '<div class="&amp;">' );
 		$processor->next_tag();
-
-		$processor->add_class( '&' );
-		$processor->get_updated_html();
 
 		$processor->add_class( '"' );
 		$processor->get_updated_html();


### PR DESCRIPTION
Ensure the class name modifications preserve correct HTML encoding when calling `add_class` and `get_updated_html` repeatedly.

There was an inconsistency in this branching where `$existing_class` would get a correctly decoded attribute value if there was a value returned from `get_enqueued_attribute_value()` but would otherwise get raw, unparsed HTML if there was a class attribute in the HTML:

https://github.com/WordPress/wordpress-develop/blob/3a87241015aff96c7a38c1304949908b9588b218/src/wp-includes/html-api/class-wp-html-tag-processor.php#L2339-L2350

Note that `::get_enqueued_attribute_value()` returns a decoded value:

https://github.com/WordPress/wordpress-develop/blob/3a87241015aff96c7a38c1304949908b9588b218/src/wp-includes/html-api/class-wp-html-tag-processor.php#L2734

This inconsistent behavior was hidden by the use of `esc_attr()` which avoids double-escaping character references, so when `::set_attribute()` was later called it would only encoded character references that did not appear to already be encoded.

https://github.com/WordPress/wordpress-develop/blob/3a87241015aff96c7a38c1304949908b9588b218/src/wp-includes/html-api/class-wp-html-tag-processor.php#L2479

When `:set_attribute()` was changed in r60919 (4892d469437c916e6cda52d6a9c617850c354910) to always escape attribute values, the double-escaping manifested.

> `WP_HTML_Tag_Processor` and `WP_HTML_Processor` may incorrectly encode class names containing the characters `&`, `<`, `>`, `"`, or `'` when modifying them via class methods like `::add_class()` and calling `::get_updated_html()`.
> 
> For example:
> 
> ```php
> $p = new WP_HTML_Tag_Processor('<div></div>');
> $p->next_tag();
> $p->add_class('&');
> echo $p->get_updated_html() . "\n";
> $p->add_class('OK');
> echo $p->get_updated_html() . "\n";
> ```
> 
> Will print:
> 
> ```html
> <div class="&amp;"></div>
> <div class="&amp;amp; OK"></div>
> ```
> 
> Notice that the first pass is correct, `&` has been correctly encoded in the class attribute as &amp;. However, after calling `::add_class()` and `::get_updated_html()` again, the `&` has incorrectly been double-encoded as `&amp;amp;`.
> 
> The same code in WordPress 6.8 would print:
> 
> ```html
> <div class="&amp;"></div>
> <div class="&amp; OK"></div>
> ```
> 
> This is related to r60919 that was released in WordPress 6.9. The double-encoding behavior was present before, but it was "corrected" in this case by the use of `esc_attr()` that avoids any double-encoding. When `esc_attr()` usage was removed in r60919, the double-escaping behavior manifests causing this issue.
> 

Trac ticket: https://core.trac.wordpress.org/ticket/64340

Originally reported in https://github.com/WordPress/gutenberg/issues/73713.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
