### PR TITLE
Scripts and styles: Remove redundant HTML5 type attributes

### DIFF
--- a/src/wp-activate.php
+++ b/src/wp-activate.php
@@ -100,7 +100,7 @@ add_action( 'wp_head', 'do_activate_header' );
  */
 function wpmu_activate_stylesheet() {
 	?>
-	<style type="text/css">
+	<style>
 		.wp-activate-container { width: 90%; margin: 0 auto; }
 		.wp-activate-container form { margin-top: 2em; }
 		#submit, #key { width: 100%; font-size: 24px; box-sizing: border-box; }

--- a/src/wp-admin/includes/ajax-actions.php
+++ b/src/wp-admin/includes/ajax-actions.php
@@ -3946,7 +3946,7 @@ function wp_ajax_parse_media_shortcode() {
 	$styles = wpview_media_sandbox_styles();
 
 	foreach ( $styles as $style ) {
-		$head .= '<link type="text/css" rel="stylesheet" href="' . $style . '">';
+		$head .= '<link rel="stylesheet" href="' . $style . '">';
 	}
 
 	if ( ! empty( $wp_scripts ) ) {

--- a/src/wp-admin/includes/plugin-install.php
+++ b/src/wp-admin/includes/plugin-install.php
@@ -606,7 +606,7 @@ function install_plugin_information() {
 		$low          = empty( $api->banners['low'] ) ? $api->banners['high'] : $api->banners['low'];
 		$high         = empty( $api->banners['high'] ) ? $api->banners['low'] : $api->banners['high'];
 		?>
-		<style type="text/css">
+		<style>
 			#plugin-information-title.with-banner {
 				background-image: url( <?php echo esc_url( $low ); ?> );
 			}

--- a/src/wp-admin/includes/privacy-tools.php
+++ b/src/wp-admin/includes/privacy-tools.php
@@ -451,7 +451,7 @@ function wp_privacy_generate_personal_data_export_file( $request_id ) {
 	fwrite( $file, "<html>\n" );
 	fwrite( $file, "<head>\n" );
 	fwrite( $file, "<meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />\n" );
-	fwrite( $file, "<style type='text/css'>" );
+	fwrite( $file, '<style>' );
 	fwrite( $file, 'body { color: black; font-family: Arial, sans-serif; font-size: 11pt; margin: 15px auto; width: 860px; }' );
 	fwrite( $file, 'table { background: #f0f0f0; border: 1px solid #ddd; margin-bottom: 20px; width: 100%; }' );
 	fwrite( $file, 'th { padding: 5px; text-align: left; width: 20%; }' );

--- a/src/wp-content/themes/twentyeleven/functions.php
+++ b/src/wp-content/themes/twentyeleven/functions.php
@@ -335,7 +335,7 @@ if ( ! function_exists( 'twentyeleven_header_style' ) ) :
 
 		// If we get this far, we have custom styles. Let's do this.
 		?>
-		<style type="text/css" id="twentyeleven-header-css">
+		<style id="twentyeleven-header-css">
 		<?php
 		// Has the text been hidden?
 		if ( 'blank' === $text_color ) :

--- a/src/wp-content/themes/twentyeleven/header.php
+++ b/src/wp-content/themes/twentyeleven/header.php
@@ -38,7 +38,7 @@ if ( ( $paged >= 2 || $page >= 2 ) && ! is_404() ) {
 ?>
 	</title>
 <link rel="profile" href="https://gmpg.org/xfn/11" />
-<link rel="stylesheet" type="text/css" media="all" href="<?php echo esc_url( get_stylesheet_uri() ); ?>?ver=20251202" />
+<link rel="stylesheet" media="all" href="<?php echo esc_url( get_stylesheet_uri() ); ?>?ver=20251202" />
 <link rel="pingback" href="<?php echo esc_url( get_bloginfo( 'pingback_url' ) ); ?>">
 <?php
 	/*

--- a/src/wp-content/themes/twentyfifteen/inc/custom-header.php
+++ b/src/wp-content/themes/twentyfifteen/inc/custom-header.php
@@ -95,7 +95,7 @@ if ( ! function_exists( 'twentyfifteen_header_style' ) ) :
 
 		// If we get this far, we have custom styles. Let's do this.
 		?>
-		<style type="text/css" id="twentyfifteen-header-css">
+		<style id="twentyfifteen-header-css">
 		<?php
 		// Short header for when there is no Custom Header and Header Text is hidden.
 		if ( empty( $header_image ) && ! display_header_text() ) :

--- a/src/wp-content/themes/twentyfourteen/inc/custom-header.php
+++ b/src/wp-content/themes/twentyfourteen/inc/custom-header.php
@@ -69,7 +69,7 @@ if ( ! function_exists( 'twentyfourteen_header_style' ) ) :
 
 		// If we get this far, we have custom styles.
 		?>
-		<style type="text/css" id="twentyfourteen-header-css">
+		<style id="twentyfourteen-header-css">
 		<?php
 		// Has the text been hidden?
 		if ( ! display_header_text() ) :

--- a/src/wp-content/themes/twentynineteen/functions.php
+++ b/src/wp-content/themes/twentynineteen/functions.php
@@ -349,7 +349,7 @@ function twentynineteen_colors_css_wrap() {
 	}
 	?>
 
-	<style type="text/css" id="custom-theme-colors" <?php echo is_customize_preview() ? 'data-hue="' . absint( $primary_color ) . '"' : ''; ?>>
+	<style id="custom-theme-colors" <?php echo is_customize_preview() ? 'data-hue="' . absint( $primary_color ) . '"' : ''; ?>>
 		<?php echo twentynineteen_custom_colors_css(); ?>
 	</style>
 	<?php

--- a/src/wp-content/themes/twentyseventeen/functions.php
+++ b/src/wp-content/themes/twentyseventeen/functions.php
@@ -443,7 +443,7 @@ function twentyseventeen_colors_css_wrap() {
 		$customize_preview_data_hue = 'data-hue="' . $hue . '"';
 	}
 	?>
-	<style type="text/css" id="custom-theme-colors" <?php echo $customize_preview_data_hue; ?>>
+	<style id="custom-theme-colors" <?php echo $customize_preview_data_hue; ?>>
 		<?php echo twentyseventeen_custom_colors_css(); ?>
 	</style>
 	<?php

--- a/src/wp-content/themes/twentyseventeen/inc/custom-header.php
+++ b/src/wp-content/themes/twentyseventeen/inc/custom-header.php
@@ -77,7 +77,7 @@ if ( ! function_exists( 'twentyseventeen_header_style' ) ) :
 
 		// If we get this far, we have custom styles. Let's do this.
 		?>
-		<style id="twentyseventeen-custom-header-styles" type="text/css">
+		<style id="twentyseventeen-custom-header-styles">
 		<?php
 		// Has the text been hidden?
 		if ( 'blank' === $header_text_color ) :

--- a/src/wp-content/themes/twentysixteen/inc/customizer.php
+++ b/src/wp-content/themes/twentysixteen/inc/customizer.php
@@ -90,7 +90,7 @@ if ( ! function_exists( 'twentysixteen_header_style' ) ) :
 
 		// If the header text has been hidden.
 		?>
-		<style type="text/css" id="twentysixteen-header-css">
+		<style id="twentysixteen-header-css">
 		.site-branding {
 			margin: 0 auto 0 0;
 		}

--- a/src/wp-content/themes/twentyten/functions.php
+++ b/src/wp-content/themes/twentyten/functions.php
@@ -275,7 +275,7 @@ if ( ! function_exists( 'twentyten_admin_header_style' ) ) :
 	 */
 	function twentyten_admin_header_style() {
 		?>
-	<style type="text/css" id="twentyten-admin-header-css">
+	<style id="twentyten-admin-header-css">
 	/* Shows the same border as on front end */
 	#headimg {
 	border-bottom: 1px solid #000;

--- a/src/wp-content/themes/twentyten/header.php
+++ b/src/wp-content/themes/twentyten/header.php
@@ -39,7 +39,7 @@ if ( ( $paged >= 2 || $page >= 2 ) && ! is_404() ) {
 ?>
 	</title>
 <link rel="profile" href="https://gmpg.org/xfn/11" />
-<link rel="stylesheet" type="text/css" media="all" href="<?php echo esc_url( get_stylesheet_uri() ); ?>?ver=20251202" />
+<link rel="stylesheet" media="all" href="<?php echo esc_url( get_stylesheet_uri() ); ?>?ver=20251202" />
 <link rel="pingback" href="<?php echo esc_url( get_bloginfo( 'pingback_url' ) ); ?>">
 <?php
 	/*

--- a/src/wp-content/themes/twentythirteen/inc/custom-header.php
+++ b/src/wp-content/themes/twentythirteen/inc/custom-header.php
@@ -96,7 +96,7 @@ function twentythirteen_header_style() {
 
 	// If we get this far, we have custom styles.
 	?>
-	<style type="text/css" id="twentythirteen-header-css">
+	<style id="twentythirteen-header-css">
 	<?php
 	if ( ! empty( $header_image ) ) :
 		?>

--- a/src/wp-content/themes/twentytwelve/inc/custom-header.php
+++ b/src/wp-content/themes/twentytwelve/inc/custom-header.php
@@ -77,7 +77,7 @@ function twentytwelve_header_style() {
 
 	// If we get this far, we have custom styles.
 	?>
-	<style type="text/css" id="twentytwelve-header-css">
+	<style id="twentytwelve-header-css">
 	<?php
 		// Has the text been hidden?
 	if ( ! display_header_text() ) :

--- a/src/wp-includes/class-wp-styles.php
+++ b/src/wp-includes/class-wp-styles.php
@@ -101,36 +101,11 @@ class WP_Styles extends WP_Dependencies {
 	public $default_dirs;
 
 	/**
-	 * Holds a string which contains the type attribute for style tag.
-	 *
-	 * If the active theme does not declare HTML5 support for 'style',
-	 * then it initializes as `type='text/css'`.
-	 *
-	 * @since 5.3.0
-	 * @var string
-	 */
-	private $type_attr = '';
-
-	/**
 	 * Constructor.
 	 *
 	 * @since 2.6.0
 	 */
 	public function __construct() {
-		if (
-			(
-				function_exists( 'is_admin' ) &&
-				! is_admin()
-			)
-			&&
-			(
-				function_exists( 'current_theme_supports' ) &&
-				! current_theme_supports( 'html5', 'style' )
-			)
-		) {
-			$this->type_attr = " type='text/css'";
-		}
-
 		/**
 		 * Fires when the WP_Styles instance is initialized.
 		 *
@@ -179,9 +154,8 @@ class WP_Styles extends WP_Dependencies {
 
 		if ( $inline_style ) {
 			$inline_style_tag = sprintf(
-				"<style id='%s-inline-css'%s>\n%s\n</style>\n",
+				"<style id='%s-inline-css'>\n%s\n</style>\n",
 				esc_attr( $handle ),
-				$this->type_attr,
 				$inline_style
 			);
 		} else {
@@ -227,12 +201,11 @@ class WP_Styles extends WP_Dependencies {
 		$title = isset( $obj->extra['title'] ) ? $obj->extra['title'] : '';
 
 		$tag = sprintf(
-			"<link rel='%s' id='%s-css'%s href='%s'%s media='%s' />\n",
+			"<link rel='%s' id='%s-css'%s href='%s' media='%s' />\n",
 			$rel,
 			esc_attr( $handle ),
 			$title ? sprintf( " title='%s'", esc_attr( $title ) ) : '',
 			$href,
-			$this->type_attr,
 			esc_attr( $media )
 		);
 
@@ -259,12 +232,11 @@ class WP_Styles extends WP_Dependencies {
 			}
 
 			$rtl_tag = sprintf(
-				"<link rel='%s' id='%s-rtl-css'%s href='%s'%s media='%s' />\n",
+				"<link rel='%s' id='%s-rtl-css'%s href='%s' media='%s' />\n",
 				$rel,
 				esc_attr( $handle ),
 				$title ? sprintf( " title='%s'", esc_attr( $title ) ) : '',
 				$rtl_href,
-				$this->type_attr,
 				esc_attr( $media )
 			);
 
@@ -360,9 +332,8 @@ class WP_Styles extends WP_Dependencies {
 		}
 
 		printf(
-			"<style id='%s-inline-css'%s>\n%s\n</style>\n",
+			"<style id='%s-inline-css'>\n%s\n</style>\n",
 			esc_attr( $handle ),
-			$this->type_attr,
 			$output
 		);
 

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -5897,10 +5897,9 @@ function _wp_theme_json_webfonts_handler() {
 function print_embed_styles() {
 	_deprecated_function( __FUNCTION__, '6.4.0', 'wp_enqueue_embed_styles' );
 
-	$type_attr = current_theme_supports( 'html5', 'style' ) ? '' : ' type="text/css"';
 	$suffix    = SCRIPT_DEBUG ? '' : '.min';
 	?>
-	<style<?php echo $type_attr; ?>>
+	<style>
 		<?php echo file_get_contents( ABSPATH . WPINC . "/css/wp-embed-template$suffix.css" ); ?>
 	</style>
 	<?php
@@ -5922,9 +5921,8 @@ function print_emoji_styles() {
 
 	$printed = true;
 
-	$type_attr = current_theme_supports( 'html5', 'style' ) ? '' : ' type="text/css"';
 	?>
-	<style<?php echo $type_attr; ?>>
+	<style>
 	img.wp-smiley,
 	img.emoji {
 		display: inline !important;
@@ -5949,9 +5947,8 @@ function print_emoji_styles() {
  */
 function wp_admin_bar_header() {
 	_deprecated_function( __FUNCTION__, '6.4.0', 'wp_enqueue_admin_bar_header_styles' );
-	$type_attr = current_theme_supports( 'html5', 'style' ) ? '' : ' type="text/css"';
 	?>
-	<style<?php echo $type_attr; ?> media="print">#wpadminbar { display:none; }</style>
+	<style media="print">#wpadminbar { display:none; }</style>
 	<?php
 }
 
@@ -5963,9 +5960,8 @@ function wp_admin_bar_header() {
  */
 function _admin_bar_bump_cb() {
 	_deprecated_function( __FUNCTION__, '6.4.0', 'wp_enqueue_admin_bar_bump_styles' );
-	$type_attr = current_theme_supports( 'html5', 'style' ) ? '' : ' type="text/css"';
 	?>
-	<style<?php echo $type_attr; ?> media="screen">
+	<style media="screen">
 	html { margin-top: 32px !important; }
 	@media screen and ( max-width: 782px ) {
 	  html { margin-top: 46px !important; }

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -5897,7 +5897,7 @@ function _wp_theme_json_webfonts_handler() {
 function print_embed_styles() {
 	_deprecated_function( __FUNCTION__, '6.4.0', 'wp_enqueue_embed_styles' );
 
-	$suffix    = SCRIPT_DEBUG ? '' : '.min';
+	$suffix = SCRIPT_DEBUG ? '' : '.min';
 	?>
 	<style>
 		<?php echo file_get_contents( ABSPATH . WPINC . "/css/wp-embed-template$suffix.css" ); ?>

--- a/src/wp-includes/fonts/class-wp-font-face.php
+++ b/src/wp-includes/fonts/class-wp-font-face.php
@@ -62,17 +62,6 @@ class WP_Font_Face {
 	private $valid_font_display = array( 'auto', 'block', 'fallback', 'swap', 'optional' );
 
 	/**
-	 * Array of font-face style tag's attribute(s)
-	 * where the key is the attribute name and the
-	 * value is its value.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @var string[]
-	 */
-	private $style_tag_attrs = array();
-
-	/**
 	 * Generates and prints the `@font-face` styles for the given fonts.
 	 *
 	 * @since 6.4.0
@@ -212,24 +201,7 @@ class WP_Font_Face {
 	 * @return string The style element.
 	 */
 	private function get_style_element() {
-		$attributes = $this->generate_style_element_attributes();
-
-		return "<style class='wp-fonts-local'{$attributes}>\n%s\n</style>\n";
-	}
-
-	/**
-	 * Gets the defined <style> element's attributes.
-	 *
-	 * @since 6.4.0
-	 *
-	 * @return string A string of attribute=value when defined, else, empty string.
-	 */
-	private function generate_style_element_attributes() {
-		$attributes = '';
-		foreach ( $this->style_tag_attrs as $name => $value ) {
-			$attributes .= " {$name}='{$value}'";
-		}
-		return $attributes;
+		return "<style class='wp-fonts-local'>\n%s\n</style>\n";
 	}
 
 	/**

--- a/src/wp-includes/fonts/class-wp-font-face.php
+++ b/src/wp-includes/fonts/class-wp-font-face.php
@@ -73,21 +73,6 @@ class WP_Font_Face {
 	private $style_tag_attrs = array();
 
 	/**
-	 * Creates and initializes an instance of WP_Font_Face.
-	 *
-	 * @since 6.4.0
-	 */
-	public function __construct() {
-		if (
-			function_exists( 'is_admin' ) && ! is_admin()
-			&&
-			function_exists( 'current_theme_supports' ) && ! current_theme_supports( 'html5', 'style' )
-		) {
-			$this->style_tag_attrs = array( 'type' => 'text/css' );
-		}
-	}
-
-	/**
 	 * Generates and prints the `@font-face` styles for the given fonts.
 	 *
 	 * @since 6.4.0

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -3921,7 +3921,7 @@ function _default_wp_die_handler( $message, $title = '', $args = array() ) {
 		}
 		?>
 	<title><?php echo $title; ?></title>
-	<style type="text/css">
+	<style>
 		html {
 			background: #f1f1f1;
 		}

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -5061,7 +5061,7 @@ function wp_admin_css( $file = 'wp-admin', $force_echo = false ) {
 	}
 
 	$stylesheet_link = sprintf(
-		"<link rel='stylesheet' href='%s' type='text/css' />\n",
+		"<link rel='stylesheet' href='%s' />\n",
 		esc_url( wp_admin_css_uri( $file ) )
 	);
 
@@ -5080,7 +5080,7 @@ function wp_admin_css( $file = 'wp-admin', $force_echo = false ) {
 
 	if ( function_exists( 'is_rtl' ) && is_rtl() ) {
 		$rtl_stylesheet_link = sprintf(
-			"<link rel='stylesheet' href='%s' type='text/css' />\n",
+			"<link rel='stylesheet' href='%s' />\n",
 			esc_url( wp_admin_css_uri( "$file-rtl" ) )
 		);
 

--- a/src/wp-includes/media.php
+++ b/src/wp-includes/media.php
@@ -2871,10 +2871,8 @@ function gallery_shortcode( $attr ) {
 	 *                    Otherwise, defaults to true.
 	 */
 	if ( apply_filters( 'use_default_gallery_style', ! $html5 ) ) {
-		$type_attr = current_theme_supports( 'html5', 'style' ) ? '' : ' type="text/css"';
-
 		$gallery_style = "
-		<style{$type_attr}>
+		<style>
 			#{$selector} {
 				margin: auto;
 			}

--- a/src/wp-includes/ms-deprecated.php
+++ b/src/wp-includes/ms-deprecated.php
@@ -94,7 +94,7 @@ function graceful_fail( $message ) {
 <html><head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 <title>Error!</title>
-<style type="text/css">
+<style>
 img {
 	border: 0;
 }

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2206,7 +2206,7 @@ function _print_scripts() {
 	}
 
 	$concat    = trim( $wp_scripts->concat, ', ' );
-	$type_attr = current_theme_supports( 'html5', 'script' ) ? '' : " type='text/javascript'";
+	$type_attr = '';
 
 	if ( $concat ) {
 		if ( ! empty( $wp_scripts->print_code ) ) {
@@ -2399,7 +2399,7 @@ function _print_styles() {
 	}
 
 	$concat    = trim( $wp_styles->concat, ', ' );
-	$type_attr = current_theme_supports( 'html5', 'style' ) ? '' : ' type="text/css"';
+	$type_attr = '';
 
 	if ( $concat ) {
 		$dir = $wp_styles->text_direction;
@@ -2905,12 +2905,8 @@ function wp_sanitize_script_attributes( $attributes ) {
  * @return string String containing `<script>` opening and closing tags.
  */
 function wp_get_script_tag( $attributes ) {
-	if ( ! isset( $attributes['type'] ) && ! is_admin() && ! current_theme_supports( 'html5', 'script' ) ) {
-		// Keep the type attribute as the first for legacy reasons (it has always been this way in core).
-		$attributes = array_merge(
-			array( 'type' => 'text/javascript' ),
-			$attributes
-		);
+	if ( isset( $attributes['type'] ) && 'text/javascript' === $attributes['type'] ) {
+		unset( $attributes['type'] );
 	}
 	/**
 	 * Filters attributes to be added to a script tag.
@@ -2953,13 +2949,8 @@ function wp_print_script_tag( $attributes ) {
  * @return string String containing inline JavaScript code wrapped around `<script>` tag.
  */
 function wp_get_inline_script_tag( $data, $attributes = array() ) {
-	$is_html5 = current_theme_supports( 'html5', 'script' ) || is_admin();
-	if ( ! isset( $attributes['type'] ) && ! $is_html5 ) {
-		// Keep the type attribute as the first for legacy reasons (it has always been this way in core).
-		$attributes = array_merge(
-			array( 'type' => 'text/javascript' ),
-			$attributes
-		);
+	if ( isset( $attributes['type'] ) && 'text/javascript' === $attributes['type'] ) {
+		unset( $attributes['type'] );
 	}
 
 	/*
@@ -2987,15 +2978,12 @@ function wp_get_inline_script_tag( $data, $attributes = array() ) {
 	 * @see https://www.w3.org/TR/xhtml1/#h-4.8
 	 */
 	if (
-		! $is_html5 &&
-		(
-			! isset( $attributes['type'] ) ||
-			'module' === $attributes['type'] ||
-			str_contains( $attributes['type'], 'javascript' ) ||
-			str_contains( $attributes['type'], 'ecmascript' ) ||
-			str_contains( $attributes['type'], 'jscript' ) ||
-			str_contains( $attributes['type'], 'livescript' )
-		)
+		! isset( $attributes['type'] ) ||
+		'module' === $attributes['type'] ||
+		str_contains( $attributes['type'], 'javascript' ) ||
+		str_contains( $attributes['type'], 'ecmascript' ) ||
+		str_contains( $attributes['type'], 'jscript' ) ||
+		str_contains( $attributes['type'], 'livescript' )
 	) {
 		/*
 		 * If the string `]]>` exists within the JavaScript it would break

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2205,12 +2205,11 @@ function _print_scripts() {
 		$zip = 'gzip';
 	}
 
-	$concat    = trim( $wp_scripts->concat, ', ' );
-	$type_attr = '';
+	$concat = trim( $wp_scripts->concat, ', ' );
 
 	if ( $concat ) {
 		if ( ! empty( $wp_scripts->print_code ) ) {
-			echo "\n<script{$type_attr}>\n";
+			echo "\n<script>\n";
 			echo "/* <![CDATA[ */\n"; // Not needed in HTML 5.
 			echo $wp_scripts->print_code;
 			echo sprintf( "\n//# sourceURL=%s\n", rawurlencode( 'js-inline-concat-' . $concat ) );
@@ -2226,7 +2225,7 @@ function _print_scripts() {
 		}
 
 		$src = $wp_scripts->base_url . "/wp-admin/load-scripts.php?c={$zip}" . $concatenated . '&ver=' . $wp_scripts->default_version;
-		echo "<script{$type_attr} src='" . esc_attr( $src ) . "'></script>\n";
+		echo "<script src='" . esc_attr( $src ) . "'></script>\n";
 	}
 
 	if ( ! empty( $wp_scripts->print_html ) ) {
@@ -2398,8 +2397,7 @@ function _print_styles() {
 		$zip = 'gzip';
 	}
 
-	$concat    = trim( $wp_styles->concat, ', ' );
-	$type_attr = '';
+	$concat = trim( $wp_styles->concat, ', ' );
 
 	if ( $concat ) {
 		$dir = $wp_styles->text_direction;
@@ -2414,10 +2412,10 @@ function _print_styles() {
 		}
 
 		$href = $wp_styles->base_url . "/wp-admin/load-styles.php?c={$zip}&dir={$dir}" . $concatenated . '&ver=' . $ver;
-		echo "<link rel='stylesheet' href='" . esc_attr( $href ) . "'{$type_attr} media='all' />\n";
+		echo "<link rel='stylesheet' href='" . esc_attr( $href ) . "' media='all' />\n";
 
 		if ( ! empty( $wp_styles->print_code ) ) {
-			echo "<style{$type_attr}>\n";
+			echo "<style>\n";
 			echo $wp_styles->print_code;
 			echo sprintf( "\n/*# sourceURL=%s */", rawurlencode( $concat_source_url ) );
 			echo "\n</style>\n";
@@ -2905,9 +2903,6 @@ function wp_sanitize_script_attributes( $attributes ) {
  * @return string String containing `<script>` opening and closing tags.
  */
 function wp_get_script_tag( $attributes ) {
-	if ( isset( $attributes['type'] ) && 'text/javascript' === $attributes['type'] ) {
-		unset( $attributes['type'] );
-	}
 	/**
 	 * Filters attributes to be added to a script tag.
 	 *
@@ -2949,10 +2944,6 @@ function wp_print_script_tag( $attributes ) {
  * @return string String containing inline JavaScript code wrapped around `<script>` tag.
  */
 function wp_get_inline_script_tag( $data, $attributes = array() ) {
-	if ( isset( $attributes['type'] ) && 'text/javascript' === $attributes['type'] ) {
-		unset( $attributes['type'] );
-	}
-
 	/*
 	 * XHTML extracts the contents of the SCRIPT element and then the XML parser
 	 * decodes character references and other syntax elements. This can lead to
@@ -2978,12 +2969,15 @@ function wp_get_inline_script_tag( $data, $attributes = array() ) {
 	 * @see https://www.w3.org/TR/xhtml1/#h-4.8
 	 */
 	if (
-		! isset( $attributes['type'] ) ||
-		'module' === $attributes['type'] ||
-		str_contains( $attributes['type'], 'javascript' ) ||
-		str_contains( $attributes['type'], 'ecmascript' ) ||
-		str_contains( $attributes['type'], 'jscript' ) ||
-		str_contains( $attributes['type'], 'livescript' )
+		! current_theme_supports( 'html5', 'script' ) &&
+		(
+			! isset( $attributes['type'] ) ||
+			'module' === $attributes['type'] ||
+			str_contains( $attributes['type'], 'javascript' ) ||
+			str_contains( $attributes['type'], 'ecmascript' ) ||
+			str_contains( $attributes['type'], 'jscript' ) ||
+			str_contains( $attributes['type'], 'livescript' )
+		)
 	) {
 		/*
 		 * If the string `]]>` exists within the JavaScript it would break

--- a/src/wp-includes/theme-compat/header.php
+++ b/src/wp-includes/theme-compat/header.php
@@ -23,11 +23,11 @@ _deprecated_file(
 
 <title><?php echo wp_get_document_title(); ?></title>
 
-<link rel="stylesheet" href="<?php bloginfo( 'stylesheet_url' ); ?>" type="text/css" media="screen" />
+<link rel="stylesheet" href="<?php bloginfo( 'stylesheet_url' ); ?>" media="screen" />
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />
 
 <?php if ( file_exists( get_stylesheet_directory() . '/images/kubrickbgwide.jpg' ) ) { ?>
-<style type="text/css" media="screen">
+<style media="screen">
 
 	<?php
 	// Checks to see whether it needs a sidebar.

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -733,12 +733,9 @@ function locale_stylesheet() {
 		return;
 	}
 
-	$type_attr = current_theme_supports( 'html5', 'style' ) ? '' : ' type="text/css"';
-
 	printf(
-		'<link rel="stylesheet" href="%s"%s media="screen" />',
-		$stylesheet,
-		$type_attr
+		'<link rel="stylesheet" href="%s" media="screen" />',
+		$stylesheet
 	);
 }
 

--- a/src/wp-includes/widgets/class-wp-widget-recent-comments.php
+++ b/src/wp-includes/widgets/class-wp-widget-recent-comments.php
@@ -55,12 +55,7 @@ class WP_Widget_Recent_Comments extends WP_Widget {
 			return;
 		}
 
-		$type_attr = current_theme_supports( 'html5', 'style' ) ? '' : ' type="text/css"';
-
-		printf(
-			'<style%s>.recentcomments a{display:inline !important;padding:0 !important;margin:0 !important;}</style>',
-			$type_attr
-		);
+		echo '<style>.recentcomments a{display:inline !important;padding:0 !important;margin:0 !important;}</style>';
 	}
 
 	/**

--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -176,7 +176,7 @@ function login_header( $title = null, $message = '', $wp_error = null ) {
 		$classes[] = 'interim-login';
 
 		?>
-		<style type="text/css">html{background-color: transparent;}</style>
+		<style>html{background-color: transparent;}</style>
 		<?php
 
 		if ( 'success' === $interim_login ) {

--- a/src/wp-signup.php
+++ b/src/wp-signup.php
@@ -63,7 +63,7 @@ do_action( 'before_signup_header' );
  */
 function wpmu_signup_stylesheet() {
 	?>
-	<style type="text/css">
+	<style>
 		.mu_register { width: 90%; margin: 0 auto; }
 		.mu_register form { margin-top: 2em; }
 		.mu_register fieldset,

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -185,9 +185,6 @@ JS;
 	/**
 	 * Tests that inline scripts in the `after` position, attached to a blocking main script, are rendered as javascript.
 	 *
-	 * If a main script with a `blocking` strategy has an `after` inline script,
-	 * the inline script should be rendered as.
-	 *
 	 * @ticket 12009
 	 *
 	 * @covers WP_Scripts::do_item

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -47,7 +47,7 @@ class Tests_Dependencies_Scripts extends WP_UnitTestCase {
 		$GLOBALS['wp_styles']                   = new WP_Styles();
 
 		$this->wp_scripts_print_translations_output  = <<<JS
-<script type='text/javascript' id='__HANDLE__-js-translations'>
+<script id='__HANDLE__-js-translations'>
 /* <![CDATA[ */
 ( function( domain, translations ) {
 	var localeData = translations.locale_data[ domain ] || translations.locale_data.messages;
@@ -82,10 +82,10 @@ JS;
 		wp_enqueue_script( 'empty-deps-version', 'example.com', array(), 1.2 );
 		wp_enqueue_script( 'empty-deps-null-version', 'example.com', array(), null );
 
-		$expected  = "<script type='text/javascript' src='http://example.com?ver={$wp_version}' id='no-deps-no-version-js'></script>\n";
-		$expected .= "<script type='text/javascript' src='http://example.com?ver={$wp_version}' id='empty-deps-no-version-js'></script>\n";
-		$expected .= "<script type='text/javascript' src='http://example.com?ver=1.2' id='empty-deps-version-js'></script>\n";
-		$expected .= "<script type='text/javascript' src='http://example.com' id='empty-deps-null-version-js'></script>\n";
+		$expected  = "<script src='http://example.com?ver={$wp_version}' id='no-deps-no-version-js'></script>\n";
+		$expected .= "<script src='http://example.com?ver={$wp_version}' id='empty-deps-no-version-js'></script>\n";
+		$expected .= "<script src='http://example.com?ver=1.2' id='empty-deps-version-js'></script>\n";
+		$expected .= "<script src='http://example.com' id='empty-deps-null-version-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 
@@ -126,7 +126,7 @@ JS;
 		wp_enqueue_script( 'ms-isa-1', 'http://example.org/ms-isa-1.js', array(), null, compact( 'strategy' ) );
 		wp_add_inline_script( 'ms-isa-1', 'console.log(\'after one\');', 'after' );
 		$output    = get_echo( 'wp_print_scripts' );
-		$expected  = "<script type='text/javascript' src='http://example.org/ms-isa-1.js' id='ms-isa-1-js' data-wp-strategy='{$strategy}'></script>\n";
+		$expected  = "<script src='http://example.org/ms-isa-1.js' id='ms-isa-1-js' data-wp-strategy='{$strategy}'></script>\n";
 		$expected .= wp_get_inline_script_tag(
 			"console.log('after one');\n//# sourceURL=ms-isa-1-js-after",
 			array(
@@ -140,7 +140,7 @@ JS;
 	 * Tests that inline scripts in the `after` position, attached to a blocking main script, are rendered as javascript.
 	 *
 	 * If a main script with a `blocking` strategy has an `after` inline script,
-	 * the inline script should be rendered as type='text/javascript'.
+	 * the inline script should be rendered as.
 	 *
 	 * @ticket 12009
 	 *
@@ -154,7 +154,7 @@ JS;
 		wp_add_inline_script( 'ms-insa-3', 'console.log(\'after one\');', 'after' );
 		$output = get_echo( 'wp_print_scripts' );
 
-		$expected  = "<script type='text/javascript' src='http://example.org/ms-insa-3.js' id='ms-insa-3-js'></script>\n";
+		$expected  = "<script src='http://example.org/ms-insa-3.js' id='ms-insa-3-js'></script>\n";
 		$expected .= wp_get_inline_script_tag(
 			"console.log('after one');\n//# sourceURL=ms-insa-3-js-after",
 			array(
@@ -195,17 +195,16 @@ JS;
 				'id' => 'ds-i1-1-js-before',
 			)
 		);
-		$expected .= "<script type='text/javascript' src='http://example.org/ds-i1-1.js' id='ds-i1-1-js' {$strategy}='{$strategy}' data-wp-strategy='{$strategy}'></script>\n";
-		$expected .= "<script type='text/javascript' src='http://example.org/ds-i1-2.js' id='ds-i1-2-js' {$strategy}='{$strategy}' data-wp-strategy='{$strategy}'></script>\n";
-		$expected .= "<script type='text/javascript' src='http://example.org/ds-i1-3.js' id='ds-i1-3-js' {$strategy}='{$strategy}' data-wp-strategy='{$strategy}'></script>\n";
+		$expected .= "<script src='http://example.org/ds-i1-1.js' id='ds-i1-1-js' {$strategy}='{$strategy}' data-wp-strategy='{$strategy}'></script>\n";
+		$expected .= "<script src='http://example.org/ds-i1-2.js' id='ds-i1-2-js' {$strategy}='{$strategy}' data-wp-strategy='{$strategy}'></script>\n";
+		$expected .= "<script src='http://example.org/ds-i1-3.js' id='ds-i1-3-js' {$strategy}='{$strategy}' data-wp-strategy='{$strategy}'></script>\n";
 		$expected .= wp_get_inline_script_tag(
 			"console.log('before last');\n//# sourceURL=ms-i1-1-js-before",
 			array(
-				'id'   => 'ms-i1-1-js-before',
-				'type' => 'text/javascript',
+				'id' => 'ms-i1-1-js-before',
 			)
 		);
-		$expected .= "<script type='text/javascript' src='http://example.org/ms-i1-1.js' id='ms-i1-1-js' {$strategy}='{$strategy}' data-wp-strategy='{$strategy}'></script>\n";
+		$expected .= "<script src='http://example.org/ms-i1-1.js' id='ms-i1-1-js' {$strategy}='{$strategy}' data-wp-strategy='{$strategy}'></script>\n";
 
 		$this->assertEqualHTML( $expected, $output, '<body>', 'Inline scripts in the "before" position, that are attached to a deferred main script, are failing to print/execute.' );
 	}
@@ -224,7 +223,7 @@ JS;
 		// No dependents, No dependencies then async.
 		wp_enqueue_script( 'main-script-a1', '/main-script-a1.js', array(), null, array( 'strategy' => 'async' ) );
 		$output   = get_echo( 'wp_print_scripts' );
-		$expected = "<script type='text/javascript' src='/main-script-a1.js' id='main-script-a1-js' async='async' data-wp-strategy='async'></script>\n";
+		$expected = "<script src='/main-script-a1.js' id='main-script-a1-js' async='async' data-wp-strategy='async'></script>\n";
 		$this->assertEqualHTML( $expected, $output, '<body>', 'Scripts enqueued with an async loading strategy are failing to have the async attribute applied to the script handle when being printed.' );
 	}
 
@@ -246,8 +245,8 @@ JS;
 		wp_enqueue_script( 'dependency-script-a2', '/dependency-script-a2.js', array(), null );
 		wp_enqueue_script( 'main-script-a2', '/main-script-a2.js', array( 'dependency-script-a2' ), null, compact( 'strategy' ) );
 		$output    = get_echo( 'wp_print_scripts' );
-		$expected  = "<script id='dependency-script-a2-js' src='/dependency-script-a2.js' type='text/javascript'></script>\n";
-		$expected .= "<script type='text/javascript' src='/main-script-a2.js' id='main-script-a2-js' {$strategy}='{$strategy}' data-wp-strategy='{$strategy}'></script>";
+		$expected  = "<script id='dependency-script-a2-js' src='/dependency-script-a2.js'></script>\n";
+		$expected .= "<script src='/main-script-a2.js' id='main-script-a2-js' {$strategy}='{$strategy}' data-wp-strategy='{$strategy}'></script>";
 		$this->assertEqualHTML( $expected, $output, '<body>', 'Dependents of a blocking dependency are free to have any strategy.' );
 	}
 
@@ -269,8 +268,8 @@ JS;
 		wp_enqueue_script( 'dependent-script-a3', '/dependent-script-a3.js', array( 'main-script-a3' ), null );
 		$output   = get_echo( 'wp_print_scripts' );
 		$expected = <<<JS
-			<script type='text/javascript' src='/main-script-a3.js' id='main-script-a3-js' data-wp-strategy='{$strategy}'></script>
-			<script id="dependent-script-a3-js" src="/dependent-script-a3.js" type="text/javascript"></script>
+			<script src='/main-script-a3.js' id='main-script-a3-js' data-wp-strategy='{$strategy}'></script>
+			<script id="dependent-script-a3-js" src="/dependent-script-a3.js"></script>
 JS;
 		$this->assertEqualHTML( $expected, $output, '<body>', 'Blocking dependents must force delayed dependencies to become blocking.' );
 	}
@@ -520,27 +519,27 @@ JS;
 					}
 				},
 				'expected_markup' => <<<HTML
-<script id="blocking-not-async-without-dependency-js-before" type="text/javascript">
+<script id="blocking-not-async-without-dependency-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-not-async-without-dependency: before inline" )
 //# sourceURL=blocking-not-async-without-dependency-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=blocking-not-async-without-dependency:%20script' id='blocking-not-async-without-dependency-js'></script>
-<script id="blocking-not-async-without-dependency-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=blocking-not-async-without-dependency:%20script' id='blocking-not-async-without-dependency-js'></script>
+<script id="blocking-not-async-without-dependency-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-not-async-without-dependency: after inline" )
 //# sourceURL=blocking-not-async-without-dependency-js-after
 /* ]]> */
 </script>
-<script id="async-with-blocking-dependency-js-before" type="text/javascript">
+<script id="async-with-blocking-dependency-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "async-with-blocking-dependency: before inline" )
 //# sourceURL=async-with-blocking-dependency-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=async-with-blocking-dependency:%20script' id='async-with-blocking-dependency-js' data-wp-strategy='async'></script>
-<script id="async-with-blocking-dependency-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=async-with-blocking-dependency:%20script' id='async-with-blocking-dependency-js' data-wp-strategy='async'></script>
+<script id="async-with-blocking-dependency-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "async-with-blocking-dependency: after inline" )
 //# sourceURL=async-with-blocking-dependency-js-after
@@ -569,40 +568,40 @@ HTML
 					}
 				},
 				'expected_markup' => <<<HTML
-<script id="async-no-dependency-js-before" type="text/javascript">
+<script id="async-no-dependency-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "async-no-dependency: before inline" )
 //# sourceURL=async-no-dependency-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=async-no-dependency:%20script' id='async-no-dependency-js' data-wp-strategy='async'></script>
-<script id="async-no-dependency-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=async-no-dependency:%20script' id='async-no-dependency-js' data-wp-strategy='async'></script>
+<script id="async-no-dependency-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "async-no-dependency: after inline" )
 //# sourceURL=async-no-dependency-js-after
 /* ]]> */
 </script>
-<script id="async-one-async-dependency-js-before" type="text/javascript">
+<script id="async-one-async-dependency-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "async-one-async-dependency: before inline" )
 //# sourceURL=async-one-async-dependency-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=async-one-async-dependency:%20script' id='async-one-async-dependency-js' data-wp-strategy='async'></script>
-<script id="async-one-async-dependency-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=async-one-async-dependency:%20script' id='async-one-async-dependency-js' data-wp-strategy='async'></script>
+<script id="async-one-async-dependency-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "async-one-async-dependency: after inline" )
 //# sourceURL=async-one-async-dependency-js-after
 /* ]]> */
 </script>
-<script id="async-two-async-dependencies-js-before" type="text/javascript">
+<script id="async-two-async-dependencies-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "async-two-async-dependencies: before inline" )
 //# sourceURL=async-two-async-dependencies-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=async-two-async-dependencies:%20script' id='async-two-async-dependencies-js' data-wp-strategy='async'></script>
-<script id="async-two-async-dependencies-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=async-two-async-dependencies:%20script' id='async-two-async-dependencies-js' data-wp-strategy='async'></script>
+<script id="async-two-async-dependencies-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "async-two-async-dependencies: after inline" )
 //# sourceURL=async-two-async-dependencies-js-after
@@ -623,27 +622,27 @@ HTML
 					}
 				},
 				'expected_markup' => <<<HTML
-<script id="async-with-blocking-dependent-js-before" type="text/javascript">
+<script id="async-with-blocking-dependent-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "async-with-blocking-dependent: before inline" )
 //# sourceURL=async-with-blocking-dependent-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=async-with-blocking-dependent:%20script' id='async-with-blocking-dependent-js' data-wp-strategy='async'></script>
-<script id="async-with-blocking-dependent-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=async-with-blocking-dependent:%20script' id='async-with-blocking-dependent-js' data-wp-strategy='async'></script>
+<script id="async-with-blocking-dependent-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "async-with-blocking-dependent: after inline" )
 //# sourceURL=async-with-blocking-dependent-js-after
 /* ]]> */
 </script>
-<script id="blocking-dependent-of-async-js-before" type="text/javascript">
+<script id="blocking-dependent-of-async-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-dependent-of-async: before inline" )
 //# sourceURL=blocking-dependent-of-async-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=blocking-dependent-of-async:%20script' id='blocking-dependent-of-async-js'></script>
-<script id="blocking-dependent-of-async-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=blocking-dependent-of-async:%20script' id='blocking-dependent-of-async-js'></script>
+<script id="blocking-dependent-of-async-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-dependent-of-async: after inline" )
 //# sourceURL=blocking-dependent-of-async-js-after
@@ -664,27 +663,27 @@ HTML
 					}
 				},
 				'expected_markup' => <<<HTML
-<script id="async-with-defer-dependent-js-before" type="text/javascript">
+<script id="async-with-defer-dependent-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "async-with-defer-dependent: before inline" )
 //# sourceURL=async-with-defer-dependent-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=async-with-defer-dependent:%20script' id='async-with-defer-dependent-js' data-wp-strategy='async'></script>
-<script id="async-with-defer-dependent-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=async-with-defer-dependent:%20script' id='async-with-defer-dependent-js' data-wp-strategy='async'></script>
+<script id="async-with-defer-dependent-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "async-with-defer-dependent: after inline" )
 //# sourceURL=async-with-defer-dependent-js-after
 /* ]]> */
 </script>
-<script id="defer-dependent-of-async-js-before" type="text/javascript">
+<script id="defer-dependent-of-async-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-async: before inline" )
 //# sourceURL=defer-dependent-of-async-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-async:%20script' id='defer-dependent-of-async-js' data-wp-strategy='defer'></script>
-<script id="defer-dependent-of-async-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=defer-dependent-of-async:%20script' id='defer-dependent-of-async-js' data-wp-strategy='defer'></script>
+<script id="defer-dependent-of-async-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-async: after inline" )
 //# sourceURL=defer-dependent-of-async-js-after
@@ -708,26 +707,26 @@ HTML
 					$this->add_test_inline_script( $handle2, 'after' );
 				},
 				'expected_markup' => <<<HTML
-<script id="blocking-bundle-of-none-js-before" type="text/javascript">
+<script id="blocking-bundle-of-none-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-bundle-of-none: before inline" )
 //# sourceURL=blocking-bundle-of-none-js-before
 /* ]]> */
 </script>
-<script id="blocking-bundle-of-none-js-after" type="text/javascript">
+<script id="blocking-bundle-of-none-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-bundle-of-none: after inline" )
 //# sourceURL=blocking-bundle-of-none-js-after
 /* ]]> */
 </script>
-<script id="defer-dependent-of-blocking-bundle-of-none-js-before" type="text/javascript">
+<script id="defer-dependent-of-blocking-bundle-of-none-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-blocking-bundle-of-none: before inline" )
 //# sourceURL=defer-dependent-of-blocking-bundle-of-none-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-blocking-bundle-of-none:%20script' id='defer-dependent-of-blocking-bundle-of-none-js' data-wp-strategy='defer'></script>
-<script id="defer-dependent-of-blocking-bundle-of-none-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=defer-dependent-of-blocking-bundle-of-none:%20script' id='defer-dependent-of-blocking-bundle-of-none-js' data-wp-strategy='defer'></script>
+<script id="defer-dependent-of-blocking-bundle-of-none-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-blocking-bundle-of-none: after inline" )
 //# sourceURL=defer-dependent-of-blocking-bundle-of-none-js-after
@@ -754,40 +753,40 @@ HTML
 					}
 				},
 				'expected_markup' => <<<HTML
-<script id="blocking-bundle-member-one-js-before" type="text/javascript">
+<script id="blocking-bundle-member-one-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-bundle-member-one: before inline" )
 //# sourceURL=blocking-bundle-member-one-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=blocking-bundle-member-one:%20script' id='blocking-bundle-member-one-js'></script>
-<script id="blocking-bundle-member-one-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=blocking-bundle-member-one:%20script' id='blocking-bundle-member-one-js'></script>
+<script id="blocking-bundle-member-one-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-bundle-member-one: after inline" )
 //# sourceURL=blocking-bundle-member-one-js-after
 /* ]]> */
 </script>
-<script id="blocking-bundle-member-two-js-before" type="text/javascript">
+<script id="blocking-bundle-member-two-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-bundle-member-two: before inline" )
 //# sourceURL=blocking-bundle-member-two-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=blocking-bundle-member-two:%20script' id='blocking-bundle-member-two-js'></script>
-<script id="blocking-bundle-member-two-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=blocking-bundle-member-two:%20script' id='blocking-bundle-member-two-js'></script>
+<script id="blocking-bundle-member-two-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-bundle-member-two: after inline" )
 //# sourceURL=blocking-bundle-member-two-js-after
 /* ]]> */
 </script>
-<script id="defer-dependent-of-blocking-bundle-of-two-js-before" type="text/javascript">
+<script id="defer-dependent-of-blocking-bundle-of-two-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-blocking-bundle-of-two: before inline" )
 //# sourceURL=defer-dependent-of-blocking-bundle-of-two-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-blocking-bundle-of-two:%20script' id='defer-dependent-of-blocking-bundle-of-two-js' data-wp-strategy='defer'></script>
-<script id="defer-dependent-of-blocking-bundle-of-two-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=defer-dependent-of-blocking-bundle-of-two:%20script' id='defer-dependent-of-blocking-bundle-of-two-js' data-wp-strategy='defer'></script>
+<script id="defer-dependent-of-blocking-bundle-of-two-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-blocking-bundle-of-two: after inline" )
 //# sourceURL=defer-dependent-of-blocking-bundle-of-two-js-after
@@ -813,26 +812,26 @@ HTML
 					$this->add_test_inline_script( $handle2, 'after' );
 				},
 				'expected_markup' => <<<HTML
-<script id="defer-bundle-of-none-js-before" type="text/javascript">
+<script id="defer-bundle-of-none-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-bundle-of-none: before inline" )
 //# sourceURL=defer-bundle-of-none-js-before
 /* ]]> */
 </script>
-<script id="defer-bundle-of-none-js-after" type="text/javascript">
+<script id="defer-bundle-of-none-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-bundle-of-none: after inline" )
 //# sourceURL=defer-bundle-of-none-js-after
 /* ]]> */
 </script>
-<script id="defer-dependent-of-defer-bundle-of-none-js-before" type="text/javascript">
+<script id="defer-dependent-of-defer-bundle-of-none-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-defer-bundle-of-none: before inline" )
 //# sourceURL=defer-dependent-of-defer-bundle-of-none-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-defer-bundle-of-none:%20script' id='defer-dependent-of-defer-bundle-of-none-js' data-wp-strategy='defer'></script>
