### PR TITLE
Fix gmdate() type error on dashboard recent posts (PHP 8.3)

### DIFF
--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1015,7 +1015,6 @@ function wp_dashboard_recent_posts( $args ) {
 			$time = intval( get_the_time( 'U' ) );
 
             if ( gmdate( 'Y-m-d', $time ) === $today ) {
-
 				$relative = __( 'Today' );
 			} elseif ( gmdate( 'Y-m-d', $time ) === $tomorrow ) {
 				$relative = __( 'Tomorrow' );

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1013,8 +1013,8 @@ function wp_dashboard_recent_posts( $args ) {
 			$posts->the_post();
 
 			$time = intval( get_the_time( 'U' ) );
-
-            if ( gmdate( 'Y-m-d', $time ) === $today ) {
+			
+			if ( gmdate( 'Y-m-d', $time ) === $today ) {
 				$relative = __( 'Today' );
 			} elseif ( gmdate( 'Y-m-d', $time ) === $tomorrow ) {
 				$relative = __( 'Tomorrow' );

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1014,9 +1014,8 @@ function wp_dashboard_recent_posts( $args ) {
 
 			$time = intval( get_the_time( 'U' ) );
 
+            if ( gmdate( 'Y-m-d', $time ) === $today ) {
 
-
-			if ( gmdate( 'Y-m-d', $time ) === $today ) {
 				$relative = __( 'Today' );
 			} elseif ( gmdate( 'Y-m-d', $time ) === $tomorrow ) {
 				$relative = __( 'Tomorrow' );

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1012,7 +1012,8 @@ function wp_dashboard_recent_posts( $args ) {
 		while ( $posts->have_posts() ) {
 			$posts->the_post();
 
-			$time = get_the_time( 'U' );
+			$time = (int) get_the_time( 'U' );
+
 
 			if ( gmdate( 'Y-m-d', $time ) === $today ) {
 				$relative = __( 'Today' );

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1012,7 +1012,8 @@ function wp_dashboard_recent_posts( $args ) {
 		while ( $posts->have_posts() ) {
 			$posts->the_post();
 
-			$time = (int) get_the_time( 'U' );
+			$time = intval( get_the_time( 'U' ) );
+
 
 
 			if ( gmdate( 'Y-m-d', $time ) === $today ) {


### PR DESCRIPTION
This pull request fixes a PHP 8.3 fatal error in the WordPress dashboard Recent Posts widget.

In wp_dashboard_recent_posts(), get_the_time( 'U' ) returns a string, but gmdate() requires an integer or null in PHP 8.3. This causes a TypeError and breaks the admin dashboard when running WordPress on PHP 8.3.

The fix casts the timestamp to an integer before passing it to gmdate(), restoring compatibility while keeping the existing behavior unchanged.

Trac ticket: https://core.trac.wordpress.org/ticket/64496
