### PR TITLE
Tests: Ensure whitespace appears in assertEqualHTML tests

### DIFF
--- a/tests/phpunit/includes/build-visual-html-tree.php
+++ b/tests/phpunit/includes/build-visual-html-tree.php
@@ -202,7 +202,7 @@ function build_visual_html_tree( string $html, ?string $fragment_context ): stri
 			case '#cdata-section':
 			case '#text':
 				$text_content = $processor->get_modifiable_text();
-				if ( '' === trim( $text_content, " \f\t\r\n" ) ) {
+				if ( '' === $text_content ) {
 					break;
 				}
 				$was_text = true;

--- a/tests/phpunit/includes/build-visual-html-tree.php
+++ b/tests/phpunit/includes/build-visual-html-tree.php
@@ -237,7 +237,7 @@ function build_visual_html_tree( string $html, ?string $fragment_context ): stri
 							++$indent_level;
 						}
 
-						// If there are no attributes, we're done here.
+						// When no attributes are present, there’s nothing left to do.
 						if ( empty( $block_attrs ) ) {
 							break;
 						}

--- a/tests/phpunit/includes/build-visual-html-tree.php
+++ b/tests/phpunit/includes/build-visual-html-tree.php
@@ -237,7 +237,7 @@ function build_visual_html_tree( string $html, ?string $fragment_context ): stri
 							++$indent_level;
 						}
 
-						// If they're no attributes, we're done here.
+						// If there are no attributes, we're done here.
 						if ( empty( $block_attrs ) ) {
 							break;
 						}

--- a/tests/phpunit/tests/block-template-utils.php
+++ b/tests/phpunit/tests/block-template-utils.php
@@ -306,10 +306,9 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	 */
 	public function test_block_template_add_skip_link_inserts_link_and_adds_main_id_when_missing() {
 		$template_html = '<div class="wp-site-blocks"><main>Content</main></div>';
-		$expected      = '
-			<a class="skip-link screen-reader-text" id="wp-skip-link" href="#wp--skip-link--target">Skip to content</a>
-			<div class="wp-site-blocks"><main id="wp--skip-link--target">Content</main></div>
-		';
+		$expected      =
+			'<a class="skip-link screen-reader-text" id="wp-skip-link" href="#wp--skip-link--target">Skip to content</a>' .
+			'<div class="wp-site-blocks"><main id="wp--skip-link--target">Content</main></div>';
 
 		$this->assertEqualHTML( $expected, _block_template_add_skip_link( $template_html ) );
 	}
@@ -323,10 +322,9 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	 */
 	public function test_block_template_add_skip_link_uses_existing_main_id() {
 		$template_html = '<div class="wp-site-blocks"><main id="custom-id">Content</main></div>';
-		$expected      = '
-			<a class="skip-link screen-reader-text" id="wp-skip-link" href="#custom-id">Skip to content</a>
-			<div class="wp-site-blocks"><main id="custom-id">Content</main></div>
-		';
+		$expected      =
+			'<a class="skip-link screen-reader-text" id="wp-skip-link" href="#custom-id">Skip to content</a>' .
+			'<div class="wp-site-blocks"><main id="custom-id">Content</main></div>';
 
 		$this->assertEqualHTML( $expected, _block_template_add_skip_link( $template_html ) );
 	}
@@ -340,10 +338,9 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	 */
 	public function test_block_template_add_skip_link_handles_boolean_main_id() {
 		$template_html = '<div class="wp-site-blocks"><main id>Content</main></div>';
-		$expected      = '
-			<a class="skip-link screen-reader-text" id="wp-skip-link" href="#wp--skip-link--target">Skip to content</a>
-			<div class="wp-site-blocks"><main id="wp--skip-link--target">Content</main></div>
-		';
+		$expected      =
+			'<a class="skip-link screen-reader-text" id="wp-skip-link" href="#wp--skip-link--target">Skip to content</a>' .
+			'<div class="wp-site-blocks"><main id="wp--skip-link--target">Content</main></div>';
 
 		$this->assertEqualHTML( $expected, _block_template_add_skip_link( $template_html ) );
 	}
@@ -357,10 +354,9 @@ class Tests_Block_Template_Utils extends WP_UnitTestCase {
 	 */
 	public function test_block_template_add_skip_link_preserves_whitespace_main_id() {
 		$template_html = '<div class="wp-site-blocks"><main id=" my-id ">Content</main></div>';
-		$expected      = '
-			<a class="skip-link screen-reader-text" id="wp-skip-link" href="#%20my-id%20">Skip to content</a>
-			<div class="wp-site-blocks"><main id=" my-id ">Content</main></div>
-		';
+		$expected      =
+			'<a class="skip-link screen-reader-text" id="wp-skip-link" href="#%20my-id%20">Skip to content</a>' .
+			'<div class="wp-site-blocks"><main id=" my-id ">Content</main></div>';
 
 		$this->assertEqualHTML( $expected, _block_template_add_skip_link( $template_html ) );
 	}

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -682,7 +682,7 @@ HTML;
 			$expected_rendered_block,
 			$rendered_block,
 			'<body>',
-			"Rendered block does not contain expected HTML:\n$rendered_block"
+			'Rendered block does not contain expected HTML.'
 		);
 	}
 

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -708,7 +708,7 @@ HTML
 		);
 
 		// TODO: Why not use do_blocks() instead?
-		$parsed_blocks  = parse_blocks( trim( $block_markup ) );
+		$parsed_blocks  = parse_blocks( $block_markup );
 		$parsed_block   = $parsed_blocks[0];
 		$context        = array();
 		$block          = new WP_Block( $parsed_block, $context, $this->registry );

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -718,16 +718,6 @@ HTML
 		$this->assertSameSets( $expected_scripts, wp_scripts()->queue, 'Enqueued scripts do not meet expectations' );
 		$this->assertSameSets( $expected_script_modules, wp_script_modules()->get_queue(), 'Enqueued script modules do not meet expectations' );
 
-		//echo "\n===\n";
-		//var_export( $rendered_block );
-		echo "\n===\n";
-		var_export( self::replaceInvisible( $rendered_block ) );
-		//echo "\n===\n";
-		//var_export( $expected_rendered_block );
-		echo "\n===\n";
-		var_export( self::replaceInvisible( $expected_rendered_block ) );
-		echo "\n===\n";
-
 		$this->assertEqualHTML(
 			$expected_rendered_block,
 			$rendered_block,
@@ -1490,27 +1480,5 @@ HTML
 		$this->assertSame( 2, $pre_render_callback->get_call_count() );
 		$this->assertSame( 2, $render_block_data_callback->get_call_count() );
 		$this->assertSame( 2, $render_block_context_callback->get_call_count() );
-	}
-
-	private static function replaceInvisible( string $s ): string {
-		return preg_replace_callback(
-			'/[\\x00-\\x1F\\x7F]/u',
-			static function ( array $matches ): string {
-				$codePoint = /** @type {number} */ ord($matches[0]);
-				switch ( $codePoint ) {
-					// U+007F DELETE -> U+2421 SYMBOL FOR DELETE
-					case 0x7f:
-						return "\u{2421}";
-
-					// Include a newline with newline replacement
-					case 0x0a:
-						return "\u{240A}\n";
-				}
-
-				// There's a nice Control Pictures Block at 0x2400 offset for the matched range
-				return mb_chr( $codePoint + 0x2400 );
-			},
-			$s
-		);
 	}
 }

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -371,13 +371,13 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 		$block_markup = <<<'HTML'
 <!-- wp:static -->
 <div class="static">
-	<!-- wp:static-child -->
-	<div class="static-child">First child</div>
-	<!-- /wp:static-child -->
-	<!-- wp:dynamic /-->
-	<!-- wp:static-child -->
-	<div class="static-child">Last child</div>
-	<!-- /wp:static-child -->
+<!-- wp:static-child -->
+<div class="static-child">First child</div>
+<!-- /wp:static-child -->
+<!-- wp:dynamic /-->
+<!-- wp:static-child -->
+<div class="static-child">Last child</div>
+<!-- /wp:static-child -->
 </div>
 <!-- /wp:static -->
 HTML;
