### PR TITLE
Block Bindings: Add featured_media field(s) to core/post-data source

### DIFF
--- a/src/wp-includes/block-bindings/post-data.php
+++ b/src/wp-includes/block-bindings/post-data.php
@@ -63,6 +63,19 @@ function _block_bindings_post_data_get_value( array $source_args, $block_instanc
 		return esc_attr( get_the_date( 'c', $post_id ) );
 	}
 
+	if ( 'featured_media.id' === $field ) {
+		return get_post_thumbnail_id( $post_id );
+	}
+
+	if ( 'featured_media.url' === $field ) {
+		if ( 'core/cover' === $block_name && isset( $block_instance->attributes['sizeSlug'] ) ) {
+			$size_slug = $block_instance->attributes['sizeSlug'];
+			return get_the_post_thumbnail_url( $post_id, $size_slug );
+		}
+
+		return get_the_post_thumbnail_url( $post_id );
+	}
+
 	if ( 'modified' === $field ) {
 		// Only return the modified date if it is later than the publishing date.
 		if ( get_the_modified_date( 'U', $post_id ) > get_the_date( 'U', $post_id ) ) {


### PR DESCRIPTION
Backport for (part of) https://github.com/WordPress/gutenberg/pull/74610.

TODO: 
- [ ] Rename source item from `featured_media` to `featuredMedia`?
- [ ] Add test coverage

Trac ticket: TBD

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
