### PR TITLE
Scripts: Remove special behaviors for non-HTML5 scripts

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2871,8 +2871,7 @@ function wp_enqueue_editor_format_library_assets() {
  * @return string String made of sanitized `<script>` tag attributes.
  */
 function wp_sanitize_script_attributes( $attributes ) {
-	$html5_script_support = is_admin() || current_theme_supports( 'html5', 'script' );
-	$attributes_string    = '';
+	$attributes_string = '';
 
 	/*
 	 * If HTML5 script tag is supported, only the attribute name is added
@@ -2881,7 +2880,7 @@ function wp_sanitize_script_attributes( $attributes ) {
 	foreach ( $attributes as $attribute_name => $attribute_value ) {
 		if ( is_bool( $attribute_value ) ) {
 			if ( $attribute_value ) {
-				$attributes_string .= $html5_script_support ? ' ' . esc_attr( $attribute_name ) : sprintf( ' %1$s="%2$s"', esc_attr( $attribute_name ), esc_attr( $attribute_name ) );
+				$attributes_string .= ' ' . esc_attr( $attribute_name );
 			}
 		} else {
 			$attributes_string .= sprintf( ' %1$s="%2$s"', esc_attr( $attribute_name ), esc_attr( $attribute_value ) );

--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2211,10 +2211,8 @@ function _print_scripts() {
 	if ( $concat ) {
 		if ( ! empty( $wp_scripts->print_code ) ) {
 			echo "\n<script{$type_attr}>\n";
-			echo "/* <![CDATA[ */\n"; // Not needed in HTML 5.
 			echo $wp_scripts->print_code;
 			echo sprintf( "\n//# sourceURL=%s\n", rawurlencode( 'js-inline-concat-' . $concat ) );
-			echo "/* ]]> */\n";
 			echo "</script>\n";
 		}
 
@@ -2960,56 +2958,6 @@ function wp_get_inline_script_tag( $data, $attributes = array() ) {
 			array( 'type' => 'text/javascript' ),
 			$attributes
 		);
-	}
-
-	/*
-	 * XHTML extracts the contents of the SCRIPT element and then the XML parser
-	 * decodes character references and other syntax elements. This can lead to
-	 * misinterpretation of the script contents or invalid XHTML documents.
-	 *
-	 * Wrapping the contents in a CDATA section instructs the XML parser not to
-	 * transform the contents of the SCRIPT element before passing them to the
-	 * JavaScript engine.
-	 *
-	 * Example:
-	 *
-	 *     <script>console.log('&hellip;');</script>
-	 *
-	 *     In an HTML document this would print "&hellip;" to the console,
-	 *     but in an XHTML document it would print "…" to the console.
-	 *
-	 *     <script>console.log('An image is <img> in HTML');</script>
-	 *
-	 *     In an HTML document this would print "An image is <img> in HTML",
-	 *     but it's an invalid XHTML document because it interprets the `<img>`
-	 *     as an empty tag missing its closing `/`.
-	 *
-	 * @see https://www.w3.org/TR/xhtml1/#h-4.8
-	 */
-	if (
-		! $is_html5 &&
-		(
-			! isset( $attributes['type'] ) ||
-			'module' === $attributes['type'] ||
-			str_contains( $attributes['type'], 'javascript' ) ||
-			str_contains( $attributes['type'], 'ecmascript' ) ||
-			str_contains( $attributes['type'], 'jscript' ) ||
-			str_contains( $attributes['type'], 'livescript' )
-		)
-	) {
-		/*
-		 * If the string `]]>` exists within the JavaScript it would break
-		 * out of any wrapping CDATA section added here, so to start, it's
-		 * necessary to escape that sequence which requires splitting the
-		 * content into two CDATA sections wherever it's found.
-		 *
-		 * Note: it's only necessary to escape the closing `]]>` because
-		 * an additional `<![CDATA[` leaves the contents unchanged.
-		 */
-		$data = str_replace( ']]>', ']]]]><![CDATA[>', $data );
-
-		// Wrap the entire escaped script inside a CDATA section.
-		$data = sprintf( "/* <![CDATA[ */\n%s\n/* ]]> */", $data );
 	}
 
 	$data = "\n" . trim( $data, "\n\r " ) . "\n";

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -239,9 +239,9 @@ JS;
 				'id' => 'ds-i1-1-js-before',
 			)
 		);
-		$expected .= "<script type='text/javascript' src='http://example.org/ds-i1-1.js' id='ds-i1-1-js' {$strategy}='{$strategy}' data-wp-strategy='{$strategy}'></script>\n";
-		$expected .= "<script type='text/javascript' src='http://example.org/ds-i1-2.js' id='ds-i1-2-js' {$strategy}='{$strategy}' data-wp-strategy='{$strategy}'></script>\n";
-		$expected .= "<script type='text/javascript' src='http://example.org/ds-i1-3.js' id='ds-i1-3-js' {$strategy}='{$strategy}' data-wp-strategy='{$strategy}'></script>\n";
+		$expected .= "<script type='text/javascript' src='http://example.org/ds-i1-1.js' id='ds-i1-1-js' {$strategy} data-wp-strategy='{$strategy}'></script>\n";
+		$expected .= "<script type='text/javascript' src='http://example.org/ds-i1-2.js' id='ds-i1-2-js' {$strategy} data-wp-strategy='{$strategy}'></script>\n";
+		$expected .= "<script type='text/javascript' src='http://example.org/ds-i1-3.js' id='ds-i1-3-js' {$strategy} data-wp-strategy='{$strategy}'></script>\n";
 		$expected .= wp_get_inline_script_tag(
 			"console.log('before last');\n//# sourceURL=ms-i1-1-js-before",
 			array(
@@ -249,7 +249,7 @@ JS;
 				'type' => 'text/javascript',
 			)
 		);
-		$expected .= "<script type='text/javascript' src='http://example.org/ms-i1-1.js' id='ms-i1-1-js' {$strategy}='{$strategy}' data-wp-strategy='{$strategy}'></script>\n";
+		$expected .= "<script type='text/javascript' src='http://example.org/ms-i1-1.js' id='ms-i1-1-js' {$strategy} data-wp-strategy='{$strategy}'></script>\n";
 
 		$this->assertEqualHTML( $expected, $output, '<body>', 'Inline scripts in the "before" position, that are attached to a deferred main script, are failing to print/execute.' );
 	}
@@ -268,7 +268,7 @@ JS;
 		// No dependents, No dependencies then async.
 		wp_enqueue_script( 'main-script-a1', '/main-script-a1.js', array(), null, array( 'strategy' => 'async' ) );
 		$output   = get_echo( 'wp_print_scripts' );
-		$expected = "<script type='text/javascript' src='/main-script-a1.js' id='main-script-a1-js' async='async' data-wp-strategy='async'></script>\n";
+		$expected = "<script type='text/javascript' src='/main-script-a1.js' id='main-script-a1-js' async data-wp-strategy='async'></script>\n";
 		$this->assertEqualHTML( $expected, $output, '<body>', 'Scripts enqueued with an async loading strategy are failing to have the async attribute applied to the script handle when being printed.' );
 	}
 
@@ -291,7 +291,7 @@ JS;
 		wp_enqueue_script( 'main-script-a2', '/main-script-a2.js', array( 'dependency-script-a2' ), null, compact( 'strategy' ) );
 		$output    = get_echo( 'wp_print_scripts' );
 		$expected  = "<script id='dependency-script-a2-js' src='/dependency-script-a2.js' type='text/javascript'></script>\n";
-		$expected .= "<script type='text/javascript' src='/main-script-a2.js' id='main-script-a2-js' {$strategy}='{$strategy}' data-wp-strategy='{$strategy}'></script>";
+		$expected .= "<script type='text/javascript' src='/main-script-a2.js' id='main-script-a2-js' {$strategy} data-wp-strategy='{$strategy}'></script>";
 		$this->assertEqualHTML( $expected, $output, '<body>', 'Dependents of a blocking dependency are free to have any strategy.' );
 	}
 
@@ -956,7 +956,7 @@ HTML
 scriptEventLog.push( "defer-with-before-inline: before inline" )
 //# sourceURL=defer-with-before-inline-js-before
 </script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-with-before-inline%3A+script' id='defer-with-before-inline-js' defer='defer' data-wp-strategy='defer'></script>
