### PR TITLE
Implement PHPStan level 8 compliance for `script-loader.php`

### DIFF
--- a/src/wp-includes/class-wp-dependencies.php
+++ b/src/wp-includes/class-wp-dependencies.php
@@ -264,9 +264,10 @@ class WP_Dependencies {
 	 * @since 2.6.0 Moved from `WP_Scripts`.
 	 *
 	 * @param string           $handle Name of the item. Should be unique.
-	 * @param string|false     $src    Full URL of the item, or path of the item relative
+	 * @param string|bool      $src    Full URL of the item, or path of the item relative
 	 *                                 to the WordPress root directory. If source is set to false,
-	 *                                 the item is an alias of other items it depends on.
+	 *                                 the item is an alias of other items it depends on. If the source is set to true,
+	 *                                 then filters will apply on the src (which is not the case when it is an alias).
 	 * @param string[]         $deps   Optional. An array of registered item handles this item depends on.
 	 *                                 Default empty array.
 	 * @param string|bool|null $ver    Optional. String specifying item version number, if it has one,

--- a/src/wp-includes/class-wp-dependency.php
+++ b/src/wp-includes/class-wp-dependency.php
@@ -30,9 +30,10 @@ class _WP_Dependency {
 	 * The handle source.
 	 *
 	 * If source is set to false, the item is an alias of other items it depends on.
+	 * If source is set to true, the item is a provisional alias since filters may provide an actual URL.
 	 *
 	 * @since 2.6.0
-	 * @var string|false
+	 * @var string|bool
 	 */
 	public $src;
 

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -413,7 +413,7 @@ class WP_Scripts extends WP_Dependencies {
 			return true;
 		}
 
-		if ( ! preg_match( '|^(https?:)?//|', $src ) && ! ( $this->content_url && str_starts_with( $src, $this->content_url ) ) ) {
+		if ( is_string( $src ) && ! preg_match( '|^(https?:)?//|', $src ) && ! ( $this->content_url && str_starts_with( $src, $this->content_url ) ) ) {
 			$src = $this->base_url . $src;
 		}
 
@@ -429,12 +429,17 @@ class WP_Scripts extends WP_Dependencies {
 				$query_args = array_merge( $query_args, $parsed_args );
 			}
 		}
-		$src = add_query_arg( rawurlencode_deep( $query_args ), $src );
+		if ( count( $query_args ) > 0 ) {
+			$src = add_query_arg( rawurlencode_deep( $query_args ), $src );
+		}
 
 		/** This filter is documented in wp-includes/class-wp-scripts.php */
-		$src = esc_url_raw( apply_filters( 'script_loader_src', $src, $handle ) );
-
-		if ( ! $src ) {
+		$src = apply_filters( 'script_loader_src', $src, $handle );
+		if ( ! is_string( $src ) ) {
+			return true;
+		}
+		$src = esc_url_raw( $src );
+		if ( ! is_string( $src ) || ! $src ) {
 			return true;
 		}
 

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -372,8 +372,8 @@ class WP_Scripts extends WP_Dependencies {
 			 *
 			 * @since 2.2.0
 			 *
-			 * @param string $src    Script loader source path.
-			 * @param string $handle Script handle.
+			 * @param string|true $src    Script loader source path.
+			 * @param string      $handle Script handle.
 			 */
 			$filtered_src = apply_filters( 'script_loader_src', $src, $handle );
 

--- a/src/wp-includes/class-wp-styles.php
+++ b/src/wp-includes/class-wp-styles.php
@@ -407,7 +407,7 @@ class WP_Styles extends WP_Dependencies {
 	 * @return string Style's fully-qualified URL.
 	 */
 	public function _css_href( $src, $ver, $handle ) {
-		if ( ! is_bool( $src ) && ! preg_match( '|^(https?:)?//|', $src ) && ! ( $this->content_url && str_starts_with( $src, $this->content_url ) ) ) {
+		if ( is_string( $src ) && ! preg_match( '|^(https?:)?//|', $src ) && ! ( $this->content_url && str_starts_with( $src, $this->content_url ) ) ) {
 			$src = $this->base_url . $src;
 		}
 

--- a/src/wp-includes/class-wp-styles.php
+++ b/src/wp-includes/class-wp-styles.php
@@ -401,7 +401,7 @@ class WP_Styles extends WP_Dependencies {
 	 *
 	 * @since 2.6.0
 	 *
-	 * @param string            $src    The source of the enqueued style.
+	 * @param string|true       $src    The source of the enqueued style.
 	 * @param string|false|null $ver    The version of the enqueued style.
 	 * @param string            $handle The style's registered handle.
 	 * @return string Style's fully-qualified URL.
@@ -423,15 +423,17 @@ class WP_Styles extends WP_Dependencies {
 				$query_args = array_merge( $query_args, $parsed_args );
 			}
 		}
-		$src = add_query_arg( rawurlencode_deep( $query_args ), $src );
+		if ( count( $query_args ) > 0 ) {
+			$src = add_query_arg( rawurlencode_deep( $query_args ), $src );
+		}
 
 		/**
 		 * Filters an enqueued style's fully-qualified URL.
 		 *
 		 * @since 2.6.0
 		 *
-		 * @param string $src    The source URL of the enqueued style.
-		 * @param string $handle The style's registered handle.
+		 * @param string|true $src    The source URL of the enqueued style.
+		 * @param string      $handle The style's registered handle.
 		 */
 		$src = apply_filters( 'style_loader_src', $src, $handle );
 		return esc_url( $src );

--- a/src/wp-includes/functions.wp-scripts.php
+++ b/src/wp-includes/functions.wp-scripts.php
@@ -141,7 +141,7 @@ function wp_add_inline_script( $handle, $data, $position = 'after' ) {
 			),
 			'4.5.0'
 		);
-		$data = trim( preg_replace( '#<script[^>]*>(.*)</script>#is', '$1', $data ) );
+		$data = trim( (string) preg_replace( '#<script[^>]*>(.*)</script>#is', '$1', $data ) );
 	}
 
 	return wp_scripts()->add_inline_script( $handle, $data, $position );
@@ -160,15 +160,15 @@ function wp_add_inline_script( $handle, $data, $position = 'after' ) {
  * @since 6.3.0 The $in_footer parameter of type boolean was overloaded to be an $args parameter of type array.
  * @since 6.9.0 The $fetchpriority parameter of type string was added to the $args parameter of type array.
  *
- * @param string           $handle    Name of the script. Should be unique.
- * @param string|false     $src       Full URL of the script, or path of the script relative to the WordPress root directory.
- *                                    If source is set to false, script is an alias of other scripts it depends on.
- * @param string[]         $deps      Optional. An array of registered script handles this script depends on. Default empty array.
- * @param string|bool|null $ver       Optional. String specifying script version number, if it has one, which is added to the URL
- *                                    as a query string for cache busting purposes. If version is set to false, a version
- *                                    number is automatically added equal to current installed WordPress version.
- *                                    If set to null, no version is added.
- * @param array|bool       $args     {
+ * @param string                          $handle Name of the script. Should be unique.
+ * @param string|false                    $src    Full URL of the script, or path of the script relative to the WordPress root directory.
+ *                                                If source is set to false, script is an alias of other scripts it depends on.
+ * @param string[]                        $deps   Optional. An array of registered script handles this script depends on. Default empty array.
+ * @param string|bool|null                $ver    Optional. String specifying script version number, if it has one, which is added to the URL
+ *                                                as a query string for cache busting purposes. If version is set to false, a version
+ *                                                number is automatically added equal to current installed WordPress version.
+ *                                                If set to null, no version is added.
+ * @param array<string, string|bool>|bool $args   {
  *     Optional. An array of additional script loading strategies. Default empty array.
  *     Otherwise, it may be a boolean in which case it determines whether the script is printed in the footer. Default false.
  *
@@ -221,10 +221,10 @@ function wp_register_script( $handle, $src, $deps = array(), $ver = false, $args
  *
  * @todo Documentation cleanup
  *
- * @param string $handle      Script handle the data will be attached to.
- * @param string $object_name Name for the JavaScript object. Passed directly, so it should be qualified JS variable.
- *                            Example: '/[a-zA-Z0-9_]+/'.
- * @param array  $l10n        The data itself. The data can be either a single or multi-dimensional array.
+ * @param string               $handle      Script handle the data will be attached to.
+ * @param string               $object_name Name for the JavaScript object. Passed directly, so it should be qualified JS variable.
+ *                                          Example: '/[a-zA-Z0-9_]+/'.
+ * @param array<string, mixed> $l10n        The data itself. The data can be either a single or multi-dimensional array.
  * @return bool True if the script was successfully localized, false otherwise.
  */
 function wp_localize_script( $handle, $object_name, $l10n ) {
@@ -346,15 +346,15 @@ function wp_deregister_script( $handle ) {
  * @since 6.3.0 The $in_footer parameter of type boolean was overloaded to be an $args parameter of type array.
  * @since 6.9.0 The $fetchpriority parameter of type string was added to the $args parameter of type array.
  *
- * @param string           $handle    Name of the script. Should be unique.
- * @param string           $src       Full URL of the script, or path of the script relative to the WordPress root directory.
- *                                    Default empty.
- * @param string[]         $deps      Optional. An array of registered script handles this script depends on. Default empty array.
- * @param string|bool|null $ver       Optional. String specifying script version number, if it has one, which is added to the URL
- *                                    as a query string for cache busting purposes. If version is set to false, a version
- *                                    number is automatically added equal to current installed WordPress version.
- *                                    If set to null, no version is added.
- * @param array|bool       $args     {
+ * @param string                          $handle Name of the script. Should be unique.
+ * @param string                          $src    Full URL of the script, or path of the script relative to the WordPress root directory.
+ *                                                Default empty.
+ * @param string[]                        $deps   Optional. An array of registered script handles this script depends on. Default empty array.
+ * @param string|bool|null                $ver    Optional. String specifying script version number, if it has one, which is added to the URL
+ *                                                as a query string for cache busting purposes. If version is set to false, a version
+ *                                                number is automatically added equal to current installed WordPress version.
+ *                                                If set to null, no version is added.
+ * @param array<string, string|bool>|bool $args   {
  *     Optional. An array of additional script loading strategies. Default empty array.
  *     Otherwise, it may be a boolean in which case it determines whether the script is printed in the footer. Default false.
  *

--- a/src/wp-includes/functions.wp-scripts.php
+++ b/src/wp-includes/functions.wp-scripts.php
@@ -161,8 +161,10 @@ function wp_add_inline_script( $handle, $data, $position = 'after' ) {
  * @since 6.9.0 The $fetchpriority parameter of type string was added to the $args parameter of type array.
  *
  * @param string                          $handle Name of the script. Should be unique.
- * @param string|false                    $src    Full URL of the script, or path of the script relative to the WordPress root directory.
+ * @param string|bool                     $src    Full URL of the script, or path of the script relative to the WordPress root directory.
  *                                                If source is set to false, script is an alias of other scripts it depends on.
+ *                                                If source is set to true, it is a provisional alias where {@see 'wp_script_loader_src'} filters
+ *                                                may also provide an actual URL.
  * @param string[]                        $deps   Optional. An array of registered script handles this script depends on. Default empty array.
  * @param string|bool|null                $ver    Optional. String specifying script version number, if it has one, which is added to the URL
  *                                                as a query string for cache busting purposes. If version is set to false, a version

--- a/src/wp-includes/functions.wp-scripts.php
+++ b/src/wp-includes/functions.wp-scripts.php
@@ -163,7 +163,7 @@ function wp_add_inline_script( $handle, $data, $position = 'after' ) {
  * @param string                          $handle Name of the script. Should be unique.
  * @param string|bool                     $src    Full URL of the script, or path of the script relative to the WordPress root directory.
  *                                                If source is set to false, script is an alias of other scripts it depends on.
- *                                                If source is set to true, it is a provisional alias where {@see 'wp_script_loader_src'} filters
+ *                                                If source is set to true, it is a provisional alias where {@see 'script_loader_src'} filters
  *                                                may also provide an actual URL.
  * @param string[]                        $deps   Optional. An array of registered script handles this script depends on. Default empty array.
  * @param string|bool|null                $ver    Optional. String specifying script version number, if it has one, which is added to the URL

--- a/src/wp-includes/functions.wp-styles.php
+++ b/src/wp-includes/functions.wp-styles.php
@@ -38,7 +38,7 @@ function wp_styles() {
  *
  * @global WP_Styles $wp_styles The WP_Styles object for printing styles.
  *
- * @param string|bool|array $handles Styles to be printed. Default 'false'.
+ * @param string|false|string[] $handles Styles to be printed. Default 'false'.
  * @return string[] On success, an array of handles of processed WP_Dependencies items; otherwise, an empty array.
  */
 function wp_print_styles( $handles = false ) {
@@ -98,7 +98,7 @@ function wp_add_inline_style( $handle, $data ) {
 			),
 			'3.7.0'
 		);
-		$data = trim( preg_replace( '#<style[^>]*>(.*)</style>#is', '$1', $data ) );
+		$data = trim( (string) preg_replace( '#<style[^>]*>(.*)</style>#is', '$1', $data ) );
 	}
 
 	return wp_styles()->add_inline_style( $handle, $data );

--- a/src/wp-includes/functions.wp-styles.php
+++ b/src/wp-includes/functions.wp-styles.php
@@ -114,8 +114,10 @@ function wp_add_inline_style( $handle, $data ) {
  * @since 4.3.0 A return value was added.
  *
  * @param string           $handle Name of the stylesheet. Should be unique.
- * @param string|false     $src    Full URL of the stylesheet, or path of the stylesheet relative to the WordPress root directory.
+ * @param string|bool      $src    Full URL of the stylesheet, or path of the stylesheet relative to the WordPress root directory.
  *                                 If source is set to false, stylesheet is an alias of other stylesheets it depends on.
+ *                                 If source is set to true, it is a provisional alias where {@see 'wp_style_loader_src'} filters
+ *                                 may also provide an actual URL.
  * @param string[]         $deps   Optional. An array of registered stylesheet handles this stylesheet depends on. Default empty array.
  * @param string|bool|null $ver    Optional. String specifying stylesheet version number, if it has one, which is added to the URL
  *                                 as a query string for cache busting purposes. If version is set to false, a version

--- a/src/wp-includes/functions.wp-styles.php
+++ b/src/wp-includes/functions.wp-styles.php
@@ -116,7 +116,7 @@ function wp_add_inline_style( $handle, $data ) {
  * @param string           $handle Name of the stylesheet. Should be unique.
  * @param string|bool      $src    Full URL of the stylesheet, or path of the stylesheet relative to the WordPress root directory.
  *                                 If source is set to false, stylesheet is an alias of other stylesheets it depends on.
- *                                 If source is set to true, it is a provisional alias where {@see 'wp_style_loader_src'} filters
+ *                                 If source is set to true, it is a provisional alias where {@see 'style_loader_src'} filters
  *                                 may also provide an actual URL.
  * @param string[]         $deps   Optional. An array of registered stylesheet handles this stylesheet depends on. Default empty array.
  * @param string|bool|null $ver    Optional. String specifying stylesheet version number, if it has one, which is added to the URL

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3074,20 +3074,6 @@ function wp_maybe_inline_styles() {
 				continue;
 			}
 			$style['css'] = file_get_contents( $style['path'] );
-			if ( false === $style['css'] ) {
-				_doing_it_wrong(
-					__FUNCTION__,
-					sprintf(
-						/* translators: 1: 'path', 2: filesystem path, 3: style handle */
-						__( 'Unable to read the "%1$s" key with value "%2$s" for stylesheet "%3$s".' ),
-						'path',
-						esc_html( $style['path'] ),
-						esc_html( $style['handle'] )
-					),
-					'7.0.0'
-				);
-				continue;
-			}
 
 			/*
 			 * Check if the style contains relative URLs that need to be modified.

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2966,8 +2966,8 @@ function wp_get_inline_script_tag( $data, $attributes = array() ) {
  *
  * @since 5.7.0
  *
- * @param string $data       Data for script tag: JavaScript, importmap, speculationrules, etc.
- * @param array<string, >  $attributes Optional. Key-value pairs representing `<script>` tag attributes.
+ * @param string                     $data       Data for script tag: JavaScript, importmap, speculationrules, etc.
+ * @param array<string, string|bool> $attributes Optional. Key-value pairs representing `<script>` tag attributes.
  */
 function wp_print_inline_script_tag( $data, $attributes = array() ) {
 	echo wp_get_inline_script_tag( $data, $attributes );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3073,7 +3073,7 @@ function wp_maybe_inline_styles() {
 				);
 				continue;
 			}
-			$style['css'] = file_get_contents( $style['path'] );
+			$style['css'] = (string) file_get_contents( $style['path'] );
 
 			/*
 			 * Check if the style contains relative URLs that need to be modified.

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3080,7 +3080,18 @@ function wp_maybe_inline_styles() {
 		$path = $wp_styles->get_data( $handle, 'path' );
 		if ( is_string( $path ) && '' !== $path && is_string( $src ) && '' !== $src ) {
 			$size = wp_filesize( $path );
-			if ( ! $size ) {
+			if ( 0 === $size ) {
+				_doing_it_wrong(
+					__FUNCTION__,
+					sprintf(
+						/* translators: 1: 'path', 2: filesystem path, 3: style handle */
+						__( 'Unable to read the "%1$s" key with value "%2$s" for stylesheet "%3$s".' ),
+						'path',
+						esc_html( $path ),
+						esc_html( $handle )
+					),
+					'7.0.0'
+				);
 				continue;
 			}
 			$styles[] = array(
@@ -3124,7 +3135,7 @@ function wp_maybe_inline_styles() {
 					__FUNCTION__,
 					sprintf(
 						/* translators: 1: 'path', 2: filesystem path, 3: style handle */
-						__( 'Unable to read file contents the "%1$s" key with value "%2$s" for stylesheet "%3$s".' ),
+						__( 'Unable to read the "%1$s" key with value "%2$s" for stylesheet "%3$s".' ),
 						'path',
 						esc_html( $style['path'] ),
 						esc_html( $style['handle'] )

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -88,21 +88,21 @@ function wp_default_packages_vendor( $scripts ) {
 	$suffix = wp_scripts_get_suffix();
 
 	$vendor_scripts = array(
-		'react',
-		'react-dom'         => array( 'react' ),
-		'react-jsx-runtime' => array( 'react' ),
-		'regenerator-runtime',
-		'moment',
-		'lodash',
-		'wp-polyfill-fetch',
-		'wp-polyfill-formdata',
-		'wp-polyfill-node-contains',
-		'wp-polyfill-url',
-		'wp-polyfill-dom-rect',
-		'wp-polyfill-element-closest',
-		'wp-polyfill-object-fit',
-		'wp-polyfill-inert',
-		'wp-polyfill',
+		'react'                       => array(),
+		'react-dom'                   => array( 'react' ),
+		'react-jsx-runtime'           => array( 'react' ),
+		'regenerator-runtime'         => array(),
+		'moment'                      => array(),
+		'lodash'                      => array(),
+		'wp-polyfill-fetch'           => array(),
+		'wp-polyfill-formdata'        => array(),
+		'wp-polyfill-node-contains'   => array(),
+		'wp-polyfill-url'             => array(),
+		'wp-polyfill-dom-rect'        => array(),
+		'wp-polyfill-element-closest' => array(),
+		'wp-polyfill-object-fit'      => array(),
+		'wp-polyfill-inert'           => array(),
+		'wp-polyfill'                 => array(),
 	);
 
 	$vendor_scripts_versions = array(
@@ -124,15 +124,13 @@ function wp_default_packages_vendor( $scripts ) {
 	);
 
 	foreach ( $vendor_scripts as $handle => $dependencies ) {
-		if ( is_string( $dependencies ) ) {
-			$handle       = $dependencies;
-			$dependencies = array();
-		}
-
-		$path    = "/wp-includes/js/dist/vendor/$handle$suffix.js";
-		$version = $vendor_scripts_versions[ $handle ];
-
-		$scripts->add( $handle, $path, $dependencies, $version, 1 );
+		$scripts->add(
+			$handle,
+			"/wp-includes/js/dist/vendor/$handle$suffix.js",
+			$dependencies,
+			$vendor_scripts_versions[ $handle ],
+			1
+		);
 	}
 
 	did_action( 'init' ) && $scripts->add_inline_script( 'lodash', 'window.lodash = _.noConflict();' );
@@ -188,7 +186,7 @@ function wp_get_script_polyfill( $scripts, $tests ) {
 		$src = $scripts->registered[ $handle ]->src;
 		$ver = $scripts->registered[ $handle ]->ver;
 
-		if ( ! preg_match( '|^(https?:)?//|', $src ) && ! ( $scripts->content_url && str_starts_with( $src, $scripts->content_url ) ) ) {
+		if ( is_string( $src ) && ! preg_match( '|^(https?:)?//|', $src ) && ! ( $scripts->content_url && str_starts_with( $src, $scripts->content_url ) ) ) {
 			$src = $scripts->base_url . $src;
 		}
 
@@ -690,14 +688,14 @@ function wp_scripts_get_suffix( $type = '' ) {
 		 * via wp-admin/load-scripts.php or wp-admin/load-styles.php, in which case
 		 * wp-includes/functions.php is not loaded.
 		 */
-		require ABSPATH . WPINC . '/version.php';
+		$versions = require ABSPATH . WPINC . '/version.php';
 
 		/*
 		 * Note: str_contains() is not used here, as this file can be included
 		 * via wp-admin/load-scripts.php or wp-admin/load-styles.php, in which case
 		 * the polyfills from wp-includes/compat.php are not loaded.
 		 */
-		$develop_src = false !== strpos( $wp_version, '-src' );
+		$develop_src = false !== strpos( $versions['wp_version'] ?? '', '-src' );
 
 		if ( ! defined( 'SCRIPT_DEBUG' ) ) {
 			define( 'SCRIPT_DEBUG', $develop_src );
@@ -1086,7 +1084,7 @@ function wp_default_scripts( $scripts ) {
 			'var mejsL10n = %s;',
 			wp_json_encode(
 				array(
-					'language' => strtolower( strtok( determine_locale(), '_-' ) ),
+					'language' => strtolower( (string) strtok( determine_locale(), '_-' ) ),
 					'strings'  => array(
 						'mejs.download-file'       => __( 'Download File' ),
 						'mejs.install-flash'       => __( 'You are using a browser that does not have Flash player enabled or installed. Please turn on your Flash player plugin or download the latest version from https://get.adobe.com/flashplayer/' ),
@@ -1553,7 +1551,7 @@ function wp_default_styles( $styles ) {
 	 * via wp-admin/load-scripts.php or wp-admin/load-styles.php, in which case
 	 * wp-includes/functions.php is not loaded.
 	 */
-	require ABSPATH . WPINC . '/version.php';
+	$versions = require ABSPATH . WPINC . '/version.php';
 
 	if ( ! defined( 'SCRIPT_DEBUG' ) ) {
 		/*
@@ -1561,7 +1559,7 @@ function wp_default_styles( $styles ) {
 		 * via wp-admin/load-scripts.php or wp-admin/load-styles.php, in which case
 		 * the polyfills from wp-includes/compat.php are not loaded.
 		 */
-		define( 'SCRIPT_DEBUG', false !== strpos( $wp_version, '-src' ) );
+		define( 'SCRIPT_DEBUG', false !== strpos( $versions['wp_version'] ?? '', '-src' ) );
 	}
 
 	$guessurl = site_url();
@@ -1605,7 +1603,7 @@ function wp_default_styles( $styles ) {
 	}
 
 	// Register a stylesheet for the selected admin color scheme.
-	$styles->add( 'colors', true, array( 'wp-admin', 'buttons' ) );
+	$styles->add( 'colors', false, array( 'wp-admin', 'buttons' ) );
 
 	$suffix = SCRIPT_DEBUG ? '' : '.min';
 
@@ -1904,7 +1902,7 @@ function wp_prototype_before_jquery( $js_array ) {
 
 	unset( $js_array[ $prototype ] );
 
-	array_splice( $js_array, $jquery, 0, 'prototype' );
+	array_splice( $js_array, (int) $jquery, 0, 'prototype' );
 
 	return $js_array;
 }
@@ -2080,7 +2078,7 @@ function wp_style_loader_src( $src, $handle ) {
 	global $_wp_admin_css_colors;
 
 	if ( wp_installing() ) {
-		return preg_replace( '#^wp-admin/#', './', $src );
+		return (string) preg_replace( '#^wp-admin/#', './', $src );
 	}
 
 	if ( 'colors' === $handle ) {
@@ -2352,7 +2350,7 @@ function print_admin_styles() {
  * @global WP_Styles $wp_styles
  * @global bool      $concatenate_scripts
  *
- * @return array|void
+ * @return string[]|void
  */
 function print_late_styles() {
 	global $wp_styles, $concatenate_scripts;
@@ -2508,8 +2506,8 @@ function wp_common_block_scripts_and_styles() {
  *
  * @since 6.1.0
  *
- * @param array $nodes The nodes to filter.
- * @return array A filtered array of style nodes.
+ * @param array<array<string, mixed>> $nodes The nodes to filter.
+ * @return array<array<string, mixed>> A filtered array of style nodes.
  */
 function wp_filter_out_block_nodes( $nodes ) {
 	return array_filter(
@@ -2869,7 +2867,7 @@ function wp_enqueue_editor_format_library_assets() {
  *
  * @since 5.7.0
  *
- * @param array $attributes Key-value pairs representing `<script>` tag attributes.
+ * @param array<string, string|bool> $attributes Key-value pairs representing `<script>` tag attributes.
  * @return string String made of sanitized `<script>` tag attributes.
  */
 function wp_sanitize_script_attributes( $attributes ) {
@@ -2901,7 +2899,7 @@ function wp_sanitize_script_attributes( $attributes ) {
  *
  * @since 5.7.0
  *
- * @param array $attributes Key-value pairs representing `<script>` tag attributes.
+ * @param array<string, string|bool> $attributes Key-value pairs representing `<script>` tag attributes.
  * @return string String containing `<script>` opening and closing tags.
  */
 function wp_get_script_tag( $attributes ) {
@@ -2934,7 +2932,7 @@ function wp_get_script_tag( $attributes ) {
  *
  * @since 5.7.0
  *
- * @param array $attributes Key-value pairs representing `<script>` tag attributes.
+ * @param array<string, string|bool> $attributes Key-value pairs representing `<script>` tag attributes.
  */
 function wp_print_script_tag( $attributes ) {
 	echo wp_get_script_tag( $attributes );
@@ -2948,8 +2946,8 @@ function wp_print_script_tag( $attributes ) {
  *
  * @since 5.7.0
  *
- * @param string $data       Data for script tag: JavaScript, importmap, speculationrules, etc.
- * @param array  $attributes Optional. Key-value pairs representing `<script>` tag attributes.
+ * @param string                     $data       Data for script tag: JavaScript, importmap, speculationrules, etc.
+ * @param array<string, string|bool> $attributes Optional. Key-value pairs representing `<script>` tag attributes.
  * @return string String containing inline JavaScript code wrapped around `<script>` tag.
  */
 function wp_get_inline_script_tag( $data, $attributes = array() ) {
@@ -2990,6 +2988,7 @@ function wp_get_inline_script_tag( $data, $attributes = array() ) {
 		! $is_html5 &&
 		(
 			! isset( $attributes['type'] ) ||
+			! is_string( $attributes['type'] ) ||
 			'module' === $attributes['type'] ||
 			str_contains( $attributes['type'], 'javascript' ) ||
 			str_contains( $attributes['type'], 'ecmascript' ) ||
@@ -3019,10 +3018,10 @@ function wp_get_inline_script_tag( $data, $attributes = array() ) {
 	 *
 	 * @since 5.7.0
 	 *
-	 * @param array  $attributes Key-value pairs representing `<script>` tag attributes.
-	 *                           Only the attribute name is added to the `<script>` tag for
-	 *                           entries with a boolean value, and that are true.
-	 * @param string $data       Inline data.
+	 * @param array<string, string|bool> $attributes Key-value pairs representing `<script>` tag attributes.
+	 *                                               Only the attribute name is added to the `<script>` tag for
+	 *                                               entries with a boolean value, and that are true.
+	 * @param string                     $data       Inline data.
 	 */
 	$attributes = apply_filters( 'wp_inline_script_attributes', $attributes, $data );
 
@@ -3038,7 +3037,7 @@ function wp_get_inline_script_tag( $data, $attributes = array() ) {
  * @since 5.7.0
  *
  * @param string $data       Data for script tag: JavaScript, importmap, speculationrules, etc.
- * @param array  $attributes Optional. Key-value pairs representing `<script>` tag attributes.
+ * @param array<string, >  $attributes Optional. Key-value pairs representing `<script>` tag attributes.
  */
 function wp_print_inline_script_tag( $data, $attributes = array() ) {
 	echo wp_get_inline_script_tag( $data, $attributes );
@@ -3057,7 +3056,7 @@ function wp_print_inline_script_tag( $data, $attributes = array() ) {
  * @global WP_Styles $wp_styles
  */
 function wp_maybe_inline_styles() {
-	global $wp_styles;
+	$wp_styles = wp_styles();
 
 	$total_inline_limit = 40000;
 	/**
@@ -3079,7 +3078,7 @@ function wp_maybe_inline_styles() {
 		}
 		$src  = $wp_styles->registered[ $handle ]->src;
 		$path = $wp_styles->get_data( $handle, 'path' );
-		if ( $path && $src ) {
+		if ( is_string( $path ) && '' !== $path && is_string( $src ) && '' !== $src ) {
 			$size = wp_filesize( $path );
 			if ( ! $size ) {
 				continue;
@@ -3120,6 +3119,20 @@ function wp_maybe_inline_styles() {
 
 			// Get the styles if we don't already have them.
 			$style['css'] = file_get_contents( $style['path'] );
+			if ( false === $style['css'] ) {
+				_doing_it_wrong(
+					__FUNCTION__,
+					sprintf(
+						/* translators: 1: 'path', 2: filesystem path, 3: style handle */
+						__( 'Unable to read file contents the "%1$s" key with value "%2$s" for stylesheet "%3$s".' ),
+						'path',
+						esc_html( $style['path'] ),
+						esc_html( $style['handle'] )
+					),
+					'7.0.0'
+				);
+				continue;
+			}
 
 			/*
 			 * Check if the style contains relative URLs that need to be modified.
@@ -3155,7 +3168,7 @@ function wp_maybe_inline_styles() {
  * @return string The CSS with URLs made relative to the WordPress installation.
  */
 function _wp_normalize_relative_css_links( $css, $stylesheet_url ) {
-	return preg_replace_callback(
+	return (string) preg_replace_callback(
 		'#(url\s*\(\s*[\'"]?\s*)([^\'"\)]+)#',
 		static function ( $matches ) use ( $stylesheet_url ) {
 			list( , $prefix, $url ) = $matches;
@@ -3231,7 +3244,7 @@ function wp_enqueue_block_support_styles( $style, $priority = 10 ) {
  *
  * @since 6.1.0
  *
- * @param array $options {
+ * @param array<string, bool> $options {
  *     Optional. An array of options to pass to wp_style_engine_get_stylesheet_from_context().
  *     Default empty array.
  *
@@ -3303,8 +3316,8 @@ function wp_enqueue_stored_styles( $options = array() ) {
  *
  * @since 5.9.0
  *
- * @param string $block_name The block-name, including namespace.
- * @param array  $args       {
+ * @param string                                   $block_name The block-name, including namespace.
+ * @param array<string, string|string[]|bool|null> $args       {
  *     An array of arguments. See wp_register_style() for full information about each argument.
  *
  *     @type string           $handle The handle for the stylesheet.
@@ -3726,7 +3739,7 @@ function wp_hoist_late_printed_styles() {
 		if ( count( $enqueued_block_styles ) > 0 ) {
 			ob_start();
 			wp_styles()->do_items( $enqueued_block_styles );
-			$printed_block_styles = ob_get_clean();
+			$printed_block_styles = (string) ob_get_clean();
 		}
 
 		/*
@@ -3736,7 +3749,7 @@ function wp_hoist_late_printed_styles() {
 		 */
 		ob_start();
 		wp_styles()->do_footer_items();
-		$printed_late_styles = ob_get_clean();
+		$printed_late_styles = (string) ob_get_clean();
 	};
 
 	/*
@@ -3753,14 +3766,14 @@ function wp_hoist_late_printed_styles() {
 		// The normal priority for wp_print_footer_scripts() is to run at 20.
 		add_action( 'wp_footer', $capture_late_styles, 20 );
 	} else {
-		remove_action( 'wp_print_footer_scripts', '_wp_footer_scripts', $wp_print_footer_scripts_priority );
+		remove_action( 'wp_print_footer_scripts', '_wp_footer_scripts', (int) $wp_print_footer_scripts_priority );
 		add_action(
 			'wp_print_footer_scripts',
 			static function () use ( $capture_late_styles ) {
 				$capture_late_styles();
 				print_footer_scripts();
 			},
-			$wp_print_footer_scripts_priority
+			(int) $wp_print_footer_scripts_priority
 		);
 	}
 

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -1602,8 +1602,14 @@ function wp_default_styles( $styles ) {
 		$open_sans_font_url = "https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,300,400,600&subset=$subsets&display=fallback";
 	}
 
-	// Register a stylesheet for the selected admin color scheme.
-	$styles->add( 'colors', false, array( 'wp-admin', 'buttons' ) );
+	/*
+	 * Register a stylesheet for the selected admin color scheme.
+	 * The src here is uniquely `true` to ensure that the dependency is not treated as an alias and so that the
+	 * `wp_style_loader_src` filters will apply. This results in the wp_style_loader_src() function applying on the
+	 * value so that it can dynamically apply the user-selected color. If no user-defined color is supplied, then
+	 * the function returns `false` so that it ultimately does behave as an alias.
+	 */
+	$styles->add( 'colors', true, array( 'wp-admin', 'buttons' ) );
 
 	$suffix = SCRIPT_DEBUG ? '' : '.min';
 
@@ -2070,15 +2076,15 @@ function wp_localize_community_events() {
  *
  * @global array $_wp_admin_css_colors
  *
- * @param string $src    Source URL.
- * @param string $handle Either 'colors' or 'colors-rtl'.
- * @return string|false URL path to CSS stylesheet for Administration Screens.
+ * @param string|bool $src    Source URL.
+ * @param string      $handle Either 'colors' or 'colors-rtl'.
+ * @return string|bool URL path to CSS stylesheet for Administration Screens.
  */
 function wp_style_loader_src( $src, $handle ) {
 	global $_wp_admin_css_colors;
 
 	if ( wp_installing() ) {
-		return (string) preg_replace( '#^wp-admin/#', './', $src );
+		return (string) preg_replace( '#^wp-admin/#', './', $src ); // TODO: Parameter #3 $subject of function preg_replace expects array<float|int|string>|string, bool|string given.
 	}
 
 	if ( 'colors' === $handle ) {
@@ -2095,7 +2101,7 @@ function wp_style_loader_src( $src, $handle ) {
 			return false;
 		}
 
-		$parsed = parse_url( $src );
+		$parsed = parse_url( $src ); // TODO: Parameter #1 $url of function parse_url expects string, bool|string given.
 		if ( isset( $parsed['query'] ) && $parsed['query'] ) {
 			wp_parse_str( $parsed['query'], $qv );
 			$url = add_query_arg( $qv, $url );

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -55,3 +55,11 @@ $required_php_extensions = array(
  * @global string $required_mysql_version
  */
 $required_mysql_version = '5.5.5';
+
+return compact(
+	'wp_version',
+	'wp_db_version',
+	'tinymce_version',
+	'required_php_version',
+	'required_php_extensions'
+);

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -61,5 +61,6 @@ return compact(
 	'wp_db_version',
 	'tinymce_version',
 	'required_php_version',
-	'required_php_extensions'
+	'required_php_extensions',
+	'required_mysql_version'
 );

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -769,6 +769,8 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 64447
+	 *
 	 * @covers ::wp_maybe_inline_styles
 	 * @expectedIncorrectUsage wp_maybe_inline_styles
 	 */

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -769,6 +769,23 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::wp_maybe_inline_styles
+	 * @expectedIncorrectUsage wp_maybe_inline_styles
+	 */
+	public function test_wp_maybe_inline_styles_bad_path() {
+		$handle   = 'test-handle';
+		$inc_path = '/css/ancient-themes.css'; // Does not exist.
+		$url      = '/' . WPINC . $inc_path;
+		wp_register_style( $handle, $url );
+		wp_style_add_data( $handle, 'path', ABSPATH . WPINC . $inc_path );
+		wp_enqueue_style( $handle );
+
+		wp_maybe_inline_styles();
+
+		$this->assertSame( $GLOBALS['wp_styles']->registered[ $handle ]->src, $url );
+	}
+
+	/**
 	 * @ticket 63887
 	 */
 	public function test_source_url_encoding() {

--- a/tests/phpunit/tests/functions/wpGetWpVersion.php
+++ b/tests/phpunit/tests/functions/wpGetWpVersion.php
@@ -31,4 +31,33 @@ class Tests_Functions_WpGetWpVersion extends WP_UnitTestCase {
 
 		$this->assertSame( $original_wp_version, $actual );
 	}
+
+	/**
+	 * Tests the `$wp_version` global matches the return value of requiring version.php.
+	 */
+	public function test_versions_returned_by_version_php() {
+		$versions = require ABSPATH . WPINC . '/version.php';
+		$this->assertIsArray( $versions, 'Expected requiring version.php to return an array.' );
+
+		$this->assertEqualSets(
+			array(
+				'wp_version',
+				'wp_db_version',
+				'tinymce_version',
+				'required_php_version',
+				'required_php_extensions',
+				'required_mysql_version',
+			),
+			array_keys( $versions ),
+			'Expected the same keys to be returned in the array when requiring version.php.'
+		);
+
+		$this->assertSame( wp_get_wp_version(), $versions['wp_version'], 'Expected global $wp_version to match the "wp_version" key.' );
+		$this->assertIsString( $versions['wp_version'], 'Expected type for wp_version.' );
+		$this->assertIsInt( $versions['wp_db_version'], 'Expected type for wp_db_version.' );
+		$this->assertIsString( $versions['tinymce_version'], 'Expected type for tinymce_version.' );
+		$this->assertIsString( $versions['required_php_version'], 'Expected type for required_php_version.' );
+		$this->assertIsArray( $versions['required_php_extensions'], 'Expected type for required_php_extensions.' );
+		$this->assertIsString( $versions['required_mysql_version'], 'Expected type for required_mysql_version.' );
+	}
 }


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64238

This fixes the following PHPStan issues for [level 8 compliance](https://phpstan.org/user-guide/rule-levels#:~:text=report%20calling%20methods%20and%20accessing%20properties%20on%20nullable%20types):

```bash
phpstan analyze --memory-limit=4G --level=8 src/wp-includes/script-loader.php
```

```
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   script-loader.php                                                                                                                                                                                                                                                                                                                                                  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  133    Offset 0|1|2|3|4|5|6|7|8|9|10|11|12|'lodash'|'moment'|'react'|'react-dom'|'react-jsx-runtime'|'regenerator-runtime'|'wp-polyfill'|'wp-polyfill-dom-rect'|'wp-polyfill-element…'|'wp-polyfill-fetch'|'wp-polyfill-formdata'|'wp-polyfill-inert'|'wp-polyfill-node…'|'wp-polyfill-object…'|'wp-polyfill-url' might not exist on array{react: '18.3.1.1', react-dom:  
         '18.3.1.1', react-jsx-runtime: '18.3.1', regenerator-runtime: '0.14.1', moment: '2.30.1', lodash: '4.17.21', wp-polyfill-fetch: '3.6.20', wp-polyfill-formdata: '4.0.10', ...}.                                                                                                                                                                                    
         🪪  offsetAccess.notFound                                                                                                                                                                                                                                                                                                                                          
         at src/wp-includes/script-loader.php:133                                                                                                                                                                                                                                                                                                                           
  135    Parameter #1 $handle of method WP_Dependencies::add() expects string, int|string given.                                                                                                                                                                                                                                                                            
         🪪  argument.type                                                                                                                                                                                                                                                                                                                                                  
         at src/wp-includes/script-loader.php:135                                                                                                                                                                                                                                                                                                                           
  191    Parameter #1 $haystack of function str_starts_with expects string, string|false given.                                                                                                                                                                                                                                                                             
         🪪  argument.type                                                                                                                                                                                                                                                                                                                                                  
         at src/wp-includes/script-loader.php:191                                                                                                                                                                                                                                                                                                                           
  191    Parameter #2 $subject of function preg_match expects string, string|false given.                                                                                                                                                                                                                                                                                   
         🪪  argument.type                                                                                                                                                                                                                                                                                                                                                  
         at src/wp-includes/script-loader.php:191                                                                                                                                                                                                                                                                                                                           
  700    Variable $wp_version might not be defined.                                                                                                                                                                                                                                                                                                                         
         🪪  variable.undefined                                                                                                                                                                                                                                                                                                                                             
         at src/wp-includes/script-loader.php:700                                                                                                                                                                                                                                                                                                                           
  1089   Parameter #1 $string of function strtolower expects string, string|false given.                                                                                                                                                                                                                                                                                    
         🪪  argument.type                                                                                                                                                                                                                                                                                                                                                  
         at src/wp-includes/script-loader.php:1089                                                                                                                                                                                                                                                                                                                          
  1564   Variable $wp_version might not be defined.                                                                                                                                                                                                                                                                                                                         
         🪪  variable.undefined                                                                                                                                                                                                                                                                                                                                             
         at src/wp-includes/script-loader.php:1564                                                                                                                                                                                                                                                                                                                          
  1608   Parameter #2 $src of method WP_Dependencies::add() expects string|false, true given.                                                                                                                                                                                                                                                                               
         🪪  argument.type                                                                                                                                                                                                                                                                                                                                                  
         at src/wp-includes/script-loader.php:1608                                                                                                                                                                                                                                                                                                                          
  1907   Parameter #2 $offset of function array_splice expects int, int|string given.                                                                                                                                                                                                                                                                                       
         🪪  argument.type                                                                                                                                                                                                                                                                                                                                                  
         at src/wp-includes/script-loader.php:1907                                                                                                                                                                                                                                                                                                                          
  2083   Function wp_style_loader_src() should return string|false but returns string|null.                                                                                                                                                                                                                                                                                 
         🪪  return.type                                                                                                                                                                                                                                                                                                                                                    
         at src/wp-includes/script-loader.php:2083                                                                                                                                                                                                                                                                                                                          
  2357   Function print_late_styles() return type has no value type specified in iterable type array.                                                                                                                                                                                                                                                                       
         🪪  missingType.iterableValue                                                                                                                                                                                                                                                                                                                                      
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                                                                                                                                                                                         
         at src/wp-includes/script-loader.php:2357                                                                                                                                                                                                                                                                                                                          
  2514   Function wp_filter_out_block_nodes() has parameter $nodes with no value type specified in iterable type array.                                                                                                                                                                                                                                                     
         🪪  missingType.iterableValue                                                                                                                                                                                                                                                                                                                                      
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                                                                                                                                                                                         
         at src/wp-includes/script-loader.php:2514                                                                                                                                                                                                                                                                                                                          
  2514   Function wp_filter_out_block_nodes() return type has no value type specified in iterable type array.                                                                                                                                                                                                                                                               
         🪪  missingType.iterableValue                                                                                                                                                                                                                                                                                                                                      
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                                                                                                                                                                                         
         at src/wp-includes/script-loader.php:2514                                                                                                                                                                                                                                                                                                                          
  2875   Function wp_sanitize_script_attributes() has parameter $attributes with no value type specified in iterable type array.                                                                                                                                                                                                                                            
         🪪  missingType.iterableValue                                                                                                                                                                                                                                                                                                                                      
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                                                                                                                                                                                         
         at src/wp-includes/script-loader.php:2875                                                                                                                                                                                                                                                                                                                          
  2907   Function wp_get_script_tag() has parameter $attributes with no value type specified in iterable type array.                                                                                                                                                                                                                                                        
         🪪  missingType.iterableValue                                                                                                                                                                                                                                                                                                                                      
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                                                                                                                                                                                         
         at src/wp-includes/script-loader.php:2907                                                                                                                                                                                                                                                                                                                          
  2939   Function wp_print_script_tag() has parameter $attributes with no value type specified in iterable type array.                                                                                                                                                                                                                                                      
         🪪  missingType.iterableValue                                                                                                                                                                                                                                                                                                                                      
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                                                                                                                                                                                         
         at src/wp-includes/script-loader.php:2939                                                                                                                                                                                                                                                                                                                          
  2955   Function wp_get_inline_script_tag() has parameter $attributes with no value type specified in iterable type array.                                                                                                                                                                                                                                                 
         🪪  missingType.iterableValue                                                                                                                                                                                                                                                                                                                                      
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                                                                                                                                                                                         
         at src/wp-includes/script-loader.php:2955                                                                                                                                                                                                                                                                                                                          
  3043   Function wp_print_inline_script_tag() has parameter $attributes with no value type specified in iterable type array.                                                                                                                                                                                                                                               
         🪪  missingType.iterableValue                                                                                                                                                                                                                                                                                                                                      
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                                                                                                                                                                                         
         at src/wp-includes/script-loader.php:3043                                                                                                                                                                                                                                                                                                                          
  3081   Call to an undefined method object::get_data().                                                                                                                                                                                                                                                                                                                    
         🪪  method.notFound                                                                                                                                                                                                                                                                                                                                                
         at src/wp-includes/script-loader.php:3081                                                                                                                                                                                                                                                                                                                          
  3099   Parameter #1 $array of function usort contains unresolvable type.                                                                                                                                                                                                                                                                                                  
         🪪  argument.unresolvableType                                                                                                                                                                                                                                                                                                                                      
         at src/wp-includes/script-loader.php:3099                                                                                                                                                                                                                                                                                                                          
  3100   Parameter #2 $callback of function usort contains unresolvable type.                                                                                                                                                                                                                                                                                               
         🪪  argument.unresolvableType                                                                                                                                                                                                                                                                                                                                      
         at src/wp-includes/script-loader.php:3100                                                                                                                                                                                                                                                                                                                          
  3128   Parameter #1 $css of function _wp_normalize_relative_css_links expects string, string|false given.                                                                                                                                                                                                                                                                 
         🪪  argument.type                                                                                                                                                                                                                                                                                                                                                  
         at src/wp-includes/script-loader.php:3128                                                                                                                                                                                                                                                                                                                          
  3158   Function _wp_normalize_relative_css_links() should return string but returns string|null.                                                                                                                                                                                                                                                                          
         🪪  return.type                                                                                                                                                                                                                                                                                                                                                    
         at src/wp-includes/script-loader.php:3158                                                                                                                                                                                                                                                                                                                          
  3244   Function wp_enqueue_stored_styles() has parameter $options with no value type specified in iterable type array.                                                                                                                                                                                                                                                    
         🪪  missingType.iterableValue                                                                                                                                                                                                                                                                                                                                      
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                                                                                                                                                                                         
         at src/wp-includes/script-loader.php:3244                                                                                                                                                                                                                                                                                                                          
  3318   Function wp_enqueue_block_style() has parameter $args with no value type specified in iterable type array.                                                                                                                                                                                                                                                         
         🪪  missingType.iterableValue                                                                                                                                                                                                                                                                                                                                      
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                                                                                                                                                                                         
         at src/wp-includes/script-loader.php:3318                                                                                                                                                                                                                                                                                                                          
  3756   Parameter #3 $priority of function remove_action expects int, int|true given.                                                                                                                                                                                                                                                                                      
         🪪  argument.type                                                                                                                                                                                                                                                                                                                                                  
         at src/wp-includes/script-loader.php:3756                                                                                                                                                                                                                                                                                                                          
  3763   Parameter #3 $priority of function add_action expects int, int|true given.                                                                                                                                                                                                                                                                                         
         🪪  argument.type                                                                                                                                                                                                                                                                                                                                                  
         at src/wp-includes/script-loader.php:3763                                                                                                                                                                                                                                                                                                                          
  3846   Parameter #1 $text of method WP_HTML_Tag_Processor@anonymous/script-loader.php:3773::insert_after() expects string, string|false given.                                                                                                                                                                                                                            
         🪪  argument.type                                                                                                                                                                                                                                                                                                                                                  
         at src/wp-includes/script-loader.php:3846                                                                                                                                                                                                                                                                                                                          
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 


 [ERROR] Found 28 errors                                                                                                
```

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
