### PR TITLE
Update `build_query_vars_from_query_block` to handle new `taxQuery` structure

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2742,9 +2742,10 @@ function build_query_vars_from_query_block( $block, $page ) {
 			}
 			$query['tax_query'] = array_merge( $query['tax_query'], $tax_query_back_compat );
 		}
-		$tax_query_input = $block->context['query']['taxQuery'];
-		if ( ! empty( $tax_query_input ) && is_array( $tax_query_input ) ) {
-			$tax_query = array();
+
+		if ( ! empty( $block->context['query']['taxQuery'] ) && is_array( $block->context['query']['taxQuery'] ) ) {
+			$tax_query_input = $block->context['query']['taxQuery'];
+			$tax_query       = array();
 			// If there are keys other than include/exclude, it's the old
 			// format e.g. "taxQuery":{"category":[4]}
 			if ( ! empty( array_diff( array_keys( $tax_query_input ), array( 'include', 'exclude' ) ) ) ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2764,11 +2764,11 @@ function build_query_vars_from_query_block( $block, $page ) {
 				// Helper function to build tax_query conditions from taxonomy terms.
 				$build_conditions = static function ( array $terms, string $operator = 'IN' ): array {
 					$conditions = array();
-					foreach ( $terms as $taxonomy => $terms ) {
-						if ( ! empty( $terms ) && is_taxonomy_viewable( $taxonomy ) ) {
+					foreach ( $terms as $taxonomy => $tax_terms ) {
+						if ( ! empty( $tax_terms ) && is_taxonomy_viewable( $taxonomy ) ) {
 							$conditions[] = array(
 								'taxonomy'         => $taxonomy,
-								'terms'            => array_filter( array_map( 'intval', $terms ) ),
+								'terms'            => array_filter( array_map( 'intval', $tax_terms ) ),
 								'operator'         => $operator,
 								'include_children' => false,
 							);

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2762,7 +2762,8 @@ function build_query_vars_from_query_block( $block, $page ) {
 				// This is the new format e.g. "taxQuery":{"include":{"category":[4]},"exclude":{"post_tag":[5]}}
 
 				// Helper function to build tax_query conditions from taxonomy terms.
-				$build_conditions = static function ( array $terms, string $operator = 'IN' ): array {
+				$build_conditions = static function ( $terms, string $operator = 'IN' ): array {
+					$terms      = (array) $terms;
 					$conditions = array();
 					foreach ( $terms as $taxonomy => $tax_terms ) {
 						if ( ! empty( $tax_terms ) && is_taxonomy_viewable( $taxonomy ) ) {

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2660,6 +2660,7 @@ function wp_migrate_old_typography_shape( $metadata ) {
  * @since 5.8.0
  * @since 6.1.0 Added `query_loop_block_query_vars` filter and `parents` support in query.
  * @since 6.7.0 Added support for the `format` property in query.
+ * @since 7.0.0 Updated `taxQuery` structure.
  *
  * @param WP_Block $block Block instance.
  * @param int      $page  Current query's page.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2779,11 +2779,11 @@ function build_query_vars_from_query_block( $block, $page ) {
 
 				// Separate exclude from include terms.
 				$exclude_terms = isset( $tax_query_input['exclude'] ) && is_array( $tax_query_input['exclude'] )
-				? $tax_query_input['exclude']
-				: array();
+					? $tax_query_input['exclude']
+					: array();
 				$include_terms = isset( $tax_query_input['include'] ) && is_array( $tax_query_input['include'] )
-				? $tax_query_input['include']
-				: array();
+					? $tax_query_input['include']
+					: array();
 
 				$tax_query = array_merge(
 					$build_conditions( $include_terms ),

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2742,18 +2742,58 @@ function build_query_vars_from_query_block( $block, $page ) {
 			}
 			$query['tax_query'] = array_merge( $query['tax_query'], $tax_query_back_compat );
 		}
-		if ( ! empty( $block->context['query']['taxQuery'] ) ) {
+		$tax_query_input = $block->context['query']['taxQuery'];
+		if ( ! empty( $tax_query_input ) && is_array( $tax_query_input ) ) {
 			$tax_query = array();
-			foreach ( $block->context['query']['taxQuery'] as $taxonomy => $terms ) {
-				if ( is_taxonomy_viewable( $taxonomy ) && ! empty( $terms ) ) {
-					$tax_query[] = array(
-						'taxonomy'         => $taxonomy,
-						'terms'            => array_filter( array_map( 'intval', $terms ) ),
-						'include_children' => false,
-					);
+			// If there are keys other than include/exclude, it's the old
+			// format e.g. "taxQuery":{"category":[4]}
+			if ( ! empty( array_diff( array_keys( $tax_query_input ), array( 'include', 'exclude' ) ) ) ) {
+				foreach ( $block->context['query']['taxQuery'] as $taxonomy => $terms ) {
+					if ( is_taxonomy_viewable( $taxonomy ) && ! empty( $terms ) ) {
+						$tax_query[] = array(
+							'taxonomy'         => $taxonomy,
+							'terms'            => array_filter( array_map( 'intval', $terms ) ),
+							'include_children' => false,
+						);
+					}
 				}
+			} else {
+				// This is the new format e.g. "taxQuery":{"include":{"category":[4]},"exclude":{"post_tag":[5]}}
+
+				// Helper function to build tax_query conditions from taxonomy terms.
+				$build_conditions = static function ( $terms, $operator = 'IN' ) {
+					$conditions = array();
+					foreach ( $terms as $taxonomy => $terms ) {
+						if ( ! empty( $terms ) && is_taxonomy_viewable( $taxonomy ) ) {
+							$conditions[] = array(
+								'taxonomy'         => $taxonomy,
+								'terms'            => array_filter( array_map( 'intval', $terms ) ),
+								'operator'         => $operator,
+								'include_children' => false,
+							);
+						}
+					}
+					return $conditions;
+				};
+
+				// Separate exclude from include terms.
+				$exclude_terms = isset( $tax_query_input['exclude'] ) && is_array( $tax_query_input['exclude'] )
+				? $tax_query_input['exclude']
+				: array();
+				$include_terms = isset( $tax_query_input['include'] ) && is_array( $tax_query_input['include'] )
+				? $tax_query_input['include']
+				: array();
+
+				$tax_query = array_merge(
+					$build_conditions( $include_terms ),
+					$build_conditions( $exclude_terms, 'NOT IN' )
+				);
 			}
-			$query['tax_query'] = array_merge( $query['tax_query'], $tax_query );
+
+			if ( ! empty( $tax_query ) ) {
+				// Merge with any existing `tax_query` conditions.
+				$query['tax_query'] = array_merge( $query['tax_query'], $tax_query );
+			}
 		}
 		if ( ! empty( $block->context['query']['format'] ) && is_array( $block->context['query']['format'] ) ) {
 			$formats = $block->context['query']['format'];

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -2762,7 +2762,7 @@ function build_query_vars_from_query_block( $block, $page ) {
 				// This is the new format e.g. "taxQuery":{"include":{"category":[4]},"exclude":{"post_tag":[5]}}
 
 				// Helper function to build tax_query conditions from taxonomy terms.
-				$build_conditions = static function ( $terms, $operator = 'IN' ) {
+				$build_conditions = static function ( array $terms, string $operator = 'IN' ): array {
 					$conditions = array();
 					foreach ( $terms as $taxonomy => $terms ) {
 						if ( ! empty( $terms ) && is_taxonomy_viewable( $taxonomy ) ) {

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -838,6 +838,102 @@ HTML
 	}
 
 	/**
+	 * @ticket 64416
+	 */
+	public function test_build_query_vars_from_query_block_tax_query_old_format() {
+		$this->registry->register(
+			'core/example',
+			array( 'uses_context' => array( 'query' ) )
+		);
+
+		$parsed_blocks = parse_blocks( '<!-- wp:example {"ok":true} -->a<!-- wp:example /-->b<!-- /wp:example -->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = array(
+			'query' => array(
+				'taxQuery' => array(
+					'category' => array( 1, 2, 3 ),
+					'post_tag' => array( 10, 20 ),
+				),
+			),
+		);
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+		$query         = build_query_vars_from_query_block( $block, 1 );
+
+		$this->assertSame(
+			array(
+				'post_type'    => 'post',
+				'order'        => 'DESC',
+				'orderby'      => 'date',
+				'post__not_in' => array(),
+				'tax_query'    => array(
+					array(
+						'taxonomy'         => 'category',
+						'terms'            => array( 1, 2, 3 ),
+						'include_children' => false,
+					),
+					array(
+						'taxonomy'         => 'post_tag',
+						'terms'            => array( 10, 20 ),
+						'include_children' => false,
+					),
+				),
+			),
+			$query
+		);
+	}
+
+	/**
+	 * @ticket 64416
+	 */
+	public function test_build_query_vars_from_query_block_tax_query_include_exclude() {
+		$this->registry->register(
+			'core/example',
+			array( 'uses_context' => array( 'query' ) )
+		);
+
+		$parsed_blocks = parse_blocks( '<!-- wp:example {"ok":true} -->a<!-- wp:example /-->b<!-- /wp:example -->' );
+		$parsed_block  = $parsed_blocks[0];
+		$context       = array(
+			'query' => array(
+				'taxQuery' => array(
+					'include' => array(
+						'category' => array( 1, 2, 3 ),
+					),
+					'exclude' => array(
+						'post_tag' => array( 15 ),
+					),
+				),
+			),
+		);
+		$block         = new WP_Block( $parsed_block, $context, $this->registry );
+		$query         = build_query_vars_from_query_block( $block, 1 );
+
+		$this->assertSame(
+			array(
+				'post_type'    => 'post',
+				'order'        => 'DESC',
+				'orderby'      => 'date',
+				'post__not_in' => array(),
+				'tax_query'    => array(
+					array(
+						'taxonomy'         => 'category',
+						'terms'            => array( 1, 2, 3 ),
+						'operator'         => 'IN',
+						'include_children' => false,
+					),
+					array(
+						'taxonomy'         => 'post_tag',
+						'terms'            => array( 15 ),
+						'operator'         => 'NOT IN',
+						'include_children' => false,
+					),
+				),
+			),
+			$query
+		);
+	}
+
+	/**
 	 * @ticket 62014
 	 */
 	public function test_build_query_vars_from_query_block_standard_post_formats() {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64416

In GB we've updated the structure of Query Loop's taxQuery to also handle exclusion of terms in this PR (https://github.com/WordPress/gutenberg/pull/73790).


The new structure is: 
```js
{
	query: {
		taxQuery: {
			include: {
				category: [1, 2, 3],
				post_tag: [10, 20]
			}
			exclude: {
				category: [5, 6],
				post_tag: [15]
			}
		}
	}
}
```

We need to update build_query_vars_from_query_block to handle this new taxQuery structure.


## Testing instructions

Since this change should be handling Query Loop structure for 7.0 after the packages sync, we can test by:
1. Create two posts and post category.
2. Add the new post category to **one** of your posts.
3. In one post (doesn't matter which) insert a custom `Query Loop` (through inspector controls) and add a `taxonomy:category` filter with your created category.
4. In that post, switch to the code editor and add the below code for a Query Loop that includes the new `taxQuery` structure. Make sure to update the `category id` from the snippet, with the category id you've created. This refers to the `"taxQuery":{"include":{"category":[3]}}` part, where you should probably need to update the `3`.
```html
<!-- wp:query {"queryId":35,"query":{"perPage":2,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[],"format":[],"taxQuery":{"include":{"category":[3]}}}} -->
<div class="wp-block-query"><!-- wp:post-template -->
<!-- wp:post-title /-->

<!-- wp:post-terms {"term":"category"} /-->

<!-- wp:post-terms {"term":"post_tag"} /-->

<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"date"}}}}} /-->
<!-- /wp:post-template -->

<!-- wp:query-pagination -->
<!-- wp:query-pagination-previous /-->

<!-- wp:query-pagination-numbers /-->

<!-- wp:query-pagination-next /-->
<!-- /wp:query-pagination -->

<!-- wp:query-no-results -->
<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
<p></p>
<!-- /wp:paragraph -->
<!-- /wp:query-no-results --></div>
<!-- /wp:query -->
```

5. Save the post
6. Observe that in the editor the category filter should not work for the copied block (as the packages are not sync)
7. Visit front end and observe that the results are filtered properly based on the category for both blocks (old structure and the upcoming new structure).

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