+<script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-with-before-inline%3A+script' id='defer-with-before-inline-js' defer data-wp-strategy='defer'></script>
 HTML
 				,
 			),
@@ -987,9 +987,9 @@ HTML
 					wp_enqueue_script( 'theme-functions', 'https://example.com/theme-functions.js', array( 'jquery' ), null, array( 'strategy' => 'defer' ) );
 				},
 				'expected_markup' => <<<HTML
-<script type='text/javascript' src='http://$wp_tests_domain/wp-includes/js/jquery/jquery.js' id='jquery-core-js' defer='defer' data-wp-strategy='defer'></script>
-<script type='text/javascript' src='http://$wp_tests_domain/wp-includes/js/jquery/jquery-migrate.js' id='jquery-migrate-js' defer='defer' data-wp-strategy='defer'></script>
-<script type='text/javascript' src='https://example.com/theme-functions.js' id='theme-functions-js' defer='defer' data-wp-strategy='defer'></script>
+<script type='text/javascript' src='http://$wp_tests_domain/wp-includes/js/jquery/jquery.js' id='jquery-core-js' defer data-wp-strategy='defer'></script>
+<script type='text/javascript' src='http://$wp_tests_domain/wp-includes/js/jquery/jquery-migrate.js' id='jquery-migrate-js' defer data-wp-strategy='defer'></script>
+<script type='text/javascript' src='https://example.com/theme-functions.js' id='theme-functions-js' defer data-wp-strategy='defer'></script>
 HTML
 				,
 			),
@@ -1041,9 +1041,9 @@ HTML
 					$this->enqueue_test_script( 'defer-dependent-of-async-aliases', 'defer', array( $alias_handle ) );
 				},
 				'expected_markup' => <<<HTML
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=async1%3A+script' id='async1-js' defer='defer' data-wp-strategy='async'></script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=async2%3A+script' id='async2-js' defer='defer' data-wp-strategy='async'></script>
-<script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-async-aliases%3A+script' id='defer-dependent-of-async-aliases-js' defer='defer' data-wp-strategy='defer'></script>
+<script type='text/javascript' src='https://example.com/external.js?script_event_log=async1%3A+script' id='async1-js' defer data-wp-strategy='async'></script>
+<script type='text/javascript' src='https://example.com/external.js?script_event_log=async2%3A+script' id='async2-js' defer data-wp-strategy='async'></script>
+<script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-async-aliases%3A+script' id='defer-dependent-of-async-aliases-js' defer data-wp-strategy='defer'></script>
 HTML
 				,
 			),
@@ -1174,10 +1174,10 @@ HTML
 		);
 		// Note: All of these scripts have fetchpriority=high because the leaf dependent script has that fetch priority.
 		$output    = get_echo( 'wp_print_scripts' );
-		$expected  = "<script type='text/javascript' src='/main-script-d4.js'        id='main-script-d4-js'        defer='defer' data-wp-strategy='defer' fetchpriority='high' data-wp-fetchpriority='auto'></script>\n";
-		$expected .= "<script type='text/javascript' src='/dependent-script-d4-1.js' id='dependent-script-d4-1-js' defer='defer' data-wp-strategy='defer' fetchpriority='high' data-wp-fetchpriority='auto'></script>\n";
-		$expected .= "<script type='text/javascript' src='/dependent-script-d4-2.js' id='dependent-script-d4-2-js' defer='defer' data-wp-strategy='async' fetchpriority='high' data-wp-fetchpriority='low'></script>\n";
-		$expected .= "<script type='text/javascript' src='/dependent-script-d4-3.js' id='dependent-script-d4-3-js' defer='defer' data-wp-strategy='defer' fetchpriority='high'></script>\n";
+		$expected  = "<script type='text/javascript' src='/main-script-d4.js'        id='main-script-d4-js'        defer data-wp-strategy='defer' fetchpriority='high' data-wp-fetchpriority='auto'></script>\n";
+		$expected .= "<script type='text/javascript' src='/dependent-script-d4-1.js' id='dependent-script-d4-1-js' defer data-wp-strategy='defer' fetchpriority='high' data-wp-fetchpriority='auto'></script>\n";
+		$expected .= "<script type='text/javascript' src='/dependent-script-d4-2.js' id='dependent-script-d4-2-js' defer data-wp-strategy='async' fetchpriority='high' data-wp-fetchpriority='low'></script>\n";
+		$expected .= "<script type='text/javascript' src='/dependent-script-d4-3.js' id='dependent-script-d4-3-js' defer data-wp-strategy='defer' fetchpriority='high'></script>\n";
 
 		$this->assertEqualHTML( $expected, $output, '<body>', 'Scripts registered as defer but that have dependents that are async are expected to have said dependents deferred.' );
 	}
@@ -1427,7 +1427,7 @@ HTML
 
 		$actual = $this->normalize_markup_for_snapshot( get_echo( array( $wp_scripts, 'print_scripts' ) ) );
 		$this->assertEqualHTML(
-			'<script type="text/javascript" src="/wp-includes/js/comment-reply.js" id="comment-reply-js" async="async" data-wp-strategy="async" fetchpriority="low"></script>',
+			'<script type="text/javascript" src="/wp-includes/js/comment-reply.js" id="comment-reply-js" async data-wp-strategy="async" fetchpriority="low"></script>',
 			$actual,
 			'<body>',
 			"Snapshot:\n$actual"
@@ -1464,7 +1464,7 @@ HTML
 
 		$this->assertEqualHTML(
 			sprintf(
-				'<script type="text/javascript" src="%s" id="comment-reply-js" async="async" data-wp-strategy="async" fetchpriority="low"></script>',
+				'<script type="text/javascript" src="%s" id="comment-reply-js" async data-wp-strategy="async" fetchpriority="low"></script>',
 				includes_url( 'js/comment-reply.js' )
 			),
 			$markup
@@ -1814,7 +1814,7 @@ HTML
 		$print_scripts = get_echo( '_print_scripts' );
 
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep,two-concat-dep,three-concat-dep&amp;ver={$wp_version}'></script>\n";
-		$expected .= "<script type='text/javascript' src='/main-script.js' id='main-defer-script-js' defer='defer' data-wp-strategy='defer'></script>\n";
+		$expected .= "<script type='text/javascript' src='/main-script.js' id='main-defer-script-js' defer data-wp-strategy='defer'></script>\n";
 
 		$this->assertEqualHTML( $expected, $print_scripts, '<body>', 'Scripts are being incorrectly concatenated when a main script is registered with a "defer" loading strategy. Deferred scripts should not be part of the script concat loading query.' );
 	}
@@ -1845,7 +1845,7 @@ HTML
 		$print_scripts = get_echo( '_print_scripts' );
 
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep-1,two-concat-dep-1,three-concat-dep-1&amp;ver={$wp_version}'></script>\n";
-		$expected .= "<script type='text/javascript' src='/main-script.js' id='main-async-script-1-js' async='async' data-wp-strategy='async'></script>\n";
+		$expected .= "<script type='text/javascript' src='/main-script.js' id='main-async-script-1-js' async data-wp-strategy='async'></script>\n";
 
 		$this->assertEqualHTML( $expected, $print_scripts, '<body>', 'Scripts are being incorrectly concatenated when a main script is registered with an "async" loading strategy. Async scripts should not be part of the script concat loading query.' );
 	}
@@ -1880,7 +1880,7 @@ HTML
 		$print_scripts = get_echo( '_print_scripts' );
 
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one-concat-dep-2,two-concat-dep-2,three-concat-dep-2,four-concat-dep-2,five-concat-dep-2,six-concat-dep-2&amp;ver={$wp_version}'></script>\n";
-		$expected .= "<script type='text/javascript' src='/main-script.js' id='deferred-script-2-js' defer='defer' data-wp-strategy='defer'></script>\n";
+		$expected .= "<script type='text/javascript' src='/main-script.js' id='deferred-script-2-js' defer data-wp-strategy='defer'></script>\n";
 
 		$this->assertEqualHTML( $expected, $print_scripts, '<body>', 'Scripts are being incorrectly concatenated when a main script is registered as deferred after other blocking scripts are registered. Deferred scripts should not be part of the script concat loader query string. ' );
 	}
@@ -3652,10 +3652,10 @@ HTML;
 					);
 				},
 				'expected_header'    => '
