### PR TITLE
Remove tabindex on media library tabpanels

### DIFF
--- a/src/js/media/views/media-frame.js
+++ b/src/js/media/views/media-frame.js
@@ -110,7 +110,7 @@ MediaFrame = Frame.extend(/** @lends wp.media.view.MediaFrame.prototype */{
 			tabPanelEl
 				.attr( {
 					role: 'tabpanel',
-					'aria-labelledby': ariaLabelledby
+					'aria-labelledby': ariaLabelledby,
 				} );
 		}
 	},

--- a/src/js/media/views/media-frame.js
+++ b/src/js/media/views/media-frame.js
@@ -101,7 +101,7 @@ MediaFrame = Frame.extend(/** @lends wp.media.view.MediaFrame.prototype */{
 			tabPanelEl = this.$el.find( '.media-frame-tab-panel' ),
 			ariaLabelledby;
 
-		tabPanelEl.removeAttr( 'role aria-labelledby tabindex' );
+		tabPanelEl.removeAttr( 'role aria-labelledby' );
 
 		if ( this.state().get( 'menu' ) && this.menuView && this.menuView.isVisible ) {
 			ariaLabelledby = 'menu-item-' + stateId;
@@ -110,8 +110,7 @@ MediaFrame = Frame.extend(/** @lends wp.media.view.MediaFrame.prototype */{
 			tabPanelEl
 				.attr( {
 					role: 'tabpanel',
-					'aria-labelledby': ariaLabelledby,
-					tabIndex: '0'
+					'aria-labelledby': ariaLabelledby
 				} );
 		}
 	},
@@ -127,7 +126,7 @@ MediaFrame = Frame.extend(/** @lends wp.media.view.MediaFrame.prototype */{
 		var tabPanelEl = this.$el.find( '.media-frame-content' ),
 			ariaLabelledby;
 
-		tabPanelEl.removeAttr( 'role aria-labelledby tabindex' );
+		tabPanelEl.removeAttr( 'role aria-labelledby' );
 
 		// Set the tab panel attributes only if the tabs are visible.
 		if ( this.state().get( 'router' ) && this.routerView && this.routerView.isVisible && this.content._mode ) {
@@ -137,7 +136,6 @@ MediaFrame = Frame.extend(/** @lends wp.media.view.MediaFrame.prototype */{
 				.attr( {
 					role: 'tabpanel',
 					'aria-labelledby': ariaLabelledby,
-					tabIndex: '0'
 				} );
 		}
 	},


### PR DESCRIPTION
Reduces verbosity for screen readers which attempt to read the full content of the panel; reduces keypress distance to controls by one.


Trac ticket: https://core.trac.wordpress.org/ticket/63984

## Use of AI Tools

None

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
