### PR TITLE
Code Modernization: Use null coalescing operator for improved readability

### DIFF
--- a/src/wp-admin/edit-comments.php
+++ b/src/wp-admin/edit-comments.php
@@ -319,13 +319,13 @@ if ( isset( $_REQUEST['approved'] )
 	|| isset( $_REQUEST['unspammed'] )
 	|| isset( $_REQUEST['same'] )
 ) {
-	$approved  = isset( $_REQUEST['approved'] ) ? (int) $_REQUEST['approved'] : 0;
-	$deleted   = isset( $_REQUEST['deleted'] ) ? (int) $_REQUEST['deleted'] : 0;
-	$trashed   = isset( $_REQUEST['trashed'] ) ? (int) $_REQUEST['trashed'] : 0;
-	$untrashed = isset( $_REQUEST['untrashed'] ) ? (int) $_REQUEST['untrashed'] : 0;
-	$spammed   = isset( $_REQUEST['spammed'] ) ? (int) $_REQUEST['spammed'] : 0;
-	$unspammed = isset( $_REQUEST['unspammed'] ) ? (int) $_REQUEST['unspammed'] : 0;
-	$same      = isset( $_REQUEST['same'] ) ? (int) $_REQUEST['same'] : 0;
+	$approved  = (int) ( $_REQUEST['approved'] ?? 0 );
+	$deleted   = (int) ( $_REQUEST['deleted'] ?? 0 );
+	$trashed   = (int) ( $_REQUEST['trashed'] ?? 0 );
+	$untrashed = (int) ( $_REQUEST['untrashed'] ?? 0 );
+	$spammed   = (int) ( $_REQUEST['spammed'] ?? 0 );
+	$unspammed = (int) ( $_REQUEST['unspammed'] ?? 0 );
+	$same      = (int) ( $_REQUEST['same'] ?? 0 );
 
 	if ( $approved > 0 || $deleted > 0 || $trashed > 0 || $untrashed > 0 || $spammed > 0 || $unspammed > 0 || $same > 0 ) {
 		if ( $approved > 0 ) {

--- a/src/wp-includes/class-wp-block-parser-frame.php
+++ b/src/wp-includes/class-wp-block-parser-frame.php
@@ -73,7 +73,7 @@ class WP_Block_Parser_Frame {
 		$this->block              = $block;
 		$this->token_start        = $token_start;
 		$this->token_length       = $token_length;
-		$this->prev_offset        = isset( $prev_offset ) ? $prev_offset : $token_start + $token_length;
+		$this->prev_offset        = $prev_offset ?? $token_start + $token_length;
 		$this->leading_html_start = $leading_html_start;
 	}
 }

--- a/src/wp-includes/class-wp-locale.php
+++ b/src/wp-includes/class-wp-locale.php
@@ -450,7 +450,7 @@ class WP_Locale {
 		 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
 		 * Do not translate into your own language.
 		 */
-		$word_count_type = is_null( $this->word_count_type ) ? _x( 'words', 'Word count type. Do not translate!' ) : $this->word_count_type;
+		$word_count_type = $this->word_count_type ?? _x( 'words', 'Word count type. Do not translate!' );
 
 		// Check for valid types.
 		if ( 'characters_excluding_spaces' !== $word_count_type && 'characters_including_spaces' !== $word_count_type ) {

--- a/src/wp-includes/class-wp-theme-json-resolver.php
+++ b/src/wp-includes/class-wp-theme-json-resolver.php
@@ -144,7 +144,7 @@ class WP_Theme_JSON_Resolver {
 	protected static function translate( $theme_json, $domain = 'default' ) {
 		if ( null === static::$i18n_schema ) {
 			$i18n_schema         = wp_json_file_decode( __DIR__ . '/theme-i18n.json' );
-			static::$i18n_schema = null === $i18n_schema ? array() : $i18n_schema;
+			static::$i18n_schema = $i18n_schema ?? array();
 		}
 
 		return translate_settings_using_i18n_schema( static::$i18n_schema, $theme_json, $domain );

--- a/src/wp-includes/customize/class-wp-customize-partial.php
+++ b/src/wp-includes/customize/class-wp-customize-partial.php
@@ -230,7 +230,7 @@ class WP_Customize_Partial {
 			 * Note that the string return takes precedence because the $ob_render may just\
 			 * include PHP warnings or notices.
 			 */
-			$rendered = null !== $return_render ? $return_render : $ob_render;
+			$rendered = $return_render ?? $ob_render;
 		}
 
 		/**

--- a/src/wp-includes/functions.php
+++ b/src/wp-includes/functions.php
@@ -951,7 +951,7 @@ function do_enclose( $content, $post ) {
 
 			$headers = wp_get_http_headers( $url );
 			if ( $headers ) {
-				$len           = isset( $headers['Content-Length'] ) ? (int) $headers['Content-Length'] : 0;
+				$len           = (int) ( $headers['Content-Length'] ?? 0 );
 				$type          = $headers['Content-Type'] ?? '';
 				$allowed_types = array( 'video', 'audio' );
 

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -453,7 +453,7 @@ final class WP_Interactivity_API {
 		$this->namespace_stack = null;
 		$this->context_stack   = null;
 
-		return null === $result ? $html : $result;
+		return $result ?? $html;
 	}
 
 	/**

--- a/src/wp-includes/l10n.php
+++ b/src/wp-includes/l10n.php
@@ -1490,7 +1490,7 @@ function get_available_languages( $dir = null ) {
 
 	$languages = array();
 
-	$path       = is_null( $dir ) ? WP_LANG_DIR : $dir;
+	$path       = $dir ?? WP_LANG_DIR;
 	$lang_files = $wp_textdomain_registry->get_language_files_from_path( $path );
 
 	if ( $lang_files ) {

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -110,7 +110,7 @@ function wp_force_plain_post_permalink( $post = null, $sample = null ) {
 		$sample = true;
 	} else {
 		$post   = get_post( $post );
-		$sample = null !== $sample ? $sample : false;
+		$sample = $sample ?? false;
 	}
 
 	if ( ! $post ) {

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -483,7 +483,7 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 			remove_filter( 'post_password_required', array( $this, 'check_password_required' ) );
 		}
 
-		$page        = isset( $query_args['paged'] ) ? (int) $query_args['paged'] : 0;
+		$page        = (int) ( $query_args['paged'] ?? 0 );
 		$total_posts = $posts_query->found_posts;
 
 		if ( $total_posts < 1 && $page > 1 ) {

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -728,7 +728,7 @@ function get_current_user_id() {
 		return 0;
 	}
 	$user = wp_get_current_user();
-	return ( isset( $user->ID ) ? (int) $user->ID : 0 );
+	return (int) ( $user->ID ?? 0 );
 }
 
 /**
@@ -2682,7 +2682,7 @@ function wp_update_user( $userdata ) {
 
 	$userdata_raw = $userdata;
 
-	$user_id = isset( $userdata['ID'] ) ? (int) $userdata['ID'] : 0;
+	$user_id = (int) ( $userdata['ID'] ?? 0 );
 	if ( ! $user_id ) {
 		return new WP_Error( 'invalid_user_id', __( 'Invalid user ID.' ) );
 	}

--- a/src/wp-includes/widgets.php
+++ b/src/wp-includes/widgets.php
@@ -1720,15 +1720,15 @@ function wp_widget_rss_form( $args, $inputs = null ) {
 
 	$args['title'] = $args['title'] ?? '';
 	$args['url']   = $args['url'] ?? '';
-	$args['items'] = isset( $args['items'] ) ? (int) $args['items'] : 0;
+	$args['items'] = (int) ( $args['items'] ?? 0 );
 
 	if ( $args['items'] < 1 || 20 < $args['items'] ) {
 		$args['items'] = 10;
 	}
 
-	$args['show_summary'] = isset( $args['show_summary'] ) ? (int) $args['show_summary'] : (int) $inputs['show_summary'];
-	$args['show_author']  = isset( $args['show_author'] ) ? (int) $args['show_author'] : (int) $inputs['show_author'];
-	$args['show_date']    = isset( $args['show_date'] ) ? (int) $args['show_date'] : (int) $inputs['show_date'];
+	$args['show_summary'] = (int) ( $args['show_summary'] ?? $inputs['show_summary'] );
+	$args['show_author']  = (int) ( $args['show_author'] ?? $inputs['show_author'] );
+	$args['show_date']    = (int) ( $args['show_date'] ?? $inputs['show_date'] );
 
 	if ( ! empty( $args['error'] ) ) {
 		echo '<p class="widget-error"><strong>' . __( 'RSS Error:' ) . '</strong> ' . esc_html( $args['error'] ) . '</p>';
@@ -1798,10 +1798,10 @@ function wp_widget_rss_process( $widget_rss, $check_feed = true ) {
 		$items = 10;
 	}
 	$url          = sanitize_url( strip_tags( $widget_rss['url'] ) );
-	$title        = isset( $widget_rss['title'] ) ? trim( strip_tags( $widget_rss['title'] ) ) : '';
-	$show_summary = isset( $widget_rss['show_summary'] ) ? (int) $widget_rss['show_summary'] : 0;
-	$show_author  = isset( $widget_rss['show_author'] ) ? (int) $widget_rss['show_author'] : 0;
-	$show_date    = isset( $widget_rss['show_date'] ) ? (int) $widget_rss['show_date'] : 0;
+	$title        = trim( strip_tags( $widget_rss['title'] ?? '' ) );
+	$show_summary = (int) ( $widget_rss['show_summary'] ?? 0 );
+	$show_author  = (int) ( $widget_rss['show_author'] ?? 0 );
+	$show_date    = (int) ( $widget_rss['show_date'] ?? 0 );
 	$error        = false;
 	$link         = '';
 


### PR DESCRIPTION
This pull request focuses on simplifying and modernizing conditional assignment patterns across several core files by replacing explicit null checks with the null coalescing operator (`??`). This change streamlines the code, making it more concise and easier to read without altering its behavior.

The PR refactors from:
```php
return null === $foo ? array() : $foo;
```

to

```php
return $foo ?? array();
```

Trac ticket: https://core.trac.wordpress.org/ticket/63430

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
