### PR TITLE
Fix regression in `wp.sanitize.stripTags()` when input is `null` or `undefined`

### DIFF
--- a/src/js/_enqueues/wp/sanitize.js
+++ b/src/js/_enqueues/wp/sanitize.js
@@ -23,6 +23,10 @@
 		 * @return {string} Stripped text.
 		 */
 		stripTags: function( text ) {
+			if ( null === text || 'undefined' === typeof text ) {
+				return '';
+			}
+
 			const domParser = new DOMParser();
 			const htmlDocument = domParser.parseFromString(
 				text,

--- a/tests/qunit/index.html
+++ b/tests/qunit/index.html
@@ -155,6 +155,7 @@
 		<script src="wp-includes/js/api-request.js"></script>
 		<script src="wp-includes/js/jquery.js"></script>
 		<script src="wp-includes/js/wp-api.js"></script>
+		<script src="wp-includes/js/wp-sanitize.js"></script>
 		<script src="wp-admin/js/customize-controls.js"></script>
 		<script src="wp-admin/js/customize-controls-utils.js"></script>
 		<script src="wp-admin/js/customize-nav-menus.js"></script>

--- a/tests/qunit/wp-includes/js/wp-sanitize.js
+++ b/tests/qunit/wp-includes/js/wp-sanitize.js
@@ -1,0 +1,40 @@
+/* global wp */
+
+QUnit.module( 'wp.sanitize.stripTags' );
+
+QUnit.test( 'stripTags should return empty string for null input', function( assert ) {
+	const result = wp.sanitize.stripTags( null );
+	assert.strictEqual( result, '', 'stripTags( null ) should return ""' );
+} );
+
+QUnit.test( 'stripTags should return empty string for undefined input', function( assert ) {
+	const result = wp.sanitize.stripTags( undefined );
+	assert.strictEqual( result, '', 'stripTags( undefined ) should return ""' );
+} );
+
+QUnit.test( 'stripTags should strip tags from string', function( assert ) {
+	const result = wp.sanitize.stripTags( '<p>Hello <b>World</b></p>' );
+	assert.strictEqual( result, 'Hello World', 'stripTags( "<p>Hello <b>World</b></p>" ) should return "Hello World"' );
+} );
+
+QUnit.test( 'stripTags should convert numbers to strings', function( assert ) {
+	const result = wp.sanitize.stripTags( 123 );
+	assert.strictEqual( result, '123', 'stripTags( 123 ) should return "123"' );
+} );
+
+QUnit.module( 'wp.sanitize.stripTagsAndEncodeText' );
+
+QUnit.test( 'stripTagsAndEncodeText should return empty string for null input', function( assert ) {
+	const result = wp.sanitize.stripTagsAndEncodeText( null );
+	assert.strictEqual( result, '', 'stripTagsAndEncodeText( null ) should return ""' );
+} );
+
+QUnit.test( 'stripTagsAndEncodeText should return empty string for undefined input', function( assert ) {
+	const result = wp.sanitize.stripTagsAndEncodeText( undefined );
+	assert.strictEqual( result, '', 'stripTagsAndEncodeText( undefined ) should return ""' );
+} );
+
+QUnit.test( 'stripTagsAndEncodeText should strip tags and encode text', function( assert ) {
+	const result = wp.sanitize.stripTagsAndEncodeText( '<p>Hello & <b>World</b></p>' );
+	assert.strictEqual( result, 'Hello &amp; World', 'stripTagsAndEncodeText( "<p>Hello & <b>World</b></p>" ) should return "Hello &amp; World"' );
+} );


### PR DESCRIPTION
Ensure that `wp.sanitize.stripTags()` returns an empty string when the input is `null` or `undefined`, preventing it from being converted to the string "null" by `DOMParser`.

Added regression tests.

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64574

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
