### PR TITLE
Build/Test Tools: Ensure `assertEqualHTML()` recognizes whitespace text.

### DIFF
--- a/tests/phpunit/includes/build-visual-html-tree.php
+++ b/tests/phpunit/includes/build-visual-html-tree.php
@@ -202,7 +202,7 @@ function build_visual_html_tree( string $html, ?string $fragment_context ): stri
 			case '#cdata-section':
 			case '#text':
 				$text_content = $processor->get_modifiable_text();
-				if ( '' === trim( $text_content, " \f\t\r\n" ) ) {
+				if ( '' === $text_content ) {
 					break;
 				}
 				$was_text = true;
@@ -237,7 +237,7 @@ function build_visual_html_tree( string $html, ?string $fragment_context ): stri
 							++$indent_level;
 						}
 
-						// If they're no attributes, we're done here.
+						// When no attributes are present, there’s nothing left to do.
 						if ( empty( $block_attrs ) ) {
 							break;
 						}

--- a/tests/phpunit/tests/blocks/wpBlock.php
+++ b/tests/phpunit/tests/blocks/wpBlock.php
@@ -368,32 +368,39 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function data_provider_test_render_enqueues_scripts_and_styles(): array {
-		$block_markup = '
-			<!-- wp:static -->
-			<div class="static">
-				<!-- wp:static-child -->
-				<div class="static-child">First child</div>
-				<!-- /wp:static-child -->
-				<!-- wp:dynamic /-->
-				<!-- wp:static-child -->
-				<div class="static-child">Last child</div>
-				<!-- /wp:static-child -->
-			</div>
-			<!-- /wp:static -->
-		';
+		$block_markup = <<<'HTML'
+<!-- wp:static -->
+<div class="static">
+<!-- wp:static-child -->
+<div class="static-child">First child</div>
+<!-- /wp:static-child -->
+<!-- wp:dynamic /-->
+<!-- wp:static-child -->
+<div class="static-child">Last child</div>
+<!-- /wp:static-child -->
+</div>
+<!-- /wp:static -->
+HTML;
 
 		// TODO: Add case where a dynamic block renders other blocks?
 		return array(
 			'all_printed'                             => array(
 				'set_up'                  => null,
 				'block_markup'            => $block_markup,
-				'expected_rendered_block' => '
-					<div class="static">
-						<div class="static-child">First child</div>
-						<p class="dynamic">Hello World!</p>
-						<div class="static-child">Last child</div>
-					</div>
-				',
+				'expected_rendered_block' => <<<'HTML'
+
+<div class="static">
+
+<div class="static-child">First child</div>
+
+<p class="dynamic">Hello World!</p>
+
+<div class="static-child">Last child</div>
+
+</div>
+
+HTML
+				,
 				'expected_styles'         => array( 'static-view-style', 'static-child-view-style', 'dynamic-view-style' ),
 				'expected_scripts'        => array( 'static-view-script', 'static-child-view-script', 'dynamic-view-script' ),
 				'expected_script_modules' => array( 'static-view-script-module', 'static-child-view-script-module', 'dynamic-view-script-module' ),
@@ -414,13 +421,20 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 					);
 				},
 				'block_markup'            => $block_markup,
-				'expected_rendered_block' => '
-					<div class="static">
-						<div class="static-child">First child</div>
-						<p class="dynamic filtered">Hello World!</p>
-						<div class="static-child">Last child</div>
-					</div>
-				',
+				'expected_rendered_block' => <<<'HTML'
+
+<div class="static">
+
+<div class="static-child">First child</div>
+
+<p class="dynamic filtered">Hello World!</p>
+
+<div class="static-child">Last child</div>
+
+</div>
+
+HTML
+				,
 				'expected_styles'         => array( 'static-view-style', 'dynamic-extra', 'static-child-view-style', 'dynamic-view-style' ),
 				'expected_scripts'        => array( 'static-view-script', 'static-child-view-script', 'dynamic-view-script' ),
 				'expected_script_modules' => array( 'static-view-script-module', 'static-child-view-script-module', 'dynamic-view-script-module' ),
@@ -430,12 +444,20 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 					add_filter( 'render_block_core/dynamic', '__return_empty_string' );
 				},
 				'block_markup'            => $block_markup,
-				'expected_rendered_block' => '
-					<div class="static">
-						<div class="static-child">First child</div>
-						<div class="static-child">Last child</div>
-					</div>
-				',
+				'expected_rendered_block' => <<<'HTML'
+
+<div class="static">
+
+<div class="static-child">First child</div>
+
+
+
+<div class="static-child">Last child</div>
+
+</div>
+
+HTML
+				,
 				'expected_styles'         => array( 'static-view-style', 'static-child-view-style' ),
 				'expected_scripts'        => array( 'static-view-script', 'static-child-view-script' ),
 				'expected_script_modules' => array( 'static-view-script-module', 'static-child-view-script-module' ),
@@ -456,12 +478,20 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 					);
 				},
 				'block_markup'            => $block_markup,
