### PR TITLE
Prefer published post for singular slug queries

### DIFF
--- a/src/wp-includes/class-wp-query.php
+++ b/src/wp-includes/class-wp-query.php
@@ -2539,6 +2539,14 @@ class WP_Query {
 			}
 		}
 
+		if ( '' !== $orderby
+			&& empty( $query_vars['post_status'] )
+			&& ( '' !== $query_vars['name'] || '' !== $query_vars['pagename'] || '' !== $query_vars['attachment'] )
+		) {
+			// Prefer published posts for singular slug/path queries unless a post_status was requested.
+			$orderby = "{$wpdb->posts}.post_status = 'publish' DESC, $orderby";
+		}
+
 		// Order search results by relevance only when another "orderby" is not specified in the query.
 		if ( ! empty( $query_vars['s'] ) ) {
 			$search_orderby = '';

--- a/tests/phpunit/tests/post/query.php
+++ b/tests/phpunit/tests/post/query.php
@@ -327,6 +327,42 @@ class Tests_Post_Query extends WP_UnitTestCase {
 		$this->assertSame( $ordered, wp_list_pluck( $q->posts, 'post_name' ) );
 	}
 
+	/**
+	 * @ticket 47988
+	 */
+	public function test_singular_name_query_prefers_published_post_over_draft_with_same_slug() {
+		$slug = 'shared-slug-47988';
+
+		$published_id = self::factory()->post->create(
+			array(
+				'post_name'     => $slug,
+				'post_status'   => 'publish',
+				'post_date'     => '2023-01-01 00:00:00',
+				'post_date_gmt' => '2023-01-01 00:00:00',
+			)
+		);
+
+		// Make the draft newer so post_date DESC would normally pick it first.
+		$draft_id = self::factory()->post->create(
+			array(
+				'post_name'     => $slug,
+				'post_status'   => 'draft',
+				'post_date'     => '2023-01-02 00:00:00',
+				'post_date_gmt' => '2023-01-02 00:00:00',
+			)
+		);
+
+		$query = new WP_Query(
+			array(
+				'name'      => $slug,
+				'post_type' => 'post',
+			)
+		);
+
+		$this->assertNotEmpty( $query->posts );
+		$this->assertSame( array( $published_id, $draft_id ), wp_list_pluck( $query->posts, 'ID' ) );
+	}
+
 	public function test_post_status() {
 		$statuses1 = get_post_stati();
 		$this->assertContains( 'auto-draft', $statuses1 );


### PR DESCRIPTION
## Summary
- Prefer published posts when resolving singular slug/path queries without explicit post_status.
- Add a unit test covering draft vs published slug conflicts.

## Testing
- ./vendor/bin/phpunit --filter test_singular_name_query_prefers_published_post_over_draft_with_same_slug tests/phpunit/tests/post/query.php
- ./vendor/bin/phpunit tests/phpunit/tests/post/query.php

See: https://core.trac.wordpress.org/ticket/47988