-<script id="defer-dependent-of-defer-bundle-of-none-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=defer-dependent-of-defer-bundle-of-none:%20script' id='defer-dependent-of-defer-bundle-of-none-js' data-wp-strategy='defer'></script>
+<script id="defer-dependent-of-defer-bundle-of-none-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-defer-bundle-of-none: after inline" )
 //# sourceURL=defer-dependent-of-defer-bundle-of-none-js-after
@@ -856,40 +855,40 @@ HTML
 					}
 				},
 				'expected_markup' => <<<HTML
-<script id="blocking-dependency-with-defer-following-dependency-js-before" type="text/javascript">
+<script id="blocking-dependency-with-defer-following-dependency-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-dependency-with-defer-following-dependency: before inline" )
 //# sourceURL=blocking-dependency-with-defer-following-dependency-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=blocking-dependency-with-defer-following-dependency:%20script' id='blocking-dependency-with-defer-following-dependency-js'></script>
-<script id="blocking-dependency-with-defer-following-dependency-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=blocking-dependency-with-defer-following-dependency:%20script' id='blocking-dependency-with-defer-following-dependency-js'></script>
+<script id="blocking-dependency-with-defer-following-dependency-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-dependency-with-defer-following-dependency: after inline" )
 //# sourceURL=blocking-dependency-with-defer-following-dependency-js-after
 /* ]]> */
 </script>
