### PR TITLE
Use inaccessible content attributes as old browser fallback.

### DIFF
--- a/src/js/_enqueues/vendor/thickbox/thickbox.css
+++ b/src/js/_enqueues/vendor/thickbox/thickbox.css
@@ -134,6 +134,7 @@
 }
 
 .tb-close-icon:before {
+	content: "\f158";
 	content: "\f158" / '';
 	font: normal 20px/29px dashicons;
 	-webkit-font-smoothing: antialiased;

--- a/src/wp-admin/css/admin-menu.css
+++ b/src/wp-admin/css/admin-menu.css
@@ -503,6 +503,7 @@ ul#adminmenu > li.current > a.current:after {
 }
 
 #collapse-button .collapse-button-icon:after {
+	content: "\f148";
 	content: "\f148" / '';
 	display: block;
 	position: relative;

--- a/src/wp-admin/css/colors/_admin.scss
+++ b/src/wp-admin/css/colors/_admin.scss
@@ -68,6 +68,7 @@ span.wp-media-buttons-icon:before {
 /* Forms */
 
 input[type=checkbox]:checked::before {
+	content: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20d%3D%27M14.83%204.89l1.34.94-5.81%208.38H9.02L5.78%209.67l1.34-1.25%202.57%202.4z%27%20fill%3D%27#{url-friendly-colour(variables.$form-checked)}%27%2F%3E%3C%2Fsvg%3E");
 	content: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20d%3D%27M14.83%204.89l1.34.94-5.81%208.38H9.02L5.78%209.67l1.34-1.25%202.57%202.4z%27%20fill%3D%27#{url-friendly-colour(variables.$form-checked)}%27%2F%3E%3C%2Fsvg%3E") / '';
 }
 

--- a/src/wp-admin/css/common.css
+++ b/src/wp-admin/css/common.css
@@ -559,6 +559,7 @@ code {
 }
 
 .js-update-details-toggle[aria-expanded="true"] .dashicons::before {
+	content: "\f142";
 	content: "\f142" / '';
 }
 
@@ -805,6 +806,7 @@ img.emoji {
 .notice-dismiss:before {
 	background: none;
 	color: #787c82;
+	content: "\f153";
 	content: "\f153" / '';
 	display: block;
 	font: normal 16px/20px dashicons;
@@ -1132,6 +1134,7 @@ th.action-links {
 }
 
 .wp-filter .drawer-toggle:before {
+	content: "\f111";
 	content: "\f111" / '';
 	margin: 0 5px 0 0;
 	color: #646970;
@@ -1524,6 +1527,7 @@ div.error {
 
 #plugin-information-footer .update-now:not(.button-disabled):before {
 	color: #d63638;
+	content: "\f463";
 	content: "\f463" / '';
 	display: inline-block;
 	font: normal 20px/1 dashicons;
@@ -1586,6 +1590,7 @@ div.error {
 .button.installing:before,
 .button.activating-message:before {
 	color: #d63638;
+	content: "\f463";
 	content: "\f463" / '';
 }
 
@@ -1622,12 +1627,14 @@ div.error {
 .button.updated-message:before,
 .button.activated-message:before {
 	color: #68de7c;
+	content: "\f147";
 	content: "\f147" / '';
 }
 
 /* Error icon. */
 .update-message.notice-error p:before {
 	color: #d63638;
+	content: "\f534";
 	content: "\f534" / '';
 }
 
@@ -1837,6 +1844,7 @@ p.auto-update-status {
 
 #screen-meta-links .show-settings:after {
 	right: 0;
+	content: "\f140";
 	content: "\f140" / '';
 	font: normal 20px/1 dashicons;
 	display: inline-block;
@@ -1850,6 +1858,7 @@ p.auto-update-status {
 }
 
 #screen-meta-links .screen-meta-active:after {
+	content: "\f142";
 	content: "\f142" / '';
 }
 
@@ -2671,10 +2680,12 @@ div.star-holder .star-rating {
 }
 
 .star-rating .star-full:before {
+	content: "\f155";
 	content: "\f155" / '';
 }
 
 .star-rating .star-half:before {
+	content: "\f459";
 	content: "\f459" / '';
 }
 
@@ -2683,6 +2694,7 @@ div.star-holder .star-rating {
 }
 
 .star-rating .star-empty:before {
+	content: "\f154";
 	content: "\f154" / '';
 }
 
@@ -3174,6 +3186,7 @@ div.action-links {
 }
 
 .plugin-details-modal #TB_closeWindowButton:after {
+	content: "\f335";
 	content: "\f335" / '';
 	font: normal 32px/29px 'dashicons';
 	-webkit-font-smoothing: antialiased;
@@ -3200,6 +3213,7 @@ img {
 .meta-box-sortables .postbox .order-lower-indicator::before,
 .bulk-action-notice .toggle-indicator::before,
 .privacy-text-box .toggle-indicator::before {
+	content: "\f142";
 	content: "\f142" / '';
 	display: inline-block;
 	font: normal 20px/1 dashicons;
@@ -3212,15 +3226,18 @@ img {
 .meta-box-sortables .postbox.closed .handlediv .toggle-indicator::before,
 .bulk-action-notice .bulk-action-errors-collapsed .toggle-indicator::before,
 .privacy-text-box.closed .toggle-indicator::before {
+	content: "\f140";
 	content: "\f140" / '';
 }
 
 .postbox .handle-order-higher .order-higher-indicator::before {
+	content: "\f343";
 	content: "\f343" / '';
 	color: inherit;
 }
 
 .postbox .handle-order-lower .order-lower-indicator::before {
+	content: "\f347";
 	content: "\f347" / '';
 	color: inherit;
 }
@@ -3344,9 +3361,11 @@ img {
 	pointer-events: none;
 }
 [role="treeitem"][aria-expanded="false"] > .folder-label .icon:after {
+	content: "\f139";
 	content: "\f139" / '';
 }
 [role="treeitem"][aria-expanded="true"] > .folder-label .icon:after {
+	content: "\f140";
 	content: "\f140" / '';
 }
 [role="treeitem"] .folder-label {
@@ -3562,6 +3581,7 @@ img {
 .wp-customizer .control-section .accordion-section-title:after,
 .wp-customizer .accordion-section-title:after,
 .widget-top .widget-action .toggle-indicator:before {
+	content: "\f140";
 	content: "\f140" / '';
 	font: normal 20px/1 dashicons;
 	display: block;
@@ -3610,6 +3630,7 @@ img {
 .nav-menus-php .menu-item-edit-active .item-edit:before,
 .widget.open .widget-top .widget-action .toggle-indicator:before,
 .widget.widget-in-question .widget-top .widget-action .toggle-indicator:before {
+	content: "\f142";
 	content: "\f142" / '';
 }
 

--- a/src/wp-admin/css/customize-controls.css
+++ b/src/wp-admin/css/customize-controls.css
@@ -233,6 +233,7 @@ body.trashing #publish-settings {
 	display: inline-block;
 }
 #customize-control-trash_changeset .button-link:before {
+	content: "\f182";
 	content: "\f182" / '';
 	font: normal 22px dashicons;
 	text-decoration: none;
@@ -594,6 +595,7 @@ body.trashing #publish-settings {
 
 #customize-theme-controls .accordion-section-title:after,
 #customize-outer-theme-controls .accordion-section-title:after {
+	content: "\f345";
 	content: "\f345" / '';
 	color: #a7aaad;
 	pointer-events: none;
@@ -931,6 +933,7 @@ h3.customize-section-title {
 
 .customize-controls-close:before {
 	font: normal 22px/45px dashicons;
+	content: "\f335";
 	content: "\f335" / '';
 	position: relative;
 	top: -3px;
@@ -940,6 +943,7 @@ h3.customize-section-title {
 .customize-panel-back:before,
 .customize-section-back:before {
 	font: normal 20px/72px dashicons;
+	content: "\f341";
 	content: "\f341" / '';
 	position: relative;
 	left: 9px;
@@ -1026,6 +1030,7 @@ p.customize-section-description {
 
 .customize-section-description a.external-link:after {
 	font: 16px/11px dashicons;
+	content: "\f504";
 	content: "\f504" / '';
 	top: 3px;
 	position: relative;
@@ -1357,6 +1362,7 @@ p.customize-section-description {
 }
 
 .customize-control .dropdown-arrow:after {
+	content: "\f140";
 	content: "\f140" / '';
 	font: normal 20px/1 dashicons;
 	display: block;
@@ -1881,6 +1887,7 @@ p.customize-section-description {
 }
 
 .themes-filter-bar .feature-filter-toggle:before {
+	content: "\f111";
 	content: "\f111" / '';
 	margin: 0 5px 0 0;
 	font: normal 16px/1 dashicons;
@@ -2019,6 +2026,7 @@ p.customize-section-description {
 }
 
 .control-panel-themes .theme-section .customize-themes-section-title.selected:after {
+	content: "\f147";
 	content: "\f147" / '';
 	font: 16px/1 dashicons;
 	box-sizing: border-box;
@@ -2522,6 +2530,7 @@ body.cheatin p {
 .add-new-widget:before,
 .add-new-menu-item:before,
 #available-menu-items .new-content-item .add-content:before {
+	content: "\f132";
 	content: "\f132" / '';
 	display: inline-block;
 	position: relative;
@@ -2601,11 +2610,13 @@ body.cheatin p {
 
 .move-widget-down:before,
 .menus-move-down:before {
+	content: "\f347";
 	content: "\f347" / '';
 }
 
 .move-widget-up:before,
 .menus-move-up:before {
+	content: "\f343";
 	content: "\f343" / '';
 }
 
@@ -2766,6 +2777,7 @@ body.adding-widget .add-new-widget:before,
 
 #available-widgets-filter .clear-results:before,
 #available-menu-items-search .clear-results:before {
+	content: "\f335";
 	content: "\f335" / '';
 	font: normal 20px/1 dashicons;
 	vertical-align: middle;
@@ -2977,6 +2989,7 @@ body.adding-widget .add-new-widget:before,
 	.customize-controls-preview-toggle .preview:before,
 	.customize-controls-preview-toggle .controls:before {
 		font: normal 20px/1 dashicons;
+		content: "\f177";
 		content: "\f177" / '';
 		position: relative;
 		top: 4px;
@@ -2984,6 +2997,7 @@ body.adding-widget .add-new-widget:before,
 	}
 
 	.customize-controls-preview-toggle .controls:before {
+		content: "\f540";
 		content: "\f540" / '';
 	}
 

--- a/src/wp-admin/css/customize-nav-menus.css
+++ b/src/wp-admin/css/customize-nav-menus.css
@@ -141,10 +141,12 @@
 }
 
 .menus-move-left:before {
+	content: "\f341";
 	content: "\f341" / '';
 }
 
 .menus-move-right:before {
+	content: "\f345";
 	content: "\f345" / '';
 }
 
@@ -177,6 +179,7 @@
 }
 
 .wp-customizer .menu-item.menu-item-edit-active .item-edit .toggle-indicator:before {
+	content: "\f142";
 	content: "\f142" / '';
 }
 
@@ -277,6 +280,7 @@
 .customize-screen-options-toggle:before {
 	-moz-osx-font-smoothing: grayscale;
 	border: none;
+	content: "\f111";
 	content: "\f111" / '';
 	display: block;
 	font: 18px/1 dashicons;
@@ -320,6 +324,7 @@
 
 .wp-customizer .menu-item .item-edit .toggle-indicator:before,
 #available-menu-items .accordion-section-title .toggle-indicator:before {
+	content: "\f140";
 	content: "\f140" / '';
 	display: block;
 	padding: 1px 2px 1px 0;
@@ -466,6 +471,7 @@
 }
 
 .menu-item-bar .item-delete:before {
+	content: "\f335";
 	content: "\f335" / '';
 	position: absolute;
 	top: 9px;
@@ -651,6 +657,7 @@
 }
 
 #available-menu-items .item-add:before {
+	content: "\f543";
 	content: "\f543" / '';
 	position: relative;
 	left: 2px;
@@ -669,6 +676,7 @@
 }
 
 #available-menu-items .menu-item-handle.item-added .item-add:before {
+	content: "\f147";
 	content: "\f147" / '';
 }
 

--- a/src/wp-admin/css/customize-widgets.css
+++ b/src/wp-admin/css/customize-widgets.css
@@ -349,65 +349,65 @@ body.adding-widget #customize-preview {
 #available-widgets [class*="comment"] .widget-title:before,
 #available-widgets [class*="testimonial"] .widget-title:before,
 #available-widgets [class*="chat"] .widget-title:before {
-	content:"\f101";
-	content:"\f101" / '';
+	content: "\f101";
+	content: "\f101" / '';
 }
 
 /* dashicons-admin-post */
 #available-widgets [class*="post"] .widget-title:before {
-	content:"\f109";
-	content:"\f109" / '';
+	content: "\f109";
+	content: "\f109" / '';
 }
 
 /* dashicons-admin-page */
 #available-widgets [class*="page"] .widget-title:before {
-	content:"\f105";
-	content:"\f105" / '';
+	content: "\f105";
+	content: "\f105" / '';
 }
 
 /* dashicons-text */
 #available-widgets [class*="text"] .widget-title:before {
-	content:"\f478";
-	content:"\f478" / '';
+	content: "\f478";
+	content: "\f478" / '';
 }
 
 /* dashicons-admin-links */
 #available-widgets [class*="link"] .widget-title:before {
-	content:"\f103";
-	content:"\f103" / '';
+	content: "\f103";
+	content: "\f103" / '';
 }
 
 /* dashicons-search */
 #available-widgets [class*="search"] .widget-title:before {
-	content:"\f179";
-	content:"\f179" / '';
+	content: "\f179";
+	content: "\f179" / '';
 }
 
 /* dashicons-menu */
 #available-widgets [class*="menu"] .widget-title:before,
 #available-widgets [class*="nav"] .widget-title:before {
-	content:"\f333";
-	content:"\f333" / '';
+	content: "\f333";
+	content: "\f333" / '';
 }
 
 /* dashicons-tagcloud */
 #available-widgets [class*="tag"] .widget-title:before {
-	content:"\f479";
-	content:"\f479" / '';
+	content: "\f479";
+	content: "\f479" / '';
 }
 
 /* dashicons-rss */
 #available-widgets [class*="rss"] .widget-title:before {
-	content:"\f303";
-	content:"\f303" / '';
+	content: "\f303";
+	content: "\f303" / '';
 	top: -6px;
 }
 
 /* dashicons-calendar */
 #available-widgets [class*="event"] .widget-title:before,
 #available-widgets [class*="calendar"] .widget-title:before {
-	content:"\f145";
-	content:"\f145" / '';
+	content: "\f145";
+	content: "\f145" / '';
 	top: -4px;
 }
 
@@ -416,30 +416,30 @@ body.adding-widget #customize-preview {
 #available-widgets [class*="photo"] .widget-title:before,
 #available-widgets [class*="slide"] .widget-title:before,
 #available-widgets [class*="instagram"] .widget-title:before {
-	content:"\f128";
-	content:"\f128" / '';
+	content: "\f128";
+	content: "\f128" / '';
 }
 
 /* dashicons-format-gallery */
 #available-widgets [class*="album"] .widget-title:before,
 #available-widgets [class*="galler"] .widget-title:before {
-	content:"\f161";
-	content:"\f161" / '';
+	content: "\f161";
+	content: "\f161" / '';
 }
 
 /* dashicons-format-video */
 #available-widgets [class*="video"] .widget-title:before,
 #available-widgets [class*="tube"] .widget-title:before {
-	content:"\f126";
-	content:"\f126" / '';
+	content: "\f126";
+	content: "\f126" / '';
 }
 
 /* dashicons-format-audio */
 #available-widgets [class*="music"] .widget-title:before,
 #available-widgets [class*="radio"] .widget-title:before,
 #available-widgets [class*="audio"] .widget-title:before {
-	content:"\f127";
-	content:"\f127" / '';
+	content: "\f127";
+	content: "\f127" / '';
 }
 
 /* dashicons-admin-users */
@@ -450,38 +450,38 @@ body.adding-widget #customize-preview {
 #available-widgets [class*="subscriber"] .widget-title:before,
 #available-widgets [class*="profile"] .widget-title:before,
 #available-widgets [class*="grofile"] .widget-title:before {
-	content:"\f110";
-	content:"\f110" / '';
+	content: "\f110";
+	content: "\f110" / '';
 }
 
 /* dashicons-cart */
 #available-widgets [class*="commerce"] .widget-title:before,
 #available-widgets [class*="shop"] .widget-title:before,
 #available-widgets [class*="cart"] .widget-title:before {
-	content:"\f174";
-	content:"\f174" / '';
+	content: "\f174";
+	content: "\f174" / '';
 	top: -4px;
 }
 
 /* dashicons-shield */
 #available-widgets [class*="secur"] .widget-title:before,
 #available-widgets [class*="firewall"] .widget-title:before {
-	content:"\f332";
-	content:"\f332" / '';
+	content: "\f332";
+	content: "\f332" / '';
 }
 
 /* dashicons-chart-bar */
 #available-widgets [class*="analytic"] .widget-title:before,
 #available-widgets [class*="stat"] .widget-title:before,
 #available-widgets [class*="poll"] .widget-title:before {
-	content:"\f185";
-	content:"\f185" / '';
+	content: "\f185";
+	content: "\f185" / '';
 }
 
 /* dashicons-feedback */
 #available-widgets [class*="form"] .widget-title:before {
-	content:"\f175";
-	content:"\f175" / '';
+	content: "\f175";
+	content: "\f175" / '';
 }
 
 /* dashicons-email-alt */
@@ -489,48 +489,48 @@ body.adding-widget #customize-preview {
 #available-widgets [class*="news"] .widget-title:before,
 #available-widgets [class*="contact"] .widget-title:before,
 #available-widgets [class*="mail"] .widget-title:before {
-	content:"\f466";
-	content:"\f466" / '';
+	content: "\f466";
+	content: "\f466" / '';
 }
 
 /* dashicons-share */
 #available-widgets [class*="share"] .widget-title:before,
 #available-widgets [class*="socia"] .widget-title:before {
