### PR TITLE
Add caching for the `/gutenberg` directory

### DIFF
--- a/.github/workflows/reusable-build-package.yml
+++ b/.github/workflows/reusable-build-package.yml
@@ -15,6 +15,8 @@ jobs:
   #
   # Performs the following steps:
   # - Checks out the repository.
+  # - Retrieves the pinned commit hash for the Gutenberg repository.
+  # - Configures caching for the /gutenberg directory.
   # - Sets up Node.js.
   # - Runs the build script.
   # - Prepares the directory structure for the ZIP.

--- a/.github/workflows/reusable-build-package.yml
+++ b/.github/workflows/reusable-build-package.yml
@@ -44,8 +44,8 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: |
-            'gutenberg'
-            '!gutenberg/node_modules'
+            gutenberg
+            !gutenberg/node_modules
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-build-package.yml
+++ b/.github/workflows/reusable-build-package.yml
@@ -37,14 +37,14 @@ jobs:
           persist-credentials: false
 
       - name: Retrieve the pinned Gutenberg SHA value
-        id: gutenberg-pinned-ref
-        run: echo "ref=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+        id: gutenberg-pinned-sha
+        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
 
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: 'gutenberg'
-          key: gutenberg-${{ steps.gutenberg-pinned-ref.outputs.ref }}
+          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/reusable-build-package.yml
+++ b/.github/workflows/reusable-build-package.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Retrieve the pinned Gutenberg SHA value
         id: gutenberg-pinned-sha
-        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> "$GITHUB_OUTPUT"
 
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/reusable-build-package.yml
+++ b/.github/workflows/reusable-build-package.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           path: |
             gutenberg
-            !gutenberg/node_modules/
+            !gutenberg/node_modules/**/
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-build-package.yml
+++ b/.github/workflows/reusable-build-package.yml
@@ -34,6 +34,16 @@ jobs:
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
           persist-credentials: false
 
+      - name: Retrieve the pinned Gutenberg SHA value
+        id: gutenberg-pinned-ref
+        run: echo "ref=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+
+      - name: Configure caching for Gutenberg directory.
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: 'gutenberg'
+          key: gutenberg-${{ steps.gutenberg-pinned-ref.outputs.ref }}
+
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:

--- a/.github/workflows/reusable-build-package.yml
+++ b/.github/workflows/reusable-build-package.yml
@@ -43,9 +43,7 @@ jobs:
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          path: |
-            gutenberg
-            !gutenberg/node_modules/**/
+          path: gutenberg
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js
@@ -72,3 +70,6 @@ jobs:
           name: wordpress-develop
           path: develop.zip
           if-no-files-found: error
+
+      - name: Clean up node_modules directory
+        run: rm -rf gutenberg/node_modules

--- a/.github/workflows/reusable-build-package.yml
+++ b/.github/workflows/reusable-build-package.yml
@@ -70,6 +70,3 @@ jobs:
           name: wordpress-develop
           path: develop.zip
           if-no-files-found: error
-
-      - name: Clean up node_modules directory
-        run: rm -rf gutenberg/node_modules

--- a/.github/workflows/reusable-build-package.yml
+++ b/.github/workflows/reusable-build-package.yml
@@ -43,7 +43,9 @@ jobs:
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          path: 'gutenberg'
+          path: |
+            'gutenberg'
+            '!gutenberg/node_modules'
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-build-package.yml
+++ b/.github/workflows/reusable-build-package.yml
@@ -46,7 +46,7 @@ jobs:
           path: |
             'gutenberg'
             '!gutenberg/node_modules'
-          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
+          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/reusable-build-package.yml
+++ b/.github/workflows/reusable-build-package.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           path: |
             gutenberg
-            !gutenberg/node_modules
+            !gutenberg/node_modules/
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-check-built-files.yml
+++ b/.github/workflows/reusable-check-built-files.yml
@@ -41,6 +41,16 @@ jobs:
         with:
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
+      - name: Retrieve the pinned Gutenberg SHA value
+        id: gutenberg-pinned-ref
+        run: echo "ref=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+
+      - name: Configure caching for Gutenberg directory.
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: 'gutenberg'
+          key: gutenberg-${{ steps.gutenberg-pinned-ref.outputs.ref }}
+
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:

