### PR TITLE
Accessibility: Fix invalid role="presentation" usage on login page

### DIFF
--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -219,7 +219,11 @@ function login_header( $title = null, $message = '', $wp_error = null ) {
 	endif;
 	?>
 	<div id="login">
-		<h1 role="presentation" class="wp-login-logo"><a href="<?php echo esc_url( $login_header_url ); ?>"><?php echo $login_header_text; ?></a></h1>
+		<div role="presentation" class="wp-login-logo">
+			<h1>
+				<a href="https://wordpress.org/">Powered by WordPress</a>
+			</h1>
+		</div>
 	<?php
 	/**
 	 * Filters the message to display above the login form.


### PR DESCRIPTION
Removes role="presentation" from the `<h1>` element on the login page where it contained semantically meaningful child elements (a link). According to W3C ARIA specification, role="presentation" should not be applied to semantic containers that hold semantically meaningful children.

Fixes an accessibility violation (WCAG 1.3.1) where screen readers could improperly announce the heading structure. The role is moved to a wrapper <div> while preserving the visual appearance and maintaining proper heading semantics.

Trac ticket: https://core.trac.wordpress.org/ticket/64460

Files changed: wp-login.php