### PR TITLE
Fix PHPStan error with `wp_insert_user()` which causes it to hang

### DIFF
--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2209,6 +2209,10 @@ function wp_insert_user( $userdata ) {
 		$userdata = get_object_vars( $userdata );
 	} elseif ( $userdata instanceof WP_User ) {
 		$userdata = $userdata->to_array();
+	} elseif ( $userdata instanceof Traversable ) {
+		$userdata = iterator_to_array( $userdata );
+	} elseif ( ! ( $userdata instanceof ArrayAccess ) ) {
+		$userdata = (array) $userdata;
 	}
 
 	// Are we updating or creating?
@@ -2244,7 +2248,7 @@ function wp_insert_user( $userdata ) {
 		$user_pass = wp_hash_password( $userdata['user_pass'] );
 	}
 
-	$sanitized_user_login = sanitize_user( $userdata['user_login'], true );
+	$sanitized_user_login = sanitize_user( $userdata['user_login'] ?? '', true );
 
 	/**
 	 * Filters a username after it has been sanitized.
@@ -2560,7 +2564,7 @@ function wp_insert_user( $userdata ) {
 	$meta = apply_filters( 'insert_user_meta', $meta, $user, $update, $userdata );
 
 	$custom_meta = array();
-	if ( array_key_exists( 'meta_input', $userdata ) && is_array( $userdata['meta_input'] ) && ! empty( $userdata['meta_input'] ) ) {
+	if ( ! empty( $userdata['meta_input'] ) && is_array( $userdata['meta_input'] ) ) {
 		$custom_meta = $userdata['meta_input'];
 	}
 

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2598,7 +2598,7 @@ function wp_insert_user( $userdata ) {
 	$meta = apply_filters( 'insert_user_meta', $meta, $user, $update, $userdata );
 
 	$custom_meta = array();
-	if ( ! empty( $userdata['meta_input'] ) && is_array( $userdata['meta_input'] ) ) {
+	if ( array_key_exists( 'meta_input', $userdata ) && is_array( $userdata['meta_input'] ) && ! empty( $userdata['meta_input'] ) ) {
 		$custom_meta = $userdata['meta_input'];
 	}
 

--- a/src/wp-includes/user.php
+++ b/src/wp-includes/user.php
@@ -2211,7 +2211,41 @@ function wp_insert_user( $userdata ) {
 		$userdata = $userdata->to_array();
 	} elseif ( $userdata instanceof Traversable ) {
 		$userdata = iterator_to_array( $userdata );
-	} elseif ( ! ( $userdata instanceof ArrayAccess ) ) {
+	} elseif ( $userdata instanceof ArrayAccess ) {
+		$userdata_obj = $userdata;
+		$userdata     = array();
+		foreach (
+			array(
+				'ID',
+				'user_pass',
+				'user_login',
+				'user_nicename',
+				'user_url',
+				'user_email',
+				'display_name',
+				'nickname',
+				'first_name',
+				'last_name',
+				'description',
+				'rich_editing',
+				'syntax_highlighting',
+				'comment_shortcuts',
+				'admin_color',
+				'use_ssl',
+				'user_registered',
+				'user_activation_key',
+				'spam',
+				'show_admin_bar_front',
+				'role',
+				'locale',
+				'meta_input',
+			) as $key
+		) {
+			if ( isset( $userdata_obj[ $key ] ) ) {
+				$userdata[ $key ] = $userdata_obj[ $key ];
+			}
+		}
+	} else {
 		$userdata = (array) $userdata;
 	}
 

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -982,7 +982,6 @@ class Tests_User extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'WP_User', $user );
 	}
 
-
 	/**
 	 * @ticket 61175
 	 * @covers ::wp_insert_user

--- a/tests/phpunit/tests/user.php
+++ b/tests/phpunit/tests/user.php
@@ -982,6 +982,145 @@ class Tests_User extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'WP_User', $user );
 	}
 
+
+	/**
+	 * @ticket 61175
+	 * @covers ::wp_insert_user
+	 */
+	public function test_wp_insert_user_with_null() {
+		// Note: $this->expectWarning() is deprecated and will be removed in PHPUnit 10.
+		$warnings = array();
+		set_error_handler(
+			static function ( int $errno, string $errstr ) use ( &$warnings ) {
+				$warnings[] = compact( 'errno', 'errstr' );
+				return true;
+			},
+			E_USER_WARNING
+		);
+		$user = wp_insert_user( null );
+		restore_error_handler();
+
+		$this->assertWPError( $user );
+		$this->assertSame( 'empty_user_login', $user->get_error_code() );
+	}
+
+	/**
+	 * @ticket 61175
+	 * @covers ::wp_insert_user
+	 */
+	public function test_wp_insert_user_with_stdclass() {
+		$data    = array(
+			'user_login' => 'new-admin',
+			'user_pass'  => 'better-password',
+		);
+		$user_id = wp_insert_user( (object) $data );
+		$this->assertIsInt( $user_id, 'Expected user to be created.' );
+		$user = new WP_User( $user_id );
+		$this->assertSame( $data['user_login'], $user->user_login );
+	}
+
+	/**
+	 * @ticket 61175
+	 * @covers ::wp_insert_user
+	 */
+	public function test_wp_insert_user_with_wp_user() {
+		$username         = 'new-admin';
+		$user             = new WP_User();
+		$user->user_login = $username;
+		$user->user_pass  = 'better-password';
+
+		$user_id = wp_insert_user( $user );
+		$this->assertIsInt( $user_id, 'Expected user to be created.' );
+		$user = new WP_User( $user_id );
+		$this->assertSame( $username, $user->user_login );
+	}
+
+	/**
+	 * @ticket 61175
+	 * @covers ::wp_insert_user
+	 */
+	public function test_wp_insert_user_with_traversable() {
+		$internal_data = array(
+			'user_login' => 'new-admin',
+			'user_pass'  => 'better-password',
+		);
+
+		$array_access_user = new class( $internal_data ) implements ArrayAccess, IteratorAggregate {
+			private array $data;
+
+			public function __construct( array $data ) {
+				$this->data = $data;
+			}
+
+			public function offsetExists( $offset ): bool {
+				return isset( $this->data[ $offset ] );
+			}
+
+			#[\ReturnTypeWillChange]
+			public function offsetGet( $offset ) {
+				return $this->data[ $offset ];
+			}
+
+			public function offsetSet( $offset, $value ): void {
+				$this->data[ $offset ] = $value;
+			}
+
+			public function offsetUnset( $offset ): void {
+				unset( $this->data[ $offset ] );
+			}
+
+			public function getIterator(): ArrayIterator {
+				return new ArrayIterator( $this->data );
+			}
+		};
+
+		$user_id = wp_insert_user( $array_access_user );
+		$this->assertIsInt( $user_id, 'Expected user to be created.' );
+		$user = new WP_User( $user_id );
+		$this->assertSame( $internal_data['user_login'], $user->user_login );
+	}
+
+	/**
+	 * @ticket 61175
+	 * @covers ::wp_insert_user
+	 */
+	public function test_wp_insert_user_with_only_array_access() {
+		$internal_data = array(
+			'user_login' => 'new-admin',
+			'user_pass'  => 'better-password',
+		);
+
+		$array_access_user = new class( $internal_data ) implements ArrayAccess  {
+			private array $data;
+
+			public function __construct( array $data ) {
+				$this->data = $data;
+			}
+
+			public function offsetExists( $offset ): bool {
+				return isset( $this->data[ $offset ] );
+			}
+
+			#[\ReturnTypeWillChange]
+			public function offsetGet( $offset ) {
+				return $this->data[ $offset ];
+			}
+
+			public function offsetSet( $offset, $value ): void {
+				$this->data[ $offset ] = $value;
+			}
+
+			public function offsetUnset( $offset ): void {
+				unset( $this->data[ $offset ] );
+			}
+		};
+
+		$user_id = wp_insert_user( $array_access_user );
+		$this->assertIsInt( $user_id, 'Expected user to be created.' );
+		$user = new WP_User( $user_id );
+		$this->assertSame( $internal_data['user_login'], $user->user_login );
+	}
+
 	/**
 	 * @ticket 27317
 	 * @dataProvider data_illegal_user_logins


### PR DESCRIPTION
The commits in this PR were cherry-picked from https://github.com/WordPress/wordpress-develop/pull/10419 for Core-61175.

See https://github.com/WordPress/wordpress-develop/pull/10419#issuecomment-3911582777:

> I also got to the bottom of the issue with `wp_insert_user()` causing PHPStan to hang. Or at least, I think I did. The issue is that PHPStan couldn't figure out what `$userdata`'s type was. So in 77d9403...512e368 I've ensured that `$userdata` always is a string, and I went the extra mile to ensure back-compat for passing in unexpected values to that function.

Trac ticket: https://core.trac.wordpress.org/ticket/64238

## Use of AI Tools

n/a

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