-					<script type="text/javascript" src="https://example.com/script-a.js" id="script-a-js" defer="defer" data-wp-strategy="defer"></script>
+					<script type="text/javascript" src="https://example.com/script-a.js" id="script-a-js" defer data-wp-strategy="defer"></script>
 				',
 				'expected_footer'    => '
-					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js" defer="defer" data-wp-strategy="defer"></script>
+					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js" defer data-wp-strategy="defer"></script>
 				',
 				'expected_in_footer' => array(
 					'script-b',
@@ -3702,12 +3702,12 @@ HTML;
 					);
 				},
 				'expected_header'    => '
-					<script type="text/javascript" src="https://example.com/script-a.js" id="script-a-js" defer="defer" data-wp-strategy="defer"></script>
-					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js" defer="defer" data-wp-strategy="defer"></script>
+					<script type="text/javascript" src="https://example.com/script-a.js" id="script-a-js" defer data-wp-strategy="defer"></script>
+					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js" defer data-wp-strategy="defer"></script>
 				',
 				'expected_footer'    => '
-					<script type="text/javascript" src="https://example.com/script-c.js" id="script-c-js" defer="defer" data-wp-strategy="defer"></script>
-					<script type="text/javascript" src="https://example.com/script-d.js" id="script-d-js" defer="defer" data-wp-strategy="defer"></script>
+					<script type="text/javascript" src="https://example.com/script-c.js" id="script-c-js" defer data-wp-strategy="defer"></script>
+					<script type="text/javascript" src="https://example.com/script-d.js" id="script-d-js" defer data-wp-strategy="defer"></script>
 				',
 				'expected_in_footer' => array(
 					'script-c',
@@ -3750,9 +3750,9 @@ HTML;
 				'expected_header'    => '',
 				'expected_footer'    => '
 					<script type="text/javascript" src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="defer"></script>
-					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js" defer="defer" data-wp-strategy="defer"></script>
+					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js" defer data-wp-strategy="defer"></script>
 					<script type="text/javascript" src="https://example.com/script-c.js" id="script-c-js"></script>
-					<script type="text/javascript" src="https://example.com/script-d.js" id="script-d-js" defer="defer" data-wp-strategy="defer"></script>
+					<script type="text/javascript" src="https://example.com/script-d.js" id="script-d-js" defer data-wp-strategy="defer"></script>
 				',
 				'expected_in_footer' => array(
 					'script-a',
@@ -3797,11 +3797,11 @@ HTML;
 				},
 				'expected_header'    => '
 					<script type="text/javascript" src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="defer"></script>
-					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js" defer="defer" data-wp-strategy="defer"></script>
+					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js" defer data-wp-strategy="defer"></script>
 				',
 				'expected_footer'    => '
 					<script type="text/javascript" src="https://example.com/script-c.js" id="script-c-js"></script>
-					<script type="text/javascript" src="https://example.com/script-d.js" id="script-d-js" defer="defer" data-wp-strategy="defer"></script>
+					<script type="text/javascript" src="https://example.com/script-d.js" id="script-d-js" defer data-wp-strategy="defer"></script>
 				',
 				'expected_in_footer' => array(
 					'script-c',

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -329,7 +329,6 @@ JS;
 	 * @param string $strategy Strategy.
 	 */
 	public function test_delayed_dependent_with_blocking_dependency_not_enqueued( $strategy ) {
-		$this->add_html5_script_theme_support();
 		wp_enqueue_script( 'main-script-a4', '/main-script-a4.js', array(), null, compact( 'strategy' ) );
 		// This dependent is registered but not enqueued, so it should not factor into the eligible loading strategy.
 		wp_register_script( 'dependent-script-a4', '/dependent-script-a4.js', array( 'main-script-a4' ), null );
@@ -1075,7 +1074,6 @@ HTML
 	 * @covers ::wp_enqueue_script
 	 */
 	public function test_loading_strategy_with_defer_having_no_dependents_nor_dependencies() {
-		$this->add_html5_script_theme_support();
 		wp_enqueue_script( 'main-script-d1', 'http://example.com/main-script-d1.js', array(), null, array( 'strategy' => 'defer' ) );
 		$output   = get_echo( 'wp_print_scripts' );
 		$expected = str_replace( "'", '"', "<script src='http://example.com/main-script-d1.js' id='main-script-d1-js' defer data-wp-strategy='defer'></script>\n" );
@@ -1092,7 +1090,6 @@ HTML
 	 * @covers ::wp_enqueue_script
 	 */
 	public function test_loading_strategy_with_defer_dependent_and_varied_dependencies() {
-		$this->add_html5_script_theme_support();
 		wp_enqueue_script( 'dependency-script-d2-1', 'http://example.com/dependency-script-d2-1.js', array(), null, array( 'strategy' => 'defer' ) );
 		wp_enqueue_script( 'dependency-script-d2-2', 'http://example.com/dependency-script-d2-2.js', array(), null );
 		wp_enqueue_script( 'dependency-script-d2-3', 'http://example.com/dependency-script-d2-3.js', array( 'dependency-script-d2-2' ), null, array( 'strategy' => 'defer' ) );
@@ -1112,7 +1109,6 @@ HTML
 	 * @covers ::wp_enqueue_script
 	 */
 	public function test_loading_strategy_with_all_defer_dependencies() {
-		$this->add_html5_script_theme_support();
 		wp_enqueue_script( 'main-script-d3', 'http://example.com/main-script-d3.js', array(), null, array( 'strategy' => 'defer' ) );
 		wp_enqueue_script( 'dependent-script-d3-1', 'http://example.com/dependent-script-d3-1.js', array( 'main-script-d3' ), null, array( 'strategy' => 'defer' ) );
 		wp_enqueue_script( 'dependent-script-d3-2', 'http://example.com/dependent-script-d3-2.js', array( 'dependent-script-d3-1' ), null, array( 'strategy' => 'defer' ) );
@@ -1886,8 +1882,6 @@ HTML
 	 */
 	public function test_wp_enqueue_script_with_html5_support_does_not_contain_type_attribute() {
 		global $wp_version;
-
-		$this->add_html5_script_theme_support();
 
 		$GLOBALS['wp_scripts']                  = new WP_Scripts();
 		$GLOBALS['wp_scripts']->default_version = get_bloginfo( 'version' );
@@ -3492,13 +3486,6 @@ HTML;
 	}
 
 	/**
-	 * Adds html5 script theme support.
-	 */
-	protected function add_html5_script_theme_support() {
-		add_theme_support( 'html5', array( 'script' ) );
-	}
-
-	/**
 	 * Test that a script is moved to the footer if it is made non-deferrable, was in the header and
 	 * all scripts that depend on it are in the footer.
 	 *
@@ -3962,8 +3949,6 @@ HTML;
 	 * @ticket 63887
 	 */
 	public function test_source_url_encoding() {
-		$this->add_html5_script_theme_support();
-
 		$handle = '# test/</script> #';
 
 		wp_enqueue_script( $handle, '/example.js', array(), '0.0' );
@@ -3996,7 +3981,6 @@ HTML;
 	 */
 	public function test_source_url_with_concat() {
 		global $wp_scripts, $concatenate_scripts, $wp_version;
-		$this->add_html5_script_theme_support();
 
 		$concatenate_scripts = true;
 
@@ -4031,7 +4015,6 @@ HTML;
 	 */
 	public function test_print_translations_no_display_no_sourceurl() {
 		global $wp_scripts;
-		$this->add_html5_script_theme_support();
 
 		wp_register_script( 'wp-i18n', '/wp-includes/js/dist/wp-i18n.js', array(), null );
 		wp_enqueue_script( 'test-example', '/wp-includes/js/script.js', array(), null );

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -48,14 +48,12 @@ class Tests_Dependencies_Scripts extends WP_UnitTestCase {
 
 		$this->wp_scripts_print_translations_output  = <<<JS
 <script type='text/javascript' id='__HANDLE__-js-translations'>
-/* <![CDATA[ */
 ( function( domain, translations ) {
 	var localeData = translations.locale_data[ domain ] || translations.locale_data.messages;
 	localeData[""].domain = domain;
 	wp.i18n.setLocaleData( localeData, domain );
 } )( "__DOMAIN__", __JSON_TRANSLATIONS__ );
 //# sourceURL=__HANDLE__-js-translations
-/* ]]> */
 </script>
 JS;
 		$this->wp_scripts_print_translations_output .= "\n";
@@ -567,30 +565,22 @@ JS;
 				},
 				'expected_markup' => <<<HTML
 <script id="blocking-not-async-without-dependency-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "blocking-not-async-without-dependency: before inline" )
 //# sourceURL=blocking-not-async-without-dependency-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=blocking-not-async-without-dependency%3A+script' id='blocking-not-async-without-dependency-js'></script>
 <script id="blocking-not-async-without-dependency-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "blocking-not-async-without-dependency: after inline" )
 //# sourceURL=blocking-not-async-without-dependency-js-after
-/* ]]> */
 </script>
 <script id="async-with-blocking-dependency-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "async-with-blocking-dependency: before inline" )
 //# sourceURL=async-with-blocking-dependency-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=async-with-blocking-dependency%3A+script' id='async-with-blocking-dependency-js' data-wp-strategy='async'></script>
 <script id="async-with-blocking-dependency-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "async-with-blocking-dependency: after inline" )
 //# sourceURL=async-with-blocking-dependency-js-after
-/* ]]> */
 </script>
 HTML
 				,
@@ -616,43 +606,31 @@ HTML
 				},
 				'expected_markup' => <<<HTML
 <script id="async-no-dependency-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "async-no-dependency: before inline" )
 //# sourceURL=async-no-dependency-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=async-no-dependency%3A+script' id='async-no-dependency-js' data-wp-strategy='async'></script>
 <script id="async-no-dependency-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "async-no-dependency: after inline" )
 //# sourceURL=async-no-dependency-js-after
-/* ]]> */
 </script>
 <script id="async-one-async-dependency-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "async-one-async-dependency: before inline" )
 //# sourceURL=async-one-async-dependency-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=async-one-async-dependency%3A+script' id='async-one-async-dependency-js' data-wp-strategy='async'></script>
 <script id="async-one-async-dependency-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "async-one-async-dependency: after inline" )
 //# sourceURL=async-one-async-dependency-js-after
-/* ]]> */
 </script>
 <script id="async-two-async-dependencies-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "async-two-async-dependencies: before inline" )
 //# sourceURL=async-two-async-dependencies-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=async-two-async-dependencies%3A+script' id='async-two-async-dependencies-js' data-wp-strategy='async'></script>
 <script id="async-two-async-dependencies-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "async-two-async-dependencies: after inline" )
 //# sourceURL=async-two-async-dependencies-js-after
-/* ]]> */
 </script>
 HTML
 				,
@@ -670,30 +648,22 @@ HTML
 				},
 				'expected_markup' => <<<HTML
 <script id="async-with-blocking-dependent-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "async-with-blocking-dependent: before inline" )
 //# sourceURL=async-with-blocking-dependent-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=async-with-blocking-dependent%3A+script' id='async-with-blocking-dependent-js' data-wp-strategy='async'></script>
 <script id="async-with-blocking-dependent-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "async-with-blocking-dependent: after inline" )
 //# sourceURL=async-with-blocking-dependent-js-after
-/* ]]> */
 </script>
 <script id="blocking-dependent-of-async-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "blocking-dependent-of-async: before inline" )
 //# sourceURL=blocking-dependent-of-async-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=blocking-dependent-of-async%3A+script' id='blocking-dependent-of-async-js'></script>
 <script id="blocking-dependent-of-async-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "blocking-dependent-of-async: after inline" )
 //# sourceURL=blocking-dependent-of-async-js-after
-/* ]]> */
 </script>
 HTML
 				,
@@ -711,30 +681,22 @@ HTML
 				},
 				'expected_markup' => <<<HTML
 <script id="async-with-defer-dependent-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "async-with-defer-dependent: before inline" )
 //# sourceURL=async-with-defer-dependent-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=async-with-defer-dependent%3A+script' id='async-with-defer-dependent-js' data-wp-strategy='async'></script>
 <script id="async-with-defer-dependent-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "async-with-defer-dependent: after inline" )
 //# sourceURL=async-with-defer-dependent-js-after
-/* ]]> */
 </script>
 <script id="defer-dependent-of-async-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-async: before inline" )
 //# sourceURL=defer-dependent-of-async-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-async%3A+script' id='defer-dependent-of-async-js' data-wp-strategy='defer'></script>
 <script id="defer-dependent-of-async-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-async: after inline" )
 //# sourceURL=defer-dependent-of-async-js-after
-/* ]]> */
 </script>
 HTML
 				,
@@ -755,29 +717,21 @@ HTML
 				},
 				'expected_markup' => <<<HTML
 <script id="blocking-bundle-of-none-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "blocking-bundle-of-none: before inline" )
 //# sourceURL=blocking-bundle-of-none-js-before
-/* ]]> */
 </script>
 <script id="blocking-bundle-of-none-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "blocking-bundle-of-none: after inline" )
 //# sourceURL=blocking-bundle-of-none-js-after
-/* ]]> */
 </script>
 <script id="defer-dependent-of-blocking-bundle-of-none-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-blocking-bundle-of-none: before inline" )
 //# sourceURL=defer-dependent-of-blocking-bundle-of-none-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-blocking-bundle-of-none%3A+script' id='defer-dependent-of-blocking-bundle-of-none-js' data-wp-strategy='defer'></script>
 <script id="defer-dependent-of-blocking-bundle-of-none-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-blocking-bundle-of-none: after inline" )
 //# sourceURL=defer-dependent-of-blocking-bundle-of-none-js-after
-/* ]]> */
 </script>
 HTML
 				,
@@ -801,43 +755,31 @@ HTML
 				},
 				'expected_markup' => <<<HTML
 <script id="blocking-bundle-member-one-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "blocking-bundle-member-one: before inline" )
 //# sourceURL=blocking-bundle-member-one-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=blocking-bundle-member-one%3A+script' id='blocking-bundle-member-one-js'></script>
 <script id="blocking-bundle-member-one-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "blocking-bundle-member-one: after inline" )
 //# sourceURL=blocking-bundle-member-one-js-after
