### PR TITLE
Fix: Color schema is not correctly applied to the beta label

### DIFF
--- a/src/wp-admin/css/colors/_admin.scss
+++ b/src/wp-admin/css/colors/_admin.scss
@@ -365,11 +365,9 @@ ul#adminmenu > li.current > a.current:after {
 }
 
 #adminmenu li.current a .awaiting-mod,
-#adminmenu li a.wp-has-current-submenu .update-plugins,
-#adminmenu li:hover a .awaiting-mod,
-#adminmenu li.menu-top:hover > a .update-plugins {
+#adminmenu li a.wp-has-current-submenu .update-plugins {
 	color: variables.$menu-bubble-current-text;
-	background: variables.$menu-bubble-current-background;
+	background: variables.$menu-bubble-background;
 }
 
 

--- a/src/wp-admin/css/colors/_variables.scss
+++ b/src/wp-admin/css/colors/_variables.scss
@@ -49,7 +49,6 @@ $menu-submenu-current-text: $text-color !default;
 $menu-bubble-text: $text-color !default;
 $menu-bubble-background: $notification-color !default;
 $menu-bubble-current-text: $text-color !default;
-$menu-bubble-current-background: $menu-submenu-background !default;
 
 $menu-collapse-text: $menu-icon !default;
 $menu-collapse-icon: $menu-icon !default;


### PR DESCRIPTION
> [!NOTE]
> This PR is the same as #3938. I submitted this new PR because I accidentally closed #3938 and it can no longer be reopened.

Trac ticket: https://core.trac.wordpress.org/ticket/57577

The site editor has a beta label and the `.awaiting-mod` class is used to indicate that it is a badge. I think this is the class originally used for the comment badge.

The background color style for this class works correctly if the top menu is given a badge. However, with the advent of the site editor, I believe the use of this badge in the child menu causes unintended behavior.

Therefore, I have updated the selector so that no matter which menu the badge with this class is used in, the background color will be applied correctly. Ideally, we might need a selector for the site editor, but since the beta label should be removed in the future, I have kept the current class name.

## Before

https://user-images.githubusercontent.com/54422211/215320957-b3f9440b-f857-4f88-8b1a-b0f730a02f2e.mp4

## After

https://user-images.githubusercontent.com/54422211/215320960-767eeda6-7919-4c4a-8846-a2f289e8d434.mp4