### PR TITLE
Theme JSON: Define preset CSS vars for blocks based on feature selectors

### DIFF
--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2471,19 +2471,87 @@ class WP_Theme_JSON {
 				continue;
 			}
 
-			$selector = $metadata['selector'];
+			$selector          = $metadata['selector'];
+			$feature_selectors = $metadata['selectors'] ?? array();
+			$node              = _wp_array_get( $this->theme_json, $metadata['path'], array() );
 
-			$node                    = _wp_array_get( $this->theme_json, $metadata['path'], array() );
-			$declarations            = static::compute_preset_vars( $node, $origins );
-			$theme_vars_declarations = static::compute_theme_vars( $node );
-			foreach ( $theme_vars_declarations as $theme_vars_declaration ) {
-				$declarations[] = $theme_vars_declaration;
+			/*
+			 * Group preset declarations by selector. Blocks that define
+			 * feature-level selectors need their preset CSS variables
+			 * output under that feature selector instead of the block's
+			 * root selector.
+			 */
+			$vars_by_selector              = array();
+			$vars_by_selector[ $selector ] = array();
+
+			foreach ( static::PRESETS_METADATA as $preset_metadata ) {
+				if ( empty( $preset_metadata['css_vars'] ) ) {
+					continue;
+				}
+
+				$values_by_slug = static::get_settings_values_by_slug( $node, $preset_metadata, $origins );
+				if ( empty( $values_by_slug ) ) {
+					continue;
+				}
+
+				$target = static::get_feature_selector( $feature_selectors, $preset_metadata['path'][0], $selector );
+
+				if ( ! isset( $vars_by_selector[ $target ] ) ) {
+					$vars_by_selector[ $target ] = array();
+				}
+
+				foreach ( $values_by_slug as $slug => $value ) {
+					$vars_by_selector[ $target ][] = array(
+						'name'  => static::replace_slug_in_string( $preset_metadata['css_vars'], $slug ),
+						'value' => $value,
+					);
+				}
 			}
 
-			$stylesheet .= static::to_ruleset( $selector, $declarations );
+			// Theme vars always use the block's default selector.
+			foreach ( static::compute_theme_vars( $node ) as $theme_var ) {
+				$vars_by_selector[ $selector ][] = $theme_var;
+			}
+
+			foreach ( $vars_by_selector as $rule_selector => $declarations ) {
+				$stylesheet .= static::to_ruleset( $rule_selector, $declarations );
+			}
 		}
 
 		return $stylesheet;