-/* ]]> */
 </script>
 <script id="blocking-bundle-member-two-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "blocking-bundle-member-two: before inline" )
 //# sourceURL=blocking-bundle-member-two-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=blocking-bundle-member-two%3A+script' id='blocking-bundle-member-two-js'></script>
 <script id="blocking-bundle-member-two-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "blocking-bundle-member-two: after inline" )
 //# sourceURL=blocking-bundle-member-two-js-after
-/* ]]> */
 </script>
 <script id="defer-dependent-of-blocking-bundle-of-two-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-blocking-bundle-of-two: before inline" )
 //# sourceURL=defer-dependent-of-blocking-bundle-of-two-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-blocking-bundle-of-two%3A+script' id='defer-dependent-of-blocking-bundle-of-two-js' data-wp-strategy='defer'></script>
 <script id="defer-dependent-of-blocking-bundle-of-two-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-blocking-bundle-of-two: after inline" )
 //# sourceURL=defer-dependent-of-blocking-bundle-of-two-js-after
-/* ]]> */
 </script>
 HTML
 				,
@@ -860,29 +802,21 @@ HTML
 				},
 				'expected_markup' => <<<HTML
 <script id="defer-bundle-of-none-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-bundle-of-none: before inline" )
 //# sourceURL=defer-bundle-of-none-js-before
-/* ]]> */
 </script>
 <script id="defer-bundle-of-none-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-bundle-of-none: after inline" )
 //# sourceURL=defer-bundle-of-none-js-after
-/* ]]> */
 </script>
 <script id="defer-dependent-of-defer-bundle-of-none-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-defer-bundle-of-none: before inline" )
 //# sourceURL=defer-dependent-of-defer-bundle-of-none-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-defer-bundle-of-none%3A+script' id='defer-dependent-of-defer-bundle-of-none-js' data-wp-strategy='defer'></script>
 <script id="defer-dependent-of-defer-bundle-of-none-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-defer-bundle-of-none: after inline" )
 //# sourceURL=defer-dependent-of-defer-bundle-of-none-js-after
-/* ]]> */
 </script>
 HTML
 				,
@@ -903,43 +837,31 @@ HTML
 				},
 				'expected_markup' => <<<HTML
 <script id="blocking-dependency-with-defer-following-dependency-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "blocking-dependency-with-defer-following-dependency: before inline" )
 //# sourceURL=blocking-dependency-with-defer-following-dependency-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=blocking-dependency-with-defer-following-dependency%3A+script' id='blocking-dependency-with-defer-following-dependency-js'></script>
 <script id="blocking-dependency-with-defer-following-dependency-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "blocking-dependency-with-defer-following-dependency: after inline" )
 //# sourceURL=blocking-dependency-with-defer-following-dependency-js-after
