### PR TITLE
Unflake the `test_object_cache_thresholds` test for the 6.9 branch

### DIFF
--- a/tests/phpunit/tests/admin/wpSiteHealth.php
+++ b/tests/phpunit/tests/admin/wpSiteHealth.php
@@ -490,7 +490,7 @@ class Tests_Admin_wpSiteHealth extends WP_UnitTestCase {
 			array( 'comments_count', 0 ),
 			array( 'posts_count', 0 ),
 			array( 'terms_count', 1 ),
-			array( 'options_count', 100 ),
+			array( 'options_count', 1 ),
 			array( 'users_count', 0 ),
 			array( 'alloptions_count', 1 ),
 			array( 'alloptions_bytes', 10 ),

--- a/tests/phpunit/tests/admin/wpSiteHealth.php
+++ b/tests/phpunit/tests/admin/wpSiteHealth.php
@@ -489,7 +489,7 @@ class Tests_Admin_wpSiteHealth extends WP_UnitTestCase {
 		return array(
 			array( 'comments_count', 0 ),
 			array( 'posts_count', 0 ),
-			array( 'terms_count', 1 ),
+			array( 'terms_count', 0 ),
 			array( 'options_count', 1 ),
 			array( 'users_count', 0 ),
 			array( 'alloptions_count', 1 ),

--- a/tests/phpunit/tests/admin/wpSiteHealth.php
+++ b/tests/phpunit/tests/admin/wpSiteHealth.php
@@ -492,8 +492,8 @@ class Tests_Admin_wpSiteHealth extends WP_UnitTestCase {
 			array( 'terms_count', 1 ),
 			array( 'options_count', 100 ),
 			array( 'users_count', 0 ),
-			array( 'alloptions_count', 100 ),
-			array( 'alloptions_bytes', 1000 ),
+			array( 'alloptions_count', 1 ),
+			array( 'alloptions_bytes', 10 ),
 		);
 	}
 


### PR DESCRIPTION
Reduces the thresholds for all options tests to be very low in order to substantially reduce the change the WordPress environment will affect the test.

Includes the change committed (see r61438)  for the options count for backporting to 6.9.

Trac ticket: https://core.trac.wordpress.org/ticket/60831

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
