### PR TITLE
Interactivity API: Update loading bar to use private router store

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -1290,7 +1290,7 @@ CSS;
 		echo <<<HTML
 			<div
 				class="wp-interactivity-router-loading-bar"
-				data-wp-interactive="core/router"
+				data-wp-interactive="core/router/private"
 				data-wp-class--start-animation="state.navigation.hasStarted"
 				data-wp-class--finish-animation="state.navigation.hasFinished"
 			></div>


### PR DESCRIPTION
The Interactivity Router store contains internal properties (`state.navigation.hasStarted`, `state.navigation.hasFinished`) that are not part of the public API. Gutenberg PR [#70882](https://github.com/WordPress/gutenberg/pull/70882) moves these properties to a new private `core/router/private` store and adds deprecation warnings when they are accessed through the public `core/router` store.

This PR updates the loading bar markup in `WP_Interactivity_API::print_router_markup()` to use `data-wp-interactive="core/router/private"` instead of `data-wp-interactive="core/router"`, so it accesses the private store directly and avoids triggering the deprecation warnings.

Trac ticket: https://core.trac.wordpress.org/ticket/64647
Related Gutenberg PR: https://github.com/WordPress/gutenberg/pull/70882

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