--- a/.github/workflows/reusable-check-built-files.yml
+++ b/.github/workflows/reusable-check-built-files.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           path: |
             gutenberg
-            !gutenberg/node_modules
+            !gutenberg/node_modules/
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-check-built-files.yml
+++ b/.github/workflows/reusable-check-built-files.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Retrieve the pinned Gutenberg SHA value
         id: gutenberg-pinned-sha
-        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> "$GITHUB_OUTPUT"
 
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/reusable-check-built-files.yml
+++ b/.github/workflows/reusable-check-built-files.yml
@@ -51,8 +51,8 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: |
-            'gutenberg'
-            '!gutenberg/node_modules'
+            gutenberg
+            !gutenberg/node_modules
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-check-built-files.yml
+++ b/.github/workflows/reusable-check-built-files.yml
@@ -44,14 +44,14 @@ jobs:
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
       - name: Retrieve the pinned Gutenberg SHA value
-        id: gutenberg-pinned-ref
-        run: echo "ref=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+        id: gutenberg-pinned-sha
+        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
 
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: 'gutenberg'
-          key: gutenberg-${{ steps.gutenberg-pinned-ref.outputs.ref }}
+          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/reusable-check-built-files.yml
+++ b/.github/workflows/reusable-check-built-files.yml
@@ -50,7 +50,9 @@ jobs:
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          path: 'gutenberg'
+          path: |
+            'gutenberg'
+            '!gutenberg/node_modules'
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-check-built-files.yml
+++ b/.github/workflows/reusable-check-built-files.yml
@@ -53,7 +53,7 @@ jobs:
           path: |
             'gutenberg'
             '!gutenberg/node_modules'
-          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
+          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/reusable-check-built-files.yml
+++ b/.github/workflows/reusable-check-built-files.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           path: |
             gutenberg
-            !gutenberg/node_modules/
+            !gutenberg/node_modules/**/
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-check-built-files.yml
+++ b/.github/workflows/reusable-check-built-files.yml
@@ -120,6 +120,3 @@ jobs:
         with:
           name: pr-built-file-changes
           path: changes.diff
-
-      - name: Clean up node_modules directory
-        run: rm -rf gutenberg/node_modules

--- a/.github/workflows/reusable-check-built-files.yml
+++ b/.github/workflows/reusable-check-built-files.yml
@@ -50,9 +50,7 @@ jobs:
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          path: |
-            gutenberg
-            !gutenberg/node_modules/**/
+          path: gutenberg
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js
@@ -122,3 +120,6 @@ jobs:
         with:
           name: pr-built-file-changes
           path: changes.diff
+
+      - name: Clean up node_modules directory
+        run: rm -rf gutenberg/node_modules

--- a/.github/workflows/reusable-check-built-files.yml
+++ b/.github/workflows/reusable-check-built-files.yml
@@ -16,6 +16,8 @@ jobs:
   #
   # Performs the following steps:
   # - Checks out the repository.
+  # - Retrieves the pinned commit hash for the Gutenberg repository.
+  # - Configures caching for the /gutenberg directory.
   # - Sets up Node.js.
   # - Configures caching for Composer.
   # - Installs Composer dependencies.

--- a/.github/workflows/reusable-coding-standards-javascript.yml
+++ b/.github/workflows/reusable-coding-standards-javascript.yml
@@ -42,14 +42,14 @@ jobs:
           persist-credentials: false
 
       - name: Retrieve the pinned Gutenberg SHA value
-        id: gutenberg-pinned-ref
-        run: echo "ref=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+        id: gutenberg-pinned-sha
+        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
 
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: 'gutenberg'
-          key: gutenberg-${{ steps.gutenberg-pinned-ref.outputs.ref }}
+          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/reusable-coding-standards-javascript.yml
+++ b/.github/workflows/reusable-coding-standards-javascript.yml
@@ -48,7 +48,9 @@ jobs:
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          path: 'gutenberg'
+          path: |
+            'gutenberg'
+            '!gutenberg/node_modules'
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-coding-standards-javascript.yml
+++ b/.github/workflows/reusable-coding-standards-javascript.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           path: |
             gutenberg