-/* ]]> */
 </script>
 <script id="defer-dependency-with-blocking-preceding-dependency-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-dependency-with-blocking-preceding-dependency: before inline" )
 //# sourceURL=defer-dependency-with-blocking-preceding-dependency-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependency-with-blocking-preceding-dependency%3A+script' id='defer-dependency-with-blocking-preceding-dependency-js' data-wp-strategy='defer'></script>
 <script id="defer-dependency-with-blocking-preceding-dependency-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-dependency-with-blocking-preceding-dependency: after inline" )
 //# sourceURL=defer-dependency-with-blocking-preceding-dependency-js-after
-/* ]]> */
 </script>
 <script id="defer-dependent-of-blocking-and-defer-dependencies-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-blocking-and-defer-dependencies: before inline" )
 //# sourceURL=defer-dependent-of-blocking-and-defer-dependencies-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-blocking-and-defer-dependencies%3A+script' id='defer-dependent-of-blocking-and-defer-dependencies-js' data-wp-strategy='defer'></script>
 <script id="defer-dependent-of-blocking-and-defer-dependencies-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-blocking-and-defer-dependencies: after inline" )
 //# sourceURL=defer-dependent-of-blocking-and-defer-dependencies-js-after
-/* ]]> */
 </script>
 HTML
 				,
@@ -960,43 +882,31 @@ HTML
 				},
 				'expected_markup' => <<<HTML
 <script id="defer-dependency-with-blocking-following-dependency-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-dependency-with-blocking-following-dependency: before inline" )
 //# sourceURL=defer-dependency-with-blocking-following-dependency-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependency-with-blocking-following-dependency%3A+script' id='defer-dependency-with-blocking-following-dependency-js' data-wp-strategy='defer'></script>
 <script id="defer-dependency-with-blocking-following-dependency-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-dependency-with-blocking-following-dependency: after inline" )
 //# sourceURL=defer-dependency-with-blocking-following-dependency-js-after
-/* ]]> */
 </script>
 <script id="blocking-dependency-with-defer-preceding-dependency-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "blocking-dependency-with-defer-preceding-dependency: before inline" )
 //# sourceURL=blocking-dependency-with-defer-preceding-dependency-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=blocking-dependency-with-defer-preceding-dependency%3A+script' id='blocking-dependency-with-defer-preceding-dependency-js'></script>
 <script id="blocking-dependency-with-defer-preceding-dependency-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "blocking-dependency-with-defer-preceding-dependency: after inline" )
 //# sourceURL=blocking-dependency-with-defer-preceding-dependency-js-after
-/* ]]> */
 </script>
 <script id="defer-dependent-of-defer-and-blocking-dependencies-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-defer-and-blocking-dependencies: before inline" )
 //# sourceURL=defer-dependent-of-defer-and-blocking-dependencies-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-defer-and-blocking-dependencies%3A+script' id='defer-dependent-of-defer-and-blocking-dependencies-js' data-wp-strategy='defer'></script>
 <script id="defer-dependent-of-defer-and-blocking-dependencies-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-defer-and-blocking-dependencies: after inline" )
 //# sourceURL=defer-dependent-of-defer-and-blocking-dependencies-js-after
-/* ]]> */
 </script>
 HTML
 				,
@@ -1014,30 +924,22 @@ HTML
 				},
 				'expected_markup' => <<<HTML
 <script id="defer-with-async-dependent-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-with-async-dependent: before inline" )
 //# sourceURL=defer-with-async-dependent-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-with-async-dependent%3A+script' id='defer-with-async-dependent-js' data-wp-strategy='defer'></script>
 <script id="defer-with-async-dependent-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-with-async-dependent: after inline" )
 //# sourceURL=defer-with-async-dependent-js-after
-/* ]]> */
 </script>
 <script id="async-dependent-of-defer-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "async-dependent-of-defer: before inline" )
 //# sourceURL=async-dependent-of-defer-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=async-dependent-of-defer%3A+script' id='async-dependent-of-defer-js' data-wp-strategy='async'></script>
 <script id="async-dependent-of-defer-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "async-dependent-of-defer: after inline" )
 //# sourceURL=async-dependent-of-defer-js-after
-/* ]]> */
 </script>
 HTML
 				,
@@ -1051,10 +953,8 @@ HTML
 				},
 				'expected_markup' => <<<HTML
 <script id="defer-with-before-inline-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-with-before-inline: before inline" )
 //# sourceURL=defer-with-before-inline-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-with-before-inline%3A+script' id='defer-with-before-inline-js' defer='defer' data-wp-strategy='defer'></script>
 HTML
@@ -1070,10 +970,8 @@ HTML
 				'expected_markup' => <<<HTML
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-with-after-inline%3A+script' id='defer-with-after-inline-js' data-wp-strategy='defer'></script>
 <script id="defer-with-after-inline-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-with-after-inline: after inline" )
 //# sourceURL=defer-with-after-inline-js-after
-/* ]]> */
 </script>
 HTML
 				,
@@ -1118,17 +1016,13 @@ HTML
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=inner-bundle-member-two%3A+script' id='inner-bundle-member-two-js' data-wp-strategy='defer'></script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=outer-bundle-leaf-member%3A+script' id='outer-bundle-leaf-member-js'></script>
 <script id="defer-dependent-of-nested-aliases-js-before" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-nested-aliases: before inline" )
 //# sourceURL=defer-dependent-of-nested-aliases-js-before
-/* ]]> */
 </script>
 <script type='text/javascript' src='https://example.com/external.js?script_event_log=defer-dependent-of-nested-aliases%3A+script' id='defer-dependent-of-nested-aliases-js' data-wp-strategy='defer'></script>
 <script id="defer-dependent-of-nested-aliases-js-after" type="text/javascript">
-/* <![CDATA[ */
 scriptEventLog.push( "defer-dependent-of-nested-aliases: after inline" )
 //# sourceURL=defer-dependent-of-nested-aliases-js-after
-/* ]]> */
 </script>
 HTML
 				,
@@ -2084,7 +1978,7 @@ HTML
 		// Enqueue and add data.
 		wp_enqueue_script( 'test-only-data', 'example.com', array(), null );
 		wp_script_add_data( 'test-only-data', 'data', 'testing' );
-		$expected  = "<script type='text/javascript' id='test-only-data-js-extra'>\n/* <![CDATA[ */\ntesting\n//# sourceURL=test-only-data-js-extra\n/* ]]> */\n</script>\n";
+		$expected  = "<script type='text/javascript' id='test-only-data-js-extra'>\ntesting\n//# sourceURL=test-only-data-js-extra\n</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-only-data-js'></script>\n";
 
 		// Go!
@@ -2322,10 +2216,8 @@ HTML
 
 		$expected  = <<<HTML
 <script type='text/javascript' id='test-example-js-before'>
-/* <![CDATA[ */
 console.log("before");
 //# sourceURL=test-example-js-before
-/* ]]> */
 </script>
 HTML;
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
@@ -2343,10 +2235,8 @@ HTML;
 		$expected  = "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
 		$expected .= <<<HTML
 <script type='text/javascript' id='test-example-js-after'>
-/* <![CDATA[ */
 console.log("after");
 //# sourceURL=test-example-js-after
-/* ]]> */
 </script>
 HTML;
 
@@ -2361,9 +2251,9 @@ HTML;
 		wp_add_inline_script( 'test-example', 'console.log("before");', 'before' );
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
 
-		$expected  = "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
+		$expected  = "<script type='text/javascript' id='test-example-js-before'>\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='test-example-js-after'>\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n</script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2376,7 +2266,7 @@ HTML;
 		wp_enqueue_script( 'test-example' );
 		wp_add_inline_script( 'test-example', 'console.log("before");', 'before' );
 
-		$expected = "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
+		$expected = "<script type='text/javascript' id='test-example-js-before'>\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n</script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2389,7 +2279,7 @@ HTML;
 		wp_enqueue_script( 'test-example' );
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
 
-		$expected = "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
+		$expected = "<script type='text/javascript' id='test-example-js-after'>\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n</script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2403,8 +2293,8 @@ HTML;
 		wp_add_inline_script( 'test-example', 'console.log("before");', 'before' );
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
 
