### PR TITLE
Use wp_check_filetype to determine file extension

### DIFF
--- a/src/wp-includes/customize/class-wp-customize-media-control.php
+++ b/src/wp-includes/customize/class-wp-customize-media-control.php
@@ -93,7 +93,7 @@ class WP_Customize_Media_Control extends WP_Customize_Control {
 				 * Note that the default value must be a URL, NOT an attachment ID.
 				 */
 				$ext  = wp_check_filetype( $this->setting->default )['ext'];
-				$type = in_array( $ext, array( 'jpg', 'png', 'gif', 'bmp', 'webp', 'avif' ), true ) ? 'image' : 'document';
+				$type = in_array( $ext, array( 'jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'avif' ), true ) ? 'image' : 'document';
 
 				$default_attachment = array(
 					'id'    => 1,

--- a/src/wp-includes/customize/class-wp-customize-media-control.php
+++ b/src/wp-includes/customize/class-wp-customize-media-control.php
@@ -94,7 +94,7 @@ class WP_Customize_Media_Control extends WP_Customize_Control {
 				 */
 				$wp_filetype = wp_check_filetype( $this->setting->default );
 				$ext  = $wp_filetype['ext'];
-				
+
 				$type = in_array( $ext, array( 'jpg', 'png', 'gif', 'bmp', 'webp', 'avif' ), true ) ? 'image' : 'document';
 
 				$default_attachment = array(

--- a/src/wp-includes/customize/class-wp-customize-media-control.php
+++ b/src/wp-includes/customize/class-wp-customize-media-control.php
@@ -92,8 +92,9 @@ class WP_Customize_Media_Control extends WP_Customize_Control {
 				 * Fake an attachment model - needs all fields used by template.
 				 * Note that the default value must be a URL, NOT an attachment ID.
 				 */
-				$ext  = wp_check_filetype( $this->setting->default )['ext'];
-				$type = in_array( $ext, array( 'jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'avif' ), true ) ? 'image' : 'document';
+				$ext       = wp_check_filetype( $this->setting->default )['ext'];
+				$ext_types = wp_get_ext_types();
+				$type      = isset( $ext_types['image'] ) && in_array( $ext, $ext_types['image'], true ) ? 'image' : 'document';
 
 				$default_attachment = array(
 					'id'    => 1,

--- a/src/wp-includes/customize/class-wp-customize-media-control.php
+++ b/src/wp-includes/customize/class-wp-customize-media-control.php
@@ -92,9 +92,7 @@ class WP_Customize_Media_Control extends WP_Customize_Control {
 				 * Fake an attachment model - needs all fields used by template.
 				 * Note that the default value must be a URL, NOT an attachment ID.
 				 */
-				$wp_filetype = wp_check_filetype( $this->setting->default );
-				$ext  = $wp_filetype['ext'];
-
+				$ext  = wp_check_filetype( $this->setting->default )['ext'];
 				$type = in_array( $ext, array( 'jpg', 'png', 'gif', 'bmp', 'webp', 'avif' ), true ) ? 'image' : 'document';
 
 				$default_attachment = array(

--- a/src/wp-includes/customize/class-wp-customize-media-control.php
+++ b/src/wp-includes/customize/class-wp-customize-media-control.php
@@ -92,7 +92,9 @@ class WP_Customize_Media_Control extends WP_Customize_Control {
 				 * Fake an attachment model - needs all fields used by template.
 				 * Note that the default value must be a URL, NOT an attachment ID.
 				 */
-				$ext  = substr( $this->setting->default, -3 );
+				$wp_filetype = wp_check_filetype( $this->setting->default );
+				$ext  = $wp_filetype['ext'];
+				
 				$type = in_array( $ext, array( 'jpg', 'png', 'gif', 'bmp', 'webp', 'avif' ), true ) ? 'image' : 'document';
 
 				$default_attachment = array(

--- a/tests/phpunit/tests/customize/media-control.php
+++ b/tests/phpunit/tests/customize/media-control.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Tests for the WP_Customize_Media_Control class.
+ *
+ * @package WordPress
+ *
+ * @coversDefaultClass WP_Customize_Media_Control
+ *
+ * @group customize
+ */
+class Test_WP_Customize_Media_Control extends WP_UnitTestCase {
+
+	/**
+	 * Manager.
+	 */
+	public ?WP_Customize_Manager $wp_customize;
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
+		$GLOBALS['wp_customize'] = new WP_Customize_Manager();
+		$this->wp_customize      = $GLOBALS['wp_customize'];
+	}
+
+	/**
+	 * @ticket 64557
+	 *
+	 * @covers ::to_json
+	 */
+	public function test_to_json() {
+		$this->wp_customize->add_setting(
+			'some_jpg',
+			array(
+				'default' => 'https://example.com/image.jpg',
+			)
+		);
+		$this->wp_customize->add_setting(
+			'some_avif',
+			array(
+				'default' => 'https://example.com/image.avif',
+			)
+		);
+		$this->wp_customize->add_setting(
+			'some_pdf',
+			array(
+				'default' => 'https://example.com/image.pdf',
+			)
+		);
+		$this->wp_customize->add_setting( 'no_default' );
+
+		$some_jpg_control   = $this->wp_customize->add_control( new WP_Customize_Media_Control( $this->wp_customize, 'some_jpg' ) );
+		$some_avif_control  = $this->wp_customize->add_control( new WP_Customize_Media_Control( $this->wp_customize, 'some_avif' ) );
+		$some_pdf_control   = $this->wp_customize->add_control( new WP_Customize_Media_Control( $this->wp_customize, 'some_pdf' ) );
+		$no_default_control = $this->wp_customize->add_control( new WP_Customize_Media_Control( $this->wp_customize, 'no_default' ) );
+
+		$some_jpg_control_json  = $some_jpg_control->json();
+		$some_avif_control_json = $some_avif_control->json();
+		$some_pdf_control_json  = $some_pdf_control->json();
+
+		$this->assertSame( 'image', $some_jpg_control_json['defaultAttachment']['type'] );
+		$this->assertSame( 'image', $some_avif_control_json['defaultAttachment']['type'] );
+		$this->assertSame( 'document', $some_pdf_control_json['defaultAttachment']['type'] );
+		$this->assertArrayNotHasKey( 'defaultAttachment', $no_default_control->json() );
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		$this->wp_customize = null;
+		unset( $GLOBALS['wp_customize'] );
+		parent::tear_down();
+	}
+}

--- a/tests/phpunit/tests/customize/media-control.php
+++ b/tests/phpunit/tests/customize/media-control.php
@@ -11,18 +11,11 @@
 class Test_WP_Customize_Media_Control extends WP_UnitTestCase {
 
 	/**
-	 * Manager.
-	 */
-	public ?WP_Customize_Manager $wp_customize;
-
-	/**
 	 * Set up.
 	 */
 	public function set_up() {
 		parent::set_up();
 		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
-		$GLOBALS['wp_customize'] = new WP_Customize_Manager();
-		$this->wp_customize      = $GLOBALS['wp_customize'];
 	}
 
 	/**
@@ -31,30 +24,32 @@ class Test_WP_Customize_Media_Control extends WP_UnitTestCase {
 	 * @covers ::to_json
 	 */
 	public function test_to_json() {
-		$this->wp_customize->add_setting(
+		$manager = new WP_Customize_Manager();
+
+		$manager->add_setting(
 			'some_jpg',
 			array(
 				'default' => 'https://example.com/image.jpg',
 			)
 		);
-		$this->wp_customize->add_setting(
+		$manager->add_setting(
 			'some_avif',
 			array(
 				'default' => 'https://example.com/image.avif',
 			)
 		);
-		$this->wp_customize->add_setting(
+		$manager->add_setting(
 			'some_pdf',
 			array(
 				'default' => 'https://example.com/image.pdf',
 			)
 		);
-		$this->wp_customize->add_setting( 'no_default' );
+		$manager->add_setting( 'no_default' );
 
-		$some_jpg_control   = $this->wp_customize->add_control( new WP_Customize_Media_Control( $this->wp_customize, 'some_jpg' ) );
-		$some_avif_control  = $this->wp_customize->add_control( new WP_Customize_Media_Control( $this->wp_customize, 'some_avif' ) );
-		$some_pdf_control   = $this->wp_customize->add_control( new WP_Customize_Media_Control( $this->wp_customize, 'some_pdf' ) );
-		$no_default_control = $this->wp_customize->add_control( new WP_Customize_Media_Control( $this->wp_customize, 'no_default' ) );
+		$some_jpg_control   = $manager->add_control( new WP_Customize_Media_Control( $manager, 'some_jpg' ) );
+		$some_avif_control  = $manager->add_control( new WP_Customize_Media_Control( $manager, 'some_avif' ) );
+		$some_pdf_control   = $manager->add_control( new WP_Customize_Media_Control( $manager, 'some_pdf' ) );
+		$no_default_control = $manager->add_control( new WP_Customize_Media_Control( $manager, 'no_default' ) );
 
 		$some_jpg_control_json  = $some_jpg_control->json();
 		$some_avif_control_json = $some_avif_control->json();
@@ -64,14 +59,5 @@ class Test_WP_Customize_Media_Control extends WP_UnitTestCase {
 		$this->assertSame( 'image', $some_avif_control_json['defaultAttachment']['type'] );
 		$this->assertSame( 'document', $some_pdf_control_json['defaultAttachment']['type'] );
 		$this->assertArrayNotHasKey( 'defaultAttachment', $no_default_control->json() );
-	}
-
-	/**
-	 * Tear down.
-	 */
-	public function tear_down() {
-		$this->wp_customize = null;
-		unset( $GLOBALS['wp_customize'] );
-		parent::tear_down();
 	}
 }


### PR DESCRIPTION
Previously:

- https://github.com/WordPress/wordpress-develop/pull/10803

<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64557#ticket

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**

# Commit Message

Customize: Use `wp_check_filetype()` instead of `substr()` to extract file extension.

This fixes compatibility with image files that have 4-character extensions, such as `.webp` and `.avif`.

Follow-up to [57524], [50810], [30309].

Props buutqn, westonruter.
See #35725, #51228.
Fixes #64557.