### PR TITLE
Refine `wp.sanitize.stripTags()` when input is an empty value

### DIFF
--- a/src/js/_enqueues/wp/sanitize.js
+++ b/src/js/_enqueues/wp/sanitize.js
@@ -23,7 +23,7 @@
 		 * @return {string} Stripped text.
 		 */
 		stripTags: function( text ) {
-			if ( null === text || 'undefined' === typeof text ) {
+			if ( null == text ) {
 				return '';
 			}
 

--- a/src/js/_enqueues/wp/sanitize.js
+++ b/src/js/_enqueues/wp/sanitize.js
@@ -23,7 +23,7 @@
 		 * @return {string} Stripped text.
 		 */
 		stripTags: function( text ) {
-			if ( null == text ) {
+			if ( ! text ) {
 				return '';
 			}
 

--- a/tests/qunit/wp-includes/js/wp-sanitize.js
+++ b/tests/qunit/wp-includes/js/wp-sanitize.js
@@ -22,6 +22,21 @@ QUnit.test( 'stripTags should convert numbers to strings', function( assert ) {
 	assert.strictEqual( result, '123', 'stripTags( 123 ) should return "123"' );
 } );
 
+QUnit.test( 'stripTags should return "0" for input 0', function( assert ) {
+	const result = wp.sanitize.stripTags( 0 );
+	assert.strictEqual( result, '0', 'stripTags( 0 ) should return "0"' );
+} );
+
+QUnit.test( 'stripTags should return "0" for input "0"', function( assert ) {
+	const result = wp.sanitize.stripTags( '0' );
+	assert.strictEqual( result, '0', 'stripTags( "0" ) should return "0"' );
+} );
+
+QUnit.test( 'stripTags should return empty string for empty string input', function( assert ) {
+	const result = wp.sanitize.stripTags( '' );
+	assert.strictEqual( result, '', 'stripTags( "" ) should return ""' );
+} );
+
 QUnit.module( 'wp.sanitize.stripTagsAndEncodeText' );
 
 QUnit.test( 'stripTagsAndEncodeText should return empty string for null input', function( assert ) {

--- a/tests/qunit/wp-includes/js/wp-sanitize.js
+++ b/tests/qunit/wp-includes/js/wp-sanitize.js
@@ -22,9 +22,9 @@ QUnit.test( 'stripTags should convert numbers to strings', function( assert ) {
 	assert.strictEqual( result, '123', 'stripTags( 123 ) should return "123"' );
 } );
 
-QUnit.test( 'stripTags should return "0" for input 0', function( assert ) {
+QUnit.test( 'stripTags should return empty string for input 0', function( assert ) {
 	const result = wp.sanitize.stripTags( 0 );
-	assert.strictEqual( result, '0', 'stripTags( 0 ) should return "0"' );
+	assert.strictEqual( result, '', 'stripTags( 0 ) should return ""' );
 } );
 
 QUnit.test( 'stripTags should return "0" for input "0"', function( assert ) {
@@ -32,9 +32,14 @@ QUnit.test( 'stripTags should return "0" for input "0"', function( assert ) {
 	assert.strictEqual( result, '0', 'stripTags( "0" ) should return "0"' );
 } );
 
-QUnit.test( 'stripTags should return "false" for input false', function( assert ) {
+QUnit.test( 'stripTags should return empty string for input false', function( assert ) {
 	const result = wp.sanitize.stripTags( false );
-	assert.strictEqual( result, 'false', 'stripTags( false ) should return "false"' );
+	assert.strictEqual( result, '', 'stripTags( false ) should return ""' );
+} );
+
+QUnit.test( 'stripTags should return empty string for input NaN', function( assert ) {
+	const result = wp.sanitize.stripTags( NaN );
+	assert.strictEqual( result, '', 'stripTags( NaN ) should return ""' );
 } );
 
 QUnit.test( 'stripTags should return empty string for empty string input', function( assert ) {

--- a/tests/qunit/wp-includes/js/wp-sanitize.js
+++ b/tests/qunit/wp-includes/js/wp-sanitize.js
@@ -32,6 +32,11 @@ QUnit.test( 'stripTags should return "0" for input "0"', function( assert ) {
 	assert.strictEqual( result, '0', 'stripTags( "0" ) should return "0"' );
 } );
 
+QUnit.test( 'stripTags should return "false" for input false', function( assert ) {
+	const result = wp.sanitize.stripTags( false );
+	assert.strictEqual( result, 'false', 'stripTags( false ) should return "false"' );
+} );
+
 QUnit.test( 'stripTags should return empty string for empty string input', function( assert ) {
 	const result = wp.sanitize.stripTags( '' );
 	assert.strictEqual( result, '', 'stripTags( "" ) should return ""' );


### PR DESCRIPTION
This further improves back-compat for `wp.sanitize.stripTags()` when a falsy value is passed, including `false`, `0`, and `NaN`. In these three cases, the function in 6.9 returns an empty string. In contrast, the function in 7.0-alpha would return stringifed versions of those falsy valies.

Follow-up to:

* @sirreal: https://github.com/WordPress/wordpress-develop/pull/10833#discussion_r2758059447
* @Hug0-Drelon: https://github.com/WordPress/wordpress-develop/pull/10833#discussion_r2757723749

Trac ticket: https://core.trac.wordpress.org/ticket/64574

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
