### PR TITLE
Support directory relative references in `esc_url()`

### DIFF
--- a/src/wp-includes/formatting.php
+++ b/src/wp-includes/formatting.php
@@ -4509,10 +4509,10 @@ function esc_url( $url, $protocols = null, $_context = 'display' ) {
 	/*
 	 * If the URL doesn't appear to contain a scheme, we presume
 	 * it needs http:// prepended (unless it's a relative link
-	 * starting with /, # or ?, or a PHP file). If the first item
-	 * in $protocols is 'https', then https:// is prepended.
+	 * starting with ., /, # or ?, or a PHP file). If the first
+	 * item in $protocols is 'https', then https:// is prepended.
 	 */
-	if ( ! str_contains( $url, ':' ) && ! in_array( $url[0], array( '/', '#', '?' ), true ) &&
+	if ( ! str_contains( $url, ':' ) && ! in_array( $url[0], array( '.', '/', '#', '?' ), true ) &&
 		! preg_match( '/^[a-z0-9-]+?\.php/i', $url )
 	) {
 		$scheme = ( is_array( $protocols ) && 'https' === array_first( $protocols ) ) ? 'https://' : 'http://';

--- a/tests/phpunit/tests/formatting/escUrl.php
+++ b/tests/phpunit/tests/formatting/escUrl.php
@@ -311,4 +311,13 @@ EOT;
 		$this->assertSame( '//[::FFFF::127.0.0.1]/?foo%5Bbar%5D=baz', esc_url( '//[::FFFF::127.0.0.1]/?foo[bar]=baz' ) );
 		$this->assertSame( 'http://[::FFFF::127.0.0.1]/?foo%5Bbar%5D=baz', esc_url( 'http://[::FFFF::127.0.0.1]/?foo[bar]=baz' ) );
 	}
+
+	/**
+	 * @ticket 46791
+	 */
+	public function test_directory_relative_references() {
+		$this->assertSame( './current-directory', esc_url( './current-directory' ) );
+		$this->assertSame( '../parent-directory', esc_url( '../parent-directory' ) );
+		$this->assertSame( '../../../../up-four-directories', esc_url( '../../../../up-four-directories' ) );
+	}
 }

--- a/tests/phpunit/tests/formatting/escUrl.php
+++ b/tests/phpunit/tests/formatting/escUrl.php
@@ -35,11 +35,18 @@ class Tests_Formatting_EscUrl extends WP_UnitTestCase {
 		$this->assertSame( 'http://example.com/', esc_url( 'http://example.com/%0%0%0ADa' ) );
 	}
 
+	/**
+	 * @ticket 24976
+	 * @ticket 46791
+	 */
 	public function test_relative() {
 		$this->assertSame( '/example.php', esc_url( '/example.php' ) );
 		$this->assertSame( 'example.php', esc_url( 'example.php' ) );
 		$this->assertSame( '#fragment', esc_url( '#fragment' ) );
 		$this->assertSame( '?foo=bar', esc_url( '?foo=bar' ) );
+		$this->assertSame( './current-directory', esc_url( './current-directory' ) );
+		$this->assertSame( '../parent-directory', esc_url( '../parent-directory' ) );
+		$this->assertSame( '../../../../up-four-directories', esc_url( '../../../../up-four-directories' ) );
 	}
 
 	/**
@@ -310,14 +317,5 @@ EOT;
 		// IPv6 with square brackets in the query? Why not.
 		$this->assertSame( '//[::FFFF::127.0.0.1]/?foo%5Bbar%5D=baz', esc_url( '//[::FFFF::127.0.0.1]/?foo[bar]=baz' ) );
 		$this->assertSame( 'http://[::FFFF::127.0.0.1]/?foo%5Bbar%5D=baz', esc_url( 'http://[::FFFF::127.0.0.1]/?foo[bar]=baz' ) );
-	}
-
-	/**
-	 * @ticket 46791
-	 */
-	public function test_directory_relative_references() {
-		$this->assertSame( './current-directory', esc_url( './current-directory' ) );
-		$this->assertSame( '../parent-directory', esc_url( '../parent-directory' ) );
-		$this->assertSame( '../../../../up-four-directories', esc_url( '../../../../up-four-directories' ) );
 	}
 }


### PR DESCRIPTION
Does not prepend the fallback protocol when the reference starts with a dot (`./` or `../`).

Props: subrataemfluence

[Trac 46791](https://core.trac.wordpress.org/ticket/46791)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
