### PR TITLE
Fix missing space before troubleshooting link in fatal error handler

### DIFF
--- a/src/wp-includes/class-wp-fatal-error-handler.php
+++ b/src/wp-includes/class-wp-fatal-error-handler.php
@@ -201,7 +201,7 @@ class WP_Fatal_Error_Handler {
 		}
 
 		$message = sprintf(
-			'<p>%s</p><p><a href="%s">%s</a></p>',
+			'<p>%s</p><p> <a href="%s">%s</a></p>',
 			$message,
 			/* translators: Documentation about troubleshooting. */
 			__( 'https://wordpress.org/documentation/article/faq-troubleshooting/' ),


### PR DESCRIPTION
Adds whitespace between fatal error message and troubleshooting link. Prevents sentence concatenation like "forums.Learn more".

Trac ticket: [#64527](https://core.trac.wordpress.org/ticket/64527)