### PR TITLE
Abilities API: Support schema in show_in_abilities for settings

### DIFF
--- a/src/wp-includes/abilities/class-wp-settings-abilities.php
+++ b/src/wp-includes/abilities/class-wp-settings-abilities.php
@@ -137,7 +137,7 @@ class WP_Settings_Abilities {
 	 *
 	 * Creates a JSON Schema that documents each setting group and its settings
 	 * with their types, titles, descriptions, defaults, and any additional
-	 * schema properties from show_in_rest.
+	 * schema properties from show_in_abilities.
 	 *
 	 * @since 7.0.0
 	 *
@@ -161,6 +161,11 @@ class WP_Settings_Abilities {
 				$setting_schema['description'] = $args['description'];
 			} elseif ( ! empty( $args['label'] ) ) {
 				$setting_schema['description'] = $args['label'];
+			}
+
+			// Merge custom schema from show_in_abilities if provided as an array.
+			if ( is_array( $args['show_in_abilities'] ) && ! empty( $args['show_in_abilities']['schema'] ) ) {
+				$setting_schema = array_merge( $setting_schema, $args['show_in_abilities']['schema'] );
 			}
 
 			if ( ! isset( $group_properties[ $group ] ) ) {

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2768,20 +2768,17 @@ function register_initial_settings() {
 	);
 
 	if ( ! is_multisite() ) {
+		$uri_schema = array( 'format' => 'uri' );
 		register_setting(
 			'general',
 			'siteurl',
 			array(
 				'show_in_rest'      => array(
 					'name'   => 'url',
-					'schema' => array(
-						'format' => 'uri',
-					),
+					'schema' => $uri_schema,
 				),
 				'show_in_abilities' => array(
-					'schema' => array(
-						'format' => 'uri',
-					),
+					'schema' => $uri_schema,
 				),
 				'type'              => 'string',
 				'description'       => __( 'Site URL.' ),
@@ -2790,20 +2787,17 @@ function register_initial_settings() {
 	}
 
 	if ( ! is_multisite() ) {
+		$email_schema = array( 'format' => 'email' );
 		register_setting(
 			'general',
 			'admin_email',
 			array(
 				'show_in_rest'      => array(
 					'name'   => 'email',
-					'schema' => array(
-						'format' => 'email',
-					),
+					'schema' => $email_schema,
 				),
 				'show_in_abilities' => array(
-					'schema' => array(
-						'format' => 'email',
-					),
+					'schema' => $email_schema,
 				),
 				'type'              => 'string',
 				'description'       => __( 'This address is used for admin purposes, like new user notification.' ),
@@ -2953,19 +2947,17 @@ function register_initial_settings() {
 		)
 	);
 
+	$open_closed_enum_schema = array( 'enum' => array( 'open', 'closed' ) );
+
 	register_setting(
 		'discussion',
 		'default_ping_status',
 		array(
 			'show_in_rest'      => array(
-				'schema' => array(
-					'enum' => array( 'open', 'closed' ),
-				),
+				'schema' => $open_closed_enum_schema,
 			),
 			'show_in_abilities' => array(
-				'schema' => array(
-					'enum' => array( 'open', 'closed' ),
-				),
+				'schema' => $open_closed_enum_schema,
 			),
 			'type'              => 'string',
 			'description'       => __( 'Allow link notifications from other blogs (pingbacks and trackbacks) on new articles.' ),
@@ -2977,14 +2969,10 @@ function register_initial_settings() {
 		'default_comment_status',
 		array(
 			'show_in_rest'      => array(
-				'schema' => array(
-					'enum' => array( 'open', 'closed' ),
-				),
+				'schema' => $open_closed_enum_schema,
 			),
 			'show_in_abilities' => array(
-				'schema' => array(
-					'enum' => array( 'open', 'closed' ),
-				),
+				'schema' => $open_closed_enum_schema,
 			),
 			'type'              => 'string',
 			'label'             => __( 'Allow comments on new posts' ),

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2778,7 +2778,11 @@ function register_initial_settings() {
 						'format' => 'uri',
 					),
 				),
-				'show_in_abilities' => true,
+				'show_in_abilities' => array(
+					'schema' => array(
+						'format' => 'uri',
+					),
+				),
 				'type'              => 'string',
 				'description'       => __( 'Site URL.' ),
 			)
@@ -2796,7 +2800,11 @@ function register_initial_settings() {
 						'format' => 'email',
 					),
 				),
-				'show_in_abilities' => true,
+				'show_in_abilities' => array(
+					'schema' => array(
+						'format' => 'email',
+					),
+				),
 				'type'              => 'string',
 				'description'       => __( 'This address is used for admin purposes, like new user notification.' ),
 			)
@@ -2954,7 +2962,11 @@ function register_initial_settings() {
 					'enum' => array( 'open', 'closed' ),
 				),
 			),
-			'show_in_abilities' => true,
+			'show_in_abilities' => array(
+				'schema' => array(
+					'enum' => array( 'open', 'closed' ),
+				),
+			),
 			'type'              => 'string',
 			'description'       => __( 'Allow link notifications from other blogs (pingbacks and trackbacks) on new articles.' ),
 		)
@@ -2969,7 +2981,11 @@ function register_initial_settings() {
 					'enum' => array( 'open', 'closed' ),
 				),
 			),
-			'show_in_abilities' => true,
+			'show_in_abilities' => array(
+				'schema' => array(
+					'enum' => array( 'open', 'closed' ),
+				),
+			),
 			'type'              => 'string',
 			'label'             => __( 'Allow comments on new posts' ),
 			'description'       => __( 'Allow people to submit comments on new posts.' ),

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -3010,8 +3010,9 @@ function register_initial_settings() {
  *     @type bool|array $show_in_rest        Whether data associated with this setting should be included in the REST API.
  *                                           When registering complex settings, this argument may optionally be an
  *                                           array with a 'schema' key.
- *     @type bool       $show_in_abilities  Whether this setting should be exposed through the Abilities API.
- *                                           Default false.
+ *     @type bool|array $show_in_abilities  Whether this setting should be exposed through the Abilities API.
+ *                                           When registering complex settings, this argument may optionally be an
+ *                                           array with a 'schema' key. Default false.
  *     @type mixed      $default            Default value when calling `get_option()`.
  * }
  */

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
@@ -353,4 +353,65 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 
 		$this->assertSame( 'Test Site Name', $data['general']['blogname'] );
 	}
+
+	/**
+	 * Tests that settings with enum schema in show_in_abilities include it in output schema.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_get_settings_output_schema_includes_enum(): void {
+		$ability       = wp_get_ability( 'core/get-settings' );
+		$output_schema = $ability->get_output_schema();
+
+		// Check default_ping_status has enum.
+		$this->assertArrayHasKey( 'discussion', $output_schema['properties'] );
+		$this->assertArrayHasKey( 'default_ping_status', $output_schema['properties']['discussion']['properties'] );
+		$this->assertArrayHasKey( 'enum', $output_schema['properties']['discussion']['properties']['default_ping_status'] );
+		$this->assertSame( array( 'open', 'closed' ), $output_schema['properties']['discussion']['properties']['default_ping_status']['enum'] );
+
+		// Check default_comment_status has enum.
+		$this->assertArrayHasKey( 'default_comment_status', $output_schema['properties']['discussion']['properties'] );
+		$this->assertArrayHasKey( 'enum', $output_schema['properties']['discussion']['properties']['default_comment_status'] );
+		$this->assertSame( array( 'open', 'closed' ), $output_schema['properties']['discussion']['properties']['default_comment_status']['enum'] );
+	}
+
+	/**
+	 * Tests that boolean show_in_abilities (true) still works correctly.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_get_settings_boolean_show_in_abilities_still_works(): void {
+		$ability       = wp_get_ability( 'core/get-settings' );
+		$output_schema = $ability->get_output_schema();
+
+		// blogname uses show_in_abilities => true (boolean).
+		$this->assertArrayHasKey( 'general', $output_schema['properties'] );
+		$this->assertArrayHasKey( 'blogname', $output_schema['properties']['general']['properties'] );
+		$this->assertSame( 'string', $output_schema['properties']['general']['properties']['blogname']['type'] );
+	}
+
+	/**
+	 * Tests that custom show_in_abilities schema preserves base schema properties while adding custom ones.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_get_settings_output_schema_preserves_base_schema(): void {
+		$ability       = wp_get_ability( 'core/get-settings' );
+		$output_schema = $ability->get_output_schema();
+
+		// default_comment_status has show_in_abilities with schema but also has label and description.
+		$this->assertArrayHasKey( 'discussion', $output_schema['properties'] );
+		$this->assertArrayHasKey( 'default_comment_status', $output_schema['properties']['discussion']['properties'] );
+
+		$setting_schema = $output_schema['properties']['discussion']['properties']['default_comment_status'];
+
+		// Verify base schema properties are preserved.
+		$this->assertSame( 'string', $setting_schema['type'] );
+		$this->assertArrayHasKey( 'title', $setting_schema );
+		$this->assertArrayHasKey( 'description', $setting_schema );
+
+		// Verify custom schema property (enum) is merged.
+		$this->assertArrayHasKey( 'enum', $setting_schema );
+		$this->assertSame( array( 'open', 'closed' ), $setting_schema['enum'] );
+	}
 }

--- a/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
+++ b/tests/phpunit/tests/rest-api/wpRestAbilitiesSettingsController.php
@@ -414,4 +414,28 @@ class Tests_REST_API_WpRestAbilitiesSettingsController extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'enum', $setting_schema );
 		$this->assertSame( array( 'open', 'closed' ), $setting_schema['enum'] );
 	}
+
+	/**
+	 * Tests that ability returns error when setting value violates schema enum.
+	 *
+	 * @ticket 64605
+	 */
+	public function test_core_get_settings_returns_error_for_invalid_enum_value(): void {
+		// Set an invalid value for default_ping_status (violates enum: ['open', 'closed']).
+		update_option( 'default_ping_status', 'invalid_value' );
+
+		$request = new WP_REST_Request( 'GET', '/wp-abilities/v1/abilities/core/get-settings/run' );
+		$request->set_query_params(
+			array(
+				'input' => array(
+					'slugs' => array( 'default_ping_status' ),
+				),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 500, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertSame( 'ability_invalid_output', $data['code'] );
+	}
 }


### PR DESCRIPTION
Adds support for providing custom schema properties via `show_in_abilities` for settings, similar to how `show_in_rest` works. Following feedback from @justlevine.

Updates 4 settings that had a custom schema to also pass it via`show_in_abilities`:
- `siteurl` - `format: 'uri'`
- `admin_email` - `format: 'email'`
- `default_ping_status` - `enum: ['open', 'closed']`
- `default_comment_status` - `enum: ['open', 'closed']`

## Test plan

- Run `npm run test:php -- --group abilities-api --filter Settings`
- Verify all 16 tests pass