-<script id="defer-dependency-with-blocking-preceding-dependency-js-before" type="text/javascript">
+<script id="defer-dependency-with-blocking-preceding-dependency-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependency-with-blocking-preceding-dependency: before inline" )
 //# sourceURL=defer-dependency-with-blocking-preceding-dependency-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependency-with-blocking-preceding-dependency:%20script' id='defer-dependency-with-blocking-preceding-dependency-js' data-wp-strategy='defer'></script>
-<script id="defer-dependency-with-blocking-preceding-dependency-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=defer-dependency-with-blocking-preceding-dependency:%20script' id='defer-dependency-with-blocking-preceding-dependency-js' data-wp-strategy='defer'></script>
+<script id="defer-dependency-with-blocking-preceding-dependency-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependency-with-blocking-preceding-dependency: after inline" )
 //# sourceURL=defer-dependency-with-blocking-preceding-dependency-js-after
 /* ]]> */
 </script>
-<script id="defer-dependent-of-blocking-and-defer-dependencies-js-before" type="text/javascript">
+<script id="defer-dependent-of-blocking-and-defer-dependencies-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-blocking-and-defer-dependencies: before inline" )
 //# sourceURL=defer-dependent-of-blocking-and-defer-dependencies-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-blocking-and-defer-dependencies:%20script' id='defer-dependent-of-blocking-and-defer-dependencies-js' data-wp-strategy='defer'></script>
