### PR TITLE
Block Editor: Use dedicated navigation-overlay icon for template part area

### DIFF
--- a/src/wp-includes/block-template-utils.php
+++ b/src/wp-includes/block-template-utils.php
@@ -105,7 +105,7 @@ function get_allowed_block_template_part_areas() {
 			'description' => __(
 				'The Navigation Overlay template defines a full-screen overlay area that typically contains navigation links and can be toggled on and off.'
 			),
-			'icon'        => 'overlay',
+			'icon'        => 'navigation-overlay',
 			'area_tag'    => 'div',
 		),
 	);


### PR DESCRIPTION
Backports the navigation-overlay icon change from https://github.com/WordPress/gutenberg/pull/75426.

In `get_allowed_block_template_part_areas()` in `block-template-utils.php`, the Navigation Overlay area previously registered with `'icon' => 'overlay'` as a placeholder. This updates it to the dedicated `'navigation-overlay'` icon introduced alongside the icons package change in Gutenberg.

Trac ticket: https://core.trac.wordpress.org/ticket/64629

## Use of AI Tools

This pull request was prepared with assistance from Claude Code (Anthropic, claude-sonnet-4-5-20250929). The code change has been reviewed and is the responsibility of the author.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**