### PR TITLE
KSES: Early-abort in wp_kses_hair() when no attributes exist.

### DIFF
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -1624,7 +1624,7 @@ function wp_kses_hair( $attr, $allowed_protocols ) {
 	$processor->next_token();
 
 	$attribute_names = $processor->get_attribute_names_with_prefix( '' );
-	if ( ! isset( $attribute_names ) ) {
+	if ( null === $attribute_names || 0 === count( $attribute_names ) ) {
 		return $attributes;
 	}
 


### PR DESCRIPTION
Trac ticket: Core-63724

When `wp_kses_hair()` calls into the HTML API to parse an attribute string, it checks if the result might be `null` and returns early, skipping a few minor operations. It could also skip when the returned attribute count is zero.

This patch adds the additional check and early-return.

Developed in:
Discussed in: https://core.trac.wordpress.org/ticket/63724

Follow-up to [[61499]](https://core.trac.wordpress.org/changeset/61499).
Props dd32, dmsnell.