### PR TITLE
Handle multiple feeds in `fetch_feed()`.

### DIFF
--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -806,6 +806,21 @@ function fetch_feed( $url ) {
 		require_once ABSPATH . WPINC . '/class-simplepie.php';
 	}
 
+	if ( is_array( $url ) && count( $url ) <= 1 ) {
+		$url = array_shift( $url );
+	} elseif ( is_array( $url ) ) {
+		$feeds = array();
+		foreach ( (array) $url as $feed_url ) {
+			$feeds[] = fetch_feed( $feed_url );
+		}
+		$items = SimplePie\SimplePie::merge_items( $feeds );
+
+		$feed = new SimplePie\SimplePie();
+		$feed->init();
+		$feed->data['items'] = $items;
+		return $feed;
+	}
+
 	require_once ABSPATH . WPINC . '/class-wp-feed-cache-transient.php';
 	require_once ABSPATH . WPINC . '/class-wp-simplepie-file.php';
 	require_once ABSPATH . WPINC . '/class-wp-simplepie-sanitize-kses.php';

--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -849,6 +849,7 @@ function fetch_feed( $url ) {
 		$url = array_shift( $url );
 	} elseif ( is_array( $url ) ) {
 		$feeds              = array();
+		$simplepie_errors   = array();
 		$simplepie_instance = clone $feed;
 		foreach ( $url as $feed_url ) {
 			$simplepie_instance->set_feed_url( $feed_url );
@@ -856,11 +857,22 @@ function fetch_feed( $url ) {
 			$simplepie_instance->set_output_encoding( get_bloginfo( 'charset' ) );
 
 			if ( $simplepie_instance->error() ) {
-				return new WP_Error( 'simplepie-error', $simplepie_instance->error() );
+				$simplepie_errors[] = sprintf(
+					/* translators: %1$s is the feed URL, %2$s is the error message. */
+					__( 'Error fetching feed %1$s: %2$s' ),
+					esc_url( $feed_url ),
+					$simplepie_instance->error()
+				);
+				continue;
 			}
 
 			$feeds[] = $simplepie_instance;
 		}
+
+		if ( ! empty( $simplepie_errors ) ) {
+			return new WP_Error( 'simplepie-error', $simplepie_errors );
+		}
+
 		$items = SimplePie\SimplePie::merge_items( $feeds );
 		$feed->init();
 		$feed->data['items'] = $items;

--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -846,12 +846,8 @@ function fetch_feed( $url ) {
 	do_action_ref_array( 'wp_feed_options', array( &$feed, $url ) );
 
 	if ( empty( $url ) ) {
-		/*
-		 * Known error: no URL provided do not attempt to process.
-		 *
-		 * Accounts for either an empty string or an empty array passed as the $url parameter.
-		 */
-		return new WP_Error( 'simplepie-error', __( 'A URL was not provided.' ) );
+		// Ensure $url is an empty string, even if passed as an empty array.
+		$url = '';
 	} elseif ( is_array( $url ) && count( $url ) === 1 ) {
 		$url = array_shift( $url );
 	} elseif ( is_array( $url ) ) {

--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -882,9 +882,8 @@ function fetch_feed( $url ) {
 			return new WP_Error( 'simplepie-error', $simplepie_errors );
 		}
 
-		$items = SimplePie\SimplePie::merge_items( $feeds );
 		$feed->init();
-		$feed->data['items'] = $items;
+		$feed->data['items'] = SimplePie\SimplePie::merge_items( $feeds );
 		return $feed;
 	}
 

--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -846,8 +846,23 @@ function fetch_feed( $url ) {
 	do_action_ref_array( 'wp_feed_options', array( &$feed, $url ) );
 
 	if ( empty( $url ) ) {
-		// Ensure $url is an empty string, even if passed as an empty array.
-		$url = '';
+		/*
+		 * @todo: Set $url to empty string once supported by SimplePie.
+		 *
+		 * The early return without proceeding is to work around a PHP 8.5
+		 * deprecation issue resolved in https://github.com/simplepie/simplepie/pull/949
+		 *
+		 * To avoid the duplicate code, this block can be replaced with `$url = '';` once SimplePie
+		 * is upgraded to a version that includes the fix.
+		 */
+		$feed->init();
+		$feed->set_output_encoding( get_bloginfo( 'charset' ) );
+
+		if ( $feed->error() ) {
+			return new WP_Error( 'simplepie-error', $feed->error() );
+		}
+
+		return $feed;
 	} elseif ( is_array( $url ) && count( $url ) === 1 ) {
 		$url = array_shift( $url );
 	} elseif ( is_array( $url ) ) {

--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -832,20 +832,6 @@ function fetch_feed( $url ) {
 
 	$feed->get_registry()->register( SimplePie\File::class, 'WP_SimplePie_File', true );
 
-	if ( is_array( $url ) && count( $url ) <= 1 ) {
-		$url = array_shift( $url );
-	} elseif ( is_array( $url ) ) {
-		$feeds = array();
-		foreach ( (array) $url as $feed_url ) {
-			$feeds[] = fetch_feed( $feed_url );
-		}
-		$items = SimplePie\SimplePie::merge_items( $feeds );
-		$feed->init();
-		$feed->data['items'] = $items;
-		return $feed;
-	}
-
-	$feed->set_feed_url( $url );
 	/** This filter is documented in wp-includes/class-wp-feed-cache-transient.php */
 	$feed->set_cache_duration( apply_filters( 'wp_feed_cache_transient_lifetime', 12 * HOUR_IN_SECONDS, $url ) );
 
@@ -859,6 +845,29 @@ function fetch_feed( $url ) {
 	 */
 	do_action_ref_array( 'wp_feed_options', array( &$feed, $url ) );
 
+	if ( is_array( $url ) && count( $url ) <= 1 ) {
+		$url = array_shift( $url );
+	} elseif ( is_array( $url ) ) {
+		$feeds              = array();
+		$simplepie_instance = clone $feed;
+		foreach ( (array) $url as $feed_url ) {
+			$simplepie_instance->set_feed_url( $feed_url );
+			$simplepie_instance->init();
+			$simplepie_instance->set_output_encoding( get_bloginfo( 'charset' ) );
+
+			if ( $simplepie_instance->error() ) {
+				return new WP_Error( 'simplepie-error', $simplepie_instance->error() );
+			}
+
+			$feeds[] = $simplepie_instance;
+		}
+		$items = SimplePie\SimplePie::merge_items( $feeds );
+		$feed->init();
+		$feed->data['items'] = $items;
+		return $feed;
+	}
+
+	$feed->set_feed_url( $url );
 	$feed->init();
 	$feed->set_output_encoding( get_bloginfo( 'charset' ) );
 

--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -805,6 +805,9 @@ function fetch_feed( $url ) {
 	if ( ! class_exists( 'SimplePie\SimplePie', false ) ) {
 		require_once ABSPATH . WPINC . '/class-simplepie.php';
 	}
+	require_once ABSPATH . WPINC . '/class-wp-feed-cache-transient.php';
+	require_once ABSPATH . WPINC . '/class-wp-simplepie-file.php';
+	require_once ABSPATH . WPINC . '/class-wp-simplepie-sanitize-kses.php';
 
 	if ( is_array( $url ) && count( $url ) <= 1 ) {
 		$url = array_shift( $url );
@@ -816,14 +819,21 @@ function fetch_feed( $url ) {
 		$items = SimplePie\SimplePie::merge_items( $feeds );
 
 		$feed = new SimplePie\SimplePie();
+		$feed->get_registry()->register( SimplePie\Sanitize::class, 'WP_SimplePie_Sanitize_KSES', true );
+		$feed->sanitize = new WP_SimplePie_Sanitize_KSES();
+		if ( method_exists( 'SimplePie_Cache', 'register' ) ) {
+			SimplePie_Cache::register( 'wp_transient', 'WP_Feed_Cache_Transient' );
+			$feed->set_cache_location( 'wp_transient' );
+		} else {
+			// Back-compat for SimplePie 1.2.x.
+			require_once ABSPATH . WPINC . '/class-wp-feed-cache.php';
+			$feed->set_cache_class( 'WP_Feed_Cache' );
+		}
+		$feed->get_registry()->register( SimplePie\File::class, 'WP_SimplePie_File', true );
 		$feed->init();
 		$feed->data['items'] = $items;
 		return $feed;
 	}
-
-	require_once ABSPATH . WPINC . '/class-wp-feed-cache-transient.php';
-	require_once ABSPATH . WPINC . '/class-wp-simplepie-file.php';
-	require_once ABSPATH . WPINC . '/class-wp-simplepie-sanitize-kses.php';
 
 	$feed = new SimplePie\SimplePie();
 

--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -805,35 +805,10 @@ function fetch_feed( $url ) {
 	if ( ! class_exists( 'SimplePie\SimplePie', false ) ) {
 		require_once ABSPATH . WPINC . '/class-simplepie.php';
 	}
+
 	require_once ABSPATH . WPINC . '/class-wp-feed-cache-transient.php';
 	require_once ABSPATH . WPINC . '/class-wp-simplepie-file.php';
 	require_once ABSPATH . WPINC . '/class-wp-simplepie-sanitize-kses.php';
-
-	if ( is_array( $url ) && count( $url ) <= 1 ) {
-		$url = array_shift( $url );
-	} elseif ( is_array( $url ) ) {
-		$feeds = array();
-		foreach ( (array) $url as $feed_url ) {
-			$feeds[] = fetch_feed( $feed_url );
-		}
-		$items = SimplePie\SimplePie::merge_items( $feeds );
-
-		$feed = new SimplePie\SimplePie();
-		$feed->get_registry()->register( SimplePie\Sanitize::class, 'WP_SimplePie_Sanitize_KSES', true );
-		$feed->sanitize = new WP_SimplePie_Sanitize_KSES();
-		if ( method_exists( 'SimplePie_Cache', 'register' ) ) {
-			SimplePie_Cache::register( 'wp_transient', 'WP_Feed_Cache_Transient' );
-			$feed->set_cache_location( 'wp_transient' );
-		} else {
-			// Back-compat for SimplePie 1.2.x.
-			require_once ABSPATH . WPINC . '/class-wp-feed-cache.php';
-			$feed->set_cache_class( 'WP_Feed_Cache' );
-		}
-		$feed->get_registry()->register( SimplePie\File::class, 'WP_SimplePie_File', true );
-		$feed->init();
-		$feed->data['items'] = $items;
-		return $feed;
-	}
 
 	$feed = new SimplePie\SimplePie();
 
@@ -856,6 +831,19 @@ function fetch_feed( $url ) {
 	}
 
 	$feed->get_registry()->register( SimplePie\File::class, 'WP_SimplePie_File', true );
+
+	if ( is_array( $url ) && count( $url ) <= 1 ) {
+		$url = array_shift( $url );
+	} elseif ( is_array( $url ) ) {
+		$feeds = array();
+		foreach ( (array) $url as $feed_url ) {
+			$feeds[] = fetch_feed( $feed_url );
+		}
+		$items = SimplePie\SimplePie::merge_items( $feeds );
+		$feed->init();
+		$feed->data['items'] = $items;
+		return $feed;
+	}
 
 	$feed->set_feed_url( $url );
 	/** This filter is documented in wp-includes/class-wp-feed-cache-transient.php */

--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -851,7 +851,7 @@ function fetch_feed( $url ) {
 		 *
 		 * Accounts for either an empty string or an empty array passed as the $url parameter.
 		 */
-		return new WP_Error( 'simplepie-error', __( 'WP HTTP Error: A valid URL was not provided.' ) );
+		return new WP_Error( 'simplepie-error', __( 'A URL was not provided.' ) );
 	} elseif ( is_array( $url ) && count( $url ) === 1 ) {
 		$url = array_shift( $url );
 	} elseif ( is_array( $url ) ) {

--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -850,7 +850,7 @@ function fetch_feed( $url ) {
 	} elseif ( is_array( $url ) ) {
 		$feeds              = array();
 		$simplepie_instance = clone $feed;
-		foreach ( (array) $url as $feed_url ) {
+		foreach ( $url as $feed_url ) {
 			$simplepie_instance->set_feed_url( $feed_url );
 			$simplepie_instance->init();
 			$simplepie_instance->set_output_encoding( get_bloginfo( 'charset' ) );

--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -855,10 +855,10 @@ function fetch_feed( $url ) {
 	} elseif ( is_array( $url ) && count( $url ) === 1 ) {
 		$url = array_shift( $url );
 	} elseif ( is_array( $url ) ) {
-		$feeds              = array();
-		$simplepie_errors   = array();
-		$simplepie_instance = clone $feed;
+		$feeds            = array();
+		$simplepie_errors = array();
 		foreach ( $url as $feed_url ) {
+			$simplepie_instance = clone $feed;
 			$simplepie_instance->set_feed_url( $feed_url );
 			$simplepie_instance->init();
 			$simplepie_instance->set_output_encoding( get_bloginfo( 'charset' ) );
@@ -870,10 +870,12 @@ function fetch_feed( $url ) {
 					esc_url( $feed_url ),
 					$simplepie_instance->error()
 				);
+				unset( $simplepie_instance );
 				continue;
 			}
 
 			$feeds[] = $simplepie_instance;
+			unset( $simplepie_instance );
 		}
 
 		if ( ! empty( $simplepie_errors ) ) {

--- a/src/wp-includes/feed.php
+++ b/src/wp-includes/feed.php
@@ -845,7 +845,14 @@ function fetch_feed( $url ) {
 	 */
 	do_action_ref_array( 'wp_feed_options', array( &$feed, $url ) );
 
-	if ( is_array( $url ) && count( $url ) <= 1 ) {
+	if ( empty( $url ) ) {
+		/*
+		 * Known error: no URL provided do not attempt to process.
+		 *
+		 * Accounts for either an empty string or an empty array passed as the $url parameter.
+		 */
+		return new WP_Error( 'simplepie-error', __( 'WP HTTP Error: A valid URL was not provided.' ) );
+	} elseif ( is_array( $url ) && count( $url ) === 1 ) {
 		$url = array_shift( $url );
 	} elseif ( is_array( $url ) ) {
 		$feeds              = array();

--- a/tests/phpunit/tests/feed/fetchFeed.php
+++ b/tests/phpunit/tests/feed/fetchFeed.php
@@ -45,7 +45,7 @@ class Tests_Feed_FetchFeed extends WP_UnitTestCase {
 	 * @ticket 64136
 	 */
 	public function test_fetch_feed_supports_multiple_feeds() {
-		$feed    = fetch_feed( array( 'https://wordpress.org/news/feed/', 'https://wordpress.org/news/feed/' ) );
+		$feed    = fetch_feed( array( 'https://wordpress.org/news/feed/', 'https://wordpress.org/news/feed/atom/' ) );
 		$content = array();
 
 		foreach ( $feed->get_items( 0, 2 ) as $item ) {

--- a/tests/phpunit/tests/feed/fetchFeed.php
+++ b/tests/phpunit/tests/feed/fetchFeed.php
@@ -52,7 +52,7 @@ class Tests_Feed_FetchFeed extends WP_UnitTestCase {
 			$content[] = $item->get_content();
 		}
 
-		$this->assertEqualHTML( $content[0], $content[1], null, 'The contents of both items should be identical.' );
+		$this->assertEqualHTML( $content[0], $content[1], null, 'The contents of the first two items should be identical.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/feed/fetchFeed.php
+++ b/tests/phpunit/tests/feed/fetchFeed.php
@@ -92,6 +92,32 @@ class Tests_Feed_FetchFeed extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure fetch_feed() returns WP_Error for empty URL (string).
+	 *
+	 * @ticket 64136
+	 */
+	public function test_fetch_feed_returns_an_error_for_unspecified_url() {
+		$feed = fetch_feed( '' );
+
+		$this->assertWPError( $feed, 'A WP_Error object is expected when no URL is provided.' );
+		$this->assertSame( 'simplepie-error', $feed->get_error_code() );
+		$this->assertSame( 'WP HTTP Error: A valid URL was not provided.', $feed->get_error_message() );
+	}
+
+	/**
+	 * Ensure fetch_feed() returns WP_Error for empty URL (array).
+	 *
+	 * @ticket 64136
+	 */
+	public function test_fetch_feed_returns_an_error_for_unspecified_url_array() {
+		$feed = fetch_feed( array() );
+
+		$this->assertWPError( $feed, 'A WP_Error object is expected when no URL is provided.' );
+		$this->assertSame( 'simplepie-error', $feed->get_error_code() );
+		$this->assertSame( 'WP HTTP Error: A valid URL was not provided.', $feed->get_error_message() );
+	}
+
+	/**
 	 * Ensure fetch_feed() accepts multiple feeds.
 	 *
 	 * The main purpose of this test is to ensure that the SimplePie deprecation warning

--- a/tests/phpunit/tests/feed/fetchFeed.php
+++ b/tests/phpunit/tests/feed/fetchFeed.php
@@ -53,6 +53,7 @@ class Tests_Feed_FetchFeed extends WP_UnitTestCase {
 		}
 
 		$this->assertEqualHTML( $content[0], $content[1], null, 'The contents of the first two items should be identical.' );
+		$this->assertCount( 20, $feed->get_items(), 'The feed should contain 20 items.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/feed/fetchFeed.php
+++ b/tests/phpunit/tests/feed/fetchFeed.php
@@ -101,7 +101,7 @@ class Tests_Feed_FetchFeed extends WP_UnitTestCase {
 
 		$this->assertWPError( $feed, 'A WP_Error object is expected when no URL is provided.' );
 		$this->assertSame( 'simplepie-error', $feed->get_error_code() );
-		$this->assertSame( 'WP HTTP Error: A valid URL was not provided.', $feed->get_error_message() );
+		$this->assertSame( 'A URL was not provided.', $feed->get_error_message() );
 	}
 
 	/**
@@ -114,7 +114,7 @@ class Tests_Feed_FetchFeed extends WP_UnitTestCase {
 
 		$this->assertWPError( $feed, 'A WP_Error object is expected when no URL is provided.' );
 		$this->assertSame( 'simplepie-error', $feed->get_error_code() );
-		$this->assertSame( 'WP HTTP Error: A valid URL was not provided.', $feed->get_error_message() );
+		$this->assertSame( 'A URL was not provided.', $feed->get_error_message() );
 	}
 
 	/**

--- a/tests/phpunit/tests/feed/fetchFeed.php
+++ b/tests/phpunit/tests/feed/fetchFeed.php
@@ -34,6 +34,64 @@ class Tests_Feed_FetchFeed extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure WP_Error object returned for 404 response.
+	 *
+	 * @ticket 64136
+	 */
+	public function test_fetch_feed_returns_error_for_404_response() {
+		// Priority 15 to ensure this runs after the mocked_rss_response filter.
+		add_filter( 'pre_http_request', array( $this, 'mocked_rss_404_error_response' ), 15 );
+
+		$feed = fetch_feed( 'https://example.org/news/feed/' );
+
+		$this->assertWPError( $feed, 'A WP_Error object is expected for failing requests.' );
+		$this->assertSame( 'simplepie-error', $feed->get_error_code() );
+	}
+
+	/**
+	 * Ensure fetch_feed() returns WP_Error if any feed errors.
+	 *
+	 * @ticket 64136
+	 */
+	public function test_fetch_feed_multiple_returns_error_if_any_feed_errors() {
+		// Priority 15 to ensure this runs after the mocked_rss_response filter.
+		add_filter( 'pre_http_request', array( $this, 'mocked_rss_404_error_response' ), 15 );
+		add_filter(
+			'pre_http_request',
+			/**
+			 * Remove the 404 error response after the first call.
+			 */
+			function ( $response ) {
+				remove_filter( 'pre_http_request', array( $this, 'mocked_rss_404_error_response' ), 15 );
+
+				return $response;
+			},
+			20 // Priority 20 to ensure it runs after the 404 error response.
+		);
+
+		$feed = fetch_feed( array( 'https://example.org/news/feed/', 'https://wordpress.org/news/feed/' ) );
+
+		$this->assertWPError( $feed, 'A WP_Error object is expected for any failing requests.' );
+		$this->assertSame( 'simplepie-error', $feed->get_error_code() );
+		$this->assertCount( 1, $feed->get_error_messages()[0], 'There should be one error message for the failed feed.' );
+	}
+
+	/**
+	 * Ensure fetch_feed() includes messages for all feeds that error.
+	 *
+	 * @ticket 64136
+	 */
+	public function test_fetch_feed_multiple_returns_error_if_all_feeds_error() {
+		// Priority 15 to ensure this runs after the mocked_rss_response filter.
+		add_filter( 'pre_http_request', array( $this, 'mocked_rss_404_error_response' ), 15 );
+		$feed = fetch_feed( array( 'https://example.org/news/feed/', 'https://example.com/news/feed/' ) );
+
+		$this->assertWPError( $feed, 'A WP_Error object is expected for failing requests.' );
+		$this->assertSame( 'simplepie-error', $feed->get_error_code() );
+		$this->assertCount( 2, $feed->get_error_messages()[0], 'There should be two error messages, one for each failed feed.' );
+	}
+
+	/**
 	 * Ensure fetch_feed() accepts multiple feeds.
 	 *
 	 * The main purpose of this test is to ensure that the SimplePie deprecation warning
@@ -129,6 +187,26 @@ class Tests_Feed_FetchFeed extends WP_UnitTestCase {
 			'response' => array(
 				'code'    => 200,
 				'message' => 'OK',
+			),
+			'cookies'  => array(),
+			'filename' => null,
+		);
+	}
+
+	/**
+	 * Mock 404 error response for `fetch_feed()`.
+	 *
+	 * This simulates a 404 response to test error handling in `fetch_feed()`.
+	 *
+	 * @return array Mocked 404 error response data.
+	 */
+	public function mocked_rss_404_error_response() {
+		return array(
+			'headers'  => new WpOrg\Requests\Utility\CaseInsensitiveDictionary(),
+			'body'     => '',
+			'response' => array(
+				'code'    => 404,
+				'message' => 'Not Found',
 			),
 			'cookies'  => array(),
 			'filename' => null,

--- a/tests/phpunit/tests/feed/fetchFeed.php
+++ b/tests/phpunit/tests/feed/fetchFeed.php
@@ -92,29 +92,25 @@ class Tests_Feed_FetchFeed extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensure fetch_feed() returns WP_Error for empty URL (string).
+	 * Ensure fetch_feed() returns a SimplePie object for an empty URL (string).
 	 *
 	 * @ticket 64136
 	 */
-	public function test_fetch_feed_returns_an_error_for_unspecified_url() {
+	public function test_fetch_feed_returns_a_simplepie_object_for_unspecified_url_string() {
 		$feed = fetch_feed( '' );
 
-		$this->assertWPError( $feed, 'A WP_Error object is expected when no URL is provided.' );
-		$this->assertSame( 'simplepie-error', $feed->get_error_code() );
-		$this->assertSame( 'A URL was not provided.', $feed->get_error_message() );
+		$this->assertInstanceOf( 'SimplePie\\SimplePie', $feed );
 	}
 
 	/**
-	 * Ensure fetch_feed() returns WP_Error for empty URL (array).
+	 * Ensure fetch_feed() returns a SimplePie object for an empty URL (array).
 	 *
 	 * @ticket 64136
 	 */
-	public function test_fetch_feed_returns_an_error_for_unspecified_url_array() {
+	public function test_fetch_feed_returns_a_simplepie_object_for_unspecified_url_array() {
 		$feed = fetch_feed( array() );
 
-		$this->assertWPError( $feed, 'A WP_Error object is expected when no URL is provided.' );
-		$this->assertSame( 'simplepie-error', $feed->get_error_code() );
-		$this->assertSame( 'A URL was not provided.', $feed->get_error_message() );
+		$this->assertInstanceOf( 'SimplePie\\SimplePie', $feed );
 	}
 
 	/**

--- a/tests/phpunit/tests/feed/fetchFeed.php
+++ b/tests/phpunit/tests/feed/fetchFeed.php
@@ -34,6 +34,28 @@ class Tests_Feed_FetchFeed extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure fetch_feed() accepts multiple feeds.
+	 *
+	 * The main purpose of this test is to ensure that the SimplePie deprecation warning
+	 * is not thrown when requesting multiple feeds.
+	 *
+	 * Secondly it confirms that the markup of the first two items match as they will
+	 * both be from the same feed URL as the array contains the WordPress News feed twice.
+	 *
+	 * @ticket 64136
+	 */
+	public function test_fetch_feed_supports_multiple_feeds() {
+		$feed    = fetch_feed( array( 'https://wordpress.org/news/feed/', 'https://wordpress.org/news/feed/' ) );
+		$content = array();
+
+		foreach ( $feed->get_items( 0, 2 ) as $item ) {
+			$content[] = $item->get_content();
+		}
+
+		$this->assertEqualHTML( $content[0], $content[1], null, 'The contents of both items should be identical.' );
+	}
+
+	/**
 	 * Ensure that fetch_feed() is cached on second and subsequent calls.
 	 *
 	 * Note: The HTTP request is mocked on the `pre_http_request` filter so


### PR DESCRIPTION
Handles passing an array to `fetch_feed()` by requesting each feed individually and then calling `SimplePie\SimplePie::merge_items();` on the result before passing the data back in to a SimplePie object.

I don't love this so would love some suggestions of anything I am missing.

Trac ticket: https://core.trac.wordpress.org/ticket/64136

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
