### PR TITLE
Fix: JQuery .proxy deprecated and QMIGRATE: Boolean attribute 'disabled' is not set to its lowercased name in Jquery 4.0

### DIFF
--- a/src/js/_enqueues/vendor/plupload/wp-plupload.js
+++ b/src/js/_enqueues/vendor/plupload/wp-plupload.js
@@ -68,10 +68,20 @@ window.wp = window.wp || {};
 		 */
 		$.extend( true, this, options );
 
-		// Proxy all methods so this always refers to the current instance.
+		/*
+		 * Bind all methods so this always refers to the current instance.
+		 * Note: Using .bind() creates new function references. If these bound functions
+		 * are used with jQuery event handlers, be aware that jQuery's event subsystem
+		 * tracks functions by reference. The bound function will be seen as a single
+		 * function even when binding different contexts, which can make unbinding
+		 * specific handlers difficult. Use unique event namespaces (e.g., 'click.myproxy1')
+		 * when binding and unbinding to avoid removing the wrong handler.
+		 *
+		 * Ref - https://api.jquery.com/jQuery.proxy/
+		 */
 		for ( key in this ) {
 			if ( typeof this[ key ] === 'function' ) {
-				this[ key ] = $.proxy( this[ key ], this );
+				this[ key ] = this[ key ].bind( this );
 			}
 		}
 

--- a/src/js/_enqueues/vendor/plupload/wp-plupload.js
+++ b/src/js/_enqueues/vendor/plupload/wp-plupload.js
@@ -68,20 +68,10 @@ window.wp = window.wp || {};
 		 */
 		$.extend( true, this, options );
 
-		/*
-		 * Bind all methods so this always refers to the current instance.
-		 * Note: Using .bind() creates new function references. If these bound functions
-		 * are used with jQuery event handlers, be aware that jQuery's event subsystem
-		 * tracks functions by reference. The bound function will be seen as a single
-		 * function even when binding different contexts, which can make unbinding
-		 * specific handlers difficult. Use unique event namespaces (e.g., 'click.myproxy1')
-		 * when binding and unbinding to avoid removing the wrong handler.
-		 *
-		 * Ref - https://api.jquery.com/jQuery.proxy/
-		 */
+		// Proxy all methods so this always refers to the current instance.
 		for ( key in this ) {
 			if ( typeof this[ key ] === 'function' ) {
-				this[ key ] = this[ key ].bind( this );
+				this[ key ] = $.proxy( this[ key ], this );
 			}
 		}
 

--- a/src/js/media/controllers/cropper.js
+++ b/src/js/media/controllers/cropper.js
@@ -116,7 +116,7 @@ Cropper = wp.media.controller.State.extend(/** @lends wp.media.controller.Croppe
 						selection.set({cropDetails: controller.state().imgSelect.getSelection()});
 
 						this.$el.text(l10n.cropping);
-						this.$el.attr('disabled', true);
+						this.$el.prop( 'disabled', true );
 
 						controller.state().doCrop( selection ).done( function( croppedImage ) {
 							controller.trigger('cropped', croppedImage );

--- a/src/js/media/views/button.js
+++ b/src/js/media/views/button.js
@@ -64,7 +64,7 @@ var Button = wp.media.View.extend(/** @lends wp.media.view.Button.prototype */{
 		classes = _.uniq( classes.concat( this.options.classes ) );
 		this.el.className = classes.join(' ');
 
-		this.$el.attr( 'disabled', model.disabled );
+		this.$el.prop( 'disabled', model.disabled );
 		this.$el.text( this.model.get('text') );
 
 		return this;


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64425

- Updated `attr` to use `prop`.
- Use bind instead of proxy with a comment to update the function used with namespace.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
