### PR TITLE
Theme_JSON_Resolver: add defensive coding against null result

### DIFF
--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -515,7 +515,7 @@ class WP_Theme_JSON_Resolver {
 
 		$global_style_query = new WP_Query();
 		$recent_posts       = $global_style_query->query( $args );
-		if ( count( $recent_posts ) === 1 && is_object( $recent_posts[0] ) ) {
+		if ( count( $recent_posts ) === 1 && $recent_posts[0] instanceof WP_Post ) {
 			$user_cpt = get_object_vars( $recent_posts[0] );
 		} elseif ( $create_post ) {
 			$cpt_post_id = wp_insert_post(

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -515,7 +515,7 @@ class WP_Theme_JSON_Resolver {
 
 		$global_style_query = new WP_Query();
 		$recent_posts       = $global_style_query->query( $args );
-		if ( count( $recent_posts ) === 1 ) {
+		if ( count( $recent_posts ) === 1 && is_object( $recent_posts[0] ) ) {
 			$user_cpt = get_object_vars( $recent_posts[0] );
 		} elseif ( $create_post ) {
 			$cpt_post_id = wp_insert_post(
@@ -532,7 +532,10 @@ class WP_Theme_JSON_Resolver {
 				true
 			);
 			if ( ! is_wp_error( $cpt_post_id ) ) {
-				$user_cpt = get_object_vars( get_post( $cpt_post_id ) );
+				$post = get_post( $cpt_post_id );
+				if ( is_object( $post ) ) {
+					$user_cpt = get_object_vars( $post );
+				}
 			}
 		}
 

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -533,7 +533,7 @@ class WP_Theme_JSON_Resolver {
 			);
 			if ( ! is_wp_error( $cpt_post_id ) ) {
 				$post = get_post( $cpt_post_id );
-				if ( is_object( $post ) ) {
+				if ( $post instanceof WP_Post ) {
 					$user_cpt = get_object_vars( $post );
 				}
 			}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64434
Backports https://github.com/WordPress/gutenberg/pull/74124

## What?

This PR adds defensive checks to prevent some errors we've seen in hosts.

In certain scenarios, get_post function returns null after the wp_insert_post function is called. Although the post is saved, it's assumed that it can be immediately accessed, which is not always true.

## Why?

See https://github.com/WordPress/gutenberg/issues/70161

## How?

Check if it's an object before passing it to `get_object_vars`.


## How to reproduce

Unfortunately, there's no steps to reproduce it consistently. We've just seen reports by hosts that this happens occassionally in certain transition states for the site (creation, migration, etc.).
