### PR TITLE
[RFC] Posts: Introduce register_content_type() API for declarative content modeling

### DIFF
--- a/src/wp-includes/class-wp-content-type.php
+++ b/src/wp-includes/class-wp-content-type.php
@@ -1,0 +1,718 @@
+<?php
+/**
+ * Content Type API: WP_Content_Type class
+ *
+ * @package WordPress
+ * @subpackage Post
+ * @since 7.0.0
+ */
+
+/**
+ * Core class used for interacting with content types.
+ *
+ * A content type is a higher-level abstraction that combines a post type
+ * with its associated meta field definitions in a single, declarative API.
+ *
+ * @since 7.0.0
+ *
+ * @see register_content_type()
+ */
+#[AllowDynamicProperties]
+final class WP_Content_Type {
+
+	/**
+	 * Content type key (same as post type key).
+	 *
+	 * @since 7.0.0
+	 * @var string
+	 */
+	public $name;
+
+	/**
+	 * The registered WP_Post_Type object.
+	 *
+	 * @since 7.0.0
+	 * @var WP_Post_Type|null
+	 */
+	public $post_type_object;
+
+	/**
+	 * Array of field definitions.
+	 *
+	 * @since 7.0.0
+	 * @var array
+	 */
+	public $fields = array();
+
+	/**
+	 * UI hints for editor/admin integrations.
+	 *
+	 * @since 7.0.0
+	 * @var array
+	 */
+	public $ui = array();
+
+	/**
+	 * Original arguments passed to register_content_type().
+	 *
+	 * @since 7.0.0
+	 * @var array
+	 */
+	public $original_args = array();
+
+	/**
+	 * Supported field types for validation.
+	 *
+	 * @since 7.0.0
+	 * @var array
+	 */
+	private static $supported_field_types = array(
+		'string',
+		'integer',
+		'number',
+		'boolean',
+		'array',
+		'object',
+	);
+
+	/**
+	 * Supported control types for UI hints.
+	 *
+	 * @since 7.0.0
+	 * @var array
+	 */
+	private static $supported_control_types = array(
+		'text',
+		'textarea',
+		'number',
+		'checkbox',
+		'select',
+		'radio',
+		'date',
+		'datetime',
+		'email',
+		'url',
+		'color',
+		'range',
+	);
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string $content_type Content type key.
+	 * @param array  $args         Arguments for registering the content type.
+	 */
+	public function __construct( $content_type, $args = array() ) {
+		$this->name          = $content_type;
+		$this->original_args = $args;
+
+		$this->set_props( $args );
+	}
+
+	/**
+	 * Sets content type properties.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array $args Array of arguments for registering a content type.
+	 */
+	public function set_props( $args ) {
+		// Extract fields and UI from args.
+		$this->fields = isset( $args['fields'] ) ? $args['fields'] : array();
+		$this->ui     = isset( $args['ui'] ) ? $args['ui'] : array();
+
+		// Normalize field definitions.
+		$this->fields = $this->normalize_fields( $this->fields );
+	}
+
+	/**
+	 * Normalizes field definitions to ensure consistent structure.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array $fields Array of field definitions.
+	 * @return array Normalized field definitions.
+	 */
+	private function normalize_fields( $fields ) {
+		$normalized = array();
+
+		foreach ( $fields as $key => $field ) {
+			// Handle shorthand field reference (string instead of array).
+			if ( is_string( $field ) ) {
+				$key   = $field;
+				$field = array();
+			}
+
+			$type = isset( $field['type'] ) ? $field['type'] : 'string';
+			$enum = isset( $field['enum'] ) ? $field['enum'] : array();
+
+			// Determine default value: use first enum value if enum is set and no default provided.
+			$default = $this->get_default_for_type( $type );
+			if ( ! empty( $enum ) && ! isset( $field['default'] ) ) {
+				$default = $enum[0];
+			}
+
+			$normalized[ $key ] = wp_parse_args(
+				$field,
+				array(
+					'type'              => 'string',
+					'single'            => true,
+					'show_in_rest'      => true,
+					'label'             => $this->generate_label( $key ),
+					'description'       => '',
+					'required'          => false,
+					'default'           => $default,
+					'sanitize_callback' => null,
+					'auth_callback'     => null,
+					'control'           => $this->get_default_control( $type ),
+					'enum'              => array(),
+					'revisions_enabled' => false,
+				)
+			);
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Gets the default value for a field type.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string $type Field type.
+	 * @return mixed Default value appropriate for the type.
+	 */
+	private function get_default_for_type( $type ) {
+		$defaults = array(
+			'string'  => '',
+			'integer' => 0,
+			'number'  => 0,
+			'boolean' => false,
+			'array'   => array(),
+			'object'  => array(),
+		);
+
+		return isset( $defaults[ $type ] ) ? $defaults[ $type ] : '';
+	}
+
+	/**
+	 * Generates a human-readable label from a field key.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string $key Field key.
+	 * @return string Generated label.
+	 */
+	private function generate_label( $key ) {
+		return ucwords( str_replace( array( '_', '-' ), ' ', $key ) );
+	}
+
+	/**
+	 * Gets the default control type for a field type.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string $type Field type.
+	 * @return string Default control type.
+	 */
+	private function get_default_control( $type ) {
+		$control_map = array(
+			'string'  => 'text',
+			'integer' => 'number',
+			'number'  => 'number',
+			'boolean' => 'checkbox',
+			'array'   => 'textarea',
+			'object'  => 'textarea',
+		);
+
+		return isset( $control_map[ $type ] ) ? $control_map[ $type ] : 'text';
+	}
+
+	/**
+	 * Validates field definitions.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return true|WP_Error True if valid, WP_Error on failure.
+	 */
+	public function validate_fields() {
+		foreach ( $this->fields as $key => $field ) {
+			// Validate field key.
+			if ( empty( $key ) || ! is_string( $key ) ) {
+				return new WP_Error(
+					'invalid_field_key',
+					__( 'Field keys must be non-empty strings.' )
+				);
+			}
+
+			// Validate field type.
+			if ( ! in_array( $field['type'], self::$supported_field_types, true ) ) {
+				return new WP_Error(
+					'invalid_field_type',
+					sprintf(
+						/* translators: 1: Field key, 2: Invalid type, 3: Supported types. */
+						__( 'Invalid field type "%2$s" for field "%1$s". Supported types: %3$s.' ),
+						$key,
+						$field['type'],
+						implode( ', ', self::$supported_field_types )
+					)
+				);
+			}
+
+			// Validate control type if specified.
+			if ( ! empty( $field['control'] ) && ! in_array( $field['control'], self::$supported_control_types, true ) ) {
+				/**
+				 * Filters the list of supported control types for content type fields.
+				 *
+				 * @since 7.0.0
+				 *
+				 * @param array  $supported_control_types List of supported control types.
+				 * @param string $content_type            Content type key.
+				 */
+				$custom_controls = apply_filters( 'content_type_supported_controls', self::$supported_control_types, $this->name );
+
+				if ( ! in_array( $field['control'], $custom_controls, true ) ) {
+					return new WP_Error(
+						'invalid_control_type',
+						sprintf(
+							/* translators: 1: Field key, 2: Invalid control type. */
+							__( 'Invalid control type "%2$s" for field "%1$s".' ),
+							$key,
+							$field['control']
+						)
+					);
+				}
+			}
+
+			// Validate enum values if type supports it.
+			if ( ! empty( $field['enum'] ) && ! is_array( $field['enum'] ) ) {
+				return new WP_Error(
+					'invalid_enum_values',
+					sprintf(
+						/* translators: %s: Field key. */
+						__( 'Enum values for field "%s" must be an array.' ),
+						$key
+					)
+				);
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Registers the post type.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array $post_type_args Arguments for register_post_type().
+	 * @return WP_Post_Type|WP_Error The registered post type object, or WP_Error on failure.
+	 */
+	public function register_post_type( $post_type_args ) {
+		$this->post_type_object = register_post_type( $this->name, $post_type_args );
+
+		return $this->post_type_object;
+	}
+
+	/**
+	 * Registers all meta fields for this content type.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return bool True on success.
+	 */
+	public function register_meta_fields() {
+		foreach ( $this->fields as $key => $field ) {
+			$meta_args = $this->build_meta_args( $field );
+			register_post_meta( $this->name, $key, $meta_args );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Builds arguments for register_post_meta() from a field definition.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array $field Field definition.
+	 * @return array Arguments for register_post_meta().
+	 */
+	private function build_meta_args( $field ) {
+		$meta_args = array(
+			'type'              => $field['type'],
+			'single'            => $field['single'],
+			'show_in_rest'      => $this->build_rest_schema( $field ),
+			'description'       => $field['description'],
+			'default'           => $field['default'],
+			'revisions_enabled' => $field['revisions_enabled'],
+		);
+
+		// Add label for REST API documentation.
+		if ( ! empty( $field['label'] ) ) {
+			$meta_args['label'] = $field['label'];
+		}
+
+		// Add sanitize callback if provided, or generate one based on type and constraints.
+		if ( ! empty( $field['sanitize_callback'] ) ) {
+			$meta_args['sanitize_callback'] = $field['sanitize_callback'];
+		} else {
+			$meta_args['sanitize_callback'] = $this->get_sanitize_callback( $field );
+		}
+
+		// Add auth callback if provided.
+		if ( ! empty( $field['auth_callback'] ) ) {
+			$meta_args['auth_callback'] = $field['auth_callback'];
+		}
+
+		return $meta_args;
+	}
+
+	/**
+	 * Builds REST API schema from a field definition.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array $field Field definition.
+	 * @return bool|array REST schema or boolean.
+	 */
+	private function build_rest_schema( $field ) {
+		if ( empty( $field['show_in_rest'] ) ) {
+			return false;
+		}
+
+		// If show_in_rest is already an array (custom schema), use it.
+		if ( is_array( $field['show_in_rest'] ) ) {
+			return $field['show_in_rest'];
+		}
+
+		// Build schema from field definition.
+		$schema = array(
+			'type' => $field['type'],
+		);
+
+		// Add description.
+		if ( ! empty( $field['description'] ) ) {
+			$schema['description'] = $field['description'];
+		}
+
+		// Add default value only if explicitly set and different from type default.
+		if ( array_key_exists( 'default', $field ) ) {
+			$type_default = $this->get_default_for_type( $field['type'] );
+			if ( $field['default'] !== $type_default ) {
+				$schema['default'] = $field['default'];
+			}
+		}
+
+		// Add enum constraint.
+		if ( ! empty( $field['enum'] ) ) {
+			$schema['enum'] = $field['enum'];
+		}
+
+		// Handle required fields.
+		if ( ! empty( $field['required'] ) ) {
+			$schema['required'] = true;
+		}
+
+		// Handle array type - must specify items schema for REST API.
+		if ( 'array' === $field['type'] ) {
+			$schema['items'] = isset( $field['items'] ) ? $field['items'] : array( 'type' => 'string' );
+		}
+
+		// Handle object type - add additionalProperties for flexibility.
+		if ( 'object' === $field['type'] ) {
+			$schema['additionalProperties'] = true;
+		}
+
+		// Wrap in REST API expected format.
+		return array(
+			'schema' => $schema,
+		);
+	}
+
+	/**
+	 * Gets a sanitize callback based on field type and constraints.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array $field Field definition.
+	 * @return callable|null Sanitize callback or null.
+	 */
+	private function get_sanitize_callback( $field ) {
+		$type = $field['type'];
+
+		// If enum is set, validate against allowed values.
+		if ( ! empty( $field['enum'] ) ) {
+			$enum_values = $field['enum'];
+			return function ( $value ) use ( $enum_values, $type ) {
+				// First sanitize by type.
+				$value = WP_Content_Type::sanitize_by_type( $value, $type );
+
+				// Then validate against enum.
+				if ( in_array( $value, $enum_values, true ) ) {
+					return $value;
+				}
+
+				return isset( $enum_values[0] ) ? $enum_values[0] : '';
+			};
+		}
+
+		// Default sanitization by type.
+		return function ( $value ) use ( $type ) {
+			return WP_Content_Type::sanitize_by_type( $value, $type );
+		};
+	}
+
+	/**
+	 * Sanitizes a value based on its type.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param mixed  $value Value to sanitize.
+	 * @param string $type  Field type.
+	 * @return mixed Sanitized value.
+	 */
+	public static function sanitize_by_type( $value, $type ) {
+		switch ( $type ) {
+			case 'string':
+				return sanitize_text_field( $value );
+
+			case 'integer':
+				return (int) $value;
+
+			case 'number':
+				return (float) $value;
+
+			case 'boolean':
+				return (bool) $value;
+
+			case 'array':
+				if ( is_array( $value ) ) {
+					return array_map( 'sanitize_text_field', $value );
+				}
+				return array();
+
+			case 'object':
+				if ( is_array( $value ) || is_object( $value ) ) {
+					return (array) $value;
+				}
+				return array();
+
+			default:
+				return sanitize_text_field( $value );
+		}
+	}
+
+	/**
+	 * Gets the field definition for a specific field.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string $field_key Field key.
+	 * @return array|null Field definition or null if not found.
+	 */
+	public function get_field( $field_key ) {
+		return isset( $this->fields[ $field_key ] ) ? $this->fields[ $field_key ] : null;
+	}
+
+	/**
+	 * Gets all field definitions.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return array Array of field definitions.
+	 */
+	public function get_fields() {
+		return $this->fields;
+	}
+
+	/**
+	 * Gets required fields.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return array Array of required field keys.
+	 */
+	public function get_required_fields() {
+		$required = array();
+
+		foreach ( $this->fields as $key => $field ) {
+			if ( ! empty( $field['required'] ) ) {
+				$required[] = $key;
+			}
+		}
+
+		return $required;
+	}
+
+	/**
+	 * Gets UI hints.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return array UI hints array.
+	 */
+	public function get_ui() {
+		return $this->ui;
+	}
+
+	/**
+	 * Gets the REST API schema for all fields.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return array REST API schema.
+	 */
+	public function get_rest_schema() {
+		$schema = array(
+			'type'       => 'object',
+			'properties' => array(),
+		);
+
+		foreach ( $this->fields as $key => $field ) {
+			if ( empty( $field['show_in_rest'] ) ) {
+				continue;
+			}
+
+			$schema['properties'][ $key ] = array(
+				'type'        => $field['type'],
+				'description' => $field['description'],
+			);
+
+			if ( ! empty( $field['enum'] ) ) {
+				$schema['properties'][ $key ]['enum'] = $field['enum'];
+			}
+
+			if ( ! empty( $field['required'] ) ) {
+				if ( ! isset( $schema['required'] ) ) {
+					$schema['required'] = array();
+				}
+				$schema['required'][] = $key;
+			}
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Validates field values against the content type schema.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array $values Array of field key => value pairs.
+	 * @return true|WP_Error True if valid, WP_Error on failure.
+	 */
+	public function validate_values( $values ) {
+		$errors = new WP_Error();
+
+		// Check required fields.
+		foreach ( $this->get_required_fields() as $required_key ) {
+			if ( ! isset( $values[ $required_key ] ) || '' === $values[ $required_key ] ) {
+				$field = $this->get_field( $required_key );
+				$errors->add(
+					'missing_required_field',
+					sprintf(
+						/* translators: %s: Field label. */
+						__( 'The field "%s" is required.' ),
+						$field['label']
+					),
+					array( 'field' => $required_key )
+				);
+			}
+		}
+
+		// Validate each provided value.
+		foreach ( $values as $key => $value ) {
+			$field = $this->get_field( $key );
+
+			if ( ! $field ) {
+				continue; // Skip unknown fields.
+			}
+
+			// Validate type.
+			if ( ! $this->validate_type( $value, $field['type'] ) ) {
+				$errors->add(
+					'invalid_field_type',
+					sprintf(
+						/* translators: 1: Field label, 2: Expected type. */
+						__( 'The field "%1$s" must be of type %2$s.' ),
+						$field['label'],
+						$field['type']
+					),
+					array( 'field' => $key )
+				);
+			}
+
+			// Validate enum.
+			if ( ! empty( $field['enum'] ) && ! in_array( $value, $field['enum'], true ) ) {
+				$errors->add(
+					'invalid_enum_value',
+					sprintf(
+						/* translators: 1: Field label, 2: Allowed values. */
+						__( 'The field "%1$s" must be one of: %2$s.' ),
+						$field['label'],
+						implode( ', ', $field['enum'] )
+					),
+					array( 'field' => $key )
+				);
+			}
+		}
+
+		if ( $errors->has_errors() ) {
+			return $errors;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validates a value against an expected type.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param mixed  $value Value to validate.
+	 * @param string $type  Expected type.
+	 * @return bool True if valid.
+	 */
+	private function validate_type( $value, $type ) {
+		switch ( $type ) {
+			case 'string':
+				return is_string( $value );
+
+			case 'integer':
+				return is_int( $value ) || ( is_string( $value ) && ctype_digit( $value ) );
+
+			case 'number':
+				return is_numeric( $value );
+
+			case 'boolean':
+				return is_bool( $value ) || in_array( $value, array( 0, 1, '0', '1', 'true', 'false' ), true );
+
+			case 'array':
+				return is_array( $value );
+
+			case 'object':
+				return is_array( $value ) || is_object( $value );
+
+			default:
+				return true;
+		}
+	}
+
+	/**
+	 * Converts the content type to an array.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return array Content type data as array.
+	 */
+	public function to_array() {
+		return array(
+			'name'   => $this->name,
+			'fields' => $this->fields,
+			'ui'     => $this->ui,
+		);
+	}
+}

--- a/src/wp-includes/content-type.php
+++ b/src/wp-includes/content-type.php
@@ -1,0 +1,553 @@
+<?php
+/**
+ * WordPress Content Type API
+ *
+ * Provides a declarative API for registering content types that combines
+ * post type registration with field/meta definitions in a single call.
+ *
+ * @package WordPress
+ * @subpackage Post
+ * @since 7.0.0
+ */
+
+/**
+ * Global content types registry.
+ *
+ * @since 7.0.0
+ * @global array $wp_content_types
+ */
+global $wp_content_types;
+
+/**
+ * Registers a content type.
+ *
+ * A content type is a higher-level abstraction that combines a post type
+ * with its associated meta field definitions. This function:
+ *
+ * 1. Calls register_post_type() with the provided arguments.
+ * 2. Registers each declared field as post meta via register_post_meta().
+ * 3. Stores UI hints for editor/admin integrations.
+ *
+ * @since 7.0.0
+ *
+ * @global array $wp_content_types Global content types registry.
+ *
+ * @param string $content_type Content type key. Must not exceed 20 characters and may only
+ *                             contain lowercase alphanumeric characters, dashes, and underscores.
+ * @param array  $args {
+ *     Array of arguments for registering a content type.
+ *
+ *     @type array $labels      An array of labels for the post type.
+ *     @type bool  $public      Whether the post type is public. Default false.
+ *     @type bool  $show_in_rest Whether to expose this post type in the REST API. Default true.
+ *     @type array $fields {
+ *         Array of field definitions, keyed by field name.
+ *
+ *         @type string   $type              The data type. Accepts 'string', 'integer', 'number',
+ *                                           'boolean', 'array', 'object'. Default 'string'.
+ *         @type bool     $single            Whether the meta key has one value per object. Default true.
+ *         @type bool     $show_in_rest      Whether to include in REST API. Default true.
+ *         @type bool     $required          Whether the field is required. Default false.
+ *         @type string   $label             Human-readable label for the field.
+ *         @type string   $description       Description of the field.
+ *         @type mixed    $default           Default value for the field.
+ *         @type string   $control           UI control type hint. Accepts 'text', 'textarea',
+ *                                           'number', 'checkbox', 'select', 'radio', 'date',
+ *                                           'datetime', 'email', 'url', 'color', 'range'.
+ *         @type array    $enum              Array of allowed values for validation.
+ *         @type callable $sanitize_callback Custom sanitization callback.
+ *         @type callable $auth_callback     Custom authorization callback.
+ *         @type bool     $revisions_enabled Whether to enable revisions for this meta. Default false.
+ *     }
+ *     @type array $ui {
+ *         UI hints for editor/admin integrations.
+ *
+ *         @type array $editor_panel {
+ *             Editor panel configuration.
+ *
+ *             @type string $title  Panel title.
+ *             @type array  $fields Array of field keys to include in the panel.
+ *         }
+ *         @type array $list_table_columns Array of field keys to show as list table columns.
+ *     }
+ *     @type string $label       Name of the post type shown in the menu.
+ *     @type string $description A short descriptive summary of what the post type is.
+ *     @type bool   $hierarchical Whether the post type is hierarchical. Default false.
+ *     @type array  $supports    Core feature(s) the post type supports.
+ *     @type array  $taxonomies  An array of taxonomy identifiers to register for the post type.
+ *     @type bool   $has_archive Whether there should be post type archives. Default false.
+ *     @type array  $rewrite     Triggers the handling of rewrites for this post type.
+ *     @type string $capability_type The string to use to build the read, edit, and delete capabilities.
+ *     @type bool   $map_meta_cap Whether to use the internal default meta capability handling.
+ *     @type string $menu_icon   The URL to the icon to be used for this menu.
+ *     @type int    $menu_position The position in the menu order the post type should appear.
+ *     @type bool   $show_ui     Whether to generate a default UI for managing this post type.
+ *     @type bool   $show_in_menu Whether to show the post type in the admin menu.
+ *     @type bool   $show_in_nav_menus Whether to make the post type available for selection in navigation menus.
+ *     @type bool   $show_in_admin_bar Whether to make the post type available in the admin bar.
+ *     @type bool   $can_export  Whether to allow this post type to be exported.
+ *     @type bool   $delete_with_user Whether to delete posts of this type when deleting a user.
+ *     @type string $template    Array of blocks to use as the default initial state for an editor session.
+ *     @type string $template_lock Whether the template should be locked.
+ * }
+ * @return WP_Content_Type|WP_Error The registered content type object on success, WP_Error on failure.
+ *
+ * @example
+ * register_content_type( 'book', array(
+ *     'labels' => array(
+ *         'name'          => 'Books',
+ *         'singular_name' => 'Book',
+ *     ),
+ *     'public'       => true,
+ *     'show_in_rest' => true,
+ *     'supports'     => array( 'title', 'editor', 'thumbnail' ),
+ *     'fields'       => array(
+ *         'isbn' => array(
+ *             'type'     => 'string',
+ *             'single'   => true,
+ *             'required' => true,
+ *             'label'    => 'ISBN',
+ *             'control'  => 'text',
+ *         ),
+ *         'published_year' => array(
+ *             'type'    => 'integer',
+ *             'single'  => true,
+ *             'label'   => 'Published Year',
+ *             'control' => 'number',
+ *         ),
+ *         'genre' => array(
+ *             'type'    => 'string',
+ *             'single'  => true,
+ *             'label'   => 'Genre',
+ *             'control' => 'select',
+ *             'enum'    => array( 'fiction', 'non-fiction', 'mystery', 'sci-fi' ),
+ *         ),
+ *     ),
+ *     'ui' => array(
+ *         'editor_panel' => array(
+ *             'title'  => 'Book Details',
+ *             'fields' => array( 'isbn', 'published_year', 'genre' ),
+ *         ),
+ *     ),
+ * ) );
+ */
+function register_content_type( $content_type, $args = array() ) {
+	global $wp_content_types;
+
+	if ( ! is_array( $wp_content_types ) ) {
+		$wp_content_types = array();
+	}
+
+	// Sanitize content type name.
+	$content_type = sanitize_key( $content_type );
+
+	if ( empty( $content_type ) || strlen( $content_type ) > 20 ) {
+		_doing_it_wrong(
+			__FUNCTION__,
+			__( 'Content type names must be between 1 and 20 characters in length.' ),
+			'7.0.0'
+		);
+		return new WP_Error(
+			'content_type_length_invalid',
+			__( 'Content type names must be between 1 and 20 characters in length.' )
+		);
+	}
+
+	// Check if content type already exists.
+	if ( isset( $wp_content_types[ $content_type ] ) ) {
+		_doing_it_wrong(
+			__FUNCTION__,
+			sprintf(
+				/* translators: %s: Content type key. */
+				__( 'Content type "%s" is already registered.' ),
+				$content_type
+			),
+			'7.0.0'
+		);
+		return new WP_Error(
+			'content_type_exists',
+			sprintf(
+				/* translators: %s: Content type key. */
+				__( 'Content type "%s" is already registered.' ),
+				$content_type
+			)
+		);
+	}
+
+	/**
+	 * Filters the arguments for registering a content type.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array  $args         Array of arguments for registering a content type.
+	 * @param string $content_type Content type key.
+	 */
+	$args = apply_filters( 'register_content_type_args', $args, $content_type );
+
+	// Set default for show_in_rest if not specified.
+	if ( ! isset( $args['show_in_rest'] ) ) {
+		$args['show_in_rest'] = true;
+	}
+
+	// Create the content type object.
+	$content_type_object = new WP_Content_Type( $content_type, $args );
+
+	// Validate fields.
+	$validation = $content_type_object->validate_fields();
+	if ( is_wp_error( $validation ) ) {
+		return $validation;
+	}
+
+	// Extract fields and UI from args before passing to register_post_type.
+	$post_type_args = $args;
+	unset( $post_type_args['fields'] );
+	unset( $post_type_args['ui'] );
+
+	// Register the post type.
+	$post_type_result = $content_type_object->register_post_type( $post_type_args );
+
+	if ( is_wp_error( $post_type_result ) ) {
+		return $post_type_result;
+	}
+
+	// Register all meta fields.
+	$content_type_object->register_meta_fields();
+
+	// Store in global registry.
+	$wp_content_types[ $content_type ] = $content_type_object;
+
+	/**
+	 * Fires after a content type is registered.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string          $content_type        Content type key.
+	 * @param WP_Content_Type $content_type_object Registered content type object.
+	 * @param array           $args                Original arguments passed to register_content_type().
+	 */
+	do_action( 'registered_content_type', $content_type, $content_type_object, $args );
+
+	/**
+	 * Fires after a specific content type is registered.
+	 *
+	 * The dynamic portion of the hook name, `$content_type`, refers to the content type key.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param WP_Content_Type $content_type_object Registered content type object.
+	 * @param array           $args                Original arguments passed to register_content_type().
+	 */
+	do_action( "registered_content_type_{$content_type}", $content_type_object, $args );
+
+	return $content_type_object;
+}
+
+/**
+ * Unregisters a content type.
+ *
+ * Can not be used to unregister built-in post types.
+ *
+ * @since 7.0.0
+ *
+ * @global array $wp_content_types Global content types registry.
+ *
+ * @param string $content_type Content type key to unregister.
+ * @return true|WP_Error True on success, WP_Error on failure.
+ */
+function unregister_content_type( $content_type ) {
+	global $wp_content_types;
+
+	if ( ! content_type_exists( $content_type ) ) {
+		return new WP_Error(
+			'content_type_not_exists',
+			__( 'Content type does not exist.' )
+		);
+	}
+
+	$content_type_object = $wp_content_types[ $content_type ];
+
+	// Unregister all meta fields.
+	foreach ( $content_type_object->get_fields() as $field_key => $field ) {
+		unregister_post_meta( $content_type, $field_key );
+	}
+
+	// Unregister the post type.
+	$result = unregister_post_type( $content_type );
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
+	}
+
+	// Remove from content types registry.
+	unset( $wp_content_types[ $content_type ] );
+
+	/**
+	 * Fires after a content type is unregistered.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string $content_type Content type key.
+	 */
+	do_action( 'unregistered_content_type', $content_type );
+
+	return true;
+}
+
+/**
+ * Checks if a content type is registered.
+ *
+ * @since 7.0.0
+ *
+ * @global array $wp_content_types Global content types registry.
+ *
+ * @param string $content_type Content type key.
+ * @return bool True if the content type is registered, false otherwise.
+ */
+function content_type_exists( $content_type ) {
+	return (bool) get_content_type_object( $content_type );
+}
+
+/**
+ * Retrieves a registered content type object.
+ *
+ * @since 7.0.0
+ *
+ * @global array $wp_content_types Global content types registry.
+ *
+ * @param string $content_type Content type key.
+ * @return WP_Content_Type|null The registered content type object, or null if not found.
+ */
+function get_content_type_object( $content_type ) {
+	global $wp_content_types;
+
+	if ( ! is_scalar( $content_type ) || empty( $wp_content_types[ $content_type ] ) ) {
+		return null;
+	}
+
+	return $wp_content_types[ $content_type ];
+}
+
+/**
+ * Retrieves a list of registered content types.
+ *
+ * @since 7.0.0
+ *
+ * @global array $wp_content_types Global content types registry.
+ *
+ * @param array  $args     Optional. An array of key => value arguments to match against
+ *                         the content type objects. Default empty array.
+ * @param string $output   Optional. The type of output to return. Accepts content type 'names'
+ *                         or 'objects'. Default 'names'.
+ * @param string $operator Optional. The logical operation to perform. Accepts 'and' or 'or'.
+ *                         'or' means only one element from the array needs to match; 'and'
+ *                         means all elements must match. Default 'and'.
+ * @return string[]|WP_Content_Type[] An array of content type names or objects.
+ */
+function get_content_types( $args = array(), $output = 'names', $operator = 'and' ) {
+	global $wp_content_types;
+
+	if ( ! is_array( $wp_content_types ) ) {
+		return array();
+	}
+
+	$field = ( 'names' === $output ) ? 'name' : false;
+
+	return wp_filter_object_list( $wp_content_types, $args, $operator, $field );
+}
+
+/**
+ * Retrieves the fields defined for a content type.
+ *
+ * @since 7.0.0
+ *
+ * @param string $content_type Content type key.
+ * @return array|null Array of field definitions, or null if content type not found.
+ */
+function get_content_type_fields( $content_type ) {
+	$content_type_object = get_content_type_object( $content_type );
+
+	if ( ! $content_type_object ) {
+		return null;
+	}
+
+	return $content_type_object->get_fields();
+}
+
+/**
+ * Retrieves a specific field from a content type.
+ *
+ * @since 7.0.0
+ *
+ * @param string $content_type Content type key.
+ * @param string $field_key    Field key.
+ * @return array|null Field definition, or null if not found.
+ */
+function get_content_type_field( $content_type, $field_key ) {
+	$content_type_object = get_content_type_object( $content_type );
+
+	if ( ! $content_type_object ) {
+		return null;
+	}
+
+	return $content_type_object->get_field( $field_key );
+}
+
+/**
+ * Retrieves the UI hints for a content type.
+ *
+ * @since 7.0.0
+ *
+ * @param string $content_type Content type key.
+ * @return array|null UI hints array, or null if content type not found.
+ */
+function get_content_type_ui( $content_type ) {
+	$content_type_object = get_content_type_object( $content_type );
+
+	if ( ! $content_type_object ) {
+		return null;
+	}
+
+	return $content_type_object->get_ui();
+}
+
+/**
+ * Retrieves the REST API schema for a content type's fields.
+ *
+ * @since 7.0.0
+ *
+ * @param string $content_type Content type key.
+ * @return array|null REST schema array, or null if content type not found.
+ */
+function get_content_type_rest_schema( $content_type ) {
+	$content_type_object = get_content_type_object( $content_type );
+
+	if ( ! $content_type_object ) {
+		return null;
+	}
+
+	return $content_type_object->get_rest_schema();
+}
+
+/**
+ * Validates field values for a content type.
+ *
+ * @since 7.0.0
+ *
+ * @param string $content_type Content type key.
+ * @param array  $values       Array of field key => value pairs to validate.
+ * @return true|WP_Error True if valid, WP_Error on failure.
+ */
+function validate_content_type_values( $content_type, $values ) {
+	$content_type_object = get_content_type_object( $content_type );
+
+	if ( ! $content_type_object ) {
+		return new WP_Error(
+			'content_type_not_exists',
+			__( 'Content type does not exist.' )
+		);
+	}
+
+	return $content_type_object->validate_values( $values );
+}
+
+/**
+ * Adds REST API endpoint for content type schema.
+ *
+ * Registers a REST route that exposes the content type's field schema
+ * for use by client applications.
+ *
+ * @since 7.0.0
+ */
+function _register_content_type_rest_routes() {
+	register_rest_route(
+		'wp/v2',
+		'/content-types',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => '_rest_get_content_types',
+			'permission_callback' => '__return_true',
+			'schema'              => array(
+				'description' => __( 'List of registered content types with their field schemas.' ),
+				'type'        => 'array',
+				'items'       => array(
+					'type'       => 'object',
+					'properties' => array(
+						'name'   => array(
+							'type'        => 'string',
+							'description' => __( 'Content type identifier.' ),
+						),
+						'fields' => array(
+							'type'        => 'object',
+							'description' => __( 'Field definitions.' ),
+						),
+						'ui'     => array(
+							'type'        => 'object',
+							'description' => __( 'UI hints.' ),
+						),
+					),
+				),
+			),
+		)
+	);
+
+	register_rest_route(
+		'wp/v2',
+		'/content-types/(?P<content_type>[a-z0-9_-]+)',
+		array(
+			'methods'             => WP_REST_Server::READABLE,
+			'callback'            => '_rest_get_content_type',
+			'permission_callback' => '__return_true',
+			'args'                => array(
+				'content_type' => array(
+					'description'       => __( 'Content type identifier.' ),
+					'type'              => 'string',
+					'required'          => true,
+					'sanitize_callback' => 'sanitize_key',
+				),
+			),
+		)
+	);
+}
+add_action( 'rest_api_init', '_register_content_type_rest_routes' );
+
+/**
+ * REST API callback to get all content types.
+ *
+ * @since 7.0.0
+ *
+ * @param WP_REST_Request $request Request object.
+ * @return WP_REST_Response Response object.
+ */
+function _rest_get_content_types( $request ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+	$content_types = get_content_types( array(), 'objects' );
+	$response      = array();
+
+	foreach ( $content_types as $content_type ) {
+		$response[] = $content_type->to_array();
+	}
+
+	return rest_ensure_response( $response );
+}
+
+/**
+ * REST API callback to get a single content type.
+ *
+ * @since 7.0.0
+ *
+ * @param WP_REST_Request $request Request object.
+ * @return WP_REST_Response|WP_Error Response object or error.
+ */
+function _rest_get_content_type( $request ) {
+	$content_type        = $request->get_param( 'content_type' );
+	$content_type_object = get_content_type_object( $content_type );
+
+	if ( ! $content_type_object ) {
+		return new WP_Error(
+			'rest_content_type_invalid',
+			__( 'Invalid content type.' ),
+			array( 'status' => 404 )
+		);
+	}
+
+	return rest_ensure_response( $content_type_object->to_array() );
+}

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -219,6 +219,8 @@ require ABSPATH . WPINC . '/post.php';
 require ABSPATH . WPINC . '/class-walker-page.php';
 require ABSPATH . WPINC . '/class-walker-page-dropdown.php';
 require ABSPATH . WPINC . '/class-wp-post-type.php';
+require ABSPATH . WPINC . '/class-wp-content-type.php';
+require ABSPATH . WPINC . '/content-type.php';
 require ABSPATH . WPINC . '/class-wp-post.php';
 require ABSPATH . WPINC . '/post-template.php';
 require ABSPATH . WPINC . '/revision.php';

--- a/tests/phpunit/tests/post/wpContentType.php
+++ b/tests/phpunit/tests/post/wpContentType.php
@@ -1,0 +1,730 @@
+<?php
+/**
+ * Tests for the Content Type API.
+ *
+ * @package WordPress
+ * @subpackage Post
+ */
+
+/**
+ * Tests for the Content Type API.
+ *
+ * @group post
+ * @group content-type
+ */
+class Tests_Post_WP_Content_Type extends WP_UnitTestCase {
+
+	/**
+	 * Clean up content types after each test.
+	 */
+	public function tear_down() {
+		global $wp_content_types;
+
+		// Unregister any test content types.
+		if ( is_array( $wp_content_types ) ) {
+			foreach ( array_keys( $wp_content_types ) as $content_type ) {
+				// Skip cleanup if it starts with 'test_' or known test types.
+				if ( strpos( $content_type, 'cpt' ) === 0 || strpos( $content_type, 'book' ) === 0 ) {
+					unregister_content_type( $content_type );
+				}
+			}
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test that register_content_type() returns a WP_Content_Type object on success.
+	 */
+	public function test_register_content_type_returns_object() {
+		$result = register_content_type(
+			'cpt_test',
+			array(
+				'labels' => array(
+					'name' => 'Test CPT',
+				),
+			)
+		);
+
+		$this->assertInstanceOf( 'WP_Content_Type', $result );
+		$this->assertSame( 'cpt_test', $result->name );
+	}
+
+	/**
+	 * Test that register_content_type() also registers the post type.
+	 */
+	public function test_register_content_type_registers_post_type() {
+		register_content_type(
+			'cpt_test',
+			array(
+				'labels' => array(
+					'name' => 'Test CPT',
+				),
+				'public' => true,
+			)
+		);
+
+		$this->assertTrue( post_type_exists( 'cpt_test' ) );
+
+		$post_type = get_post_type_object( 'cpt_test' );
+		$this->assertTrue( $post_type->public );
+	}
+
+	/**
+	 * Test that register_content_type() registers meta fields.
+	 */
+	public function test_register_content_type_registers_meta_fields() {
+		register_content_type(
+			'cpt_test',
+			array(
+				'fields' => array(
+					'test_field' => array(
+						'type'   => 'string',
+						'single' => true,
+					),
+				),
+			)
+		);
+
+		$registered_meta = get_registered_meta_keys( 'post', 'cpt_test' );
+
+		$this->assertArrayHasKey( 'test_field', $registered_meta );
+		$this->assertSame( 'string', $registered_meta['test_field']['type'] );
+	}
+
+	/**
+	 * Test that register_content_type() fails for invalid content type names.
+	 */
+	public function test_register_content_type_invalid_name_too_long() {
+		$this->setExpectedIncorrectUsage( 'register_content_type' );
+
+		$result = register_content_type( 'this_name_is_way_too_long', array() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'content_type_length_invalid', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that register_content_type() fails for empty content type names.
+	 */
+	public function test_register_content_type_invalid_name_empty() {
+		$this->setExpectedIncorrectUsage( 'register_content_type' );
+
+		$result = register_content_type( '', array() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'content_type_length_invalid', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that register_content_type() fails for duplicate content types.
+	 */
+	public function test_register_content_type_duplicate() {
+		$this->setExpectedIncorrectUsage( 'register_content_type' );
+
+		register_content_type( 'cpt_test', array() );
+		$result = register_content_type( 'cpt_test', array() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'content_type_exists', $result->get_error_code() );
+	}
+
+	/**
+	 * Test content_type_exists() function.
+	 */
+	public function test_content_type_exists() {
+		$this->assertFalse( content_type_exists( 'cpt_test' ) );
+
+		register_content_type( 'cpt_test', array() );
+
+		$this->assertTrue( content_type_exists( 'cpt_test' ) );
+	}
+
+	/**
+	 * Test get_content_type_object() function.
+	 */
+	public function test_get_content_type_object() {
+		$this->assertNull( get_content_type_object( 'cpt_test' ) );
+
+		register_content_type( 'cpt_test', array() );
+
+		$content_type = get_content_type_object( 'cpt_test' );
+		$this->assertInstanceOf( 'WP_Content_Type', $content_type );
+		$this->assertSame( 'cpt_test', $content_type->name );
+	}
+
+	/**
+	 * Test get_content_types() function.
+	 */
+	public function test_get_content_types() {
+		register_content_type( 'cpt_one', array() );
+		register_content_type( 'cpt_two', array() );
+
+		$types = get_content_types();
+		$this->assertContains( 'cpt_one', $types );
+		$this->assertContains( 'cpt_two', $types );
+
+		$objects = get_content_types( array(), 'objects' );
+		$this->assertArrayHasKey( 'cpt_one', $objects );
+		$this->assertArrayHasKey( 'cpt_two', $objects );
+		$this->assertInstanceOf( 'WP_Content_Type', $objects['cpt_one'] );
+	}
+
+	/**
+	 * Test unregister_content_type() function.
+	 */
+	public function test_unregister_content_type() {
+		register_content_type(
+			'cpt_test',
+			array(
+				'fields' => array(
+					'test_field' => array(
+						'type' => 'string',
+					),
+				),
+			)
+		);
+
+		$this->assertTrue( content_type_exists( 'cpt_test' ) );
+		$this->assertTrue( post_type_exists( 'cpt_test' ) );
+
+		$result = unregister_content_type( 'cpt_test' );
+
+		$this->assertTrue( $result );
+		$this->assertFalse( content_type_exists( 'cpt_test' ) );
+		$this->assertFalse( post_type_exists( 'cpt_test' ) );
+	}
+
+	/**
+	 * Test unregister_content_type() for non-existent type.
+	 */
+	public function test_unregister_content_type_not_exists() {
+		$result = unregister_content_type( 'nonexistent' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'content_type_not_exists', $result->get_error_code() );
+	}
+
+	/**
+	 * Test get_content_type_fields() function.
+	 */
+	public function test_get_content_type_fields() {
+		register_content_type(
+			'book',
+			array(
+				'fields' => array(
+					'isbn' => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+					'year' => array(
+						'type' => 'integer',
+					),
+				),
+			)
+		);
+
+		$fields = get_content_type_fields( 'book' );
+
+		$this->assertArrayHasKey( 'isbn', $fields );
+		$this->assertArrayHasKey( 'year', $fields );
+		$this->assertSame( 'string', $fields['isbn']['type'] );
+		$this->assertTrue( $fields['isbn']['required'] );
+		$this->assertSame( 'integer', $fields['year']['type'] );
+	}
+
+	/**
+	 * Test get_content_type_field() function.
+	 */
+	public function test_get_content_type_field() {
+		register_content_type(
+			'book',
+			array(
+				'fields' => array(
+					'isbn' => array(
+						'type'        => 'string',
+						'description' => 'International Standard Book Number',
+					),
+				),
+			)
+		);
+
+		$field = get_content_type_field( 'book', 'isbn' );
+
+		$this->assertIsArray( $field );
+		$this->assertSame( 'string', $field['type'] );
+		$this->assertSame( 'International Standard Book Number', $field['description'] );
+
+		$nonexistent = get_content_type_field( 'book', 'nonexistent' );
+		$this->assertNull( $nonexistent );
+	}
+
+	/**
+	 * Test get_content_type_ui() function.
+	 */
+	public function test_get_content_type_ui() {
+		register_content_type(
+			'book',
+			array(
+				'fields' => array(
+					'isbn' => array( 'type' => 'string' ),
+					'year' => array( 'type' => 'integer' ),
+				),
+				'ui'     => array(
+					'editor_panel' => array(
+						'title'  => 'Book Details',
+						'fields' => array( 'isbn', 'year' ),
+					),
+				),
+			)
+		);
+
+		$ui = get_content_type_ui( 'book' );
+
+		$this->assertArrayHasKey( 'editor_panel', $ui );
+		$this->assertSame( 'Book Details', $ui['editor_panel']['title'] );
+		$this->assertSame( array( 'isbn', 'year' ), $ui['editor_panel']['fields'] );
+	}
+
+	/**
+	 * Test field type validation.
+	 */
+	public function test_field_type_validation_invalid_type() {
+		$result = register_content_type(
+			'cpt_test',
+			array(
+				'fields' => array(
+					'test_field' => array(
+						'type' => 'invalid_type',
+					),
+				),
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_field_type', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that all valid field types are accepted.
+	 *
+	 * @dataProvider data_valid_field_types
+	 *
+	 * @param string $type Field type to test.
+	 */
+	public function test_valid_field_types( $type ) {
+		$result = register_content_type(
+			'cpt_' . $type,
+			array(
+				'fields' => array(
+					'test_field' => array(
+						'type' => $type,
+					),
+				),
+			)
+		);
+
+		$this->assertInstanceOf( 'WP_Content_Type', $result );
+	}
+
+	/**
+	 * Data provider for valid field types.
+	 */
+	public function data_valid_field_types() {
+		return array(
+			array( 'string' ),
+			array( 'integer' ),
+			array( 'number' ),
+			array( 'boolean' ),
+			array( 'array' ),
+			array( 'object' ),
+		);
+	}
+
+	/**
+	 * Test field normalization with defaults.
+	 */
+	public function test_field_normalization() {
+		register_content_type(
+			'cpt_test',
+			array(
+				'fields' => array(
+					'minimal_field' => array(),
+				),
+			)
+		);
+
+		$field = get_content_type_field( 'cpt_test', 'minimal_field' );
+
+		$this->assertSame( 'string', $field['type'] );
+		$this->assertTrue( $field['single'] );
+		$this->assertTrue( $field['show_in_rest'] );
+		$this->assertFalse( $field['required'] );
+		$this->assertSame( 'Minimal Field', $field['label'] );
+		$this->assertSame( 'text', $field['control'] );
+	}
+
+	/**
+	 * Test show_in_rest defaults to true for content types.
+	 */
+	public function test_show_in_rest_default() {
+		register_content_type( 'cpt_test', array() );
+
+		$post_type = get_post_type_object( 'cpt_test' );
+		$this->assertTrue( $post_type->show_in_rest );
+	}
+
+	/**
+	 * Test enum field validation.
+	 */
+	public function test_enum_field_validation() {
+		register_content_type(
+			'book',
+			array(
+				'fields' => array(
+					'genre' => array(
+						'type' => 'string',
+						'enum' => array( 'fiction', 'non-fiction', 'mystery' ),
+					),
+				),
+			)
+		);
+
+		$content_type = get_content_type_object( 'book' );
+		$field        = $content_type->get_field( 'genre' );
+
+		$this->assertSame( array( 'fiction', 'non-fiction', 'mystery' ), $field['enum'] );
+	}
+
+	/**
+	 * Test validate_content_type_values() function with valid values.
+	 */
+	public function test_validate_values_valid() {
+		register_content_type(
+			'book',
+			array(
+				'fields' => array(
+					'isbn' => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+					'year' => array(
+						'type' => 'integer',
+					),
+				),
+			)
+		);
+
+		$result = validate_content_type_values(
+			'book',
+			array(
+				'isbn' => '978-0-123456-78-9',
+				'year' => 2024,
+			)
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test validate_content_type_values() function with missing required field.
+	 */
+	public function test_validate_values_missing_required() {
+		register_content_type(
+			'book',
+			array(
+				'fields' => array(
+					'isbn' => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+				),
+			)
+		);
+
+		$result = validate_content_type_values( 'book', array() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'missing_required_field', $result->get_error_code() );
+	}
+
+	/**
+	 * Test validate_content_type_values() function with invalid enum value.
+	 */
+	public function test_validate_values_invalid_enum() {
+		register_content_type(
+			'book',
+			array(
+				'fields' => array(
+					'genre' => array(
+						'type' => 'string',
+						'enum' => array( 'fiction', 'non-fiction' ),
+					),
+				),
+			)
+		);
+
+		$result = validate_content_type_values(
+			'book',
+			array(
+				'genre' => 'invalid_genre',
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'invalid_enum_value', $result->get_error_code() );
+	}
+
+	/**
+	 * Test get_content_type_rest_schema() function.
+	 */
+	public function test_get_rest_schema() {
+		register_content_type(
+			'book',
+			array(
+				'fields' => array(
+					'isbn' => array(
+						'type'        => 'string',
+						'required'    => true,
+						'description' => 'ISBN number',
+					),
+					'year' => array(
+						'type' => 'integer',
+					),
+				),
+			)
+		);
+
+		$schema = get_content_type_rest_schema( 'book' );
+
+		$this->assertSame( 'object', $schema['type'] );
+		$this->assertArrayHasKey( 'isbn', $schema['properties'] );
+		$this->assertArrayHasKey( 'year', $schema['properties'] );
+		$this->assertSame( 'string', $schema['properties']['isbn']['type'] );
+		$this->assertSame( 'ISBN number', $schema['properties']['isbn']['description'] );
+		$this->assertContains( 'isbn', $schema['required'] );
+	}
+
+	/**
+	 * Test registered_content_type action hook.
+	 */
+	public function test_registered_content_type_action() {
+		$action_called = false;
+		$captured_args = array();
+
+		add_action(
+			'registered_content_type',
+			function ( $content_type, $content_type_object, $args ) use ( &$action_called, &$captured_args ) {
+				$action_called = true;
+				$captured_args = compact( 'content_type', 'content_type_object', 'args' );
+			},
+			10,
+			3
+		);
+
+		register_content_type(
+			'cpt_test',
+			array(
+				'public' => true,
+			)
+		);
+
+		$this->assertTrue( $action_called );
+		$this->assertSame( 'cpt_test', $captured_args['content_type'] );
+		$this->assertInstanceOf( 'WP_Content_Type', $captured_args['content_type_object'] );
+		$this->assertTrue( $captured_args['args']['public'] );
+	}
+
+	/**
+	 * Test register_content_type_args filter hook.
+	 */
+	public function test_register_content_type_args_filter() {
+		add_filter(
+			'register_content_type_args',
+			function ( $args, $content_type ) {
+				$args['description'] = 'Filtered description';
+				return $args;
+			},
+			10,
+			2
+		);
+
+		register_content_type( 'cpt_test', array() );
+
+		$post_type = get_post_type_object( 'cpt_test' );
+		$this->assertSame( 'Filtered description', $post_type->description );
+	}
+
+	/**
+	 * Test WP_Content_Type::to_array() method.
+	 */
+	public function test_content_type_to_array() {
+		register_content_type(
+			'book',
+			array(
+				'fields' => array(
+					'isbn' => array( 'type' => 'string' ),
+				),
+				'ui'     => array(
+					'editor_panel' => array( 'title' => 'Details' ),
+				),
+			)
+		);
+
+		$content_type = get_content_type_object( 'book' );
+		$array        = $content_type->to_array();
+
+		$this->assertSame( 'book', $array['name'] );
+		$this->assertArrayHasKey( 'isbn', $array['fields'] );
+		$this->assertArrayHasKey( 'editor_panel', $array['ui'] );
+	}
+
+	/**
+	 * Test WP_Content_Type::get_required_fields() method.
+	 */
+	public function test_get_required_fields() {
+		register_content_type(
+			'book',
+			array(
+				'fields' => array(
+					'isbn'   => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+					'year'   => array(
+						'type'     => 'integer',
+						'required' => false,
+					),
+					'author' => array(
+						'type'     => 'string',
+						'required' => true,
+					),
+				),
+			)
+		);
+
+		$content_type = get_content_type_object( 'book' );
+		$required     = $content_type->get_required_fields();
+
+		$this->assertCount( 2, $required );
+		$this->assertContains( 'isbn', $required );
+		$this->assertContains( 'author', $required );
+		$this->assertNotContains( 'year', $required );
+	}
+
+	/**
+	 * Test sanitization callback for string field.
+	 */
+	public function test_sanitize_string_field() {
+		$sanitized = WP_Content_Type::sanitize_by_type( '<script>alert("xss")</script>test', 'string' );
+		$this->assertSame( 'test', $sanitized );
+	}
+
+	/**
+	 * Test sanitization callback for integer field.
+	 */
+	public function test_sanitize_integer_field() {
+		$sanitized = WP_Content_Type::sanitize_by_type( '42.9', 'integer' );
+		$this->assertSame( 42, $sanitized );
+	}
+
+	/**
+	 * Test sanitization callback for number field.
+	 */
+	public function test_sanitize_number_field() {
+		$sanitized = WP_Content_Type::sanitize_by_type( '42.9', 'number' );
+		$this->assertSame( 42.9, $sanitized );
+	}
+
+	/**
+	 * Test sanitization callback for boolean field.
+	 */
+	public function test_sanitize_boolean_field() {
+		$this->assertTrue( WP_Content_Type::sanitize_by_type( '1', 'boolean' ) );
+		$this->assertTrue( WP_Content_Type::sanitize_by_type( 1, 'boolean' ) );
+		$this->assertFalse( WP_Content_Type::sanitize_by_type( '0', 'boolean' ) );
+		$this->assertFalse( WP_Content_Type::sanitize_by_type( 0, 'boolean' ) );
+	}
+
+	/**
+	 * Test default control types for different field types.
+	 */
+	public function test_default_control_types() {
+		register_content_type(
+			'cpt_test',
+			array(
+				'fields' => array(
+					'string_field'  => array( 'type' => 'string' ),
+					'integer_field' => array( 'type' => 'integer' ),
+					'number_field'  => array( 'type' => 'number' ),
+					'boolean_field' => array( 'type' => 'boolean' ),
+				),
+			)
+		);
+
+		$fields = get_content_type_fields( 'cpt_test' );
+
+		$this->assertSame( 'text', $fields['string_field']['control'] );
+		$this->assertSame( 'number', $fields['integer_field']['control'] );
+		$this->assertSame( 'number', $fields['number_field']['control'] );
+		$this->assertSame( 'checkbox', $fields['boolean_field']['control'] );
+	}
+
+	/**
+	 * Test complete book example from RFC.
+	 */
+	public function test_complete_book_example() {
+		$result = register_content_type(
+			'book',
+			array(
+				'labels'       => array(
+					'name'          => 'Books',
+					'singular_name' => 'Book',
+				),
+				'public'       => true,
+				'show_in_rest' => true,
+				'supports'     => array( 'title', 'editor', 'thumbnail' ),
+				'fields'       => array(
+					'isbn'           => array(
+						'type'         => 'string',
+						'single'       => true,
+						'required'     => true,
+						'show_in_rest' => true,
+						'label'        => 'ISBN',
+						'control'      => 'text',
+					),
+					'published_year' => array(
+						'type'         => 'integer',
+						'single'       => true,
+						'show_in_rest' => true,
+						'label'        => 'Published Year',
+						'control'      => 'number',
+					),
+				),
+				'ui'           => array(
+					'editor_panel' => array(
+						'title'  => 'Book Details',
+						'fields' => array( 'isbn', 'published_year' ),
+					),
+				),
+			)
+		);
+
+		$this->assertInstanceOf( 'WP_Content_Type', $result );
+		$this->assertTrue( post_type_exists( 'book' ) );
+
+		$post_type = get_post_type_object( 'book' );
+		$this->assertSame( 'Books', $post_type->labels->name );
+		$this->assertTrue( $post_type->public );
+		$this->assertTrue( $post_type->show_in_rest );
+
+		$fields = get_content_type_fields( 'book' );
+		$this->assertArrayHasKey( 'isbn', $fields );
+		$this->assertArrayHasKey( 'published_year', $fields );
+		$this->assertTrue( $fields['isbn']['required'] );
+		$this->assertSame( 'integer', $fields['published_year']['type'] );
+
+		$ui = get_content_type_ui( 'book' );
+		$this->assertSame( 'Book Details', $ui['editor_panel']['title'] );
+	}
+}

--- a/tests/phpunit/tests/rest-api/rest-schema-setup.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-setup.php
@@ -133,6 +133,8 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 			'/wp/v2/users/(?P<user_id>(?:[\\d]+|me))/application-passwords/(?P<uuid>[\\w\\-]+)',
 			'/wp/v2/comments',
 			'/wp/v2/comments/(?P<id>[\\d]+)',
+			'/wp/v2/content-types',
+			'/wp/v2/content-types/(?P<content_type>[a-z0-9_-]+)',
 			'/wp/v2/global-styles/(?P<id>[\/\d+]+)',
 			'/wp/v2/global-styles/(?P<parent>[\d]+)/revisions',
 			'/wp/v2/global-styles/(?P<parent>[\d]+)/revisions/(?P<id>[\d]+)',

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -260,6 +260,47 @@ mockedApiResponse.Schema = {
                 "self": "http://example.org/index.php?rest_route=/wp/v2"
             }
         },
+        "/wp/v2/content-types": {
+            "namespace": "wp/v2",
+            "methods": [
+                "GET"
+            ],
+            "endpoints": [
+                {
+                    "methods": [
+                        "GET"
+                    ],
+                    "args": []
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "http://example.org/index.php?rest_route=/wp/v2/content-types"
+                    }
+                ]
+            }
+        },
+        "/wp/v2/content-types/(?P<content_type>[a-z0-9_-]+)": {
+            "namespace": "wp/v2",
+            "methods": [
+                "GET"
+            ],
+            "endpoints": [
+                {
+                    "methods": [
+                        "GET"
+                    ],
+                    "args": {
+                        "content_type": {
+                            "description": "Content type identifier.",
+                            "type": "string",
+                            "required": true
+                        }
+                    }
+                }
+            ]
+        },
         "/wp/v2/posts": {
             "namespace": "wp/v2",
             "methods": [


### PR DESCRIPTION
## Summary

This is a prototype implementation of the **[Declarative Content Modeling RFC](https://docs.google.com/document/d/1Z8ei9vOsj_TvyApq1EKet9BhzA4zdm8uFPd9cXJWpJs/edit?tab=t.0)** that introduces `register_content_type()` - a higher-level API for registering content types in WordPress.


## Try it out

[![Open in WordPress Playground](https://img.shields.io/badge/Open%20in-WordPress%20Playground-3858e9?logo=wordpress)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/whyisjake/content-type-api-demo/main/blueprint.json)

[Try the demo in WordPress Playground](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/whyisjake/content-type-api-demo/main/blueprint.json) - includes a "Books" content type with sample data.

### What it does

- Registers a post type via `register_post_type()`
- Registers meta fields via `register_post_meta()` for each declared field
- Provides automatic REST API schema generation
- Supports field type validation (string, integer, number, boolean, array, object)
- Stores UI hints for potential editor/admin integrations

### Example usage

```php
register_content_type( 'book', array(
    'labels'       => array( 'name' => 'Books' ),
    'public'       => true,
    'show_in_rest' => true,
    'fields'       => array(
        'isbn' => array(
            'type'     => 'string',
            'required' => true,
            'label'    => 'ISBN',
        ),
        'published_year' => array(
            'type'  => 'integer',
            'label' => 'Published Year',
        ),
    ),
    'ui' => array(
        'editor_panel' => array(
            'title'  => 'Book Details',
            'fields' => array( 'isbn', 'published_year' ),
        ),
    ),
) );
```

### New functions

- `register_content_type()` / `unregister_content_type()`
- `content_type_exists()` / `get_content_type_object()` / `get_content_types()`
- `get_content_type_fields()` / `get_content_type_field()`
- `get_content_type_ui()` / `get_content_type_rest_schema()`
- `validate_content_type_values()`

### Files added

- `src/wp-includes/class-wp-content-type.php` - Core class
- `src/wp-includes/content-type.php` - API functions
- `tests/phpunit/tests/post/wpContentType.php` - Unit tests (38 tests)

## Status

🚧 **Work in Progress** - This is an early prototype for discussion and feedback.

## Test plan

- [x] All 38 unit tests pass
- [ ] Manual testing with example plugin
- [ ] REST API endpoint testing
- [ ] Editor integration testing