### PR TITLE
Add: WordPress Core get settings ability

### DIFF
--- a/src/wp-includes/abilities.php
+++ b/src/wp-includes/abilities.php
@@ -9,6 +9,8 @@
 
 declare( strict_types = 1 );
 
+require_once __DIR__ . '/abilities/class-wp-settings-abilities.php';
+
 /**
  * Registers the core ability categories.
  *
@@ -257,4 +259,6 @@ function wp_register_core_abilities(): void {
 			),
 		)
 	);
+
+	WP_Settings_Abilities::register();
 }

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Registers core settings abilities.
+ *
+ * This is a utility class to encapsulate the registration of settings-related abilities.
+ * It is not intended to be instantiated or consumed directly by any other code or plugin.
+ *
+ * @package WordPress
+ * @subpackage Abilities_API
+ * @since 6.9.0
+ *
+ * @internal This class is not part of the public API.
+ * @access private
+ */
+
+declare( strict_types=1 );
+
+/**
+ * Registers core settings abilities.
+ *
+ * @since 6.9.0
+ * @access private
+ */
+class WP_Settings_Abilities {
+
+	/**
+	 * Registers all settings abilities.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @return void
+	 */
+	public static function register(): void {
+		self::register_get_settings();
+	}
+
+	/**
+	 * Registers the core/get-settings ability.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @return void
+	 */
+	private static function register_get_settings(): void {
+		wp_register_ability(
+			'core/get-settings',
+			array(
+				'label'               => __( 'Get Settings' ),
+				'description'         => __( 'Returns registered WordPress settings exposed to the REST API, grouped by their registration group. Returns key-value pairs similar to the REST API settings endpoint.' ),
+				'category'            => 'site',
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'group' => array(
+							'type'        => 'string',
+							'description' => __( 'Optional: Filter settings by group name (e.g., general, reading, writing, discussion).' ),
+						),
+					),
+					'additionalProperties' => false,
+					'default'              => array(),
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'description'          => __( 'Settings grouped by registration group. Each group contains key-value pairs where the key is the setting name (or REST alias) and the value is the current setting value.' ),
+					'additionalProperties' => array(
+						'type'                 => 'object',
+						'description'          => __( 'A settings group containing setting name to value mappings.' ),
+						'additionalProperties' => true,
+					),
+				),
+				'execute_callback'    => array( __CLASS__, 'execute_get_settings' ),
+				'permission_callback' => array( __CLASS__, 'check_manage_options' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readOnlyHint'    => true,
+						'destructiveHint' => false,
+						'idempotentHint'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Permission callback for settings abilities.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @return bool True if the current user can manage options, false otherwise.
+	 */
+	public static function check_manage_options(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Execute callback for core/get-settings ability.
+	 *
+	 * Retrieves all registered settings that are exposed to the REST API,
+	 * grouped by their registration group.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param array $input {
+	 *     Optional. Input parameters.
+	 *
+	 *     @type string $group Optional. Filter settings by group name.
+	 * }
+	 * @return array Settings grouped by registration group.
+	 */
+	public static function execute_get_settings( $input = array() ): array {
+		$input        = is_array( $input ) ? $input : array();
+		$filter_group = ! empty( $input['group'] ) ? $input['group'] : null;
+
+		$registered_settings = get_registered_settings();
+		$settings_by_group   = array();
+
+		foreach ( $registered_settings as $option_name => $args ) {
+			// Only include settings exposed to REST API.
+			if ( empty( $args['show_in_rest'] ) ) {
+				continue;
+			}
+
+			$group = $args['group'] ?? 'general';
+
+			// Skip if filtering by group and doesn't match.
+			if ( $filter_group && $group !== $filter_group ) {
+				continue;
+			}
+
+			// Determine the REST name (may be aliased via show_in_rest.name).
+			$rest_name = $option_name;
+			if ( is_array( $args['show_in_rest'] ) && ! empty( $args['show_in_rest']['name'] ) ) {
+				$rest_name = $args['show_in_rest']['name'];
+			}
+
+			// Get default value.
+			$default = $args['default'] ?? null;
+			if ( is_array( $args['show_in_rest'] ) && isset( $args['show_in_rest']['schema']['default'] ) ) {
+				$default = $args['show_in_rest']['schema']['default'];
+			}
+
+			// Get current value.
+			$value = get_option( $option_name, $default );
+
+			// Cast value to proper type.
+			$value = self::cast_value( $value, $args['type'] ?? 'string' );
+
+			// Initialize group if needed.
+			if ( ! isset( $settings_by_group[ $group ] ) ) {
+				$settings_by_group[ $group ] = array();
+			}
+
+			$settings_by_group[ $group ][ $rest_name ] = $value;
+		}
+
+		ksort( $settings_by_group );
+
+		return $settings_by_group;
+	}
+
+	/**
+	 * Casts a value to the appropriate type based on the setting's registered type.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @param mixed  $value The value to cast.
+	 * @param string $type  The registered type (string, boolean, integer, number, array, object).
+	 * @return mixed The cast value.
+	 */
+	private static function cast_value( $value, string $type ) {
+		switch ( $type ) {
+			case 'boolean':
+				return (bool) $value;
+			case 'integer':
+				return (int) $value;
+			case 'number':
+				return (float) $value;
+			case 'array':
+			case 'object':
+				return is_array( $value ) ? $value : array();
+			case 'string':
+			default:
+				return (string) $value;
+		}
+	}
+}

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -24,6 +24,14 @@ declare( strict_types=1 );
 class WP_Settings_Abilities {
 
 	/**
+	 * Available setting groups with show_in_rest enabled.
+	 *
+	 * @since 6.9.0
+	 * @var array
+	 */
+	private static $available_groups;
+
+	/**
 	 * Registers all settings abilities.
 	 *
 	 * @since 6.9.0
@@ -31,7 +39,45 @@ class WP_Settings_Abilities {
 	 * @return void
 	 */
 	public static function register(): void {
+		self::init();
 		self::register_get_settings();
+	}
+
+	/**
+	 * Initializes shared data for settings abilities.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @return void
+	 */
+	private static function init(): void {
+		self::$available_groups = self::get_available_groups();
+	}
+
+	/**
+	 * Gets unique setting groups that have show_in_rest enabled.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @return array List of unique group names.
+	 */
+	private static function get_available_groups(): array {
+		$groups = array();
+
+		foreach ( get_registered_settings() as $args ) {
+			if ( empty( $args['show_in_rest'] ) ) {
+				continue;
+			}
+
+			$group = $args['group'] ?? 'general';
+			if ( ! in_array( $group, $groups, true ) ) {
+				$groups[] = $group;
+			}
+		}
+
+		sort( $groups );
+
+		return $groups;
 	}
 
 	/**
@@ -53,7 +99,8 @@ class WP_Settings_Abilities {
 					'properties'           => array(
 						'group' => array(
 							'type'        => 'string',
-							'description' => __( 'Optional: Filter settings by group name (e.g., general, reading, writing, discussion).' ),
+							'description' => __( 'Filter settings by group name. If omitted, returns all groups.' ),
+							'enum'        => self::$available_groups,
 						),
 					),
 					'additionalProperties' => false,

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -322,7 +322,7 @@ class WP_Settings_Abilities {
 	 * @param string $type  The registered type (string, boolean, integer, number, array, object).
 	 * @return string|bool|int|float|array The cast value.
 	 */
-	private static function cast_value( $value, string $type ): string|bool|int|float|array {
+	private static function cast_value( $value, string $type ) {
 		switch ( $type ) {
 			case 'boolean':
 				return (bool) $value;

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -18,7 +18,7 @@ declare( strict_types=1 );
 /**
  * Registers core settings abilities.
  *
- * @since 6.9.0
+ * @since 7.0.0
  * @access private
  */
 class WP_Settings_Abilities {
@@ -26,7 +26,7 @@ class WP_Settings_Abilities {
 	/**
 	 * Available setting groups with show_in_rest enabled.
 	 *
-	 * @since 6.9.0
+	 * @since 7.0.0
 	 * @var array
 	 */
 	private static $available_groups;
@@ -34,7 +34,7 @@ class WP_Settings_Abilities {
 	/**
 	 * Dynamic output schema built from registered settings.
 	 *
-	 * @since 6.9.0
+	 * @since 7.0.0
 	 * @var array
 	 */
 	private static $output_schema;
@@ -50,7 +50,7 @@ class WP_Settings_Abilities {
 	/**
 	 * Registers all settings abilities.
 	 *
-	 * @since 6.9.0
+	 * @since 7.0.0
 	 *
 	 * @return void
 	 */
@@ -62,7 +62,7 @@ class WP_Settings_Abilities {
 	/**
 	 * Initializes shared data for settings abilities.
 	 *
-	 * @since 6.9.0
+	 * @since 7.0.0
 	 *
 	 * @return void
 	 */
@@ -75,7 +75,7 @@ class WP_Settings_Abilities {
 	/**
 	 * Gets unique setting groups that have show_in_rest enabled.
 	 *
-	 * @since 6.9.0
+	 * @since 7.0.0
 	 *
 	 * @return array List of unique group names.
 	 */
@@ -128,7 +128,7 @@ class WP_Settings_Abilities {
 	 * with their types, titles, descriptions, defaults, and any additional
 	 * schema properties from show_in_rest.
 	 *
-	 * @since 6.9.0
+	 * @since 7.0.0
 	 *
 	 * @return array JSON Schema for the output.
 	 */
@@ -185,7 +185,7 @@ class WP_Settings_Abilities {
 	/**
 	 * Registers the core/get-settings ability.
 	 *
-	 * @since 6.9.0
+	 * @since 7.0.0
 	 *
 	 * @return void
 	 */
@@ -254,7 +254,7 @@ class WP_Settings_Abilities {
 	/**
 	 * Permission callback for settings abilities.
 	 *
-	 * @since 6.9.0
+	 * @since 7.0.0
 	 *
 	 * @return bool True if the current user can manage options, false otherwise.
 	 */
@@ -268,7 +268,7 @@ class WP_Settings_Abilities {
 	 * Retrieves all registered settings that are exposed to the REST API,
 	 * grouped by their registration group.
 	 *
-	 * @since 6.9.0
+	 * @since 7.0.0
 	 *
 	 * @param array $input {
 	 *     Optional. Input parameters.
@@ -321,7 +321,7 @@ class WP_Settings_Abilities {
 	/**
 	 * Casts a value to the appropriate type based on the setting's registered type.
 	 *
-	 * @since 6.9.0
+	 * @since 7.0.0
 	 *
 	 * @param mixed  $value The value to cast.
 	 * @param string $type  The registered type (string, boolean, integer, number, array, object).

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -113,12 +113,7 @@ class WP_Settings_Abilities {
 				continue;
 			}
 
-			$rest_name = $option_name;
-			if ( is_array( $args['show_in_rest'] ) && ! empty( $args['show_in_rest']['name'] ) ) {
-				$rest_name = $args['show_in_rest']['name'];
-			}
-
-			$slugs[] = $rest_name;
+			$slugs[] = $option_name;
 		}
 
 		sort( $slugs );
@@ -147,11 +142,6 @@ class WP_Settings_Abilities {
 
 			$group = $args['group'] ?? 'general';
 
-			$rest_name = $option_name;
-			if ( is_array( $args['show_in_rest'] ) && ! empty( $args['show_in_rest']['name'] ) ) {
-				$rest_name = $args['show_in_rest']['name'];
-			}
-
 			$setting_schema = array(
 				'type' => $args['type'] ?? 'string',
 			);
@@ -164,10 +154,6 @@ class WP_Settings_Abilities {
 				$setting_schema['description'] = $args['description'];
 			} elseif ( ! empty( $args['label'] ) ) {
 				$setting_schema['description'] = $args['label'];
-			}
-
-			if ( isset( $args['default'] ) ) {
-				$setting_schema['default'] = $args['default'];
 			}
 
 			if ( ! isset( $group_properties[ $group ] ) ) {
@@ -183,7 +169,7 @@ class WP_Settings_Abilities {
 				);
 			}
 
-			$group_properties[ $group ]['properties'][ $rest_name ] = $setting_schema;
+			$group_properties[ $group ]['properties'][ $option_name ] = $setting_schema;
 		}
 
 		ksort( $group_properties );
@@ -291,19 +277,11 @@ class WP_Settings_Abilities {
 				continue;
 			}
 
-			$rest_name = $option_name;
-			if ( is_array( $args['show_in_rest'] ) && ! empty( $args['show_in_rest']['name'] ) ) {
-				$rest_name = $args['show_in_rest']['name'];
-			}
-
-			if ( $filter_slugs && ! in_array( $rest_name, $filter_slugs, true ) ) {
+			if ( $filter_slugs && ! in_array( $option_name, $filter_slugs, true ) ) {
 				continue;
 			}
 
 			$default = $args['default'] ?? null;
-			if ( is_array( $args['show_in_rest'] ) && isset( $args['show_in_rest']['schema']['default'] ) ) {
-				$default = $args['show_in_rest']['schema']['default'];
-			}
 
 			$value = get_option( $option_name, $default );
 			$value = self::cast_value( $value, $args['type'] ?? 'string' );
@@ -312,7 +290,7 @@ class WP_Settings_Abilities {
 				$settings_by_group[ $group ] = array();
 			}
 
-			$settings_by_group[ $group ][ $rest_name ] = $value;
+			$settings_by_group[ $group ][ $option_name ] = $value;
 		}
 
 		ksort( $settings_by_group );

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -334,9 +334,9 @@ class WP_Settings_Abilities {
 	 *
 	 * @param mixed  $value The value to cast.
 	 * @param string $type  The registered type (string, boolean, integer, number, array, object).
-	 * @return mixed The cast value.
+	 * @return string|bool|int|float|array The cast value.
 	 */
-	private static function cast_value( $value, string $type ) {
+	private static function cast_value( $value, string $type ): string|bool|int|float|array {
 		switch ( $type ) {
 			case 'boolean':
 				return (bool) $value;

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -192,9 +192,9 @@ class WP_Settings_Abilities {
 				'permission_callback' => array( __CLASS__, 'check_manage_options' ),
 				'meta'                => array(
 					'annotations'  => array(
-						'readOnlyHint'    => true,
-						'destructiveHint' => false,
-						'idempotentHint'  => true,
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
 					),
 					'show_in_rest' => true,
 				),

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -159,11 +159,6 @@ class WP_Settings_Abilities {
 			if ( ! isset( $group_properties[ $group ] ) ) {
 				$group_properties[ $group ] = array(
 					'type'                 => 'object',
-					'description'          => sprintf(
-						/* translators: %s: Settings group name. */
-						__( '%s settings.' ),
-						ucfirst( $group )
-					),
 					'properties'           => array(),
 					'additionalProperties' => false,
 				);

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -73,6 +73,25 @@ class WP_Settings_Abilities {
 	}
 
 	/**
+	 * Gets registered settings that have show_in_abilities enabled.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return array Associative array of option_name => args for allowed settings.
+	 */
+	private static function get_allowed_settings(): array {
+		$settings = array();
+
+		foreach ( get_registered_settings() as $option_name => $args ) {
+			if ( ! empty( $args['show_in_abilities'] ) ) {
+				$settings[ $option_name ] = $args;
+			}
+		}
+
+		return $settings;
+	}
+
+	/**
 	 * Gets unique setting groups that have show_in_abilities enabled.
 	 *
 	 * @since 7.0.0
@@ -82,11 +101,7 @@ class WP_Settings_Abilities {
 	private static function get_available_groups(): array {
 		$groups = array();
 
-		foreach ( get_registered_settings() as $args ) {
-			if ( empty( $args['show_in_abilities'] ) ) {
-				continue;
-			}
-
+		foreach ( self::get_allowed_settings() as $args ) {
 			$group = $args['group'] ?? 'general';
 			if ( ! in_array( $group, $groups, true ) ) {
 				$groups[] = $group;
@@ -108,11 +123,7 @@ class WP_Settings_Abilities {
 	private static function get_available_slugs(): array {
 		$slugs = array();
 
-		foreach ( get_registered_settings() as $option_name => $args ) {
-			if ( empty( $args['show_in_abilities'] ) ) {
-				continue;
-			}
-
+		foreach ( self::get_allowed_settings() as $option_name => $args ) {
 			$slugs[] = $option_name;
 		}
 
@@ -135,11 +146,7 @@ class WP_Settings_Abilities {
 	private static function build_output_schema(): array {
 		$group_properties = array();
 
-		foreach ( get_registered_settings() as $option_name => $args ) {
-			if ( empty( $args['show_in_abilities'] ) ) {
-				continue;
-			}
-
+		foreach ( self::get_allowed_settings() as $option_name => $args ) {
 			$group = $args['group'] ?? 'general';
 
 			$setting_schema = array(
@@ -278,14 +285,9 @@ class WP_Settings_Abilities {
 		$filter_group = ! empty( $input['group'] ) ? $input['group'] : null;
 		$filter_slugs = ! empty( $input['slugs'] ) ? $input['slugs'] : null;
 
-		$registered_settings = get_registered_settings();
-		$settings_by_group   = array();
+		$settings_by_group = array();
 
-		foreach ( $registered_settings as $option_name => $args ) {
-			if ( empty( $args['show_in_abilities'] ) ) {
-				continue;
-			}
-
+		foreach ( self::get_allowed_settings() as $option_name => $args ) {
 			$group = $args['group'] ?? 'general';
 
 			if ( $filter_group && $group !== $filter_group ) {

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -7,7 +7,7 @@
  *
  * @package WordPress
  * @subpackage Abilities_API
- * @since 6.9.0
+ * @since 7.0.0
  *
  * @internal This class is not part of the public API.
  * @access private

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -32,6 +32,14 @@ class WP_Settings_Abilities {
 	private static $available_groups;
 
 	/**
+	 * Dynamic output schema built from registered settings.
+	 *
+	 * @since 6.9.0
+	 * @var array
+	 */
+	private static $output_schema;
+
+	/**
 	 * Registers all settings abilities.
 	 *
 	 * @since 6.9.0
@@ -52,6 +60,7 @@ class WP_Settings_Abilities {
 	 */
 	private static function init(): void {
 		self::$available_groups = self::get_available_groups();
+		self::$output_schema    = self::build_output_schema();
 	}
 
 	/**
@@ -81,6 +90,85 @@ class WP_Settings_Abilities {
 	}
 
 	/**
+	 * Builds a rich output schema from registered settings metadata.
+	 *
+	 * Creates a JSON Schema that documents each setting group and its settings
+	 * with their types, titles, descriptions, defaults, and any additional
+	 * schema properties from show_in_rest.
+	 *
+	 * @since 6.9.0
+	 *
+	 * @return array JSON Schema for the output.
+	 */
+	private static function build_output_schema(): array {
+		$group_properties = array();
+
+		foreach ( get_registered_settings() as $option_name => $args ) {
+			if ( empty( $args['show_in_rest'] ) ) {
+				continue;
+			}
+
+			$group = $args['group'] ?? 'general';
+
+			// Determine the REST name (may be aliased via show_in_rest.name).
+			$rest_name = $option_name;
+			if ( is_array( $args['show_in_rest'] ) && ! empty( $args['show_in_rest']['name'] ) ) {
+				$rest_name = $args['show_in_rest']['name'];
+			}
+
+			// Build setting schema from registered metadata.
+			$setting_schema = array(
+				'type' => $args['type'] ?? 'string',
+			);
+
+			// Add title from label if available.
+			if ( ! empty( $args['label'] ) ) {
+				$setting_schema['title'] = $args['label'];
+			}
+
+			// Use description if set, otherwise fall back to label.
+			if ( ! empty( $args['description'] ) ) {
+				$setting_schema['description'] = $args['description'];
+			} elseif ( ! empty( $args['label'] ) ) {
+				$setting_schema['description'] = $args['label'];
+			}
+
+			// Include default if set.
+			if ( isset( $args['default'] ) ) {
+				$setting_schema['default'] = $args['default'];
+			}
+
+			// Merge any schema from show_in_rest (enum, format, etc.).
+			if ( is_array( $args['show_in_rest'] ) && ! empty( $args['show_in_rest']['schema'] ) ) {
+				$setting_schema = array_merge( $setting_schema, $args['show_in_rest']['schema'] );
+			}
+
+			// Initialize group if needed.
+			if ( ! isset( $group_properties[ $group ] ) ) {
+				$group_properties[ $group ] = array(
+					'type'        => 'object',
+					'description' => sprintf(
+						/* translators: %s: Settings group name. */
+						__( '%s settings.' ),
+						ucfirst( $group )
+					),
+					'properties'  => array(),
+				);
+			}
+
+			$group_properties[ $group ]['properties'][ $rest_name ] = $setting_schema;
+		}
+
+		ksort( $group_properties );
+
+		return array(
+			'type'        => 'object',
+			'description' => __( 'Settings grouped by registration group. Each group contains settings with their current values.' ),
+			'properties'  => $group_properties,
+		);
+	}
+
+	/**
 	 * Registers the core/get-settings ability.
 	 *
 	 * @since 6.9.0
@@ -106,15 +194,7 @@ class WP_Settings_Abilities {
 					'additionalProperties' => false,
 					'default'              => array(),
 				),
-				'output_schema'       => array(
-					'type'                 => 'object',
-					'description'          => __( 'Settings grouped by registration group. Each group contains key-value pairs where the key is the setting name (or REST alias) and the value is the current setting value.' ),
-					'additionalProperties' => array(
-						'type'                 => 'object',
-						'description'          => __( 'A settings group containing setting name to value mappings.' ),
-						'additionalProperties' => true,
-					),
-				),
+				'output_schema'       => self::$output_schema,
 				'execute_callback'    => array( __CLASS__, 'execute_get_settings' ),
 				'permission_callback' => array( __CLASS__, 'check_manage_options' ),
 				'meta'                => array(

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -170,19 +170,16 @@ class WP_Settings_Abilities {
 				$setting_schema['default'] = $args['default'];
 			}
 
-			if ( is_array( $args['show_in_rest'] ) && ! empty( $args['show_in_rest']['schema'] ) ) {
-				$setting_schema = array_merge( $setting_schema, $args['show_in_rest']['schema'] );
-			}
-
 			if ( ! isset( $group_properties[ $group ] ) ) {
 				$group_properties[ $group ] = array(
-					'type'        => 'object',
-					'description' => sprintf(
+					'type'                 => 'object',
+					'description'          => sprintf(
 						/* translators: %s: Settings group name. */
 						__( '%s settings.' ),
 						ucfirst( $group )
 					),
-					'properties'  => array(),
+					'properties'           => array(),
+					'additionalProperties' => false,
 				);
 			}
 
@@ -192,9 +189,10 @@ class WP_Settings_Abilities {
 		ksort( $group_properties );
 
 		return array(
-			'type'        => 'object',
-			'description' => __( 'Settings grouped by registration group. Each group contains settings with their current values.' ),
-			'properties'  => $group_properties,
+			'type'                 => 'object',
+			'description'          => __( 'Settings grouped by registration group. Each group contains settings with their current values.' ),
+			'properties'           => $group_properties,
+			'additionalProperties' => false,
 		);
 	}
 
@@ -228,11 +226,6 @@ class WP_Settings_Abilities {
 								'enum' => self::$available_slugs,
 							),
 						),
-					),
-					'oneOf'                => array(
-						array( 'required' => array( 'group' ) ),
-						array( 'required' => array( 'slugs' ) ),
-						array( 'maxProperties' => 0 ),
 					),
 					'additionalProperties' => false,
 					'default'              => array(),

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -173,7 +173,7 @@ class WP_Settings_Abilities {
 			'core/get-settings',
 			array(
 				'label'               => __( 'Get Settings' ),
-				'description'         => __( 'Returns registered WordPress settings exposed to the REST API, grouped by their registration group. Returns key-value pairs similar to the REST API settings endpoint.' ),
+				'description'         => __( 'Returns registered WordPress settings grouped by their registration group. Returns key-value pairs per setting.' ),
 				'category'            => 'site',
 				'input_schema'        => array(
 					'type'                 => 'object',

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -40,6 +40,14 @@ class WP_Settings_Abilities {
 	private static $output_schema;
 
 	/**
+	 * Available setting slugs with show_in_rest enabled.
+	 *
+	 * @since 7.0.0
+	 * @var array
+	 */
+	private static $available_slugs;
+
+	/**
 	 * Registers all settings abilities.
 	 *
 	 * @since 6.9.0
@@ -60,6 +68,7 @@ class WP_Settings_Abilities {
 	 */
 	private static function init(): void {
 		self::$available_groups = self::get_available_groups();
+		self::$available_slugs  = self::get_available_slugs();
 		self::$output_schema    = self::build_output_schema();
 	}
 
@@ -87,6 +96,34 @@ class WP_Settings_Abilities {
 		sort( $groups );
 
 		return $groups;
+	}
+
+	/**
+	 * Gets unique setting slugs that have show_in_rest enabled.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return array List of unique setting slugs.
+	 */
+	private static function get_available_slugs(): array {
+		$slugs = array();
+
+		foreach ( get_registered_settings() as $option_name => $args ) {
+			if ( empty( $args['show_in_rest'] ) ) {
+				continue;
+			}
+
+			$rest_name = $option_name;
+			if ( is_array( $args['show_in_rest'] ) && ! empty( $args['show_in_rest']['name'] ) ) {
+				$rest_name = $args['show_in_rest']['name'];
+			}
+
+			$slugs[] = $rest_name;
+		}
+
+		sort( $slugs );
+
+		return $slugs;
 	}
 
 	/**
@@ -180,9 +217,22 @@ class WP_Settings_Abilities {
 					'properties'           => array(
 						'group' => array(
 							'type'        => 'string',
-							'description' => __( 'Filter settings by group name. If omitted, returns all groups.' ),
+							'description' => __( 'Filter settings by group name. If omitted, returns all groups. Cannot be used with slugs.' ),
 							'enum'        => self::$available_groups,
 						),
+						'slugs' => array(
+							'type'        => 'array',
+							'description' => __( 'Filter settings by specific setting slugs. If omitted, returns all settings. Cannot be used with group.' ),
+							'items'       => array(
+								'type' => 'string',
+								'enum' => self::$available_slugs,
+							),
+						),
+					),
+					'oneOf'                => array(
+						array( 'required' => array( 'group' ) ),
+						array( 'required' => array( 'slugs' ) ),
+						array( 'maxProperties' => 0 ),
 					),
 					'additionalProperties' => false,
 					'default'              => array(),
@@ -224,13 +274,15 @@ class WP_Settings_Abilities {
 	 * @param array $input {
 	 *     Optional. Input parameters.
 	 *
-	 *     @type string $group Optional. Filter settings by group name.
+	 *     @type string   $group Optional. Filter settings by group name. Cannot be used with slugs.
+	 *     @type string[] $slugs Optional. Filter settings by specific setting slugs. Cannot be used with group.
 	 * }
 	 * @return array Settings grouped by registration group.
 	 */
 	public static function execute_get_settings( $input = array() ): array {
 		$input        = is_array( $input ) ? $input : array();
 		$filter_group = ! empty( $input['group'] ) ? $input['group'] : null;
+		$filter_slugs = ! empty( $input['slugs'] ) ? $input['slugs'] : null;
 
 		$registered_settings = get_registered_settings();
 		$settings_by_group   = array();
@@ -249,6 +301,10 @@ class WP_Settings_Abilities {
 			$rest_name = $option_name;
 			if ( is_array( $args['show_in_rest'] ) && ! empty( $args['show_in_rest']['name'] ) ) {
 				$rest_name = $args['show_in_rest']['name'];
+			}
+
+			if ( $filter_slugs && ! in_array( $rest_name, $filter_slugs, true ) ) {
+				continue;
 			}
 
 			$default = $args['default'] ?? null;

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -27,7 +27,7 @@ class WP_Settings_Abilities {
 	 * Available setting groups with show_in_abilities enabled.
 	 *
 	 * @since 7.0.0
-	 * @var array
+	 * @var string[]
 	 */
 	private static $available_groups;
 
@@ -43,7 +43,7 @@ class WP_Settings_Abilities {
 	 * Available setting slugs with show_in_abilities enabled.
 	 *
 	 * @since 7.0.0
-	 * @var array
+	 * @var string[]
 	 */
 	private static $available_slugs;
 
@@ -96,7 +96,7 @@ class WP_Settings_Abilities {
 	 *
 	 * @since 7.0.0
 	 *
-	 * @return array List of unique group names.
+	 * @return string[] List of unique group names.
 	 */
 	private static function get_available_groups(): array {
 		$groups = array();
@@ -118,7 +118,7 @@ class WP_Settings_Abilities {
 	 *
 	 * @since 7.0.0
 	 *
-	 * @return array List of unique setting slugs.
+	 * @return string[] List of unique setting slugs.
 	 */
 	private static function get_available_slugs(): array {
 		$slugs = array();

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -110,40 +110,33 @@ class WP_Settings_Abilities {
 
 			$group = $args['group'] ?? 'general';
 
-			// Determine the REST name (may be aliased via show_in_rest.name).
 			$rest_name = $option_name;
 			if ( is_array( $args['show_in_rest'] ) && ! empty( $args['show_in_rest']['name'] ) ) {
 				$rest_name = $args['show_in_rest']['name'];
 			}
 
-			// Build setting schema from registered metadata.
 			$setting_schema = array(
 				'type' => $args['type'] ?? 'string',
 			);
 
-			// Add title from label if available.
 			if ( ! empty( $args['label'] ) ) {
 				$setting_schema['title'] = $args['label'];
 			}
 
-			// Use description if set, otherwise fall back to label.
 			if ( ! empty( $args['description'] ) ) {
 				$setting_schema['description'] = $args['description'];
 			} elseif ( ! empty( $args['label'] ) ) {
 				$setting_schema['description'] = $args['label'];
 			}
 
-			// Include default if set.
 			if ( isset( $args['default'] ) ) {
 				$setting_schema['default'] = $args['default'];
 			}
 
-			// Merge any schema from show_in_rest (enum, format, etc.).
 			if ( is_array( $args['show_in_rest'] ) && ! empty( $args['show_in_rest']['schema'] ) ) {
 				$setting_schema = array_merge( $setting_schema, $args['show_in_rest']['schema'] );
 			}
 
-			// Initialize group if needed.
 			if ( ! isset( $group_properties[ $group ] ) ) {
 				$group_properties[ $group ] = array(
 					'type'        => 'object',
@@ -243,37 +236,29 @@ class WP_Settings_Abilities {
 		$settings_by_group   = array();
 
 		foreach ( $registered_settings as $option_name => $args ) {
-			// Only include settings exposed to REST API.
 			if ( empty( $args['show_in_rest'] ) ) {
 				continue;
 			}
 
 			$group = $args['group'] ?? 'general';
 
-			// Skip if filtering by group and doesn't match.
 			if ( $filter_group && $group !== $filter_group ) {
 				continue;
 			}
 
-			// Determine the REST name (may be aliased via show_in_rest.name).
 			$rest_name = $option_name;
 			if ( is_array( $args['show_in_rest'] ) && ! empty( $args['show_in_rest']['name'] ) ) {
 				$rest_name = $args['show_in_rest']['name'];
 			}
 
-			// Get default value.
 			$default = $args['default'] ?? null;
 			if ( is_array( $args['show_in_rest'] ) && isset( $args['show_in_rest']['schema']['default'] ) ) {
 				$default = $args['show_in_rest']['schema']['default'];
 			}
 
-			// Get current value.
 			$value = get_option( $option_name, $default );
-
-			// Cast value to proper type.
 			$value = self::cast_value( $value, $args['type'] ?? 'string' );
 
-			// Initialize group if needed.
 			if ( ! isset( $settings_by_group[ $group ] ) ) {
 				$settings_by_group[ $group ] = array();
 			}

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -24,7 +24,7 @@ declare( strict_types=1 );
 class WP_Settings_Abilities {
 
 	/**
-	 * Available setting groups with show_in_rest enabled.
+	 * Available setting groups with show_in_abilities enabled.
 	 *
 	 * @since 7.0.0
 	 * @var array
@@ -40,7 +40,7 @@ class WP_Settings_Abilities {
 	private static $output_schema;
 
 	/**
-	 * Available setting slugs with show_in_rest enabled.
+	 * Available setting slugs with show_in_abilities enabled.
 	 *
 	 * @since 7.0.0
 	 * @var array
@@ -73,7 +73,7 @@ class WP_Settings_Abilities {
 	}
 
 	/**
-	 * Gets unique setting groups that have show_in_rest enabled.
+	 * Gets unique setting groups that have show_in_abilities enabled.
 	 *
 	 * @since 7.0.0
 	 *
@@ -83,7 +83,7 @@ class WP_Settings_Abilities {
 		$groups = array();
 
 		foreach ( get_registered_settings() as $args ) {
-			if ( wp_is_serving_rest_request() && empty( $args['show_in_rest'] ) ) {
+			if ( empty( $args['show_in_abilities'] ) ) {
 				continue;
 			}
 
@@ -99,7 +99,7 @@ class WP_Settings_Abilities {
 	}
 
 	/**
-	 * Gets unique setting slugs that have show_in_rest enabled.
+	 * Gets unique setting slugs that have show_in_abilities enabled.
 	 *
 	 * @since 7.0.0
 	 *
@@ -109,7 +109,7 @@ class WP_Settings_Abilities {
 		$slugs = array();
 
 		foreach ( get_registered_settings() as $option_name => $args ) {
-			if ( wp_is_serving_rest_request() && empty( $args['show_in_rest'] ) ) {
+			if ( empty( $args['show_in_abilities'] ) ) {
 				continue;
 			}
 
@@ -136,7 +136,7 @@ class WP_Settings_Abilities {
 		$group_properties = array();
 
 		foreach ( get_registered_settings() as $option_name => $args ) {
-			if ( wp_is_serving_rest_request() && empty( $args['show_in_rest'] ) ) {
+			if ( empty( $args['show_in_abilities'] ) ) {
 				continue;
 			}
 
@@ -260,7 +260,7 @@ class WP_Settings_Abilities {
 	/**
 	 * Execute callback for core/get-settings ability.
 	 *
-	 * Retrieves all registered settings that are exposed to the REST API,
+	 * Retrieves all registered settings that are exposed through the Abilities API,
 	 * grouped by their registration group.
 	 *
 	 * @since 7.0.0
@@ -282,7 +282,7 @@ class WP_Settings_Abilities {
 		$settings_by_group   = array();
 
 		foreach ( $registered_settings as $option_name => $args ) {
-			if ( wp_is_serving_rest_request() && empty( $args['show_in_rest'] ) ) {
+			if ( empty( $args['show_in_abilities'] ) ) {
 				continue;
 			}
 

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -197,24 +197,44 @@ class WP_Settings_Abilities {
 				'description'         => __( 'Returns registered WordPress settings grouped by their registration group. Returns key-value pairs per setting.' ),
 				'category'            => 'site',
 				'input_schema'        => array(
-					'type'                 => 'object',
-					'properties'           => array(
-						'group' => array(
-							'type'        => 'string',
-							'description' => __( 'Filter settings by group name. If omitted, returns all groups. Cannot be used with slugs.' ),
-							'enum'        => self::$available_groups,
+					'default' => (object) array(),
+					'oneOf'   => array(
+						// Branch 1: No filter (empty object).
+						array(
+							'type'                 => 'object',
+							'additionalProperties' => false,
+							'maxProperties'        => 0,
 						),
-						'slugs' => array(
-							'type'        => 'array',
-							'description' => __( 'Filter settings by specific setting slugs. If omitted, returns all settings. Cannot be used with group.' ),
-							'items'       => array(
-								'type' => 'string',
-								'enum' => self::$available_slugs,
+						// Branch 2: Filter by group only.
+						array(
+							'type'                 => 'object',
+							'properties'           => array(
+								'group' => array(
+									'type'        => 'string',
+									'description' => __( 'Filter settings by group name.' ),
+									'enum'        => self::$available_groups,
+								),
 							),
+							'required'             => array( 'group' ),
+							'additionalProperties' => false,
+						),
+						// Branch 3: Filter by slugs only.
+						array(
+							'type'                 => 'object',
+							'properties'           => array(
+								'slugs' => array(
+									'type'        => 'array',
+									'description' => __( 'Filter settings by specific setting slugs.' ),
+									'items'       => array(
+										'type' => 'string',
+										'enum' => self::$available_slugs,
+									),
+								),
+							),
+							'required'             => array( 'slugs' ),
+							'additionalProperties' => false,
 						),
 					),
-					'additionalProperties' => false,
-					'default'              => array(),
 				),
 				'output_schema'       => self::$output_schema,
 				'execute_callback'    => array( __CLASS__, 'execute_get_settings' ),

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -83,7 +83,7 @@ class WP_Settings_Abilities {
 		$groups = array();
 
 		foreach ( get_registered_settings() as $args ) {
-			if ( empty( $args['show_in_rest'] ) ) {
+			if ( wp_is_serving_rest_request() && empty( $args['show_in_rest'] ) ) {
 				continue;
 			}
 
@@ -109,7 +109,7 @@ class WP_Settings_Abilities {
 		$slugs = array();
 
 		foreach ( get_registered_settings() as $option_name => $args ) {
-			if ( empty( $args['show_in_rest'] ) ) {
+			if ( wp_is_serving_rest_request() && empty( $args['show_in_rest'] ) ) {
 				continue;
 			}
 
@@ -136,7 +136,7 @@ class WP_Settings_Abilities {
 		$group_properties = array();
 
 		foreach ( get_registered_settings() as $option_name => $args ) {
-			if ( empty( $args['show_in_rest'] ) ) {
+			if ( wp_is_serving_rest_request() && empty( $args['show_in_rest'] ) ) {
 				continue;
 			}
 
@@ -267,7 +267,7 @@ class WP_Settings_Abilities {
 		$settings_by_group   = array();
 
 		foreach ( $registered_settings as $option_name => $args ) {
-			if ( empty( $args['show_in_rest'] ) ) {
+			if ( wp_is_serving_rest_request() && empty( $args['show_in_rest'] ) ) {
 				continue;
 			}
 

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2743,12 +2743,13 @@ function register_initial_settings() {
 		'general',
 		'blogname',
 		array(
-			'show_in_rest' => array(
+			'show_in_rest'      => array(
 				'name' => 'title',
 			),
-			'type'         => 'string',
-			'label'        => __( 'Title' ),
-			'description'  => __( 'Site title.' ),
+			'show_in_abilities' => true,
+			'type'              => 'string',
+			'label'             => __( 'Title' ),
+			'description'       => __( 'Site title.' ),
 		)
 	);
 
@@ -2756,12 +2757,13 @@ function register_initial_settings() {
 		'general',
 		'blogdescription',
 		array(
-			'show_in_rest' => array(
+			'show_in_rest'      => array(
 				'name' => 'description',
 			),
-			'type'         => 'string',
-			'label'        => __( 'Tagline' ),
-			'description'  => __( 'Site tagline.' ),
+			'show_in_abilities' => true,
+			'type'              => 'string',
+			'label'             => __( 'Tagline' ),
+			'description'       => __( 'Site tagline.' ),
 		)
 	);
 
@@ -2770,14 +2772,15 @@ function register_initial_settings() {
 			'general',
 			'siteurl',
 			array(
-				'show_in_rest' => array(
+				'show_in_rest'      => array(
 					'name'   => 'url',
 					'schema' => array(
 						'format' => 'uri',
 					),
 				),
-				'type'         => 'string',
-				'description'  => __( 'Site URL.' ),
+				'show_in_abilities' => true,
+				'type'              => 'string',
+				'description'       => __( 'Site URL.' ),
 			)
 		);
 	}
@@ -2787,14 +2790,15 @@ function register_initial_settings() {
 			'general',
 			'admin_email',
 			array(
-				'show_in_rest' => array(
+				'show_in_rest'      => array(
 					'name'   => 'email',
 					'schema' => array(
 						'format' => 'email',
 					),
 				),
-				'type'         => 'string',
-				'description'  => __( 'This address is used for admin purposes, like new user notification.' ),
+				'show_in_abilities' => true,
+				'type'              => 'string',
+				'description'       => __( 'This address is used for admin purposes, like new user notification.' ),
 			)
 		);
 	}
@@ -2803,11 +2807,12 @@ function register_initial_settings() {
 		'general',
 		'timezone_string',
 		array(
-			'show_in_rest' => array(
+			'show_in_rest'      => array(
 				'name' => 'timezone',
 			),
-			'type'         => 'string',
-			'description'  => __( 'A city in the same timezone as you.' ),
+			'show_in_abilities' => true,
+			'type'              => 'string',
+			'description'       => __( 'A city in the same timezone as you.' ),
 		)
 	);
 
@@ -2815,9 +2820,10 @@ function register_initial_settings() {
 		'general',
 		'date_format',
 		array(
-			'show_in_rest' => true,
-			'type'         => 'string',
-			'description'  => __( 'A date format for all date strings.' ),
+			'show_in_rest'      => true,
+			'show_in_abilities' => true,
+			'type'              => 'string',
+			'description'       => __( 'A date format for all date strings.' ),
 		)
 	);
 
@@ -2825,9 +2831,10 @@ function register_initial_settings() {
 		'general',
 		'time_format',
 		array(
-			'show_in_rest' => true,
-			'type'         => 'string',
-			'description'  => __( 'A time format for all time strings.' ),
+			'show_in_rest'      => true,
+			'show_in_abilities' => true,
+			'type'              => 'string',
+			'description'       => __( 'A time format for all time strings.' ),
 		)
 	);
 
@@ -2835,9 +2842,10 @@ function register_initial_settings() {
 		'general',
 		'start_of_week',
 		array(
-			'show_in_rest' => true,
-			'type'         => 'integer',
-			'description'  => __( 'A day number of the week that the week should start on.' ),
+			'show_in_rest'      => true,
+			'show_in_abilities' => true,
+			'type'              => 'integer',
+			'description'       => __( 'A day number of the week that the week should start on.' ),
 		)
 	);
 
@@ -2845,12 +2853,13 @@ function register_initial_settings() {
 		'general',
 		'WPLANG',
 		array(
-			'show_in_rest' => array(
+			'show_in_rest'      => array(
 				'name' => 'language',
 			),
-			'type'         => 'string',
-			'description'  => __( 'WordPress locale code.' ),
-			'default'      => 'en_US',
+			'show_in_abilities' => true,
+			'type'              => 'string',
+			'description'       => __( 'WordPress locale code.' ),
+			'default'           => 'en_US',
 		)
 	);
 
@@ -2858,10 +2867,11 @@ function register_initial_settings() {
 		'writing',
 		'use_smilies',
 		array(
-			'show_in_rest' => true,
-			'type'         => 'boolean',
-			'description'  => __( 'Convert emoticons like :-) and :-P to graphics on display.' ),
-			'default'      => true,
+			'show_in_rest'      => true,
+			'show_in_abilities' => true,
+			'type'              => 'boolean',
+			'description'       => __( 'Convert emoticons like :-) and :-P to graphics on display.' ),
+			'default'           => true,
 		)
 	);
 
@@ -2869,9 +2879,10 @@ function register_initial_settings() {
 		'writing',
 		'default_category',
 		array(
-			'show_in_rest' => true,
-			'type'         => 'integer',
-			'description'  => __( 'Default post category.' ),
+			'show_in_rest'      => true,
+			'show_in_abilities' => true,
+			'type'              => 'integer',
+			'description'       => __( 'Default post category.' ),
 		)
 	);
 
@@ -2879,9 +2890,10 @@ function register_initial_settings() {
 		'writing',
 		'default_post_format',
 		array(
-			'show_in_rest' => true,
-			'type'         => 'string',
-			'description'  => __( 'Default post format.' ),
+			'show_in_rest'      => true,
+			'show_in_abilities' => true,
+			'type'              => 'string',
+			'description'       => __( 'Default post format.' ),
 		)
 	);
 
@@ -2889,11 +2901,12 @@ function register_initial_settings() {
 		'reading',
 		'posts_per_page',
 		array(
-			'show_in_rest' => true,
-			'type'         => 'integer',
-			'label'        => __( 'Maximum posts per page' ),
-			'description'  => __( 'Blog pages show at most.' ),
-			'default'      => 10,
+			'show_in_rest'      => true,
+			'show_in_abilities' => true,
+			'type'              => 'integer',
+			'label'             => __( 'Maximum posts per page' ),
+			'description'       => __( 'Blog pages show at most.' ),
+			'default'           => 10,
 		)
 	);
 
@@ -2901,10 +2914,11 @@ function register_initial_settings() {
 		'reading',
 		'show_on_front',
 		array(
-			'show_in_rest' => true,
-			'type'         => 'string',
-			'label'        => __( 'Show on front' ),
-			'description'  => __( 'What to show on the front page' ),
+			'show_in_rest'      => true,
+			'show_in_abilities' => true,
+			'type'              => 'string',
+			'label'             => __( 'Show on front' ),
+			'description'       => __( 'What to show on the front page' ),
 		)
 	);
 
@@ -2912,10 +2926,11 @@ function register_initial_settings() {
 		'reading',
 		'page_on_front',
 		array(
-			'show_in_rest' => true,
-			'type'         => 'integer',
-			'label'        => __( 'Page on front' ),
-			'description'  => __( 'The ID of the page that should be displayed on the front page' ),
+			'show_in_rest'      => true,
+			'show_in_abilities' => true,
+			'type'              => 'integer',
+			'label'             => __( 'Page on front' ),
+			'description'       => __( 'The ID of the page that should be displayed on the front page' ),
 		)
 	);
 
@@ -2923,9 +2938,10 @@ function register_initial_settings() {
 		'reading',
 		'page_for_posts',
 		array(
-			'show_in_rest' => true,
-			'type'         => 'integer',
-			'description'  => __( 'The ID of the page that should display the latest posts' ),
+			'show_in_rest'      => true,
+			'show_in_abilities' => true,
+			'type'              => 'integer',
+			'description'       => __( 'The ID of the page that should display the latest posts' ),
 		)
 	);
 
@@ -2933,13 +2949,14 @@ function register_initial_settings() {
 		'discussion',
 		'default_ping_status',
 		array(
-			'show_in_rest' => array(
+			'show_in_rest'      => array(
 				'schema' => array(
 					'enum' => array( 'open', 'closed' ),
 				),
 			),
-			'type'         => 'string',
-			'description'  => __( 'Allow link notifications from other blogs (pingbacks and trackbacks) on new articles.' ),
+			'show_in_abilities' => true,
+			'type'              => 'string',
+			'description'       => __( 'Allow link notifications from other blogs (pingbacks and trackbacks) on new articles.' ),
 		)
 	);
 
@@ -2947,14 +2964,15 @@ function register_initial_settings() {
 		'discussion',
 		'default_comment_status',
 		array(
-			'show_in_rest' => array(
+			'show_in_rest'      => array(
 				'schema' => array(
 					'enum' => array( 'open', 'closed' ),
 				),
 			),
-			'type'         => 'string',
-			'label'        => __( 'Allow comments on new posts' ),
-			'description'  => __( 'Allow people to submit comments on new posts.' ),
+			'show_in_abilities' => true,
+			'type'              => 'string',
+			'label'             => __( 'Allow comments on new posts' ),
+			'description'       => __( 'Allow people to submit comments on new posts.' ),
 		)
 	);
 }
@@ -2985,10 +3003,12 @@ function register_initial_settings() {
  *     @type string     $label             A label of the data attached to this setting.
  *     @type string     $description       A description of the data attached to this setting.
  *     @type callable   $sanitize_callback A callback function that sanitizes the option's value.
- *     @type bool|array $show_in_rest      Whether data associated with this setting should be included in the REST API.
- *                                         When registering complex settings, this argument may optionally be an
- *                                         array with a 'schema' key.
- *     @type mixed      $default           Default value when calling `get_option()`.
+ *     @type bool|array $show_in_rest        Whether data associated with this setting should be included in the REST API.
+ *                                           When registering complex settings, this argument may optionally be an
+ *                                           array with a 'schema' key.
+ *     @type bool       $show_in_abilities  Whether this setting should be exposed through the Abilities API.
+ *                                           Default false.
+ *     @type mixed      $default            Default value when calling `get_option()`.
  * }
  */
 function register_setting( $option_group, $option_name, $args = array() ) {
@@ -3001,12 +3021,13 @@ function register_setting( $option_group, $option_name, $args = array() ) {
 	$GLOBALS['new_whitelist_options'] = &$new_allowed_options;
 
 	$defaults = array(
-		'type'              => 'string',
-		'group'             => $option_group,
-		'label'             => '',
-		'description'       => '',
-		'sanitize_callback' => null,
-		'show_in_rest'      => false,
+		'type'               => 'string',
+		'group'              => $option_group,
+		'label'              => '',
+		'description'        => '',
+		'sanitize_callback'  => null,
+		'show_in_rest'       => false,
+		'show_in_abilities'  => false,
 	);
 
 	// Back-compat: old sanitize callback is added.

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
@@ -1,0 +1,356 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Tests for the core/get-settings ability via REST API.
+ *
+ * @covers WP_Settings_Abilities
+ *
+ * @group abilities-api
+ * @group rest-api
+ */
+class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
+
+	/**
+	 * REST Server instance.
+	 *
+	 * @var WP_REST_Server
+	 */
+	protected $server;
+
+	/**
+	 * Administrator user ID.
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * Subscriber user ID.
+	 *
+	 * @var int
+	 */
+	protected static $subscriber_id;
+
+	/**
+	 * Set up before class.
+	 */
+	public static function set_up_before_class(): void {
+		parent::set_up_before_class();
+
+		self::$admin_id      = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		self::$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		// Register initial settings first so abilities can build schemas.
+		register_initial_settings();
+
+		// Ensure core abilities are registered for these tests.
+		remove_action( 'wp_abilities_api_categories_init', '_unhook_core_ability_categories_registration', 1 );
+		remove_action( 'wp_abilities_api_init', '_unhook_core_abilities_registration', 1 );
+
+		add_action( 'wp_abilities_api_categories_init', 'wp_register_core_ability_categories' );
+		add_action( 'wp_abilities_api_init', 'wp_register_core_abilities' );
+		do_action( 'wp_abilities_api_categories_init' );
+		do_action( 'wp_abilities_api_init' );
+	}
+
+	/**
+	 * Tear down after class.
+	 */
+	public static function tear_down_after_class(): void {
+		// Re-add the unhook functions for subsequent tests.
+		add_action( 'wp_abilities_api_categories_init', '_unhook_core_ability_categories_registration', 1 );
+		add_action( 'wp_abilities_api_init', '_unhook_core_abilities_registration', 1 );
+
+		// Remove the core abilities and their categories.
+		foreach ( wp_get_abilities() as $ability ) {
+			wp_unregister_ability( $ability->get_name() );
+		}
+		foreach ( wp_get_ability_categories() as $ability_category ) {
+			wp_unregister_ability_category( $ability_category->get_slug() );
+		}
+
+		parent::tear_down_after_class();
+	}
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		do_action( 'rest_api_init' );
+
+		wp_set_current_user( self::$admin_id );
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down(): void {
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Tests that unauthenticated users cannot access the get-settings ability.
+	 *
+	 * @ticket 62635
+	 */
+	public function test_core_get_settings_requires_authentication(): void {
+		wp_set_current_user( 0 );
+
+		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/**
+	 * Tests that subscribers cannot access the get-settings ability.
+	 *
+	 * @ticket 62635
+	 */
+	public function test_core_get_settings_requires_manage_options_capability(): void {
+		wp_set_current_user( self::$subscriber_id );
+
+		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * Tests that administrators can access the get-settings ability.
+	 *
+	 * @ticket 62635
+	 */
+	public function test_core_get_settings_allows_administrators(): void {
+		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * Tests that the get-settings ability returns settings grouped by registration group.
+	 *
+	 * @ticket 62635
+	 */
+	public function test_core_get_settings_returns_grouped_settings(): void {
+		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( 'general', $data );
+		$this->assertArrayHasKey( 'blogname', $data['general'] );
+		$this->assertArrayHasKey( 'blogdescription', $data['general'] );
+	}
+
+	/**
+	 * Tests that the get-settings ability can filter by group.
+	 *
+	 * @ticket 62635
+	 */
+	public function test_core_get_settings_filters_by_group(): void {
+		$request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
+		$request->set_query_params(
+			array(
+				'input' => array(
+					'group' => 'general',
+				),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertIsArray( $data );
+		$this->assertCount( 1, $data );
+		$this->assertArrayHasKey( 'general', $data );
+	}
+
+	/**
+	 * Tests that the get-settings ability can filter by specific slugs.
+	 *
+	 * @ticket 62635
+	 */
+	public function test_core_get_settings_filters_by_slugs(): void {
+		$request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
+		$request->set_query_params(
+			array(
+				'input' => array(
+					'slugs' => array( 'blogname', 'blogdescription' ),
+				),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( 'general', $data );
+		$this->assertCount( 2, $data['general'] );
+		$this->assertArrayHasKey( 'blogname', $data['general'] );
+		$this->assertArrayHasKey( 'blogdescription', $data['general'] );
+	}
+
+	/**
+	 * Tests that settings without show_in_abilities are excluded.
+	 *
+	 * @ticket 62635
+	 */
+	public function test_core_get_settings_excludes_settings_without_show_in_abilities(): void {
+		register_setting(
+			'general',
+			'test_setting_excluded',
+			array(
+				'type'              => 'string',
+				'default'           => 'test_value',
+				'show_in_abilities' => false,
+			)
+		);
+		update_option( 'test_setting_excluded', 'test_value' );
+
+		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertArrayNotHasKey( 'test_setting_excluded', $data['general'] ?? array() );
+
+		unregister_setting( 'general', 'test_setting_excluded' );
+		delete_option( 'test_setting_excluded' );
+	}
+
+	/**
+	 * Tests that core settings with show_in_abilities are included.
+	 *
+	 * @ticket 62635
+	 */
+	public function test_core_get_settings_includes_settings_with_show_in_abilities(): void {
+		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		// blogname has show_in_abilities => true in register_initial_settings().
+		$this->assertArrayHasKey( 'general', $data );
+		$this->assertArrayHasKey( 'blogname', $data['general'] );
+
+		// use_smilies has show_in_abilities => true.
+		$this->assertArrayHasKey( 'writing', $data );
+		$this->assertArrayHasKey( 'use_smilies', $data['writing'] );
+	}
+
+	/**
+	 * Tests that boolean settings are cast to actual booleans.
+	 *
+	 * @ticket 62635
+	 */
+	public function test_core_get_settings_casts_boolean_values(): void {
+		$request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
+		$request->set_query_params(
+			array(
+				'input' => array(
+					'slugs' => array( 'use_smilies' ),
+				),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'writing', $data );
+		$this->assertArrayHasKey( 'use_smilies', $data['writing'] );
+		$this->assertIsBool( $data['writing']['use_smilies'] );
+	}
+
+	/**
+	 * Tests that integer settings are cast to actual integers.
+	 *
+	 * @ticket 62635
+	 */
+	public function test_core_get_settings_casts_integer_values(): void {
+		$request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
+		$request->set_query_params(
+			array(
+				'input' => array(
+					'slugs' => array( 'start_of_week' ),
+				),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'general', $data );
+		$this->assertArrayHasKey( 'start_of_week', $data['general'] );
+		$this->assertIsInt( $data['general']['start_of_week'] );
+	}
+
+	/**
+	 * Tests that the get-settings ability requires GET method (read-only).
+	 *
+	 * @ticket 62635
+	 */
+	public function test_core_get_settings_requires_get_method(): void {
+		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/get-settings/run' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( array( 'input' => array() ) ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 405, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( 'rest_ability_invalid_method', $data['code'] );
+	}
+
+	/**
+	 * Tests that the get-settings ability returns correct values.
+	 *
+	 * @ticket 62635
+	 */
+	public function test_core_get_settings_returns_correct_values(): void {
+		update_option( 'blogname', 'Test Site Name' );
+
+		$request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
+		$request->set_query_params(
+			array(
+				'input' => array(
+					'slugs' => array( 'blogname' ),
+				),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertSame( 'Test Site Name', $data['general']['blogname'] );
+	}
+}

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
@@ -102,7 +102,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that unauthenticated users cannot access the get-settings ability.
 	 *
-	 * @ticket 62635
+	 * @ticket 64605
 	 */
 	public function test_core_get_settings_requires_authentication(): void {
 		wp_set_current_user( 0 );
@@ -116,7 +116,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that subscribers cannot access the get-settings ability.
 	 *
-	 * @ticket 62635
+	 * @ticket 64605
 	 */
 	public function test_core_get_settings_requires_manage_options_capability(): void {
 		wp_set_current_user( self::$subscriber_id );
@@ -130,7 +130,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that administrators can access the get-settings ability.
 	 *
-	 * @ticket 62635
+	 * @ticket 64605
 	 */
 	public function test_core_get_settings_allows_administrators(): void {
 		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
@@ -142,7 +142,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that the get-settings ability returns settings grouped by registration group.
 	 *
-	 * @ticket 62635
+	 * @ticket 64605
 	 */
 	public function test_core_get_settings_returns_grouped_settings(): void {
 		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
@@ -161,7 +161,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that the get-settings ability can filter by group.
 	 *
-	 * @ticket 62635
+	 * @ticket 64605
 	 */
 	public function test_core_get_settings_filters_by_group(): void {
 		$request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
@@ -186,7 +186,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that the get-settings ability can filter by specific slugs.
 	 *
-	 * @ticket 62635
+	 * @ticket 64605
 	 */
 	public function test_core_get_settings_filters_by_slugs(): void {
 		$request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
@@ -213,7 +213,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that settings without show_in_abilities are excluded.
 	 *
-	 * @ticket 62635
+	 * @ticket 64605
 	 */
 	public function test_core_get_settings_excludes_settings_without_show_in_abilities(): void {
 		register_setting(
@@ -243,7 +243,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that core settings with show_in_abilities are included.
 	 *
-	 * @ticket 62635
+	 * @ticket 64605
 	 */
 	public function test_core_get_settings_includes_settings_with_show_in_abilities(): void {
 		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
@@ -265,7 +265,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that boolean settings are cast to actual booleans.
 	 *
-	 * @ticket 62635
+	 * @ticket 64605
 	 */
 	public function test_core_get_settings_casts_boolean_values(): void {
 		$request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
@@ -290,7 +290,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that integer settings are cast to actual integers.
 	 *
-	 * @ticket 62635
+	 * @ticket 64605
 	 */
 	public function test_core_get_settings_casts_integer_values(): void {
 		$request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
@@ -315,7 +315,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that the get-settings ability requires GET method (read-only).
 	 *
-	 * @ticket 62635
+	 * @ticket 64605
 	 */
 	public function test_core_get_settings_requires_get_method(): void {
 		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/get-settings/run' );
@@ -332,7 +332,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that the get-settings ability returns correct values.
 	 *
-	 * @ticket 62635
+	 * @ticket 64605
 	 */
 	public function test_core_get_settings_returns_correct_values(): void {
 		update_option( 'blogname', 'Test Site Name' );


### PR DESCRIPTION
Part of: https://github.com/WordPress/ai/issues/40
Inspired by the work on https://github.com/galatanovidiu/mcp-adapter-implementation-example/tree/experiment/layerd-mcp-tools/includes/Abilities by @galatanovidiu.
Ticket: https://core.trac.wordpress.org/ticket/64605
## Summary

This PR adds a `core/get-settings` ability to the WordPress Abilities API. This ability dynamically discovers and exposes all WordPress settings. For now all abilities that are register `show_in_rest = true` are exposed. We should probably have a setting related to the ability exposition but can be a follow.


## Organization

Following the pattern established in https://github.com/WordPress/wordpress-develop/pull/10665, this PR adds a new class `WP_Settings_Abilities` in `src/wp-includes/abilities/class-wp-settings-abilities.php`. The class is organized into:

* **Initialization**: `init()` method that collects available groups and builds the output schema
* **Schema Building**: `build_output_schema()` creates a rich JSON Schema from registered settings metadata
* **Ability Registration**: `register_get_settings()` registers the ability with dynamic schemas
* **Execution**: `execute_get_settings()` retrieves and returns settings grouped by their registration group
* **Utilities**: Helper methods for permission checking and value type casting

## Test plan

* Open `http://localhost:6888/site-wp-dev-1/wp-admin/post-new.php`
* Open the browser console and run the following examples:

```javascript
// Get all settings
await wp.apiFetch({
  path: wp.url.addQueryArgs(
    '/wp-abilities/v1/abilities/core/get-settings/run'
  )
});
```

* [ ] Verify all settings are returned grouped by their registration group (general, reading, writing, discussion)

```javascript
// Get only general settings
await wp.apiFetch({
  path: wp.url.addQueryArgs(
    '/wp-abilities/v1/abilities/core/get-settings/run',
   { input: { group: 'general' } } 
)});
```

* [ ] Verify only general settings are returned when filtering by group

```javascript
// Check the ability schema
await wp.apiFetch({
  path: '/wp-abilities/v1/abilities/core/get-settings'
});
```

* [ ] Verify the input schema includes a dynamic `enum` of available groups
* [ ] Verify the output schema documents each group and its settings with types, descriptions, and defaults

* [ ] Test permission check: Verify non-admin users cannot access the ability (requires `manage_options` capability)
