### PR TITLE
#64429: Fix script module fetchpriority when dependent is not enqueued

### DIFF
--- a/src/wp-includes/class-wp-script-modules.php
+++ b/src/wp-includes/class-wp-script-modules.php
@@ -461,9 +461,9 @@ class WP_Script_Modules {
 			'id'   => $id . '-js-module',
 		);
 
-		$script_module = $this->registered[ $id ];
-		$dependents    = $this->get_recursive_dependents( $id );
-		$fetchpriority = $this->get_highest_fetchpriority( array_merge( array( $id ), $dependents ) );
+		$script_module     = $this->registered[ $id ];
+		$queued_dependents = array_intersect( $this->queue, $this->get_recursive_dependents( $id ) );
+		$fetchpriority     = $this->get_highest_fetchpriority( array_merge( array( $id ), $queued_dependents ) );
 		if ( 'auto' !== $fetchpriority ) {
 			$attributes['fetchpriority'] = $fetchpriority;
 		}

--- a/src/wp-includes/class-wp-scripts.php
+++ b/src/wp-includes/class-wp-scripts.php
@@ -1092,7 +1092,7 @@ JS;
 	 *
 	 * @since 6.9.0
 	 * @see self::filter_eligible_strategies()
-	 * @see WP_Script_Modules::get_highest_fetchpriority_with_dependents()
+	 * @see WP_Script_Modules::get_highest_fetchpriority()
 	 *
 	 * @param string                $handle         Script module ID.
 	 * @param array<string, true>   $checked        Optional. An array of already checked script handles, used to avoid recursive loops.

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -1517,6 +1517,30 @@ HTML
 	}
 
 	/**
+	 * Tests expected priority is used when a dependent is registered but not enqueued.
+	 *
+	 * @ticket 64429
+	 *
+	 * @covers WP_Scripts::print_scripts
+	 * @covers WP_Scripts::get_highest_fetchpriority_with_dependents
+	 */
+	public function test_priority_of_dependency_for_non_enqueued_dependent() {
+		$wp_scripts = wp_scripts();
+		wp_default_scripts( $wp_scripts );
+
+		$wp_scripts->add( 'not-enqueued', 'https://example.com/not-enqueued.js', array( 'comment-reply' ), null, array( 'priority' => 'high' ) );
+		$wp_scripts->enqueue( 'comment-reply' );
+
+		$actual = $this->normalize_markup_for_snapshot( get_echo( array( $wp_scripts, 'print_scripts' ) ) );
+		$this->assertEqualHTML(
+			'<script type="text/javascript" src="/wp-includes/js/comment-reply.js" id="comment-reply-js" async="async" data-wp-strategy="async" fetchpriority="low"></script>',
+			$actual,
+			'<body>',
+			"Snapshot:\n$actual"
+		);
+	}
+
+	/**
 	 * Tests that printing a script without enqueueing has the same output as when it is enqueued.
 	 *
 	 * @ticket 61734
@@ -4255,5 +4279,27 @@ HTML;
 				"ver={$default_version}&amp;qs1=q1&amp;qs2=q2",
 			),
 		);
+	}
+
+	/**
+	 * Normalizes markup for snapshot.
+	 *
+	 * @param string $markup Markup.
+	 * @return string Normalized markup.
+	 */
+	private function normalize_markup_for_snapshot( string $markup ): string {
+		$processor = new WP_HTML_Tag_Processor( $markup );
+		$clean_url = static function ( string $url ): string {
+			$url = preg_replace( '#^https?://[^/]+#', '', $url );
+			return remove_query_arg( 'ver', $url );
+		};
+		while ( $processor->next_tag() ) {
+			if ( 'LINK' === $processor->get_tag() && is_string( $processor->get_attribute( 'href' ) ) ) {
+				$processor->set_attribute( 'href', $clean_url( $processor->get_attribute( 'href' ) ) );
+			} elseif ( 'SCRIPT' === $processor->get_tag() && is_string( $processor->get_attribute( 'src' ) ) ) {
+				$processor->set_attribute( 'src', $clean_url( $processor->get_attribute( 'src' ) ) );
+			}
+		}
+		return $processor->get_updated_html();
 	}
 }

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -1553,16 +1553,15 @@ HTML;
 	 */
 	public function data_provider_to_test_fetchpriority_bumping(): array {
 		return array(
-			'enqueue_bajo' => array(
+			'enqueue_bajo'          => array(
 				'enqueues' => array( 'bajo' ),
 				'expected' => array(
 					'preload_links' => array(),
 					'script_tags'   => array(
 						'bajo' => array(
-							'url'                   => '/bajo.js',
-							'fetchpriority'         => 'high',
-							'in_footer'             => false,
-							'data-wp-fetchpriority' => 'low',
+							'url'           => '/bajo.js',
+							'fetchpriority' => 'low', // Priority of 'low' not 'high' because the 'auto' dependent was not enqueued.
+							'in_footer'     => false,
 						),
 					),
 					'import_map'    => array(
@@ -1570,7 +1569,30 @@ HTML;
 					),
 				),
 			),
-			'enqueue_auto' => array(
+			'enqueue_bajo_and_auto' => array(
+				'enqueues' => array( 'bajo', 'auto' ),
+				'expected' => array(
+					'preload_links' => array(),
+					'script_tags'   => array(
+						'bajo' => array(
+							'url'                   => '/bajo.js',
+							'fetchpriority'         => 'auto',
+							'in_footer'             => false,
+							'data-wp-fetchpriority' => 'low',
+						),
+						'auto' => array(
+							'url'           => '/auto.js',
+							'fetchpriority' => 'auto',
+							'in_footer'     => false,
+						),
+					),
+					'import_map'    => array(
+						'dyno' => '/dyno.js',
+						'bajo' => '/bajo.js',
+					),
+				),
+			),
+			'enqueue_auto'          => array(
 				'enqueues' => array( 'auto' ),
 				'expected' => array(
 					'preload_links' => array(
@@ -1582,10 +1604,9 @@ HTML;
 					),
 					'script_tags'   => array(
 						'auto' => array(
-							'url'                   => '/auto.js',
-							'fetchpriority'         => 'high',
-							'in_footer'             => false,
-							'data-wp-fetchpriority' => 'auto',
+							'url'           => '/auto.js',
+							'fetchpriority' => 'auto', // Priority of 'auto' not 'high' because the 'alto' dependent was not enqueued.
+							'in_footer'     => false,
 						),
 					),
 					'import_map'    => array(
@@ -1594,7 +1615,7 @@ HTML;
 					),
 				),
 			),
-			'enqueue_alto' => array(
+			'enqueue_alto'          => array(
 				'enqueues' => array( 'alto' ),
 				'expected' => array(
 					'preload_links' => array(
@@ -1833,6 +1854,10 @@ HTML;
 	 * Tests expected priority is used when a dependent is registered but not enqueued.
 	 *
 	 * @ticket 64429
+	 *
+	 * @covers ::wp_default_script_modules
+	 * @covers WP_Script_Modules::print_enqueued_script_modules
+	 * @covers WP_Script_Modules::get_highest_fetchpriority
 	 */
 	public function test_priority_of_dependency_for_non_enqueued_dependent() {
 		wp_default_script_modules();

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -1864,12 +1864,12 @@ HTML;
 		wp_register_script_module( 'not-enqueued', 'https://example.com/not-enqueued.js', array( '@wordpress/a11y' ), null, array( 'priority' => 'high' ) );
 		wp_enqueue_script_module( '@wordpress/a11y' );
 
-		$actual_script_modules = $this->normalize_markup_for_snapshot( get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) ) );
+		$actual = $this->normalize_markup_for_snapshot( get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) ) );
 		$this->assertEqualHTML(
 			'<script type="module" src="/wp-includes/js/dist/script-modules/a11y/index.min.js" id="@wordpress/a11y-js-module" fetchpriority="low"></script>',
-			$actual_script_modules,
+			$actual,
 			'<body>',
-			"Snapshot:\n$actual_script_modules"
+			"Snapshot:\n$actual"
 		);
 	}
 

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -1830,6 +1830,25 @@ HTML;
 	}
 
 	/**
+	 * Tests expected priority is used when a dependent is registered but not enqueued.
+	 *
+	 * @ticket 64429
+	 */
+	public function test_priority_of_dependency_for_non_enqueued_dependent() {
+		wp_default_script_modules();
+		wp_register_script_module( 'not-enqueued', 'https://example.com/not-enqueued.js', array( '@wordpress/a11y' ), null, array( 'priority' => 'high' ) );
+		wp_enqueue_script_module( '@wordpress/a11y' );
+
+		$actual_script_modules = $this->normalize_markup_for_snapshot( get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) ) );
+		$this->assertEqualHTML(
+			'<script type="module" src="/wp-includes/js/dist/script-modules/a11y/index.min.js" id="@wordpress/a11y-js-module" fetchpriority="low"></script>',
+			$actual_script_modules,
+			'<body>',
+			"Snapshot:\n$actual_script_modules"
+		);
+	}
+
+	/**
 	 * Tests that a dependent with high priority for default script modules with a low fetch priority are printed as expected.
 	 *
 	 * @covers ::wp_default_script_modules


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

When `WP_Script_Modules::print_script_module()` was calculating the highest `fetchpriority` for its script module dependents, it was not considering whether those dependents were actually enqueued. Now it does.

Note the issue was not present for classic scripts.

Test cases have been added for scripts and script modules.

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64429

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