-		$expected  = "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
+		$expected  = "<script type='text/javascript' id='test-example-js-before'>\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n</script>\n";
+		$expected .= "<script type='text/javascript' id='test-example-js-after'>\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n</script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2419,9 +2309,9 @@ HTML;
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
 
-		$expected  = "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
+		$expected  = "<script type='text/javascript' id='test-example-js-before'>\nconsole.log(\"before\");\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='test-example-js-after'>\nconsole.log(\"after\");\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n</script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2435,10 +2325,10 @@ HTML;
 		wp_add_inline_script( 'test-example', 'console.log("before");', 'before' );
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
 
-		$expected  = "<script type='text/javascript' id='test-example-js-extra'>\n/* <![CDATA[ */\nvar testExample = {\"foo\":\"bar\"};\n//# sourceURL=test-example-js-extra\n/* ]]> */\n</script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
+		$expected  = "<script type='text/javascript' id='test-example-js-extra'>\nvar testExample = {\"foo\":\"bar\"};\n//# sourceURL=test-example-js-extra\n</script>\n";
+		$expected .= "<script type='text/javascript' id='test-example-js-before'>\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='test-example-js-after'>\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n</script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
 	}
@@ -2459,9 +2349,9 @@ HTML;
 		wp_add_inline_script( 'one', 'console.log("before one");', 'before' );
 		wp_add_inline_script( 'two', 'console.log("before two");', 'before' );
 
-		$expected  = "<script type='text/javascript' id='one-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before one\");\n//# sourceURL=one-js-before\n/* ]]> */\n</script>\n";
+		$expected  = "<script type='text/javascript' id='one-js-before'>\nconsole.log(\"before one\");\n//# sourceURL=one-js-before\n</script>\n";
 		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}one.js?ver={$wp_version}' id='one-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='two-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before two\");\n//# sourceURL=two-js-before\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='two-js-before'>\nconsole.log(\"before two\");\n//# sourceURL=two-js-before\n</script>\n";
 		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}two.js?ver={$wp_version}' id='two-js'></script>\n";
 		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}three.js?ver={$wp_version}' id='three-js'></script>\n";
 
@@ -2483,7 +2373,7 @@ HTML;
 
 		wp_add_inline_script( 'one', 'console.log("before one");', 'before' );
 
-		$expected  = "<script type='text/javascript' id='one-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before one\");\n//# sourceURL=one-js-before\n/* ]]> */\n</script>\n";
+		$expected  = "<script type='text/javascript' id='one-js-before'>\nconsole.log(\"before one\");\n//# sourceURL=one-js-before\n</script>\n";
 		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}one.js?ver={$wp_version}' id='one-js'></script>\n";
 		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}two.js?ver={$wp_version}' id='two-js'></script>\n";
 		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}three.js?ver={$wp_version}' id='three-js'></script>\n";
@@ -2510,9 +2400,9 @@ HTML;
 
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one&amp;ver={$wp_version}'></script>\n";
 		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}two.js?ver={$wp_version}' id='two-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='two-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after two\");\n//# sourceURL=two-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='two-js-after'>\nconsole.log(\"after two\");\n//# sourceURL=two-js-after\n</script>\n";
 		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}three.js?ver={$wp_version}' id='three-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='three-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after three\");\n//# sourceURL=three-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='three-js-after'>\nconsole.log(\"after three\");\n//# sourceURL=three-js-after\n</script>\n";
 		$expected .= "<script type='text/javascript' src='{$this->default_scripts_dir}four.js?ver={$wp_version}' id='four-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
@@ -2558,7 +2448,7 @@ HTML;
 
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core,jquery-migrate&amp;ver={$wp_version}'></script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='test-example-js-after'>\nconsole.log(\"after\");\n//# sourceURL=test-example-js-after\n</script>\n";
 
 		wp_enqueue_script( 'test-example', 'http://example.com', array( 'jquery' ), null );
 		wp_add_inline_script( 'test-example', 'console.log("after");' );
@@ -2606,7 +2496,7 @@ HTML;
 		$wp_scripts->do_concat = true;
 
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core,jquery-migrate&amp;ver={$wp_version}'></script>\n";
-		$expected .= "<script type='text/javascript' id='test-example-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='test-example-js-before'>\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
 
 		wp_enqueue_script( 'test-example', 'http://example.com', array( 'jquery' ), null );
@@ -2632,19 +2522,17 @@ HTML;
 
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=jquery-core,jquery-migrate,wp-dom-ready,wp-hooks&amp;ver={$wp_version}'></script>\n";
 		$expected .= "<script type='text/javascript' id='test-example-js-before'>\n";
-		$expected .= "/* <![CDATA[ */\nconsole.log(\"before\");\n//# sourceURL=test-example-js-before\n/* ]]> */\n";
+		$expected .= "console.log(\"before\");\n//# sourceURL=test-example-js-before\n";
 		$expected .= "</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
 		$expected .= "<script type='text/javascript' src='/wp-includes/js/dist/i18n.min.js' id='wp-i18n-js'></script>\n";
 		$expected .= "<script type='text/javascript' id='wp-i18n-js-after'>\n";
-		$expected .= "/* <![CDATA[ */\n";
 		$expected .= "wp.i18n.setLocaleData( { 'text direction\u0004ltr': [ 'ltr' ] } );\n";
 		$expected .= "//# sourceURL=wp-i18n-js-after\n";
-		$expected .= "/* ]]> */\n";
 		$expected .= "</script>\n";
 		$expected .= "<script type='text/javascript' src='/wp-includes/js/dist/a11y.min.js' id='wp-a11y-js'></script>\n";
 		$expected .= "<script type='text/javascript' src='http://example2.com' id='test-example2-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='test-example2-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after\");\n//# sourceURL=test-example2-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='test-example2-js-after'>\nconsole.log(\"after\");\n//# sourceURL=test-example2-js-after\n</script>\n";
 		wp_enqueue_script( 'test-example', 'http://example.com', array( 'jquery' ), null );
 		wp_add_inline_script( 'test-example', 'console.log("before");', 'before' );
 		wp_enqueue_script( 'test-example2', 'http://example2.com', array( 'wp-a11y' ), null );
@@ -2699,10 +2587,8 @@ HTML;
 		$this->assertEqualHTMLScriptTagById( $expected, $print_scripts );
 
 		$expected  = "<script type='text/javascript' id='customize-dependency-js-after'>\n";
-		$expected .= "/* <![CDATA[ */\n";
 		$expected .= "tryCustomizeDependency()\n";
 		$expected .= "//# sourceURL=customize-dependency-js-after\n";
-		$expected .= "/* ]]> */\n";
 		$expected .= "</script>\n";
 		$this->assertEqualHTMLScriptTagById( $expected, $print_scripts );
 	}
@@ -2723,7 +2609,7 @@ HTML;
 		wp_enqueue_script( 'four', '/wp-includes/js/script4.js' );
 
 		$expected  = "<script type='text/javascript' src='/wp-includes/js/script.js?ver={$wp_version}' id='one-js'></script>\n";
-		$expected .= "<script type='text/javascript' id='one-js-after'>\n/* <![CDATA[ */\nconsole.log(\"after one\");\n//# sourceURL=one-js-after\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='one-js-after'>\nconsole.log(\"after one\");\n//# sourceURL=one-js-after\n</script>\n";
 		$expected .= "<script type='text/javascript' src='/wp-includes/js/script2.js?ver={$wp_version}' id='two-js'></script>\n";
 		$expected .= "<script type='text/javascript' src='/wp-includes/js/script3.js?ver={$wp_version}' id='three-js'></script>\n";
 		$expected .= "<script type='text/javascript' src='/wp-includes/js/script4.js?ver={$wp_version}' id='four-js'></script>\n";
@@ -2747,7 +2633,7 @@ HTML;
 		wp_enqueue_script( 'four', '/wp-includes/js/script4.js' );
 
 		$expected  = "<script type='text/javascript' src='/wp-admin/load-scripts.php?c=0&amp;load%5Bchunk_0%5D=one,two&amp;ver={$wp_version}'></script>\n";
