### PR TITLE
Scripts: Do not add CDATA wrappers in admin

### DIFF
--- a/src/wp-includes/script-loader.php
+++ b/src/wp-includes/script-loader.php
@@ -2969,8 +2969,8 @@ function wp_get_inline_script_tag( $data, $attributes = array() ) {
 	 * @see https://www.w3.org/TR/xhtml1/#h-4.8
 	 */
 	if (
-		! current_theme_supports( 'html5', 'script' ) &&
-		(
+		( ! current_theme_supports( 'html5', 'script' ) && ! is_admin() )
+		&& (
 			! isset( $attributes['type'] ) ||
 			'module' === $attributes['type'] ||
 			str_contains( $attributes['type'], 'javascript' ) ||


### PR DESCRIPTION
r61411 introduced a regression where CDATA wrappers would be added to WP Admin for themes without HTML5 script support.

See https://github.com/WordPress/wordpress-develop/pull/10658#discussion_r2648473490 (thanks @sabernhardt).

Follow-up to r61411.

The CDATA wrappers are expected to be removed in [Ticket 64442](https://core.trac.wordpress.org/ticket/64442) / https://github.com/WordPress/wordpress-develop/pull/10660, but this smaller change can be landed first.

Trac ticket: https://core.trac.wordpress.org/ticket/64428

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