-<script id="defer-dependent-of-blocking-and-defer-dependencies-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=defer-dependent-of-blocking-and-defer-dependencies:%20script' id='defer-dependent-of-blocking-and-defer-dependencies-js' data-wp-strategy='defer'></script>
+<script id="defer-dependent-of-blocking-and-defer-dependencies-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-blocking-and-defer-dependencies: after inline" )
 //# sourceURL=defer-dependent-of-blocking-and-defer-dependencies-js-after
@@ -913,40 +912,40 @@ HTML
 					}
 				},
 				'expected_markup' => <<<HTML
-<script id="defer-dependency-with-blocking-following-dependency-js-before" type="text/javascript">
+<script id="defer-dependency-with-blocking-following-dependency-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependency-with-blocking-following-dependency: before inline" )
 //# sourceURL=defer-dependency-with-blocking-following-dependency-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependency-with-blocking-following-dependency:%20script' id='defer-dependency-with-blocking-following-dependency-js' data-wp-strategy='defer'></script>
-<script id="defer-dependency-with-blocking-following-dependency-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=defer-dependency-with-blocking-following-dependency:%20script' id='defer-dependency-with-blocking-following-dependency-js' data-wp-strategy='defer'></script>
+<script id="defer-dependency-with-blocking-following-dependency-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependency-with-blocking-following-dependency: after inline" )
 //# sourceURL=defer-dependency-with-blocking-following-dependency-js-after
 /* ]]> */
 </script>
-<script id="blocking-dependency-with-defer-preceding-dependency-js-before" type="text/javascript">
+<script id="blocking-dependency-with-defer-preceding-dependency-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-dependency-with-defer-preceding-dependency: before inline" )
 //# sourceURL=blocking-dependency-with-defer-preceding-dependency-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=blocking-dependency-with-defer-preceding-dependency:%20script' id='blocking-dependency-with-defer-preceding-dependency-js'></script>
-<script id="blocking-dependency-with-defer-preceding-dependency-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=blocking-dependency-with-defer-preceding-dependency:%20script' id='blocking-dependency-with-defer-preceding-dependency-js'></script>
+<script id="blocking-dependency-with-defer-preceding-dependency-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "blocking-dependency-with-defer-preceding-dependency: after inline" )
 //# sourceURL=blocking-dependency-with-defer-preceding-dependency-js-after
 /* ]]> */
 </script>
-<script id="defer-dependent-of-defer-and-blocking-dependencies-js-before" type="text/javascript">
+<script id="defer-dependent-of-defer-and-blocking-dependencies-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-defer-and-blocking-dependencies: before inline" )
 //# sourceURL=defer-dependent-of-defer-and-blocking-dependencies-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-defer-and-blocking-dependencies:%20script' id='defer-dependent-of-defer-and-blocking-dependencies-js' data-wp-strategy='defer'></script>
-<script id="defer-dependent-of-defer-and-blocking-dependencies-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=defer-dependent-of-defer-and-blocking-dependencies:%20script' id='defer-dependent-of-defer-and-blocking-dependencies-js' data-wp-strategy='defer'></script>
+<script id="defer-dependent-of-defer-and-blocking-dependencies-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-defer-and-blocking-dependencies: after inline" )
 //# sourceURL=defer-dependent-of-defer-and-blocking-dependencies-js-after
@@ -967,27 +966,27 @@ HTML
 					}
 				},
 				'expected_markup' => <<<HTML
-<script id="defer-with-async-dependent-js-before" type="text/javascript">
+<script id="defer-with-async-dependent-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-with-async-dependent: before inline" )
 //# sourceURL=defer-with-async-dependent-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-with-async-dependent:%20script' id='defer-with-async-dependent-js' data-wp-strategy='defer'></script>
-<script id="defer-with-async-dependent-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=defer-with-async-dependent:%20script' id='defer-with-async-dependent-js' data-wp-strategy='defer'></script>
+<script id="defer-with-async-dependent-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-with-async-dependent: after inline" )
 //# sourceURL=defer-with-async-dependent-js-after
 /* ]]> */
 </script>
-<script id="async-dependent-of-defer-js-before" type="text/javascript">
+<script id="async-dependent-of-defer-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "async-dependent-of-defer: before inline" )
 //# sourceURL=async-dependent-of-defer-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=async-dependent-of-defer:%20script' id='async-dependent-of-defer-js' data-wp-strategy='async'></script>
-<script id="async-dependent-of-defer-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=async-dependent-of-defer:%20script' id='async-dependent-of-defer-js' data-wp-strategy='async'></script>
+<script id="async-dependent-of-defer-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "async-dependent-of-defer: after inline" )
 //# sourceURL=async-dependent-of-defer-js-after
@@ -1004,13 +1003,13 @@ HTML
 					$this->add_test_inline_script( $handle, 'before' );
 				},
 				'expected_markup' => <<<HTML
-<script id="defer-with-before-inline-js-before" type="text/javascript">
+<script id="defer-with-before-inline-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-with-before-inline: before inline" )
 //# sourceURL=defer-with-before-inline-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-with-before-inline:%20script' id='defer-with-before-inline-js' defer='defer' data-wp-strategy='defer'></script>
+<script src='https://example.com/external.js?script_event_log=defer-with-before-inline:%20script' id='defer-with-before-inline-js' defer='defer' data-wp-strategy='defer'></script>
 HTML
 				,
 			),
@@ -1022,8 +1021,8 @@ HTML
 					$this->add_test_inline_script( $handle, 'after' );
 				},
 				'expected_markup' => <<<HTML
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-with-after-inline:%20script' id='defer-with-after-inline-js' data-wp-strategy='defer'></script>
-<script id="defer-with-after-inline-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=defer-with-after-inline:%20script' id='defer-with-after-inline-js' data-wp-strategy='defer'></script>
+<script id="defer-with-after-inline-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-with-after-inline: after inline" )
 //# sourceURL=defer-with-after-inline-js-after
@@ -1043,9 +1042,9 @@ HTML
 					wp_enqueue_script( 'theme-functions', 'https://example.com/theme-functions.js', array( 'jquery' ), null, array( 'strategy' => 'defer' ) );
 				},
 				'expected_markup' => <<<HTML
-<script type='text/javascript' src='http://$wp_tests_domain/wp-includes/js/jquery/jquery.js' id='jquery-core-js' defer='defer' data-wp-strategy='defer'></script>
-<script type='text/javascript' src='http://$wp_tests_domain/wp-includes/js/jquery/jquery-migrate.js' id='jquery-migrate-js' defer='defer' data-wp-strategy='defer'></script>
-<script type='text/javascript' src='https://example.com/theme-functions.js' id='theme-functions-js' defer='defer' data-wp-strategy='defer'></script>
+<script src='http://$wp_tests_domain/wp-includes/js/jquery/jquery.js' id='jquery-core-js' defer='defer' data-wp-strategy='defer'></script>
+<script src='http://$wp_tests_domain/wp-includes/js/jquery/jquery-migrate.js' id='jquery-migrate-js' defer='defer' data-wp-strategy='defer'></script>
+<script src='https://example.com/theme-functions.js' id='theme-functions-js' defer='defer' data-wp-strategy='defer'></script>
 HTML
 				,
 			),
