### PR TITLE
Add Notes column to posts list table

### DIFF
--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -25,14 +25,16 @@
 }
 
 .column-response .post-com-count-wrapper,
-.column-comments .post-com-count-wrapper {
+.column-comments .post-com-count-wrapper,
+.column-notes .post-com-count-wrapper {
 	white-space: nowrap;
 	word-wrap: normal;
 }
 
 /* comments bubble common */
 .column-response .post-com-count,
-.column-comments .post-com-count {
+.column-comments .post-com-count,
+.column-notes .post-com-count {
 	display: inline-block;
 	vertical-align: top;
 }
@@ -41,14 +43,16 @@
 .column-response .post-com-count-no-comments,
 .column-response .post-com-count-approved,
 .column-comments .post-com-count-no-comments,
-.column-comments .post-com-count-approved {
+.column-comments .post-com-count-approved,
+.column-notes .post-com-count {
 	margin-top: 5px;
 }
 
 .column-response .comment-count-no-comments,
 .column-response .comment-count-approved,
 .column-comments .comment-count-no-comments,
-.column-comments .comment-count-approved {
+.column-comments .comment-count-approved,
+.column-notes .comment-count {
 	box-sizing: border-box;
 	display: block;
 	padding: 0 8px;
@@ -65,7 +69,8 @@
 .column-response .post-com-count-no-comments:after,
 .column-response .post-com-count-approved:after,
 .column-comments .post-com-count-no-comments:after,
-.column-comments .post-com-count-approved:after {
+.column-comments .post-com-count-approved:after,
+.notes .post-com-count:after {
 	content: "";
 	display: block;
 	margin-left: 8px;
@@ -78,14 +83,17 @@
 .column-response a.post-com-count-approved:hover .comment-count-approved,
 .column-response a.post-com-count-approved:focus .comment-count-approved,
 .column-comments a.post-com-count-approved:hover .comment-count-approved,
-.column-comments a.post-com-count-approved:focus .comment-count-approved {
+.column-comments a.post-com-count-approved:focus .comment-count-approved,
+.column-notes a.post-com-count:hover .comment-count,
+.column-notes a.post-com-count:focus .comment-count {
 	background: #2271b1;
 }
 
 .column-response a.post-com-count-approved:hover:after,
 .column-response a.post-com-count-approved:focus:after,
 .column-comments a.post-com-count-approved:hover:after,
-.column-comments a.post-com-count-approved:focus:after {
+.column-comments a.post-com-count-approved:focus:after,
+.column-notes a.post-com-count:focus:after {
 	border-top-color: #2271b1;
 }
 
@@ -299,7 +307,9 @@ table.fixed {
 .fixed .column-parent,
 .fixed .column-links,
 .fixed .column-author,
-.fixed .column-format {
+.fixed .column-format,
+.fixed .column-comments,
+.fixed .column-notes {
 	width: 10%;
 }
 
@@ -342,7 +352,6 @@ table.fixed {
 }
 
 .fixed .column-comments {
-	width: 5.5em;
 	text-align: left;
 }
 
@@ -2006,29 +2015,34 @@ div.action-links,
 	.column-response .post-com-count-no-comments:after,
 	.column-response .post-com-count-approved:after,
 	.column-comments .post-com-count-no-comments:after,
-	.column-comments .post-com-count-approved:after {
+	.column-comments .post-com-count-approved:after,
+	.column-notes .post-com-count:after {
 		content: none;
 	}
 
 	.column-response .post-com-count [aria-hidden="true"],
-	.column-comments .post-com-count [aria-hidden="true"] {
+	.column-comments .post-com-count [aria-hidden="true"],
+	.column-notes .post-com-count [aria-hidden="true"] {
 		display: none;
 	}
 
 	.column-response .post-com-count-wrapper,
-	.column-comments .post-com-count-wrapper {
+	.column-comments .post-com-count-wrapper,
+	.column-notes .post-com-count-wrapper {
 		white-space: normal;
 	}
 
 	.column-response .post-com-count-wrapper > a,
-	.column-comments .post-com-count-wrapper > a {
+	.column-comments .post-com-count-wrapper > a,
+	.column-notes .post-com-count-wrapper > a {
 		display: block;
 	}
 
 	.column-response .post-com-count-no-comments,
 	.column-response .post-com-count-approved,
 	.column-comments .post-com-count-no-comments,
-	.column-comments .post-com-count-approved {
+	.column-comments .post-com-count-approved,
+	.column-notes .post-com-count {
 		margin-top: 0;
 		margin-right: 0.5em;
 	}

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -955,6 +955,73 @@ class WP_List_Table {
 	}
 
 	/**
+	 * Displays a note count bubble.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param int $post_id          The post ID.
+	 */
+	protected function notes_bubble( $post_id ) {
+		$post_object   = get_post( $post_id );
+		$edit_post_cap = $post_object ? 'edit_post' : 'edit_posts';
+
+		if ( ! current_user_can( $edit_post_cap, $post_id )
+			&& ( post_password_required( $post_id )
+				|| ! current_user_can( 'read_post', $post_id ) )
+		) {
+			// The user has no access to the post and thus cannot see the notes.
+			return false;
+		}
+
+		$args = array(
+			'type'    => 'note',
+			'count'   => true,
+			'status'  => 'any',
+			'post_id' => $post_id,
+		);
+		$args = apply_filters( 'post_column_notes_query_args', $args );
+
+		$note_count        = get_comments( $args );
+		$note_count_number = number_format_i18n( $note_count );
+
+		$notes_phrase = sprintf(
+			/* translators: %s: Number of notes. */
+			_n( '%s note', '%s notes', $note_count ),
+			$note_count_number
+		);
+
+		if ( ! $note_count ) {
+			// No notes at all.
+			printf(
+				'<span aria-hidden="true">&#8212;</span>' .
+				'<span class="screen-reader-text">%s</span>',
+				__( 'No notes' )
+			);
+		} elseif ( $note_count && 'trash' === get_post_status( $post_id ) ) {
+			// Don't link the notes bubble for a trashed post.
+			printf(
+				'<span class="post-com-count">' .
+				'<span class="comment-count" aria-hidden="true">%s</span>' .
+				'<span class="screen-reader-text">%s</span>' .
+				'</span>',
+				$note_count_number,
+				$notes_phrase
+			);
+		} else {
+			// Link the note bubble to the edit post screen.
+			printf(
+				'<a href="%s" class="post-com-count">' .
+				'<span class="comment-count" aria-hidden="true">%s</span>' .
+				'<span class="screen-reader-text">%s</span>' .
+				'</a>',
+				get_edit_post_link( $post_id ),
+				$note_count_number,
+				$notes_phrase
+			);
+		}
+	}
+
+	/**
 	 * Gets the current page number.
 	 *
 	 * @since 3.1.0

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -705,12 +705,11 @@ class WP_Posts_List_Table extends WP_List_Table {
 		if ( post_type_supports( $post_type, 'comments' )
 			&& ! in_array( $post_status, array( 'pending', 'draft', 'future' ), true )
 		) {
-			$posts_columns['comments'] = sprintf(
-				'<span class="vers comment-grey-bubble" title="%1$s" aria-hidden="true"></span><span class="screen-reader-text">%2$s</span>',
-				esc_attr__( 'Comments' ),
-				/* translators: Hidden accessibility text. */
-				__( 'Comments' )
-			);
+			$posts_columns['comments'] = __( 'Comments' );
+		}
+
+		if ( post_type_supports( $post_type, 'editor', 'notes' ) ) {
+			$posts_columns['notes'] = __( 'Notes' );
 		}
 
 		$posts_columns['date'] = __( 'Date' );
@@ -762,27 +761,19 @@ class WP_Posts_List_Table extends WP_List_Table {
 
 		$post_type = $this->screen->post_type;
 
-		if ( 'page' === $post_type ) {
-			if ( isset( $_GET['orderby'] ) ) {
-				$title_orderby_text = __( 'Table ordered by Title.' );
-			} else {
-				$title_orderby_text = __( 'Table ordered by Hierarchical Menu Order and Title.' );
-			}
+		$title_orderby_text = __( 'Table ordered by Title.' );
 
-			$sortables = array(
-				'title'    => array( 'title', false, __( 'Title' ), $title_orderby_text, 'asc' ),
-				'parent'   => array( 'parent', false ),
-				'comments' => array( 'comment_count', false, __( 'Comments' ), __( 'Table ordered by Comments.' ) ),
-				'date'     => array( 'date', true, __( 'Date' ), __( 'Table ordered by Date.' ) ),
-			);
-		} else {
-			$sortables = array(
-				'title'    => array( 'title', false, __( 'Title' ), __( 'Table ordered by Title.' ) ),
-				'parent'   => array( 'parent', false ),
-				'comments' => array( 'comment_count', false, __( 'Comments' ), __( 'Table ordered by Comments.' ) ),
-				'date'     => array( 'date', true, __( 'Date' ), __( 'Table ordered by Date.' ), 'desc' ),
-			);
+		if ( 'page' === $post_type && ! isset( $_GET['orderby'] ) ) {
+			$title_orderby_text = __( 'Table ordered by Hierarchical Menu Order and Title.' );
 		}
+
+		$sortables = array(
+			'title'    => array( 'title', false, __( 'Title' ), $title_orderby_text ),
+			'parent'   => array( 'parent', false ),
+			'comments' => array( 'comment_count', false, __( 'Comments' ), __( 'Table ordered by Comments.' ) ),
+			'notes'    => array( 'note_count', false, __( 'Notes' ), __( 'Table ordered by Notes.' ) ),
+			'date'     => array( 'date', true, __( 'Date' ), __( 'Table ordered by Date.' ), 'desc' ),
+		);
 		// Custom Post Types: there's a filter for that, see get_column_info().
 
 		return $sortables;
@@ -1263,11 +1254,29 @@ class WP_Posts_List_Table extends WP_List_Table {
 	public function column_comments( $post ) {
 		?>
 		<div class="post-com-count-wrapper">
-		<?php
+			<?php
 			$pending_comments = isset( $this->comment_pending_count[ $post->ID ] ) ? $this->comment_pending_count[ $post->ID ] : 0;
 
 			$this->comments_bubble( $post->ID, $pending_comments );
+			?>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Handles the notes column output.
+	 *
+	 * @since 7.0
+	 *
+	 * @param WP_Post $post The current WP_Post object.
+	 */
+	public function column_notes( $post ) {
+		global $_wp_post_type_features;
 		?>
+		<div class="post-com-count-wrapper">
+			<?php
+			$this->notes_bubble( $post->ID );
+			?>
 		</div>
 		<?php
 	}

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -2340,15 +2340,39 @@ function get_all_post_type_supports( $post_type ) {
  *
  * @global array $_wp_post_type_features
  *
- * @param string $post_type The post type being checked.
- * @param string $feature   The feature being checked.
+ * @param string      $post_type   The post type being checked.
+ * @param string      $feature     The feature being checked.
+ * @param string|null $sub_feature The sub-feature being checked.
  * @return bool Whether the post type supports the given feature.
  */
-function post_type_supports( $post_type, $feature ) {
+function post_type_supports( $post_type, $feature, $sub_feature = null ) {
 	global $_wp_post_type_features;
 
-	return ( isset( $_wp_post_type_features[ $post_type ][ $feature ] ) );
+	if ( ! isset( $_wp_post_type_features[ $post_type ] ) ) {
+		return false;
+	}
+
+	if ( ! isset( $_wp_post_type_features[ $post_type ][ $feature ] ) ) {
+		return false;
+	}
+
+	if ( null === $sub_feature ) {
+		return ! empty( $_wp_post_type_features[ $post_type ][ $feature ] );
+	}
+
+	if ( ! is_array( $_wp_post_type_features[ $post_type ][ $feature ] ) ) {
+		return false;
+	}
+
+	if ( array_key_exists( $sub_feature, $_wp_post_type_features[ $post_type ][ $feature ] ) ) {
+		return true;
+	}
+
+	$sub_features = array_merge( ...$_wp_post_type_features[ $post_type ][ $feature ] );
+
+	return isset( $sub_features[ $sub_feature ] );
 }
+
 /**
  * Retrieves a list of post type names that support a specific feature.
  *


### PR DESCRIPTION
<!-- Insert a description of your changes here -->
- Adds a new column to the posts list table for Notes.
- Changes the header for the Comments column to text instead of an icon
- Add sub-feature support to the post_type_supports function

Trac ticket: https://core.trac.wordpress.org/ticket/64377

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