-            !gutenberg/node_modules
+            !gutenberg/node_modules/
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-coding-standards-javascript.yml
+++ b/.github/workflows/reusable-coding-standards-javascript.yml
@@ -49,8 +49,8 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: |
-            'gutenberg'
-            '!gutenberg/node_modules'
+            gutenberg
+            !gutenberg/node_modules
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-coding-standards-javascript.yml
+++ b/.github/workflows/reusable-coding-standards-javascript.yml
@@ -71,6 +71,3 @@ jobs:
 
       - name: Ensure version-controlled files are not modified or deleted
         run: git diff --exit-code
-
-      - name: Clean up node_modules directory
-        run: rm -rf gutenberg/node_modules

--- a/.github/workflows/reusable-coding-standards-javascript.yml
+++ b/.github/workflows/reusable-coding-standards-javascript.yml
@@ -20,6 +20,8 @@ jobs:
   #
   # Performs the following steps:
   # - Checks out the repository.
+  # - Retrieves the pinned commit hash for the Gutenberg repository.
+  # - Configures caching for the /gutenberg directory.
   # - Sets up Node.js.
   # - Logs debug information about the GitHub Action runner.
   # - Installs npm dependencies.

--- a/.github/workflows/reusable-coding-standards-javascript.yml
+++ b/.github/workflows/reusable-coding-standards-javascript.yml
@@ -51,7 +51,7 @@ jobs:
           path: |
             'gutenberg'
             '!gutenberg/node_modules'
-          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
+          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/reusable-coding-standards-javascript.yml
+++ b/.github/workflows/reusable-coding-standards-javascript.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Retrieve the pinned Gutenberg SHA value
         id: gutenberg-pinned-sha
-        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> "$GITHUB_OUTPUT"
 
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/reusable-coding-standards-javascript.yml
+++ b/.github/workflows/reusable-coding-standards-javascript.yml
@@ -48,9 +48,7 @@ jobs:
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          path: |
-            gutenberg
-            !gutenberg/node_modules/**/
+          path: gutenberg
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js
@@ -73,3 +71,6 @@ jobs:
 
       - name: Ensure version-controlled files are not modified or deleted
         run: git diff --exit-code
+
+      - name: Clean up node_modules directory
+        run: rm -rf gutenberg/node_modules

--- a/.github/workflows/reusable-coding-standards-javascript.yml
+++ b/.github/workflows/reusable-coding-standards-javascript.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           path: |
             gutenberg
-            !gutenberg/node_modules/
+            !gutenberg/node_modules/**/
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-coding-standards-javascript.yml
+++ b/.github/workflows/reusable-coding-standards-javascript.yml
@@ -39,6 +39,16 @@ jobs:
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
           persist-credentials: false
 
+      - name: Retrieve the pinned Gutenberg SHA value
+        id: gutenberg-pinned-ref
+        run: echo "ref=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+
+      - name: Configure caching for Gutenberg directory.
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: 'gutenberg'
+          key: gutenberg-${{ steps.gutenberg-pinned-ref.outputs.ref }}
+
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:

--- a/.github/workflows/reusable-end-to-end-tests.yml
+++ b/.github/workflows/reusable-end-to-end-tests.yml
@@ -91,8 +91,8 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: |
-            'gutenberg'
-            '!gutenberg/node_modules'
+            gutenberg
+            !gutenberg/node_modules
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-end-to-end-tests.yml
+++ b/.github/workflows/reusable-end-to-end-tests.yml
@@ -84,14 +84,14 @@ jobs:
           persist-credentials: false
 
       - name: Retrieve the pinned Gutenberg SHA value
-        id: gutenberg-pinned-ref
-        run: echo "ref=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+        id: gutenberg-pinned-sha
+        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
 
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: 'gutenberg'
-          key: gutenberg-${{ steps.gutenberg-pinned-ref.outputs.ref }}
+          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/reusable-end-to-end-tests.yml
+++ b/.github/workflows/reusable-end-to-end-tests.yml
@@ -90,7 +90,9 @@ jobs:
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          path: 'gutenberg'
+          path: |
+            'gutenberg'
+            '!gutenberg/node_modules'
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-end-to-end-tests.yml
+++ b/.github/workflows/reusable-end-to-end-tests.yml
@@ -93,7 +93,7 @@ jobs:
           path: |
             'gutenberg'
             '!gutenberg/node_modules'