-	content:"\f237";
-	content:"\f237" / '';
+	content: "\f237";
+	content: "\f237" / '';
 }
 
 /* dashicons-translation */
 #available-widgets [class*="lang"] .widget-title:before,
 #available-widgets [class*="translat"] .widget-title:before {
-	content:"\f326";
-	content:"\f326" / '';
+	content: "\f326";
+	content: "\f326" / '';
 }
 
 /* dashicons-location-alt */
 #available-widgets [class*="locat"] .widget-title:before,
 #available-widgets [class*="map"] .widget-title:before {
-	content:"\f231";
-	content:"\f231" / '';
+	content: "\f231";
+	content: "\f231" / '';
 }
 
 /* dashicons-download */
 #available-widgets [class*="download"] .widget-title:before {
-	content:"\f316";
-	content:"\f316" / '';
+	content: "\f316";
+	content: "\f316" / '';
 }
 
 /* dashicons-cloud */
 #available-widgets [class*="weather"] .widget-title:before {
-	content:"\f176";
-	content:"\f176" / '';
+	content: "\f176";
+	content: "\f176" / '';
 	top: -4px;
 }
 
 /* dashicons-facebook */
 #available-widgets [class*="facebook"] .widget-title:before {
-	content:"\f304";
-	content:"\f304" / '';
+	content: "\f304";
+	content: "\f304" / '';
 }
 
 /* dashicons-twitter */

