### PR TITLE
Use role=button on featured image set and remove, handle space/enter.

### DIFF
--- a/src/js/_enqueues/wp/media/editor.js
+++ b/src/js/_enqueues/wp/media/editor.js
@@ -704,11 +704,7 @@
 		 */
 		init: function() {
 			$('#postimagediv').on( 'click keyup keydown', '#set-post-thumbnail', function( event ) {
-				if ( 
-					event.type === 'keyup' && event.key === ' '
-					|| event.type === 'keydown' && event.key === 'Enter'
-					|| event.type === 'click'
-				) {
+				if ( ( event.type === 'keyup' && event.key === ' ' ) || ( event.type === 'keydown' && event.key === 'Enter' ) || event.type === 'click' ) {
 					event.preventDefault();
 					// Stop propagation to prevent thickbox from activating.
 					event.stopPropagation();
@@ -716,11 +712,7 @@
 					wp.media.featuredImage.frame().open();
 				}
 			}).on( 'click keyup keydown', '#remove-post-thumbnail', function(event) {
-				if ( 
-					event.type === 'keyup' && event.key === ' '
-					|| event.type === 'keydown' && event.key === 'Enter'
-					|| event.type === 'click'
-				) {
+				if ( ( event.type === 'keyup' && event.key === ' ' ) || ( event.type === 'keydown' && event.key === 'Enter' ) || event.type === 'click' ) {
 					wp.media.featuredImage.remove();
 					return false;
 				}

--- a/src/js/_enqueues/wp/media/editor.js
+++ b/src/js/_enqueues/wp/media/editor.js
@@ -703,15 +703,27 @@
 		 * Update the featured image id when the 'remove' link is clicked.
 		 */
 		init: function() {
-			$('#postimagediv').on( 'click', '#set-post-thumbnail', function( event ) {
-				event.preventDefault();
-				// Stop propagation to prevent thickbox from activating.
-				event.stopPropagation();
+			$('#postimagediv').on( 'click keyup keydown', '#set-post-thumbnail', function( event ) {
+				if ( 
+					event.type === 'keyup' && event.key === ' '
+					|| event.type === 'keydown' && event.key === 'Enter'
+					|| event.type === 'click'
+				) {
+					event.preventDefault();
+					// Stop propagation to prevent thickbox from activating.
+					event.stopPropagation();
 
-				wp.media.featuredImage.frame().open();
-			}).on( 'click', '#remove-post-thumbnail', function() {
-				wp.media.featuredImage.remove();
-				return false;
+					wp.media.featuredImage.frame().open();
+				}
+			}).on( 'click keyup keydown', '#remove-post-thumbnail', function(event) {
+				if ( 
+					event.type === 'keyup' && event.key === ' '
+					|| event.type === 'keydown' && event.key === 'Enter'
+					|| event.type === 'click'
+				) {
+					wp.media.featuredImage.remove();
+					return false;
+				}
 			});
 		}
 	};

--- a/src/js/_enqueues/wp/media/editor.js
+++ b/src/js/_enqueues/wp/media/editor.js
@@ -711,7 +711,7 @@
 
 					wp.media.featuredImage.frame().open();
 				}
-			}).on( 'click keyup keydown', '#remove-post-thumbnail', function(event) {
+			}).on( 'click keyup keydown', '#remove-post-thumbnail', function( event ) {
 				if ( ( event.type === 'keyup' && event.key === ' ' ) || ( event.type === 'keydown' && event.key === 'Enter' ) || event.type === 'click' ) {
 					wp.media.featuredImage.remove();
 					return false;

--- a/src/wp-admin/includes/post.php
+++ b/src/wp-admin/includes/post.php
@@ -1644,7 +1644,7 @@ function _wp_post_thumbnail_html( $thumbnail_id = null, $post = null ) {
 
 	$post               = get_post( $post );
 	$post_type_object   = get_post_type_object( $post->post_type );
-	$set_thumbnail_link = '<p class="hide-if-no-js"><a href="%s" id="set-post-thumbnail"%s class="thickbox">%s</a></p>';
+	$set_thumbnail_link = '<p class="hide-if-no-js"><a href="%s" id="set-post-thumbnail"%s class="thickbox" role="button" aria-haspopup="dialog" aria-controls="wp-media-modal">%s</a></p>';
 	$upload_iframe_src  = get_upload_iframe_src( 'image', $post->ID );
 
 	$content = sprintf(
@@ -1683,7 +1683,7 @@ function _wp_post_thumbnail_html( $thumbnail_id = null, $post = null ) {
 				$thumbnail_html
 			);
 			$content .= '<p class="hide-if-no-js howto" id="set-post-thumbnail-desc">' . __( 'Click the image to edit or update' ) . '</p>';
-			$content .= '<p class="hide-if-no-js"><a href="#" id="remove-post-thumbnail">' . esc_html( $post_type_object->labels->remove_featured_image ) . '</a></p>';
+			$content .= '<p class="hide-if-no-js"><a href="#" id="remove-post-thumbnail" role="button">' . esc_html( $post_type_object->labels->remove_featured_image ) . '</a></p>';
 		}
 	}
 


### PR DESCRIPTION
PR changes the "Set featured image" control to use `role="button"`, add `aria-haspopup`, and `aria-controls` targeting the media modal. Also adds `role="button"` on the remove featured image.

Adds handlers to trigger on space/enter.

This doesn't change the control to an actual button to avoid interfering with styling, though that could be done, as well.

Trac ticket: https://core.trac.wordpress.org/ticket/63980

## Use of AI Tools

None

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
