### PR TITLE
Mail: Temporary Failover Fix to Avoid Sender Issues

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -445,12 +445,8 @@ if ( ! function_exists( 'wp_mail' ) ) :
 
 		try {
 			// This block should be removed once PHPMailer supports setting the envelope sender separately.
-			$sendmail_path = ini_get( 'sendmail_path' );
-			if ( str_contains( $sendmail_path, '-f' ) ) {
-				$phpmailer->setFrom( $from_email, $from_name, false );
-			} else {
-				$phpmailer->setFrom( $from_email, $from_name );
-			}
+			$auto = ! str_contains( $sendmail_path, ' -f' );
+			$phpmailer->setFrom( $from_email, $from_name, $auto );
 		} catch ( PHPMailer\PHPMailer\Exception $e ) {
 			$mail_error_data                             = compact( 'to', 'subject', 'message', 'headers', 'attachments' );
 			$mail_error_data['phpmailer_exception_code'] = $e->getCode();

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -444,7 +444,13 @@ if ( ! function_exists( 'wp_mail' ) ) :
 		$from_name = apply_filters( 'wp_mail_from_name', $from_name );
 
 		try {
-			$phpmailer->setFrom( $from_email, $from_name );
+			// This block should be removed once PHPMailer supports setting the envelope sender separately.
+			$sendmail_path = ini_get( 'sendmail_path' );
+			if ( str_contains( $sendmail_path, '-f' ) ) {
+				$phpmailer->setFrom( $from_email, $from_name, false );
+			} else {
+				$phpmailer->setFrom( $from_email, $from_name );
+			}
 		} catch ( PHPMailer\PHPMailer\Exception $e ) {
 			$mail_error_data                             = compact( 'to', 'subject', 'message', 'headers', 'attachments' );
 			$mail_error_data['phpmailer_exception_code'] = $e->getCode();

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -446,7 +446,7 @@ if ( ! function_exists( 'wp_mail' ) ) :
 		try {
 			// This block should be removed once PHPMailer supports setting the envelope sender separately.
 			// @see https://core.trac.wordpress.org/ticket/64368.
-			$auto = ! str_contains( $sendmail_path, ' -f' );
+			$auto = ! str_contains( ini_get( 'sendmail_path' ), ' -f' );
 			$phpmailer->setFrom( $from_email, $from_name, $auto );
 		} catch ( PHPMailer\PHPMailer\Exception $e ) {
 			$mail_error_data                             = compact( 'to', 'subject', 'message', 'headers', 'attachments' );

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -444,8 +444,7 @@ if ( ! function_exists( 'wp_mail' ) ) :
 		$from_name = apply_filters( 'wp_mail_from_name', $from_name );
 
 		try {
-			// This block should be removed once PHPMailer supports setting the envelope sender separately.
-			// @see https://core.trac.wordpress.org/ticket/64368.
+			// Passing $auto can be removed once PHPMailer supports setting the envelope sender separately. See <https://core.trac.wordpress.org/ticket/64368>.
 			$auto = ! str_contains( ini_get( 'sendmail_path' ), ' -f' );
 			$phpmailer->setFrom( $from_email, $from_name, $auto );
 		} catch ( PHPMailer\PHPMailer\Exception $e ) {

--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -445,6 +445,7 @@ if ( ! function_exists( 'wp_mail' ) ) :
 
 		try {
 			// This block should be removed once PHPMailer supports setting the envelope sender separately.
+			// @see https://core.trac.wordpress.org/ticket/64368.
 			$auto = ! str_contains( $sendmail_path, ' -f' );
 			$phpmailer->setFrom( $from_email, $from_name, $auto );
 		} catch ( PHPMailer\PHPMailer\Exception $e ) {


### PR DESCRIPTION
Since I can't be 100% sure that PHPMailer will update on time for 6.9.1 and I don't really know when 6.9.1 is schedule for release, I'm providing here a failover as @dmsnell suggested.

Trac ticket: https://core.trac.wordpress.org/ticket/64368

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
