### PR TITLE
Build: Fix Gutenberg copy script missing constants.php and incorrect base URL

### DIFF
--- a/tools/gutenberg/build-gutenberg.js
+++ b/tools/gutenberg/build-gutenberg.js
@@ -145,10 +145,10 @@ async function main() {
 		// On Unix, arguments are passed directly without shell parsing
 		const baseUrlArg =
 			process.platform === 'win32'
-				? '--base-url="includes_url( \'build\' )"'
-				: "--base-url=includes_url( 'build' )";
+				? '--base-url="includes_url( \'build/\' )"'
+				: "--base-url=includes_url( 'build/' )";
 
-		await exec( 'npm', [ 'run', 'build', '--', '--fast', baseUrlArg ], {
+		await exec( 'npm', [ 'run', 'build', '--', '--skip-types', baseUrlArg ], {
 			cwd: gutenbergDir,
 		} );
 

--- a/tools/gutenberg/copy-gutenberg-build.js
+++ b/tools/gutenberg/copy-gutenberg-build.js
@@ -39,7 +39,7 @@ const COPY_CONFIG = {
 	// PHP infrastructure files (to wp-includes/build/)
 	phpInfrastructure: {
 		destination: 'build',
-		files: [ 'routes.php', 'pages.php' ],
+		files: [ 'routes.php', 'pages.php', 'constants.php' ],
 		directories: [ 'pages', 'routes' ],
 	},
 


### PR DESCRIPTION
## Summary

The previous Gutenberg hash upgrade brought a new `@wordpress/build` package to Core but the build scripts in Core were not updated in consequence. It resulted in a broken font library page. This PR fixes it.

- Add `constants.php` to the list of PHP infrastructure files copied from Gutenberg's build output to Core in `copy-gutenberg-build.js`
- Fix the `--base-url` argument in `build-gutenberg.js` to include the trailing slash inside `includes_url('build/')` instead of outside the function call
- Rename `fast` to `skip-types` to get back to sane performance for CI jobs and gutenberg builds. 

Fixes https://core.trac.wordpress.org/ticket/64656.

## Test plan

- Visit the Font Library admin page and confirm it loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)