--- a/src/wp-admin/css/customize-widgets.css
+++ b/src/wp-admin/css/customize-widgets.css
@@ -340,9 +340,10 @@ body.adding-widget #customize-preview {
 
 /* dashicons-category */
 #available-widgets [class*="categor"] .widget-title:before {
-	content:"\f318";
-	content:"\f318" / '';
-	top: -4px; }
+	content: "\f318";
+	content: "\f318" / '';
+	top: -4px;
+}
 
 /* dashicons-admin-comments */
 #available-widgets [class*="comment"] .widget-title:before,

--- a/src/wp-admin/css/customize-widgets.css
+++ b/src/wp-admin/css/customize-widgets.css
@@ -130,6 +130,7 @@
 }
 
 .move-widget:before {
+	content: "\f504";
 	content: "\f504" / '';
 }
 
@@ -170,6 +171,7 @@
 
 #customize-theme-controls .widget-area-select li:before {
 	display: none;
+	content: "\f147";
 	content: "\f147" / '';
 	position: absolute;
 	top: 12px;
@@ -292,6 +294,7 @@ body.adding-widget #customize-preview {
 }
 
 #available-widgets .widget-title:before {
+	content: "\f132";
 	content: "\f132" / '';
 	position: absolute;
 	top: -3px;
@@ -308,73 +311,135 @@ body.adding-widget #customize-preview {
 }
 
 /* dashicons-smiley */
-#available-widgets [class*="easy"] .widget-title:before { content: "\f328" / ''; top: -4px; }
+#available-widgets [class*="easy"] .widget-title:before {
+	content: "\f328";
+	content: "\f328" / '';
+	top: -4px;
+}
 
 /* dashicons-star-filled */
 #available-widgets [class*="super"] .widget-title:before,
-#available-widgets [class*="like"] .widget-title:before { content: "\f155" / ''; top: -4px; }
+#available-widgets [class*="like"] .widget-title:before {
+	content: "\f155";
+	content: "\f155" / '';
+	top: -4px;
+}
 
 /* dashicons-wordpress */
-#available-widgets [class*="meta"] .widget-title:before { content: "\f120" / ''; }
+#available-widgets [class*="meta"] .widget-title:before {
+	content: "\f120";
+	content: "\f120" / '';
+}
 
 /* dashicons-archive */
-#available-widgets [class*="archives"] .widget-title:before { content: "\f480" / ''; top: -4px; }
+#available-widgets [class*="archives"] .widget-title:before {
+	content: "\f480";
+	content: "\f480" / '';
+	top: -4px;
+}
 
 /* dashicons-category */
-#available-widgets [class*="categor"] .widget-title:before { content: "\f318" / ''; top: -4px; }
+#available-widgets [class*="categor"] .widget-title:before {
+	content:"\f318";
+	content:"\f318" / '';
+	top: -4px; }
 
 /* dashicons-admin-comments */
 #available-widgets [class*="comment"] .widget-title:before,
 #available-widgets [class*="testimonial"] .widget-title:before,
