### PR TITLE
Fix PHPStan issues up to level 8 in `WP_Dependencies`, `_WP_Dependency`, `WP_Scripts`, and `WP_Styles`

### DIFF
--- a/src/wp-includes/class-wp-dependencies.php
+++ b/src/wp-includes/class-wp-dependencies.php
@@ -56,7 +56,8 @@ class WP_Dependencies {
 	/**
 	 * An array of additional arguments passed when a handle is registered.
 	 *
-	 * Arguments are appended to the item query string.
+	 * They keys are dependency handles and the values are query strings which are appended to the item URL's query
+	 * string, after the `ver` if provided.
 	 *
 	 * @since 2.6.0
 	 *

--- a/src/wp-includes/class-wp-dependencies.php
+++ b/src/wp-includes/class-wp-dependencies.php
@@ -60,7 +60,7 @@ class WP_Dependencies {
 	 *
 	 * @since 2.6.0
 	 *
-	 * @var array
+	 * @var array<string, string>
 	 */
 	public $args = array();
 
@@ -100,7 +100,7 @@ class WP_Dependencies {
 	 *
 	 * @since 5.9.0
 	 *
-	 * @var array
+	 * @var array<string, string|null>
 	 */
 	private $queued_before_register = array();
 

--- a/src/wp-includes/class-wp-dependencies.php
+++ b/src/wp-includes/class-wp-dependencies.php
@@ -56,7 +56,7 @@ class WP_Dependencies {
 	/**
 	 * An array of additional arguments passed when a handle is registered.
 	 *
-	 * They keys are dependency handles and the values are query strings which are appended to the item URL's query
+	 * The keys are dependency handles and the values are query strings which are appended to the item URL's query
 	 * string, after the `ver` if provided.
 	 *
 	 * @since 2.6.0

--- a/src/wp-includes/class-wp-dependency.php
+++ b/src/wp-includes/class-wp-dependency.php
@@ -66,7 +66,7 @@ class _WP_Dependency {
 	 * Extra data to supply to the handle.
 	 *
 	 * @since 2.6.0
-	 * @var array
+	 * @var array<string, mixed>
 	 */
 	public $extra = array();
 
@@ -82,7 +82,7 @@ class _WP_Dependency {
 	 * Translation path set for this dependency.
 	 *
 	 * @since 5.0.0
-	 * @var string
+	 * @var string|null
 	 */
 	public $translations_path;
 

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -118,7 +118,7 @@ class WP_Scripts extends WP_Dependencies {
 	 * List of default directories.
 	 *
 	 * @since 2.8.0
-	 * @var string[]
+	 * @var string[]|null
 	 */
 	public $default_dirs;
 

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -46,7 +46,7 @@ class WP_Scripts extends WP_Dependencies {
 	 * Holds handles of scripts which are enqueued in footer.
 	 *
 	 * @since 2.8.0
-	 * @var array
+	 * @var string[]
 	 */
 	public $in_footer = array();
 
@@ -118,7 +118,7 @@ class WP_Scripts extends WP_Dependencies {
 	 * List of default directories.
 	 *
 	 * @since 2.8.0
-	 * @var array
+	 * @var string[]
 	 */
 	public $default_dirs;
 
@@ -589,9 +589,9 @@ class WP_Scripts extends WP_Dependencies {
 	 *
 	 * @since 2.1.0
 	 *
-	 * @param string $handle      Name of the script to attach data to.
-	 * @param string $object_name Name of the variable that will contain the data.
-	 * @param array  $l10n        Array of data to localize.
+	 * @param string               $handle      Name of the script to attach data to.
+	 * @param string               $object_name Name of the variable that will contain the data.
+	 * @param array<string, mixed> $l10n        Array of data to localize.
 	 * @return bool True on success, false on failure.
 	 */
 	public function localize( $handle, $object_name, $l10n ) {

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -374,7 +374,8 @@ class WP_Scripts extends WP_Dependencies {
 			$filtered_src = apply_filters( 'script_loader_src', $src, $handle );
 
 			if (
-				$this->in_default_dir( $filtered_src )
+				is_string( $filtered_src )
+				&& $this->in_default_dir( $filtered_src )
 				&& ( $before_script || $after_script || $translations_stop_concat || $this->is_delayed_strategy( $strategy ) )
 			) {
 				$this->do_concat = false;

--- a/src/wp-includes/class-wp-styles.php
+++ b/src/wp-includes/class-wp-styles.php
@@ -96,7 +96,7 @@ class WP_Styles extends WP_Dependencies {
 	 * List of default directories.
 	 *
 	 * @since 2.8.0
-	 * @var array
+	 * @var string[]
 	 */
 	public $default_dirs;
 
@@ -183,7 +183,7 @@ class WP_Styles extends WP_Dependencies {
 		}
 
 		if ( $this->do_concat ) {
-			if ( $this->in_default_dir( $src ) && ! isset( $obj->extra['alt'] ) ) {
+			if ( $src && $this->in_default_dir( $src ) && ! isset( $obj->extra['alt'] ) ) {
 				$this->concat         .= "$handle,";
 				$this->concat_version .= "$handle$ver";
 

--- a/src/wp-includes/class-wp-styles.php
+++ b/src/wp-includes/class-wp-styles.php
@@ -183,7 +183,7 @@ class WP_Styles extends WP_Dependencies {
 		}
 
 		if ( $this->do_concat ) {
-			if ( $src && $this->in_default_dir( $src ) && ! isset( $obj->extra['alt'] ) ) {
+			if ( is_string( $src ) && $this->in_default_dir( $src ) && ! isset( $obj->extra['alt'] ) ) {
 				$this->concat         .= "$handle,";
 				$this->concat_version .= "$handle$ver";
 

--- a/src/wp-includes/class-wp-styles.php
+++ b/src/wp-includes/class-wp-styles.php
@@ -96,7 +96,7 @@ class WP_Styles extends WP_Dependencies {
 	 * List of default directories.
 	 *
 	 * @since 2.8.0
-	 * @var string[]
+	 * @var string[]|null
 	 */
 	public $default_dirs;
 


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64238

Running this PHPStan command:

```bash
phpstan analyze --memory-limit=4G --level=8 src/wp-includes/class-wp-scripts.php src/wp-includes/class-wp-styles.php src/wp-includes/class-wp-dependencies.php src/wp-includes/class-wp-dependency.php
```

Results in the following report for `trunk`:

```
 ------ ------------------------------------------------------------------------------------------------------------ 
  Line   class-wp-dependencies.php                                                                                   
 ------ ------------------------------------------------------------------------------------------------------------ 
  65     Property WP_Dependencies::$args type has no value type specified in iterable type array.                    
         🪪  missingType.iterableValue                                                                               
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                  
         at src/wp-includes/class-wp-dependencies.php:65                                                             
  105    Property WP_Dependencies::$queued_before_register type has no value type specified in iterable type array.  
         🪪  missingType.iterableValue                                                                               
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                  
         at src/wp-includes/class-wp-dependencies.php:105                                                            
 ------ ------------------------------------------------------------------------------------------------------------ 

 ------ -------------------------------------------------------------------------------------------- 
  Line   class-wp-dependency.php                                                                     
 ------ -------------------------------------------------------------------------------------------- 
  71     Property _WP_Dependency::$extra type has no value type specified in iterable type array.    
         🪪  missingType.iterableValue                                                               
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type  
         at src/wp-includes/class-wp-dependency.php:71                                               
 ------ -------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------- 
  Line   class-wp-scripts.php                                                                                    
 ------ -------------------------------------------------------------------------------------------------------- 
  51     Property WP_Scripts::$in_footer type has no value type specified in iterable type array.                
         🪪  missingType.iterableValue                                                                           
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type              
         at src/wp-includes/class-wp-scripts.php:51                                                              
  123    Property WP_Scripts::$default_dirs type has no value type specified in iterable type array.             
         🪪  missingType.iterableValue                                                                           
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type              
         at src/wp-includes/class-wp-scripts.php:123                                                             
  597    Method WP_Scripts::localize() has parameter $l10n with no value type specified in iterable type array.  
         🪪  missingType.iterableValue                                                                           
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type              
         at src/wp-includes/class-wp-scripts.php:597                                                             
  724    Property _WP_Dependency::$translations_path (string) in isset() is not nullable.                        
         🪪  isset.property                                                                                      
         at src/wp-includes/class-wp-scripts.php:724                                                             
 ------ -------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------- 
  Line   class-wp-styles.php                                                                          
 ------ --------------------------------------------------------------------------------------------- 
  101    Property WP_Styles::$default_dirs type has no value type specified in iterable type array.   
         🪪  missingType.iterableValue                                                                
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type   
         at src/wp-includes/class-wp-styles.php:101                                                   
  186    Parameter #1 $src of method WP_Styles::in_default_dir() expects string, string|false given.  
         🪪  argument.type                                                                            
         at src/wp-includes/class-wp-styles.php:186                                                   
 ------ --------------------------------------------------------------------------------------------- 

 [ERROR] Found 9 errors                                                                                                 
```

With this PR, the issues are fixed.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