-          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
+          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/reusable-end-to-end-tests.yml
+++ b/.github/workflows/reusable-end-to-end-tests.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Retrieve the pinned Gutenberg SHA value
         id: gutenberg-pinned-sha
-        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> "$GITHUB_OUTPUT"
 
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/reusable-end-to-end-tests.yml
+++ b/.github/workflows/reusable-end-to-end-tests.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           path: |
             gutenberg
-            !gutenberg/node_modules/
+            !gutenberg/node_modules/**/
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-end-to-end-tests.yml
+++ b/.github/workflows/reusable-end-to-end-tests.yml
@@ -81,6 +81,16 @@ jobs:
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
           persist-credentials: false
 
+      - name: Retrieve the pinned Gutenberg SHA value
+        id: gutenberg-pinned-ref
+        run: echo "ref=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+
+      - name: Configure caching for Gutenberg directory.
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: 'gutenberg'
+          key: gutenberg-${{ steps.gutenberg-pinned-ref.outputs.ref }}
+
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:

--- a/.github/workflows/reusable-end-to-end-tests.yml
+++ b/.github/workflows/reusable-end-to-end-tests.yml
@@ -167,6 +167,3 @@ jobs:
 
       - name: Ensure version-controlled files are not modified or deleted
         run: git diff --exit-code
-
-      - name: Clean up node_modules directory
-        run: rm -rf gutenberg/node_modules

--- a/.github/workflows/reusable-end-to-end-tests.yml
+++ b/.github/workflows/reusable-end-to-end-tests.yml
@@ -90,9 +90,7 @@ jobs:
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          path: |
-            gutenberg
-            !gutenberg/node_modules/**/
+          path: gutenberg
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js
@@ -169,3 +167,6 @@ jobs:
 
       - name: Ensure version-controlled files are not modified or deleted
         run: git diff --exit-code
+
+      - name: Clean up node_modules directory
+        run: rm -rf gutenberg/node_modules

--- a/.github/workflows/reusable-end-to-end-tests.yml
+++ b/.github/workflows/reusable-end-to-end-tests.yml
@@ -48,6 +48,8 @@ jobs:
   # Performs the following steps:
   # - Sets environment variables.
   # - Checks out the repository.
+  # - Retrieves the pinned commit hash for the Gutenberg repository.
+  # - Configures caching for the /gutenberg directory.
   # - Sets up Node.js.
   # - Logs debug information about the GitHub Action runner.
   # - Installs npm dependencies.

--- a/.github/workflows/reusable-end-to-end-tests.yml
+++ b/.github/workflows/reusable-end-to-end-tests.yml
@@ -92,7 +92,7 @@ jobs:
         with:
           path: |
             gutenberg
-            !gutenberg/node_modules
+            !gutenberg/node_modules/
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-javascript-tests.yml
+++ b/.github/workflows/reusable-javascript-tests.yml
@@ -21,6 +21,8 @@ jobs:
   #
   # Performs the following steps:
   # - Checks out the repository.
+  # - Retrieves the pinned commit hash for the Gutenberg repository.
+  # - Configures caching for the /gutenberg directory.
   # - Sets up Node.js.
   # - Logs debug information about the GitHub Action runner.
   # - Installs npm dependencies.

--- a/.github/workflows/reusable-javascript-tests.yml
+++ b/.github/workflows/reusable-javascript-tests.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Retrieve the pinned Gutenberg SHA value
         id: gutenberg-pinned-sha
-        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> "$GITHUB_OUTPUT"
 
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/reusable-javascript-tests.yml
+++ b/.github/workflows/reusable-javascript-tests.yml
@@ -43,14 +43,14 @@ jobs:
           persist-credentials: false
 
       - name: Retrieve the pinned Gutenberg SHA value
-        id: gutenberg-pinned-ref
-        run: echo "ref=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+        id: gutenberg-pinned-sha
+        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
 
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: 'gutenberg'
-          key: gutenberg-${{ steps.gutenberg-pinned-ref.outputs.ref }}
+          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/reusable-javascript-tests.yml
+++ b/.github/workflows/reusable-javascript-tests.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           path: |
             gutenberg
-            !gutenberg/node_modules/
+            !gutenberg/node_modules/**/
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-javascript-tests.yml
+++ b/.github/workflows/reusable-javascript-tests.yml
@@ -81,6 +81,3 @@ jobs:
 
       - name: Ensure version-controlled files are not modified or deleted
         run: git diff --exit-code