@@ -390,13 +390,13 @@ HTML;
 				'expected_rendered_block' => <<<'HTML'
 
 <div class="static">
-&#x9;
-	<div class="static-child">First child</div>
-&#x9;
-	<p class="dynamic">Hello World!</p>
-&#x9;
-	<div class="static-child">Last child</div>
-&#x9;
+
+<div class="static-child">First child</div>
+
+<p class="dynamic">Hello World!</p>
+
+<div class="static-child">Last child</div>
+
 </div>
 
 HTML
@@ -424,13 +424,13 @@ HTML
 				'expected_rendered_block' => <<<'HTML'
 
 <div class="static">
-&#x9;
-	<div class="static-child">First child</div>
-&#x9;
-	<p class="dynamic filtered">Hello World!</p>
-&#x9;
-	<div class="static-child">Last child</div>
-&#x9;
+
+<div class="static-child">First child</div>
+
+<p class="dynamic filtered">Hello World!</p>
+
+<div class="static-child">Last child</div>
+
 </div>
 
 HTML
@@ -447,13 +447,13 @@ HTML
 				'expected_rendered_block' => <<<'HTML'
 
 <div class="static">
-&#x9;
-	<div class="static-child">First child</div>
-&#x9;
-&#x9;
-&#x9;
-	<div class="static-child">Last child</div>
-&#x9;
+
+<div class="static-child">First child</div>
+
+
+
+<div class="static-child">Last child</div>
+
 </div>
 
 HTML
@@ -481,13 +481,13 @@ HTML
 				'expected_rendered_block' => <<<'HTML'
 
 <div class="static">
-&#x9;
-	<div class="static-child">First child</div>
-&#x9;
-&#x9;
-&#x9;
-	<div class="static-child">Last child</div>
-&#x9;
+
+<div class="static-child">First child</div>
+
+
+
+<div class="static-child">Last child</div>
+
 </div>
 
 HTML
@@ -521,9 +521,9 @@ HTML
 				'expected_rendered_block' => <<<'HTML'
 
 <div class="static">
-&#x9;
-	<p class="dynamic">Hello World!</p>
-&#x9;
+
+<p class="dynamic">Hello World!</p>
+
 </div>
 
 HTML
@@ -550,11 +550,11 @@ HTML
 				'expected_rendered_block' => <<<'HTML'
 
 <div class="static">
-&#x9;
-	<div class="static-child">First child</div>
-&#x9;
-	<p class="dynamic">Hello World!</p>
-&#x9;
+
+<div class="static-child">First child</div>
+
+<p class="dynamic">Hello World!</p>
+
 </div>
 
 HTML

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -387,13 +387,20 @@ HTML;
 			'all_printed'                             => array(
 				'set_up'                  => null,
 				'block_markup'            => $block_markup,
-				'expected_rendered_block' => '
-					<div class="static">
-						<div class="static-child">First child</div>
-						<p class="dynamic">Hello World!</p>
-						<div class="static-child">Last child</div>
-					</div>
-				',
+				'expected_rendered_block' => <<<'HTML'
+
+<div class="static">
+&#x9;
+	<div class="static-child">First child</div>
+&#x9;
+	<p class="dynamic">Hello World!</p>
+&#x9;
+	<div class="static-child">Last child</div>
+&#x9;
+</div>
+
+HTML
+				,
 				'expected_styles'         => array( 'static-view-style', 'static-child-view-style', 'dynamic-view-style' ),
 				'expected_scripts'        => array( 'static-view-script', 'static-child-view-script', 'dynamic-view-script' ),
 				'expected_script_modules' => array( 'static-view-script-module', 'static-child-view-script-module', 'dynamic-view-script-module' ),
@@ -414,13 +421,20 @@ HTML;
 					);
 				},
 				'block_markup'            => $block_markup,
-				'expected_rendered_block' => '
-					<div class="static">
-						<div class="static-child">First child</div>
-						<p class="dynamic filtered">Hello World!</p>
-						<div class="static-child">Last child</div>
-					</div>
-				',
+				'expected_rendered_block' => <<<'HTML'
+
+<div class="static">
+&#x9;
+	<div class="static-child">First child</div>
+&#x9;
+	<p class="dynamic filtered">Hello World!</p>
+&#x9;
+	<div class="static-child">Last child</div>
+&#x9;
+</div>
+
+HTML
+				,
 				'expected_styles'         => array( 'static-view-style', 'dynamic-extra', 'static-child-view-style', 'dynamic-view-style' ),
 				'expected_scripts'        => array( 'static-view-script', 'static-child-view-script', 'dynamic-view-script' ),
 				'expected_script_modules' => array( 'static-view-script-module', 'static-child-view-script-module', 'dynamic-view-script-module' ),
@@ -430,12 +444,20 @@ HTML;
 					add_filter( 'render_block_core/dynamic', '__return_empty_string' );
 				},
 				'block_markup'            => $block_markup,
-				'expected_rendered_block' => '
-					<div class="static">
-						<div class="static-child">First child</div>
-						<div class="static-child">Last child</div>
-					</div>
-				',
+				'expected_rendered_block' => <<<'HTML'
+
+<div class="static">
+&#x9;
+	<div class="static-child">First child</div>
+&#x9;
+&#x9;
+&#x9;
+	<div class="static-child">Last child</div>
+&#x9;
+</div>
+
+HTML
+				,
 				'expected_styles'         => array( 'static-view-style', 'static-child-view-style' ),
 				'expected_scripts'        => array( 'static-view-script', 'static-child-view-script' ),
 				'expected_script_modules' => array( 'static-view-script-module', 'static-child-view-script-module' ),
@@ -456,12 +478,20 @@ HTML;
 					);
 				},
 				'block_markup'            => $block_markup,
-				'expected_rendered_block' => '
-					<div class="static">
-						<div class="static-child">First child</div>
-						<div class="static-child">Last child</div>
-					</div>
-				',
+				'expected_rendered_block' => <<<'HTML'
+
+<div class="static">
+&#x9;
+	<div class="static-child">First child</div>
+&#x9;
+&#x9;
+&#x9;
+	<div class="static-child">Last child</div>
+&#x9;
+</div>
+
+HTML
+				,
 				'expected_styles'         => array( 'static-view-style', 'static-child-view-style', 'dynamic-view-style' ),
 				'expected_scripts'        => array( 'static-view-script', 'static-child-view-script', 'dynamic-view-script' ),
 				'expected_script_modules' => array( 'static-view-script-module', 'static-child-view-script-module', 'dynamic-view-script-module' ),
@@ -488,11 +518,16 @@ HTML;
 					add_filter( 'render_block_core/static-child', '__return_empty_string' );
 				},
 				'block_markup'            => $block_markup,
-				'expected_rendered_block' => '
-					<div class="static">
-						<p class="dynamic">Hello World!</p>
-					</div>
-				',
+				'expected_rendered_block' => <<<'HTML'
+
+<div class="static">
+&#x9;
+	<p class="dynamic">Hello World!</p>
+&#x9;
+</div>
+
+HTML
+				,
 				'expected_styles'         => array( 'static-view-style', 'dynamic-view-style' ),
 				'expected_scripts'        => array( 'static-view-script', 'dynamic-view-script' ),
 				'expected_script_modules' => array( 'static-view-script-module', 'dynamic-view-script-module' ),
@@ -512,12 +547,18 @@ HTML;
 					);
 				},
 				'block_markup'            => $block_markup,
