### PR TITLE
Update/move gutenberg checkout to postinstall

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1457,7 +1457,6 @@ module.exports = function(grunt) {
 	} );
 
 	grunt.registerTask( 'gutenberg-integrate', 'Complete Gutenberg integration workflow.', [
-		'gutenberg-checkout',
 		'gutenberg-build',
 		'gutenberg-copy'
 	] );

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "WordPress",
 			"version": "7.0.0",
+			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"backbone": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
 		"wicg-inert": "3.1.3"
 	},
 	"scripts": {
+		"postinstall": "npm run gutenberg:checkout",
 		"build": "grunt build",
 		"build:dev": "grunt build --dev",
 		"dev": "grunt watch --dev",


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64393

Moves Gutenberg checkout to postinstall hook, separating dependency setup from build. Removes checkout step from the build step.

## Benefits:

  - Faster build times: checkout happens once at install, not every build (although the script was already accounting for this before)
  - Cleaner separation of concerns: dependencies are ready before any build runs

## Test plan

  - Run npm install and verify Gutenberg checkout runs automatically
  - Run npm run build and verify build completes successfully
  - Run npm run build:dev and verify dev build works