### PR TITLE
Twenty Nineteen: Enhance get_the_archive_title filter flexibility

### DIFF
--- a/src/wp-content/themes/twentynineteen/inc/template-functions.php
+++ b/src/wp-content/themes/twentynineteen/inc/template-functions.php
@@ -97,7 +97,7 @@ function twentynineteen_get_the_archive_title() {
 	}
 	return $title;
 }
-add_filter( 'get_the_archive_title', 'twentynineteen_get_the_archive_title' );
+add_filter( 'get_the_archive_title', 'twentynineteen_get_the_archive_title', 1 );
 
 /**
  * Adds custom 'sizes' attribute to responsive image functionality for post thumbnails.

--- a/src/wp-content/themes/twentytwenty/inc/template-tags.php
+++ b/src/wp-content/themes/twentytwenty/inc/template-tags.php
@@ -811,7 +811,7 @@ function twentytwenty_get_the_archive_title( $title ) {
 	return preg_replace( $regex['pattern'], $regex['replacement'], $title );
 }
 
-add_filter( 'get_the_archive_title', 'twentytwenty_get_the_archive_title' );
+add_filter( 'get_the_archive_title', 'twentytwenty_get_the_archive_title', 1 );
 
 /**
  * Miscellaneous


### PR DESCRIPTION
**Description**
Changes the priority of the `get_the_archive_title` filter in `twentynineteen_get_the_archive_title` from 10 to 1. This allows plugins and child themes to override the archive title using the default priority of 10, resolving conflict issues where the theme would forcefully overwrite plugin customizations.

This PR refreshes the initial patch provided by @mukesh27.

I tested the patch and confirmed that everything behaves as expected. The patch just needed a refresh, so I am submitting this PR to update the initial patch.

Tickets: https://core.trac.wordpress.org/ticket/45955

**Steps to Reproduce**
1. Install and activate the **Twenty Nineteen** theme.
2. Create and activate a helper plugin (or add to child theme's `functions.php`) with the following code to override the archive title at the default priority (10):
    ```php
        <?php
        /**
         * Plugin Name: Test Trac 45955
         */
        
        function trac_test_archive_title( $title ) {
	        return 'TEST PASSED: Plugin Override Successful';
        }
        add_filter( 'get_the_archive_title', 'trac_test_archive_title' );
    ```
3. Visit any archive page on the frontend (e.g., a Category, Tag, or Author archive).
4. Observe that the page title is **NOT** changed to "TEST PASSED...". It remains the default theme title (e.g., "Category Archives: ...").

**Test Report**
1. Apply the patch.
2. Visit the same archive page as above.
3. Observe that the page title **IS** now changed to "TEST PASSED: Plugin Override Successful".
4. This confirms the theme now allows plugins to override the title at the default priority.
