### PR TITLE
Abilities: Backport enqueue of @wordpress/core-abilities script module

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -600,6 +600,7 @@ add_action( 'admin_enqueue_scripts', 'wp_localize_jquery_ui_datepicker', 1000 );
 add_action( 'admin_enqueue_scripts', 'wp_common_block_scripts_and_styles' );
 add_action( 'admin_enqueue_scripts', 'wp_enqueue_command_palette_assets' );
 add_action( 'admin_enqueue_scripts', 'wp_enqueue_view_transitions_admin_css' );
+add_action( 'admin_enqueue_scripts', 'wp_enqueue_admin_script_modules' );
 add_action( 'enqueue_block_assets', 'wp_enqueue_classic_theme_styles' );
 add_action( 'enqueue_block_assets', 'wp_enqueue_registered_block_scripts_and_styles' );
 add_action( 'enqueue_block_assets', 'enqueue_block_styles_assets', 30 );

--- a/src/wp-includes/script-modules.php
+++ b/src/wp-includes/script-modules.php
@@ -215,3 +215,12 @@ function wp_enqueue_block_editor_script_modules() {
 	 */
 	wp_enqueue_script_module( '@wordpress/latex-to-mathml/loader' );
 }
+
+/**
+ * Enqueues script modules required in the admin.
+ *
+ * @since 7.0.0
+ */
+function wp_enqueue_admin_script_modules() {
+	wp_enqueue_script_module( '@wordpress/core-abilities' );
+}


### PR DESCRIPTION
This PR adds the enqueuing of `@wordpress/core-abilities` script module, enabling the abilities API to be available for dynamic imports.

Backports the PHP changes of https://github.com/WordPress/gutenberg/pull/73428

The abilities API packages (@wordpress/abilities and @wordpress/core-abilities) were added to WordPress core (during the Gutenberg version change) but are not currently available for dynamic imports because they are not enqueued and therefore not included in the import map.

This ticket adds the necessary enqueue so that await import('@wordpress/abilities') works when used by WordPress plugins (and can be tested from the browser console).

In Gutenberg, the @wordpress/core-abilities module is enqueued in via lib/client-assets.php. WordPress core needs the equivalent functionality.

This changes makes sure the abilities are property available to be consumed e.g: from plugins, workflows, browser based assistants and in webmcp as we are experimenting at https://github.com/WordPress/ai/pull/224.

Trac ticket: #64648

## Testing Instructions

1. Load any WordPress admin page
2. Open browser DevTools Console
3. Run: `const abilitiesAPI = (await import( '@wordpress/abilities' ) );`
4.  Run `abilitiesAPI.getAbilities();`. Verify the abilities are returned.
5. Run `await abilitiesAPI.executeAbility('core/get-site-info');`, verify the ability was executed and the information returned.
