### PR TITLE
TRAC: 54484 - REST API: Return empty object instead of empty array for meta field

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-blocks-controller.php
@@ -57,9 +57,19 @@ class WP_REST_Blocks_Controller extends WP_REST_Posts_Controller {
 		unset( $data['title']['rendered'] );
 		unset( $data['content']['rendered'] );
 
-		// Add the core wp_pattern_sync_status meta as top level property to the response.
-		$data['wp_pattern_sync_status'] = $data['meta']['wp_pattern_sync_status'] ?? '';
-		unset( $data['meta']['wp_pattern_sync_status'] );
+		/*
+		 * Add the core wp_pattern_sync_status meta as top level property to the response.
+		 * Handle both array and object (stdClass) meta values.
+		 */
+		if ( is_array( $data['meta'] ) && isset( $data['meta']['wp_pattern_sync_status'] ) ) {
+			$data['wp_pattern_sync_status'] = $data['meta']['wp_pattern_sync_status'];
+			unset( $data['meta']['wp_pattern_sync_status'] );
+		} elseif ( is_object( $data['meta'] ) && property_exists( $data['meta'], 'wp_pattern_sync_status' ) ) {
+			$data['wp_pattern_sync_status'] = $data['meta']->wp_pattern_sync_status;
+			unset( $data['meta']->wp_pattern_sync_status );
+		} else {
+			$data['wp_pattern_sync_status'] = '';
+		}
 		return $data;
 	}
 

--- a/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
+++ b/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
@@ -588,6 +588,10 @@ abstract class WP_REST_Meta_Fields {
 	 * @return array|false The meta array, if valid, false otherwise.
 	 */
 	public function check_meta_is_array( $value, $request, $param ) {
+		if ( is_object( $value ) ) {
+			$value = (array) $value;
+		}
+
 		if ( ! is_array( $value ) ) {
 			return false;
 		}

--- a/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
+++ b/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
@@ -74,7 +74,8 @@ abstract class WP_REST_Meta_Fields {
 	 *
 	 * @param int             $object_id Object ID to fetch meta for.
 	 * @param WP_REST_Request $request   Full details about the request.
-	 * @return array Array containing the meta values keyed by name.
+	 * @return array|stdClass Array containing the meta values keyed by name,
+	 *                        or stdClass if empty to ensure JSON object encoding.
 	 */
 	public function get_value( $object_id, $request ) {
 		$fields   = $this->get_registered_fields();
@@ -103,6 +104,11 @@ abstract class WP_REST_Meta_Fields {
 			}
 
 			$response[ $name ] = $value;
+		}
+
+		// Use stdClass so that JSON result is {} and not [].
+		if ( empty( $response ) ) {
+			return new stdClass();
 		}
 
 		return $response;

--- a/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
+++ b/src/wp-includes/rest-api/fields/class-wp-rest-meta-fields.php
@@ -74,8 +74,8 @@ abstract class WP_REST_Meta_Fields {
 	 *
 	 * @param int             $object_id Object ID to fetch meta for.
 	 * @param WP_REST_Request $request   Full details about the request.
-	 * @return array|stdClass Array containing the meta values keyed by name,
-	 *                        or stdClass if empty to ensure JSON object encoding.
+	 * @return array|object Array containing the meta values keyed by name,
+	 *                      or an empty object if to ensure JSON object encoding.
 	 */
 	public function get_value( $object_id, $request ) {
 		$fields   = $this->get_registered_fields();
@@ -108,7 +108,7 @@ abstract class WP_REST_Meta_Fields {
 
 		// Use stdClass so that JSON result is {} and not [].
 		if ( empty( $response ) ) {
-			return new stdClass();
+			return (object) array();
 		}
 
 		return $response;


### PR DESCRIPTION
**Ticket:** https://core.trac.wordpress.org/ticket/54484