-				'expected_rendered_block' => '
-					<div class="static">
-						<div class="static-child">First child</div>
-						<div class="static-child">Last child</div>
-					</div>
-				',
+				'expected_rendered_block' => <<<'HTML'
+
+<div class="static">
+
+<div class="static-child">First child</div>
+
+
+
+<div class="static-child">Last child</div>
+
+</div>
+
+HTML
+				,
 				'expected_styles'         => array( 'static-view-style', 'static-child-view-style', 'dynamic-view-style' ),
 				'expected_scripts'        => array( 'static-view-script', 'static-child-view-script', 'dynamic-view-script' ),
 				'expected_script_modules' => array( 'static-view-script-module', 'static-child-view-script-module', 'dynamic-view-script-module' ),
@@ -488,11 +518,16 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 					add_filter( 'render_block_core/static-child', '__return_empty_string' );
 				},
 				'block_markup'            => $block_markup,
-				'expected_rendered_block' => '
-					<div class="static">
-						<p class="dynamic">Hello World!</p>
-					</div>
-				',
+				'expected_rendered_block' => <<<'HTML'
+
+<div class="static">
+
+<p class="dynamic">Hello World!</p>
+
+</div>
+
+HTML
+				,
 				'expected_styles'         => array( 'static-view-style', 'dynamic-view-style' ),
 				'expected_scripts'        => array( 'static-view-script', 'dynamic-view-script' ),
 				'expected_script_modules' => array( 'static-view-script-module', 'dynamic-view-script-module' ),
@@ -512,12 +547,18 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 					);
 				},
 				'block_markup'            => $block_markup,
-				'expected_rendered_block' => '
-					<div class="static">
-						<div class="static-child">First child</div>
-						<p class="dynamic">Hello World!</p>
-					</div>
-				',
+				'expected_rendered_block' => <<<'HTML'
+
+<div class="static">
+
+<div class="static-child">First child</div>
+
+<p class="dynamic">Hello World!</p>
+
+</div>
+
+HTML
+				,
 				'expected_styles'         => array( 'static-view-style', 'static-child-view-style', 'dynamic-view-style' ),
 				'expected_scripts'        => array( 'static-view-script', 'static-child-view-script', 'dynamic-view-script' ),
 				'expected_script_modules' => array( 'static-view-script-module', 'static-child-view-script-module', 'dynamic-view-script-module' ),
@@ -562,9 +603,8 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 					);
 				},
 				'block_markup'            => '<!-- wp:static --><div class="static"></div><!-- /wp:static -->',
-				'expected_rendered_block' => '
-					<div class="static yes-admin-bar-script-enqueued yes-admin-bar-style-enqueued"></div>
-				',
+				'expected_rendered_block' =>
+					'<div class="static yes-admin-bar-script-enqueued yes-admin-bar-style-enqueued"></div>',
 				'expected_styles'         => array( 'static-view-style', 'admin-bar' ),
 				'expected_scripts'        => array( 'static-view-script', 'admin-bar' ),
 				'expected_script_modules' => array( 'static-view-script-module' ),
@@ -668,7 +708,7 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 		);
 
 		// TODO: Why not use do_blocks() instead?
-		$parsed_blocks  = parse_blocks( trim( $block_markup ) );
+		$parsed_blocks  = parse_blocks( $block_markup );
 		$parsed_block   = $parsed_blocks[0];
 		$context        = array();
 		$block          = new WP_Block( $parsed_block, $context, $this->registry );
@@ -682,7 +722,7 @@ class Tests_Blocks_wpBlock extends WP_UnitTestCase {
 			$expected_rendered_block,
 			$rendered_block,
 			'<body>',
-			"Rendered block does not contain expected HTML:\n$rendered_block"
+			'Rendered block does not contain expected HTML.'
 		);
 	}
 

--- a/tests/phpunit/tests/build-visual-html-tree.php
+++ b/tests/phpunit/tests/build-visual-html-tree.php
@@ -9,13 +9,13 @@
  */
 class Tests_Build_Equivalent_HTML_Semantic_Tree extends WP_UnitTestCase {
 	public function data_build_equivalent_html_semantic_tree() {
-		$block_markup = <<<END
-			<!-- wp:separator {"className":"is-style-default has-custom-classname","style":{"spacing":{"margin":{"top":"50px","bottom":"50px"}}},"backgroundColor":"accent-1"} -->
-			  <hr class="wp-block-separator is-style-default has-custom-classname" style="margin-top: 50px; margin-bottom: 50px" />
-			<!-- /wp:separator -->
-END;
+		$block_markup = <<<'HTML'
+<!-- wp:separator {"className":"is-style-default has-custom-classname","style":{"spacing":{"margin":{"top":"50px","bottom":"50px"}}},"backgroundColor":"accent-1"} -->
+  <hr class="wp-block-separator is-style-default has-custom-classname" style="margin-top: 50px; margin-bottom: 50px" />
+<!-- /wp:separator -->
+HTML;
 
-		$tree_structure = <<<END
+		$tree_structure = <<<'TREE'
 BLOCK["core/separator"]
   {
     "backgroundColor": "accent-1",
@@ -29,19 +29,55 @@ BLOCK["core/separator"]
       }
     }
   }
+  "
+  "
   <hr>
     class="has-custom-classname is-style-default wp-block-separator"
     style="margin-top:50px;margin-bottom:50px;"
+  "
+"
 
-END;
+TREE;
 
