### PR TITLE
Customize: Preserve CSS cascade for Additional CSS in classic themes

### DIFF
--- a/tests/phpunit/tests/template.php
+++ b/tests/phpunit/tests/template.php
@@ -1561,6 +1561,7 @@ class Tests_Template extends WP_UnitTestCase {
 						'global-styles-inline-css',
 						'normal-css',
 						'normal-inline-css',
+						'wp-custom-css',
 					),
 					'BODY' => array(
 						'late-css',
@@ -1622,6 +1623,7 @@ class Tests_Template extends WP_UnitTestCase {
 						'global-styles-inline-css',
 						'normal-css',
 						'normal-inline-css',
+						'wp-custom-css',
 					),
 					'BODY' => array(
 						'late-css',


### PR DESCRIPTION
Restores the `$is_block_theme` check that was inadvertently removed in [61473]. This ensures that for classic themes, the Customizer's Additional CSS continues to be printed separately via `wp_custom_css_cb()` at priority 101 in `wp_head`, preserving its position at the end of the `<head>` for highest CSS specificity.

For block themes, the Customizer CSS is merged into the global styles stylesheet before the global styles custom CSS, maintaining the intended cascade order.

This fixes two issues introduced by the Global Styles lift for classic themes:
1. Live preview in the Customizer not working for Additional CSS changes.
2. Additional CSS losing its cascade advantage due to being buried in the global styles stylesheet.

Props westonruter.

Trac ticket: https://core.trac.wordpress.org/ticket/64408

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**