-
-      - name: Clean up node_modules directory
-        run: rm -rf gutenberg/node_modules

--- a/.github/workflows/reusable-javascript-tests.yml
+++ b/.github/workflows/reusable-javascript-tests.yml
@@ -40,6 +40,16 @@ jobs:
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
           persist-credentials: false
 
+      - name: Retrieve the pinned Gutenberg SHA value
+        id: gutenberg-pinned-ref
+        run: echo "ref=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+
+      - name: Configure caching for Gutenberg directory.
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: 'gutenberg'
+          key: gutenberg-${{ steps.gutenberg-pinned-ref.outputs.ref }}
+
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:

--- a/.github/workflows/reusable-javascript-tests.yml
+++ b/.github/workflows/reusable-javascript-tests.yml
@@ -49,7 +49,9 @@ jobs:
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          path: 'gutenberg'
+          path: |
+            'gutenberg'
+            '!gutenberg/node_modules'
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-javascript-tests.yml
+++ b/.github/workflows/reusable-javascript-tests.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           path: |
             gutenberg
-            !gutenberg/node_modules
+            !gutenberg/node_modules/
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-javascript-tests.yml
+++ b/.github/workflows/reusable-javascript-tests.yml
@@ -52,7 +52,7 @@ jobs:
           path: |
             'gutenberg'
             '!gutenberg/node_modules'
-          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
+          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/reusable-javascript-tests.yml
+++ b/.github/workflows/reusable-javascript-tests.yml
@@ -49,9 +49,7 @@ jobs:
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          path: |
-            gutenberg
-            !gutenberg/node_modules/**/
+          path: gutenberg
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js
@@ -83,3 +81,6 @@ jobs:
 
       - name: Ensure version-controlled files are not modified or deleted
         run: git diff --exit-code
+
+      - name: Clean up node_modules directory
+        run: rm -rf gutenberg/node_modules

--- a/.github/workflows/reusable-javascript-tests.yml
+++ b/.github/workflows/reusable-javascript-tests.yml
@@ -50,8 +50,8 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: |
-            'gutenberg'
-            '!gutenberg/node_modules'
+            gutenberg
+            !gutenberg/node_modules
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -132,7 +132,7 @@ jobs:
         with:
           path: |
             gutenberg
-            !gutenberg/node_modules/
+            !gutenberg/node_modules/**/
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -133,7 +133,7 @@ jobs:
           path: |
             'gutenberg'
             '!gutenberg/node_modules'
-          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
+          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -77,7 +77,9 @@ jobs:
   # Performs the following steps:
   # - Configure environment variables.
   # - Checkout repository.
-  # - Set up Node.js.
+  # - Retrieves the pinned commit hash for the Gutenberg repository.
+  # - Configures caching for the /gutenberg directory.
+  # - Sets up Node.js.
   # - Log debug information.
   # - Install npm dependencies.
   # - Install Playwright browsers.

--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -130,9 +130,7 @@ jobs:
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          path: |
-            gutenberg
-            !gutenberg/node_modules/**/
+          path: gutenberg
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js
@@ -282,3 +280,6 @@ jobs:
 
       - name: Ensure version-controlled files are not modified or deleted
         run: git diff --exit-code
+
+      - name: Clean up node_modules directory
+        run: rm -rf gutenberg/node_modules

--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -132,7 +132,7 @@ jobs:
         with:
           path: |
             gutenberg
-            !gutenberg/node_modules
+            !gutenberg/node_modules/
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -131,8 +131,8 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: |
-            'gutenberg'
-            '!gutenberg/node_modules'
+            gutenberg
+            !gutenberg/node_modules
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -124,14 +124,14 @@ jobs:
           persist-credentials: false
 
       - name: Retrieve the pinned Gutenberg SHA value
-        id: gutenberg-pinned-ref
-        run: echo "ref=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+        id: gutenberg-pinned-sha
+        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
 
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: 'gutenberg'
-          key: gutenberg-${{ steps.gutenberg-pinned-ref.outputs.ref }}
+          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -130,7 +130,9 @@ jobs:
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          path: 'gutenberg'
+          path: |
+            'gutenberg'
+            '!gutenberg/node_modules'
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -121,6 +121,16 @@ jobs:
           fetch-depth: ${{ github.event_name == 'workflow_dispatch' && '2' || '1' }}
           persist-credentials: false
 