-				'expected_rendered_block' => '
-					<div class="static">
-						<div class="static-child">First child</div>
-						<p class="dynamic">Hello World!</p>
-					</div>
-				',
+				'expected_rendered_block' => <<<'HTML'
+
+<div class="static">
+&#x9;
+	<div class="static-child">First child</div>
+&#x9;
+	<p class="dynamic">Hello World!</p>
+&#x9;
+</div>
+
+HTML
+				,
 				'expected_styles'         => array( 'static-view-style', 'static-child-view-style', 'dynamic-view-style' ),
 				'expected_scripts'        => array( 'static-view-script', 'static-child-view-script', 'dynamic-view-script' ),
 				'expected_script_modules' => array( 'static-view-script-module', 'static-child-view-script-module', 'dynamic-view-script-module' ),

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -368,19 +368,19 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function data_provider_test_render_enqueues_scripts_and_styles(): array {
-		$block_markup = '
-			<!-- wp:static -->
-			<div class="static">
-				<!-- wp:static-child -->
-				<div class="static-child">First child</div>
-				<!-- /wp:static-child -->
-				<!-- wp:dynamic /-->
-				<!-- wp:static-child -->
-				<div class="static-child">Last child</div>
-				<!-- /wp:static-child -->
-			</div>
-			<!-- /wp:static -->
-		';
+		$block_markup = <<<'HTML'
+<!-- wp:static -->
+<div class="static">
+	<!-- wp:static-child -->
+	<div class="static-child">First child</div>
+	<!-- /wp:static-child -->
+	<!-- wp:dynamic /-->
+	<!-- wp:static-child -->
+	<div class="static-child">Last child</div>
+	<!-- /wp:static-child -->
+</div>
+<!-- /wp:static -->
+HTML;
 
 		// TODO: Add case where a dynamic block renders other blocks?
 		return array(

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -562,9 +562,8 @@ HTML;
 					);
 				},
 				'block_markup'            => '<!-- wp:static --><div class="static"></div><!-- /wp:static -->',
-				'expected_rendered_block' => '
-					<div class="static yes-admin-bar-script-enqueued yes-admin-bar-style-enqueued"></div>
-				',
+				'expected_rendered_block' =>
+					'<div class="static yes-admin-bar-script-enqueued yes-admin-bar-style-enqueued"></div>',
 				'expected_styles'         => array( 'static-view-style', 'admin-bar' ),
 				'expected_scripts'        => array( 'static-view-script', 'admin-bar' ),
 				'expected_script_modules' => array( 'static-view-script-module' ),

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -718,6 +718,16 @@ HTML
 		$this->assertSameSets( $expected_scripts, wp_scripts()->queue, 'Enqueued scripts do not meet expectations' );
 		$this->assertSameSets( $expected_script_modules, wp_script_modules()->get_queue(), 'Enqueued script modules do not meet expectations' );
 
+		//echo "\n===\n";
+		//var_export( $rendered_block );
+		echo "\n===\n";
+		var_export( self::replaceInvisible( $rendered_block ) );
+		//echo "\n===\n";
+		//var_export( $expected_rendered_block );
+		echo "\n===\n";
+		var_export( self::replaceInvisible( $expected_rendered_block ) );
+		echo "\n===\n";
+
 		$this->assertEqualHTML(
 			$expected_rendered_block,
 			$rendered_block,
@@ -1480,5 +1490,27 @@ HTML
 		$this->assertSame( 2, $pre_render_callback->get_call_count() );
 		$this->assertSame( 2, $render_block_data_callback->get_call_count() );
 		$this->assertSame( 2, $render_block_context_callback->get_call_count() );
+	}
+
+	private static function replaceInvisible( string $s ): string {
+		return preg_replace_callback(
+			'/[\\x00-\\x1F\\x7F]/u',
+			static function ( array $matches ): string {
+				$codePoint = /** @type {number} */ ord($matches[0]);
+				switch ( $codePoint ) {
+					// U+007F DELETE -> U+2421 SYMBOL FOR DELETE
+					case 0x7f:
+						return "\u{2421}";
+
+					// Include a newline with newline replacement
+					case 0x0a:
+						return "\u{240A}\n";
+				}
+
+				// There's a nice Control Pictures Block at 0x2400 offset for the matched range
+				return mb_chr( $codePoint + 0x2400 );
+			},
+			$s
+		);
 	}
 }

--- a/tests/phpunit/tests/build-visual-html-tree.php
+++ b/tests/phpunit/tests/build-visual-html-tree.php
@@ -9,13 +9,13 @@
  */
 class Tests_Build_Equivalent_HTML_Semantic_Tree extends WP_UnitTestCase {
 	public function data_build_equivalent_html_semantic_tree() {
-		$block_markup = <<<END
-			<!-- wp:separator {"className":"is-style-default has-custom-classname","style":{"spacing":{"margin":{"top":"50px","bottom":"50px"}}},"backgroundColor":"accent-1"} -->
-			  <hr class="wp-block-separator is-style-default has-custom-classname" style="margin-top: 50px; margin-bottom: 50px" />
-			<!-- /wp:separator -->
-END;
+		$block_markup = <<<'HTML'
+<!-- wp:separator {"className":"is-style-default has-custom-classname","style":{"spacing":{"margin":{"top":"50px","bottom":"50px"}}},"backgroundColor":"accent-1"} -->
+  <hr class="wp-block-separator is-style-default has-custom-classname" style="margin-top: 50px; margin-bottom: 50px" />
+<!-- /wp:separator -->
+HTML;
 
-		$tree_structure = <<<END
+		$tree_structure = <<<'TREE'
 BLOCK["core/separator"]
   {
     "backgroundColor": "accent-1",
@@ -33,7 +33,7 @@ BLOCK["core/separator"]
     class="has-custom-classname is-style-default wp-block-separator"
     style="margin-top:50px;margin-bottom:50px;"
 
-END;
+TREE;
 
 		return array(
 			'Block delimiter' => array( $block_markup, $tree_structure ),

--- a/tests/phpunit/tests/build-visual-html-tree.php
+++ b/tests/phpunit/tests/build-visual-html-tree.php
@@ -39,9 +39,40 @@ BLOCK["core/separator"]
 
 TREE;
 
-		return array(
-			'Block delimiter' => array( $block_markup, $tree_structure ),
-		);
+		yield 'Block delimiter' => array( $block_markup, $tree_structure );
+
+		$block_markup = <<<'HTML'
+<!-- wp:example/block -->
+	One
+	<!-- wp:example/nested-void /-->
+	Two
+	<!-- wp:example/nested -->
+		Three
+	<!-- /wp:example/nested -->
+	Four
+<!-- /wp:example/block -->
+HTML;
+
+		$tree_structure = <<<'TREE'
+BLOCK["example/block"]
+  "
+	One
+	"
+  BLOCK["example/nested-void"]
+  "
+	Two
+	"
+  BLOCK["example/nested"]
+    "
+		Three
+	"
+  "
+	Four
+"
+
+TREE;
+
+		yield 'Text nodes in blocks' => array( $block_markup, $tree_structure );
 	}
 
 	/**

--- a/tests/phpunit/tests/build-visual-html-tree.php
+++ b/tests/phpunit/tests/build-visual-html-tree.php
@@ -77,6 +77,7 @@ TREE;
 
 	/**
 	 * @ticket 63527
+	 * @ticket 64531
 	 *
 	 * @covers ::build_visual_html_tree
 	 *

--- a/tests/phpunit/tests/build-visual-html-tree.php
+++ b/tests/phpunit/tests/build-visual-html-tree.php
@@ -141,4 +141,41 @@ TREE;
 
 		$this->assertNotSame( $tree_expected, $tree_actual );
 	}
+
+	/**
+	 * @ticket 64531
+	 *
+	 * @covers ::build_visual_html_tree
+	 */
+	public function test_spacing() {
+		$html = <<<'HTML'
+<p> space-surrounded&#x20;</p>
+<p>&nbsp;nbsp-surrounded&#xA0;</p>
+<p>
+newline-surrounded&#xA;</p>
+<p>&#x9;tab-surrounded	</p>
+<p>ok</p>
+HTML;
+
+		$expected = <<<TREE
+<p>
+  " space-surrounded "
+"\n"
+<p>
+  "\u{00A0}nbsp-surrounded\u{00A0}"
+"\n"
+<p>
+  "\nnewline-surrounded\n"
+"\n"
+<p>
+  "\ttab-surrounded\t"
+"\n"
+<p>
+  "ok"
+
+TREE;
+
+		$tree_result = build_visual_html_tree( $html, '<body>' );
+		$this->assertSame( $expected, $tree_result );
+	}
 }

--- a/tests/phpunit/tests/build-visual-html-tree.php
+++ b/tests/phpunit/tests/build-visual-html-tree.php
@@ -29,9 +29,13 @@ BLOCK["core/separator"]
       }
     }
   }
