### PR TITLE
Update Gutenberg Build tool to include the minified CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "https://develop.svn.wordpress.org/trunk"
 	},
 	"gutenberg": {
-		"ref": "b79bbe25a1b00ce640bfab363f182c678181082f"
+		"ref": "dea73b609a80016eb1cf3893ea183fe106a06740"
 	},
 	"engines": {
 		"node": ">=20.10.0",


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64393

 ## Description

Updates the Gutenberg hash to include WordPress/gutenberg#74380, which fixes the CSS build to generate both minified (.min.css) and non-minified (.css) versions. Previously, Gutenberg only produced a single CSS file, causing 404s when SCRIPT_DEBUG is false (Core expects .min.css files).

## Testing

  1. Run npm run build:dev
  2. Verify both style.css and style.min.css exist in src/wp-includes/blocks/*/
  3. Test with SCRIPT_DEBUG=true and SCRIPT_DEBUG=false — editor should load correctly in both cases