### PR TITLE
Allow deleting expired transients by prefix

### DIFF
--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1651,9 +1651,11 @@ function delete_expired_transients( $force_db = false, $prefix = false ) {
 		return;
 	}
 
-	$prefix         = $prefix ?? '';
-	$transient_like = $wpdb->esc_like( "_transient_$prefix" ) . '%';
-	$timeout_like   = $wpdb->esc_like( '_transient_timeout_' ) . '%';
+	$transient_like = $wpdb->esc_like(
+		'_transient_' . ( $prefix ? $prefix : '' )
+	) . '%';
+
+	$timeout_like = $wpdb->esc_like( '_transient_timeout_' ) . '%';
 
 	$wpdb->query(
 		$wpdb->prepare(
@@ -1672,7 +1674,11 @@ function delete_expired_transients( $force_db = false, $prefix = false ) {
 
 	if ( ! is_multisite() ) {
 		// Single-site: site transients stored in options table.
-		$site_timeout_like = $wpdb->esc_like( "_site_transient_$prefix" ) . '%';
+
+		$site_transient_like = $wpdb->esc_like(
+			'_site_transient_' . ( $prefix ? $prefix : '' )
+		) . '%';
+
 		$site_timeout_like = $wpdb->esc_like( '_site_transient_timeout_' ) . '%';
 
 		$wpdb->query(
@@ -1692,8 +1698,12 @@ function delete_expired_transients( $force_db = false, $prefix = false ) {
 
 	} elseif ( is_main_site() && is_main_network() ) {
 		// Multisite: site transients stored in sitemeta.
-		$site_transient_like = $wpdb->esc_like( "_site_transient_$prefix" ) . '%';
-		$site_timeout_like   = $wpdb->esc_like( '_site_transient_timeout_' ) . '%';
+
+		$site_transient_like = $wpdb->esc_like(
+			'_site_transient_' . ( $prefix ? $prefix : '' )
+		) . '%';
+
+		$site_timeout_like = $wpdb->esc_like( '_site_transient_timeout_' ) . '%';
 
 		$wpdb->query(
 			$wpdb->prepare(

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1631,55 +1631,84 @@ function set_transient( $transient, $value, $expiration = 0 ) {
  *
  * @since 4.9.0
  *
- * @global wpdb $wpdb WordPress database abstraction object.
- *
- * @param bool $force_db Optional. Force cleanup to run against the database even when an external object cache is used.
+ * @param bool        $force_db Optional. Force cleanup to run against the database even when an
+ *                              external object cache is used. Default false.
+ * @param string|bool $prefix   Optional. Transient name prefix. When provided, only expired transients
+ *                              matching this prefix will be deleted. This parameter is only applied
+ *                              when not using an external object cache or when `$force_db` is true.
+ *                              Default false.
  */
-function delete_expired_transients( $force_db = false ) {
+function delete_expired_transients( $force_db = false, $prefix = false ) {
 	global $wpdb;
 
+	// Skip DB cleanup when using external object cache unless forced.
 	if ( ! $force_db && wp_using_ext_object_cache() ) {
 		return;
 	}
 
+	$transient_like = $wpdb->esc_like(
+		'_transient_' . ( $prefix ? $prefix : '' )
+	) . '%';
+
+	$timeout_like = $wpdb->esc_like( '_transient_timeout_' ) . '%';
+
 	$wpdb->query(
 		$wpdb->prepare(
-			"DELETE a, b FROM {$wpdb->options} a, {$wpdb->options} b
-			WHERE a.option_name LIKE %s
-			AND a.option_name NOT LIKE %s
-			AND b.option_name = CONCAT( '_transient_timeout_', SUBSTRING( a.option_name, 12 ) )
-			AND b.option_value < %d",
-			$wpdb->esc_like( '_transient_' ) . '%',
-			$wpdb->esc_like( '_transient_timeout_' ) . '%',
+			"DELETE a, b
+			 FROM {$wpdb->options} a
+			 JOIN {$wpdb->options} b
+			   ON b.option_name = CONCAT( '_transient_timeout_', SUBSTRING( a.option_name, 12 ) )
+			 WHERE a.option_name LIKE %s
+			   AND a.option_name NOT LIKE %s
+			   AND b.option_value < %d",
+			$transient_like,
+			$timeout_like,
 			time()
 		)
 	);
 
 	if ( ! is_multisite() ) {
-		// Single site stores site transients in the options table.
+		// Single-site: site transients stored in options table.
+		$site_transient_like = $wpdb->esc_like(
+			'_site_transient_' . ( $prefix ? $prefix : '' )
+		) . '%';
+
+		$site_timeout_like = $wpdb->esc_like( '_site_transient_timeout_' ) . '%';
+
 		$wpdb->query(
 			$wpdb->prepare(
-				"DELETE a, b FROM {$wpdb->options} a, {$wpdb->options} b
-				WHERE a.option_name LIKE %s
-				AND a.option_name NOT LIKE %s
-				AND b.option_name = CONCAT( '_site_transient_timeout_', SUBSTRING( a.option_name, 17 ) )
-				AND b.option_value < %d",
-				$wpdb->esc_like( '_site_transient_' ) . '%',
-				$wpdb->esc_like( '_site_transient_timeout_' ) . '%',
+				"DELETE a, b
+				 FROM {$wpdb->options} a
+				 JOIN {$wpdb->options} b
+				   ON b.option_name = CONCAT( '_site_transient_timeout_', SUBSTRING( a.option_name, 17 ) )
+				 WHERE a.option_name LIKE %s
+				   AND a.option_name NOT LIKE %s
+				   AND b.option_value < %d",
+				$site_transient_like,
+				$site_timeout_like,
 				time()
 			)
 		);
+
 	} elseif ( is_main_site() && is_main_network() ) {
-		// Multisite stores site transients in the sitemeta table.
+		// Multisite: site transients stored in sitemeta.
+		$site_transient_like = $wpdb->esc_like(
+			'_site_transient_' . ( $prefix ? $prefix : '' )
+		) . '%';
+
+		$site_timeout_like = $wpdb->esc_like( '_site_transient_timeout_' ) . '%';
+
 		$wpdb->query(
 			$wpdb->prepare(
-				"DELETE a, b FROM {$wpdb->sitemeta} a, {$wpdb->sitemeta} b
-				WHERE a.meta_key LIKE %s
-				AND a.meta_key NOT LIKE %s
-				AND b.meta_key = CONCAT( '_site_transient_timeout_', SUBSTRING( a.meta_key, 17 ) )
-				AND b.meta_value < %d",
-				$wpdb->esc_like( '_site_transient_' ) . '%',
-				$wpdb->esc_like( '_site_transient_timeout_' ) . '%',
+				"DELETE a, b
+				 FROM {$wpdb->sitemeta} a
+				 JOIN {$wpdb->sitemeta} b
+				   ON b.meta_key = CONCAT( '_site_transient_timeout_', SUBSTRING( a.meta_key, 17 ) )
+				 WHERE a.meta_key LIKE %s
+				   AND a.meta_key NOT LIKE %s
+				   AND b.meta_value < %d",
+				$site_transient_like,
+				$site_timeout_like,
 				time()
 			)
 		);

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1631,6 +1631,8 @@ function set_transient( $transient, $value, $expiration = 0 ) {
  *
  * @since 4.9.0
  *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ *
  * @param bool        $force_db Optional. Force cleanup to run against the database even when an
  *                              external object cache is used. Default false.
  * @param string|bool $prefix   Optional. Transient name prefix. When provided, only expired transients

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -1599,8 +1599,11 @@ function set_transient( $transient, $value, $expiration = 0 ) {
 		 * @since 6.8.0
 		 *
 		 * @param string $transient  The name of the transient.
+		 *                           @since 6.8.0
 		 * @param mixed  $value      Transient value.
+		 *                           @since 6.8.0
 		 * @param int    $expiration Time until expiration in seconds.
+		 *                           @since 6.8.0
 		 */
 		do_action( 'set_transient', $transient, $value, $expiration );
 
@@ -1648,11 +1651,9 @@ function delete_expired_transients( $force_db = false, $prefix = false ) {
 		return;
 	}
 
-	$transient_like = $wpdb->esc_like(
-		'_transient_' . ( $prefix ? $prefix : '' )
-	) . '%';
-
-	$timeout_like = $wpdb->esc_like( '_transient_timeout_' ) . '%';
+	$prefix         = $prefix ?? '';
+	$transient_like = $wpdb->esc_like( "_transient_$prefix" ) . '%';
+	$timeout_like   = $wpdb->esc_like( '_transient_timeout_' ) . '%';
 
 	$wpdb->query(
 		$wpdb->prepare(
@@ -1671,10 +1672,7 @@ function delete_expired_transients( $force_db = false, $prefix = false ) {
 
 	if ( ! is_multisite() ) {
 		// Single-site: site transients stored in options table.
-		$site_transient_like = $wpdb->esc_like(
-			'_site_transient_' . ( $prefix ? $prefix : '' )
-		) . '%';
-
+		$site_timeout_like = $wpdb->esc_like( "_site_transient_$prefix" ) . '%';
 		$site_timeout_like = $wpdb->esc_like( '_site_transient_timeout_' ) . '%';
 
 		$wpdb->query(
@@ -1694,11 +1692,8 @@ function delete_expired_transients( $force_db = false, $prefix = false ) {
 
 	} elseif ( is_main_site() && is_main_network() ) {
 		// Multisite: site transients stored in sitemeta.
-		$site_transient_like = $wpdb->esc_like(
-			'_site_transient_' . ( $prefix ? $prefix : '' )
-		) . '%';
-
-		$site_timeout_like = $wpdb->esc_like( '_site_transient_timeout_' ) . '%';
+		$site_transient_like = $wpdb->esc_like( "_site_transient_$prefix" ) . '%';
+		$site_timeout_like   = $wpdb->esc_like( '_site_transient_timeout_' ) . '%';
 
 		$wpdb->query(
 			$wpdb->prepare(


### PR DESCRIPTION
Adds an optional `$prefix` parameter to `delete_expired_transients()` to allow
scoped cleanup of expired transients when not using an external object cache
or when `$force_db` is enabled.

This enables plugins to safely clean up only their own expired transients.

Trac ticket: https://core.trac.wordpress.org/ticket/64553