### PR TITLE
Fix: Normalize user role keys to string for admin filter

### DIFF
--- a/src/wp-admin/includes/class-wp-users-list-table.php
+++ b/src/wp-admin/includes/class-wp-users-list-table.php
@@ -220,6 +220,7 @@ class WP_Users_List_Table extends WP_List_Table {
 		);
 
 		foreach ( $wp_roles->get_names() as $this_role => $name ) {
+			$this_role = (string) $this_role;
 			if ( $count_users && ! isset( $avail_roles[ $this_role ] ) ) {
 				continue;
 			}


### PR DESCRIPTION
This PR fixes an issue where user roles created with integer keys do not appear in the admin users filter dropdown.

The fix normalizes role keys to strings when building the filter views, ensuring roles created with integer keys are displayed correctly in the Users admin screen.

Trac ticket

https://core.trac.wordpress.org/ticket/43796