+      - name: Retrieve the pinned Gutenberg SHA value
+        id: gutenberg-pinned-ref
+        run: echo "ref=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+
+      - name: Configure caching for Gutenberg directory.
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: 'gutenberg'
+          key: gutenberg-${{ steps.gutenberg-pinned-ref.outputs.ref }}
+
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:

--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Retrieve the pinned Gutenberg SHA value
         id: gutenberg-pinned-sha
-        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> "$GITHUB_OUTPUT"
 
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/reusable-performance-test-v2.yml
+++ b/.github/workflows/reusable-performance-test-v2.yml
@@ -280,6 +280,3 @@ jobs:
 
       - name: Ensure version-controlled files are not modified or deleted
         run: git diff --exit-code
-
-      - name: Clean up node_modules directory
-        run: rm -rf gutenberg/node_modules

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -139,14 +139,14 @@ jobs:
           persist-credentials: false
 
       - name: Retrieve the pinned Gutenberg SHA value
-        id: gutenberg-pinned-ref
-        run: echo "ref=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+        id: gutenberg-pinned-sha
+        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
 
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: 'gutenberg'
-          key: gutenberg-${{ steps.gutenberg-pinned-ref.outputs.ref }}
+          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -148,7 +148,7 @@ jobs:
           path: |
             'gutenberg'
             '!gutenberg/node_modules'
-          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
+          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -136,6 +136,16 @@ jobs:
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
           persist-credentials: false
 
+      - name: Retrieve the pinned Gutenberg SHA value
+        id: gutenberg-pinned-ref
+        run: echo "ref=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+
+      - name: Configure caching for Gutenberg directory.
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: 'gutenberg'
+          key: gutenberg-${{ steps.gutenberg-pinned-ref.outputs.ref }}
+
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -145,7 +145,9 @@ jobs:
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          path: 'gutenberg'
+          path: |
+            'gutenberg'
+            '!gutenberg/node_modules'
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -281,6 +281,3 @@ jobs:
         env:
           WPT_REPORT_API_KEY: "${{ secrets.WPT_REPORT_API_KEY }}"
         run: docker compose run --rm -e WPT_REPORT_API_KEY -e WPT_PREPARE_DIR=/var/www -e WPT_TEST_DIR=/var/www php php test-runner/report.php
-
-      - name: Clean up node_modules directory
-        run: rm -rf gutenberg/node_modules

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -147,7 +147,7 @@ jobs:
         with:
           path: |
             gutenberg
-            !gutenberg/node_modules/
+            !gutenberg/node_modules/**/
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -147,7 +147,7 @@ jobs:
         with:
           path: |
             gutenberg
-            !gutenberg/node_modules
+            !gutenberg/node_modules/
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -145,9 +145,7 @@ jobs:
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          path: |
-            gutenberg
-            !gutenberg/node_modules/**/
+          path: gutenberg
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js
@@ -283,3 +281,6 @@ jobs:
         env:
           WPT_REPORT_API_KEY: "${{ secrets.WPT_REPORT_API_KEY }}"
         run: docker compose run --rm -e WPT_REPORT_API_KEY -e WPT_PREPARE_DIR=/var/www -e WPT_TEST_DIR=/var/www php php test-runner/report.php
+
+      - name: Clean up node_modules directory
+        run: rm -rf gutenberg/node_modules

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -146,8 +146,8 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: |
-            'gutenberg'
-            '!gutenberg/node_modules'
+            gutenberg
+            !gutenberg/node_modules
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -101,6 +101,8 @@ jobs:
   # Performs the following steps:
   # - Sets environment variables.
   # - Checks out the repository.
+  # - Retrieves the pinned commit hash for the Gutenberg repository.
+  # - Configures caching for the /gutenberg directory.
   # - Sets up Node.js.
   # - Sets up PHP.
   # - Installs Composer dependencies.

--- a/.github/workflows/reusable-phpunit-tests-v3.yml
+++ b/.github/workflows/reusable-phpunit-tests-v3.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Retrieve the pinned Gutenberg SHA value
         id: gutenberg-pinned-sha
