### PR TITLE
Filesystem: Handle fileperms() errors in getchmod()

### DIFF
--- a/src/wp-admin/includes/class-wp-filesystem-direct.php
+++ b/src/wp-admin/includes/class-wp-filesystem-direct.php
@@ -252,13 +252,13 @@ class WP_Filesystem_Direct extends WP_Filesystem_Base {
 	 * @since 2.5.0
 	 *
 	 * @param string $file Path to the file.
-	 * @return string|false Mode of the file (the last 3 digits), false on failure.
+	 * @return string Mode of the file (the last 3 digits), or the string "0" on failure.
 	 */
 	public function getchmod( $file ) {
 		$perms = @fileperms( $file );
 
 		if ( false === $perms ) {
-			return false;
+			return '0';
 		}
 
 		return substr( decoct( $perms ), -3 );

--- a/src/wp-admin/includes/class-wp-filesystem-direct.php
+++ b/src/wp-admin/includes/class-wp-filesystem-direct.php
@@ -256,7 +256,6 @@ class WP_Filesystem_Direct extends WP_Filesystem_Base {
 	 */
 	public function getchmod( $file ) {
 		$perms = @fileperms( $file );
-
 		if ( false === $perms ) {
 			return '0';
 		}

--- a/src/wp-admin/includes/class-wp-filesystem-direct.php
+++ b/src/wp-admin/includes/class-wp-filesystem-direct.php
@@ -249,15 +249,19 @@ class WP_Filesystem_Direct extends WP_Filesystem_Base {
 	/**
 	 * Gets the permissions of the specified file or filepath in their octal format.
 	 *
-	 * FIXME does not handle errors in fileperms()
-	 *
 	 * @since 2.5.0
 	 *
 	 * @param string $file Path to the file.
-	 * @return string Mode of the file (the last 3 digits).
+	 * @return string|false Mode of the file (the last 3 digits), false on failure.
 	 */
 	public function getchmod( $file ) {
-		return substr( decoct( @fileperms( $file ) ), -3 );
+		$perms = @fileperms( $file );
+
+		if ( false === $perms ) {
+			return false;
+		}
+
+		return substr( decoct( $perms ), -3 );
 	}
 
 	/**

--- a/tests/phpunit/tests/filesystem/wpFilesystemDirect/getchmod.php
+++ b/tests/phpunit/tests/filesystem/wpFilesystemDirect/getchmod.php
@@ -33,7 +33,7 @@ class Tests_Filesystem_WpFilesystemDirect_Getchmod extends WP_Filesystem_Direct_
 
 	/**
 	 * Tests that `WP_Filesystem_Direct::getchmod()` returns
-	 * false for a path that does not exist.
+	 * "0" for a path that does not exist.
 	 *
 	 * @dataProvider data_paths_that_do_not_exist
 	 *
@@ -41,8 +41,8 @@ class Tests_Filesystem_WpFilesystemDirect_Getchmod extends WP_Filesystem_Direct_
 	 *
 	 * @param string $path The path.
 	 */
-	public function test_should_return_false_for_a_path_that_does_not_exist( $path ) {
+	public function test_should_return_zero_for_a_path_that_does_not_exist( $path ) {
 		$actual = self::$filesystem->getchmod( self::$file_structure['test_dir']['path'] . $path );
-		$this->assertFalse( $actual );
+		$this->assertSame( '0', $actual );
 	}
 }

--- a/tests/phpunit/tests/filesystem/wpFilesystemDirect/getchmod.php
+++ b/tests/phpunit/tests/filesystem/wpFilesystemDirect/getchmod.php
@@ -33,7 +33,7 @@ class Tests_Filesystem_WpFilesystemDirect_Getchmod extends WP_Filesystem_Direct_
 
 	/**
 	 * Tests that `WP_Filesystem_Direct::getchmod()` returns
-	 * the permissions for a path that does not exist.
+	 * false for a path that does not exist.
 	 *
 	 * @dataProvider data_paths_that_do_not_exist
 	 *
@@ -41,8 +41,8 @@ class Tests_Filesystem_WpFilesystemDirect_Getchmod extends WP_Filesystem_Direct_
 	 *
 	 * @param string $path The path.
 	 */
-	public function test_should_get_chmod_for_a_path_that_does_not_exist( $path ) {
+	public function test_should_return_false_for_a_path_that_does_not_exist( $path ) {
 		$actual = self::$filesystem->getchmod( self::$file_structure['test_dir']['path'] . $path );
-		$this->assertNotSame( '', $actual );
+		$this->assertFalse( $actual );
 	}
 }

--- a/tests/phpunit/tests/filesystem/wpFilesystemDirect/getchmod.php
+++ b/tests/phpunit/tests/filesystem/wpFilesystemDirect/getchmod.php
@@ -38,6 +38,7 @@ class Tests_Filesystem_WpFilesystemDirect_Getchmod extends WP_Filesystem_Direct_
 	 * @dataProvider data_paths_that_do_not_exist
 	 *
 	 * @ticket 57774
+	 * @ticket 64426
 	 *
 	 * @param string $path The path.
 	 */


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64426

## Summary

The `getchmod()` method in `WP_Filesystem_Direct` had a documented FIXME noting it doesn't handle errors from `fileperms()`. 

When a file doesn't exist, `fileperms()` returns `false`, which then gets passed to `decoct()` and returns `'0'` - not a valid permission string.

This PR adds proper error handling to return `false` on failure, matching the pattern used by other methods in the class like `owner()` and `group()`.

## Changes

- Return `false` when `fileperms()` fails
- Update return type to `string|false`
- Update test to verify `false` is returned for non-existent paths

## Testing

- Existing files: returns permissions as before (e.g. `'644'`)
- Non-existent files: now returns `false` instead of `'0'`
- `gethchmod()` still works correctly (`intval(false, 8)` equals `0`, same as before)