### PR TITLE
get_post_states: post type checks

### DIFF
--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2291,7 +2291,7 @@ function _post_states( $post, $display = true ) {
  *
  * @since 5.3.0
  *
- * @param WP_Post|mixed $post The post to retrieve states for.
+ * @param WP_Post $post The post to retrieve states for.
  * @return string[] Array of post state labels keyed by their state.
  */
 function get_post_states( $post ) {

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2291,7 +2291,7 @@ function _post_states( $post, $display = true ) {
  *
  * @since 5.3.0
  *
- * @param WP_Post $post The post to retrieve states for.
+ * @param WP_Post|mixed $post The post to retrieve states for.
  * @return string[] Array of post state labels keyed by their state.
  */
 function get_post_states( $post ) {

--- a/src/wp-admin/includes/template.php
+++ b/src/wp-admin/includes/template.php
@@ -2297,6 +2297,10 @@ function _post_states( $post, $display = true ) {
 function get_post_states( $post ) {
 	$post_states = array();
 
+	if ( ! $post instanceof WP_Post ) {
+		return $post_states;
+	}
+
 	if ( isset( $_REQUEST['post_status'] ) ) {
 		$post_status = $_REQUEST['post_status'];
 	} else {

--- a/src/wp-includes/nav-menu.php
+++ b/src/wp-includes/nav-menu.php
@@ -875,10 +875,12 @@ function wp_setup_nav_menu_item( $menu_item ) {
 					$menu_item->type_label = $object->labels->singular_name;
 					// Denote post states for special pages (only in the admin).
 					if ( function_exists( 'get_post_states' ) ) {
-						$menu_post   = get_post( $menu_item->object_id );
-						$post_states = get_post_states( $menu_post );
-						if ( $post_states ) {
-							$menu_item->type_label = wp_strip_all_tags( implode( ', ', $post_states ) );
+						$menu_post = get_post( $menu_item->object_id );
+						if ( $menu_post instanceof WP_Post ) {
+							$post_states = get_post_states( $menu_post );
+							if ( $post_states ) {
+								$menu_item->type_label = wp_strip_all_tags( implode( ', ', $post_states ) );
+							}
 						}
 					}
 				} else {

--- a/tests/phpunit/tests/admin/includesTemplate.php
+++ b/tests/phpunit/tests/admin/includesTemplate.php
@@ -508,7 +508,6 @@ class Tests_Admin_IncludesTemplate extends WP_UnitTestCase {
 	 */
 	public function test_get_post_states_with_null_returns_empty_array() {
 		$result = get_post_states( null );
-		$this->assertIsArray( $result, 'get_post_states() should return an array when passed null.' );
-		$this->assertEmpty( $result, 'get_post_states() should return an empty array when passed null.' );
+		$this->assertSame( array(), $result, 'get_post_states() should return an empty array when WP_Post is not supplied.' );
 	}
 }

--- a/tests/phpunit/tests/admin/includesTemplate.php
+++ b/tests/phpunit/tests/admin/includesTemplate.php
@@ -494,4 +494,21 @@ class Tests_Admin_IncludesTemplate extends WP_UnitTestCase {
 		// This doesn't actually get removed due to the invalid priority.
 		remove_meta_box( 'dashboard2', 'dashboard', 'normal' );
 	}
+
+	/**
+	 * Tests that get_post_states() handles a null value gracefully.
+	 *
+	 * This can happen when get_post() returns null (e.g., when a post
+	 * doesn't exist) and that result is passed to get_post_states()
+	 * without being checked first.
+	 *
+	 * @ticket 58932
+	 *
+	 * @covers ::get_post_states
+	 */
+	public function test_get_post_states_with_null_returns_empty_array() {
+		$result = get_post_states( null );
+		$this->assertIsArray( $result, 'get_post_states() should return an array when passed null.' );
+		$this->assertEmpty( $result, 'get_post_states() should return an empty array when passed null.' );
+	}
 }


### PR DESCRIPTION
https://core.trac.wordpress.org/ticket/58932

The function `get_post_states()` requires a WP_Post object as an arg.  But `get_post()` can return `null` - so we need multiple layers of defense here.

First, `get_post_states()` needs to validate that it has a WP_Post object before trying to treat $post as an object.

Second, the call to `get_post_states()` in `wp-includes/nav-menu.php` needs to be conditional on `get_post()` returning a WP_Post object.

This also includes a new test for `get_post_states()` to make sure it does the right thing when given something other than a WP_Post object.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
