### PR TITLE
Real-time collaboration: Fix comment syncing on site editor

### DIFF
--- a/src/wp-includes/collaboration/class-wp-http-polling-sync-server.php
+++ b/src/wp-includes/collaboration/class-wp-http-polling-sync-server.php
@@ -278,6 +278,11 @@ class WP_HTTP_Polling_Sync_Server {
 			return isset( $taxonomy->cap->assign_terms ) && current_user_can( $taxonomy->cap->assign_terms );
 		}
 
+		// Handle root comment entities
+		if ( 'root' === $entity_kind && 'comment' === $entity_name && is_numeric( $object_id ) ) {
+			return current_user_can( 'edit_comment', (int) $object_id );
+		}
+
 		// All the remaining checks are for collections. If an object ID is provided,
 		// reject the request.
 		if ( null !== $object_id ) {

--- a/src/wp-includes/collaboration/class-wp-http-polling-sync-server.php
+++ b/src/wp-includes/collaboration/class-wp-http-polling-sync-server.php
@@ -278,7 +278,7 @@ class WP_HTTP_Polling_Sync_Server {
 			return isset( $taxonomy->cap->assign_terms ) && current_user_can( $taxonomy->cap->assign_terms );
 		}
 
-		// Handle root comment entities
+		// Handle single comment entities with a defined object ID.
 		if ( 'root' === $entity_kind && 'comment' === $entity_name && is_numeric( $object_id ) ) {
 			return current_user_can( 'edit_comment', (int) $object_id );
 		}


### PR DESCRIPTION
Backport fix for "Disconnected" dialog in the site editor when real-time collaboration is enabled. See related Gutenberg fix in https://github.com/WordPress/gutenberg/pull/75746:

> ## What?
> 
> When comments are a part of the post template, the site editor will show a "Disconnected" dialog when real-time collaboration is enabled:
> 
> <img width="1715" height="832" alt="image" src="https://github.com/user-attachments/assets/b20f1c21-9140-4e01-a24d-7b5de2dd73a7" />
> 
> This can be replicated by:
> 
> 1. Disable RTC via WordPress Admin -> Settings -> Writing, and uncheck the "Enable real-time collaboration" checkbox. Click the "Save Changes" button.
> 2. Go to WordPress Admin -> Appearance -> Editor.
> 3. Edit the post template to include comments and then click "Save":
> 
>     https://github.com/user-attachments/assets/e097b9b5-63f1-4b6f-b9f3-741deb718cff
> 
> 4. Re-enable RTC.
> 5. Go back to the appearance editor and wait a bit.
> 6. See the "Disconnected" dialog above.
> 
> ## Why?
> 
> When comments are present on the site editor page, we request entity rooms for individual comments loaded on the page, like `root/comment:1`, `root/comment:2`, etc. Due to the fact that these have specified object IDs, [this part of the code](https://github.com/Automattic/gutenberg/blob/ddf6fdeacd1e3c33c467443cc56f9bf2853d9b35/lib/compat/wordpress-7.0/class-wp-http-polling-sync-server.php#L291-L293) returns `false` and returns a `401` to the user, triggering the dialog.
> 
> ## How?
> 
> The fix here adds a special case for comments with specified IDs and does a special check against the comment. This isn't particularly robust for other special cases we may run into, but it does allow subscriptions to individual comment rooms.

Trac ticket: https://core.trac.wordpress.org/ticket/64622
