### PR TITLE
Validate font face and font family settings as JSON strings

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-font-faces-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-font-faces-controller.php
@@ -161,6 +161,15 @@ class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
 	 * @return true|WP_Error True if the settings are valid, otherwise a WP_Error object.
 	 */
 	public function validate_create_font_face_settings( $value, $request ) {
+		// Check whether $value is a string, since it should be stringified JSON in the request.
+		if ( ! is_string( $value ) ) {
+			return new WP_Error(
+				'rest_invalid_param',
+				__( 'font_face_settings parameter must be a valid JSON string.' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		$settings = json_decode( $value, true );
 
 		// Check settings string is valid JSON.

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-font-faces-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-font-faces-controller.php
@@ -161,13 +161,12 @@ class WP_REST_Font_Faces_Controller extends WP_REST_Posts_Controller {
 	 * @return true|WP_Error True if the settings are valid, otherwise a WP_Error object.
 	 */
 	public function validate_create_font_face_settings( $value, $request ) {
-		// Check whether $value is a string, since it should be stringified JSON in the request.
-		if ( ! is_string( $value ) ) {
-			return new WP_Error(
-				'rest_invalid_param',
-				__( 'font_face_settings parameter must be a valid JSON string.' ),
-				array( 'status' => 400 )
-			);
+		// Enforce JSON Schema validity for field before applying custom validation logic.
+		$args     = $this->get_create_params();
+		$validity = rest_validate_value_from_schema( $value, $args['font_face_settings'], 'font_face_settings' );
+
+		if ( is_wp_error( $validity ) ) {
+			return $validity;
 		}
 
 		$settings = json_decode( $value, true );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-font-families-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-font-families-controller.php
@@ -87,14 +87,12 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 	 * @return true|WP_Error True if the settings are valid, otherwise a WP_Error object.
 	 */
 	public function validate_font_family_settings( $value, $request ) {
-		// Check whether $value is a string, since it should be stringified JSON in the request.
-		if ( ! is_string( $value ) ) {
-			return new WP_Error(
-				'rest_invalid_param',
-				/* translators: %s: Parameter name: "font_family_settings". */
-				sprintf( __( '%s parameter must be a valid JSON string.' ), 'font_family_settings' ),
-				array( 'status' => 400 )
-			);
+		// Enforce JSON Schema validity for field before applying custom validation logic.
+		$args     = $this->get_endpoint_args_for_item_schema( $request->get_method() );
+		$validity = rest_validate_value_from_schema( $value, $args['font_family_settings'], 'font_family_settings' );
+
+		if ( is_wp_error( $validity ) ) {
+			return $validity;
 		}
 
 		$settings = json_decode( $value, true );

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-font-families-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-font-families-controller.php
@@ -87,6 +87,16 @@ class WP_REST_Font_Families_Controller extends WP_REST_Posts_Controller {
 	 * @return true|WP_Error True if the settings are valid, otherwise a WP_Error object.
 	 */
 	public function validate_font_family_settings( $value, $request ) {
+		// Check whether $value is a string, since it should be stringified JSON in the request.
+		if ( ! is_string( $value ) ) {
+			return new WP_Error(
+				'rest_invalid_param',
+				/* translators: %s: Parameter name: "font_family_settings". */
+				sprintf( __( '%s parameter must be a valid JSON string.' ), 'font_family_settings' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		$settings = json_decode( $value, true );
 
 		// Check settings string is valid JSON.

--- a/tests/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
+++ b/tests/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
@@ -781,7 +781,7 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400, 'The response should return an error for "rest_invalid_param" with 400 status.' );
-		$expected_message = 'font_face_settings parameter must be a valid JSON string.';
+		$expected_message = 'font_face_settings is not of type string.';
 		$message          = $response->as_error()->get_all_error_data()[0]['params']['font_face_settings'];
 		$this->assertSame( $expected_message, $message, 'The response error message should match.' );
 	}

--- a/tests/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
+++ b/tests/phpunit/tests/fonts/font-library/wpRestFontFacesController.php
@@ -772,6 +772,23 @@ class Tests_REST_WpRestFontFacesController extends WP_Test_REST_Controller_Testc
 	/**
 	 * @covers WP_REST_Font_Faces_Controller::validate_create_font_face_settings
 	 */
+	public function test_create_item_non_string_settings() {
+		wp_set_current_user( self::$admin_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families/' . self::$font_family_id . '/font-faces' );
+		$request->set_param( 'theme_json_version', WP_REST_Font_Faces_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED );
+		$request->set_param( 'font_face_settings', self::$default_settings );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400, 'The response should return an error for "rest_invalid_param" with 400 status.' );
+		$expected_message = 'font_face_settings parameter must be a valid JSON string.';
+		$message          = $response->as_error()->get_all_error_data()[0]['params']['font_face_settings'];
+		$this->assertSame( $expected_message, $message, 'The response error message should match.' );
+	}
+
+	/**
+	 * @covers WP_REST_Font_Faces_Controller::validate_create_font_face_settings
+	 */
 	public function test_create_item_invalid_file_src() {
 		$files = $this->setup_font_file_upload( array( 'woff2' ) );
 

--- a/tests/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
+++ b/tests/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
@@ -629,6 +629,23 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 	}
 
 	/**
+	 * @covers WP_REST_Font_Family_Controller::validate_font_family_settings
+	 */
+	public function test_create_item_non_string_settings() {
+		wp_set_current_user( self::$admin_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families' );
+		$request->set_param( 'theme_json_version', WP_REST_Font_Families_Controller::LATEST_THEME_JSON_VERSION_SUPPORTED );
+		$request->set_param( 'font_family_settings', self::$default_settings );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400, 'The response should return an error for "rest_invalid_param" with 400 status.' );
+		$expected_message = 'font_family_settings parameter must be a valid JSON string.';
+		$message          = $response->as_error()->get_all_error_data()[0]['params']['font_family_settings'];
+		$this->assertSame( $expected_message, $message, 'The response error message should match.' );
+	}
+
+	/**
 	 * @covers WP_REST_Font_Family_Controller::create_item
 	 */
 	public function test_create_item_with_duplicate_slug() {
@@ -825,6 +842,22 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400, 'The response should return an error for "rest_invalid_param" with 400 status.' );
 		$expected_message = 'font_family_settings[slug] cannot be updated.';
+		$message          = $response->as_error()->get_all_error_data()[0]['params']['font_family_settings'];
+		$this->assertSame( $expected_message, $message, 'The response error message should match.' );
+	}
+
+	/**
+	 * @covers WP_REST_Font_Family_Controller::validate_font_family_settings
+	 */
+	public function test_update_item_non_string_settings() {
+		wp_set_current_user( self::$admin_id );
+		$request = new WP_REST_Request( 'POST', '/wp/v2/font-families/' . self::$font_family_id1 );
+		$request->set_param( 'font_family_settings', self::$default_settings );
+
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_invalid_param', $response, 400, 'The response should return an error for "rest_invalid_param" with 400 status.' );
+		$expected_message = 'font_family_settings parameter must be a valid JSON string.';
 		$message          = $response->as_error()->get_all_error_data()[0]['params']['font_family_settings'];
 		$this->assertSame( $expected_message, $message, 'The response error message should match.' );
 	}

--- a/tests/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
+++ b/tests/phpunit/tests/fonts/font-library/wpRestFontFamiliesController.php
@@ -640,7 +640,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400, 'The response should return an error for "rest_invalid_param" with 400 status.' );
-		$expected_message = 'font_family_settings parameter must be a valid JSON string.';
+		$expected_message = 'font_family_settings is not of type string.';
 		$message          = $response->as_error()->get_all_error_data()[0]['params']['font_family_settings'];
 		$this->assertSame( $expected_message, $message, 'The response error message should match.' );
 	}
@@ -857,7 +857,7 @@ class Tests_REST_WpRestFontFamiliesController extends WP_Test_REST_Controller_Te
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_invalid_param', $response, 400, 'The response should return an error for "rest_invalid_param" with 400 status.' );
-		$expected_message = 'font_family_settings parameter must be a valid JSON string.';
+		$expected_message = 'font_family_settings is not of type string.';
 		$message          = $response->as_error()->get_all_error_data()[0]['params']['font_family_settings'];
 		$this->assertSame( $expected_message, $message, 'The response error message should match.' );
 	}


### PR DESCRIPTION
<!--
Hi there! Thanks for contributing to WordPress!

Pull Requests in this GitHub repository **must** be linked to a ticket in the WordPress Core Trac instance (https://core.trac.wordpress.org), and are only used for code review. **No pull requests will be merged on GitHub.**

See the WordPress Handbook page on using PRs for Code Review more information: https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/

If this is your first time contributing, you may also find reviewing these guides first to be helpful:
- FAQs for New Contributors: https://make.wordpress.org/core/handbook/tutorials/faq-for-new-contributors/
- Contributing with Code Guide: https://make.wordpress.org/core/handbook/contribute/
- WordPress Coding Standards: https://make.wordpress.org/core/handbook/best-practices/coding-standards/
- Inline Documentation Standards: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/
- Browser Support Policies: https://make.wordpress.org/core/handbook/best-practices/browser-support/
- Proper spelling and grammar related best practices: https://make.wordpress.org/core/handbook/best-practices/spelling/
- ✨ If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/
-->

* Ensure strict type guards for both settings params before JSON decode and return rest_invalid_param when input is not a string.
* Add/extend REST API unit tests to cover non-string settings payloads and assert 400 error responses.

Trac ticket: https://core.trac.wordpress.org/ticket/64666

## Use of AI Tools
Used Github Copilot for unit test cases which is updated and reviewed by me.

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
