### PR TITLE
Posts: Fix hierarchical parent selection for pages with non-published ancestors

### DIFF
--- a/src/wp-admin/includes/meta-boxes.php
+++ b/src/wp-admin/includes/meta-boxes.php
@@ -1010,6 +1010,7 @@ function page_attributes_meta_box( $post ) {
 			'show_option_none' => __( '(no parent)' ),
 			'sort_column'      => 'menu_order, post_title',
 			'echo'             => 0,
+			'post_status'      => array( 'publish', 'draft', 'pending', 'private' ),
 		);
 
 		/**

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6269,6 +6269,18 @@ function get_page_children( $page_id, $pages ) {
 	if ( 0 === $page_id ) {
 		$parent_ids = array_keys( $children );
 		$page_ids   = wp_list_pluck( $pages, 'ID' );
+		
+		foreach ( $parent_ids as $parent_id ) {
+			if ( 0 !== $parent_id && ! in_array( $parent_id, $page_ids, true ) ) {
+				foreach ( $children[ $parent_id ] as $orphan ) {
+					$page_list[] = $orphan;
+					if ( isset( $children[ $orphan->ID ] ) ) {
+						$orphan_pages = get_page_children( $orphan->ID, $pages );
+						$page_list          = array_merge( $page_list, $orphan_pages );
+					}
+				}
+			}
+		}
 	}
 
 	return $page_list;

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6269,14 +6269,14 @@ function get_page_children( $page_id, $pages ) {
 	if ( 0 === $page_id ) {
 		$parent_ids = array_keys( $children );
 		$page_ids   = wp_list_pluck( $pages, 'ID' );
-		
+
 		foreach ( $parent_ids as $parent_id ) {
 			if ( 0 !== $parent_id && ! in_array( $parent_id, $page_ids, true ) ) {
 				foreach ( $children[ $parent_id ] as $orphan ) {
 					$page_list[] = $orphan;
 					if ( isset( $children[ $orphan->ID ] ) ) {
 						$orphan_pages = get_page_children( $orphan->ID, $pages );
-						$page_list          = array_merge( $page_list, $orphan_pages );
+						$page_list    = array_merge( $page_list, $orphan_pages );
 					}
 				}
 			}

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6271,7 +6271,13 @@ function get_page_children( $page_id, $pages ) {
 		$page_ids   = wp_list_pluck( $pages, 'ID' );
 
 		foreach ( $parent_ids as $parent_id ) {
-			if ( 0 !== $parent_id && ! in_array( $parent_id, $page_ids, true ) ) {
+			if ( 0 === $parent_id || in_array( $parent_id, $page_ids, true ) ) {
+				continue;
+			}
+
+			$parent_exists = (bool) get_post( $parent_id );
+
+			if ( $parent_exists && isset( $children[ $parent_id ] ) ) {
 				foreach ( $children[ $parent_id ] as $orphan ) {
 					$page_list[] = $orphan;
 					if ( isset( $children[ $orphan->ID ] ) ) {

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -6266,6 +6266,11 @@ function get_page_children( $page_id, $pages ) {
 		}
 	}
 
+	if ( 0 === $page_id ) {
+		$parent_ids = array_keys( $children );
+		$page_ids   = wp_list_pluck( $pages, 'ID' );
+	}
+
 	return $page_list;
 }
 

--- a/tests/phpunit/tests/post/wpDropdownPages.php
+++ b/tests/phpunit/tests/post/wpDropdownPages.php
@@ -248,4 +248,36 @@ NO;
 		$this->assertStringContainsString( 'value="' . $child_id . '"', $output, 'Published child page should remain available even when parent is trashed.' );
 		$this->assertStringNotContainsString( 'value="' . $parent_id . '"', $output, 'Trashed parent should not appear in dropdown.' );
 	}
+
+	/**
+	 * Test that published child pages remain selectable when parent is draft or pending.
+	 *
+	 * @ticket 11235
+	 */
+	public function test_child_page_available_when_parent_not_published() {
+		$parent_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			)
+		);
+
+		$child_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_parent' => $parent_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		wp_update_post(
+			array(
+				'ID'          => $parent_id,
+				'post_status' => 'draft',
+			)
+		);
+
+		$output = wp_dropdown_pages( array( 'echo' => 0 ) );
+		$this->assertStringContainsString( 'value="' . $child_id . '"', $output, 'Published child should be available when parent is draft.' );
+	}
 }

--- a/tests/phpunit/tests/post/wpDropdownPages.php
+++ b/tests/phpunit/tests/post/wpDropdownPages.php
@@ -233,7 +233,6 @@ NO;
 			)
 		);
 
-		
 		$child_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'page',

--- a/tests/phpunit/tests/post/wpDropdownPages.php
+++ b/tests/phpunit/tests/post/wpDropdownPages.php
@@ -233,6 +233,7 @@ NO;
 			)
 		);
 
+		
 		$child_id = self::factory()->post->create(
 			array(
 				'post_type'   => 'page',

--- a/tests/phpunit/tests/post/wpDropdownPages.php
+++ b/tests/phpunit/tests/post/wpDropdownPages.php
@@ -219,4 +219,33 @@ NO;
 
 		$this->assertMatchesRegularExpression( '/<select[^>]+class=\'bar\'/', $found );
 	}
+
+	/**
+	 * Test that published child pages remain selectable when parent is trashed.
+	 *
+	 * @ticket 11235
+	 */
+	public function test_child_page_available_when_parent_trashed() {
+		$parent_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			)
+		);
+
+		$child_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_parent' => $parent_id,
+				'post_status' => 'publish',
+			)
+		);
+
+		wp_trash_post( $parent_id );
+
+		$output = wp_dropdown_pages( array( 'echo' => 0 ) );
+		
+		$this->assertStringContainsString( 'value="' . $child_id . '"', $output, 'Published child page should remain available even when parent is trashed.' );
+		$this->assertStringNotContainsString( 'value="' . $parent_id . '"', $output, 'Trashed parent should not appear in dropdown.' );
+	}
 }

--- a/tests/phpunit/tests/post/wpDropdownPages.php
+++ b/tests/phpunit/tests/post/wpDropdownPages.php
@@ -244,7 +244,7 @@ NO;
 		wp_trash_post( $parent_id );
 
 		$output = wp_dropdown_pages( array( 'echo' => 0 ) );
-		
+
 		$this->assertStringContainsString( 'value="' . $child_id . '"', $output, 'Published child page should remain available even when parent is trashed.' );
 		$this->assertStringNotContainsString( 'value="' . $parent_id . '"', $output, 'Trashed parent should not appear in dropdown.' );
 	}


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/11235

Fixes a bug where published child pages with non-published (trashed, draft, pending, or private) parents disappeared from parent selection dropdowns.

When a page's parent was trashed or set to draft/pending status, that page could no longer be selected as a parent for other pages, even though it was still published and functioning normally.

This pr modified `get_page_children()` to include orphaned pages when building hierarchical trees. This ensures published pages remain available for selection regardless of their parent's status.

Also updated the admin parent dropdown to query multiple post statuses, making the parent's status visible in the UI when applicable. This PR might affect the performance and I am open to discuss a better approach if performance is affected. Tests are still a WIP, trying out new edge cases.

### Testing
```bash
npm run test:php -- --filter=Tests_Post_wpDropdownPages
```

Inspired by and, props to the patch - https://core.trac.wordpress.org/attachment/ticket/11235/11235.diff