-		return array(
-			'Block delimiter' => array( $block_markup, $tree_structure ),
-		);
+		yield 'Block delimiter' => array( $block_markup, $tree_structure );
+
+		$block_markup = <<<'HTML'
+<!-- wp:example/block -->
+	One
+	<!-- wp:example/nested-void /-->
+	Two
+	<!-- wp:example/nested -->
+		Three
+	<!-- /wp:example/nested -->
+	Four
+<!-- /wp:example/block -->
+HTML;
+
+		$tree_structure = <<<'TREE'
+BLOCK["example/block"]
+  "
+	One
+	"
+  BLOCK["example/nested-void"]
+  "
+	Two
+	"
+  BLOCK["example/nested"]
+    "
+		Three
+	"
+  "
+	Four
+"
+
+TREE;
+
+		yield 'Text nodes in blocks' => array( $block_markup, $tree_structure );
 	}
 
 	/**
 	 * @ticket 63527
+	 * @ticket 64531
 	 *
 	 * @covers ::build_visual_html_tree
 	 *
@@ -140,5 +176,42 @@ END;
 		$tree_actual   = build_visual_html_tree( $actual, '<body>' );
 
 		$this->assertNotSame( $tree_expected, $tree_actual );
+	}
+
+	/**
+	 * @ticket 64531
+	 *
+	 * @covers ::build_visual_html_tree
+	 */
+	public function test_spacing() {
+		$html = <<<'HTML'
+<p> space-surrounded&#x20;</p>
+<p>&nbsp;nbsp-surrounded&#xA0;</p>
+<p>
+newline-surrounded&#xA;</p>
+<p>&#x9;tab-surrounded	</p>
+<p>ok</p>
+HTML;
+
+		$expected = <<<TREE
+<p>
+  " space-surrounded "
+"\n"
+<p>
+  "\u{00A0}nbsp-surrounded\u{00A0}"
+"\n"
+<p>
+  "\nnewline-surrounded\n"
+"\n"
+<p>
+  "\ttab-surrounded\t"
+"\n"
+<p>
+  "ok"
+
+TREE;
+
+		$tree_result = build_visual_html_tree( $html, '<body>' );
+		$this->assertSame( $expected, $tree_result );
 	}
 }

--- a/tests/phpunit/tests/dependencies/scripts.php
+++ b/tests/phpunit/tests/dependencies/scripts.php
@@ -247,7 +247,7 @@ JS;
 		wp_enqueue_script( 'main-script-a2', '/main-script-a2.js', array( 'dependency-script-a2' ), null, compact( 'strategy' ) );
 		$output    = get_echo( 'wp_print_scripts' );
 		$expected  = "<script id='dependency-script-a2-js' src='/dependency-script-a2.js' type='text/javascript'></script>\n";
-		$expected .= "<script type='text/javascript' src='/main-script-a2.js' id='main-script-a2-js' {$strategy}='{$strategy}' data-wp-strategy='{$strategy}'></script>";
+		$expected .= "<script type='text/javascript' src='/main-script-a2.js' id='main-script-a2-js' {$strategy}='{$strategy}' data-wp-strategy='{$strategy}'></script>\n";
 		$this->assertEqualHTML( $expected, $output, '<body>', 'Dependents of a blocking dependency are free to have any strategy.' );
 	}
 
@@ -269,8 +269,9 @@ JS;
 		wp_enqueue_script( 'dependent-script-a3', '/dependent-script-a3.js', array( 'main-script-a3' ), null );
 		$output   = get_echo( 'wp_print_scripts' );
 		$expected = <<<JS
-			<script type='text/javascript' src='/main-script-a3.js' id='main-script-a3-js' data-wp-strategy='{$strategy}'></script>
-			<script id="dependent-script-a3-js" src="/dependent-script-a3.js" type="text/javascript"></script>
+<script type='text/javascript' src='/main-script-a3.js' id='main-script-a3-js' data-wp-strategy='{$strategy}'></script>
+<script id="dependent-script-a3-js" src="/dependent-script-a3.js" type="text/javascript"></script>
+
 JS;
 		$this->assertEqualHTML( $expected, $output, '<body>', 'Blocking dependents must force delayed dependencies to become blocking.' );
 	}
@@ -1353,22 +1354,20 @@ HTML
 		return array(
 			'enqueue_bajo' => array(
 				'enqueues' => array( 'bajo' ),
-				'expected' => '<script fetchpriority="low" id="bajo-js" src="/bajo.js" type="text/javascript"></script>',
+				'expected' => "<script fetchpriority='low' id='bajo-js' src='/bajo.js' type='text/javascript'></script>\n",
 			),
 			'enqueue_auto' => array(
 				'enqueues' => array( 'auto' ),
-				'expected' => '
-					<script type="text/javascript" src="/bajo.js" id="bajo-js" data-wp-fetchpriority="low"></script>
-					<script type="text/javascript" src="/auto.js" id="auto-js"></script>
-				',
+				'expected' =>
+					"<script type='text/javascript' src='/bajo.js' id='bajo-js' data-wp-fetchpriority='low'></script>\n" .
+					"<script type='text/javascript' src='/auto.js' id='auto-js'></script>\n",
 			),
 			'enqueue_alto' => array(
 				'enqueues' => array( 'alto' ),
-				'expected' => '
-					<script type="text/javascript" src="/bajo.js" id="bajo-js" fetchpriority="high" data-wp-fetchpriority="low"></script>
-					<script type="text/javascript" src="/auto.js" id="auto-js" fetchpriority="high" data-wp-fetchpriority="auto"></script>
-					<script type="text/javascript" src="/alto.js" id="alto-js" fetchpriority="high"></script>
-				',
+				'expected' =>
+					"<script type='text/javascript' src='/bajo.js' id='bajo-js' fetchpriority='high' data-wp-fetchpriority='low'></script>\n" .
+					"<script type='text/javascript' src='/auto.js' id='auto-js' fetchpriority='high' data-wp-fetchpriority='auto'></script>\n" .
+					"<script type='text/javascript' src='/alto.js' id='alto-js' fetchpriority='high'></script>\n",
 			),
 		);
 	}
