### PR TITLE
Fix: Prefix/suffix for new site slug input does not appear correctly on RTL

### DIFF
--- a/src/wp-admin/network/site-new.php
+++ b/src/wp-admin/network/site-new.php
@@ -217,21 +217,18 @@ if ( ! empty( $messages ) ) {
 				</label>
 			</th>
 			<td>
-			<?php if ( is_subdomain_install() ) { ?>
 				<span class="code">
-					<input name="blog[domain]" type="text" class="regular-text code" id="site-address" aria-describedby="site-address-desc" autocapitalize="none" autocorrect="off" required /><code class="no-break">.<?php echo preg_replace( '|^www\.|', '', get_network()->domain ); ?></code>
+					<?php if ( is_subdomain_install() ) : ?>
+						<input name="blog[domain]" type="text" class="regular-text code" id="site-address" aria-describedby="site-address-desc" autocapitalize="none" autocorrect="off" required /><!--
+						--><code class="no-break"><?php echo esc_html( '.' . preg_replace( '|^www\.|', '', get_network()->domain ) ); ?></code>
+					<?php else : ?>
+						<code class="no-break"><?php echo esc_html( get_network()->domain . get_network()->path ); ?></code><!--
+						--><input name="blog[domain]" type="text" class="regular-text code" id="site-address" aria-describedby="site-address-desc" autocapitalize="none" autocorrect="off" required />
+					<?php endif; ?>
 				</span>
-				<?php
-			} else {
-				echo '<span class="code">';
-				echo '<code class="no-break">' . get_network()->domain . get_network()->path . '</code>';
-				?>
-				<input name="blog[domain]" type="text" class="regular-text code" id="site-address" aria-describedby="site-address-desc" autocapitalize="none" autocorrect="off" required />
-				<?php
-				echo '</span>';
-			}
-			echo '<p class="description" id="site-address-desc">' . __( 'Only lowercase letters (a-z), numbers, and hyphens are allowed.' ) . '</p>';
-			?>
+				<p class="description" id="site-address-desc">
+					<?php _e( 'Only lowercase letters (a-z), numbers, and hyphens are allowed.' ); ?>
+				</p>
 			</td>
 		</tr>
 		<tr class="form-field form-required">

--- a/src/wp-admin/network/site-new.php
+++ b/src/wp-admin/network/site-new.php
@@ -218,13 +218,17 @@ if ( ! empty( $messages ) ) {
 			</th>
 			<td>
 			<?php if ( is_subdomain_install() ) { ?>
-				<input name="blog[domain]" type="text" class="regular-text ltr" id="site-address" aria-describedby="site-address-desc" autocapitalize="none" autocorrect="off" required /><span class="no-break">.<?php echo preg_replace( '|^www\.|', '', get_network()->domain ); ?></span>
+				<span class="code">
+					<input name="blog[domain]" type="text" class="regular-text code" id="site-address" aria-describedby="site-address-desc" autocapitalize="none" autocorrect="off" required /><code class="no-break">.<?php echo preg_replace( '|^www\.|', '', get_network()->domain ); ?></code>
+				</span>
 				<?php
 			} else {
-				echo get_network()->domain . get_network()->path
+				echo '<span class="code">';
+				echo '<code class="no-break">' . get_network()->domain . get_network()->path . '</code>';
 				?>
-				<input name="blog[domain]" type="text" class="regular-text ltr" id="site-address" aria-describedby="site-address-desc" autocapitalize="none" autocorrect="off" required />
+				<input name="blog[domain]" type="text" class="regular-text code" id="site-address" aria-describedby="site-address-desc" autocapitalize="none" autocorrect="off" required />
 				<?php
+				echo '</span>';
 			}
 			echo '<p class="description" id="site-address-desc">' . __( 'Only lowercase letters (a-z), numbers, and hyphens are allowed.' ) . '</p>';
 			?>


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Prefix/suffix for new site slug input does not appear correctly on RTL

Trac ticket: [https://core.trac.wordpress.org/ticket/64381](https://core.trac.wordpress.org/ticket/64381#ticket)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
