### PR TITLE
Tests: Update scripts tests to use semantic HTML comparison

### DIFF
--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -2636,7 +2636,6 @@ HTML;
 		$wp_scripts->base_url  = '';
 		$wp_scripts->do_concat = true;
 
-
 		$handle = 'customize-dependency';
 		wp_enqueue_script( $handle, '/customize-dependency.js', array( 'customize-controls' ), null );
 		wp_add_inline_script( $handle, 'tryCustomizeDependency()' );

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -69,6 +69,20 @@ JS;
 		parent::tear_down();
 	}
 
+	/**
+	 * Asserts that two HTML SCRIPT tags are semantically equal within a larger HTML text.
+	 *
+	 * The expected string should contain a single SCRIPT tag with an ID attribute. This ID will
+	 * be used to locate the corresponding SCRIPT tag within the provided HTML.
+	 *
+	 * The provided HTML will be traversed to locate the SCRIPT tag with the matcing ID.
+	 *
+	 * These two tags will be compared for semantic equality of their HTML.
+	 *
+	 * @param string $expected The expected SCRIPT tag HTML.
+	 * @param string $html     The HTML to search within.
+	 * @param string $message  Optional. Message to display upon failure. Default 'The SCRIPT tag did not match.'.
+	 */
 	private function assertEqualHTMLScriptTagById( string $expected, string $html, string $message = 'The SCRIPT tag did not match.' ) {
 		$find_id_tag_processor = new WP_HTML_Tag_Processor( $expected );
 		$find_id_tag_processor->next_token();

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -1580,15 +1580,13 @@ HTML
 		wp_enqueue_script( 'main-script-b1', '/main-script-b1.js', array(), null );
 		$output   = get_echo( 'wp_print_scripts' );
 		$expected = "<script type='text/javascript' src='/main-script-b1.js' id='main-script-b1-js'></script>\n";
-		$expected = str_replace( "'", '"', $expected );
-		$this->assertSame( $expected, $output, 'Scripts registered with a "blocking" strategy, and who have no dependencies, should have no loading strategy attributes printed.' );
+		$this->assertEqualHTML( $expected, $output, '<body>', 'Scripts registered with a "blocking" strategy, and who have no dependencies, should have no loading strategy attributes printed.' );
 
 		// strategy args not set.
 		wp_enqueue_script( 'main-script-b2', '/main-script-b2.js', array(), null, array() );
 		$output   = get_echo( 'wp_print_scripts' );
 		$expected = "<script type='text/javascript' src='/main-script-b2.js' id='main-script-b2-js'></script>\n";
-		$expected = str_replace( "'", '"', $expected );
-		$this->assertSame( $expected, $output, 'Scripts registered with no strategy assigned, and who have no dependencies, should have no loading strategy attributes printed.' );
+		$this->assertEqualHTML( $expected, $output, '<body>', 'Scripts registered with no strategy assigned, and who have no dependencies, should have no loading strategy attributes printed.' );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -2638,13 +2638,6 @@ HTML;
 		$wp_scripts->base_url  = '';
 		$wp_scripts->do_concat = true;
 
-		$expected_tail  = "<script type='text/javascript' src='/customize-dependency.js' id='customize-dependency-js'></script>\n";
-		$expected_tail .= "<script type='text/javascript' id='customize-dependency-js-after'>\n";
-		$expected_tail .= "/* <![CDATA[ */\n";
-		$expected_tail .= "tryCustomizeDependency()\n";
-		$expected_tail .= "//# sourceURL=customize-dependency-js-after\n";
-		$expected_tail .= "/* ]]> */\n";
-		$expected_tail .= "</script>\n";
 
 		$handle = 'customize-dependency';
 		wp_enqueue_script( $handle, '/customize-dependency.js', array( 'customize-controls' ), null );
@@ -2657,9 +2650,16 @@ HTML;
 		_print_scripts();
 		$print_scripts = $this->getActualOutput();
 
-		$tail = substr( $print_scripts, strrpos( $print_scripts, '<script type="text/javascript" src="/customize-dependency.js" id="customize-dependency-js">' ) );
+		$expected = "<script type='text/javascript' src='/customize-dependency.js' id='customize-dependency-js'></script>\n";
+		$this->assertEqualHTMLScriptTagById( $expected, $print_scripts );
 
-		$this->assertEqualHTML( $expected_tail, $tail );
+		$expected  = "<script type='text/javascript' id='customize-dependency-js-after'>\n";
+		$expected .= "/* <![CDATA[ */\n";
+		$expected .= "tryCustomizeDependency()\n";
+		$expected .= "//# sourceURL=customize-dependency-js-after\n";
+		$expected .= "/* ]]> */\n";
+		$expected .= "</script>\n";
+		$this->assertEqualHTMLScriptTagById( $expected, $print_scripts );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -69,6 +69,28 @@ JS;
 		parent::tear_down();
 	}
 
