### PR TITLE
wp_dashboard_recent_comments function: avoid unnecessary SQL query

### DIFF
--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1102,7 +1102,7 @@ function wp_dashboard_recent_comments( $total_items = 5 ) {
 
 		$comments_query['offset'] += $comments_query['number'];
 		$comments_query['number']  = $total_items * 10;
-	} while ( $comments_count < $total_items && $fetch_count === count( $possible ) );
+	} while ( $comments_count < $total_items && count( $possible ) === $fetch_count );
 
 	if ( $comments ) {
 		echo '<div id="latest-comments" class="activity-block table-view-list">';

--- a/src/wp-admin/includes/dashboard.php
+++ b/src/wp-admin/includes/dashboard.php
@@ -1076,7 +1076,8 @@ function wp_dashboard_recent_comments( $total_items = 5 ) {
 
 	$comments_count = 0;
 	do {
-		$possible = get_comments( $comments_query );
+		$fetch_count = $comments_query['number'] - $comments_query['offset'];
+		$possible    = get_comments( $comments_query );
 
 		if ( empty( $possible ) || ! is_array( $possible ) ) {
 			break;
@@ -1091,8 +1092,8 @@ function wp_dashboard_recent_comments( $total_items = 5 ) {
 				continue;
 			}
 
-			$comments[]     = $comment;
-			$comments_count = count( $comments );
+			$comments[] = $comment;
+			++$comments_count;
 
 			if ( $comments_count === $total_items ) {
 				break 2;
@@ -1101,7 +1102,7 @@ function wp_dashboard_recent_comments( $total_items = 5 ) {
 
 		$comments_query['offset'] += $comments_query['number'];
 		$comments_query['number']  = $total_items * 10;
-	} while ( $comments_count < $total_items );
+	} while ( $comments_count < $total_items && $fetch_count === count( $possible ) );
 
 	if ( $comments ) {
 		echo '<div id="latest-comments" class="activity-block table-view-list">';


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

Tune `wp_dashboard_recent_comments` performance:
- further reduce the number of `count` calls (related to the history of changes in this function)
- harden while-loop condition to avoid SQLs when the last query fetched less than what was aimed (next query fetches nothing)

Trac ticket: https://core.trac.wordpress.org/ticket/64506

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
