### PR TITLE
Build: Fix redirect and error handling in performance results logging

### DIFF
--- a/.github/workflows/reusable-performance-report-v2.yml
+++ b/.github/workflows/reusable-performance-report-v2.yml
@@ -104,7 +104,7 @@ jobs:
         env:
           BASE_SHA: ${{ steps.base-sha.outputs.result }}
           CODEVITALS_PROJECT_TOKEN: ${{ secrets.CODEVITALS_PROJECT_TOKEN }}
-          HOST_NAME: www.codevitals.run
+          HOST_NAME: codevitals.run
         run: |
           if [ -z "$CODEVITALS_PROJECT_TOKEN" ]; then
             echo "Performance results could not be published. 'CODEVITALS_PROJECT_TOKEN' is not set"

--- a/.github/workflows/reusable-performance.yml
+++ b/.github/workflows/reusable-performance.yml
@@ -347,7 +347,7 @@ jobs:
         env:
           BASE_SHA: ${{ steps.base-sha.outputs.result }}
           CODEVITALS_PROJECT_TOKEN: ${{ secrets.CODEVITALS_PROJECT_TOKEN }}
-          HOST_NAME: "www.codevitals.run"
+          HOST_NAME: "codevitals.run"
         run: |
           if [ -z "$CODEVITALS_PROJECT_TOKEN" ]; then
             echo "Performance results could not be published. 'CODEVITALS_PROJECT_TOKEN' is not set"

--- a/tests/performance/log-results.js
+++ b/tests/performance/log-results.js
@@ -10,7 +10,6 @@
 /**
  * External dependencies.
  */
-const https = require( 'https' );
 const [ token, branch, hash, baseHash, date, host ] =
 	process.argv.slice( 2 );
 const { median, parseFile, accumulateValues } = require( './utils' );
@@ -82,40 +81,40 @@ for ( const { title, results } of afterStats ) {
 	}
 }
 
-const data = new TextEncoder().encode(
-	JSON.stringify( {
-		branch,
-		hash,
-		baseHash,
-		timestamp: date,
-		metrics: metrics,
-		baseMetrics: baseMetrics,
-	} )
-);
-
-const options = {
-	hostname: host,
-	port: 443,
-	path: '/api/log?token=' + token,
-	method: 'POST',
-	headers: {
-		'Content-Type': 'application/json',
-		'Content-Length': data.length,
-	},
-};
-
-const req = https.request( options, ( res ) => {
-	console.log( `statusCode: ${ res.statusCode }` );
-
-	res.on( 'data', ( d ) => {
-		process.stdout.write( d );
-	} );
+const data = JSON.stringify( {
+	branch,
+	hash,
+	baseHash,
+	timestamp: date,
+	metrics: metrics,
+	baseMetrics: baseMetrics,
 } );
 
-req.on( 'error', ( error ) => {
-	console.error( error );
-	process.exit( 1 );
-} );
+( async () => {
+	try {
+		const response = await fetch(
+			`https://${ host }/api/log?token=${ token }`,
+			{
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: data,
+			}
+		);
 
-req.write( data );
-req.end();
+		console.log( `statusCode: ${ response.status }` );
+
+		const responseText = await response.text();
+		if ( responseText ) {
+			console.log( responseText );
+		}
+
+		if ( ! response.ok ) {
+			process.exit( 1 );
+		}
+	} catch ( error ) {
+		console.error( error );
+		process.exit( 1 );
+	}
+} )();


### PR DESCRIPTION
## Summary
- Replace `https.request()` with native `fetch()` in `log-results.js`
- Properly follow HTTP redirects (301/302)
- Exit with non-zero code on non-2xx responses

## Problem
The performance results logging script would silently succeed even when the API returned a redirect or error response, causing performance results to be lost without any indication in CI.

## Solution
Use native `fetch()` (Node 18+) which automatically follows redirects and check `response.ok` to properly fail on error responses.

Trac ticket: https://core.trac.wordpress.org/ticket/64534

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)