+	private function assertEqualHTMLScriptTagById( string $expected, string $html, ?string $message ) {
+		$find_id_tag_processor = new WP_HTML_Tag_Processor( $expected );
+		$find_id_tag_processor->next_token();
+		$id = $find_id_tag_processor->get_attribute( 'id' );
+		assert( is_string( $id ) );
+
+		$processor = ( new class('', WP_HTML_Processor::CONSTRUCTOR_UNLOCK_CODE ) extends WP_HTML_Processor {
+			public function get_script_html() {
+				assert( 'SCRIPT' === $this->get_tag() );
+				$this->set_bookmark( 'here' );
+				$span = $this->bookmarks['_here'];
+				return substr( $this->html, $span->start, $span->length );
+			}
+		} )::create_fragment( $html );
+
+		while ( $processor->next_tag( 'SCRIPT' ) && $processor->get_attribute( 'id' ) !== $id ) {
+			// Loop until we find the right script tag.
+		}
+		$this->assertSame( 'SCRIPT', $processor->get_tag(), "Matching tag `script#{$id}` could not be found." );
+		$this->assertEqualHTML( $expected, $processor->get_script_html(), '<body>', $message );
+	}
+
 	/**
 	 * Test versioning
 	 *

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -69,7 +69,7 @@ JS;
 		parent::tear_down();
 	}
 
-	private function assertEqualHTMLScriptTagById( string $expected, string $html, ?string $message ) {
+	private function assertEqualHTMLScriptTagById( string $expected, string $html, string $message = 'The SCRIPT tag did not match.' ) {
 		$find_id_tag_processor = new WP_HTML_Tag_Processor( $expected );
 		$find_id_tag_processor->next_token();
 		$id = $find_id_tag_processor->get_attribute( 'id' );

--- a/tests/phpunit/tests/dependencies/wpScriptTag.php
+++ b/tests/phpunit/tests/dependencies/wpScriptTag.php
@@ -11,7 +11,7 @@ class Tests_Functions_wpScriptTag extends WP_UnitTestCase {
 	public function get_script_tag_type_set() {
 		add_theme_support( 'html5', array( 'script' ) );
 
-		$this->assertSame(
+		$this->assertEqualHTML(
 			'<script src="https://localhost/PATH/FILE.js" type="application/javascript" nomodule></script>' . "\n",
 			wp_get_script_tag(
 				array(
@@ -25,7 +25,7 @@ class Tests_Functions_wpScriptTag extends WP_UnitTestCase {
 
 		remove_theme_support( 'html5' );
 
-		$this->assertSame(
+		$this->assertEqualHTML(
 			'<script src="https://localhost/PATH/FILE.js" type="application/javascript" nomodule></script>' . "\n",
 			wp_get_script_tag(
 				array(
@@ -44,7 +44,7 @@ class Tests_Functions_wpScriptTag extends WP_UnitTestCase {
 	public function test_get_script_tag_type_not_set() {
 		add_theme_support( 'html5', array( 'script' ) );
 
-		$this->assertSame(
+		$this->assertEqualHTML(
 			'<script src="https://localhost/PATH/FILE.js" nomodule></script>' . "\n",
 			wp_get_script_tag(
 				array(
@@ -80,7 +80,7 @@ class Tests_Functions_wpScriptTag extends WP_UnitTestCase {
 			'nomodule' => true,
 		);
 
-		$this->assertSame(
+		$this->assertEqualHTML(
 			wp_get_script_tag( $attributes ),
 			get_echo(
 				'wp_print_script_tag',
@@ -90,7 +90,7 @@ class Tests_Functions_wpScriptTag extends WP_UnitTestCase {
 
 		remove_theme_support( 'html5' );
 
-		$this->assertSame(
+		$this->assertEqualHTML(
 			wp_get_script_tag( $attributes ),
 			get_echo(
 				'wp_print_script_tag',


### PR DESCRIPTION
These tests failed with semantically equivalent HTML while working on https://github.com/WordPress/wordpress-develop/pull/10639.

`assertEqualHTML` makes the tests more robust.

Trac ticket: https://core.trac.wordpress.org/ticket/64225

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