-#available-widgets [class*="chat"] .widget-title:before { content: "\f101" / ''; }
+#available-widgets [class*="chat"] .widget-title:before {
+	content:"\f101";
+	content:"\f101" / '';
+}
 
 /* dashicons-admin-post */
-#available-widgets [class*="post"] .widget-title:before { content: "\f109" / ''; }
+#available-widgets [class*="post"] .widget-title:before {
+	content:"\f109";
+	content:"\f109" / '';
+}
 
 /* dashicons-admin-page */
-#available-widgets [class*="page"] .widget-title:before { content: "\f105" / ''; }
+#available-widgets [class*="page"] .widget-title:before {
+	content:"\f105";
+	content:"\f105" / '';
+}
 
 /* dashicons-text */
-#available-widgets [class*="text"] .widget-title:before { content: "\f478" / ''; }
+#available-widgets [class*="text"] .widget-title:before {
+	content:"\f478";
+	content:"\f478" / '';
+}
 
 /* dashicons-admin-links */
-#available-widgets [class*="link"] .widget-title:before { content: "\f103" / ''; }
+#available-widgets [class*="link"] .widget-title:before {
+	content:"\f103";
+	content:"\f103" / '';
+}
 
 /* dashicons-search */
-#available-widgets [class*="search"] .widget-title:before { content: "\f179" / ''; }
+#available-widgets [class*="search"] .widget-title:before {
+	content:"\f179";
+	content:"\f179" / '';
+}
 
 /* dashicons-menu */
 #available-widgets [class*="menu"] .widget-title:before,
-#available-widgets [class*="nav"] .widget-title:before { content: "\f333" / ''; }
+#available-widgets [class*="nav"] .widget-title:before {
+	content:"\f333";
+	content:"\f333" / '';
+}
 
 /* dashicons-tagcloud */
-#available-widgets [class*="tag"] .widget-title:before { content: "\f479" / ''; }
+#available-widgets [class*="tag"] .widget-title:before {
+	content:"\f479";
+	content:"\f479" / '';
+}
 
 /* dashicons-rss */
-#available-widgets [class*="rss"] .widget-title:before { content: "\f303" / ''; top: -6px; }
+#available-widgets [class*="rss"] .widget-title:before {
+	content:"\f303";
+	content:"\f303" / '';
+	top: -6px;
+}
 
 /* dashicons-calendar */
 #available-widgets [class*="event"] .widget-title:before,
-#available-widgets [class*="calendar"] .widget-title:before { content: "\f145" / ''; top: -4px;}
+#available-widgets [class*="calendar"] .widget-title:before {
+	content:"\f145";
+	content:"\f145" / '';
+	top: -4px;
+}
 
 /* dashicons-format-image */
 #available-widgets [class*="image"] .widget-title:before,
 #available-widgets [class*="photo"] .widget-title:before,
 #available-widgets [class*="slide"] .widget-title:before,
-#available-widgets [class*="instagram"] .widget-title:before { content: "\f128" / ''; }
+#available-widgets [class*="instagram"] .widget-title:before {
+	content:"\f128";
+	content:"\f128" / '';
+}
 
 /* dashicons-format-gallery */
 #available-widgets [class*="album"] .widget-title:before,
-#available-widgets [class*="galler"] .widget-title:before { content: "\f161" / ''; }
+#available-widgets [class*="galler"] .widget-title:before {
+	content:"\f161";
+	content:"\f161" / '';
+}
 
 /* dashicons-format-video */
 #available-widgets [class*="video"] .widget-title:before,
-#available-widgets [class*="tube"] .widget-title:before { content: "\f126" / ''; }
+#available-widgets [class*="tube"] .widget-title:before {
+	content:"\f126";
+	content:"\f126" / '';
+}
 
 /* dashicons-format-audio */
 #available-widgets [class*="music"] .widget-title:before,
 #available-widgets [class*="radio"] .widget-title:before,
-#available-widgets [class*="audio"] .widget-title:before { content: "\f127" / ''; }
+#available-widgets [class*="audio"] .widget-title:before {
+	content:"\f127";
+	content:"\f127" / '';
+}
 
 /* dashicons-admin-users */
 #available-widgets [class*="login"] .widget-title:before,
@@ -383,55 +448,96 @@ body.adding-widget #customize-preview {
 #available-widgets [class*="avatar"] .widget-title:before,
 #available-widgets [class*="subscriber"] .widget-title:before,
 #available-widgets [class*="profile"] .widget-title:before,
-#available-widgets [class*="grofile"] .widget-title:before { content: "\f110" / ''; }
+#available-widgets [class*="grofile"] .widget-title:before {
+	content:"\f110";
+	content:"\f110" / '';
+}
 
 /* dashicons-cart */
 #available-widgets [class*="commerce"] .widget-title:before,
 #available-widgets [class*="shop"] .widget-title:before,
-#available-widgets [class*="cart"] .widget-title:before { content: "\f174" / ''; top: -4px; }
+#available-widgets [class*="cart"] .widget-title:before {
+	content:"\f174";
+	content:"\f174" / '';
+	top: -4px;
+}
 
 /* dashicons-shield */
 #available-widgets [class*="secur"] .widget-title:before,
-#available-widgets [class*="firewall"] .widget-title:before { content: "\f332" / ''; }
+#available-widgets [class*="firewall"] .widget-title:before {
+	content:"\f332";
+	content:"\f332" / '';
+}
 
 /* dashicons-chart-bar */
 #available-widgets [class*="analytic"] .widget-title:before,
 #available-widgets [class*="stat"] .widget-title:before,
-#available-widgets [class*="poll"] .widget-title:before { content: "\f185" / ''; }
+#available-widgets [class*="poll"] .widget-title:before {
+	content:"\f185";
+	content:"\f185" / '';
+}
 
 /* dashicons-feedback */
-#available-widgets [class*="form"] .widget-title:before { content: "\f175" / ''; }
+#available-widgets [class*="form"] .widget-title:before {
+	content:"\f175";
+	content:"\f175" / '';
+}
 
 /* dashicons-email-alt */
 #available-widgets [class*="subscribe"] .widget-title:before,
 #available-widgets [class*="news"] .widget-title:before,
 #available-widgets [class*="contact"] .widget-title:before,
-#available-widgets [class*="mail"] .widget-title:before { content: "\f466" / ''; }
+#available-widgets [class*="mail"] .widget-title:before {
+	content:"\f466";
+	content:"\f466" / '';
+}
 
 /* dashicons-share */
 #available-widgets [class*="share"] .widget-title:before,
-#available-widgets [class*="socia"] .widget-title:before { content: "\f237" / ''; }
+#available-widgets [class*="socia"] .widget-title:before {
+	content:"\f237";
+	content:"\f237" / '';
+}
 
 /* dashicons-translation */
 #available-widgets [class*="lang"] .widget-title:before,
-#available-widgets [class*="translat"] .widget-title:before { content: "\f326" / ''; }
+#available-widgets [class*="translat"] .widget-title:before {
+	content:"\f326";
+	content:"\f326" / '';
+}
 
 /* dashicons-location-alt */
 #available-widgets [class*="locat"] .widget-title:before,
-#available-widgets [class*="map"] .widget-title:before { content: "\f231" / ''; }
+#available-widgets [class*="map"] .widget-title:before {
+	content:"\f231;
+	content:"\f231" / '';
+}
 
 /* dashicons-download */
-#available-widgets [class*="download"] .widget-title:before { content: "\f316" / ''; }
+#available-widgets [class*="download"] .widget-title:before {
+	content:"\f316";
+	content:"\f316" / '';
+}
 
 /* dashicons-cloud */
