### PR TITLE
Fix PHPStan level 0 issues for Customizer setting subclasses by returning correct types

### DIFF
--- a/src/wp-includes/class-wp-customize-setting.php
+++ b/src/wp-includes/class-wp-customize-setting.php
@@ -708,7 +708,7 @@ class WP_Customize_Setting {
 			 */
 			do_action( "customize_update_{$this->type}", $value, $this );
 
-			return has_action( "customize_update_{$this->type}" );
+			return (bool) has_action( "customize_update_{$this->type}" );
 		}
 	}
 

--- a/src/wp-includes/customize/class-wp-customize-background-image-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-background-image-setting.php
@@ -28,8 +28,10 @@ final class WP_Customize_Background_Image_Setting extends WP_Customize_Setting {
 	 * @since 3.4.0
 	 *
 	 * @param mixed $value The value to update. Not used.
+	 * @return bool Always returns true.
 	 */
 	public function update( $value ) {
 		remove_theme_mod( 'background_image_thumb' );
+		return true;
 	}
 }

--- a/src/wp-includes/customize/class-wp-customize-background-image-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-background-image-setting.php
@@ -26,9 +26,10 @@ final class WP_Customize_Background_Image_Setting extends WP_Customize_Setting {
 
 	/**
 	 * @since 3.4.0
+	 * @since 7.0.0 Return type updated from void to true for compatibility with base class.
 	 *
 	 * @param mixed $value The value to update. Not used.
-	 * @return bool Always returns true.
+	 * @return true Always returns true.
 	 */
 	public function update( $value ) {
 		remove_theme_mod( 'background_image_thumb' );

--- a/src/wp-includes/customize/class-wp-customize-filter-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-filter-setting.php
@@ -24,6 +24,9 @@ class WP_Customize_Filter_Setting extends WP_Customize_Setting {
 	 * @since 3.4.0
 	 *
 	 * @param mixed $value The value to update.
+	 * @return bool Always returns true.
 	 */
-	public function update( $value ) {}
+	public function update( $value ) {
+		return true;
+	}
 }

--- a/src/wp-includes/customize/class-wp-customize-filter-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-filter-setting.php
@@ -22,9 +22,10 @@ class WP_Customize_Filter_Setting extends WP_Customize_Setting {
 	 * Saves the value of the setting, using the related API.
 	 *
 	 * @since 3.4.0
+	 * @since 7.0.0 Return type updated from void to true for compatibility with base class.
 	 *
 	 * @param mixed $value The value to update.
-	 * @return bool Always returns true.
+	 * @return true Always returns true.
 	 */
 	public function update( $value ) {
 		return true;

--- a/src/wp-includes/customize/class-wp-customize-header-image-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-header-image-setting.php
@@ -28,11 +28,12 @@ final class WP_Customize_Header_Image_Setting extends WP_Customize_Setting {
 
 	/**
 	 * @since 3.4.0
+	 * @since 7.0.0 Return type updated from void to true for compatibility with base class.
 	 *
 	 * @global Custom_Image_Header $custom_image_header
 	 *
 	 * @param mixed $value The value to update.
-	 * @return bool Always returns true.
+	 * @return true Always returns true.
 	 */
 	public function update( $value ) {
 		global $custom_image_header;

--- a/src/wp-includes/customize/class-wp-customize-header-image-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-header-image-setting.php
@@ -32,6 +32,7 @@ final class WP_Customize_Header_Image_Setting extends WP_Customize_Setting {
 	 * @global Custom_Image_Header $custom_image_header
 	 *
 	 * @param mixed $value The value to update.
+	 * @return bool Always returns true.
 	 */
 	public function update( $value ) {
 		global $custom_image_header;
@@ -58,5 +59,6 @@ final class WP_Customize_Header_Image_Setting extends WP_Customize_Setting {
 		} else {
 			$custom_image_header->set_header_image( $value );
 		}
+		return true;
 	}
 }

--- a/src/wp-includes/customize/class-wp-customize-nav-menu-item-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menu-item-setting.php
@@ -765,11 +765,11 @@ class WP_Customize_Nav_Menu_Item_Setting extends WP_Customize_Setting {
 	 * @param array|false $value The menu item array to update. If false, then the menu item will be deleted
 	 *                           entirely. See WP_Customize_Nav_Menu_Item_Setting::$default for what the value
 	 *                           should consist of.
-	 * @return null|void
+	 * @return bool Whether updated.
 	 */
 	protected function update( $value ) {
 		if ( $this->is_updated ) {
-			return;
+			return ( 'error' !== $this->update_status );
 		}
 
 		$this->is_updated = true;
@@ -806,19 +806,19 @@ class WP_Customize_Nav_Menu_Item_Setting extends WP_Customize_Setting {
 				if ( ! $nav_menu_setting || ! ( $nav_menu_setting instanceof WP_Customize_Nav_Menu_Setting ) ) {
 					$this->update_status = 'error';
 					$this->update_error  = new WP_Error( 'unexpected_nav_menu_setting' );
-					return;
+					return false;
 				}
 
 				if ( false === $nav_menu_setting->save() ) {
 					$this->update_status = 'error';
 					$this->update_error  = new WP_Error( 'nav_menu_setting_failure' );
-					return;
+					return false;
 				}
 
 				if ( (int) $value['nav_menu_term_id'] !== $nav_menu_setting->previous_term_id ) {
 					$this->update_status = 'error';
 					$this->update_error  = new WP_Error( 'unexpected_previous_term_id' );
-					return;
+					return false;
 				}
 
 				$value['nav_menu_term_id'] = $nav_menu_setting->term_id;
@@ -832,19 +832,19 @@ class WP_Customize_Nav_Menu_Item_Setting extends WP_Customize_Setting {
 				if ( ! $parent_nav_menu_item_setting || ! ( $parent_nav_menu_item_setting instanceof WP_Customize_Nav_Menu_Item_Setting ) ) {
 					$this->update_status = 'error';
 					$this->update_error  = new WP_Error( 'unexpected_nav_menu_item_setting' );
-					return;
+					return false;
 				}
 
 				if ( false === $parent_nav_menu_item_setting->save() ) {
 					$this->update_status = 'error';
 					$this->update_error  = new WP_Error( 'nav_menu_item_setting_failure' );
-					return;
+					return false;
 				}
 
 				if ( (int) $value['menu_item_parent'] !== $parent_nav_menu_item_setting->previous_post_id ) {
 					$this->update_status = 'error';
 					$this->update_error  = new WP_Error( 'unexpected_previous_post_id' );
-					return;
+					return false;
 				}
 
 				$value['menu_item_parent'] = $parent_nav_menu_item_setting->post_id;
@@ -886,6 +886,8 @@ class WP_Customize_Nav_Menu_Item_Setting extends WP_Customize_Setting {
 				}
 			}
 		}
+
+		return ( 'error' !== $this->update_status );
 	}
 
 	/**

--- a/src/wp-includes/customize/class-wp-customize-nav-menu-item-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menu-item-setting.php
@@ -759,6 +759,7 @@ class WP_Customize_Nav_Menu_Item_Setting extends WP_Customize_Setting {
 	 * To delete a menu, the client can send false as the value.
 	 *
 	 * @since 4.3.0
+	 * @since 7.0.0 Return type updated from null|void to bool for compatibility with base class.
 	 *
 	 * @see wp_update_nav_menu_item()
 	 *

--- a/src/wp-includes/customize/class-wp-customize-nav-menu-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menu-setting.php
@@ -466,6 +466,7 @@ class WP_Customize_Nav_Menu_Setting extends WP_Customize_Setting {
 	 * To delete a menu, the client can send false as the value.
 	 *
 	 * @since 4.3.0
+	 * @since 7.0.0 Return type updated from null|void to bool for compatibility with base class.
 	 *
 	 * @see wp_update_nav_menu_object()
 	 *

--- a/src/wp-includes/customize/class-wp-customize-nav-menu-setting.php
+++ b/src/wp-includes/customize/class-wp-customize-nav-menu-setting.php
@@ -478,11 +478,11 @@ class WP_Customize_Nav_Menu_Setting extends WP_Customize_Setting {
 	 *     @type int    $parent      The id of the parent term. Default 0.
 	 *     @type bool   $auto_add    Whether pages will auto_add to this menu. Default false.
 	 * }
-	 * @return null|void
+	 * @return bool Whether updated.
 	 */
 	protected function update( $value ) {
 		if ( $this->is_updated ) {
-			return;
+			return ( 'error' !== $this->update_status );
 		}
 
 		$this->is_updated = true;
@@ -582,6 +582,8 @@ class WP_Customize_Nav_Menu_Setting extends WP_Customize_Setting {
 				$this->_widget_nav_menu_updates[ $nav_menu_widget_setting->id ] = $updated_widget_instance;
 			}
 		}
+
+		return ( 'error' !== $this->update_status );
 	}
 
 	/**


### PR DESCRIPTION
The changes in this PR were cherry-picked (e.g. 2f724070eca10d8503c6453732cbc9131d7da010 and 22370b6a9783ed0bd56c9b1b731617b8b9cedcbf) from https://github.com/WordPress/wordpress-develop/pull/10419 for Core-61175.

This Customizer ensures return type consistency for the update methods for setting classes. In practice, these methods are protected and the return value is never read, so it's just about housekeeping. It keeps the overridden methods compatible with the parent class's method. 

Trac ticket: https://core.trac.wordpress.org/ticket/64238

## Use of AI Tools

n/a

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
