### PR TITLE
Build: copyBlockAssets: Use cpSync for proper recursive copy

### DIFF
--- a/tools/gutenberg/copy-gutenberg-build.js
+++ b/tools/gutenberg/copy-gutenberg-build.js
@@ -223,16 +223,15 @@ function copyBlockAssets( config ) {
 			// 1. Copy scripts/JSON (everything except PHP)
 			const blockScriptsSrc = path.join( scriptsSrc, blockName );
 			if ( fs.existsSync( blockScriptsSrc ) ) {
-				const files = fs.readdirSync( blockScriptsSrc );
-				for ( const file of files ) {
-					if ( file.endsWith( '.php' ) ) {
-						continue; // Skip PHP, copied from packages
+				fs.cpSync(
+					blockScriptsSrc,
+					blockDest,
+					{
+						recursive: true,
+						// Skip PHP, copied from packages
+						filter: f => ! f.endsWith( '.php' ),
 					}
-					fs.copyFileSync(
-						path.join( blockScriptsSrc, file ),
-						path.join( blockDest, file )
-					);
-				}
+				);
 			}
 
 			// 2. Copy styles (if they exist in per-block directory)


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/64559

Issue first described in https://github.com/WordPress/gutenberg/pull/74805#issuecomment-3800272544

Replace manual file iteration via `fs.cpSync` — which didn't support unexpected nested directories in block types' source dirs — with `fs.cpSync`.