@@ -1422,16 +1421,17 @@ HTML
 		wp_enqueue_script( 'x' );
 
 		$actual   = get_echo( 'wp_print_scripts' );
-		$expected = '
-			<script type="text/javascript" src="/z.js" id="z-js" fetchpriority="high" data-wp-fetchpriority="auto"></script>
-			<script type="text/javascript" src="/d.js" id="d-js" fetchpriority="high"></script>
-			<script type="text/javascript" src="/e.js" id="e-js"></script>
-			<script type="text/javascript" src="/c.js" id="c-js"></script>
-			<script type="text/javascript" src="/b.js" id="b-js"></script>
-			<script type="text/javascript" src="/a.js" id="a-js" fetchpriority="low"></script>
-			<script type="text/javascript" src="/y.js" id="y-js" fetchpriority="high" data-wp-fetchpriority="auto"></script>
-			<script type="text/javascript" src="/x.js" id="x-js" fetchpriority="high"></script>
-		';
+		$expected = <<<'HTML'
+<script type="text/javascript" src="/z.js" id="z-js" fetchpriority="high" data-wp-fetchpriority="auto"></script>
+<script type="text/javascript" src="/d.js" id="d-js" fetchpriority="high"></script>
+<script type="text/javascript" src="/e.js" id="e-js"></script>
+<script type="text/javascript" src="/c.js" id="c-js"></script>
+<script type="text/javascript" src="/b.js" id="b-js"></script>
+<script type="text/javascript" src="/a.js" id="a-js" fetchpriority="low"></script>
+<script type="text/javascript" src="/y.js" id="y-js" fetchpriority="high" data-wp-fetchpriority="auto"></script>
+<script type="text/javascript" src="/x.js" id="x-js" fetchpriority="high"></script>
+
+HTML;
 		$this->assertEqualHTML( $expected, $actual, '<body>', "Snapshot:\n$actual" );
 	}
 
@@ -1487,7 +1487,7 @@ HTML
 
 		$actual = $this->normalize_markup_for_snapshot( get_echo( array( $wp_scripts, 'print_scripts' ) ) );
 		$this->assertEqualHTML(
-			'<script type="text/javascript" src="/wp-includes/js/comment-reply.js" id="comment-reply-js" async="async" data-wp-strategy="async" fetchpriority="low"></script>',
+			"<script type='text/javascript' src='/wp-includes/js/comment-reply.js' id='comment-reply-js' async='async' data-wp-strategy='async' fetchpriority='low'></script>\n",
 			$actual,
 			'<body>',
 			"Snapshot:\n$actual"
@@ -1524,7 +1524,7 @@ HTML
 
 		$this->assertEqualHTML(
 			sprintf(
-				'<script type="text/javascript" src="%s" id="comment-reply-js" async="async" data-wp-strategy="async" fetchpriority="low"></script>',
+				"<script type='text/javascript' src='%s' id='comment-reply-js' async='async' data-wp-strategy='async' fetchpriority='low'></script>\n",
 				includes_url( 'js/comment-reply.js' )
 			),
 			$markup
@@ -2283,6 +2283,7 @@ console.log("before");
 //# sourceURL=test-example-js-before
 /* ]]> */
 </script>
+
 HTML;
 		$expected .= "<script type='text/javascript' src='http://example.com' id='test-example-js'></script>\n";
 
@@ -2304,6 +2305,7 @@ console.log("after");
 //# sourceURL=test-example-js-after
 /* ]]> */
 </script>
+
 HTML;
 
 		$this->assertEqualHTML( $expected, get_echo( 'wp_print_scripts' ) );
@@ -3654,10 +3656,9 @@ HTML;
 					wp_enqueue_script( 'script-b', 'https://example.com/script-b.js', array( 'script-a' ), null, array( 'in_footer' => true ) );
 				},
 				'expected_header'    => '',
-				'expected_footer'    => '
-					<script type="text/javascript" src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="defer"></script>
-					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js"></script>
-				',
+				'expected_footer'    =>
+					"<script type='text/javascript' src='https://example.com/script-a.js' id='script-a-js' data-wp-strategy='defer'></script>\n" .
+					"<script type='text/javascript' src='https://example.com/script-b.js' id='script-b-js'></script>\n",
 				'expected_in_footer' => array(
 					'script-a',
 					'script-b',
@@ -3675,10 +3676,9 @@ HTML;
 					wp_enqueue_script( 'script-b', 'https://example.com/script-b.js', array( 'script-a' ), null, array( 'in_footer' => true ) );
 				},
 				'expected_header'    => '',
-				'expected_footer'    => '
-					<script type="text/javascript" src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="async"></script>
-					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js"></script>
-				',
+				'expected_footer'    =>
+					"<script type='text/javascript' src='https://example.com/script-a.js' id='script-a-js' data-wp-strategy='async'></script>\n" .
+					"<script type='text/javascript' src='https://example.com/script-b.js' id='script-b-js'></script>\n",
 				'expected_in_footer' => array(
 					'script-a',
 					'script-b',
@@ -3695,10 +3695,9 @@ HTML;
 					wp_enqueue_script( 'script-a', 'https://example.com/script-a.js', array(), null, array( 'strategy' => 'defer' ) );
 					wp_enqueue_script( 'script-b', 'https://example.com/script-b.js', array( 'script-a' ), null, array( 'in_footer' => false ) );
 				},
-				'expected_header'    => '
-					<script type="text/javascript" src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="defer"></script>
-					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js"></script>
-				',
+				'expected_header'    =>
+					"<script type='text/javascript' src='https://example.com/script-a.js' id='script-a-js' data-wp-strategy='defer'></script>\n" .
+					"<script type='text/javascript' src='https://example.com/script-b.js' id='script-b-js'></script>\n",
 				'expected_footer'    => '',
 				'expected_in_footer' => array(),
 				'expected_groups'    => array(
@@ -3722,12 +3721,10 @@ HTML;
 						)
 					);
 				},
