### PR TITLE
HTML API: Fix missing null-check in wp_kses_hair() refactor.

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -1623,6 +1623,11 @@ function wp_kses_hair( $attr, $allowed_protocols ) {
 	$processor = new WP_HTML_Tag_Processor( "<wp {$attr}>" );
 	$processor->next_token();
 
+	$attribute_names = $processor->get_attribute_names_with_prefix( '' );
+	if ( ! isset( $attribute_names ) ) {
+		return $attributes;
+	}
+
 	$syntax_characters = array(
 		'&' => '&amp;',
 		'<' => '&lt;',
@@ -1631,7 +1636,7 @@ function wp_kses_hair( $attr, $allowed_protocols ) {
 		'"' => '&quot;',
 	);
 
-	foreach ( $processor->get_attribute_names_with_prefix( '' ) as $name ) {
+	foreach ( $attribute_names as $name ) {
 		$value   = $processor->get_attribute( $name );
 		$is_bool = true === $value;
 		if ( is_string( $value ) && in_array( $name, $uris, true ) ) {

--- a/tests/phpunit/tests/kses/wpKsesHair.php
+++ b/tests/phpunit/tests/kses/wpKsesHair.php
@@ -39,6 +39,28 @@ class Tests_Kses_WpKsesHair extends WP_UnitTestCase {
 	 * @return Generator
 	 */
 	public function data_attribute_parsing() {
+		yield 'empty attributes' => array(
+			'',
+			array(),
+		);
+
+		yield 'prematurely-terminated attributes' => array(
+			'>',
+			array(),
+		);
+
+		yield 'prematurely-terminated malformed attributes' => array(
+			'foo>bar="baz"',
+			array(
+				'foo' => array(
+					'name'  => 'foo',
+					'value' => '',
+					'whole' => 'foo',
+					'vless' => 'y',
+				),
+			),
+		);
+
 		yield 'single attribute with double quotes' => array(
 			'class="test-class"',
 			array(


### PR DESCRIPTION
## Status

 - [x] Add test case to cover/catch this.

## Description

Trac ticket: Core-63724

When no attributes are present, `wp_kses_hair()` should return an empty array, but when the refactor was merged, the code assumed there would be attributes.

An alternative fix is to use null-coalescing to iterate over an empty array. This would produce a marginally smaller function and read slightly more cleanly, but there’s no need to enter the `foreach` loop when it’s known in advance that there’s nothing over which to iterate.

Developed in: https://github.com/WordPress/wordpress-develop/pull/10758
Discussed in: https://core.trac.wordpress.org/ticket/63724

Follow-up to: [61467]
Props: dd32, dmsnell.
See: Core-63724