### PR TITLE
docs: add missing null to $post param types

### DIFF
--- a/src/wp-includes/category-template.php
+++ b/src/wp-includes/category-template.php
@@ -1487,7 +1487,7 @@ function the_terms( $post_id, $taxonomy, $before = '', $sep = ', ', $after = '' 
  *
  * @param string|int|array $category Optional. The category name/term_id/slug,
  *                                   or an array of them to check for. Default empty.
- * @param int|WP_Post      $post     Optional. Post to check. Defaults to the current post.
+ * @param int|WP_Post|null $post     Optional. Post to check. Defaults to the current post.
  * @return bool True if the current post has any of the given categories
  *              (or any category, if no category specified). False otherwise.
  */
@@ -1514,7 +1514,7 @@ function has_category( $category = '', $post = null ) {
  *
  * @param string|int|array $tag  Optional. The tag name/term_id/slug,
  *                               or an array of them to check for. Default empty.
- * @param int|WP_Post      $post Optional. Post to check. Defaults to the current post.
+ * @param int|WP_Post|null $post Optional. Post to check. Defaults to the current post.
  * @return bool True if the current post has any of the given tags
  *              (or any tag, if no tag specified). False otherwise.
  */
@@ -1535,7 +1535,7 @@ function has_tag( $tag = '', $post = null ) {
  * @param string|int|array $term     Optional. The term name/term_id/slug,
  *                                   or an array of them to check for. Default empty.
  * @param string           $taxonomy Optional. Taxonomy name. Default empty.
- * @param int|WP_Post      $post     Optional. Post to check. Defaults to the current post.
+ * @param int|WP_Post|null $post     Optional. Post to check. Defaults to the current post.
  * @return bool True if the current post has any of the given terms
  *              (or any term, if no term specified). False otherwise.
  */

--- a/src/wp-includes/comment-template.php
+++ b/src/wp-includes/comment-template.php
@@ -2157,8 +2157,8 @@ function comment_form_title( $no_reply_text = false, $reply_text = false, $link_
  *
  * @access private
  *
- * @param int|WP_Post $post The post the comment is being displayed for.
- *                          Defaults to the current global post.
+ * @param int|WP_Post|null $post The post the comment is being displayed for.
+ *                               Defaults to the current global post.
  * @return int Comment's reply to ID.
  */
 function _get_comment_reply_id( $post = null ) {

--- a/src/wp-includes/embed.php
+++ b/src/wp-includes/embed.php
@@ -413,7 +413,7 @@ function wp_maybe_enqueue_oembed_host_js( $html ) {
  *
  * @since 4.4.0
  *
- * @param int|WP_Post $post Optional. Post ID or object. Defaults to the current post.
+ * @param int|WP_Post|null $post Optional. Post ID or object. Defaults to the current post.
  * @return string|false The post embed URL on success, false if the post doesn't exist.
  */
 function get_post_embed_url( $post = null ) {
@@ -482,9 +482,9 @@ function get_oembed_endpoint_url( $permalink = '', $format = 'json' ) {
  *
  * @since 4.4.0
  *
- * @param int         $width  The width for the response.
- * @param int         $height The height for the response.
- * @param int|WP_Post $post   Optional. Post ID or object. Default is global `$post`.
+ * @param int              $width  The width for the response.
+ * @param int              $height The height for the response.
+ * @param int|WP_Post|null $post   Optional. Post ID or object. Default is global `$post`.
  * @return string|false Embed code on success, false if post doesn't exist.
  */
 function get_post_embed_html( $width, $height, $post = null ) {

--- a/src/wp-includes/general-template.php
+++ b/src/wp-includes/general-template.php
@@ -2716,8 +2716,8 @@ function the_date( $format = '', $before = '', $after = '', $display = true ) {
  *
  * @since 3.0.0
  *
- * @param string      $format Optional. PHP date format. Defaults to the 'date_format' option.
- * @param int|WP_Post $post   Optional. Post ID or WP_Post object. Default current post.
+ * @param string           $format Optional. PHP date format. Defaults to the 'date_format' option.
+ * @param int|WP_Post|null $post   Optional. Post ID or WP_Post object. Default current post.
  * @return string|int|false Date the current post was written. False on failure.
  */
 function get_the_date( $format = '', $post = null ) {
@@ -2782,8 +2782,8 @@ function the_modified_date( $format = '', $before = '', $after = '', $display = 
  * @since 2.1.0
  * @since 4.6.0 Added the `$post` parameter.
  *
- * @param string      $format Optional. PHP date format. Defaults to the 'date_format' option.
- * @param int|WP_Post $post   Optional. Post ID or WP_Post object. Default current post.
+ * @param string           $format Optional. PHP date format. Defaults to the 'date_format' option.
+ * @param int|WP_Post|null $post   Optional. Post ID or WP_Post object. Default current post.
  * @return string|int|false Date the current post was modified. False on failure.
  */
 function get_the_modified_date( $format = '', $post = null ) {
@@ -2838,10 +2838,10 @@ function the_time( $format = '' ) {
  *
  * @since 1.5.0
  *
- * @param string      $format Optional. Format to use for retrieving the time the post
- *                            was written. Accepts 'G', 'U', or PHP date format.
- *                            Defaults to the 'time_format' option.
- * @param int|WP_Post $post   Post ID or post object. Default is global `$post` object.
+ * @param string           $format Optional. Format to use for retrieving the time the post
+ *                                 was written. Accepts 'G', 'U', or PHP date format.
+ *                                 Defaults to the 'time_format' option.
+ * @param int|WP_Post|null $post   Post ID or post object. Default is global `$post` object.
  * @return string|int|false Formatted date string or Unix timestamp if `$format` is 'U' or 'G'.
  *                          False on failure.
  */
@@ -2874,10 +2874,10 @@ function get_the_time( $format = '', $post = null ) {
  *
  * @since 2.0.0
  *
- * @param string      $format    Optional. Format to use for retrieving the time the post
- *                               was written. Accepts 'G', 'U', or PHP date format. Default 'U'.
- * @param bool        $gmt       Optional. Whether to retrieve the GMT time. Default false.
- * @param int|WP_Post $post      Post ID or post object. Default is global `$post` object.
+ * @param string           $format    Optional. Format to use for retrieving the time the post
+ *                                    was written. Accepts 'G', 'U', or PHP date format. Default 'U'.
+ * @param bool             $gmt       Optional. Whether to retrieve the GMT time. Default false.
+ * @param int|WP_Post|null $post      Post ID or post object. Default is global `$post` object.
  * @param bool        $translate Whether to translate the time string. Default false.
  * @return string|int|false Formatted date string or Unix timestamp if `$format` is 'U' or 'G'.
  *                          False on failure.
@@ -2938,11 +2938,11 @@ function get_post_time( $format = 'U', $gmt = false, $post = null, $translate = 
  *
  * @since 5.3.0
  *
- * @param int|WP_Post $post   Optional. Post ID or post object. Default is global `$post` object.
- * @param string      $field  Optional. Published or modified time to use from database. Accepts 'date' or 'modified'.
- *                            Default 'date'.
- * @param string      $source Optional. Local or UTC time to use from database. Accepts 'local' or 'gmt'.
- *                            Default 'local'.
+ * @param int|WP_Post|null $post   Optional. Post ID or post object. Default is global `$post` object.
+ * @param string           $field  Optional. Published or modified time to use from database. Accepts 'date' or 'modified'.
+ *                                 Default 'date'.
+ * @param string           $source Optional. Local or UTC time to use from database. Accepts 'local' or 'gmt'.
+ *                                 Default 'local'.
  * @return DateTimeImmutable|false Time object on success, false on failure.
  */
 function get_post_datetime( $post = null, $field = 'date', $source = 'local' ) {
@@ -2983,9 +2983,9 @@ function get_post_datetime( $post = null, $field = 'date', $source = 'local' ) {
  *
  * @since 5.3.0
  *
- * @param int|WP_Post $post  Optional. Post ID or post object. Default is global `$post` object.
- * @param string      $field Optional. Published or modified time to use from database. Accepts 'date' or 'modified'.
- *                           Default 'date'.
+ * @param int|WP_Post|null $post  Optional. Post ID or post object. Default is global `$post` object.
+ * @param string           $field Optional. Published or modified time to use from database. Accepts 'date' or 'modified'.
+ *                                Default 'date'.
  * @return int|false Unix timestamp on success, false on failure.
  */
 function get_post_timestamp( $post = null, $field = 'date' ) {
@@ -3026,10 +3026,10 @@ function the_modified_time( $format = '' ) {
  * @since 2.0.0
  * @since 4.6.0 Added the `$post` parameter.
  *
- * @param string      $format Optional. Format to use for retrieving the time the post
- *                            was modified. Accepts 'G', 'U', or PHP date format.
- *                            Defaults to the 'time_format' option.
- * @param int|WP_Post $post   Optional. Post ID or WP_Post object. Default current post.
+ * @param string           $format Optional. Format to use for retrieving the time the post
+ *                                 was modified. Accepts 'G', 'U', or PHP date format.
+ *                                 Defaults to the 'time_format' option.
+ * @param int|WP_Post|null $post   Optional. Post ID or WP_Post object. Default current post.
  * @return string|int|false Formatted date string or Unix timestamp. False on failure.
  */
 function get_the_modified_time( $format = '', $post = null ) {
@@ -3063,11 +3063,11 @@ function get_the_modified_time( $format = '', $post = null ) {
  *
  * @since 2.0.0
  *
- * @param string      $format    Optional. Format to use for retrieving the time the post
- *                               was modified. Accepts 'G', 'U', or PHP date format. Default 'U'.
- * @param bool        $gmt       Optional. Whether to retrieve the GMT time. Default false.
- * @param int|WP_Post $post      Post ID or post object. Default is global `$post` object.
- * @param bool        $translate Whether to translate the time string. Default false.
+ * @param string           $format    Optional. Format to use for retrieving the time the post
+ *                                    was modified. Accepts 'G', 'U', or PHP date format. Default 'U'.
+ * @param bool             $gmt       Optional. Whether to retrieve the GMT time. Default false.
+ * @param int|WP_Post|null $post      Post ID or post object. Default is global `$post` object.
+ * @param bool             $translate Whether to translate the time string. Default false.
  * @return string|int|false Formatted date string or Unix timestamp if `$format` is 'U' or 'G'.
  *                          False on failure.
  */

--- a/src/wp-includes/link-template.php
+++ b/src/wp-includes/link-template.php
@@ -94,7 +94,7 @@ function permalink_anchor( $mode = 'id' ) {
  *
  * @since 5.7.0
  *
- * @param WP_Post|int|null $post   Optional. Post ID or post object. Defaults to global $post.
+ * @param int|WP_Post|null $post   Optional. Post ID or post object. Defaults to global $post.
  * @param bool|null        $sample Optional. Whether to force consideration based on sample links.
  *                                 If omitted, a sample link is generated if a post object is passed
  *                                 with the filter property set to 'sample'.

--- a/src/wp-includes/ms-blogs.php
+++ b/src/wp-includes/ms-blogs.php
@@ -906,7 +906,7 @@ function _update_posts_count_on_delete( $post_id, $post ) {
  *
  * @param string  $new_status The status the post is changing to.
  * @param string  $old_status The status the post is changing from.
- * @param WP_Post $post       Post object
+ * @param WP_Post|null $post       Post object.
  */
 function _update_posts_count_on_transition_post_status( $new_status, $old_status, $post = null ) {
 	if ( $new_status === $old_status ) {

--- a/src/wp-includes/post-template.php
+++ b/src/wp-includes/post-template.php
@@ -407,7 +407,7 @@ function the_excerpt() {
  * @since 0.71
  * @since 4.5.0 Introduced the `$post` parameter.
  *
- * @param int|WP_Post $post Optional. Post ID or WP_Post object. Default is global $post.
+ * @param int|WP_Post|null $post Optional. Post ID or WP_Post object. Default is global $post.
  * @return string Post excerpt.
  */
 function get_the_excerpt( $post = null ) {
@@ -460,7 +460,7 @@ function has_excerpt( $post = 0 ) {
  *
  * @param string|string[] $css_class Optional. One or more classes to add to the class list.
  *                                   Default empty.
- * @param int|WP_Post     $post      Optional. Post ID or post object. Defaults to the global `$post`.
+ * @param int|WP_Post|null $post      Optional. Post ID or post object. Defaults to the global `$post`.
  */
 function post_class( $css_class = '', $post = null ) {
 	// Separates classes with a single space, collates classes for post DIV.
@@ -488,7 +488,7 @@ function post_class( $css_class = '', $post = null ) {
  *
  * @param string|string[] $css_class Optional. Space-separated string or array of class names
  *                                   to add to the class list. Default empty.
- * @param int|WP_Post     $post      Optional. Post ID or post object.
+ * @param int|WP_Post|null $post      Optional. Post ID or post object.
  * @return string[] Array of class names.
  */
 function get_post_class( $css_class = '', $post = null ) {
@@ -1883,7 +1883,7 @@ function is_page_template( $template = '' ) {
  * @since 3.4.0
  * @since 4.7.0 Now works with any post type, not just pages.
  *
- * @param int|WP_Post $post Optional. Post ID or WP_Post object. Default is global $post.
+ * @param int|WP_Post|null $post Optional. Post ID or WP_Post object. Default is global $post.
  * @return string|false Page template filename. Returns an empty string when the default page template
  *                      is in use. Returns false if the post does not exist.
  */

--- a/src/wp-includes/post.php
+++ b/src/wp-includes/post.php
@@ -1223,7 +1223,7 @@ function get_post_field( $field, $post = null, $context = 'display' ) {
  *
  * @since 2.0.0
  *
- * @param int|WP_Post $post Optional. Post ID or post object. Defaults to global $post.
+ * @param int|WP_Post|null $post Optional. Post ID or post object. Defaults to global $post.
  * @return string|false The mime type on success, false on failure.
  */
 function get_post_mime_type( $post = null ) {

--- a/src/wp-includes/widgets/class-wp-widget-media.php
+++ b/src/wp-includes/widgets/class-wp-widget-media.php
@@ -360,8 +360,8 @@ abstract class WP_Widget_Media extends WP_Widget {
 	 *
 	 * @since 4.8.0
 	 *
-	 * @param array   $states An array of media states.
-	 * @param WP_Post $post   The current attachment object.
+	 * @param array        $states An array of media states.
+	 * @param WP_Post|null $post   The current attachment object.
 	 * @return array
 	 */
 	public function display_media_state( $states, $post = null ) {


### PR DESCRIPTION
  Several functions across core accept `null` as a valid value for their `$post` parameter (`$post = null` in the function signature), but the `@param` type annotation does not include `null`.

  This patch adds `null` to the `@param` type for all affected functions across 9 files, and reorders `wp_force_plain_post_permalink()` from `WP_Post|int|null` to the conventional `int|WP_Post|null`.

  ## Changes
  - **general-template.php**: `get_the_date`, `get_the_modified_date`, `get_the_time`, `get_post_time`, `get_post_datetime`, `get_the_modified_time`, `get_post_modified_time`, `get_post_timestamp`
  - **comment-template.php**: `_get_comment_reply_id`
  - **embed.php**: `get_post_embed_url`, `get_post_embed_html`
  - **post.php**: `get_post_mime_type`
  - **post-template.php**: `get_the_excerpt`, `post_class`, `get_post_class`, `get_page_template_slug`
  - **category-template.php**: `has_category`, `has_tag`, `has_term`
  - **ms-blogs.php**: `_update_posts_count_on_transition_post_status`
  - **class-wp-widget-media.php**: `display_media_state`
  - **link-template.php**: `wp_force_plain_post_permalink` (type reorder)


Trac ticket:  https://core.trac.wordpress.org/ticket/64645       

## Use of AI Tools

Used Claude Code to identify all locations of the missing phpdoc and to help with summarizing the changes. Every change was monitored and reviewed by myself before opening the PR. 

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
