### PR TITLE
Prevent undefined index notice in WP_Locale::get_weekday()

### DIFF
--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -266,7 +266,7 @@ class WP_Locale {
 	 * @return string Full translated weekday.
 	 */
 	public function get_weekday( $weekday_number ) {
-		return $this->weekday[ $weekday_number ];
+		return isset( $this->weekday[ $weekday_number ] ) ? $this->weekday[ $weekday_number ] : '';
 	}
 
 	/**


### PR DESCRIPTION
This PR adds a guard condition to prevent PHP notices when accessing an undefined weekday index. The change is minimal and does not affect existing behavior.
