### PR TITLE
Build: Invoke Gutenberg build script directly to fix base-url argument passing

### DIFF
--- a/.github/workflows/reusable-test-core-build-process.yml
+++ b/.github/workflows/reusable-test-core-build-process.yml
@@ -122,6 +122,15 @@ jobs:
       - name: Ensure version-controlled files are not modified or deleted during building
         run: git diff --exit-code
 
+      - name: Verify Gutenberg constants.php
+        if: ${{ inputs.directory == 'build' }}
+        run: |
+          echo "--- Gutenberg build output ---"
+          cat gutenberg/build/constants.php 2>/dev/null || echo "File not found in gutenberg/build/"
+          echo ""
+          echo "--- WordPress wp-includes/build/constants.php ---"
+          cat ${{ inputs.directory }}/wp-includes/build/constants.php 2>/dev/null || echo "File not found in ${{ inputs.directory }}/wp-includes/build/"
+
       - name: Create ZIP of built files
         if: ${{ inputs.directory == 'build' && contains( inputs.os, 'ubuntu-' ) }}
         run: zip -r wordpress.zip build/.

--- a/tools/gutenberg/build-gutenberg.js
+++ b/tools/gutenberg/build-gutenberg.js
@@ -141,14 +141,11 @@ async function main() {
 	const startTime = Date.now();
 
 	try {
-		// On Windows, shell mode is used and needs the argument wrapped in quotes
-		// On Unix, arguments are passed directly without shell parsing
-		const baseUrlArg =
-			process.platform === 'win32'
-				? '--base-url="includes_url( \'build/\' )"'
-				: "--base-url=includes_url( 'build/' )";
-
-		await exec( 'npm', [ 'run', 'build', '--', '--skip-types', baseUrlArg ], {
+		await exec( 'node', [
+			'bin/build.mjs',
+			'--skip-types',
+			"--base-url=includes_url( 'build/' )",
+		], {
 			cwd: gutenbergDir,
 		} );
 

--- a/tools/gutenberg/build-gutenberg.js
+++ b/tools/gutenberg/build-gutenberg.js
@@ -141,12 +141,22 @@ async function main() {
 	const startTime = Date.now();
 
 	try {
+		// Invoke the build script directly with node instead of going through
+		// `npm run build --` to avoid shell argument mangling of the base-url
+		// value (which contains spaces, parentheses, and single quotes).
+		// The PATH is extended with node_modules/.bin so that bin commands
+		// like `wp-build` are found, matching what npm would normally provide.
+		const binPath = path.join( gutenbergDir, 'node_modules', '.bin' );
 		await exec( 'node', [
 			'bin/build.mjs',
 			'--skip-types',
 			"--base-url=includes_url( 'build/' )",
 		], {
 			cwd: gutenbergDir,
+			env: {
+				...process.env,
+				PATH: binPath + path.delimiter + process.env.PATH,
+			},
 		} );
 
 		const duration = Math.round( ( Date.now() - startTime ) / 1000 );


### PR DESCRIPTION
Invoke `node bin/build.mjs` directly instead of going through `npm run build --`, which forwards arguments through a shell layer that can mangle the `--base-url` value (containing spaces, parentheses, and single quotes) on some platforms. This may have caused the generated `constants.php` to be missing the trailing slash in the `build_url` on certain Linux machines.

Trac ticket: https://core.trac.wordpress.org/ticket/64656

## Use of AI Tools

This PR was co-authored with Claude Code (Claude Opus 4.6).

---
**This Pull Request is for code review only. Please keep all other discussion in the Trac ticket. Do not merge this Pull Request. See [GitHub Pull Requests for Code Review](https://make.wordpress.org/core/handbook/contribute/git/github-pull-requests-for-code-review/) in the Core Handbook for more details.**