### PR TITLE
Build: Copy Icons manifest file from Gutenberg

### DIFF
--- a/tools/gutenberg/copy-gutenberg-build.js
+++ b/tools/gutenberg/copy-gutenberg-build.js
@@ -12,6 +12,7 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 const json2php = require( 'json2php' );
+const glob = require( 'glob' );
 
 // Paths
 const rootDir = path.resolve( __dirname, '../..' );
@@ -1072,7 +1073,7 @@ async function main() {
 		const dest = path.join( wpIncludesDir, fileMap.destination );
 		fs.mkdirSync( dest, { recursive: true } );
 		for ( const src of fileMap.files ) {
-			const matches = fs.globSync( path.join( gutenbergDir, src ) );
+			const matches = glob.sync( path.join( gutenbergDir, src ) );
 			if ( ! matches.length ) {
 				throw new Error( `No files found matching '${ src }'` );
 			}

--- a/tools/gutenberg/copy-gutenberg-build.js
+++ b/tools/gutenberg/copy-gutenberg-build.js
@@ -105,6 +105,10 @@ const COPY_CONFIG = {
 			files: [ 'packages/icons/src/manifest.php' ],
 			destination: 'icons',
 		},
+		{
+			files: [ 'packages/icons/src/library/*.svg' ],
+			destination: 'icons/library',
+		},
 	],
 };
 
@@ -1068,10 +1072,17 @@ async function main() {
 		const dest = path.join( wpIncludesDir, fileMap.destination );
 		fs.mkdirSync( dest, { recursive: true } );
 		for ( const src of fileMap.files ) {
-			fs.copyFileSync(
-				path.join( gutenbergDir, src ),
-				path.join( dest, path.basename( src ) )
-			);
+			// Don't run `src` through `glob` unless it contains asterisks, so
+			// that non-existing files cause errors when calling `copyFile`
+			const matches = src.includes( '*' )
+				? fs.globSync( path.join( gutenbergDir, src ) )
+				: [ path.join( gutenbergDir, src ) ];
+			for ( const match of matches ) {
+				fs.copyFileSync(
+					match,
+					path.join( dest, path.basename( match ) )
+				);
+			}
 		}
 	}
 

--- a/tools/gutenberg/copy-gutenberg-build.js
+++ b/tools/gutenberg/copy-gutenberg-build.js
@@ -98,6 +98,14 @@ const COPY_CONFIG = {
 			{ from: 'theme-i18n.json', to: 'theme-i18n.json' },
 		],
 	},
+
+	// Specific files to copy to wp-includes/$destination
+	wpIncludes: [
+		{
+			files: [ 'packages/icons/src/manifest.php' ],
+			destination: 'icons',
+		},
+	],
 };
 
 /**
@@ -982,10 +990,7 @@ async function main() {
 						}
 					}
 				}
-			} else if (
-				entry.isFile() &&
-				entry.name.endsWith( '.js' )
-			) {
+			} else if ( entry.isFile() && entry.name.endsWith( '.js' ) ) {
 				// Copy root-level JS files
 				const dest = path.join( scriptsDest, entry.name );
 				fs.mkdirSync( path.dirname( dest ), { recursive: true } );
@@ -1054,6 +1059,19 @@ async function main() {
 			console.log( `   ✅ ${ fileMap.to }` );
 		} else {
 			console.log( `   ⚠️  Not found: ${ fileMap.from }` );
+		}
+	}
+
+	// Copy remaining files to wp-includes
+	console.log( '\n📦 Copying remaining files to wp-includes...' );
+	for ( const fileMap of COPY_CONFIG.wpIncludes ) {
+		const dest = path.join( wpIncludesDir, fileMap.destination );
+		fs.mkdirSync( dest, { recursive: true } );
+		for ( const src of fileMap.files ) {
+			fs.copyFileSync(
+				path.join( gutenbergDir, src ),
+				path.join( dest, path.basename( src ) )
+			);
 		}
 	}
 

--- a/tools/gutenberg/copy-gutenberg-build.js
+++ b/tools/gutenberg/copy-gutenberg-build.js
@@ -1072,11 +1072,10 @@ async function main() {
 		const dest = path.join( wpIncludesDir, fileMap.destination );
 		fs.mkdirSync( dest, { recursive: true } );
 		for ( const src of fileMap.files ) {
-			// Don't run `src` through `glob` unless it contains asterisks, so
-			// that non-existing files cause errors when calling `copyFile`
-			const matches = src.includes( '*' )
-				? fs.globSync( path.join( gutenbergDir, src ) )
-				: [ path.join( gutenbergDir, src ) ];
+			const matches = fs.globSync( path.join( gutenbergDir, src ) );
+			if ( ! matches.length ) {
+				throw new Error( `No files found matching '${ src }'` );
+			}
 			for ( const match of matches ) {
 				fs.copyFileSync(
 					match,


### PR DESCRIPTION
Companion PR to Gutenberg's https://github.com/WordPress/gutenberg/pull/74943

See the original PR for more context. This change will ensure that Gutenberg's `packages/icons/src/manifest.php` will be available in Core at `wp-includes/icons/manifest.php` along with the core SVG files at `wp-includes/icons/library/*.svg`.

Trac ticket: <!-- insert a link to the WordPress Trac ticket here -->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
