### PR TITLE
Plugin Upgrader: Fix reactivation of renamed plugins after update

### DIFF
--- a/src/wp-admin/includes/class-wp-upgrader.php
+++ b/src/wp-admin/includes/class-wp-upgrader.php
@@ -718,6 +718,28 @@ class WP_Upgrader {
 
 		$this->result = compact( 'source', 'source_files', 'destination', 'destination_name', 'local_destination', 'remote_destination', 'clear_destination' );
 
+		// Reactivate plugin if it was previously active and the plugin slug changed.
+		if ( ! empty( $args['hook_extra']['plugin'] ) ) {
+
+			$old_plugin = $args['hook_extra']['plugin'];
+			$old_slug   = dirname( $old_plugin );
+			$new_slug   = $this->result['destination_name'];
+
+			if ( $new_slug && $new_slug !== $old_slug ) {
+
+				wp_clean_plugins_cache( true );
+
+				$plugins = get_plugins( '/' . $new_slug );
+
+				if ( ! empty( $plugins ) ) {
+					$new_main_file = array_key_first( $plugins );
+					$new_plugin    = $new_slug . '/' . $new_main_file;
+
+					activate_plugins( array( $new_plugin ), '', false, true );
+				}
+			}
+		}
+
 		/**
 		 * Filters the installation response after the installation has finished.
 		 *


### PR DESCRIPTION
When a plugin is renamed between versions (directory or main file),
WordPress deactivates the old plugin during upgrade but fails to reactivate
the new one because the original plugin path no longer exists.

This patch detects slug changes after installation and reactivates the new plugin
if the previous version was active.

Fixes https://core.trac.wordpress.org/ticket/60550