### PR TITLE
[63728] Enhancement: Enhance the Posts list table filtering functionality by adding an aut…

### DIFF
--- a/src/wp-admin/css/forms.css
+++ b/src/wp-admin/css/forms.css
@@ -514,6 +514,26 @@ input[type="number"].tiny-text {
 	max-width: 12.5rem;
 }
 
+.tablenav .actions label {
+	float: left;
+	margin-right: 8px;
+	margin-top: 0;
+	line-height: 2.16666667;
+	vertical-align: middle;
+	font-weight: 600;
+}
+
+.tablenav .actions .filters-group {
+	border: 0;
+	padding: 0;
+	margin: 0;
+}
+
+.tablenav .actions label + select {
+	margin-left: 0;
+	margin-right: 12px;
+}
+
 #timezone_string option {
 	margin-left: 1em;
 }

--- a/src/wp-admin/includes/class-wp-list-table.php
+++ b/src/wp-admin/includes/class-wp-list-table.php
@@ -760,7 +760,7 @@ class WP_List_Table {
 
 		$selected_month = isset( $_GET['m'] ) ? (int) $_GET['m'] : 0;
 		?>
-		<label for="filter-by-date" class="screen-reader-text"><?php echo get_post_type_object( $post_type )->labels->filter_by_date; ?></label>
+		<label for="filter-by-date"><?php echo esc_html( get_post_type_object( $post_type )->labels->filter_by_date ); ?></label>
 		<select name="m" id="filter-by-date">
 			<option<?php selected( $selected_month, 0 ); ?> value="0"><?php _e( 'All dates' ); ?></option>
 		<?php

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -488,9 +488,9 @@ class WP_Posts_List_Table extends WP_List_Table {
 
 			echo '<label for="cat">' . esc_html( get_taxonomy( 'category' )->labels->filter_by_item ) . '</label>';
 
-		wp_dropdown_categories( $dropdown_options );
+			wp_dropdown_categories( $dropdown_options );
+		}
 	}
-}
 	/**
 	 * Displays an authors drop-down for filtering on the Posts list table.
 	 *

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -490,8 +490,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 
 			wp_dropdown_categories( $dropdown_options );
 		}
-	}
-	
+	}	
 	/**
 	 * Displays an authors drop-down for filtering on the Posts list table.
 	 *

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -486,10 +486,82 @@ class WP_Posts_List_Table extends WP_List_Table {
 				'selected'        => $cat,
 			);
 
-			echo '<label class="screen-reader-text" for="cat">' . get_taxonomy( 'category' )->labels->filter_by_item . '</label>';
+			echo '<label for="cat">' . esc_html( get_taxonomy( 'category' )->labels->filter_by_item ) . '</label>';
 
 			wp_dropdown_categories( $dropdown_options );
 		}
+	}
+	
+	/**
+	 * Displays an authors drop-down for filtering on the Posts list table.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @param string $post_type Post type slug.
+	 */
+	protected function authors_dropdown( $post_type ) {
+		/**
+		 * Filters whether to remove the 'Authors' drop-down from the post list table.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param bool   $disable   Whether to disable the authors drop-down. Default false.
+		 * @param string $post_type Post type slug.
+		 */
+		if ( apply_filters( 'disable_authors_dropdown', false, $post_type ) ) {
+			return;
+		}
+
+		$post_type_object = get_post_type_object( $post_type );
+
+		// Only show author filter if post type supports authors.
+		if ( ! post_type_supports( $post_type, 'author' ) ) {
+			return;
+		}
+
+		// Check if there are multiple authors with published posts for this post type.
+		$authors = get_users(
+			array(
+				'who'                 => 'authors',
+				'has_published_posts' => array( $post_type ),
+				'fields'              => array( 'ID', 'display_name' ),
+				'orderby'             => 'display_name',
+			)
+		);
+
+		// Only display the dropdown if there are multiple authors.
+		if ( count( $authors ) < 2 ) {
+			return;
+		}
+
+		$selected_author = isset( $_GET['author'] ) ? (int) $_GET['author'] : 0;
+
+		/**
+		 * Filters the authors shown in the authors drop-down.
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param WP_User[] $authors   Array of WP_User objects.
+		 * @param string    $post_type Post type slug.
+		 */
+		$authors = apply_filters( 'posts_authors_dropdown_authors', $authors, $post_type );
+
+		?>
+		<label for="filter-by-author"><?php esc_html_e( 'Filter by author' ); ?></label>
+		<select name="author" id="filter-by-author">
+			<option value="0"<?php selected( $selected_author, 0 ); ?>><?php esc_html_e( 'All authors' ); ?></option>
+			<?php
+			foreach ( $authors as $author ) {
+				printf(
+					'<option value="%1$d"%2$s>%3$s</option>',
+					(int) $author->ID,
+					selected( $selected_author, $author->ID, false ),
+					esc_html( $author->display_name )
+				);
+			}
+			?>
+		</select>
+		<?php
 	}
 
 	/**
@@ -533,10 +605,9 @@ class WP_Posts_List_Table extends WP_List_Table {
 
 		$displayed_post_format = $_GET['post_format'] ?? '';
 		?>
-		<label for="filter-by-format" class="screen-reader-text">
+		<label for="filter-by-format">
 			<?php
-			/* translators: Hidden accessibility text. */
-			_e( 'Filter by post format' );
+			_e( 'Format' );
 			?>
 		</label>
 		<select name="post_format" id="filter-by-format">
