### PR TITLE
Issue `_doing_it_wrong()` when registered style has invalid `path` and allow empty stylesheets to be inlined

### DIFF
--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -69,7 +69,7 @@ jobs:
     secrets: inherit
     if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ ubuntu-24.04 ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
@@ -146,7 +146,7 @@ jobs:
     secrets: inherit
     if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ ubuntu-24.04 ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
@@ -198,7 +198,7 @@ jobs:
     secrets: inherit
     if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ ubuntu-24.04 ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
@@ -246,7 +246,7 @@ jobs:
     secrets: inherit
     if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         php: [ '7.2', '7.4', '8.0', '8.4' ]
         db-type: [ 'mysql' ]
@@ -275,7 +275,7 @@ jobs:
     secrets: inherit
     if: ${{ ! startsWith( github.repository, 'WordPress/' ) && github.event_name == 'pull_request' }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         php: [ '7.2', '8.4' ]
         db-version: [ '8.4', '11.8' ]

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -69,7 +69,7 @@ jobs:
     secrets: inherit
     if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ ubuntu-24.04 ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
@@ -146,7 +146,7 @@ jobs:
     secrets: inherit
     if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ ubuntu-24.04 ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
@@ -198,7 +198,7 @@ jobs:
     secrets: inherit
     if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ ubuntu-24.04 ]
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
@@ -246,7 +246,7 @@ jobs:
     secrets: inherit
     if: ${{ startsWith( github.repository, 'WordPress/' ) && ( github.repository == 'WordPress/wordpress-develop' || github.event_name == 'pull_request' ) }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         php: [ '7.2', '7.4', '8.0', '8.4' ]
         db-type: [ 'mysql' ]
@@ -275,7 +275,7 @@ jobs:
     secrets: inherit
     if: ${{ ! startsWith( github.repository, 'WordPress/' ) && github.event_name == 'pull_request' }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         php: [ '7.2', '8.4' ]
         db-version: [ '8.4', '11.8' ]

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3081,7 +3081,7 @@ function wp_maybe_inline_styles() {
 		$path = $wp_styles->get_data( $handle, 'path' );
 		if ( $path && $src ) {
 			$size = wp_filesize( $path );
-			if ( 0 === $size ) {
+			if ( 0 === $size && ! file_exists( $path ) ) {
 				_doing_it_wrong(
 					__FUNCTION__,
 					sprintf(

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3130,7 +3130,7 @@ function wp_maybe_inline_styles() {
 			}
 
 			// Get the styles if we don't already have them.
-			$style['css'] = file_get_contents( $style['path'] );
+			$style['css'] = @file_get_contents( $style['path'] );
 			if ( false === $style['css'] ) {
 				_doing_it_wrong(
 					__FUNCTION__,

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3130,8 +3130,7 @@ function wp_maybe_inline_styles() {
 			}
 
 			// Get the styles if we don't already have them.
-			$style['css'] = @file_get_contents( $style['path'] );
-			if ( false === $style['css'] ) {
+			if ( ! is_readable( $style['path'] ) ) {
 				_doing_it_wrong(
 					__FUNCTION__,
 					sprintf(
@@ -3145,6 +3144,7 @@ function wp_maybe_inline_styles() {
 				);
 				continue;
 			}
+			$style['css'] = file_get_contents( $style['path'] );
 
 			/*
 			 * Check if the style contains relative URLs that need to be modified.

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -3081,7 +3081,18 @@ function wp_maybe_inline_styles() {
 		$path = $wp_styles->get_data( $handle, 'path' );
 		if ( $path && $src ) {
 			$size = wp_filesize( $path );
-			if ( ! $size ) {
+			if ( 0 === $size ) {
+				_doing_it_wrong(
+					__FUNCTION__,
+					sprintf(
+						/* translators: 1: 'path', 2: filesystem path, 3: style handle */
+						__( 'Unable to read the "%1$s" key with value "%2$s" for stylesheet "%3$s".' ),
+						'path',
+						esc_html( $path ),
+						esc_html( $handle )
+					),
+					'7.0.0'
+				);
 				continue;
 			}
 			$styles[] = array(
@@ -3120,6 +3131,20 @@ function wp_maybe_inline_styles() {
 
 			// Get the styles if we don't already have them.
 			$style['css'] = file_get_contents( $style['path'] );
+			if ( false === $style['css'] ) {
+				_doing_it_wrong(
+					__FUNCTION__,
+					sprintf(
+						/* translators: 1: 'path', 2: filesystem path, 3: style handle */
+						__( 'Unable to read the "%1$s" key with value "%2$s" for stylesheet "%3$s".' ),
+						'path',
+						esc_html( $style['path'] ),
+						esc_html( $style['handle'] )
+					),
+					'7.0.0'
+				);
+				continue;
+			}
 
 			/*
 			 * Check if the style contains relative URLs that need to be modified.

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -774,7 +774,39 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	 * @covers ::wp_maybe_inline_styles
 	 * @expectedIncorrectUsage wp_maybe_inline_styles
 	 */
-	public function test_wp_maybe_inline_styles_bad_path() {
+	public function test_wp_maybe_inline_styles_bad_path_at_file_size_check() {
+		$handle   = 'test-handle';
+		$inc_path = '/css/ancient-themes.css'; // Does not exist.
+		$url      = '/' . WPINC . $inc_path;
+		wp_register_style( $handle, $url );
+		wp_style_add_data( $handle, 'path', ABSPATH . WPINC . $inc_path );
+		wp_enqueue_style( $handle );
+
+		wp_maybe_inline_styles();
+
+		$this->assertSame( $GLOBALS['wp_styles']->registered[ $handle ]->src, $url );
+	}
+
+	/**
+	 * @ticket 64447
+	 *
+	 * @covers ::wp_maybe_inline_styles
+	 * @expectedIncorrectUsage wp_maybe_inline_styles
+	 */
+	public function test_wp_maybe_inline_styles_bad_path_with_file_size_provided() {
+		// This ensures the initial file size check is bypassed.
+		add_filter(
+			'pre_wp_filesize',
+			static function ( $size, $path ) {
+				if ( str_contains( $path, 'ancient-themes.css' ) ) {
+					$size = 1000;
+				}
+				return $size;
+			},
+			10,
+			2
+		);
+
 		$handle   = 'test-handle';
 		$inc_path = '/css/ancient-themes.css'; // Does not exist.
 		$url      = '/' . WPINC . $inc_path;

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -716,10 +716,12 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 
 	/**
 	 * @ticket 58394
+	 * @ticket 64447
 	 *
 	 * @covers ::wp_maybe_inline_styles
+	 * @expectedIncorrectUsage wp_maybe_inline_styles
 	 */
-	public function test_test_wp_maybe_inline_styles_missing_file() {
+	public function test_wp_maybe_inline_styles_missing_file() {
 		$filter = new MockAction();
 		add_filter( 'pre_wp_filesize', array( $filter, 'filter' ) );
 		$url = '/' . WPINC . '/css/invalid.css';
@@ -774,33 +776,14 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	 * @covers ::wp_maybe_inline_styles
 	 * @expectedIncorrectUsage wp_maybe_inline_styles
 	 */
-	public function test_wp_maybe_inline_styles_bad_path_at_file_size_check() {
-		$handle   = 'test-handle';
-		$inc_path = '/css/ancient-themes.css'; // Does not exist.
-		$url      = '/' . WPINC . $inc_path;
-		wp_register_style( $handle, $url );
-		wp_style_add_data( $handle, 'path', ABSPATH . WPINC . $inc_path );
-		wp_enqueue_style( $handle );
-
-		wp_maybe_inline_styles();
-
-		$this->assertSame( $GLOBALS['wp_styles']->registered[ $handle ]->src, $url );
-	}
-
-	/**
-	 * @ticket 64447
-	 *
-	 * @covers ::wp_maybe_inline_styles
-	 * @expectedIncorrectUsage wp_maybe_inline_styles
-	 */
 	public function test_wp_maybe_inline_styles_bad_path_with_file_size_provided() {
-		$inc_path = '/css/ancient-themes.css'; // Does not exist.
+		$style_path = '/css/invalid.css'; // Does not exist.
 
 		// This ensures the initial file size check is bypassed.
 		add_filter(
 			'pre_wp_filesize',
-			static function ( $size, $path ) use ( $inc_path ) {
-				if ( str_contains( $path, $inc_path ) ) {
+			static function ( $size, $path ) use ( $style_path ) {
+				if ( str_contains( $path, $style_path ) ) {
 					$size = 1000;
 				}
 				return $size;
@@ -810,9 +793,9 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		);
 
 		$handle = 'test-handle';
-		$url    = '/' . WPINC . $inc_path;
+		$url    = '/' . WPINC . $style_path;
 		wp_register_style( $handle, $url );
-		wp_style_add_data( $handle, 'path', ABSPATH . WPINC . $inc_path );
+		wp_style_add_data( $handle, 'path', ABSPATH . WPINC . $style_path );
 		wp_enqueue_style( $handle );
 
 		wp_maybe_inline_styles();
@@ -826,13 +809,13 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	 * @covers ::wp_maybe_inline_styles
 	 */
 	public function test_wp_maybe_inline_styles_good_path_with_zero_file_size_provided() {
-		$inc_path = '/css/classic-themes.css';
+		$style_path = '/css/classic-themes.css';
 
 		// This simulates the file having a zero size.
 		add_filter(
 			'pre_wp_filesize',
-			static function ( $size, $path ) use ( $inc_path ) {
-				if ( str_contains( $path, $inc_path ) ) {
+			static function ( $size, $path ) use ( $style_path ) {
+				if ( str_contains( $path, $style_path ) ) {
 					$size = 0;
 				}
 				return $size;
@@ -842,8 +825,8 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		);
 
 		$handle = 'test-handle';
-		wp_register_style( $handle, '/' . WPINC . $inc_path );
-		wp_style_add_data( $handle, 'path', ABSPATH . WPINC . $inc_path );
+		wp_register_style( $handle, '/' . WPINC . $style_path );
+		wp_style_add_data( $handle, 'path', ABSPATH . WPINC . $style_path );
 		wp_enqueue_style( $handle );
 
 		wp_maybe_inline_styles();

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -794,11 +794,13 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	 * @expectedIncorrectUsage wp_maybe_inline_styles
 	 */
 	public function test_wp_maybe_inline_styles_bad_path_with_file_size_provided() {
+		$inc_path = '/css/ancient-themes.css'; // Does not exist.
+
 		// This ensures the initial file size check is bypassed.
 		add_filter(
 			'pre_wp_filesize',
-			static function ( $size, $path ) {
-				if ( str_contains( $path, 'ancient-themes.css' ) ) {
+			static function ( $size, $path ) use ( $inc_path ) {
+				if ( str_contains( $path, $inc_path ) ) {
 					$size = 1000;
 				}
 				return $size;
@@ -807,9 +809,8 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 			2
 		);
 
-		$handle   = 'test-handle';
-		$inc_path = '/css/ancient-themes.css'; // Does not exist.
-		$url      = '/' . WPINC . $inc_path;
+		$handle = 'test-handle';
+		$url    = '/' . WPINC . $inc_path;
 		wp_register_style( $handle, $url );
 		wp_style_add_data( $handle, 'path', ABSPATH . WPINC . $inc_path );
 		wp_enqueue_style( $handle );
@@ -817,6 +818,37 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		wp_maybe_inline_styles();
 
 		$this->assertSame( $GLOBALS['wp_styles']->registered[ $handle ]->src, $url );
+	}
+
+	/**
+	 * @ticket 64447
+	 *
+	 * @covers ::wp_maybe_inline_styles
+	 */
+	public function test_wp_maybe_inline_styles_good_path_with_zero_file_size_provided() {
+		$inc_path = '/css/classic-themes.css';
+
+		// This simulates the file having a zero size.
+		add_filter(
+			'pre_wp_filesize',
+			static function ( $size, $path ) use ( $inc_path ) {
+				if ( str_contains( $path, $inc_path ) ) {
+					$size = 0;
+				}
+				return $size;
+			},
+			10,
+			2
+		);
+
+		$handle = 'test-handle';
+		wp_register_style( $handle, '/' . WPINC . $inc_path );
+		wp_style_add_data( $handle, 'path', ABSPATH . WPINC . $inc_path );
+		wp_enqueue_style( $handle );
+
+		wp_maybe_inline_styles();
+
+		$this->assertFalse( $GLOBALS['wp_styles']->registered[ $handle ]->src );
 	}
 
 	/**

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -769,6 +769,25 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 64447
+	 *
+	 * @covers ::wp_maybe_inline_styles
+	 * @expectedIncorrectUsage wp_maybe_inline_styles
+	 */
+	public function test_wp_maybe_inline_styles_bad_path() {
+		$handle   = 'test-handle';
+		$inc_path = '/css/ancient-themes.css'; // Does not exist.
+		$url      = '/' . WPINC . $inc_path;
+		wp_register_style( $handle, $url );
+		wp_style_add_data( $handle, 'path', ABSPATH . WPINC . $inc_path );
+		wp_enqueue_style( $handle );
+
+		wp_maybe_inline_styles();
+
+		$this->assertSame( $GLOBALS['wp_styles']->registered[ $handle ]->src, $url );
+	}
+
+	/**
 	 * @ticket 63887
 	 */
 	public function test_source_url_encoding() {

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -6677,7 +6677,7 @@ EOF;
 	 * @dataProvider data_provider_data_provider_to_test_wp_enqueue_img_auto_sizes_contain_css_fix
 	 */
 	public function test_wp_enqueue_img_auto_sizes_contain_css_fix( ?Closure $set_up, bool $expected, ?string $expected_deprecated = null ): void {
-		// These files is created as part of the build process, but the unit tests don't run the build prior to running unit tests on GHA.
+		// These files are created as part of the build process, but the unit tests don't run the build prior to running unit tests on GHA.
 		self::touch( ABSPATH . WPINC . '/css/dist/block-library/style.css' );
 		self::touch( ABSPATH . WPINC . '/css/dist/block-library/common.css' );
 

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -6677,7 +6677,8 @@ EOF;
 	 * @dataProvider data_provider_data_provider_to_test_wp_enqueue_img_auto_sizes_contain_css_fix
 	 */
 	public function test_wp_enqueue_img_auto_sizes_contain_css_fix( ?Closure $set_up, bool $expected, ?string $expected_deprecated = null ): void {
-		// This file is created as part of the build process, but the unit tests don't run the build prior to running unit tests on GHA.
+		// These files is created as part of the build process, but the unit tests don't run the build prior to running unit tests on GHA.
+		self::touch( ABSPATH . WPINC . '/css/dist/block-library/style.css' );
 		self::touch( ABSPATH . WPINC . '/css/dist/block-library/common.css' );
 
 		if ( $set_up ) {

--- a/tests/phpunit/tests/media.php
+++ b/tests/phpunit/tests/media.php
@@ -6677,6 +6677,9 @@ EOF;
 	 * @dataProvider data_provider_data_provider_to_test_wp_enqueue_img_auto_sizes_contain_css_fix
 	 */
 	public function test_wp_enqueue_img_auto_sizes_contain_css_fix( ?Closure $set_up, bool $expected, ?string $expected_deprecated = null ): void {
+		// This file is created as part of the build process, but the unit tests don't run the build prior to running unit tests on GHA.
+		self::touch( ABSPATH . WPINC . '/css/dist/block-library/common.css' );
+
 		if ( $set_up ) {
 			$set_up();
 		}

--- a/tests/phpunit/tests/template.php
+++ b/tests/phpunit/tests/template.php
@@ -1716,10 +1716,6 @@ class Tests_Template extends WP_UnitTestCase {
 			wp_should_load_separate_core_block_assets()
 		);
 		$this->ensure_style_asset_file_created( 'wp-block-library-theme', 'css/dist/block-library/theme.css', true );
-		$block_library_dependency = wp_styles()->query( 'wp-block-library' );
-		$this->assertTrue( (bool) $block_library_dependency, 'Expected wp-block-library stylesheet to be registered.' );
-		$this->assertIsString( $block_library_dependency->src, 'Expected wp-block-library to have a string src. Dependency: ' . json_encode( $block_library_dependency ) );
-		$this->assertNotEmpty( file_get_contents( $block_library_dependency->extra['path'] ), 'Expected wp-block-library file to not be empty.' );
 
 		if ( wp_should_load_separate_core_block_assets() ) {
 			$this->ensure_style_asset_file_created( 'wp-block-separator', 'blocks/separator/style.css', true );
@@ -1746,7 +1742,6 @@ class Tests_Template extends WP_UnitTestCase {
 
 		// Simulate wp_head.
 		$head_output = get_echo( 'wp_head' );
-		$this->assertContains( 'wp-block-library', wp_styles()->done, 'Expected wp-block-library to have been added to wp_styles()->done.' );
 
 		$this->assertStringContainsString( 'early', $head_output, 'Expected the early-enqueued stylesheet to be present.' );
 
@@ -1814,7 +1809,7 @@ class Tests_Template extends WP_UnitTestCase {
 		$this->assertSame(
 			$expected_styles,
 			$found_subset_styles,
-			'Expected the same styles. Snapshot: ' . self::get_array_snapshot_export( $found_subset_styles ) . "\nAnd wp-block-library: " . json_encode( $block_library_dependency, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n And file contents: " . file_get_contents( $block_library_dependency->extra['path'] )
+			'Expected the same styles. Snapshot: ' . self::get_array_snapshot_export( $found_subset_styles ) )
 		);
 	}
 

--- a/tests/phpunit/tests/template.php
+++ b/tests/phpunit/tests/template.php
@@ -1706,30 +1706,18 @@ class Tests_Template extends WP_UnitTestCase {
 		register_core_block_style_handles();
 		$this->assertTrue( WP_Block_Type_Registry::get_instance()->is_registered( 'core/separator' ), 'Expected the core/separator block to be registered.' );
 
-		// Ensure all registered styles added as part of the build process are present on the disk. .These files are created as part of the build process, but the unit tests don't run the build prior to running unit tests on GHA.
-		foreach ( wp_styles()->registered as $handle => $dependency ) {
-			if ( ! is_string( $dependency->src ) ) {
-				continue;
-			}
-			$path     = wp_parse_url( $dependency->src, PHP_URL_PATH );
-			$position = strpos( $path, WPINC . '/' );
-			if ( false === $position ) {
-				continue;
-			}
-			$absolute_path = ABSPATH . substr( $path, $position );
-			if ( ! file_exists( $absolute_path ) ) {
-				self::touch( $absolute_path );
-				file_put_contents( $absolute_path, "/* Stub for $handle */" );
-			}
-		}
-
 		// Ensure stylesheet files exist on the filesystem since a build may not have been done.
 		$this->ensure_style_asset_file_created(
 			'wp-block-library',
-			wp_should_load_separate_core_block_assets() ? 'css/dist/block-library/common.css' : 'css/dist/block-library/style.css'
+			wp_should_load_separate_core_block_assets() ? 'css/dist/block-library/common.css' : 'css/dist/block-library/style.css',
+			wp_should_load_separate_core_block_assets()
 		);
+		$dependency = wp_styles()->query( 'wp-block-library' );
+		$this->assertTrue( (bool) $dependency, 'Expected wp-block-library stylesheet to be registered.' );
+		$this->assertIsString( $dependency->src, 'Expected wp-block-library to have a string src. Dependency: ' . json_encode( $dependency ) );
+
 		if ( wp_should_load_separate_core_block_assets() ) {
-			$this->ensure_style_asset_file_created( 'wp-block-separator', 'blocks/separator/style.css' );
+			$this->ensure_style_asset_file_created( 'wp-block-separator', 'blocks/separator/style.css', true );
 		}
 		$this->assertFalse( wp_is_block_theme(), 'Test is not relevant to block themes (only classic themes).' );
 
@@ -1834,10 +1822,11 @@ class Tests_Template extends WP_UnitTestCase {
 	 *
 	 * @param string $handle        Style handle.
 	 * @param string $relative_path Relative path to the CSS file in wp-includes.
+	 * @param bool   $add_path_data Whether to add the path data.
 	 *
 	 * @throws Exception If the supplied style handle is not registered as expected.
 	 */
-	private function ensure_style_asset_file_created( string $handle, string $relative_path ) {
+	private function ensure_style_asset_file_created( string $handle, string $relative_path, bool $add_path_data = false ) {
 		$dependency = wp_styles()->query( $handle );
 		if ( ! $dependency ) {
 			throw new Exception( "The stylesheet for $handle is not registered." );
@@ -1851,7 +1840,9 @@ class Tests_Template extends WP_UnitTestCase {
 			}
 			file_put_contents( $path, "/* CSS for $handle */" );
 		}
-		wp_style_add_data( $handle, 'path', $path );
+		if ( $add_path_data ) {
+			wp_style_add_data( $handle, 'path', $path );
+		}
 	}
 
 	public function assertTemplateHierarchy( $url, array $expected, $message = '' ) {

--- a/tests/phpunit/tests/template.php
+++ b/tests/phpunit/tests/template.php
@@ -1677,8 +1677,10 @@ class Tests_Template extends WP_UnitTestCase {
 	 * @dataProvider data_wp_hoist_late_printed_styles
 	 */
 	public function test_wp_hoist_late_printed_styles( ?Closure $set_up, int $inline_size_limit, array $expected_styles ): void {
-		// This file is created as part of the build process, but the unit tests don't run the build prior to running unit tests on GHA.
+		// These files is created as part of the build process, but the unit tests don't run the build prior to running unit tests on GHA.
 		self::touch( ABSPATH . WPINC . '/css/dist/block-library/theme.css' );
+		self::touch( ABSPATH . WPINC . '/css/dist/block-library/style.css' );
+		self::touch( ABSPATH . WPINC . '/css/dist/block-library/common.css' );
 
 		switch_theme( 'default' );
 		global $wp_styles;

--- a/tests/phpunit/tests/template.php
+++ b/tests/phpunit/tests/template.php
@@ -1716,9 +1716,9 @@ class Tests_Template extends WP_UnitTestCase {
 			wp_should_load_separate_core_block_assets()
 		);
 		$this->ensure_style_asset_file_created( 'wp-block-library-theme', 'css/dist/block-library/theme.css', true );
-		$dependency = wp_styles()->query( 'wp-block-library' );
-		$this->assertTrue( (bool) $dependency, 'Expected wp-block-library stylesheet to be registered.' );
-		$this->assertIsString( $dependency->src, 'Expected wp-block-library to have a string src. Dependency: ' . json_encode( $dependency ) );
+		$block_library_dependency = wp_styles()->query( 'wp-block-library' );
+		$this->assertTrue( (bool) $block_library_dependency, 'Expected wp-block-library stylesheet to be registered.' );
+		$this->assertIsString( $block_library_dependency->src, 'Expected wp-block-library to have a string src. Dependency: ' . json_encode( $block_library_dependency ) );
 
 		if ( wp_should_load_separate_core_block_assets() ) {
 			$this->ensure_style_asset_file_created( 'wp-block-separator', 'blocks/separator/style.css', true );
@@ -1813,7 +1813,7 @@ class Tests_Template extends WP_UnitTestCase {
 		$this->assertSame(
 			$expected_styles,
 			$found_subset_styles,
-			'Expected the same styles. Snapshot: ' . self::get_array_snapshot_export( $found_subset_styles )
+			'Expected the same styles. Snapshot: ' . self::get_array_snapshot_export( $found_subset_styles ) . "\nAnd wp-block-library: " . json_encode( $block_library_dependency, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) . "\n And file contents: " . file_get_contents( $block_library_dependency->extra['path'] )
 		);
 	}
 

--- a/tests/phpunit/tests/template.php
+++ b/tests/phpunit/tests/template.php
@@ -1719,6 +1719,7 @@ class Tests_Template extends WP_UnitTestCase {
 		$block_library_dependency = wp_styles()->query( 'wp-block-library' );
 		$this->assertTrue( (bool) $block_library_dependency, 'Expected wp-block-library stylesheet to be registered.' );
 		$this->assertIsString( $block_library_dependency->src, 'Expected wp-block-library to have a string src. Dependency: ' . json_encode( $block_library_dependency ) );
+		$this->assertNotEmpty( file_get_contents( $block_library_dependency->extra['path'] ), 'Expected wp-block-library file to not be empty.' );
 
 		if ( wp_should_load_separate_core_block_assets() ) {
 			$this->ensure_style_asset_file_created( 'wp-block-separator', 'blocks/separator/style.css', true );
@@ -1838,11 +1839,8 @@ class Tests_Template extends WP_UnitTestCase {
 		}
 		$dependency->src = includes_url( $relative_path );
 		$path            = ABSPATH . WPINC . '/' . $relative_path;
-		if ( ! file_exists( $path ) ) {
-			$dir = dirname( $path );
-			if ( ! file_exists( $dir ) ) {
-				mkdir( $dir, 0777, true );
-			}
+		self::touch( $path );
+		if ( 0 === filesize( $path ) ) {
 			file_put_contents( $path, "/* CSS for $handle */" );
 		}
 		if ( $add_path_data ) {

--- a/tests/phpunit/tests/template.php
+++ b/tests/phpunit/tests/template.php
@@ -1744,6 +1744,7 @@ class Tests_Template extends WP_UnitTestCase {
 
 		// Simulate wp_head.
 		$head_output = get_echo( 'wp_head' );
+		$this->assertContains( 'wp-block-library', wp_styles()->done, 'Expected wp-block-library to have been added to wp_styles()->done.' );
 
 		$this->assertStringContainsString( 'early', $head_output, 'Expected the early-enqueued stylesheet to be present.' );
 

--- a/tests/phpunit/tests/template.php
+++ b/tests/phpunit/tests/template.php
@@ -1677,6 +1677,9 @@ class Tests_Template extends WP_UnitTestCase {
 	 * @dataProvider data_wp_hoist_late_printed_styles
 	 */
 	public function test_wp_hoist_late_printed_styles( ?Closure $set_up, int $inline_size_limit, array $expected_styles ): void {
+		// This file is created as part of the build process, but the unit tests don't run the build prior to running unit tests on GHA.
+		self::touch( ABSPATH . WPINC . '/css/dist/block-library/theme.css' );
+
 		switch_theme( 'default' );
 		global $wp_styles;
 		$wp_styles = null;

--- a/tests/phpunit/tests/template.php
+++ b/tests/phpunit/tests/template.php
@@ -1677,11 +1677,6 @@ class Tests_Template extends WP_UnitTestCase {
 	 * @dataProvider data_wp_hoist_late_printed_styles
 	 */
 	public function test_wp_hoist_late_printed_styles( ?Closure $set_up, int $inline_size_limit, array $expected_styles ): void {
-		// These files is created as part of the build process, but the unit tests don't run the build prior to running unit tests on GHA.
-		self::touch( ABSPATH . WPINC . '/css/dist/block-library/theme.css' );
-		self::touch( ABSPATH . WPINC . '/css/dist/block-library/style.css' );
-		self::touch( ABSPATH . WPINC . '/css/dist/block-library/common.css' );
-
 		switch_theme( 'default' );
 		global $wp_styles;
 		$wp_styles = null;
@@ -1710,6 +1705,23 @@ class Tests_Template extends WP_UnitTestCase {
 		// Ensure that separate core block assets get registered.
 		register_core_block_style_handles();
 		$this->assertTrue( WP_Block_Type_Registry::get_instance()->is_registered( 'core/separator' ), 'Expected the core/separator block to be registered.' );
+
+		// Ensure all registered styles added as part of the build process are present on the disk. .These files are created as part of the build process, but the unit tests don't run the build prior to running unit tests on GHA.
+		foreach ( wp_styles()->registered as $handle => $dependency ) {
+			if ( ! is_string( $dependency->src ) ) {
+				continue;
+			}
+			$path     = wp_parse_url( $dependency->src, PHP_URL_PATH );
+			$position = strpos( $path, WPINC . '/' );
+			if ( false === $position ) {
+				continue;
+			}
+			$absolute_path = ABSPATH . substr( $path, $position );
+			if ( ! file_exists( $absolute_path ) ) {
+				self::touch( $absolute_path );
+				file_put_contents( $absolute_path, "/* Stub for $handle */" );
+			}
+		}
 
 		// Ensure stylesheet files exist on the filesystem since a build may not have been done.
 		$this->ensure_style_asset_file_created(

--- a/tests/phpunit/tests/template.php
+++ b/tests/phpunit/tests/template.php
@@ -1715,6 +1715,7 @@ class Tests_Template extends WP_UnitTestCase {
 			wp_should_load_separate_core_block_assets() ? 'css/dist/block-library/common.css' : 'css/dist/block-library/style.css',
 			wp_should_load_separate_core_block_assets()
 		);
+		$this->ensure_style_asset_file_created( 'wp-block-library-theme', 'css/dist/block-library/theme.css', true );
 		$dependency = wp_styles()->query( 'wp-block-library' );
 		$this->assertTrue( (bool) $dependency, 'Expected wp-block-library stylesheet to be registered.' );
 		$this->assertIsString( $dependency->src, 'Expected wp-block-library to have a string src. Dependency: ' . json_encode( $dependency ) );

--- a/tests/phpunit/tests/template.php
+++ b/tests/phpunit/tests/template.php
@@ -1677,6 +1677,9 @@ class Tests_Template extends WP_UnitTestCase {
 	 * @dataProvider data_wp_hoist_late_printed_styles
 	 */
 	public function test_wp_hoist_late_printed_styles( ?Closure $set_up, int $inline_size_limit, array $expected_styles ): void {
+		// `_print_emoji_detection_script()` assumes `wp-includes/js/wp-emoji-loader.js` is present:
+		self::touch( ABSPATH . WPINC . '/js/wp-emoji-loader.js' );
+
 		switch_theme( 'default' );
 		global $wp_styles;
 		$wp_styles = null;

--- a/tests/phpunit/tests/template.php
+++ b/tests/phpunit/tests/template.php
@@ -1712,13 +1712,12 @@ class Tests_Template extends WP_UnitTestCase {
 		// Ensure stylesheet files exist on the filesystem since a build may not have been done.
 		$this->ensure_style_asset_file_created(
 			'wp-block-library',
-			wp_should_load_separate_core_block_assets() ? 'css/dist/block-library/common.css' : 'css/dist/block-library/style.css',
-			wp_should_load_separate_core_block_assets()
+			wp_should_load_separate_core_block_assets() ? 'css/dist/block-library/common.css' : 'css/dist/block-library/style.css'
 		);
-		$this->ensure_style_asset_file_created( 'wp-block-library-theme', 'css/dist/block-library/theme.css', true );
+		$this->ensure_style_asset_file_created( 'wp-block-library-theme', 'css/dist/block-library/theme.css' );
 
 		if ( wp_should_load_separate_core_block_assets() ) {
-			$this->ensure_style_asset_file_created( 'wp-block-separator', 'blocks/separator/style.css', true );
+			$this->ensure_style_asset_file_created( 'wp-block-separator', 'blocks/separator/style.css' );
 		}
 		$this->assertFalse( wp_is_block_theme(), 'Test is not relevant to block themes (only classic themes).' );
 
@@ -1809,7 +1808,7 @@ class Tests_Template extends WP_UnitTestCase {
 		$this->assertSame(
 			$expected_styles,
 			$found_subset_styles,
-			'Expected the same styles. Snapshot: ' . self::get_array_snapshot_export( $found_subset_styles ) )
+			'Expected the same styles. Snapshot: ' . self::get_array_snapshot_export( $found_subset_styles )
 		);
 	}
 
@@ -1823,11 +1822,10 @@ class Tests_Template extends WP_UnitTestCase {
 	 *
 	 * @param string $handle        Style handle.
 	 * @param string $relative_path Relative path to the CSS file in wp-includes.
-	 * @param bool   $add_path_data Whether to add the path data.
 	 *
 	 * @throws Exception If the supplied style handle is not registered as expected.
 	 */
-	private function ensure_style_asset_file_created( string $handle, string $relative_path, bool $add_path_data = false ) {
+	private function ensure_style_asset_file_created( string $handle, string $relative_path ) {
 		$dependency = wp_styles()->query( $handle );
 		if ( ! $dependency ) {
 			throw new Exception( "The stylesheet for $handle is not registered." );
@@ -1838,9 +1836,7 @@ class Tests_Template extends WP_UnitTestCase {
 		if ( 0 === filesize( $path ) ) {
 			file_put_contents( $path, "/* CSS for $handle */" );
 		}
-		if ( $add_path_data ) {
-			wp_style_add_data( $handle, 'path', $path );
-		}
+		wp_style_add_data( $handle, 'path', $path );
 	}
 
 	public function assertTemplateHierarchy( $url, array $expected, $message = '' ) {


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64447

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
