### PR TITLE
Ensure user switching doesn’t occur for current user.

### DIFF
--- a/src/wp-includes/pluggable.php
+++ b/src/wp-includes/pluggable.php
@@ -30,7 +30,7 @@ if ( ! function_exists( 'wp_set_current_user' ) ) :
 		// If `$id` matches the current user, there is nothing to do.
 		if ( isset( $current_user )
 		&& ( $current_user instanceof WP_User )
-		&& ( $id === $current_user->ID )
+		&& ( (int) $id === $current_user->ID )
 		&& ( null !== $id )
 		) {
 			return $current_user;

--- a/tests/phpunit/tests/user/wpSetCurrentUser.php
+++ b/tests/phpunit/tests/user/wpSetCurrentUser.php
@@ -67,7 +67,7 @@ class Tests_User_wpSetCurrentUser extends WP_UnitTestCase {
 	 */
 	public function test_should_not_switch_to_same_user_type_equivalency( string $type_function ) {
 		wp_set_current_user( self::$user_id );
-		$this->assertSame( self::$user_id, get_current_user_id() );
+		$this->assertSame( self::$user_id, get_current_user_id(), "Current user's ID should match the ID of the user switched to." );
 
 		$action = new MockAction();
 		add_action( 'set_current_user', array( $action, 'action' ) );

--- a/tests/phpunit/tests/user/wpSetCurrentUser.php
+++ b/tests/phpunit/tests/user/wpSetCurrentUser.php
@@ -57,4 +57,32 @@ class Tests_User_wpSetCurrentUser extends WP_UnitTestCase {
 		$this->assertSame( $user, wp_get_current_user() );
 		$this->assertSame( self::$user_id2, get_current_user_id() );
 	}
+
+	/**
+	 * Ensure user switching doesn't occur for the same user, even if type is non-int.
+	 *
+	 * @dataProvider data_should_not_switch_to_same_user_type_equivalency
+	 */
+	public function test_should_not_switch_to_same_user_type_equivalency( $type_function ) {
+		wp_set_current_user( self::$user_id );
+		$this->assertSame( self::$user_id, get_current_user_id() );
+
+		$action = new MockAction();
+		add_action( 'set_current_user', array( $action, 'action' ) );
+
+		wp_set_current_user( $type_function( self::$user_id ) );
+		$this->assertSame( 0, $action->get_call_count(), 'set_current_user should not be fired when switching to the same user.' );
+	}
+
+	/**
+	 * Data provider for test_should_not_switch_to_same_user_type_equivalency.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public function data_should_not_switch_to_same_user_type_equivalency() {
+		return array(
+			'integer' => array( 'type_function' => 'intval' ),
+			'string'  => array( 'type_function' => 'strval' ),
+		);
+	}
 }

--- a/tests/phpunit/tests/user/wpSetCurrentUser.php
+++ b/tests/phpunit/tests/user/wpSetCurrentUser.php
@@ -65,7 +65,7 @@ class Tests_User_wpSetCurrentUser extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_should_not_switch_to_same_user_type_equivalency
 	 */
-	public function test_should_not_switch_to_same_user_type_equivalency( $type_function ) {
+	public function test_should_not_switch_to_same_user_type_equivalency( string $type_function ) {
 		wp_set_current_user( self::$user_id );
 		$this->assertSame( self::$user_id, get_current_user_id() );
 
@@ -81,7 +81,7 @@ class Tests_User_wpSetCurrentUser extends WP_UnitTestCase {
 	 *
 	 * @return array[] Data provider.
 	 */
-	public function data_should_not_switch_to_same_user_type_equivalency() {
+	public function data_should_not_switch_to_same_user_type_equivalency(): array {
 		return array(
 			'integer' => array( 'type_function' => 'intval' ),
 			'string'  => array( 'type_function' => 'strval' ),

--- a/tests/phpunit/tests/user/wpSetCurrentUser.php
+++ b/tests/phpunit/tests/user/wpSetCurrentUser.php
@@ -61,6 +61,8 @@ class Tests_User_wpSetCurrentUser extends WP_UnitTestCase {
 	/**
 	 * Ensure user switching doesn't occur for the same user, even if type is non-int.
 	 *
+	 * @ticket 64628
+	 *
 	 * @dataProvider data_should_not_switch_to_same_user_type_equivalency
 	 */
 	public function test_should_not_switch_to_same_user_type_equivalency( $type_function ) {


### PR DESCRIPTION
Ensures the user switching does not occur when attempting to switch to the same user with the user ID cast to a string.

Trac ticket: https://core.trac.wordpress.org/ticket/64628

## Use of AI Tools

Nil.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