@@ -1068,17 +1067,17 @@ HTML
 					$this->add_test_inline_script( 'defer-dependent-of-nested-aliases', 'after' );
 				},
 				'expected_markup' => <<<HTML
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=inner-bundle-member-one:%20script' id='inner-bundle-member-one-js' data-wp-strategy='defer'></script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=inner-bundle-member-two:%20script' id='inner-bundle-member-two-js' data-wp-strategy='defer'></script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=outer-bundle-leaf-member:%20script' id='outer-bundle-leaf-member-js'></script>
-<script id="defer-dependent-of-nested-aliases-js-before" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=inner-bundle-member-one:%20script' id='inner-bundle-member-one-js' data-wp-strategy='defer'></script>
+<script src='https://example.com/external.js?script_event_log=inner-bundle-member-two:%20script' id='inner-bundle-member-two-js' data-wp-strategy='defer'></script>
+<script src='https://example.com/external.js?script_event_log=outer-bundle-leaf-member:%20script' id='outer-bundle-leaf-member-js'></script>
+<script id="defer-dependent-of-nested-aliases-js-before">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-nested-aliases: before inline" )
 //# sourceURL=defer-dependent-of-nested-aliases-js-before
 /* ]]> */
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-nested-aliases:%20script' id='defer-dependent-of-nested-aliases-js' data-wp-strategy='defer'></script>
-<script id="defer-dependent-of-nested-aliases-js-after" type="text/javascript">
+<script src='https://example.com/external.js?script_event_log=defer-dependent-of-nested-aliases:%20script' id='defer-dependent-of-nested-aliases-js' data-wp-strategy='defer'></script>
+<script id="defer-dependent-of-nested-aliases-js-after">
 /* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-nested-aliases: after inline" )
 //# sourceURL=defer-dependent-of-nested-aliases-js-after
@@ -1101,9 +1100,9 @@ HTML
 					$this->enqueue_test_script( 'defer-dependent-of-async-aliases', 'defer', array( $alias_handle ) );
 				},
 				'expected_markup' => <<<HTML
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=async1:%20script' id='async1-js' defer='defer' data-wp-strategy='async'></script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=async2:%20script' id='async2-js' defer='defer' data-wp-strategy='async'></script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-async-aliases:%20script' id='defer-dependent-of-async-aliases-js' defer='defer' data-wp-strategy='defer'></script>
+<script src='https://example.com/external.js?script_event_log=async1:%20script' id='async1-js' defer='defer' data-wp-strategy='async'></script>
+<script src='https://example.com/external.js?script_event_log=async2:%20script' id='async2-js' defer='defer' data-wp-strategy='async'></script>
+<script src='https://example.com/external.js?script_event_log=defer-dependent-of-async-aliases:%20script' id='defer-dependent-of-async-aliases-js' defer='defer' data-wp-strategy='defer'></script>
 HTML
 				,
 			),
@@ -1234,10 +1233,10 @@ HTML
 		);
 		// Note: All of these scripts have fetchpriority=high because the leaf dependent script has that fetch priority.
 		$output    = get_echo( 'wp_print_scripts' );
-		$expected  = "<script type='text/javascript' src='/main-script-d4.js'        id='main-script-d4-js'        defer='defer' data-wp-strategy='defer' fetchpriority='high' data-wp-fetchpriority='auto'></script>\n";
-		$expected .= "<script type='text/javascript' src='/dependent-script-d4-1.js' id='dependent-script-d4-1-js' defer='defer' data-wp-strategy='defer' fetchpriority='high' data-wp-fetchpriority='auto'></script>\n";
-		$expected .= "<script type='text/javascript' src='/dependent-script-d4-2.js' id='dependent-script-d4-2-js' defer='defer' data-wp-strategy='async' fetchpriority='high' data-wp-fetchpriority='low'></script>\n";
-		$expected .= "<script type='text/javascript' src='/dependent-script-d4-3.js' id='dependent-script-d4-3-js' defer='defer' data-wp-strategy='defer' fetchpriority='high'></script>\n";
+		$expected  = "<script src='/main-script-d4.js'        id='main-script-d4-js'        defer='defer' data-wp-strategy='defer' fetchpriority='high' data-wp-fetchpriority='auto'></script>\n";
+		$expected .= "<script src='/dependent-script-d4-1.js' id='dependent-script-d4-1-js' defer='defer' data-wp-strategy='defer' fetchpriority='high' data-wp-fetchpriority='auto'></script>\n";
+		$expected .= "<script src='/dependent-script-d4-2.js' id='dependent-script-d4-2-js' defer='defer' data-wp-strategy='async' fetchpriority='high' data-wp-fetchpriority='low'></script>\n";
+		$expected .= "<script src='/dependent-script-d4-3.js' id='dependent-script-d4-3-js' defer='defer' data-wp-strategy='defer' fetchpriority='high'></script>\n";
 
 		$this->assertEqualHTML( $expected, $output, '<body>', 'Scripts registered as defer but that have dependents that are async are expected to have said dependents deferred.' );
 	}
@@ -1353,21 +1352,21 @@ HTML
 		return array(
 			'enqueue_bajo' => array(
 				'enqueues' => array( 'bajo' ),
-				'expected' => '<script fetchpriority="low" id="bajo-js" src="/bajo.js" type="text/javascript"></script>',
+				'expected' => '<script fetchpriority="low" id="bajo-js" src="/bajo.js"></script>',
 			),
 			'enqueue_auto' => array(
 				'enqueues' => array( 'auto' ),
 				'expected' => '
-					<script type="text/javascript" src="/bajo.js" id="bajo-js" data-wp-fetchpriority="low"></script>
-					<script type="text/javascript" src="/auto.js" id="auto-js"></script>
+					<script src="/bajo.js" id="bajo-js" data-wp-fetchpriority="low"></script>
+					<script src="/auto.js" id="auto-js"></script>
 				',
 			),
 			'enqueue_alto' => array(
 				'enqueues' => array( 'alto' ),
 				'expected' => '
-					<script type="text/javascript" src="/bajo.js" id="bajo-js" fetchpriority="high" data-wp-fetchpriority="low"></script>
-					<script type="text/javascript" src="/auto.js" id="auto-js" fetchpriority="high" data-wp-fetchpriority="auto"></script>
-					<script type="text/javascript" src="/alto.js" id="alto-js" fetchpriority="high"></script>
+					<script src="/bajo.js" id="bajo-js" fetchpriority="high" data-wp-fetchpriority="low"></script>
+					<script src="/auto.js" id="auto-js" fetchpriority="high" data-wp-fetchpriority="auto"></script>
+					<script src="/alto.js" id="alto-js" fetchpriority="high"></script>
 				',
 			),
 		);
@@ -1423,14 +1422,14 @@ HTML
 
 		$actual   = get_echo( 'wp_print_scripts' );
 		$expected = '
-			<script type="text/javascript" src="/z.js" id="z-js" fetchpriority="high" data-wp-fetchpriority="auto"></script>
-			<script type="text/javascript" src="/d.js" id="d-js" fetchpriority="high"></script>
-			<script type="text/javascript" src="/e.js" id="e-js"></script>
-			<script type="text/javascript" src="/c.js" id="c-js"></script>
-			<script type="text/javascript" src="/b.js" id="b-js"></script>
-			<script type="text/javascript" src="/a.js" id="a-js" fetchpriority="low"></script>
-			<script type="text/javascript" src="/y.js" id="y-js" fetchpriority="high" data-wp-fetchpriority="auto"></script>
-			<script type="text/javascript" src="/x.js" id="x-js" fetchpriority="high"></script>
+			<script src="/z.js" id="z-js" fetchpriority="high" data-wp-fetchpriority="auto"></script>
+			<script src="/d.js" id="d-js" fetchpriority="high"></script>
+			<script src="/e.js" id="e-js"></script>
+			<script src="/c.js" id="c-js"></script>
+			<script src="/b.js" id="b-js"></script>
+			<script src="/a.js" id="a-js" fetchpriority="low"></script>
+			<script src="/y.js" id="y-js" fetchpriority="high" data-wp-fetchpriority="auto"></script>
+			<script src="/x.js" id="x-js" fetchpriority="high"></script>
 		';
 		$this->assertEqualHTML( $expected, $actual, '<body>', "Snapshot:\n$actual" );
 	}
@@ -1500,7 +1499,7 @@ HTML
 
 		$this->assertEqualHTML(
 			sprintf(
-				'<script type="text/javascript" src="%s" id="comment-reply-js" async="async" data-wp-strategy="async" fetchpriority="low"></script>',
+				'<script src="%s" id="comment-reply-js" async="async" data-wp-strategy="async" fetchpriority="low"></script>',
 				includes_url( 'js/comment-reply.js' )
 			),
 			$markup
@@ -1540,7 +1539,7 @@ HTML
 		wp_enqueue_script( 'dependent-script-d4-2', '/dependent-script-d4-2.js', array( 'dependent-script-d4-1' ), null );
 		wp_enqueue_script( 'dependent-script-d4-3', '/dependent-script-d4-3.js', array( 'dependent-script-d4-2' ), null, array( 'strategy' => 'defer' ) );
 		$output   = get_echo( 'wp_print_scripts' );
-		$expected = str_replace( "'", '"', "<script type='text/javascript' src='/main-script-d4.js' id='main-script-d4-js' data-wp-strategy='defer'></script>\n" );
+		$expected = str_replace( "'", '"', "<script src='/main-script-d4.js' id='main-script-d4-js' data-wp-strategy='defer'></script>\n" );
 		$this->assertStringContainsString( $expected, $output, 'Scripts registered as defer but that have all dependents with no strategy, should become blocking (no strategy).' );
 	}
 
@@ -1557,14 +1556,14 @@ HTML
 	public function test_loading_strategy_with_valid_blocking_registration() {
 		wp_enqueue_script( 'main-script-b1', '/main-script-b1.js', array(), null );
 		$output   = get_echo( 'wp_print_scripts' );
-		$expected = "<script type='text/javascript' src='/main-script-b1.js' id='main-script-b1-js'></script>\n";
+		$expected = "<script src='/main-script-b1.js' id='main-script-b1-js'></script>\n";
 		$expected = str_replace( "'", '"', $expected );
 		$this->assertSame( $expected, $output, 'Scripts registered with a "blocking" strategy, and who have no dependencies, should have no loading strategy attributes printed.' );
 
 		// strategy args not set.
 		wp_enqueue_script( 'main-script-b2', '/main-script-b2.js', array(), null, array() );
 		$output   = get_echo( 'wp_print_scripts' );
-		$expected = "<script type='text/javascript' src='/main-script-b2.js' id='main-script-b2-js'></script>\n";
+		$expected = "<script src='/main-script-b2.js' id='main-script-b2-js'></script>\n";
 		$expected = str_replace( "'", '"', $expected );
 		$this->assertSame( $expected, $output, 'Scripts registered with no strategy assigned, and who have no dependencies, should have no loading strategy attributes printed.' );
 	}
@@ -1622,10 +1621,10 @@ HTML
 		$actual_header = get_echo( 'wp_print_head_scripts' );
 		$actual_footer = get_echo( 'wp_print_scripts' );
 
-		$expected_header  = "<script type='text/javascript' src='/header-old.js' id='header-old-js'></script>\n";
-		$expected_header .= "<script type='text/javascript' src='/header-new.js' id='header-new-js'></script>\n";
-		$expected_header .= "<script type='text/javascript' src='/enqueue-header-old.js' id='enqueue-header-old-js'></script>\n";
-		$expected_header .= "<script type='text/javascript' src='/enqueue-header-new.js' id='enqueue-header-new-js'></script>\n";
+		$expected_header  = "<script src='/header-old.js' id='header-old-js'></script>\n";
+		$expected_header .= "<script src='/header-new.js' id='header-new-js'></script>\n";
+		$expected_header .= "<script src='/enqueue-header-old.js' id='enqueue-header-old-js'></script>\n";
+		$expected_header .= "<script src='/enqueue-header-new.js' id='enqueue-header-new-js'></script>\n";
 
 		$this->assertEqualHTML( $expected_header, $actual_header, '<body>', 'Scripts registered/enqueued using the older $in_footer parameter or the newer $args parameter should have the same outcome.' );
 		$this->assertEmpty( $actual_footer, 'Expected footer to be empty since all scripts were for head.' );
@@ -1649,10 +1648,10 @@ HTML
 		$actual_header = get_echo( 'wp_print_head_scripts' );
 		$actual_footer = get_echo( 'wp_print_scripts' );
 
-		$expected_footer  = "<script type='text/javascript' src='/footer-old.js' id='footer-old-js'></script>\n";
-		$expected_footer .= "<script type='text/javascript' src='/footer-new.js' id='footer-new-js'></script>\n";
-		$expected_footer .= "<script type='text/javascript' src='/enqueue-footer-old.js' id='enqueue-footer-old-js'></script>\n";
-		$expected_footer .= "<script type='text/javascript' src='/enqueue-footer-new.js' id='enqueue-footer-new-js'></script>\n";
+		$expected_footer  = "<script src='/footer-old.js' id='footer-old-js'></script>\n";
+		$expected_footer .= "<script src='/footer-new.js' id='footer-new-js'></script>\n";
+		$expected_footer .= "<script src='/enqueue-footer-old.js' id='enqueue-footer-old-js'></script>\n";
+		$expected_footer .= "<script src='/enqueue-footer-new.js' id='enqueue-footer-new-js'></script>\n";
 
 		$this->assertEmpty( $actual_header, 'Expected header to be empty since all scripts targeted footer.' );
 		$this->assertEqualHTML( $expected_footer, $actual_footer, '<body>', 'Scripts registered/enqueued using the older $in_footer parameter or the newer $args parameter should have the same outcome.' );
@@ -1775,7 +1774,7 @@ HTML
 		wp_enqueue_script( 'invalid-strategy' );
 
 		$this->assertEqualHTML(
-			"<script type='text/javascript' src='/defaults.js' id='invalid-strategy-js'></script>\n",
+			"<script src='/defaults.js' id='invalid-strategy-js'></script>\n",
 			get_echo( 'wp_print_scripts' )
 		);
 	}
@@ -1800,7 +1799,7 @@ HTML
 		wp_enqueue_script( 'invalid-strategy' );
 
 		$this->assertEqualHTML(
-			"<script type='text/javascript' src='/defaults.js' id='invalid-strategy-js'></script>\n",
+			"<script src='/defaults.js' id='invalid-strategy-js'></script>\n",
 			get_echo( 'wp_print_scripts' )
 		);
 	}
@@ -1821,7 +1820,7 @@ HTML
 		wp_enqueue_script( 'invalid-strategy', '/defaults.js', array(), null, array( 'strategy' => 'random-strategy' ) );
 
 		$this->assertEqualHTML(
-			"<script type='text/javascript' src='/defaults.js' id='invalid-strategy-js'></script>\n",
+			"<script src='/defaults.js' id='invalid-strategy-js'></script>\n",
 			get_echo( 'wp_print_scripts' )
 		);
 	}
@@ -1851,8 +1850,8 @@ HTML
 		wp_print_scripts();
 		$print_scripts = get_echo( '_print_scripts' );
 
-		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep,two-concat-dep,three-concat-dep&amp;ver={$wp_version}'></script>\n";
-		$expected .= "<script type='text/javascript' src='/main-script.js' id='main-defer-script-js' defer='defer' data-wp-strategy='defer'></script>\n";
+		$expected  = "<script src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep,two-concat-dep,three-concat-dep&amp;ver={$wp_version}'></script>\n";
+		$expected .= "<script src='/main-script.js' id='main-defer-script-js' defer='defer' data-wp-strategy='defer'></script>\n";
 
 		$this->assertEqualHTML( $expected, $print_scripts, '<body>', 'Scripts are being incorrectly concatenated when a main script is registered with a "defer" loading strategy. Deferred scripts should not be part of the script concat loading query.' );
 	}
@@ -1882,8 +1881,8 @@ HTML
 		wp_print_scripts();
 		$print_scripts = get_echo( '_print_scripts' );
 
-		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep-1,two-concat-dep-1,three-concat-dep-1&amp;ver={$wp_version}'></script>\n";
-		$expected .= "<script type='text/javascript' src='/main-script.js' id='main-async-script-1-js' async='async' data-wp-strategy='async'></script>\n";
+		$expected  = "<script src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep-1,two-concat-dep-1,three-concat-dep-1&amp;ver={$wp_version}'></script>\n";
+		$expected .= "<script src='/main-script.js' id='main-async-script-1-js' async='async' data-wp-strategy='async'></script>\n";
 
 		$this->assertEqualHTML( $expected, $print_scripts, '<body>', 'Scripts are being incorrectly concatenated when a main script is registered with an "async" loading strategy. Async scripts should not be part of the script concat loading query.' );
 	}
@@ -1917,8 +1916,8 @@ HTML
 		wp_print_scripts();
 		$print_scripts = get_echo( '_print_scripts' );
 
-		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep-2,two-concat-dep-2,three-concat-dep-2,four-concat-dep-2,five-concat-dep-2,six-concat-dep-2&amp;ver={$wp_version}'></script>\n";
-		$expected .= "<script type='text/javascript' src='/main-script.js' id='deferred-script-2-js' defer='defer' data-wp-strategy='defer'></script>\n";
+		$expected  = "<script src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep-2,two-concat-dep-2,three-concat-dep-2,four-concat-dep-2,five-concat-dep-2,six-concat-dep-2&amp;ver={$wp_version}'></script>\n";
+		$expected .= "<script src='/main-script.js' id='deferred-script-2-js' defer='defer' data-wp-strategy='defer'></script>\n";
 
 		$this->assertEqualHTML( $expected, $print_scripts, '<body>', 'Scripts are being incorrectly concatenated when a main script is registered as deferred after other blocking scripts are registered. Deferred scripts should not be part of the script concat loader query string. ' );
 	}
@@ -1957,24 +1956,24 @@ HTML
 
 		// Try with an HTTP reference.
 		wp_enqueue_script( 'jquery-http', 'http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js' );
-		$expected .= "<script type='text/javascript' src='http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js?ver={$wp_version}' id='jquery-http-js'></script>\n";
+		$expected .= "<script src='http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js?ver={$wp_version}' id='jquery-http-js'></script>\n";
 
 		// Try with an HTTPS reference.
 		wp_enqueue_script( 'jquery-https', 'https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js' );
-		$expected .= "<script type='text/javascript' src='https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js?ver={$wp_version}' id='jquery-https-js'></script>\n";
+		$expected .= "<script src='https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js?ver={$wp_version}' id='jquery-https-js'></script>\n";
 
 		// Try with an automatic protocol reference (//).
 		wp_enqueue_script( 'jquery-doubleslash', '//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js' );
-		$expected .= "<script type='text/javascript' src='//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js?ver={$wp_version}' id='jquery-doubleslash-js'></script>\n";
+		$expected .= "<script src='//ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js?ver={$wp_version}' id='jquery-doubleslash-js'></script>\n";
 
 		// Try with a local resource and an automatic protocol reference (//).
 		$url = '//my_plugin/script.js';
 		wp_enqueue_script( 'plugin-script', $url );
-		$expected .= "<script type='text/javascript' src='$url?ver={$wp_version}' id='plugin-script-js'></script>\n";
+		$expected .= "<script src='$url?ver={$wp_version}' id='plugin-script-js'></script>\n";
 
 		// Try with a bad protocol.
 		wp_enqueue_script( 'jquery-ftp', 'ftp://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js' );
-		$expected .= "<script type='text/javascript' src='{$wp_scripts->base_url}ftp://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js?ver={$wp_version}' id='jquery-ftp-js'></script>\n";
+		$expected .= "<script src='{$wp_scripts->base_url}ftp://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js?ver={$wp_version}' id='jquery-ftp-js'></script>\n";
 
 		// Go!
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
@@ -2002,7 +2001,7 @@ HTML
 		wp_print_scripts();
 		$print_scripts = get_echo( '_print_scripts' );
 
-		$expected = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one,two,three&amp;ver={$wp_version}'></script>\n";
+		$expected = "<script src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one,two,three&amp;ver={$wp_version}'></script>\n";
 
 		$this->assertSame( $expected, $print_scripts );
 	}
@@ -2016,8 +2015,8 @@ HTML
 		// Enqueue and add data.
 		wp_enqueue_script( 'test-only-data', 'example.com', array(), null );
 		wp_script_add_data( 'test-only-data', 'data', 'testing' );
-		$expected  = "<script type='text/javascript' id='test-only-data-js-extra'>\n/* <![CDATA[ */\ntesting\n//# sourceURL=test-only-data-js-extra\n/* ]]> */\n</script>\n";
-		$expected .= "<script type='text/javascript' src='http://example.com' id='test-only-data-js'></script>\n";
+		$expected  = "<script id='test-only-data-js-extra'>\n/* <![CDATA[ */\ntesting\n//# sourceURL=test-only-data-js-extra\n/* ]]> */\n</script>\n";
+		$expected .= "<script src='http://example.com' id='test-only-data-js'></script>\n";
 
 		// Go!
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
@@ -2052,7 +2051,7 @@ HTML
 		// Enqueue and add an invalid key.
 		wp_enqueue_script( 'test-invalid', 'example.com', array(), null );
 		wp_script_add_data( 'test-invalid', 'invalid', 'testing' );
