### PR TITLE
Restore re-usable GB built workflow to unbreak 6.9 branch build tests.

### DIFF
--- a/.github/workflows/reusable-test-gutenberg-build-process.yml
+++ b/.github/workflows/reusable-test-gutenberg-build-process.yml
@@ -1,0 +1,100 @@
+##
+# A reusable workflow that tests the Gutenberg plugin build process when run within a wordpress-develop checkout.
+##
+name: Test the Gutenberg plugin Build Process
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        description: 'Operating system to run tests on'
+        required: false
+        type: 'string'
+        default: 'ubuntu-24.04'
+      directory:
+        description: 'Directory to run WordPress from. Valid values are `src` or `build`'
+        required: false
+        type: 'string'
+        default: 'src'
+
+env:
+  GUTENBERG_DIRECTORY: ${{ inputs.directory == 'build' && 'build' || 'src' }}/wp-content/plugins/gutenberg
+  PUPPETEER_SKIP_DOWNLOAD: ${{ true }}
+  NODE_OPTIONS: '--max-old-space-size=8192'
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
+jobs:
+  # Verifies that installing npm dependencies and building the Gutenberg plugin works as expected.
+  #
+  # Performs the following steps:
+  # - Checks out the repository.
+  # - Checks out the Gutenberg plugin into the plugins directory.
+  # - Sets up Node.js.
+  # - Logs debug information about the GitHub Action runner.
+  # - Installs Gutenberg npm dependencies.
+  # - Runs the Gutenberg build process.
+  # - Installs Core npm dependencies.
+  # - Builds WordPress to run from the relevant location (src or build).
+  # - Builds Gutenberg.
+  # - Ensures version-controlled files are not modified or deleted.
+  build-process-tests:
+    name: ${{ contains( inputs.os, 'macos-' ) && 'MacOS' || contains( inputs.os, 'windows-' ) && 'Windows' || 'Linux' }}
+    permissions:
+      contents: read
+    runs-on: ${{ inputs.os }}
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+          persist-credentials: false
+
+      - name: Checkout Gutenberg plugin
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: 'WordPress/gutenberg'
+          path: ${{ env.GUTENBERG_DIRECTORY }}
+          show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            ${{ env.GUTENBERG_DIRECTORY }}/package-lock.json
+
+      - name: Log debug information
+        run: |
+          npm --version
+          node --version
+          curl --version
+          git --version
+
+      - name: Install Gutenberg Dependencies
+        run: npm ci
+        working-directory: ${{ env.GUTENBERG_DIRECTORY }}
+
+      - name: Build Gutenberg
+        run: npm run build
+        working-directory: ${{ env.GUTENBERG_DIRECTORY }}
+
+      - name: Install Core Dependencies
+        run: npm ci
+
+      - name: Build WordPress to run from ${{ inputs.directory }}
+        run: npm run ${{ inputs.directory == 'src' && 'build:dev' || 'build' }}
+
+      - name: Run Gutenberg build script after building Core to run from ${{ inputs.directory }}
+        run: npm run build
+        working-directory: ${{ env.GUTENBERG_DIRECTORY }}
+
+      - name: Ensure version-controlled files are not modified or deleted during building
+        run: git diff --exit-code


### PR DESCRIPTION
Restores the workflow file `.github/workflows/reusable-test-gutenberg-build-process.yml` removed in 22294af4ed3b46f577f42590ba4cc19ca0a93f3f.

This file is required by the WordPress 6.9 branche for the Test Build Processes test to complete. At present these tests are silently failing. See this [action run on the 6.9 branch](https://github.com/WordPress/wordpress-develop/actions/runs/21501060924) for an example of a silent failure.

~An alternative approach may be to update the workflow on the 6.9 branch to pull this file from there. Let me know what you would prefer.~ _Edit: The file is used by 6.8 too so will need to be restored to trunk._

Trac ticket: https://core.trac.wordpress.org/ticket/64393

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