-        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> "$GITHUB_OUTPUT"
 
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/reusable-test-core-build-process.yml
+++ b/.github/workflows/reusable-test-core-build-process.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           path: |
             gutenberg
-            !gutenberg/node_modules/
+            !gutenberg/node_modules/**/
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       # This date is used to ensure that the PHPCS cache is cleared at least once every week.

--- a/.github/workflows/reusable-test-core-build-process.yml
+++ b/.github/workflows/reusable-test-core-build-process.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Retrieve the pinned Gutenberg SHA value
         id: gutenberg-pinned-sha
-        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> "$GITHUB_OUTPUT"
 
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/reusable-test-core-build-process.yml
+++ b/.github/workflows/reusable-test-core-build-process.yml
@@ -168,6 +168,3 @@ jobs:
         with:
           name: pr-number
           path: pr-number/
-
-      - name: Clean up node_modules directory
-        run: rm -rf gutenberg/node_modules

--- a/.github/workflows/reusable-test-core-build-process.yml
+++ b/.github/workflows/reusable-test-core-build-process.yml
@@ -84,9 +84,7 @@ jobs:
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          path: |
-            gutenberg
-            !gutenberg/node_modules/**/
+          path: gutenberg
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       # This date is used to ensure that the PHPCS cache is cleared at least once every week.
@@ -170,3 +168,6 @@ jobs:
         with:
           name: pr-number
           path: pr-number/
+
+      - name: Clean up node_modules directory
+        run: rm -rf gutenberg/node_modules

--- a/.github/workflows/reusable-test-core-build-process.yml
+++ b/.github/workflows/reusable-test-core-build-process.yml
@@ -75,6 +75,16 @@ jobs:
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
           persist-credentials: false
 
+      - name: Retrieve the pinned Gutenberg SHA value
+        id: gutenberg-pinned-ref
+        run: echo "ref=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+
+      - name: Configure caching for Gutenberg directory.
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: 'gutenberg'
+          key: gutenberg-${{ steps.gutenberg-pinned-ref.outputs.ref }}
+
       # This date is used to ensure that the PHPCS cache is cleared at least once every week.
       # http://man7.org/linux/man-pages/man1/date.1.html
       - name: "Get last Monday's date"

--- a/.github/workflows/reusable-test-core-build-process.yml
+++ b/.github/workflows/reusable-test-core-build-process.yml
@@ -87,7 +87,7 @@ jobs:
           path: |
             'gutenberg'
             '!gutenberg/node_modules'
-          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
+          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       # This date is used to ensure that the PHPCS cache is cleared at least once every week.
       # http://man7.org/linux/man-pages/man1/date.1.html

--- a/.github/workflows/reusable-test-core-build-process.yml
+++ b/.github/workflows/reusable-test-core-build-process.yml
@@ -78,14 +78,14 @@ jobs:
           persist-credentials: false
 
       - name: Retrieve the pinned Gutenberg SHA value
-        id: gutenberg-pinned-ref
-        run: echo "ref=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+        id: gutenberg-pinned-sha
+        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
 
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: 'gutenberg'
-          key: gutenberg-${{ steps.gutenberg-pinned-ref.outputs.ref }}
+          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
 
       # This date is used to ensure that the PHPCS cache is cleared at least once every week.
       # http://man7.org/linux/man-pages/man1/date.1.html

--- a/.github/workflows/reusable-test-core-build-process.yml
+++ b/.github/workflows/reusable-test-core-build-process.yml
@@ -50,6 +50,8 @@ jobs:
   #
   # Performs the following steps:
   # - Checks out the repository.
+  # - Retrieves the pinned commit hash for the Gutenberg repository.
+  # - Configures caching for the /gutenberg directory.
   # - Sets up Node.js.
   # - Logs debug information about the GitHub Action runner.
   # - Installs npm dependencies.

--- a/.github/workflows/reusable-test-core-build-process.yml
+++ b/.github/workflows/reusable-test-core-build-process.yml
@@ -85,8 +85,8 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: |
-            'gutenberg'
-            '!gutenberg/node_modules'
+            gutenberg
+            !gutenberg/node_modules
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       # This date is used to ensure that the PHPCS cache is cleared at least once every week.

