### PR TITLE
Block Support: Allow serialization skipping for ariaLabel

### DIFF
--- a/src/wp-includes/block-supports/aria-label.php
+++ b/src/wp-includes/block-supports/aria-label.php
@@ -49,7 +49,10 @@ function wp_apply_aria_label_support( $block_type, $block_attributes ) {
 	}
 
 	$has_aria_label_support = block_has_support( $block_type, array( 'ariaLabel' ), false );
-	if ( ! $has_aria_label_support ) {
+	if (
+		! $has_aria_label_support ||
+		wp_should_skip_block_supports_serialization( $block_type, 'ariaLabel' )
+	) {
 		return array();
 	}
 

--- a/tests/phpunit/tests/block-supports/aria-label.php
+++ b/tests/phpunit/tests/block-supports/aria-label.php
@@ -47,6 +47,7 @@ class Tests_Block_Supports_Aria_Label extends WP_UnitTestCase {
 	 * Tests that aria-label block support works as expected.
 	 *
 	 * @ticket 62919
+	 * @ticket 64594
 	 *
 	 * @dataProvider data_aria_label_block_support
 	 *

--- a/tests/phpunit/tests/block-supports/aria-label.php
+++ b/tests/phpunit/tests/block-supports/aria-label.php
@@ -44,7 +44,7 @@ class Tests_Block_Supports_Aria_Label extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that position block support works as expected.
+	 * Tests that aria-label block support works as expected.
 	 *
 	 * @ticket 62919
 	 *
@@ -52,7 +52,7 @@ class Tests_Block_Supports_Aria_Label extends WP_UnitTestCase {
 	 *
 	 * @param boolean|array $support  Aria label block support configuration.
 	 * @param string        $value    Aria label value for attribute object.
-	 * @param array         $expected Expected aria label block support styles.
+	 * @param array         $expected Expected aria-label attributes.
 	 */
 	public function test_wp_apply_aria_label_support( $support, $value, $expected ) {
 		$block_type  = self::register_aria_label_block_with_support(
@@ -79,6 +79,13 @@ class Tests_Block_Supports_Aria_Label extends WP_UnitTestCase {
 			),
 			'aria-label attribute is not applied if block does not support it' => array(
 				'support'  => false,
+				'value'    => 'Label',
+				'expected' => array(),
+			),
+			'aria-label attribute is not applied when serialization is skipped' => array(
+				'support'  => array(
+					'__experimentalSkipSerialization' => true,
+				),
 				'value'    => 'Label',
 				'expected' => array(),
 			),


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
-->

<!-- Insert a description of your changes here -->

Trac ticket: https://core.trac.wordpress.org/ticket/64594

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
