### PR TITLE
Scripts: Add script tag attribute handling tests

### DIFF
--- a/tests/phpunit/tests/dependencies/wpInlineScriptTag.php
+++ b/tests/phpunit/tests/dependencies/wpInlineScriptTag.php
@@ -94,4 +94,74 @@ JS;
 			)
 		);
 	}
+
+	/**
+	 * Test the behavior of generated script tag attributes passed different values and types of values.
+	 *
+	 * @ticket 64500
+	 */
+	public function test_script_tag_attribute_value_types() {
+		$expected = <<<'HTML'
+<script
+	true
+	null
+	empty-string=""
+	0-string="0"
+	1-string="1"
+	0-numeric="0"
+	1-numeric="1"
+>
+"script data";
+</script>
+
+HTML;
+
+		$this->assertEqualHTML(
+			$expected,
+			wp_get_inline_script_tag(
+				'"script data";',
+				array(
+					'true'         => true,
+					'false'        => false,
+					'null'         => null,
+					'empty-string' => '',
+					'0-string'     => '0',
+					'1-string'     => '1',
+					'0-numeric'    => 0,
+					'1-numeric'    => 1,
+				)
+			),
+		);
+	}
+
+	/**
+	 * Test the behavior of generated script tag repeated attributes.
+	 *
+	 * HTML will ignore case-insensitive repeated attributes. Ensure that the handling of input
+	 * attributes aligns with expectations.
+	 *
+	 * @ticket 64500
+	 */
+	public function test_script_tag_repeat_attributes() {
+		$expected = <<<'HTML'
+<script test="test-a">
+"script data";
+</script>
+
+HTML;
+
+		$this->assertEqualHTML(
+			$expected,
+			wp_get_inline_script_tag(
+				'"script data";',
+				array(
+					'test' => 'test-a',
+					'tesT' => 'tesT-b',
+					'teST' => 'teST-c',
+					'tEST' => 'tEST-d',
+					'TEST' => 'TEST-e',
+				)
+			),
+		);
+	}
 }

--- a/tests/phpunit/tests/dependencies/wpScriptTag.php
+++ b/tests/phpunit/tests/dependencies/wpScriptTag.php
@@ -98,4 +98,68 @@ class Tests_Dependencies_wpScriptTag extends WP_UnitTestCase {
 			)
 		);
 	}
+
+	/**
+	 * Test the behavior of generated script tag attributes passed different values and types of values.
+	 *
+	 * @ticket 64500
+	 */
+	public function test_script_tag_attribute_value_types() {
+		$expected = <<<'HTML'
+<script
+	true
+	null
+	empty-string=""
+	0-string="0"
+	1-string="1"
+	0-numeric="0"
+	1-numeric="1"
+></script>
+
+HTML;
+
+		$this->assertEqualHTML(
+			$expected,
+			wp_get_script_tag(
+				array(
+					'true'         => true,
+					'false'        => false,
+					'null'         => null,
+					'empty-string' => '',
+					'0-string'     => '0',
+					'1-string'     => '1',
+					'0-numeric'    => 0,
+					'1-numeric'    => 1,
+				)
+			),
+		);
+	}
+
+	/**
+	 * Test the behavior of generated script tag repeated attributes.
+	 *
+	 * HTML will ignore case-insensitive repeated attributes. Ensure that the handling of input
+	 * attributes aligns with expectations.
+	 *
+	 * @ticket 64500
+	 */
+	public function test_script_tag_repeat_attributes() {
+		$expected = <<<'HTML'
+<script test="test-a"></script>
+
+HTML;
+
+		$this->assertEqualHTML(
+			$expected,
+			wp_get_script_tag(
+				array(
+					'test' => 'test-a',
+					'tesT' => 'tesT-b',
+					'teST' => 'teST-c',
+					'tEST' => 'tEST-d',
+					'TEST' => 'TEST-e',
+				)
+			),
+		);
+	}
 }


### PR DESCRIPTION
Add tests that verify the behavior of `wp_get_inline_script_tag()` `wp_get_script_tag()` attribute handling. This is relevant for the work in https://github.com/WordPress/wordpress-develop/pull/10639. See https://github.com/WordPress/wordpress-develop/pull/10639#discussion_r2687294023.

Tests are added using `assertEqualHTML()` assertions that verify the behavior when:
- Different attribute values and types are provided.
- Repeated attribute names are provided (correct order handling)

Trac ticket: https://core.trac.wordpress.org/ticket/64500

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