+  "
+  "
   <hr>
     class="has-custom-classname is-style-default wp-block-separator"
     style="margin-top:50px;margin-bottom:50px;"
+  "
+"
 
 TREE;
 

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -2582,7 +2582,7 @@ HTML;
 		$expected  = "<script id='customize-dependency-js-after'>\n";
 		$expected .= "tryCustomizeDependency()\n";
 		$expected .= "//# sourceURL=customize-dependency-js-after\n";
-		$expected .= "</script>";
+		$expected .= '</script>';
 		$this->assertEqualHTMLScriptTagById( $expected, $print_scripts );
 	}
 

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -3520,9 +3520,6 @@ HTML;
 		wp_scripts()->do_footer_items();
 		$footer = ob_get_clean();
 
-		// $expected_footer = trim( $expected_footer, "\n\t" );
-		// $expected_header = trim( $expected_header, "\n\t" );
-
 		$this->assertEqualHTML( $expected_header, $header, '<body>', 'Expected header script markup to match.' );
 		$this->assertEqualHTML( $expected_footer, $footer, '<body>', 'Expected footer script markup to match.' );
 		$this->assertEqualSets( $expected_in_footer, wp_scripts()->in_footer, 'Expected to have the same handles for in_footer.' );

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -287,7 +287,7 @@ JS;
 		wp_enqueue_script( 'main-script-a2', '/main-script-a2.js', array( 'dependency-script-a2' ), null, compact( 'strategy' ) );
 		$output    = get_echo( 'wp_print_scripts' );
 		$expected  = "<script id='dependency-script-a2-js' src='/dependency-script-a2.js'></script>\n";
-		$expected .= "<script src='/main-script-a2.js' id='main-script-a2-js' {$strategy} data-wp-strategy='{$strategy}'></script>";
+		$expected .= "<script src='/main-script-a2.js' id='main-script-a2-js' {$strategy} data-wp-strategy='{$strategy}'></script>\n";
 		$this->assertEqualHTML( $expected, $output, '<body>', 'Dependents of a blocking dependency are free to have any strategy.' );
 	}
 
@@ -309,8 +309,9 @@ JS;
 		wp_enqueue_script( 'dependent-script-a3', '/dependent-script-a3.js', array( 'main-script-a3' ), null );
 		$output   = get_echo( 'wp_print_scripts' );
 		$expected = <<<JS
-			<script src='/main-script-a3.js' id='main-script-a3-js' data-wp-strategy='{$strategy}'></script>
-			<script id="dependent-script-a3-js" src="/dependent-script-a3.js"></script>
+<script src='/main-script-a3.js' id='main-script-a3-js' data-wp-strategy='{$strategy}'></script>
+<script id="dependent-script-a3-js" src="/dependent-script-a3.js"></script>
+
 JS;
 		$this->assertEqualHTML( $expected, $output, '<body>', 'Blocking dependents must force delayed dependencies to become blocking.' );
 	}
@@ -1076,7 +1077,7 @@ HTML
 	public function test_loading_strategy_with_defer_having_no_dependents_nor_dependencies() {
 		wp_enqueue_script( 'main-script-d1', 'http://example.com/main-script-d1.js', array(), null, array( 'strategy' => 'defer' ) );
 		$output   = get_echo( 'wp_print_scripts' );
-		$expected = "<script src='http://example.com/main-script-d1.js' id='main-script-d1-js' defer data-wp-strategy='defer'></script>\n";
+		$expected = "<script src='http://example.com/main-script-d1.js' id='main-script-d1-js' defer data-wp-strategy='defer'></script>";
 		$this->assertEqualHTMLScriptTagById( $expected, $output, 'Expected defer, as there is no dependent or dependency' );
 	}
 
@@ -1285,22 +1286,20 @@ HTML
 		return array(
 			'enqueue_bajo' => array(
 				'enqueues' => array( 'bajo' ),
-				'expected' => '<script fetchpriority="low" id="bajo-js" src="/bajo.js"></script>',
+				'expected' => "<script fetchpriority='low' id='bajo-js' src='/bajo.js'></script>\n",
 			),
 			'enqueue_auto' => array(
 				'enqueues' => array( 'auto' ),
-				'expected' => '
-					<script src="/bajo.js" id="bajo-js" data-wp-fetchpriority="low"></script>
-					<script src="/auto.js" id="auto-js"></script>
-				',
+				'expected' =>
+					"<script src='/bajo.js' id='bajo-js' data-wp-fetchpriority='low'></script>\n" .
+					"<script src='/auto.js' id='auto-js'></script>\n",
 			),
 			'enqueue_alto' => array(
 				'enqueues' => array( 'alto' ),
-				'expected' => '
-					<script src="/bajo.js" id="bajo-js" fetchpriority="high" data-wp-fetchpriority="low"></script>
-					<script src="/auto.js" id="auto-js" fetchpriority="high" data-wp-fetchpriority="auto"></script>
-					<script src="/alto.js" id="alto-js" fetchpriority="high"></script>
-				',
+				'expected' =>
+					"<script src='/bajo.js' id='bajo-js' fetchpriority='high' data-wp-fetchpriority='low'></script>\n" .
+					"<script src='/auto.js' id='auto-js' fetchpriority='high' data-wp-fetchpriority='auto'></script>\n" .
+					"<script src='/alto.js' id='alto-js' fetchpriority='high'></script>\n",
 			),
 		);
 	}
@@ -1354,16 +1353,17 @@ HTML
 		wp_enqueue_script( 'x' );
 
 		$actual   = get_echo( 'wp_print_scripts' );
-		$expected = '
-			<script src="/z.js" id="z-js" fetchpriority="high" data-wp-fetchpriority="auto"></script>
-			<script src="/d.js" id="d-js" fetchpriority="high"></script>
-			<script src="/e.js" id="e-js"></script>
-			<script src="/c.js" id="c-js"></script>
-			<script src="/b.js" id="b-js"></script>
-			<script src="/a.js" id="a-js" fetchpriority="low"></script>
-			<script src="/y.js" id="y-js" fetchpriority="high" data-wp-fetchpriority="auto"></script>
-			<script src="/x.js" id="x-js" fetchpriority="high"></script>
-		';
+		$expected = <<<'HTML'
+<script src="/z.js" id="z-js" fetchpriority="high" data-wp-fetchpriority="auto"></script>
+<script src="/d.js" id="d-js" fetchpriority="high"></script>
+<script src="/e.js" id="e-js"></script>
+<script src="/c.js" id="c-js"></script>
+<script src="/b.js" id="b-js"></script>
+<script src="/a.js" id="a-js" fetchpriority="low"></script>
+<script src="/y.js" id="y-js" fetchpriority="high" data-wp-fetchpriority="auto"></script>
+<script src="/x.js" id="x-js" fetchpriority="high"></script>
+
+HTML;
 		$this->assertEqualHTML( $expected, $actual, '<body>', "Snapshot:\n$actual" );
 	}
 