+	}
+
+	/**
+	 * Returns the appropriate selector for a block support feature's
+	 * preset CSS variables.
+	 *
+	 * If the block defines a feature-level selector (as a string or an
+	 * object with a `root` key), that selector is returned. Otherwise,
+	 * the block's default selector is used.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array  $feature_selectors The block's feature selectors map.
+	 * @param string $feature_key       The feature to look up (e.g. 'dimensions').
+	 * @param string $default_selector  Fallback selector.
+	 * @return string The resolved selector.
+	 */
+	private static function get_feature_selector( $feature_selectors, $feature_key, $default_selector ) {
+		if ( ! isset( $feature_selectors[ $feature_key ] ) ) {
+			return $default_selector;
+		}
+
+		$feature = $feature_selectors[ $feature_key ];
+
+		if ( is_string( $feature ) ) {
+			return $feature;
+		}
+
+		if ( isset( $feature['root'] ) ) {
+			return $feature['root'];
+		}
+
+		return $default_selector;
 	}
 
 	/**
@@ -3136,8 +3204,9 @@ class WP_Theme_JSON {
 			}
 
 			$nodes[] = array(
-				'path'     => array( 'settings', 'blocks', $name ),
-				'selector' => $selector,
+				'path'      => array( 'settings', 'blocks', $name ),
+				'selector'  => $selector,
+				'selectors' => $selectors[ $name ]['selectors'] ?? array(),
 			);
 		}
 

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2531,9 +2531,9 @@ class WP_Theme_JSON {
 	 *
 	 * @since 7.0.0
 	 *
-	 * @param array  $feature_selectors The block's feature selectors map.
-	 * @param string $feature_key       The feature to look up (e.g. 'dimensions').
-	 * @param string $default_selector  Fallback selector.
+	 * @param array<string, string|array> $feature_selectors The block's feature selectors map.
+	 * @param string                      $feature_key       The feature to look up (e.g. 'dimensions').
+	 * @param string                      $default_selector  Fallback selector.
 	 * @return string The resolved selector.
 	 */
 	private static function get_feature_selector( array $feature_selectors, string $feature_key, string $default_selector ): string {

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2531,9 +2531,9 @@ class WP_Theme_JSON {
 	 *
 	 * @since 7.0.0
 	 *
-	 * @param array<string, string|array> $feature_selectors The block's feature selectors map.
-	 * @param string                      $feature_key       The feature to look up (e.g. 'dimensions').
-	 * @param string                      $default_selector  Fallback selector.
+	 * @param array<string, string|array<string, string>> $feature_selectors The block's feature selectors map.
+	 * @param string                                      $feature_key       The feature to look up (e.g. 'dimensions').
+	 * @param string                                      $default_selector  Fallback selector.
 	 * @return string The resolved selector.
 	 */
 	private static function get_feature_selector( array $feature_selectors, string $feature_key, string $default_selector ): string {
@@ -2547,7 +2547,11 @@ class WP_Theme_JSON {
 			return $feature;
 		}
 
-		return $feature['root'] ?? $default_selector;
+		if ( isset( $feature['root'] ) && is_string( $feature['root'] ) ) {
+			return $feature['root'];
+		}
+
+		return $default_selector;
 	}
 
 	/**

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2529,7 +2529,7 @@ class WP_Theme_JSON {
 	 * object with a `root` key), that selector is returned. Otherwise,
 	 * the block's default selector is used.
 	 *
-	 * @since 7.0.0
+	 * @since 7.1.0
 	 *
 	 * @param array<string, string|array<string, string>> $feature_selectors The block's feature selectors map.
 	 * @param string                                      $feature_key       The feature to look up (e.g. 'dimensions').

--- a/src/wp-includes/class-wp-theme-json.php
+++ b/src/wp-includes/class-wp-theme-json.php
@@ -2536,7 +2536,7 @@ class WP_Theme_JSON {
 	 * @param string $default_selector  Fallback selector.
 	 * @return string The resolved selector.
 	 */
-	private static function get_feature_selector( $feature_selectors, $feature_key, $default_selector ) {
+	private static function get_feature_selector( array $feature_selectors, string $feature_key, string $default_selector ): string {
 		if ( ! isset( $feature_selectors[ $feature_key ] ) ) {
 			return $default_selector;
 		}
@@ -2547,11 +2547,7 @@ class WP_Theme_JSON {
 			return $feature;
 		}
 
-		if ( isset( $feature['root'] ) ) {
-			return $feature['root'];
-		}
-
-		return $default_selector;
+		return $feature['root'] ?? $default_selector;
 	}
 
 	/**

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -783,6 +783,63 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @ticket 64598
+	 */
+	public function test_get_stylesheet_preset_css_vars_use_feature_selector() {
+		register_block_type(
+			'test/feature-selector',
+			array(
+				'api_version' => 3,
+				'selectors'   => array(
+					'root'       => '.wp-block-test-feature-selector .wp-block-test-feature-selector__inner',
+					'dimensions' => array(
+						'root' => '.wp-block-test-feature-selector',
+					),
+				),
+			)
+		);
+
+		$theme_json = new WP_Theme_JSON(
+			array(
+				'version'  => WP_Theme_JSON::LATEST_SCHEMA,
+				'settings' => array(
+					'blocks' => array(
+						'test/feature-selector' => array(
+							'dimensions' => array(
+								'dimensionSizes' => array(
+									array(
+										'slug' => '25',
+										'size' => '25%',
+									),
+									array(
+										'slug' => '50',
+										'size' => '50%',
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$variables = $theme_json->get_stylesheet( array( 'variables' ) );
+
+		// Dimension preset CSS vars should be on the feature selector,
+		// not the block's root selector.
+		$this->assertStringContainsString(
+			'.wp-block-test-feature-selector{--wp--preset--dimension--25: 25%;--wp--preset--dimension--50: 50%;}',
+			$variables
+		);
+		$this->assertStringNotContainsString(
+			'.wp-block-test-feature-selector .wp-block-test-feature-selector__inner{--wp--preset--dimension',
+			$variables
+		);
+
+		unregister_block_type( 'test/feature-selector' );
+	}
+
+	/**
 	 * @ticket 53175
 	 * @ticket 54336
 	 * @ticket 58550

--- a/tests/phpunit/tests/theme/wpThemeJson.php
+++ b/tests/phpunit/tests/theme/wpThemeJson.php
@@ -44,6 +44,16 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 		static::$user_id = self::factory()->user->create();
 	}
 
+	public function tear_down() {
+		$registry = WP_Block_Type_Registry::get_instance();
+
+		if ( $registry->is_registered( 'test/feature-selector' ) ) {
+			unregister_block_type( 'test/feature-selector' );
+		}
+
+		parent::tear_down();
+	}
+
 	/**
 	 * @ticket 52991
 	 * @ticket 54336
@@ -835,8 +845,6 @@ class Tests_Theme_wpThemeJson extends WP_UnitTestCase {
 			'.wp-block-test-feature-selector .wp-block-test-feature-selector__inner{--wp--preset--dimension',
 			$variables
 		);
-
-		unregister_block_type( 'test/feature-selector' );
 	}
 
 	/**


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64598

This PR brings the changes from the following Gutenberg PR to core:

WordPress/gutenberg#75226

## Description
Updates the global styles engine and theme JSON processing to generate preset CSS custom properties (vars) for blocks based on their feature-specific selectors rather than only the block's root selector. This enables blocks whose root selector targets an inner element to have preset CSS vars output on the appropriate outer wrapper selector.

See: WordPress/gutenberg#74242

## Testing
1. Run the PHP unit tests: `phpunit --filter=WP_Theme_JSON_Test`
2. Verify all existing tests continue to pass, including the new `test_get_stylesheet_preset_css_vars_use_feature_selector` test.
3. For manual testing, register a block that defines a feature-level selector (e.g. a `dimensions.root` selector different from the block's root selector), define `dimensionSizes` presets for that block in theme.json, and confirm the CSS vars are output on the feature selector rather than the block's root selector.

