### PR TITLE
Docs: Replace @since x.y.z with actual version in WP_Roles and capabilities docs.

### DIFF
--- a/src/wp-includes/capabilities.php
+++ b/src/wp-includes/capabilities.php
@@ -1124,7 +1124,7 @@ function get_role( $role ) {
  *     ) );
  *
  * @since 2.0.0
- * @since x.y.z Support was added for a numerically indexed array of strings for the capabilities array.
+ * @since 6.9.0 Support was added for a numerically indexed array of strings for the capabilities array.
  *
  * @param string                               $role         Role name.
  * @param string                               $display_name Display name for role.

--- a/src/wp-includes/class-wp-roles.php
+++ b/src/wp-includes/class-wp-roles.php
@@ -165,7 +165,7 @@ class WP_Roles {
 	 *     ) );
 	 *
 	 * @since 2.0.0
-	 * @since x.y.z Support was added for a numerically indexed array of strings for the capabilities array.
+	 * @since 6.9.0 Support was added for a numerically indexed array of strings for the capabilities array.
 	 *
 	 * @param string                               $role         Role name.
 	 * @param string                               $display_name Role display name.


### PR DESCRIPTION
This PR replaces placeholder @since x.y.z tags with the accurate version number 6.9.0 in:

- wp-includes/class-wp-roles.php
- wp-includes/capabilities.php

These updates follow WordPress documentation standards and align with Core ticket #64366.

Trac ticket: https://core.trac.wordpress.org/ticket/64366

Fixes #64366.
