### PR TITLE
Improve specificity of phpdoc types in `WP_Script_Modules` and functions in `script-modules.php`

### DIFF
--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -88,31 +88,31 @@ class WP_Script_Modules {
 	 * @since 6.5.0
 	 * @since 6.9.0 Added the $args parameter.
 	 *
-	 * @param string            $id       The identifier of the script module. Should be unique. It will be used in the
-	 *                                    final import map.
-	 * @param string            $src      Optional. Full URL of the script module, or path of the script module relative
-	 *                                    to the WordPress root directory. If it is provided and the script module has
-	 *                                    not been registered yet, it will be registered.
-	 * @param array             $deps     {
-	 *                                        Optional. List of dependencies.
+	 * @param string                     $id       The identifier of the script module. Should be unique. It will be used in the
+	 *                                             final import map.
+	 * @param string                     $src      Optional. Full URL of the script module, or path of the script module relative
+	 *                                             to the WordPress root directory. If it is provided and the script module has
+	 *                                             not been registered yet, it will be registered.
+	 * @param array<string|array>        $deps     {
+	 *                                                 Optional. List of dependencies.
 	 *
-	 *                                        @type string|array ...$0 {
-	 *                                            An array of script module identifiers of the dependencies of this script
-	 *                                            module. The dependencies can be strings or arrays. If they are arrays,
-	 *                                            they need an `id` key with the script module identifier, and can contain
-	 *                                            an `import` key with either `static` or `dynamic`. By default,
-	 *                                            dependencies that don't contain an `import` key are considered static.
+	 *                                                 @type string|array ...$0 {
+	 *                                                     An array of script module identifiers of the dependencies of this script
+	 *                                                     module. The dependencies can be strings or arrays. If they are arrays,
+	 *                                                     they need an `id` key with the script module identifier, and can contain
+	 *                                                     an `import` key with either `static` or `dynamic`. By default,
+	 *                                                     dependencies that don't contain an `import` key are considered static.
 	 *
-	 *                                            @type string $id     The script module identifier.
-	 *                                            @type string $import Optional. Import type. May be either `static` or
-	 *                                                                 `dynamic`. Defaults to `static`.
-	 *                                        }
-	 *                                    }
-	 * @param string|false|null $version  Optional. String specifying the script module version number. Defaults to false.
-	 *                                    It is added to the URL as a query string for cache busting purposes. If $version
-	 *                                    is set to false, the version number is the currently installed WordPress version.
-	 *                                    If $version is set to null, no version is added.
-	 * @param array             $args     {
+	 *                                                     @type string $id     The script module identifier.
+	 *                                                     @type string $import Optional. Import type. May be either `static` or
+	 *                                                                          `dynamic`. Defaults to `static`.
+	 *                                                 }
+	 *                                             }
+	 * @param string|false|null          $version  Optional. String specifying the script module version number. Defaults to false.
+	 *                                             It is added to the URL as a query string for cache busting purposes. If $version
+	 *                                             is set to false, the version number is the currently installed WordPress version.
+	 *                                             If $version is set to null, no version is added.
+	 * @param array<string, string|bool> $args     {
 	 *     Optional. An array of additional args. Default empty array.
 	 *
 	 *     @type bool                $in_footer     Whether to print the script module in the footer. Only relevant to block themes. Default 'false'. Optional.
@@ -260,31 +260,31 @@ class WP_Script_Modules {
 	 * @since 6.5.0
 	 * @since 6.9.0 Added the $args parameter.
 	 *
-	 * @param string            $id       The identifier of the script module. Should be unique. It will be used in the
-	 *                                    final import map.
-	 * @param string            $src      Optional. Full URL of the script module, or path of the script module relative
-	 *                                    to the WordPress root directory. If it is provided and the script module has
-	 *                                    not been registered yet, it will be registered.
-	 * @param array             $deps     {
-	 *                                        Optional. List of dependencies.
+	 * @param string                     $id       The identifier of the script module. Should be unique. It will be used in the
+	 *                                             final import map.
+	 * @param string                     $src      Optional. Full URL of the script module, or path of the script module relative
+	 *                                             to the WordPress root directory. If it is provided and the script module has
+	 *                                             not been registered yet, it will be registered.
+	 * @param array<string|array>        $deps     {
+	 *                                                 Optional. List of dependencies.
 	 *
-	 *                                        @type string|array ...$0 {
-	 *                                            An array of script module identifiers of the dependencies of this script
-	 *                                            module. The dependencies can be strings or arrays. If they are arrays,
-	 *                                            they need an `id` key with the script module identifier, and can contain
-	 *                                            an `import` key with either `static` or `dynamic`. By default,
-	 *                                            dependencies that don't contain an `import` key are considered static.
+	 *                                                 @type string|array ...$0 {
+	 *                                                     An array of script module identifiers of the dependencies of this script
+	 *                                                     module. The dependencies can be strings or arrays. If they are arrays,
+	 *                                                     they need an `id` key with the script module identifier, and can contain
+	 *                                                     an `import` key with either `static` or `dynamic`. By default,
+	 *                                                     dependencies that don't contain an `import` key are considered static.
 	 *
-	 *                                            @type string $id     The script module identifier.
-	 *                                            @type string $import Optional. Import type. May be either `static` or
-	 *                                                                 `dynamic`. Defaults to `static`.
-	 *                                        }
-	 *                                    }
-	 * @param string|false|null $version  Optional. String specifying the script module version number. Defaults to false.
-	 *                                    It is added to the URL as a query string for cache busting purposes. If $version
-	 *                                    is set to false, the version number is the currently installed WordPress version.
-	 *                                    If $version is set to null, no version is added.
-	 * @param array             $args     {
+	 *                                                     @type string $id     The script module identifier.
+	 *                                                     @type string $import Optional. Import type. May be either `static` or
+	 *                                                                          `dynamic`. Defaults to `static`.
+	 *                                                 }
+	 *                                             }
+	 * @param string|false|null          $version  Optional. String specifying the script module version number. Defaults to false.
+	 *                                             It is added to the URL as a query string for cache busting purposes. If $version
+	 *                                             is set to false, the version number is the currently installed WordPress version.
+	 *                                             If $version is set to null, no version is added.
+	 * @param array<string, string|bool> $args     {
 	 *     Optional. An array of additional args. Default empty array.
 	 *
 	 *     @type bool                $in_footer     Whether to print the script module in the footer. Only relevant to block themes. Default 'false'. Optional.
@@ -534,8 +534,8 @@ class WP_Script_Modules {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @return array Array with an `imports` key mapping to an array of script module identifiers and their respective
-	 *               URLs, including the version query.
+	 * @return array<string, array<string, string>> Array with an `imports` key mapping to an array of script module
+	 *                                              identifiers and their respective URLs, including the version query.
 	 */
 	private function get_import_map(): array {
 		$imports = array();
@@ -556,7 +556,7 @@ class WP_Script_Modules {
 	 *
 	 * @since 6.5.0
 	 *
-	 * @return array<string, array> Script modules marked for enqueue, keyed by script module identifier.
+	 * @return array<string, array<string, mixed>> Script modules marked for enqueue, keyed by script module identifier.
 	 */
 	private function get_marked_for_enqueue(): array {
 		return wp_array_slice_assoc(
@@ -577,7 +577,7 @@ class WP_Script_Modules {
 	 * @param string[] $ids          The identifiers of the script modules for which to gather dependencies.
 	 * @param string[] $import_types Optional. Import types of dependencies to retrieve: 'static', 'dynamic', or both.
 	 *                                         Default is both.
-	 * @return array<string, array> List of dependencies, keyed by script module identifier.
+	 * @return array<string, array<string, mixed>> List of dependencies, keyed by script module identifier.
 	 */
 	private function get_dependencies( array $ids, array $import_types = array( 'static', 'dynamic' ) ): array {
 		$all_dependencies = array();

--- a/src/wp-includes/script-modules.php
+++ b/src/wp-includes/script-modules.php
@@ -37,31 +37,31 @@ function wp_script_modules(): WP_Script_Modules {
  * @since 6.5.0
  * @since 6.9.0 Added the $args parameter.
  *
- * @param string            $id      The identifier of the script module. Should be unique. It will be used in the
- *                                   final import map.
- * @param string            $src     Optional. Full URL of the script module, or path of the script module relative
- *                                   to the WordPress root directory. If it is provided and the script module has
- *                                   not been registered yet, it will be registered.
- * @param array             $deps    {
- *                                       Optional. List of dependencies.
+ * @param string                     $id      The identifier of the script module. Should be unique. It will be used in the
+ *                                            final import map.
+ * @param string                     $src     Optional. Full URL of the script module, or path of the script module relative
+ *                                            to the WordPress root directory. If it is provided and the script module has
+ *                                            not been registered yet, it will be registered.
+ * @param array<string|array>        $deps    {
+ *                                                Optional. List of dependencies.
  *
- *                                       @type string|array ...$0 {
- *                                           An array of script module identifiers of the dependencies of this script
- *                                           module. The dependencies can be strings or arrays. If they are arrays,
- *                                           they need an `id` key with the script module identifier, and can contain
- *                                           an `import` key with either `static` or `dynamic`. By default,
- *                                           dependencies that don't contain an `import` key are considered static.
+ *                                                @type string|array ...$0 {
+ *                                                    An array of script module identifiers of the dependencies of this script
+ *                                                    module. The dependencies can be strings or arrays. If they are arrays,
+ *                                                    they need an `id` key with the script module identifier, and can contain
+ *                                                    an `import` key with either `static` or `dynamic`. By default,
+ *                                                    dependencies that don't contain an `import` key are considered static.
  *
- *                                           @type string $id     The script module identifier.
- *                                           @type string $import Optional. Import type. May be either `static` or
- *                                                                `dynamic`. Defaults to `static`.
- *                                       }
- *                                   }
- * @param string|false|null $version Optional. String specifying the script module version number. Defaults to false.
- *                                   It is added to the URL as a query string for cache busting purposes. If $version
- *                                   is set to false, the version number is the currently installed WordPress version.
- *                                   If $version is set to null, no version is added.
- * @param array             $args    {
+ *                                                    @type string $id     The script module identifier.
+ *                                                    @type string $import Optional. Import type. May be either `static` or
+ *                                                                         `dynamic`. Defaults to `static`.
+ *                                                }
+ *                                            }
+ * @param string|false|null          $version Optional. String specifying the script module version number. Defaults to false.
+ *                                            It is added to the URL as a query string for cache busting purposes. If $version
+ *                                            is set to false, the version number is the currently installed WordPress version.
+ *                                            If $version is set to null, no version is added.
+ * @param array<string, string|bool> $args    {
  *     Optional. An array of additional args. Default empty array.
  *
  *     @type bool                $in_footer     Whether to print the script module in the footer. Only relevant to block themes. Default 'false'. Optional.
@@ -81,31 +81,31 @@ function wp_register_script_module( string $id, string $src, array $deps = array
  * @since 6.5.0
  * @since 6.9.0 Added the $args parameter.
  *
- * @param string            $id      The identifier of the script module. Should be unique. It will be used in the
- *                                   final import map.
- * @param string            $src     Optional. Full URL of the script module, or path of the script module relative
- *                                   to the WordPress root directory. If it is provided and the script module has
- *                                   not been registered yet, it will be registered.
- * @param array             $deps    {
- *                                       Optional. List of dependencies.
+ * @param string                     $id      The identifier of the script module. Should be unique. It will be used in the
+ *                                            final import map.
+ * @param string                     $src     Optional. Full URL of the script module, or path of the script module relative
+ *                                            to the WordPress root directory. If it is provided and the script module has
+ *                                            not been registered yet, it will be registered.
+ * @param array<string|array>        $deps    {
+ *                                                Optional. List of dependencies.
  *
- *                                       @type string|array ...$0 {
- *                                           An array of script module identifiers of the dependencies of this script
- *                                           module. The dependencies can be strings or arrays. If they are arrays,
- *                                           they need an `id` key with the script module identifier, and can contain
- *                                           an `import` key with either `static` or `dynamic`. By default,
- *                                           dependencies that don't contain an `import` key are considered static.
+ *                                                @type string|array ...$0 {
+ *                                                    An array of script module identifiers of the dependencies of this script
+ *                                                    module. The dependencies can be strings or arrays. If they are arrays,
+ *                                                    they need an `id` key with the script module identifier, and can contain
+ *                                                    an `import` key with either `static` or `dynamic`. By default,
+ *                                                    dependencies that don't contain an `import` key are considered static.
  *
- *                                           @type string $id     The script module identifier.
- *                                           @type string $import Optional. Import type. May be either `static` or
- *                                                                `dynamic`. Defaults to `static`.
- *                                       }
- *                                   }
- * @param string|false|null $version Optional. String specifying the script module version number. Defaults to false.
- *                                   It is added to the URL as a query string for cache busting purposes. If $version
- *                                   is set to false, the version number is the currently installed WordPress version.
- *                                   If $version is set to null, no version is added.
- * @param array             $args    {
+ *                                                    @type string $id     The script module identifier.
+ *                                                    @type string $import Optional. Import type. May be either `static` or
+ *                                                                         `dynamic`. Defaults to `static`.
+ *                                                }
+ *                                            }
+ * @param string|false|null          $version Optional. String specifying the script module version number. Defaults to false.
+ *                                            It is added to the URL as a query string for cache busting purposes. If $version
+ *                                            is set to false, the version number is the currently installed WordPress version.
+ *                                            If $version is set to null, no version is added.
+ * @param array<string, string|bool> $args    {
  *     Optional. An array of additional args. Default empty array.
  *
  *     @type bool                $in_footer     Whether to print the script module in the footer. Only relevant to block themes. Default 'false'. Optional.


### PR DESCRIPTION
This addresses the following PHPStan level 6 issues:

```
 ------ --------------------------------------------------------------------------------------------------------------- 
  Line   class-wp-script-modules.php                                                                                    
 ------ --------------------------------------------------------------------------------------------------------------- 
  122    Method WP_Script_Modules::register() has parameter $args with no value type specified in iterable type array.       
         🪪  missingType.iterableValue                                                                                       
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                          
         at src/wp-includes/class-wp-script-modules.php:122                                                                  
  294    Method WP_Script_Modules::enqueue() has parameter $args with no value type specified in iterable type array.        
         🪪  missingType.iterableValue                                                                                       
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                          
         at src/wp-includes/class-wp-script-modules.php:294                                                                  
  540    Method WP_Script_Modules::get_import_map() return type has no value type specified in iterable type array.          
         🪪  missingType.iterableValue                                                                                       
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                          
         at src/wp-includes/class-wp-script-modules.php:540                                                                  
  561    Method WP_Script_Modules::get_marked_for_enqueue() return type has no value type specified in iterable type array.  
         🪪  missingType.iterableValue                                                                                       
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                          
         at src/wp-includes/class-wp-script-modules.php:561                                                                  
  582    Method WP_Script_Modules::get_dependencies() return type has no value type specified in iterable type array.        
         🪪  missingType.iterableValue                                                                                       
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                          
         at src/wp-includes/class-wp-script-modules.php:582   

 ------ --------------------------------------------------------------------------------------------------------------- 
  Line   script-modules.php                                                                                             
 ------ --------------------------------------------------------------------------------------------------------------- 
  71     Function wp_register_script_module() has parameter $args with no value type specified in iterable type array.  
         🪪  missingType.iterableValue                                                                                  
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                     
         at src/wp-includes/script-modules.php:71                                                                       
  115    Function wp_enqueue_script_module() has parameter $args with no value type specified in iterable type array.   
         🪪  missingType.iterableValue                                                                                  
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                     
         at src/wp-includes/script-modules.php:115                                                                      
```

Trac ticket: https://core.trac.wordpress.org/ticket/64238

Gemini summary:

The changes observed in `src/wp-includes/class-wp-script-modules.php` and `src/wp-includes/script-modules.php` are focused on enhancing PHPDoc type hints. Specifically, `array` type declarations have been refined using PHPStan's PHPDoc Types, which aligns perfectly with the WordPress coding standards outlined in `GEMINI.md` regarding PHPStan Level 10 compliance.

**Specific observations:**

*   **PHPDoc Type Hinting:** The `array` type declarations for `$deps` and `$args` parameters have been updated to `array<string|array>` and `array<string, string|bool>` respectively. This provides more precise information about the expected structure of these arrays, which is a significant improvement for static analysis.
*   **Return Type Hinting:** Similarly, the return types for `get_import_map()`, `get_marked_for_enqueue()`, and `get_dependencies()` methods have been updated with detailed `array` shapes, such as `array<string, array<string, string>>` and `array<string, array<string, mixed>>`. This greatly improves the clarity and maintainability of the code.
*   **`@since` Tags:** All `@since` tags are correctly present and reflect the versions `6.5.0` and `6.9.0` where the changes (or parameters) were introduced.
*   **PHP 7.2 Compatibility:** Since these modifications are strictly within PHPDoc comments and do not alter the underlying PHP syntax, there are no concerns regarding compatibility with PHP 7.2.
*   **Test Files:** No files within the `tests` directory were modified, so the requirement to check for `@ticket` tags is not applicable here.

**Overall:**

The changes are well-aligned with the project's stated coding standards, specifically regarding the use of PHPStan's PHPDoc types. The increased type specificity will benefit static analysis, code understanding, and future maintenance. The changes are precise and introduce no regressions or compatibility issues.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
