### PR TITLE
Early filter invalid hosts in wp_http_validate_url()

### DIFF
--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -587,13 +587,12 @@ function wp_http_validate_url( $url ) {
 	$parsed_home = parse_url( get_option( 'home' ) );
 	$same_host   = isset( $parsed_home['host'] ) && strtolower( $parsed_home['host'] ) === strtolower( $parsed_url['host'] );
 	$host        = trim( $parsed_url['host'], '.' );
+	$is_ipv4     = (bool) preg_match(
+		'#^(([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)\.){3}([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)$#',
+		$host
+	);
 
 	if ( ! $same_host ) {
-		$is_ipv4 = (bool) preg_match(
-			'#^(([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)\.){3}([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)$#',
-			$host
-		);
-
 		if (
 			! $is_ipv4
 			&& extension_loaded( 'filter' )

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -594,9 +594,9 @@ function wp_http_validate_url( $url ) {
 
 	if ( ! $same_host ) {
 		if (
-			! $is_ipv4
-			&& extension_loaded( 'filter' )
-			&& ! filter_var(
+			! $is_ipv4 &&
+			extension_loaded( 'filter' ) &&
+			! filter_var(
 				$host,
 				FILTER_VALIDATE_DOMAIN,
 				array( 'flags' => FILTER_FLAG_HOSTNAME )

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -596,7 +596,7 @@ function wp_http_validate_url( $url ) {
 
 		if (
 			! $is_ipv4
-			&& function_exists( 'filter_var' )
+			&& extension_loaded( 'filter' )
 			&& ! filter_var(
 				$host,
 				FILTER_VALIDATE_DOMAIN,

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -589,16 +589,23 @@ function wp_http_validate_url( $url ) {
 	$host        = trim( $parsed_url['host'], '.' );
 
 	if ( ! $same_host ) {
+		$is_ipv4 = (bool) preg_match(
+			'#^(([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)\.){3}([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)$#',
+			$host
+		);
+
 		if (
-			function_exists( 'filter_var' )
-			&& defined( 'FILTER_VALIDATE_DOMAIN' )
-			&& defined( 'FILTER_FLAG_HOSTNAME' )
-			&& ! filter_var( $host, FILTER_VALIDATE_IP )
-			&& ! filter_var( $host, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME )
+			! $is_ipv4
+			&& function_exists( 'filter_var' )
+			&& ! filter_var(
+				$host,
+				FILTER_VALIDATE_DOMAIN,
+				array( 'flags' => FILTER_FLAG_HOSTNAME )
+			)
 		) {
 			return false;
 		}
-		if ( preg_match( '#^(([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)\.){3}([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)$#', $host ) ) {
+		if ( $is_ipv4 ) {
 			$ip = $host;
 		} else {
 			$ip = gethostbyname( $host );

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -589,6 +589,15 @@ function wp_http_validate_url( $url ) {
 	$host        = trim( $parsed_url['host'], '.' );
 
 	if ( ! $same_host ) {
+		if (
+			function_exists( 'filter_var' )
+			&& defined( 'FILTER_VALIDATE_DOMAIN' )
+			&& defined( 'FILTER_FLAG_HOSTNAME' )
+			&& ! filter_var( $host, FILTER_VALIDATE_IP )
+			&& ! filter_var( $host, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME )
+		) {
+			return false;
+		}
 		if ( preg_match( '#^(([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)\.){3}([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)$#', $host ) ) {
 			$ip = $host;
 		} else {

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -587,24 +587,21 @@ function wp_http_validate_url( $url ) {
 	$parsed_home = parse_url( get_option( 'home' ) );
 	$same_host   = isset( $parsed_home['host'] ) && strtolower( $parsed_home['host'] ) === strtolower( $parsed_url['host'] );
 	$host        = trim( $parsed_url['host'], '.' );
-	$is_ipv4     = (bool) preg_match(
-		'#^(([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)\.){3}([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)$#',
-		$host
-	);
 
 	if ( ! $same_host ) {
 		if (
-			! $is_ipv4 &&
 			extension_loaded( 'filter' ) &&
 			false === filter_var(
 				$host,
 				FILTER_VALIDATE_DOMAIN,
 				array( 'flags' => FILTER_FLAG_HOSTNAME )
-			)
+			) &&
+			! preg_match( '#^(([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)\.){3}([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)$#', $host )
 		) {
 			return false;
 		}
-		if ( $is_ipv4 ) {
+
+		if ( preg_match( '#^(([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)\.){3}([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)$#', $host ) ) {
 			$ip = $host;
 		} else {
 			$ip = gethostbyname( $host );

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -596,7 +596,7 @@ function wp_http_validate_url( $url ) {
 		if (
 			! $is_ipv4 &&
 			extension_loaded( 'filter' ) &&
-			! filter_var(
+			false === filter_var(
 				$host,
 				FILTER_VALIDATE_DOMAIN,
 				array( 'flags' => FILTER_FLAG_HOSTNAME )

--- a/src/wp-includes/http.php
+++ b/src/wp-includes/http.php
@@ -589,19 +589,48 @@ function wp_http_validate_url( $url ) {
 	$host        = trim( $parsed_url['host'], '.' );
 
 	if ( ! $same_host ) {
-		if (
-			extension_loaded( 'filter' ) &&
-			false === filter_var(
-				$host,
-				FILTER_VALIDATE_DOMAIN,
-				array( 'flags' => FILTER_FLAG_HOSTNAME )
-			) &&
-			! preg_match( '#^(([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)\.){3}([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)$#', $host )
-		) {
-			return false;
+		$is_ipv4 = (bool) preg_match(
+			'#^(([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)\.){3}([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)$#',
+			$host
+		);
+
+		$is_ipv6_literal = ( 0 === strpos( $host, '[' ) );
+
+		if ( extension_loaded( 'filter' ) && ! $is_ipv4 && ! $is_ipv6_literal ) {
+			$host_to_validate = $host;
+
+			/*
+			 * Historically wp_http_validate_url() has allowed underscores in subdomains
+			 * (e.g. some legacy Blogspot hosts). If underscores are present, validate
+			 * only the registrable domain portion (last two labels) using FILTER_FLAG_HOSTNAME.
+			 */
+			if ( false !== strpos( $host, '_' ) ) {
+				$labels = explode( '.', $host );
+
+				if ( count( $labels ) < 2 ) {
+					return false;
+				}
+
+				$host_to_validate = implode( '.', array_slice( $labels, -2 ) );
+
+				// Underscores must not appear in the registrable domain portion.
+				if ( false !== strpos( $host_to_validate, '_' ) ) {
+					return false;
+				}
+			}
+
+			if (
+				false === filter_var(
+					$host_to_validate,
+					FILTER_VALIDATE_DOMAIN,
+					array( 'flags' => FILTER_FLAG_HOSTNAME )
+				)
+			) {
+				return false;
+			}
 		}
 
-		if ( preg_match( '#^(([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)\.){3}([1-9]?\d|1\d\d|25[0-5]|2[0-4]\d)$#', $host ) ) {
+		if ( $is_ipv4 ) {
 			$ip = $host;
 		} else {
 			$ip = gethostbyname( $host );

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -566,11 +566,11 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 				'url'           => 'https://example.com:81/caniload.php',
 				'cb_safe_ports' => 'callback_remove_safe_ports',
 			),
-			'underscore_in_hostname'						=> array(
-				'url'			=> 'https://foo_bar.example.com/',
+			'underscore_in_hostname'                        => array(
+				'url'           => 'https://foo_bar.example.com/',
 			),
-			'valid_ip_host'									=> array(
-				'url'			=> 'https://1.1.1.1/',
+			'valid_ip_host'                                 => array(
+				'url'           => 'https://1.1.1.1/',
 			),
 		);
 	}

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -566,6 +566,9 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 				'url'           => 'https://example.com:81/caniload.php',
 				'cb_safe_ports' => 'callback_remove_safe_ports',
 			),
+			'underscore_in_hostname' => array(
+				'url' => 'https://foo_bar.example.com/',
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -566,8 +566,8 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 				'url'           => 'https://example.com:81/caniload.php',
 				'cb_safe_ports' => 'callback_remove_safe_ports',
 			),
-			'underscore_in_hostname' => array(
-				'url' => 'https://foo_bar.example.com/',
+			'underscore_in_hostname'						=> array(
+				'url'			=> 'https://foo_bar.example.com/',
 			),
 		);
 	}

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -566,7 +566,7 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 				'url'           => 'https://example.com:81/caniload.php',
 				'cb_safe_ports' => 'callback_remove_safe_ports',
 			),
-			'underscore_in_hostname' => array(
+			'underscore_in_hostname'                       => array(
 				'url' => 'https://foo_bar.example.com/',
 			),
 		);

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -569,6 +569,9 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 			'underscore_in_hostname'						=> array(
 				'url'			=> 'https://foo_bar.example.com/',
 			),
+			'valid_ip_host'									=> array(
+				'url'			=> 'https://1.1.1.1/',
+			),
 		);
 	}
 

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -566,11 +566,8 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 				'url'           => 'https://example.com:81/caniload.php',
 				'cb_safe_ports' => 'callback_remove_safe_ports',
 			),
-			'underscore_in_hostname'                        => array(
-				'url'           => 'https://foo_bar.example.com/',
-			),
-			'valid_ip_host'                                 => array(
-				'url'           => 'https://1.1.1.1/',
+			'underscore_in_hostname' => array(
+				'url' => 'https://foo_bar.example.com/',
 			),
 		);
 	}

--- a/tests/phpunit/tests/http/http.php
+++ b/tests/phpunit/tests/http/http.php
@@ -716,4 +716,40 @@ class Tests_HTTP_HTTP extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'WpOrg\Requests\Cookie\Jar', $cookie_jar );
 		$this->assertInstanceOf( 'WpOrg\Requests\Cookie', $cookie_jar['1'] );
 	}
+
+	/**
+	 * @ticket 64457
+	 *
+	 * Ensure hostname validation does not regress valid edge cases
+	 * while rejecting clearly invalid hosts.
+	 */
+	public function test_wp_http_validate_url_hostname_edge_cases() {
+		$this->assertFalse(
+			wp_http_validate_url( 'h_ttp://example.org' ),
+			'Underscore in scheme should be invalid.'
+		);
+
+		$this->assertFalse(
+			wp_http_validate_url( 'https://hey_ho_lets_go._example.org' ),
+			'Underscore in a standalone label should be invalid.'
+		);
+
+		$this->assertFalse(
+			wp_http_validate_url( 'https://omg.c_om' ),
+			'Underscore in TLD should be invalid.'
+		);
+
+		$old_home = get_option( 'home' );
+
+		try {
+			update_option( 'home', 'https://peter_is_amazing.example.org' );
+
+			$this->assertNotFalse(
+				wp_http_validate_url( 'https://peter_is_amazing.example.org' ),
+				'Underscores in subdomain should remain valid.'
+			);
+		} finally {
+			update_option( 'home', $old_home );
+		}
+	}
 }


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64457

Adds early hostname validation using the Filter extension when available, while falling back to the existing behavior when it’s not. Includes a test case for underscore hostnames.