-		$expected = "<script type='text/javascript' src='http://example.com' id='test-invalid-js'></script>\n";
+		$expected = "<script src='http://example.com' id='test-invalid-js'></script>\n";
 
 		// Go!
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
@@ -2075,8 +2074,8 @@ HTML
 	 * @ticket 35229
 	 */
 	public function test_wp_register_script_with_handle_without_source() {
-		$expected  = "<script type='text/javascript' src='http://example.com?ver=1' id='handle-one-js'></script>\n";
-		$expected .= "<script type='text/javascript' src='http://example.com?ver=2' id='handle-two-js'></script>\n";
+		$expected  = "<script src='http://example.com?ver=1' id='handle-one-js'></script>\n";
+		$expected .= "<script src='http://example.com?ver=2' id='handle-two-js'></script>\n";
 
 		wp_register_script( 'handle-one', 'http://example.com', array(), 1 );
 		wp_register_script( 'handle-two', 'http://example.com', array(), 2 );
@@ -2168,9 +2167,9 @@ HTML
 		$header = get_echo( 'wp_print_head_scripts' );
 		$footer = get_echo( 'wp_print_footer_scripts' );
 
-		$expected_header  = "<script type='text/javascript' src='/child-footer.js' id='child-footer-js'></script>\n";
-		$expected_header .= "<script type='text/javascript' src='/child-head.js' id='child-head-js'></script>\n";
-		$expected_footer  = "<script type='text/javascript' src='/parent.js' id='parent-js'></script>\n";
+		$expected_header  = "<script src='/child-footer.js' id='child-footer-js'></script>\n";
+		$expected_header .= "<script src='/child-head.js' id='child-head-js'></script>\n";
+		$expected_footer  = "<script src='/parent.js' id='parent-js'></script>\n";
 
 		$this->assertEqualHTML( $expected_header, $header, '<body>', 'Expected same header markup.' );
 		$this->assertEqualHTML( $expected_footer, $footer, '<body>', 'Expected same footer markup.' );
@@ -2189,9 +2188,9 @@ HTML
 		$header = get_echo( 'wp_print_head_scripts' );
 		$footer = get_echo( 'wp_print_footer_scripts' );
 
-		$expected_header  = "<script type='text/javascript' src='/child-head.js' id='child-head-js'></script>\n";
-		$expected_footer  = "<script type='text/javascript' src='/child-footer.js' id='child-footer-js'></script>\n";
-		$expected_footer .= "<script type='text/javascript' src='/parent.js' id='parent-js'></script>\n";
+		$expected_header  = "<script src='/child-head.js' id='child-head-js'></script>\n";
+		$expected_footer  = "<script src='/child-footer.js' id='child-footer-js'></script>\n";
+		$expected_footer .= "<script src='/parent.js' id='parent-js'></script>\n";
 
 		$this->assertEqualHTML( $expected_header, $header, '<body>', 'Expected same header markup.' );
 		$this->assertEqualHTML( $expected_footer, $footer, '<body>', 'Expected same footer markup.' );
@@ -2215,14 +2214,14 @@ HTML
 		$header = get_echo( 'wp_print_head_scripts' );
 		$footer = get_echo( 'wp_print_footer_scripts' );
 
-		$expected_header  = "<script type='text/javascript' src='/child-head.js' id='child-head-js'></script>\n";
-		$expected_header .= "<script type='text/javascript' src='/grandchild-head.js' id='grandchild-head-js'></script>\n";
-		$expected_header .= "<script type='text/javascript' src='/child2-head.js' id='child2-head-js'></script>\n";
-		$expected_header .= "<script type='text/javascript' src='/parent-header.js' id='parent-header-js'></script>\n";
+		$expected_header  = "<script src='/child-head.js' id='child-head-js'></script>\n";
+		$expected_header .= "<script src='/grandchild-head.js' id='grandchild-head-js'></script>\n";
+		$expected_header .= "<script src='/child2-head.js' id='child2-head-js'></script>\n";
+		$expected_header .= "<script src='/parent-header.js' id='parent-header-js'></script>\n";
 
-		$expected_footer  = "<script type='text/javascript' src='/child-footer.js' id='child-footer-js'></script>\n";
-		$expected_footer .= "<script type='text/javascript' src='/child2-footer.js' id='child2-footer-js'></script>\n";
-		$expected_footer .= "<script type='text/javascript' src='/parent-footer.js' id='parent-footer-js'></script>\n";
+		$expected_footer  = "<script src='/child-footer.js' id='child-footer-js'></script>\n";
+		$expected_footer .= "<script src='/child2-footer.js' id='child2-footer-js'></script>\n";
+		$expected_footer .= "<script src='/parent-footer.js' id='parent-footer-js'></script>\n";
 
 		$this->assertEqualHTML( $expected_header, $header, '<body>', 'Expected same header markup.' );
 		$this->assertEqualHTML( $expected_footer, $footer, '<body>', 'Expected same footer markup.' );
@@ -2253,14 +2252,14 @@ HTML
 		wp_add_inline_script( 'test-example', 'console.log("before");', 'before' );
 
 		$expected  = <<<HTML
-<script type='text/javascript' id='test-example-js-before'>
+<script id='test-example-js-before'>
 /* <![CDATA[ */
 console.log("before");
 //# sourceURL=test-example-js-before
 /* ]]> */
 </script>
 HTML;
-		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
+		$expected .= "<script src='http://example.com' id='test-example-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2272,9 +2271,9 @@ HTML;
 		wp_enqueue_script( 'test-example', 'example.com', array(), null );
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
 
-		$expected  = "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
+		$expected  = "<script src='http://example.com' id='test-example-js'></script>\n";
 		$expected .= <<<HTML
-<script type='text/javascript' id='test-example-js-after'>
+<script id='test-example-js-after'>
 /* <![CDATA[ */
 console.log("after");
 //# sourceURL=test-example-js-after
@@ -2293,9 +2292,9 @@ HTML;
 		wp_add_inline_script( 'test-example', 'console.log("before");', 'before' );
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
 
-		$expected  = "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
-		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
+		$expected  = "<script id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
+		$expected .= "<script src='http://example.com' id='test-example-js'></script>\n";
+		$expected .= "<script id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2308,7 +2307,7 @@ HTML;
 		wp_enqueue_script( 'test-example' );
 		wp_add_inline_script( 'test-example', 'console.log("before");', 'before' );
 
-		$expected = "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
+		$expected = "<script id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2321,7 +2320,7 @@ HTML;
 		wp_enqueue_script( 'test-example' );
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
 
-		$expected = "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
+		$expected = "<script id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2335,8 +2334,8 @@ HTML;
 		wp_add_inline_script( 'test-example', 'console.log("before");', 'before' );
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
 
-		$expected  = "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
+		$expected  = "<script id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
+		$expected .= "<script id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2351,9 +2350,9 @@ HTML;
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
 
-		$expected  = "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
-		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
+		$expected  = "<script id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
+		$expected .= "<script src='http://example.com' id='test-example-js'></script>\n";
+		$expected .= "<script id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2367,10 +2366,10 @@ HTML;
 		wp_add_inline_script( 'test-example', 'console.log("before");', 'before' );
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
 
-		$expected  = "<script type='text/javascript' id='test-example-js-extra'>\n/* <![CDATA[ */\nvar testExample = {\"foo\":\"bar\"};\n//# sourceURL=test-example-js-extra\n/* ]]> */\n</script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
-		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
+		$expected  = "<script id='test-example-js-extra'>\n/* <![CDATA[ */\nvar testExample = {\"foo\":\"bar\"};\n//# sourceURL=test-example-js-extra\n/* ]]> */\n</script>\n";
+		$expected .= "<script id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
+		$expected .= "<script src='http://example.com' id='test-example-js'></script>\n";
+		$expected .= "<script id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2391,11 +2390,11 @@ HTML;
 		wp_add_inline_script( 'one', 'console.log("before one");', 'before' );
 		wp_add_inline_script( 'two', 'console.log("before two");', 'before' );
 
-		$expected  = "<script type='text/javascript' id='one-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before one\");\n//# sourceURL=one-js-before\n/* ]]> */\n</script>\n";
-		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}one.js?ver={$wp_version}' id='one-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='two-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before two\");\n//# sourceURL=two-js-before\n/* ]]> */\n</script>\n";
-		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}two.js?ver={$wp_version}' id='two-js'></script>\n";
-		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}three.js?ver={$wp_version}' id='three-js'></script>\n";
+		$expected  = "<script id='one-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before one\");\n//# sourceURL=one-js-before\n/* ]]> */\n</script>\n";
+		$expected .= "<script src='{$this->default_scripts_dir}one.js?ver={$wp_version}' id='one-js'></script>\n";
+		$expected .= "<script id='two-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before two\");\n//# sourceURL=two-js-before\n/* ]]> */\n</script>\n";
+		$expected .= "<script src='{$this->default_scripts_dir}two.js?ver={$wp_version}' id='two-js'></script>\n";
+		$expected .= "<script src='{$this->default_scripts_dir}three.js?ver={$wp_version}' id='three-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2415,10 +2414,10 @@ HTML;
 
 		wp_add_inline_script( 'one', 'console.log("before one");', 'before' );
 
-		$expected  = "<script type='text/javascript' id='one-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before one\");\n//# sourceURL=one-js-before\n/* ]]> */\n</script>\n";
-		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}one.js?ver={$wp_version}' id='one-js'></script>\n";
-		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}two.js?ver={$wp_version}' id='two-js'></script>\n";
-		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}three.js?ver={$wp_version}' id='three-js'></script>\n";
+		$expected  = "<script id='one-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before one\");\n//# sourceURL=one-js-before\n/* ]]> */\n</script>\n";
+		$expected .= "<script src='{$this->default_scripts_dir}one.js?ver={$wp_version}' id='one-js'></script>\n";
+		$expected .= "<script src='{$this->default_scripts_dir}two.js?ver={$wp_version}' id='two-js'></script>\n";
+		$expected .= "<script src='{$this->default_scripts_dir}three.js?ver={$wp_version}' id='three-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2440,12 +2439,12 @@ HTML;
 		wp_add_inline_script( 'two', 'console.log("after two");' );
 		wp_add_inline_script( 'three', 'console.log("after three");' );
 
-		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one&amp;ver={$wp_version}'></script>\n";
-		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}two.js?ver={$wp_version}' id='two-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='two-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after two\");\n//# sourceURL=two-js-after\n/* ]]> */\n</script>\n";
-		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}three.js?ver={$wp_version}' id='three-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='three-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after three\");\n//# sourceURL=three-js-after\n/* ]]> */\n</script>\n";
-		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}four.js?ver={$wp_version}' id='four-js'></script>\n";
+		$expected  = "<script src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one&amp;ver={$wp_version}'></script>\n";
+		$expected .= "<script src='{$this->default_scripts_dir}two.js?ver={$wp_version}' id='two-js'></script>\n";
+		$expected .= "<script id='two-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after two\");\n//# sourceURL=two-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script src='{$this->default_scripts_dir}three.js?ver={$wp_version}' id='three-js'></script>\n";
+		$expected .= "<script id='three-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after three\");\n//# sourceURL=three-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script src='{$this->default_scripts_dir}four.js?ver={$wp_version}' id='four-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2488,9 +2487,9 @@ HTML;
 		$wp_scripts->base_url  = '';
 		$wp_scripts->do_concat = true;
 
-		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core,jquery-migrate&amp;ver={$wp_version}'></script>\n";
-		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
+		$expected  = "<script src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core,jquery-migrate&amp;ver={$wp_version}'></script>\n";
+		$expected .= "<script src='http://example.com' id='test-example-js'></script>\n";
+		$expected .= "<script id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
 
 		wp_enqueue_script( 'test-example', 'http://example.com', array( 'jquery' ), null );
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
@@ -2537,9 +2536,9 @@ HTML;
 		$wp_scripts->base_url  = '';
 		$wp_scripts->do_concat = true;
 
-		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core,jquery-migrate&amp;ver={$wp_version}'></script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
-		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
+		$expected  = "<script src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core,jquery-migrate&amp;ver={$wp_version}'></script>\n";
+		$expected .= "<script id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
+		$expected .= "<script src='http://example.com' id='test-example-js'></script>\n";
 
 		wp_enqueue_script( 'test-example', 'http://example.com', array( 'jquery' ), null );
 		wp_add_inline_script( 'test-example', 'console.log("before");', 'before' );
@@ -2562,21 +2561,21 @@ HTML;
 		$wp_scripts->base_url  = '';
 		$wp_scripts->do_concat = true;
 
-		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core,jquery-migrate,wp-dom-ready,wp-hooks&amp;ver={$wp_version}'></script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-before'>\n";
+		$expected  = "<script src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core,jquery-migrate,wp-dom-ready,wp-hooks&amp;ver={$wp_version}'></script>\n";
+		$expected .= "<script id='test-example-js-before'>\n";
 		$expected .= "/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n";
 		$expected .= "</script>\n";
-		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
-		$expected .= "<script type='text/javascript' src='/wp-includes/js/dist/i18n.min.js' id='wp-i18n-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='wp-i18n-js-after'>\n";
+		$expected .= "<script src='http://example.com' id='test-example-js'></script>\n";
+		$expected .= "<script src='/wp-includes/js/dist/i18n.min.js' id='wp-i18n-js'></script>\n";
+		$expected .= "<script id='wp-i18n-js-after'>\n";
 		$expected .= "/* <![CDATA[ */\n";
 		$expected .= "wp.i18n.setLocaleData( { 'text direction\u0004ltr': [ 'ltr' ] } );\n";
 		$expected .= "//# sourceURL=wp-i18n-js-after\n";
 		$expected .= "/* ]]> */\n";
 		$expected .= "</script>\n";
-		$expected .= "<script type='text/javascript' src='/wp-includes/js/dist/a11y.min.js' id='wp-a11y-js'></script>\n";
-		$expected .= "<script type='text/javascript' src='http://example2.com' id='test-example2-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='test-example2-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example2-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script src='/wp-includes/js/dist/a11y.min.js' id='wp-a11y-js'></script>\n";
+		$expected .= "<script src='http://example2.com' id='test-example2-js'></script>\n";
+		$expected .= "<script id='test-example2-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example2-js-after\n/* ]]> */\n</script>\n";
 		wp_enqueue_script( 'test-example', 'http://example.com', array( 'jquery' ), null );
 		wp_add_inline_script( 'test-example', 'console.log("before");', 'before' );
 		wp_enqueue_script( 'test-example2', 'http://example2.com', array( 'wp-a11y' ), null );
@@ -2616,8 +2615,8 @@ HTML;
 		$wp_scripts->base_url  = '';
 		$wp_scripts->do_concat = true;
 
-		$expected_tail  = "<script type='text/javascript' src='/customize-dependency.js' id='customize-dependency-js'></script>\n";
-		$expected_tail .= "<script type='text/javascript' id='customize-dependency-js-after'>\n";
+		$expected_tail  = "<script src='/customize-dependency.js' id='customize-dependency-js'></script>\n";
+		$expected_tail .= "<script id='customize-dependency-js-after'>\n";
 		$expected_tail .= "/* <![CDATA[ */\n";
 		$expected_tail .= "tryCustomizeDependency()\n";
 		$expected_tail .= "//# sourceURL=customize-dependency-js-after\n";
@@ -2635,7 +2634,7 @@ HTML;
 		_print_scripts();
 		$print_scripts = $this->getActualOutput();
 
-		$tail = substr( $print_scripts, strrpos( $print_scripts, '<script type="text/javascript" src="/customize-dependency.js" id="customize-dependency-js">' ) );
+		$tail = substr( $print_scripts, strrpos( $print_scripts, '<script src="/customize-dependency.js" id="customize-dependency-js">' ) );
 
 		$this->assertEqualHTML( $expected_tail, $tail );
 	}
@@ -2655,11 +2654,11 @@ HTML;
 		wp_enqueue_script( 'three', '/wp-includes/js/script3.js' );
 		wp_enqueue_script( 'four', '/wp-includes/js/script4.js' );
 
-		$expected  = "<script type='text/javascript' src='/wp-includes/js/script.js?ver={$wp_version}' id='one-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='one-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after one\");\n//# sourceURL=one-js-after\n/* ]]> */\n</script>\n";
-		$expected .= "<script type='text/javascript' src='/wp-includes/js/script2.js?ver={$wp_version}' id='two-js'></script>\n";
-		$expected .= "<script type='text/javascript' src='/wp-includes/js/script3.js?ver={$wp_version}' id='three-js'></script>\n";
-		$expected .= "<script type='text/javascript' src='/wp-includes/js/script4.js?ver={$wp_version}' id='four-js'></script>\n";
+		$expected  = "<script src='/wp-includes/js/script.js?ver={$wp_version}' id='one-js'></script>\n";
+		$expected .= "<script id='one-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after one\");\n//# sourceURL=one-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script src='/wp-includes/js/script2.js?ver={$wp_version}' id='two-js'></script>\n";
+		$expected .= "<script src='/wp-includes/js/script3.js?ver={$wp_version}' id='three-js'></script>\n";
+		$expected .= "<script src='/wp-includes/js/script4.js?ver={$wp_version}' id='four-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2679,10 +2678,10 @@ HTML;
 		wp_add_inline_script( 'three', 'console.log("before three");', 'before' );
 		wp_enqueue_script( 'four', '/wp-includes/js/script4.js' );
 
