### PR TITLE
Tests: Update fonts tests to use semantic HTML comparison

### DIFF
--- a/tests/phpunit/tests/fonts/font-face/wpFontFace/generateAndPrint.php
+++ b/tests/phpunit/tests/fonts/font-face/wpFontFace/generateAndPrint.php
@@ -34,7 +34,11 @@ class Tests_Fonts_WPFontFace_GenerateAndPrint extends WP_UnitTestCase {
 		$style_element   = "<style class='wp-fonts-local' type='text/css'>\n%s\n</style>\n";
 		$expected_output = sprintf( $style_element, $expected );
 
-		$this->expectOutputString( $expected_output );
-		$font_face->generate_and_print( $fonts );
+		$output = get_echo(
+			function () use ( $font_face, $fonts ) {
+				$font_face->generate_and_print( $fonts );
+			}
+		);
+		$this->assertEqualHTML( $expected_output, $output );
 	}
 }

--- a/tests/phpunit/tests/fonts/font-face/wpFontFace/generateAndPrint.php
+++ b/tests/phpunit/tests/fonts/font-face/wpFontFace/generateAndPrint.php
@@ -34,11 +34,7 @@ class Tests_Fonts_WPFontFace_GenerateAndPrint extends WP_UnitTestCase {
 		$style_element   = "<style class='wp-fonts-local' type='text/css'>\n%s\n</style>\n";
 		$expected_output = sprintf( $style_element, $expected );
 
-		$output = get_echo(
-			function () use ( $font_face, $fonts ) {
-				$font_face->generate_and_print( $fonts );
-			}
-		);
+		$output = get_echo( array( $font_face, 'generate_and_print' ), array( $fonts ) );
 		$this->assertEqualHTML( $expected_output, $output );
 	}
 }

--- a/tests/phpunit/tests/fonts/font-face/wpPrintFontFaces.php
+++ b/tests/phpunit/tests/fonts/font-face/wpPrintFontFaces.php
@@ -37,11 +37,7 @@ class Tests_Fonts_WpPrintFontFaces extends WP_Font_Face_UnitTestCase {
 	public function test_should_print_given_fonts( array $fonts, $expected ) {
 		$expected_output = $this->get_expected_styles_output( $expected );
 
-		$output = get_echo(
-			function () use ( $fonts ) {
-				wp_print_font_faces( $fonts );
-			}
-		);
+		$output = get_echo( 'wp_print_font_faces', array( $fonts ) );
 		$this->assertEqualHTML( $expected_output, $output );
 	}
 
@@ -65,11 +61,7 @@ class Tests_Fonts_WpPrintFontFaces extends WP_Font_Face_UnitTestCase {
 
 CSS;
 
-		$output = get_echo(
-			function () use ( $fonts ) {
-				wp_print_font_faces( $fonts );
-			}
-		);
+		$output = get_echo( 'wp_print_font_faces', array( $fonts ) );
 		$this->assertEqualHTML( $expected_output, $output );
 	}
 

--- a/tests/phpunit/tests/fonts/font-face/wpPrintFontFaces.php
+++ b/tests/phpunit/tests/fonts/font-face/wpPrintFontFaces.php
@@ -37,8 +37,12 @@ class Tests_Fonts_WpPrintFontFaces extends WP_Font_Face_UnitTestCase {
 	public function test_should_print_given_fonts( array $fonts, $expected ) {
 		$expected_output = $this->get_expected_styles_output( $expected );
 
-		$this->expectOutputString( $expected_output );
-		wp_print_font_faces( $fonts );
+		$output = get_echo(
+			function () use ( $fonts ) {
+				wp_print_font_faces( $fonts );
+			}
+		);
+		$this->assertEqualHTML( $expected_output, $output );
 	}
 
 	public function test_should_escape_tags() {
@@ -60,9 +64,13 @@ class Tests_Fonts_WpPrintFontFaces extends WP_Font_Face_UnitTestCase {
 </style>
 
 CSS;
-		$this->expectOutputString( $expected_output );
 
-		wp_print_font_faces( $fonts );
+		$output = get_echo(
+			function () use ( $fonts ) {
+				wp_print_font_faces( $fonts );
+			}
+		);
+		$this->assertEqualHTML( $expected_output, $output );
 	}
 
 	public function test_should_print_fonts_in_merged_data() {
@@ -71,8 +79,8 @@ CSS;
 		$expected        = $this->get_expected_fonts_for_fonts_block_theme( 'font_face_styles' );
 		$expected_output = $this->get_expected_styles_output( $expected );
 
-		$this->expectOutputString( $expected_output );
-		wp_print_font_faces();
+		$output = get_echo( 'wp_print_font_faces' );
+		$this->assertEqualHTML( $expected_output, $output );
 	}
 
 	private function get_expected_styles_output( $styles ) {

--- a/tests/phpunit/tests/fonts/font-face/wpPrintFontFacesFromStyleVariations.php
+++ b/tests/phpunit/tests/fonts/font-face/wpPrintFontFacesFromStyleVariations.php
@@ -43,8 +43,8 @@ class Tests_Fonts_WpPrintFontFacesFromStyleVariations extends WP_Font_Face_UnitT
 		$expected        = $this->get_custom_style_variations( 'expected_styles' );
 		$expected_output = $this->get_expected_styles_output( $expected );
 
-		$this->expectOutputString( $expected_output );
-		wp_print_font_faces_from_style_variations();
+		$output = get_echo( 'wp_print_font_faces_from_style_variations' );
+		$this->assertEqualHTML( $expected_output, $output );
 	}
 
 	private function get_expected_styles_output( $styles ) {


### PR DESCRIPTION
These tests failed with semantically equivalent HTML while working on https://github.com/WordPress/wordpress-develop/pull/10656.

`assertEqualHTML` makes the tests more robust.

Trac ticket: https://core.trac.wordpress.org/ticket/64225

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
