### PR TITLE
Add: WordPress Core update settings ability

### DIFF
--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -142,7 +142,7 @@ class WP_Settings_Abilities {
 	 *
 	 * @since 7.0.0
 	 *
-	 * @return array JSON Schema for settings.
+	 * @return array<string, mixed> JSON Schema for settings.
 	 */
 	private static function build_settings_schema(): array {
 		$group_properties = array();

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -437,16 +437,18 @@ class WP_Settings_Abilities {
 					$sanitized_value = call_user_func( $args['sanitize_callback'], $sanitized_value );
 				}
 
-				$updated = update_option( $option_name, $sanitized_value );
-				if ( $updated || get_option( $option_name ) === $sanitized_value ) {
+				$setting_type = $args['type'] ?? 'string';
+				$updated      = update_option( $option_name, $sanitized_value );
+
+				// Cast current value for comparison (handles type mismatches from database).
+				$current_value = self::cast_value( get_option( $option_name ), $setting_type );
+
+				if ( $updated || $current_value === $sanitized_value ) {
 					// Add to updated_settings with the same grouped structure.
 					if ( ! isset( $updated_settings[ $group ] ) ) {
 						$updated_settings[ $group ] = array();
 					}
-					$updated_settings[ $group ][ $option_name ] = self::cast_value(
-						get_option( $option_name ),
-						$args['type'] ?? 'string'
-					);
+					$updated_settings[ $group ][ $option_name ] = $current_value;
 				} else {
 					return new WP_Error(
 						'rest_setting_update_failed',

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -37,7 +37,7 @@ class WP_Settings_Abilities {
 	 * @since 7.0.0
 	 * @var array
 	 */
-	private static $settings_schema;
+	private static array $settings_schema;
 
 	/**
 	 * Available setting slugs with show_in_abilities enabled.

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -29,7 +29,7 @@ class WP_Settings_Abilities {
 	 * @since 7.0.0
 	 * @var string[]
 	 */
-	private static $available_groups;
+	private static array $available_groups;
 
 	/**
 	 * Schema for settings grouped by registration group.

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -263,8 +263,6 @@ class WP_Settings_Abilities {
 	 * Registers the core/update-settings ability.
 	 *
 	 * @since 7.0.0
-	 *
-	 * @return void
 	 */
 	private static function register_update_settings(): void {
 		// Reuse settings schema with updated descriptions for input and output.

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -378,7 +378,7 @@ class WP_Settings_Abilities {
 	 * }
 	 * @return array<string, array<string, mixed>|object>|WP_Error Updated settings on success, WP_Error on failure.
 	 */
-	public static function execute_update_settings( $input = array() ) {
+	public static function execute_update_settings( $input = array() ): array {
 		$input = is_array( $input ) ? $input : array();
 
 		if ( empty( $input['settings'] ) || ! is_array( $input['settings'] ) ) {

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -57,6 +57,7 @@ class WP_Settings_Abilities {
 	public static function register(): void {
 		self::init();
 		self::register_get_settings();
+		self::register_update_settings();
 	}
 
 	/**
@@ -259,6 +260,60 @@ class WP_Settings_Abilities {
 	}
 
 	/**
+	 * Registers the core/update-settings ability.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return void
+	 */
+	private static function register_update_settings(): void {
+		wp_register_ability(
+			'core/update-settings',
+			array(
+				'label'               => __( 'Update Settings' ),
+				'description'         => __( 'Updates registered WordPress settings. Only settings with show_in_abilities enabled can be modified.' ),
+				'category'            => 'site',
+				'input_schema'        => array(
+					'type'                 => 'object',
+					'required'             => array( 'settings' ),
+					'properties'           => array(
+						'settings' => array(
+							'type'                 => 'object',
+							'description'          => __( 'Settings to update, grouped by registration group. Same structure as returned by core/get-settings.' ),
+							'additionalProperties' => true,
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'output_schema'       => array(
+					'type'                 => 'object',
+					'properties'           => array(
+						'updated_settings'  => array(
+							'type'        => 'object',
+							'description' => __( 'Settings that were successfully updated, grouped by registration group. Same shape as input.' ),
+						),
+						'validation_errors' => array(
+							'type'        => 'object',
+							'description' => __( 'Validation errors grouped by registration group. Same shape as input but with error messages as values.' ),
+						),
+					),
+					'additionalProperties' => false,
+				),
+				'execute_callback'    => array( __CLASS__, 'execute_update_settings' ),
+				'permission_callback' => array( __CLASS__, 'check_manage_options' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+				),
+			)
+		);
+	}
+
+	/**
 	 * Permission callback for settings abilities.
 	 *
 	 * @since 7.0.0
@@ -318,6 +373,130 @@ class WP_Settings_Abilities {
 		ksort( $settings_by_group );
 
 		return $settings_by_group;
+	}
+
+	/**
+	 * Execute callback for core/update-settings ability.
+	 *
+	 * Updates registered settings that are exposed through the Abilities API.
+	 * Returns updated settings and validation errors in a grouped structure
+	 * matching the input format.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array $input {
+	 *     Input parameters.
+	 *
+	 *     @type array $settings Settings to update, grouped by registration group.
+	 * }
+	 * @return array {
+	 *     @type array $updated_settings  Settings that were successfully updated, grouped by registration group.
+	 *     @type array $validation_errors Validation errors grouped by registration group.
+	 * }
+	 */
+	public static function execute_update_settings( $input = array() ): array {
+		$input = is_array( $input ) ? $input : array();
+
+		if ( empty( $input['settings'] ) || ! is_array( $input['settings'] ) ) {
+			return array(
+				'updated_settings'  => (object) array(),
+				'validation_errors' => (object) array(),
+			);
+		}
+
+		$grouped_settings  = $input['settings'];
+		$allowed_settings  = self::get_allowed_settings();
+
+		$updated_settings  = array();
+		$validation_errors = array();
+
+		// Iterate through groups (general, reading, writing, etc.).
+		foreach ( $grouped_settings as $group => $settings ) {
+			if ( ! is_array( $settings ) ) {
+				if ( ! isset( $validation_errors[ $group ] ) ) {
+					$validation_errors[ $group ] = array();
+				}
+				$validation_errors[ $group ]['_error'] = __( 'Group settings must be an object.' );
+				continue;
+			}
+
+			// Iterate through settings within each group.
+			foreach ( $settings as $option_name => $value ) {
+				// Check if setting is allowed.
+				if ( ! isset( $allowed_settings[ $option_name ] ) ) {
+					if ( ! isset( $validation_errors[ $group ] ) ) {
+						$validation_errors[ $group ] = array();
+					}
+					$validation_errors[ $group ][ $option_name ] = __( 'Setting is not allowed to be modified.' );
+					continue;
+				}
+
+				$args = $allowed_settings[ $option_name ];
+
+				// Verify setting belongs to the specified group.
+				$setting_group = $args['group'] ?? 'general';
+				if ( $setting_group !== $group ) {
+					if ( ! isset( $validation_errors[ $group ] ) ) {
+						$validation_errors[ $group ] = array();
+					}
+					$validation_errors[ $group ][ $option_name ] = sprintf(
+						/* translators: 1: Expected group, 2: Provided group. */
+						__( 'Setting belongs to group "%1$s", not "%2$s".' ),
+						$setting_group,
+						$group
+					);
+					continue;
+				}
+
+				// Build schema for validation.
+				$schema = array(
+					'type' => $args['type'] ?? 'string',
+				);
+				if ( is_array( $args['show_in_rest'] ) && isset( $args['show_in_rest']['schema'] ) ) {
+					$schema = array_merge( $schema, $args['show_in_rest']['schema'] );
+				}
+
+				// Validate value against schema.
+				$validation = rest_validate_value_from_schema( $value, $schema, $option_name );
+				if ( is_wp_error( $validation ) ) {
+					if ( ! isset( $validation_errors[ $group ] ) ) {
+						$validation_errors[ $group ] = array();
+					}
+					$validation_errors[ $group ][ $option_name ] = $validation->get_error_message();
+					continue;
+				}
+
+				// Sanitize the value.
+				$sanitized_value = rest_sanitize_value_from_schema( $value, $schema );
+
+				// Apply registered sanitize callback if exists.
+				if ( ! empty( $args['sanitize_callback'] ) && is_callable( $args['sanitize_callback'] ) ) {
+					$sanitized_value = call_user_func( $args['sanitize_callback'], $sanitized_value );
+				}
+
+				$updated = update_option( $option_name, $sanitized_value );
+				if ( $updated || get_option( $option_name ) === $sanitized_value ) {
+					// Add to updated_settings with the same grouped structure.
+					if ( ! isset( $updated_settings[ $group ] ) ) {
+						$updated_settings[ $group ] = array();
+					}
+					$updated_settings[ $group ][ $option_name ] = self::cast_value(
+						get_option( $option_name ),
+						$args['type'] ?? 'string'
+					);
+				} else {
+					if ( ! isset( $validation_errors[ $group ] ) ) {
+						$validation_errors[ $group ] = array();
+					}
+					$validation_errors[ $group ][ $option_name ] = __( 'Failed to update setting.' );
+				}
+			}
+		}
+
+		return array(
+			'updated_settings'  => ! empty( $updated_settings ) ? $updated_settings : (object) array(),
+			'validation_errors' => ! empty( $validation_errors ) ? $validation_errors : (object) array(),
+		);
 	}
 
 	/**

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -422,7 +422,7 @@ class WP_Settings_Abilities {
 
 				$sanitized_value = rest_sanitize_value_from_schema( $value, $schema );
 
-				if ( ! empty( $args['sanitize_callback'] ) && is_callable( $args['sanitize_callback'] ) ) {
+				if ( isset( $args['sanitize_callback'] ) && is_callable( $args['sanitize_callback'] ) ) {
 					$sanitized_value = call_user_func( $args['sanitize_callback'], $sanitized_value );
 				}
 

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -400,36 +400,33 @@ class WP_Settings_Abilities {
 
 			// Iterate through settings within each group.
 			foreach ( $settings as $option_name => $value ) {
-				// Skip settings that are not allowed (handled by schema validation).
 				if ( ! isset( $allowed_settings[ $option_name ] ) ) {
 					continue;
 				}
 
 				$args = $allowed_settings[ $option_name ];
 
-				// Skip settings in wrong group (handled by schema validation).
 				$setting_group = $args['group'] ?? 'general';
 				if ( $setting_group !== $group ) {
 					continue;
 				}
 
-				// Build schema for sanitization.
+				$setting_type = $args['type'] ?? 'string';
+
 				$schema = array(
-					'type' => $args['type'] ?? 'string',
+					'type' => $setting_type,
 				);
 				if ( is_array( $args['show_in_rest'] ) && isset( $args['show_in_rest']['schema'] ) ) {
 					$schema = array_merge( $schema, $args['show_in_rest']['schema'] );
 				}
 
-				// Sanitize the value.
 				$sanitized_value = rest_sanitize_value_from_schema( $value, $schema );
 
-				// Apply registered sanitize callback if exists.
 				if ( ! empty( $args['sanitize_callback'] ) && is_callable( $args['sanitize_callback'] ) ) {
 					$sanitized_value = call_user_func( $args['sanitize_callback'], $sanitized_value );
 				}
 
-				$setting_type = $args['type'] ?? 'string';
+				
 				$updated      = update_option( $option_name, $sanitized_value );
 
 				// Cast values for comparison (handles type mismatches from database and REST sanitization).
@@ -437,7 +434,6 @@ class WP_Settings_Abilities {
 				$sanitized_value = self::cast_value( $sanitized_value, $setting_type );
 
 				if ( $updated || $current_value === $sanitized_value ) {
-					// Add to updated_settings with the same grouped structure.
 					if ( ! isset( $updated_settings[ $group ] ) ) {
 						$updated_settings[ $group ] = array();
 					}

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -371,7 +371,7 @@ class WP_Settings_Abilities {
 	 *
 	 * @since 7.0.0
 	 *
-	 * @param array $input {
+	 * @param array<string, mixed> $input {
 	 *     Input parameters.
 	 *
 	 *     @type array $settings Settings to update, grouped by registration group.

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -35,7 +35,7 @@ class WP_Settings_Abilities {
 	 * Schema for settings grouped by registration group.
 	 *
 	 * @since 7.0.0
-	 * @var array
+	 * @var array<string, mixed>
 	 */
 	private static array $settings_schema;
 

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -382,7 +382,7 @@ class WP_Settings_Abilities {
 	 *
 	 *     @type array $settings Settings to update, grouped by registration group.
 	 * }
-	 * @return array|WP_Error Updated settings on success, WP_Error on failure.
+	 * @return array<string, array<string, mixed>|object>|WP_Error Updated settings on success, WP_Error on failure.
 	 */
 	public static function execute_update_settings( $input = array() ) {
 		$input = is_array( $input ) ? $input : array();

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -399,8 +399,7 @@ class WP_Settings_Abilities {
 
 		if ( empty( $input['settings'] ) || ! is_array( $input['settings'] ) ) {
 			return array(
-				'updated_settings'  => (object) array(),
-				'validation_errors' => (object) array(),
+				'updated_settings' => (object) array(),
 			);
 		}
 
@@ -493,10 +492,15 @@ class WP_Settings_Abilities {
 			}
 		}
 
-		return array(
-			'updated_settings'  => ! empty( $updated_settings ) ? $updated_settings : (object) array(),
-			'validation_errors' => ! empty( $validation_errors ) ? $validation_errors : (object) array(),
+		$result = array(
+			'updated_settings' => ! empty( $updated_settings ) ? $updated_settings : (object) array(),
 		);
+
+		if ( ! empty( $validation_errors ) ) {
+			$result['validation_errors'] = $validation_errors;
+		}
+
+		return $result;
 	}
 
 	/**

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -267,9 +267,12 @@ class WP_Settings_Abilities {
 	 * @return void
 	 */
 	private static function register_update_settings(): void {
-		// Reuse settings schema with updated description for input.
+		// Reuse settings schema with updated descriptions for input and output.
 		$input_settings_schema                = self::$settings_schema;
 		$input_settings_schema['description'] = __( 'Settings to update, grouped by registration group. Same structure as returned by core/get-settings.' );
+
+		$output_settings_schema                = self::$settings_schema;
+		$output_settings_schema['description'] = __( 'Settings that were successfully updated, grouped by registration group.' );
 
 		wp_register_ability(
 			'core/update-settings',
@@ -288,14 +291,7 @@ class WP_Settings_Abilities {
 				'output_schema'       => array(
 					'type'                 => 'object',
 					'properties'           => array(
-						'updated_settings'  => array(
-							'type'        => 'object',
-							'description' => __( 'Settings that were successfully updated, grouped by registration group. Same shape as input.' ),
-						),
-						'validation_errors' => array(
-							'type'        => 'object',
-							'description' => __( 'Validation errors grouped by registration group. Same shape as input but with error messages as values.' ),
-						),
+						'updated_settings' => $output_settings_schema,
 					),
 					'additionalProperties' => false,
 				),
@@ -379,8 +375,7 @@ class WP_Settings_Abilities {
 	 * Execute callback for core/update-settings ability.
 	 *
 	 * Updates registered settings that are exposed through the Abilities API.
-	 * Returns updated settings and validation errors in a grouped structure
-	 * matching the input format.
+	 * Returns updated settings grouped by registration group.
 	 *
 	 * @since 7.0.0
 	 *
@@ -389,12 +384,9 @@ class WP_Settings_Abilities {
 	 *
 	 *     @type array $settings Settings to update, grouped by registration group.
 	 * }
-	 * @return array {
-	 *     @type array $updated_settings  Settings that were successfully updated, grouped by registration group.
-	 *     @type array $validation_errors Validation errors grouped by registration group.
-	 * }
+	 * @return array|WP_Error Updated settings on success, WP_Error on failure.
 	 */
-	public static function execute_update_settings( $input = array() ): array {
+	public static function execute_update_settings( $input = array() ) {
 		$input = is_array( $input ) ? $input : array();
 
 		if ( empty( $input['settings'] ) || ! is_array( $input['settings'] ) ) {
@@ -406,63 +398,35 @@ class WP_Settings_Abilities {
 		$grouped_settings = $input['settings'];
 		$allowed_settings = self::get_allowed_settings();
 
-		$updated_settings  = array();
-		$validation_errors = array();
+		$updated_settings = array();
 
 		// Iterate through groups (general, reading, writing, etc.).
 		foreach ( $grouped_settings as $group => $settings ) {
 			if ( ! is_array( $settings ) ) {
-				if ( ! isset( $validation_errors[ $group ] ) ) {
-					$validation_errors[ $group ] = array();
-				}
-				$validation_errors[ $group ]['_error'] = __( 'Group settings must be an object.' );
 				continue;
 			}
 
 			// Iterate through settings within each group.
 			foreach ( $settings as $option_name => $value ) {
-				// Check if setting is allowed.
+				// Skip settings that are not allowed (handled by schema validation).
 				if ( ! isset( $allowed_settings[ $option_name ] ) ) {
-					if ( ! isset( $validation_errors[ $group ] ) ) {
-						$validation_errors[ $group ] = array();
-					}
-					$validation_errors[ $group ][ $option_name ] = __( 'Setting is not allowed to be modified.' );
 					continue;
 				}
 
 				$args = $allowed_settings[ $option_name ];
 
-				// Verify setting belongs to the specified group.
+				// Skip settings in wrong group (handled by schema validation).
 				$setting_group = $args['group'] ?? 'general';
 				if ( $setting_group !== $group ) {
-					if ( ! isset( $validation_errors[ $group ] ) ) {
-						$validation_errors[ $group ] = array();
-					}
-					$validation_errors[ $group ][ $option_name ] = sprintf(
-						/* translators: 1: Expected group, 2: Provided group. */
-						__( 'Setting belongs to group "%1$s", not "%2$s".' ),
-						$setting_group,
-						$group
-					);
 					continue;
 				}
 
-				// Build schema for validation.
+				// Build schema for sanitization.
 				$schema = array(
 					'type' => $args['type'] ?? 'string',
 				);
 				if ( is_array( $args['show_in_rest'] ) && isset( $args['show_in_rest']['schema'] ) ) {
 					$schema = array_merge( $schema, $args['show_in_rest']['schema'] );
-				}
-
-				// Validate value against schema.
-				$validation = rest_validate_value_from_schema( $value, $schema, $option_name );
-				if ( is_wp_error( $validation ) ) {
-					if ( ! isset( $validation_errors[ $group ] ) ) {
-						$validation_errors[ $group ] = array();
-					}
-					$validation_errors[ $group ][ $option_name ] = $validation->get_error_message();
-					continue;
 				}
 
 				// Sanitize the value.
@@ -484,23 +448,22 @@ class WP_Settings_Abilities {
 						$args['type'] ?? 'string'
 					);
 				} else {
-					if ( ! isset( $validation_errors[ $group ] ) ) {
-						$validation_errors[ $group ] = array();
-					}
-					$validation_errors[ $group ][ $option_name ] = __( 'Failed to update setting.' );
+					return new WP_Error(
+						'rest_setting_update_failed',
+						sprintf(
+							/* translators: %s: Option name. */
+							__( 'Failed to update setting: %s.' ),
+							$option_name
+						),
+						array( 'status' => 500 )
+					);
 				}
 			}
 		}
 
-		$result = array(
+		return array(
 			'updated_settings' => ! empty( $updated_settings ) ? $updated_settings : (object) array(),
 		);
-
-		if ( ! empty( $validation_errors ) ) {
-			$result['validation_errors'] = $validation_errors;
-		}
-
-		return $result;
 	}
 
 	/**

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -432,8 +432,9 @@ class WP_Settings_Abilities {
 				$setting_type = $args['type'] ?? 'string';
 				$updated      = update_option( $option_name, $sanitized_value );
 
-				// Cast current value for comparison (handles type mismatches from database).
-				$current_value = self::cast_value( get_option( $option_name ), $setting_type );
+				// Cast values for comparison (handles type mismatches from database and REST sanitization).
+				$current_value   = self::cast_value( get_option( $option_name ), $setting_type );
+				$sanitized_value = self::cast_value( $sanitized_value, $setting_type );
 
 				if ( $updated || $current_value === $sanitized_value ) {
 					// Add to updated_settings with the same grouped structure.

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -404,8 +404,8 @@ class WP_Settings_Abilities {
 			);
 		}
 
-		$grouped_settings  = $input['settings'];
-		$allowed_settings  = self::get_allowed_settings();
+		$grouped_settings = $input['settings'];
+		$allowed_settings = self::get_allowed_settings();
 
 		$updated_settings  = array();
 		$validation_errors = array();

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -45,7 +45,7 @@ class WP_Settings_Abilities {
 	 * @since 7.0.0
 	 * @var string[]
 	 */
-	private static $available_slugs;
+	private static array $available_slugs;
 
 	/**
 	 * Registers all settings abilities.

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -137,7 +137,7 @@ class WP_Settings_Abilities {
 	 *
 	 * Creates a JSON Schema that documents each setting group and its settings
 	 * with their types, titles, descriptions, defaults, and any additional
-	 * schema properties from show_in_rest.
+	 * schema properties from show_in_abilities.
 	 *
 	 * @since 7.0.0
 	 *
@@ -161,6 +161,11 @@ class WP_Settings_Abilities {
 				$setting_schema['description'] = $args['description'];
 			} elseif ( ! empty( $args['label'] ) ) {
 				$setting_schema['description'] = $args['label'];
+			}
+
+			// Merge custom schema from show_in_abilities if provided as an array.
+			if ( is_array( $args['show_in_abilities'] ) && ! empty( $args['show_in_abilities']['schema'] ) ) {
+				$setting_schema = array_merge( $setting_schema, $args['show_in_abilities']['schema'] );
 			}
 
 			if ( ! isset( $group_properties[ $group ] ) ) {

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -432,12 +432,7 @@ class WP_Settings_Abilities {
 				$current_value   = self::cast_value( get_option( $option_name ), $setting_type );
 				$sanitized_value = self::cast_value( $sanitized_value, $setting_type );
 
-				if ( $updated || $current_value === $sanitized_value ) {
-					if ( ! isset( $updated_settings[ $group ] ) ) {
-						$updated_settings[ $group ] = array();
-					}
-					$updated_settings[ $group ][ $option_name ] = $current_value;
-				} else {
+				if ( ! $updated && $current_value !== $sanitized_value ) {
 					return new WP_Error(
 						'rest_setting_update_failed',
 						sprintf(
@@ -448,6 +443,12 @@ class WP_Settings_Abilities {
 						array( 'status' => 500 )
 					);
 				}
+
+				if ( ! isset( $updated_settings[ $group ] ) ) {
+					$updated_settings[ $group ] = array();
+				}
+
+				$updated_settings[ $group ][ $option_name ] = $current_value;
 			}
 		}
 

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -122,15 +122,7 @@ class WP_Settings_Abilities {
 	 * @return string[] List of unique setting slugs.
 	 */
 	private static function get_available_slugs(): array {
-		$slugs = array();
-
-		foreach ( self::get_allowed_settings() as $option_name => $args ) {
-			$slugs[] = $option_name;
-		}
-
-		sort( $slugs );
-
-		return $slugs;
+		return sort( array_keys( self::get_allowed_settings() ) );
 	}
 
 	/**

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -32,12 +32,12 @@ class WP_Settings_Abilities {
 	private static $available_groups;
 
 	/**
-	 * Dynamic output schema built from registered settings.
+	 * Schema for settings grouped by registration group.
 	 *
 	 * @since 7.0.0
 	 * @var array
 	 */
-	private static $output_schema;
+	private static $settings_schema;
 
 	/**
 	 * Available setting slugs with show_in_abilities enabled.
@@ -70,7 +70,7 @@ class WP_Settings_Abilities {
 	private static function init(): void {
 		self::$available_groups = self::get_available_groups();
 		self::$available_slugs  = self::get_available_slugs();
-		self::$output_schema    = self::build_output_schema();
+		self::$settings_schema  = self::build_settings_schema();
 	}
 
 	/**
@@ -134,7 +134,7 @@ class WP_Settings_Abilities {
 	}
 
 	/**
-	 * Builds a rich output schema from registered settings metadata.
+	 * Builds a schema for settings grouped by registration group.
 	 *
 	 * Creates a JSON Schema that documents each setting group and its settings
 	 * with their types, titles, descriptions, defaults, and any additional
@@ -142,9 +142,9 @@ class WP_Settings_Abilities {
 	 *
 	 * @since 7.0.0
 	 *
-	 * @return array JSON Schema for the output.
+	 * @return array JSON Schema for settings.
 	 */
-	private static function build_output_schema(): array {
+	private static function build_settings_schema(): array {
 		$group_properties = array();
 
 		foreach ( self::get_allowed_settings() as $option_name => $args ) {
@@ -244,7 +244,7 @@ class WP_Settings_Abilities {
 						),
 					),
 				),
-				'output_schema'       => self::$output_schema,
+				'output_schema'       => self::$settings_schema,
 				'execute_callback'    => array( __CLASS__, 'execute_get_settings' ),
 				'permission_callback' => array( __CLASS__, 'check_manage_options' ),
 				'meta'                => array(
@@ -267,6 +267,10 @@ class WP_Settings_Abilities {
 	 * @return void
 	 */
 	private static function register_update_settings(): void {
+		// Reuse settings schema with updated description for input.
+		$input_settings_schema                = self::$settings_schema;
+		$input_settings_schema['description'] = __( 'Settings to update, grouped by registration group. Same structure as returned by core/get-settings.' );
+
 		wp_register_ability(
 			'core/update-settings',
 			array(
@@ -277,11 +281,7 @@ class WP_Settings_Abilities {
 					'type'                 => 'object',
 					'required'             => array( 'settings' ),
 					'properties'           => array(
-						'settings' => array(
-							'type'                 => 'object',
-							'description'          => __( 'Settings to update, grouped by registration group. Same structure as returned by core/get-settings.' ),
-							'additionalProperties' => true,
-						),
+						'settings' => $input_settings_schema,
 					),
 					'additionalProperties' => false,
 				),

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -122,7 +122,9 @@ class WP_Settings_Abilities {
 	 * @return string[] List of unique setting slugs.
 	 */
 	private static function get_available_slugs(): array {
-		return sort( array_keys( self::get_allowed_settings() ) );
+		$slugs = array_keys( self::get_allowed_settings() );
+		sort( $slugs );
+		return $slugs;
 	}
 
 	/**

--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -426,8 +426,7 @@ class WP_Settings_Abilities {
 					$sanitized_value = call_user_func( $args['sanitize_callback'], $sanitized_value );
 				}
 
-				
-				$updated      = update_option( $option_name, $sanitized_value );
+				$updated = update_option( $option_name, $sanitized_value );
 
 				// Cast values for comparison (handles type mismatches from database and REST sanitization).
 				$current_value   = self::cast_value( get_option( $option_name ), $setting_type );

--- a/src/wp-includes/block-supports/auto-register.php
+++ b/src/wp-includes/block-supports/auto-register.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Auto-register block support.
+ *
+ * @package WordPress
+ * @since 7.0.0
+ */
+
+/**
+ * Marks user-defined attributes for auto-generated inspector controls.
+ *
+ * This filter runs during block type registration, before the WP_Block_Type
+ * is instantiated. Block supports add their attributes AFTER the block type
+ * is created (via {@see WP_Block_Supports::register_attributes()}), so any attributes
+ * present at this stage are user-defined.
+ *
+ * The marker tells generateFieldsFromAttributes() which attributes should
+ * get auto-generated inspector controls. Attributes are excluded if they:
+ * - Have a 'source' (HTML-derived, edited inline not via inspector)
+ * - Have role 'local' (internal state, not user-configurable)
+ * - Have an unsupported type (only 'string', 'number', 'integer', 'boolean' are supported)
+ * - Were added by block supports (added after this filter runs)
+ *
+ * @since 7.0.0
+ * @access private
+ *
+ * @param array<string, mixed> $args Array of arguments for registering a block type.
+ * @return array<string, mixed> Modified block type arguments.
+ */
+function wp_mark_auto_generate_control_attributes( array $args ): array {
+	if ( empty( $args['attributes'] ) || ! is_array( $args['attributes'] ) ) {
+		return $args;
+	}
+
+	$has_auto_register = ! empty( $args['supports']['autoRegister'] );
+	if ( ! $has_auto_register ) {
+		return $args;
+	}
+
+	foreach ( $args['attributes'] as $attr_key => $attr_schema ) {
+		// Skip HTML-derived attributes (edited inline, not via inspector).
+		if ( ! empty( $attr_schema['source'] ) ) {
+			continue;
+		}
+		// Skip internal attributes (not user-configurable).
+		if ( isset( $attr_schema['role'] ) && 'local' === $attr_schema['role'] ) {
+			continue;
+		}
+		// Skip unsupported types (only 'string', 'number', 'integer', 'boolean' are supported).
+		$type = $attr_schema['type'] ?? null;
+		if ( ! in_array( $type, array( 'string', 'number', 'integer', 'boolean' ), true ) ) {
+			continue;
+		}
+		$args['attributes'][ $attr_key ]['autoGenerateControl'] = true;
+	}
+
+	return $args;
+}
+
+// Priority 5 to mark original attributes before other filters (priority 10+) might add their own.
+add_filter( 'register_block_type_args', 'wp_mark_auto_generate_control_attributes', 5 );

--- a/src/wp-includes/blocks.php
+++ b/src/wp-includes/blocks.php
@@ -3131,3 +3131,31 @@ function _wp_footnotes_force_filtered_html_on_import_filter( $arg ) {
 	}
 	return $arg;
 }
+
+/**
+ * Exposes blocks with autoRegister flag for ServerSideRender in the editor.
+ *
+ * Detects blocks that have the autoRegister flag set in their supports
+ * and passes them to JavaScript for auto-registration with ServerSideRender.
+ *
+ * @access private
+ * @since 7.0.0
+ */
+function _wp_enqueue_auto_register_blocks() {
+	$auto_register_blocks = array();
+	$registered_blocks    = WP_Block_Type_Registry::get_instance()->get_all_registered();
+
+	foreach ( $registered_blocks as $block_name => $block_type ) {
+		if ( ! empty( $block_type->supports['autoRegister'] ) && ! empty( $block_type->render_callback ) ) {
+			$auto_register_blocks[] = $block_name;
+		}
+	}
+
+	if ( ! empty( $auto_register_blocks ) ) {
+		wp_add_inline_script(
+			'wp-block-library',
+			sprintf( 'window.__unstableAutoRegisterBlocks = %s;', wp_json_encode( $auto_register_blocks ) ),
+			'before'
+		);
+	}
+}

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -623,6 +623,7 @@ add_action( 'enqueue_block_editor_assets', 'wp_enqueue_editor_block_directory_as
 add_action( 'enqueue_block_editor_assets', 'wp_enqueue_editor_format_library_assets' );
 add_action( 'enqueue_block_editor_assets', 'wp_enqueue_block_editor_script_modules' );
 add_action( 'enqueue_block_editor_assets', 'wp_enqueue_global_styles_css_custom_properties' );
+add_action( 'enqueue_block_editor_assets', '_wp_enqueue_auto_register_blocks' );
 add_action( 'wp_print_scripts', 'wp_just_in_time_script_localization' );
 add_filter( 'print_scripts_array', 'wp_prototype_before_jquery' );
 add_action( 'customize_controls_print_styles', 'wp_resource_hints', 1 );

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2768,20 +2768,17 @@ function register_initial_settings() {
 	);
 
 	if ( ! is_multisite() ) {
+		$uri_schema = array( 'format' => 'uri' );
 		register_setting(
 			'general',
 			'siteurl',
 			array(
 				'show_in_rest'      => array(
 					'name'   => 'url',
-					'schema' => array(
-						'format' => 'uri',
-					),
+					'schema' => $uri_schema,
 				),
 				'show_in_abilities' => array(
-					'schema' => array(
-						'format' => 'uri',
-					),
+					'schema' => $uri_schema,
 				),
 				'type'              => 'string',
 				'description'       => __( 'Site URL.' ),
@@ -2790,20 +2787,17 @@ function register_initial_settings() {
 	}
 
 	if ( ! is_multisite() ) {
+		$email_schema = array( 'format' => 'email' );
 		register_setting(
 			'general',
 			'admin_email',
 			array(
 				'show_in_rest'      => array(
 					'name'   => 'email',
-					'schema' => array(
-						'format' => 'email',
-					),
+					'schema' => $email_schema,
 				),
 				'show_in_abilities' => array(
-					'schema' => array(
-						'format' => 'email',
-					),
+					'schema' => $email_schema,
 				),
 				'type'              => 'string',
 				'description'       => __( 'This address is used for admin purposes, like new user notification.' ),
@@ -2953,19 +2947,17 @@ function register_initial_settings() {
 		)
 	);
 
+	$open_closed_enum_schema = array( 'enum' => array( 'open', 'closed' ) );
+
 	register_setting(
 		'discussion',
 		'default_ping_status',
 		array(
 			'show_in_rest'      => array(
-				'schema' => array(
-					'enum' => array( 'open', 'closed' ),
-				),
+				'schema' => $open_closed_enum_schema,
 			),
 			'show_in_abilities' => array(
-				'schema' => array(
-					'enum' => array( 'open', 'closed' ),
-				),
+				'schema' => $open_closed_enum_schema,
 			),
 			'type'              => 'string',
 			'description'       => __( 'Allow link notifications from other blogs (pingbacks and trackbacks) on new articles.' ),
@@ -2977,14 +2969,10 @@ function register_initial_settings() {
 		'default_comment_status',
 		array(
 			'show_in_rest'      => array(
-				'schema' => array(
-					'enum' => array( 'open', 'closed' ),
-				),
+				'schema' => $open_closed_enum_schema,
 			),
 			'show_in_abilities' => array(
-				'schema' => array(
-					'enum' => array( 'open', 'closed' ),
-				),
+				'schema' => $open_closed_enum_schema,
 			),
 			'type'              => 'string',
 			'label'             => __( 'Allow comments on new posts' ),

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2778,7 +2778,11 @@ function register_initial_settings() {
 						'format' => 'uri',
 					),
 				),
-				'show_in_abilities' => true,
+				'show_in_abilities' => array(
+					'schema' => array(
+						'format' => 'uri',
+					),
+				),
 				'type'              => 'string',
 				'description'       => __( 'Site URL.' ),
 			)
@@ -2796,7 +2800,11 @@ function register_initial_settings() {
 						'format' => 'email',
 					),
 				),
-				'show_in_abilities' => true,
+				'show_in_abilities' => array(
+					'schema' => array(
+						'format' => 'email',
+					),
+				),
 				'type'              => 'string',
 				'description'       => __( 'This address is used for admin purposes, like new user notification.' ),
 			)
@@ -2954,7 +2962,11 @@ function register_initial_settings() {
 					'enum' => array( 'open', 'closed' ),
 				),
 			),
-			'show_in_abilities' => true,
+			'show_in_abilities' => array(
+				'schema' => array(
+					'enum' => array( 'open', 'closed' ),
+				),
+			),
 			'type'              => 'string',
 			'description'       => __( 'Allow link notifications from other blogs (pingbacks and trackbacks) on new articles.' ),
 		)
@@ -2969,7 +2981,11 @@ function register_initial_settings() {
 					'enum' => array( 'open', 'closed' ),
 				),
 			),
-			'show_in_abilities' => true,
+			'show_in_abilities' => array(
+				'schema' => array(
+					'enum' => array( 'open', 'closed' ),
+				),
+			),
 			'type'              => 'string',
 			'label'             => __( 'Allow comments on new posts' ),
 			'description'       => __( 'Allow people to submit comments on new posts.' ),

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -3026,13 +3026,13 @@ function register_setting( $option_group, $option_name, $args = array() ) {
 	$GLOBALS['new_whitelist_options'] = &$new_allowed_options;
 
 	$defaults = array(
-		'type'               => 'string',
-		'group'              => $option_group,
-		'label'              => '',
-		'description'        => '',
-		'sanitize_callback'  => null,
-		'show_in_rest'       => false,
-		'show_in_abilities'  => false,
+		'type'              => 'string',
+		'group'             => $option_group,
+		'label'             => '',
+		'description'       => '',
+		'sanitize_callback' => null,
+		'show_in_rest'      => false,
+		'show_in_abilities' => false,
 	);
 
 	// Back-compat: old sanitize callback is added.

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -3010,8 +3010,9 @@ function register_initial_settings() {
  *     @type bool|array $show_in_rest        Whether data associated with this setting should be included in the REST API.
  *                                           When registering complex settings, this argument may optionally be an
  *                                           array with a 'schema' key.
- *     @type bool       $show_in_abilities  Whether this setting should be exposed through the Abilities API.
- *                                           Default false.
+ *     @type bool|array $show_in_abilities  Whether this setting should be exposed through the Abilities API.
+ *                                           When registering complex settings, this argument may optionally be an
+ *                                           array with a 'schema' key. Default false.
  *     @type mixed      $default            Default value when calling `get_option()`.
  * }
  */

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -394,6 +394,7 @@ require ABSPATH . WPINC . '/block-patterns.php';
 require ABSPATH . WPINC . '/class-wp-block-supports.php';
 require ABSPATH . WPINC . '/block-supports/utils.php';
 require ABSPATH . WPINC . '/block-supports/align.php';
+require ABSPATH . WPINC . '/block-supports/auto-register.php';
 require ABSPATH . WPINC . '/block-supports/custom-classname.php';
 require ABSPATH . WPINC . '/block-supports/generated-classname.php';
 require ABSPATH . WPINC . '/block-supports/settings.php';

--- a/tests/phpunit/tests/block-supports/auto-register.php
+++ b/tests/phpunit/tests/block-supports/auto-register.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * @group block-supports
+ *
+ * @covers ::wp_mark_auto_generate_control_attributes
+ */
+class Tests_Block_Supports_Auto_Register extends WP_UnitTestCase {
+
+	/**
+	 * Tests that attributes are marked when autoRegister is enabled.
+	 *
+	 * @ticket 64639
+	 */
+	public function test_marks_attributes_with_auto_register_flag() {
+		$settings = array(
+			'supports'   => array( 'autoRegister' => true ),
+			'attributes' => array(
+				'title' => array( 'type' => 'string' ),
+				'count' => array( 'type' => 'integer' ),
+			),
+		);
+
+		$result = wp_mark_auto_generate_control_attributes( $settings );
+
+		$this->assertTrue( $result['attributes']['title']['autoGenerateControl'] );
+		$this->assertTrue( $result['attributes']['count']['autoGenerateControl'] );
+	}
+
+	/**
+	 * Tests that attributes are not marked without autoRegister flag.
+	 *
+	 * @ticket 64639
+	 */
+	public function test_does_not_mark_attributes_without_auto_register() {
+		$settings = array(
+			'attributes' => array(
+				'title' => array( 'type' => 'string' ),
+			),
+		);
+
+		$result = wp_mark_auto_generate_control_attributes( $settings );
+
+		$this->assertArrayNotHasKey( 'autoGenerateControl', $result['attributes']['title'] );
+	}
+
+	/**
+	 * Tests that attributes with source are excluded.
+	 *
+	 * @ticket 64639
+	 */
+	public function test_excludes_attributes_with_source() {
+		$settings = array(
+			'supports'   => array( 'autoRegister' => true ),
+			'attributes' => array(
+				'title'   => array( 'type' => 'string' ),
+				'content' => array(
+					'type'   => 'string',
+					'source' => 'html',
+				),
+			),
+		);
+
+		$result = wp_mark_auto_generate_control_attributes( $settings );
+
+		$this->assertTrue( $result['attributes']['title']['autoGenerateControl'] );
+		$this->assertArrayNotHasKey( 'autoGenerateControl', $result['attributes']['content'] );
+	}
+
+	/**
+	 * Tests that attributes with role: local are excluded.
+	 *
+	 * Example: The 'blob' attribute in media blocks (image, video, file, audio)
+	 * stores a temporary blob URL during file upload. This is internal state
+	 * that shouldn't be shown in the inspector or saved to the database.
+	 *
+	 * @ticket 64639
+	 */
+	public function test_excludes_attributes_with_role_local() {
+		$settings = array(
+			'supports'   => array( 'autoRegister' => true ),
+			'attributes' => array(
+				'title' => array( 'type' => 'string' ),
+				'blob'  => array(
+					'type' => 'string',
+					'role' => 'local',
+				),
+			),
+		);
+
+		$result = wp_mark_auto_generate_control_attributes( $settings );
+
+		$this->assertTrue( $result['attributes']['title']['autoGenerateControl'] );
+		$this->assertArrayNotHasKey( 'autoGenerateControl', $result['attributes']['blob'] );
+	}
+
+	/**
+	 * Tests that empty attributes are handled gracefully.
+	 *
+	 * @ticket 64639
+	 */
+	public function test_handles_empty_attributes() {
+		$settings = array(
+			'supports' => array( 'autoRegister' => true ),
+		);
+
+		$result = wp_mark_auto_generate_control_attributes( $settings );
+
+		$this->assertSame( $settings, $result );
+	}
+
+	/**
+	 * Tests that only allowed attributes are marked.
+	 *
+	 * @ticket 64639
+	 */
+	public function test_excludes_unsupported_types() {
+		$settings = array(
+			'supports'   => array( 'autoRegister' => true ),
+			'attributes' => array(
+				// Supported types
+				'text'     => array( 'type' => 'string' ),
+				'price'    => array( 'type' => 'number' ),
+				'count'    => array( 'type' => 'integer' ),
+				'enabled'  => array( 'type' => 'boolean' ),
+				// Unsupported types
+				'metadata' => array( 'type' => 'object' ),
+				'items'    => array( 'type' => 'array' ),
+				'config'   => array( 'type' => 'null' ),
+				'unknown'  => array( 'type' => 'unknown' ),
+			),
+		);
+
+		$result = wp_mark_auto_generate_control_attributes( $settings );
+
+		$this->assertTrue( $result['attributes']['text']['autoGenerateControl'] );
+		$this->assertTrue( $result['attributes']['price']['autoGenerateControl'] );
+		$this->assertTrue( $result['attributes']['count']['autoGenerateControl'] );
+		$this->assertTrue( $result['attributes']['enabled']['autoGenerateControl'] );
+		$this->assertArrayNotHasKey( 'autoGenerateControl', $result['attributes']['metadata'] );
+		$this->assertArrayNotHasKey( 'autoGenerateControl', $result['attributes']['items'] );
+		$this->assertArrayNotHasKey( 'autoGenerateControl', $result['attributes']['config'] );
+		$this->assertArrayNotHasKey( 'autoGenerateControl', $result['attributes']['unknown'] );
+	}
+}

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
@@ -590,7 +590,6 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 		$data = $response->get_data();
 
 		$this->assertArrayHasKey( 'updated_settings', $data );
-		$this->assertArrayNotHasKey( 'validation_errors', $data );
 		$this->assertArrayHasKey( 'general', $data['updated_settings'] );
 		$this->assertArrayHasKey( 'blogname', $data['updated_settings']['general'] );
 		$this->assertArrayHasKey( 'blogdescription', $data['updated_settings']['general'] );
@@ -739,7 +738,6 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 		$data = $response->get_data();
 
 		$this->assertEmpty( (array) $data['updated_settings'] );
-		$this->assertArrayNotHasKey( 'validation_errors', $data );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
@@ -450,7 +450,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that unauthenticated users cannot access the update-settings ability.
 	 *
-	 * @ticket 64605
+	 * @ticket 64616
 	 */
 	public function test_core_update_settings_requires_authentication(): void {
 		wp_set_current_user( 0 );
@@ -478,7 +478,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that subscribers cannot access the update-settings ability.
 	 *
-	 * @ticket 64605
+	 * @ticket 64616
 	 */
 	public function test_core_update_settings_requires_manage_options_capability(): void {
 		wp_set_current_user( self::$subscriber_id );
@@ -506,7 +506,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that administrators can access the update-settings ability.
 	 *
-	 * @ticket 64605
+	 * @ticket 64616
 	 */
 	public function test_core_update_settings_allows_administrators(): void {
 		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
@@ -532,7 +532,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that the update-settings ability successfully updates settings.
 	 *
-	 * @ticket 64605
+	 * @ticket 64616
 	 */
 	public function test_core_update_settings_updates_settings_in_database(): void {
 		$original_title = get_option( 'blogname' );
@@ -564,7 +564,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that the update-settings ability returns grouped structure matching input.
 	 *
-	 * @ticket 64605
+	 * @ticket 64616
 	 */
 	public function test_core_update_settings_returns_grouped_structure(): void {
 		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
@@ -601,7 +601,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that the update-settings ability can update multiple groups.
 	 *
-	 * @ticket 64605
+	 * @ticket 64616
 	 */
 	public function test_core_update_settings_updates_multiple_groups(): void {
 		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
@@ -637,7 +637,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that the update-settings ability rejects settings without show_in_abilities.
 	 *
-	 * @ticket 64605
+	 * @ticket 64616
 	 */
 	public function test_core_update_settings_rejects_settings_without_show_in_abilities(): void {
 		register_setting(
@@ -681,7 +681,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that the update-settings ability rejects settings in wrong group.
 	 *
-	 * @ticket 64605
+	 * @ticket 64616
 	 */
 	public function test_core_update_settings_rejects_settings_in_wrong_group(): void {
 		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
@@ -713,7 +713,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that the update-settings ability requires POST method.
 	 *
-	 * @ticket 64605
+	 * @ticket 64616
 	 */
 	public function test_core_update_settings_requires_post_method(): void {
 		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/update-settings/run' );
@@ -728,7 +728,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that the update-settings ability casts boolean values correctly.
 	 *
-	 * @ticket 64605
+	 * @ticket 64616
 	 */
 	public function test_core_update_settings_casts_boolean_values(): void {
 		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
@@ -761,7 +761,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that the update-settings ability casts integer values correctly.
 	 *
-	 * @ticket 64605
+	 * @ticket 64616
 	 */
 	public function test_core_update_settings_casts_integer_values(): void {
 		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
@@ -794,7 +794,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that the update-settings ability handles partial success.
 	 *
-	 * @ticket 64605
+	 * @ticket 64616
 	 */
 	public function test_core_update_settings_handles_partial_success(): void {
 		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
@@ -832,7 +832,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests that the update-settings ability returns empty objects when no settings provided.
 	 *
-	 * @ticket 64605
+	 * @ticket 64616
 	 */
 	public function test_core_update_settings_returns_empty_when_no_settings(): void {
 		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
@@ -859,7 +859,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	/**
 	 * Tests the symmetry between get-settings and update-settings.
 	 *
-	 * @ticket 64605
+	 * @ticket 64616
 	 */
 	public function test_core_update_settings_symmetry_with_get_settings(): void {
 		// First, get settings.

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
@@ -45,6 +45,14 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 		// Register initial settings first so abilities can build schemas.
 		register_initial_settings();
 
+		// Unregister any existing abilities/categories to avoid "already registered" notices.
+		foreach ( wp_get_abilities() as $ability ) {
+			wp_unregister_ability( $ability->get_name() );
+		}
+		foreach ( wp_get_ability_categories() as $ability_category ) {
+			wp_unregister_ability_category( $ability_category->get_slug() );
+		}
+
 		// Ensure core abilities are registered for these tests.
 		remove_action( 'wp_abilities_api_categories_init', '_unhook_core_ability_categories_registration', 1 );
 		remove_action( 'wp_abilities_api_init', '_unhook_core_abilities_registration', 1 );

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
@@ -590,7 +590,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 		$data = $response->get_data();
 
 		$this->assertArrayHasKey( 'updated_settings', $data );
-		$this->assertArrayHasKey( 'validation_errors', $data );
+		$this->assertArrayNotHasKey( 'validation_errors', $data );
 		$this->assertArrayHasKey( 'general', $data['updated_settings'] );
 		$this->assertArrayHasKey( 'blogname', $data['updated_settings']['general'] );
 		$this->assertArrayHasKey( 'blogdescription', $data['updated_settings']['general'] );
@@ -805,8 +805,8 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 					'input' => array(
 						'settings' => array(
 							'general' => array(
-								'blogname'            => 'Partial Success Test',
-								'unknown_setting'     => 'should_fail', // Not allowed.
+								'blogname'        => 'Partial Success Test',
+								'unknown_setting' => 'should_fail', // Not allowed.
 							),
 						),
 					),
@@ -853,7 +853,7 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 		$data = $response->get_data();
 
 		$this->assertEmpty( (array) $data['updated_settings'] );
-		$this->assertEmpty( (array) $data['validation_errors'] );
+		$this->assertArrayNotHasKey( 'validation_errors', $data );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
@@ -438,4 +438,461 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 		$data = $response->get_data();
 		$this->assertSame( 'ability_invalid_output', $data['code'] );
 	}
+
+	/**
+	 * Tests that unauthenticated users cannot access the update-settings ability.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_update_settings_requires_authentication(): void {
+		wp_set_current_user( 0 );
+
+		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'input' => array(
+						'settings' => array(
+							'general' => array(
+								'blogname' => 'New Title',
+							),
+						),
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/**
+	 * Tests that subscribers cannot access the update-settings ability.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_update_settings_requires_manage_options_capability(): void {
+		wp_set_current_user( self::$subscriber_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'input' => array(
+						'settings' => array(
+							'general' => array(
+								'blogname' => 'New Title',
+							),
+						),
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * Tests that administrators can access the update-settings ability.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_update_settings_allows_administrators(): void {
+		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'input' => array(
+						'settings' => array(
+							'general' => array(
+								'blogname' => 'Admin Updated Title',
+							),
+						),
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * Tests that the update-settings ability successfully updates settings.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_update_settings_updates_settings_in_database(): void {
+		$original_title = get_option( 'blogname' );
+
+		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'input' => array(
+						'settings' => array(
+							'general' => array(
+								'blogname' => 'Updated Site Title',
+							),
+						),
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'Updated Site Title', get_option( 'blogname' ) );
+
+		// Restore original value.
+		update_option( 'blogname', $original_title );
+	}
+
+	/**
+	 * Tests that the update-settings ability returns grouped structure matching input.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_update_settings_returns_grouped_structure(): void {
+		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'input' => array(
+						'settings' => array(
+							'general' => array(
+								'blogname'        => 'Test Title',
+								'blogdescription' => 'Test Description',
+							),
+						),
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'updated_settings', $data );
+		$this->assertArrayHasKey( 'validation_errors', $data );
+		$this->assertArrayHasKey( 'general', $data['updated_settings'] );
+		$this->assertArrayHasKey( 'blogname', $data['updated_settings']['general'] );
+		$this->assertArrayHasKey( 'blogdescription', $data['updated_settings']['general'] );
+		$this->assertSame( 'Test Title', $data['updated_settings']['general']['blogname'] );
+		$this->assertSame( 'Test Description', $data['updated_settings']['general']['blogdescription'] );
+	}
+
+	/**
+	 * Tests that the update-settings ability can update multiple groups.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_update_settings_updates_multiple_groups(): void {
+		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'input' => array(
+						'settings' => array(
+							'general' => array(
+								'blogname' => 'Multi Group Test',
+							),
+							'reading' => array(
+								'posts_per_page' => 15,
+							),
+						),
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'general', $data['updated_settings'] );
+		$this->assertArrayHasKey( 'reading', $data['updated_settings'] );
+		$this->assertSame( 'Multi Group Test', $data['updated_settings']['general']['blogname'] );
+		$this->assertSame( 15, $data['updated_settings']['reading']['posts_per_page'] );
+	}
+
+	/**
+	 * Tests that the update-settings ability rejects settings without show_in_abilities.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_update_settings_rejects_settings_without_show_in_abilities(): void {
+		register_setting(
+			'general',
+			'test_setting_not_allowed',
+			array(
+				'type'              => 'string',
+				'default'           => 'default_value',
+				'show_in_abilities' => false,
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'input' => array(
+						'settings' => array(
+							'general' => array(
+								'test_setting_not_allowed' => 'new_value',
+							),
+						),
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertEmpty( (array) $data['updated_settings'] );
+		$this->assertArrayHasKey( 'general', $data['validation_errors'] );
+		$this->assertArrayHasKey( 'test_setting_not_allowed', $data['validation_errors']['general'] );
+
+		unregister_setting( 'general', 'test_setting_not_allowed' );
+	}
+
+	/**
+	 * Tests that the update-settings ability rejects settings in wrong group.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_update_settings_rejects_settings_in_wrong_group(): void {
+		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'input' => array(
+						'settings' => array(
+							'reading' => array(
+								'blogname' => 'Wrong Group Test', // blogname belongs to 'general', not 'reading'.
+							),
+						),
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertEmpty( (array) $data['updated_settings'] );
+		$this->assertArrayHasKey( 'reading', $data['validation_errors'] );
+		$this->assertArrayHasKey( 'blogname', $data['validation_errors']['reading'] );
+	}
+
+	/**
+	 * Tests that the update-settings ability requires POST method.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_update_settings_requires_post_method(): void {
+		$request  = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/update-settings/run' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 405, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( 'rest_ability_invalid_method', $data['code'] );
+	}
+
+	/**
+	 * Tests that the update-settings ability casts boolean values correctly.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_update_settings_casts_boolean_values(): void {
+		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'input' => array(
+						'settings' => array(
+							'writing' => array(
+								'use_smilies' => false,
+							),
+						),
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'writing', $data['updated_settings'] );
+		$this->assertArrayHasKey( 'use_smilies', $data['updated_settings']['writing'] );
+		$this->assertIsBool( $data['updated_settings']['writing']['use_smilies'] );
+		$this->assertFalse( $data['updated_settings']['writing']['use_smilies'] );
+	}
+
+	/**
+	 * Tests that the update-settings ability casts integer values correctly.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_update_settings_casts_integer_values(): void {
+		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'input' => array(
+						'settings' => array(
+							'reading' => array(
+								'posts_per_page' => 25,
+							),
+						),
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'reading', $data['updated_settings'] );
+		$this->assertArrayHasKey( 'posts_per_page', $data['updated_settings']['reading'] );
+		$this->assertIsInt( $data['updated_settings']['reading']['posts_per_page'] );
+		$this->assertSame( 25, $data['updated_settings']['reading']['posts_per_page'] );
+	}
+
+	/**
+	 * Tests that the update-settings ability handles partial success.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_update_settings_handles_partial_success(): void {
+		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'input' => array(
+						'settings' => array(
+							'general' => array(
+								'blogname'            => 'Partial Success Test',
+								'unknown_setting'     => 'should_fail', // Not allowed.
+							),
+						),
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		// blogname should be updated.
+		$this->assertArrayHasKey( 'general', $data['updated_settings'] );
+		$this->assertArrayHasKey( 'blogname', $data['updated_settings']['general'] );
+		$this->assertSame( 'Partial Success Test', $data['updated_settings']['general']['blogname'] );
+
+		// unknown_setting should have an error.
+		$this->assertArrayHasKey( 'general', $data['validation_errors'] );
+		$this->assertArrayHasKey( 'unknown_setting', $data['validation_errors']['general'] );
+	}
+
+	/**
+	 * Tests that the update-settings ability returns empty objects when no settings provided.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_update_settings_returns_empty_when_no_settings(): void {
+		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'input' => array(
+						'settings' => array(),
+					),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$this->assertEmpty( (array) $data['updated_settings'] );
+		$this->assertEmpty( (array) $data['validation_errors'] );
+	}
+
+	/**
+	 * Tests the symmetry between get-settings and update-settings.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_update_settings_symmetry_with_get_settings(): void {
+		// First, get settings.
+		$get_request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
+		$get_request->set_query_params(
+			array(
+				'input' => array(
+					'slugs' => array( 'blogname', 'blogdescription' ),
+				),
+			)
+		);
+		$get_response = $this->server->dispatch( $get_request );
+		$settings     = $get_response->get_data();
+
+		// Modify the settings.
+		$settings['general']['blogname']        = 'Symmetry Test Title';
+		$settings['general']['blogdescription'] = 'Symmetry Test Description';
+
+		// Update settings with the same structure.
+		$update_request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
+		$update_request->set_header( 'Content-Type', 'application/json' );
+		$update_request->set_body(
+			wp_json_encode(
+				array(
+					'input' => array(
+						'settings' => $settings,
+					),
+				)
+			)
+		);
+		$update_response = $this->server->dispatch( $update_request );
+
+		$this->assertSame( 200, $update_response->get_status() );
+
+		$data = $update_response->get_data();
+
+		$this->assertSame( 'Symmetry Test Title', $data['updated_settings']['general']['blogname'] );
+		$this->assertSame( 'Symmetry Test Description', $data['updated_settings']['general']['blogdescription'] );
+
+		// Verify the values are actually in the database.
+		$this->assertSame( 'Symmetry Test Title', get_option( 'blogname' ) );
+		$this->assertSame( 'Symmetry Test Description', get_option( 'blogdescription' ) );
+	}
 }

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
@@ -635,82 +635,6 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the update-settings ability rejects settings without show_in_abilities.
-	 *
-	 * @ticket 64616
-	 */
-	public function test_core_update_settings_rejects_settings_without_show_in_abilities(): void {
-		register_setting(
-			'general',
-			'test_setting_not_allowed',
-			array(
-				'type'              => 'string',
-				'default'           => 'default_value',
-				'show_in_abilities' => false,
-			)
-		);
-
-		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
-		$request->set_header( 'Content-Type', 'application/json' );
-		$request->set_body(
-			wp_json_encode(
-				array(
-					'input' => array(
-						'settings' => array(
-							'general' => array(
-								'test_setting_not_allowed' => 'new_value',
-							),
-						),
-					),
-				)
-			)
-		);
-		$response = $this->server->dispatch( $request );
-
-		$this->assertSame( 200, $response->get_status() );
-
-		$data = $response->get_data();
-
-		$this->assertEmpty( (array) $data['updated_settings'] );
-		$this->assertArrayHasKey( 'general', $data['validation_errors'] );
-		$this->assertArrayHasKey( 'test_setting_not_allowed', $data['validation_errors']['general'] );
-
-		unregister_setting( 'general', 'test_setting_not_allowed' );
-	}
-
-	/**
-	 * Tests that the update-settings ability rejects settings in wrong group.
-	 *
-	 * @ticket 64616
-	 */
-	public function test_core_update_settings_rejects_settings_in_wrong_group(): void {
-		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
-		$request->set_header( 'Content-Type', 'application/json' );
-		$request->set_body(
-			wp_json_encode(
-				array(
-					'input' => array(
-						'settings' => array(
-							'reading' => array(
-								'blogname' => 'Wrong Group Test', // blogname belongs to 'general', not 'reading'.
-							),
-						),
-					),
-				)
-			)
-		);
-		$response = $this->server->dispatch( $request );
-
-		$this->assertSame( 200, $response->get_status() );
-
-		$data = $response->get_data();
-
-		$this->assertEmpty( (array) $data['updated_settings'] );
-		$this->assertArrayHasKey( 'reading', $data['validation_errors'] );
-		$this->assertArrayHasKey( 'blogname', $data['validation_errors']['reading'] );
-	}
-
-	/**
 	 * Tests that the update-settings ability requires POST method.
 	 *
 	 * @ticket 64616
@@ -789,44 +713,6 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'posts_per_page', $data['updated_settings']['reading'] );
 		$this->assertIsInt( $data['updated_settings']['reading']['posts_per_page'] );
 		$this->assertSame( 25, $data['updated_settings']['reading']['posts_per_page'] );
-	}
-
-	/**
-	 * Tests that the update-settings ability handles partial success.
-	 *
-	 * @ticket 64616
-	 */
-	public function test_core_update_settings_handles_partial_success(): void {
-		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
-		$request->set_header( 'Content-Type', 'application/json' );
-		$request->set_body(
-			wp_json_encode(
-				array(
-					'input' => array(
-						'settings' => array(
-							'general' => array(
-								'blogname'        => 'Partial Success Test',
-								'unknown_setting' => 'should_fail', // Not allowed.
-							),
-						),
-					),
-				)
-			)
-		);
-		$response = $this->server->dispatch( $request );
-
-		$this->assertSame( 200, $response->get_status() );
-
-		$data = $response->get_data();
-
-		// blogname should be updated.
-		$this->assertArrayHasKey( 'general', $data['updated_settings'] );
-		$this->assertArrayHasKey( 'blogname', $data['updated_settings']['general'] );
-		$this->assertSame( 'Partial Success Test', $data['updated_settings']['general']['blogname'] );
-
-		// unknown_setting should have an error.
-		$this->assertArrayHasKey( 'general', $data['validation_errors'] );
-		$this->assertArrayHasKey( 'unknown_setting', $data['validation_errors']['general'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
@@ -353,4 +353,65 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 
 		$this->assertSame( 'Test Site Name', $data['general']['blogname'] );
 	}
+
+	/**
+	 * Tests that settings with enum schema in show_in_abilities include it in output schema.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_get_settings_output_schema_includes_enum(): void {
+		$ability       = wp_get_ability( 'core/get-settings' );
+		$output_schema = $ability->get_output_schema();
+
+		// Check default_ping_status has enum.
+		$this->assertArrayHasKey( 'discussion', $output_schema['properties'] );
+		$this->assertArrayHasKey( 'default_ping_status', $output_schema['properties']['discussion']['properties'] );
+		$this->assertArrayHasKey( 'enum', $output_schema['properties']['discussion']['properties']['default_ping_status'] );
+		$this->assertSame( array( 'open', 'closed' ), $output_schema['properties']['discussion']['properties']['default_ping_status']['enum'] );
+
+		// Check default_comment_status has enum.
+		$this->assertArrayHasKey( 'default_comment_status', $output_schema['properties']['discussion']['properties'] );
+		$this->assertArrayHasKey( 'enum', $output_schema['properties']['discussion']['properties']['default_comment_status'] );
+		$this->assertSame( array( 'open', 'closed' ), $output_schema['properties']['discussion']['properties']['default_comment_status']['enum'] );
+	}
+
+	/**
+	 * Tests that boolean show_in_abilities (true) still works correctly.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_get_settings_boolean_show_in_abilities_still_works(): void {
+		$ability       = wp_get_ability( 'core/get-settings' );
+		$output_schema = $ability->get_output_schema();
+
+		// blogname uses show_in_abilities => true (boolean).
+		$this->assertArrayHasKey( 'general', $output_schema['properties'] );
+		$this->assertArrayHasKey( 'blogname', $output_schema['properties']['general']['properties'] );
+		$this->assertSame( 'string', $output_schema['properties']['general']['properties']['blogname']['type'] );
+	}
+
+	/**
+	 * Tests that custom show_in_abilities schema preserves base schema properties while adding custom ones.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_get_settings_output_schema_preserves_base_schema(): void {
+		$ability       = wp_get_ability( 'core/get-settings' );
+		$output_schema = $ability->get_output_schema();
+
+		// default_comment_status has show_in_abilities with schema but also has label and description.
+		$this->assertArrayHasKey( 'discussion', $output_schema['properties'] );
+		$this->assertArrayHasKey( 'default_comment_status', $output_schema['properties']['discussion']['properties'] );
+
+		$setting_schema = $output_schema['properties']['discussion']['properties']['default_comment_status'];
+
+		// Verify base schema properties are preserved.
+		$this->assertSame( 'string', $setting_schema['type'] );
+		$this->assertArrayHasKey( 'title', $setting_schema );
+		$this->assertArrayHasKey( 'description', $setting_schema );
+
+		// Verify custom schema property (enum) is merged.
+		$this->assertArrayHasKey( 'enum', $setting_schema );
+		$this->assertSame( array( 'open', 'closed' ), $setting_schema['enum'] );
+	}
 }

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
@@ -414,4 +414,28 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'enum', $setting_schema );
 		$this->assertSame( array( 'open', 'closed' ), $setting_schema['enum'] );
 	}
+
+	/**
+	 * Tests that ability returns error when setting value violates schema enum.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_get_settings_returns_error_for_invalid_enum_value(): void {
+		// Set an invalid value for default_ping_status (violates enum: ['open', 'closed']).
+		update_option( 'default_ping_status', 'invalid_value' );
+
+		$request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
+		$request->set_query_params(
+			array(
+				'input' => array(
+					'slugs' => array( 'default_ping_status' ),
+				),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 500, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertSame( 'ability_invalid_output', $data['code'] );
+	}
 }

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
@@ -343,6 +343,8 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	 * @ticket 64605
 	 */
 	public function test_core_get_settings_returns_correct_values(): void {
+		$original_blogname = get_option( 'blogname' );
+
 		update_option( 'blogname', 'Test Site Name' );
 
 		$request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
@@ -360,6 +362,9 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 		$data = $response->get_data();
 
 		$this->assertSame( 'Test Site Name', $data['general']['blogname'] );
+
+		// Restore original value.
+		update_option( 'blogname', $original_blogname );
 	}
 
 	/**
@@ -509,6 +514,8 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	 * @ticket 64616
 	 */
 	public function test_core_update_settings_allows_administrators(): void {
+		$original_blogname = get_option( 'blogname' );
+
 		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_body(
@@ -527,6 +534,9 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 		$response = $this->server->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );
+
+		// Restore original value.
+		update_option( 'blogname', $original_blogname );
 	}
 
 	/**
@@ -567,6 +577,9 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	 * @ticket 64616
 	 */
 	public function test_core_update_settings_returns_grouped_structure(): void {
+		$original_blogname        = get_option( 'blogname' );
+		$original_blogdescription = get_option( 'blogdescription' );
+
 		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_body(
@@ -595,6 +608,10 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'blogdescription', $data['updated_settings']['general'] );
 		$this->assertSame( 'Test Title', $data['updated_settings']['general']['blogname'] );
 		$this->assertSame( 'Test Description', $data['updated_settings']['general']['blogdescription'] );
+
+		// Restore original values.
+		update_option( 'blogname', $original_blogname );
+		update_option( 'blogdescription', $original_blogdescription );
 	}
 
 	/**
@@ -603,6 +620,9 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	 * @ticket 64616
 	 */
 	public function test_core_update_settings_updates_multiple_groups(): void {
+		$original_blogname       = get_option( 'blogname' );
+		$original_posts_per_page = get_option( 'posts_per_page' );
+
 		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_body(
@@ -631,6 +651,10 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'reading', $data['updated_settings'] );
 		$this->assertSame( 'Multi Group Test', $data['updated_settings']['general']['blogname'] );
 		$this->assertSame( 15, $data['updated_settings']['reading']['posts_per_page'] );
+
+		// Restore original values.
+		update_option( 'blogname', $original_blogname );
+		update_option( 'posts_per_page', $original_posts_per_page );
 	}
 
 	/**
@@ -654,6 +678,8 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	 * @ticket 64616
 	 */
 	public function test_core_update_settings_casts_boolean_values(): void {
+		$original_use_smilies = get_option( 'use_smilies' );
+
 		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_body(
@@ -679,6 +705,9 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'use_smilies', $data['updated_settings']['writing'] );
 		$this->assertIsBool( $data['updated_settings']['writing']['use_smilies'] );
 		$this->assertFalse( $data['updated_settings']['writing']['use_smilies'] );
+
+		// Restore original value.
+		update_option( 'use_smilies', $original_use_smilies );
 	}
 
 	/**
@@ -687,6 +716,8 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	 * @ticket 64616
 	 */
 	public function test_core_update_settings_casts_integer_values(): void {
+		$original_posts_per_page = get_option( 'posts_per_page' );
+
 		$request = new WP_REST_Request( 'POST', '/wp-abilities/v1/abilities/core/update-settings/run' );
 		$request->set_header( 'Content-Type', 'application/json' );
 		$request->set_body(
@@ -712,6 +743,9 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'posts_per_page', $data['updated_settings']['reading'] );
 		$this->assertIsInt( $data['updated_settings']['reading']['posts_per_page'] );
 		$this->assertSame( 25, $data['updated_settings']['reading']['posts_per_page'] );
+
+		// Restore original value.
+		update_option( 'posts_per_page', $original_posts_per_page );
 	}
 
 	/**
@@ -746,6 +780,9 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 	 * @ticket 64616
 	 */
 	public function test_core_update_settings_symmetry_with_get_settings(): void {
+		$original_blogname        = get_option( 'blogname' );
+		$original_blogdescription = get_option( 'blogdescription' );
+
 		// First, get settings.
 		$get_request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
 		$get_request->set_query_params(
@@ -786,5 +823,9 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 		// Verify the values are actually in the database.
 		$this->assertSame( 'Symmetry Test Title', get_option( 'blogname' ) );
 		$this->assertSame( 'Symmetry Test Description', get_option( 'blogdescription' ) );
+
+		// Restore original values.
+		update_option( 'blogname', $original_blogname );
+		update_option( 'blogdescription', $original_blogdescription );
 	}
 }


### PR DESCRIPTION
Part of: https://github.com/WordPress/ai/issues/40
Inspired by the work on https://github.com/galatanovidiu/mcp-adapter-implementation-example/tree/experiment/layerd-mcp-tools/includes/Abilities by @galatanovidiu.
Ticket: https://core.trac.wordpress.org/ticket/64616

This PR adds a `core/update-settings` ability to the WordPress Abilities API. This ability allows updating WordPress settings that have `show_in_abilities = true`. It complements the existing `core/get-settings` ability by providing a symmetric API for reading and writing settings.

The input and output structures are designed for symmetry with `core/get-settings`:
- Input accepts settings grouped by registration group (same structure returned by `core/get-settings`)
- Output returns `updated_settings` (with updated values) and `validation_errors` (with error messages) in the same grouped structure

## Organization

Following the pattern established in #10747, this PR extends the `WP_Settings_Abilities` class in `src/wp-includes/abilities/class-wp-settings-abilities.php`. The implementation maximizes code reuse:

* **Schema Reuse**: Uses a permissive input schema that allows the execute callback to handle validation
* **Shared Methods**: Reuses `get_allowed_settings()`, `check_manage_options()`, and `cast_value()` from the existing implementation
* **Registration**: `register_update_settings()` registers the ability with appropriate annotations (`readonly: false`, `destructive: false`, `idempotent: true`)
* **Execution**: `execute_update_settings()` validates, sanitizes, and updates settings, returning both successful updates and validation errors

## Test plan

* Open `/wp-admin/post-new.php`
* Open the browser console and run the following examples:

```javascript
// Update a single setting
await wp.apiFetch({
  path: '/wp-abilities/v1/abilities/core/update-settings/run',
  method: 'POST',
  data: {
    input: {
      settings: {
        general: {
          blogname: 'New Site Title'
        }
      }
    }
  }
});
```

* [ ] Verify the setting is updated in the database

```javascript
// Update multiple settings across groups
await wp.apiFetch({
  path: '/wp-abilities/v1/abilities/core/update-settings/run',
  method: 'POST',
  data: {
    input: {
      settings: {
        general: {
          blogname: 'New Site Title',
          blogdescription: 'New Tagline'
        },
        reading: {
          posts_per_page: 15
        }
      }
    }
  }
});
```

* [ ] Verify multiple settings across different groups are updated

```javascript
// Check the ability schema
await wp.apiFetch({
  path: '/wp-abilities/v1/abilities/core/update-settings'
});
```

* [ ] Verify the input schema documents the settings structure
* [ ] Verify the output schema documents `updated_settings` and `validation_errors`

```javascript
// Workflow: Get settings, modify, update (symmetry test)
const settings = await wp.apiFetch({
  path: '/wp-abilities/v1/abilities/core/get-settings/run'
});
settings.general.blogname = 'Modified Title';
await wp.apiFetch({
  path: '/wp-abilities/v1/abilities/core/update-settings/run',
  method: 'POST',
  data: { input: { settings } }
});
```

* [ ] Verify the get -> modify -> update workflow works seamlessly

```javascript
// Test partial success with invalid settings
await wp.apiFetch({
  path: '/wp-abilities/v1/abilities/core/update-settings/run',
  method: 'POST',
  data: {
    input: {
      settings: {
        general: {
          blogname: 'Valid Title',
          unknown_setting: 'should fail'
        }
      }
    }
  }
});
```

* [ ] Verify `blogname` is in `updated_settings` and `unknown_setting` is in `validation_errors`

* [ ] Test permission check: Verify non-admin users cannot access the ability (requires `manage_options` capability)
* [ ] Verify settings without `show_in_abilities` cannot be modified
* [ ] Verify settings placed in wrong groups are rejected with appropriate error messages

## Test plan with Gutenberg


* Open `/wp-admin/post-new.php`
* Open the browser console

Set abilitiesAPI:
```
const abilitiesAPI = (await import( '@wordpress/abilities' ) );
 ```

Run the following examples:


```javascript
// Update a single setting
await abilitiesAPI.executeAbility('core/update-settings', {
  settings: {
    general: {
      blogname: 'New Site Title'
    }
  }
});
```

* [ ] Verify the setting is updated in the database

```javascript
// Update multiple settings across groups
await abilitiesAPI.executeAbility('core/update-settings', {
  settings: {
    general: {
      blogname: 'New Site Title',
      blogdescription: 'New Tagline'
    },
    reading: {
      posts_per_page: 15
    }
  }
});
```

* [ ] Verify multiple settings across different groups are updated

```javascript
// Workflow: Get settings, modify, update (symmetry test)
const settings = await abilitiesAPI.executeAbility('core/get-settings');
settings.general.blogname = 'Modified Title';
await abilitiesAPI.executeAbility('core/update-settings', { settings });
```

* [ ] Verify the get -> modify -> update workflow works seamlessly

```javascript
await abilitiesAPI.executeAbility('core/update-settings', {
  settings: {
    general: {
      blogname: 'Valid Title',
      unknown_setting: 'should fail'
    }
  }
});
```

* [ ] Verify there is an invalid schema error.
