### PR TITLE
Build/Test Tools: Optimize `uglify:core` and `copy:files` glob patterns in Grunt tasks.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -926,7 +926,7 @@ module.exports = function(grunt) {
 					'wp-includes/js/tinymce/plugins/wp*/plugin.js',
 
 					// Exceptions.
-					'!**/*.min.js',
+					'!{wp-admin,wp-includes}/**/*.min.js',
 					'!wp-admin/js/custom-header.js', // Why? We should minify this.
 					'!wp-admin/js/farbtastic.js',
 					'!wp-includes/js/wp-emoji-loader.js', // This is a module. See the emoji-loader task below.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -287,7 +287,7 @@ module.exports = function(grunt) {
 							'!wp-includes/certificates/legacy-1024bit.pem',
 							'!.{svn,git}', // Exclude version control folders.
 							'!wp-includes/version.php', // Exclude version.php.
-							'!**/*.map', // The build doesn't need .map files.
+							'!{wp-admin,wp-includes,wp-content/themes/twenty*,wp-content/plugins/akismet}/**/*.map', // The build doesn't need .map files.
 							'!index.php', '!wp-admin/index.php',
 							'!_index.php', '!wp-admin/_index.php'
 						] ),


### PR DESCRIPTION
The `uglify:core` task utilizes a negative glob pattern `!**/*.min.js` to prevent re-minifying already minified files. In development builds (`npm run build:dev`), this pattern operates relative to the `src/` directory. Consequently, the glob expansion scans the entire `src/` directory tree, including `wp-content`.

For environments where `wp-content` contains deep directory structures—such as plugins with `node_modules` dependencies—this traversal becomes prohibitively slow, causing the build process to hang.

This change scopes the exclusion pattern to `!{wp-admin,wp-includes}/**/*.min.js`, limiting the file scan to the relevant core directories and preventing unnecessary recursion into `wp-content`.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64563

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**


# Drafted Commit Message

Build/Test Tools: Optimize `uglify:core` and `copy:files` glob patterns in Grunt tasks.

The `uglify:core` and `copy:files` tasks utilized broad negative glob patterns (`!**/*.min.js` and `!**/*.map`) to exclude files from processing. The glob expansion scans the entire `src/` directory tree, including `wp-content`. For environments where `wp-content` contains deep directory structures (such as plugins with `node_modules` dependencies) this traversal becomes prohibitively slow, causing the build process to hang.

This change scopes the exclusion patterns to specific directories (e.g. `wp-admin`, `wp-includes`, default themes, and Akismet), limiting the file scan to relevant core paths and preventing unnecessary recursion into `wp-content`.

In one dev environment, this reduces `npm run build:dev` from 43s to 9s, and `npm run build` from 51s to 13s.

Developed in https://github.com/WordPress/wordpress-develop/pull/10809

Follow up to [61475].

Props westonruter, jonsurrell.
See #63606.
Fixes #64563.