### PR TITLE
Tests: Add unit tests for `object_ids` handling in `WP_Term_Query`

### DIFF
--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -591,10 +591,7 @@ class WP_Term_Query {
 		}
 
 		if ( null !== $args['object_ids'] ) {
-			$args['object_ids'] = array_map(
-				'intval',
-				(array) $args['object_ids']
-			);
+			$args['object_ids'] = array_map( 'intval', (array) $args['object_ids'] );
 		}
 
 		if ( ! empty( $args['object_ids'] ) ) {

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -590,7 +590,7 @@ class WP_Term_Query {
 			);
 		}
 
-		if ( '' === $args['object_ids'] ) {
+		if ( empty( $args['object_ids'] ) && ! is_numeric( $args['object_ids'] ) ) {
 			$args['object_ids'] = array();
 		} else {
 			$args['object_ids'] = array_map( 'intval', (array) $args['object_ids'] );

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -590,10 +590,11 @@ class WP_Term_Query {
 			);
 		}
 
-		if ( empty( $args['object_ids'] ) && ! is_numeric( $args['object_ids'] ) ) {
-			$args['object_ids'] = array();
-		} else {
-			$args['object_ids'] = array_map( 'intval', (array) $args['object_ids'] );
+		if ( null !== $args['object_ids'] ) {
+			$args['object_ids'] = array_map(
+				'intval',
+				(array) $args['object_ids']
+			);
 		}
 
 		if ( ! empty( $args['object_ids'] ) ) {

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -76,7 +76,7 @@ class WP_Term_Query {
 	 * List of terms located by the query.
 	 *
 	 * @since 4.6.0
-	 * @var array
+	 * @var array|null
 	 */
 	public $terms;
 

--- a/src/wp-includes/class-wp-term-query.php
+++ b/src/wp-includes/class-wp-term-query.php
@@ -590,7 +590,9 @@ class WP_Term_Query {
 			);
 		}
 
-		if ( null !== $args['object_ids'] ) {
+		if ( '' === $args['object_ids'] ) {
+			$args['object_ids'] = array();
+		} elseif ( null !== $args['object_ids'] ) {
 			$args['object_ids'] = array_map( 'intval', (array) $args['object_ids'] );
 		}
 

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -474,6 +474,26 @@ class Tests_Term_Query extends WP_UnitTestCase {
 	/**
 	 * @ticket 63256
 	 */
+	public function test_object_ids_false_should_return_all_terms() {
+		register_taxonomy( 'wptests_tax_1', 'post' );
+
+		$terms = self::factory()->term->create_many( 3, array( 'taxonomy' => 'wptests_tax_1' ) );
+
+		$query = new WP_Term_Query(
+			array(
+				'taxonomy'   => 'wptests_tax_1',
+				'object_ids' => false,
+				'hide_empty' => false,
+				'fields'     => 'ids',
+			)
+		);
+
+		$this->assertSameSets( $terms, $query->terms, 'When object_ids is false, all terms should be returned without filtering.' );
+	}
+
+	/**
+	 * @ticket 63256
+	 */
 	public function test_object_ids_zero_should_be_treated_as_numeric() {
 		register_taxonomy( 'wptests_tax_1', 'post' );
 

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -477,7 +477,7 @@ class Tests_Term_Query extends WP_UnitTestCase {
 	public function test_object_ids_false_should_return_all_terms() {
 		register_taxonomy( 'wptests_tax_1', 'post' );
 
-		$terms = self::factory()->term->create_many( 3, array( 'taxonomy' => 'wptests_tax_1' ) );
+		self::factory()->term->create_many( 3, array( 'taxonomy' => 'wptests_tax_1' ) );
 
 		$query = new WP_Term_Query(
 			array(
@@ -488,7 +488,7 @@ class Tests_Term_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSameSets( $terms, $query->terms, 'When object_ids is false, all terms should be returned without filtering.' );
+		$this->assertSame( array(), $query->terms, 'When object_ids is false, all terms should be returned without filtering.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -477,7 +477,7 @@ class Tests_Term_Query extends WP_UnitTestCase {
 	public function test_object_ids_zero_should_be_treated_as_numeric() {
 		register_taxonomy( 'wptests_tax_1', 'post' );
 
-		$term = self::factory()->term->create( array( 'taxonomy' => 'wptests_tax_1' ) );
+		self::factory()->term->create( array( 'taxonomy' => 'wptests_tax_1' ) );
 
 		$query = new WP_Term_Query(
 			array(
@@ -488,7 +488,7 @@ class Tests_Term_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertIsArray( $query->terms, 'When object_ids is 0, it should be treated as a numeric value and return an array.' );
+		$this->assertSame( array(), $query->terms, 'When object_ids is 0, it should be treated as a numeric value and return an array.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -452,7 +452,6 @@ class Tests_Term_Query extends WP_UnitTestCase {
 	}
 
 	/**
-	 *
 	 * @ticket 63256
 	 */
 	public function test_object_ids_null_should_return_all_terms() {
@@ -469,11 +468,10 @@ class Tests_Term_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSameSets( $terms, $query->terms );
+		$this->assertSameSets( $terms, $query->terms, 'When object_ids is null, all terms should be returned without filtering.' );
 	}
 
 	/**
-	 *
 	 * @ticket 63256
 	 */
 	public function test_object_ids_zero_should_be_treated_as_numeric() {
@@ -490,7 +488,7 @@ class Tests_Term_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertIsArray( $query->terms );
+		$this->assertIsArray( $query->terms, 'When object_ids is 0, it should be treated as a numeric value and return an array.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -474,7 +474,7 @@ class Tests_Term_Query extends WP_UnitTestCase {
 	/**
 	 * @ticket 63256
 	 */
-	public function test_object_ids_false_should_return_all_terms() {
+	public function test_object_ids_false_should_return_no_terms() {
 		register_taxonomy( 'wptests_tax_1', 'post' );
 
 		self::factory()->term->create_many( 3, array( 'taxonomy' => 'wptests_tax_1' ) );
@@ -488,7 +488,7 @@ class Tests_Term_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSame( array(), $query->terms, 'When object_ids is false, all terms should be returned without filtering.' );
+		$this->assertSame( array(), $query->terms, 'When object_ids is false, no terms should be returned without filtering.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -468,6 +468,7 @@ class Tests_Term_Query extends WP_UnitTestCase {
 			)
 		);
 
+		$this->assertNull( $query->query_vars['object_ids'], 'When object_ids is null, it should remain null to avoid unnecessary processing.' );
 		$this->assertSameSets( $terms, $query->terms, 'When object_ids is null, all terms should be returned without filtering.' );
 	}
 

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -489,7 +489,7 @@ class Tests_Term_Query extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertSame( array(), $query->terms, 'When object_ids is false, no terms should be returned without filtering.' );
+		$this->assertSame( array(), $query->terms, 'When object_ids is false, no terms should be returned.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/term/query.php
+++ b/tests/phpunit/tests/term/query.php
@@ -452,6 +452,48 @@ class Tests_Term_Query extends WP_UnitTestCase {
 	}
 
 	/**
+	 *
+	 * @ticket 63256
+	 */
+	public function test_object_ids_null_should_return_all_terms() {
+		register_taxonomy( 'wptests_tax_1', 'post' );
+
+		$terms = self::factory()->term->create_many( 3, array( 'taxonomy' => 'wptests_tax_1' ) );
+
+		$query = new WP_Term_Query(
+			array(
+				'taxonomy'   => 'wptests_tax_1',
+				'object_ids' => null,
+				'hide_empty' => false,
+				'fields'     => 'ids',
+			)
+		);
+
+		$this->assertSameSets( $terms, $query->terms );
+	}
+
+	/**
+	 *
+	 * @ticket 63256
+	 */
+	public function test_object_ids_zero_should_be_treated_as_numeric() {
+		register_taxonomy( 'wptests_tax_1', 'post' );
+
+		$term = self::factory()->term->create( array( 'taxonomy' => 'wptests_tax_1' ) );
+
+		$query = new WP_Term_Query(
+			array(
+				'taxonomy'   => 'wptests_tax_1',
+				'object_ids' => 0,
+				'hide_empty' => false,
+				'fields'     => 'ids',
+			)
+		);
+
+		$this->assertIsArray( $query->terms );
+	}
+
+	/**
 	 * @ticket 38295
 	 * @group cache
 	 */


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/63256

Adds unit test coverage for the fix implemented in #8668 that addresses unnecessary `array_map()` processing in `WP_Term_Query::get_terms()` when `object_ids` is not set.

This PR - 

   - Verifies that when `object_ids` is `null` (default), all terms are returned without filtering
   - Ensures the optimization skips unnecessary `array_map()` processing
   - Validates that numeric zero (`0`) is treated as a valid object ID
   - Prevents regression where `0` might be incorrectly treated as empty

### Testing
```bash
npm run test:php -- --filter=Tests_Term_Query
```

Follows the patch of https://github.com/WordPress/wordpress-develop/pull/8668 by @dilipbheda

Props: @dilipbheda for the original patch