-		$expected .= "<script type='text/javascript' id='three-js-before'>\n/* <![CDATA[ */\nconsole.log(\"before three\");\n//# sourceURL=three-js-before\n/* ]]> */\n</script>\n";
+		$expected .= "<script type='text/javascript' id='three-js-before'>\nconsole.log(\"before three\");\n//# sourceURL=three-js-before\n</script>\n";
 		$expected .= "<script type='text/javascript' src='/wp-includes/js/script3.js?ver={$wp_version}' id='three-js'></script>\n";
 		$expected .= "<script type='text/javascript' src='/wp-includes/js/script4.js?ver={$wp_version}' id='four-js'></script>\n";
 
@@ -2768,7 +2654,7 @@ HTML;
 				),
 				'delayed'        => false,
 				'expected_data'  => "/*before foo 1*/\n//# sourceURL=foo-js-before",
-				'expected_tag'   => "<script id='foo-js-before' type='text/javascript'>\n/* <![CDATA[ */\n/*before foo 1*/\n//# sourceURL=foo-js-before\n/* ]]> */\n</script>\n",
+				'expected_tag'   => "<script id='foo-js-before' type='text/javascript'>\n/*before foo 1*/\n//# sourceURL=foo-js-before\n</script>\n",
 			),
 			'after-blocking'  => array(
 				'position'       => 'after',
@@ -2778,7 +2664,7 @@ HTML;
 				),
 				'delayed'        => false,
 				'expected_data'  => "/*after foo 1*/\n/*after foo 2*/\n//# sourceURL=foo-js-after",
-				'expected_tag'   => "<script id='foo-js-after' type='text/javascript'>\n/* <![CDATA[ */\n/*after foo 1*/\n/*after foo 2*/\n//# sourceURL=foo-js-after\n/* ]]> */\n</script>\n",
+				'expected_tag'   => "<script id='foo-js-after' type='text/javascript'>\n/*after foo 1*/\n/*after foo 2*/\n//# sourceURL=foo-js-after\n</script>\n",
 			),
 			'before-delayed'  => array(
 				'position'       => 'before',
@@ -2787,7 +2673,7 @@ HTML;
 				),
 				'delayed'        => true,
 				'expected_data'  => "/*before foo 1*/\n//# sourceURL=foo-js-before",
-				'expected_tag'   => "<script id='foo-js-before' type='text/javascript'>\n/* <![CDATA[ */\n/*before foo 1*/\n//# sourceURL=foo-js-before\n/* ]]> */\n</script>\n",
+				'expected_tag'   => "<script id='foo-js-before' type='text/javascript'>\n/*before foo 1*/\n//# sourceURL=foo-js-before\n</script>\n",
 			),
 			'after-delayed'   => array(
 				'position'       => 'after',
@@ -2797,7 +2683,7 @@ HTML;
 				),
 				'delayed'        => true,
 				'expected_data'  => "/*after foo 1*/\n/*after foo 2*/\n//# sourceURL=foo-js-after",
-				'expected_tag'   => "<script id='foo-js-after' type='text/javascript'>\n/* <![CDATA[ */\n/*after foo 1*/\n/*after foo 2*/\n//# sourceURL=foo-js-after\n/* ]]> */\n</script>\n",
+				'expected_tag'   => "<script id='foo-js-after' type='text/javascript'>\n/*after foo 1*/\n/*after foo 2*/\n//# sourceURL=foo-js-after\n</script>\n",
 			),
 		);
 	}
@@ -3506,7 +3392,7 @@ HTML;
 		wp_enqueue_script( 'test-example', 'example.com', array(), null );
 		wp_localize_script( 'test-example', 'testExample', $l10n_data );
 
-		$expected  = "<script type='text/javascript' id='test-example-js-extra'>\n/* <![CDATA[ */\nvar testExample = {$expected};\n//# sourceURL=test-example-js-extra\n/* ]]> */\n</script>\n";
+		$expected  = "<script type='text/javascript' id='test-example-js-extra'>\nvar testExample = {$expected};\n//# sourceURL=test-example-js-extra\n</script>\n";
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
@@ -4131,10 +4017,8 @@ HTML;
 
 		$expected = <<<HTML
 <script>
-/* <![CDATA[ */
 var one = {"key":"val"};var two = {"key":"val"};
 //# sourceURL=js-inline-concat-one%2Ctwo
-/* ]]> */
 </script>
 <script src="/wp-admin/load-scripts.php?c=0&load%5Bchunk_0%5D=one,two&ver={$wp_version}"></script>
 

--- a/tests/phpunit/tests/dependencies/wpInlineScriptTag.php
+++ b/tests/phpunit/tests/dependencies/wpInlineScriptTag.php
@@ -134,20 +134,6 @@ JS;
 		);
 	}
 
-	/**
-	 * Tests that CDATA wrapper duplication is handled.
-	 *
-	 * @ticket 58664
-	 */
-	public function test_get_inline_script_tag_with_duplicated_cdata_wrappers() {
-		remove_theme_support( 'html5' );
-
-		$this->assertSame(
-			"<script type=\"text/javascript\">\n/* <![CDATA[ */\n/* <![CDATA[ */ console.log( 'Hello World!' ); /* ]]]]><![CDATA[> */\n/* ]]> */\n</script>\n",
-			wp_get_inline_script_tag( "/* <![CDATA[ */ console.log( 'Hello World!' ); /* ]]> */" )
-		);
-	}
-
 	public function data_provider_to_test_cdata_wrapper_omitted_for_non_javascript_scripts() {
 		return array(
 			'no-type'     => array(
@@ -196,25 +182,5 @@ JS;
 				'expected_cdata' => false,
 			),
 		);
-	}
-
-	/**
-	 * Tests that CDATA wrapper is not added for non-JavaScript scripts.
-	 *
-	 * @ticket 60320
-	 *
-	 * @dataProvider data_provider_to_test_cdata_wrapper_omitted_for_non_javascript_scripts
-	 */
-	public function test_cdata_wrapper_omitted_for_non_javascript_scripts( $type, $data, $expected_cdata ) {
-		remove_theme_support( 'html5' );
-
-		$attrs = array();
-		if ( $type ) {
-			$attrs['type'] = $type;
-		}
-		$script = wp_get_inline_script_tag( $data, $attrs );
-		$this->assertSame( $expected_cdata, str_contains( $script, '/* <![CDATA[ */' ) );
-		$this->assertSame( $expected_cdata, str_contains( $script, '/* ]]> */' ) );
-		$this->assertStringContainsString( $data, $script );
 	}
 }

--- a/tests/phpunit/tests/dependencies/wpInlineScriptTag.php
+++ b/tests/phpunit/tests/dependencies/wpInlineScriptTag.php
@@ -34,22 +34,6 @@ document.addEventListener( 'DOMContentLoaded', function () {
 JS;
 
 	public function get_inline_script_tag_type_set() {
-		add_theme_support( 'html5', array( 'script' ) );
-
-		$this->assertSame(
-			'<script type="application/javascript" nomodule>' . "\n{$this->event_handler}\n</script>\n",
-			wp_get_inline_script_tag(
-				$this->event_handler,
-				array(
-					'type'     => 'application/javascript',
-					'async'    => false,
-					'nomodule' => true,
-				)
-			)
-		);
-
-		remove_theme_support( 'html5' );
-
 		$this->assertSame(
 			'<script type="application/javascript" nomodule>' . "\n{$this->event_handler}\n</script>\n",
 			wp_get_inline_script_tag(
@@ -64,8 +48,6 @@ JS;
 	}
 
 	public function test_get_inline_script_tag_type_not_set() {
-		add_theme_support( 'html5', array( 'script' ) );
-
 		$this->assertSame(
 			"<script nomodule>\n{$this->event_handler}\n</script>\n",
 			wp_get_inline_script_tag(
@@ -76,19 +58,13 @@ JS;
 				)
 			)
 		);
-
-		remove_theme_support( 'html5' );
 	}
 
 	public function test_get_inline_script_tag_unescaped_src() {
-		add_theme_support( 'html5', array( 'script' ) );
-
 		$this->assertSame(
 			"<script>\n{$this->event_handler}\n</script>\n",
 			wp_get_inline_script_tag( $this->event_handler )
 		);
-
-		remove_theme_support( 'html5' );
 	}
 
 	public function test_print_script_tag_prints_get_inline_script_tag() {
@@ -101,8 +77,6 @@ JS;
 				return $attributes;
 			}
 		);
-
-		add_theme_support( 'html5', array( 'script' ) );
 
 		$attributes = array(
 			'id'       => 'utils-js-before',
@@ -118,69 +92,6 @@ JS;
 					$attributes,
 				)
 			)
-		);
-
-		remove_theme_support( 'html5' );
-
-		$this->assertSame(
-			wp_get_inline_script_tag( $this->event_handler, $attributes ),
-			get_echo(
-				'wp_print_inline_script_tag',
-				array(
-					$this->event_handler,
-					$attributes,
-				)
-			)
-		);
-	}
-
-	public function data_provider_to_test_cdata_wrapper_omitted_for_non_javascript_scripts() {
-		return array(
-			'no-type'     => array(
-				'type'           => null,
-				'data'           => 'alert("hello")',
-				'expected_cdata' => true,
-			),
-			'js-type'     => array(
-				'type'           => 'text/javascript',
-				'data'           => 'alert("hello")',
-				'expected_cdata' => true,
-			),
-			'js-alt-type' => array(
-				'type'           => 'application/javascript',
-				'data'           => 'alert("hello")',
-				'expected_cdata' => true,
-			),
-			'module'      => array(
-				'type'           => 'module',
-				'data'           => 'alert("hello")',
-				'expected_cdata' => true,
-			),
-			'importmap'   => array(
-				'type'           => 'importmap',
-				'data'           => '{"imports":{"bar":"http:\/\/localhost:10023\/bar.js?ver=6.5-alpha-57321"}}',
-				'expected_cdata' => false,
-			),
-			'html'        => array(
-				'type'           => 'text/html',
-				'data'           => '<div>template code</div>',
-				'expected_cdata' => false,
-			),
-			'json'        => array(
-				'type'           => 'application/json',
-				'data'           => '{}',
-				'expected_cdata' => false,
-			),
-			'ld'          => array(
-				'type'           => 'application/ld+json',
-				'data'           => '{}',
-				'expected_cdata' => false,
-			),
-			'specrules'   => array(
-				'type'           => 'speculationrules',
-				'data'           => '{}',
-				'expected_cdata' => false,
-			),
 		);
 	}
 }

