### PR TITLE
Harden `wp_delete_object_term_relationships()` to account for not returning an array of term IDs (e.g. a `WP_Error`)

### DIFF
--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2000,7 +2000,7 @@ function wp_delete_object_term_relationships( $object_id, $taxonomies ) {
 	foreach ( (array) $taxonomies as $taxonomy ) {
 		$term_ids = wp_get_object_terms( $object_id, $taxonomy, array( 'fields' => 'ids' ) );
 		if ( ! is_array( $term_ids ) ) {
-			// Skip return value in the case of an error or a 'wp_get_object_terms' filter returning an invalid value.
+			// Skip return value in the case of an error or the 'wp_get_object_terms' filter returning an invalid value.
 			continue;
 		}
 		$term_ids = array_map( 'intval', $term_ids );

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -1999,6 +1999,10 @@ function wp_delete_object_term_relationships( $object_id, $taxonomies ) {
 
 	foreach ( (array) $taxonomies as $taxonomy ) {
 		$term_ids = wp_get_object_terms( $object_id, $taxonomy, array( 'fields' => 'ids' ) );
+		if ( is_wp_error( $term_ids ) ) {
+			// Skip this taxonomy if it returns an error
+			continue;
+		}
 		$term_ids = array_map( 'intval', $term_ids );
 		wp_remove_object_terms( $object_id, $term_ids, $taxonomy );
 	}

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -1999,8 +1999,11 @@ function wp_delete_object_term_relationships( $object_id, $taxonomies ) {
 
 	foreach ( (array) $taxonomies as $taxonomy ) {
 		$term_ids = wp_get_object_terms( $object_id, $taxonomy, array( 'fields' => 'ids' ) );
-		if ( is_wp_error( $term_ids ) ) {
-			// Skip this taxonomy if it returns an error
+		if ( ! is_array( $term_ids ) ) {
+			/*
+			 * Skip this taxonomy if it doesn't return an array. It could return a WP_Error, or it could return a string,
+			 * or with the 'wp_get_object_terms' filter it could return anything.
+			 */
 			continue;
 		}
 		$term_ids = array_map( 'intval', $term_ids );

--- a/src/wp-includes/taxonomy.php
+++ b/src/wp-includes/taxonomy.php
@@ -2000,10 +2000,7 @@ function wp_delete_object_term_relationships( $object_id, $taxonomies ) {
 	foreach ( (array) $taxonomies as $taxonomy ) {
 		$term_ids = wp_get_object_terms( $object_id, $taxonomy, array( 'fields' => 'ids' ) );
 		if ( ! is_array( $term_ids ) ) {
-			/*
-			 * Skip this taxonomy if it doesn't return an array. It could return a WP_Error, or it could return a string,
-			 * or with the 'wp_get_object_terms' filter it could return anything.
-			 */
+			// Skip return value in the case of an error or a 'wp_get_object_terms' filter returning an invalid value.
 			continue;
 		}
 		$term_ids = array_map( 'intval', $term_ids );

--- a/tests/phpunit/tests/term/wpDeleteObjectTermRelationships.php
+++ b/tests/phpunit/tests/term/wpDeleteObjectTermRelationships.php
@@ -54,6 +54,9 @@ class Tests_Term_WpDeleteObjectTermRelationships extends WP_UnitTestCase {
 		$this->assertSameSets( array( $t2 ), $terms );
 	}
 
+	/**
+	 * @ticket 64406
+	 */
 	public function test_delete_when_error() {
 		$taxonomy_name = 'wptests_tax';
 		register_taxonomy( $taxonomy_name, 'post' );

--- a/tests/phpunit/tests/term/wpDeleteObjectTermRelationships.php
+++ b/tests/phpunit/tests/term/wpDeleteObjectTermRelationships.php
@@ -53,4 +53,21 @@ class Tests_Term_WpDeleteObjectTermRelationships extends WP_UnitTestCase {
 
 		$this->assertSameSets( array( $t2 ), $terms );
 	}
+
+	public function test_delete_when_error() {
+		$taxonomy_name = 'wptests_tax';
+		register_taxonomy( $taxonomy_name, 'post' );
+		$term_id   = self::factory()->term->create( array( 'taxonomy' => $taxonomy_name ) );
+		$object_id = 567;
+		wp_set_object_terms( $object_id, array( $term_id ), $taxonomy_name );
+
+		// Confirm the setup.
+		$terms = wp_get_object_terms( $object_id, array( $taxonomy_name ), array( 'fields' => 'ids' ) );
+		$this->assertSame( array( $term_id ), $terms, 'Expected same object terms.' );
+
+		// Try wp_delete_object_term_relationships() when the taxonomy is invalid (no change expected).
+		wp_delete_object_term_relationships( $object_id, 'wptests_taxation' );
+		$terms = wp_get_object_terms( $object_id, array( $taxonomy_name ), array( 'fields' => 'ids' ) );
+		$this->assertSame( array( $term_id ), $terms, 'Expected the object terms to be unchanged.' );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64406

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
