### PR TITLE
Block Supports: Prevent fatal error in `WP_Duotone` when the duotone …

### DIFF
--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -550,6 +550,10 @@ class WP_Duotone {
 	 * @return string The slug of the duotone preset or an empty string if no slug is found.
 	 */
 	private static function get_slug_from_attribute( $duotone_attr ) {
+		if ( ! is_string( $duotone_attr ) ) {
+			return '';
+		}
+
 		// Uses Branch Reset Groups `(?|…)` to return one capture group.
 		preg_match( '/(?|var:preset\|duotone\|(\S+)|var\(--wp--preset--duotone--(\S+)\))/', $duotone_attr, $matches );
 
@@ -569,6 +573,10 @@ class WP_Duotone {
 	 * @return bool True if the duotone preset present and valid.
 	 */
 	private static function is_preset( $duotone_attr ) {
+		if ( ! is_string( $duotone_attr ) ) {
+			return false;
+		}
+
 		$slug      = self::get_slug_from_attribute( $duotone_attr );
 		$filter_id = self::get_filter_id( $slug );
 
@@ -1050,6 +1058,11 @@ class WP_Duotone {
 				continue;
 			}
 			// If it has a duotone filter preset, save the block name and the preset slug.
+			// Only process if it's a string (preset reference), not an array (custom colors).
+			if ( ! is_string( $duotone_attr ) ) {
+				continue;
+			}
+
 			$slug = self::get_slug_from_attribute( $duotone_attr );
 
 			if ( $slug && $slug !== $duotone_attr ) {

--- a/src/wp-includes/class-wp-duotone.php
+++ b/src/wp-includes/class-wp-duotone.php
@@ -546,8 +546,8 @@ class WP_Duotone {
 	 *
 	 * @since 6.3.0
 	 *
-	 * @param string $duotone_attr The duotone attribute from a block.
-	 * @return string The slug of the duotone preset or an empty string if no slug is found.
+	 * @param string|string[] $duotone_attr The duotone attribute from a block.
+	 * @return string The slug of the duotone preset or an empty string if no slug is found (including when an array was passed).
 	 */
 	private static function get_slug_from_attribute( $duotone_attr ) {
 		if ( ! is_string( $duotone_attr ) ) {
@@ -570,7 +570,7 @@ class WP_Duotone {
 	 * @since 6.3.0
 	 *
 	 * @param string $duotone_attr The duotone attribute from a block.
-	 * @return bool True if the duotone preset present and valid.
+	 * @param string|string[] $duotone_attr The duotone attribute from a block.
 	 */
 	private static function is_preset( $duotone_attr ) {
 		if ( ! is_string( $duotone_attr ) ) {

--- a/tests/phpunit/tests/block-supports/duotone.php
+++ b/tests/phpunit/tests/block-supports/duotone.php
@@ -93,6 +93,8 @@ class Tests_Block_Supports_Duotone extends WP_UnitTestCase {
 			'pipe-slug-no-value'              => array( 'var:preset|duotone|', '' ),
 			'css-var-spaces'                  => array( 'var(--wp--preset--duotone--    ', '' ),
 			'pipe-slug-spaces'                => array( 'var:preset|duotone|  ', '' ),
+			'array-of-colors'                 => array( array( '#000000', '#ffffff' ), '' ),
+			'empty-array'                     => array( array(), '' ),
 		);
 	}
 
@@ -164,6 +166,8 @@ class Tests_Block_Supports_Duotone extends WP_UnitTestCase {
 			'css-var-invalid-slug-chars'      => array( 'var(--wp--preset--duotone--.)', false ),
 			'css-var-missing-end-parenthesis' => array( 'var(--wp--preset--duotone--blue-orange', false ),
 			'invalid'                         => array( 'not a valid attribute', false ),
+			'array-of-colors'                 => array( array( '#000000', '#ffffff' ), false ),
+			'empty-array'                     => array( array(), false ),
 		);
 	}
 


### PR DESCRIPTION
## Trac ticket

https://core.trac.wordpress.org/ticket/64612

## Description

This PR backports the fix from Gutenberg PR #75283 to prevent a fatal error when the duotone attribute in `theme.json` is an array (custom colors) instead of a string (preset reference).

## Problem

A fatal error occurs in `WP_Duotone::get_slug_from_attribute()` when `$duotone_attr` is an array:

```
Fatal error: Uncaught TypeError: preg_match(): Argument #2 ($subject) must be of type string, array given in wp-includes/class-wp-duotone.php
```

This happens when a theme's `theme.json` defines duotone with an array of colors (custom colors) rather than a preset reference string.

## Solution

Add type checks to ensure `$duotone_attr` is a string before attempting to parse it:

1. `get_slug_from_attribute()` - Returns empty string for non-string input
2. `is_preset()` - Returns false for non-string input
3. `get_all_global_style_block_names()` - Skips non-string duotone attributes

## Testing

1. Apply a theme with a `theme.json` that has an array value for duotone (custom colors)
2. Verify no fatal error occurs
3. Run PHPUnit tests: `phpunit tests/phpunit/tests/block-supports/duotone.php`


Props xavier-lc for the Gutenberg PR.