### PR TITLE
Formatting: Strip invalid XML characters in `esc_xml()`

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4760,6 +4760,16 @@ function esc_textarea( $text ) {
 function esc_xml( $text ) {
 	$safe_text = wp_check_invalid_utf8( $text );
 
+	// Strip invalid XML characters.
+	$is_utf8 = in_array( get_option( 'blog_charset' ), array( 'utf8', 'utf-8', 'UTF8', 'UTF-8' ), true );
+	if ( $is_utf8 ) {
+		$safe_text = preg_replace(
+			'/[^\x{9}\x{A}\x{D}\x{20}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]/u',
+			'',
+			$safe_text
+		);
+	}
+
 	$cdata_regex = '\<\!\[CDATA\[.*?\]\]\>';
 	$regex       = <<<EOF
 /

--- a/tests/phpunit/tests/formatting/escXml.php
+++ b/tests/phpunit/tests/formatting/escXml.php
@@ -139,4 +139,76 @@ class Tests_Formatting_EscXml extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Test that invalid XML control characters are stripped.
+	 *
+	 * @dataProvider data_strips_invalid_xml_characters
+	 *
+	 * @param string $source   The source string containing invalid XML characters.
+	 * @param string $expected The expected string with invalid characters removed.
+	 */
+	public function test_strips_invalid_xml_characters( $source, $expected ) {
+		update_option( 'blog_charset', 'UTF-8' );
+		$actual = esc_xml( $source );
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Data provider for `test_strips_invalid_xml_characters()`.
+	 *
+	 * @return array {
+	 *     @type string $source   The source string containing invalid XML characters.
+	 *     @type string $expected The expected string with invalid characters removed.
+	 * }
+	 */
+	public function data_strips_invalid_xml_characters() {
+		return array(
+			// Vertical tab (0x0B) - invalid in XML.
+			array(
+				"This contains a vertical tab\x0Bcharacter",
+				'This contains a vertical tabcharacter',
+			),
+			// File separator (0x1C) - invalid in XML.
+			array(
+				"File separator\x1Ctest",
+				'File separatortest',
+			),
+			// NULL byte (0x00) - invalid in XML.
+			array(
+				"Text with\x00null byte",
+				'Text withnull byte',
+			),
+			// Bell character (0x07) - invalid in XML.
+			array(
+				"Bell\x07character",
+				'Bellcharacter',
+			),
+			// Multiple invalid characters.
+			array(
+				"Multiple\x00invalid\x0B\x1Ccharacters\x07here",
+				'Multipleinvalidcharactershere',
+			),
+			// Valid control characters should be preserved: tab (0x09), LF (0x0A), CR (0x0D).
+			array(
+				"Tab\tlinefeed\ncarriage return\rtest",
+				"Tab\tlinefeed\ncarriage return\rtest",
+			),
+			// Mix of valid and invalid.
+			array(
+				"Valid\ttab but\x0Binvalid vertical tab",
+				"Valid\ttab butinvalid vertical tab",
+			),
+			// Text without invalid characters should remain unchanged.
+			array(
+				'Normal text with spaces and punctuation!',
+				'Normal text with spaces and punctuation!',
+			),
+			// Unicode characters in valid range should be preserved.
+			array(
+				'Unicode: café, naïve, 日本語',
+				'Unicode: café, naïve, 日本語',
+			),
+		);
+	}
 }

--- a/tests/phpunit/tests/formatting/escXml.php
+++ b/tests/phpunit/tests/formatting/escXml.php
@@ -222,4 +222,14 @@ class Tests_Formatting_EscXml extends WP_UnitTestCase {
 		$actual   = esc_xml( $source );
 		$this->assertSame( $expected, $actual );
 	}
+
+	/**
+	 * Test that the function works correctly when charset is not UTF-8.
+	 */
+	public function test_non_utf8_charset_skips_invalid_character_stripping() {
+		update_option( 'blog_charset', 'ISO-8859-1' );
+		$source = "Test\x0Btext";
+		$actual = esc_xml( $source );
+		$this->assertIsString( $actual );
+	}
 }

--- a/tests/phpunit/tests/formatting/escXml.php
+++ b/tests/phpunit/tests/formatting/escXml.php
@@ -211,4 +211,15 @@ class Tests_Formatting_EscXml extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Test that invalid XML characters within CDATA sections are also stripped.
+	 */
+	public function test_strips_invalid_xml_characters_outside_cdata() {
+		update_option( 'blog_charset', 'UTF-8' );
+		$source   = "Text\x0Bwith<![CDATA[valid <content>]]>and\x1Cmore\x00invalid";
+		$expected = 'Textwith<![CDATA[valid <content>]]>andmoreinvalid';
+		$actual   = esc_xml( $source );
+		$this->assertSame( $expected, $actual );
+	}
 }


### PR DESCRIPTION

Trac ticket: https://core.trac.wordpress.org/ticket/19998

This PR enhances the `esc_xml()` function to strip control characters that are not valid according to the XML 1.0 specification. This prevents feed parsers from breaking when encountering invalid characters like vertical tabs, null bytes, and other unprintable control characters in user-supplied content.

- Modified `esc_xml()` in `src/wp-includes/formatting.php` to strip invalid XML characters using regex pattern that matches XML 1.0 spec
- Character stripping only applies when `blog_charset` is UTF-8 to avoid encoding issues
- Preserves valid control characters (tab `\x09`, line feed `\x0A`, carriage return `\x0D`)
- Removes invalid characters (null bytes, vertical tabs, file separators, and other unprintable characters)
- Added comprehensive unit tests covering various scenarios
