### PR TITLE
Only fix `.wp-block` width in the editor, without back-compat

### DIFF
--- a/src/wp-content/themes/twentyeleven/editor-blocks.css
+++ b/src/wp-content/themes/twentyeleven/editor-blocks.css
@@ -78,7 +78,13 @@ Description: Used to style blocks in the editor.
 }
 
 .wp-block {
-	max-width: 614px; /* 584px + 30px to account for padding */
+	max-width: 584px;
+}
+
+.editor-post-title__block,
+.editor-default-block-appender,
+.editor-block-list__block {
+	max-width: 614px; /* Account for padding in older WordPress versions. */
 }
 
 /* Link styles */

--- a/src/wp-content/themes/twentyeleven/editor-blocks.css
+++ b/src/wp-content/themes/twentyeleven/editor-blocks.css
@@ -81,12 +81,6 @@ Description: Used to style blocks in the editor.
 	max-width: 584px;
 }
 
-.editor-post-title__block,
-.editor-default-block-appender,
-.editor-block-list__block {
-	max-width: 614px; /* Account for padding in older WordPress versions. */
-}
-
 /* Link styles */
 
 .edit-post-visual-editor a,

--- a/src/wp-content/themes/twentyfifteen/css/editor-blocks.css
+++ b/src/wp-content/themes/twentyfifteen/css/editor-blocks.css
@@ -336,7 +336,13 @@ Description: Used to style blocks in the editor.
 }
 
 .wp-block {
-	max-width: 690px; /* 660px + 30px to account for padding. */
+	max-width: 660px;
+}
+
+.editor-post-title__block,
+.editor-default-block-appender,
+.editor-block-list__block {
+	max-width: 690px; /* Account for padding in older WordPress versions. */
 }
 
 /* Link styles */

--- a/src/wp-content/themes/twentyfifteen/css/editor-blocks.css
+++ b/src/wp-content/themes/twentyfifteen/css/editor-blocks.css
@@ -339,12 +339,6 @@ Description: Used to style blocks in the editor.
 	max-width: 660px;
 }
 
-.editor-post-title__block,
-.editor-default-block-appender,
-.editor-block-list__block {
-	max-width: 690px; /* Account for padding in older WordPress versions. */
-}
-
 /* Link styles */
 
 .edit-post-visual-editor a,

--- a/src/wp-content/themes/twentyfourteen/css/editor-blocks.css
+++ b/src/wp-content/themes/twentyfourteen/css/editor-blocks.css
@@ -75,7 +75,13 @@ Description: Used to style blocks in the editor.
 /* Main column width */
 
 .wp-block {
-	max-width: 504px; /* 474px + 30px to account for padding */
+	max-width: 474px;
+}
+
+.editor-post-title__block,
+.editor-default-block-appender,
+.editor-block-list__block {
+	max-width: 504px; /* Account for padding in older WordPress versions. */
 }
 
 /* Link styles */

--- a/src/wp-content/themes/twentyfourteen/css/editor-blocks.css
+++ b/src/wp-content/themes/twentyfourteen/css/editor-blocks.css
@@ -78,12 +78,6 @@ Description: Used to style blocks in the editor.
 	max-width: 474px;
 }
 
-.editor-post-title__block,
-.editor-default-block-appender,
-.editor-block-list__block {
-	max-width: 504px; /* Account for padding in older WordPress versions. */
-}
-
 /* Link styles */
 
 .edit-post-visual-editor a,

--- a/src/wp-content/themes/twentysixteen/css/editor-blocks.css
+++ b/src/wp-content/themes/twentysixteen/css/editor-blocks.css
@@ -182,7 +182,13 @@ Description: Used to style blocks in the editor.
 }
 
 .wp-block {
-	max-width: 630px; /* 600px + 30px to account for padding. */
+	max-width: 600px;
+}
+
+.editor-post-title__block,
+.editor-default-block-appender,
+.editor-block-list__block {
+	max-width: 630px; /* Account for padding in older WordPress versions. */
 }
 
 /* Link styles */