-#available-widgets [class*="weather"] .widget-title:before { content: "\f176" / ''; top: -4px;}
+#available-widgets [class*="weather"] .widget-title:before {
+	content:"\f176";
+	content:"\f176" / '';
+	top: -4px;
+}
 
 /* dashicons-facebook */
-#available-widgets [class*="facebook"] .widget-title:before { content: "\f304" / ''; }
+#available-widgets [class*="facebook"] .widget-title:before {
+	content:"\f304";
+	content:"\f304" / '';
+}
 
 /* dashicons-twitter */
 #available-widgets [class*="tweet"] .widget-title:before,
-#available-widgets [class*="twitter"] .widget-title:before { content: "\f301" / ''; }
+#available-widgets [class*="twitter"] .widget-title:before {
+	content: "\f301";
+	content: "\f301" / '';
+}
 
 @media screen and (max-height: 700px) and (min-width: 981px) {
 	/* Compact widget-tops on smaller laptops, but not tablets. See ticket #27112#comment:4 */

--- a/src/wp-admin/css/customize-widgets.css
+++ b/src/wp-admin/css/customize-widgets.css
@@ -509,7 +509,7 @@ body.adding-widget #customize-preview {
 /* dashicons-location-alt */
 #available-widgets [class*="locat"] .widget-title:before,
 #available-widgets [class*="map"] .widget-title:before {
-	content:"\f231;
+	content:"\f231";
 	content:"\f231" / '';
 }
 

--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -352,54 +352,63 @@
 /* @deprecated 5.9.0 -- Icons removed from welcome panel. */
 .welcome-panel .welcome-write-blog:before,
 .welcome-panel .welcome-edit-page:before {
+	content: "\f119";
 	content: "\f119" / '';
 	top: -3px;
 }
 
 /* @deprecated 5.9.0 -- Icons removed from welcome panel. */
 .welcome-panel .welcome-add-page:before {
+	content: "\f132";
 	content: "\f132" / '';
 	top: -1px;
 }
 
 /* @deprecated 5.9.0 -- Icons removed from welcome panel. */
 .welcome-panel .welcome-setup-home:before {
+	content: "\f102";
 	content: "\f102" / '';
 	top: -1px;
 }
 
 /* @deprecated 5.9.0 -- Icons removed from welcome panel. */
 .welcome-panel .welcome-view-site:before {
+	content: "\f115";
 	content: "\f115" / '';
 	top: -2px;
 }
 
 /* @deprecated 5.9.0 -- Icons removed from welcome panel. */
 .welcome-panel .welcome-widgets-menus:before {
+	content: "\f116";
 	content: "\f116" / '';
 	top: -2px;
 }
 
 /* @deprecated 5.9.0 -- Icons removed from welcome panel. */
 .welcome-panel .welcome-widgets:before {
+	content: "\f538";
 	content: "\f538" / '';
 	top: -2px;
 }
 
 /* @deprecated 5.9.0 -- Icons removed from welcome panel. */
 .welcome-panel .welcome-menus:before {
+	content: "\f163";
 	content: "\f163" / '';
 	top: -2px;
 }
 
 /* @deprecated 5.9.0 -- Icons removed from welcome panel. */
 .welcome-panel .welcome-comments:before {
+	content: "\f117";
 	content: "\f117" / '';
 	top: -1px;
 }
 
 /* @deprecated 5.9.0 -- Icons removed from welcome panel. */
 .welcome-panel .welcome-learn-more:before {
+	content: "\f118";
 	content: "\f118" / '';
 	top: -1px;
 }
@@ -409,37 +418,46 @@
 #dashboard_right_now .search-engines-info:before,
 #dashboard_right_now li a:before,
 #dashboard_right_now li > span:before { /* get only the first level span to exclude screen-reader-text in mu-storage */
-	content: "\f159" / ''; /* generic icon for items added by CPTs ? */
 	padding: 0 5px 0 0;
+	/* generic icon for items added by CPTs ? */
+	content: "\f159";
+	content: "\f159" / '';
 }
 
 #dashboard_right_now .page-count a:before,
 #dashboard_right_now .page-count span:before {
+	content: "\f105";
 	content: "\f105" / '';
 }
 
 #dashboard_right_now .post-count a:before,
 #dashboard_right_now .post-count span:before {
+	content: "\f109";
 	content: "\f109" / '';
 }
 
 #dashboard_right_now .comment-count a:before {
+	content: "\f101";
 	content: "\f101" / '';
 }
 
 #dashboard_right_now .comment-mod-count a:before {
+	content: "\f125";
 	content: "\f125" / '';
 }
 
 #dashboard_right_now .storage-count a:before {
+	content: "\f104";
 	content: "\f104" / '';
 }
 
 #dashboard_right_now .storage-count.warning a:before {
+	content: "\f153";
 	content: "\f153" / '';
 }
 
 #dashboard_right_now .search-engines-info:before {
+	content: "\f348";
 	content: "\f348" / '';
 	color: #d63638;
 }
@@ -559,6 +577,7 @@
 }
 
 .community-events .ce-separator::before {
+	content: "\2022";
 	content: "\2022" / '';
 }
 
@@ -574,9 +593,11 @@
 	font-size: 18px;
 }
 .event-meetup .event-icon:before {
+	content: "\f484";
 	content: "\f484" / '';
 }
 .event-wordcamp .event-icon:before {
+	content: "\f486";
 	content: "\f486" / '';
 }
 
@@ -859,6 +880,7 @@ body #dashboard-widgets .postbox form .submit {
 /* Dashboard activity widget */
 
 #dashboard_activity .comment-meta span.approve:before {
+	content: "\f227";
 	content: "\f227" / '';
 	font: 20px/.5 dashicons;
 	margin-left: 5px;
@@ -1133,6 +1155,7 @@ a.rsswidget {
 }
 
 .rss-widget cite:before {
+	content: "\2014";
 	content: "\2014" / '';
 }
 

--- a/src/wp-admin/css/edit.css
+++ b/src/wp-admin/css/edit.css
@@ -503,36 +503,43 @@ form#tags-filter {
 
 #post-body .misc-pub-post-status:before,
 #post-body .misc-pub-comment-status:before {
+	content: "\f173";
 	content: "\f173" / '';
 }
 
 #post-body #visibility:before {
+	content: "\f177";
 	content: "\f177" / '';
 }
 
 .curtime #timestamp:before {
+	content: "\f145";
 	content: "\f145" / '';
 	position: relative;
 	top: -1px;
 }
 
 #post-body .misc-pub-uploadedby:before {
+	content: "\f110";
 	content: "\f110" / '';
 	position: relative;
 	top: -1px;
 }
 
 #post-body .misc-pub-uploadedto:before {
+	content: "\f318";
 	content: "\f318" / '';
 	position: relative;
 	top: -1px;
 }
 
 #post-body .misc-pub-revisions:before {
+	content: "\f321";
 	content: "\f321" / '';
 }
 
 #post-body .misc-pub-response-to:before {
+	content: "\f101";
 	content: "\f101" / '';
 }
 
