### PR TITLE
Site Health: Add common cache headers for improved caching diagnostics

### DIFF
--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -3412,6 +3412,16 @@ class WP_Site_Health {
 			},
 			'x-srcache-store-status' => $cache_hit_callback,
 			'x-srcache-fetch-status' => $cache_hit_callback,
+
+			// Generic caching proxies (Nginx, Varnish, etc.)
+			'x-cache' => $cache_hit_callback,
+			'x-cache-status' => $cache_hit_callback,
+			
+			// Cloudflare
+			'cf-cache-status' => $cache_hit_callback,
+			
+			// Apache mod_cache
+			'x-cache-detail' => $cache_hit_callback,			
 		);
 
 		/**

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -3419,9 +3419,6 @@ class WP_Site_Health {
 
 			// Cloudflare
 			'cf-cache-status' => $cache_hit_callback,
-
-			// Apache mod_cache
-			'x-cache-detail' => $cache_hit_callback,
 		);
 
 		/**

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -3414,14 +3414,14 @@ class WP_Site_Health {
 			'x-srcache-fetch-status' => $cache_hit_callback,
 
 			// Generic caching proxies (Nginx, Varnish, etc.)
-			'x-cache' => $cache_hit_callback,
+			'x-cache'        => $cache_hit_callback,
 			'x-cache-status' => $cache_hit_callback,
 			
 			// Cloudflare
 			'cf-cache-status' => $cache_hit_callback,
 			
 			// Apache mod_cache
-			'x-cache-detail' => $cache_hit_callback,			
+			'x-cache-detail' => $cache_hit_callback,
 		);
 
 		/**

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -3416,10 +3416,10 @@ class WP_Site_Health {
 			// Generic caching proxies (Nginx, Varnish, etc.)
 			'x-cache'        => $cache_hit_callback,
 			'x-cache-status' => $cache_hit_callback,
-			
+
 			// Cloudflare
 			'cf-cache-status' => $cache_hit_callback,
-			
+
 			// Apache mod_cache
 			'x-cache-detail' => $cache_hit_callback,
 		);

--- a/src/wp-admin/includes/class-wp-site-health.php
+++ b/src/wp-admin/includes/class-wp-site-health.php
@@ -3414,8 +3414,11 @@ class WP_Site_Health {
 			'x-srcache-fetch-status' => $cache_hit_callback,
 
 			// Generic caching proxies (Nginx, Varnish, etc.)
-			'x-cache'        => $cache_hit_callback,
-			'x-cache-status' => $cache_hit_callback,
+			'x-cache'           => $cache_hit_callback,
+			'x-cache-status'    => $cache_hit_callback,
+			'x-litespeed-cache' => $cache_hit_callback,
+			'x-proxy-cache'     => $cache_hit_callback,
+			'via'               => '',
 
 			// Cloudflare
 			'cf-cache-status' => $cache_hit_callback,


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63748

This PR adds support for detecting common server-level cache headers in the Site Health page cache test, improving accuracy for sites using Nginx FastCGI cache, Varnish, LiteSpeed, Cloudflare CDN, and other widely-deployed caching solutions.

This extends the get_page_cache_headers() method to include the following commonly-used cache headers:
#### Added Headers:

- x-cache - Generic cache status header used by Varnish, Apache mod_cache, Nginx, and many CDN providers
- x-cache-status - Most common convention for Nginx FastCGI cache (using $upstream_cache_status variable)
- x-litespeed-cache - LiteSpeed Web Server and LiteSpeed Cache plugin
- x-proxy-cache - Generic reverse proxy cache indicator
- cf-cache-status - Cloudflare CDN cache status (automatically added by Cloudflare)
- via - Standard HTTP header indicating proxy/intermediary presence (RFC 9110)