### PR TITLE
Style Engine: Bail early when adding a declaration if not passed a string

### DIFF
--- a/src/wp-includes/style-engine/class-wp-style-engine-css-declarations.php
+++ b/src/wp-includes/style-engine/class-wp-style-engine-css-declarations.php
@@ -59,6 +59,11 @@ class WP_Style_Engine_CSS_Declarations {
 			return $this;
 		}
 
+		// Bail early if value is not a string. Prevents fatal errors from malformed block markup.
+		if ( ! is_string( $value ) ) {
+			return $this;
+		}
+
 		// Trims the value. If empty, bail early.
 		$value = trim( $value );
 		if ( '' === $value ) {

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
@@ -290,4 +290,32 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 			'Output after removing "color" and "margin" declarations via `remove_declarations()` does not match expectations'
 		);
 	}
+
+	/**
+	 * Tests that non-string values are rejected without causing fatal errors.
+	 *
+	 * @ticket 56467
+	 *
+	 * @covers ::add_declaration
+	 */
+	public function test_should_reject_non_string_values() {
+		$css_declarations = new WP_Style_Engine_CSS_Declarations();
+
+		// Add valid string value first.
+		$css_declarations->add_declaration( 'color', 'red' );
+
+		// Try to add array value - should be silently rejected.
+		$css_declarations->add_declaration( 'padding-margin', array( 'top' => '10px' ) );
+
+		// Try to add other non-string values.
+		$css_declarations->add_declaration( 'font-size', 123 );
+		$css_declarations->add_declaration( 'margin', null );
+
+		// Only the valid string value should be stored.
+		$this->assertSame(
+			array( 'color' => 'red' ),
+			$css_declarations->get_declarations(),
+			'Non-string values should be rejected without causing errors.'
+		);
+	}
 }

--- a/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
+++ b/tests/phpunit/tests/style-engine/wpStyleEngineCssDeclarations.php
@@ -294,7 +294,7 @@ class Tests_Style_Engine_wpStyleEngineCSSDeclarations extends WP_UnitTestCase {
 	/**
 	 * Tests that non-string values are rejected without causing fatal errors.
 	 *
-	 * @ticket 56467
+	 * @ticket 64545
 	 *
 	 * @covers ::add_declaration
 	 */


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

This PR hardens `add_declaration` in the Style Engine when passed non-string values. The changes are already in Gutenberg over in: https://github.com/WordPress/gutenberg/pull/74881

Trac ticket: https://core.trac.wordpress.org/ticket/64545

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