--- a/tests/phpunit/tests/dependencies/wpSanitizeScriptAttributes.php
+++ b/tests/phpunit/tests/dependencies/wpSanitizeScriptAttributes.php
@@ -10,8 +10,6 @@
 class Tests_Dependencies_wpSanitizeScriptAttributes extends WP_UnitTestCase {
 
 	public function test_sanitize_script_attributes_type_set() {
-		add_theme_support( 'html5', array( 'script' ) );
-
 		$this->assertSame(
 			' type="application/javascript" src="https://DOMAIN.TLD/PATH/FILE.js" nomodule',
 			wp_sanitize_script_attributes(
@@ -23,40 +21,11 @@ class Tests_Dependencies_wpSanitizeScriptAttributes extends WP_UnitTestCase {
 				)
 			)
 		);
-
-		remove_theme_support( 'html5' );
-
-		$this->assertSame(
-			' src="https://DOMAIN.TLD/PATH/FILE.js" type="application/javascript" nomodule="nomodule"',
-			wp_sanitize_script_attributes(
-				array(
-					'src'      => 'https://DOMAIN.TLD/PATH/FILE.js',
-					'type'     => 'application/javascript',
-					'async'    => false,
-					'nomodule' => true,
-				)
-			)
-		);
 	}
 
 	public function test_sanitize_script_attributes_type_not_set() {
-		add_theme_support( 'html5', array( 'script' ) );
-
 		$this->assertSame(
 			' src="https://DOMAIN.TLD/PATH/FILE.js" nomodule',
-			wp_sanitize_script_attributes(
-				array(
-					'src'      => 'https://DOMAIN.TLD/PATH/FILE.js',
-					'async'    => false,
-					'nomodule' => true,
-				)
-			)
-		);
-
-		remove_theme_support( 'html5' );
-
-		$this->assertSame(
-			' src="https://DOMAIN.TLD/PATH/FILE.js" nomodule="nomodule"',
 			wp_sanitize_script_attributes(
 				array(
 					'src'      => 'https://DOMAIN.TLD/PATH/FILE.js',
@@ -69,19 +38,13 @@ class Tests_Dependencies_wpSanitizeScriptAttributes extends WP_UnitTestCase {
 
 
 	public function test_sanitize_script_attributes_no_attributes() {
-		add_theme_support( 'html5', array( 'script' ) );
-
 		$this->assertSame(
 			'',
 			wp_sanitize_script_attributes( array() )
 		);
-
-		remove_theme_support( 'html5' );
 	}
 
 	public function test_sanitize_script_attributes_relative_src() {
-		add_theme_support( 'html5', array( 'script' ) );
-
 		$this->assertSame(
 			' src="PATH/FILE.js" nomodule',
 			wp_sanitize_script_attributes(
@@ -92,14 +55,10 @@ class Tests_Dependencies_wpSanitizeScriptAttributes extends WP_UnitTestCase {
 				)
 			)
 		);
-
-		remove_theme_support( 'html5' );
 	}
 
 
 	public function test_sanitize_script_attributes_only_false_boolean_attributes() {
-		add_theme_support( 'html5', array( 'script' ) );
-
 		$this->assertSame(
 			'',
 			wp_sanitize_script_attributes(
@@ -109,13 +68,9 @@ class Tests_Dependencies_wpSanitizeScriptAttributes extends WP_UnitTestCase {
 				)
 			)
 		);
-
-		remove_theme_support( 'html5' );
 	}
 
 	public function test_sanitize_script_attributes_only_true_boolean_attributes() {
-		add_theme_support( 'html5', array( 'script' ) );
-
 		$this->assertSame(
 			' async nomodule',
 			wp_sanitize_script_attributes(
@@ -125,7 +80,5 @@ class Tests_Dependencies_wpSanitizeScriptAttributes extends WP_UnitTestCase {
 				)
 			)
 		);
-
-		remove_theme_support( 'html5' );
 	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64442

> HTML5 script theme support is not worth considering today, themes do not control and are not concerned with HTML5 script rendering. [Data suggests that the overwhelming majority of page views are HTML5, not XHTML](https://github.com/GoogleChromeLabs/wpp-research/pull/74) (props [@westonruter](https://profiles.wordpress.org/westonruter/)) and theme scripts are not broken regardless of their declared support.
> 
> This declared support has two impacts, it will add a type attribute to script tags and it will add CDATA wrappers.
> 
> This is an inline script without declared HTML5 script support:
> 
> ```html
> <script type="text/javascript" async="async">
> /* <![CDATA[ */
> "script contents";
> /* ]]> */
> </script>
> ```

> And the same script with support:
>
> ```html 
> <script async>
> "script contents";
> </script>
> ```
>
> [#64428](https://core.trac.wordpress.org/ticket/64428) proposes removal of the type attribute on scripts and styles. This ticket focuses on all aspects of theme support for HTML5 scripts. Declaring HTML5 script support can be deprecated, and the CDATA and type attribute removed.
> 
> The CDATA wrappers are redundant for JavaScript in HTML5 and are harmful where script tags do not contain JavaScript ([#60320](https://core.trac.wordpress.org/ticket/60320)). The HTML5 checks add needless complication to code.
> 
> The redundant attribute and CDATA wrappers are only relevant for XHTML. This requires the appropriate Content-Type: application/xhtml+xml HTTP header to be sent, [something that themes do not appear to do.](https://www.wpdirectory.net/search/01KD2YQR0PBPKMCRJKAT8BT760) The HTTP content type header is more closely tied to server configuration ([PHP defaults to text/html](https://www.php.net/manual/en/ini.core.php#ini.default-mimetype)) than theme support. Themes do not really know whether a page will be served and interpreted as XHTML.
> 
> This is part of [#59883](https://core.trac.wordpress.org/ticket/59883).
> Related to [#64428](https://core.trac.wordpress.org/ticket/64428) and [#64419](https://core.trac.wordpress.org/ticket/64419).

Related to #10658.

To do:
- [x] Remove the `::add_html5_script_theme_support()` method from script tests. Depends on [ticket 64428](https://core.trac.wordpress.org/ticket/64428) (https://github.com/WordPress/wordpress-develop/pull/10658)
      https://github.com/WordPress/wordpress-develop/blob/3d9fde3265bd0cbc1b0967c0c0613ebf6ea20ced/tests/phpunit/tests/dependencies/scripts.php#L3612-L3617
- [x] Review html5 behavior in `tests/phpunit/tests/dependencies/wpInlineScriptTag.php` (type attribute and CDATA behaviors).

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
