### PR TITLE
Revert: Enable RTC by default

### DIFF
--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -565,7 +565,7 @@ function populate_options( array $options = array() ) {
 		'wp_notes_notify'                 => 1,
 
 		// 7.0.0
-		'enable_real_time_collaboration'  => 1,
+		'enable_real_time_collaboration'  => 0,
 	);
 
 	// 3.3.0

--- a/src/wp-includes/option.php
+++ b/src/wp-includes/option.php
@@ -2892,7 +2892,7 @@ function register_initial_settings() {
 			'type'              => 'boolean',
 			'description'       => __( 'Enable Real-Time Collaboration' ),
 			'sanitize_callback' => 'rest_sanitize_boolean',
-			'default'           => true,
+			'default'           => false,
 			'show_in_rest'      => true,
 		)
 	);

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -20,8 +20,7 @@ mockedApiResponse.Schema = {
         "wp/v2",
         "wp-site-health/v1",
         "wp-block-editor/v1",
-        "wp-abilities/v1",
-        "wp-sync/v1"
+        "wp-abilities/v1"
     ],
     "authentication": {
         "application-passwords": {
@@ -12699,111 +12698,6 @@ mockedApiResponse.Schema = {
                     }
                 }
             ]
-        },
-        "/wp-sync/v1": {
-            "namespace": "wp-sync/v1",
-            "methods": [
-                "GET"
-            ],
-            "endpoints": [
-                {
-                    "methods": [
-                        "GET"
-                    ],
-                    "args": {
-                        "namespace": {
-                            "default": "wp-sync/v1",
-                            "required": false
-                        },
-                        "context": {
-                            "default": "view",
-                            "required": false
-                        }
-                    }
-                }
-            ],
-            "_links": {
-                "self": [
-                    {
-                        "href": "http://example.org/index.php?rest_route=/wp-sync/v1"
-                    }
-                ]
-            }
-        },
-        "/wp-sync/v1/updates": {
-            "namespace": "wp-sync/v1",
-            "methods": [
-                "POST"
-            ],
-            "endpoints": [
-                {
-                    "methods": [
-                        "POST"
-                    ],
-                    "args": {
-                        "rooms": {
-                            "items": {
-                                "properties": {
-                                    "after": {
-                                        "minimum": 0,
-                                        "required": true,
-                                        "type": "integer"
-                                    },
-                                    "awareness": {
-                                        "required": true,
-                                        "type": "object"
-                                    },
-                                    "client_id": {
-                                        "minimum": 1,
-                                        "required": true,
-                                        "type": "integer"
-                                    },
-                                    "room": {
-                                        "required": true,
-                                        "type": "string",
-                                        "pattern": "^[^/]+/[^/:]+(?::\\S+)?$"
-                                    },
-                                    "updates": {
-                                        "items": {
-                                            "properties": {
-                                                "data": {
-                                                    "type": "string",
-                                                    "required": true
-                                                },
-                                                "type": {
-                                                    "type": "string",
-                                                    "required": true,
-                                                    "enum": [
-                                                        "compaction",
-                                                        "sync_step1",
-                                                        "sync_step2",
-                                                        "update"
-                                                    ]
-                                                }
-                                            },
-                                            "required": true,
-                                            "type": "object"
-                                        },
-                                        "minItems": 0,
-                                        "required": true,
-                                        "type": "array"
-                                    }
-                                },
-                                "type": "object"
-                            },
-                            "type": "array",
-                            "required": true
-                        }
-                    }
-                }
-            ],
-            "_links": {
-                "self": [
-                    {
-                        "href": "http://example.org/index.php?rest_route=/wp-sync/v1/updates"
-                    }
-                ]
-            }
         }
     },
     "site_logo": 0,
@@ -14658,7 +14552,7 @@ mockedApiResponse.settings = {
     "use_smilies": true,
     "default_category": 1,
     "default_post_format": "0",
-    "enable_real_time_collaboration": true,
+    "enable_real_time_collaboration": false,
     "posts_per_page": 10,
     "show_on_front": "posts",
     "page_on_front": 0,


### PR DESCRIPTION
Revert the changes that enabled RTC by default for WP 7.0 Beta 1 per [this comment](https://core.trac.wordpress.org/ticket/64622). 

- This preserves the unit tests for `WP_REST_Autosaves_Controller`; they pass whether the feature is enabled or not.
- Since the REST API endpoints are conditionally registered, the QUnit fixtures must be updated.

Trac ticket: https://core.trac.wordpress.org/ticket/64622