@@ -574,6 +645,7 @@ class WP_Posts_List_Table extends WP_List_Table {
 			$this->months_dropdown( $this->screen->post_type );
 			$this->categories_dropdown( $this->screen->post_type );
 			$this->formats_dropdown( $this->screen->post_type );
+			$this->authors_dropdown( $this->screen->post_type );
 
 			/**
 			 * Fires before the Filter button on the Posts and Pages list tables.
@@ -595,8 +667,11 @@ class WP_Posts_List_Table extends WP_List_Table {
 			$output = ob_get_clean();
 
 			if ( ! empty( $output ) ) {
+				echo '<fieldset class="filters-group">';
+				echo '<legend class="screen-reader-text">' . esc_html__( 'Filters' ) . '</legend>';
 				echo $output;
 				submit_button( __( 'Filter' ), '', 'filter_action', false, array( 'id' => 'post-query-submit' ) );
+				echo '</fieldset>';
 			}
 		}
 

--- a/src/wp-admin/includes/class-wp-posts-list-table.php
+++ b/src/wp-admin/includes/class-wp-posts-list-table.php
@@ -488,9 +488,9 @@ class WP_Posts_List_Table extends WP_List_Table {
 
 			echo '<label for="cat">' . esc_html( get_taxonomy( 'category' )->labels->filter_by_item ) . '</label>';
 
-			wp_dropdown_categories( $dropdown_options );
-		}
-	}	
+		wp_dropdown_categories( $dropdown_options );
+	}
+}
 	/**
 	 * Displays an authors drop-down for filtering on the Posts list table.
 	 *


### PR DESCRIPTION
Trac: https://core.trac.wordpress.org/ticket/63728

## Problem

The WordPress Posts list table filter area had several usability and accessibility issues:

1. **No author filtering capability** - Users couldn't filter posts by author directly from the list table, requiring manual URL manipulation or additional plugins
2. **Hidden filter labels** - All filter dropdowns (date, category, format) had labels hidden with `screen-reader-text` class, making it difficult for sighted users to understand what each dropdown represented
3. **Poor semantic structure** - Filters lacked proper grouping, reducing accessibility for screen reader users
4. **Single-user sites showing unnecessary filters** - No conditional logic to hide author filters when only one author exists

## Root Cause

The original implementation prioritized visual compactness over usability:

- Labels were intentionally hidden to save horizontal space in the admin interface
- No author filter existed because it was considered an edge case, despite being a common need for multi-author sites
- The lack of semantic HTML grouping (fieldset/legend) meant screen readers couldn't properly announce the filter group context
- No conditional rendering logic existed to optimize the UI for single vs multi-author sites

## Solution

### 1. Added Author Filter Dropdown
- Created new `authors_dropdown()` method in `WP_Posts_List_Table` class
- Conditionally displays only when:
  - Post type supports authors
  - Site has 2 or more authors with published posts
- Uses optimized query with `has_published_posts` parameter to fetch only relevant authors
- Includes filter hooks (`disable_authors_dropdown`, `posts_authors_dropdown_authors`) for extensibility

### 2. Made All Filter Labels Visible
- Removed `screen-reader-text` class from date, category, and format filter labels
- Labels now display inline before their corresponding dropdowns
- Improved label text: simplified "Filter by post format" to just "Format" to reduce repetition

### 3. Added Semantic Grouping
- Wrapped all filters in `<fieldset class="filters-group">` element
- Added `<legend class="screen-reader-text">Filters</legend>` for screen reader context
- This allows screen readers to announce "Filters" group when navigating the controls

### 4. Enhanced CSS Styling
- Added styles to properly align labels with dropdowns using `float: left`
- Set `font-weight: 600` on labels for better visibility
- Adjusted `line-height: 2.16666667` to vertically align with select elements
- Proper spacing with labels having 8px margin and selects after labels having 12px margin

### Backward Compatibility
- All existing filter hooks remain intact
- New filter hooks follow WordPress naming conventions
- CSS changes are additive, not destructive
- Existing functionality fully preserved

### Testing
Tested on:
- Single-author sites (author dropdown correctly hidden)
- Multi-author sites (author dropdown appears with correct authors)
- Custom post types with/without author support
- All filter combinations work correctly