### PR TITLE
REST API: Preserve parent when generating unique slug for draft child…

### DIFF
--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php
@@ -963,7 +963,11 @@ class WP_REST_Posts_Controller extends WP_REST_Controller {
 		 * To ensure that a unique slug is generated, pass the post data with the 'publish' status.
 		 */
 		if ( ! empty( $post->post_name ) && in_array( $post_status, array( 'draft', 'pending' ), true ) ) {
-			$post_parent     = ! empty( $post->post_parent ) ? $post->post_parent : 0;
+			if ( ! empty( $post->post_parent ) ) {
+				$post_parent = (int) $post->post_parent;
+			} else {
+				$post_parent = ! empty( $post_before->post_parent ) ? (int) $post_before->post_parent : 0;
+			}
 			$post->post_name = wp_unique_post_slug(
 				$post->post_name,
 				$post->ID,


### PR DESCRIPTION
Fixes #64670

When updating a draft hierarchical post via the REST API, post_parent is often
omitted from the request. This caused wp_unique_post_slug() to be called with a
parent ID of 0, resulting in false slug conflicts.

This change falls back to the existing post_parent from $post_before when no
parent is provided, aligning block editor behavior with Quick Edit.