### PR TITLE
Build: Remove all sourceMappingURL comments when copying Gutenberg files

### DIFF
--- a/tools/gutenberg/copy-gutenberg-build.js
+++ b/tools/gutenberg/copy-gutenberg-build.js
@@ -922,7 +922,7 @@ async function main() {
 
 	// Transform function to remove source map comments from all JS files
 	const removeSourceMaps = ( content ) => {
-		return content.replace( /\/\/# sourceMappingURL=.*$/m, '' ).trimEnd();
+		return content.replace( /\/\/# sourceMappingURL=.*$/gm, '' ).trimEnd();
 	};
 
 	if ( fs.existsSync( scriptsSrc ) ) {


### PR DESCRIPTION
## Summary

The `removeSourceMaps` regex in `copy-gutenberg-build.js` was missing the `/g` (global) flag, so it only stripped the **first** `//# sourceMappingURL=` comment per file.

Bundled files such as the `@wordpress/vips` web worker can contain **multiple** `sourceMappingURL` references from concatenated modules (esbuild builds worker bundles with `sourcemap: true`, and when webpack bundles the module entry point it preserves comments from source modules). This causes the `verify:source-maps` build check to fail:

```
Warning: The build/wp-includes/js/dist/script-modules/vips/worker.js file must not contain a sourceMappingURL.
```

Adding the `/g` flag ensures every occurrence is removed, consistent with the existing `replace:source-maps` Grunt task which already uses the global flag.

Fixes the build failure reported in https://github.com/WordPress/wordpress-develop/pull/10968#issuecomment-3920484908.

## Test plan

- [ ] Verify the `verify:source-maps` build check passes with this change when the vips package is included in the Gutenberg build output
- [ ] Confirm existing source map removal still works correctly for all other packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)