### PR TITLE
Formatting: Convert multiplication symbol to 'x' in title slugs

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2289,7 +2289,11 @@ function sanitize_title_with_dashes( $title, $raw_title = '', $context = 'displa
 	$title = preg_replace( '|---([a-fA-F0-9][a-fA-F0-9])---|', '%$1', $title );
 
 	// Convert multiplication sign and times entities to 'x'.
-	$title = str_replace( array( '×', '&times;', '&#215;' ), 'x', $title );
+	$times_replacements = array( '×', '&times;', '&#215;' );
+	if ( 'save' === $context ) {
+		$times_replacements[] = '%c3%97';
+	}
+	$title = str_replace( $times_replacements, 'x', $title );
 
 	if ( wp_is_valid_utf8( $title ) ) {
 		if ( function_exists( 'mb_strtolower' ) ) {
@@ -2386,9 +2390,6 @@ function sanitize_title_with_dashes( $title, $raw_title = '', $context = 'displa
 			'-',
 			$title
 		);
-
-		// Convert &times to 'x'.
-		$title = str_replace( '%c3%97', 'x', $title );
 	}
 
 	// Remove HTML entities.

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2292,6 +2292,7 @@ function sanitize_title_with_dashes( $title, $raw_title = '', $context = 'displa
 	$times_replacements = array( '×', '&times;', '&#215;' );
 	if ( 'save' === $context ) {
 		$times_replacements[] = '%c3%97';
+		$times_replacements[] = '%C3%97';
 	}
 	$title = str_replace( $times_replacements, 'x', $title );
 

--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -2288,6 +2288,9 @@ function sanitize_title_with_dashes( $title, $raw_title = '', $context = 'displa
 	// Restore octets.
 	$title = preg_replace( '|---([a-fA-F0-9][a-fA-F0-9])---|', '%$1', $title );
 
+	// Convert multiplication sign and times entities to 'x'.
+	$title = str_replace( array( '×', '&times;', '&#215;' ), 'x', $title );
+
 	if ( wp_is_valid_utf8( $title ) ) {
 		if ( function_exists( 'mb_strtolower' ) ) {
 			$title = mb_strtolower( $title, 'UTF-8' );

--- a/tests/phpunit/tests/formatting/sanitizeTitleWithDashes.php
+++ b/tests/phpunit/tests/formatting/sanitizeTitleWithDashes.php
@@ -146,7 +146,39 @@ class Tests_Formatting_SanitizeTitleWithDashes extends WP_UnitTestCase {
 	 * @ticket 19820
 	 */
 	public function test_replaces_multiply_sign() {
-		$this->assertSame( '6x7-is-42', sanitize_title_with_dashes( '6×7 is 42', '', 'save' ) );
+		$this->assertSame( '6x7-is-42', sanitize_title_with_dashes( '6×7 is 42', '', 'save' ), 'Multiplication sign (×) should be replaced with letter x' );
+	}
+
+	/**
+	 * @ticket 64284
+	 */
+	public function test_replaces_multiply_sign_with_spaces() {
+		$this->assertSame( 'iphone-12-x-256gb', sanitize_title_with_dashes( 'iPhone 12 × 256GB', '', 'save' ), 'Product title with multiplication sign and spaces should convert × to x' );
+		$this->assertSame( 'screen-1920-x-1080', sanitize_title_with_dashes( 'Screen 1920 × 1080', '', 'save' ), 'Screen dimensions with multiplication sign should convert × to x' );
+	}
+
+	/**
+	 * @ticket 64284
+	 */
+	public function test_replaces_times_html_entity() {
+		$this->assertSame( '6x7-is-42', sanitize_title_with_dashes( '6&times;7 is 42', '', 'save' ), 'HTML entity &times; should be replaced with letter x' );
+		$this->assertSame( 'product-5x10', sanitize_title_with_dashes( 'Product 5&times;10', '', 'save' ), 'HTML entity &times; without spaces should be replaced with letter x' );
+	}
+
+	/**
+	 * @ticket 64284
+	 */
+	public function test_replaces_times_numeric_entity() {
+		$this->assertSame( '3x4-equals-12', sanitize_title_with_dashes( '3&#215;4 equals 12', '', 'save' ), 'Numeric HTML entity &#215; should be replaced with letter x' );
+	}
+
+	/**
+	 * @ticket 64284
+	 */
+	public function test_replaces_multiply_sign_in_display_context() {
+		// Should work in display context too, not just 'save'.
+		$this->assertSame( '6x7', sanitize_title_with_dashes( '6×7', '', 'display' ), 'Multiplication sign should be replaced with x in display context' );
+		$this->assertSame( 'testx', sanitize_title_with_dashes( 'test×', '' ), 'Multiplication sign should be replaced with x when context is not specified' );
 	}
 
 	/**

--- a/tests/phpunit/tests/formatting/sanitizeTitleWithDashes.php
+++ b/tests/phpunit/tests/formatting/sanitizeTitleWithDashes.php
@@ -182,6 +182,14 @@ class Tests_Formatting_SanitizeTitleWithDashes extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 64284
+	 */
+	public function test_replaces_url_encoded_multiply_sign() {
+		$this->assertSame( 'x', sanitize_title_with_dashes( '%c3%97', '', 'save' ), 'URL-encoded multiplication sign (lowercase %c3%97) should be replaced with x in save context' );
+		$this->assertSame( 'x', sanitize_title_with_dashes( '%C3%97', '', 'save' ), 'URL-encoded multiplication sign (uppercase %C3%97) should be replaced with x in save context' );
+	}
+
+	/**
 	 * @ticket 20772
 	 */
 	public function test_replaces_standalone_diacritic() {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64284

This PR ensures the multiplication symbol (×) and its HTML entities are consistently replaced with the letter "x" when sanitizing titles for slugs.

Users sometimes accidentally type × (U+00D7, Multiplication Sign) instead of x (U+0078, Latin Small Letter X) in post titles. The existing code only replaced the URL-encoded form (`%c3%97`) after encoding, which didn't handle the character consistently in all cases.

This PR adds replacement of the multiplication character and its entities **before** URL encoding occurs:
- Direct character: `×`
- HTML entity: `&times;`
- Numeric entity: `&#215;`

The existing replacement of `%c3%97` (line 2387) is retained as a fallback for already-encoded content.

## Examples

| Input | Output |
|-------|--------|
| `iPhone 12 × 256GB` | `iphone-12-x-256gb` |
| `Screen 1920 × 1080` | `screen-1920-x-1080` |
| `6×7 is 42` | `6x7-is-42` |
| `Product 5&times;10` | `product-5x10` |

