### PR TITLE
IXR: check if scheme and host keys exist before accessing in IXR_Client and WP_HTTP_IXR_Client

### DIFF
--- a/src/wp-includes/IXR/class-IXR-client.php
+++ b/src/wp-includes/IXR/class-IXR-client.php
@@ -30,7 +30,7 @@ class IXR_Client
         if (!$path) {
             // Assume we have been given a URL instead
             $bits = parse_url($server);
-            $this->server = $bits['host'];
+            $this->server = $bits['host'] ?? '';
             $this->port = $bits['port'] ?? 80;
             $this->path = $bits['path'] ?? '/';
 

--- a/src/wp-includes/class-wp-http-ixr-client.php
+++ b/src/wp-includes/class-wp-http-ixr-client.php
@@ -23,8 +23,8 @@ class WP_HTTP_IXR_Client extends IXR_Client {
 		if ( ! $path ) {
 			// Assume we have been given a URL instead.
 			$bits         = parse_url( $server );
-			$this->scheme = $bits['scheme'];
-			$this->server = $bits['host'];
+			$this->scheme = $bits['scheme'] ?? '';
+			$this->server = $bits['host'] ?? '';
 			$this->port   = $bits['port'] ?? $port;
 			$this->path   = ! empty( $bits['path'] ) ? $bits['path'] : '/';
 

--- a/src/wp-includes/class-wp-http-ixr-client.php
+++ b/src/wp-includes/class-wp-http-ixr-client.php
@@ -26,7 +26,7 @@ class WP_HTTP_IXR_Client extends IXR_Client {
 			$this->scheme = $bits['scheme'] ?? '';
 			$this->server = $bits['host'] ?? '';
 			$this->port   = $bits['port'] ?? $port;
-			$this->path   = ! empty( $bits['path'] ) ? $bits['path'] : '/';
+			$this->path   = $bits['path'] ?? '/';
 
 			// Make absolutely sure we have a path.
 			if ( ! $this->path ) {

--- a/tests/phpunit/tests/xmlrpc/client.php
+++ b/tests/phpunit/tests/xmlrpc/client.php
@@ -17,6 +17,11 @@ class Tests_XMLRPC_Client extends WP_XMLRPC_UnitTestCase {
 		$this->assertSame( '/server.php?this-is-needed=true', $client->path );
 	}
 
+	public function test_ixr_client_does_not_error_when_host_is_missing() {
+		$client = new IXR_Client( '/no-host-here' );
+		$this->assertSame( '', $client->server );
+	}
+
 	/**
 	 * @ticket 26947
 	 */

--- a/tests/phpunit/tests/xmlrpc/client.php
+++ b/tests/phpunit/tests/xmlrpc/client.php
@@ -20,7 +20,7 @@ class Tests_XMLRPC_Client extends WP_XMLRPC_UnitTestCase {
 	/**
 	 * @ticket 64635
 	 */
-	public function test_ixr_client_does_not_error_when_host_is_missing() {
+	public function test_ixr_client_can_handle_missing_host() {
 		$client = new IXR_Client( '/no-host-here' );
 		$this->assertSame( '', $client->server );
 	}
@@ -33,5 +33,34 @@ class Tests_XMLRPC_Client extends WP_XMLRPC_UnitTestCase {
 		$this->assertSame( 'example.com', $client->server );
 		$this->assertFalse( $client->port );
 		$this->assertSame( '/server.php?this-is-needed=true', $client->path );
+	}
+
+	/**
+	 * @ticket 40784
+	 */
+	public function test_wp_ixr_client_can_handle_protocolless_urls() {
+		$client = new WP_HTTP_IXR_Client( '//example.com/server.php' );
+		$this->assertSame( '', $client->scheme );
+		$this->assertSame( 'example.com', $client->server );
+	}
+
+	/**
+	 * @ticket 40784
+	 */
+	public function test_wp_ixr_client_can_handle_relative_urls() {
+		$client = new WP_HTTP_IXR_Client( '/server.php' );
+		$this->assertSame( '', $client->scheme );
+		$this->assertSame( '', $client->server );
+		$this->assertSame( '/server.php', $client->path );
+	}
+
+	/**
+	 * @ticket 40784
+	 */
+	public function test_wp_ixr_client_can_handle_invalid_urls() {
+		$client = new WP_HTTP_IXR_Client( '' );
+		$this->assertSame( '', $client->scheme );
+		$this->assertSame( '', $client->server );
+		$this->assertSame( '/', $client->path );
 	}
 }

--- a/tests/phpunit/tests/xmlrpc/client.php
+++ b/tests/phpunit/tests/xmlrpc/client.php
@@ -17,6 +17,9 @@ class Tests_XMLRPC_Client extends WP_XMLRPC_UnitTestCase {
 		$this->assertSame( '/server.php?this-is-needed=true', $client->path );
 	}
 
+	/**
+	 * @ticket 64635
+	 */
 	public function test_ixr_client_does_not_error_when_host_is_missing() {
 		$client = new IXR_Client( '/no-host-here' );
 		$this->assertSame( '', $client->server );


### PR DESCRIPTION
## Summary

- `IXR_Client` accesses `$bits['host']` from `parse_url()` without checking if the key exists, which can trigger an undefined index warning for URLs without a host component (e.g. relative paths).
- Uses the null coalescing operator (`??`) to fall back to an empty string, consistent with how `port` and `path` are already handled on the adjacent lines.
- Adds a unit test to verify no error is triggered when the host is missing.

## Trac ticket

https://core.trac.wordpress.org/ticket/64635
https://core.trac.wordpress.org/ticket/40784

## Test plan

- [x] Verify `IXR_Client` no longer triggers an undefined index warning when instantiated with a URL lacking a host component
- [x] Run `npm run test:php -- --filter ixr_client` and confirm the tests pass


----

# Drafted Commit Message

XML-RPC: Account for parsed URLs that do not specify `host` or `scheme`.

Developed in https://github.com/WordPress/wordpress-develop/pull/10916

Props bluefuton, tfrommen, chrispecoraro, drebbits.web, westonruter.
Fixes #64635, #40784.