-		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one,two&amp;ver={$wp_version}'></script>\n";
-		$expected .= "<script type='text/javascript' id='three-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before three\");\n//# sourceURL=three-js-before\n/* ]]> */\n</script>\n";
-		$expected .= "<script type='text/javascript' src='/wp-includes/js/script3.js?ver={$wp_version}' id='three-js'></script>\n";
-		$expected .= "<script type='text/javascript' src='/wp-includes/js/script4.js?ver={$wp_version}' id='four-js'></script>\n";
+		$expected  = "<script src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one,two&amp;ver={$wp_version}'></script>\n";
+		$expected .= "<script id='three-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before three\");\n//# sourceURL=three-js-before\n/* ]]> */\n</script>\n";
+		$expected .= "<script src='/wp-includes/js/script3.js?ver={$wp_version}' id='three-js'></script>\n";
+		$expected .= "<script src='/wp-includes/js/script4.js?ver={$wp_version}' id='four-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2701,7 +2700,7 @@ HTML;
 				),
 				'delayed'        => false,
 				'expected_data'  => "/*before foo 1*/\n//# sourceURL=foo-js-before",
-				'expected_tag'   => "<script id='foo-js-before' type='text/javascript'>\n/* <![CDATA[ */\n/*before foo 1*/\n//# sourceURL=foo-js-before\n/* ]]> */\n</script>\n",
+				'expected_tag'   => "<script id='foo-js-before'>\n/* <![CDATA[ */\n/*before foo 1*/\n//# sourceURL=foo-js-before\n/* ]]> */\n</script>\n",
 			),
 			'after-blocking'  => array(
 				'position'       => 'after',
@@ -2711,7 +2710,7 @@ HTML;
 				),
 				'delayed'        => false,
 				'expected_data'  => "/*after foo 1*/\n/*after foo 2*/\n//# sourceURL=foo-js-after",
-				'expected_tag'   => "<script id='foo-js-after' type='text/javascript'>\n/* <![CDATA[ */\n/*after foo 1*/\n/*after foo 2*/\n//# sourceURL=foo-js-after\n/* ]]> */\n</script>\n",
+				'expected_tag'   => "<script id='foo-js-after'>\n/* <![CDATA[ */\n/*after foo 1*/\n/*after foo 2*/\n//# sourceURL=foo-js-after\n/* ]]> */\n</script>\n",
 			),
 			'before-delayed'  => array(
 				'position'       => 'before',
@@ -2720,7 +2719,7 @@ HTML;
 				),
 				'delayed'        => true,
 				'expected_data'  => "/*before foo 1*/\n//# sourceURL=foo-js-before",
-				'expected_tag'   => "<script id='foo-js-before' type='text/javascript'>\n/* <![CDATA[ */\n/*before foo 1*/\n//# sourceURL=foo-js-before\n/* ]]> */\n</script>\n",
+				'expected_tag'   => "<script id='foo-js-before'>\n/* <![CDATA[ */\n/*before foo 1*/\n//# sourceURL=foo-js-before\n/* ]]> */\n</script>\n",
 			),
 			'after-delayed'   => array(
 				'position'       => 'after',
@@ -2730,7 +2729,7 @@ HTML;
 				),
 				'delayed'        => true,
 				'expected_data'  => "/*after foo 1*/\n/*after foo 2*/\n//# sourceURL=foo-js-after",
-				'expected_tag'   => "<script id='foo-js-after' type='text/javascript'>\n/* <![CDATA[ */\n/*after foo 1*/\n/*after foo 2*/\n//# sourceURL=foo-js-after\n/* ]]> */\n</script>\n",
+				'expected_tag'   => "<script id='foo-js-after'>\n/* <![CDATA[ */\n/*after foo 1*/\n/*after foo 2*/\n//# sourceURL=foo-js-after\n/* ]]> */\n</script>\n",
 			),
 		);
 	}
@@ -2800,7 +2799,7 @@ HTML;
 		wp_enqueue_script( 'test-example', '/wp-includes/js/script.js', array(), null );
 		wp_set_script_translations( 'test-example', 'default', DIR_TESTDATA . '/languages' );
 
-		$expected  = "<script type='text/javascript' src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
+		$expected  = "<script src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
 		$expected .= str_replace(
 			array(
 				'__DOMAIN__',
@@ -2814,7 +2813,7 @@ HTML;
 			),
 			$this->wp_scripts_print_translations_output
 		);
-		$expected .= "<script type='text/javascript' src='/wp-includes/js/script.js' id='test-example-js'></script>\n";
+		$expected .= "<script src='/wp-includes/js/script.js' id='test-example-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2832,7 +2831,7 @@ HTML;
 		$wp_textdomain_registry->set_custom_path( 'internationalized-plugin', DIR_TESTDATA . '/languages/plugins' );
 		wp_set_script_translations( 'domain-path-plugin', 'internationalized-plugin' );
 
-		$expected  = "<script type='text/javascript' src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
+		$expected  = "<script src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
 		$expected .= str_replace(
 			array(
 				'__DOMAIN__',
@@ -2846,7 +2845,7 @@ HTML;
 			),
 			$this->wp_scripts_print_translations_output
 		);
-		$expected .= "<script type='text/javascript' src='/wp-content/plugins/my-plugin/js/script.js' id='domain-path-plugin-js'></script>\n";
+		$expected .= "<script src='/wp-content/plugins/my-plugin/js/script.js' id='domain-path-plugin-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2867,7 +2866,7 @@ HTML;
 		$wp_textdomain_registry->set_custom_path( 'admin', DIR_TESTDATA . '/languages' );
 		wp_set_script_translations( 'script-handle', 'admin' );
 
-		$expected  = "<script type='text/javascript' src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
+		$expected  = "<script src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
 		$expected .= str_replace(
 			array(
 				'__DOMAIN__',
@@ -2881,7 +2880,7 @@ HTML;
 			),
 			$this->wp_scripts_print_translations_output
 		);
-		$expected .= "<script type='text/javascript' src='/wp-admin/js/script.js' id='script-handle-js'></script>\n";
+		$expected .= "<script src='/wp-admin/js/script.js' id='script-handle-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2894,7 +2893,7 @@ HTML;
 		wp_enqueue_script( 'plugin-example', '/wp-content/plugins/my-plugin/js/script.js', array(), null );
 		wp_set_script_translations( 'plugin-example', 'internationalized-plugin', DIR_TESTDATA . '/languages/plugins' );
 
-		$expected  = "<script type='text/javascript' src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
+		$expected  = "<script src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
 		$expected .= str_replace(
 			array(
 				'__DOMAIN__',
@@ -2908,7 +2907,7 @@ HTML;
 			),
 			$this->wp_scripts_print_translations_output
 		);
-		$expected .= "<script type='text/javascript' src='/wp-content/plugins/my-plugin/js/script.js' id='plugin-example-js'></script>\n";
+		$expected .= "<script src='/wp-content/plugins/my-plugin/js/script.js' id='plugin-example-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2921,7 +2920,7 @@ HTML;
 		wp_enqueue_script( 'theme-example', '/wp-content/themes/my-theme/js/script.js', array(), null );
 		wp_set_script_translations( 'theme-example', 'internationalized-theme', DIR_TESTDATA . '/languages/themes' );
 
-		$expected  = "<script type='text/javascript' src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
+		$expected  = "<script src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
 		$expected .= str_replace(
 			array(
 				'__DOMAIN__',
@@ -2935,7 +2934,7 @@ HTML;
 			),
 			$this->wp_scripts_print_translations_output
 		);
-		$expected .= "<script type='text/javascript' src='/wp-content/themes/my-theme/js/script.js' id='theme-example-js'></script>\n";
+		$expected .= "<script src='/wp-content/themes/my-theme/js/script.js' id='theme-example-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2948,7 +2947,7 @@ HTML;
 		wp_enqueue_script( 'script-handle', '/wp-admin/js/script.js', array(), null );
 		wp_set_script_translations( 'script-handle', 'admin', DIR_TESTDATA . '/languages/' );
 
-		$expected  = "<script type='text/javascript' src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
+		$expected  = "<script src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
 		$expected .= str_replace(
 			array(
 				'__DOMAIN__',
@@ -2962,7 +2961,7 @@ HTML;
 			),
 			$this->wp_scripts_print_translations_output
 		);
-		$expected .= "<script type='text/javascript' src='/wp-admin/js/script.js' id='script-handle-js'></script>\n";
+		$expected .= "<script src='/wp-admin/js/script.js' id='script-handle-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2991,8 +2990,8 @@ HTML;
 		wp_enqueue_script( 'test-example', '/wp-admin/js/script.js', array(), null );
 		wp_set_script_translations( 'test-example', 'admin', DIR_TESTDATA . '/languages/' );
 
-		$expected  = "<script type='text/javascript' src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
-		$expected .= "<script type='text/javascript' src='/wp-admin/js/script.js' id='test-example-js'></script>\n";
+		$expected  = "<script src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
+		$expected .= "<script src='/wp-admin/js/script.js' id='test-example-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -3007,7 +3006,7 @@ HTML;
 
 		wp_enqueue_script( 'test-example' );
 
-		$expected  = "<script type='text/javascript' src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
+		$expected  = "<script src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
 		$expected .= str_replace(
 			array(
 				'__DOMAIN__',
@@ -3021,7 +3020,7 @@ HTML;
 			),
 			$this->wp_scripts_print_translations_output
 		);
-		$expected .= "<script type='text/javascript' src='/wp-includes/js/script.js' id='test-example-js'></script>\n";
+		$expected .= "<script src='/wp-includes/js/script.js' id='test-example-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -3036,7 +3035,7 @@ HTML;
 
 		wp_enqueue_script( 'test-example', '/wp-includes/js/script2.js', array( 'test-dependency' ), null );
 
-		$expected  = "<script type='text/javascript' src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
+		$expected  = "<script src='/wp-includes/js/dist/wp-i18n.js' id='wp-i18n-js'></script>\n";
 		$expected .= str_replace(
 			array(
 				'__DOMAIN__',
@@ -3050,8 +3049,8 @@ HTML;
 			),
 			$this->wp_scripts_print_translations_output
 		);
-		$expected .= "<script type='text/javascript' src='/wp-includes/js/script.js' id='test-dependency-js'></script>\n";
-		$expected .= "<script type='text/javascript' src='/wp-includes/js/script2.js' id='test-example-js'></script>\n";
+		$expected .= "<script src='/wp-includes/js/script.js' id='test-dependency-js'></script>\n";
+		$expected .= "<script src='/wp-includes/js/script2.js' id='test-example-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -3439,8 +3438,8 @@ HTML;
 		wp_enqueue_script( 'test-example', 'example.com', array(), null );
 		wp_localize_script( 'test-example', 'testExample', $l10n_data );
 
-		$expected  = "<script type='text/javascript' id='test-example-js-extra'>\n/* <![CDATA[ */\nvar testExample = {$expected};\n//# sourceURL=test-example-js-extra\n/* ]]> */\n</script>\n";
-		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
+		$expected  = "<script id='test-example-js-extra'>\n/* <![CDATA[ */\nvar testExample = {$expected};\n//# sourceURL=test-example-js-extra\n/* ]]> */\n</script>\n";
+		$expected .= "<script src='http://example.com' id='test-example-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -3503,9 +3502,9 @@ HTML;
 		);
 
 		// The non-default script should end concatenation and maintain order.
-		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core&amp;ver={$wp_version}'></script>\n";
-		$expected .= "<script type='text/javascript' src='/plugins/wp-i18n.js' id='wp-i18n-js'></script>\n";
-		$expected .= "<script type='text/javascript' src='/default/common.js' id='common-js'></script>\n";
+		$expected  = "<script src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core&amp;ver={$wp_version}'></script>\n";
+		$expected .= "<script src='/plugins/wp-i18n.js' id='wp-i18n-js'></script>\n";
+		$expected .= "<script src='/default/common.js' id='common-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, $print_scripts );
 	}
@@ -3631,8 +3630,8 @@ HTML;
 				},
 				'expected_header'    => '',
 				'expected_footer'    => '
-					<script type="text/javascript" src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="defer"></script>
-					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js"></script>
+					<script src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="defer"></script>
+					<script src="https://example.com/script-b.js" id="script-b-js"></script>
 				',
 				'expected_in_footer' => array(
 					'script-a',
@@ -3652,8 +3651,8 @@ HTML;
 				},
 				'expected_header'    => '',
 				'expected_footer'    => '
-					<script type="text/javascript" src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="async"></script>
-					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js"></script>
+					<script src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="async"></script>
+					<script src="https://example.com/script-b.js" id="script-b-js"></script>
 				',
 				'expected_in_footer' => array(
 					'script-a',
@@ -3672,8 +3671,8 @@ HTML;
 					wp_enqueue_script( 'script-b', 'https://example.com/script-b.js', array( 'script-a' ), null, array( 'in_footer' => false ) );
 				},
 				'expected_header'    => '
-					<script type="text/javascript" src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="defer"></script>
-					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js"></script>
+					<script src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="defer"></script>
+					<script src="https://example.com/script-b.js" id="script-b-js"></script>
 				',
 				'expected_footer'    => '',
 				'expected_in_footer' => array(),
@@ -3699,10 +3698,10 @@ HTML;
 					);
 				},
 				'expected_header'    => '
-					<script type="text/javascript" src="https://example.com/script-a.js" id="script-a-js" defer="defer" data-wp-strategy="defer"></script>
+					<script src="https://example.com/script-a.js" id="script-a-js" defer="defer" data-wp-strategy="defer"></script>
 				',
 				'expected_footer'    => '
-					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js" defer="defer" data-wp-strategy="defer"></script>
+					<script src="https://example.com/script-b.js" id="script-b-js" defer="defer" data-wp-strategy="defer"></script>
 				',
 				'expected_in_footer' => array(
 					'script-b',
@@ -3749,12 +3748,12 @@ HTML;
 					);
 				},
 				'expected_header'    => '
-					<script type="text/javascript" src="https://example.com/script-a.js" id="script-a-js" defer="defer" data-wp-strategy="defer"></script>
-					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js" defer="defer" data-wp-strategy="defer"></script>
+					<script src="https://example.com/script-a.js" id="script-a-js" defer="defer" data-wp-strategy="defer"></script>
+					<script src="https://example.com/script-b.js" id="script-b-js" defer="defer" data-wp-strategy="defer"></script>
 				',
 				'expected_footer'    => '
-					<script type="text/javascript" src="https://example.com/script-c.js" id="script-c-js" defer="defer" data-wp-strategy="defer"></script>
-					<script type="text/javascript" src="https://example.com/script-d.js" id="script-d-js" defer="defer" data-wp-strategy="defer"></script>
+					<script src="https://example.com/script-c.js" id="script-c-js" defer="defer" data-wp-strategy="defer"></script>
+					<script src="https://example.com/script-d.js" id="script-d-js" defer="defer" data-wp-strategy="defer"></script>
 				',
 				'expected_in_footer' => array(
 					'script-c',
@@ -3796,10 +3795,10 @@ HTML;
 				},
 				'expected_header'    => '',
 				'expected_footer'    => '
-					<script type="text/javascript" src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="defer"></script>
-					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js" defer="defer" data-wp-strategy="defer"></script>
-					<script type="text/javascript" src="https://example.com/script-c.js" id="script-c-js"></script>
-					<script type="text/javascript" src="https://example.com/script-d.js" id="script-d-js" defer="defer" data-wp-strategy="defer"></script>
+					<script src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="defer"></script>
+					<script src="https://example.com/script-b.js" id="script-b-js" defer="defer" data-wp-strategy="defer"></script>
+					<script src="https://example.com/script-c.js" id="script-c-js"></script>
+					<script src="https://example.com/script-d.js" id="script-d-js" defer="defer" data-wp-strategy="defer"></script>
 				',
 				'expected_in_footer' => array(
 					'script-a',
@@ -3843,12 +3842,12 @@ HTML;
 					);
 				},
 				'expected_header'    => '
