### PR TITLE
HTML5 script support is always true

### DIFF
--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -3031,10 +3031,6 @@ function _custom_logo_header_styles() {
 function get_theme_support( $feature, ...$args ) {
 	global $_wp_theme_features;
 
-	if ( 'custom-header-uploads' === $feature ) {
-		return get_theme_support( 'custom-header', 'uploads' );
-	}
-
 	if ( ! isset( $_wp_theme_features[ $feature ] ) ) {
 		return false;
 	}
@@ -3159,6 +3155,10 @@ function _remove_theme_support( $feature ) {
  * @return bool True if the active theme supports the feature, false otherwise.
  */
 function current_theme_supports( $feature, ...$args ) {
+	if ( 'custom-header-uploads' === $feature ) {
+		return current_theme_supports( 'custom-header', 'uploads' );
+	}
+
 	$feature_support = get_theme_support( $feature, ...$args );
 
 	if ( ! $feature_support ) {

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -3193,6 +3193,12 @@ function current_theme_supports( $feature, ...$args ) {
 			 * Specific areas of HTML5 support *must* be passed via an array to add_theme_support().
 			 */
 			$type = $args[0];
+
+			// HTML5 script support is always enabled since non-HTML5 script output was removed in 7.0.
+			if ( 'html5' === $feature && 'script' === $type ) {
+				return true;
+			}
+
 			return in_array( $type, $_wp_theme_features[ $feature ][0], true );
 
 		case 'custom-logo':

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -3149,28 +3149,26 @@ function _remove_theme_support( $feature ) {
  *              by adding it to the function signature.
  * @since 7.0.0 HTML5 script support will always report `true`.
  *
- * @global array $_wp_theme_features
- *
  * @param string $feature The feature being checked. See add_theme_support() for the list
  *                        of possible values.
  * @param mixed  ...$args Optional extra arguments to be checked against certain features.
  * @return bool True if the active theme supports the feature, false otherwise.
  */
 function current_theme_supports( $feature, ...$args ) {
-	global $_wp_theme_features;
-
 	if ( 'custom-header-uploads' === $feature ) {
 		return current_theme_supports( 'custom-header', 'uploads' );
 	}
 
-	if ( ! isset( $_wp_theme_features[ $feature ] ) ) {
+	$feature_support = get_theme_support( $feature, ...$args );
+
+	if ( ! $feature_support ) {
 		return false;
 	}
 
 	// If no args passed then no extra checks need to be performed.
 	if ( ! $args ) {
 		/** This filter is documented in wp-includes/theme.php */
-		return apply_filters( "current_theme_supports-{$feature}", true, $args, $_wp_theme_features[ $feature ] ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+		return apply_filters( "current_theme_supports-{$feature}", true, $args, $feature_support ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 	}
 
 	switch ( $feature ) {
@@ -3180,11 +3178,11 @@ function current_theme_supports( $feature, ...$args ) {
 			 * by passing an array of types to add_theme_support().
 			 * If no array was passed, then any type is accepted.
 			 */
-			if ( true === $_wp_theme_features[ $feature ] ) {  // Registered for all types.
+			if ( true === $feature_support ) {  // Registered for all types.
 				return true;
 			}
 			$content_type = $args[0];
-			return in_array( $content_type, $_wp_theme_features[ $feature ][0], true );
+			return in_array( $content_type, $feature_support[0], true );
 
 		case 'html5':
 		case 'post-formats':
@@ -3201,13 +3199,13 @@ function current_theme_supports( $feature, ...$args ) {
 				return true;
 			}
 
-			return in_array( $type, $_wp_theme_features[ $feature ][0], true );
+			return in_array( $type, $feature_support[0], true );
 
 		case 'custom-logo':
 		case 'custom-header':
 		case 'custom-background':
 			// Specific capabilities can be registered by passing an array to add_theme_support().
-			return ( isset( $_wp_theme_features[ $feature ][0][ $args[0] ] ) && $_wp_theme_features[ $feature ][0][ $args[0] ] );
+			return ( isset( $feature_support[0][ $args[0] ] ) && $feature_support[0][ $args[0] ] );
 	}
 
 	/**
@@ -3222,7 +3220,7 @@ function current_theme_supports( $feature, ...$args ) {
 	 * @param array  $args     Array of arguments for the feature.
 	 * @param string $feature  The theme feature.
 	 */
-	return apply_filters( "current_theme_supports-{$feature}", true, $args, $_wp_theme_features[ $feature ] ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+	return apply_filters( "current_theme_supports-{$feature}", true, $args, $feature_support ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 }
 
 /**

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -4403,7 +4403,7 @@ function _add_default_theme_supports() {
 	 * (which use default template functions) and `[caption]` and `[gallery]` shortcodes.
 	 * Other blocks contain their own HTML5 markup.
 	 */
-	add_theme_support( 'html5', array( 'comment-form', 'comment-list', 'search-form', 'gallery', 'caption', 'style', 'script' ) );
+	add_theme_support( 'html5', array( 'comment-form', 'comment-list', 'search-form', 'gallery', 'caption', 'style' ) );
 	add_theme_support( 'automatic-feed-links' );
 
 	add_filter( 'should_load_separate_core_block_assets', '__return_true' );

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -2645,6 +2645,7 @@ function get_theme_starter_content() {
  * @since 6.5.0 The `appearance-tools` feature enables a few design tools for blocks,
  *              see `WP_Theme_JSON::APPEARANCE_TOOLS_OPT_INS` for a complete list.
  * @since 6.6.0 The `editor-spacing-sizes` feature was added.
+ * @since 7.0.0 Deprecated the `html5` feature 'script'.
  *
  * @global array $_wp_theme_features
  *

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -3031,6 +3031,10 @@ function _custom_logo_header_styles() {
 function get_theme_support( $feature, ...$args ) {
 	global $_wp_theme_features;
 
+	if ( 'custom-header-uploads' === $feature ) {
+		return get_theme_support( 'custom-header', 'uploads' );
+	}
+
 	if ( ! isset( $_wp_theme_features[ $feature ] ) ) {
 		return false;
 	}
@@ -3155,10 +3159,6 @@ function _remove_theme_support( $feature ) {
  * @return bool True if the active theme supports the feature, false otherwise.
  */
 function current_theme_supports( $feature, ...$args ) {
-	if ( 'custom-header-uploads' === $feature ) {
-		return current_theme_supports( 'custom-header', 'uploads' );
-	}
-
 	$feature_support = get_theme_support( $feature, ...$args );
 
 	if ( ! $feature_support ) {

--- a/src/wp-includes/theme.php
+++ b/src/wp-includes/theme.php
@@ -3146,6 +3146,7 @@ function _remove_theme_support( $feature ) {
  * @since 2.9.0
  * @since 5.3.0 Formalized the existing and already documented `...$args` parameter
  *              by adding it to the function signature.
+ * @since 7.0.0 HTML5 script support will always report `true`.
  *
  * @global array $_wp_theme_features
  *
@@ -3194,7 +3195,7 @@ function current_theme_supports( $feature, ...$args ) {
 			 */
 			$type = $args[0];
 
-			// HTML5 script support is always enabled since non-HTML5 script output was removed in 7.0.
+			// Non-HTML5 script support is deprecated. HTML5 script support is always enabled.
 			if ( 'html5' === $feature && 'script' === $type ) {
 				return true;
 			}

--- a/tests/phpunit/tests/rest-api/rest-themes-controller.php
+++ b/tests/phpunit/tests/rest-api/rest-themes-controller.php
@@ -429,7 +429,13 @@ class WP_Test_REST_Themes_Controller extends WP_Test_REST_Controller_Testcase {
 		$this->assertArrayHasKey( 'editor-spacing-sizes', $theme_supports );
 		$this->assertArrayHasKey( 'editor-styles', $theme_supports );
 		$this->assertArrayHasKey( 'formats', $theme_supports );
+
 		$this->assertArrayHasKey( 'html5', $theme_supports );
+		$this->assertSame(
+			array( 'search-form', 'comment-form', 'comment-list', 'gallery', 'caption', 'style', 'script' ),
+			$theme_supports['html5']
+		);
+
 		$this->assertArrayHasKey( 'post-thumbnails', $theme_supports );
 		$this->assertArrayHasKey( 'responsive-embeds', $theme_supports );
 		$this->assertArrayHasKey( 'title-tag', $theme_supports );

--- a/tests/phpunit/tests/theme/support.php
+++ b/tests/phpunit/tests/theme/support.php
@@ -153,14 +153,6 @@ class Tests_Theme_Support extends WP_UnitTestCase {
 		// Should be true even without any theme support registered.
 		remove_theme_support( 'html5' );
 		$this->assertTrue( current_theme_supports( 'html5', 'script' ) );
-
-		// Should still be true after adding other html5 types but not script.
-		add_theme_support( 'html5', array( 'comment-form' ) );
-		$this->assertTrue( current_theme_supports( 'html5', 'script' ) );
-
-		// Other types should still work normally.
-		$this->assertTrue( current_theme_supports( 'html5', 'comment-form' ) );
-		$this->assertFalse( current_theme_supports( 'html5', 'search-form' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/theme/support.php
+++ b/tests/phpunit/tests/theme/support.php
@@ -142,6 +142,28 @@ class Tests_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that `current_theme_supports( 'html5', 'script' )` always returns true.
+	 *
+	 * Non-HTML5 script output was removed in WordPress 7.0, so script support
+	 * is now always enabled regardless of theme configuration.
+	 *
+	 * @ticket 64442
+	 */
+	public function test_html5_script_support_always_true() {
+		// Should be true even without any theme support registered.
+		remove_theme_support( 'html5' );
+		$this->assertTrue( current_theme_supports( 'html5', 'script' ) );
+
+		// Should still be true after adding other html5 types but not script.
+		add_theme_support( 'html5', array( 'comment-form' ) );
+		$this->assertTrue( current_theme_supports( 'html5', 'script' ) );
+
+		// Other types should still work normally.
+		$this->assertTrue( current_theme_supports( 'html5', 'comment-form' ) );
+		$this->assertFalse( current_theme_supports( 'html5', 'search-form' ) );
+	}
+
+	/**
 	 * @ticket 51390
 	 *
 	 * @expectedIncorrectUsage add_theme_support( 'post-formats' )


### PR DESCRIPTION
Since non-HTML5 script output was completely removed in r61415, all scripts are now output as HTML5. This change makes the theme support check reflect that reality by always returning true for script support, regardless of whether themes explicitly declare support.

The behavior of `add_theme_support()` and `remove_theme_support()` remains unchanged.
Only the check via `current_theme_supports( 'html5', 'script' )` is affected.

Theme REST API calls to remain unchanged:

```js
(await wp.apiFetch({path: '/wp/v2/themes?status=active' }))[0].theme_supports.html5
// ['comment-form', 'comment-list', 'search-form', 'gallery', 'caption', 'style', 'script']
```

`get_theme_support()` behavior is _unchanged_ at this time so `current_theme_supports()` may be incoherent. Additionally if _no_ `html5` support is enabled for a theme, `script` support remains false. REST API theme response inherits this strange behavior because it relies on both `get_theme_support()` _and_ `current_theme_supports()`. Details in https://github.com/WordPress/wordpress-develop/pull/10919#issuecomment-3896349183.

Trac ticket: https://core.trac.wordpress.org/ticket/64442

## Use of AI Tools

The basic implementation was performed by Claude Code. I performed full review and adaptation of the changes.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
