### PR TITLE
Interactivity API: populate router's `state.url` in the server

### DIFF
--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -1314,6 +1314,14 @@ HTML;
 		if ( 'enter' === $mode && ! $this->has_processed_router_region ) {
 			$this->has_processed_router_region = true;
 
+			// Initializes the `state.url` property from the server.
+			wp_interactivity_state(
+				'core/router',
+				array(
+					'url' => set_url_scheme( 'http://' . $_SERVER['HTTP_HOST'] . wp_unslash( $_SERVER['REQUEST_URI'] ) ),
+				)
+			);
+
 			// Enqueues as an inline style.
 			wp_register_style( 'wp-interactivity-router-animations', false );
 			wp_add_inline_style( 'wp-interactivity-router-animations', $this->get_router_animation_styles() );

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -1318,7 +1318,7 @@ HTML;
 			wp_interactivity_state(
 				'core/router',
 				array(
-					'url' => set_url_scheme( 'http://' . $_SERVER['HTTP_HOST'] . wp_unslash( $_SERVER['REQUEST_URI'] ) ),
+					'url' => get_self_link(),
 				)
 			);
 

--- a/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
+++ b/src/wp-includes/interactivity-api/class-wp-interactivity-api.php
@@ -1315,7 +1315,7 @@ HTML;
 			$this->has_processed_router_region = true;
 
 			// Initializes the `state.url` property from the server.
-			wp_interactivity_state(
+			$this->state(
 				'core/router',
 				array(
 					'url' => get_self_link(),

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-router-region.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-router-region.php
@@ -77,6 +77,25 @@ class Tests_WP_Interactivity_API_WP_Router_Region extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Processes directives while temporarily replacing the global
+	 * WP_Interactivity_API instance so that global functions like
+	 * `wp_interactivity_state` operate on the test instance.
+	 *
+	 * @param string $html The HTML to process.
+	 * @return string The processed HTML.
+	 */
+	protected function process_directives( string $html ): string {
+		global $wp_interactivity;
+		$prev             = $wp_interactivity;
+		$wp_interactivity = $this->interactivity;
+
+		$result = $this->interactivity->process_directives( $html );
+
+		$wp_interactivity = $prev;
+		return $result;
+	}
+
+	/**
 	 * Tests that no elements are added if the `data-wp-router-region` is
 	 * missing.
 	 *
@@ -125,5 +144,62 @@ class Tests_WP_Interactivity_API_WP_Router_Region extends WP_UnitTestCase {
 		$p      = new WP_HTML_Tag_Processor( $footer );
 		$this->assertTrue( $p->next_tag( $query ) );
 		$this->assertFalse( $p->next_tag( $query ) );
+	}
+
+	/**
+	 * Tests that the `data-wp-router-region` directive initializes the
+	 * `core/router` state URL from the server.
+	 *
+	 * @ticket 64649
+	 *
+	 * @covers ::process_directives
+	 */
+	public function test_wp_router_region_initializes_state_url() {
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['REQUEST_URI'] = '/test-page/?query=1';
+
+		$html = '<div data-wp-router-region="region A">Interactive region</div>';
+		$this->process_directives( $html );
+
+		$state = $this->interactivity->state( 'core/router' );
+		$this->assertSame( 'http://example.com/test-page/?query=1', $state['url'] );
+	}
+
+	/**
+	 * Tests that the `core/router` state URL uses HTTPS when SSL is active.
+	 *
+	 * @ticket 64649
+	 *
+	 * @covers ::process_directives
+	 */
+	public function test_wp_router_region_initializes_state_url_with_https() {
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['REQUEST_URI'] = '/test-page/';
+		$_SERVER['HTTPS']       = 'on';
+
+		$html = '<div data-wp-router-region="region A">Interactive region</div>';
+		$this->process_directives( $html );
+
+		$state = $this->interactivity->state( 'core/router' );
+		$this->assertSame( 'https://example.com/test-page/', $state['url'] );
+	}
+
+	/**
+	 * Tests that the `core/router` state URL is not set when no
+	 * `data-wp-router-region` directive is present.
+	 *
+	 * @ticket 64649
+	 *
+	 * @covers ::process_directives
+	 */
+	public function test_wp_router_region_does_not_set_state_url_without_directive() {
+		$_SERVER['HTTP_HOST']   = 'example.com';
+		$_SERVER['REQUEST_URI'] = '/test-page/';
+
+		$html = '<div>Nothing here</div>';
+		$this->process_directives( $html );
+
+		$state = $this->interactivity->state( 'core/router' );
+		$this->assertEmpty( $state );
 	}
 }

--- a/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-router-region.php
+++ b/tests/phpunit/tests/interactivity-api/wpInteractivityAPI-wp-router-region.php
@@ -155,14 +155,13 @@ class Tests_WP_Interactivity_API_WP_Router_Region extends WP_UnitTestCase {
 	 * @covers ::process_directives
 	 */
 	public function test_wp_router_region_initializes_state_url() {
-		$_SERVER['HTTP_HOST']   = 'example.com';
 		$_SERVER['REQUEST_URI'] = '/test-page/?query=1';
 
 		$html = '<div data-wp-router-region="region A">Interactive region</div>';
 		$this->process_directives( $html );
 
 		$state = $this->interactivity->state( 'core/router' );
-		$this->assertSame( 'http://example.com/test-page/?query=1', $state['url'] );
+		$this->assertSame( home_url( '/test-page/?query=1' ), $state['url'] );
 	}
 
 	/**
@@ -173,15 +172,14 @@ class Tests_WP_Interactivity_API_WP_Router_Region extends WP_UnitTestCase {
 	 * @covers ::process_directives
 	 */
 	public function test_wp_router_region_initializes_state_url_with_https() {
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/test-page/';
+		$_SERVER['REQUEST_URI'] = '/';
 		$_SERVER['HTTPS']       = 'on';
 
 		$html = '<div data-wp-router-region="region A">Interactive region</div>';
 		$this->process_directives( $html );
 
 		$state = $this->interactivity->state( 'core/router' );
-		$this->assertSame( 'https://example.com/test-page/', $state['url'] );
+		$this->assertStringStartsWith( 'https://', $state['url'] );
 	}
 
 	/**
@@ -193,8 +191,7 @@ class Tests_WP_Interactivity_API_WP_Router_Region extends WP_UnitTestCase {
 	 * @covers ::process_directives
 	 */
 	public function test_wp_router_region_does_not_set_state_url_without_directive() {
-		$_SERVER['HTTP_HOST']   = 'example.com';
-		$_SERVER['REQUEST_URI'] = '/test-page/';
+		$_SERVER['REQUEST_URI'] = '/';
 
 		$html = '<div>Nothing here</div>';
 		$this->process_directives( $html );


### PR DESCRIPTION
### What

This PR populates `state.url` in the `core/router` Interactivity API namespace on the server, inside the `data-wp-router-region` directive processor.

Trac ticket: https://core.trac.wordpress.org/ticket/64649

### Why

After Gutenberg PR https://github.com/WordPress/gutenberg/pull/70882, `state.url` in the interactivity router is no longer unconditionally set to `window.location.href` on the client. Instead, it falls back to `window.location.href` only if the server hasn't already provided a value:

```js
state.url = state.url || window.location.href;
```

This PR provides that server-side value by calling `wp_interactivity_state( 'core/router', ... )` during directive processing, following the same URL construction pattern used by `redirect_canonical()` and `get_self_link()`.

### How

- Adds a `wp_interactivity_state( 'core/router', array( 'url' => ... ) )` call inside `data_wp_router_region_processor()` in `WP_Interactivity_API`.
- The URL is constructed using `set_url_scheme()`, `$_SERVER['HTTP_HOST']`, and `$_SERVER['REQUEST_URI']`.

### Testing

1. Create a page with a Query Loop block using enhanced pagination (which uses `data-wp-router-region`).
2. View the page source and verify the interactivity script module data JSON includes `"core/router"` with the `"url"` property matching the current page URL.
3. Verify client-side navigation still works correctly.

### Use of AI tools

Claude Code was used to research the best way to construct the URL and how other internal WordPress functions do it, and assist in creating the tests.


<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