-					<script type="text/javascript" src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="defer"></script>
-					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js" defer="defer" data-wp-strategy="defer"></script>
+					<script src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="defer"></script>
+					<script src="https://example.com/script-b.js" id="script-b-js" defer="defer" data-wp-strategy="defer"></script>
 				',
 				'expected_footer'    => '
-					<script type="text/javascript" src="https://example.com/script-c.js" id="script-c-js"></script>
-					<script type="text/javascript" src="https://example.com/script-d.js" id="script-d-js" defer="defer" data-wp-strategy="defer"></script>
+					<script src="https://example.com/script-c.js" id="script-c-js"></script>
+					<script src="https://example.com/script-d.js" id="script-d-js" defer="defer" data-wp-strategy="defer"></script>
 				',
 				'expected_in_footer' => array(
 					'script-c',

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -622,7 +622,7 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 			$this->assertTrue( $processor->next_tag() );
 			$this->assertSame( 'STYLE', $processor->get_tag() );
 			$this->assertSame( $handle . '-inline-css', $processor->get_attribute( 'id' ) );
-			$this->assertSame( 'text/css', $processor->get_attribute( 'type' ) );
+			$this->assertNull( $processor->get_attribute( 'type' ) );
 
 			$expected_inline_styles = $expected_after;
 			if ( isset( $additional_inline_style ) ) {

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -63,10 +63,10 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		wp_enqueue_style( 'no-deps-null-version-print-media', 'example.com', array(), null, 'print' );
 
 		$ver       = get_bloginfo( 'version' );
-		$expected  = "<link rel='stylesheet' id='no-deps-no-version-css' href='http://example.com?ver=$ver' type='text/css' media='all' />\n";
-		$expected .= "<link rel='stylesheet' id='no-deps-version-css' href='http://example.com?ver=1.2' type='text/css' media='all' />\n";
-		$expected .= "<link rel='stylesheet' id='no-deps-null-version-css' href='http://example.com' type='text/css' media='all' />\n";
-		$expected .= "<link rel='stylesheet' id='no-deps-null-version-print-media-css' href='http://example.com' type='text/css' media='print' />\n";
+		$expected  = "<link rel='stylesheet' id='no-deps-no-version-css' href='http://example.com?ver=$ver' media='all' />\n";
+		$expected .= "<link rel='stylesheet' id='no-deps-version-css' href='http://example.com?ver=1.2' media='all' />\n";
+		$expected .= "<link rel='stylesheet' id='no-deps-null-version-css' href='http://example.com' media='all' />\n";
+		$expected .= "<link rel='stylesheet' id='no-deps-null-version-print-media-css' href='http://example.com' media='print' />\n";
 
 		$this->assertSame( $expected, get_echo( 'wp_print_styles' ) );
 
@@ -101,7 +101,7 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	public function test_awkward_handles_are_supported_consistently( $handle ) {
 		wp_enqueue_style( $handle, 'example.com', array(), null );
 
-		$expected = "<link rel='stylesheet' id='$handle-css' href='http://example.com' type='text/css' media='all' />\n";
+		$expected = "<link rel='stylesheet' id='$handle-css' href='http://example.com' media='all' />\n";
 
 		$this->assertSame( $expected, get_echo( 'wp_print_styles' ) );
 	}
@@ -137,24 +137,24 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 
 		// Try with an HTTP reference.
 		wp_enqueue_style( 'reset-css-http', 'http://yui.yahooapis.com/2.8.1/build/reset/reset-min.css' );
-		$expected .= "<link rel='stylesheet' id='reset-css-http-css' href='http://yui.yahooapis.com/2.8.1/build/reset/reset-min.css?ver=$ver' type='text/css' media='all' />\n";
+		$expected .= "<link rel='stylesheet' id='reset-css-http-css' href='http://yui.yahooapis.com/2.8.1/build/reset/reset-min.css?ver=$ver' media='all' />\n";
 
 		// Try with an HTTPS reference.
 		wp_enqueue_style( 'reset-css-https', 'http://yui.yahooapis.com/2.8.1/build/reset/reset-min.css' );
-		$expected .= "<link rel='stylesheet' id='reset-css-https-css' href='http://yui.yahooapis.com/2.8.1/build/reset/reset-min.css?ver=$ver' type='text/css' media='all' />\n";
+		$expected .= "<link rel='stylesheet' id='reset-css-https-css' href='http://yui.yahooapis.com/2.8.1/build/reset/reset-min.css?ver=$ver' media='all' />\n";
 
 		// Try with an automatic protocol reference (//).
 		wp_enqueue_style( 'reset-css-doubleslash', '//yui.yahooapis.com/2.8.1/build/reset/reset-min.css' );
-		$expected .= "<link rel='stylesheet' id='reset-css-doubleslash-css' href='//yui.yahooapis.com/2.8.1/build/reset/reset-min.css?ver=$ver' type='text/css' media='all' />\n";
+		$expected .= "<link rel='stylesheet' id='reset-css-doubleslash-css' href='//yui.yahooapis.com/2.8.1/build/reset/reset-min.css?ver=$ver' media='all' />\n";
 
 		// Try with a local resource and an automatic protocol reference (//).
 		$url = '//my_plugin/style.css';
 		wp_enqueue_style( 'plugin-style', $url );
-		$expected .= "<link rel='stylesheet' id='plugin-style-css' href='$url?ver=$ver' type='text/css' media='all' />\n";
+		$expected .= "<link rel='stylesheet' id='plugin-style-css' href='$url?ver=$ver' media='all' />\n";
 
 		// Try with a bad protocol.
 		wp_enqueue_style( 'reset-css-ftp', 'ftp://yui.yahooapis.com/2.8.1/build/reset/reset-min.css' );
-		$expected .= "<link rel='stylesheet' id='reset-css-ftp-css' href='{$wp_styles->base_url}ftp://yui.yahooapis.com/2.8.1/build/reset/reset-min.css?ver=$ver' type='text/css' media='all' />\n";
+		$expected .= "<link rel='stylesheet' id='reset-css-ftp-css' href='{$wp_styles->base_url}ftp://yui.yahooapis.com/2.8.1/build/reset/reset-min.css?ver=$ver' media='all' />\n";
 
 		// Go!
 		$this->assertSame( $expected, get_echo( 'wp_print_styles' ) );
@@ -177,8 +177,8 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		$style .= "\tbackground: red;\n";
 		$style .= '}';
 
-		$expected  = "<link rel='stylesheet' id='handle-css' href='http://example.com?ver=1' type='text/css' media='all' />\n";
-		$expected .= "<style id='handle-inline-css' type='text/css'>\n";
+		$expected  = "<link rel='stylesheet' id='handle-css' href='http://example.com?ver=1' media='all' />\n";
+		$expected .= "<style id='handle-inline-css'>\n";
 		$expected .= "$style\n";
 		$expected .= "/*# sourceURL=handle-inline-css */\n";
 		$expected .= "</style>\n";
@@ -206,8 +206,8 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		$style .= "\tbackground: red;\n";
 		$style .= '}';
 
-		$expected  = "<link rel='stylesheet' id='handle-css' href='http://example.com?ver=1' type='text/css' media='all' />\n";
-		$expected .= "<style id='handle-inline-css' type='text/css'>\n";
+		$expected  = "<link rel='stylesheet' id='handle-css' href='http://example.com?ver=1' media='all' />\n";
+		$expected .= "<style id='handle-inline-css'>\n";
 		$expected .= "$style\n";
 		$expected .= "</style>\n";
 
@@ -300,8 +300,8 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		$style2 .= "\tbackground: blue;\n";
 		$style2 .= '}';
 
-		$expected  = "<link rel='stylesheet' id='handle-css' href='http://example.com?ver=1' type='text/css' media='all' />\n";
-		$expected .= "<style id='handle-inline-css' type='text/css'>\n";
+		$expected  = "<link rel='stylesheet' id='handle-css' href='http://example.com?ver=1' media='all' />\n";
+		$expected .= "<style id='handle-inline-css'>\n";
 		$expected .= "$style1\n";
 		$expected .= "$style2\n";
 		$expected .= "/*# sourceURL=handle-inline-css */\n";
@@ -327,8 +327,8 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		$style .= "\tbackground: red;\n";
 		$style .= '}';
 
-		$expected  = "<link rel='stylesheet' id='handle-css' href='http://example.com?ver=1' type='text/css' media='all' />\n";
-		$expected .= "<style id='handle-inline-css' type='text/css'>\n";
+		$expected  = "<link rel='stylesheet' id='handle-css' href='http://example.com?ver=1' media='all' />\n";
+		$expected .= "<style id='handle-inline-css'>\n";
 		$expected .= "$style\n";
 		$expected .= "/*# sourceURL=handle-inline-css */\n";
 		$expected .= "</style>\n";
@@ -347,7 +347,7 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	 */
 	public function test_unnecessary_style_tags() {
 
-		$expected = "<link rel='stylesheet' id='handle-css' href='http://example.com?ver=1' type='text/css' media='all' />\n";
+		$expected = "<link rel='stylesheet' id='handle-css' href='http://example.com?ver=1' media='all' />\n";
 
 		wp_enqueue_style( 'handle', 'http://example.com', array(), 1 );
 
@@ -385,9 +385,9 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 	public function test_wp_add_inline_style_for_handle_without_source() {
 		$style = 'a { color: blue; }';
 
-		$expected  = "<link rel='stylesheet' id='handle-one-css' href='http://example.com?ver=1' type='text/css' media='all' />\n";
-		$expected .= "<link rel='stylesheet' id='handle-two-css' href='http://example.com?ver=1' type='text/css' media='all' />\n";
-		$expected .= "<style id='handle-three-inline-css' type='text/css'>\n";
+		$expected  = "<link rel='stylesheet' id='handle-one-css' href='http://example.com?ver=1' media='all' />\n";
+		$expected .= "<link rel='stylesheet' id='handle-two-css' href='http://example.com?ver=1' media='all' />\n";
+		$expected .= "<style id='handle-three-inline-css'>\n";
 		$expected .= "$style\n";
 		$expected .= "/*# sourceURL=handle-three-inline-css */\n";
 		$expected .= "</style>\n";
@@ -771,8 +771,8 @@ class Tests_Dependencies_Styles extends WP_UnitTestCase {
 		wp_add_inline_style( $handle, 'custom-el { content: "ok"; }' );
 
 		$expected = <<<HTML
-<link rel='stylesheet' href="/example.css?ver=0.0" id="# test/</style> #-css" media="all" type="text/css">
-<style id="# test/</style> #-inline-css" type="text/css">
+<link rel='stylesheet' href="/example.css?ver=0.0" id="# test/</style> #-css" media="all">
+<style id="# test/</style> #-inline-css">
 custom-el { content: "ok"; }
 /*# sourceURL=%23%20test%2F%3C%2Fstyle%3E%20%23-inline-css */
 </style>

--- a/tests/phpunit/tests/dependencies/wpInlineScriptTag.php
+++ b/tests/phpunit/tests/dependencies/wpInlineScriptTag.php
@@ -143,7 +143,7 @@ JS;
 		remove_theme_support( 'html5' );
 
 		$this->assertSame(
-			"<script type=\"text/javascript\">\n/* <![CDATA[ */\n/* <![CDATA[ */ console.log( 'Hello World!' ); /* ]]]]><![CDATA[> */\n/* ]]> */\n</script>\n",
+			"<script>\n/* <![CDATA[ */\n/* <![CDATA[ */ console.log( 'Hello World!' ); /* ]]]]><![CDATA[> */\n/* ]]> */\n</script>\n",
 			wp_get_inline_script_tag( "/* <![CDATA[ */ console.log( 'Hello World!' ); /* ]]> */" )
 		);
 	}

--- a/tests/phpunit/tests/fonts/font-face/wpFontFace/generateAndPrint.php
+++ b/tests/phpunit/tests/fonts/font-face/wpFontFace/generateAndPrint.php
@@ -31,7 +31,7 @@ class Tests_Fonts_WPFontFace_GenerateAndPrint extends WP_UnitTestCase {
 	 */
 	public function test_should_generate_and_print_given_fonts( array $fonts, $expected ) {
 		$font_face       = new WP_Font_Face();
-		$style_element   = "<style class='wp-fonts-local' type='text/css'>\n%s\n</style>\n";
+		$style_element   = "<style class='wp-fonts-local'>\n%s\n</style>\n";
 		$expected_output = sprintf( $style_element, $expected );
 
 		$this->expectOutputString( $expected_output );

--- a/tests/phpunit/tests/fonts/font-face/wpPrintFontFaces.php
+++ b/tests/phpunit/tests/fonts/font-face/wpPrintFontFaces.php
@@ -55,7 +55,7 @@ class Tests_Fonts_WpPrintFontFaces extends WP_Font_Face_UnitTestCase {
 		);
 
 		$expected_output = <<<CSS
-<style class='wp-fonts-local' type='text/css'>
+<style class='wp-fonts-local'>
 @font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-display:fallback;src:url('http://example.com/assets/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');font-stretch:;}
 </style>
 
@@ -76,7 +76,7 @@ CSS;
 	}
 
 	private function get_expected_styles_output( $styles ) {
-		$style_element = "<style class='wp-fonts-local' type='text/css'>\n%s\n</style>\n";
+		$style_element = "<style class='wp-fonts-local'>\n%s\n</style>\n";
 		return sprintf( $style_element, $styles );
 	}
 }

--- a/tests/phpunit/tests/fonts/font-face/wpPrintFontFacesFromStyleVariations.php
+++ b/tests/phpunit/tests/fonts/font-face/wpPrintFontFacesFromStyleVariations.php
@@ -48,7 +48,7 @@ class Tests_Fonts_WpPrintFontFacesFromStyleVariations extends WP_Font_Face_UnitT
 	}
 
 	private function get_expected_styles_output( $styles ) {
-		$style_element = "<style class='wp-fonts-local' type='text/css'>\n%s\n</style>\n";
+		$style_element = "<style class='wp-fonts-local'>\n%s\n</style>\n";
 		return sprintf( $style_element, $styles );
 	}
 }

--- a/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
+++ b/tests/phpunit/tests/privacy/wpPrivacyGeneratePersonalDataExportFile.php
@@ -331,7 +331,7 @@ class Tests_Privacy_wpPrivacyGeneratePersonalDataExportFile extends WP_UnitTestC
 		$expected .= "<html>\n";
 		$expected .= "<head>\n";
 		$expected .= "<meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />\n";
-		$expected .= "<style type='text/css'>body { color: black; font-family: Arial, sans-serif; font-size: 11pt; margin: 15px auto; width: 860px; }table { background: #f0f0f0; border: 1px solid #ddd; margin-bottom: 20px; width: 100%; }th { padding: 5px; text-align: left; width: 20%; }td { padding: 5px; }tr:nth-child(odd) { background-color: #fafafa; }.return-to-top { text-align: right; }</style><title>Personal Data Export for {$request->email}</title></head>\n";
+		$expected .= "<style>body { color: black; font-family: Arial, sans-serif; font-size: 11pt; margin: 15px auto; width: 860px; }table { background: #f0f0f0; border: 1px solid #ddd; margin-bottom: 20px; width: 100%; }th { padding: 5px; text-align: left; width: 20%; }td { padding: 5px; }tr:nth-child(odd) { background-color: #fafafa; }.return-to-top { text-align: right; }</style><title>Personal Data Export for {$request->email}</title></head>\n";
 		$expected .= "<body>\n";
 		$expected .= '<h1 id="top">Personal Data Export</h1>';
 


### PR DESCRIPTION
Building on https://github.com/WordPress/wordpress-develop/pull/10645 (included here).

Trac ticket: https://core.trac.wordpress.org/ticket/64428

> The script-loader and WP_Styles both make checks against current_theme_supports( 'html5', 'style' ) and current_theme_supports( 'html5', 'script' ), and multiple places in the rest of the codebase unconditionally produce type="text/css" and type="text/javascript" HTML attributes on the associated tags.
> 
> This is a legacy convention predating HTML5 in 2008 and can be removed. These are the default values when the attributes are absent, and this does not depend on or change with declared theme support.
> 
> Removing the type attribute simplifies logic and normalizes the produced HTML content.
> 
> This is part of [#59883](https://core.trac.wordpress.org/ticket/59883)
> 
> See also [PR#10641](https://github.com/WordPress/wordpress-develop/pull/10641)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