-				'expected_header'    => '
-					<script type="text/javascript" src="https://example.com/script-a.js" id="script-a-js" defer="defer" data-wp-strategy="defer"></script>
-				',
-				'expected_footer'    => '
-					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js" defer="defer" data-wp-strategy="defer"></script>
-				',
+				'expected_header'    =>
+					"<script type='text/javascript' src='https://example.com/script-a.js' id='script-a-js' defer='defer' data-wp-strategy='defer'></script>\n",
+				'expected_footer'    =>
+					"<script type='text/javascript' src='https://example.com/script-b.js' id='script-b-js' defer='defer' data-wp-strategy='defer'></script>\n",
 				'expected_in_footer' => array(
 					'script-b',
 				),
@@ -3772,14 +3769,12 @@ HTML;
 						)
 					);
 				},
-				'expected_header'    => '
-					<script type="text/javascript" src="https://example.com/script-a.js" id="script-a-js" defer="defer" data-wp-strategy="defer"></script>
-					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js" defer="defer" data-wp-strategy="defer"></script>
-				',
-				'expected_footer'    => '
-					<script type="text/javascript" src="https://example.com/script-c.js" id="script-c-js" defer="defer" data-wp-strategy="defer"></script>
-					<script type="text/javascript" src="https://example.com/script-d.js" id="script-d-js" defer="defer" data-wp-strategy="defer"></script>
-				',
+				'expected_header'    =>
+					"<script type='text/javascript' src='https://example.com/script-a.js' id='script-a-js' defer='defer' data-wp-strategy='defer'></script>\n" .
+					"<script type='text/javascript' src='https://example.com/script-b.js' id='script-b-js' defer='defer' data-wp-strategy='defer'></script>\n",
+				'expected_footer'    =>
+					"<script type='text/javascript' src='https://example.com/script-c.js' id='script-c-js' defer='defer' data-wp-strategy='defer'></script>\n" .
+					"<script type='text/javascript' src='https://example.com/script-d.js' id='script-d-js' defer='defer' data-wp-strategy='defer'></script>\n",
 				'expected_in_footer' => array(
 					'script-c',
 					'script-d',
@@ -3819,12 +3814,11 @@ HTML;
 					);
 				},
 				'expected_header'    => '',
-				'expected_footer'    => '
-					<script type="text/javascript" src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="defer"></script>
-					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js" defer="defer" data-wp-strategy="defer"></script>
-					<script type="text/javascript" src="https://example.com/script-c.js" id="script-c-js"></script>
-					<script type="text/javascript" src="https://example.com/script-d.js" id="script-d-js" defer="defer" data-wp-strategy="defer"></script>
-				',
+				'expected_footer'    =>
+					"<script type='text/javascript' src='https://example.com/script-a.js' id='script-a-js' data-wp-strategy='defer'></script>\n" .
+					"<script type='text/javascript' src='https://example.com/script-b.js' id='script-b-js' defer='defer' data-wp-strategy='defer'></script>\n" .
+					"<script type='text/javascript' src='https://example.com/script-c.js' id='script-c-js'></script>\n" .
+					"<script type='text/javascript' src='https://example.com/script-d.js' id='script-d-js' defer='defer' data-wp-strategy='defer'></script>\n",
 				'expected_in_footer' => array(
 					'script-a',
 					'script-b',
@@ -3866,14 +3860,12 @@ HTML;
 						)
 					);
 				},
