### PR TITLE
Remove redundant comment for conditionally-defined function in Twenty Twenty-One

### DIFF
--- a/src/wp-content/themes/twentytwentyone/inc/block-patterns.php
+++ b/src/wp-content/themes/twentytwentyone/inc/block-patterns.php
@@ -27,12 +27,9 @@ if ( function_exists( 'register_block_pattern_category' ) ) {
 	add_action( 'init', 'twenty_twenty_one_register_block_pattern_category' );
 }
 
-/**
- * Register Block Patterns.
- */
 if ( function_exists( 'register_block_pattern' ) ) {
 	/**
-	 * Registers Block Pattern.
+	 * Registers Block Patterns.
 	 *
 	 * @since Twenty Twenty-One 1.0
 	 *


### PR DESCRIPTION
Removes the redundant docblock-style comment before `function_exists()`, and pluralizes "Patterns" in the function summary for `twenty_twenty_one_register_block_pattern()`.

Props: huzaifaalmesbah

[Trac 64226](https://core.trac.wordpress.org/ticket/64226)

Previously: #10529, #10786

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
