### PR TITLE
Remove block editor assets from the front end in Twenty Twenty-One

### DIFF
--- a/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-custom-colors.php
+++ b/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-custom-colors.php
@@ -23,7 +23,9 @@ class Twenty_Twenty_One_Custom_Colors {
 		add_action( 'wp_enqueue_scripts', array( $this, 'custom_color_variables' ) );
 
 		// Enqueue color variables for editor.
-		add_action( 'enqueue_block_assets', array( $this, 'editor_custom_color_variables' ) );
+		if ( is_admin() ) {
+			add_action( 'enqueue_block_assets', array( $this, 'editor_custom_color_variables' ) );
+		}
 
 		// Add body-class if needed.
 		add_filter( 'body_class', array( $this, 'body_class' ) );

--- a/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
+++ b/src/wp-content/themes/twentytwentyone/classes/class-twenty-twenty-one-dark-mode.php
@@ -20,7 +20,9 @@ class Twenty_Twenty_One_Dark_Mode {
 	public function __construct() {
 
 		// Enqueue assets for the block-editor.
-		add_action( 'enqueue_block_assets', array( $this, 'editor_custom_color_variables' ) );
+		if ( is_admin() ) {
+			add_action( 'enqueue_block_assets', array( $this, 'editor_custom_color_variables' ) );
+		}
 
 		// Add styles for dark-mode.
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );


### PR DESCRIPTION
Checks whether `is_admin()` before adding scripts and styles on 'enqueue_block_assets' action in both `Twenty_Twenty_One_Custom_Colors` and `Twenty_Twenty_One_Dark_Mode`.

[Trac 60111](https://core.trac.wordpress.org/ticket/60111)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
