### PR TITLE
Fix for Issue #64610

### DIFF
--- a/src/wp-admin/includes/class-wp-filesystem-direct.php
+++ b/src/wp-admin/includes/class-wp-filesystem-direct.php
@@ -173,6 +173,11 @@ class WP_Filesystem_Direct extends WP_Filesystem_Base {
 			// Avoid calling chmod if the requested mode is already
 			// set, to avoid chmod throwing an exception when we aren't owner
 			$currentmode = fileperms( $file ) & 0777;
+
+			// fileperms populates the stat cache, so have to
+			// clear it to maintain parity with previous behavior
+			clearstatcache( true, $file );
+
 			if ( $currentmode === $mode ) {
 				return true;
 			}

--- a/src/wp-admin/includes/class-wp-filesystem-direct.php
+++ b/src/wp-admin/includes/class-wp-filesystem-direct.php
@@ -170,6 +170,13 @@ class WP_Filesystem_Direct extends WP_Filesystem_Base {
 		}
 
 		if ( ! $recursive || ! $this->is_dir( $file ) ) {
+			// Avoid calling chmod if the requested mode is already
+			// set, to avoid chmod throwing an exception when we aren't owner
+			$currentmode = fileperms( $file ) & 0777;
+			if ( $currentmode === $mode ) {
+				return true;
+			}
+
 			return chmod( $file, $mode );
 		}
 


### PR DESCRIPTION
This PR includes changes to the core WordPress direct filesystem API that prevent warnings being emitted when chmod is invoked on a file that would cause the existing mode of the file to be redundantly set. This prevents spurious warnings when the web process doesn't have ownership over the files, and thus can't chmod them, even if only to re-assert the existing mode.

Trac ticket: https://core.trac.wordpress.org/ticket/64610

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
