### PR TITLE
Blocks: Add helper function for Terms Query pagination

### DIFF
--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -3107,20 +3107,6 @@ function build_terms_query_vars_from_block( $block ) {
 }
 
 /**
- * Registers the 'termspage' public query variable to support pagination for the Terms Query block.
- *
- * @since 7.0.0
- *
- * @param array<int, string> $vars The array of existing query variables.
- * @return array<int, string> Modified query variables including 'termspage'.
- */
-function terms_query_register_query_vars( $vars ) {
-	$vars[] = 'termspage';
-	return $vars;
-}
-add_filter( 'query_vars', 'terms_query_register_query_vars' );
-
-/**
  * Strips all HTML from the content of footnotes, and sanitizes the ID.
  *
  * This function expects slashed data on the footnotes content.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -3059,7 +3059,7 @@ function get_comments_pagination_arrow( $block, $pagination_type = 'next' ) {
  * @param WP_Block $block Block instance.
  * @return array<string, mixed> Query vars suitable for get_terms() or wp_count_terms().
  */
-function build_terms_query_vars_from_block( $block ) {
+function build_terms_query_vars_from_block( WP_Block $block ): array {
 	$query = $block->context['termQuery'];
 
 	$query_vars = array(

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -3057,7 +3057,7 @@ function get_comments_pagination_arrow( $block, $pagination_type = 'next' ) {
  * @since 7.0.0
  *
  * @param WP_Block $block Block instance.
- * @return array Query vars suitable for get_terms() or wp_count_terms().
+ * @return array<string, mixed> Query vars suitable for get_terms() or wp_count_terms().
  */
 function build_terms_query_vars_from_block( $block ) {
 	$query = $block->context['termQuery'];
@@ -3107,12 +3107,12 @@ function build_terms_query_vars_from_block( $block ) {
 }
 
 /**
- * Registers the 'termspage' query variable for terms pagination.
+ * Registers the 'termspage' public query variable to support pagination for the Terms Query block.
  *
  * @since 7.0.0
  *
- * @param array $vars The array of existing query variables.
- * @return array Modified query variables including 'termspage'.
+ * @param array<int, string> $vars The array of existing query variables.
+ * @return array<int, string> Modified query variables including 'termspage'.
  */
 function terms_query_register_query_vars( $vars ) {
 	$vars[] = 'termspage';

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -3050,6 +3050,77 @@ function get_comments_pagination_arrow( $block, $pagination_type = 'next' ) {
 }
 
 /**
+ * Builds query vars for terms from a Terms Query block instance.
+ *
+ * It's used with the Terms Query inner blocks (Term Template, Terms Query Pagination).
+ *
+ * @since 7.0.0
+ *
+ * @param WP_Block $block Block instance.
+ * @return array Query vars suitable for get_terms() or wp_count_terms().
+ */
+function build_terms_query_vars_from_block( $block ) {
+	$query = $block->context['termQuery'];
+
+	$query_vars = array(
+		'number'     => $query['perPage'],
+		'order'      => $query['order'],
+		'orderby'    => $query['orderBy'],
+		'hide_empty' => $query['hideEmpty'],
+	);
+
+	$inherit_query = isset( $query['inherit'] ) && $query['inherit'] && ( is_tax() || is_category() || is_tag() );
+
+	if ( $inherit_query ) {
+		// Get the current term and taxonomy from the queried object.
+		$queried_object = get_queried_object();
+
+		// For hierarchical taxonomies, show children of the current term.
+		// For non-hierarchical taxonomies, show all terms (don't set parent).
+		if ( is_taxonomy_hierarchical( $queried_object->taxonomy ) ) {
+			// If showNested is true, use child_of to include nested terms.
+			// Otherwise, use parent to show only direct children.
+			if ( ! empty( $query['showNested'] ) ) {
+				$query_vars['child_of'] = $queried_object->term_id;
+			} else {
+				$query_vars['parent'] = $queried_object->term_id;
+			}
+		}
+		$query_vars['taxonomy'] = $queried_object->taxonomy;
+	} else {
+		// If not inheriting set `taxonomy` from the block attribute.
+		$query_vars['taxonomy'] = $query['taxonomy'];
+
+		// If we are including specific terms we ignore `showNested` argument.
+		if ( ! empty( $query['include'] ) ) {
+			$query_vars['include'] = array_unique( array_map( 'intval', $query['include'] ) );
+			$query_vars['orderby'] = 'include';
+			$query_vars['order']   = 'asc';
+		} elseif ( is_taxonomy_hierarchical( $query['taxonomy'] ) && empty( $query['showNested'] ) ) {
+			// We set parent only when inheriting from the taxonomy archive context or not
+			// showing nested terms, otherwise nested terms are not displayed.
+			$query_vars['parent'] = 0;
+		}
+	}
+
+	return $query_vars;
+}
+
+/**
+ * Registers the 'termspage' query variable for terms pagination.
+ *
+ * @since 7.0.0
+ *
+ * @param array $vars The array of existing query variables.
+ * @return array Modified query variables including 'termspage'.
+ */
+function terms_query_register_query_vars( $vars ) {
+	$vars[] = 'termspage';
+	return $vars;
+}
+add_filter( 'query_vars', 'terms_query_register_query_vars' );
+
+/**
  * Strips all HTML from the content of footnotes, and sanitizes the ID.
  *
  * This function expects slashed data on the footnotes content.

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -3069,11 +3069,11 @@ function build_terms_query_vars_from_block( WP_Block $block ): array {
 		'hide_empty' => $query['hideEmpty'],
 	);
 
-	$inherit_query = isset( $query['inherit'] ) && $query['inherit'] && ( is_tax() || is_category() || is_tag() );
+	$inherit_query = ( $query['inherit'] ?? false ) && ( is_tax() || is_category() || is_tag() );
 
-	if ( $inherit_query ) {
-		// Get the current term and taxonomy from the queried object.
-		$queried_object = get_queried_object();
+	// Get the current term and taxonomy from the queried object.
+	$queried_object = get_queried_object();
+	if ( $queried_object instanceof WP_Term && $inherit_query ) {
 
 		// For hierarchical taxonomies, show children of the current term.
 		// For non-hierarchical taxonomies, show all terms (don't set parent).

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -3054,7 +3054,7 @@ function get_comments_pagination_arrow( $block, $pagination_type = 'next' ) {
  *
  * It's used with the Terms Query inner blocks (Term Template, Terms Query Pagination).
  *
- * @since 7.0.0
+ * @since 7.1.0
  *
  * @param WP_Block $block Block instance.
  * @return array<string, mixed> Query vars suitable for get_terms() or wp_count_terms().

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -3060,6 +3060,18 @@ function get_comments_pagination_arrow( $block, $pagination_type = 'next' ) {
  * @return array<string, mixed> Query vars suitable for get_terms() or wp_count_terms().
  */
 function build_terms_query_vars_from_block( WP_Block $block ): array {
+	/**
+	 * @var array{
+	 *     perPage: positive-int,
+	 *     order: string,
+	 *     orderBy: string,
+	 *     hideEmpty: bool,
+	 *     inherit?: bool,
+	 *     showNested?: bool,
+	 *     taxonomy: string,
+	 *     include: int[],
+	 * } $query
+	 */
 	$query = $block->context['termQuery'];
 
 	$query_vars = array(

--- a/src/wp-includes/class-wp.php
+++ b/src/wp-includes/class-wp.php
@@ -15,7 +15,7 @@ class WP {
 	 * @since 2.0.0
 	 * @var string[]
 	 */
-	public $public_query_vars = array( 'm', 'p', 'posts', 'w', 'cat', 'withcomments', 'withoutcomments', 's', 'search', 'exact', 'sentence', 'calendar', 'page', 'paged', 'more', 'tb', 'pb', 'author', 'order', 'orderby', 'year', 'monthnum', 'day', 'hour', 'minute', 'second', 'name', 'category_name', 'tag', 'feed', 'author_name', 'pagename', 'page_id', 'error', 'attachment', 'attachment_id', 'subpost', 'subpost_id', 'preview', 'robots', 'favicon', 'taxonomy', 'term', 'cpage', 'post_type', 'embed' );
+	public $public_query_vars = array( 'm', 'p', 'posts', 'w', 'cat', 'withcomments', 'withoutcomments', 's', 'search', 'exact', 'sentence', 'calendar', 'page', 'paged', 'more', 'tb', 'pb', 'author', 'order', 'orderby', 'year', 'monthnum', 'day', 'hour', 'minute', 'second', 'name', 'category_name', 'tag', 'feed', 'author_name', 'pagename', 'page_id', 'error', 'attachment', 'attachment_id', 'subpost', 'subpost_id', 'preview', 'robots', 'favicon', 'taxonomy', 'term', 'cpage', 'post_type', 'embed', 'termspage' );
 
 	/**
 	 * Private query variables.

--- a/tests/phpunit/tests/query/vars.php
+++ b/tests/phpunit/tests/query/vars.php
@@ -67,6 +67,7 @@ class Tests_Query_Vars extends WP_UnitTestCase {
 				'cpage',
 				'post_type',
 				'embed',
+				'termspage',
 
 				// Dynamically added public query vars:
 				'post_format',


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64608

Adds `build_terms_query_vars_from_block()` to `wp-includes/blocks.php` and registers the `termspage` public query variable (added to `WP::$public_query_vars` in `wp-includes/class-wp.php`) to support pagination in the Terms Query block.

These changes are used in https://github.com/WordPress/gutenberg/pull/74545 by:
- The updated **Term Template** block (which now supports paginated term results via the `termspage` query variable)
- The new **Terms Query Pagination** blocks (`core/terms-query-pagination`, `core/terms-query-pagination-next`, `core/terms-query-pagination-previous`, `core/terms-query-pagination-numbers`)

`build_terms_query_vars_from_block()` extracts and normalizes query arguments from the block context, handling both inherited (taxonomy archive) and custom term queries. It follows the same pattern as the existing `build_query_vars_from_query_block()` and `build_comment_query_vars_from_block()`.

The `termspage` query variable is registered directly in `WP::$public_query_vars` (rather than via a `query_vars` filter as in the Gutenberg plugin) so pagination URLs resolve. See the updated `tests/phpunit/tests/query/vars.php`.
