### PR TITLE
Bump $wp_db_version

### DIFF
--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -23,7 +23,7 @@ $wp_version = '7.0-alpha-61215-src';
  *
  * @global int $wp_db_version
  */
-$wp_db_version = 61644;
+$wp_db_version = 64622;
 
 /**
  * Holds the TinyMCE version.


### PR DESCRIPTION
Increase `$wp_db_version` since the schema was changed in https://github.com/WordPress/wordpress-develop/pull/10894

Trac ticket: https://core.trac.wordpress.org/ticket/64622

The new option is set by `populate_options()`, which is only called during an upgrade.