### PR TITLE
Pin Gutenberg plugin to version 22.3.0

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -65,6 +65,7 @@ jobs:
         LOCAL_SCRIPT_DEBUG: [ true, false ]
     with:
       LOCAL_SCRIPT_DEBUG: ${{ matrix.LOCAL_SCRIPT_DEBUG }}
+      gutenberg-version: '22.3.0'
 
   slack-notifications:
     name: Slack Notifications

--- a/.gitignore
+++ b/.gitignore
@@ -87,7 +87,6 @@ wp-tests-config.php
 /src/wp-content/themes/twentynineteen/node_modules
 /src/wp-content/themes/twentytwentyone/node_modules
 /src/wp-content/themes/twentytwenty/node_modules
-/src/wp-content/themes/twentytwentyfive/node_modules
 
 # Operating system specific files
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ wp-tests-config.php
 /src/wp-content/themes/twentynineteen/node_modules
 /src/wp-content/themes/twentytwentyone/node_modules
 /src/wp-content/themes/twentytwenty/node_modules
+/src/wp-content/themes/twentytwentyfive/node_modules
 
 # Operating system specific files
 .DS_Store


### PR DESCRIPTION
This pins the Gutenberg plugin to version 22.3.0 (the last version compatible with WP 6.8) in E2E test workflow.

Trac ticket: Core-64660.

## Use of AI Tools

None
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