@@ -1419,7 +1419,7 @@ HTML
 
 		$actual = $this->normalize_markup_for_snapshot( get_echo( array( $wp_scripts, 'print_scripts' ) ) );
 		$this->assertEqualHTML(
-			'<script src="/wp-includes/js/comment-reply.js" id="comment-reply-js" async data-wp-strategy="async" fetchpriority="low"></script>',
+			"<script src='/wp-includes/js/comment-reply.js' id='comment-reply-js' async data-wp-strategy='async' fetchpriority='low'></script>\n",
 			$actual,
 			'<body>',
 			"Snapshot:\n$actual"
@@ -1456,7 +1456,7 @@ HTML
 
 		$this->assertEqualHTML(
 			sprintf(
-				'<script src="%s" id="comment-reply-js" async data-wp-strategy="async" fetchpriority="low"></script>',
+				"<script src='%s' id='comment-reply-js' async data-wp-strategy='async' fetchpriority='low'></script>\n",
 				includes_url( 'js/comment-reply.js' )
 			),
 			$markup
@@ -1497,7 +1497,7 @@ HTML
 		wp_enqueue_script( 'dependent-script-d4-3', '/dependent-script-d4-3.js', array( 'dependent-script-d4-2' ), null, array( 'strategy' => 'defer' ) );
 
 		$output   = get_echo( 'wp_print_scripts' );
-		$expected = "<script src='/main-script-d4.js' id='main-script-d4-js' data-wp-strategy='defer'></script>\n";
+		$expected = "<script src='/main-script-d4.js' id='main-script-d4-js' data-wp-strategy='defer'></script>";
 		$this->assertEqualHTMLScriptTagById( $expected, $output, 'Scripts registered as defer but that have all dependents with no strategy, should become blocking (no strategy).' );
 	}
 
@@ -2210,6 +2210,7 @@ HTML
 console.log("before");
 //# sourceURL=test-example-js-before
 </script>
+
 HTML;
 		$expected .= "<script src='http://example.com' id='test-example-js'></script>\n";
 
@@ -2229,6 +2230,7 @@ HTML;
 console.log("after");
 //# sourceURL=test-example-js-after
 </script>
+
 HTML;
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
@@ -2574,13 +2576,13 @@ HTML;
 		_print_scripts();
 		$print_scripts = $this->getActualOutput();
 
-		$expected = "<script src='/customize-dependency.js' id='customize-dependency-js'></script>\n";
+		$expected = "<script src='/customize-dependency.js' id='customize-dependency-js'></script>";
 		$this->assertEqualHTMLScriptTagById( $expected, $print_scripts );
 
 		$expected  = "<script id='customize-dependency-js-after'>\n";
 		$expected .= "tryCustomizeDependency()\n";
 		$expected .= "//# sourceURL=customize-dependency-js-after\n";
-		$expected .= "</script>\n";
+		$expected .= "</script>";
 		$this->assertEqualHTMLScriptTagById( $expected, $print_scripts );
 	}
 
@@ -3518,6 +3520,9 @@ HTML;
 		wp_scripts()->do_footer_items();
 		$footer = ob_get_clean();
 
+		// $expected_footer = trim( $expected_footer, "\n\t" );
+		// $expected_header = trim( $expected_header, "\n\t" );
+
 		$this->assertEqualHTML( $expected_header, $header, '<body>', 'Expected header script markup to match.' );
 		$this->assertEqualHTML( $expected_footer, $footer, '<body>', 'Expected footer script markup to match.' );
 		$this->assertEqualSets( $expected_in_footer, wp_scripts()->in_footer, 'Expected to have the same handles for in_footer.' );
@@ -3567,10 +3572,9 @@ HTML;
 					wp_enqueue_script( 'script-b', 'https://example.com/script-b.js', array( 'script-a' ), null, array( 'in_footer' => true ) );
 				},
 				'expected_header'    => '',
-				'expected_footer'    => '
-					<script src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="defer"></script>
-					<script src="https://example.com/script-b.js" id="script-b-js"></script>
-				',
+				'expected_footer'    =>
+					"<script src='https://example.com/script-a.js' id='script-a-js' data-wp-strategy='defer'></script>\n" .
+					"<script src='https://example.com/script-b.js' id='script-b-js'></script>\n",
 				'expected_in_footer' => array(
 					'script-a',
 					'script-b',
@@ -3588,10 +3592,9 @@ HTML;
 					wp_enqueue_script( 'script-b', 'https://example.com/script-b.js', array( 'script-a' ), null, array( 'in_footer' => true ) );
 				},
 				'expected_header'    => '',
-				'expected_footer'    => '
-					<script src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="async"></script>
-					<script src="https://example.com/script-b.js" id="script-b-js"></script>
-				',
+				'expected_footer'    =>
+					"<script src='https://example.com/script-a.js' id='script-a-js' data-wp-strategy='async'></script>\n" .
+					"<script src='https://example.com/script-b.js' id='script-b-js'></script>\n",
 				'expected_in_footer' => array(
 					'script-a',
 					'script-b',
@@ -3608,10 +3611,9 @@ HTML;
 					wp_enqueue_script( 'script-a', 'https://example.com/script-a.js', array(), null, array( 'strategy' => 'defer' ) );
 					wp_enqueue_script( 'script-b', 'https://example.com/script-b.js', array( 'script-a' ), null, array( 'in_footer' => false ) );
 				},
-				'expected_header'    => '
-					<script src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="defer"></script>
-					<script src="https://example.com/script-b.js" id="script-b-js"></script>
-				',
+				'expected_header'    =>
+					"<script src='https://example.com/script-a.js' id='script-a-js' data-wp-strategy='defer'></script>\n" .
+					"<script src='https://example.com/script-b.js' id='script-b-js'></script>\n",
 				'expected_footer'    => '',
 				'expected_in_footer' => array(),
 				'expected_groups'    => array(
@@ -3635,12 +3637,10 @@ HTML;
 						)
 					);
 				},
-				'expected_header'    => '
-					<script src="https://example.com/script-a.js" id="script-a-js" defer data-wp-strategy="defer"></script>
-				',
-				'expected_footer'    => '
-					<script src="https://example.com/script-b.js" id="script-b-js" defer data-wp-strategy="defer"></script>
-				',
+				'expected_header'    =>
+					"<script src='https://example.com/script-a.js' id='script-a-js' defer data-wp-strategy='defer'></script>\n",
+				'expected_footer'    =>
+					"<script src='https://example.com/script-b.js' id='script-b-js' defer data-wp-strategy='defer'></script>\n",
 				'expected_in_footer' => array(
 					'script-b',
 				),
@@ -3685,14 +3685,12 @@ HTML;
 						)
 					);
 				},
-				'expected_header'    => '
-					<script src="https://example.com/script-a.js" id="script-a-js" defer data-wp-strategy="defer"></script>
-					<script src="https://example.com/script-b.js" id="script-b-js" defer data-wp-strategy="defer"></script>
-				',
-				'expected_footer'    => '
-					<script src="https://example.com/script-c.js" id="script-c-js" defer data-wp-strategy="defer"></script>
-					<script src="https://example.com/script-d.js" id="script-d-js" defer data-wp-strategy="defer"></script>
-				',
+				'expected_header'    =>
+					"<script src='https://example.com/script-a.js' id='script-a-js' defer data-wp-strategy='defer'></script>\n" .
+					"<script src='https://example.com/script-b.js' id='script-b-js' defer data-wp-strategy='defer'></script>\n",
+				'expected_footer'    =>
+					"<script src='https://example.com/script-c.js' id='script-c-js' defer data-wp-strategy='defer'></script>\n" .
+					"<script src='https://example.com/script-d.js' id='script-d-js' defer data-wp-strategy='defer'></script>\n",
 				'expected_in_footer' => array(
 					'script-c',
 					'script-d',
@@ -3732,12 +3730,11 @@ HTML;
 					);
 				},
 				'expected_header'    => '',
