### PR TITLE
Use assertEqualHTML in Script Modules HTML tests

### DIFF
--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -1234,7 +1234,7 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 </script>
 
 HTML;
-		$this->assertSame( $expected, $actual );
+		$this->assertEqualHTML( $expected, $actual );
 	}
 
 	/**
@@ -1259,7 +1259,7 @@ HTML;
 </script>
 
 HTML;
-		$this->assertSame( $expected, $actual );
+		$this->assertEqualHTML( $expected, $actual );
 	}
 
 	/**
@@ -1332,7 +1332,7 @@ HTML;
 
 HTML;
 
-		$this->assertSame( $expected, $actual );
+		$this->assertEqualHTML( $expected, $actual );
 	}
 
 	/**


### PR DESCRIPTION
These tests failed with semantically equivalent HTML while working on https://github.com/WordPress/wordpress-develop/pull/10639.

`assertEqualHTML` makes the tests more robust.

Trac ticket: https://core.trac.wordpress.org/ticket/64225

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
