### PR TITLE
Build: Faster Gutenberg Builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"url": "https://develop.svn.wordpress.org/trunk"
 	},
 	"gutenberg": {
-		"ref": "dea73b609a80016eb1cf3893ea183fe106a06740"
+		"ref": "892bfad51d2261f44f3a21f934b1c72bd29a2449"
 	},
 	"engines": {
 		"node": ">=20.10.0",

--- a/tools/gutenberg/build-gutenberg.js
+++ b/tools/gutenberg/build-gutenberg.js
@@ -148,7 +148,7 @@ async function main() {
 				? '--base-url="includes_url( \'build\' )"'
 				: "--base-url=includes_url( 'build' )";
 
-		await exec( 'npm', [ 'run', 'build', '--', baseUrlArg ], {
+		await exec( 'npm', [ 'run', 'build', '--', '--fast', baseUrlArg ], {
 			cwd: gutenbergDir,
 		} );
 


### PR DESCRIPTION
This updates the Gutenberg build integration to use the new --fast flag, which skips TypeScript-related steps (version validation, tsc --build, and type declaration checks) that aren't needed when building for WordPress Core. These steps only produce .d.ts type declaration files which aren't shipped with Core.

The Gutenberg ref is also updated to include the commit that adds the --fast flag support.

Trac ticket: https://core.trac.wordpress.org/ticket/64393