-				'expected_footer'    => '
-					<script src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="defer"></script>
-					<script src="https://example.com/script-b.js" id="script-b-js" defer data-wp-strategy="defer"></script>
-					<script src="https://example.com/script-c.js" id="script-c-js"></script>
-					<script src="https://example.com/script-d.js" id="script-d-js" defer data-wp-strategy="defer"></script>
-				',
+				'expected_footer'    =>
+					"<script src='https://example.com/script-a.js' id='script-a-js' data-wp-strategy='defer'></script>\n" .
+					"<script src='https://example.com/script-b.js' id='script-b-js' defer data-wp-strategy='defer'></script>\n" .
+					"<script src='https://example.com/script-c.js' id='script-c-js'></script>\n" .
+					"<script src='https://example.com/script-d.js' id='script-d-js' defer data-wp-strategy='defer'></script>\n",
 				'expected_in_footer' => array(
 					'script-a',
 					'script-b',
@@ -3779,14 +3776,12 @@ HTML;
 						)
 					);
 				},
-				'expected_header'    => '
-					<script src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="defer"></script>
-					<script src="https://example.com/script-b.js" id="script-b-js" defer data-wp-strategy="defer"></script>
-				',
-				'expected_footer'    => '
-					<script src="https://example.com/script-c.js" id="script-c-js"></script>
-					<script src="https://example.com/script-d.js" id="script-d-js" defer data-wp-strategy="defer"></script>
-				',
+				'expected_header'    =>
+					"<script src='https://example.com/script-a.js' id='script-a-js' data-wp-strategy='defer'></script>\n" .
+					"<script src='https://example.com/script-b.js' id='script-b-js' defer data-wp-strategy='defer'></script>\n",
+				'expected_footer'    =>
+					"<script src='https://example.com/script-c.js' id='script-c-js'></script>\n" .
+					"<script src='https://example.com/script-d.js' id='script-d-js' defer data-wp-strategy='defer'></script>\n",
 				'expected_in_footer' => array(
 					'script-c',
 					'script-d',
@@ -3997,6 +3992,7 @@ HTML;
 		$print_scripts = get_echo( '_print_scripts' );
 
 		$expected = <<<HTML
+
 <script>
 var one = {"key":"val"};var two = {"key":"val"};
 //# sourceURL=js-inline-concat-one%2Ctwo
@@ -4070,7 +4066,7 @@ HTML;
 		wp_enqueue_script( 'test-script?qs1=q1&qs2=q2', '/test-script.js', array(), $version );
 		$markup = get_echo( 'wp_print_scripts' );
 
-		$expected = "<script src='/test-script.js?{$expected_query_string}' id='test-script-js'></script>";
+		$expected = "<script src='/test-script.js?{$expected_query_string}' id='test-script-js'></script>\n";
 		$this->assertEqualHTML( $expected, $markup, '<body>', 'Expected equal snapshot for wp_print_scripts() with version ' . var_export( $version, true ) . ":\n$markup" );
 	}
 
@@ -4091,7 +4087,7 @@ HTML;
 		wp_enqueue_script( 'test-script?qs1=q1&qs2=q2' );
 		$markup = get_echo( 'wp_print_scripts' );
 
-		$expected = "<script src='/test-script.js?{$expected_query_string}' id='test-script-js'></script>";
+		$expected = "<script src='/test-script.js?{$expected_query_string}' id='test-script-js'></script>\n";
 		$this->assertEqualHTML( $expected, $markup, '<body>', 'Expected equal snapshot for wp_print_scripts() with version ' . var_export( $version, true ) . ":\n$markup" );
 	}
 

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -882,6 +882,7 @@ HTML;
 h1 { background: blue; }h2 { color: green; }
 /*# sourceURL=css-inline-concat-one%2Ctwo */
 </style>
+
 HTML;
 
 		$this->assertEqualHTML( $expected, $printed );
@@ -935,7 +936,7 @@ HTML;
 		wp_enqueue_style( 'test-style?qs1=q1&qs2=q2', '/test-style.css', array(), $version );
 		$markup = get_echo( 'wp_print_styles' );
 
-		$expected = "<link rel='stylesheet' href='/test-style.css?{$expected_query_string}' id='test-style-css' media='all' />";
+		$expected = "<link rel='stylesheet' href='/test-style.css?{$expected_query_string}' id='test-style-css' media='all' />\n";
 		$this->assertEqualHTML( $expected, $markup, '<body>', 'Expected equal snapshot for wp_print_styles() with version ' . var_export( $version, true ) . ":\n$markup" );
 	}
 
@@ -956,7 +957,7 @@ HTML;
 		wp_enqueue_style( 'test-style?qs1=q1&qs2=q2' );
 		$markup = get_echo( 'wp_print_styles' );
 
-		$expected = "<link rel='stylesheet' href='/test-style.css?{$expected_query_string}' id='test-style-css' media='all' />";
+		$expected = "<link rel='stylesheet' href='/test-style.css?{$expected_query_string}' id='test-style-css' media='all' />\n";
 		$this->assertEqualHTML( $expected, $markup, '<body>', 'Expected equal snapshot for wp_print_styles() with version ' . var_export( $version, true ) . ":\n$markup" );
 	}
 

--- a/tests/phpunit/tests/functions/wpGetArchives.php
+++ b/tests/phpunit/tests/functions/wpGetArchives.php
@@ -221,10 +221,10 @@ EOF;
 		$ids = array_slice( array_reverse( self::$post_ids ), 0, 3 );
 
 		$expected = join(
-			"\n",
+			'',
 			array_map(
 				static function ( $id ) {
-					return sprintf( '<li><a href="%s">%s</a></li>', get_permalink( $id ), get_the_title( $id ) );
+					return sprintf( "\t<li><a href='%s'>%s</a></li>\n", get_permalink( $id ), get_the_title( $id ) );
 				},
 				$ids
 			)

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -582,7 +582,7 @@ HTML;
 			$expected,
 			$actual,
 			'<body>',
-			"Expected only one SCRIPT tag to be printed. Snapshot:\n$actual"
+			'Expected only one SCRIPT tag to be printed.'
 		);
 	}
 
@@ -1489,7 +1489,7 @@ HTML;
 			$actual_head,
 			$expected,
 			'<body>',
-			"Expected equal script modules in the HEAD. Snapshot:\n$actual_head"
+			'Expected equal script modules in the HEAD.'
 		);
 
 		$expected = <<<'HTML'
@@ -1502,7 +1502,7 @@ HTML;
 			$actual_footer,
 			$expected,
 			'<body>',
-			"Expected equal script modules in the footer. Snapshot:\n$actual_footer"
+			'Expected equal script modules in the footer.'
 		);
 	}
 
@@ -1765,7 +1765,7 @@ HTML;
 <script type="module" src="/x.js" id="x-js-module" fetchpriority="high"></script>
 
 HTML;