-				'expected_header'    => '
-					<script type="text/javascript" src="https://example.com/script-a.js" id="script-a-js" data-wp-strategy="defer"></script>
-					<script type="text/javascript" src="https://example.com/script-b.js" id="script-b-js" defer="defer" data-wp-strategy="defer"></script>
-				',
-				'expected_footer'    => '
-					<script type="text/javascript" src="https://example.com/script-c.js" id="script-c-js"></script>
-					<script type="text/javascript" src="https://example.com/script-d.js" id="script-d-js" defer="defer" data-wp-strategy="defer"></script>
-				',
+				'expected_header'    =>
+					"<script type='text/javascript' src='https://example.com/script-a.js' id='script-a-js' data-wp-strategy='defer'></script>\n" .
+					"<script type='text/javascript' src='https://example.com/script-b.js' id='script-b-js' defer='defer' data-wp-strategy='defer'></script>\n",
+				'expected_footer'    =>
+					"<script type='text/javascript' src='https://example.com/script-c.js' id='script-c-js'></script>\n" .
+					"<script type='text/javascript' src='https://example.com/script-d.js' id='script-d-js' defer='defer' data-wp-strategy='defer'></script>\n",
 				'expected_in_footer' => array(
 					'script-c',
 					'script-d',
@@ -4087,6 +4079,7 @@ HTML;
 		$print_scripts = get_echo( '_print_scripts' );
 
 		$expected = <<<HTML
+
 <script>
 /* <![CDATA[ */
 var one = {"key":"val"};var two = {"key":"val"};

--- a/tests/phpunit/tests/dependencies/styles.php
+++ b/tests/phpunit/tests/dependencies/styles.php
@@ -810,6 +810,7 @@ HTML;
 h1 { background: blue; }h2 { color: green; }
 /*# sourceURL=css-inline-concat-one%2Ctwo */
 </style>
+
 HTML;
 
 		$this->assertEqualHTML( $expected, $printed );

--- a/tests/phpunit/tests/script-modules/wpScriptModules.php
+++ b/tests/phpunit/tests/script-modules/wpScriptModules.php
@@ -572,15 +572,17 @@ class Tests_Script_Modules_WpScriptModules extends WP_UnitTestCase {
 			10,
 			2
 		);
-		$actual = get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) );
+		$actual   = get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) );
+		$expected = <<<'HTML'
+<script type="module" src="/src.js" id="with-src-js-module"></script>
+<script type="module" src="/was-empty-but-added-via-filter.js" id="without-src-but-filtered-js-module"></script>
+
+HTML;
 		$this->assertEqualHTML(
-			'
-				<script type="module" src="/src.js" id="with-src-js-module"></script>
-				<script type="module" src="/was-empty-but-added-via-filter.js" id="without-src-but-filtered-js-module"></script>
-			',
+			$expected,
 			$actual,
 			'<body>',
-			"Expected only one SCRIPT tag to be printed. Snapshot:\n$actual"
+			'Expected only one SCRIPT tag to be printed.'
 		);
 	}
 
@@ -1476,25 +1478,31 @@ HTML;
 		$actual_head   = get_echo( array( wp_script_modules(), 'print_head_enqueued_script_modules' ) );
 		$actual_footer = get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) );
 
+		$expected = <<<'HTML'
+<script type="module" src="/default.js" id="default-js-module"></script>
+<script type="module" src="/not-in-footer-via-enqueue.js" id="not-in-footer-via-enqueue-js-module"></script>
+<script type="module" src="/not-in-footer-via-override.js" id="not-in-footer-via-override-js-module"></script>
+
+HTML;
+
 		$this->assertEqualHTML(
 			$actual_head,
-			'
-				<script type="module" src="/default.js" id="default-js-module"></script>
-				<script type="module" src="/not-in-footer-via-enqueue.js" id="not-in-footer-via-enqueue-js-module"></script>
-				<script type="module" src="/not-in-footer-via-override.js" id="not-in-footer-via-override-js-module"></script>
-			',
+			$expected,
 			'<body>',
-			"Expected equal script modules in the HEAD. Snapshot:\n$actual_head"
+			'Expected equal script modules in the HEAD.'
 		);
+
+		$expected = <<<'HTML'
+<script type="module" src="/in-footer-via-register.js" id="in-footer-via-register-js-module"></script>
+<script type="module" src="/in-footer-via-enqueue.js" id="in-footer-via-enqueue-js-module"></script>
+<script type="module" src="/in-footer-via-override.js" id="in-footer-via-override-js-module"></script>
+
+HTML;
 		$this->assertEqualHTML(
 			$actual_footer,
-			'
-				<script type="module" src="/in-footer-via-register.js" id="in-footer-via-register-js-module"></script>
-				<script type="module" src="/in-footer-via-enqueue.js" id="in-footer-via-enqueue-js-module"></script>
-				<script type="module" src="/in-footer-via-override.js" id="in-footer-via-override-js-module"></script>
-			',
+			$expected,
 			'<body>',
-			"Expected equal script modules in the footer. Snapshot:\n$actual_footer"
+			'Expected equal script modules in the footer.'
 		);
 	}
 
@@ -1746,17 +1754,18 @@ HTML;
 
 		$actual   = get_echo( array( wp_script_modules(), 'print_script_module_preloads' ) );
 		$actual  .= get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) );
