### PR TITLE
Twenty Twenty-Four: Remove duplicated comments in functions.php

### DIFF
--- a/src/wp-content/themes/twentytwentyfour/functions.php
+++ b/src/wp-content/themes/twentytwentyfour/functions.php
@@ -8,10 +8,6 @@
  * @since Twenty Twenty-Four 1.0
  */
 
-/**
- * Register block styles.
- */
-
 if ( ! function_exists( 'twentytwentyfour_block_styles' ) ) :
 	/**
 	 * Registers custom block styles.
@@ -146,10 +142,6 @@ endif;
 
 add_action( 'init', 'twentytwentyfour_block_styles' );
 
-/**
- * Enqueue block stylesheets.
- */
-
 if ( ! function_exists( 'twentytwentyfour_block_stylesheets' ) ) :
 	/**
 	 * Enqueues custom block stylesheets.
@@ -179,10 +171,6 @@ if ( ! function_exists( 'twentytwentyfour_block_stylesheets' ) ) :
 endif;
 
 add_action( 'init', 'twentytwentyfour_block_stylesheets' );
-
-/**
- * Register pattern categories.
- */
 
 if ( ! function_exists( 'twentytwentyfour_pattern_categories' ) ) :
 	/**


### PR DESCRIPTION
Removes three instances of comments in  `src/wp-content/themes/twentytwentyfour/functions.php`  
that duplicate the function summaries in the DocBlocks immediately following them.

## Rationale
The comments **“Register block styles.”**, **“Enqueue block stylesheets.”**, and **“Register pattern categories.”** are unnecessary because the DocBlocks for the following functions already clearly describe their purposes:

- `twentytwentyfour_block_styles`
- `twentytwentyfour_block_stylesheets`
- `twentytwentyfour_pattern_categories`

Removing these duplicate comments improves code cleanliness and avoids redundant documentation.

Ticket: https://core.trac.wordpress.org/ticket/64226
