### PR TITLE
Fix: Type Error with gmdate() in dashboard Activity widget

### DIFF
--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1014,7 +1014,9 @@ function wp_dashboard_recent_posts( $args ) {
 
 			$time = get_the_time( 'U' );
 
-			if ( gmdate( 'Y-m-d', $time ) === $today ) {
+			if ( ! is_int( $time ) ) {
+				$relative = '';
+			} elseif ( gmdate( 'Y-m-d', $time ) === $today ) {
 				$relative = __( 'Today' );
 			} elseif ( gmdate( 'Y-m-d', $time ) === $tomorrow ) {
 				$relative = __( 'Tomorrow' );
@@ -1033,7 +1035,7 @@ function wp_dashboard_recent_posts( $args ) {
 			printf(
 				'<li><span>%1$s</span> <a href="%2$s" aria-label="%3$s">%4$s</a></li>',
 				/* translators: 1: Relative date, 2: Time. */
-				sprintf( _x( '%1$s, %2$s', 'dashboard' ), $relative, get_the_time() ),
+				$relative ? sprintf( _x( '%1$s, %2$s', 'dashboard' ), $relative, get_the_time() ) : '',
 				$recent_post_link,
 				/* translators: %s: Post title. */
 				esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;' ), $draft_or_post_title ) ),

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1015,8 +1015,7 @@ function wp_dashboard_recent_posts( $args ) {
 			$time = get_the_time( 'U' );
 
 			if ( ! is_int( $time ) ) {
-				/* translators: Date and time format for recent posts on the dashboard, from a different calendar year, see https://www.php.net/manual/datetime.format.php */
-				$relative = date_i18n( __( 'M jS Y' ), $time );
+				$relative = '';
 			} elseif ( gmdate( 'Y-m-d', $time ) === $today ) {
 				$relative = __( 'Today' );
 			} elseif ( gmdate( 'Y-m-d', $time ) === $tomorrow ) {
@@ -1036,7 +1035,7 @@ function wp_dashboard_recent_posts( $args ) {
 			printf(
 				'<li><span>%1$s</span> <a href="%2$s" aria-label="%3$s">%4$s</a></li>',
 				/* translators: 1: Relative date, 2: Time. */
-				sprintf( _x( '%1$s, %2$s', 'dashboard' ), $relative, get_the_time() ),
+				$relative ? sprintf( _x( '%1$s, %2$s', 'dashboard' ), $relative, get_the_time() ) : get_the_time(),
 				$recent_post_link,
 				/* translators: %s: Post title. */
 				esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;' ), $draft_or_post_title ) ),

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1015,7 +1015,8 @@ function wp_dashboard_recent_posts( $args ) {
 			$time = get_the_time( 'U' );
 
 			if ( ! is_int( $time ) ) {
-				$relative = '';
+				/* translators: Date and time format for recent posts on the dashboard, from a different calendar year, see https://www.php.net/manual/datetime.format.php */
+				$relative = date_i18n( __( 'M jS Y' ), $time );
 			} elseif ( gmdate( 'Y-m-d', $time ) === $today ) {
 				$relative = __( 'Today' );
 			} elseif ( gmdate( 'Y-m-d', $time ) === $tomorrow ) {
@@ -1035,7 +1036,7 @@ function wp_dashboard_recent_posts( $args ) {
 			printf(
 				'<li><span>%1$s</span> <a href="%2$s" aria-label="%3$s">%4$s</a></li>',
 				/* translators: 1: Relative date, 2: Time. */
-				$relative ? sprintf( _x( '%1$s, %2$s', 'dashboard' ), $relative, get_the_time() ) : get_the_time(),
+				sprintf( _x( '%1$s, %2$s', 'dashboard' ), $relative, get_the_time() ),
 				$recent_post_link,
 				/* translators: %s: Post title. */
 				esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;' ), $draft_or_post_title ) ),

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1035,7 +1035,7 @@ function wp_dashboard_recent_posts( $args ) {
 			printf(
 				'<li><span>%1$s</span> <a href="%2$s" aria-label="%3$s">%4$s</a></li>',
 				/* translators: 1: Relative date, 2: Time. */
-				$relative ? sprintf( _x( '%1$s, %2$s', 'dashboard' ), $relative, get_the_time() ) : get_the_time(),
+				$relative ? sprintf( _x( '%1$s, %2$s', 'dashboard' ), $relative, get_the_time() ) : '',
 				$recent_post_link,
 				/* translators: %s: Post title. */
 				esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;' ), $draft_or_post_title ) ),

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1035,7 +1035,7 @@ function wp_dashboard_recent_posts( $args ) {
 			printf(
 				'<li><span>%1$s</span> <a href="%2$s" aria-label="%3$s">%4$s</a></li>',
 				/* translators: 1: Relative date, 2: Time. */
-				$relative ? sprintf( _x( '%1$s, %2$s', 'dashboard' ), $relative, get_the_time() ) : '',
+				$relative ? sprintf( _x( '%1$s, %2$s', 'dashboard' ), $relative, get_the_time() ) : get_the_time(),
 				$recent_post_link,
 				/* translators: %s: Post title. */
 				esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;' ), $draft_or_post_title ) ),

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1014,13 +1014,15 @@ function wp_dashboard_recent_posts( $args ) {
 
 			$time = get_the_time( 'U' );
 
-			if ( ! is_int( $time ) || gmdate( 'Y', $time ) !== $year ) {
-				/* translators: Date and time format for recent posts on the dashboard, from a different calendar year, see https://www.php.net/manual/datetime.format.php */
-				$relative = date_i18n( __( 'M jS Y' ), $time );
+			if ( ! is_int( $time ) ) {
+				$relative = null;
 			} elseif ( gmdate( 'Y-m-d', $time ) === $today ) {
 				$relative = __( 'Today' );
 			} elseif ( gmdate( 'Y-m-d', $time ) === $tomorrow ) {
 				$relative = __( 'Tomorrow' );
+			} elseif ( gmdate( 'Y', $time ) !== $year ) {
+				/* translators: Date and time format for recent posts on the dashboard, from a different calendar year, see https://www.php.net/manual/datetime.format.php */
+				$relative = date_i18n( __( 'M jS Y' ), $time );
 			} else {
 				/* translators: Date and time format for recent posts on the dashboard, see https://www.php.net/manual/datetime.format.php */
 				$relative = date_i18n( __( 'M jS' ), $time );
@@ -1033,7 +1035,7 @@ function wp_dashboard_recent_posts( $args ) {
 			printf(
 				'<li><span>%1$s</span> <a href="%2$s" aria-label="%3$s">%4$s</a></li>',
 				/* translators: 1: Relative date, 2: Time. */
-				sprintf( _x( '%1$s, %2$s', 'dashboard' ), $relative, get_the_time() ),
+				sprintf( _x( '%1$s, %2$s', 'dashboard' ), $relative ?? get_the_date(), get_the_time() ),
 				$recent_post_link,
 				/* translators: %s: Post title. */
 				esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;' ), $draft_or_post_title ) ),

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1015,17 +1015,17 @@ function wp_dashboard_recent_posts( $args ) {
 			$time = get_the_time( 'U' );
 
 			if ( ! is_int( $time ) ) {
-				$relative = get_the_date();
+				$date = get_the_date();
 			} elseif ( gmdate( 'Y-m-d', $time ) === $today ) {
-				$relative = __( 'Today' );
+				$date = __( 'Today' );
 			} elseif ( gmdate( 'Y-m-d', $time ) === $tomorrow ) {
-				$relative = __( 'Tomorrow' );
+				$date = __( 'Tomorrow' );
 			} elseif ( gmdate( 'Y', $time ) !== $year ) {
 				/* translators: Date and time format for recent posts on the dashboard, from a different calendar year, see https://www.php.net/manual/datetime.format.php */
-				$relative = date_i18n( __( 'M jS Y' ), $time );
+				$date = date_i18n( __( 'M jS Y' ), $time );
 			} else {
 				/* translators: Date and time format for recent posts on the dashboard, see https://www.php.net/manual/datetime.format.php */
-				$relative = date_i18n( __( 'M jS' ), $time );
+				$date = date_i18n( __( 'M jS' ), $time );
 			}
 
 			// Use the post edit link for those who can edit, the permalink otherwise.
@@ -1035,7 +1035,7 @@ function wp_dashboard_recent_posts( $args ) {
 			printf(
 				'<li><span>%1$s</span> <a href="%2$s" aria-label="%3$s">%4$s</a></li>',
 				/* translators: 1: Relative date, 2: Time. */
-				sprintf( _x( '%1$s, %2$s', 'dashboard' ), $relative, get_the_time() ),
+				sprintf( _x( '%1$s, %2$s', 'dashboard' ), $date, get_the_time() ),
 				$recent_post_link,
 				/* translators: %s: Post title. */
 				esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;' ), $draft_or_post_title ) ),

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1015,7 +1015,7 @@ function wp_dashboard_recent_posts( $args ) {
 			$time = get_the_time( 'U' );
 
 			if ( ! is_int( $time ) ) {
-				$relative = null;
+				$relative = get_the_date();
 			} elseif ( gmdate( 'Y-m-d', $time ) === $today ) {
 				$relative = __( 'Today' );
 			} elseif ( gmdate( 'Y-m-d', $time ) === $tomorrow ) {
@@ -1035,7 +1035,7 @@ function wp_dashboard_recent_posts( $args ) {
 			printf(
 				'<li><span>%1$s</span> <a href="%2$s" aria-label="%3$s">%4$s</a></li>',
 				/* translators: 1: Relative date, 2: Time. */
-				sprintf( _x( '%1$s, %2$s', 'dashboard' ), $relative ?? get_the_date(), get_the_time() ),
+				sprintf( _x( '%1$s, %2$s', 'dashboard' ), $relative, get_the_time() ),
 				$recent_post_link,
 				/* translators: %s: Post title. */
 				esc_attr( sprintf( __( 'Edit &#8220;%s&#8221;' ), $draft_or_post_title ) ),

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1015,7 +1015,8 @@ function wp_dashboard_recent_posts( $args ) {
 			$time = get_the_time( 'U' );
 
 			if ( ! is_int( $time ) ) {
-				$date = get_the_date();
+				/* translators: Date and time format for recent posts on the dashboard, from a different calendar year, see https://www.php.net/manual/datetime.format.php */
+				$date = get_the_date( __( 'M jS Y' ) );
 			} elseif ( gmdate( 'Y-m-d', $time ) === $today ) {
 				$date = __( 'Today' );
 			} elseif ( gmdate( 'Y-m-d', $time ) === $tomorrow ) {

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1014,16 +1014,13 @@ function wp_dashboard_recent_posts( $args ) {
 
 			$time = get_the_time( 'U' );
 
-			if ( ! is_int( $time ) ) {
+			if ( ! is_int( $time ) || gmdate( 'Y', $time ) !== $year ) {
 				/* translators: Date and time format for recent posts on the dashboard, from a different calendar year, see https://www.php.net/manual/datetime.format.php */
 				$relative = date_i18n( __( 'M jS Y' ), $time );
 			} elseif ( gmdate( 'Y-m-d', $time ) === $today ) {
 				$relative = __( 'Today' );
 			} elseif ( gmdate( 'Y-m-d', $time ) === $tomorrow ) {
 				$relative = __( 'Tomorrow' );
-			} elseif ( gmdate( 'Y', $time ) !== $year ) {
-				/* translators: Date and time format for recent posts on the dashboard, from a different calendar year, see https://www.php.net/manual/datetime.format.php */
-				$relative = date_i18n( __( 'M jS Y' ), $time );
 			} else {
 				/* translators: Date and time format for recent posts on the dashboard, see https://www.php.net/manual/datetime.format.php */
 				$relative = date_i18n( __( 'M jS' ), $time );

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1014,13 +1014,16 @@ function wp_dashboard_recent_posts( $args ) {
 
 			$time = get_the_time( 'U' );
 
-			if ( ! is_int( $time ) || gmdate( 'Y', $time ) !== $year ) {
+			if ( ! is_int( $time ) ) {
 				/* translators: Date and time format for recent posts on the dashboard, from a different calendar year, see https://www.php.net/manual/datetime.format.php */
 				$relative = date_i18n( __( 'M jS Y' ), $time );
 			} elseif ( gmdate( 'Y-m-d', $time ) === $today ) {
 				$relative = __( 'Today' );
 			} elseif ( gmdate( 'Y-m-d', $time ) === $tomorrow ) {
 				$relative = __( 'Tomorrow' );
+			} elseif ( gmdate( 'Y', $time ) !== $year ) {
+				/* translators: Date and time format for recent posts on the dashboard, from a different calendar year, see https://www.php.net/manual/datetime.format.php */
+				$relative = date_i18n( __( 'M jS Y' ), $time );
 			} else {
 				/* translators: Date and time format for recent posts on the dashboard, see https://www.php.net/manual/datetime.format.php */
 				$relative = date_i18n( __( 'M jS' ), $time );


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64496

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

# Drafted Commit Message

Administration: Avoid PHP type error with `gmdate()` in `wp_dashboard_recent_posts()`.

This fixes an issue when a non-integer is returned by `get_the_time( 'U' )` which can occur when a plugin filters `get_the_time`. The non-relative date is displayed in the Activity dashboard widget in this case.

Developed in https://github.com/WordPress/wordpress-develop/pull/10729

Props sabernhardt, vanhoucke, westonruter.
Fixes #64496.
