### PR TITLE
Fix prefixes in build php files and persist theme-json i18n file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ wp-tests-config.php
 /src/wp-includes/class-wp-block-parser-block.php
 /src/wp-includes/class-wp-block-parser-frame.php
 /src/wp-includes/theme.json
-/src/wp-includes/theme-i18n.json
 /packagehash.txt
 /artifacts
 /setup.log

--- a/src/wp-includes/theme-i18n.json
+++ b/src/wp-includes/theme-i18n.json
@@ -1,0 +1,137 @@
+{
+	"title": "Style variation name",
+	"description": "Style variation description",
+	"settings": {
+		"typography": {
+			"fontSizes": [
+				{
+					"name": "Font size name"
+				}
+			],
+			"fontFamilies": [
+				{
+					"name": "Font family name"
+				}
+			]
+		},
+		"color": {
+			"palette": [
+				{
+					"name": "Color name"
+				}
+			],
+			"gradients": [
+				{
+					"name": "Gradient name"
+				}
+			],
+			"duotone": [
+				{
+					"name": "Duotone name"
+				}
+			]
+		},
+		"spacing": {
+			"spacingSizes": [
+				{
+					"name": "Space size name"
+				}
+			]
+		},
+		"dimensions": {
+			"aspectRatios": [
+				{
+					"name": "Aspect ratio name"
+				}
+			],
+			"dimensionSizes": [
+				{
+					"name": "Dimension size name"
+				}
+			]
+		},
+		"shadow": {
+			"presets": [
+				{
+					"name": "Shadow name"
+				}
+			]
+		},
+		"border": {
+			"radiusSizes": [
+				{
+					"name": "Border radius size name"
+				}
+			]
+		},
+		"blocks": {
+			"*": {
+				"typography": {
+					"fontSizes": [
+						{
+							"name": "Font size name"
+						}
+					],
+					"fontFamilies": [
+						{
+							"name": "Font family name"
+						}
+					]
+				},
+				"color": {
+					"palette": [
+						{
+							"name": "Color name"
+						}
+					],
+					"gradients": [
+						{
+							"name": "Gradient name"
+						}
+					],
+					"duotone": [
+						{
+							"name": "Duotone name"
+						}
+					]
+				},
+				"dimensions": {
+					"aspectRatios": [
+						{
+							"name": "Aspect ratio name"
+						}
+					],
+					"dimensionSizes": [
+						{
+							"name": "Dimension size name"
+						}
+					]
+				},
+				"spacing": {
+					"spacingSizes": [
+						{
+							"name": "Space size name"
+						}
+					]
+				},
+				"border": {
+					"radiusSizes": [
+						{
+							"name": "Border radius size name"
+						}
+					]
+				}
+			}
+		}
+	},
+	"customTemplates": [
+		{
+			"title": "Custom template name"
+		}
+	],
+	"templateParts": [
+		{
+			"title": "Template part name"
+		}
+	]
+}

--- a/tools/gutenberg/build-gutenberg.js
+++ b/tools/gutenberg/build-gutenberg.js
@@ -114,6 +114,10 @@ async function main() {
 		gutenbergPackageJson.config.IS_GUTENBERG_PLUGIN = false;
 		gutenbergPackageJson.config.IS_WORDPRESS_CORE = true;
 
+		// Set wpPlugin.name for Core naming convention
+		gutenbergPackageJson.wpPlugin = gutenbergPackageJson.wpPlugin || {};
+		gutenbergPackageJson.wpPlugin.name = 'wp';
+
 		fs.writeFileSync(
 			gutenbergPackageJsonPath,
 			JSON.stringify( gutenbergPackageJson, null, '\t' ) + '\n'
@@ -121,6 +125,7 @@ async function main() {
 
 		console.log( '   ✅ IS_GUTENBERG_PLUGIN = false' );
 		console.log( '   ✅ IS_WORDPRESS_CORE = true' );
+		console.log( '   ✅ wpPlugin.name = wp' );
 	} catch ( error ) {
 		console.error(
 			'❌ Error modifying Gutenberg package.json:',


### PR DESCRIPTION
This fixes a couple of issues raised by @swissspidy on the Gutenberg integration script.

 - It restores the theme.json i18n file for wp-cli to work properly.
 - It renames gutenberg_ prefixes to wp_

Trac ticket: https://core.trac.wordpress.org/ticket/64393
