### PR TITLE
Fix PHPStan level 8 issues in `functions.wp-styles.php` and `functions.wp-scripts.php`

### DIFF
--- a/src/wp-includes/functions.wp-scripts.php
+++ b/src/wp-includes/functions.wp-scripts.php
@@ -141,7 +141,7 @@ function wp_add_inline_script( $handle, $data, $position = 'after' ) {
 			),
 			'4.5.0'
 		);
-		$data = trim( preg_replace( '#<script[^>]*>(.*)</script>#is', '$1', $data ) );
+		$data = trim( (string) preg_replace( '#<script[^>]*>(.*)</script>#is', '$1', $data ) );
 	}
 
 	return wp_scripts()->add_inline_script( $handle, $data, $position );
@@ -160,15 +160,15 @@ function wp_add_inline_script( $handle, $data, $position = 'after' ) {
  * @since 6.3.0 The $in_footer parameter of type boolean was overloaded to be an $args parameter of type array.
  * @since 6.9.0 The $fetchpriority parameter of type string was added to the $args parameter of type array.
  *
- * @param string           $handle    Name of the script. Should be unique.
- * @param string|false     $src       Full URL of the script, or path of the script relative to the WordPress root directory.
- *                                    If source is set to false, script is an alias of other scripts it depends on.
- * @param string[]         $deps      Optional. An array of registered script handles this script depends on. Default empty array.
- * @param string|bool|null $ver       Optional. String specifying script version number, if it has one, which is added to the URL
- *                                    as a query string for cache busting purposes. If version is set to false, a version
- *                                    number is automatically added equal to current installed WordPress version.
- *                                    If set to null, no version is added.
- * @param array|bool       $args     {
+ * @param string                          $handle Name of the script. Should be unique.
+ * @param string|false                    $src    Full URL of the script, or path of the script relative to the WordPress root directory.
+ *                                                If source is set to false, script is an alias of other scripts it depends on.
+ * @param string[]                        $deps   Optional. An array of registered script handles this script depends on. Default empty array.
+ * @param string|bool|null                $ver    Optional. String specifying script version number, if it has one, which is added to the URL
+ *                                                as a query string for cache busting purposes. If version is set to false, a version
+ *                                                number is automatically added equal to current installed WordPress version.
+ *                                                If set to null, no version is added.
+ * @param array<string, string|bool>|bool $args   {
  *     Optional. An array of additional script loading strategies. Default empty array.
  *     Otherwise, it may be a boolean in which case it determines whether the script is printed in the footer. Default false.
  *
@@ -221,10 +221,10 @@ function wp_register_script( $handle, $src, $deps = array(), $ver = false, $args
  *
  * @todo Documentation cleanup
  *
- * @param string $handle      Script handle the data will be attached to.
- * @param string $object_name Name for the JavaScript object. Passed directly, so it should be qualified JS variable.
- *                            Example: '/[a-zA-Z0-9_]+/'.
- * @param array  $l10n        The data itself. The data can be either a single or multi-dimensional array.
+ * @param string               $handle      Script handle the data will be attached to.
+ * @param string               $object_name Name for the JavaScript object. Passed directly, so it should be qualified JS variable.
+ *                                          Example: '/[a-zA-Z0-9_]+/'.
+ * @param array<string, mixed> $l10n        The data itself. The data can be either a single or multi-dimensional array.
  * @return bool True if the script was successfully localized, false otherwise.
  */
 function wp_localize_script( $handle, $object_name, $l10n ) {
@@ -346,15 +346,15 @@ function wp_deregister_script( $handle ) {
  * @since 6.3.0 The $in_footer parameter of type boolean was overloaded to be an $args parameter of type array.
  * @since 6.9.0 The $fetchpriority parameter of type string was added to the $args parameter of type array.
  *
- * @param string           $handle    Name of the script. Should be unique.
- * @param string           $src       Full URL of the script, or path of the script relative to the WordPress root directory.
- *                                    Default empty.
- * @param string[]         $deps      Optional. An array of registered script handles this script depends on. Default empty array.
- * @param string|bool|null $ver       Optional. String specifying script version number, if it has one, which is added to the URL
- *                                    as a query string for cache busting purposes. If version is set to false, a version
- *                                    number is automatically added equal to current installed WordPress version.
- *                                    If set to null, no version is added.
- * @param array|bool       $args     {
+ * @param string                          $handle Name of the script. Should be unique.
+ * @param string                          $src    Full URL of the script, or path of the script relative to the WordPress root directory.
+ *                                                Default empty.
+ * @param string[]                        $deps   Optional. An array of registered script handles this script depends on. Default empty array.
+ * @param string|bool|null                $ver    Optional. String specifying script version number, if it has one, which is added to the URL
+ *                                                as a query string for cache busting purposes. If version is set to false, a version
+ *                                                number is automatically added equal to current installed WordPress version.
+ *                                                If set to null, no version is added.
+ * @param array<string, string|bool>|bool $args   {
  *     Optional. An array of additional script loading strategies. Default empty array.
  *     Otherwise, it may be a boolean in which case it determines whether the script is printed in the footer. Default false.
  *

--- a/src/wp-includes/functions.wp-styles.php
+++ b/src/wp-includes/functions.wp-styles.php
@@ -38,7 +38,7 @@ function wp_styles() {
  *
  * @global WP_Styles $wp_styles The WP_Styles object for printing styles.
  *
- * @param string|bool|array $handles Styles to be printed. Default 'false'.
+ * @param string|false|string[] $handles Styles to be printed. Default 'false'.
  * @return string[] On success, an array of handles of processed WP_Dependencies items; otherwise, an empty array.
  */
 function wp_print_styles( $handles = false ) {
@@ -98,7 +98,7 @@ function wp_add_inline_style( $handle, $data ) {
 			),
 			'3.7.0'
 		);
-		$data = trim( preg_replace( '#<style[^>]*>(.*)</style>#is', '$1', $data ) );
+		$data = trim( (string) preg_replace( '#<style[^>]*>(.*)</style>#is', '$1', $data ) );
 	}
 
 	return wp_styles()->add_inline_style( $handle, $data );


### PR DESCRIPTION
This is a subset of https://github.com/WordPress/wordpress-develop/pull/10627

This PR addresses the following issues PHPStan [level 8](https://phpstan.org/user-guide/rule-levels#:~:text=report%20calling%20methods%20and%20accessing%20properties%20on%20nullable%20types) issues:

```bash
phpstan analyze --memory-limit=4G --level=8 src/wp-includes/functions.wp-styles.php src/wp-includes/functions.wp-scripts.php
```

Before:

```
Note: Using configuration file /Users/westonruter/repos/wordpress-develop/phpstan.neon.
 2/2 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ --------------------------------------------------------------------------------------------------------
  Line   functions.wp-scripts.php
 ------ --------------------------------------------------------------------------------------------------------
  144    Parameter #1 $string of function trim expects string, string|null given.
         🪪  argument.type
  181    Function wp_register_script() has parameter $args with no value type specified in iterable type array.
         🪪  missingType.iterableValue
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type
  230    Function wp_localize_script() has parameter $l10n with no value type specified in iterable type array.
         🪪  missingType.iterableValue
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type
  366    Function wp_enqueue_script() has parameter $args with no value type specified in iterable type array.
         🪪  missingType.iterableValue
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type
 ------ --------------------------------------------------------------------------------------------------------

 ------ ------------------------------------------------------------------------------------------------------------------------------------
  Line   functions.wp-styles.php
 ------ ------------------------------------------------------------------------------------------------------------------------------------
  44     Function wp_print_styles() has parameter $handles with no value type specified in iterable type array.
         🪪  missingType.iterableValue
         💡  See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type
  68     Parameter #1 $handles of method WP_Dependencies::do_items() expects array<string>|string|false, array|bool|non-empty-string given.
         🪪  argument.type
  101    Parameter #1 $string of function trim expects string, string|null given.
         🪪  argument.type
 ------ ------------------------------------------------------------------------------------------------------------------------------------
```

After:

```
[OK] No errors
```

Trac ticket: https://core.trac.wordpress.org/ticket/64238

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
