### PR TITLE
Removed unnecessary leading space at class in wp-login.php

### DIFF
--- a/src/wp-login.php
+++ b/src/wp-login.php
@@ -184,7 +184,7 @@ function login_header( $title = null, $message = '', $wp_error = null ) {
 		}
 	}
 
-	$classes[] = ' locale-' . sanitize_html_class( strtolower( str_replace( '_', '-', get_locale() ) ) );
+	$classes[] = 'locale-' . sanitize_html_class( strtolower( str_replace( '_', '-', get_locale() ) ) );
 
 	/**
 	 * Filters the login page body classes.


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/64673

## Description

There is an unnecessary leading space in the class attribute construction on line 187 of wp-login.php.
The class string is generated using:

`implode( ' ', $classes )`

Since `implode( ' ', $classes )` in line 201 already inserts a space between each class name, adding an additional leading space before the output results in a double space in the rendered class attribute.

## Expected Behavior

The class attribute should not contain a leading space. The extra space should be removed to ensure clean and consistent markup.

## Proposed Fix

Remove the unnecessary leading space before the implode() output so that spacing is handled solely by `implode( ' ', $classes )`.

## Impact

1. Minor markup cleanup
2. Improves code quality and consistency
3. Prevents unintended formatting inconsistencies