### PR TITLE
HTML API: Use more-universal syntax for variable function calling.

### DIFF
--- a/src/wp-includes/html-api/class-wp-html-open-elements.php
+++ b/src/wp-includes/html-api/class-wp-html-open-elements.php
@@ -715,7 +715,7 @@ class WP_HTML_Open_Elements {
 		}
 
 		if ( null !== $this->push_handler ) {
-			( $this->push_handler )( $item );
+			call_user_func( $this->push_handler, $item );
 		}
 	}
 
@@ -763,7 +763,7 @@ class WP_HTML_Open_Elements {
 		}
 
 		if ( null !== $this->pop_handler ) {
-			( $this->pop_handler )( $item );
+			call_user_func( $this->pop_handler, $item );
 		}
 	}
 


### PR DESCRIPTION
Replace Closure call syntax `( $fn )( ...$args )` with equivalent `call_user_func( $fn, ...$args )`.

This prevents an issue with the [WordPress documentation parser](https://github.com/WordPress/phpdoc-parser/) and removes a block to generating updated documentation:

> Parse Error: Syntax error, unexpected '('

Follow-up to [[58304]](https://core.trac.wordpress.org/changeset/58304).
See [#61348](https://core.trac.wordpress.org/ticket/61348).

Trac ticket: https://core.trac.wordpress.org/ticket/64224