### PR TITLE
Interactivity API: Fix `data-wp-bind` to continue processing valid directives after encountering invalid ones

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -1026,7 +1026,7 @@ final class WP_Interactivity_API {
 			$entries = $this->get_directive_entries( $p, 'bind' );
 			foreach ( $entries as $entry ) {
 				if ( empty( $entry['suffix'] ) || null !== $entry['unique_id'] ) {
-						return;
+						continue;
 				}
 
 				$result = $this->evaluate( $entry );

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-bind.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-bind.php
@@ -430,4 +430,18 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 		$this->assertNull( $p->get_attribute( 'id' ) );
 		$this->assertNull( $p->get_attribute( 'id---unique-id' ) );
 	}
+
+	/**
+	 * Tests that `data-wp-bind` ignores directives with unique IDs but still
+	 * processes valid bind directives on the same element.
+	 *
+	 * @ticket XXXX
+	 *
+	 * @covers ::process_directives
+	 */
+	public function test_wp_bind_ignores_unique_id_but_processes_valid_binds() {
+		$html    = '<div data-wp-bind--id---unique-id="myPlugin::state.id" data-wp-bind--id="myPlugin::state.id">Text</div>';
+		list($p) = $this->process_directives( $html );
+		$this->assertSame( 'some-id', $p->get_attribute( 'id' ) );
+	}
 }

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-bind.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-bind.php
@@ -135,6 +135,20 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that `data-wp-bind` ignores directives with no suffix but still
+	 * processes valid bind directives on the same element.
+	 *
+	 * @ticket XXXX
+	 *
+	 * @covers ::process_directives
+	 */
+	public function test_wp_bind_ignores_empty_suffix_but_processes_valid_binds() {
+		$html    = '<div data-wp-bind="myPlugin::state.id" data-wp-bind--id="myPlugin::state.id">Text</div>';
+		list($p) = $this->process_directives( $html );
+		$this->assertSame( 'some-id', $p->get_attribute( 'id' ) );
+	}
+
+	/**
 	 * Tests that `data-wp-bind` does nothing when referencing non-existent
 	 * references.
 	 *

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-bind.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-bind.php
@@ -138,7 +138,7 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	 * Tests that `data-wp-bind` ignores directives with no suffix but still
 	 * processes valid bind directives on the same element.
 	 *
-	 * @ticket XXXX
+	 * @ticket 64518
 	 *
 	 * @covers ::process_directives
 	 */
@@ -435,7 +435,7 @@ class Tests_WP_Interactivity_API_WP_Bind extends WP_UnitTestCase {
 	 * Tests that `data-wp-bind` ignores directives with unique IDs but still
 	 * processes valid bind directives on the same element.
 	 *
-	 * @ticket XXXX
+	 * @ticket 64518
 	 *
 	 * @covers ::process_directives
 	 */


### PR DESCRIPTION
## What

This PR fixes a bug in the `data_wp_bind_processor` method where a `return` statement inside a `foreach` loop was causing the function to exit entirely when encountering a bind directive with an empty suffix or a unique ID.

## Why

When an element has multiple `data-wp-bind` directives, such as:

```html
<div data-wp-bind="myPlugin::state.id" data-wp-bind--id="myPlugin::state.id">Text</div>
```

The first directive (`data-wp-bind` with no suffix) is invalid and should be skipped. However, the `return` statement was causing the entire function to exit, preventing the valid `data-wp-bind--id` directive from being processed.

## How

Changed `return` to `continue` so that invalid entries are skipped while valid entries continue to be processed.

---

Trac ticket: https://core.trac.wordpress.org/ticket/64518

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