-		$this->assertEqualHTML( $expected, $actual, '<body>', "Snapshot:\n$actual" );
+		$this->assertEqualHTML( $expected, $actual );
 	}
 
 	/**
@@ -1812,7 +1812,7 @@ HTML;
 <script type="module" src="/z.js" id="z-js-module" fetchpriority="high"></script>
 
 HTML;
-		$this->assertEqualHTML( $expected, $actual, '<body>', "Snapshot:\n$actual" );
+		$this->assertEqualHTML( $expected, $actual );
 	}
 
 	/**
@@ -1833,30 +1833,24 @@ HTML;
 		$actual_preloads = $this->normalize_markup_for_snapshot( get_echo( array( wp_script_modules(), 'print_script_module_preloads' ) ) );
 		$this->assertEqualHTML(
 			"<link rel='modulepreload' href='/wp-includes/js/dist/script-modules/interactivity/index.min.js' id='@wordpress/interactivity-js-modulepreload' fetchpriority='low'>\n",
-			$actual_preloads,
-			'<body>',
-			"Snapshot:\n$actual_preloads"
+			$actual_preloads
 		);
 
 		$actual_head_script_modules = $this->normalize_markup_for_snapshot( get_echo( array( wp_script_modules(), 'print_head_enqueued_script_modules' ) ) );
 		$this->assertEqualHTML(
 			'',
-			$actual_head_script_modules,
-			'<body>',
-			"Snapshot:\n$actual_head_script_modules"
+			$actual_head_script_modules
 		);
 
 		$actual_footer_script_modules = $this->normalize_markup_for_snapshot( get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) ) );
-		$expected = <<<'HTML'
+		$expected                     = <<<'HTML'
 <script type="module" src="/wp-includes/js/dist/script-modules/a11y/index.min.js" id="@wordpress/a11y-js-module" fetchpriority="low"></script>
 <script type="module" src="/wp-includes/js/dist/script-modules/block-library/navigation/view.min.js" id="@wordpress/block-library/navigation/view-js-module" fetchpriority="low" data-wp-router-options="{&quot;loadOnClientNavigation&quot;:true}"></script>
 
 HTML;
 		$this->assertEqualHTML(
 			$expected,
-			$actual_footer_script_modules,
-			'<body>',
-			"Snapshot:\n$actual_footer_script_modules"
+			$actual_footer_script_modules
 		);
 	}
 
@@ -1877,9 +1871,7 @@ HTML;
 		$actual = $this->normalize_markup_for_snapshot( get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) ) );
 		$this->assertEqualHTML(
 			"<script type='module' src='/wp-includes/js/dist/script-modules/a11y/index.min.js' id='@wordpress/a11y-js-module' fetchpriority='low'></script>\n",
-			$actual,
-			'<body>',
-			"Snapshot:\n$actual"
+			$actual
 		);
 	}
 
@@ -1912,7 +1904,7 @@ HTML;
 <script type="module" src="/super-important-module.js" id="super-important-js-module" fetchpriority="high"></script>
 
 HTML;
-		$this->assertEqualHTML( $expected, $actual, '<body>', "Snapshot:\n$actual" );
+		$this->assertEqualHTML( $expected, $actual );
 	}
 
 	/**
@@ -2354,13 +2346,13 @@ HTML;
 			"<link rel='modulepreload' href='/static1.js' id='static1-js-modulepreload'>\n",
 			$preload_links,
 			'<body>',
-			"Expected preload links to match snapshot:\n$preload_links"
+			'Expected preload links to match.'
 		);
 		$this->assertEqualHTML(
 			"<script type='module' src='/enqueued.js' id='enqueued-js-module'></script>\n",
 			$script_modules,
 			'<body>',
-			"Expected script modules to match snapshot:\n$script_modules"
+			'Expected script modules to match.'
 		);
 	}
 

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -572,12 +572,14 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 			10,
 			2
 		);
-		$actual = get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) );
+		$actual   = get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) );
+		$expected = <<<'HTML'
+<script type="module" src="/src.js" id="with-src-js-module"></script>
+<script type="module" src="/was-empty-but-added-via-filter.js" id="without-src-but-filtered-js-module"></script>
+
+HTML;
 		$this->assertEqualHTML(
-			'
-				<script type="module" src="/src.js" id="with-src-js-module"></script>
-				<script type="module" src="/was-empty-but-added-via-filter.js" id="without-src-but-filtered-js-module"></script>
-			',
+			$expected,
 			$actual,
 			'<body>',
 			"Expected only one SCRIPT tag to be printed. Snapshot:\n$actual"
@@ -1476,23 +1478,29 @@ HTML;
 		$actual_head   = get_echo( array( wp_script_modules(), 'print_head_enqueued_script_modules' ) );
 		$actual_footer = get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) );
 
+		$expected = <<<'HTML'
+<script type="module" src="/default.js" id="default-js-module"></script>
+<script type="module" src="/not-in-footer-via-enqueue.js" id="not-in-footer-via-enqueue-js-module"></script>
+<script type="module" src="/not-in-footer-via-override.js" id="not-in-footer-via-override-js-module"></script>
+
+HTML;
+
 		$this->assertEqualHTML(
 			$actual_head,
-			'
-				<script type="module" src="/default.js" id="default-js-module"></script>
-				<script type="module" src="/not-in-footer-via-enqueue.js" id="not-in-footer-via-enqueue-js-module"></script>
-				<script type="module" src="/not-in-footer-via-override.js" id="not-in-footer-via-override-js-module"></script>
-			',
+			$expected,
 			'<body>',
 			"Expected equal script modules in the HEAD. Snapshot:\n$actual_head"
 		);
+
+		$expected = <<<'HTML'
+<script type="module" src="/in-footer-via-register.js" id="in-footer-via-register-js-module"></script>
+<script type="module" src="/in-footer-via-enqueue.js" id="in-footer-via-enqueue-js-module"></script>
+<script type="module" src="/in-footer-via-override.js" id="in-footer-via-override-js-module"></script>
+
+HTML;
 		$this->assertEqualHTML(
 			$actual_footer,
-			'
-				<script type="module" src="/in-footer-via-register.js" id="in-footer-via-register-js-module"></script>
-				<script type="module" src="/in-footer-via-enqueue.js" id="in-footer-via-enqueue-js-module"></script>
-				<script type="module" src="/in-footer-via-override.js" id="in-footer-via-override-js-module"></script>
-			',
+			$expected,
 			'<body>',
 			"Expected equal script modules in the footer. Snapshot:\n$actual_footer"
 		);
@@ -1746,16 +1754,17 @@ HTML;
 
 		$actual   = get_echo( array( wp_script_modules(), 'print_script_module_preloads' ) );
 		$actual  .= get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) );
-		$expected = '
-			<link rel="modulepreload" href="/z.js" id="z-js-modulepreload" fetchpriority="high">
-			<link rel="modulepreload" href="/d.js" id="d-js-modulepreload" fetchpriority="high">
-			<link rel="modulepreload" href="/e.js" id="e-js-modulepreload" fetchpriority="low">
-			<link rel="modulepreload" href="/c.js" id="c-js-modulepreload" fetchpriority="low">
-			<link rel="modulepreload" href="/b.js" id="b-js-modulepreload" fetchpriority="low">
-			<link rel="modulepreload" href="/y.js" id="y-js-modulepreload" fetchpriority="high">
-			<script type="module" src="/a.js" id="a-js-module" fetchpriority="low"></script>
-			<script type="module" src="/x.js" id="x-js-module" fetchpriority="high"></script>
-		';
+		$expected = <<<'HTML'
+<link rel="modulepreload" href="/z.js" id="z-js-modulepreload" fetchpriority="high">
+<link rel="modulepreload" href="/d.js" id="d-js-modulepreload" fetchpriority="high">
+<link rel="modulepreload" href="/e.js" id="e-js-modulepreload" fetchpriority="low">
+<link rel="modulepreload" href="/c.js" id="c-js-modulepreload" fetchpriority="low">
+<link rel="modulepreload" href="/b.js" id="b-js-modulepreload" fetchpriority="low">
+<link rel="modulepreload" href="/y.js" id="y-js-modulepreload" fetchpriority="high">
+<script type="module" src="/a.js" id="a-js-module" fetchpriority="low"></script>
+<script type="module" src="/x.js" id="x-js-module" fetchpriority="high"></script>
+
+HTML;
 		$this->assertEqualHTML( $expected, $actual, '<body>', "Snapshot:\n$actual" );
 	}
 
@@ -1791,17 +1800,18 @@ HTML;
 
 		$actual   = get_echo( array( wp_script_modules(), 'print_script_module_preloads' ) );
 		$actual  .= get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) );
-		$expected = '
-			<link rel="modulepreload" href="/d.js" id="d-js-modulepreload" fetchpriority="low">
-			<link rel="modulepreload" href="/e.js" id="e-js-modulepreload" fetchpriority="high" data-wp-fetchpriority="low">
-			<link rel="modulepreload" href="/a.js" id="a-js-modulepreload" fetchpriority="low" data-wp-fetchpriority="high">
-			<link rel="modulepreload" href="/b.js" id="b-js-modulepreload">
-			<link rel="modulepreload" href="/f.js" id="f-js-modulepreload" fetchpriority="high">
-			<link rel="modulepreload" href="/c.js" id="c-js-modulepreload" fetchpriority="high">
-			<script type="module" src="/x.js" id="x-js-module" fetchpriority="low"></script>
-			<script type="module" src="/y.js" id="y-js-module"></script>
-			<script type="module" src="/z.js" id="z-js-module" fetchpriority="high"></script>
-		';
+		$expected = <<<'HTML'
+<link rel="modulepreload" href="/d.js" id="d-js-modulepreload" fetchpriority="low">
+<link rel="modulepreload" href="/e.js" id="e-js-modulepreload" fetchpriority="high" data-wp-fetchpriority="low">
+<link rel="modulepreload" href="/a.js" id="a-js-modulepreload" fetchpriority="low" data-wp-fetchpriority="high">
+<link rel="modulepreload" href="/b.js" id="b-js-modulepreload">
+<link rel="modulepreload" href="/f.js" id="f-js-modulepreload" fetchpriority="high">
+<link rel="modulepreload" href="/c.js" id="c-js-modulepreload" fetchpriority="high">
+<script type="module" src="/x.js" id="x-js-module" fetchpriority="low"></script>
+<script type="module" src="/y.js" id="y-js-module"></script>
+<script type="module" src="/z.js" id="z-js-module" fetchpriority="high"></script>
+
+HTML;
 		$this->assertEqualHTML( $expected, $actual, '<body>', "Snapshot:\n$actual" );
 	}
 
@@ -1822,9 +1832,7 @@ HTML;
 
 		$actual_preloads = $this->normalize_markup_for_snapshot( get_echo( array( wp_script_modules(), 'print_script_module_preloads' ) ) );
 		$this->assertEqualHTML(
-			'
-				<link rel="modulepreload" href="/wp-includes/js/dist/script-modules/interactivity/index.min.js" id="@wordpress/interactivity-js-modulepreload" fetchpriority="low">
-			',
+			"<link rel='modulepreload' href='/wp-includes/js/dist/script-modules/interactivity/index.min.js' id='@wordpress/interactivity-js-modulepreload' fetchpriority='low'>\n",
 			$actual_preloads,
 			'<body>',
 			"Snapshot:\n$actual_preloads"
@@ -1839,11 +1847,13 @@ HTML;
 		);
 
 		$actual_footer_script_modules = $this->normalize_markup_for_snapshot( get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) ) );
+		$expected = <<<'HTML'
+<script type="module" src="/wp-includes/js/dist/script-modules/a11y/index.min.js" id="@wordpress/a11y-js-module" fetchpriority="low"></script>
+<script type="module" src="/wp-includes/js/dist/script-modules/block-library/navigation/view.min.js" id="@wordpress/block-library/navigation/view-js-module" fetchpriority="low" data-wp-router-options="{&quot;loadOnClientNavigation&quot;:true}"></script>
+
+HTML;
 		$this->assertEqualHTML(
-			'
-				<script type="module" src="/wp-includes/js/dist/script-modules/a11y/index.min.js" id="@wordpress/a11y-js-module" fetchpriority="low"></script>
-				<script type="module" src="/wp-includes/js/dist/script-modules/block-library/navigation/view.min.js" id="@wordpress/block-library/navigation/view-js-module" fetchpriority="low" data-wp-router-options="{&quot;loadOnClientNavigation&quot;:true}"></script>
-			',
+			$expected,
 			$actual_footer_script_modules,
 			'<body>',
 			"Snapshot:\n$actual_footer_script_modules"
@@ -1866,7 +1876,7 @@ HTML;
 
 		$actual = $this->normalize_markup_for_snapshot( get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) ) );
 		$this->assertEqualHTML(
-			'<script type="module" src="/wp-includes/js/dist/script-modules/a11y/index.min.js" id="@wordpress/a11y-js-module" fetchpriority="low"></script>',
+			"<script type='module' src='/wp-includes/js/dist/script-modules/a11y/index.min.js' id='@wordpress/a11y-js-module' fetchpriority='low'></script>\n",
 			$actual,
 			'<body>',
 			"Snapshot:\n$actual"
@@ -1895,12 +1905,13 @@ HTML;
 
 		$actual = $this->normalize_markup_for_snapshot( $actual );
 
-		$expected = '
-			<link rel="modulepreload" href="/wp-includes/js/dist/script-modules/a11y/index.min.js" id="@wordpress/a11y-js-modulepreload" fetchpriority="high" data-wp-fetchpriority="low">
-			<link rel="modulepreload" href="/wp-includes/js/dist/script-modules/interactivity/index.min.js" id="@wordpress/interactivity-js-modulepreload" fetchpriority="high" data-wp-fetchpriority="low">
-			<link rel="modulepreload" href="/wp-includes/js/dist/script-modules/block-library/navigation/view.min.js" id="@wordpress/block-library/navigation/view-js-modulepreload" fetchpriority="high" data-wp-fetchpriority="low">
-			<script type="module" src="/super-important-module.js" id="super-important-js-module" fetchpriority="high"></script>
-		';
+		$expected = <<<'HTML'
+<link rel="modulepreload" href="/wp-includes/js/dist/script-modules/a11y/index.min.js" id="@wordpress/a11y-js-modulepreload" fetchpriority="high" data-wp-fetchpriority="low">
+<link rel="modulepreload" href="/wp-includes/js/dist/script-modules/interactivity/index.min.js" id="@wordpress/interactivity-js-modulepreload" fetchpriority="high" data-wp-fetchpriority="low">
+<link rel="modulepreload" href="/wp-includes/js/dist/script-modules/block-library/navigation/view.min.js" id="@wordpress/block-library/navigation/view-js-modulepreload" fetchpriority="high" data-wp-fetchpriority="low">
+<script type="module" src="/super-important-module.js" id="super-important-js-module" fetchpriority="high"></script>
+
+HTML;
 		$this->assertEqualHTML( $expected, $actual, '<body>', "Snapshot:\n$actual" );
 	}
 
@@ -2340,17 +2351,13 @@ HTML;
 			"Expected import map to match snapshot:\n" . var_export( $import_map, true )
 		);
 		$this->assertEqualHTML(
-			'
-				<link rel="modulepreload" href="/static1.js" id="static1-js-modulepreload">
-			',
+			"<link rel='modulepreload' href='/static1.js' id='static1-js-modulepreload'>\n",
 			$preload_links,
 			'<body>',
 			"Expected preload links to match snapshot:\n$preload_links"
 		);
 		$this->assertEqualHTML(
-			'
-				<script type="module" src="/enqueued.js" id="enqueued-js-module"></script>
-			',
+			"<script type='module' src='/enqueued.js' id='enqueued-js-module'></script>\n",
 			$script_modules,
 			'<body>',
 			"Expected script modules to match snapshot:\n$script_modules"


### PR DESCRIPTION
Ensure that leading text whitespace is included in `assertEqualHTML` comparisons. See the Trac ticket description:

> Some leading whitespace is trimmed from text nodes resulting in incorrect assertions like the following (passes, but should not):
> 
> ```php
> 
> $this->assertEqualHTML(
>   "<p> x</p>",
>   "<p>\nx</p>"
> );
> ```
> 
> The following tree is constructed by build_visual_html_tree() in both cases:
> 
> ```
> <p>
>   "x"
> ```
> 
> The expected trees are:
> 
> ```
> <p>
>   " x"
> ```
> ```
> <p>
>   "
> x"
> ```

Trac ticket: https://core.trac.wordpress.org/ticket/64531

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