-		$expected = '
-			<link rel="modulepreload" href="/z.js" id="z-js-modulepreload" fetchpriority="high">
-			<link rel="modulepreload" href="/d.js" id="d-js-modulepreload" fetchpriority="high">
-			<link rel="modulepreload" href="/e.js" id="e-js-modulepreload" fetchpriority="low">
-			<link rel="modulepreload" href="/c.js" id="c-js-modulepreload" fetchpriority="low">
-			<link rel="modulepreload" href="/b.js" id="b-js-modulepreload" fetchpriority="low">
-			<link rel="modulepreload" href="/y.js" id="y-js-modulepreload" fetchpriority="high">
-			<script type="module" src="/a.js" id="a-js-module" fetchpriority="low"></script>
-			<script type="module" src="/x.js" id="x-js-module" fetchpriority="high"></script>
-		';
-		$this->assertEqualHTML( $expected, $actual, '<body>', "Snapshot:\n$actual" );
+		$expected = <<<'HTML'
+<link rel="modulepreload" href="/z.js" id="z-js-modulepreload" fetchpriority="high">
+<link rel="modulepreload" href="/d.js" id="d-js-modulepreload" fetchpriority="high">
+<link rel="modulepreload" href="/e.js" id="e-js-modulepreload" fetchpriority="low">
+<link rel="modulepreload" href="/c.js" id="c-js-modulepreload" fetchpriority="low">
+<link rel="modulepreload" href="/b.js" id="b-js-modulepreload" fetchpriority="low">
+<link rel="modulepreload" href="/y.js" id="y-js-modulepreload" fetchpriority="high">
+<script type="module" src="/a.js" id="a-js-module" fetchpriority="low"></script>
+<script type="module" src="/x.js" id="x-js-module" fetchpriority="high"></script>
+
+HTML;
+		$this->assertEqualHTML( $expected, $actual );
 	}
 
 	/**
@@ -1791,18 +1800,19 @@ HTML;
 
 		$actual   = get_echo( array( wp_script_modules(), 'print_script_module_preloads' ) );
 		$actual  .= get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) );
-		$expected = '
-			<link rel="modulepreload" href="/d.js" id="d-js-modulepreload" fetchpriority="low">
-			<link rel="modulepreload" href="/e.js" id="e-js-modulepreload" fetchpriority="high" data-wp-fetchpriority="low">
-			<link rel="modulepreload" href="/a.js" id="a-js-modulepreload" fetchpriority="low" data-wp-fetchpriority="high">
-			<link rel="modulepreload" href="/b.js" id="b-js-modulepreload">
-			<link rel="modulepreload" href="/f.js" id="f-js-modulepreload" fetchpriority="high">
-			<link rel="modulepreload" href="/c.js" id="c-js-modulepreload" fetchpriority="high">
-			<script type="module" src="/x.js" id="x-js-module" fetchpriority="low"></script>
-			<script type="module" src="/y.js" id="y-js-module"></script>
-			<script type="module" src="/z.js" id="z-js-module" fetchpriority="high"></script>
-		';
-		$this->assertEqualHTML( $expected, $actual, '<body>', "Snapshot:\n$actual" );
+		$expected = <<<'HTML'
+<link rel="modulepreload" href="/d.js" id="d-js-modulepreload" fetchpriority="low">
+<link rel="modulepreload" href="/e.js" id="e-js-modulepreload" fetchpriority="high" data-wp-fetchpriority="low">
+<link rel="modulepreload" href="/a.js" id="a-js-modulepreload" fetchpriority="low" data-wp-fetchpriority="high">
+<link rel="modulepreload" href="/b.js" id="b-js-modulepreload">
+<link rel="modulepreload" href="/f.js" id="f-js-modulepreload" fetchpriority="high">
+<link rel="modulepreload" href="/c.js" id="c-js-modulepreload" fetchpriority="high">
+<script type="module" src="/x.js" id="x-js-module" fetchpriority="low"></script>
+<script type="module" src="/y.js" id="y-js-module"></script>
+<script type="module" src="/z.js" id="z-js-module" fetchpriority="high"></script>
+
+HTML;
+		$this->assertEqualHTML( $expected, $actual );
 	}
 
 	/**
@@ -1822,31 +1832,25 @@ HTML;
 
 		$actual_preloads = $this->normalize_markup_for_snapshot( get_echo( array( wp_script_modules(), 'print_script_module_preloads' ) ) );
 		$this->assertEqualHTML(
-			'
-				<link rel="modulepreload" href="/wp-includes/js/dist/script-modules/interactivity/debug.min.js" id="@wordpress/interactivity-js-modulepreload" fetchpriority="low">
-			',
-			$actual_preloads,
-			'<body>',
-			"Snapshot:\n$actual_preloads"
+			"<link rel='modulepreload' href='/wp-includes/js/dist/script-modules/interactivity/debug.min.js' id='@wordpress/interactivity-js-modulepreload' fetchpriority='low'>\n",
+			$actual_preloads
 		);
 
 		$actual_head_script_modules = $this->normalize_markup_for_snapshot( get_echo( array( wp_script_modules(), 'print_head_enqueued_script_modules' ) ) );
 		$this->assertEqualHTML(
 			'',
-			$actual_head_script_modules,
-			'<body>',
-			"Snapshot:\n$actual_head_script_modules"
+			$actual_head_script_modules
 		);
 
 		$actual_footer_script_modules = $this->normalize_markup_for_snapshot( get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) ) );
+		$expected                     = <<<'HTML'
+<script type="module" src="/wp-includes/js/dist/script-modules/a11y/index.min.js" id="@wordpress/a11y-js-module" fetchpriority="low"></script>
+<script type="module" src="/wp-includes/js/dist/script-modules/block-library/navigation/view.min.js" id="@wordpress/block-library/navigation/view-js-module" fetchpriority="low" data-wp-router-options="{&quot;loadOnClientNavigation&quot;:true}"></script>
+
+HTML;
 		$this->assertEqualHTML(
-			'
-				<script type="module" src="/wp-includes/js/dist/script-modules/a11y/index.min.js" id="@wordpress/a11y-js-module" fetchpriority="low"></script>
-				<script type="module" src="/wp-includes/js/dist/script-modules/block-library/navigation/view.min.js" id="@wordpress/block-library/navigation/view-js-module" fetchpriority="low" data-wp-router-options="{&quot;loadOnClientNavigation&quot;:true}"></script>
-			',
-			$actual_footer_script_modules,
-			'<body>',
-			"Snapshot:\n$actual_footer_script_modules"
+			$expected,
+			$actual_footer_script_modules
 		);
 	}
 
@@ -1866,10 +1870,8 @@ HTML;
 
 		$actual = $this->normalize_markup_for_snapshot( get_echo( array( wp_script_modules(), 'print_enqueued_script_modules' ) ) );
 		$this->assertEqualHTML(
-			'<script type="module" src="/wp-includes/js/dist/script-modules/a11y/index.min.js" id="@wordpress/a11y-js-module" fetchpriority="low"></script>',
-			$actual,
-			'<body>',
-			"Snapshot:\n$actual"
+			"<script type='module' src='/wp-includes/js/dist/script-modules/a11y/index.min.js' id='@wordpress/a11y-js-module' fetchpriority='low'></script>\n",
+			$actual
 		);
 	}
 
@@ -1895,13 +1897,14 @@ HTML;
 
 		$actual = $this->normalize_markup_for_snapshot( $actual );
 
-		$expected = '
-			<link rel="modulepreload" href="/wp-includes/js/dist/script-modules/a11y/index.min.js" id="@wordpress/a11y-js-modulepreload" fetchpriority="high" data-wp-fetchpriority="low">
-			<link rel="modulepreload" href="/wp-includes/js/dist/script-modules/interactivity/debug.min.js" id="@wordpress/interactivity-js-modulepreload" fetchpriority="high" data-wp-fetchpriority="low">
-			<link rel="modulepreload" href="/wp-includes/js/dist/script-modules/block-library/navigation/view.min.js" id="@wordpress/block-library/navigation/view-js-modulepreload" fetchpriority="high" data-wp-fetchpriority="low">
-			<script type="module" src="/super-important-module.js" id="super-important-js-module" fetchpriority="high"></script>
-		';
-		$this->assertEqualHTML( $expected, $actual, '<body>', "Snapshot:\n$actual" );
+		$expected = <<<'HTML'
+<link rel="modulepreload" href="/wp-includes/js/dist/script-modules/a11y/index.min.js" id="@wordpress/a11y-js-modulepreload" fetchpriority="high" data-wp-fetchpriority="low">
+<link rel="modulepreload" href="/wp-includes/js/dist/script-modules/interactivity/debug.min.js" id="@wordpress/interactivity-js-modulepreload" fetchpriority="high" data-wp-fetchpriority="low">
+<link rel="modulepreload" href="/wp-includes/js/dist/script-modules/block-library/navigation/view.min.js" id="@wordpress/block-library/navigation/view-js-modulepreload" fetchpriority="high" data-wp-fetchpriority="low">
+<script type="module" src="/super-important-module.js" id="super-important-js-module" fetchpriority="high"></script>
+
+HTML;
+		$this->assertEqualHTML( $expected, $actual );
 	}
 
 	/**
@@ -2340,20 +2343,16 @@ HTML;
 			"Expected import map to match snapshot:\n" . var_export( $import_map, true )
 		);
 		$this->assertEqualHTML(
-			'
-				<link rel="modulepreload" href="/static1.js" id="static1-js-modulepreload">
-			',
+			"<link rel='modulepreload' href='/static1.js' id='static1-js-modulepreload'>\n",
 			$preload_links,
 			'<body>',
-			"Expected preload links to match snapshot:\n$preload_links"
+			'Expected preload links to match.'
 		);
 		$this->assertEqualHTML(
-			'
-				<script type="module" src="/enqueued.js" id="enqueued-js-module"></script>
-			',
+			"<script type='module' src='/enqueued.js' id='enqueued-js-module'></script>\n",
 			$script_modules,
 			'<body>',
-			"Expected script modules to match snapshot:\n$script_modules"
+			'Expected script modules to match.'
 		);
 	}
 }


### PR DESCRIPTION
# Backport testing PR for r61519

> Ensure whitespace text nodes are correctly represented by `build_visual_html_tree()`.
> 
> The `build_visual_html_tree()` function used by `assertEqualHTML()` would remove some leading whitespace from text nodes. Some whitespace-only text nodes were omitted from the tree.
> 
> Developed in https://github.com/WordPress/wordpress-develop/pull/10765.
> 
> Follow-up to [60295].
> 
> Props jonsurrell, dmsnell, bernhard-reiter.
> Fixes #64531.

Backport of [[61519]](https://core.trac.wordpress.org/changeset/61519).

Trac ticket: https://core.trac.wordpress.org/ticket/64531

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
