### PR TITLE
Post Types: Add 'at_a_glance' property and update dashboard widget logic. Refresh: 45035.diff

### DIFF
--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -409,18 +409,7 @@
 #dashboard_right_now .search-engines-info:before,
 #dashboard_right_now li a:before,
 #dashboard_right_now li > span:before { /* get only the first level span to exclude screen-reader-text in mu-storage */
-	content: "\f159" / ''; /* generic icon for items added by CPTs ? */
 	padding: 0 5px 0 0;
-}
-
-#dashboard_right_now .page-count a:before,
-#dashboard_right_now .page-count span:before {
-	content: "\f105" / '';
-}
-
-#dashboard_right_now .post-count a:before,
-#dashboard_right_now .post-count span:before {
-	content: "\f109" / '';
 }
 
 #dashboard_right_now .comment-count a:before {

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -302,21 +302,24 @@ function wp_dashboard_right_now() {
 	<div class="main">
 	<ul>
 	<?php
-	// Posts and Pages.
-	foreach ( array( 'post', 'page' ) as $post_type ) {
-		$num_posts = wp_count_posts( $post_type );
+	// At a Glance Post Types.
+	foreach ( get_post_types( array( 'at_a_glance' => true ) ) as $post_type ) {
+		$num_posts          = wp_count_posts( $post_type );
+		$num_post_published = intval( $num_posts->publish );
 
-		if ( $num_posts && $num_posts->publish ) {
-			if ( 'post' === $post_type ) {
-				/* translators: %s: Number of posts. */
-				$text = _n( '%s Post', '%s Posts', $num_posts->publish );
-			} else {
-				/* translators: %s: Number of pages. */
-				$text = _n( '%s Page', '%s Pages', $num_posts->publish );
-			}
-
-			$text             = sprintf( $text, number_format_i18n( $num_posts->publish ) );
+		if ( $num_posts && $num_post_published ) {
 			$post_type_object = get_post_type_object( $post_type );
+
+			if ( ! $post_type_object ) {
+				continue;
+			}
+			if ( 1 === $num_post_published ) {
+				$post_label = $post_type_object->labels->singular_name;
+			} else {
+				$post_label = $post_type_object->labels->name;
+			}
+			/* translators: %d: Number of posts, %s post label. */
+			$text = sprintf( '%d %s', number_format_i18n( $num_post_published ), $post_label );
 
 			if ( $post_type_object && current_user_can( $post_type_object->cap->edit_posts ) ) {
 				printf( '<li class="%1$s-count"><a href="edit.php?post_type=%1$s">%2$s</a></li>', $post_type, $text );

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -318,8 +318,7 @@ function wp_dashboard_right_now() {
 			} else {
 				$post_label = $post_type_object->labels->name;
 			}
-			/* translators: %d: Number of posts, %s post label. */
-			$text = sprintf( '%d %s', number_format_i18n( $num_post_published ), $post_label );
+			$text = number_format_i18n( $num_post_published ) . ' ' . $post_label;
 
 			if ( $post_type_object && current_user_can( $post_type_object->cap->edit_posts ) ) {
 				printf( '<li class="%1$s-count"><a href="edit.php?post_type=%1$s">%2$s</a></li>', $post_type, $text );

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -320,10 +320,31 @@ function wp_dashboard_right_now() {
 			}
 			$text = number_format_i18n( $num_post_published ) . ' ' . $post_label;
 
-			if ( $post_type_object && current_user_can( $post_type_object->cap->edit_posts ) ) {
-				printf( '<li class="%1$s-count"><a href="edit.php?post_type=%1$s">%2$s</a></li>', $post_type, $text );
+			$icon_class = '';
+
+			if ( str_starts_with( $post_type_object->menu_icon, 'dashicons' ) ) {
+				$icon_class = $post_type_object->menu_icon;
+			} elseif ( str_starts_with( $post_type_object->menu_icon, 'data:image/svg+xml;base64,' ) ) {
+				printf(
+					'<style>
+#dashboard_right_now li.%1$s-count a:before,
+#dashboard_right_now li.%1$s-count > span:before {
+	content: url( %2$s );
+	height: auto;
+	width: 20px;
+}
+</style>',
+					$post_type,
+					$post_type_object->menu_icon
+				);
+			}
+
+			$class_attr = $icon_class ? sprintf( ' class="%s"', $icon_class ) : '';
+
+			if ( current_user_can( $post_type_object->cap->edit_posts ) ) {
+				printf( '<li class="%1$s-count"><a%3$s href="edit.php?post_type=%1$s">%2$s</a></li>', $post_type, $text, $class_attr );
 			} else {
-				printf( '<li class="%1$s-count"><span>%2$s</span></li>', $post_type, $text );
+				printf( '<li class="%1$s-count"><span%3$s>%2$s</span></li>', $post_type, $text, $class_attr );
 			}
 		}
 	}

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -303,16 +303,12 @@ function wp_dashboard_right_now() {
 	<ul>
 	<?php
 	// At a Glance Post Types.
-	foreach ( get_post_types( array( 'at_a_glance' => true ) ) as $post_type ) {
+	foreach ( get_post_types( array( 'at_a_glance' => true ), 'objects' ) as $post_type_object ) {
+		$post_type          = $post_type_object->name;
 		$num_posts          = wp_count_posts( $post_type );
 		$num_post_published = intval( $num_posts->publish );
 
 		if ( $num_posts && $num_post_published ) {
-			$post_type_object = get_post_type_object( $post_type );
-
-			if ( ! $post_type_object ) {
-				continue;
-			}
 			if ( 1 === $num_post_published ) {
 				$post_label = $post_type_object->labels->singular_name;
 			} else {

--- a/src/wp-includes/class-wp-post-type.php
+++ b/src/wp-includes/class-wp-post-type.php
@@ -148,6 +148,15 @@ final class WP_Post_Type {
 	public $show_in_menu = null;
 
 	/**
+	 * Makes this post type visible in the At a Glance dashboard widget.
+	 *
+	 * Default is the value of $show_in_menu.
+	 *
+	 * @var bool $at_a_glance
+	 */
+	public $at_a_glance = null;
+
+	/**
 	 * Makes this post type available for selection in navigation menus.
 	 *
 	 * Default is the value $public.
@@ -553,6 +562,7 @@ final class WP_Post_Type {
 			'rest_base'                       => false,
 			'rest_namespace'                  => false,
 			'rest_controller_class'           => false,
+			'at_a_glance'                     => null,
 			'autosave_rest_controller_class'  => false,
 			'revisions_rest_controller_class' => false,
 			'late_route_registration'         => false,
@@ -589,6 +599,11 @@ final class WP_Post_Type {
 		// If not set, default to the setting for 'show_ui'.
 		if ( null === $args['show_in_menu'] || ! $args['show_ui'] ) {
 			$args['show_in_menu'] = $args['show_ui'];
+		}
+
+		// If not set, default to the setting for show_in_menu
+		if ( null === $args['at_a_glance'] ) {
+			$args['at_a_glance'] = (bool) $args['show_in_menu'];
 		}
 
 		// If not set, default to the setting for 'show_in_menu'.

--- a/src/wp-includes/class-wp-post-type.php
+++ b/src/wp-includes/class-wp-post-type.php
@@ -199,7 +199,7 @@ final class WP_Post_Type {
 	 * @since 4.6.0
 	 * @var string $menu_icon
 	 */
-	public $menu_icon = null;
+	public $menu_icon;
 
 	/**
 	 * The string to use to build the read, edit, and delete capabilities.

--- a/src/wp-includes/class-wp-post-type.php
+++ b/src/wp-includes/class-wp-post-type.php
@@ -547,6 +547,7 @@ final class WP_Post_Type {
 			'show_in_admin_bar'               => null,
 			'menu_position'                   => null,
 			'menu_icon'                       => null,
+			'at_a_glance'                     => null,
 			'capability_type'                 => 'post',
 			'capabilities'                    => array(),
 			'map_meta_cap'                    => null,
@@ -562,7 +563,6 @@ final class WP_Post_Type {
 			'rest_base'                       => false,
 			'rest_namespace'                  => false,
 			'rest_controller_class'           => false,
-			'at_a_glance'                     => null,
 			'autosave_rest_controller_class'  => false,
 			'revisions_rest_controller_class' => false,
 			'late_route_registration'         => false,
@@ -601,7 +601,7 @@ final class WP_Post_Type {
 			$args['show_in_menu'] = $args['show_ui'];
 		}
 
-		// If not set, default to the setting for show_in_menu
+		// If not set, default to the setting for show_in_menu.
 		if ( null === $args['at_a_glance'] ) {
 			$args['at_a_glance'] = (bool) $args['show_in_menu'];
 		}

--- a/src/wp-includes/class-wp-post-type.php
+++ b/src/wp-includes/class-wp-post-type.php
@@ -606,6 +606,11 @@ final class WP_Post_Type {
 			$args['at_a_glance'] = (bool) $args['show_in_menu'];
 		}
 
+		// If not set, default to the post icon.
+		if ( null === $args['menu_icon'] ) {
+			$args['menu_icon'] = 'dashicons-admin-post';
+		}
+
 		// If not set, default to the setting for 'show_in_menu'.
 		if ( null === $args['show_in_admin_bar'] ) {
 			$args['show_in_admin_bar'] = (bool) $args['show_in_menu'];

--- a/src/wp-includes/class-wp-post-type.php
+++ b/src/wp-includes/class-wp-post-type.php
@@ -152,6 +152,7 @@ final class WP_Post_Type {
 	 *
 	 * Default is the value of $show_in_menu.
 	 *
+	 * @since 7.0.0
 	 * @var bool $at_a_glance
 	 */
 	public $at_a_glance = null;

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -103,6 +103,7 @@ function create_initial_post_types() {
 			),
 			'public'                => true,
 			'show_ui'               => true,
+			'at_a_glance'           => false,
 			'_builtin'              => true, /* internal use only. don't use this when registering your own post type. */
 			'_edit_link'            => 'post.php?post=%d', /* internal use only. don't use this when registering your own post type. */
 			'capability_type'       => 'post',

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -1735,6 +1735,8 @@ function get_post_types( $args = array(), $output = 'names', $operator = 'and' )
  *                                                         of a Dashicons helper class to use a font icon, e.g.
  *                                                        'dashicons-chart-pie'. Pass 'none' to leave div.wp-menu-image empty
  *                                                         so an icon can be added via CSS. Defaults to use the posts icon.
+ *     @type bool         $at_a_glance                     Whether to display this post type in the 'At a Glance' dashboard widget.
+ *                                                         Default is value of $show_in_menu.
  *     @type string|array $capability_type                 The string to use to build the read, edit, and delete capabilities.
  *                                                         May be passed as an array to allow for alternative plurals when using
  *                                                         this argument as a base to construct the capabilities, e.g.

--- a/tests/phpunit/tests/post/types.php
+++ b/tests/phpunit/tests/post/types.php
@@ -676,4 +676,24 @@ class Tests_Post_Types extends WP_UnitTestCase {
 		);
 		$this->assertFalse( $post_type->embeddable, 'Post type should not be embeddable even though it is public' );
 	}
+
+	/**
+	 * @ticket 45035
+	 * @covers ::register_post_type()
+	 */
+	public function test_register_post_type_at_a_glance_should_default_to_value_of_show_in_menu() {
+		/*
+		 * 'public'       Default is false
+		 * 'show_ui'      Default is null ('public')
+		 * 'show_in_menu' Default is null ('show_ui' > 'public')
+		 * 'at_a_glance'  Default is null ('show_in_menu' > 'show_ui' > 'public')
+		 */
+		$args = register_post_type( $this->post_type, array( 'public' => $public = false ) );
+		// Should fall back to 'show_in_menu'.
+		$this->assertSame( $args->show_in_menu, $args->at_a_glance );
+		// Should fall back to 'show_ui'.
+		$this->assertSame( $args->show_ui, $args->at_a_glance );
+		// Should fall back to 'public'.
+		$this->assertSame( $public, $args->at_a_glance );
+	}
 }

--- a/tests/phpunit/tests/post/types.php
+++ b/tests/phpunit/tests/post/types.php
@@ -679,6 +679,7 @@ class Tests_Post_Types extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 45035
+	 *
 	 * @covers ::register_post_type()
 	 */
 	public function test_register_post_type_at_a_glance_should_default_to_value_of_show_in_menu() {


### PR DESCRIPTION
Following the patch in `45035.diff` by @gwelser, I have refreshed and updated to work. 

### Testing Instructions
1. Add a new CPT
2. Set the `at_a_glance` argument to `true` in that CPT
2. Create a couple posts in that CPT, some published some not published
3. Go to the admin dashboard, and check if "At a Glance" show the right number of published posts

Trac ticket: https://core.trac.wordpress.org/ticket/45035

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