@@ -1228,42 +1235,52 @@ label.post-format-icon {
 }
 
 .post-format-icon.post-format-standard::before {
+	content: "\f109";
 	content: "\f109" / '';
 }
 
 .post-format-icon.post-format-image::before {
+	content: "\f128";
 	content: "\f128" / '';
 }
 
 .post-format-icon.post-format-gallery::before {
+	content: "\f161";
 	content: "\f161" / '';
 }
 
 .post-format-icon.post-format-audio::before {
+	content: "\f127";
 	content: "\f127" / '';
 }
 
 .post-format-icon.post-format-video::before {
+	content: "\f126";
 	content: "\f126" / '';
 }
 
 .post-format-icon.post-format-chat::before {
+	content: "\f125";
 	content: "\f125" / '';
 }
 
 .post-format-icon.post-format-status::before {
+	content: "\f130";
 	content: "\f130" / '';
 }
 
 .post-format-icon.post-format-aside::before {
+	content: "\f123";
 	content: "\f123" / '';
 }
 
 .post-format-icon.post-format-quote::before {
+	content: "\f122";
 	content: "\f122" / '';
 }
 
 .post-format-icon.post-format-link::before {
+	content: "\f103";
 	content: "\f103" / '';
 }
 

--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -174,6 +174,7 @@ input[type="radio"]:checked::before {
 
 input[type="checkbox"]:checked::before {
 	/* Use the "Yes" SVG Dashicon */
+	content: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20d%3D%27M14.83%204.89l1.34.94-5.81%208.38H9.02L5.78%209.67l1.34-1.25%202.57%202.4z%27%20fill%3D%27%233582c4%27%2F%3E%3C%2Fsvg%3E");
 	content: url("data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2020%2020%27%3E%3Cpath%20d%3D%27M14.83%204.89l1.34.94-5.81%208.38H9.02L5.78%209.67l1.34-1.25%202.57%202.4z%27%20fill%3D%27%233582c4%27%2F%3E%3C%2Fsvg%3E") / '';
 	margin: -0.1875rem 0 0 -0.25rem;
 	height: 1.3125rem;
@@ -239,6 +240,7 @@ textarea[readonly] {
 }
 
 .form-table .form-required.form-invalid td:after {
+	content: "\f534";
 	content: "\f534" / '';
 	font: normal 20px/1 dashicons;
 	color: #d63638;
@@ -252,6 +254,7 @@ textarea[readonly] {
 }
 
 .form-table .form-required.user-pass1-wrap.form-invalid .password-input-wrapper:after {
+	content: "\f534";
 	content: "\f534" / '';
 	font: normal 20px/1 dashicons;
 	color: #d63638;
@@ -1119,6 +1122,7 @@ table.form-table td .updated p {
 .pressthis-bookmarklet span:before {
 	color: #787c82;
 	font: normal 20px/1 dashicons;
+	content: "\f157";
 	content: "\f157" / '';
 	position: relative;
 	display: inline-block;

--- a/src/wp-admin/css/list-tables.css
+++ b/src/wp-admin/css/list-tables.css
@@ -268,6 +268,7 @@ th .comment-grey-bubble {
 }
 
 th .comment-grey-bubble:before {
+	content: "\f101";
 	content: "\f101" / '';
 	font: normal 20px/.5 dashicons;
 	display: inline-block;
@@ -488,10 +489,12 @@ table.media .column-title .filename {
 }
 
 .sorting-indicator.asc:before {
+	content: "\f142";
 	content: "\f142" / '';
 }
 
 .sorting-indicator.desc:before {
+	content: "\f140";
 	content: "\f140" / '';
 }
 
@@ -552,6 +555,7 @@ th.sorted.desc:hover .sorting-indicator.asc:before {
 	display: block;
 	padding: 1px 2px 1px 0;
 	color: #3c434a; /* same as table headers sort arrows */
+	content: "\f140";
 	content: "\f140" / '';
 	font: normal 20px/1 dashicons;
 	line-height: 1;
@@ -560,6 +564,7 @@ th.sorted.desc:hover .sorting-indicator.asc:before {
 }
 
 .wp-list-table .is-expanded .toggle-row:before {
+	content: "\f142";
 	content: "\f142" / '';
 }
 
@@ -600,6 +605,7 @@ th.sorted.desc:hover .sorting-indicator.asc:before {
 
 .locked-indicator-icon:before {
 	color: #8c8f94;
+	content: "\f160";
 	content: "\f160" / '';
 	display: inline-block;
 	font: normal 20px/1 dashicons;
@@ -775,14 +781,17 @@ th.sorted a span {
 }
 
 .view-switch .view-list:before {
+	content: "\f163";
 	content: "\f163" / '';
 }
 
 .view-switch .view-excerpt:before {
+	content: "\f164";
 	content: "\f164" / '';
 }
 
 .view-switch .view-grid:before {
+	content: "\f509";
 	content: "\f509" / '';
 }
 
@@ -1409,6 +1418,7 @@ ul.cat-checklist input[name="post_category[]"]:indeterminate::before {
 
 .plugin-card .update-now:before {
 	color: #d63638;
+	content: "\f463";
 	content: "\f463" / '';
 	display: inline-block;
 	font: normal 20px/1 dashicons;
@@ -1419,6 +1429,7 @@ ul.cat-checklist input[name="post_category[]"]:indeterminate::before {
 }
 
 .plugin-card .updating-message:before {
+	content: "\f463";
 	content: "\f463" / '';
 	animation: rotation 2s infinite linear;
 }
@@ -1434,6 +1445,7 @@ ul.cat-checklist input[name="post_category[]"]:indeterminate::before {
 
 .plugin-card .updated-message:before {
 	color: #68de7c;
+	content: "\f147";
 	content: "\f147" / '';
 }
 
@@ -1720,11 +1732,13 @@ div.action-links,
 }
 
 .plugin-card .column-compatibility .compatibility-incompatible:before {
+	content: "\f158";
 	content: "\f158" / '';
 	color: #d63638;
 }
 
 .plugin-card .column-compatibility .compatibility-compatible:before {
+	content: "\f147";
 	content: "\f147" / '';
 	color: #007017;
 }

--- a/src/wp-admin/css/media.css
+++ b/src/wp-admin/css/media.css
@@ -356,6 +356,7 @@
 	vertical-align: top;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+	content: "\f158";
 	content: "\f158" / '';
 }
 
@@ -620,6 +621,7 @@ border color while dragging a file over the uploader drop area */
 }
 
 .upload-php .media-modal-close .media-modal-icon:before {
+	content: "\f335";
 	content: "\f335" / '';
 	font-size: 22px;
 }
@@ -692,10 +694,12 @@ border color while dragging a file over the uploader drop area */
 }
 
 .edit-attachment-frame .edit-media-header .left:before {
+	content: "\f341";
 	content: "\f341" / '';
 }
 
 .edit-attachment-frame .edit-media-header .right:before {
+	content: "\f345";
 	content: "\f345" / '';
 }
 
@@ -1011,22 +1015,27 @@ border color while dragging a file over the uploader drop area */
 }
 
 .imgedit-crop:before {
+	content: "\f165";
 	content: "\f165" / '';
 }
 
 .imgedit-scale:before {
+	content: "\f211";
 	content: "\f211" / '';
 }
 
 .imgedit-rotate:before {
+	content: "\f167";
 	content: "\f167" / '';
 }
 
 .imgedit-undo:before {
+	content: "\f171";
 	content: "\f171" / '';
 }
 
 .imgedit-redo:before {
+	content: "\f172";
 	content: "\f172" / '';
 }
 

--- a/src/wp-admin/css/revisions.css
+++ b/src/wp-admin/css/revisions.css
@@ -493,6 +493,7 @@ div.revisions-controls > .wp-slider > .ui-slider-handle {
 	top: 2px;
 	left: 2px;
 	color: #50575e;
+	content: "\f229";
 	content: "\f229" / '';
 	font: normal 18px/1 dashicons;
 	-webkit-font-smoothing: antialiased;
@@ -511,18 +512,22 @@ div.revisions-controls > .wp-slider > .ui-slider-handle {
 }
 
 .wp-slider .ui-slider-handle.from-handle:before {
+	content: "\f139";
 	content: "\f139" / '';
 }
 
 .wp-slider .ui-slider-handle.to-handle:before {
+	content: "\f141";
 	content: "\f141" / '';
 }
 
 .rtl .wp-slider .ui-slider-handle.from-handle:before {
+	content: "\f141";
 	content: "\f141" / '';
 }
 
 .rtl .wp-slider .ui-slider-handle.to-handle:before {
+	content: "\f139";
 	content: "\f139" / '';
 	right: -1px;
 }

--- a/src/wp-admin/css/site-health.css
+++ b/src/wp-admin/css/site-health.css
@@ -189,22 +189,26 @@ are styled in the Privacy section of edit.css */
 
 .health-check-body .pass::before,
 .health-check-body .good::before {
+	content: "\f147";
 	content: "\f147" / '';
 	color: #00a32a;
 }
 
 .health-check-body .warning::before {
+	content: "\f460";
 	content: "\f460" / '';
 	color: #dba617;
 }
 
 .health-check-body .info::before {
+	content: "\f348";
 	content: "\f348" / '';
 	color: #72aee6;
 }
 
 .health-check-body .fail::before,
 .health-check-body .error::before {
+	content: "\f335";
 	content: "\f335" / '';
 	color: #d63638;
 }

--- a/src/wp-admin/css/themes.css
+++ b/src/wp-admin/css/themes.css
@@ -304,6 +304,7 @@ body.js .theme-browser.search-loading {
 	background: rgba(140, 143, 148, 0.1);
 	border-radius: 50%;
 	display: inline-block;
+	content: "\f132";
 	content: "\f132" / '';
 	-webkit-font-smoothing: antialiased;
 	font: normal 74px/115px dashicons;
@@ -408,6 +409,7 @@ body.js .theme-browser.search-loading {
 	font: normal 22px/50px dashicons !important;
 	color: #787c82;
 	display: inline-block;
+	content: "\f335";
 	content: "\f335" / '';
 	font-weight: 300;
 }
@@ -467,10 +469,12 @@ body.js .theme-browser.search-loading {
 }
 
 .theme-overlay .theme-header .left:before {
+	content: "\f341";
 	content: "\f341" / '';
 }
 
 .theme-overlay .theme-header .right:before {
+	content: "\f345";
 	content: "\f345" / '';
 }
 
@@ -1022,6 +1026,7 @@ body.folded .theme-browser ~ .theme-overlay .theme-wrap {
 
 .theme-browser .theme .notice-success p:before {
 	color: #68de7c;
+	content: "\f147";
 	content: "\f147" / '';
 	display: inline-block;
 	font: normal 20px/1 'dashicons';
@@ -1517,6 +1522,7 @@ body.full-overlay-active {
 
 .theme-install-overlay .close-full-overlay:before {
 	font: normal 22px/1 dashicons;
+	content: "\f335";
 	content: "\f335" / '';
 	position: relative;
 	top: 7px;
@@ -1525,6 +1531,7 @@ body.full-overlay-active {
 
 .theme-install-overlay .previous-theme:before {
 	font: normal 20px/1 dashicons;
+	content: "\f341";
 	content: "\f341" / '';
 	position: relative;
 	top: 6px;
@@ -1533,6 +1540,7 @@ body.full-overlay-active {
 
 .theme-install-overlay .next-theme:before {
 	font: normal 20px/1 dashicons;
+	content: "\f345";
 	content: "\f345" / '';
 	position: relative;
 	top: 6px;
@@ -1619,6 +1627,7 @@ body.full-overlay-active {
 
 .wp-full-overlay .collapse-sidebar-arrow:before {
 	display: block;
+	content: "\f148";
 	content: "\f148" / '';
 	background: #f0f0f1;
 	font: normal 20px/1 dashicons;
@@ -1740,14 +1749,17 @@ body.full-overlay-active {
 }
 
 .wp-full-overlay-footer .devices .preview-desktop:before {
+	content: "\f472";
 	content: "\f472" / '';
 }
 
 .wp-full-overlay-footer .devices .preview-tablet:before {
+	content: "\f471";
 	content: "\f471" / '';
 }
 
 .wp-full-overlay-footer .devices .preview-mobile:before {
+	content: "\f470";
 	content: "\f470" / '';
 }
 

--- a/src/wp-admin/css/widgets.css
+++ b/src/wp-admin/css/widgets.css
@@ -729,6 +729,7 @@ div#widgets-right .widget-top:hover,
 }
 
 .widgets-chooser .widgets-chooser-selected:before {
+	content: "\f147";
 	content: "\f147" / '';
 	display: block;
 	-webkit-font-smoothing: antialiased;

--- a/src/wp-includes/css/admin-bar.css
+++ b/src/wp-includes/css/admin-bar.css
@@ -324,6 +324,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	top: 1px;
 	right: 10px;
 	padding: 4px 0;
+	content: "\f139";
 	content: "\f139" / '';
 	color: inherit;
 }
@@ -336,6 +337,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 #wpadminbar .ab-top-secondary .menupop .menupop > .ab-item .wp-admin-bar-arrow:before {
 	top: 1px;
 	left: 6px;
+	content: "\f141";
 	content: "\f141" / '';
 }
 
@@ -409,6 +411,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 #wp-admin-bar-my-account > .ab-item:before {
+	content: "\f110";
 	content: "\f110" / '';
 	top: 2px;
 	float: right;
@@ -503,6 +506,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 #wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon:before {
+	content: "\f120";
 	content: "\f120" / '';
 	top: 2px;
 }
@@ -533,6 +537,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 #wpadminbar .quicklinks li div.blavatar:before {
+	content: "\f120";
 	content: "\f120" / '';
 	display: inline-block;
 }
@@ -543,30 +548,36 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 #wpadminbar #wp-admin-bar-my-sites > .ab-item:before,
 #wpadminbar #wp-admin-bar-site-name > .ab-item:before {
+	content: "\f541";
 	content: "\f541" / '';
 	top: 2px;
 }
 
 #wpadminbar #wp-admin-bar-site-editor > .ab-item:before {
+	content: "\f100";
 	content: "\f100" / '';
 	top: 2px;
 }
 
 #wpadminbar #wp-admin-bar-customize > .ab-item:before {
+	content: "\f540";
 	content: "\f540" / '';
 	top: 2px;
 }
 
 #wpadminbar #wp-admin-bar-edit > .ab-item:before {
+	content: "\f464";
 	content: "\f464" / '';
 	top: 2px;
 }
 
 #wpadminbar #wp-admin-bar-site-name > .ab-item:before {
+	content: "\f226";
 	content: "\f226" / '';
 }
 
 .wp-admin #wpadminbar #wp-admin-bar-site-name > .ab-item:before {
+	content: "\f102";
 	content: "\f102" / '';
 }
 
@@ -580,6 +591,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 #wpadminbar #wp-admin-bar-comments .ab-icon:before {
+	content: "\f101";
 	content: "\f101" / '';
 	top: 3px;
 }
@@ -592,6 +604,7 @@ html:lang(he-il) .rtl #wpadminbar * {
  * New Content
  */
 #wpadminbar #wp-admin-bar-new-content .ab-icon:before {
+	content: "\f132";
 	content: "\f132" / '';
 	top: 4px;
 }
@@ -600,6 +613,7 @@ html:lang(he-il) .rtl #wpadminbar * {
  * Updates
  */
 #wpadminbar #wp-admin-bar-updates .ab-icon:before {
+	content: "\f463";
 	content: "\f463" / '';
 	top: 2px;
 }
@@ -637,6 +651,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	left: 5px;
 	z-index: 20;
 	font: normal 20px/1 dashicons !important;
+	content: "\f179";
 	content: "\f179" / '';
 	speak: never;
 	-webkit-font-smoothing: antialiased;

--- a/src/wp-includes/css/editor.css
+++ b/src/wp-includes/css/editor.css
@@ -922,54 +922,67 @@ i.mce-i-remove {
 }
 
 i.mce-i-bold:before {
+	content: "\f200";
 	content: "\f200" / '';
 }
 
 i.mce-i-italic:before {
+	content: "\f201";
 	content: "\f201" / '';
 }
 
 i.mce-i-bullist:before {
+	content: "\f203";
 	content: "\f203" / '';
 }
 
 i.mce-i-numlist:before {
+	content: "\f204";
 	content: "\f204" / '';
 }
 
 i.mce-i-blockquote:before {
+	content: "\f205";
 	content: "\f205" / '';
 }
 
 i.mce-i-alignleft:before {
+	content: "\f206";
 	content: "\f206" / '';
 }
 
 i.mce-i-aligncenter:before {
+	content: "\f207";
 	content: "\f207" / '';
 }
 
 i.mce-i-alignright:before {
+	content: "\f208";
 	content: "\f208" / '';
 }
 
 i.mce-i-link:before {
+	content: "\f103";
 	content: "\f103" / '';
 }
 
 i.mce-i-unlink:before {
+	content: "\f225";
 	content: "\f225" / '';
 }
 
 i.mce-i-wp_more:before {
+	content: "\f209";
 	content: "\f209" / '';
 }
 
 i.mce-i-strikethrough:before {
+	content: "\f224";
 	content: "\f224" / '';
 }
 
 i.mce-i-spellchecker:before {
+	content: "\f210";
 	content: "\f210" / '';
 }
 
@@ -977,89 +990,110 @@ i.mce-i-fullscreen:before,
 i.mce-i-wp_fullscreen:before,
 i.mce-i-dfw:before,
 .qt-dfw:before {
+	content: "\f211";
 	content: "\f211" / '';
 }
 
 i.mce-i-wp_adv:before {
+	content: "\f212";
 	content: "\f212" / '';
 }
 
 i.mce-i-underline:before {
+	content: "\f213";
 	content: "\f213" / '';
 }
 
 i.mce-i-alignjustify:before {
+	content: "\f214";
 	content: "\f214" / '';
 }
 
 i.mce-i-forecolor:before,
 i.mce-i-backcolor:before {
+	content: "\f215";
 	content: "\f215" / '';
 }
 
 i.mce-i-pastetext:before {
+	content: "\f217";
 	content: "\f217" / '';
 }
 
 i.mce-i-removeformat:before {
+	content: "\f218";
 	content: "\f218" / '';
 }
 
 i.mce-i-charmap:before {
+	content: "\f220";
 	content: "\f220" / '';
 }
 
 i.mce-i-outdent:before {
+	content: "\f221";
 	content: "\f221" / '';
 }
 
 i.mce-i-indent:before {
+	content: "\f222";
 	content: "\f222" / '';
 }
 
 i.mce-i-undo:before {
+	content: "\f171";
 	content: "\f171" / '';
 }
 
 i.mce-i-redo:before {
+	content: "\f172";
 	content: "\f172" / '';
 }
 
 i.mce-i-help:before,
 i.mce-i-wp_help:before {
+	content: "\f223";
 	content: "\f223" / '';
 }
 
 i.mce-i-wp-media-library:before {
+	content: "\f104";
 	content: "\f104" / '';
 }
 
 i.mce-i-ltr:before {
+	content: "\f320";
 	content: "\f320" / '';
 }
 
 i.mce-i-wp_page:before {
+	content: "\f105";
 	content: "\f105" / '';
 }
 
 i.mce-i-hr:before {
+	content: "\f460";
 	content: "\f460" / '';
 }
 
 i.mce-i-remove:before {
+	content: "\f158";
 	content: "\f158" / '';
 }
 
 i.mce-i-wp_code:before {
+	content: "\f475";
 	content: "\f475" / '';
 }
 
 /* RTL button icons */
 .rtl i.mce-i-outdent:before {
+	content: "\f222";
 	content: "\f222" / '';
 }
 
 .rtl i.mce-i-indent:before {
+	content: "\f221";
 	content: "\f221" / '';
 }
 
@@ -1211,6 +1245,7 @@ i.mce-i-wp_code:before {
 }
 
 .wp-media-buttons .add_media span.wp-media-buttons-icon:before {
+	content: "\f104";
 	content: "\f104" / '';
 }
 
@@ -1428,6 +1463,7 @@ i.mce-i-wp_code:before {
 	-moz-osx-font-smoothing: grayscale;
 	width: 36px;
 	height: 36px;
+	content: "\f158";
 	content: "\f158" / '';
 }
 

--- a/src/wp-includes/css/jquery-ui-dialog.css
+++ b/src/wp-includes/css/jquery-ui-dialog.css
@@ -302,6 +302,7 @@
 	line-height: 1.8;
 	width: 36px;
 	height: 36px;
+	content: "\f158";
 	content: "\f158" / '';
 }
 

--- a/src/wp-includes/css/media-views.css
+++ b/src/wp-includes/css/media-views.css
@@ -246,6 +246,7 @@
 }
 
 .media-modal-close .media-modal-icon:before {
+	content: "\f158";
 	content: "\f158" / '';
 	font: normal 20px/1 dashicons;
 	vertical-align: middle;
@@ -1245,6 +1246,7 @@
 	font: normal 30px/1 dashicons !important;
 	color: #50575e;
 	display: inline-block;
+	content: "\f335";
 	content: "\f335" / '';
 	font-weight: 300;
 	margin-top: 1px;
@@ -1999,6 +2001,7 @@
 }
 
 .media-modal .imgedit-help-toggled span.dashicons:before {
+	content: "\f142";
 	content: "\f142" / '';
 }
 
@@ -2181,12 +2184,14 @@
 	vertical-align: top;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+	content: "\f140";
 	content: "\f140" / '';
 	display: inline-block;
 	margin-top: -2px;
 }
 
 .image-details .advanced-visible .advanced-toggle:after {
+	content: "\f142";
 	content: "\f142" / '';
 }
 

--- a/src/wp-includes/css/wp-auth-check.css
+++ b/src/wp-includes/css/wp-auth-check.css
@@ -93,6 +93,7 @@
 }
 
 #wp-auth-check-wrap .wp-auth-check-close:before {
+	content: "\f158";
 	content: "\f158" / '';
 	font: normal 20px/22px dashicons;
 	-webkit-font-smoothing: antialiased !important;

--- a/src/wp-includes/css/wp-pointer.css
+++ b/src/wp-includes/css/wp-pointer.css
@@ -23,6 +23,7 @@
 	background: #fff;
 	border-radius: 50%;
 	color: #2271b1;
+	content: "\f227";
 	content: "\f227" / '';
 	font: normal 20px/1.6 dashicons;
 	position: absolute;
@@ -64,6 +65,7 @@
 .wp-pointer-buttons a.close:before {
 	background: none;
 	color: #787c82;
+	content: "\f153";
 	content: "\f153" / '';
 	display: block !important;
 	font: normal 16px/1 dashicons;


### PR DESCRIPTION
Adds fallback `content` properties for browsers that do not support alt text.

In each case that the content property includes alt text, it is preceded by a version without alt text for browsers that do not support the feature. For example:

```css
.thing:before {
  content: "\f157";
  content: "\f157" / '';
}
```

Trac ticket: https://core.trac.wordpress.org/ticket/64350
