### PR TITLE
Abilities API: Allow nested namespace ability names (2-4 segments)

### DIFF
--- a/src/wp-includes/abilities-api.php
+++ b/src/wp-includes/abilities-api.php
@@ -132,7 +132,8 @@ declare( strict_types = 1 );
  *
  * Ability names must follow these rules:
  *
- *  - Include a namespace prefix (e.g., `my-plugin/my-ability`).
+ *  - Contain 2 to 4 segments separated by forward slashes
+ *    (e.g., `my-plugin/my-ability`, `my-plugin/resource/find`, `my-plugin/resource/sub/find`).
  *  - Use only lowercase alphanumeric characters, dashes, and forward slashes.
  *  - Use descriptive, action-oriented names (e.g., `process-payment`, `generate-report`).
  *
@@ -225,8 +226,9 @@ declare( strict_types = 1 );
  * @see wp_register_ability_category()
  * @see wp_unregister_ability()
  *
- * @param string               $name The name of the ability. Must be a namespaced string containing
- *                                   a prefix, e.g., `my-plugin/my-ability`. Can only contain lowercase
+ * @param string               $name The name of the ability. Must contain 2 to 4 segments separated
+ *                                   by forward slashes, e.g., `my-plugin/my-ability` or
+ *                                   `my-plugin/resource/my-ability`. Can only contain lowercase
  *                                   alphanumeric characters, dashes, and forward slashes.
  * @param array<string, mixed> $args {
  *     An associative array of arguments for configuring the ability.
@@ -318,7 +320,7 @@ function wp_register_ability( string $name, array $args ): ?WP_Ability {
  * @see wp_register_ability()
  *
  * @param string $name The name of the ability to unregister, including namespace prefix
- *                     (e.g., 'my-plugin/my-ability').
+ *                     (e.g., 'my-plugin/my-ability' or 'my-plugin/resource/find').
  * @return WP_Ability|null The unregistered ability instance on success, `null` on failure.
  */
 function wp_unregister_ability( string $name ): ?WP_Ability {
@@ -351,7 +353,7 @@ function wp_unregister_ability( string $name ): ?WP_Ability {
  * @see wp_get_ability()
  *
  * @param string $name The name of the ability to check, including namespace prefix
- *                     (e.g., 'my-plugin/my-ability').
+ *                     (e.g., 'my-plugin/my-ability' or 'my-plugin/resource/find').
  * @return bool `true` if the ability is registered, `false` otherwise.
  */
 function wp_has_ability( string $name ): bool {
@@ -383,7 +385,7 @@ function wp_has_ability( string $name ): bool {
  * @see wp_has_ability()
  *
  * @param string $name The name of the ability, including namespace prefix
- *                     (e.g., 'my-plugin/my-ability').
+ *                     (e.g., 'my-plugin/my-ability' or 'my-plugin/resource/find').
  * @return WP_Ability|null The registered ability instance, or `null` if not registered.
  */
 function wp_get_ability( string $name ): ?WP_Ability {

--- a/src/wp-includes/abilities-api.php
+++ b/src/wp-includes/abilities-api.php
@@ -226,10 +226,8 @@ declare( strict_types = 1 );
  * @see wp_register_ability_category()
  * @see wp_unregister_ability()
  *
- * @param string               $name The name of the ability. Must contain 2 to 4 segments separated
- *                                   by forward slashes, e.g., `my-plugin/my-ability` or
- *                                   `my-plugin/resource/my-ability`. Can only contain lowercase
- *                                   alphanumeric characters, dashes, and forward slashes.
+ * @param string               $name The name of the ability. Must be the fully-namespaced
+ *                                   string identifier, e.g. `my-plugin/my-ability` or `my-plugin/resource/my-ability`
  * @param array<string, mixed> $args {
  *     An associative array of arguments for configuring the ability.
  *

--- a/src/wp-includes/abilities-api.php
+++ b/src/wp-includes/abilities-api.php
@@ -227,7 +227,7 @@ declare( strict_types = 1 );
  * @see wp_unregister_ability()
  *
  * @param string               $name The name of the ability. Must be the fully-namespaced
- *                                   string identifier, e.g. `my-plugin/my-ability` or `my-plugin/resource/my-ability`
+ *                                   string identifier, e.g. `my-plugin/my-ability` or `my-plugin/resource/my-ability`.
  * @param array<string, mixed> $args {
  *     An associative array of arguments for configuring the ability.
  *

--- a/src/wp-includes/abilities-api/class-wp-abilities-registry.php
+++ b/src/wp-includes/abilities-api/class-wp-abilities-registry.php
@@ -43,10 +43,8 @@ final class WP_Abilities_Registry {
 	 *
 	 * @see wp_register_ability()
 	 *
-	 * @param string               $name The name of the ability. The name must contain 2 to 4 segments
-	 *                                   separated by forward slashes, e.g. `my-plugin/my-ability` or
-	 *                                   `my-plugin/resource/my-ability`. It can only contain lowercase
-	 *                                   alphanumeric characters, dashes, and forward slashes.
+	 * @param string               $name The name of the ability. Must be the fully-namespaced
+ *                                       string identifier, e.g. `my-plugin/my-ability` or `my-plugin/resource/my-ability`.
 	 * @param array<string, mixed> $args {
 	 *     An associative array of arguments for the ability.
 	 *

--- a/src/wp-includes/abilities-api/class-wp-abilities-registry.php
+++ b/src/wp-includes/abilities-api/class-wp-abilities-registry.php
@@ -43,9 +43,10 @@ final class WP_Abilities_Registry {
 	 *
 	 * @see wp_register_ability()
 	 *
-	 * @param string               $name The name of the ability. The name must be a string containing a namespace
-	 *                                   prefix, i.e. `my-plugin/my-ability`. It can only contain lowercase
-	 *                                   alphanumeric characters, dashes and the forward slash.
+	 * @param string               $name The name of the ability. The name must contain 2 to 4 segments
+	 *                                   separated by forward slashes, e.g. `my-plugin/my-ability` or
+	 *                                   `my-plugin/resource/my-ability`. It can only contain lowercase
+	 *                                   alphanumeric characters, dashes, and forward slashes.
 	 * @param array<string, mixed> $args {
 	 *     An associative array of arguments for the ability.
 	 *
@@ -78,11 +79,11 @@ final class WP_Abilities_Registry {
 	 * @return WP_Ability|null The registered ability instance on success, null on failure.
 	 */
 	public function register( string $name, array $args ): ?WP_Ability {
-		if ( ! preg_match( '/^[a-z0-9-]+\/[a-z0-9-]+$/', $name ) ) {
+		if ( ! preg_match( '/^[a-z0-9-]+(?:\/[a-z0-9-]+){1,3}$/', $name ) ) {
 			_doing_it_wrong(
 				__METHOD__,
 				__(
-					'Ability name must be a string containing a namespace prefix, i.e. "my-plugin/my-ability". It can only contain lowercase alphanumeric characters, dashes and the forward slash.'
+					'Ability name must contain 2 to 4 segments separated by forward slashes, e.g. "my-plugin/my-ability" or "my-plugin/resource/my-ability". It can only contain lowercase alphanumeric characters, dashes, and forward slashes.'
 				),
 				'6.9.0'
 			);

--- a/src/wp-includes/abilities-api/class-wp-ability.php
+++ b/src/wp-includes/abilities-api/class-wp-ability.php
@@ -52,7 +52,7 @@ class WP_Ability {
 
 	/**
 	 * The name of the ability, with its namespace.
-	 * Example: `my-plugin/my-ability`.
+	 * Examples: `my-plugin/my-ability`, `my-plugin/resource/find`.
 	 *
 	 * @since 6.9.0
 	 * @var string
@@ -340,7 +340,7 @@ class WP_Ability {
 
 	/**
 	 * Retrieves the name of the ability, with its namespace.
-	 * Example: `my-plugin/my-ability`.
+	 * Examples: `my-plugin/my-ability`, `my-plugin/resource/find`.
 	 *
 	 * @since 6.9.0
 	 *

--- a/tests/phpunit/tests/abilities-api/wpAbilitiesRegistry.php
+++ b/tests/phpunit/tests/abilities-api/wpAbilitiesRegistry.php
@@ -137,6 +137,74 @@ class Tests_Abilities_API_WpAbilitiesRegistry extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Should accept ability name with 3 segments (2 slashes).
+	 *
+	 * @ticket 64098
+	 *
+	 * @covers WP_Abilities_Registry::register
+	 */
+	public function test_register_valid_name_with_three_segments() {
+		$result = $this->registry->register( 'test/sub/add-numbers', self::$test_ability_args );
+		$this->assertInstanceOf( WP_Ability::class, $result );
+		$this->assertSame( 'test/sub/add-numbers', $result->get_name() );
+	}
+
+	/**
+	 * Should accept ability name with 4 segments (3 slashes).
+	 *
+	 * @ticket 64098
+	 *
+	 * @covers WP_Abilities_Registry::register
+	 */
+	public function test_register_valid_name_with_four_segments() {
+		$result = $this->registry->register( 'test/sub/deep/add-numbers', self::$test_ability_args );
+		$this->assertInstanceOf( WP_Ability::class, $result );
+		$this->assertSame( 'test/sub/deep/add-numbers', $result->get_name() );
+	}
+
+	/**
+	 * Should reject ability name with 5 segments (exceeds maximum of 4).
+	 *
+	 * @ticket 64098
+	 *
+	 * @covers WP_Abilities_Registry::register
+	 *
+	 * @expectedIncorrectUsage WP_Abilities_Registry::register
+	 */
+	public function test_register_invalid_name_with_five_segments() {
+		$result = $this->registry->register( 'test/a/b/c/too-deep', self::$test_ability_args );
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Should reject ability name with empty segments (double slashes).
+	 *
+	 * @ticket 64098
+	 *
+	 * @covers WP_Abilities_Registry::register
+	 *
+	 * @expectedIncorrectUsage WP_Abilities_Registry::register
+	 */
+	public function test_register_invalid_name_with_empty_segment() {
+		$result = $this->registry->register( 'test//add-numbers', self::$test_ability_args );
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Should reject ability name with trailing slash.
+	 *
+	 * @ticket 64098
+	 *
+	 * @covers WP_Abilities_Registry::register
+	 *
+	 * @expectedIncorrectUsage WP_Abilities_Registry::register
+	 */
+	public function test_register_invalid_name_with_trailing_slash() {
+		$result = $this->registry->register( 'test/add-numbers/', self::$test_ability_args );
+		$this->assertNull( $result );
+	}
+
+	/**
 	 * Should reject ability registration without a label.
 	 *
 	 * @ticket 64098

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesV1RunController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesV1RunController.php
@@ -379,6 +379,43 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 			)
 		);
 
+		// Ability with nested namespace (3 segments).
+		$this->register_test_ability(
+			'test/math/add',
+			array(
+				'label'               => 'Nested Add',
+				'description'         => 'Adds numbers with nested namespace',
+				'category'            => 'math',
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'a' => array(
+							'type'        => 'number',
+							'description' => 'First number',
+						),
+						'b' => array(
+							'type'        => 'number',
+							'description' => 'Second number',
+						),
+					),
+					'required'             => array( 'a', 'b' ),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type' => 'number',
+				),
+				'execute_callback'    => static function ( array $input ) {
+					return $input['a'] + $input['b'];
+				},
+				'permission_callback' => static function () {
+					return current_user_can( 'edit_posts' );
+				},
+				'meta'                => array(
+					'show_in_rest' => true,
+				),
+			)
+		);
+
 		// Read-only ability for query params testing.
 		$this->register_test_ability(
 			'test/query-params',
@@ -430,6 +467,31 @@ class Tests_REST_API_WpRestAbilitiesV1RunController extends WP_UnitTestCase {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 8, $response->get_data() );
+	}
+
+	/**
+	 * Test executing an ability with a nested namespace (3 segments) via REST.
+	 *
+	 * @ticket 64098
+	 */
+	public function test_execute_nested_namespace_ability(): void {
+		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/test/math/add/run' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'input' => array(
+						'a' => 10,
+						'b' => 7,
+					),
+				)
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 17, $response->get_data() );
 	}
 
 	/**


### PR DESCRIPTION
This PR Expands ability name validation from exactly 2 segments (`namespace/ability`) to 2-4 segments, enabling names like `my-plugin/resource/find` and `my-plugin/resource/sub/find`.


## Details

The current ability naming convention only allows a single namespace separator (`my-plugin/my-ability`). This is too restrictive for organizing abilities into logical resource groups. With this change, plugins can register abilities like `core/posts/find`, `core/posts/create`, or `my-plugin/resource/sub/action`.

The validation regex in `WP_Abilities_Registry::register()` changes from:
```
/^[a-z0-9-]+\/[a-z0-9-]+$/
```
to:
```
/^[a-z0-9-]+(?:\/[a-z0-9-]+){1,3}$/
```

This allows the first segment plus 1-3 additional slash-delimited segments (2-4 total). The REST API route patterns in both controllers already accepted multiple slashes, so no route changes were needed.

This PR comes from a suggestion from @justlevine at https://github.com/WordPress/wordpress-develop/pull/10665#issuecomment-3769756790 :
> Necessary caveats out of the way, I'd recommend we solve the naming issue holistically with nested namespaces, a pattern that because it's good for human cognitive overload, which just so happens to mean that it aligns with inference best practices too. (related: [core.trac.wordpress.org/ticket/64345#comment:5](https://core.trac.wordpress.org/ticket/64345#comment:5)).

> Which would turn these into:

> core/posts/find or get (As noted inline, I think getting a single post is superfluous, and both use cases can be more intuitively handled with an improved input shape, e.g. by ).
core/posts/create
core/posts/update

And we plan to use this new type of naming for post abilities.

cc: @justlevine, @JasonTheAdams


## Test plan

- [ ] Run `npm run test:php -- --group abilities-api` and verify all tests pass
- [ ] Verify existing 2-segment ability names (`core/get-site-info`, etc.) continue to work
- [ ] Verify 3-segment names like `test/math/add` can be registered and executed via REST
- [ ] Verify 5-segment names are rejected with a clear error message


Ticket: https://core.trac.wordpress.org/ticket/64596
