### PR TITLE
Block Template Utils: Add navigation overlay template part area const…

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -19,6 +19,9 @@ if ( ! defined( 'WP_TEMPLATE_PART_AREA_SIDEBAR' ) ) {
 if ( ! defined( 'WP_TEMPLATE_PART_AREA_UNCATEGORIZED' ) ) {
 	define( 'WP_TEMPLATE_PART_AREA_UNCATEGORIZED', 'uncategorized' );
 }
+if ( ! defined( 'WP_TEMPLATE_PART_AREA_NAVIGATION_OVERLAY' ) ) {
+	define( 'WP_TEMPLATE_PART_AREA_NAVIGATION_OVERLAY', 'navigation-overlay' );
+}
 
 /**
  * For backward compatibility reasons,
@@ -95,6 +98,15 @@ function get_allowed_block_template_part_areas() {
 			),
 			'icon'        => 'footer',
 			'area_tag'    => 'footer',
+		),
+		array(
+			'area'        => WP_TEMPLATE_PART_AREA_NAVIGATION_OVERLAY,
+			'label'       => _x( 'Navigation Overlay', 'template part area' ),
+			'description' => __(
+				'The Navigation Overlay template defines a page area that is used specifically for navigation overlays.'
+			),
+			'icon'        => 'overlay',
+			'area_tag'    => 'div',
 		),
 	);
 


### PR DESCRIPTION
## Summary

Backports the changes from Gutenberg PR https://github.com/WordPress/gutenberg/pull/74444 to rename the navigation overlay template part area.

This PR introduces the `WP_TEMPLATE_PART_AREA_NAVIGATION_OVERLAY` constant to define a dedicated template part area for navigation overlays, providing more specificity than the generic "overlay" naming.

  ## Changes

  - Adds new constant `WP_TEMPLATE_PART_AREA_NAVIGATION_OVERLAY` with value `'navigation-overlay'` in `src/wp-includes/block-template-utils.php`

  ## Context

The Gutenberg PR renamed the generic "overlay" template part area to "navigation-overlay" for better clarity and specificity. This backport brings that constant definition to WordPress core.


The backport is minimal since WordPress core only needs the PHP constant definition. The JavaScript changes in the Gutenberg PR are bundled with the block library and will be included when the Gutenberg packages are synced to core.

There is an accompanying PR that was an earlier version of this here: https://github.com/WordPress/wordpress-develop/pull/10581

Props: `getdave`

Trac ticket: https://core.trac.wordpress.org/ticket/64334#ticket


