### PR TITLE
Block Bindings: Remove `$supported_blocks` property from the registry

### DIFF
--- a/src/wp-includes/class-wp-block-bindings-registry.php
+++ b/src/wp-includes/class-wp-block-bindings-registry.php
@@ -45,19 +45,6 @@ final class WP_Block_Bindings_Registry {
 	);
 
 	/**
-	 * Supported blocks that can use the block bindings API.
-	 *
-	 * @since 6.5.0
-	 * @var string[]
-	 */
-	private $supported_blocks = array(
-		'core/paragraph',
-		'core/heading',
-		'core/image',
-		'core/button',
-	);
-
-	/**
 	 * Registers a new block bindings source.
 	 *
 	 * This is a low-level method. For most use cases, it is recommended to use


### PR DESCRIPTION
We should remove the private property `$supported_blocks` from the `WP_Block_Bindings_Registry` class as it is not used anymore.

- It was added in: https://core.trac.wordpress.org/changeset/57641
- The usage was removed in: https://core.trac.wordpress.org/changeset/59080

Trac ticket: https://core.trac.wordpress.org/ticket/64633

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