--- a/.github/workflows/reusable-test-core-build-process.yml
+++ b/.github/workflows/reusable-test-core-build-process.yml
@@ -84,7 +84,9 @@ jobs:
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          path: 'gutenberg'
+          path: |
+            'gutenberg'
+            '!gutenberg/node_modules'
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
 
       # This date is used to ensure that the PHPCS cache is cleared at least once every week.

--- a/.github/workflows/reusable-test-core-build-process.yml
+++ b/.github/workflows/reusable-test-core-build-process.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           path: |
             gutenberg
-            !gutenberg/node_modules
+            !gutenberg/node_modules/
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       # This date is used to ensure that the PHPCS cache is cleared at least once every week.

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -91,6 +91,16 @@ jobs:
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
           persist-credentials: false
 
+      - name: Retrieve the pinned Gutenberg SHA value
+        id: gutenberg-pinned-ref
+        run: echo "ref=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+
+      - name: Configure caching for Gutenberg directory.
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: 'gutenberg'
+          key: gutenberg-${{ steps.gutenberg-pinned-ref.outputs.ref }}
+
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -100,9 +100,7 @@ jobs:
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          path: |
-            gutenberg
-            !gutenberg/node_modules/**/
+          path: gutenberg
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js
@@ -182,3 +180,6 @@ jobs:
 
       - name: Ensure version-controlled files are not modified or deleted
         run: git diff --exit-code
+
+      - name: Clean up node_modules directory
+        run: rm -rf gutenberg/node_modules

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Retrieve the pinned Gutenberg SHA value
         id: gutenberg-pinned-sha
-        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> "$GITHUB_OUTPUT"
 
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -57,6 +57,8 @@ jobs:
   # Performs the following steps:
   # - Sets environment variables.
   # - Checks out the repository.
+  # - Retrieves the pinned commit hash for the Gutenberg repository.
+  # - Configures caching for the /gutenberg directory.
   # - Sets up Node.js.
   # - Sets up PHP.
   # - Installs Composer dependencies.

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -103,7 +103,7 @@ jobs:
           path: |
             'gutenberg'
             '!gutenberg/node_modules'
-          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
+          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -100,7 +100,9 @@ jobs:
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          path: 'gutenberg'
+          path: |
+            'gutenberg'
+            '!gutenberg/node_modules'
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -180,6 +180,3 @@ jobs:
 
       - name: Ensure version-controlled files are not modified or deleted
         run: git diff --exit-code
-
-      - name: Clean up node_modules directory
-        run: rm -rf gutenberg/node_modules

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -101,8 +101,8 @@ jobs:
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: |
-            'gutenberg'
-            '!gutenberg/node_modules'
+            gutenberg
+            !gutenberg/node_modules
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -94,14 +94,14 @@ jobs:
           persist-credentials: false
 
       - name: Retrieve the pinned Gutenberg SHA value
-        id: gutenberg-pinned-ref
-        run: echo "ref=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
+        id: gutenberg-pinned-sha
+        run: echo "sha=$(jq -r '.gutenberg.ref' package.json)" >> $GITHUB_OUTPUT
 
       - name: Configure caching for Gutenberg directory.
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: 'gutenberg'
-          key: gutenberg-${{ steps.gutenberg-pinned-ref.outputs.ref }}
+          key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha}}
 
       - name: Set up Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -102,7 +102,7 @@ jobs:
         with:
           path: |
             gutenberg
-            !gutenberg/node_modules
+            !gutenberg/node_modules/
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js

--- a/.github/workflows/reusable-test-local-docker-environment-v1.yml
+++ b/.github/workflows/reusable-test-local-docker-environment-v1.yml
@@ -102,7 +102,7 @@ jobs:
         with:
           path: |
             gutenberg
-            !gutenberg/node_modules/
+            !gutenberg/node_modules/**/
           key: gutenberg-${{ steps.gutenberg-pinned-sha.outputs.sha }}-${{ hashFiles( 'tools/gutenberg/*', 'package*.json', 'Gruntfile.js' ) }}
 
       - name: Set up Node.js


### PR DESCRIPTION
This adds caching for the `/gutenberg` directory in GitHub Actions workflows in an attempt to avoid every single job from performing a full checkout, install, and build of the Gutenberg plugin at the pinned SHA reference.

Trac ticket: Core-64393.

## Use of AI Tools

Used Claude code for the `jq` one liner.

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**