--- a/src/wp-content/themes/twentysixteen/css/editor-blocks.css
+++ b/src/wp-content/themes/twentysixteen/css/editor-blocks.css
@@ -185,12 +185,6 @@ Description: Used to style blocks in the editor.
 	max-width: 600px;
 }
 
-.editor-post-title__block,
-.editor-default-block-appender,
-.editor-block-list__block {
-	max-width: 630px; /* Account for padding in older WordPress versions. */
-}
-
 /* Link styles */
 
 .edit-post-visual-editor a,

--- a/src/wp-content/themes/twentyten/editor-blocks.css
+++ b/src/wp-content/themes/twentyten/editor-blocks.css
@@ -77,7 +77,13 @@ Description: Used to style blocks in the editor.
 /* Main column width */
 
 .wp-block {
-	max-width: 670px; /* 640px + 30px to account for padding */
+	max-width: 640px;
+}
+
+.editor-post-title__block,
+.editor-default-block-appender,
+.editor-block-list__block {
+	max-width: 670px; /* Account for padding in older WordPress versions. */
 }
 
 /* Link styles */

--- a/src/wp-content/themes/twentyten/editor-blocks.css
+++ b/src/wp-content/themes/twentyten/editor-blocks.css
@@ -80,12 +80,6 @@ Description: Used to style blocks in the editor.
 	max-width: 640px;
 }
 
-.editor-post-title__block,
-.editor-default-block-appender,
-.editor-block-list__block {
-	max-width: 670px; /* Account for padding in older WordPress versions. */
-}
-
 /* Link styles */
 
 .edit-post-visual-editor a,

--- a/src/wp-content/themes/twentythirteen/css/editor-blocks.css
+++ b/src/wp-content/themes/twentythirteen/css/editor-blocks.css
@@ -56,7 +56,13 @@ Description: Used to style blocks in the editor.
 /* Main content width */
 
 .wp-block {
-	max-width: 634px; /* 604px + 30px to account for padding */
+	max-width: 604px;
+}
+
+.editor-post-title__block,
+.editor-default-block-appender,
+.editor-block-list__block {
+	max-width: 634px; /* Account for padding in older WordPress versions. */
 }
 
 .wp-block.alignwide,

--- a/src/wp-content/themes/twentythirteen/css/editor-blocks.css
+++ b/src/wp-content/themes/twentythirteen/css/editor-blocks.css
@@ -59,12 +59,6 @@ Description: Used to style blocks in the editor.
 	max-width: 604px;
 }
 
-.editor-post-title__block,
-.editor-default-block-appender,
-.editor-block-list__block {
-	max-width: 634px; /* Account for padding in older WordPress versions. */
-}
-
 .wp-block.alignwide,
 .wp-block.alignfull {
 	max-width: inherit;

--- a/src/wp-content/themes/twentytwelve/css/editor-blocks.css
+++ b/src/wp-content/themes/twentytwelve/css/editor-blocks.css
@@ -76,7 +76,13 @@ Description: Used to style blocks in the editor.
 /* Main column width */
 
 .wp-block {
-	max-width: 655px; /* 625px + 30px for padding */
+	max-width: 625px;
+}
+
+.editor-post-title__block,
+.editor-default-block-appender,
+.editor-block-list__block {
+	max-width: 655px; /* Account for padding in older WordPress versions. */
 }
 
 /* Link styles */

--- a/src/wp-content/themes/twentytwelve/css/editor-blocks.css
+++ b/src/wp-content/themes/twentytwelve/css/editor-blocks.css
@@ -79,12 +79,6 @@ Description: Used to style blocks in the editor.
 	max-width: 625px;
 }
 
-.editor-post-title__block,
-.editor-default-block-appender,
-.editor-block-list__block {
-	max-width: 655px; /* Account for padding in older WordPress versions. */
-}
-
 /* Link styles */
 
 .edit-post-visual-editor a,


### PR DESCRIPTION
Option 2:
- Corrects the `max-width` value for blocks in the editor for themes Twenty Ten through Twenty Sixteen.
- Lets the width be 30 pixels narrower in the editor if the WordPress version is still before 5.4.

[Trac 63276](https://core.trac.wordpress.org/ticket/63276)

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
