### PR TITLE
Show dependency install/active state in plugin list

### DIFF
--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1568,14 +1568,12 @@ class WP_Plugins_List_Table extends WP_List_Table {
 		}
 
 		$requires = null;
-		
 		if ( ! empty( $dependency_names ) ) {
 
 			$links = array();
 
 			foreach ( $dependency_names as $slug => $name ) {
 				$link = $this->get_dependency_view_details_link( $name, $slug );
-		
 				$dependency_file = WP_Plugin_Dependencies::get_dependency_filepath( $slug );
 
 				$is_installed = false;

--- a/src/wp-admin/includes/class-wp-plugins-list-table.php
+++ b/src/wp-admin/includes/class-wp-plugins-list-table.php
@@ -1567,18 +1567,62 @@ class WP_Plugins_List_Table extends WP_List_Table {
 			return;
 		}
 
-		$links = array();
-		foreach ( $dependency_names as $slug => $name ) {
-			$links[] = $this->get_dependency_view_details_link( $name, $slug );
-		}
+		$requires = null;
+		
+		if ( ! empty( $dependency_names ) ) {
 
-		$is_active = is_multisite() ? is_plugin_active_for_network( $dependent ) : is_plugin_active( $dependent );
-		$comma     = wp_get_list_item_separator();
-		$requires  = sprintf(
-			/* translators: %s: List of dependency names. */
-			__( '<strong>Requires:</strong> %s' ),
-			implode( $comma, $links )
-		);
+			$links = array();
+
+			foreach ( $dependency_names as $slug => $name ) {
+				$link = $this->get_dependency_view_details_link( $name, $slug );
+		
+				$dependency_file = WP_Plugin_Dependencies::get_dependency_filepath( $slug );
+
+				$is_installed = false;
+				$is_active    = false;
+
+				if ( $dependency_file ) {
+					$is_installed = true;
+					$is_active    = is_multisite()
+						? is_plugin_active_for_network( $dependency_file ) || is_plugin_active( $dependency_file )
+						: is_plugin_active( $dependency_file );
+				}
+
+				if ( ! $is_installed ) {
+					$link .= sprintf(
+						' <span class="dependency-state dependency-state--missing">%s</span>
+						  <span class="screen-reader-text">%s</span>',
+						__( '(not installed)' ),
+						__( 'Not installed' )
+					);
+				} elseif ( $is_active ) {
+					$link .= sprintf(
+						' <span class="dependency-state dependency-state--active">%s</span>
+						  <span class="dashicons dashicons-yes-alt dependency-icon dependency-icon--active" aria-hidden="true"></span>
+						  <span class="screen-reader-text">%s</span>',
+						__( '(installed, active)' ),
+						__( 'Installed and active' )
+					);
+				} else {
+					$link .= sprintf(
+						' <span class="dependency-state dependency-state--installed">%s</span>
+						  <span class="dashicons dashicons-yes-alt dependency-icon dependency-icon--installed" aria-hidden="true"></span>
+						  <span class="screen-reader-text">%s</span>',
+						__( '(installed, inactive)' ),
+						__( 'Installed but inactive' )
+					);
+				}
+
+				$links[] = $link;
+			}
+
+			$comma    = wp_get_list_item_separator();
+			$requires = sprintf(
+				/* translators: %s: List of dependency names. */
+				__( '<strong>Requires:</strong> %s' ),
+				implode( $comma, $links )
+			);
+		}
 
 		$notice        = '';
 		$error_message = '';


### PR DESCRIPTION
Improves the plugin dependencies UI by indicating whether required plugins
are installed, active, or missing.

Follow-up to #10686.
Trac: [#64475](https://core.trac.wordpress.org/ticket/64475)
