### PR TITLE
General: Restore and deprecate `wp_register_development_scripts`

### DIFF
--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -6486,7 +6486,7 @@ function wp_print_auto_sizes_contain_css_fix() {
  * @see https://github.com/WordPress/gutenberg/tree/trunk/packages/scripts#start
  *
  * @since 6.0.0
- * @deprecated 7.0.0
+ * @deprecated 7.0.0 Obsolete due to a change in how Gutenberg is included in Core. See #64393.
  *
  * @param WP_Scripts $scripts WP_Scripts object.
  */

--- a/src/wp-includes/deprecated.php
+++ b/src/wp-includes/deprecated.php
@@ -6479,3 +6479,17 @@ function wp_print_auto_sizes_contain_css_fix() {
 	<style>img:is([sizes="auto" i], [sizes^="auto," i]) { contain-intrinsic-size: 3000px 1500px }</style>
 	<?php
 }
+
+/**
+ * Registers development scripts that integrate with `@wordpress/scripts`.
+ *
+ * @see https://github.com/WordPress/gutenberg/tree/trunk/packages/scripts#start
+ *
+ * @since 6.0.0
+ * @deprecated 7.0.0
+ *
+ * @param WP_Scripts $scripts WP_Scripts object.
+ */
+function wp_register_development_scripts( $scripts ) {
+	_deprecated_function( __FUNCTION__, '7.0.0' );
+}


### PR DESCRIPTION
## Summary

- Restores the `wp_register_development_scripts` function that was removed in commit 22294af4ed3b46f577f42590ba4cc19ca0a93f3f
- Marks the function as deprecated for WordPress 7.0.0 following Core deprecation conventions
- The function is now a no-op stub that triggers a deprecation notice when `WP_DEBUG` is enabled

## Background

WordPress Core policy is to deprecate functions rather than remove them outright to maintain backward compatibility. This PR restores the function signature while deprecating it properly.

## Test plan

- [ ] Verify calling `wp_register_development_scripts()` no longer causes a fatal error
- [ ] Verify with `WP_DEBUG` enabled, calling the function triggers a deprecation notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)