### PR TITLE
wpdb: catch mysqli exceptions in _do_query()

### DIFF
--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -2348,7 +2348,12 @@ class wpdb {
 		}
 
 		if ( ! empty( $this->dbh ) ) {
-			$this->result = mysqli_query( $this->dbh, $query );
+		    try {
+		        $this->result = mysqli_query( $this->dbh, $query );
+		    } catch ( Exception $e ) {
+		        $this->result = false;
+		        $this->last_error = $e->getMessage();
+		    }
 		}
 
 		++$this->num_queries;

--- a/src/wp-includes/class-wpdb.php
+++ b/src/wp-includes/class-wpdb.php
@@ -2348,12 +2348,11 @@ class wpdb {
 		}
 
 		if ( ! empty( $this->dbh ) ) {
-		    try {
-		        $this->result = mysqli_query( $this->dbh, $query );
-		    } catch ( Exception $e ) {
-		        $this->result = false;
-		        $this->last_error = $e->getMessage();
-		    }
+			try {
+				$this->result = mysqli_query( $this->dbh, $query );
+			} catch ( mysqli_sql_exception $exception ) {
+				$this->last_error = $exception->getMessage();
+			}
 		}
 
 		++$this->num_queries;


### PR DESCRIPTION
Fixes #64523

This PR wraps wpdb::_do_query() mysqli_query() calls in a try/catch block
to prevent fatal errors when mysqli exception mode is enabled
(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT).

Steps to test:
1. Enable mysqli exception mode via mysqli_report().
2. Run an invalid query using $wpdb->query().
3. Confirm no fatal error occurs and $wpdb->last_error is set.
